### PR TITLE
Typing: add `.module.pyi` stubs for more APIs

### DIFF
--- a/src/Gui/FreeCADGui.PySideUic.module.pyi
+++ b/src/Gui/FreeCADGui.PySideUic.module.pyi
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``FreeCADGui.PySideUic`` helper module.
+
+This source-adjacent stub file carries the PySide UI-loading convenience
+helpers that FreeCAD exposes from the GUI layer.
+"""
+
+from __future__ import annotations
+
+from os import PathLike
+from typing import TypeAlias
+
+_UiPath: TypeAlias = str | PathLike[str]
+
+def loadUiType(ui_file: _UiPath, /) -> tuple[type[object], type[object]] | None:
+    """Compile one Qt Designer `.ui` file in memory and return its form and base classes."""
+    ...
+
+def loadUi(ui_file: _UiPath, base: object | None = None, /) -> object | None:
+    """Load one Qt Designer `.ui` file and return the created widget tree."""
+    ...
+
+def createCustomWidget(
+    class_name: str,
+    parent: object | None = None,
+    name: str = "",
+    /,
+) -> object | None:
+    """Create one FreeCAD custom widget by class name."""
+    ...

--- a/src/Gui/FreeCADGui._AbstractSplitView.pyi
+++ b/src/Gui/FreeCADGui._AbstractSplitView.pyi
@@ -49,6 +49,14 @@ class _AbstractSplitView:
         """Return one contained viewer by index."""
         ...
 
+    def __len__(self) -> int:
+        """Return the number of contained 3D viewers."""
+        ...
+
+    def __getitem__(self, index: int, /) -> _View3DInventorViewer:
+        """Return one contained viewer by index using sequence access."""
+        ...
+
     def close(self) -> None:
         """Close the split-view container."""
         ...

--- a/src/Gui/FreeCADGui._AbstractSplitView.pyi
+++ b/src/Gui/FreeCADGui._AbstractSplitView.pyi
@@ -9,7 +9,7 @@ from FreeCADGui import _MDIView, _View3DInventorViewer
 class _AbstractSplitView:
     """Split-view container that manages multiple 3D viewers."""
 
-    def fitAll(self, factor: float = 1.0, /) -> None:
+    def fitAll(self) -> None:
         """Fit all visible content into the active split view."""
         ...
 

--- a/src/Gui/FreeCADGui._Control.pyi
+++ b/src/Gui/FreeCADGui._Control.pyi
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from FreeCADGui import Document, _TaskDialog
 
 class _Control:
@@ -25,8 +27,8 @@ class _Control:
         """Close the active task dialog."""
         ...
 
-    def addTaskWatcher(self, watchers: object, /) -> None:
-        """Register one task watcher object."""
+    def addTaskWatcher(self, watchers: Sequence[object], /) -> None:
+        """Register one sequence of task watcher objects."""
         ...
 
     def clearTaskWatcher(self) -> None:

--- a/src/Gui/FreeCADGui._MDIView.pyi
+++ b/src/Gui/FreeCADGui._MDIView.pyi
@@ -4,9 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Literal, overload
+from typing import Literal, TypeAlias, overload
 
 from FreeCAD import DocumentObject
+
+_ActiveObjectReference: TypeAlias = tuple[DocumentObject, DocumentObject, str]
+_EmptyActiveObjectReference: TypeAlias = tuple[None, None, str]
 
 class _MDIView:
     """Base MDI view wrapper for FreeCAD GUI view types."""
@@ -65,7 +68,7 @@ class _MDIView:
     @overload
     def getActiveObject(
         self, name: str, resolve: Literal[False], /
-    ) -> tuple[DocumentObject | None, DocumentObject | None, str]: ...
+    ) -> _ActiveObjectReference | _EmptyActiveObjectReference: ...
     def cast_to_base(self) -> _MDIView:
         """Return this view as the base MDI view wrapper."""
         ...

--- a/src/Gui/FreeCADGui._View3DInventor.pyi
+++ b/src/Gui/FreeCADGui._View3DInventor.pyi
@@ -4,10 +4,78 @@
 
 from __future__ import annotations
 
-from typing import Any, overload
+from collections.abc import Callable
+from typing import Any, Literal, TypeAlias, TypedDict, overload
 
-from FreeCAD import Placement, Rotation, Vector
+from FreeCAD import DocumentObject, Placement, Rotation, Vector
 from FreeCADGui import _MDIView, _View3DInventorViewer
+
+_Point2: TypeAlias = tuple[int, int]
+_Point3: TypeAlias = tuple[float, float, float]
+_Quaternion: TypeAlias = tuple[float, float, float, float]
+_ViewOrientation: TypeAlias = (
+    Literal[
+        "Top",
+        "Bottom",
+        "Front",
+        "Rear",
+        "Left",
+        "Right",
+        "Isometric",
+        "Dimetric",
+        "Trimetric",
+        "Custom",
+    ]
+    | str
+)
+_CameraType: TypeAlias = Literal["Orthographic", "Perspective"] | int | str
+_DraggerCallbackType: TypeAlias = Literal[
+    "addFinishCallback",
+    "addStartCallback",
+    "addMotionCallback",
+    "addValueChangedCallback",
+]
+
+class _View3DObjectInfo(TypedDict, total=False):
+    """Hit-test payload returned for one picked object in the 3D view."""
+
+    x: float
+    y: float
+    z: float
+    Document: str
+    Object: str
+    Component: str
+    ParentObject: DocumentObject
+    SubName: str
+
+class _View3DRayInfo(TypedDict, total=False):
+    """World-space ray-pick payload returned by ``getObjectInfoRay()``."""
+
+    PickedPoint: Vector
+    Document: str
+    Object: str
+    ParentObject: str
+    Component: str
+    SubName: str
+
+class _View3DEventInfo(TypedDict, total=False):
+    """Dictionary payload passed to one classic 3D-view event callback."""
+
+    Type: str
+    Time: str
+    Position: _Point2
+    ShiftDown: bool
+    CtrlDown: bool
+    AltDown: bool
+    State: str
+    Key: str
+    Button: str
+    Delta: int
+    Translation: _Point3
+    Rotation: _Quaternion
+
+_View3DEventCallback: TypeAlias = Callable[[_View3DEventInfo], object]
+_View3DProxyCallback: TypeAlias = Callable[[object], object]
 
 class _View3DInventor:
     """Primary 3D Inventor view wrapper used by the FreeCAD GUI."""
@@ -64,7 +132,9 @@ class _View3DInventor:
         """Orient the camera trimetrically."""
         ...
 
-    def viewDefaultOrientation(self, view: str | None = None, scale: float = -1.0, /) -> None:
+    def viewDefaultOrientation(
+        self, view: _ViewOrientation | None = None, scale: float = -1.0, /
+    ) -> None:
         """Restore the default camera orientation."""
         ...
 
@@ -84,8 +154,14 @@ class _View3DInventor:
         """Zoom the camera out."""
         ...
 
+    @overload
+    def viewPosition(self) -> Placement | None:
+        """Return the current view placement."""
+        ...
+
+    @overload
     def viewPosition(
-        self, placement: Placement | None = None, steps: int = 0, duration: int = -1, /
+        self, placement: Placement, steps: int = 0, duration: int = -1, /
     ) -> Placement | None:
         """Return or animate the current view placement."""
         ...
@@ -145,7 +221,7 @@ class _View3DInventor:
         """Return the current camera description."""
         ...
 
-    def getCameraNode(self) -> Any:
+    def getCameraNode(self) -> Any | None:
         """Return the underlying camera node."""
         ...
 
@@ -157,7 +233,7 @@ class _View3DInventor:
         """Return the current camera up direction."""
         ...
 
-    def setViewDirection(self, direction: Vector | tuple[float, float, float], /) -> None:
+    def setViewDirection(self, direction: _Point3, /) -> None:
         """Set the camera view direction."""
         ...
 
@@ -182,7 +258,7 @@ class _View3DInventor:
         """Return the current camera type name."""
         ...
 
-    def setCameraType(self, camera_type: int | str, /) -> None:
+    def setCameraType(self, camera_type: _CameraType, /) -> None:
         """Set the camera type."""
         ...
 
@@ -194,11 +270,13 @@ class _View3DInventor:
         """Return the current cursor position in view coordinates."""
         ...
 
-    def getObjectInfo(self, point: object, radius: float = 0.0, /) -> dict[str, Any] | None:
+    def getObjectInfo(self, point: _Point2, radius: float = 0.0, /) -> _View3DObjectInfo | None:
         """Return hit-test information for one point."""
         ...
 
-    def getObjectsInfo(self, point: object, radius: float = 0.0, /) -> list[dict[str, Any]] | None:
+    def getObjectsInfo(
+        self, point: _Point2, radius: float = 0.0, /
+    ) -> list[_View3DObjectInfo] | None:
         """Return hit-test information for all objects near one point."""
         ...
 
@@ -207,7 +285,7 @@ class _View3DInventor:
         ...
 
     @overload
-    def getObjectInfoRay(self, start: Vector, direction: Vector, /) -> dict[str, Any] | None:
+    def getObjectInfoRay(self, start: Vector, direction: Vector, /) -> _View3DRayInfo | None:
         """Return hit-test information for one world-space ray."""
         ...
 
@@ -221,32 +299,49 @@ class _View3DInventor:
         direction_y: float,
         direction_z: float,
         /,
-    ) -> dict[str, Any] | None: ...
+    ) -> _View3DRayInfo | None: ...
+    @overload
     def getPoint(self, x: int, y: int, /) -> Vector:
         """Project one screen-space point into world coordinates."""
         ...
 
+    @overload
+    def getPoint(self, point: _Point2, /) -> Vector: ...
+    @overload
     def getPointOnFocalPlane(self, x: int, y: int, /) -> Vector:
         """Project one screen-space point onto the focal plane."""
         ...
 
-    def getPointOnScreen(self, point: Vector | tuple[float, float, float], /) -> tuple[int, int]:
+    @overload
+    def getPointOnFocalPlane(self, point: _Point2, /) -> Vector: ...
+    @overload
+    def getPointOnScreen(self, point: Vector, /) -> _Point2:
         """Project one world-space point onto the screen."""
         ...
 
-    def getPointOnViewport(self, point: Vector | tuple[float, float, float], /) -> tuple[int, int]:
+    @overload
+    def getPointOnScreen(self, x: float, y: float, z: float, /) -> _Point2: ...
+    @overload
+    def getPointOnViewport(self, point: Vector, /) -> _Point2:
         """Project one world-space point into viewport coordinates."""
         ...
 
+    @overload
+    def getPointOnViewport(self, x: float, y: float, z: float, /) -> _Point2: ...
+    @overload
     def projectPointToLine(self, x: int, y: int, /) -> tuple[Vector, Vector]:
         """Project one screen-space point to a world-space line."""
         ...
 
-    def addEventCallback(self, event_type: str, callback: object, /) -> object:
+    @overload
+    def projectPointToLine(self, point: _Point2, /) -> tuple[Vector, Vector]: ...
+    def addEventCallback(
+        self, event_type: str, callback: _View3DEventCallback, /
+    ) -> _View3DEventCallback:
         """Register one event callback."""
         ...
 
-    def removeEventCallback(self, event_type: str, callback: object, /) -> None:
+    def removeEventCallback(self, event_type: str, callback: _View3DEventCallback, /) -> None:
         """Remove one event callback."""
         ...
 
@@ -267,26 +362,26 @@ class _View3DInventor:
         ...
 
     def addEventCallbackPivy(
-        self, event_type: object, callback: object, extended: int = 1, /
-    ) -> object:
+        self, event_type: object, callback: _View3DProxyCallback, extended: bool | int = 1, /
+    ) -> _View3DProxyCallback:
         """Register one Pivy event callback."""
         ...
 
     def removeEventCallbackPivy(
-        self, event_type: object, callback: object, extended: int = 1, /
-    ) -> object:
+        self, event_type: object, callback: _View3DProxyCallback, extended: bool | int = 1, /
+    ) -> _View3DProxyCallback:
         """Remove one Pivy event callback."""
         ...
 
     def addEventCallbackSWIG(
-        self, event_type: object, callback: object, extended: int = 1, /
-    ) -> object:
+        self, event_type: object, callback: _View3DProxyCallback, extended: bool | int = 1, /
+    ) -> _View3DProxyCallback:
         """Register one SWIG event callback."""
         ...
 
     def removeEventCallbackSWIG(
-        self, event_type: object, callback: object, extended: int = 1, /
-    ) -> object:
+        self, event_type: object, callback: _View3DProxyCallback, extended: bool | int = 1, /
+    ) -> _View3DProxyCallback:
         """Remove one SWIG event callback."""
         ...
 
@@ -311,14 +406,22 @@ class _View3DInventor:
         ...
 
     def addDraggerCallback(
-        self, dragger: object, callback_type: str, callback: object, /
-    ) -> object:
+        self,
+        dragger: object,
+        callback_type: _DraggerCallbackType,
+        callback: _View3DProxyCallback,
+        /,
+    ) -> _View3DProxyCallback:
         """Register one dragger callback."""
         ...
 
     def removeDraggerCallback(
-        self, dragger: object, callback_type: str, callback: object, /
-    ) -> object:
+        self,
+        dragger: object,
+        callback_type: _DraggerCallbackType,
+        callback: _View3DProxyCallback,
+        /,
+    ) -> _View3DProxyCallback:
         """Remove one dragger callback."""
         ...
 
@@ -339,7 +442,7 @@ class _View3DInventor:
         toggle: int = -1,
         beforeEditing: bool = False,
         noManip: bool = True,
-        pla: object | None = None,
+        pla: Placement = ...,
     ) -> None:
         """Toggle or configure the clipping plane."""
         ...

--- a/src/Gui/FreeCADGui._View3DInventorViewer.pyi
+++ b/src/Gui/FreeCADGui._View3DInventorViewer.pyi
@@ -4,9 +4,14 @@
 
 from __future__ import annotations
 
-from typing import Any, overload
+from typing import Any, TypeAlias, overload
 
 from FreeCAD import Matrix, Vector
+from FreeCADGui import NavigationStyle
+
+_Point2: TypeAlias = tuple[int, int]
+_Point3: TypeAlias = tuple[float, float, float]
+_Color: TypeAlias = tuple[float, float, float]
 
 class _View3DInventorViewer:
     """Low-level Coin viewer wrapper behind the 3D view."""
@@ -27,7 +32,7 @@ class _View3DInventorViewer:
         """Replace the root scene graph."""
         ...
 
-    def seekToPoint(self, point: tuple[int, int] | tuple[float, float, float], /) -> None:
+    def seekToPoint(self, point: _Point2 | _Point3, /) -> None:
         """Center the viewer on one screen or world point."""
         ...
 
@@ -45,14 +50,14 @@ class _View3DInventorViewer:
         ...
 
     @overload
-    def getPoint(self, point: tuple[int, int], /) -> Vector: ...
+    def getPoint(self, point: _Point2, /) -> Vector: ...
     @overload
     def getPointOnFocalPlane(self, x: int, y: int, /) -> Vector:
         """Project one screen-space point onto the focal plane."""
         ...
 
     @overload
-    def getPointOnFocalPlane(self, point: tuple[int, int], /) -> Vector: ...
+    def getPointOnFocalPlane(self, point: _Point2, /) -> Vector: ...
     def getPickRadius(self) -> float:
         """Return the current pick radius."""
         ...
@@ -79,9 +84,9 @@ class _View3DInventorViewer:
 
     def setGradientBackgroundColor(
         self,
-        from_color: tuple[float, float, float],
-        to_color: tuple[float, float, float],
-        mid_color: tuple[float, float, float] | None = None,
+        from_color: _Color,
+        to_color: _Color,
+        mid_color: _Color | None = None,
         /,
     ) -> None:
         """Set explicit gradient background colors."""
@@ -115,6 +120,6 @@ class _View3DInventorViewer:
         """Set the navigation-cube corner."""
         ...
 
-    def getNavigationStyle(self) -> object | None:
+    def getNavigationStyle(self) -> NavigationStyle | None:
         """Return the current navigation-style object, if any."""
         ...

--- a/src/Mod/CAM/App/PathApp.module.pyi
+++ b/src/Mod/CAM/App/PathApp.module.pyi
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``PathApp`` module-level helpers.
+
+This source-adjacent stub file carries the G-code I/O and path-construction
+helpers exposed directly by the CAM application module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal, TypeAlias, overload
+
+from FreeCAD import DocumentObject
+from FreeCAD.Base import Vector
+from Part import Shape, Wire
+
+_ShapeInput: TypeAlias = Shape | Sequence[Shape]
+_ArcPlane: TypeAlias = Literal[0, 1, 2, 3, 4, 5] | int
+_SortMode: TypeAlias = Literal[0, 1, 2, 3] | int
+_Orientation: TypeAlias = Literal[0, 1] | int
+_Direction: TypeAlias = Literal[0, 1, 2, 3, 4, 5, 6] | int
+_RetractAxis: TypeAlias = Literal[0, 1, 2] | int
+_WireSortResult: TypeAlias = tuple[list[Wire], Vector] | tuple[list[Wire], Vector, int]
+
+def write(obj: DocumentObject, filename: str, /) -> None:
+    """Export one Path feature document object to one G-code file."""
+    ...
+
+@overload
+def read(filename: str, /) -> None:
+    """Import one G-code file into the active document, creating one if needed."""
+    ...
+
+@overload
+def read(filename: str, doc_name: str, /) -> None:
+    """Import one G-code file into the named document, creating it if needed."""
+    ...
+
+def show(toolpath: Path, name: str = "Path", /) -> None:
+    """Create one document path feature from one standalone `Path` object."""
+    ...
+
+def fromShape(shape: Shape, /) -> Path:
+    """Convert one wire shape into one basic path object."""
+    ...
+
+@overload
+def fromShapes(
+    shapes: _ShapeInput,
+    start: Vector | None = None,
+    return_end: Literal[False] = False,
+    arc_plane: _ArcPlane = 1,
+    sort_mode: _SortMode = 1,
+    abscissa: float = 3.0,
+    nearest_k: int = 3,
+    orientation: _Orientation = 0,
+    direction: _Direction = 0,
+    threshold: float = 0.0,
+    retract_axis: _RetractAxis = 2,
+    retraction: float = 0.0,
+    resume_height: float = 0.0,
+    segmentation: float = 0.0,
+    feedrate: float = 0.0,
+    feedrate_v: float = 0.0,
+    verbose: bool = True,
+    abs_center: bool = False,
+    preamble: bool = True,
+    deflection: float = 0.01,
+) -> Path:
+    """Convert one shape or shape sequence into one path object."""
+    ...
+
+@overload
+def fromShapes(
+    shapes: _ShapeInput,
+    start: Vector | None = None,
+    return_end: Literal[True] = True,
+    arc_plane: _ArcPlane = 1,
+    sort_mode: _SortMode = 1,
+    abscissa: float = 3.0,
+    nearest_k: int = 3,
+    orientation: _Orientation = 0,
+    direction: _Direction = 0,
+    threshold: float = 0.0,
+    retract_axis: _RetractAxis = 2,
+    retraction: float = 0.0,
+    resume_height: float = 0.0,
+    segmentation: float = 0.0,
+    feedrate: float = 0.0,
+    feedrate_v: float = 0.0,
+    verbose: bool = True,
+    abs_center: bool = False,
+    preamble: bool = True,
+    deflection: float = 0.01,
+) -> tuple[Path, Vector]:
+    """Convert one shape or shape sequence into one path object and return its end position."""
+    ...
+
+@overload
+def sortWires(
+    shapes: _ShapeInput,
+    start: Vector | None = None,
+    arc_plane: Literal[1] = 1,
+    sort_mode: _SortMode = 1,
+    abscissa: float = 3.0,
+    nearest_k: int = 3,
+    orientation: _Orientation = 0,
+    direction: _Direction = 0,
+    threshold: float = 0.0,
+    retract_axis: _RetractAxis = 2,
+) -> tuple[list[Wire], Vector, int]:
+    """Sort one wire set and also return the resolved arc plane when auto-plane mode is used."""
+    ...
+
+@overload
+def sortWires(
+    shapes: _ShapeInput,
+    start: Vector | None = None,
+    arc_plane: _ArcPlane = 1,
+    sort_mode: _SortMode = 1,
+    abscissa: float = 3.0,
+    nearest_k: int = 3,
+    orientation: _Orientation = 0,
+    direction: _Direction = 0,
+    threshold: float = 0.0,
+    retract_axis: _RetractAxis = 2,
+) -> _WireSortResult:
+    """Sort one wire set and return the sorted wires plus their final end position."""
+    ...

--- a/src/Mod/CAM/Gui/PathGui.module.pyi
+++ b/src/Mod/CAM/Gui/PathGui.module.pyi
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``PathGui`` module-level helpers.
+
+This source-adjacent stub file carries the GUI-assisted G-code import and
+export helpers exposed directly by the CAM GUI module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import overload
+
+from FreeCAD import DocumentObject
+
+def open(filename: str, /) -> None:
+    """Open one G-code file through the GUI processor chooser."""
+    ...
+
+@overload
+def insert(filename: str, /) -> None:
+    """Insert one G-code file into the active document through the GUI processor chooser."""
+    ...
+
+@overload
+def insert(filename: str, doc_name: str, /) -> None:
+    """Insert one G-code file into the named document through the GUI processor chooser."""
+    ...
+
+def export(objects: Sequence[DocumentObject], filename: str, /) -> None:
+    """Export selected path objects through the GUI post-processor chooser."""
+    ...

--- a/src/Mod/Draft/App/DraftUtils.module.pyi
+++ b/src/Mod/Draft/App/DraftUtils.module.pyi
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``DraftUtils`` compatibility helpers.
+
+This source-adjacent stub file carries the deprecated Draft utility shim that
+still exists for DXF import compatibility.
+"""
+
+from __future__ import annotations
+
+def readDXF(
+    filename: str,
+    document: str | None = None,
+    ignore_errors: bool = True,
+    /,
+) -> None:
+    """Warn that the legacy Draft DXF helper is removed and return `None`."""
+    ...

