### PR TITLE
Sketcher: preserve ellipse internal geometry after trim

### DIFF
--- a/src/Mod/Sketcher/App/SketchObjectGeometry.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectGeometry.cpp
@@ -1156,17 +1156,19 @@ int SketchObject::deleteUnusedInternalGeometryWhenTwoFoci(int GeoId, bool delgeo
 
     std::vector<int> delgeometries;
 
-    // those with less than 2 constraints must be removed
-    if (focus2constraints < 2)
+    // those with less than 2 constraints must be removed;
+    // when deleting the parent geometry (delgeoid=true), force-remove all internal elements
+    // regardless of constraint count (e.g. Coincident constraints from exposeInternalGeometry)
+    if (focus2constraints < 2 || (delgeoid && focus2elementindex >= 0))
         delgeometries.push_back(focus2elementindex);
 
-    if (focus1constraints < 2)
+    if (focus1constraints < 2 || (delgeoid && focus1elementindex >= 0))
         delgeometries.push_back(focus1elementindex);
 
-    if (minorconstraints < 2)
+    if (minorconstraints < 2 || (delgeoid && minorelementindex >= 0))
         delgeometries.push_back(minorelementindex);
 
-    if (majorconstraints < 2)
+    if (majorconstraints < 2 || (delgeoid && majorelementindex >= 0))
         delgeometries.push_back(majorelementindex);
 
     if (delgeoid)

--- a/src/Mod/Sketcher/App/SketchObjectGeometry.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectGeometry.cpp
@@ -1154,6 +1154,42 @@ int SketchObject::deleteUnusedInternalGeometryWhenTwoFoci(int GeoId, bool delgeo
             focus2constraints++;
     }
 
+    // If a center-coincident sibling arc exists (created by a case-2 trim), transfer
+    // InternalAlignment to it instead of deleting the internal geometry.
+    if (delgeoid) {
+        int siblingGeoId = -1;
+        for (const auto& constr : vals) {
+            if (constr->Type != Sketcher::Coincident)
+                continue;
+            int candidate = (constr->First == GeoId && constr->FirstPos == PointPos::mid
+                                && constr->SecondPos == PointPos::mid)
+                ? constr->Second
+                : (constr->Second == GeoId && constr->SecondPos == PointPos::mid
+                      && constr->FirstPos == PointPos::mid)
+                    ? constr->First
+                    : -1;
+            const auto* cg = candidate >= 0 ? getGeometry(candidate) : nullptr;
+            if (cg && hasInternalGeometry(cg) && !cg->is<Part::GeomBSplineCurve>()) {
+                siblingGeoId = candidate;
+                break;
+            }
+        }
+        if (siblingGeoId >= 0) {
+            std::vector<Constraint*> transferred;
+            for (const auto& constr : vals)
+                if (constr->Type == Sketcher::InternalAlignment && constr->Second == GeoId) {
+                    auto* c = constr->copy();
+                    c->Second = siblingGeoId;
+                    transferred.push_back(c);
+                }
+            addConstraints(transferred);
+            for (auto* c : transferred)
+                delete c;
+            delGeometry(GeoId, DeleteOption::UpdateGeometry);
+            return 1;
+        }
+    }
+
     std::vector<int> delgeometries;
 
     // those with less than 2 constraints must be removed;

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -665,11 +665,24 @@ void createNewConstraintsForTrim(
     bool isPoint1ConstrainedOnGeoId1 = false;
     bool isPoint2ConstrainedOnGeoId2 = false;
 
+    const auto* trimmedGeo = obj->getGeometry(GeoId);
+    const bool isTrimmedGeoConic = trimmedGeo
+        && (trimmedGeo->isDerivedFrom<Part::GeomConic>()
+            || trimmedGeo->isDerivedFrom<Part::GeomArcOfConic>());
+
     for (const auto& oldConstrId : idsOfOldConstraints) {
         // trim-specific changes first
         const Constraint* con = allConstraints[oldConstrId];
         if (con->Type == InternalAlignment) {
-            geoIdsToBeDeleted.insert(con->First);
+            if (isTrimmedGeoConic) {
+                auto* newCon = con->copy();
+                newCon->Second = newIds.front();
+                newConstraints.push_back(newCon);
+                newToOldConstraintMap[newConstraints.back()] = oldConstrId;
+            }
+            else {
+                geoIdsToBeDeleted.insert(con->First);
+            }
             continue;
         }
         if (auto newConstr = transformPreexistingConstraintForTrim(
@@ -777,7 +790,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
             cutPoints[1]
         )) {
         // If no suitable trim points are found, then trim defaults to deleting the geometry
-        delGeometry(GeoId);
+        delGeometry(GeoId, DeleteOption::IncludeInternalGeometry);
         return 0;
     }
 
@@ -797,7 +810,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
 
     switch (paramsOfNewGeos.size()) {
         case 0: {
-            delGeometry(GeoId);
+            delGeometry(GeoId, DeleteOption::IncludeInternalGeometry);
             return 0;
         }
         case 1: {


### PR DESCRIPTION
When trimming an arc of a conic (ellipse, hyperbola, parabola), the axes and foci are geometrically unchanged, so InternalAlignment constraints must be re-attached to the remaining arc instead of deleting the internal geometry they reference.

For BSplines the control-point layout changes after trim, so the original deletion behaviour is preserved.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
Fixes https://github.com/FreeCAD/FreeCAD/issues/27122

## Before and After Videos
Before:

https://github.com/user-attachments/assets/d080a37a-2320-46ef-ad26-d2d5cd5c2917

After:


https://github.com/user-attachments/assets/40954d53-5c38-42d5-b580-a0468c4564db







<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