--- a/src/Mod/Fem/App/Fem.module.pyi
+++ b/src/Mod/Fem/App/Fem.module.pyi
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``Fem`` module-level helpers.
+
+This source-adjacent stub file carries the FEM mesh file I/O helpers and the
+VTK-backed result utilities exposed directly by the Fem application module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import overload
+
+from FreeCAD import DocumentObject
+
+# FEM mesh file and document I/O
+def open(name: str, /) -> None:
+    """Open one FEM mesh file into a new document."""
+    ...
+
+@overload
+def insert(name: str, /) -> None:
+    """Insert one FEM mesh or result file into the active document, creating one if needed."""
+    ...
+
+@overload
+def insert(name: str, doc_name: str, /) -> None:
+    """Insert one FEM mesh or result file into the named document, creating it if needed."""
+    ...
+
+def export(objects: Sequence[DocumentObject], name: str, /) -> None:
+    """Export the first selected FEM mesh object to one mesh or solver file."""
+    ...
+
+def read(name: str, /) -> FemMesh:
+    """Read one FEM mesh file and return the resulting `FemMesh` object."""
+    ...
+
+def show(mesh: FemMesh, name: str = "Mesh", /) -> None:
+    """Create one FEM mesh object in the active document from a `FemMesh`."""
+    ...
+
+# VTK-backed result helpers
+def frdToVTK(filename: str, binary: bool = True, /) -> None:
+    """Convert one CalculiX `.frd` result file to VTK output."""
+    ...
+
+@overload
+def readResult(file_name: str, /) -> None:
+    """Read one CFD or mechanical result file into the active result target."""
+    ...
+
+@overload
+def readResult(file_name: str, obj_name: str, /) -> None:
+    """Read one CFD or mechanical result file into the named document object."""
+    ...
+
+@overload
+def writeResult(file_name: str, /) -> None:
+    """Write the active CFD or FEM result object to one file."""
+    ...
+
+@overload
+def writeResult(file_name: str, obj: DocumentObject, /) -> None:
+    """Write one specific CFD or FEM result object to one file."""
+    ...
+
+def getVtkVersion() -> str:
+    """Return the VTK version string linked into this build."""
+    ...
+
+def getVtkVersionNumber() -> int:
+    """Return the VTK version as one packed integer value."""
+    ...
+
+def vtkVersionCheck(major: int, minor: int, build: int = 0, /) -> int:
+    """Pack one VTK major, minor, and build tuple into a version integer."""
+    ...
+
+def isVtkCompatible(vtkObject: object, /) -> bool:
+    """Return whether one Python VTK object is compatible with FreeCAD's VTK ABI."""
+    ...

--- a/src/Mod/Fem/Gui/FemGui.module.pyi
+++ b/src/Mod/Fem/Gui/FemGui.module.pyi
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``FemGui`` module-level helpers.
+
+This source-adjacent stub file carries the active-analysis selector and the
+GUI editor helpers exposed directly by the Fem GUI module.
+"""
+
+from __future__ import annotations
+
+from typing import overload
+
+from FreeCAD import DocumentObject
+
+@overload
+def setActiveAnalysis() -> None:
+    """Clear the currently active FEM analysis object."""
+    ...
+
+@overload
+def setActiveAnalysis(obj: DocumentObject, /) -> None:
+    """Set the active FEM analysis object."""
+    ...
+
+def getActiveAnalysis() -> DocumentObject | None:
+    """Return the active FEM analysis object, if one is currently set."""
+    ...
+
+@overload
+def open(name: str, /) -> None:
+    """Open one Abaqus or Python input file in the FEM editor."""
+    ...
+
+@overload
+def open(name: str, doc_name: str, /) -> None:
+    """Open one Abaqus or Python input file in the FEM editor."""
+    ...
+
+@overload
+def insert(name: str, /) -> None:
+    """Open one Abaqus or Python input file in the FEM editor."""
+    ...
+
+@overload
+def insert(name: str, doc_name: str, /) -> None:
+    """Open one Abaqus or Python input file in the FEM editor."""
+    ...

--- a/src/Mod/Import/App/Import.module.pyi
+++ b/src/Mod/Import/App/Import.module.pyi
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``Import`` application module.
+
+This source-adjacent stub file carries the manual import/export helpers for
+OCAF-backed CAD formats together with the DXF utility surface.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal, TypeAlias, TypedDict, overload
+
+from FreeCAD import DocumentObject
+from Part import Feature, Shape
+
+_ColorRGBA: TypeAlias = tuple[float, float, float, float]
+_DxfVersion: TypeAlias = Literal[12, 14]
+_ImportExportObject: TypeAlias = DocumentObject | tuple[DocumentObject, Sequence[_ColorRGBA]]
+_ImportColorAssignments: TypeAlias = list[tuple[Feature, list[_ColorRGBA]]]
+_UnsupportedFeatureOccurrences: TypeAlias = dict[str, list[tuple[int, str]]]
+DxfImportStats = TypedDict(
+    "DxfImportStats",
+    {
+        "dxfVersion": str,
+        "dxfEncoding": str,
+        "scalingSource": str,
+        "fileUnits": str,
+        "finalScalingFactor": float,
+        "importTimeSeconds": float,
+        "totalEntitiesCreated": int,
+        "entityCounts": dict[str, int],
+        "importSettings": dict[str, str],
+        "unsupportedFeatures": _UnsupportedFeatureOccurrences,
+        "systemBlockCounts": dict[str, int],
+    },
+)
+
+# OCAF-backed file I/O
+def open(
+    name: str,
+    docName: str | None = None,
+    importHidden: bool | None = None,
+    merge: bool | None = None,
+    useLinkGroup: bool | None = None,
+    mode: int = -1,
+) -> _ImportColorAssignments | None:
+    """Open one STEP, IGES, or glTF file and optionally return imported face colors."""
+    ...
+
+def insert(
+    name: str,
+    docName: str | None = None,
+    importHidden: bool | None = None,
+    merge: bool | None = None,
+    useLinkGroup: bool | None = None,
+    mode: int = -1,
+) -> _ImportColorAssignments | None:
+    """Insert one STEP, IGES, or glTF file into a document and optionally return face colors."""
+    ...
+
+def export(
+    obj: Sequence[_ImportExportObject],
+    name: str,
+    exportHidden: bool | None = None,
+    legacy: bool | None = None,
+    keepPlacement: bool | None = None,
+) -> None:
+    """Export document objects to one STEP, IGES, or glTF file."""
+    ...
+
+# DXF helpers
+def readDXF(
+    filename: str,
+    document: str | None = None,
+    ignore_errors: bool = True,
+    option_source: str | None = None,
+    /,
+) -> DxfImportStats:
+    """Import one DXF file and return detailed import statistics."""
+    ...
+
+@overload
+def writeDXFShape(
+    shape: Shape,
+    filename: str,
+    version: _DxfVersion | int = -1,
+    usePolyline: bool = False,
+    optionSource: str | None = None,
+    /,
+) -> None:
+    """Export one shape to a DXF file."""
+    ...
+
+@overload
+def writeDXFShape(
+    shape: Sequence[Shape],
+    filename: str,
+    version: _DxfVersion | int = -1,
+    usePolyline: bool = False,
+    optionSource: str | None = None,
+    /,
+) -> None:
+    """Export a shape sequence to a DXF file."""
+    ...
+
+@overload
+def writeDXFObject(
+    obj: DocumentObject,
+    filename: str,
+    version: _DxfVersion | int = -1,
+    usePolyline: bool = False,
+    optionSource: str | None = None,
+    /,
+) -> None:
+    """Export one document object to a DXF file."""
+    ...
+
+@overload
+def writeDXFObject(
+    obj: Sequence[DocumentObject],
+    filename: str,
+    version: _DxfVersion | int = -1,
+    usePolyline: bool = False,
+    optionSource: str | None = None,
+    /,
+) -> None:
+    """Export a document-object sequence to a DXF file."""
+    ...

--- a/src/Mod/Import/Gui/ImportGui.module.pyi
+++ b/src/Mod/Import/Gui/ImportGui.module.pyi
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``ImportGui`` module helpers.
+
+This source-adjacent stub file carries the GUI-assisted import/export helpers,
+their option dictionaries, and the DXF inspection utilities.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal, TypeAlias, TypedDict
+
+from FreeCAD import DocumentObject
+
+_DxfVersion: TypeAlias = Literal[12, 14]
+_UnsupportedFeatureOccurrences: TypeAlias = dict[str, list[tuple[int, str]]]
+DxfImportStats = TypedDict(
+    "DxfImportStats",
+    {
+        "dxfVersion": str,
+        "dxfEncoding": str,
+        "scalingSource": str,
+        "fileUnits": str,
+        "finalScalingFactor": float,
+        "importTimeSeconds": float,
+        "totalEntitiesCreated": int,
+        "entityCounts": dict[str, int],
+        "importSettings": dict[str, str],
+        "unsupportedFeatures": _UnsupportedFeatureOccurrences,
+        "systemBlockCounts": dict[str, int],
+    },
+)
+ImportOptions = TypedDict(
+    "ImportOptions",
+    {
+        "merge": bool,
+        "useLinkGroup": bool,
+        "useBaseName": bool,
+        "importHidden": bool,
+        "reduceObjects": bool,
+        "showProgress": bool,
+        "expandCompound": bool,
+        "mode": int,
+        "codePage": int,
+    },
+    total=False,
+)
+ExportOptions = TypedDict(
+    "ExportOptions",
+    {
+        "exportHidden": bool,
+        "keepPlacement": bool,
+        "legacy": bool,
+    },
+    total=False,
+)
+
+def open(
+    name: str,
+    docName: str | None = None,
+    options: ImportOptions | None = None,
+    importHidden: bool | None = None,
+    merge: bool | None = None,
+    useLinkGroup: bool | None = None,
+    mode: int = -1,
+) -> DocumentObject | None:
+    """Open one STEP, IGES, or glTF file with GUI import behavior."""
+    ...
+
+def insert(
+    name: str,
+    docName: str | None = None,
+    options: ImportOptions | None = None,
+    importHidden: bool | None = None,
+    merge: bool | None = None,
+    useLinkGroup: bool | None = None,
+    mode: int = -1,
+) -> DocumentObject | None:
+    """Insert one STEP, IGES, or glTF file with GUI import behavior."""
+    ...
+
+def preScanDxf(filepath: str, /) -> dict[str, int]:
+    """Return entity-count statistics gathered from one DXF file without importing it."""
+    ...
+
+def readDXF(
+    filename: str,
+    document: str | None = None,
+    ignore_errors: bool = True,
+    option_source: str | None = None,
+    /,
+) -> DxfImportStats:
+    """Import one DXF file through the GUI path and return import statistics."""
+    ...
+
+def importOptions(name: str, /) -> ImportOptions:
+    """Show the GUI import-options dialog for one file type and return the chosen options."""
+    ...
+
+def exportOptions(name: str, /) -> ExportOptions:
+    """Show the GUI export-options dialog for one file type and return the chosen options."""
+    ...
+
+def export(
+    obj: Sequence[DocumentObject],
+    name: str,
+    options: ExportOptions | None = None,
+    exportHidden: bool | None = None,
+    legacy: bool | None = None,
+    keepPlacement: bool | None = None,
+) -> None:
+    """Export document objects through the GUI-aware OCAF exporter."""
+    ...
+
+def ocaf(name: str, /) -> None:
+    """Open the OCAF browser for one STEP, IGES, or glTF file."""
+    ...

--- a/src/Mod/JtReader/App/JtReader.module.pyi
+++ b/src/Mod/JtReader/App/JtReader.module.pyi
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``JtReader`` module-level helpers.
+
+This source-adjacent stub file carries the JT file reader helpers exposed
+directly by the JtReader application module.
+"""
+
+from __future__ import annotations
+
+def read(name: str, /) -> None:
+    """Read one JT file through the reader backend without returning public geometry."""
+    ...
+
+def open(name: str, /) -> None:
+    """Open one JT file into a new document."""
+    ...
+
+def insert(name: str, doc_name: str, /) -> None:
+    """Insert one JT file into the named document."""
+    ...

--- a/src/Mod/Measure/App/Measure.module.pyi
+++ b/src/Mod/Measure/App/Measure.module.pyi
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``Measure`` module-level helpers.
+
+This source-adjacent stub file carries the shape-resolution helper exposed
+directly by the Measure application module.
+"""
+
+from __future__ import annotations
+
+from FreeCAD import DocumentObject
+from Part import Shape
+
+def getLocatedTopoShape(root_object: DocumentObject, subname: str, /) -> Shape | None:
+    """Resolve one document object subshape with its accumulated placement applied."""
+    ...

--- a/src/Mod/Mesh/App/Mesh.module.pyi
+++ b/src/Mod/Mesh/App/Mesh.module.pyi
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``Mesh`` module-level helpers.
+
+This source-adjacent stub file carries the file I/O helpers, primitive mesh
+constructors, and point-cloud utilities exposed by the Mesh application
+module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TypeAlias, TypedDict, overload
+
+from FreeCAD import DocumentObject
+from FreeCAD.Base import BoundBox, Placement, Vector
+
+_Point3: TypeAlias = tuple[float, float, float]
+_PolynomialCoefficients: TypeAlias = tuple[float, float, float, float, float, float]
+_MinimumVolumeBoxResult: TypeAlias = tuple[Vector, Vector, Vector, Vector, float, float, float]
+PolynomialFitResult = TypedDict(
+    "PolynomialFitResult",
+    {
+        "Sigma": float,
+        "Coefficients": _PolynomialCoefficients,
+        "Residuals": tuple[float, ...],
+    },
+)
+
+# File and document I/O
+def read(name: str, /) -> Mesh:
+    """Read one mesh file and return the resulting `Mesh` object."""
+    ...
+
+def open(name: str, /) -> None:
+    """Open one mesh file into a new document."""
+    ...
+
+@overload
+def insert(name: str, /) -> None:
+    """Insert one mesh file into the active document, creating one if needed."""
+    ...
+
+@overload
+def insert(name: str, doc_name: str, /) -> None:
+    """Insert one mesh file into the named document, creating it if needed."""
+    ...
+
+def export(
+    objectList: Sequence[DocumentObject],
+    filename: str,
+    tolerance: float = 0.1,
+    exportAmfCompressed: bool = True,
+) -> None:
+    """Export document objects to one mesh file."""
+    ...
+
+def show(mesh: Mesh, name: str = "Mesh", /) -> Feature:
+    """Create one mesh feature in the active document from a `Mesh` object."""
+    ...
+
+# Primitive mesh builders
+@overload
+def createBox(
+    length: float = 10.0,
+    width: float = 10.0,
+    height: float = 10.0,
+    edge_length: float = -1.0,
+    /,
+) -> Mesh:
+    """Create a box mesh from dimensions and an optional target edge length."""
+    ...
+
+@overload
+def createBox(box: BoundBox, /) -> Mesh:
+    """Create a box mesh from one existing bounding box."""
+    ...
+
+def createPlane(x: float = 1.0, y: float = 0.0, z: float = 0.0, /) -> Mesh:
+    """Create a two-triangle XY plane; when `y` is zero it defaults to `x`."""
+    ...
+
+def createSphere(radius: float = 5.0, sampling: int = 50, /) -> Mesh:
+    """Create a tessellated sphere mesh."""
+    ...
+
+def createEllipsoid(radius1: float = 2.0, radius2: float = 4.0, sampling: int = 50, /) -> Mesh:
+    """Create a tessellated ellipsoid mesh."""
+    ...
+
+def createCylinder(
+    radius: float = 2.0,
+    length: float = 10.0,
+    closed: bool = True,
+    edge_length: float = 1.0,
+    sampling: int = 50,
+    /,
+) -> Mesh:
+    """Create a tessellated cylinder mesh."""
+    ...
+
+def createCone(
+    radius1: float = 2.0,
+    radius2: float = 4.0,
+    length: float = 10.0,
+    closed: bool = True,
+    edge_length: float = 1.0,
+    sampling: int = 50,
+    /,
+) -> Mesh:
+    """Create a tessellated cone mesh."""
+    ...
+
+def createTorus(radius1: float = 10.0, radius2: float = 2.0, sampling: int = 50, /) -> Mesh:
+    """Create a tessellated torus mesh."""
+    ...
+
+# Point-cloud helpers
+def calculateEigenTransform(points: Sequence[Vector], /) -> Placement:
+    """Return the principal-axis placement for one point set."""
+    ...
+
+def polynomialFit(points: Sequence[Vector], /) -> PolynomialFitResult:
+    """Fit a quadratic surface to one point set and return fit diagnostics."""
+    ...
+
+def minimumVolumeOrientedBox(points: Sequence[Vector], /) -> _MinimumVolumeBoxResult:
+    """Return the oriented minimum-volume box center, axes, and extents."""
+    ...

--- a/src/Mod/MeshPart/App/MeshPart.module.pyi
+++ b/src/Mod/MeshPart/App/MeshPart.module.pyi
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``MeshPart`` projection and meshing helpers.
+
+This source-adjacent stub file carries the standalone MeshPart functions that
+bridge Part topology and Mesh data.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TypeAlias, overload
+
+from FreeCAD.Base import Vector
+from Mesh import Mesh
+from Part import Edge, Shape, Wire
+
+_Point2: TypeAlias = tuple[float, float]
+_Point3: TypeAlias = tuple[float, float, float]
+_Color: TypeAlias = tuple[float, float, float]
+_LoftPoint: TypeAlias = _Point2 | _Point3
+_VectorLike: TypeAlias = Vector | _Point3
+_ProjectedPolyline: TypeAlias = list[Vector]
+_ProjectedPolylines: TypeAlias = list[_ProjectedPolyline]
+
+def loftOnCurve(
+    curve: Shape, poly: Sequence[_LoftPoint], up_vector: _Point3, max_size: float, /
+) -> Mesh:
+    """Create one lofted mesh by sweeping a polygon along a curve-like shape."""
+    ...
+
+def findSectionParameters(edge: Edge, mesh: Mesh, direction: Vector, /) -> list[float]:
+    """Return edge parameters whose projected points land on mesh edges."""
+    ...
+
+@overload
+def projectShapeOnMesh(Shape: Shape, Mesh: Mesh, MaxDistance: float) -> _ProjectedPolylines:
+    """Project one shape to the mesh within a maximum search distance."""
+    ...
+
+@overload
+def projectShapeOnMesh(Shape: Shape, Mesh: Mesh, Direction: Vector) -> _ProjectedPolylines:
+    """Project one shape to the mesh along one explicit direction."""
+    ...
+
+@overload
+def projectShapeOnMesh(
+    Polygons: Sequence[Sequence[_VectorLike]],
+    Mesh: Mesh,
+    Direction: Vector,
+) -> _ProjectedPolylines:
+    """Project one sampled polygon sequence to the mesh along one direction."""
+    ...
+
+def projectPointsOnMesh(
+    points: Sequence[_VectorLike],
+    mesh: Mesh,
+    direction: Vector,
+    precision: float = -1.0,
+    /,
+) -> list[Vector]:
+    """Project points to the mesh along one direction and return the hits."""
+    ...
+
+def wireFromSegment(mesh: Mesh, segment: Sequence[int], /) -> list[Wire]:
+    """Create boundary wires from one mesh segment given by facet indices."""
+    ...
+
+def wireFromMesh(mesh: Mesh, /) -> list[Wire]:
+    """Create boundary wires for the full mesh border."""
+    ...
+
+@overload
+def meshFromShape(Shape: Shape, /) -> Mesh:
+    """Create a mesh from one shape using the default mesher settings."""
+    ...
+
+@overload
+def meshFromShape(
+    Shape: Shape,
+    LinearDeflection: float,
+    AngularDeflection: float = 0.5,
+    Relative: bool = False,
+    Segments: bool = False,
+    GroupColors: Sequence[_Color] | None = None,
+) -> Mesh:
+    """Create a mesh from one shape using the standard deflection-based mesher."""
+    ...
+
+@overload
+def meshFromShape(Shape: Shape, /, *, MaxLength: float) -> Mesh:
+    """Create a mesh from one shape using a maximum edge-length target."""
+    ...
+
+@overload
+def meshFromShape(Shape: Shape, /, *, MaxArea: float) -> Mesh:
+    """Create a mesh from one shape using a maximum facet-area target."""
+    ...
+
+@overload
+def meshFromShape(Shape: Shape, /, *, LocalLength: float) -> Mesh:
+    """Create a mesh from one shape using one local target edge length."""
+    ...
+
+@overload
+def meshFromShape(Shape: Shape, /, *, Deflection: float) -> Mesh:
+    """Create a mesh from one shape using one mefisto deflection value."""
+    ...
+
+@overload
+def meshFromShape(Shape: Shape, /, *, MinLength: float, MaxLength: float) -> Mesh:
+    """Create a mesh from one shape using explicit minimum and maximum lengths."""
+    ...
+
+@overload
+def meshFromShape(
+    Shape: Shape,
+    /,
+    *,
+    Fineness: int,
+    SecondOrder: bool = False,
+    Optimize: bool = True,
+    AllowQuad: bool = False,
+    MinLength: float = 0.0,
+    MaxLength: float = 0.0,
+) -> Mesh:
+    """Create a mesh from one shape using the netgen fineness-driven settings."""
+    ...
+
+@overload
+def meshFromShape(
+    Shape: Shape,
+    /,
+    *,
+    GrowthRate: float = 0.0,
+    SegPerEdge: float = 0.0,
+    SegPerRadius: float = 0.0,
+    SecondOrder: bool = False,
+    Optimize: bool = True,
+    AllowQuad: bool = False,
+    MinLength: float = 0.0,
+    MaxLength: float = 0.0,
+) -> Mesh:
+    """Create a mesh from one shape using the user-tuned netgen settings."""
+    ...

--- a/src/Mod/Part/App/Part.ShapeFix.module.pyi
+++ b/src/Mod/Part/App/Part.ShapeFix.module.pyi
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``Part.ShapeFix`` submodule helpers.
+
+This source-adjacent stub file carries the standalone shape-fixing helpers
+exposed directly by the Part ShapeFix submodule.
+"""
+
+from __future__ import annotations
+
+from Part import Shape
+
+def sameParameter(shape: Shape, enforce: bool, prec: float = 0.0, /) -> bool:
+    """Recompute same-parameter consistency on one shape and report whether it succeeded."""
+    ...
+
+def encodeRegularity(shape: Shape, tolerance: float = 1.0e-10, /) -> None:
+    """Encode one shape's edge regularity relationships using the given angular tolerance."""
+    ...
+
+def removeSmallEdges(shape: Shape, tolerance: float, /) -> Shape:
+    """Return one copy of the shape with edges smaller than the given tolerance removed."""
+    ...
+
+def fixVertexPosition(shape: Shape, tolerance: float, /) -> bool:
+    """Adjust vertex positions on one shape when their stored tolerances exceed the limit."""
+    ...
+
+def leastEdgeSize(shape: Shape, /) -> float:
+    """Return the length of the smallest edge contained in one shape."""
+    ...

--- a/src/Mod/PartDesign/App/_PartDesign.module.pyi
+++ b/src/Mod/PartDesign/App/_PartDesign.module.pyi
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the private ``_PartDesign`` helper module.
+
+This source-adjacent stub file carries the geometric helper that is exposed by
+the low-level PartDesign extension module.
+"""
+
+from __future__ import annotations
+
+from typing import TypeAlias
+
+from FreeCAD.Base import Vector
+
+_FilletArcConstruction: TypeAlias = tuple[Vector, Vector, Vector]
+
+def makeFilletArc(
+    m1: Vector,
+    p: Vector,
+    q: Vector,
+    n: Vector,
+    radius: float,
+    ccw: bool | int,
+    /,
+) -> _FilletArcConstruction:
+    """Return the tangent points and arc center for one fillet-arc construction."""
+    ...

--- a/src/Mod/Points/App/Points.module.pyi
+++ b/src/Mod/Points/App/Points.module.pyi
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``Points`` module-level helpers.
+
+This source-adjacent stub file carries the point-cloud file I/O and document
+helpers exposed directly by the Points application module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from FreeCAD import DocumentObject
+
+def open(name: str, /) -> None:
+    """Open one ASC, E57, PLY, or PCD point-cloud file into a new document."""
+    ...
+
+def insert(name: str, doc_name: str, /) -> None:
+    """Insert one ASC, E57, PLY, or PCD point-cloud file into the named document."""
+    ...
+
+def export(objectList: Sequence[DocumentObject], filename: str, /) -> None:
+    """Export the first selected points feature to one ASC, PLY, or PCD file."""
+    ...
+
+def show(points: Points, name: str = "Points", /) -> DocumentObject:
+    """Create one document object from one `Points` kernel in the active document."""
+    ...

--- a/src/Mod/ReverseEngineering/App/ReverseEngineering.module.pyi
+++ b/src/Mod/ReverseEngineering/App/ReverseEngineering.module.pyi
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``ReverseEngineering`` module helpers.
+
+This source-adjacent stub file carries the point-cloud approximation,
+reconstruction, filtering, segmentation, and sample-consensus helpers exposed
+directly by the ReverseEngineering application module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal, TypeAlias, TypedDict, overload
+
+from FreeCAD.Base import Vector
+from Mesh import Mesh
+from Part import BSplineCurve, BSplineSurface
+from Points import Points
+
+_Point3: TypeAlias = tuple[float, float, float]
+_VectorLike: TypeAlias = Vector | _Point3
+_CurvePointCloud: TypeAlias = Points | Sequence[_VectorLike]
+_SurfacePointCloud: TypeAlias = Points | Mesh | Sequence[_VectorLike]
+_Normals: TypeAlias = Sequence[_VectorLike]
+_SegmentationCluster: TypeAlias = tuple[int, ...]
+_UvDirections: TypeAlias = tuple[_VectorLike, _VectorLike]
+_ParametrizationType: TypeAlias = Literal["Uniform", "Centripetal", "ChordLength"] | str
+_SacModel: TypeAlias = Literal["Plane", "Cylinder", "Sphere", "Cone"] | str
+SampleConsensusResult = TypedDict(
+    "SampleConsensusResult",
+    {
+        "Probability": float,
+        "Parameters": tuple[float, ...],
+        "Model": tuple[int, ...],
+    },
+)
+
+# Approximation helpers
+@overload
+def approxCurve(
+    Points: _CurvePointCloud,
+    Closed: bool = False,
+    MinDegree: int = 3,
+    MaxDegree: int = 8,
+    Continuity: int = 2,
+    Tolerance: float = 1.0e-3,
+) -> BSplineCurve:
+    """Approximate one point sequence with one B-spline curve."""
+    ...
+
+@overload
+def approxCurve(
+    Points: _CurvePointCloud,
+    ParametrizationType: _ParametrizationType,
+    Closed: bool = False,
+    MinDegree: int = 3,
+    MaxDegree: int = 8,
+    Continuity: int = 2,
+    Tolerance: float = 1.0e-3,
+) -> BSplineCurve:
+    """Approximate one point sequence with one explicitly parametrized B-spline curve."""
+    ...
+
+@overload
+def approxCurve(
+    Points: _CurvePointCloud,
+    Weight1: float,
+    Weight2: float,
+    Weight3: float,
+    Closed: bool = False,
+    MaxDegree: int = 8,
+    Continuity: int = 2,
+    Tolerance: float = 1.0e-3,
+) -> BSplineCurve:
+    """Approximate one point sequence with weighted energy terms."""
+    ...
+
+def approxSurface(
+    Points: _SurfacePointCloud,
+    UDegree: int = 3,
+    VDegree: int = 3,
+    NbUPoles: int = 6,
+    NbVPoles: int = 6,
+    Smooth: bool = True,
+    Weight: float = 0.1,
+    Grad: float = 1.0,
+    Bend: float = 0.0,
+    Curv: float = 0.0,
+    Iterations: int = 5,
+    Correction: bool = True,
+    PatchFactor: float = 1.0,
+    UVDirs: _UvDirections | None = None,
+) -> BSplineSurface:
+    """Approximate one point cloud or mesh with one B-spline surface."""
+    ...
+
+# Point-cloud to mesh reconstruction
+def triangulate(
+    Points: Points,
+    SearchRadius: float,
+    Mu: float = 2.5,
+    KSearch: int = 5,
+    Normals: _Normals | None = None,
+) -> Mesh:
+    """Triangulate one point cloud into one mesh with greedy surface reconstruction."""
+    ...
+
+def poissonReconstruction(
+    Points: Points,
+    KSearch: int = 5,
+    OctreeDepth: int = -1,
+    SolverDivide: int = -1,
+    SamplesPerNode: float = -1.0,
+    Normals: _Normals | None = None,
+) -> Mesh:
+    """Reconstruct one mesh from one point cloud with the Poisson method."""
+    ...
+
+def viewTriangulation(Points: Points, Width: int, Height: int) -> Mesh:
+    """Triangulate one regularly sampled height field into one mesh."""
+    ...
+
+def gridProjection(
+    Points: Points,
+    KSearch: int = 5,
+    Normals: _Normals | None = None,
+) -> Mesh:
+    """Reconstruct one mesh from one point cloud with grid projection."""
+    ...
+
+def marchingCubesRBF(
+    Points: Points,
+    KSearch: int = 5,
+    Normals: _Normals | None = None,
+) -> Mesh:
+    """Reconstruct one mesh from one point cloud with radial-basis marching cubes."""
+    ...
+
+def marchingCubesHoppe(
+    Points: Points,
+    KSearch: int = 5,
+    Normals: _Normals | None = None,
+) -> Mesh:
+    """Reconstruct one mesh from one point cloud with Hoppe marching cubes."""
+    ...
+
+def fitBSpline(
+    Points: Points,
+    Degree: int = 2,
+    Refinement: int = 4,
+    Iterations: int = 10,
+    InteriorSmoothness: float = 0.2,
+    InteriorWeight: float = 1.0,
+    BoundarySmoothness: float = 0.2,
+    BoundaryWeight: float = 0.0,
+) -> BSplineSurface:
+    """Fit one B-spline surface directly to one point cloud."""
+    ...
+
+# Filtering and analysis
+def filterVoxelGrid(
+    Points: Points,
+    DimX: float,
+    DimY: float = 0.0,
+    DimZ: float = 0.0,
+) -> Points:
+    """Downsample one point cloud with one voxel-grid filter."""
+    ...
+
+def normalEstimation(
+    Points: Points,
+    KSearch: int = 0,
+    SearchRadius: float = 0.0,
+) -> list[Vector]:
+    """Estimate one normal vector per point in one point cloud."""
+    ...
+
+def regionGrowingSegmentation(
+    Points: Points,
+    KSearch: int = 5,
+    Normals: _Normals | None = None,
+) -> list[_SegmentationCluster]:
+    """Segment one point cloud into smooth regions and return point-index clusters."""
+    ...
+
+def featureSegmentation(Points: Points, KSearch: int = 5) -> list[_SegmentationCluster]:
+    """Segment one point cloud by geometric features and return point-index clusters."""
+    ...
+
+def sampleConsensus(
+    SacModel: _SacModel,
+    Points: Points,
+    Normals: _Normals | None = None,
+) -> SampleConsensusResult:
+    """Fit one sample-consensus primitive model to one point cloud."""
+    ...

--- a/src/Mod/Robot/App/Robot.module.pyi
+++ b/src/Mod/Robot/App/Robot.module.pyi
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``Robot`` module-level helpers.
+
+This source-adjacent stub file carries the standalone robot simulation helper
+exposed directly by the Robot application module.
+"""
+
+from __future__ import annotations
+
+def simulateToFile(
+    robot: Robot6Axis,
+    trajectory: Trajectory,
+    tick_size: float,
+    file_name: str,
+    /,
+) -> float:
+    """Run one robot simulation, write its result to one file, and return the numeric status."""
+    ...

--- a/src/Mod/Sketcher/App/Sketcher.module.pyi
+++ b/src/Mod/Sketcher/App/Sketcher.module.pyi
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``Sketcher`` module-level helpers.
+
+This source-adjacent stub file carries the standalone sketch import helpers
+exposed directly by the Sketcher application module.
+"""
+
+from __future__ import annotations
+
+def open(name: str, /) -> None:
+    """Open one sketch import file through the Sketcher module entry point."""
+    ...
+
+def insert(name: str, doc_name: str, /) -> None:
+    """Insert one `.skf` sketch flat file into the named document."""
+    ...

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetGui.module.pyi
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetGui.module.pyi
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``SpreadsheetGui`` module-level helpers.
+
+This source-adjacent stub file carries the spreadsheet file import helpers
+exposed directly by the Spreadsheet GUI module.
+"""
+
+from __future__ import annotations
+
+from typing import overload
+
+@overload
+def open(name: str, /) -> None:
+    """Open one tab-delimited text file into a new spreadsheet document."""
+    ...
+
+@overload
+def open(name: str, doc_name: str, /) -> None:
+    """Open one tab-delimited text file into a newly created named document."""
+    ...
+
+@overload
+def insert(name: str, /) -> None:
+    """Insert one tab-delimited text file into the active document, creating one if needed."""
+    ...
+
+@overload
+def insert(name: str, doc_name: str, /) -> None:
+    """Insert one tab-delimited text file into the named document, creating it if needed."""
+    ...

--- a/src/Mod/TechDraw/App/TechDraw.module.pyi
+++ b/src/Mod/TechDraw/App/TechDraw.module.pyi
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``TechDraw`` module-level helpers.
+
+This source-adjacent stub file carries the projection, export, and dimension
+helper APIs exposed directly by the TechDraw application module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Literal, TypeAlias, overload
+
+from FreeCAD.Base import Vector
+from Part import Compound, Edge, Face, Shape, Wire
+
+_ExtentDirection: TypeAlias = Literal[0, 1]
+_ProjectionSvgStyle: TypeAlias = Mapping[str, str]
+_ProjectedParts: TypeAlias = tuple[Shape, Shape, Shape, Shape]
+_ProjectedPartsEx: TypeAlias = tuple[Shape, Shape, Shape, Shape, Shape, Shape, Shape, Shape, Shape, Shape]
+
+# Wire and outline helpers
+def edgeWalker(edgePile: Sequence[Edge], inclBiggest: bool = True, /) -> list[Wire] | None:
+    """Partition one edge pile into one or more planar wires."""
+    ...
+
+def findOuterWire(edgeList: Sequence[Edge], /) -> Wire | None:
+    """Return the outer wire detected in one planar edge pile."""
+    ...
+
+def findShapeOutline(shape: Shape, scale: float, direction: Vector, /) -> Wire | None:
+    """Project one shape and return the outer wire of the resulting outline."""
+    ...
+
+# View export helpers
+def viewPartAsDxf(view: DrawViewPart, /) -> str:
+    """Return the projected edges of one view part as DXF text."""
+    ...
+
+def viewPartAsSvg(view: DrawViewPart, /) -> str:
+    """Return the projected edges of one view part as SVG markup."""
+    ...
+
+def writeDXFView(view: DrawViewPart, filename: str, alignPage: bool = True, /) -> None:
+    """Export one view part directly to one DXF file."""
+    ...
+
+def writeDXFPage(page: DrawPage, filename: str, /) -> None:
+    """Export one TechDraw page and its supported child views to one DXF file."""
+    ...
+
+# Geometry and dimension helpers
+def findCentroid(shape: Shape, direction: Vector, /) -> Vector | None:
+    """Return the projected geometric centroid of one shape in one view direction."""
+    ...
+
+def makeExtentDim(
+    view: DrawViewPart,
+    edges: Sequence[str],
+    direction: _ExtentDirection | int,
+    /,
+) -> DrawViewDimension | None:
+    """Create one horizontal or vertical extent dimension on a view part."""
+    ...
+
+def makeDistanceDim(
+    view: DrawViewPart,
+    dimType: str,
+    fromPoint: Vector,
+    toPoint: Vector,
+    /,
+) -> DrawViewDimension:
+    """Create one 2D distance dimension between two view-space points."""
+    ...
+
+def makeDistanceDim3d(
+    view: DrawViewPart,
+    dimType: str,
+    fromPoint: Vector,
+    toPoint: Vector,
+    /,
+) -> None:
+    """Create one distance dimension from two 3D model-space points."""
+    ...
+
+def makeGeomHatch(
+    face: Face,
+    scale: float = 1.0,
+    patName: str = "",
+    patFile: str = "",
+    /,
+) -> Compound | None:
+    """Create a compound of hatch edges trimmed to one face."""
+    ...
+
+# Projection helpers
+@overload
+def project(shape: Shape, /) -> _ProjectedParts:
+    """Project one shape with the default direction and return four result classes."""
+    ...
+
+@overload
+def project(shape: Shape, direction: Vector, /) -> _ProjectedParts:
+    """Project one shape in one explicit direction and return four result classes."""
+    ...
+
+@overload
+def projectEx(shape: Shape, /) -> _ProjectedPartsEx:
+    """Project one shape with the default direction and return ten result classes."""
+    ...
+
+@overload
+def projectEx(shape: Shape, direction: Vector, /) -> _ProjectedPartsEx:
+    """Project one shape in one explicit direction and return ten result classes."""
+    ...
+
+def projectToSVG(
+    topoShape: Shape,
+    direction: Vector | None = None,
+    type: str | None = None,
+    tolerance: float = 0.1,
+    vStyle: _ProjectionSvgStyle | None = None,
+    v0Style: _ProjectionSvgStyle | None = None,
+    v1Style: _ProjectionSvgStyle | None = None,
+    hStyle: _ProjectionSvgStyle | None = None,
+    h0Style: _ProjectionSvgStyle | None = None,
+    h1Style: _ProjectionSvgStyle | None = None,
+) -> str:
+    """Project one shape and return its SVG representation."""
+    ...
+
+def projectToDXF(
+    topoShape: Shape,
+    direction: Vector | None = None,
+    type: str | None = None,
+    scale: float = 1.0,
+    tolerance: float = 0.1,
+    /,
+) -> str:
+    """Project one shape and return its DXF representation."""
+    ...
+
+def removeSvgTags(svgcode: str, /) -> str:
+    """Strip outer SVG and metadata tags from one SVG fragment."""
+    ...
+
+def exportSVGEdges(topoShape: Shape, /) -> str:
+    """Export one shape's edges as SVG path content."""
+    ...
+
+def build3dCurves(topoShape: Shape, /) -> Shape:
+    """Rebuild 3D curves on one shape and return the updated shape."""
+    ...
+
+def makeCanonicalPoint(view: DrawViewPart, point: Vector, unscale: bool = True, /) -> Vector | None:
+    """Convert one point into the canonical unrotated TechDraw view-space location."""
+    ...
+
+def makeLeader(
+    parent: DrawViewPart,
+    points: Sequence[Vector],
+    startSymbol: int = 0,
+    endSymbol: int = 0,
+    /,
+) -> DrawLeaderLine:
+    """Create one leader line attached to a view part from page-space points."""
+    ...
+
+def nearestFraction(valueWithDecimals: float, /) -> tuple[int, int]:
+    """Return the nearest numerator and denominator pair for one decimal value."""
+    ...

--- a/src/Mod/TechDraw/Gui/TechDrawGui.module.pyi
+++ b/src/Mod/TechDraw/Gui/TechDrawGui.module.pyi
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``TechDrawGui`` module-level helpers.
+
+This source-adjacent stub file carries GUI export helpers and the lightweight
+scene/item bridge functions exposed directly by the TechDraw GUI module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from TechDraw import DrawPage, DrawView
+
+class QGSPage:
+    """Opaque Python wrapper for the Qt graphics scene used by one TechDraw page."""
+
+# Page export helpers
+def export(objects: Sequence[DrawPage], filename: str, /) -> None:
+    """Export one or more selected TechDraw pages through the GUI export hook."""
+    ...
+
+def exportPageAsPdf(page: DrawPage, filename: str, /) -> None:
+    """Export one TechDraw page as one PDF file."""
+    ...
+
+def exportPageAsSvg(page: DrawPage, filename: str, /) -> None:
+    """Export one TechDraw page as one SVG file."""
+    ...
+
+# Scene and item bridge helpers
+def addQGIToView(view: DrawView, item: object, /) -> None:
+    """Insert one Qt graphics item into a TechDraw view's graphics item tree."""
+    ...
+
+def addQGObjToView(view: DrawView, item: object, /) -> None:
+    """Insert one Qt graphics object into a TechDraw view's graphics item tree."""
+    ...
+
+def addQGIToScene(page: DrawPage, item: object, /) -> None:
+    """Insert one Qt graphics item directly into a TechDraw page scene."""
+    ...
+
+def addQGObjToScene(page: DrawPage, item: object, /) -> None:
+    """Insert one Qt graphics object directly into a TechDraw page scene."""
+    ...
+
+def getSceneForPage(page: DrawPage, /) -> QGSPage | None:
+    """Return the scene wrapper associated with one TechDraw page."""
+    ...

--- a/src/Mod/Web/App/Web.module.pyi
+++ b/src/Mod/Web/App/Web.module.pyi
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Typed public signatures for the ``Web`` module-level helpers.
+
+This source-adjacent stub file carries the lightweight TCP server helpers
+exposed directly by the Web application module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeAlias
+
+_ServerAddress: TypeAlias = tuple[str, int]
+_ServerFirewall: TypeAlias = Callable[[str], bool]
+
+def startServer(address: str = "127.0.0.1", port: int = 0, /) -> _ServerAddress:
+    """Start one listening server and return its bound address and port."""
+    ...
+
+def waitForConnection(
+    address: str = "127.0.0.1",
+    port: int = 0,
+    timeout: int = 0,
+    /,
+) -> bool:
+    """Listen for one connection and report whether a client connected before timeout."""
+    ...
+
+def registerServerFirewall(firewall: _ServerFirewall | None, /) -> None:
+    """Register or clear the callback that filters incoming server requests."""
+    ...

--- a/src/Tools/typing/smoke/smoke.py
+++ b/src/Tools/typing/smoke/smoke.py
@@ -152,6 +152,7 @@ def exercise(
     main_window = cast(FreeCADGui._MainWindow, object())
     mdi_view = cast(FreeCADGui._MDIView, object())
     task_dialog = cast(FreeCADGui._TaskDialog, object())
+    split_view = cast(FreeCADGui._AbstractSplitView, object())
     view = cast(FreeCADGui._View3DInventor, object())
     viewer = cast(FreeCADGui._View3DInventorViewer, object())
     resource = cast(FreeCADGui._PyResource, object())
@@ -454,6 +455,8 @@ def exercise(
     assert_type(main_window.getActiveWindow(), FreeCADGui._MDIView | None)
     assert_type(mdi_view.undoActions(), list[str])
     assert_type(mdi_view.sendMessage("ViewFit"), bool)
+    assert_type(len(split_view), int)
+    assert_type(split_view[0], FreeCADGui._View3DInventorViewer)
     assert_type(
         resource.value("objectName", "propertyName"),
         str | int | float | bool | list[str] | None,

--- a/src/Tools/typing/stubgen/discovery.py
+++ b/src/Tools/typing/stubgen/discovery.py
@@ -38,6 +38,7 @@ from .model import (
     ModuleDef,
     PYMETHODDEF_RE,
     PYMETHOD_ALIAS_RE,
+    PYCXX_SEQUENCE_SLOT_RE,
     PYIMPORT_ADD_MODULE_RE,
     PYMODULEDEF_RE,
     PYMODULE_ADD_FUNCTIONS_RE,
@@ -47,6 +48,7 @@ from .model import (
     PY_OBJECT_WRAPPER_RE,
     PublicTypeGroup,
     PublicTypeTarget,
+    SUPPORT_SEQUENCE_RE,
 )
 from .naming import valid_identifier
 from .parsing import (
@@ -82,6 +84,11 @@ KNOWN_PYCXX_MODULE_HINTS: dict[tuple[str, str], str] = {
     ("src/Base/Translate.cpp", "__Translate__"): "FreeCAD.Qt",
     ("src/Gui/UiLoader.cpp", "PySideUic"): "FreeCADGui.PySideUic",
     ("src/Mod/Part/App/AppPartPy.cpp", "ShapeFix"): "Part.ShapeFix",
+}
+
+PYCXX_SEQUENCE_SLOT_BINDINGS: dict[str, tuple[str, MethodKind]] = {
+    "sequence_length": ("__len__", "noargs"),
+    "sequence_item": ("__getitem__", "varargs"),
 }
 
 
@@ -363,6 +370,57 @@ def inferred_pymethoddef_module(
     return None
 
 
+def supported_sequence_contexts(source: str, contexts: list[ContextEntry]) -> set[str]:
+    supported: set[str] = set()
+    for match in SUPPORT_SEQUENCE_RE.finditer(source):
+        kind, context = nearest_context(contexts, match.start())
+        if kind == "python_type":
+            supported.add(context)
+    return supported
+
+
+def extract_pycxx_sequence_slots(root: Path, path: Path, source: str) -> list[BindingMethod]:
+    rel = path.relative_to(root).as_posix()
+    contexts = discover_contexts(source)
+    supported_contexts = supported_sequence_contexts(source, contexts)
+    if not supported_contexts:
+        return []
+
+    methods: list[BindingMethod] = []
+    seen: set[tuple[str, str]] = set()
+    for match in PYCXX_SEQUENCE_SLOT_RE.finditer(source):
+        slot_name = match.group("slot")
+        python_name, method_kind = PYCXX_SEQUENCE_SLOT_BINDINGS[slot_name]
+        kind, context = nearest_context(contexts, match.start())
+        if kind != "python_type" or context not in supported_contexts:
+            continue
+        key = (context, python_name)
+        if key in seen:
+            continue
+        seen.add(key)
+        owner = match.group("owner")
+        cxx_callable = f"{normalize_cpp_qualified_name(owner)}::{slot_name}" if owner else slot_name
+        methods.append(
+            BindingMethod(
+                family="pycxx_slot",
+                source=rel,
+                line=line_number(source, match.start()),
+                table=None,
+                context_kind=kind,
+                context_name=context,
+                inferred_module=None,
+                method_kind=method_kind,
+                python_name=python_name,
+                cxx_callable=cxx_callable,
+                flags="",
+                doc="",
+                generated_source=generated_source(rel),
+            )
+        )
+
+    return methods
+
+
 def extract_pycxx_methods(root: Path, path: Path, source: str) -> list[BindingMethod]:
     rel = path.relative_to(root).as_posix()
     contexts = discover_contexts(source)
@@ -498,6 +556,7 @@ def collect_methods(root: Path, source_dir: Path) -> list[BindingMethod]:
         except OSError:
             continue
         methods.extend(extract_pycxx_methods(root, path, source))
+        methods.extend(extract_pycxx_sequence_slots(root, path, source))
         methods.extend(extract_pymethoddef_methods(root, path, source, table_modules))
 
     return sorted(methods, key=lambda method: (method.source, method.line, method.python_name))

--- a/src/Tools/typing/stubgen/model.py
+++ b/src/Tools/typing/stubgen/model.py
@@ -39,6 +39,10 @@ GENERATE_FROM_PY_CALL_RE = re.compile(r"\bgenerate_from_py_?\s*\(\s*(?P<base>[^\
 #   add_varargs_method("name", &Type::method, "doc")
 ADD_METHOD_RE = re.compile(r"\b(?P<kind>add_(?:varargs|keyword|noargs)_method)\s*\(")
 
+# Match PyCXX sequence protocol opt-in like:
+#   behaviors().supportSequenceType();
+SUPPORT_SEQUENCE_RE = re.compile(r"\bbehaviors\s*\(\s*\)\s*\.\s*supportSequenceType\s*\(\s*\)")
+
 # Match behavior naming such as:
 #   behaviors().name("Vector")
 BEHAVIOR_NAME_RE = re.compile(r"\bbehaviors\s*\(\s*\)\s*\.\s*name\s*\(\s*\"([^\"]+)\"\s*\)")
@@ -135,6 +139,16 @@ GETATTR_MODULE_RE = re.compile(
 # Match class type objects referenced as:
 #   Base::VectorPy::Type
 CPP_TYPE_NAME_RE = re.compile(r"((?:[A-Za-z_]\w*\s*::\s*)*[A-Za-z_]\w*)\s*::\s*Type\b")
+
+# Match PyCXX sequence slot declarations or definitions like:
+#   Py::Object Type::sequence_item(Py_ssize_t)
+#   virtual PyCxx_ssize_t sequence_length() override;
+PYCXX_SEQUENCE_SLOT_RE = re.compile(
+    rf"^[ \t]*(?:virtual\s+)?(?:{CPP_QUALIFIED_NAME}|PyCxx_ssize_t|Py_ssize_t)"
+    rf"(?:\s*[*&])?\s+(?:(?P<owner>{CPP_QUALIFIED_NAME})\s*::\s*)?"
+    r"(?P<slot>sequence_length|sequence_item)\s*\(",
+    re.MULTILINE,
+)
 HELPER_PYI_FILES = {
     "src/Base/Metadata.pyi",
     "src/Base/PyObjectBase.pyi",
@@ -145,7 +159,7 @@ PUBLIC_STUB_DECORATORS = {
     "staticmethod",
 }
 
-BindingFamily: TypeAlias = Literal["pycxx_add_method", "pymethoddef"]
+BindingFamily: TypeAlias = Literal["pycxx_add_method", "pycxx_slot", "pymethoddef"]
 ContextKind: TypeAlias = Literal["pycxx_module", "pymethoddef_table", "python_type", "unknown"]
 MethodKind: TypeAlias = Literal["keyword", "noargs", "varargs"]
 ContextEntry: TypeAlias = tuple[int, ContextKind, str]


### PR DESCRIPTION
This adds more module-level Python bindings to source-adjacent `*.module.pyi` stubs and tighten a few curated GUI/PyCXX stub surfaces.

This adds them for the remaining manual module APIs:

- `Mesh`, `MeshPart`
- `Import`, `ImportGui`
- `TechDraw`, `TechDrawGui`
- `Fem`, `FemGui`
- `ReverseEngineering`
- `Points`, `Sketcher`, `SpreadsheetGui`, `DraftUtils`, `Measure`, `Robot`, `JtReader`, `Web`
- `Part.ShapeFix`, `_PartDesign`
- `PathApp`, `PathGui`
- `FreeCADDbg`, `FreeCADGui.PySideUic`

It also refines nearby curated GUI type stubs for:

- `FreeCADGui._View3DInventor`
- `FreeCADGui._View3DInventorViewer`
- `FreeCADGui._MDIView`
- `FreeCADGui._Control`
- `FreeCADGui._AbstractSplitView`

Finally, it adds the minimal PyCXX sequence-slot discovery needed for curated stubs to expose real public sequence behavior like `_AbstractSplitView.__len__()` and `__getitem__()`.

Note: There is no functional change in FC in this PR as these are not used anywhere outside the still unused stub generator, so it should be 100% safe to merge.
