### PR TITLE
Base/App/Gui: Fix localized quantity and expression input

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -89,6 +89,7 @@
 #include <Base/GeometryPyCXX.h>
 #include <Base/Interpreter.h>
 #include <Base/MatrixPy.h>
+#include <Base/NumericFormatting.h>
 #include <Base/QuantityPy.h>
 #include <Base/ParameterPy.h>
 #include <Base/Persistence.h>
@@ -2117,6 +2118,11 @@ void initExceptions()
 void Application::init(int argc, char ** argv)
 {
     try {
+        // Establish the initial Base snapshot before application or GUI preferences can override it.
+        Base::publishNumericLocaleContext(
+            Base::createNumericLocaleContext()
+        );
+
         Base::SystemHandler::installNewHandler();
         Base::SystemHandler::installSegfaultHandler();
 

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -87,6 +87,7 @@
 #include <Base/GeometryPyCXX.h>
 #include <Base/Interpreter.h>
 #include <Base/MatrixPy.h>
+#include <Base/NumericFormatting.h>
 #include <Base/QuantityPy.h>
 #include <Base/ParameterPy.h>
 #include <Base/Persistence.h>
@@ -2115,6 +2116,11 @@ void initExceptions()
 void Application::init(int argc, char ** argv)
 {
     try {
+        // Establish the initial Base snapshot before application or GUI preferences can override it.
+        Base::publishNumericLocaleContext(
+            Base::createNumericLocaleContext()
+        );
+
         Base::SystemHandler::installNewHandler();
         Base::SystemHandler::installSegfaultHandler();
 

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -181,6 +181,7 @@ SET(Document_CPP_SRCS
     DocumentSettings.cpp
     DocumentSettingsPyImp.cpp
     Expression.cpp
+    QuantityInput.cpp
     ExpressionTokenizer.cpp
     FeaturePython.cpp
     FeatureTest.cpp
@@ -231,6 +232,7 @@ SET(Document_HPP_SRCS
     DocumentSettings.h
     Expression.h
     ExpressionParser.h
+    QuantityInput.h
     ExpressionTokenizer.h
     ExpressionVisitors.h
     FeatureCustom.h

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -31,17 +31,24 @@
 # pragma clang diagnostic ignored "-Wdelete-non-virtual-dtor"
 #endif
 
+#include <algorithm>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/io/ios_state.hpp>
 #include <boost/math/special_functions/round.hpp>
 #include <boost/math/special_functions/trunc.hpp>
 
 #include <numbers>
+#include <cctype>
 #include <limits>
 #include <sstream>
 #include <stack>
 #include <string>
+#include <string_view>
+#include <vector>
 #include <fmt/format.h>
+
+#include <unicode/uchar.h>
+#include <unicode/utf8.h>
 
 #include <QObject>
 
@@ -51,6 +58,8 @@
 #include <App/PropertyUnits.h>
 #include <Base/Interpreter.h>
 #include <Base/MatrixPy.h>
+#include <Base/NumericFormatting.h>
+#include <Base/NumericInput.h>
 #include <Base/PlacementPy.h>
 #include <Base/QuantityPy.h>
 #include <Base/RotationPy.h>
@@ -1510,7 +1519,6 @@ void OperatorExpression::_toString(std::ostream &s, bool persistent,int) const
         //else if (!isCommutative())
         //    needsParens = true;
     }
-
     switch (op) {
     case NEG:
         s << "-" << (needsParens ? "(" : "") << left->toString(persistent) << (needsParens ? ")" : "");
@@ -3784,6 +3792,264 @@ ExpressionPtr App::ExpressionParser::parse(const App::DocumentObject* owner, con
     return std::exchange(ScanResult, nullptr);
 }
 
+namespace
+{
+bool expressionStartsAt(
+    std::string_view input,
+    const std::size_t position,
+    std::string_view value
+)
+{
+    return !value.empty() && position + value.size() <= input.size()
+        && input.substr(position, value.size()) == value;
+}
+
+bool isExpressionIdentifierContinuation(const UChar32 codePoint)
+{
+    // Keep this policy aligned with the IDENTIFIER and CELLADDRESS rules in Expression.l.
+    // Localized numeric normalization must never split a token accepted by the canonical lexer.
+    if (codePoint == '_' || codePoint == '@' || codePoint == '$') {
+        return true;
+    }
+
+    switch (u_charType(codePoint)) {
+        case U_UPPERCASE_LETTER:
+        case U_LOWERCASE_LETTER:
+        case U_TITLECASE_LETTER:
+        case U_MODIFIER_LETTER:
+        case U_OTHER_LETTER:
+        case U_NON_SPACING_MARK:
+        case U_ENCLOSING_MARK:
+        case U_COMBINING_SPACING_MARK:
+        case U_DECIMAL_DIGIT_NUMBER:
+        case U_LETTER_NUMBER:
+        case U_OTHER_NUMBER:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool followsExpressionIdentifier(std::string_view input, const std::size_t position)
+{
+    if (position == 0 || position > static_cast<std::size_t>(std::numeric_limits<int32_t>::max())) {
+        return false;
+    }
+
+    auto previous = static_cast<int32_t>(position);
+    UChar32 codePoint = U_SENTINEL;
+    const auto* bytes = reinterpret_cast<const uint8_t*>(input.data());
+    U8_PREV(bytes, 0, previous, codePoint);
+    return codePoint != U_SENTINEL && isExpressionIdentifierContinuation(codePoint);
+}
+
+bool startsExpressionNumber(
+    std::string_view input,
+    const std::size_t position,
+    const NumericLocaleContext& locale
+)
+{
+    if (position >= input.size()) {
+        return false;
+    }
+
+    // Base scans numeric tokens; App decides where expression grammar allows one to start.
+    // In particular, identifier and cell-reference suffixes remain opaque to localization.
+    if (followsExpressionIdentifier(input, position)) {
+        return false;
+    }
+
+    const auto digitAt = [&](const std::size_t offset) {
+        int digit = 0;
+        std::size_t digitLength = 0;
+        return Base::localizedDigitAt(input, offset, locale, digit, digitLength);
+    };
+    const auto decimalAt = [&](const std::size_t offset) {
+        return (offset < input.size() && input[offset] == '.')
+            || expressionStartsAt(input, offset, locale.decimalSeparator);
+    };
+
+    if (digitAt(position)) {
+        return true;
+    }
+    if (decimalAt(position)) {
+        const auto separatorLength = input[position] == '.' ? 1 : locale.decimalSeparator.size();
+        return digitAt(position + separatorLength);
+    }
+
+    const std::string_view positiveSign {
+        locale.positiveSign.data(), locale.positiveSign.size()
+    };
+    const std::string_view negativeSign {
+        locale.negativeSign.data(), locale.negativeSign.size()
+    };
+    for (const auto sign : {std::string_view {"+"}, std::string_view {"-"}, positiveSign,
+                            negativeSign}) {
+        if (!expressionStartsAt(input, position, sign)) {
+            continue;
+        }
+
+        // A sign following a numeric token is an expression operator, not part of the next
+        // numeric token. This keeps compact addition ("1+2") distinct from unary signs.
+        std::size_t previous = position;
+        while (previous > 0
+               && std::isspace(static_cast<unsigned char>(input[previous - 1]))) {
+            --previous;
+        }
+        if (previous > 0) {
+            const char preceding = input[previous - 1];
+            if (std::isalnum(static_cast<unsigned char>(preceding)) || preceding == ')'
+                || preceding == ']') {
+                return false;
+            }
+            // A UTF-8 localized digit may end with a non-ASCII continuation byte, which is not
+            // recognized by std::isalnum. Check the complete code point before treating a sign
+            // as unary so compact localized expressions keep their binary operator semantics.
+            for (std::size_t candidate = previous; candidate > 0; --candidate) {
+                int digit = 0;
+                std::size_t digitLength = 0;
+                if (Base::localizedDigitAt(input, candidate - 1, locale, digit, digitLength)
+                    && candidate - 1 + digitLength == previous) {
+                    return false;
+                }
+            }
+        }
+
+        const auto next = position + sign.size();
+        if (digitAt(next)) {
+            return true;
+        }
+        if (decimalAt(next)) {
+            const auto separatorLength = input[next] == '.' ? 1 : locale.decimalSeparator.size();
+            return digitAt(next + separatorLength);
+        }
+        return false;
+    }
+    return false;
+}
+
+bool isFunctionOpening(std::string_view input, const std::size_t position)
+{
+    if (position == 0) {
+        return false;
+    }
+    std::size_t previous = position;
+    while (previous > 0 && std::isspace(static_cast<unsigned char>(input[previous - 1]))) {
+        --previous;
+    }
+    return previous > 0
+        && (std::isalnum(static_cast<unsigned char>(input[previous - 1]))
+            || input[previous - 1] == '_');
+}
+
+std::size_t functionArgumentSeparatorLength(
+    const std::string_view input,
+    const std::size_t position,
+    const NumericLocaleContext& locale
+)
+{
+    const auto policy = Base::numericGrammarPolicy(locale, NumericSyntaxContext::FunctionArgument);
+    if (expressionStartsAt(input, position, policy.argumentSeparator)) {
+        return policy.argumentSeparator.size();
+    }
+
+    // A comma-decimal locale uses a comma as the decimal separator when it is immediately
+    // followed by a digit. Whitespace or any other following character makes it punctuation.
+    if (policy.decimalSeparator == "," && expressionStartsAt(input, position, ",")) {
+        int digit = 0;
+        std::size_t digitLength = 0;
+        const auto afterComma = position + 1;
+        if (afterComma == input.size()
+            || std::isspace(static_cast<unsigned char>(input[afterComma]))
+            || !Base::localizedDigitAt(input, afterComma, locale, digit, digitLength)) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+std::string normalizeExpressionUserInput(
+    std::string_view input,
+    const NumericLocaleContext& locale
+)
+{
+    std::string normalized;
+    normalized.reserve(input.size());
+    std::vector<bool> functionParentheses;
+
+    std::size_t position = 0;
+    while (position < input.size()) {
+        // Expression string literals are opaque to numeric tokenization. This also preserves an
+        // unterminated literal so that the expression parser can report its normal syntax error.
+        if (position + 1 < input.size() && input[position] == '<' && input[position + 1] == '<') {
+            const auto end = input.find(">>", position + 2);
+            if (end == std::string_view::npos) {
+                normalized.append(input.substr(position));
+                break;
+            }
+            const auto length = end + 2 - position;
+            normalized.append(input.substr(position, length));
+            position += length;
+            continue;
+        }
+
+        if (input[position] == '(') {
+            functionParentheses.push_back(isFunctionOpening(input, position));
+            normalized.push_back(input[position++]);
+            continue;
+        }
+        if (input[position] == ')') {
+            if (!functionParentheses.empty()) {
+                functionParentheses.pop_back();
+            }
+            normalized.push_back(input[position++]);
+            continue;
+        }
+
+        const bool inFunction = !functionParentheses.empty() && functionParentheses.back();
+        const auto syntax = inFunction ? NumericSyntaxContext::FunctionArgument
+                                       : NumericSyntaxContext::Expression;
+
+        if (inFunction) {
+            const auto separatorLength = functionArgumentSeparatorLength(input, position, locale);
+            if (separatorLength != 0) {
+                // The legacy lexer has comma-decimal rules of its own. Emit the canonical
+                // argument separator so it cannot be absorbed into a neighboring numeric
+                // literal before the grammar sees it.
+                normalized.push_back(';');
+                position += separatorLength;
+                continue;
+            }
+        }
+
+        if (startsExpressionNumber(input, position, locale)) {
+            const auto result = scanLocalizedNumber(input.substr(position), locale, syntax);
+            if (result.status != LocalizedNumberResult::Status::Complete) {
+                throw ParserError("Invalid localized number");
+            }
+            normalized += result.canonicalText;
+            position += result.consumedBytes;
+            continue;
+        }
+
+        normalized.push_back(input[position++]);
+    }
+
+    return normalized;
+}
+}  // namespace
+
+ExpressionPtr App::ExpressionParser::parseUserInput(
+    const App::DocumentObject* owner,
+    const char* buffer,
+    const Base::NumericLocaleContext& locale
+)
+{
+    const auto canonical = normalizeExpressionUserInput(buffer, locale);
+    return parse(owner, canonical.c_str());
+}
+
 std::unique_ptr<UnitExpression> ExpressionParser::parseUnit(
     const App::DocumentObject* owner,
     const char* buffer
@@ -3867,4 +4133,3 @@ bool ExpressionParser::isTokenAUnit(const std::string & str)
 #if defined(__clang__)
 # pragma clang diagnostic pop
 #endif
-

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1519,6 +1519,10 @@ void OperatorExpression::_toString(std::ostream &s, bool persistent,int) const
         //else if (!isCommutative())
         //    needsParens = true;
     }
+    if (op == UNIT && !freecad_cast<NumberExpression*>(left)) {
+        needsParens = true;
+    }
+
     switch (op) {
     case NEG:
         s << "-" << (needsParens ? "(" : "") << left->toString(persistent) << (needsParens ? ")" : "");

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -31,16 +31,20 @@
 # pragma clang diagnostic ignored "-Wdelete-non-virtual-dtor"
 #endif
 
+#include <algorithm>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/io/ios_state.hpp>
 #include <boost/math/special_functions/round.hpp>
 #include <boost/math/special_functions/trunc.hpp>
 
 #include <numbers>
+#include <cctype>
 #include <limits>
 #include <sstream>
 #include <stack>
 #include <string>
+#include <string_view>
+#include <vector>
 #include <fmt/format.h>
 
 #include <QObject>
@@ -51,6 +55,8 @@
 #include <App/PropertyUnits.h>
 #include <Base/Interpreter.h>
 #include <Base/MatrixPy.h>
+#include <Base/NumericFormatting.h>
+#include <Base/NumericInput.h>
 #include <Base/PlacementPy.h>
 #include <Base/QuantityPy.h>
 #include <Base/RotationPy.h>
@@ -1509,6 +1515,9 @@ void OperatorExpression::_toString(std::ostream &s, bool persistent,int) const
             needsParens = true;
         //else if (!isCommutative())
         //    needsParens = true;
+    }
+    if (op == UNIT && !freecad_cast<NumberExpression*>(left)) {
+        needsParens = true;
     }
 
     switch (op) {
@@ -3782,6 +3791,179 @@ ExpressionPtr App::ExpressionParser::parse(const App::DocumentObject* owner, con
     return std::exchange(ScanResult, nullptr);
 }
 
+namespace
+{
+bool expressionStartsAt(
+    std::string_view input,
+    const std::size_t position,
+    std::string_view value
+)
+{
+    return !value.empty() && position + value.size() <= input.size()
+        && input.substr(position, value.size()) == value;
+}
+
+bool startsExpressionNumber(
+    std::string_view input,
+    const std::size_t position,
+    const NumericLocaleContext& locale
+)
+{
+    if (position >= input.size()) {
+        return false;
+    }
+
+    const auto digitAt = [&](const std::size_t offset) {
+        int digit = 0;
+        std::size_t digitLength = 0;
+        return Base::localizedDigitAt(input, offset, locale, digit, digitLength);
+    };
+    const auto decimalAt = [&](const std::size_t offset) {
+        return (offset < input.size() && input[offset] == '.')
+            || expressionStartsAt(input, offset, locale.decimalSeparator);
+    };
+
+    if (digitAt(position)) {
+        return true;
+    }
+    if (decimalAt(position)) {
+        const auto separatorLength = input[position] == '.' ? 1 : locale.decimalSeparator.size();
+        return digitAt(position + separatorLength);
+    }
+
+    const std::string_view positiveSign {
+        locale.positiveSign.data(), locale.positiveSign.size()
+    };
+    const std::string_view negativeSign {
+        locale.negativeSign.data(), locale.negativeSign.size()
+    };
+    for (const auto sign : {std::string_view {"+"}, std::string_view {"-"}, positiveSign,
+                            negativeSign}) {
+        if (!expressionStartsAt(input, position, sign)) {
+            continue;
+        }
+
+        // A sign following a numeric token is an expression operator, not part of the next
+        // numeric token. This keeps compact addition ("1+2") distinct from unary signs.
+        std::size_t previous = position;
+        while (previous > 0
+               && std::isspace(static_cast<unsigned char>(input[previous - 1]))) {
+            --previous;
+        }
+        if (previous > 0) {
+            const char preceding = input[previous - 1];
+            if (std::isalnum(static_cast<unsigned char>(preceding)) || preceding == ')'
+                || preceding == ']') {
+                return false;
+            }
+            // A UTF-8 localized digit may end with a non-ASCII continuation byte, which is not
+            // recognized by std::isalnum. Check the complete code point before treating a sign
+            // as unary so compact localized expressions keep their binary operator semantics.
+            for (std::size_t candidate = previous; candidate > 0; --candidate) {
+                int digit = 0;
+                std::size_t digitLength = 0;
+                if (Base::localizedDigitAt(input, candidate - 1, locale, digit, digitLength)
+                    && candidate - 1 + digitLength == previous) {
+                    return false;
+                }
+            }
+        }
+
+        const auto next = position + sign.size();
+        if (digitAt(next)) {
+            return true;
+        }
+        if (decimalAt(next)) {
+            const auto separatorLength = input[next] == '.' ? 1 : locale.decimalSeparator.size();
+            return digitAt(next + separatorLength);
+        }
+        return false;
+    }
+    return false;
+}
+
+bool isFunctionOpening(std::string_view input, const std::size_t position)
+{
+    if (position == 0) {
+        return false;
+    }
+    std::size_t previous = position;
+    while (previous > 0 && std::isspace(static_cast<unsigned char>(input[previous - 1]))) {
+        --previous;
+    }
+    return previous > 0
+        && (std::isalnum(static_cast<unsigned char>(input[previous - 1]))
+            || input[previous - 1] == '_');
+}
+
+std::string normalizeExpressionUserInput(
+    std::string_view input,
+    const NumericLocaleContext& locale
+)
+{
+    std::string normalized;
+    normalized.reserve(input.size());
+    std::vector<bool> functionParentheses;
+
+    std::size_t position = 0;
+    while (position < input.size()) {
+        // Expression string literals are opaque to numeric tokenization. This also preserves an
+        // unterminated literal so that the expression parser can report its normal syntax error.
+        if (position + 1 < input.size() && input[position] == '<' && input[position + 1] == '<') {
+            const auto end = input.find(">>", position + 2);
+            if (end == std::string_view::npos) {
+                normalized.append(input.substr(position));
+                break;
+            }
+            const auto length = end + 2 - position;
+            normalized.append(input.substr(position, length));
+            position += length;
+            continue;
+        }
+
+        if (input[position] == '(') {
+            functionParentheses.push_back(isFunctionOpening(input, position));
+            normalized.push_back(input[position++]);
+            continue;
+        }
+        if (input[position] == ')') {
+            if (!functionParentheses.empty()) {
+                functionParentheses.pop_back();
+            }
+            normalized.push_back(input[position++]);
+            continue;
+        }
+
+        const bool inFunction = !functionParentheses.empty() && functionParentheses.back();
+        const auto syntax = inFunction ? NumericSyntaxContext::FunctionArgument
+                                       : NumericSyntaxContext::Expression;
+        if (startsExpressionNumber(input, position, locale)) {
+            const auto result = scanLocalizedNumber(input.substr(position), locale, syntax);
+            if (result.status != LocalizedNumberResult::Status::Complete) {
+                throw ParserError("Invalid localized number");
+            }
+            normalized += result.canonicalText;
+            position += result.consumedBytes;
+            continue;
+        }
+
+        normalized.push_back(input[position++]);
+    }
+
+    return normalized;
+}
+}  // namespace
+
+ExpressionPtr App::ExpressionParser::parseUserInput(
+    const App::DocumentObject* owner,
+    const char* buffer,
+    const Base::NumericLocaleContext& locale
+)
+{
+    const auto canonical = normalizeExpressionUserInput(buffer, locale);
+    return parse(owner, canonical.c_str());
+}
+
 std::unique_ptr<UnitExpression> ExpressionParser::parseUnit(
     const App::DocumentObject* owner,
     const char* buffer
@@ -3865,4 +4047,3 @@ bool ExpressionParser::isTokenAUnit(const std::string & str)
 #if defined(__clang__)
 # pragma clang diagnostic pop
 #endif
-

--- a/src/App/Expression.tab.c
+++ b/src/App/Expression.tab.c
@@ -70,6 +70,7 @@
 
 
 /* First part of user prologue.  */
+#line 28 "Expression.y"
 
 #define YYSTYPE App::ExpressionParser::semantic_type
 
@@ -78,6 +79,7 @@ std::stack<FunctionExpression::Function> functions;                /**< Function
 #define yyparse ExpressionParser_yyparse
 #define yyerror ExpressionParser_yyerror
 
+#line 80 "Expression.tab.c"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -139,8 +141,8 @@ enum yysymbol_kind_t
   YYSYMBOL_31_ = 31,                       /* '^'  */
   YYSYMBOL_NEG = 32,                       /* NEG  */
   YYSYMBOL_POS = 33,                       /* POS  */
-  YYSYMBOL_34_ = 34,                       /* ')'  */
-  YYSYMBOL_35_ = 35,                       /* '('  */
+  YYSYMBOL_34_ = 34,                       /* '('  */
+  YYSYMBOL_35_ = 35,                       /* ')'  */
   YYSYMBOL_36_ = 36,                       /* ','  */
   YYSYMBOL_37_ = 37,                       /* ';'  */
   YYSYMBOL_38_ = 38,                       /* '.'  */
@@ -492,16 +494,16 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  40
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   432
+#define YYLAST   405
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  42
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  18
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  76
+#define YYNRULES  77
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  140
+#define YYNSTATES  141
 
 /* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   281
@@ -522,7 +524,7 @@ static const yytype_int8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,    39,     2,    29,     2,     2,
-      35,    34,    27,    26,    36,     2,    38,    28,     2,     2,
+      34,    35,    27,    26,    36,     2,    38,    28,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,    25,    37,
        2,     2,     2,    24,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -553,14 +555,14 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,    83,    83,    84,    87,    88,    91,    92,    93,    94,
+       0,    83,    83,    84,    87,    88,    89,    92,    93,    94,
       95,    96,    97,    98,    99,   100,   101,   102,   103,   104,
-     105,   106,   107,   108,   109,   110,   111,   112,   113,   116,
-     117,   118,   119,   121,   122,   123,   124,   125,   126,   129,
-     133,   134,   136,   137,   138,   139,   140,   141,   142,   145,
-     146,   150,   151,   155,   156,   160,   165,   170,   176,   183,
-     190,   197,   201,   202,   203,   204,   205,   206,   207,   208,
-     212,   213,   214,   218,   219,   223,   224
+     105,   106,   107,   108,   109,   110,   111,   112,   113,   114,
+     117,   118,   119,   120,   122,   123,   124,   125,   126,   127,
+     130,   134,   135,   137,   138,   139,   140,   141,   142,   143,
+     146,   147,   151,   152,   156,   157,   161,   166,   171,   177,
+     184,   191,   198,   202,   203,   204,   205,   206,   207,   208,
+     209,   213,   214,   215,   219,   220,   224,   225
 };
 #endif
 
@@ -580,7 +582,7 @@ static const char *const yytname[] =
   "IDENTIFIER", "UNIT", "USUNIT", "INTEGER", "CONSTANT", "CELLADDRESS",
   "EQ", "NEQ", "LT", "GT", "GTE", "LTE", "STRING", "MINUSSIGN",
   "PROPERTY_REF", "DOCUMENT", "OBJECT", "EXPONENT", "'?'", "':'", "'+'",
-  "'*'", "'/'", "'%'", "NUM_AND_UNIT", "'^'", "NEG", "POS", "')'", "'('",
+  "'*'", "'/'", "'%'", "NUM_AND_UNIT", "'^'", "NEG", "POS", "'('", "')'",
   "','", "';'", "'.'", "'#'", "'['", "']'", "$accept", "input", "unit_num",
   "exp", "num", "args", "range", "us_building_unit", "other_unit",
   "unit_exp", "integer", "id_or_cell", "identifier", "iden", "indexer",
@@ -599,7 +601,7 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF (-77)
+#define YYTABLE_NINF (-78)
 
 #define yytable_value_is_error(Yyn) \
   0
@@ -608,20 +610,21 @@ yysymbol_name (yysymbol_kind_t yysymbol)
    STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-     100,   203,   -32,   -32,   -31,   -32,   -32,   -32,   -32,   -32,
-      90,   203,   203,   100,    34,    17,   -32,   401,     7,   -32,
-     -32,    93,   -10,   -19,    19,    16,    -5,    49,   203,   401,
-      78,   -32,    -9,   -32,   -32,   358,    -4,   -32,    64,   -32,
-     -32,   203,   203,   203,   203,   203,   203,   203,   203,   203,
-     203,   100,   203,   203,     7,    84,     6,     7,     7,     3,
-     156,   -32,   107,   119,   -32,    44,    52,   -32,   203,   203,
-      25,   -32,   -32,    25,    20,    20,    20,    20,    20,    20,
-      68,   381,    68,    59,    59,     6,    59,   -32,   122,     6,
-       6,   -32,   -32,    57,   -32,   167,   218,   -32,   -32,   -32,
-     -32,    94,    96,   -32,   401,   -32,   401,   -32,   -32,   -32,
-     203,   -32,   -32,   203,   238,     0,   -32,    80,    25,   401,
-     278,   203,   -32,   203,   -32,   258,    98,   -32,   -32,   -32,
-     298,   318,   203,   -32,    25,   -32,   -32,   338,   -32,   -32
+     163,    11,   -32,   -32,   -31,   -32,   -32,   -32,   -32,   -32,
+      50,    11,    11,   163,    40,    12,   -32,   374,    16,   -32,
+     -32,    85,   -10,    -9,    -3,    59,    13,     1,    11,   374,
+     114,   -32,     2,   -32,   -32,   330,    28,   -32,    24,   -32,
+     -32,    11,    11,    11,    11,    11,    11,    11,    11,    11,
+      11,   163,    11,    11,    16,   105,    39,    16,    16,    38,
+     119,   -32,   115,   120,   -32,    42,    80,   -32,    11,    11,
+      -4,    16,   -32,    -4,    77,    77,    77,    77,    77,    77,
+     104,   354,   104,   108,   108,    39,   108,   -32,   103,    39,
+      39,   -32,   -32,    57,   -32,   174,   190,   -32,   -32,   -32,
+     -32,    98,   102,   -32,   374,   -32,   374,   -32,   -32,    39,
+     -32,    11,   -32,   -32,    11,   210,     0,   -32,    84,    -4,
+     374,   250,    11,   -32,    11,   -32,   230,   109,   -32,   -32,
+     -32,   270,   290,    11,   -32,    -4,   -32,   -32,   310,   -32,
+     -32
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -629,27 +632,28 @@ static const yytype_int16 yypact[] =
    means the default is an error.  */
 static const yytype_int8 yydefact[] =
 {
-       0,     0,    29,    30,    51,    41,    40,    31,    32,    52,
-       8,     0,     0,     0,     0,     0,     7,     2,     6,    43,
-      42,     3,    53,     9,    54,    25,     0,     0,     0,    33,
-       0,    34,    53,    10,    11,     0,     0,    51,     0,    56,
+       0,     0,    30,    31,    52,    42,    41,    32,    33,    53,
+       9,     0,     0,     0,     0,     0,     8,     2,     7,    44,
+      43,     3,    54,    10,    55,    26,     0,     0,     0,    34,
+       0,    35,    54,    11,    12,     0,     0,    52,     0,    57,
        1,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,    43,     4,     0,     0,     0,
-       0,    70,     0,     0,    71,     0,     0,    26,     0,     0,
-       0,    28,    48,     0,    19,    20,    21,    22,    23,    24,
-      13,     0,    12,    14,    15,    17,    16,    18,     0,    45,
-      44,    50,    49,     0,    46,     0,     0,    61,    72,    75,
-      76,     0,     0,    58,    35,    37,    36,    38,    39,    55,
-       0,     5,    47,     0,     0,     0,    62,     0,     0,    27,
-       0,     0,    64,     0,    63,     0,     0,    59,    57,    65,
-       0,     0,     0,    66,     0,    68,    67,     0,    60,    69
+       0,     0,     0,     0,     0,    44,     4,     0,     0,     0,
+       0,    71,     0,     0,    72,     0,     0,    27,     0,     0,
+       0,    29,    49,     0,    20,    21,    22,    23,    24,    25,
+      14,     0,    13,    15,    16,    18,    17,    19,     0,    46,
+      45,    51,    50,     0,    47,     0,     0,    62,    73,    76,
+      77,     0,     0,    59,    36,    38,    37,    39,    40,     5,
+      56,     0,     6,    48,     0,     0,     0,    63,     0,     0,
+      28,     0,     0,    65,     0,    64,     0,     0,    60,    58,
+      66,     0,     0,     0,    67,     0,    69,    68,     0,    61,
+      70
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-     -32,   -32,   -32,    32,    76,   -32,    54,   -17,   -32,     2,
-      46,    -1,   -32,   -32,   112,   -32,   -32,    75
+     -32,   -32,   -32,    32,    86,   -32,    51,   -17,   -32,    36,
+      49,    -1,   -32,   -32,   127,   -32,   -32,    90
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
@@ -664,98 +668,92 @@ static const yytype_int8 yydefgoto[] =
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
-      32,    55,    21,     1,     2,     3,     4,    91,   -74,     7,
-       8,     9,    92,    39,     5,     6,    70,    40,    10,    11,
-      56,    60,    93,    57,    58,   123,    12,    59,   -76,   -76,
-      72,    37,    17,    29,    65,    28,     9,    59,    14,    47,
-      37,   124,    54,    33,    34,     9,    49,    50,    51,    52,
-      37,    53,    38,    85,    63,     9,    60,    62,    37,    89,
-      90,    91,    99,     9,   100,   103,    92,    32,    32,   108,
-     102,   111,   109,    74,    75,    76,    77,    78,    79,    80,
-      81,    82,    83,    84,    86,    87,    37,    66,     2,     3,
-      53,     9,    96,     7,     8,    50,    51,    52,   126,    53,
-     104,   106,    73,     1,     2,     3,     4,     5,     6,     7,
-       8,     9,    67,    97,    68,    69,   127,   128,    10,    11,
-      57,    58,   105,   107,    59,    98,    12,   114,   -75,   -73,
-       6,    88,   117,   138,   118,    13,   134,    64,    14,   112,
-     101,     0,   119,     0,     0,   120,     0,   125,     0,     0,
-       0,     0,     0,   130,     0,   131,     0,     0,     0,     1,
-       2,     3,     4,     0,   137,     7,     8,     9,     0,     0,
-       1,     2,     3,     4,    10,    11,     7,     8,     9,     0,
-       0,    95,    12,     0,     0,    10,    11,     0,     0,     0,
-       0,    28,   113,    12,    14,     0,     0,     0,     0,     0,
-       0,     0,    28,     0,     0,    14,     1,     2,     3,     4,
-       0,     0,     7,     8,     9,     0,     0,     0,     0,     0,
-       0,    10,    11,     0,     0,     0,     0,     0,     0,    12,
-      41,    42,    43,    44,    45,    46,     0,    47,    28,     0,
-       0,    14,    48,   115,    49,    50,    51,    52,     0,    53,
-      41,    42,    43,    44,    45,    46,     0,    47,     0,   116,
-       0,     0,    48,   121,    49,    50,    51,    52,     0,    53,
-      41,    42,    43,    44,    45,    46,     0,    47,     0,   122,
-       0,     0,    48,   132,    49,    50,    51,    52,     0,    53,
-      41,    42,    43,    44,    45,    46,     0,    47,     0,   133,
-       0,     0,    48,     0,    49,    50,    51,    52,     0,    53,
-      41,    42,    43,    44,    45,    46,     0,    47,     0,   129,
-       0,     0,    48,     0,    49,    50,    51,    52,     0,    53,
-      41,    42,    43,    44,    45,    46,     0,    47,     0,   135,
-       0,     0,    48,     0,    49,    50,    51,    52,     0,    53,
-      41,    42,    43,    44,    45,    46,     0,    47,     0,   136,
-       0,     0,    48,     0,    49,    50,    51,    52,     0,    53,
-      41,    42,    43,    44,    45,    46,     0,    47,     0,   139,
-       0,     0,    48,     0,    49,    50,    51,    52,     0,    53,
-       0,     0,    71,    41,    42,    43,    44,    45,    46,     0,
-      47,     0,     0,     0,     0,    48,   110,    49,    50,    51,
-      52,     0,    53,    41,    42,    43,    44,    45,    46,     0,
-      47,     0,     0,     0,     0,    48,     0,    49,    50,    51,
-      52,     0,    53
+      32,    55,    37,     1,     2,     3,     4,     9,   -75,     7,
+       8,     9,    40,    39,     1,     2,     3,     4,    10,    11,
+       7,     8,     9,     5,     6,   124,    12,    70,   -77,    10,
+      11,    60,    17,    29,    28,    62,    21,    12,    14,    66,
+     -77,   125,    91,    33,    34,    28,    37,    92,    37,    14,
+      54,     9,    65,     9,    56,    57,    58,    93,    38,    59,
+      99,    91,    73,    72,   100,   103,    92,    32,    32,   108,
+      59,   112,   110,    74,    75,    76,    77,    78,    79,    80,
+      81,    82,    83,    84,    86,    87,    37,    85,   -76,   -74,
+      37,     9,    96,    89,    90,     9,    47,    63,   102,    60,
+     104,   106,   127,    49,    50,    51,    52,   109,    53,     2,
+       3,     6,    57,    58,     7,     8,    59,   128,   129,   105,
+     107,    97,     1,     2,     3,     4,    98,   115,     7,     8,
+       9,    50,    51,    52,   139,    53,   118,    10,    11,    53,
+     119,    88,   113,   120,    95,    12,   121,   135,   126,    67,
+      68,    69,    64,    28,   131,   101,   132,    14,     0,     0,
+       0,     0,     0,     0,     0,   138,     1,     2,     3,     4,
+       5,     6,     7,     8,     9,     0,     0,     1,     2,     3,
+       4,    10,    11,     7,     8,     9,     0,     0,     0,    12,
+       0,     0,    10,    11,     0,     0,     0,    13,     0,   114,
+      12,    14,    41,    42,    43,    44,    45,    46,    28,    47,
+       0,     0,    14,     0,    48,   116,    49,    50,    51,    52,
+       0,    53,    41,    42,    43,    44,    45,    46,     0,    47,
+       0,   117,     0,     0,    48,   122,    49,    50,    51,    52,
+       0,    53,    41,    42,    43,    44,    45,    46,     0,    47,
+       0,   123,     0,     0,    48,   133,    49,    50,    51,    52,
+       0,    53,    41,    42,    43,    44,    45,    46,     0,    47,
+       0,   134,     0,     0,    48,     0,    49,    50,    51,    52,
+       0,    53,    41,    42,    43,    44,    45,    46,     0,    47,
+       0,   130,     0,     0,    48,     0,    49,    50,    51,    52,
+       0,    53,    41,    42,    43,    44,    45,    46,     0,    47,
+       0,   136,     0,     0,    48,     0,    49,    50,    51,    52,
+       0,    53,    41,    42,    43,    44,    45,    46,     0,    47,
+       0,   137,     0,     0,    48,     0,    49,    50,    51,    52,
+       0,    53,    41,    42,    43,    44,    45,    46,     0,    47,
+       0,   140,     0,     0,    48,     0,    49,    50,    51,    52,
+       0,    53,     0,     0,     0,    71,    41,    42,    43,    44,
+      45,    46,     0,    47,     0,     0,     0,     0,    48,   111,
+      49,    50,    51,    52,     0,    53,    41,    42,    43,    44,
+      45,    46,     0,    47,     0,     0,     0,     0,    48,     0,
+      49,    50,    51,    52,     0,    53
 };
 
 static const yytype_int16 yycheck[] =
 {
-       1,    18,     0,     3,     4,     5,     6,     4,    39,     9,
-      10,    11,     9,    14,     7,     8,    25,     0,    18,    19,
-      18,    40,    19,    27,    28,    25,    26,    31,    38,    38,
-      34,     6,     0,     1,    39,    35,    11,    31,    38,    19,
-       6,    41,    35,    11,    12,    11,    26,    27,    28,    29,
-       6,    31,    18,    51,    38,    11,    40,    38,     6,    57,
-      58,     4,    18,    11,    65,    66,     9,    68,    69,    70,
-      18,    88,    73,    41,    42,    43,    44,    45,    46,    47,
-      48,    49,    50,    51,    52,    53,     6,    38,     4,     5,
-      31,    11,    60,     9,    10,    27,    28,    29,    18,    31,
-      68,    69,    38,     3,     4,     5,     6,     7,     8,     9,
-      10,    11,    34,     6,    36,    37,   117,   118,    18,    19,
-      27,    28,    68,    69,    31,     6,    26,    95,    38,    39,
-       8,    55,    38,   134,    38,    35,    38,    25,    38,    93,
-      65,    -1,   110,    -1,    -1,   113,    -1,   115,    -1,    -1,
-      -1,    -1,    -1,   121,    -1,   123,    -1,    -1,    -1,     3,
-       4,     5,     6,    -1,   132,     9,    10,    11,    -1,    -1,
-       3,     4,     5,     6,    18,    19,     9,    10,    11,    -1,
-      -1,    25,    26,    -1,    -1,    18,    19,    -1,    -1,    -1,
-      -1,    35,    25,    26,    38,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    35,    -1,    -1,    38,     3,     4,     5,     6,
-      -1,    -1,     9,    10,    11,    -1,    -1,    -1,    -1,    -1,
-      -1,    18,    19,    -1,    -1,    -1,    -1,    -1,    -1,    26,
-      12,    13,    14,    15,    16,    17,    -1,    19,    35,    -1,
-      -1,    38,    24,    25,    26,    27,    28,    29,    -1,    31,
-      12,    13,    14,    15,    16,    17,    -1,    19,    -1,    41,
-      -1,    -1,    24,    25,    26,    27,    28,    29,    -1,    31,
-      12,    13,    14,    15,    16,    17,    -1,    19,    -1,    41,
-      -1,    -1,    24,    25,    26,    27,    28,    29,    -1,    31,
-      12,    13,    14,    15,    16,    17,    -1,    19,    -1,    41,
-      -1,    -1,    24,    -1,    26,    27,    28,    29,    -1,    31,
-      12,    13,    14,    15,    16,    17,    -1,    19,    -1,    41,
-      -1,    -1,    24,    -1,    26,    27,    28,    29,    -1,    31,
-      12,    13,    14,    15,    16,    17,    -1,    19,    -1,    41,
-      -1,    -1,    24,    -1,    26,    27,    28,    29,    -1,    31,
-      12,    13,    14,    15,    16,    17,    -1,    19,    -1,    41,
-      -1,    -1,    24,    -1,    26,    27,    28,    29,    -1,    31,
-      12,    13,    14,    15,    16,    17,    -1,    19,    -1,    41,
-      -1,    -1,    24,    -1,    26,    27,    28,    29,    -1,    31,
-      -1,    -1,    34,    12,    13,    14,    15,    16,    17,    -1,
-      19,    -1,    -1,    -1,    -1,    24,    25,    26,    27,    28,
-      29,    -1,    31,    12,    13,    14,    15,    16,    17,    -1,
-      19,    -1,    -1,    -1,    -1,    24,    -1,    26,    27,    28,
-      29,    -1,    31
+       1,    18,     6,     3,     4,     5,     6,    11,    39,     9,
+      10,    11,     0,    14,     3,     4,     5,     6,    18,    19,
+       9,    10,    11,     7,     8,    25,    26,    25,    38,    18,
+      19,    40,     0,     1,    34,    38,     0,    26,    38,    38,
+      38,    41,     4,    11,    12,    34,     6,     9,     6,    38,
+      34,    11,    39,    11,    18,    27,    28,    19,    18,    31,
+      18,     4,    38,    35,    65,    66,     9,    68,    69,    70,
+      31,    88,    73,    41,    42,    43,    44,    45,    46,    47,
+      48,    49,    50,    51,    52,    53,     6,    51,    38,    39,
+       6,    11,    60,    57,    58,    11,    19,    38,    18,    40,
+      68,    69,    18,    26,    27,    28,    29,    71,    31,     4,
+       5,     8,    27,    28,     9,    10,    31,   118,   119,    68,
+      69,     6,     3,     4,     5,     6,     6,    95,     9,    10,
+      11,    27,    28,    29,   135,    31,    38,    18,    19,    31,
+      38,    55,    93,   111,    25,    26,   114,    38,   116,    35,
+      36,    37,    25,    34,   122,    65,   124,    38,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   133,     3,     4,     5,     6,
+       7,     8,     9,    10,    11,    -1,    -1,     3,     4,     5,
+       6,    18,    19,     9,    10,    11,    -1,    -1,    -1,    26,
+      -1,    -1,    18,    19,    -1,    -1,    -1,    34,    -1,    25,
+      26,    38,    12,    13,    14,    15,    16,    17,    34,    19,
+      -1,    -1,    38,    -1,    24,    25,    26,    27,    28,    29,
+      -1,    31,    12,    13,    14,    15,    16,    17,    -1,    19,
+      -1,    41,    -1,    -1,    24,    25,    26,    27,    28,    29,
+      -1,    31,    12,    13,    14,    15,    16,    17,    -1,    19,
+      -1,    41,    -1,    -1,    24,    25,    26,    27,    28,    29,
+      -1,    31,    12,    13,    14,    15,    16,    17,    -1,    19,
+      -1,    41,    -1,    -1,    24,    -1,    26,    27,    28,    29,
+      -1,    31,    12,    13,    14,    15,    16,    17,    -1,    19,
+      -1,    41,    -1,    -1,    24,    -1,    26,    27,    28,    29,
+      -1,    31,    12,    13,    14,    15,    16,    17,    -1,    19,
+      -1,    41,    -1,    -1,    24,    -1,    26,    27,    28,    29,
+      -1,    31,    12,    13,    14,    15,    16,    17,    -1,    19,
+      -1,    41,    -1,    -1,    24,    -1,    26,    27,    28,    29,
+      -1,    31,    12,    13,    14,    15,    16,    17,    -1,    19,
+      -1,    41,    -1,    -1,    24,    -1,    26,    27,    28,    29,
+      -1,    31,    -1,    -1,    -1,    35,    12,    13,    14,    15,
+      16,    17,    -1,    19,    -1,    -1,    -1,    -1,    24,    25,
+      26,    27,    28,    29,    -1,    31,    12,    13,    14,    15,
+      16,    17,    -1,    19,    -1,    -1,    -1,    -1,    24,    -1,
+      26,    27,    28,    29,    -1,    31
 };
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
@@ -763,45 +761,46 @@ static const yytype_int16 yycheck[] =
 static const yytype_int8 yystos[] =
 {
        0,     3,     4,     5,     6,     7,     8,     9,    10,    11,
-      18,    19,    26,    35,    38,    43,    44,    45,    46,    49,
-      50,    51,    53,    54,    55,    57,    58,    59,    35,    45,
+      18,    19,    26,    34,    38,    43,    44,    45,    46,    49,
+      50,    51,    53,    54,    55,    57,    58,    59,    34,    45,
       47,    48,    53,    45,    45,    45,    51,     6,    18,    53,
        0,    12,    13,    14,    15,    16,    17,    19,    24,    26,
-      27,    28,    29,    31,    35,    49,    51,    27,    28,    31,
-      40,    56,    38,    38,    56,    39,    38,    34,    36,    37,
-      25,    34,    34,    38,    45,    45,    45,    45,    45,    45,
+      27,    28,    29,    31,    34,    49,    51,    27,    28,    31,
+      40,    56,    38,    38,    56,    39,    38,    35,    36,    37,
+      25,    35,    35,    38,    45,    45,    45,    45,    45,    45,
       45,    45,    45,    45,    45,    51,    45,    45,    46,    51,
       51,     4,     9,    19,    52,    25,    45,     6,     6,    18,
-      53,    59,    18,    53,    45,    48,    45,    48,    53,    53,
-      25,    49,    52,    25,    45,    25,    41,    38,    38,    45,
-      45,    25,    41,    25,    41,    45,    18,    53,    53,    41,
-      45,    45,    25,    41,    38,    41,    41,    45,    53,    41
+      53,    59,    18,    53,    45,    48,    45,    48,    53,    51,
+      53,    25,    49,    52,    25,    45,    25,    41,    38,    38,
+      45,    45,    25,    41,    25,    41,    45,    18,    53,    53,
+      41,    45,    45,    25,    41,    38,    41,    41,    45,    53,
+      41
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr1[] =
 {
-       0,    42,    43,    43,    44,    44,    45,    45,    45,    45,
+       0,    42,    43,    43,    44,    44,    44,    45,    45,    45,
       45,    45,    45,    45,    45,    45,    45,    45,    45,    45,
-      45,    45,    45,    45,    45,    45,    45,    45,    45,    46,
-      46,    46,    46,    47,    47,    47,    47,    47,    47,    48,
-      49,    50,    51,    51,    51,    51,    51,    51,    51,    52,
-      52,    53,    53,    54,    54,    55,    55,    55,    55,    55,
-      55,    55,    56,    56,    56,    56,    56,    56,    56,    56,
-      57,    57,    57,    58,    58,    59,    59
+      45,    45,    45,    45,    45,    45,    45,    45,    45,    45,
+      46,    46,    46,    46,    47,    47,    47,    47,    47,    47,
+      48,    49,    50,    51,    51,    51,    51,    51,    51,    51,
+      52,    52,    53,    53,    54,    54,    55,    55,    55,    55,
+      55,    55,    55,    56,    56,    56,    56,    56,    56,    56,
+      56,    57,    57,    57,    58,    58,    59,    59
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr2[] =
 {
-       0,     2,     1,     1,     2,     4,     1,     1,     1,     1,
-       2,     2,     3,     3,     3,     3,     3,     3,     3,     3,
-       3,     3,     3,     3,     3,     1,     3,     5,     3,     1,
-       1,     1,     1,     1,     1,     3,     3,     3,     3,     3,
-       1,     1,     1,     1,     3,     3,     3,     4,     3,     1,
-       1,     1,     1,     1,     1,     4,     2,     5,     3,     5,
-       7,     3,     3,     4,     4,     5,     5,     6,     6,     7,
-       2,     2,     3,     1,     1,     1,     1
+       0,     2,     1,     1,     2,     4,     4,     1,     1,     1,
+       1,     2,     2,     3,     3,     3,     3,     3,     3,     3,
+       3,     3,     3,     3,     3,     3,     1,     3,     5,     3,
+       1,     1,     1,     1,     1,     1,     3,     3,     3,     3,
+       3,     1,     1,     1,     1,     3,     3,     3,     4,     3,
+       1,     1,     1,     1,     1,     1,     4,     2,     5,     3,
+       5,     7,     3,     3,     4,     4,     5,     5,     6,     6,
+       7,     2,     2,     3,     1,     1,     1,     1
 };
 
 
@@ -1005,31 +1004,45 @@ yydestruct (const char *yymsg,
   switch (yykind)
     {
     case YYSYMBOL_exp: /* exp  */
+#line 75 "Expression.y"
             { delete ((*yyvaluep).expr); }
+#line 1007 "Expression.tab.c"
         break;
 
     case YYSYMBOL_num: /* num  */
+#line 75 "Expression.y"
             { delete ((*yyvaluep).expr); }
+#line 1013 "Expression.tab.c"
         break;
 
     case YYSYMBOL_args: /* args  */
+#line 77 "Expression.y"
             { std::vector<Expression*>::const_iterator i = ((*yyvaluep).arguments).begin(); while (i != ((*yyvaluep).arguments).end()) { delete *i; ++i; } }
+#line 1019 "Expression.tab.c"
         break;
 
     case YYSYMBOL_range: /* range  */
+#line 75 "Expression.y"
             { delete ((*yyvaluep).expr); }
+#line 1025 "Expression.tab.c"
         break;
 
     case YYSYMBOL_unit_exp: /* unit_exp  */
+#line 75 "Expression.y"
             { delete ((*yyvaluep).expr); }
+#line 1031 "Expression.tab.c"
         break;
 
     case YYSYMBOL_indexer: /* indexer  */
+#line 76 "Expression.y"
             { delete ((*yyvaluep).component); }
+#line 1037 "Expression.tab.c"
         break;
 
     case YYSYMBOL_indexable: /* indexable  */
+#line 75 "Expression.y"
             { delete ((*yyvaluep).expr); }
+#line 1043 "Expression.tab.c"
         break;
 
       default:
@@ -1297,243 +1310,362 @@ yyreduce:
   switch (yyn)
     {
   case 2: /* input: exp  */
+#line 83 "Expression.y"
                                                 { ScanResult = std::unique_ptr<Expression>((yyvsp[0].expr)); valueExpression = true;                                        }
+#line 1313 "Expression.tab.c"
     break;
 
   case 3: /* input: unit_exp  */
+#line 84 "Expression.y"
                                                 { ScanResult = std::unique_ptr<Expression>((yyvsp[0].expr)); unitExpression = true;                                         }
+#line 1319 "Expression.tab.c"
     break;
 
   case 4: /* unit_num: num unit_exp  */
+#line 87 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-1].expr), OperatorExpression::UNIT, (yyvsp[0].expr));  }
+#line 1325 "Expression.tab.c"
     break;
 
-  case 5: /* unit_num: num us_building_unit num us_building_unit  */
+  case 5: /* unit_num: '(' exp ')' unit_exp  */
+#line 88 "Expression.y"
+                                                  { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::UNIT, (yyvsp[0].expr)); }
+#line 1331 "Expression.tab.c"
+    break;
+
+  case 6: /* unit_num: num us_building_unit num us_building_unit  */
+#line 89 "Expression.y"
                                                                          { (yyval.expr) = new OperatorExpression(DocumentObject, new OperatorExpression(DocumentObject, (yyvsp[-3].expr), OperatorExpression::UNIT, (yyvsp[-2].expr)), OperatorExpression::ADD, new OperatorExpression(DocumentObject, (yyvsp[-1].expr), OperatorExpression::UNIT, (yyvsp[0].expr)));}
+#line 1337 "Expression.tab.c"
     break;
 
-  case 6: /* exp: num  */
+  case 7: /* exp: num  */
+#line 92 "Expression.y"
                                                 { (yyval.expr) = (yyvsp[0].expr);                                                                        }
+#line 1343 "Expression.tab.c"
     break;
 
-  case 7: /* exp: unit_num  */
+  case 8: /* exp: unit_num  */
+#line 93 "Expression.y"
                                                 { (yyval.expr) = (yyvsp[0].expr);                                                                        }
+#line 1349 "Expression.tab.c"
     break;
 
-  case 8: /* exp: STRING  */
+  case 9: /* exp: STRING  */
+#line 94 "Expression.y"
                                                 { (yyval.expr) = new StringExpression(DocumentObject, (yyvsp[0].string));                                  }
+#line 1355 "Expression.tab.c"
     break;
 
-  case 9: /* exp: identifier  */
+  case 10: /* exp: identifier  */
+#line 95 "Expression.y"
                                                 { (yyval.expr) = new VariableExpression(DocumentObject, (yyvsp[0].path));                                }
+#line 1361 "Expression.tab.c"
     break;
 
-  case 10: /* exp: MINUSSIGN exp  */
+  case 11: /* exp: MINUSSIGN exp  */
+#line 96 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[0].expr), OperatorExpression::NEG, new NumberExpression(DocumentObject, Quantity(-1))); }
+#line 1367 "Expression.tab.c"
     break;
 
-  case 11: /* exp: '+' exp  */
+  case 12: /* exp: '+' exp  */
+#line 97 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[0].expr), OperatorExpression::POS, new NumberExpression(DocumentObject, Quantity(1))); }
+#line 1373 "Expression.tab.c"
     break;
 
-  case 12: /* exp: exp '+' exp  */
+  case 13: /* exp: exp '+' exp  */
+#line 98 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::ADD, (yyvsp[0].expr));   }
+#line 1379 "Expression.tab.c"
     break;
 
-  case 13: /* exp: exp MINUSSIGN exp  */
+  case 14: /* exp: exp MINUSSIGN exp  */
+#line 99 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::SUB, (yyvsp[0].expr));   }
+#line 1385 "Expression.tab.c"
     break;
 
-  case 14: /* exp: exp '*' exp  */
+  case 15: /* exp: exp '*' exp  */
+#line 100 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::MUL, (yyvsp[0].expr));   }
+#line 1391 "Expression.tab.c"
     break;
 
-  case 15: /* exp: exp '/' exp  */
+  case 16: /* exp: exp '/' exp  */
+#line 101 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::DIV, (yyvsp[0].expr));   }
+#line 1397 "Expression.tab.c"
     break;
 
-  case 16: /* exp: exp '%' exp  */
+  case 17: /* exp: exp '%' exp  */
+#line 102 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::MOD, (yyvsp[0].expr));   }
+#line 1403 "Expression.tab.c"
     break;
 
-  case 17: /* exp: exp '/' unit_exp  */
+  case 18: /* exp: exp '/' unit_exp  */
+#line 103 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::DIV, (yyvsp[0].expr));   }
+#line 1409 "Expression.tab.c"
     break;
 
-  case 18: /* exp: exp '^' exp  */
+  case 19: /* exp: exp '^' exp  */
+#line 104 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::POW, (yyvsp[0].expr));   }
+#line 1415 "Expression.tab.c"
     break;
 
-  case 19: /* exp: exp EQ exp  */
+  case 20: /* exp: exp EQ exp  */
+#line 105 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::EQ, (yyvsp[0].expr));    }
+#line 1421 "Expression.tab.c"
     break;
 
-  case 20: /* exp: exp NEQ exp  */
+  case 21: /* exp: exp NEQ exp  */
+#line 106 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::NEQ, (yyvsp[0].expr));   }
+#line 1427 "Expression.tab.c"
     break;
 
-  case 21: /* exp: exp LT exp  */
+  case 22: /* exp: exp LT exp  */
+#line 107 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::LT, (yyvsp[0].expr));    }
+#line 1433 "Expression.tab.c"
     break;
 
-  case 22: /* exp: exp GT exp  */
+  case 23: /* exp: exp GT exp  */
+#line 108 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::GT, (yyvsp[0].expr));    }
+#line 1439 "Expression.tab.c"
     break;
 
-  case 23: /* exp: exp GTE exp  */
+  case 24: /* exp: exp GTE exp  */
+#line 109 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::GTE, (yyvsp[0].expr));   }
+#line 1445 "Expression.tab.c"
     break;
 
-  case 24: /* exp: exp LTE exp  */
+  case 25: /* exp: exp LTE exp  */
+#line 110 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::LTE, (yyvsp[0].expr));   }
+#line 1451 "Expression.tab.c"
     break;
 
-  case 25: /* exp: indexable  */
+  case 26: /* exp: indexable  */
+#line 111 "Expression.y"
                                                 { (yyval.expr) = (yyvsp[0].expr);                                                                        }
+#line 1457 "Expression.tab.c"
     break;
 
-  case 26: /* exp: FUNC args ')'  */
+  case 27: /* exp: FUNC args ')'  */
+#line 112 "Expression.y"
                                                 { (yyval.expr) = new FunctionExpression(DocumentObject, (yyvsp[-2].func).first, std::move((yyvsp[-2].func).second), (yyvsp[-1].arguments));}
+#line 1463 "Expression.tab.c"
     break;
 
-  case 27: /* exp: exp '?' exp ':' exp  */
+  case 28: /* exp: exp '?' exp ':' exp  */
+#line 113 "Expression.y"
                                                 { (yyval.expr) = new ConditionalExpression(DocumentObject, (yyvsp[-4].expr), (yyvsp[-2].expr), (yyvsp[0].expr));                     }
+#line 1469 "Expression.tab.c"
     break;
 
-  case 28: /* exp: '(' exp ')'  */
+  case 29: /* exp: '(' exp ')'  */
+#line 114 "Expression.y"
                                                 { (yyval.expr) = (yyvsp[-1].expr); }
+#line 1475 "Expression.tab.c"
     break;
 
-  case 29: /* num: ONE  */
+  case 30: /* num: ONE  */
+#line 117 "Expression.y"
                                                 { (yyval.expr) = new NumberExpression(DocumentObject, Quantity((yyvsp[0].fvalue)));                        }
+#line 1481 "Expression.tab.c"
     break;
 
-  case 30: /* num: NUM  */
+  case 31: /* num: NUM  */
+#line 118 "Expression.y"
                                                 { (yyval.expr) = new NumberExpression(DocumentObject, Quantity((yyvsp[0].fvalue)));                        }
+#line 1487 "Expression.tab.c"
     break;
 
-  case 31: /* num: INTEGER  */
+  case 32: /* num: INTEGER  */
+#line 119 "Expression.y"
                                                 { (yyval.expr) = new NumberExpression(DocumentObject, Quantity((double)(yyvsp[0].ivalue)));                }
+#line 1493 "Expression.tab.c"
     break;
 
-  case 32: /* num: CONSTANT  */
+  case 33: /* num: CONSTANT  */
+#line 120 "Expression.y"
                                                 { (yyval.expr) = new ConstantExpression(DocumentObject, (yyvsp[0].constant).name, Quantity((yyvsp[0].constant).fvalue));      }
+#line 1499 "Expression.tab.c"
     break;
 
-  case 33: /* args: exp  */
+  case 34: /* args: exp  */
+#line 122 "Expression.y"
                                                 { (yyval.arguments).push_back((yyvsp[0].expr));                                                               }
+#line 1505 "Expression.tab.c"
     break;
 
-  case 34: /* args: range  */
+  case 35: /* args: range  */
+#line 123 "Expression.y"
                                                 { (yyval.arguments).push_back((yyvsp[0].expr));                                                               }
+#line 1511 "Expression.tab.c"
     break;
 
-  case 35: /* args: args ',' exp  */
+  case 36: /* args: args ',' exp  */
+#line 124 "Expression.y"
                                                 { (yyvsp[-2].arguments).push_back((yyvsp[0].expr));  (yyval.arguments) = (yyvsp[-2].arguments);                                                     }
+#line 1517 "Expression.tab.c"
     break;
 
-  case 36: /* args: args ';' exp  */
+  case 37: /* args: args ';' exp  */
+#line 125 "Expression.y"
                                                 { (yyvsp[-2].arguments).push_back((yyvsp[0].expr));  (yyval.arguments) = (yyvsp[-2].arguments);                                                     }
+#line 1523 "Expression.tab.c"
     break;
 
-  case 37: /* args: args ',' range  */
+  case 38: /* args: args ',' range  */
+#line 126 "Expression.y"
                                                 { (yyvsp[-2].arguments).push_back((yyvsp[0].expr));  (yyval.arguments) = (yyvsp[-2].arguments);                                                     }
+#line 1529 "Expression.tab.c"
     break;
 
-  case 38: /* args: args ';' range  */
+  case 39: /* args: args ';' range  */
+#line 127 "Expression.y"
                                                 { (yyvsp[-2].arguments).push_back((yyvsp[0].expr));  (yyval.arguments) = (yyvsp[-2].arguments);                                                     }
+#line 1535 "Expression.tab.c"
     break;
 
-  case 39: /* range: id_or_cell ':' id_or_cell  */
+  case 40: /* range: id_or_cell ':' id_or_cell  */
+#line 130 "Expression.y"
                                                 { (yyval.expr) = new RangeExpression(DocumentObject, (yyvsp[-2].string), (yyvsp[0].string));                               }
+#line 1541 "Expression.tab.c"
     break;
 
-  case 40: /* us_building_unit: USUNIT  */
+  case 41: /* us_building_unit: USUNIT  */
+#line 134 "Expression.y"
                                                 { (yyval.expr) = new UnitExpression(DocumentObject, (yyvsp[0].quantity).scaler, (yyvsp[0].quantity).unitStr );                }
+#line 1547 "Expression.tab.c"
     break;
 
-  case 41: /* other_unit: UNIT  */
+  case 42: /* other_unit: UNIT  */
+#line 135 "Expression.y"
                                                 { (yyval.expr) = new UnitExpression(DocumentObject, (yyvsp[0].quantity).scaler, (yyvsp[0].quantity).unitStr );                }
+#line 1553 "Expression.tab.c"
     break;
 
-  case 42: /* unit_exp: other_unit  */
+  case 43: /* unit_exp: other_unit  */
+#line 137 "Expression.y"
                                                 { (yyval.expr) = (yyvsp[0].expr); }
+#line 1559 "Expression.tab.c"
     break;
 
-  case 43: /* unit_exp: us_building_unit  */
+  case 44: /* unit_exp: us_building_unit  */
+#line 138 "Expression.y"
                                                 { (yyval.expr) = (yyvsp[0].expr); }
+#line 1565 "Expression.tab.c"
     break;
 
-  case 44: /* unit_exp: unit_exp '/' unit_exp  */
+  case 45: /* unit_exp: unit_exp '/' unit_exp  */
+#line 139 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::DIV, (yyvsp[0].expr));   }
+#line 1571 "Expression.tab.c"
     break;
 
-  case 45: /* unit_exp: unit_exp '*' unit_exp  */
+  case 46: /* unit_exp: unit_exp '*' unit_exp  */
+#line 140 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::MUL, (yyvsp[0].expr));   }
+#line 1577 "Expression.tab.c"
     break;
 
-  case 46: /* unit_exp: unit_exp '^' integer  */
+  case 47: /* unit_exp: unit_exp '^' integer  */
+#line 141 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-2].expr), OperatorExpression::POW, new NumberExpression(DocumentObject, Quantity((double)(yyvsp[0].ivalue))));   }
+#line 1583 "Expression.tab.c"
     break;
 
-  case 47: /* unit_exp: unit_exp '^' MINUSSIGN integer  */
+  case 48: /* unit_exp: unit_exp '^' MINUSSIGN integer  */
+#line 142 "Expression.y"
                                                 { (yyval.expr) = new OperatorExpression(DocumentObject, (yyvsp[-3].expr), OperatorExpression::POW, new OperatorExpression(DocumentObject, new NumberExpression(DocumentObject, Quantity((double)(yyvsp[0].ivalue))), OperatorExpression::NEG, new NumberExpression(DocumentObject, Quantity(-1))));   }
+#line 1589 "Expression.tab.c"
     break;
 
-  case 48: /* unit_exp: '(' unit_exp ')'  */
+  case 49: /* unit_exp: '(' unit_exp ')'  */
+#line 143 "Expression.y"
                                                 { (yyval.expr) = (yyvsp[-1].expr);                                                                        }
+#line 1595 "Expression.tab.c"
     break;
 
-  case 49: /* integer: INTEGER  */
+  case 50: /* integer: INTEGER  */
+#line 146 "Expression.y"
                  { (yyval.ivalue) = (yyvsp[0].ivalue); }
+#line 1601 "Expression.tab.c"
     break;
 
-  case 50: /* integer: ONE  */
+  case 51: /* integer: ONE  */
+#line 147 "Expression.y"
              { (yyval.ivalue) = (yyvsp[0].fvalue); }
+#line 1607 "Expression.tab.c"
     break;
 
-  case 51: /* id_or_cell: IDENTIFIER  */
+  case 52: /* id_or_cell: IDENTIFIER  */
+#line 151 "Expression.y"
                                             { (yyval.string) = std::move((yyvsp[0].string)); }
+#line 1613 "Expression.tab.c"
     break;
 
-  case 52: /* id_or_cell: CELLADDRESS  */
+  case 53: /* id_or_cell: CELLADDRESS  */
+#line 152 "Expression.y"
                                             { (yyval.string) = std::move((yyvsp[0].string)); }
+#line 1619 "Expression.tab.c"
     break;
 
-  case 53: /* identifier: id_or_cell  */
+  case 54: /* identifier: id_or_cell  */
+#line 156 "Expression.y"
                                             { (yyval.path) = ObjectIdentifier(DocumentObject); (yyval.path) << ObjectIdentifier::SimpleComponent((yyvsp[0].string)); }
+#line 1625 "Expression.tab.c"
     break;
 
-  case 54: /* identifier: iden  */
+  case 55: /* identifier: iden  */
+#line 157 "Expression.y"
                                             { (yyval.path) = std::move((yyvsp[0].path)); }
+#line 1631 "Expression.tab.c"
     break;
 
-  case 55: /* iden: '.' STRING '.' id_or_cell  */
+  case 56: /* iden: '.' STRING '.' id_or_cell  */
+#line 161 "Expression.y"
                                             { /* Path to property of a sub-object of the current object*/
                                                 (yyval.path) = ObjectIdentifier(DocumentObject,true);
                                                 (yyval.path).setDocumentObjectName(DocumentObject,false,ObjectIdentifier::String(std::move((yyvsp[-2].string)),true),true);
                                                 (yyval.path).addComponent(ObjectIdentifier::SimpleComponent((yyvsp[0].string)));
                                             }
+#line 1641 "Expression.tab.c"
     break;
 
-  case 56: /* iden: '.' id_or_cell  */
+  case 57: /* iden: '.' id_or_cell  */
+#line 166 "Expression.y"
                                             { /* Path to property of the current document object */
                                                 (yyval.path) = ObjectIdentifier(DocumentObject,true);
                                                 (yyval.path).setDocumentObjectName(DocumentObject);
                                                 (yyval.path).addComponent(ObjectIdentifier::SimpleComponent((yyvsp[0].string)));
                                             }
+#line 1651 "Expression.tab.c"
     break;
 
-  case 57: /* iden: object '.' STRING '.' id_or_cell  */
+  case 58: /* iden: object '.' STRING '.' id_or_cell  */
+#line 171 "Expression.y"
                                             { /* Path to property of a sub-object */
                                                 (yyval.path) = ObjectIdentifier(DocumentObject);
                                                 (yyval.path).setDocumentObjectName(std::move((yyvsp[-4].string_or_identifier)), true, ObjectIdentifier::String(std::move((yyvsp[-2].string)),true),true);
                                                 (yyval.path).addComponent(ObjectIdentifier::SimpleComponent((yyvsp[0].string)));
                                                 (yyval.path).resolveAmbiguity();
                                             }
+#line 1662 "Expression.tab.c"
     break;
 
-  case 58: /* iden: object '.' id_or_cell  */
+  case 59: /* iden: object '.' id_or_cell  */
+#line 177 "Expression.y"
                                             { /* Path to property of a given document object */
                                                 (yyval.path) = ObjectIdentifier(DocumentObject);
                                                 (yyvsp[-2].string_or_identifier).checkImport(DocumentObject);
@@ -1541,9 +1673,11 @@ yyreduce:
                                                 (yyval.path).addComponent(ObjectIdentifier::SimpleComponent((yyvsp[0].string)));
                                                 (yyval.path).resolveAmbiguity();
                                             }
+#line 1674 "Expression.tab.c"
     break;
 
-  case 59: /* iden: document '#' object '.' id_or_cell  */
+  case 60: /* iden: document '#' object '.' id_or_cell  */
+#line 184 "Expression.y"
                                             { /* Path to property from an external document, within a named document object */
                                                 (yyval.path) = ObjectIdentifier(DocumentObject);
                                                 (yyval.path).setDocumentName(std::move((yyvsp[-4].string_or_identifier)), true);
@@ -1551,82 +1685,118 @@ yyreduce:
                                                 (yyval.path).addComponent(ObjectIdentifier::SimpleComponent((yyvsp[0].string)));
                                                 (yyval.path).resolveAmbiguity();
                                             }
+#line 1686 "Expression.tab.c"
     break;
 
-  case 60: /* iden: document '#' object '.' STRING '.' id_or_cell  */
+  case 61: /* iden: document '#' object '.' STRING '.' id_or_cell  */
+#line 192 "Expression.y"
                                             {   (yyval.path) = ObjectIdentifier(DocumentObject);
                                                 (yyval.path).setDocumentName(std::move((yyvsp[-6].string_or_identifier)), true);
                                                 (yyval.path).setDocumentObjectName(std::move((yyvsp[-4].string_or_identifier)), true, ObjectIdentifier::String(std::move((yyvsp[-2].string)),true));
                                                 (yyval.path).addComponent(ObjectIdentifier::SimpleComponent((yyvsp[0].string)));
                                                 (yyval.path).resolveAmbiguity();
                                             }
+#line 1697 "Expression.tab.c"
     break;
 
-  case 61: /* iden: iden '.' IDENTIFIER  */
+  case 62: /* iden: iden '.' IDENTIFIER  */
+#line 198 "Expression.y"
                                             { (yyval.path)= std::move((yyvsp[-2].path)); (yyval.path).addComponent(ObjectIdentifier::SimpleComponent((yyvsp[0].string))); }
+#line 1703 "Expression.tab.c"
     break;
 
-  case 62: /* indexer: '[' exp ']'  */
+  case 63: /* indexer: '[' exp ']'  */
+#line 202 "Expression.y"
                                             { (yyval.component) = Expression::createComponent((yyvsp[-1].expr));   }
+#line 1709 "Expression.tab.c"
     break;
 
-  case 63: /* indexer: '[' exp ':' ']'  */
+  case 64: /* indexer: '[' exp ':' ']'  */
+#line 203 "Expression.y"
                                             { (yyval.component) = Expression::createComponent((yyvsp[-2].expr),0,0,true); }
+#line 1715 "Expression.tab.c"
     break;
 
-  case 64: /* indexer: '[' ':' exp ']'  */
+  case 65: /* indexer: '[' ':' exp ']'  */
+#line 204 "Expression.y"
                                             { (yyval.component) = Expression::createComponent(0,(yyvsp[-1].expr)); }
+#line 1721 "Expression.tab.c"
     break;
 
-  case 65: /* indexer: '[' ':' ':' exp ']'  */
+  case 66: /* indexer: '[' ':' ':' exp ']'  */
+#line 205 "Expression.y"
                                             { (yyval.component) = Expression::createComponent(0,0,(yyvsp[-1].expr)); }
+#line 1727 "Expression.tab.c"
     break;
 
-  case 66: /* indexer: '[' exp ':' exp ']'  */
+  case 67: /* indexer: '[' exp ':' exp ']'  */
+#line 206 "Expression.y"
                                             { (yyval.component) = Expression::createComponent((yyvsp[-3].expr),(yyvsp[-1].expr));}
+#line 1733 "Expression.tab.c"
     break;
 
-  case 67: /* indexer: '[' exp ':' ':' exp ']'  */
+  case 68: /* indexer: '[' exp ':' ':' exp ']'  */
+#line 207 "Expression.y"
                                             { (yyval.component) = Expression::createComponent((yyvsp[-4].expr),0,(yyvsp[-1].expr)); }
+#line 1739 "Expression.tab.c"
     break;
 
-  case 68: /* indexer: '[' ':' exp ':' exp ']'  */
+  case 69: /* indexer: '[' ':' exp ':' exp ']'  */
+#line 208 "Expression.y"
                                             { (yyval.component) = Expression::createComponent(0,(yyvsp[-3].expr),(yyvsp[-1].expr)); }
+#line 1745 "Expression.tab.c"
     break;
 
-  case 69: /* indexer: '[' exp ':' exp ':' exp ']'  */
+  case 70: /* indexer: '[' exp ':' exp ':' exp ']'  */
+#line 209 "Expression.y"
                                             { (yyval.component) = Expression::createComponent((yyvsp[-5].expr),(yyvsp[-3].expr),(yyvsp[-1].expr));}
+#line 1751 "Expression.tab.c"
     break;
 
-  case 70: /* indexable: identifier indexer  */
+  case 71: /* indexable: identifier indexer  */
+#line 213 "Expression.y"
                                             { (yyval.expr) = new VariableExpression(DocumentObject,(yyvsp[-1].path)); (yyval.expr)->addComponent((yyvsp[0].component)); }
+#line 1757 "Expression.tab.c"
     break;
 
-  case 71: /* indexable: indexable indexer  */
+  case 72: /* indexable: indexable indexer  */
+#line 214 "Expression.y"
                                             { (yyvsp[-1].expr)->addComponent(std::move((yyvsp[0].component))); (yyval.expr) = (yyvsp[-1].expr); }
+#line 1763 "Expression.tab.c"
     break;
 
-  case 72: /* indexable: indexable '.' IDENTIFIER  */
+  case 73: /* indexable: indexable '.' IDENTIFIER  */
+#line 215 "Expression.y"
                                             { (yyvsp[-2].expr)->addComponent(Expression::createComponent((yyvsp[0].string))); (yyval.expr) = (yyvsp[-2].expr); }
+#line 1769 "Expression.tab.c"
     break;
 
-  case 73: /* document: STRING  */
+  case 74: /* document: STRING  */
+#line 219 "Expression.y"
                                             { (yyval.string_or_identifier) = ObjectIdentifier::String(std::move((yyvsp[0].string)), true); }
+#line 1775 "Expression.tab.c"
     break;
 
-  case 74: /* document: IDENTIFIER  */
+  case 75: /* document: IDENTIFIER  */
+#line 220 "Expression.y"
                                             { (yyval.string_or_identifier) = ObjectIdentifier::String(std::move((yyvsp[0].string)), false, true);}
+#line 1781 "Expression.tab.c"
     break;
 
-  case 75: /* object: STRING  */
+  case 76: /* object: STRING  */
+#line 224 "Expression.y"
                                             { (yyval.string_or_identifier) = ObjectIdentifier::String(std::move((yyvsp[0].string)), true); }
+#line 1787 "Expression.tab.c"
     break;
 
-  case 76: /* object: id_or_cell  */
+  case 77: /* object: id_or_cell  */
+#line 225 "Expression.y"
                                             { (yyval.string_or_identifier) = ObjectIdentifier::String(std::move((yyvsp[0].string)), false);}
+#line 1793 "Expression.tab.c"
     break;
 
 
+#line 1797 "Expression.tab.c"
 
       default: break;
     }
@@ -1819,4 +1989,4 @@ yyreturnlab:
   return yyresult;
 }
 
-
+#line 228 "Expression.y"

--- a/src/App/Expression.y
+++ b/src/App/Expression.y
@@ -85,6 +85,7 @@ input:     exp                                  { ScanResult = std::unique_ptr<E
      ;
 
 unit_num: num unit_exp %prec NUM_AND_UNIT       { $$ = new OperatorExpression(DocumentObject, $1, OperatorExpression::UNIT, $2);  }
+        | '(' exp ')' unit_exp %prec NUM_AND_UNIT { $$ = new OperatorExpression(DocumentObject, $2, OperatorExpression::UNIT, $4); }
         | num us_building_unit num us_building_unit %prec NUM_AND_UNIT   { $$ = new OperatorExpression(DocumentObject, new OperatorExpression(DocumentObject, $1, OperatorExpression::UNIT, $2), OperatorExpression::ADD, new OperatorExpression(DocumentObject, $3, OperatorExpression::UNIT, $4));}
         ;
 

--- a/src/App/ExpressionParser.h
+++ b/src/App/ExpressionParser.h
@@ -31,6 +31,11 @@
 #include <Base/Quantity.h>
 #include <Base/Vector3D.h>
 
+namespace Base
+{
+struct NumericLocaleContext;
+}
+
 namespace App
 {
 
@@ -237,6 +242,24 @@ public:
     Expression* getRight() const
     {
         return right;
+    }
+
+    void setLeft(Expression* expression)
+    {
+        if (left == expression) {
+            return;
+        }
+        delete left;
+        left = expression;
+    }
+
+    void setRight(Expression* expression)
+    {
+        if (right == expression) {
+            return;
+        }
+        delete right;
+        right = expression;
     }
 
 protected:
@@ -632,6 +655,12 @@ protected:
 namespace ExpressionParser
 {
 AppExport ExpressionPtr parse(const App::DocumentObject* owner, const char* buffer);
+/// Parse user-entered expression text using the supplied numeric-locale context.
+AppExport ExpressionPtr parseUserInput(
+    const App::DocumentObject* owner,
+    const char* buffer,
+    const Base::NumericLocaleContext& locale
+);
 AppExport std::unique_ptr<UnitExpression> parseUnit(const App::DocumentObject* owner, const char* buffer);
 AppExport ObjectIdentifier parsePath(const App::DocumentObject* owner, const char* buffer);
 AppExport bool isTokenAnIndentifier(const std::string& str);

--- a/src/App/QuantityInput.cpp
+++ b/src/App/QuantityInput.cpp
@@ -1,0 +1,424 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "QuantityInput.h"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+#include <App/Expression.h>
+#include <App/ExpressionParser.h>
+#include <App/ObjectIdentifier.h>
+#include <Base/Exception.h>
+#include <Base/NumericFormatting.h>
+#include <Base/NumericInput.h>
+
+namespace
+{
+std::size_t firstInputCharacter(std::string_view input)
+{
+    std::size_t position = 0;
+    while (position < input.size()
+           && std::isspace(static_cast<unsigned char>(input[position]))) {
+        ++position;
+    }
+    return position;
+}
+
+bool startsNumericInput(
+    std::string_view input,
+    const std::size_t position,
+    const Base::NumericLocaleContext& locale
+)
+{
+    if (position >= input.size()) {
+        return false;
+    }
+    int digit = 0;
+    std::size_t digitLength = 0;
+    if (Base::localizedDigitAt(input, position, locale, digit, digitLength)
+        || input[position] == '.') {
+        return true;
+    }
+    if (!locale.decimalSeparator.empty()
+        && input.substr(position, locale.decimalSeparator.size()) == locale.decimalSeparator) {
+        return true;
+    }
+    const std::string_view positiveSign {
+        locale.positiveSign.data(), locale.positiveSign.size()
+    };
+    const std::string_view negativeSign {
+        locale.negativeSign.data(), locale.negativeSign.size()
+    };
+    for (const auto sign : {std::string_view {"+"}, std::string_view {"-"}, positiveSign,
+                            negativeSign}) {
+        if (!sign.empty() && input.substr(position, sign.size()) == sign) {
+            const auto next = position + sign.size();
+            if (next == input.size()) {
+                return true;
+            }
+
+            int nextDigit = 0;
+            std::size_t nextDigitLength = 0;
+            return Base::localizedDigitAt(
+                       input, next, locale, nextDigit, nextDigitLength
+                   )
+                || input[next] == '.'
+                || (!locale.decimalSeparator.empty()
+                    && input.substr(next, locale.decimalSeparator.size())
+                        == locale.decimalSeparator);
+        }
+    }
+    return false;
+}
+
+class AdditiveOperatorDetector final : public App::ExpressionVisitor
+{
+public:
+    void visit(App::Expression& expression) override
+    {
+        const auto* operation = freecad_cast<const App::OperatorExpression*>(&expression);
+        if (operation
+            && (operation->getOperator() == App::OperatorExpression::ADD
+                || operation->getOperator() == App::OperatorExpression::SUB)) {
+            additive = true;
+        }
+    }
+
+    bool additive {false};
+};
+
+bool hasAdditiveOperator(
+    const std::string_view input,
+    const App::ObjectIdentifier& path,
+    const Base::NumericLocaleContext& locale
+)
+{
+    try {
+        // An unbound input has no owner to resolve. Avoid asking ObjectIdentifier to consult the
+        // application singleton in that case; quantity parsing is valid before application
+        // initialization as well.
+        const auto* owner = path.getOwner() ? path.getDocumentObject() : nullptr;
+        const std::string inputString(input);
+        auto expression = App::ExpressionParser::parseUserInput(owner, inputString.c_str(), locale);
+        AdditiveOperatorDetector detector;
+        expression->visit(detector);
+        return detector.additive;
+    }
+    catch (const Base::Exception&) {
+        // The quantity parser remains authoritative for quantity-only syntax, including
+        // bracketed comments and juxtaposed quantities that are not expression syntax.
+        return false;
+    }
+}
+
+App::InputDiagnosticKind inputDiagnosticKind(Base::NumericDiagnosticKind kind)
+{
+    switch (kind) {
+        case Base::NumericDiagnosticKind::IncompleteSign:
+        case Base::NumericDiagnosticKind::IncompleteDecimal:
+        case Base::NumericDiagnosticKind::IncompleteGrouping:
+        case Base::NumericDiagnosticKind::IncompleteExponent:
+            return App::InputDiagnosticKind::IncompleteNumber;
+        case Base::NumericDiagnosticKind::InvalidGrouping:
+        case Base::NumericDiagnosticKind::UnexpectedSeparator:
+            return App::InputDiagnosticKind::MalformedGrouping;
+        case Base::NumericDiagnosticKind::ExpectedDigit:
+        case Base::NumericDiagnosticKind::InvalidLiteral:
+            return App::InputDiagnosticKind::InvalidNumber;
+        case Base::NumericDiagnosticKind::OutOfRange:
+            return App::InputDiagnosticKind::OutOfRange;
+    }
+    return App::InputDiagnosticKind::InvalidNumber;
+}
+
+std::unique_ptr<App::Expression> rewriteOwnerlessQuantityExpression(
+    const App::Expression& expression,
+    const App::DocumentObject* owner
+)
+{
+    const auto* operation = freecad_cast<const App::OperatorExpression*>(&expression);
+    if (!operation) {
+        return expression.copy();
+    }
+
+    auto left = operation->getLeft()
+        ? rewriteOwnerlessQuantityExpression(*operation->getLeft(), owner)
+        : nullptr;
+    auto right = operation->getRight()
+        ? rewriteOwnerlessQuantityExpression(*operation->getRight(), owner)
+        : nullptr;
+
+    // In a quantity field, `1/2 mm` has historically meant `(1/2) mm`, just as
+    // `1/2"` means half an inch. The expression parser's normal precedence reads
+    // this as the inverse of a length. Preserve the quantity-field rule structurally
+    // by moving the explicit unit outside the denominator before evaluation.
+    auto* rewrittenUnitOperation = right
+        ? freecad_cast<App::OperatorExpression*>(right.get())
+        : nullptr;
+    if (operation->getOperator() == App::OperatorExpression::DIV
+        && rewrittenUnitOperation
+        && rewrittenUnitOperation->getOperator() == App::OperatorExpression::UNIT
+        && rewrittenUnitOperation->getLeft()
+        && rewrittenUnitOperation->getRight()) {
+        auto denominator = rewrittenUnitOperation->getLeft()->copy();
+        auto unit = rewrittenUnitOperation->getRight()->copy();
+        if (unit && denominator) {
+            auto quotient = std::make_unique<App::OperatorExpression>(
+                owner,
+                left.release(),
+                App::OperatorExpression::DIV,
+                denominator.release()
+            );
+            return std::make_unique<App::OperatorExpression>(
+                owner,
+                quotient.release(),
+                App::OperatorExpression::MUL,
+                unit.release()
+            );
+        }
+    }
+
+    return std::make_unique<App::OperatorExpression>(
+        owner,
+        left.release(),
+        operation->getOperator(),
+        right.release()
+    );
+}
+
+App::QuantityInputResult invalid(
+    App::InputDiagnosticKind kind,
+    const std::size_t offsetBytes = 0,
+    const std::size_t lengthBytes = 1
+)
+{
+    App::QuantityInputResult result;
+    result.status = App::InputStatus::Invalid;
+    result.diagnostic = App::InputDiagnostic {kind, offsetBytes, lengthBytes};
+    return result;
+}
+
+App::QuantityInputResult incomplete(
+    const App::InputPhase phase,
+    const App::InputDiagnosticKind kind,
+    const std::size_t offsetBytes = 0,
+    const std::size_t lengthBytes = 1
+)
+{
+    if (phase == App::InputPhase::Commit) {
+        return invalid(kind, offsetBytes, lengthBytes);
+    }
+
+    App::QuantityInputResult result;
+    result.status = App::InputStatus::Incomplete;
+    result.diagnostic = App::InputDiagnostic {kind, offsetBytes, lengthBytes};
+    return result;
+}
+
+App::Expression* applyDefaultUnitToDimensionlessTerm(
+    App::Expression* expression,
+    const Base::Unit& defaultUnit
+)
+{
+    if (!expression) {
+        return nullptr;
+    }
+
+    try {
+        auto evaluated = expression->eval();
+        auto* value = freecad_cast<App::NumberExpression*>(evaluated.get());
+        if (value && value->getQuantity().isDimensionless()) {
+            // Keep the original subtree intact. In particular, replacing a variable
+            // expression with its current value would silently remove its dependency.
+            auto unit = std::make_unique<App::UnitExpression>(
+                expression->getOwner(), Base::Quantity(1.0, defaultUnit), defaultUnit.getString()
+            );
+            return new App::OperatorExpression(
+                expression->getOwner(),
+                expression->copy().release(),
+                App::OperatorExpression::UNIT,
+                unit.release()
+            );
+        }
+    }
+    catch (const Base::UnitsMismatchError&) {
+        // A nested additive term may not be evaluable until its own default unit is applied.
+    }
+    catch (const Base::Exception&) {
+        // Other evaluation failures can also mean that a nested additive term needs its
+        // dimensionless children normalized before the expression can be evaluated.
+    }
+
+    return nullptr;
+}
+
+void applyDefaultUnitPolicyToExpression(
+    App::Expression& expression,
+    const Base::Unit& defaultUnit
+)
+{
+    auto* operation = freecad_cast<App::OperatorExpression*>(&expression);
+    if (!operation) {
+        return;
+    }
+
+    // An explicit unit operator owns the complete subtree below it. Applying the field's default
+    // unit inside that subtree would turn `(1 + 2) mm` into `(1 mm + 2 mm) mm`.
+    if (operation->getOperator() == App::OperatorExpression::UNIT) {
+        return;
+    }
+
+    if (operation->getOperator() == App::OperatorExpression::ADD
+        || operation->getOperator() == App::OperatorExpression::SUB) {
+        const auto applyToOperand = [&](App::Expression* operand, const bool left) {
+            if (!operand) {
+                return;
+            }
+
+            // A complete dimensionless operand inherits the field unit at this additive
+            // boundary. Do not descend into multiplicative, divisive, power, or explicit-unit
+            // subtrees: their internal arithmetic must retain its canonical dimensional meaning.
+            if (auto* replacement = applyDefaultUnitToDimensionlessTerm(operand, defaultUnit)) {
+                if (left) {
+                    operation->setLeft(replacement);
+                }
+                else {
+                    operation->setRight(replacement);
+                }
+                return;
+            }
+
+            // A nested additive expression may contain both dimensionless and dimensional terms
+            // (for example `1 + (2 + 3 mm)`). It is its own additive boundary and can be
+            // normalized recursively, but only after the complete operand was found not to be
+            // dimensionless.
+            const auto* nested = freecad_cast<const App::OperatorExpression*>(operand);
+            if (nested && (nested->getOperator() == App::OperatorExpression::ADD
+                           || nested->getOperator() == App::OperatorExpression::SUB)) {
+                applyDefaultUnitPolicyToExpression(*operand, defaultUnit);
+            }
+        };
+
+        applyToOperand(operation->getLeft(), true);
+        applyToOperand(operation->getRight(), false);
+        return;
+    }
+}
+
+void applyDefaultUnitPolicy(App::Expression& expression, const Base::Unit& defaultUnit)
+{
+    if (defaultUnit == Base::Unit::One) {
+        return;
+    }
+
+    applyDefaultUnitPolicyToExpression(expression, defaultUnit);
+}
+
+}  // namespace
+
+App::QuantityInputResult App::interpretQuantityInput(
+    const std::string_view input,
+    const QuantityInputGrammar grammar,
+    const ObjectIdentifier& path,
+    const Base::Unit& defaultUnit,
+    const Base::NumericLocaleContext& locale,
+    const InputPhase phase,
+    const QuantityConstraints& constraints
+)
+{
+    const auto first = firstInputCharacter(input);
+    if (first == input.size()) {
+        return incomplete(phase, InputDiagnosticKind::IncompleteNumber, first);
+    }
+
+    // Scan an initial numeric token before invoking either parser. This is what preserves the
+    // distinction between an unfinished edit ("-", "12,", "1e") and a syntax failure.
+    if (startsNumericInput(input, first, locale)) {
+        const auto scan = Base::scanLocalizedNumber(
+            input.substr(first), locale, Base::NumericSyntaxContext::Standalone
+        );
+        if (scan.status == Base::LocalizedNumberResult::Status::Incomplete) {
+            return incomplete(
+                phase,
+                InputDiagnosticKind::IncompleteNumber,
+                first + (scan.diagnostic ? scan.diagnostic->offsetBytes : 0),
+                scan.diagnostic ? scan.diagnostic->lengthBytes : 1
+            );
+        }
+        if (scan.status == Base::LocalizedNumberResult::Status::Invalid) {
+            return invalid(
+                scan.diagnostic
+                    ? inputDiagnosticKind(scan.diagnostic->kind)
+                    : InputDiagnosticKind::InvalidNumber,
+                first + (scan.diagnostic ? scan.diagnostic->offsetBytes : 0),
+                scan.diagnostic ? scan.diagnostic->lengthBytes : 1
+            );
+        }
+    }
+
+    if (grammar == QuantityInputGrammar::Quantity && hasAdditiveOperator(input, path, locale)) {
+        return invalid(InputDiagnosticKind::ExpressionSyntax, first);
+    }
+
+    Base::Quantity quantity;
+    std::shared_ptr<Expression> parsedExpression;
+    try {
+        if (grammar == QuantityInputGrammar::Expression) {
+            const auto* owner = path.getOwner() ? path.getDocumentObject() : nullptr;
+            const std::string inputString(input);
+            auto parsed = App::ExpressionParser::parseUserInput(owner, inputString.c_str(), locale);
+            parsedExpression = std::shared_ptr<Expression>(std::move(parsed));
+            if (!owner) {
+                parsedExpression = std::shared_ptr<Expression>(
+                    rewriteOwnerlessQuantityExpression(*parsedExpression, owner).release()
+                );
+            }
+            // Apply the field-unit policy before evaluation. Dimensionless additive terms are
+            // replaced as complete expressions; explicit units and multiplicative terms remain
+            // untouched.
+            applyDefaultUnitPolicy(*parsedExpression, defaultUnit);
+            const auto evaluated = parsedExpression->eval();
+            auto* number = freecad_cast<NumberExpression*>(evaluated.get());
+            if (!number) {
+                return invalid(InputDiagnosticKind::Evaluation);
+            }
+            quantity = number->getQuantity();
+            if (!owner) {
+                parsedExpression.reset();
+            }
+        }
+        else {
+            quantity = Base::Quantity::parseUserInput(std::string(input), locale);
+        }
+    }
+    catch (const Base::ParserError&) {
+        return invalid(InputDiagnosticKind::ExpressionSyntax);
+    }
+    catch (const Base::UnitsMismatchError&) {
+        return invalid(InputDiagnosticKind::IncompatibleUnit);
+    }
+    catch (const Base::Exception&) {
+        return invalid(InputDiagnosticKind::Evaluation);
+    }
+
+    if (quantity.isDimensionless()) {
+        quantity.setUnit(defaultUnit);
+    }
+
+    if (constraints.requiredUnit && !quantity.isDimensionlessOrUnit(*constraints.requiredUnit)) {
+        return invalid(InputDiagnosticKind::IncompatibleUnit);
+    }
+    if (constraints.minimum && quantity.getValue() < *constraints.minimum) {
+        return invalid(InputDiagnosticKind::OutOfRange);
+    }
+    if (constraints.maximum && quantity.getValue() > *constraints.maximum) {
+        return invalid(InputDiagnosticKind::OutOfRange);
+    }
+
+    QuantityInputResult result;
+    result.status = InputStatus::Acceptable;
+    result.quantity = quantity;
+    result.expression = std::move(parsedExpression);
+    return result;
+}

--- a/src/App/QuantityInput.cpp
+++ b/src/App/QuantityInput.cpp
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "QuantityInput.h"
+
+#include <algorithm>
+#include <charconv>
+#include <cctype>
+#include <limits>
+#include <string>
+
+#include <App/Expression.h>
+#include <App/ExpressionParser.h>
+#include <App/ObjectIdentifier.h>
+#include <Base/Exception.h>
+#include <Base/NumericFormatting.h>
+#include <Base/NumericInput.h>
+
+namespace
+{
+std::size_t firstInputCharacter(std::string_view input)
+{
+    std::size_t position = 0;
+    while (position < input.size()
+           && std::isspace(static_cast<unsigned char>(input[position]))) {
+        ++position;
+    }
+    return position;
+}
+
+bool startsNumericInput(
+    std::string_view input,
+    const std::size_t position,
+    const Base::NumericLocaleContext& locale
+)
+{
+    if (position >= input.size()) {
+        return false;
+    }
+    int digit = 0;
+    std::size_t digitLength = 0;
+    if (Base::localizedDigitAt(input, position, locale, digit, digitLength)
+        || input[position] == '.') {
+        return true;
+    }
+    if (!locale.decimalSeparator.empty()
+        && input.substr(position, locale.decimalSeparator.size()) == locale.decimalSeparator) {
+        return true;
+    }
+    const std::string_view positiveSign {
+        locale.positiveSign.data(), locale.positiveSign.size()
+    };
+    const std::string_view negativeSign {
+        locale.negativeSign.data(), locale.negativeSign.size()
+    };
+    for (const auto sign : {std::string_view {"+"}, std::string_view {"-"}, positiveSign,
+                            negativeSign}) {
+        if (!sign.empty() && input.substr(position, sign.size()) == sign) {
+            const auto next = position + sign.size();
+            if (next == input.size()) {
+                return true;
+            }
+
+            int nextDigit = 0;
+            std::size_t nextDigitLength = 0;
+            return Base::localizedDigitAt(
+                       input, next, locale, nextDigit, nextDigitLength
+                   )
+                || input[next] == '.'
+                || (!locale.decimalSeparator.empty()
+                    && input.substr(next, locale.decimalSeparator.size())
+                        == locale.decimalSeparator);
+        }
+    }
+    return false;
+}
+
+App::InputDiagnosticKind inputDiagnosticKind(Base::NumericDiagnosticKind kind)
+{
+    switch (kind) {
+        case Base::NumericDiagnosticKind::IncompleteSign:
+        case Base::NumericDiagnosticKind::IncompleteDecimal:
+        case Base::NumericDiagnosticKind::IncompleteGrouping:
+        case Base::NumericDiagnosticKind::IncompleteExponent:
+            return App::InputDiagnosticKind::IncompleteNumber;
+        case Base::NumericDiagnosticKind::InvalidGrouping:
+        case Base::NumericDiagnosticKind::UnexpectedSeparator:
+            return App::InputDiagnosticKind::MalformedGrouping;
+        case Base::NumericDiagnosticKind::ExpectedDigit:
+        case Base::NumericDiagnosticKind::InvalidLiteral:
+            return App::InputDiagnosticKind::InvalidNumber;
+        case Base::NumericDiagnosticKind::OutOfRange:
+            return App::InputDiagnosticKind::OutOfRange;
+    }
+    return App::InputDiagnosticKind::InvalidNumber;
+}
+
+App::QuantityInputResult invalid(
+    App::InputDiagnosticKind kind,
+    const std::size_t offset = 0,
+    const std::size_t length = 1
+)
+{
+    App::QuantityInputResult result;
+    result.status = App::InputStatus::Invalid;
+    result.diagnostic = App::InputDiagnostic {kind, offset, length};
+    return result;
+}
+
+App::QuantityInputResult incomplete(
+    const App::InputPhase phase,
+    const App::InputDiagnosticKind kind,
+    const std::size_t offset = 0,
+    const std::size_t length = 1
+)
+{
+    if (phase == App::InputPhase::Commit) {
+        return invalid(kind, offset, length);
+    }
+
+    App::QuantityInputResult result;
+    result.status = App::InputStatus::Incomplete;
+    result.diagnostic = App::InputDiagnostic {kind, offset, length};
+    return result;
+}
+
+std::string canonicalQuantityText(const Base::Quantity& quantity)
+{
+    char number[128] {};
+    const auto conversion = std::to_chars(
+        std::begin(number), std::end(number), quantity.getValue(), std::chars_format::general,
+        std::numeric_limits<double>::max_digits10
+    );
+    std::string result;
+    if (conversion.ec == std::errc {}) {
+        result.assign(number, conversion.ptr);
+    }
+    else {
+        result = "nan";
+    }
+    const auto unit = quantity.getUnit().getString();
+    if (!unit.empty()) {
+        result += ' ';
+        result += unit;
+    }
+    return result;
+}
+
+App::Expression* applyDefaultUnitToDimensionlessTerm(
+    App::Expression* expression,
+    const Base::Unit& defaultUnit
+)
+{
+    if (!expression) {
+        return nullptr;
+    }
+
+    try {
+        auto evaluated = expression->eval();
+        auto* number = freecad_cast<App::NumberExpression*>(evaluated.get());
+        if (number && number->getUnit() == Base::Unit::One) {
+            // Keep the original subtree intact. In particular, replacing a variable
+            // expression with its current value would silently remove its dependency.
+            auto unit = std::make_unique<App::UnitExpression>(
+                expression->getOwner(), Base::Quantity(1.0, defaultUnit), defaultUnit.getString()
+            );
+            return new App::OperatorExpression(
+                expression->getOwner(),
+                expression->copy().release(),
+                App::OperatorExpression::UNIT,
+                unit.release()
+            );
+        }
+    }
+    catch (const Base::UnitsMismatchError&) {
+        // A nested additive term may not be evaluable until its own default unit is applied.
+    }
+
+    return nullptr;
+}
+
+class DefaultUnitForAdditiveTerms final: public App::ExpressionVisitor
+{
+public:
+    explicit DefaultUnitForAdditiveTerms(const Base::Unit& defaultUnit)
+        : defaultUnit(defaultUnit)
+    {}
+
+    void visit(App::Expression& expression) override
+    {
+        auto* operation = freecad_cast<App::OperatorExpression*>(&expression);
+        if (!operation
+            || (operation->getOperator() != App::OperatorExpression::ADD
+                && operation->getOperator() != App::OperatorExpression::SUB)) {
+            return;
+        }
+
+        if (auto* replacement
+            = applyDefaultUnitToDimensionlessTerm(operation->getLeft(), defaultUnit)) {
+            operation->setLeft(replacement);
+        }
+        if (auto* replacement
+            = applyDefaultUnitToDimensionlessTerm(operation->getRight(), defaultUnit)) {
+            operation->setRight(replacement);
+        }
+    }
+
+private:
+    const Base::Unit& defaultUnit;
+};
+
+void applyDefaultUnitPolicy(App::Expression& expression, const Base::Unit& defaultUnit)
+{
+    if (defaultUnit == Base::Unit::One) {
+        return;
+    }
+
+    DefaultUnitForAdditiveTerms visitor(defaultUnit);
+    expression.visit(visitor);
+}
+
+}  // namespace
+
+App::QuantityInputResult App::interpretQuantityInput(
+    const std::string_view input,
+    const QuantityInputGrammar grammar,
+    const ObjectIdentifier& path,
+    const Base::Unit& defaultUnit,
+    const Base::NumericLocaleContext& locale,
+    const InputPhase phase,
+    const QuantityConstraints& constraints
+)
+{
+    const auto first = firstInputCharacter(input);
+    if (first == input.size()) {
+        return incomplete(phase, InputDiagnosticKind::IncompleteNumber, first);
+    }
+
+    // Scan an initial numeric token before invoking either parser. This is what preserves the
+    // distinction between an unfinished edit ("-", "12,", "1e") and a syntax failure.
+    if (startsNumericInput(input, first, locale)) {
+        const auto scan = Base::scanLocalizedNumber(
+            input.substr(first), locale, Base::NumericSyntaxContext::Standalone
+        );
+        if (scan.status == Base::LocalizedNumberResult::Status::Incomplete) {
+            return incomplete(
+                phase,
+                InputDiagnosticKind::IncompleteNumber,
+                first + (scan.diagnostic ? scan.diagnostic->offset : 0),
+                scan.diagnostic ? scan.diagnostic->length : 1
+            );
+        }
+        if (scan.status == Base::LocalizedNumberResult::Status::Invalid) {
+            return invalid(
+                scan.diagnostic
+                    ? inputDiagnosticKind(scan.diagnostic->kind)
+                    : InputDiagnosticKind::InvalidNumber,
+                first + (scan.diagnostic ? scan.diagnostic->offset : 0),
+                scan.diagnostic ? scan.diagnostic->length : 1
+            );
+        }
+    }
+
+    Base::Quantity quantity;
+    std::shared_ptr<Expression> parsedExpression;
+    try {
+        if (grammar == QuantityInputGrammar::Expression) {
+            const auto* owner = path.getDocumentObject();
+            if (!owner) {
+                return invalid(InputDiagnosticKind::ExpressionSyntax);
+            }
+            const std::string inputString(input);
+            auto parsed = App::ExpressionParser::parseUserInput(
+                owner, inputString.c_str(), locale
+            );
+            parsedExpression = std::shared_ptr<Expression>(std::move(parsed));
+            // Apply the field-unit policy before evaluation. Dimensionless additive terms are
+            // replaced as complete expressions; explicit units and multiplicative terms remain
+            // untouched.
+            applyDefaultUnitPolicy(*parsedExpression, defaultUnit);
+            const auto evaluated = parsedExpression->eval();
+            auto* number = freecad_cast<NumberExpression*>(evaluated.get());
+            if (!number) {
+                return invalid(InputDiagnosticKind::Evaluation);
+            }
+            quantity = number->getQuantity();
+        }
+        else {
+            quantity = Base::Quantity::parseUserInput(std::string(input), locale);
+        }
+    }
+    catch (const Base::ParserError&) {
+        return invalid(InputDiagnosticKind::ExpressionSyntax);
+    }
+    catch (const Base::UnitsMismatchError&) {
+        return invalid(InputDiagnosticKind::IncompatibleUnit);
+    }
+    catch (const Base::Exception&) {
+        return invalid(InputDiagnosticKind::Evaluation);
+    }
+
+    if (quantity.isDimensionless()) {
+        quantity.setUnit(defaultUnit);
+    }
+
+    if (constraints.requiredUnit && !quantity.isDimensionlessOrUnit(*constraints.requiredUnit)) {
+        return invalid(InputDiagnosticKind::IncompatibleUnit);
+    }
+    if (constraints.minimum && quantity.getValue() < *constraints.minimum) {
+        return invalid(InputDiagnosticKind::OutOfRange);
+    }
+    if (constraints.maximum && quantity.getValue() > *constraints.maximum) {
+        return invalid(InputDiagnosticKind::OutOfRange);
+    }
+
+    QuantityInputResult result;
+    result.status = InputStatus::Acceptable;
+    result.quantity = quantity;
+    result.expression = std::move(parsedExpression);
+    result.normalizedText = canonicalQuantityText(quantity);
+    return result;
+}

--- a/src/App/QuantityInput.h
+++ b/src/App/QuantityInput.h
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <optional>
+#include <memory>
+#include <string_view>
+
+#include <FCGlobal.h>
+
+#include <Base/Quantity.h>
+
+namespace App
+{
+class ObjectIdentifier;
+class Expression;
+
+/** Validation phase for user-entered quantity text. */
+enum class InputPhase
+{
+    /// Preserve correctable partial input without committing a value.
+    Editing,
+    /// Require a complete value suitable for committing to the consumer.
+    Commit
+};
+
+/** Structured outcome of quantity interpretation. */
+enum class InputStatus
+{
+    Acceptable,
+    Incomplete,
+    Invalid
+};
+
+/** Canonical grammar accepted at this input boundary. */
+enum class QuantityInputGrammar
+{
+    Quantity,
+    Expression
+};
+
+enum class InputDiagnosticKind
+{
+    IncompleteNumber,
+    MalformedGrouping,
+    InvalidNumber,
+    ExpressionSyntax,
+    Evaluation,
+    IncompatibleUnit,
+    OutOfRange
+};
+
+struct AppExport InputDiagnostic
+{
+    InputDiagnosticKind kind {InputDiagnosticKind::ExpressionSyntax};
+    /// Offset of the diagnostic range in the original UTF-8 input.
+    std::size_t offsetBytes {};
+    /// Length of the diagnostic range in UTF-8 bytes.
+    std::size_t lengthBytes {1};
+};
+
+struct AppExport QuantityConstraints
+{
+    std::optional<Base::Unit> requiredUnit;
+    std::optional<double> minimum;
+    std::optional<double> maximum;
+};
+
+struct AppExport QuantityInputResult
+{
+    InputStatus status {InputStatus::Invalid};
+    /// Interpreted quantity when status is Acceptable.
+    std::optional<Base::Quantity> quantity;
+    /// Parsed expression retained for expression-capable consumers.
+    std::shared_ptr<Expression> expression;
+    std::optional<InputDiagnostic> diagnostic;
+};
+
+/**
+ * Interpret user-entered quantity text at the shared App input boundary.
+ *
+ * This operation owns localized numeric scanning, parsing, expression evaluation, default-unit
+ * application, unit compatibility, range validation, and structured diagnostics. Editing accepts
+ * correctable incomplete input; Commit requires a complete acceptable quantity. The caller must
+ * explicitly select the accepted grammar and provide the locale used by its input surface.
+ */
+AppExport QuantityInputResult interpretQuantityInput(
+    std::string_view input,
+    QuantityInputGrammar grammar,
+    const ObjectIdentifier& path,
+    const Base::Unit& defaultUnit,
+    const Base::NumericLocaleContext& locale,
+    InputPhase phase,
+    const QuantityConstraints& constraints
+);
+
+}  // namespace App

--- a/src/App/QuantityInput.h
+++ b/src/App/QuantityInput.h
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <optional>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include <FCGlobal.h>
+
+#include <Base/Quantity.h>
+
+namespace App
+{
+class ObjectIdentifier;
+class Expression;
+
+enum class InputPhase
+{
+    Editing,
+    Commit
+};
+
+enum class InputStatus
+{
+    Acceptable,
+    Incomplete,
+    Invalid
+};
+
+enum class QuantityInputGrammar
+{
+    Quantity,
+    Expression
+};
+
+enum class InputDiagnosticKind
+{
+    IncompleteNumber,
+    MalformedGrouping,
+    InvalidNumber,
+    ExpressionSyntax,
+    Evaluation,
+    IncompatibleUnit,
+    OutOfRange
+};
+
+struct AppExport InputDiagnostic
+{
+    InputDiagnosticKind kind {InputDiagnosticKind::ExpressionSyntax};
+    std::size_t offset {};
+    std::size_t length {1};
+};
+
+struct AppExport QuantityConstraints
+{
+    std::optional<Base::Unit> requiredUnit;
+    std::optional<double> minimum;
+    std::optional<double> maximum;
+};
+
+struct AppExport QuantityInputResult
+{
+    InputStatus status {InputStatus::Invalid};
+    std::optional<Base::Quantity> quantity;
+    std::shared_ptr<Expression> expression;
+    std::string normalizedText;
+    std::optional<InputDiagnostic> diagnostic;
+};
+
+AppExport QuantityInputResult interpretQuantityInput(
+    std::string_view input,
+    QuantityInputGrammar grammar,
+    const ObjectIdentifier& path,
+    const Base::Unit& defaultUnit,
+    const Base::NumericLocaleContext& locale,
+    InputPhase phase,
+    const QuantityConstraints& constraints
+);
+
+}  // namespace App

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -3,6 +3,23 @@
 add_library(FreeCADBase SHARED)
 add_dependencies(FreeCADBase fc_version)
 
+check_cxx_source_compiles(
+    "#include <charconv>
+int main()
+{
+    double value {};
+    const auto result = std::from_chars(\"\", \"\", value, std::chars_format::general);
+    return result.ec == std::errc {};
+}"
+    FREECAD_HAS_FLOATING_POINT_FROM_CHARS
+)
+
+if(FREECAD_HAS_FLOATING_POINT_FROM_CHARS)
+    target_compile_definitions(FreeCADBase PRIVATE FC_HAS_FLOATING_POINT_FROM_CHARS=1)
+else()
+    target_compile_definitions(FreeCADBase PRIVATE FC_HAS_FLOATING_POINT_FROM_CHARS=0)
+endif()
+
 if(WIN32)
     add_definitions(-DFCBase)
     add_definitions(-DPYCXX_DLL)
@@ -181,6 +198,10 @@ SET(FreeCADBase_UNITAPI_SRCS
     UnitsSchemas.h
     UnitsSchemasData.h
     UnitsSchemasSpecs.h
+    NumericInput.h
+    NumericInput.cpp
+    NumericInputLocale.h
+    NumericInputLocale.cpp
     Quantity.h
     Quantity.cpp
     QuantityPyImp.cpp

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -236,6 +236,7 @@ SET(FreeCADBase_CPP_SRCS
     Stream.cpp
     StringUtils.cpp
     Swap.cpp
+    NumericFormatting.cpp
     ${SWIG_SRCS}
     SystemHandler.cpp
     Tools.cpp
@@ -286,6 +287,7 @@ SET(FreeCADBase_HPP_SRCS
     InputSource.h
     Interpreter.h
     Matrix.h
+    NumericFormatting.h
     Observer.h
     Parameter.h
     ParameterObserver.h

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -170,6 +170,10 @@ SET(FreeCADBase_UNITAPI_SRCS
     UnitsSchemas.h
     UnitsSchemasData.h
     UnitsSchemasSpecs.h
+    NumericInput.h
+    NumericInput.cpp
+    NumericInputLocale.h
+    NumericInputLocale.cpp
     Quantity.h
     Quantity.cpp
     QuantityPyImp.cpp

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -269,6 +269,7 @@ SET(FreeCADBase_CPP_SRCS
     Stream.cpp
     StringUtils.cpp
     Swap.cpp
+    NumericFormatting.cpp
     ${SWIG_SRCS}
     SystemHandler.cpp
     Tools.cpp
@@ -320,6 +321,7 @@ SET(FreeCADBase_HPP_SRCS
     InputSource.h
     Interpreter.h
     Matrix.h
+    NumericFormatting.h
     Observer.h
     Parameter.h
     ParameterObserver.h

--- a/src/Base/NumericFormatting.cpp
+++ b/src/Base/NumericFormatting.cpp
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "NumericFormatting.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include <unicode/decimfmt.h>
+#include <unicode/dcfmtsym.h>
+#include <unicode/locid.h>
+#include <unicode/numfmt.h>
+#include <unicode/unistr.h>
+
+#include "Exception.h"
+#include "Quantity.h"
+
+namespace
+{
+const Base::NumericLocaleContext fallbackFormatting {"en_US_POSIX", ".", ",", "+", "-", 3, 3, "0"};
+
+Base::NumericLocaleContext numericLocaleContext = fallbackFormatting;
+std::mutex numericLocaleContextMutex;
+
+std::string toUtf8(const icu::UnicodeString& text)
+{
+    std::string result;
+    text.toUTF8String(result);
+    return result;
+}
+
+bool useQtLikeGeneralScientific(const double value, const int precision)
+{
+    if (!std::isfinite(value) || value == 0.0 || precision <= 0) {
+        return false;
+    }
+
+    const auto exponent = static_cast<int>(std::floor(std::log10(std::abs(value))));
+    return exponent < -4 || exponent >= precision;
+}
+
+struct NumericFormatSymbols
+{
+    std::string decimal;
+    std::string grouping;
+    std::string positiveSign;
+    std::string negativeSign;
+    std::string zeroDigit;
+};
+
+NumericFormatSymbols resolveNumericFormatSymbols(
+    const Base::NumericLocaleContext& formatting,
+    const icu::Locale& locale
+)
+{
+    NumericFormatSymbols result {
+        formatting.decimalSeparator,
+        formatting.groupingSeparator,
+        formatting.positiveSign,
+        formatting.negativeSign,
+        formatting.zeroDigit
+    };
+
+    UErrorCode status = U_ZERO_ERROR;
+    icu::DecimalFormatSymbols symbols(locale, status);
+    if (U_SUCCESS(status)) {
+        if (result.decimal.empty()) {
+            result.decimal = toUtf8(
+                symbols.getSymbol(icu::DecimalFormatSymbols::kDecimalSeparatorSymbol)
+            );
+        }
+        if (result.grouping.empty()) {
+            result.grouping = toUtf8(
+                symbols.getSymbol(icu::DecimalFormatSymbols::kGroupingSeparatorSymbol)
+            );
+        }
+        if (result.positiveSign.empty()) {
+            result.positiveSign = toUtf8(symbols.getSymbol(icu::DecimalFormatSymbols::kPlusSignSymbol));
+        }
+        if (result.negativeSign.empty()) {
+            result.negativeSign = toUtf8(
+                symbols.getSymbol(icu::DecimalFormatSymbols::kMinusSignSymbol)
+            );
+        }
+        if (result.zeroDigit.empty()) {
+            result.zeroDigit = toUtf8(symbols.getSymbol(icu::DecimalFormatSymbols::kZeroDigitSymbol));
+        }
+    }
+
+    if (result.decimal.empty()) {
+        result.decimal = ".";
+    }
+    if (result.zeroDigit.empty()) {
+        result.zeroDigit = "0";
+    }
+
+    return result;
+}
+
+void applyNumericFormatSymbols(icu::DecimalFormat& format, const NumericFormatSymbols& symbols)
+{
+    const auto* current = format.getDecimalFormatSymbols();
+    if (!current) {
+        return;
+    }
+
+    icu::DecimalFormatSymbols adjusted(*current);
+    if (!symbols.decimal.empty()) {
+        const auto decimal = icu::UnicodeString::fromUTF8(symbols.decimal);
+        adjusted.setSymbol(icu::DecimalFormatSymbols::kDecimalSeparatorSymbol, decimal, false);
+        adjusted.setSymbol(icu::DecimalFormatSymbols::kMonetarySeparatorSymbol, decimal, false);
+    }
+    if (!symbols.grouping.empty()) {
+        const auto grouping = icu::UnicodeString::fromUTF8(symbols.grouping);
+        adjusted.setSymbol(icu::DecimalFormatSymbols::kGroupingSeparatorSymbol, grouping, false);
+        adjusted.setSymbol(icu::DecimalFormatSymbols::kMonetaryGroupingSeparatorSymbol, grouping, false);
+    }
+    if (!symbols.positiveSign.empty()) {
+        adjusted.setSymbol(
+            icu::DecimalFormatSymbols::kPlusSignSymbol,
+            icu::UnicodeString::fromUTF8(symbols.positiveSign),
+            false
+        );
+    }
+    if (!symbols.negativeSign.empty()) {
+        adjusted.setSymbol(
+            icu::DecimalFormatSymbols::kMinusSignSymbol,
+            icu::UnicodeString::fromUTF8(symbols.negativeSign),
+            false
+        );
+    }
+    if (!symbols.zeroDigit.empty()) {
+        adjusted.setSymbol(
+            icu::DecimalFormatSymbols::kZeroDigitSymbol,
+            icu::UnicodeString::fromUTF8(symbols.zeroDigit),
+            false
+        );
+    }
+    // Keep scientific output in the same token grammar consumed by FreeCAD. ICU otherwise uses
+    // locale-specific multiplication and exponent words (for example "×10^" or Arabic text),
+    // which are display notation rather than scanner syntax.
+    adjusted.setSymbol(icu::DecimalFormatSymbols::kExponentialSymbol, icu::UnicodeString("e"), false);
+    adjusted.setSymbol(
+        icu::DecimalFormatSymbols::kExponentMultiplicationSymbol,
+        icu::UnicodeString(),
+        false
+    );
+    format.setDecimalFormatSymbols(adjusted);
+}
+
+std::string localizeDecimalSeparator(std::string value, std::string_view decimalSeparator)
+{
+    if (decimalSeparator.empty() || decimalSeparator == ".") {
+        return value;
+    }
+
+    auto pos = value.find('.');
+    while (pos != std::string::npos) {
+        value.replace(pos, 1, decimalSeparator);
+        pos = value.find('.', pos + decimalSeparator.size());
+    }
+
+    return value;
+}
+
+std::string formatDefaultScientificLikeQt(
+    const double value,
+    const Base::QuantityFormat& format,
+    const NumericFormatSymbols& symbols
+)
+{
+    std::ostringstream out;
+    out << std::setprecision(std::max(1, format.getPrecision())) << value;
+    return localizeDecimalSeparator(out.str(), symbols.decimal);
+}
+}  // namespace
+
+std::string Base::formatNumericValue(
+    const double value,
+    const Base::QuantityFormat& format,
+    const Base::NumericLocaleContext& formatting
+)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    const std::string normalizedLocaleId = Base::normalizeIcuLocaleId(formatting.localeId);
+    const icu::Locale locale = icu::Locale::createFromName(normalizedLocaleId.c_str());
+    const NumericFormatSymbols symbols = resolveNumericFormatSymbols(formatting, locale);
+
+    std::unique_ptr<icu::NumberFormat> nf(icu::NumberFormat::createInstance(locale, status));
+    if (!U_SUCCESS(status) || !nf) {
+        // Fallback: locale-independent formatting.
+        std::ostringstream out;
+        switch (format.format) {
+            case Base::QuantityFormat::Fixed:
+                out << std::fixed;
+                break;
+            case Base::QuantityFormat::Scientific:
+                out << std::scientific;
+                break;
+            case Base::QuantityFormat::Default:
+            default:
+                break;
+        }
+        out << std::setprecision(format.getPrecision()) << value;
+        return localizeDecimalSeparator(out.str(), symbols.decimal);
+    }
+
+    if (auto* df = dynamic_cast<icu::DecimalFormat*>(nf.get())) {
+        applyNumericFormatSymbols(*df, symbols);
+        if (formatting.primaryGroupingSize > 0) {
+            df->setGroupingSize(formatting.primaryGroupingSize);
+        }
+        if (formatting.secondaryGroupingSize > 0) {
+            df->setSecondaryGroupingSize(formatting.secondaryGroupingSize);
+        }
+    }
+
+    if (format.option & Base::QuantityFormat::OmitGroupSeparator) {
+        nf->setGroupingUsed(false);
+    }
+
+    const int precision = format.getPrecision();
+    switch (format.format) {
+        case Base::QuantityFormat::Fixed:
+            nf->setMinimumFractionDigits(precision);
+            nf->setMaximumFractionDigits(precision);
+            break;
+        case Base::QuantityFormat::Scientific:
+            if (auto* df = dynamic_cast<icu::DecimalFormat*>(nf.get())) {
+                df->setScientificNotation(true);
+                df->setMinimumFractionDigits(precision);
+                df->setMaximumFractionDigits(precision);
+                break;
+            }
+            [[fallthrough]];
+        case Base::QuantityFormat::Default:
+            if (useQtLikeGeneralScientific(value, precision)) {
+                return formatDefaultScientificLikeQt(value, format, symbols);
+            }
+            if (auto* df = dynamic_cast<icu::DecimalFormat*>(nf.get()); precision > 0 && df) {
+                df->setSignificantDigitsUsed(true);
+                df->setMinimumSignificantDigits(1);
+                df->setMaximumSignificantDigits(precision);
+                break;
+            }
+            [[fallthrough]];
+        default:
+            nf->setMaximumFractionDigits(precision);
+            break;
+    }
+
+    icu::UnicodeString s;
+    nf->format(value, s);
+    return toUtf8(s);
+}
+
+bool Base::isCLocaleName(std::string_view localeId)
+{
+    return localeId == "C" || localeId == "c" || localeId == "C.UTF-8" || localeId == "C.utf8"
+        || localeId == "c.utf8" || localeId == "POSIX" || localeId == "posix";
+}
+
+std::string Base::normalizeIcuLocaleId(std::string_view localeId)
+{
+    if (localeId.empty() || isCLocaleName(localeId)) {
+        return "en_US_POSIX";
+    }
+
+    const std::string name(localeId);
+    const icu::Locale locale = icu::Locale::createFromName(name.c_str());
+    if (locale.isBogus()) {
+        throw Base::ValueError("Invalid ICU locale identifier: " + name);
+    }
+
+    const std::string normalizedLocaleId = locale.getName();
+    if (normalizedLocaleId.empty()) {
+        throw Base::ValueError("ICU returned an empty locale identifier for: " + name);
+    }
+    return normalizedLocaleId;
+}
+
+void Base::setIcuDefaultLocale(std::string_view localeId)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    const std::string normalizedLocaleId = normalizeIcuLocaleId(localeId);
+    const icu::Locale locale = icu::Locale::createFromName(normalizedLocaleId.c_str());
+    icu::Locale::setDefault(locale, status);
+    if (U_FAILURE(status)) {
+        throw Base::RuntimeError("Failed to set ICU default locale: " + normalizedLocaleId);
+    }
+}
+
+Base::NumericLocaleContext Base::createNumericLocaleContext()
+{
+    return createNumericLocaleContext(icu::Locale::getDefault().getName());
+}
+
+Base::NumericLocaleContext Base::createNumericLocaleContext(std::string_view localeId)
+{
+    if (isCLocaleName(localeId)) {
+        return fallbackFormatting;
+    }
+
+    const std::string normalizedLocaleId = normalizeIcuLocaleId(localeId);
+    const icu::Locale locale = icu::Locale::createFromName(normalizedLocaleId.c_str());
+    UErrorCode status = U_ZERO_ERROR;
+    std::unique_ptr<icu::NumberFormat> numberFormat(icu::NumberFormat::createInstance(locale, status));
+    auto* decimalFormat = dynamic_cast<icu::DecimalFormat*>(numberFormat.get());
+    if (U_FAILURE(status) || !decimalFormat) {
+        throw Base::RuntimeError(
+            "Failed to create ICU decimal-format symbols for: " + normalizedLocaleId
+        );
+    }
+
+    const auto* symbols = decimalFormat->getDecimalFormatSymbols();
+    if (!symbols) {
+        throw Base::RuntimeError(
+            "Failed to obtain ICU decimal-format symbols for: " + normalizedLocaleId
+        );
+    }
+
+    const auto primaryGroupingSize = decimalFormat->getGroupingSize();
+    const auto secondaryGroupingSize = decimalFormat->getSecondaryGroupingSize();
+
+    return {
+        normalizedLocaleId,
+        toUtf8(symbols->getSymbol(icu::DecimalFormatSymbols::kDecimalSeparatorSymbol)),
+        toUtf8(symbols->getSymbol(icu::DecimalFormatSymbols::kGroupingSeparatorSymbol)),
+        toUtf8(symbols->getSymbol(icu::DecimalFormatSymbols::kPlusSignSymbol)),
+        toUtf8(symbols->getSymbol(icu::DecimalFormatSymbols::kMinusSignSymbol)),
+        primaryGroupingSize,
+        secondaryGroupingSize > 0 ? secondaryGroupingSize : primaryGroupingSize,
+        toUtf8(symbols->getSymbol(icu::DecimalFormatSymbols::kZeroDigitSymbol))
+    };
+}
+
+void Base::publishNumericLocaleContext(NumericLocaleContext state)
+{
+    const std::lock_guard lock(numericLocaleContextMutex);
+    numericLocaleContext = std::move(state);
+}
+
+Base::NumericLocaleContext Base::currentNumericLocaleContext()
+{
+    const std::lock_guard lock(numericLocaleContextMutex);
+    return numericLocaleContext;
+}

--- a/src/Base/NumericFormatting.h
+++ b/src/Base/NumericFormatting.h
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include <FCGlobal.h>
+
+namespace Base
+{
+struct QuantityFormat;
+
+/**
+ * Complete numeric-locale context shared by Base, App, and GUI boundaries.
+ *
+ * Instances are passed by const reference to parsers and formatters. Publication replaces the
+ * entire value atomically, so a consumer can never observe a locale identifier paired with
+ * separators, signs, or grouping rules from a different configuration.
+ */
+struct BaseExport NumericLocaleContext
+{
+    std::string localeId;
+    std::string decimalSeparator;
+    std::string groupingSeparator;
+    std::string positiveSign;
+    std::string negativeSign;
+    int primaryGroupingSize {};
+    int secondaryGroupingSize {};
+    /// UTF-8 representation of the locale's zero digit. Decimal digits are consecutive from it.
+    std::string zeroDigit;
+
+    bool operator==(const NumericLocaleContext&) const = default;
+};
+
+/// Format a scalar value using a quantity format and an explicit numeric-locale snapshot.
+/// @throws ValueError if the snapshot contains an invalid non-C locale identifier.
+BaseExport std::string formatNumericValue(
+    double value,
+    const QuantityFormat& format,
+    const NumericLocaleContext& formatting
+);
+
+/// Return whether a localeId names the C/POSIX locale.
+BaseExport bool isCLocaleName(std::string_view localeId);
+/// Return the normalized ICU locale identifier used for numeric formatting.
+/// @throws ValueError if a non-C locale identifier is invalid.
+BaseExport std::string normalizeIcuLocaleId(std::string_view localeId);
+/// Set ICU's default locale using the normalized numeric locale identifier.
+/// @throws ValueError for an invalid identifier, or RuntimeError if ICU rejects the update.
+BaseExport void setIcuDefaultLocale(std::string_view localeId);
+
+/// Build a numeric formatting snapshot for an explicit locale identifier.
+/// @throws ValueError for an invalid identifier, or RuntimeError if ICU cannot load its symbols.
+BaseExport NumericLocaleContext createNumericLocaleContext(std::string_view localeId);
+/// Build a numeric formatting snapshot from ICU's current default locale.
+BaseExport NumericLocaleContext createNumericLocaleContext();
+/// Publish a complete snapshot for subsequent formatting and user-input parsing.
+BaseExport void publishNumericLocaleContext(NumericLocaleContext state);
+/// Return a thread-safe copy of the currently published snapshot.
+BaseExport NumericLocaleContext currentNumericLocaleContext();
+
+}  // namespace Base

--- a/src/Base/NumericFormatting.h
+++ b/src/Base/NumericFormatting.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <string>
+
+#include <FCGlobal.h>
+
+namespace Base
+{
+/**
+ * Complete numeric-locale context shared by localized scanners and their callers.
+ *
+ * The context is immutable by convention and is passed explicitly to numeric input code. It
+ * contains all symbols and grouping rules needed to recognize one localized numeric token.
+ */
+struct BaseExport NumericLocaleContext
+{
+    std::string localeId;
+    std::string decimalSeparator;
+    std::string groupingSeparator;
+    std::string positiveSign;
+    std::string negativeSign;
+    int primaryGroupingSize {};
+    int secondaryGroupingSize {};
+    std::string zeroDigit;
+
+    bool operator==(const NumericLocaleContext&) const = default;
+};
+}  // namespace Base

--- a/src/Base/NumericFormatting.h
+++ b/src/Base/NumericFormatting.h
@@ -3,16 +3,20 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 #include <FCGlobal.h>
 
 namespace Base
 {
+struct QuantityFormat;
+
 /**
- * Complete numeric-locale context shared by localized scanners and their callers.
+ * Complete numeric-locale context shared by Base, App, and GUI boundaries.
  *
- * The context is immutable by convention and is passed explicitly to numeric input code. It
- * contains all symbols and grouping rules needed to recognize one localized numeric token.
+ * Instances are passed by const reference to parsers and formatters. Publication replaces the
+ * entire value atomically, so a consumer can never observe a locale identifier paired with
+ * separators, signs, or grouping rules from a different configuration.
  */
 struct BaseExport NumericLocaleContext
 {
@@ -23,8 +27,37 @@ struct BaseExport NumericLocaleContext
     std::string negativeSign;
     int primaryGroupingSize {};
     int secondaryGroupingSize {};
+    /// UTF-8 representation of the locale's zero digit. Decimal digits are consecutive from it.
     std::string zeroDigit;
 
     bool operator==(const NumericLocaleContext&) const = default;
 };
+
+/// Format a scalar value using a quantity format and an explicit numeric-locale snapshot.
+/// @throws ValueError if the snapshot contains an invalid non-C locale identifier.
+BaseExport std::string formatNumericValue(
+    double value,
+    const QuantityFormat& format,
+    const NumericLocaleContext& formatting
+);
+
+/// Return whether a localeId names the C/POSIX locale.
+BaseExport bool isCLocaleName(std::string_view localeId);
+/// Return the normalized ICU locale identifier used for numeric formatting.
+/// @throws ValueError if a non-C locale identifier is invalid.
+BaseExport std::string normalizeIcuLocaleId(std::string_view localeId);
+/// Set ICU's default locale using the normalized numeric locale identifier.
+/// @throws ValueError for an invalid identifier, or RuntimeError if ICU rejects the update.
+BaseExport void setIcuDefaultLocale(std::string_view localeId);
+
+/// Build a numeric formatting snapshot for an explicit locale identifier.
+/// @throws ValueError for an invalid identifier, or RuntimeError if ICU cannot load its symbols.
+BaseExport NumericLocaleContext createNumericLocaleContext(std::string_view localeId);
+/// Build a numeric formatting snapshot from ICU's current default locale.
+BaseExport NumericLocaleContext createNumericLocaleContext();
+/// Publish a complete snapshot for subsequent formatting and user-input parsing.
+BaseExport void publishNumericLocaleContext(NumericLocaleContext state);
+/// Return a thread-safe copy of the currently published snapshot.
+BaseExport NumericLocaleContext currentNumericLocaleContext();
+
 }  // namespace Base

--- a/src/Base/NumericInput.cpp
+++ b/src/Base/NumericInput.cpp
@@ -1,0 +1,479 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "NumericInput.h"
+
+#include <charconv>
+#include <cmath>
+#include <cctype>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "NumericFormatting.h"
+#include "NumericInputLocale.h"
+#include "StringUtils.h"
+
+namespace
+{
+bool startsAt(std::string_view text, std::size_t position, std::string_view value)
+{
+    return !value.empty() && position + value.size() <= text.size()
+        && text.substr(position, value.size()) == value;
+}
+
+bool boundary(const char ch)
+{
+    return std::isspace(static_cast<unsigned char>(ch)) || ch == '(' || ch == ')' || ch == '['
+        || ch == ']' || ch == '<' || ch == '>' || ch == '+' || ch == '-' || ch == '*' || ch == '/'
+        || ch == '^' || ch == ';';
+}
+
+Base::NumericGrammarPolicy grammarPolicy(
+    const Base::NumericLocaleContext& locale,
+    const Base::NumericSyntaxContext syntax
+)
+{
+    if (syntax != Base::NumericSyntaxContext::FunctionArgument) {
+        return {locale.decimalSeparator, locale.groupingSeparator, {}, true};
+    }
+
+    // A comma-decimal locale uses a semicolon for function arguments. In all other locales a
+    // comma remains the function separator. Grouping is disabled when its symbol is structural.
+    const std::string_view argumentSeparator = locale.decimalSeparator == ","
+        ? std::string_view {";"}
+        : std::string_view {","};
+    return {
+        locale.decimalSeparator,
+        locale.groupingSeparator,
+        argumentSeparator,
+        locale.groupingSeparator != argumentSeparator
+    };
+}
+
+Base::LocalizedNumberResult invalid(
+    const Base::NumericDiagnosticKind kind,
+    const std::size_t offsetBytes,
+    const std::size_t consumed,
+    const std::size_t lengthBytes = 1
+)
+{
+    Base::LocalizedNumberResult result;
+    result.status = Base::LocalizedNumberResult::Status::Invalid;
+    result.consumedBytes = consumed;
+    result.diagnostic = Base::NumericDiagnostic {kind, offsetBytes, lengthBytes};
+    return result;
+}
+
+Base::LocalizedNumberResult incomplete(
+    const Base::NumericDiagnosticKind kind,
+    const std::size_t offsetBytes,
+    const std::size_t consumed,
+    std::string canonical,
+    const std::size_t lengthBytes = 1
+)
+{
+    Base::LocalizedNumberResult result;
+    result.status = Base::LocalizedNumberResult::Status::Incomplete;
+    result.consumedBytes = consumed;
+    result.canonicalText = std::move(canonical);
+    result.diagnostic = Base::NumericDiagnostic {kind, offsetBytes, lengthBytes};
+    return result;
+}
+
+enum class CanonicalNumberStatus
+{
+    Complete,
+    Invalid,
+    OutOfRange
+};
+
+CanonicalNumberStatus parseCanonicalDouble(std::string_view text, double& value)
+{
+    // CMake probes the actual overload because some standard libraries expose <charconv> without
+    // implementing floating-point from_chars.
+#if FC_HAS_FLOATING_POINT_FROM_CHARS
+    const auto first = text.data();
+    const auto last = first + text.size();
+    const auto conversion = std::from_chars(first, last, value, std::chars_format::general);
+    if (conversion.ec == std::errc::result_out_of_range) {
+        return CanonicalNumberStatus::OutOfRange;
+    }
+    if (conversion.ec != std::errc {} || conversion.ptr != last) {
+        return CanonicalNumberStatus::Invalid;
+    }
+#else
+    if (!Base::StringUtils::parseDouble(text, value)) {
+        // The scanner has already validated the canonical grammar, so a failure here means that
+        // the value cannot be represented by the fallback conversion.
+        return CanonicalNumberStatus::OutOfRange;
+    }
+#endif
+
+    return std::isfinite(value) ? CanonicalNumberStatus::Complete : CanonicalNumberStatus::OutOfRange;
+}
+
+bool decimalAt(
+    std::string_view input,
+    const std::size_t position,
+    const Base::NumericGrammarPolicy& policy,
+    std::size_t& length
+)
+{
+    length = 0;
+    if (startsAt(input, position, policy.decimalSeparator)) {
+        if (policy.decimalSeparator == policy.argumentSeparator) {
+            return false;
+        }
+        // In comma-decimal function syntax, whitespace after the comma makes it the argument
+        // separator. Adjacent comma digits remain the localized decimal form.
+        if (policy.argumentSeparator == ";" && policy.decimalSeparator == ","
+            && position + policy.decimalSeparator.size() < input.size()
+            && std::isspace(
+                static_cast<unsigned char>(input[position + policy.decimalSeparator.size()])
+            )) {
+            return false;
+        }
+        length = policy.decimalSeparator.size();
+        return true;
+    }
+    if (input[position] == '.' && policy.decimalSeparator != ".") {
+        length = 1;
+        return true;
+    }
+    return input[position] == '.';
+}
+
+bool groupingAt(
+    std::string_view input,
+    const std::size_t position,
+    const Base::NumericLocaleContext& locale,
+    const Base::NumericGrammarPolicy& policy,
+    const bool alreadyGrouped,
+    std::size_t& length
+)
+{
+    length = 0;
+    if (!policy.allowGrouping) {
+        return false;
+    }
+    if (!startsAt(input, position, policy.groupingSeparator)) {
+        return false;
+    }
+
+    // In comma-decimal locales the canonical dot is also commonly the grouping symbol. Keep a
+    // lone dot as canonical decimal syntax unless the rest of the token proves that it is a
+    // localized grouping separator followed by a localized decimal or another group.
+    if (!alreadyGrouped && policy.groupingSeparator == "." && policy.decimalSeparator != ".") {
+        const auto groupStart = position + policy.groupingSeparator.size();
+        std::size_t digitCount = 0;
+        std::size_t digitPosition = groupStart;
+        while (digitPosition < input.size()) {
+            int digit = 0;
+            std::size_t digitLength = 0;
+            if (!Base::localizedDigitAt(input, digitPosition, locale, digit, digitLength)) {
+                break;
+            }
+            ++digitCount;
+            digitPosition += digitLength;
+        }
+        const auto afterGroup = digitPosition;
+        if (digitCount != static_cast<std::size_t>(locale.primaryGroupingSize)
+            || (!startsAt(input, afterGroup, policy.decimalSeparator)
+                && !startsAt(input, afterGroup, policy.groupingSeparator))) {
+            return false;
+        }
+    }
+
+    length = policy.groupingSeparator.size();
+    if (policy.groupingSeparator == " ") {
+        int digit = 0;
+        std::size_t digitLength = 0;
+        if (position + length >= input.size()
+            || !Base::localizedDigitAt(input, position + length, locale, digit, digitLength)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool validGrouping(const std::vector<int>& groups, const Base::NumericLocaleContext& locale)
+{
+    if (groups.size() < 2 || locale.primaryGroupingSize <= 0 || locale.secondaryGroupingSize <= 0) {
+        return false;
+    }
+    if (groups.back() != locale.primaryGroupingSize) {
+        return false;
+    }
+    for (std::size_t i = 1; i + 1 < groups.size(); ++i) {
+        if (groups[i] != locale.secondaryGroupingSize) {
+            return false;
+        }
+    }
+    return groups.front() > 0 && groups.front() <= locale.secondaryGroupingSize;
+}
+
+bool signAt(
+    std::string_view input,
+    const std::size_t position,
+    const Base::NumericLocaleContext& locale,
+    std::size_t& length,
+    char& canonical
+)
+{
+    length = 0;
+    canonical = 0;
+    if (startsAt(input, position, locale.negativeSign)) {
+        length = locale.negativeSign.size();
+        canonical = '-';
+        return true;
+    }
+    if (startsAt(input, position, locale.positiveSign)) {
+        length = locale.positiveSign.size();
+        canonical = '+';
+        return true;
+    }
+    if (input[position] == '-' || input[position] == '+') {
+        length = 1;
+        canonical = input[position];
+        return true;
+    }
+    return false;
+}
+
+}  // namespace
+
+Base::NumericGrammarPolicy Base::numericGrammarPolicy(
+    const NumericLocaleContext& locale,
+    const NumericSyntaxContext syntax
+)
+{
+    return grammarPolicy(locale, syntax);
+}
+
+Base::LocalizedNumberResult Base::scanLocalizedNumber(
+    const std::string_view input,
+    const NumericLocaleContext& locale,
+    const NumericSyntaxContext syntax
+)
+{
+    const auto policy = Base::numericGrammarPolicy(locale, syntax);
+    if (input.empty()) {
+        return incomplete(NumericDiagnosticKind::ExpectedDigit, 0, 0, {});
+    }
+
+    std::size_t position = 0;
+    std::string canonical;
+    canonical.reserve(input.size());
+
+    std::size_t signLength = 0;
+    char sign = 0;
+    if (signAt(input, position, locale, signLength, sign)) {
+        // std::from_chars accepts a leading minus but not a leading plus. A positive sign is
+        // still recognized by the scanner; it is simply omitted from the canonical literal.
+        if (sign != '+') {
+            canonical.push_back(sign);
+        }
+        position += signLength;
+        if (position == input.size() || boundary(input[position])) {
+            return incomplete(NumericDiagnosticKind::IncompleteSign, position, position, canonical);
+        }
+    }
+
+    std::vector<int> groups;
+    int digitsInGroup = 0;
+    int totalDigits = 0;
+    bool grouped = false;
+    std::size_t lastGroupingStart = 0;
+    std::size_t lastGroupingLength = 0;
+
+    while (position < input.size()) {
+        int digit = 0;
+        std::size_t digitLength = 0;
+        if (localizedDigitAt(input, position, locale, digit, digitLength)) {
+            canonical.push_back(static_cast<char>('0' + digit));
+            position += digitLength;
+            ++digitsInGroup;
+            ++totalDigits;
+            continue;
+        }
+
+        std::size_t separatorLength = 0;
+        if (groupingAt(input, position, locale, policy, grouped, separatorLength)) {
+            if (digitsInGroup == 0) {
+                return invalid(NumericDiagnosticKind::InvalidGrouping, position, position, separatorLength);
+            }
+            groups.push_back(digitsInGroup);
+            digitsInGroup = 0;
+            grouped = true;
+            lastGroupingStart = position;
+            lastGroupingLength = separatorLength;
+            position += separatorLength;
+            int nextDigit = 0;
+            std::size_t nextDigitLength = 0;
+            if (position == input.size()
+                || !localizedDigitAt(input, position, locale, nextDigit, nextDigitLength)) {
+                return incomplete(
+                    NumericDiagnosticKind::IncompleteGrouping,
+                    position,
+                    position,
+                    canonical,
+                    separatorLength
+                );
+            }
+            continue;
+        }
+        break;
+    }
+
+    if (totalDigits == 0) {
+        std::size_t decimalLength = 0;
+        if (!decimalAt(input, position, policy, decimalLength)) {
+            return invalid(NumericDiagnosticKind::ExpectedDigit, position, position);
+        }
+        canonical.push_back('.');
+        position += decimalLength;
+        int nextDigit = 0;
+        std::size_t nextDigitLength = 0;
+        if (position == input.size()
+            || !localizedDigitAt(input, position, locale, nextDigit, nextDigitLength)) {
+            return incomplete(
+                NumericDiagnosticKind::IncompleteDecimal,
+                position,
+                position,
+                canonical,
+                decimalLength
+            );
+        }
+        while (position < input.size()) {
+            int fractionalDigit = 0;
+            std::size_t fractionalDigitLength = 0;
+            if (!localizedDigitAt(input, position, locale, fractionalDigit, fractionalDigitLength)) {
+                break;
+            }
+            canonical.push_back(static_cast<char>('0' + fractionalDigit));
+            position += fractionalDigitLength;
+            ++totalDigits;
+        }
+    }
+    else {
+        if (grouped) {
+            groups.push_back(digitsInGroup);
+            if (!validGrouping(groups, locale)) {
+                return invalid(
+                    NumericDiagnosticKind::InvalidGrouping,
+                    lastGroupingStart,
+                    position,
+                    lastGroupingLength
+                );
+            }
+        }
+
+        std::size_t decimalLength = 0;
+        if (position < input.size() && decimalAt(input, position, policy, decimalLength)) {
+            canonical.push_back('.');
+            position += decimalLength;
+            int nextDigit = 0;
+            std::size_t nextDigitLength = 0;
+            if (position == input.size()
+                || !localizedDigitAt(input, position, locale, nextDigit, nextDigitLength)) {
+                return incomplete(
+                    NumericDiagnosticKind::IncompleteDecimal,
+                    position,
+                    position,
+                    canonical,
+                    decimalLength
+                );
+            }
+            while (position < input.size()) {
+                int fractionalDigit = 0;
+                std::size_t fractionalDigitLength = 0;
+                if (!localizedDigitAt(input, position, locale, fractionalDigit, fractionalDigitLength)) {
+                    break;
+                }
+                canonical.push_back(static_cast<char>('0' + fractionalDigit));
+                position += fractionalDigitLength;
+            }
+        }
+    }
+
+    if (position < input.size() && (input[position] == 'e' || input[position] == 'E')) {
+        canonical.push_back('e');
+        ++position;
+        std::size_t exponentSignLength = 0;
+        char exponentSign = 0;
+        if (position < input.size()
+            && signAt(input, position, locale, exponentSignLength, exponentSign)) {
+            canonical.push_back(exponentSign);
+            position += exponentSignLength;
+        }
+        const auto exponentStart = position;
+        while (position < input.size()) {
+            int exponentDigit = 0;
+            std::size_t exponentDigitLength = 0;
+            if (!localizedDigitAt(input, position, locale, exponentDigit, exponentDigitLength)) {
+                break;
+            }
+            canonical.push_back(static_cast<char>('0' + exponentDigit));
+            position += exponentDigitLength;
+        }
+        if (position == exponentStart) {
+            return incomplete(NumericDiagnosticKind::IncompleteExponent, position, position, canonical);
+        }
+    }
+
+    if (position < input.size()) {
+        if (std::isspace(static_cast<unsigned char>(input[position]))) {
+            auto next = position;
+            while (next < input.size() && std::isspace(static_cast<unsigned char>(input[next]))) {
+                ++next;
+            }
+            int nextDigit = 0;
+            std::size_t nextDigitLength = 0;
+            if (next < input.size()
+                && localizedDigitAt(input, next, locale, nextDigit, nextDigitLength)) {
+                return invalid(
+                    NumericDiagnosticKind::UnexpectedSeparator,
+                    position,
+                    position,
+                    next - position
+                );
+            }
+        }
+
+        // Do not silently stop before a visually similar UTF-8 separator followed by another
+        // digit. Only the exact configured grouping separator belongs to this token.
+        UChar32 separatorCodePoint = 0;
+        std::size_t separatorBytes = 0;
+        int nextDigit = 0;
+        std::size_t nextDigitBytes = 0;
+        if (NumericInputPrivate::decodeUtf8(input, position, separatorCodePoint, separatorBytes)
+            && NumericInputPrivate::isSpaceLike(separatorCodePoint)
+            && localizedDigitAt(input, position + separatorBytes, locale, nextDigit, nextDigitBytes)) {
+            return invalid(NumericDiagnosticKind::UnexpectedSeparator, position, position, separatorBytes);
+        }
+
+        std::size_t separatorLength = 0;
+        if (decimalAt(input, position, policy, separatorLength)
+            || groupingAt(input, position, locale, policy, grouped, separatorLength)) {
+            return invalid(NumericDiagnosticKind::UnexpectedSeparator, position, position, separatorLength);
+        }
+    }
+
+    double value = 0.0;
+    switch (parseCanonicalDouble(canonical, value)) {
+        case CanonicalNumberStatus::Invalid:
+            return invalid(NumericDiagnosticKind::InvalidLiteral, 0, position);
+        case CanonicalNumberStatus::OutOfRange:
+            return invalid(NumericDiagnosticKind::OutOfRange, 0, position);
+        case CanonicalNumberStatus::Complete:
+            break;
+    }
+
+    LocalizedNumberResult result;
+    result.status = LocalizedNumberResult::Status::Complete;
+    result.value = value;
+    result.canonicalText = std::move(canonical);
+    result.consumedBytes = position;
+    return result;
+}

--- a/src/Base/NumericInput.cpp
+++ b/src/Base/NumericInput.cpp
@@ -1,0 +1,451 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "NumericInput.h"
+
+#include <charconv>
+#include <cmath>
+#include <cctype>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "NumericFormatting.h"
+#include "NumericInputLocale.h"
+
+namespace
+{
+bool startsAt(std::string_view text, std::size_t position, std::string_view value)
+{
+    return !value.empty() && position + value.size() <= text.size()
+        && text.substr(position, value.size()) == value;
+}
+
+bool boundary(const char ch)
+{
+    return std::isspace(static_cast<unsigned char>(ch)) || ch == '(' || ch == ')' || ch == '['
+        || ch == ']' || ch == '<' || ch == '>' || ch == '+' || ch == '-' || ch == '*' || ch == '/'
+        || ch == '^' || ch == ';';
+}
+
+struct NumericGrammarPolicy
+{
+    std::string_view decimalSeparator;
+    std::string_view groupingSeparator;
+    std::string_view argumentSeparator;
+    bool allowGrouping {true};
+};
+
+NumericGrammarPolicy grammarPolicy(
+    const Base::NumericLocaleContext& locale,
+    const Base::NumericSyntaxContext syntax
+)
+{
+    if (syntax != Base::NumericSyntaxContext::FunctionArgument) {
+        return {locale.decimalSeparator, locale.groupingSeparator, {}, true};
+    }
+
+    // A comma-decimal locale uses a semicolon for function arguments. In all other locales a
+    // comma remains the function separator. Grouping is disabled when its symbol is structural.
+    const std::string_view argumentSeparator = locale.decimalSeparator == ","
+        ? std::string_view {";"}
+        : std::string_view {","};
+    return {
+        locale.decimalSeparator,
+        locale.groupingSeparator,
+        argumentSeparator,
+        locale.groupingSeparator != argumentSeparator
+    };
+}
+
+Base::LocalizedNumberResult invalid(
+    const Base::NumericDiagnosticKind kind,
+    const std::size_t offset,
+    const std::size_t consumed,
+    const std::size_t length = 1
+)
+{
+    Base::LocalizedNumberResult result;
+    result.status = Base::LocalizedNumberResult::Status::Invalid;
+    result.consumedBytes = consumed;
+    result.diagnostic = Base::NumericDiagnostic {kind, offset, length};
+    return result;
+}
+
+Base::LocalizedNumberResult incomplete(
+    const Base::NumericDiagnosticKind kind,
+    const std::size_t offset,
+    const std::size_t consumed,
+    std::string canonical,
+    const std::size_t length = 1
+)
+{
+    Base::LocalizedNumberResult result;
+    result.status = Base::LocalizedNumberResult::Status::Incomplete;
+    result.consumedBytes = consumed;
+    result.canonicalText = std::move(canonical);
+    result.diagnostic = Base::NumericDiagnostic {kind, offset, length};
+    return result;
+}
+
+bool decimalAt(
+    std::string_view input,
+    const std::size_t position,
+    const NumericGrammarPolicy& policy,
+    std::size_t& length
+)
+{
+    length = 0;
+    if (startsAt(input, position, policy.decimalSeparator)) {
+        if (policy.decimalSeparator == policy.argumentSeparator) {
+            return false;
+        }
+        // In comma-decimal function syntax, whitespace after the comma makes it the argument
+        // separator. Adjacent comma digits remain the localized decimal form.
+        if (policy.argumentSeparator == ";" && policy.decimalSeparator == ","
+            && position + policy.decimalSeparator.size() < input.size()
+            && std::isspace(
+                static_cast<unsigned char>(input[position + policy.decimalSeparator.size()])
+            )) {
+            return false;
+        }
+        length = policy.decimalSeparator.size();
+        return true;
+    }
+    if (input[position] == '.' && policy.decimalSeparator != ".") {
+        length = 1;
+        return true;
+    }
+    return input[position] == '.';
+}
+
+bool groupingAt(
+    std::string_view input,
+    const std::size_t position,
+    const Base::NumericLocaleContext& locale,
+    const NumericGrammarPolicy& policy,
+    const bool alreadyGrouped,
+    std::size_t& length
+)
+{
+    length = 0;
+    if (!policy.allowGrouping) {
+        return false;
+    }
+    if (!startsAt(input, position, policy.groupingSeparator)) {
+        return false;
+    }
+
+    // In comma-decimal locales the canonical dot is also commonly the grouping symbol. Keep a
+    // lone dot as canonical decimal syntax unless the rest of the token proves that it is a
+    // localized grouping separator followed by a localized decimal or another group.
+    if (!alreadyGrouped && policy.groupingSeparator == "." && policy.decimalSeparator != ".") {
+        const auto groupStart = position + policy.groupingSeparator.size();
+        std::size_t digitCount = 0;
+        std::size_t digitPosition = groupStart;
+        while (digitPosition < input.size()) {
+            int digit = 0;
+            std::size_t digitLength = 0;
+            if (!Base::localizedDigitAt(input, digitPosition, locale, digit, digitLength)) {
+                break;
+            }
+            ++digitCount;
+            digitPosition += digitLength;
+        }
+        const auto afterGroup = digitPosition;
+        if (digitCount != static_cast<std::size_t>(locale.primaryGroupingSize)
+            || (!startsAt(input, afterGroup, policy.decimalSeparator)
+                && !startsAt(input, afterGroup, policy.groupingSeparator))) {
+            return false;
+        }
+    }
+
+    length = policy.groupingSeparator.size();
+    if (policy.groupingSeparator == " ") {
+        int digit = 0;
+        std::size_t digitLength = 0;
+        if (position + length >= input.size()
+            || !Base::localizedDigitAt(input, position + length, locale, digit, digitLength)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool validGrouping(const std::vector<int>& groups, const Base::NumericLocaleContext& locale)
+{
+    if (groups.size() < 2 || locale.primaryGroupingSize <= 0 || locale.secondaryGroupingSize <= 0) {
+        return false;
+    }
+    if (groups.back() != locale.primaryGroupingSize) {
+        return false;
+    }
+    for (std::size_t i = 1; i + 1 < groups.size(); ++i) {
+        if (groups[i] != locale.secondaryGroupingSize) {
+            return false;
+        }
+    }
+    return groups.front() > 0 && groups.front() <= locale.secondaryGroupingSize;
+}
+
+bool signAt(
+    std::string_view input,
+    const std::size_t position,
+    const Base::NumericLocaleContext& locale,
+    std::size_t& length,
+    char& canonical
+)
+{
+    length = 0;
+    canonical = 0;
+    if (startsAt(input, position, locale.negativeSign)) {
+        length = locale.negativeSign.size();
+        canonical = '-';
+        return true;
+    }
+    if (startsAt(input, position, locale.positiveSign)) {
+        length = locale.positiveSign.size();
+        canonical = '+';
+        return true;
+    }
+    if (input[position] == '-' || input[position] == '+') {
+        length = 1;
+        canonical = input[position];
+        return true;
+    }
+    return false;
+}
+
+}  // namespace
+
+Base::LocalizedNumberResult Base::scanLocalizedNumber(
+    const std::string_view input,
+    const NumericLocaleContext& locale,
+    const NumericSyntaxContext syntax
+)
+{
+    const auto policy = grammarPolicy(locale, syntax);
+    if (input.empty()) {
+        return incomplete(NumericDiagnosticKind::ExpectedDigit, 0, 0, {});
+    }
+
+    std::size_t position = 0;
+    std::string canonical;
+    canonical.reserve(input.size());
+
+    std::size_t signLength = 0;
+    char sign = 0;
+    if (signAt(input, position, locale, signLength, sign)) {
+        // std::from_chars accepts a leading minus but not a leading plus. A positive sign is
+        // still recognized by the scanner; it is simply omitted from the canonical literal.
+        if (sign != '+') {
+            canonical.push_back(sign);
+        }
+        position += signLength;
+        if (position == input.size() || boundary(input[position])) {
+            return incomplete(NumericDiagnosticKind::IncompleteSign, position, position, canonical);
+        }
+    }
+
+    std::vector<int> groups;
+    int digitsInGroup = 0;
+    int totalDigits = 0;
+    bool grouped = false;
+    std::size_t lastGroupingStart = 0;
+    std::size_t lastGroupingLength = 0;
+
+    while (position < input.size()) {
+        int digit = 0;
+        std::size_t digitLength = 0;
+        if (localizedDigitAt(input, position, locale, digit, digitLength)) {
+            canonical.push_back(static_cast<char>('0' + digit));
+            position += digitLength;
+            ++digitsInGroup;
+            ++totalDigits;
+            continue;
+        }
+
+        std::size_t separatorLength = 0;
+        if (groupingAt(input, position, locale, policy, grouped, separatorLength)) {
+            if (digitsInGroup == 0) {
+                return invalid(NumericDiagnosticKind::InvalidGrouping, position, position, separatorLength);
+            }
+            groups.push_back(digitsInGroup);
+            digitsInGroup = 0;
+            grouped = true;
+            lastGroupingStart = position;
+            lastGroupingLength = separatorLength;
+            position += separatorLength;
+            int nextDigit = 0;
+            std::size_t nextDigitLength = 0;
+            if (position == input.size()
+                || !localizedDigitAt(input, position, locale, nextDigit, nextDigitLength)) {
+                return incomplete(
+                    NumericDiagnosticKind::IncompleteGrouping,
+                    position,
+                    position,
+                    canonical,
+                    separatorLength
+                );
+            }
+            continue;
+        }
+        break;
+    }
+
+    if (totalDigits == 0) {
+        std::size_t decimalLength = 0;
+        if (!decimalAt(input, position, policy, decimalLength)) {
+            return invalid(NumericDiagnosticKind::ExpectedDigit, position, position);
+        }
+        canonical.push_back('.');
+        position += decimalLength;
+        int nextDigit = 0;
+        std::size_t nextDigitLength = 0;
+        if (position == input.size()
+            || !localizedDigitAt(input, position, locale, nextDigit, nextDigitLength)) {
+            return incomplete(
+                NumericDiagnosticKind::IncompleteDecimal,
+                position,
+                position,
+                canonical,
+                decimalLength
+            );
+        }
+        while (position < input.size()) {
+            int fractionalDigit = 0;
+            std::size_t fractionalDigitLength = 0;
+            if (!localizedDigitAt(input, position, locale, fractionalDigit, fractionalDigitLength)) {
+                break;
+            }
+            canonical.push_back(static_cast<char>('0' + fractionalDigit));
+            position += fractionalDigitLength;
+            ++totalDigits;
+        }
+    }
+    else {
+        if (grouped) {
+            groups.push_back(digitsInGroup);
+            if (!validGrouping(groups, locale)) {
+                return invalid(
+                    NumericDiagnosticKind::InvalidGrouping,
+                    lastGroupingStart,
+                    position,
+                    lastGroupingLength
+                );
+            }
+        }
+
+        std::size_t decimalLength = 0;
+        if (position < input.size() && decimalAt(input, position, policy, decimalLength)) {
+            canonical.push_back('.');
+            position += decimalLength;
+            int nextDigit = 0;
+            std::size_t nextDigitLength = 0;
+            if (position == input.size()
+                || !localizedDigitAt(input, position, locale, nextDigit, nextDigitLength)) {
+                return incomplete(
+                    NumericDiagnosticKind::IncompleteDecimal,
+                    position,
+                    position,
+                    canonical,
+                    decimalLength
+                );
+            }
+            while (position < input.size()) {
+                int fractionalDigit = 0;
+                std::size_t fractionalDigitLength = 0;
+                if (!localizedDigitAt(input, position, locale, fractionalDigit, fractionalDigitLength)) {
+                    break;
+                }
+                canonical.push_back(static_cast<char>('0' + fractionalDigit));
+                position += fractionalDigitLength;
+            }
+        }
+    }
+
+    if (position < input.size() && (input[position] == 'e' || input[position] == 'E')) {
+        canonical.push_back('e');
+        ++position;
+        std::size_t exponentSignLength = 0;
+        char exponentSign = 0;
+        if (position < input.size()
+            && signAt(input, position, locale, exponentSignLength, exponentSign)) {
+            canonical.push_back(exponentSign);
+            position += exponentSignLength;
+        }
+        const auto exponentStart = position;
+        while (position < input.size()) {
+            int exponentDigit = 0;
+            std::size_t exponentDigitLength = 0;
+            if (!localizedDigitAt(input, position, locale, exponentDigit, exponentDigitLength)) {
+                break;
+            }
+            canonical.push_back(static_cast<char>('0' + exponentDigit));
+            position += exponentDigitLength;
+        }
+        if (position == exponentStart) {
+            return incomplete(NumericDiagnosticKind::IncompleteExponent, position, position, canonical);
+        }
+    }
+
+    if (position < input.size()) {
+        if (std::isspace(static_cast<unsigned char>(input[position]))) {
+            auto next = position;
+            while (next < input.size() && std::isspace(static_cast<unsigned char>(input[next]))) {
+                ++next;
+            }
+            int nextDigit = 0;
+            std::size_t nextDigitLength = 0;
+            if (next < input.size()
+                && localizedDigitAt(input, next, locale, nextDigit, nextDigitLength)) {
+                return invalid(
+                    NumericDiagnosticKind::UnexpectedSeparator,
+                    position,
+                    position,
+                    next - position
+                );
+            }
+        }
+
+        // Do not silently stop before a visually similar UTF-8 separator followed by another
+        // digit. Only the exact configured grouping separator belongs to this token.
+        UChar32 separatorCodePoint = 0;
+        std::size_t separatorBytes = 0;
+        int nextDigit = 0;
+        std::size_t nextDigitBytes = 0;
+        if (NumericInputPrivate::decodeUtf8(input, position, separatorCodePoint, separatorBytes)
+            && NumericInputPrivate::isSpaceLike(separatorCodePoint)
+            && localizedDigitAt(input, position + separatorBytes, locale, nextDigit, nextDigitBytes)) {
+            return invalid(NumericDiagnosticKind::UnexpectedSeparator, position, position, separatorBytes);
+        }
+
+        std::size_t separatorLength = 0;
+        if (decimalAt(input, position, policy, separatorLength)
+            || groupingAt(input, position, locale, policy, grouped, separatorLength)) {
+            return invalid(NumericDiagnosticKind::UnexpectedSeparator, position, position, separatorLength);
+        }
+    }
+
+    double value = 0.0;
+    const auto conversion = std::from_chars(
+        canonical.data(),
+        canonical.data() + canonical.size(),
+        value,
+        std::chars_format::general
+    );
+    if (conversion.ec == std::errc::result_out_of_range) {
+        return invalid(NumericDiagnosticKind::OutOfRange, 0, position);
+    }
+    if (conversion.ec != std::errc {} || conversion.ptr != canonical.data() + canonical.size()
+        || !std::isfinite(value)) {
+        return invalid(NumericDiagnosticKind::InvalidLiteral, 0, position);
+    }
+
+    LocalizedNumberResult result;
+    result.status = LocalizedNumberResult::Status::Complete;
+    result.value = value;
+    result.canonicalText = std::move(canonical);
+    result.consumedBytes = position;
+    return result;
+}

--- a/src/Base/NumericInput.h
+++ b/src/Base/NumericInput.h
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include <FCGlobal.h>
+
+namespace Base
+{
+struct NumericLocaleContext;
+
+/** Syntactic position in which a localized number is being scanned. */
+enum class NumericSyntaxContext
+{
+    /// A complete standalone quantity or number.
+    Standalone,
+    /// A numeric token embedded in an expression.
+    Expression,
+    /// A numeric token where the locale's function separator is structural punctuation.
+    FunctionArgument
+};
+
+/** Effective separators and grouping rule for one numeric syntax context. */
+struct BaseExport NumericGrammarPolicy
+{
+    std::string_view decimalSeparator;
+    std::string_view groupingSeparator;
+    std::string_view argumentSeparator;
+    bool allowGrouping {true};
+};
+
+enum class NumericDiagnosticKind
+{
+    ExpectedDigit,
+    IncompleteSign,
+    IncompleteDecimal,
+    IncompleteGrouping,
+    IncompleteExponent,
+    InvalidGrouping,
+    UnexpectedSeparator,
+    InvalidLiteral,
+    OutOfRange
+};
+
+struct BaseExport NumericDiagnostic
+{
+    NumericDiagnosticKind kind {NumericDiagnosticKind::InvalidLiteral};
+    /// Offset of the diagnostic range in the original UTF-8 input.
+    std::size_t offsetBytes {};
+    /// Length of the diagnostic range in UTF-8 bytes.
+    std::size_t lengthBytes {};
+};
+
+/** Result of scanning one localized numeric token. */
+struct BaseExport LocalizedNumberResult
+{
+    enum class Status
+    {
+        Complete,
+        Incomplete,
+        Invalid
+    };
+
+    Status status {Status::Invalid};
+    /// Parsed value; meaningful only when status is Complete.
+    double value {};
+    /// Locale-independent spelling of a complete token.
+    std::string canonicalText;
+    /// Number of bytes belonging to the token in the original UTF-8 input.
+    std::size_t consumedBytes {};
+    /// Typed error and UTF-8 source range for incomplete or invalid input.
+    std::optional<NumericDiagnostic> diagnostic;
+};
+
+/** Return the separator policy used by the localized number scanner. */
+BaseExport NumericGrammarPolicy
+numericGrammarPolicy(const NumericLocaleContext& locale, NumericSyntaxContext syntax);
+
+/** Return the localized decimal digit at @p position, and its UTF-8 width. */
+BaseExport bool localizedDigitAt(
+    std::string_view input,
+    std::size_t position,
+    const NumericLocaleContext& locale,
+    int& digit,
+    std::size_t& consumedBytes
+);
+
+/**
+ * Scan exactly one localized numeric token without asking ICU to decide token boundaries.
+ *
+ * The caller owns the surrounding grammar and must select the corresponding syntax context.
+ * A complete result may consume only a prefix of @p input; consumedBytes identifies that prefix.
+ */
+BaseExport LocalizedNumberResult scanLocalizedNumber(
+    std::string_view input,
+    const NumericLocaleContext& locale,
+    NumericSyntaxContext syntax
+);
+
+}  // namespace Base

--- a/src/Base/NumericInput.h
+++ b/src/Base/NumericInput.h
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include <FCGlobal.h>
+
+namespace Base
+{
+struct NumericLocaleContext;
+
+enum class NumericSyntaxContext
+{
+    Standalone,
+    Expression,
+    FunctionArgument
+};
+
+enum class NumericDiagnosticKind
+{
+    ExpectedDigit,
+    IncompleteSign,
+    IncompleteDecimal,
+    IncompleteGrouping,
+    IncompleteExponent,
+    InvalidGrouping,
+    UnexpectedSeparator,
+    InvalidLiteral,
+    OutOfRange
+};
+
+struct BaseExport NumericDiagnostic
+{
+    NumericDiagnosticKind kind {NumericDiagnosticKind::InvalidLiteral};
+    std::size_t offset {};
+    std::size_t length {};
+};
+
+struct BaseExport LocalizedNumberResult
+{
+    enum class Status
+    {
+        Complete,
+        Incomplete,
+        Invalid
+    };
+
+    Status status {Status::Invalid};
+    double value {};
+    std::string canonicalText;
+    std::size_t consumedBytes {};
+    std::optional<NumericDiagnostic> diagnostic;
+};
+
+/** Return the localized decimal digit at @p position, and its UTF-8 width. */
+BaseExport bool localizedDigitAt(
+    std::string_view input,
+    std::size_t position,
+    const NumericLocaleContext& locale,
+    int& digit,
+    std::size_t& consumedBytes
+);
+
+/** Scan exactly one localized numeric token without asking ICU to decide token boundaries. */
+BaseExport LocalizedNumberResult scanLocalizedNumber(
+    std::string_view input,
+    const NumericLocaleContext& locale,
+    NumericSyntaxContext syntax
+);
+
+}  // namespace Base

--- a/src/Base/NumericInputLocale.cpp
+++ b/src/Base/NumericInputLocale.cpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "NumericInputLocale.h"
+
+#include <cstdint>
+#include <limits>
+
+#include "NumericFormatting.h"
+#include "NumericInput.h"
+
+namespace Base::NumericInputPrivate
+{
+
+bool decodeUtf8(
+    const std::string_view text,
+    const std::size_t position,
+    UChar32& codePoint,
+    std::size_t& consumedBytes
+)
+{
+    if (position >= text.size() || text.size() > std::numeric_limits<int32_t>::max()
+        || position > static_cast<std::size_t>(std::numeric_limits<int32_t>::max())) {
+        return false;
+    }
+
+    auto index = static_cast<int32_t>(position);
+    const auto* bytes = reinterpret_cast<const uint8_t*>(text.data());
+    U8_NEXT(bytes, index, static_cast<int32_t>(text.size()), codePoint);
+    if (codePoint == U_SENTINEL || index <= static_cast<int32_t>(position)) {
+        return false;
+    }
+
+    consumedBytes = static_cast<std::size_t>(index) - position;
+    return true;
+}
+
+bool isSpaceLike(const UChar32 codePoint)
+{
+    return codePoint == 0x00A0 || codePoint == 0x2007 || codePoint == 0x2009 || codePoint == 0x202F;
+}
+
+}  // namespace Base::NumericInputPrivate
+
+bool Base::localizedDigitAt(
+    const std::string_view input,
+    const std::size_t position,
+    const NumericLocaleContext& locale,
+    int& digit,
+    std::size_t& consumedBytes
+)
+{
+    digit = 0;
+    consumedBytes = 0;
+    if (position >= input.size()) {
+        return false;
+    }
+
+    if (input[position] >= '0' && input[position] <= '9') {
+        digit = input[position] - '0';
+        consumedBytes = 1;
+        return true;
+    }
+
+    UChar32 zeroCodePoint = 0;
+    std::size_t zeroLength = 0;
+    if (locale.zeroDigit.empty()
+        || !NumericInputPrivate::decodeUtf8(locale.zeroDigit, 0, zeroCodePoint, zeroLength)
+        || zeroLength != locale.zeroDigit.size()) {
+        return false;
+    }
+
+    UChar32 codePoint = 0;
+    std::size_t inputLength = 0;
+    if (!NumericInputPrivate::decodeUtf8(input, position, codePoint, inputLength)) {
+        return false;
+    }
+
+    if (codePoint < zeroCodePoint || codePoint > zeroCodePoint + 9) {
+        return false;
+    }
+
+    digit = static_cast<int>(codePoint - zeroCodePoint);
+    consumedBytes = inputLength;
+    return true;
+}

--- a/src/Base/NumericInputLocale.h
+++ b/src/Base/NumericInputLocale.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <cstddef>
+#include <string_view>
+
+#include <unicode/utf8.h>
+
+namespace Base::NumericInputPrivate
+{
+
+bool decodeUtf8(std::string_view text, std::size_t position, UChar32& codePoint, std::size_t& consumedBytes);
+
+bool isSpaceLike(UChar32 codePoint);
+
+}  // namespace Base::NumericInputPrivate

--- a/src/Base/Quantity.cpp
+++ b/src/Base/Quantity.cpp
@@ -32,6 +32,8 @@
 #include <fmt/format.h>
 
 #include "Exception.h"
+#include "NumericFormatting.h"
+#include "NumericInput.h"
 #include "Quantity.h"
 #include "Tools.h"
 #include "UnitsApi.h"
@@ -299,7 +301,7 @@ std::string Quantity::getSafeUserString() const
     if (myValue != 0.0) {
         bool useFallback {false};
         try {
-            useFallback = (parse(userStr).getValue() == 0);
+            useFallback = (parseUserInput(userStr, currentNumericLocaleContext()).getValue() == 0);
         }
         catch (const Base::ParserError&) {
             useFallback = true;
@@ -587,6 +589,7 @@ public:
     {
         // free the scan buffer
         yy_delete_buffer(my_string_buffer);
+        BEGIN(INITIAL);
     }
 
     StringBufferCleaner(const StringBufferCleaner&) = delete;
@@ -605,6 +608,103 @@ private:
 #elif defined(__GNUC__)
 # pragma GCC diagnostic pop
 #endif
+
+namespace
+{
+bool startsAt(std::string_view input, std::size_t position, std::string_view value)
+{
+    return !value.empty() && position + value.size() <= input.size()
+        && input.substr(position, value.size()) == value;
+}
+
+bool startsNumericToken(
+    std::string_view input,
+    const std::size_t position,
+    const Base::NumericLocaleContext& locale
+)
+{
+    if (position >= input.size()) {
+        return false;
+    }
+
+    int digit = 0;
+    std::size_t digitLength = 0;
+    if (Base::localizedDigitAt(input, position, locale, digit, digitLength)) {
+        return true;
+    }
+
+    const auto digitAfter = [&](const std::size_t offset) {
+        int nextDigit = 0;
+        std::size_t nextDigitLength = 0;
+        return Base::localizedDigitAt(input, offset, locale, nextDigit, nextDigitLength);
+    };
+
+    if (input[position] == '.') {
+        return digitAfter(position + 1);
+    }
+    if (startsAt(input, position, locale.decimalSeparator)) {
+        return digitAfter(position + locale.decimalSeparator.size());
+    }
+    const std::string_view positiveSign {locale.positiveSign.data(), locale.positiveSign.size()};
+    const std::string_view negativeSign {locale.negativeSign.data(), locale.negativeSign.size()};
+    for (const auto sign :
+         {std::string_view {"+"}, std::string_view {"-"}, positiveSign, negativeSign}) {
+        if (startsAt(input, position, sign)) {
+            const auto next = position + sign.size();
+            return digitAfter(next) || (next < input.size() && input[next] == '.')
+                || startsAt(input, next, locale.decimalSeparator);
+        }
+    }
+    return false;
+}
+
+std::string normalizeQuantityInput(std::string_view input, const Base::NumericLocaleContext& locale)
+{
+    std::string normalized;
+    normalized.reserve(input.size());
+
+    std::size_t position = 0;
+    while (position < input.size()) {
+        // The quantity lexer treats bracketed comments as opaque. Copy the source bytes without
+        // scanning them, including malformed-looking localized numbers.
+        if (input[position] == '[') {
+            const auto end = input.find(']', position + 1);
+            if (end == std::string_view::npos) {
+                normalized.append(input.substr(position));
+                break;
+            }
+            const auto length = end + 1 - position;
+            normalized.append(input.substr(position, length));
+            position += length;
+            continue;
+        }
+
+        if (!startsNumericToken(input, position, locale)) {
+            normalized.push_back(input[position++]);
+            continue;
+        }
+
+        const auto result = scanLocalizedNumber(
+            input.substr(position),
+            locale,
+            Base::NumericSyntaxContext::Standalone
+        );
+        if (result.status != Base::LocalizedNumberResult::Status::Complete) {
+            throw Base::ParserError("Invalid localized number");
+        }
+
+        normalized += result.canonicalText;
+        position += result.consumedBytes;
+    }
+
+    return normalized;
+}
+}  // namespace
+
+Quantity Quantity::parseUserInput(const std::string& string, const NumericLocaleContext& locale)
+{
+    return Quantity::parse(normalizeQuantityInput(string, locale));
+}
 
 Quantity Quantity::parse(const std::string& string)
 {

--- a/src/Base/Quantity.cpp
+++ b/src/Base/Quantity.cpp
@@ -32,6 +32,8 @@
 #include <fmt/format.h>
 
 #include "Exception.h"
+#include "NumericFormatting.h"
+#include "NumericInput.h"
 #include "Quantity.h"
 #include "Tools.h"
 #include "UnitsApi.h"
@@ -299,7 +301,7 @@ std::string Quantity::getSafeUserString() const
     if (myValue != 0.0) {
         bool useFallback {false};
         try {
-            useFallback = (parse(userStr).getValue() == 0);
+            useFallback = (parseUserInput(userStr, currentNumericLocaleContext()).getValue() == 0);
         }
         catch (const Base::ParserError&) {
             useFallback = true;
@@ -605,6 +607,103 @@ private:
 #elif defined(__GNUC__)
 # pragma GCC diagnostic pop
 #endif
+
+namespace
+{
+bool startsAt(std::string_view input, std::size_t position, std::string_view value)
+{
+    return !value.empty() && position + value.size() <= input.size()
+        && input.substr(position, value.size()) == value;
+}
+
+bool startsNumericToken(
+    std::string_view input,
+    const std::size_t position,
+    const Base::NumericLocaleContext& locale
+)
+{
+    if (position >= input.size()) {
+        return false;
+    }
+
+    int digit = 0;
+    std::size_t digitLength = 0;
+    if (Base::localizedDigitAt(input, position, locale, digit, digitLength)) {
+        return true;
+    }
+
+    const auto digitAfter = [&](const std::size_t offset) {
+        int nextDigit = 0;
+        std::size_t nextDigitLength = 0;
+        return Base::localizedDigitAt(input, offset, locale, nextDigit, nextDigitLength);
+    };
+
+    if (input[position] == '.') {
+        return digitAfter(position + 1);
+    }
+    if (startsAt(input, position, locale.decimalSeparator)) {
+        return digitAfter(position + locale.decimalSeparator.size());
+    }
+    const std::string_view positiveSign {locale.positiveSign.data(), locale.positiveSign.size()};
+    const std::string_view negativeSign {locale.negativeSign.data(), locale.negativeSign.size()};
+    for (const auto sign :
+         {std::string_view {"+"}, std::string_view {"-"}, positiveSign, negativeSign}) {
+        if (startsAt(input, position, sign)) {
+            const auto next = position + sign.size();
+            return digitAfter(next) || (next < input.size() && input[next] == '.')
+                || startsAt(input, next, locale.decimalSeparator);
+        }
+    }
+    return false;
+}
+
+std::string normalizeQuantityInput(std::string_view input, const Base::NumericLocaleContext& locale)
+{
+    std::string normalized;
+    normalized.reserve(input.size());
+
+    std::size_t position = 0;
+    while (position < input.size()) {
+        // The quantity lexer treats bracketed comments as opaque. Copy the source bytes without
+        // scanning them, including malformed-looking localized numbers.
+        if (input[position] == '[') {
+            const auto end = input.find(']', position + 1);
+            if (end == std::string_view::npos) {
+                normalized.append(input.substr(position));
+                break;
+            }
+            const auto length = end + 1 - position;
+            normalized.append(input.substr(position, length));
+            position += length;
+            continue;
+        }
+
+        if (!startsNumericToken(input, position, locale)) {
+            normalized.push_back(input[position++]);
+            continue;
+        }
+
+        const auto result = scanLocalizedNumber(
+            input.substr(position),
+            locale,
+            Base::NumericSyntaxContext::Standalone
+        );
+        if (result.status != Base::LocalizedNumberResult::Status::Complete) {
+            throw Base::ParserError("Invalid localized number");
+        }
+
+        normalized += result.canonicalText;
+        position += result.consumedBytes;
+    }
+
+    return normalized;
+}
+}  // namespace
+
+Quantity Quantity::parseUserInput(const std::string& string, const NumericLocaleContext& locale)
+{
+    return Quantity::parse(normalizeQuantityInput(string, locale));
+}
 
 Quantity Quantity::parse(const std::string& string)
 {

--- a/src/Base/Quantity.h
+++ b/src/Base/Quantity.h
@@ -31,6 +31,7 @@
 
 namespace Base
 {
+struct NumericLocaleContext;
 class UnitsSchema;
 
 struct BaseExport QuantityFormat
@@ -163,6 +164,8 @@ public:
     std::string getSafeUserString() const;
 
     static Quantity parse(const std::string& string);
+    /** Parse quantity text using the supplied numeric-locale context. */
+    static Quantity parseUserInput(const std::string& string, const NumericLocaleContext& locale);
 
     /// returns the unit of the quantity
     const Unit& getUnit() const

--- a/src/Base/Quantity.l
+++ b/src/Base/Quantity.l
@@ -53,6 +53,7 @@ CGRP     '\,'[0-9][0-9][0-9]
 "\["            { BEGIN(C_COMMENT); }
 <C_COMMENT>"\]" { BEGIN(INITIAL); }
 <C_COMMENT>.    { ;}
+<C_COMMENT><<EOF>> { Quantity_yyerror("Unterminated quantity comment"); }
 
 
 [ \t]   ;

--- a/src/Base/Quantity.lex.c
+++ b/src/Base/Quantity.lex.c
@@ -943,6 +943,9 @@ case 3:
 YY_RULE_SETUP
 { ;}
 	YY_BREAK
+case YY_STATE_EOF(C_COMMENT):
+{ Quantity_yyerror("Unterminated quantity comment"); }
+	YY_BREAK
 case 4:
 YY_RULE_SETUP
 ;
@@ -1589,7 +1592,6 @@ YY_RULE_SETUP
 ECHO;
 	YY_BREAK
 case YY_STATE_EOF(INITIAL):
-case YY_STATE_EOF(C_COMMENT):
 	yyterminate();
 
 	case YY_END_OF_BUFFER:

--- a/src/Base/Quantity.tab.c
+++ b/src/Base/Quantity.tab.c
@@ -70,11 +70,13 @@
 
 
 /* First part of user prologue.  */
+#line 26 "Quantity.y"
 
     #define YYSTYPE Quantity
     #define yyparse Quantity_yyparse
     #define yyerror Quantity_yyerror
 
+#line 77 "Quantity.tab.c"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -135,7 +137,8 @@ extern int yydebug;
     TAN = 275,                     /* TAN  */
     TANH = 276,                    /* TANH  */
     SQRT = 277,                    /* SQRT  */
-    NEG = 278                      /* NEG  */
+    POS = 278,                     /* POS  */
+    NEG = 279                      /* NEG  */
   };
   typedef enum yytokentype yytoken_kind_t;
 #endif
@@ -185,15 +188,16 @@ enum yysymbol_kind_t
   YYSYMBOL_23_ = 23,                       /* '+'  */
   YYSYMBOL_24_ = 24,                       /* '*'  */
   YYSYMBOL_25_ = 25,                       /* '/'  */
-  YYSYMBOL_NEG = 26,                       /* NEG  */
-  YYSYMBOL_27_ = 27,                       /* '^'  */
-  YYSYMBOL_28_ = 28,                       /* '('  */
-  YYSYMBOL_29_ = 29,                       /* ')'  */
-  YYSYMBOL_YYACCEPT = 30,                  /* $accept  */
-  YYSYMBOL_input = 31,                     /* input  */
-  YYSYMBOL_num = 32,                       /* num  */
-  YYSYMBOL_unit = 33,                      /* unit  */
-  YYSYMBOL_quantity = 34                   /* quantity  */
+  YYSYMBOL_POS = 26,                       /* POS  */
+  YYSYMBOL_NEG = 27,                       /* NEG  */
+  YYSYMBOL_28_ = 28,                       /* '^'  */
+  YYSYMBOL_29_ = 29,                       /* '('  */
+  YYSYMBOL_30_ = 30,                       /* ')'  */
+  YYSYMBOL_YYACCEPT = 31,                  /* $accept  */
+  YYSYMBOL_input = 32,                     /* input  */
+  YYSYMBOL_num = 33,                       /* num  */
+  YYSYMBOL_unit = 34,                      /* unit  */
+  YYSYMBOL_quantity = 35                   /* quantity  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
@@ -519,21 +523,21 @@ union yyalloc
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL  42
+#define YYFINAL  44
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   236
+#define YYLAST   269
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  30
+#define YYNTOKENS  31
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  5
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  37
+#define YYNRULES  38
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  96
+#define YYNSTATES  98
 
 /* YYMAXUTOK -- Last valid token kind.  */
-#define YYMAXUTOK   278
+#define YYMAXUTOK   279
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
@@ -551,12 +555,12 @@ static const yytype_int8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-      28,    29,    24,    23,     2,     2,     2,    25,     2,     2,
+      29,    30,    24,    23,     2,     2,     2,    25,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,    27,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,    28,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -574,17 +578,17 @@ static const yytype_int8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
        5,     6,     7,     8,     9,    10,    11,    12,    13,    14,
-      15,    16,    17,    18,    19,    20,    21,    22,    26
+      15,    16,    17,    18,    19,    20,    21,    22,    26,    27
 };
 
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int8 yyrline[] =
 {
-       0,    45,    45,    46,    47,    48,    49,    50,    52,    53,
-      54,    55,    56,    57,    58,    59,    60,    61,    62,    63,
-      64,    65,    66,    67,    68,    69,    70,    71,    72,    73,
-      76,    77,    78,    79,    80,    81,    83,    84
+       0,    46,    46,    47,    48,    49,    50,    51,    53,    54,
+      55,    56,    57,    58,    59,    60,    61,    62,    63,    64,
+      65,    66,    67,    68,    69,    70,    71,    72,    73,    74,
+      75,    78,    79,    80,    81,    82,    83,    85,    86
 };
 #endif
 
@@ -603,8 +607,8 @@ static const char *const yytname[] =
   "\"end of file\"", "error", "\"invalid token\"", "UNIT", "ONE", "NUM",
   "MINUSSIGN", "ACOS", "ASIN", "ATAN", "ATAN2", "COS", "EXP", "ABS", "MOD",
   "LOG", "LOG10", "POW", "SIN", "SINH", "TAN", "TANH", "SQRT", "'+'",
-  "'*'", "'/'", "NEG", "'^'", "'('", "')'", "$accept", "input", "num",
-  "unit", "quantity", YY_NULLPTR
+  "'*'", "'/'", "POS", "NEG", "'^'", "'('", "')'", "$accept", "input",
+  "num", "unit", "quantity", YY_NULLPTR
 };
 
 static const char *
@@ -614,7 +618,7 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#define YYPACT_NINF (-26)
+#define YYPACT_NINF (-27)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
@@ -628,16 +632,16 @@ yysymbol_name (yysymbol_kind_t yysymbol)
    STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-      72,   -26,   -26,   -26,   117,   -25,   -23,   -10,    -7,    -5,
-      -4,    -3,    21,    22,    23,    24,    26,    28,    72,    58,
-      92,   -12,   117,    -2,   -26,   117,    35,   117,   117,   117,
-     117,   117,   117,   117,   117,   117,   117,   117,   117,   117,
-      36,   -18,   -26,    39,   117,   117,   117,    72,   117,    -2,
-     -12,    -2,    -2,   117,    92,   117,    41,   117,    80,   125,
-     134,   141,   149,   156,   163,   171,   178,   185,   193,   200,
-     207,   -26,   -26,    -8,    -8,    35,    35,   -12,    35,    41,
-      41,   -13,   -26,   -26,   -26,   -26,   -26,   -26,   -26,   -26,
-     -26,   -26,   -26,   -26,   -26,   -26
+      74,   -27,   -27,   -27,   121,   -26,   -22,   -14,   -10,    -5,
+      16,    22,    23,    24,    25,    27,    29,    34,   121,    74,
+      10,    95,   -12,   121,    -2,   -27,   121,   -11,   121,   121,
+     121,   121,   121,   121,   121,   121,   121,   121,   121,   121,
+     121,   -11,    37,   -19,   -27,     1,   121,   121,   121,    74,
+     121,    -2,   -12,    -2,    -2,   121,    95,   121,    36,   121,
+      82,   129,   139,   149,   159,   169,   179,   189,   199,   209,
+     219,   229,   239,   -27,   -27,    -3,    -3,   -11,   -11,   -12,
+     -11,    36,    36,   -11,   -27,   -27,   -27,   -27,   -27,   -27,
+     -27,   -27,   -27,   -27,   -27,   -27,   -27,   -27
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -645,28 +649,28 @@ static const yytype_int16 yypact[] =
    means the default is an error.  */
 static const yytype_int8 yydefact[] =
 {
-       2,    30,     9,     8,     0,     0,     0,     0,     0,     0,
+       2,    31,     9,     8,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       3,     4,     5,     0,     9,     0,    14,     0,     0,     0,
+       0,     3,     4,     5,     0,     9,     0,    15,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     1,     0,     0,     0,     0,     0,     0,     0,
-      36,     0,     0,     0,     0,     6,    31,     0,     0,     0,
+       0,    14,     0,     0,     1,     0,     0,     0,     0,     0,
+       0,     0,    37,     0,     0,     0,     0,     6,    32,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,    16,    35,    11,    10,    12,    13,    37,    15,    32,
-      33,    34,     7,    17,    18,    19,    29,    21,    20,    22,
-      23,    24,    25,    26,    27,    28
+       0,     0,     0,    17,    36,    11,    10,    12,    13,    38,
+      16,    33,    34,    35,     7,    18,    19,    20,    30,    22,
+      21,    23,    24,    25,    26,    27,    28,    29
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-     -26,   -26,     0,    20,   -14
+     -27,   -27,     0,    20,   -15
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-       0,    19,    40,    41,    22
+       0,    20,    42,    43,    23
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -674,58 +678,64 @@ static const yytype_int8 yydefgoto[] =
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int8 yytable[] =
 {
-      20,     1,    43,    27,    26,    28,    51,    52,    55,    53,
-      45,    72,    51,    52,    48,    53,    46,    57,    29,    48,
-      21,    30,    54,    31,    32,    33,    49,    58,    59,    60,
-      61,    62,    63,    64,    65,    66,    67,    68,    69,    70,
-      50,    82,    44,    56,    73,    74,    75,    76,    78,    34,
-      35,    36,    37,    81,    38,    54,    39,    76,    42,    45,
-      46,    57,    48,    48,    23,    71,     0,    77,    53,     0,
-       0,    79,    80,     0,    50,     1,     2,     3,     4,     5,
-       6,     7,     0,     8,     9,    10,    44,    11,    12,     0,
-      13,    14,    15,    16,    17,     1,    43,     0,    44,     0,
-      18,     0,     0,    45,    46,    57,     0,    48,     0,    83,
-       0,     0,     0,     0,     0,    45,    46,    47,     0,    48,
-      49,    24,     3,     4,     5,     6,     7,     0,     8,     9,
-      10,    44,    11,    12,     0,    13,    14,    15,    16,    17,
-      44,     0,     0,     0,     0,    25,     0,    44,    45,    46,
-      57,     0,    48,     0,    84,    44,     0,    45,    46,    57,
-       0,    48,    44,    85,    45,    46,    57,     0,    48,    44,
-      86,     0,    45,    46,    57,     0,    48,    44,    87,    45,
-      46,    57,     0,    48,    44,    88,    45,    46,    57,     0,
-      48,    44,    89,     0,    45,    46,    57,     0,    48,    44,
-      90,    45,    46,    57,     0,    48,    44,    91,    45,    46,
-      57,     0,    48,    44,    92,     0,    45,    46,    57,     0,
-      48,     0,    93,    45,    46,    57,     0,    48,     0,    94,
-      45,    46,    57,     0,    48,     0,    95
+      21,     1,    45,    28,    27,    53,    54,    29,    57,    55,
+      44,    74,    53,    54,     0,    30,    55,    50,    41,    31,
+      22,    48,    59,    56,    32,    50,    24,    51,    60,    61,
+      62,    63,    64,    65,    66,    67,    68,    69,    70,    71,
+      72,    52,    84,    46,    58,    33,    75,    76,    77,    78,
+      80,    34,    35,    36,    37,    83,    38,    56,    39,    78,
+      47,    48,    59,    40,    55,    50,     0,    73,     0,    79,
+       0,     0,     0,    81,    82,     0,    52,     1,     2,     3,
+       4,     5,     6,     7,     0,     8,     9,    10,    46,    11,
+      12,     0,    13,    14,    15,    16,    17,    18,     1,    45,
+       0,    46,     0,    19,     0,    47,    48,    59,     0,     0,
+      50,     0,    85,     0,     0,     0,     0,     0,    47,    48,
+      49,     0,     0,    50,    51,    25,     3,     4,     5,     6,
+       7,     0,     8,     9,    10,    46,    11,    12,     0,    13,
+      14,    15,    16,    17,    18,    46,     0,     0,     0,     0,
+      26,     0,    47,    48,    59,    46,     0,    50,     0,    86,
+       0,     0,    47,    48,    59,    46,     0,    50,     0,    87,
+       0,     0,    47,    48,    59,    46,     0,    50,     0,    88,
+       0,     0,    47,    48,    59,    46,     0,    50,     0,    89,
+       0,     0,    47,    48,    59,    46,     0,    50,     0,    90,
+       0,     0,    47,    48,    59,    46,     0,    50,     0,    91,
+       0,     0,    47,    48,    59,    46,     0,    50,     0,    92,
+       0,     0,    47,    48,    59,    46,     0,    50,     0,    93,
+       0,     0,    47,    48,    59,    46,     0,    50,     0,    94,
+       0,     0,    47,    48,    59,    46,     0,    50,     0,    95,
+       0,     0,    47,    48,    59,     0,     0,    50,     0,    96,
+       0,     0,    47,    48,    59,     0,     0,    50,     0,    97
 };
 
 static const yytype_int8 yycheck[] =
 {
-       0,     3,     4,    28,     4,    28,    24,    25,    22,    27,
-      23,    29,    24,    25,    27,    27,    24,    25,    28,    27,
-       0,    28,    22,    28,    28,    28,    28,    27,    28,    29,
+       0,     3,     4,    29,     4,    24,    25,    29,    23,    28,
+       0,    30,    24,    25,    -1,    29,    28,    28,    18,    29,
+       0,    24,    25,    23,    29,    28,    25,    29,    28,    29,
       30,    31,    32,    33,    34,    35,    36,    37,    38,    39,
-      20,    55,     6,    23,    44,    45,    46,    47,    48,    28,
-      28,    28,    28,    53,    28,    55,    28,    57,     0,    23,
-      24,    25,    27,    27,    25,    29,    -1,    47,    27,    -1,
-      -1,    51,    52,    -1,    54,     3,     4,     5,     6,     7,
-       8,     9,    -1,    11,    12,    13,     6,    15,    16,    -1,
-      18,    19,    20,    21,    22,     3,     4,    -1,     6,    -1,
-      28,    -1,    -1,    23,    24,    25,    -1,    27,    -1,    29,
-      -1,    -1,    -1,    -1,    -1,    23,    24,    25,    -1,    27,
-      28,     4,     5,     6,     7,     8,     9,    -1,    11,    12,
-      13,     6,    15,    16,    -1,    18,    19,    20,    21,    22,
-       6,    -1,    -1,    -1,    -1,    28,    -1,     6,    23,    24,
-      25,    -1,    27,    -1,    29,     6,    -1,    23,    24,    25,
-      -1,    27,     6,    29,    23,    24,    25,    -1,    27,     6,
-      29,    -1,    23,    24,    25,    -1,    27,     6,    29,    23,
-      24,    25,    -1,    27,     6,    29,    23,    24,    25,    -1,
-      27,     6,    29,    -1,    23,    24,    25,    -1,    27,     6,
-      29,    23,    24,    25,    -1,    27,     6,    29,    23,    24,
-      25,    -1,    27,     6,    29,    -1,    23,    24,    25,    -1,
-      27,    -1,    29,    23,    24,    25,    -1,    27,    -1,    29,
-      23,    24,    25,    -1,    27,    -1,    29
+      40,    21,    57,     6,    24,    29,    46,    47,    48,    49,
+      50,    29,    29,    29,    29,    55,    29,    57,    29,    59,
+      23,    24,    25,    29,    28,    28,    -1,    30,    -1,    49,
+      -1,    -1,    -1,    53,    54,    -1,    56,     3,     4,     5,
+       6,     7,     8,     9,    -1,    11,    12,    13,     6,    15,
+      16,    -1,    18,    19,    20,    21,    22,    23,     3,     4,
+      -1,     6,    -1,    29,    -1,    23,    24,    25,    -1,    -1,
+      28,    -1,    30,    -1,    -1,    -1,    -1,    -1,    23,    24,
+      25,    -1,    -1,    28,    29,     4,     5,     6,     7,     8,
+       9,    -1,    11,    12,    13,     6,    15,    16,    -1,    18,
+      19,    20,    21,    22,    23,     6,    -1,    -1,    -1,    -1,
+      29,    -1,    23,    24,    25,     6,    -1,    28,    -1,    30,
+      -1,    -1,    23,    24,    25,     6,    -1,    28,    -1,    30,
+      -1,    -1,    23,    24,    25,     6,    -1,    28,    -1,    30,
+      -1,    -1,    23,    24,    25,     6,    -1,    28,    -1,    30,
+      -1,    -1,    23,    24,    25,     6,    -1,    28,    -1,    30,
+      -1,    -1,    23,    24,    25,     6,    -1,    28,    -1,    30,
+      -1,    -1,    23,    24,    25,     6,    -1,    28,    -1,    30,
+      -1,    -1,    23,    24,    25,     6,    -1,    28,    -1,    30,
+      -1,    -1,    23,    24,    25,     6,    -1,    28,    -1,    30,
+      -1,    -1,    23,    24,    25,     6,    -1,    28,    -1,    30,
+      -1,    -1,    23,    24,    25,    -1,    -1,    28,    -1,    30,
+      -1,    -1,    23,    24,    25,    -1,    -1,    28,    -1,    30
 };
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
@@ -733,33 +743,33 @@ static const yytype_int8 yycheck[] =
 static const yytype_int8 yystos[] =
 {
        0,     3,     4,     5,     6,     7,     8,     9,    11,    12,
-      13,    15,    16,    18,    19,    20,    21,    22,    28,    31,
-      32,    33,    34,    25,     4,    28,    32,    28,    28,    28,
-      28,    28,    28,    28,    28,    28,    28,    28,    28,    28,
-      32,    33,     0,     4,     6,    23,    24,    25,    27,    28,
-      33,    24,    25,    27,    32,    34,    33,    25,    32,    32,
-      32,    32,    32,    32,    32,    32,    32,    32,    32,    32,
-      32,    29,    29,    32,    32,    32,    32,    33,    32,    33,
-      33,    32,    34,    29,    29,    29,    29,    29,    29,    29,
-      29,    29,    29,    29,    29,    29
+      13,    15,    16,    18,    19,    20,    21,    22,    23,    29,
+      32,    33,    34,    35,    25,     4,    29,    33,    29,    29,
+      29,    29,    29,    29,    29,    29,    29,    29,    29,    29,
+      29,    33,    33,    34,     0,     4,     6,    23,    24,    25,
+      28,    29,    34,    24,    25,    28,    33,    35,    34,    25,
+      33,    33,    33,    33,    33,    33,    33,    33,    33,    33,
+      33,    33,    33,    30,    30,    33,    33,    33,    33,    34,
+      33,    34,    34,    33,    35,    30,    30,    30,    30,    30,
+      30,    30,    30,    30,    30,    30,    30,    30
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr1[] =
 {
-       0,    30,    31,    31,    31,    31,    31,    31,    32,    32,
-      32,    32,    32,    32,    32,    32,    32,    32,    32,    32,
-      32,    32,    32,    32,    32,    32,    32,    32,    32,    32,
-      33,    33,    33,    33,    33,    33,    34,    34
+       0,    31,    32,    32,    32,    32,    32,    32,    33,    33,
+      33,    33,    33,    33,    33,    33,    33,    33,    33,    33,
+      33,    33,    33,    33,    33,    33,    33,    33,    33,    33,
+      33,    34,    34,    34,    34,    34,    34,    35,    35
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr2[] =
 {
        0,     2,     0,     1,     1,     1,     2,     3,     1,     1,
-       3,     3,     3,     3,     2,     3,     3,     4,     4,     4,
+       3,     3,     3,     3,     2,     2,     3,     3,     4,     4,
        4,     4,     4,     4,     4,     4,     4,     4,     4,     4,
-       1,     3,     3,     3,     3,     3,     2,     3
+       4,     1,     3,     3,     3,     3,     3,     2,     3
 };
 
 
@@ -1223,150 +1233,229 @@ yyreduce:
   switch (yyn)
     {
   case 2: /* input: %empty  */
+#line 46 "Quantity.y"
                                                 { QuantResult = Quantity(std::numeric_limits<double>::min()); /* empty input */ }
+#line 1236 "Quantity.tab.c"
     break;
 
   case 3: /* input: num  */
+#line 47 "Quantity.y"
                                                 { QuantResult = yyvsp[0];             }
+#line 1242 "Quantity.tab.c"
     break;
 
   case 4: /* input: unit  */
+#line 48 "Quantity.y"
                                                 { QuantResult = yyvsp[0];             }
+#line 1248 "Quantity.tab.c"
     break;
 
   case 5: /* input: quantity  */
+#line 49 "Quantity.y"
                                                 { QuantResult = yyvsp[0];             }
+#line 1254 "Quantity.tab.c"
     break;
 
   case 6: /* input: quantity quantity  */
+#line 50 "Quantity.y"
                                                 { QuantResult = yyvsp[-1] + yyvsp[0];        }
+#line 1260 "Quantity.tab.c"
     break;
 
   case 7: /* input: quantity quantity quantity  */
+#line 51 "Quantity.y"
                                                 { QuantResult = yyvsp[-2] + yyvsp[-1] + yyvsp[0];	}
+#line 1266 "Quantity.tab.c"
     break;
 
   case 8: /* num: NUM  */
+#line 53 "Quantity.y"
                                                 { yyval = yyvsp[0]; }
+#line 1272 "Quantity.tab.c"
     break;
 
   case 9: /* num: ONE  */
+#line 54 "Quantity.y"
                                                 { yyval = yyvsp[0]; }
+#line 1278 "Quantity.tab.c"
     break;
 
   case 10: /* num: num '+' num  */
+#line 55 "Quantity.y"
                                                 { yyval = Quantity(yyvsp[-2].getValue() + yyvsp[0].getValue());     }
+#line 1284 "Quantity.tab.c"
     break;
 
   case 11: /* num: num MINUSSIGN num  */
+#line 56 "Quantity.y"
                                                 { yyval = Quantity(yyvsp[-2].getValue() - yyvsp[0].getValue());     }
+#line 1290 "Quantity.tab.c"
     break;
 
   case 12: /* num: num '*' num  */
+#line 57 "Quantity.y"
                                                 { yyval = Quantity(yyvsp[-2].getValue() * yyvsp[0].getValue());     }
+#line 1296 "Quantity.tab.c"
     break;
 
   case 13: /* num: num '/' num  */
+#line 58 "Quantity.y"
                                                 { yyval = Quantity(yyvsp[-2].getValue() / yyvsp[0].getValue());     }
+#line 1302 "Quantity.tab.c"
     break;
 
-  case 14: /* num: MINUSSIGN num  */
+  case 14: /* num: '+' num  */
+#line 59 "Quantity.y"
+                                                { yyval = Quantity(yyvsp[0].getValue());                     }
+#line 1308 "Quantity.tab.c"
+    break;
+
+  case 15: /* num: MINUSSIGN num  */
+#line 60 "Quantity.y"
                                                 { yyval = Quantity(-yyvsp[0].getValue());                    }
+#line 1314 "Quantity.tab.c"
     break;
 
-  case 15: /* num: num '^' num  */
+  case 16: /* num: num '^' num  */
+#line 61 "Quantity.y"
                                                 { yyval = Quantity(pow(yyvsp[-2].getValue(), yyvsp[0].getValue())); }
+#line 1320 "Quantity.tab.c"
     break;
 
-  case 16: /* num: '(' num ')'  */
+  case 17: /* num: '(' num ')'  */
+#line 62 "Quantity.y"
                                                 { yyval = yyvsp[-1]; }
+#line 1326 "Quantity.tab.c"
     break;
 
-  case 17: /* num: ACOS '(' num ')'  */
+  case 18: /* num: ACOS '(' num ')'  */
+#line 63 "Quantity.y"
                                                 { yyval = Quantity(acos(yyvsp[-1].getValue()));   }
+#line 1332 "Quantity.tab.c"
     break;
 
-  case 18: /* num: ASIN '(' num ')'  */
+  case 19: /* num: ASIN '(' num ')'  */
+#line 64 "Quantity.y"
                                                 { yyval = Quantity(asin(yyvsp[-1].getValue()));   }
+#line 1338 "Quantity.tab.c"
     break;
 
-  case 19: /* num: ATAN '(' num ')'  */
+  case 20: /* num: ATAN '(' num ')'  */
+#line 65 "Quantity.y"
                                                 { yyval = Quantity(atan(yyvsp[-1].getValue()));   }
+#line 1344 "Quantity.tab.c"
     break;
 
-  case 20: /* num: ABS '(' num ')'  */
+  case 21: /* num: ABS '(' num ')'  */
+#line 66 "Quantity.y"
                                                 { yyval = Quantity(fabs(yyvsp[-1].getValue()));   }
+#line 1350 "Quantity.tab.c"
     break;
 
-  case 21: /* num: EXP '(' num ')'  */
+  case 22: /* num: EXP '(' num ')'  */
+#line 67 "Quantity.y"
                                                 { yyval = Quantity(exp(yyvsp[-1].getValue()));    }
+#line 1356 "Quantity.tab.c"
     break;
 
-  case 22: /* num: LOG '(' num ')'  */
+  case 23: /* num: LOG '(' num ')'  */
+#line 68 "Quantity.y"
                                                 { yyval = Quantity(log(yyvsp[-1].getValue()));    }
+#line 1362 "Quantity.tab.c"
     break;
 
-  case 23: /* num: LOG10 '(' num ')'  */
+  case 24: /* num: LOG10 '(' num ')'  */
+#line 69 "Quantity.y"
                                                 { yyval = Quantity(log10(yyvsp[-1].getValue()));  }
+#line 1368 "Quantity.tab.c"
     break;
 
-  case 24: /* num: SIN '(' num ')'  */
+  case 25: /* num: SIN '(' num ')'  */
+#line 70 "Quantity.y"
                                                 { yyval = Quantity(sin(yyvsp[-1].getValue()));    }
+#line 1374 "Quantity.tab.c"
     break;
 
-  case 25: /* num: SINH '(' num ')'  */
+  case 26: /* num: SINH '(' num ')'  */
+#line 71 "Quantity.y"
                                                 { yyval = Quantity(sinh(yyvsp[-1].getValue()));   }
+#line 1380 "Quantity.tab.c"
     break;
 
-  case 26: /* num: TAN '(' num ')'  */
+  case 27: /* num: TAN '(' num ')'  */
+#line 72 "Quantity.y"
                                                 { yyval = Quantity(tan(yyvsp[-1].getValue()));    }
+#line 1386 "Quantity.tab.c"
     break;
 
-  case 27: /* num: TANH '(' num ')'  */
+  case 28: /* num: TANH '(' num ')'  */
+#line 73 "Quantity.y"
                                                 { yyval = Quantity(tanh(yyvsp[-1].getValue()));   }
+#line 1392 "Quantity.tab.c"
     break;
 
-  case 28: /* num: SQRT '(' num ')'  */
+  case 29: /* num: SQRT '(' num ')'  */
+#line 74 "Quantity.y"
                                                 { yyval = Quantity(sqrt(yyvsp[-1].getValue()));   }
+#line 1398 "Quantity.tab.c"
     break;
 
-  case 29: /* num: COS '(' num ')'  */
+  case 30: /* num: COS '(' num ')'  */
+#line 75 "Quantity.y"
                                                 { yyval = Quantity(cos(yyvsp[-1].getValue()));    }
+#line 1404 "Quantity.tab.c"
     break;
 
-  case 30: /* unit: UNIT  */
+  case 31: /* unit: UNIT  */
+#line 78 "Quantity.y"
                                                 { yyval = yyvsp[0];                  }
+#line 1410 "Quantity.tab.c"
     break;
 
-  case 31: /* unit: ONE '/' unit  */
+  case 32: /* unit: ONE '/' unit  */
+#line 79 "Quantity.y"
                                                 { yyval = Quantity(1.0)/yyvsp[0];    }
+#line 1416 "Quantity.tab.c"
     break;
 
-  case 32: /* unit: unit '*' unit  */
+  case 33: /* unit: unit '*' unit  */
+#line 80 "Quantity.y"
                                                 { yyval = yyvsp[-2] * yyvsp[0];             }
+#line 1422 "Quantity.tab.c"
     break;
 
-  case 33: /* unit: unit '/' unit  */
+  case 34: /* unit: unit '/' unit  */
+#line 81 "Quantity.y"
                                                 { yyval = yyvsp[-2] / yyvsp[0];             }
+#line 1428 "Quantity.tab.c"
     break;
 
-  case 34: /* unit: unit '^' num  */
+  case 35: /* unit: unit '^' num  */
+#line 82 "Quantity.y"
                                                 { yyval = yyvsp[-2].pow (yyvsp[0]);         }
+#line 1434 "Quantity.tab.c"
     break;
 
-  case 35: /* unit: '(' unit ')'  */
+  case 36: /* unit: '(' unit ')'  */
+#line 83 "Quantity.y"
                                                 { yyval = yyvsp[-1];                  }
+#line 1440 "Quantity.tab.c"
     break;
 
-  case 36: /* quantity: num unit  */
+  case 37: /* quantity: num unit  */
+#line 85 "Quantity.y"
                                                 { yyval = yyvsp[-1]*yyvsp[0];               }
+#line 1446 "Quantity.tab.c"
     break;
 
-  case 37: /* quantity: num '/' unit  */
+  case 38: /* quantity: num '/' unit  */
+#line 86 "Quantity.y"
                                                 { yyval = Quantity(yyvsp[-2])/yyvsp[0];     }
+#line 1452 "Quantity.tab.c"
     break;
 
 
+#line 1456 "Quantity.tab.c"
 
       default: break;
     }
@@ -1558,3 +1647,5 @@ yyreturnlab:
 
   return yyresult;
 }
+
+#line 89 "Quantity.y"

--- a/src/Base/Quantity.tab.c
+++ b/src/Base/Quantity.tab.c
@@ -70,11 +70,13 @@
 
 
 /* First part of user prologue.  */
+#line 26 "Quantity.y"
 
     #define YYSTYPE Quantity
     #define yyparse Quantity_yyparse
     #define yyerror Quantity_yyerror
 
+#line 77 "Quantity.tab.c"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -1231,154 +1233,229 @@ yyreduce:
   switch (yyn)
     {
   case 2: /* input: %empty  */
+#line 46 "Quantity.y"
                                                 { QuantResult = Quantity(std::numeric_limits<double>::min()); /* empty input */ }
+#line 1236 "Quantity.tab.c"
     break;
 
   case 3: /* input: num  */
+#line 47 "Quantity.y"
                                                 { QuantResult = yyvsp[0];             }
+#line 1242 "Quantity.tab.c"
     break;
 
   case 4: /* input: unit  */
+#line 48 "Quantity.y"
                                                 { QuantResult = yyvsp[0];             }
+#line 1248 "Quantity.tab.c"
     break;
 
   case 5: /* input: quantity  */
+#line 49 "Quantity.y"
                                                 { QuantResult = yyvsp[0];             }
+#line 1254 "Quantity.tab.c"
     break;
 
   case 6: /* input: quantity quantity  */
+#line 50 "Quantity.y"
                                                 { QuantResult = yyvsp[-1] + yyvsp[0];        }
+#line 1260 "Quantity.tab.c"
     break;
 
   case 7: /* input: quantity quantity quantity  */
+#line 51 "Quantity.y"
                                                 { QuantResult = yyvsp[-2] + yyvsp[-1] + yyvsp[0];	}
+#line 1266 "Quantity.tab.c"
     break;
 
   case 8: /* num: NUM  */
+#line 53 "Quantity.y"
                                                 { yyval = yyvsp[0]; }
+#line 1272 "Quantity.tab.c"
     break;
 
   case 9: /* num: ONE  */
+#line 54 "Quantity.y"
                                                 { yyval = yyvsp[0]; }
+#line 1278 "Quantity.tab.c"
     break;
 
   case 10: /* num: num '+' num  */
+#line 55 "Quantity.y"
                                                 { yyval = Quantity(yyvsp[-2].getValue() + yyvsp[0].getValue());     }
+#line 1284 "Quantity.tab.c"
     break;
 
   case 11: /* num: num MINUSSIGN num  */
+#line 56 "Quantity.y"
                                                 { yyval = Quantity(yyvsp[-2].getValue() - yyvsp[0].getValue());     }
+#line 1290 "Quantity.tab.c"
     break;
 
   case 12: /* num: num '*' num  */
+#line 57 "Quantity.y"
                                                 { yyval = Quantity(yyvsp[-2].getValue() * yyvsp[0].getValue());     }
+#line 1296 "Quantity.tab.c"
     break;
 
   case 13: /* num: num '/' num  */
+#line 58 "Quantity.y"
                                                 { yyval = Quantity(yyvsp[-2].getValue() / yyvsp[0].getValue());     }
+#line 1302 "Quantity.tab.c"
     break;
 
   case 14: /* num: '+' num  */
-                                                { yyval = Quantity(yyvsp[0].getValue());                    }
+#line 59 "Quantity.y"
+                                                { yyval = Quantity(yyvsp[0].getValue());                     }
+#line 1308 "Quantity.tab.c"
     break;
 
   case 15: /* num: MINUSSIGN num  */
+#line 60 "Quantity.y"
                                                 { yyval = Quantity(-yyvsp[0].getValue());                    }
+#line 1314 "Quantity.tab.c"
     break;
 
   case 16: /* num: num '^' num  */
+#line 61 "Quantity.y"
                                                 { yyval = Quantity(pow(yyvsp[-2].getValue(), yyvsp[0].getValue())); }
+#line 1320 "Quantity.tab.c"
     break;
 
   case 17: /* num: '(' num ')'  */
+#line 62 "Quantity.y"
                                                 { yyval = yyvsp[-1]; }
+#line 1326 "Quantity.tab.c"
     break;
 
   case 18: /* num: ACOS '(' num ')'  */
+#line 63 "Quantity.y"
                                                 { yyval = Quantity(acos(yyvsp[-1].getValue()));   }
+#line 1332 "Quantity.tab.c"
     break;
 
   case 19: /* num: ASIN '(' num ')'  */
+#line 64 "Quantity.y"
                                                 { yyval = Quantity(asin(yyvsp[-1].getValue()));   }
+#line 1338 "Quantity.tab.c"
     break;
 
   case 20: /* num: ATAN '(' num ')'  */
+#line 65 "Quantity.y"
                                                 { yyval = Quantity(atan(yyvsp[-1].getValue()));   }
+#line 1344 "Quantity.tab.c"
     break;
 
   case 21: /* num: ABS '(' num ')'  */
+#line 66 "Quantity.y"
                                                 { yyval = Quantity(fabs(yyvsp[-1].getValue()));   }
+#line 1350 "Quantity.tab.c"
     break;
 
   case 22: /* num: EXP '(' num ')'  */
+#line 67 "Quantity.y"
                                                 { yyval = Quantity(exp(yyvsp[-1].getValue()));    }
+#line 1356 "Quantity.tab.c"
     break;
 
   case 23: /* num: LOG '(' num ')'  */
+#line 68 "Quantity.y"
                                                 { yyval = Quantity(log(yyvsp[-1].getValue()));    }
+#line 1362 "Quantity.tab.c"
     break;
 
   case 24: /* num: LOG10 '(' num ')'  */
+#line 69 "Quantity.y"
                                                 { yyval = Quantity(log10(yyvsp[-1].getValue()));  }
+#line 1368 "Quantity.tab.c"
     break;
 
   case 25: /* num: SIN '(' num ')'  */
+#line 70 "Quantity.y"
                                                 { yyval = Quantity(sin(yyvsp[-1].getValue()));    }
+#line 1374 "Quantity.tab.c"
     break;
 
   case 26: /* num: SINH '(' num ')'  */
+#line 71 "Quantity.y"
                                                 { yyval = Quantity(sinh(yyvsp[-1].getValue()));   }
+#line 1380 "Quantity.tab.c"
     break;
 
   case 27: /* num: TAN '(' num ')'  */
+#line 72 "Quantity.y"
                                                 { yyval = Quantity(tan(yyvsp[-1].getValue()));    }
+#line 1386 "Quantity.tab.c"
     break;
 
   case 28: /* num: TANH '(' num ')'  */
+#line 73 "Quantity.y"
                                                 { yyval = Quantity(tanh(yyvsp[-1].getValue()));   }
+#line 1392 "Quantity.tab.c"
     break;
 
   case 29: /* num: SQRT '(' num ')'  */
+#line 74 "Quantity.y"
                                                 { yyval = Quantity(sqrt(yyvsp[-1].getValue()));   }
+#line 1398 "Quantity.tab.c"
     break;
 
   case 30: /* num: COS '(' num ')'  */
+#line 75 "Quantity.y"
                                                 { yyval = Quantity(cos(yyvsp[-1].getValue()));    }
+#line 1404 "Quantity.tab.c"
     break;
 
   case 31: /* unit: UNIT  */
+#line 78 "Quantity.y"
                                                 { yyval = yyvsp[0];                  }
+#line 1410 "Quantity.tab.c"
     break;
 
   case 32: /* unit: ONE '/' unit  */
+#line 79 "Quantity.y"
                                                 { yyval = Quantity(1.0)/yyvsp[0];    }
+#line 1416 "Quantity.tab.c"
     break;
 
   case 33: /* unit: unit '*' unit  */
+#line 80 "Quantity.y"
                                                 { yyval = yyvsp[-2] * yyvsp[0];             }
+#line 1422 "Quantity.tab.c"
     break;
 
   case 34: /* unit: unit '/' unit  */
+#line 81 "Quantity.y"
                                                 { yyval = yyvsp[-2] / yyvsp[0];             }
+#line 1428 "Quantity.tab.c"
     break;
 
   case 35: /* unit: unit '^' num  */
+#line 82 "Quantity.y"
                                                 { yyval = yyvsp[-2].pow (yyvsp[0]);         }
+#line 1434 "Quantity.tab.c"
     break;
 
   case 36: /* unit: '(' unit ')'  */
+#line 83 "Quantity.y"
                                                 { yyval = yyvsp[-1];                  }
+#line 1440 "Quantity.tab.c"
     break;
 
   case 37: /* quantity: num unit  */
+#line 85 "Quantity.y"
                                                 { yyval = yyvsp[-1]*yyvsp[0];               }
+#line 1446 "Quantity.tab.c"
     break;
 
   case 38: /* quantity: num '/' unit  */
+#line 86 "Quantity.y"
                                                 { yyval = Quantity(yyvsp[-2])/yyvsp[0];     }
+#line 1452 "Quantity.tab.c"
     break;
 
 
+#line 1456 "Quantity.tab.c"
 
       default: break;
     }
@@ -1570,3 +1647,5 @@ yyreturnlab:
 
   return yyresult;
 }
+
+#line 89 "Quantity.y"

--- a/src/Base/Quantity.y
+++ b/src/Base/Quantity.y
@@ -34,6 +34,7 @@
     %token ACOS ASIN ATAN ATAN2 COS EXP ABS MOD LOG LOG10 POW SIN SINH TAN TANH SQRT;
     %left MINUSSIGN '+'
     %left '*' '/'
+    %left POS     /* unary plus */
     %left NEG     /* negation--unary minus */
     %right '^'    /* exponentiation */
     %left ONE NUM
@@ -55,6 +56,7 @@
             |   num MINUSSIGN num               { $$ = Quantity($1.getValue() - $3.getValue());     }
             |   num '*' num                     { $$ = Quantity($1.getValue() * $3.getValue());     }
             |   num '/' num                     { $$ = Quantity($1.getValue() / $3.getValue());     }
+            |   '+' num  %prec POS              { $$ = Quantity($2.getValue());                     }
             |   MINUSSIGN num  %prec NEG        { $$ = Quantity(-$2.getValue());                    }
             |   num '^' num                     { $$ = Quantity(pow($1.getValue(), $3.getValue())); }
             |   '(' num ')'                     { $$ = $2; }

--- a/src/Base/Quantity.y
+++ b/src/Base/Quantity.y
@@ -56,7 +56,7 @@
             |   num MINUSSIGN num               { $$ = Quantity($1.getValue() - $3.getValue());     }
             |   num '*' num                     { $$ = Quantity($1.getValue() * $3.getValue());     }
             |   num '/' num                     { $$ = Quantity($1.getValue() / $3.getValue());     }
-            |   '+' num  %prec POS              { $$ = Quantity($2.getValue());                    }
+            |   '+' num  %prec POS              { $$ = Quantity($2.getValue());                     }
             |   MINUSSIGN num  %prec NEG        { $$ = Quantity(-$2.getValue());                    }
             |   num '^' num                     { $$ = Quantity(pow($1.getValue(), $3.getValue())); }
             |   '(' num ')'                     { $$ = $2; }

--- a/src/Base/Tools.cpp
+++ b/src/Base/Tools.cpp
@@ -24,7 +24,6 @@
 
 #include <unicode/uchar.h>
 #include <unicode/utf8.h>
-#include <unicode/locid.h>
 #include <chrono>
 #include <ctime>
 #include <iomanip>
@@ -44,8 +43,6 @@
 namespace
 {
 constexpr auto underscore = static_cast<UChar32>(U'_');
-std::string operatingSystemNumericLocale;
-
 bool isValidFirstChar(UChar32 c)
 {
     auto category = static_cast<UCharCategory>(u_charType(c));
@@ -310,36 +307,6 @@ std::string Base::Tools::currentDateTimeString()
     std::ostringstream out;
     out << std::put_time(&tmUtc, "%Y-%m-%dT%H:%M:%SZ");
     return out.str();
-}
-
-bool Base::Tools::isCLocaleName(std::string_view localeName)
-{
-    return localeName == "C" || localeName == "c" || localeName == "C.UTF-8" || localeName == "C.utf8"
-        || localeName == "c.utf8" || localeName == "POSIX" || localeName == "posix";
-}
-
-void Base::Tools::setOperatingSystemNumericLocale(std::string_view localeName)
-{
-    operatingSystemNumericLocale = localeName;
-}
-
-std::string Base::Tools::getOperatingSystemNumericLocale()
-{
-    return operatingSystemNumericLocale;
-}
-
-void Base::Tools::setIcuDefaultLocale(std::string_view icuLocaleId)
-{
-    UErrorCode status = U_ZERO_ERROR;
-
-    if (icuLocaleId.empty() || isCLocaleName(icuLocaleId)) {
-        icu::Locale::setDefault(icu::Locale("en_US_POSIX"), status);
-        return;
-    }
-
-    const std::string localeId(icuLocaleId);
-    const icu::Locale locale = icu::Locale::createFromName(localeId.c_str());
-    icu::Locale::setDefault(locale, status);
 }
 
 std::vector<std::string> Base::Tools::splitSubName(const std::string& subname)

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -417,11 +417,6 @@ BaseExport std::string joinList(const std::vector<std::string>& vec, const std::
  */
 BaseExport std::string currentDateTimeString();
 
-BaseExport bool isCLocaleName(std::string_view localeName);
-BaseExport void setOperatingSystemNumericLocale(std::string_view localeName);
-BaseExport std::string getOperatingSystemNumericLocale();
-BaseExport void setIcuDefaultLocale(std::string_view icuLocaleId);
-
 BaseExport std::vector<std::string> splitSubName(const std::string& subname);
 
 }  // namespace Tools

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -437,11 +437,6 @@ BaseExport std::string joinList(const std::vector<std::string>& vec, const std::
  */
 BaseExport std::string currentDateTimeString();
 
-BaseExport bool isCLocaleName(std::string_view localeName);
-BaseExport void setOperatingSystemNumericLocale(std::string_view localeName);
-BaseExport std::string getOperatingSystemNumericLocale();
-BaseExport void setIcuDefaultLocale(std::string_view icuLocaleId);
-
 BaseExport std::vector<std::string> splitSubName(const std::string& subname);
 
 }  // namespace Tools

--- a/src/Base/UnitsApi.cpp
+++ b/src/Base/UnitsApi.cpp
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 #include <iomanip>
+#include <string_view>
 
 #include <CXX/WrapPython.h>
 
@@ -127,11 +128,28 @@ std::string UnitsApi::schemaTranslate(const Quantity& quant, double& factor, std
     return schemas->currentSchema()->translate(quant, factor, unitString);
 }
 
+std::string UnitsApi::schemaTranslate(
+    const Quantity& quant,
+    const NumericLocaleContext& formatting,
+    double& factor,
+    std::string& unitString
+)
+{
+    return schemas->currentSchema()->translate(quant, formatting, factor, unitString);
+}
+
 std::string UnitsApi::schemaTranslate(const Quantity& quant)
 {
     double dummy1 {};  // to satisfy GCC
     std::string dummy2;
     return schemas->currentSchema()->translate(quant, dummy1, dummy2);
+}
+
+std::string UnitsApi::schemaTranslate(const Quantity& quant, const NumericLocaleContext& formatting)
+{
+    double dummy1 {};  // to satisfy GCC
+    std::string dummy2;
+    return schemas->currentSchema()->translate(quant, formatting, dummy1, dummy2);
 }
 
 std::string UnitsApi::toUnicodeSuperscript(const std::string& str)

--- a/src/Base/UnitsApi.h
+++ b/src/Base/UnitsApi.h
@@ -33,6 +33,8 @@ using PyObject = struct _object;
 
 namespace Base
 {
+class UnitsSchemas;
+struct NumericLocaleContext;
 class BaseExport UnitsApi
 {
     friend class UnitsModulePy;
@@ -44,7 +46,16 @@ public:
 
     static std::string schemaTranslate(const Quantity& quant, double& factor, std::string& unitString);
 
+    static std::string schemaTranslate(
+        const Quantity& quant,
+        const NumericLocaleContext& formatting,
+        double& factor,
+        std::string& unitString
+    );
+
     static std::string schemaTranslate(const Quantity& quant);
+
+    static std::string schemaTranslate(const Quantity& quant, const NumericLocaleContext& formatting);
 
     static std::string toUnicodeSuperscript(const std::string& str);
 

--- a/src/Base/UnitsSchema.cpp
+++ b/src/Base/UnitsSchema.cpp
@@ -23,145 +23,17 @@
 
 #include <cmath>
 #include <algorithm>
-#include <iomanip>
-#include <limits>
-#include <memory>
-#include <sstream>
 #include <string>
 
-#include <unicode/decimfmt.h>
-#include <unicode/dcfmtsym.h>
-#include <unicode/locid.h>
-#include <unicode/numfmt.h>
-#include <unicode/unistr.h>
-
 #include "Quantity.h"
+#include "NumericFormatting.h"
 #include "UnitsSchema.h"
 #include "UnitsSchemasData.h"
 #include "UnitsSchemasSpecs.h"
 #include "Exception.h"
-#include "Quantity.h"
 
 using Base::UnitsSchema;
 using Base::UnitsSchemaSpec;
-
-namespace
-{
-std::string toUtf8(const icu::UnicodeString& s)
-{
-    std::string out;
-    s.toUTF8String(out);
-    return out;
-}
-
-bool useQtLikeGeneralScientific(const double value, const int precision)
-{
-    if (!std::isfinite(value) || value == 0.0 || precision <= 0) {
-        return false;
-    }
-
-    const auto exponent = static_cast<int>(std::floor(std::log10(std::abs(value))));
-    return exponent < -4 || exponent >= precision;
-}
-
-std::string localizeDecimalSeparator(std::string value, const icu::Locale& locale)
-{
-    UErrorCode status = U_ZERO_ERROR;
-    icu::DecimalFormatSymbols symbols(locale, status);
-    if (!U_SUCCESS(status)) {
-        return value;
-    }
-
-    const std::string decimal = toUtf8(
-        symbols.getSymbol(icu::DecimalFormatSymbols::kDecimalSeparatorSymbol)
-    );
-    if (decimal == ".") {
-        return value;
-    }
-
-    auto pos = value.find('.');
-    while (pos != std::string::npos) {
-        value.replace(pos, 1, decimal);
-        pos = value.find('.', pos + decimal.size());
-    }
-
-    return value;
-}
-
-std::string formatDefaultScientificLikeQt(
-    const double value,
-    const Base::QuantityFormat& format,
-    const icu::Locale& locale
-)
-{
-    std::ostringstream out;
-    out << std::setprecision(std::max(1, format.getPrecision())) << value;
-    return localizeDecimalSeparator(out.str(), locale);
-}
-
-std::string formatNumberIcu(const double value, const Base::QuantityFormat& format)
-{
-    UErrorCode status = U_ZERO_ERROR;
-    icu::Locale locale = icu::Locale::getDefault();
-
-    std::unique_ptr<icu::NumberFormat> nf(icu::NumberFormat::createInstance(locale, status));
-    if (!U_SUCCESS(status) || !nf) {
-        // Fallback: locale-independent formatting.
-        std::ostringstream out;
-        switch (format.format) {
-            case Base::QuantityFormat::Fixed:
-                out << std::fixed;
-                break;
-            case Base::QuantityFormat::Scientific:
-                out << std::scientific;
-                break;
-            case Base::QuantityFormat::Default:
-            default:
-                break;
-        }
-        out << std::setprecision(format.getPrecision()) << value;
-        return out.str();
-    }
-
-    if (format.option & Base::QuantityFormat::OmitGroupSeparator) {
-        nf->setGroupingUsed(false);
-    }
-
-    const int precision = format.getPrecision();
-    switch (format.format) {
-        case Base::QuantityFormat::Fixed:
-            nf->setMinimumFractionDigits(precision);
-            nf->setMaximumFractionDigits(precision);
-            break;
-        case Base::QuantityFormat::Scientific:
-            if (auto* df = dynamic_cast<icu::DecimalFormat*>(nf.get())) {
-                df->setScientificNotation(true);
-                df->setMinimumFractionDigits(precision);
-                df->setMaximumFractionDigits(precision);
-                break;
-            }
-            [[fallthrough]];
-        case Base::QuantityFormat::Default:
-            if (useQtLikeGeneralScientific(value, precision)) {
-                return formatDefaultScientificLikeQt(value, format, locale);
-            }
-            if (auto* df = dynamic_cast<icu::DecimalFormat*>(nf.get()); precision > 0 && df) {
-                df->setSignificantDigitsUsed(true);
-                df->setMinimumSignificantDigits(1);
-                df->setMaximumSignificantDigits(precision);
-                break;
-            }
-            [[fallthrough]];
-        default:
-            nf->setMaximumFractionDigits(precision);
-            break;
-    }
-
-    icu::UnicodeString s;
-    nf->format(value, s);
-    return toUtf8(s);
-}
-}  // namespace
 
 
 UnitsSchema::UnitsSchema(UnitsSchemaSpec spec)
@@ -177,17 +49,27 @@ std::string UnitsSchema::translate(const Quantity& quant) const
 
 std::string UnitsSchema::translate(const Quantity& quant, double& factor, std::string& unitString) const
 {
+    return translate(quant, currentNumericLocaleContext(), factor, unitString);
+}
+
+std::string UnitsSchema::translate(
+    const Quantity& quant,
+    const NumericLocaleContext& formatting,
+    double& factor,
+    std::string& unitString
+) const
+{
     // Use defaults without schema-level translation.
     factor = 1.0;
     unitString = quant.getUnit().getString();
 
     if (spec.translationSpecs.empty()) {
-        return toLocale(quant, factor, unitString);
+        return toLocale(quant, formatting, factor, unitString);
     }
 
     const auto unitName = quant.getUnit().getTypeString();
     if (!spec.translationSpecs.contains(unitName)) {
-        return toLocale(quant, factor, unitString);
+        return toLocale(quant, formatting, factor, unitString);
     }
 
     const auto value = quant.getValue();
@@ -223,14 +105,21 @@ std::string UnitsSchema::translate(const Quantity& quant, double& factor, std::s
     factor = unitSpec->factor;
     unitString = unitSpec->unitString;
 
-    return toLocale(quant, factor, unitString);
+    return toLocale(quant, formatting, factor, unitString);
 }
 
-std::string UnitsSchema::toLocale(const Quantity& quant, const double factor, const std::string& unitString)
+std::string UnitsSchema::toLocale(
+    const Quantity& quant,
+    const NumericLocaleContext& formatting,
+    const double factor,
+    const std::string& unitString
+)
 {
     const QuantityFormat& format = quant.getFormat();
     const double v = quant.getValue() / factor;
-    const std::string valueString = std::isfinite(v) ? formatNumberIcu(v, format) : std::to_string(v);
+    const std::string valueString = std::isfinite(v)
+        ? Base::formatNumericValue(v, format, formatting)
+        : std::to_string(v);
 
     auto notUnit = [](auto s) {
         return s.empty() || s == "°" || s == "″" || s == "′" || s == "\"" || s == "'";

--- a/src/Base/UnitsSchema.h
+++ b/src/Base/UnitsSchema.h
@@ -33,6 +33,7 @@
 namespace Base
 {
 class Quantity;
+struct NumericLocaleContext;
 
 /**
  * An individual schema object
@@ -52,10 +53,17 @@ public:
 
     std::string translate(const Quantity& quant) const;
     std::string translate(const Quantity& quant, double& factor, std::string& unitString) const;
+    std::string translate(
+        const Quantity& quant,
+        const NumericLocaleContext& formatting,
+        double& factor,
+        std::string& unitString
+    ) const;
 
 private:
     [[nodiscard]] static std::string toLocale(
         const Quantity& quant,
+        const NumericLocaleContext& formatting,
         double factor,
         const std::string& unitString
     );

--- a/src/Doc/NumericInput.dox
+++ b/src/Doc/NumericInput.dox
@@ -1,0 +1,174 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-FileCopyrightText: 2026 FreeCAD Project contributors */
+/* SPDX-FileNotice: Part of the FreeCAD project. */
+
+/** @page localizednumericinput Localized numeric and quantity input
+
+# Overview
+
+FreeCAD keeps canonical numeric syntax separate from localized user input.
+Canonical parsers are used for persistence, scripting, and internally generated
+expressions. Interactive input boundaries may accept locale-specific digits,
+signs, decimal separators, and grouping, but must normalize that input before
+calling a canonical parser.
+
+This separation prevents the process-wide ICU or Qt locale from silently
+changing the meaning of stored data. It also lets FreeCAD validate grouping
+exactly instead of relying on a locale library's permissive parsing behavior.
+
+# Architecture
+
+Localized quantity input is processed in three layers:
+
+```text
+QLocale and ICU locale metadata
+              |
+              v
+Base::NumericLocaleContext
+              |
+              v
+Base::scanLocalizedNumber()
+              |
+              v
+App::Quantity::parseUserInput()
+App::ExpressionParser::parseUserInput()
+App::interpretQuantityInput()
+              |
+              v
+Gui::InputField and Gui::QuantitySpinBox
+```
+
+The layers have distinct responsibilities:
+
+- **Base** owns immutable locale metadata, exact numeric token scanning,
+  canonicalization, and locale-aware formatting.
+- **App** owns quantity and expression grammar, expression evaluation,
+  default-unit policy, constraints, and structured input diagnostics.
+- **Gui** derives a context from each widget's effective `QLocale`, chooses the
+  input grammar and phase explicitly, and presents translated diagnostics.
+
+# Locale context
+
+Base::NumericLocaleContext is the complete numeric-locale snapshot. It contains
+the locale identity, localized digits, separators, signs, exponent syntax, and
+primary and secondary grouping sizes.
+
+The application publishes the process-wide context as one complete value after
+locale resolution succeeds. Code must not publish or combine individual locale
+fragments. A widget with an explicit `QLocale` derives its complete context from
+that widget locale instead of copying and modifying the global snapshot.
+
+Every parser and formatter receives a context explicitly. Canonical persistence
+and scripting APIs must not acquire localized behavior by reading the published
+context implicitly.
+
+# Exact numeric scanning
+
+Base::scanLocalizedNumber() scans one numeric token. It recognizes the exact
+configured syntax, validates grouping, produces canonical ASCII text, and
+reports how many UTF-8 bytes it consumed. It does not use ICU to decide which
+characters belong to the token; ICU supplies locale metadata only.
+
+Base::LocalizedNumberResult distinguishes complete, incomplete, and invalid
+input. Its diagnostic offsets and lengths are UTF-8 byte ranges. GUI code must
+convert them before using them as indices into a `QString`, whose indices are
+UTF-16 code units.
+
+Grouping depends on Base::NumericSyntaxContext. It is allowed unless the locale
+grouping separator conflicts with a structural separator in the current grammar
+context. Function argument separators are locale-aware and are normalized to
+canonical expression syntax before parsing.
+
+Examples of the intended policy include:
+
+| Locale | Context | Input | Result |
+| --- | --- | --- | --- |
+| `en_US` | standalone quantity | `12,345.67 mm` | `12345.67 mm` |
+| `en_US` | standalone quantity | `12 345 mm` | invalid |
+| `en_IN` | standalone quantity | `12,34,567 mm` | `1234567 mm` |
+| `en_US` | expression | `(12,345.67 mm)` | `12345.67 mm` |
+| `en_US` | function argument | `pow(1,234)` | two arguments |
+| `de_DE` | function argument | `pow(1,234)` | one decimal argument |
+| `de_DE` | function argument | `pow(1;234)` | two arguments |
+
+# Quantity interpretation
+
+App::interpretQuantityInput() is the shared App-level boundary for interactive
+quantity edits. Callers choose App::QuantityInputGrammar explicitly:
+
+- `Quantity` preserves quantity-only syntax, including quantity comments and
+  juxtaposed quantities.
+- `Expression` accepts the localized expression language.
+
+The operation owns localized scanning, parsing, expression evaluation,
+default-unit application, unit compatibility, range validation, and normalized
+value production. It returns an App::QuantityInputResult containing a typed
+status, an optional quantity, an optional expression, and a semantic diagnostic.
+
+App::InputPhase separates the two validation contracts:
+
+- `Editing` permits incomplete text so the user can continue typing. It never
+  commits an incomplete candidate.
+- `Commit` requires complete valid input and reports a diagnostic otherwise.
+
+Default units are applied at additive expression boundaries. Dimensionless
+additive terms acquire the field's default unit while their original expression
+subtrees and dependencies are preserved. Additive expressions nested under
+multiplication, division, or powers are not independently rewritten.
+
+# GUI behavior
+
+Gui::InputField and Gui::QuantitySpinBox use their effective widget locale for
+both formatting and parsing. Bound fields select expression grammar. Unbound
+quantity fields preserve quantity grammar and may fall back to expression
+grammar only when the quantity parser reports expression syntax.
+
+Editing and committing are separate operations:
+
+- Incomplete edits remain editable and do not replace the committed quantity.
+- Valid commits update the quantity and preserve the normal Qt success signals.
+- Invalid commits leave the user's text visible, preserve the last committed
+  quantity, and expose a translated diagnostic.
+- Escape restores the last committed value.
+
+Editable formatting must round-trip without ambiguity. In a locale where the
+grouping character can also be interpreted as a canonical decimal point, GUI
+editable text suppresses grouping rather than producing text such as `1.234`
+whose intended value cannot be recovered reliably.
+
+# Adding an input consumer
+
+When adding a user-facing numeric or quantity input boundary:
+
+1. Derive Base::NumericLocaleContext from the consumer's effective locale.
+2. Pass that context explicitly to parsing and formatting APIs.
+3. Choose quantity or expression grammar explicitly.
+4. Use `Editing` during interactive validation and `Commit` on Return or focus
+   loss.
+5. Keep invalid committed text visible and preserve the previous value.
+6. Translate typed diagnostics in Gui; do not classify errors by message text.
+7. Convert UTF-8 diagnostic byte ranges to UTF-16 before selecting Qt text.
+
+Do not strip separators, rewrite the complete input heuristically, ask ICU to
+infer token boundaries, or add an overload that silently reads global locale
+state.
+
+# Testing
+
+Changes to this path should be tested at the narrowest responsible layer and at
+an interactive boundary:
+
+- **Base:** scanning, exact Unicode symbols, grouping patterns, diagnostics,
+  native digits, signs, exponents, and format-to-parse round trips.
+- **App:** quantity and expression grammar, function arguments, opaque syntax,
+  editing versus commit, constraints, default units, and dependency
+  preservation.
+- **Gui:** effective widget locale, keyboard and focus commits, Qt signals,
+  diagnostic selection, Escape restoration, and editable format round trips.
+- **Consumer integration:** at least one real workflow for behavior involving
+  task panels, property editors, or on-view parameters.
+
+The central invariant is that text produced for an editable quantity parses
+back to the same value and unit under the same explicit locale context.
+
+*/

--- a/src/Doc/mainpage.dox.in
+++ b/src/Doc/mainpage.dox.in
@@ -28,6 +28,7 @@
     - @ref intro_main "Introduction"
     - @ref organization "Organization of the API Documentation"
     - @ref asyncrecompute "Async recompute threading rules"
+    - @ref localizednumericinput "Localized numeric and quantity input"
     - @ref other_doc "Other Documentation"
 
     @section intro_main Introduction

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1163,6 +1163,7 @@ SET(Widget_CPP_SRCS
     NotificationArea.cpp
     PrefWidgets.cpp
     InputField.cpp
+    NumericLocale.cpp
     ProgressBar.cpp
     ProgressDialog.cpp
     QuantitySpinBox.cpp

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1169,6 +1169,7 @@ SET(Widget_CPP_SRCS
     NotificationArea.cpp
     PrefWidgets.cpp
     InputField.cpp
+    NumericLocale.cpp
     ProgressBar.cpp
     ProgressDialog.cpp
     QuantitySpinBox.cpp

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -43,6 +43,7 @@
 
 #include "Dialogs/DlgExpressionInput.h"
 #include "ui_DlgExpressionInput.h"
+#include "NumericLocale.h"
 #include "Application.h"
 #include "CommandT.h"
 #include "Tools.h"
@@ -326,8 +327,9 @@ QPoint DlgExpressionInput::expressionPosition() const
 
 bool DlgExpressionInput::checkCyclicDependencyVarSet(const QString& text)
 {
+    const auto formatting = ::Gui::numericLocaleContextFor(ui->expression->locale());
     std::shared_ptr<Expression> expr(
-        ExpressionParser::parse(path.getDocumentObject(), text.toUtf8().constData())
+        ExpressionParser::parseUserInput(path.getDocumentObject(), text.toUtf8().constData(), formatting)
     );
 
     if (expr) {
@@ -353,8 +355,9 @@ bool DlgExpressionInput::checkCyclicDependencyVarSet(const QString& text)
 void DlgExpressionInput::checkExpression(const QString& text)
 {
     // now handle expression
+    const auto formatting = ::Gui::numericLocaleContextFor(ui->expression->locale());
     std::shared_ptr<Expression> expr(
-        ExpressionParser::parse(path.getDocumentObject(), text.toUtf8().constData())
+        ExpressionParser::parseUserInput(path.getDocumentObject(), text.toUtf8().constData(), formatting)
     );
 
     if (expr) {

--- a/src/Gui/Dialogs/DlgUnitsCalculatorImp.cpp
+++ b/src/Gui/Dialogs/DlgUnitsCalculatorImp.cpp
@@ -28,6 +28,7 @@
 
 #include "Dialogs/DlgUnitsCalculatorImp.h"
 #include "ui_DlgUnitsCalculator.h"
+#include "NumericLocale.h"
 #include <Base/Quantity.h>
 #include <Base/UnitsApi.h>
 
@@ -131,9 +132,12 @@ void DlgUnitsCalculator::textChanged(QString unit)
 
 void DlgUnitsCalculator::valueChanged(const Quantity& quant)
 {
+    const auto formatting = ::Gui::numericLocaleContextFor(ui->UnitInput->locale());
     std::string unitTypeStr;
     try {
-        unitTypeStr = Quantity::parse(ui->UnitInput->text().toStdString()).getUnit().getTypeString();
+        unitTypeStr = Quantity::parseUserInput(ui->UnitInput->text().toStdString(), formatting)
+                          .getUnit()
+                          .getTypeString();
     }
     catch (const Base::ParserError&) {
     }
@@ -153,7 +157,9 @@ void DlgUnitsCalculator::valueChanged(const Quantity& quant)
             ui->pushButton_Copy->setEnabled(false);
         }
         else {  // the unit is valid and has the same type
-            double convertValue = Quantity::parse("1" + ui->UnitInput->text().toStdString()).getValue();
+            double convertValue
+                = Quantity::parseUserInput("1" + ui->UnitInput->text().toStdString(), formatting)
+                      .getValue();
             // we got now e.g. for "1 in" the value '25.4' because 1 in = 25.4 mm
             // the result is now just quant / convertValue because the input is always in a base
             // unit (an input of "1 cm" will immediately be converted to "10 mm" by Gui::InputField

--- a/src/Gui/Dialogs/DlgUnitsCalculatorImp.h
+++ b/src/Gui/Dialogs/DlgUnitsCalculatorImp.h
@@ -40,7 +40,7 @@ class Ui_DlgUnitCalculator;
  * The DlgUnitsCalculator provides a unit conversion dialog
  * \author Juergen Riegel
  */
-class DlgUnitsCalculator: public QDialog
+class GuiExport DlgUnitsCalculator: public QDialog
 {
     Q_OBJECT
 

--- a/src/Gui/EditableDatumLabel.cpp
+++ b/src/Gui/EditableDatumLabel.cpp
@@ -227,6 +227,7 @@ void EditableDatumLabel::startEdit(double val, QObject* eventFilteringObj, bool 
     editStartValue = val;
 
     lockIconLabel = new QLabel(spinBox);
+    lockIconLabel->setObjectName(QStringLiteral("onViewParameterLockIcon"));
     lockIconLabel->setAttribute(Qt::WA_TransparentForMouseEvents, true);
 
     // load icon and scale it to fit in spinbox
@@ -266,6 +267,7 @@ void EditableDatumLabel::startEdit(double val, QObject* eventFilteringObj, bool 
         this,
         &EditableDatumLabel::handleSpinBoxValueChanged
     );
+    connect(spinBox, &QuantitySpinBox::inputCleared, this, &EditableDatumLabel::handleSpinBoxInputCleared);
     if (auto* edit = spinBox->findChild<QLineEdit*>()) {
         connect(edit, &QLineEdit::textChanged, this, [this, edit]() { this->updateGeometry(edit); });
     }
@@ -300,6 +302,19 @@ void EditableDatumLabel::handleSpinBoxValueChanged()
     if (syncValueFromSpinBox()) {
         Q_EMIT valueChanged(value);
     }
+}
+
+void EditableDatumLabel::handleSpinBoxInputCleared()
+{
+    if (!isSet && !hasFinishedEditing) {
+        return;
+    }
+
+    // Clearing an OVP removes its provisional parameter; it does not create a new numeric value.
+    // Keep the committed value intact so Escape and cancellation can still restore it.
+    isSet = false;
+    resetLockedState();
+    Q_EMIT parameterUnset();
 }
 
 bool EditableDatumLabel::eventFilter(QObject* watched, QEvent* event)

--- a/src/Gui/EditableDatumLabel.h
+++ b/src/Gui/EditableDatumLabel.h
@@ -129,6 +129,7 @@ protected:
 private:
     bool syncValueFromSpinBox(bool emitParameterUnset = true);
     void handleSpinBoxValueChanged();
+    void handleSpinBoxInputCleared();
     void positionSpinbox();
     SbVec3f getTextCenterPoint() const;
     void initColors();

--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -207,6 +207,14 @@ void InputField::resizeEvent(QResizeEvent* /*event*/)
     iconLabel->move(width() - (iconSize.width() + 2 * getMargin()), (height() - iconSize.height()) / 2);
 }
 
+void InputField::changeEvent(QEvent* event)
+{
+    QLineEdit::changeEvent(event);
+    if (event->type() == QEvent::LocaleChange && validInput) {
+        updateText(actQuantity);
+    }
+}
+
 void InputField::updateIconLabel(const QString& text)
 {
     iconLabel->setVisible(text.isEmpty());
@@ -646,15 +654,10 @@ void InputField::setHistorySize(int i)
 
 void InputField::selectNumber()
 {
-    QString expr = QStringLiteral("^([%1%2]?[0-9\\%3]*)\\%4?([0-9]+(%5[%1%2]?[0-9]+)?)")
-                       .arg(locale().negativeSign())
-                       .arg(locale().positiveSign())
-                       .arg(locale().groupSeparator())
-                       .arg(locale().decimalPoint())
-                       .arg(locale().exponential());
-    auto rmatch = QRegularExpression(expr).match(text());
-    if (rmatch.hasMatch()) {
-        setSelection(0, rmatch.capturedLength());
+    const auto length
+        = Gui::numericInputSelectionLengthUtf16(text(), Gui::numericLocaleContextFor(locale()));
+    if (length > 0) {
+        setSelection(0, length);
     }
 }
 

--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -21,22 +21,24 @@
  ***************************************************************************/
 
 #include <limits>
+#include <optional>
 #include <QContextMenuEvent>
 #include <QMenu>
 #include <QPixmapCache>
-#include <QRegularExpression>
-#include <QRegularExpressionMatch>
 
 #include <App/Application.h>
 #include <App/DocumentObject.h>
 #include <App/ExpressionParser.h>
 #include <App/PropertyUnits.h>
+#include <App/QuantityInput.h>
 #include <Base/Exception.h>
 #include <Base/Quantity.h>
+#include <Base/UnitsApi.h>
 
 #include "InputField.h"
 #include "BitmapFactory.h"
 #include "Command.h"
+#include "NumericLocale.h"
 #include "QuantitySpinBox_p.h"
 
 
@@ -54,7 +56,6 @@ public:
     explicit InputValidator(InputField* parent);
     ~InputValidator() override;
 
-    void fixup(QString& input) const override;
     State validate(QString& input, int& pos) const override;
 
 private:
@@ -186,12 +187,50 @@ void InputField::updateText(const Base::Quantity& quant)
 
     double dFactor;
     std::string unitStr;
-    std::string txt = quant.getUserString(dFactor, unitStr);
+    const auto formatting = Gui::numericLocaleContextFor(locale());
+    auto displayQuantity = quant;
+    displayQuantity.setFormat(Gui::editableQuantityFormat(quant.getFormat(), formatting));
+    std::string txt = Base::UnitsApi::schemaTranslate(displayQuantity, formatting, dFactor, unitStr);
     actUnitValue = quant.getValue() / dFactor;
     // Block signals to prevent newInput from re-parsing the display text
     // and overwriting actQuantity with a precision-truncated value.
     QSignalBlocker blocker(this);
     setText(QString::fromStdString(txt));
+}
+
+App::QuantityInputResult InputField::interpretInput(const QString& input, const App::InputPhase phase) const
+{
+    const auto formatting = Gui::numericLocaleContextFor(locale());
+    App::QuantityConstraints constraints;
+    if (actUnit != Unit::One) {
+        constraints.requiredUnit = actUnit;
+    }
+    constraints.minimum = Minimum;
+    constraints.maximum = Maximum;
+
+    const auto grammar = isBound() ? App::QuantityInputGrammar::Expression
+                                   : App::QuantityInputGrammar::Quantity;
+    const auto parse = [&](const App::QuantityInputGrammar selectedGrammar) {
+        return App::interpretQuantityInput(
+            input.toUtf8().toStdString(),
+            selectedGrammar,
+            getPath(),
+            actUnit,
+            formatting,
+            phase,
+            constraints
+        );
+    };
+
+    auto result = parse(grammar);
+    // Keep quantity-only syntax on the quantity parser, but preserve the established arithmetic
+    // behavior of unbound fields when the quantity grammar reports a syntax failure.
+    if (grammar == App::QuantityInputGrammar::Quantity && result.status == App::InputStatus::Invalid
+        && result.diagnostic
+        && result.diagnostic->kind == App::InputDiagnosticKind::ExpressionSyntax) {
+        result = parse(App::QuantityInputGrammar::Expression);
+    }
+    return result;
 }
 
 void InputField::notifyValueChanged()
@@ -272,77 +311,61 @@ void InputField::contextMenuEvent(QContextMenuEvent* event)
 
 void InputField::newInput(const QString& text)
 {
-    Quantity res;
-    try {
-        QString input = text;
-        fixup(input);
+    const auto formatting = Gui::numericLocaleContextFor(locale());
+    const auto result = interpretInput(text, App::InputPhase::Editing);
 
-        if (isBound()) {
-            std::shared_ptr<Expression> e(
-                ExpressionParser::parse(getPath().getDocumentObject(), input.toUtf8())
-            );
-
-            setExpression(e);
-
-            std::unique_ptr<Expression> evalRes(getExpression()->eval());
-
-            auto* value = freecad_cast<NumberExpression*>(evalRes.get());
-            if (value) {
-                res.setValue(value->getValue());
-                res.setUnit(value->getUnit());
-            }
-        }
-        else {
-            res = Quantity::parse(input.toStdString());
-        }
-    }
-    catch (Base::Exception& e) {
-        QString errorText = QString::fromLatin1(e.what());
-        if (iconLabel->isHidden()) {
-            iconLabel->setVisible(true);
-        }
-        Q_EMIT parseError(errorText);
+    if (result.status != App::InputStatus::Acceptable) {
         validInput = false;
+        if (result.status == App::InputStatus::Invalid && result.diagnostic) {
+            Q_EMIT parseError(Gui::numericInputDiagnosticText(result.diagnostic->kind));
+        }
         return;
     }
 
-    if (res.isDimensionless()) {
-        res.setUnit(this->actUnit);
-    }
+    Quantity res = *result.quantity;
 
-    // check if unit fits!
-    if (actUnit != Unit::One && !res.isDimensionless() && actUnit != res.getUnit()) {
-        if (iconLabel->isHidden()) {
-            iconLabel->setVisible(true);
-        }
-        Q_EMIT parseError(QStringLiteral("Wrong unit"));
-        validInput = false;
-        return;
+    double dFactor;
+    std::string unitStr;
+    Base::UnitsApi::schemaTranslate(res, formatting, dFactor, unitStr);
+    actUnitValue = res.getValue() / dFactor;
+    // Preserve previous format
+    res.setFormat(this->actQuantity.getFormat());
+
+    // Commit the expression and value only after parsing, evaluation, unit validation, and range
+    // handling have all succeeded.
+    if (result.expression) {
+        setExpression(result.expression);
     }
+    actQuantity = res;
 
     if (iconLabel->isVisible()) {
         iconLabel->setVisible(false);
     }
     validInput = true;
 
-    if (res.getValue() > Maximum) {
-        res.setValue(Maximum);
-    }
-    if (res.getValue() < Minimum) {
-        res.setValue(Minimum);
-    }
-
-    double dFactor;
-    std::string unitStr;
-    res.getUserString(dFactor, unitStr);
-    actUnitValue = res.getValue() / dFactor;
-    // Preserve previous format
-    res.setFormat(this->actQuantity.getFormat());
-    actQuantity = res;
-
     // signaling
     Q_EMIT valueChanged(res);
     Q_EMIT valueChanged(res.getValue());
+}
+
+void InputField::commitInput()
+{
+    const auto result = interpretInput(text(), App::InputPhase::Commit);
+    if (result.status != App::InputStatus::Acceptable) {
+        validInput = false;
+        if (result.diagnostic) {
+            Q_EMIT parseError(Gui::numericInputDiagnosticText(result.diagnostic->kind));
+        }
+        return;
+    }
+
+    if (result.expression) {
+        setExpression(result.expression);
+    }
+    auto quantity = *result.quantity;
+    quantity.setFormat(actQuantity.getFormat());
+    actQuantity = quantity;
+    validInput = true;
 }
 
 void InputField::pushToHistory(const QString& valueq)
@@ -410,13 +433,8 @@ void InputField::setToLastUsedValue()
 
 void InputField::pushToSavedValues(const QString& valueq)
 {
-    std::string value;
-    if (valueq.isEmpty()) {
-        value = this->text().toUtf8().constData();
-    }
-    else {
-        value = valueq.toUtf8().constData();
-    }
+    const QByteArray valueUtf8 = valueq.isEmpty() ? this->text().toUtf8() : valueq.toUtf8();
+    std::string value(valueUtf8.constData(), valueUtf8.size());
 
     if (_handle.isValid()) {
         char hist1[21];
@@ -514,7 +532,12 @@ const Base::Unit& InputField::getUnit() const
 /// get stored, valid quantity as a string
 QString InputField::getQuantityString() const
 {
-    return QString::fromStdString(actQuantity.getUserString());
+    double factor;
+    std::string unitString;
+    const auto formatting = Gui::numericLocaleContextFor(locale());
+    return QString::fromStdString(
+        Base::UnitsApi::schemaTranslate(actQuantity, formatting, factor, unitString)
+    );
 }
 
 /// set, validate and display quantity from a string. Must match existing units.
@@ -531,7 +554,8 @@ QString InputField::rawText() const
     double factor;
     std::string unit;
     double value = actQuantity.getValue();
-    actQuantity.getUserString(factor, unit);
+    const auto formatting = Gui::numericLocaleContextFor(locale());
+    Base::UnitsApi::schemaTranslate(actQuantity, formatting, factor, unit);
     return QStringLiteral("%1 %2").arg(value / factor).arg(QString::fromStdString(unit));
 }
 
@@ -686,20 +710,10 @@ void InputField::focusInEvent(QFocusEvent* event)
 
 void InputField::focusOutEvent(QFocusEvent* event)
 {
-    try {
-        if (Quantity::parse(this->text().toStdString()).isDimensionless()) {
-            // if user didn't enter a unit, we virtually compensate
-            // the multiplication factor induced by user unit system
-            double factor;
-            std::string unitStr;
-            actQuantity.getUserString(factor, unitStr);
-            actQuantity = actQuantity * factor;
-        }
+    commitInput();
+    if (validInput) {
+        updateText(actQuantity);
     }
-    catch (const Base::ParserError&) {
-        // do nothing, let apply the last known good value
-    }
-    this->setText(QString::fromStdString(actQuantity.getUserString()));
     QLineEdit::focusOutEvent(event);
 }
 
@@ -707,6 +721,28 @@ void InputField::keyPressEvent(QKeyEvent* event)
 {
     if (isReadOnly()) {
         QLineEdit::keyPressEvent(event);
+        return;
+    }
+
+    if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
+        commitInput();
+        if (validInput) {
+            // Return is handled here so invalid text can suppress successful signals. Keep the
+            // normal QLineEdit editingFinished() contract for valid commits.
+            Q_EMIT returnPressed();
+            Q_EMIT editingFinished();
+            event->ignore();
+        }
+        else {
+            event->accept();
+        }
+        return;
+    }
+    if (event->key() == Qt::Key_Escape) {
+        QSignalBlocker blocker(this);
+        updateText(actQuantity);
+        validInput = true;
+        event->ignore();
         return;
     }
 
@@ -732,7 +768,8 @@ void InputField::keyPressEvent(QKeyEvent* event)
 
     double dFactor;
     std::string unitStr;
-    actQuantity.getUserString(dFactor, unitStr);
+    const auto formatting = Gui::numericLocaleContextFor(locale());
+    Base::UnitsApi::schemaTranslate(actQuantity, formatting, dFactor, unitStr);
     this->setText(QStringLiteral("%L1 %2").arg(val).arg(QString::fromStdString(unitStr)));
     event->accept();
 }
@@ -760,55 +797,20 @@ void InputField::wheelEvent(QWheelEvent* event)
 
     double dFactor;
     std::string unitStr;
-    actQuantity.getUserString(dFactor, unitStr);
+    const auto formatting = Gui::numericLocaleContextFor(locale());
+    Base::UnitsApi::schemaTranslate(actQuantity, formatting, dFactor, unitStr);
 
     this->setText(QStringLiteral("%L1 %2").arg(val).arg(QString::fromStdString(unitStr)));
     selectNumber();
     event->accept();
 }
 
-void InputField::fixup(QString& input) const
-{
-    input.remove(locale().groupSeparator());
-
-    QString asciiMinus(QStringLiteral("-"));
-    QString localeMinus(locale().negativeSign());
-    if (localeMinus != asciiMinus) {
-        input.replace(localeMinus, asciiMinus);
-    }
-
-    QString asciiPlus(QStringLiteral("+"));
-    QString localePlus(locale().positiveSign());
-    if (localePlus != asciiPlus) {
-        input.replace(localePlus, asciiPlus);
-    }
-}
-
 QValidator::State InputField::validate(QString& input, int& pos) const
 {
     Q_UNUSED(pos);
-    try {
-        Quantity res;
-        QString text = input;
-        fixup(text);
-        res = Quantity::parse(text.toStdString());
-
-        double factor;
-        std::string unitStr;
-        res.getUserString(factor, unitStr);
-        double value = res.getValue() / factor;
-        // disallow one to enter numbers out of range
-        if (value > this->Maximum || value < this->Minimum) {
-            return QValidator::Invalid;
-        }
-    }
-    catch (Base::Exception&) {
-        // Actually invalid input but the newInput slot gives
-        // some feedback
-        return QValidator::Intermediate;
-    }
-
-    return QValidator::Acceptable;
+    const auto result = interpretInput(input, App::InputPhase::Editing);
+    return result.status == App::InputStatus::Acceptable ? QValidator::Acceptable
+                                                         : QValidator::Intermediate;
 }
 
 // --------------------------------------------------------------------
@@ -819,11 +821,6 @@ InputValidator::InputValidator(InputField* parent)
 {}
 
 InputValidator::~InputValidator() = default;
-
-void InputValidator::fixup(QString& input) const
-{
-    dptr->fixup(input);
-}
 
 QValidator::State InputValidator::validate(QString& input, int& pos) const
 {

--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -207,6 +207,14 @@ void InputField::resizeEvent(QResizeEvent* /*event*/)
     iconLabel->move(width() - (iconSize.width() + 2 * getMargin()), (height() - iconSize.height()) / 2);
 }
 
+void InputField::changeEvent(QEvent* event)
+{
+    QLineEdit::changeEvent(event);
+    if (event->type() == QEvent::LocaleChange && validInput) {
+        updateText(actQuantity);
+    }
+}
+
 void InputField::updateIconLabel(const QString& text)
 {
     iconLabel->setVisible(text.isEmpty());
@@ -646,12 +654,14 @@ void InputField::setHistorySize(int i)
 
 void InputField::selectNumber()
 {
-    QString expr = QStringLiteral("^([%1%2]?[0-9\\%3]*)\\%4?([0-9]+(%5[%1%2]?[0-9]+)?)")
+    const QString zeroDigit = QString(locale().zeroDigit());
+    QString expr = QStringLiteral("^([%1%2]?[0-9\\%3%6]*)\\%4?([0-9%6]+(%5[%1%2]?[0-9%6]+)?)")
                        .arg(locale().negativeSign())
                        .arg(locale().positiveSign())
                        .arg(locale().groupSeparator())
                        .arg(locale().decimalPoint())
-                       .arg(locale().exponential());
+                       .arg(locale().exponential())
+                       .arg(zeroDigit);
     auto rmatch = QRegularExpression(expr).match(text());
     if (rmatch.hasMatch()) {
         setSelection(0, rmatch.capturedLength());

--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -21,22 +21,24 @@
  ***************************************************************************/
 
 #include <limits>
+#include <optional>
 #include <QContextMenuEvent>
 #include <QMenu>
 #include <QPixmapCache>
-#include <QRegularExpression>
-#include <QRegularExpressionMatch>
 
 #include <App/Application.h>
 #include <App/DocumentObject.h>
 #include <App/ExpressionParser.h>
 #include <App/PropertyUnits.h>
+#include <App/QuantityInput.h>
 #include <Base/Exception.h>
 #include <Base/Quantity.h>
+#include <Base/UnitsApi.h>
 
 #include "InputField.h"
 #include "BitmapFactory.h"
 #include "Command.h"
+#include "NumericLocale.h"
 #include "QuantitySpinBox_p.h"
 
 
@@ -54,7 +56,6 @@ public:
     explicit InputValidator(InputField* parent);
     ~InputValidator() override;
 
-    void fixup(QString& input) const override;
     State validate(QString& input, int& pos) const override;
 
 private:
@@ -186,7 +187,8 @@ void InputField::updateText(const Base::Quantity& quant)
 
     double dFactor;
     std::string unitStr;
-    std::string txt = quant.getUserString(dFactor, unitStr);
+    const auto formatting = Gui::numericLocaleContextFor(locale());
+    std::string txt = Base::UnitsApi::schemaTranslate(quant, formatting, dFactor, unitStr);
     actUnitValue = quant.getValue() / dFactor;
     // Block signals to prevent newInput from re-parsing the display text
     // and overwriting actQuantity with a precision-truncated value.
@@ -272,77 +274,90 @@ void InputField::contextMenuEvent(QContextMenuEvent* event)
 
 void InputField::newInput(const QString& text)
 {
-    Quantity res;
-    try {
-        QString input = text;
-        fixup(input);
-
-        if (isBound()) {
-            std::shared_ptr<Expression> e(
-                ExpressionParser::parse(getPath().getDocumentObject(), input.toUtf8())
-            );
-
-            setExpression(e);
-
-            std::unique_ptr<Expression> evalRes(getExpression()->eval());
-
-            auto* value = freecad_cast<NumberExpression*>(evalRes.get());
-            if (value) {
-                res.setValue(value->getValue());
-                res.setUnit(value->getUnit());
-            }
-        }
-        else {
-            res = Quantity::parse(input.toStdString());
-        }
+    const auto formatting = Gui::numericLocaleContextFor(locale());
+    App::QuantityConstraints constraints;
+    if (actUnit != Unit::One) {
+        constraints.requiredUnit = actUnit;
     }
-    catch (Base::Exception& e) {
-        QString errorText = QString::fromLatin1(e.what());
-        if (iconLabel->isHidden()) {
-            iconLabel->setVisible(true);
-        }
-        Q_EMIT parseError(errorText);
+    constraints.minimum = Minimum;
+    constraints.maximum = Maximum;
+    const auto result = App::interpretQuantityInput(
+        text.toUtf8().toStdString(),
+        isBound() ? App::QuantityInputGrammar::Expression : App::QuantityInputGrammar::Quantity,
+        getPath(),
+        actUnit,
+        formatting,
+        App::InputPhase::Editing,
+        constraints
+    );
+
+    if (result.status != App::InputStatus::Acceptable) {
         validInput = false;
+        if (result.status == App::InputStatus::Invalid && result.diagnostic) {
+            Q_EMIT parseError(Gui::numericInputDiagnosticText(result.diagnostic->kind));
+        }
         return;
     }
 
-    if (res.isDimensionless()) {
-        res.setUnit(this->actUnit);
-    }
+    Quantity res = *result.quantity;
 
-    // check if unit fits!
-    if (actUnit != Unit::One && !res.isDimensionless() && actUnit != res.getUnit()) {
-        if (iconLabel->isHidden()) {
-            iconLabel->setVisible(true);
-        }
-        Q_EMIT parseError(QStringLiteral("Wrong unit"));
-        validInput = false;
-        return;
+    double dFactor;
+    std::string unitStr;
+    Base::UnitsApi::schemaTranslate(res, formatting, dFactor, unitStr);
+    actUnitValue = res.getValue() / dFactor;
+    // Preserve previous format
+    res.setFormat(this->actQuantity.getFormat());
+
+    // Commit the expression and value only after parsing, evaluation, unit validation, and range
+    // handling have all succeeded.
+    if (result.expression) {
+        setExpression(result.expression);
     }
+    actQuantity = res;
 
     if (iconLabel->isVisible()) {
         iconLabel->setVisible(false);
     }
     validInput = true;
 
-    if (res.getValue() > Maximum) {
-        res.setValue(Maximum);
-    }
-    if (res.getValue() < Minimum) {
-        res.setValue(Minimum);
-    }
-
-    double dFactor;
-    std::string unitStr;
-    res.getUserString(dFactor, unitStr);
-    actUnitValue = res.getValue() / dFactor;
-    // Preserve previous format
-    res.setFormat(this->actQuantity.getFormat());
-    actQuantity = res;
-
     // signaling
     Q_EMIT valueChanged(res);
     Q_EMIT valueChanged(res.getValue());
+}
+
+void InputField::commitInput()
+{
+    const auto formatting = Gui::numericLocaleContextFor(locale());
+    App::QuantityConstraints constraints;
+    if (actUnit != Unit::One) {
+        constraints.requiredUnit = actUnit;
+    }
+    constraints.minimum = Minimum;
+    constraints.maximum = Maximum;
+    const auto result = App::interpretQuantityInput(
+        text().toUtf8().toStdString(),
+        isBound() ? App::QuantityInputGrammar::Expression : App::QuantityInputGrammar::Quantity,
+        getPath(),
+        actUnit,
+        formatting,
+        App::InputPhase::Commit,
+        constraints
+    );
+    if (result.status != App::InputStatus::Acceptable) {
+        validInput = false;
+        if (result.diagnostic) {
+            Q_EMIT parseError(Gui::numericInputDiagnosticText(result.diagnostic->kind));
+        }
+        return;
+    }
+
+    if (result.expression) {
+        setExpression(result.expression);
+    }
+    auto quantity = *result.quantity;
+    quantity.setFormat(actQuantity.getFormat());
+    actQuantity = quantity;
+    validInput = true;
 }
 
 void InputField::pushToHistory(const QString& valueq)
@@ -410,13 +425,8 @@ void InputField::setToLastUsedValue()
 
 void InputField::pushToSavedValues(const QString& valueq)
 {
-    std::string value;
-    if (valueq.isEmpty()) {
-        value = this->text().toUtf8().constData();
-    }
-    else {
-        value = valueq.toUtf8().constData();
-    }
+    const QByteArray valueUtf8 = valueq.isEmpty() ? this->text().toUtf8() : valueq.toUtf8();
+    std::string value(valueUtf8.constData(), valueUtf8.size());
 
     if (_handle.isValid()) {
         char hist1[21];
@@ -514,7 +524,12 @@ const Base::Unit& InputField::getUnit() const
 /// get stored, valid quantity as a string
 QString InputField::getQuantityString() const
 {
-    return QString::fromStdString(actQuantity.getUserString());
+    double factor;
+    std::string unitString;
+    const auto formatting = Gui::numericLocaleContextFor(locale());
+    return QString::fromStdString(
+        Base::UnitsApi::schemaTranslate(actQuantity, formatting, factor, unitString)
+    );
 }
 
 /// set, validate and display quantity from a string. Must match existing units.
@@ -531,7 +546,8 @@ QString InputField::rawText() const
     double factor;
     std::string unit;
     double value = actQuantity.getValue();
-    actQuantity.getUserString(factor, unit);
+    const auto formatting = Gui::numericLocaleContextFor(locale());
+    Base::UnitsApi::schemaTranslate(actQuantity, formatting, factor, unit);
     return QStringLiteral("%1 %2").arg(value / factor).arg(QString::fromStdString(unit));
 }
 
@@ -654,17 +670,10 @@ void InputField::setHistorySize(int i)
 
 void InputField::selectNumber()
 {
-    const QString zeroDigit = QString(locale().zeroDigit());
-    QString expr = QStringLiteral("^([%1%2]?[0-9\\%3%6]*)\\%4?([0-9%6]+(%5[%1%2]?[0-9%6]+)?)")
-                       .arg(locale().negativeSign())
-                       .arg(locale().positiveSign())
-                       .arg(locale().groupSeparator())
-                       .arg(locale().decimalPoint())
-                       .arg(locale().exponential())
-                       .arg(zeroDigit);
-    auto rmatch = QRegularExpression(expr).match(text());
-    if (rmatch.hasMatch()) {
-        setSelection(0, rmatch.capturedLength());
+    const auto length
+        = Gui::numericInputSelectionLength(text(), Gui::numericLocaleContextFor(locale()));
+    if (length > 0) {
+        setSelection(0, length);
     }
 }
 
@@ -693,20 +702,10 @@ void InputField::focusInEvent(QFocusEvent* event)
 
 void InputField::focusOutEvent(QFocusEvent* event)
 {
-    try {
-        if (Quantity::parse(this->text().toStdString()).isDimensionless()) {
-            // if user didn't enter a unit, we virtually compensate
-            // the multiplication factor induced by user unit system
-            double factor;
-            std::string unitStr;
-            actQuantity.getUserString(factor, unitStr);
-            actQuantity = actQuantity * factor;
-        }
+    commitInput();
+    if (validInput) {
+        updateText(actQuantity);
     }
-    catch (const Base::ParserError&) {
-        // do nothing, let apply the last known good value
-    }
-    this->setText(QString::fromStdString(actQuantity.getUserString()));
     QLineEdit::focusOutEvent(event);
 }
 
@@ -714,6 +713,22 @@ void InputField::keyPressEvent(QKeyEvent* event)
 {
     if (isReadOnly()) {
         QLineEdit::keyPressEvent(event);
+        return;
+    }
+
+    if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
+        commitInput();
+        if (validInput) {
+            Q_EMIT returnPressed();
+        }
+        event->accept();
+        return;
+    }
+    if (event->key() == Qt::Key_Escape) {
+        QSignalBlocker blocker(this);
+        updateText(actQuantity);
+        validInput = true;
+        event->accept();
         return;
     }
 
@@ -739,7 +754,8 @@ void InputField::keyPressEvent(QKeyEvent* event)
 
     double dFactor;
     std::string unitStr;
-    actQuantity.getUserString(dFactor, unitStr);
+    const auto formatting = Gui::numericLocaleContextFor(locale());
+    Base::UnitsApi::schemaTranslate(actQuantity, formatting, dFactor, unitStr);
     this->setText(QStringLiteral("%L1 %2").arg(val).arg(QString::fromStdString(unitStr)));
     event->accept();
 }
@@ -767,61 +783,34 @@ void InputField::wheelEvent(QWheelEvent* event)
 
     double dFactor;
     std::string unitStr;
-    actQuantity.getUserString(dFactor, unitStr);
+    const auto formatting = Gui::numericLocaleContextFor(locale());
+    Base::UnitsApi::schemaTranslate(actQuantity, formatting, dFactor, unitStr);
 
     this->setText(QStringLiteral("%L1 %2").arg(val).arg(QString::fromStdString(unitStr)));
     selectNumber();
     event->accept();
 }
 
-void InputField::fixup(QString& input) const
-{
-    input.remove(locale().groupSeparator());
-
-    QString asciiMinus(QStringLiteral("-"));
-    QString localeMinus(locale().negativeSign());
-    if (localeMinus != asciiMinus) {
-        input.replace(localeMinus, asciiMinus);
-    }
-
-    QString asciiPlus(QStringLiteral("+"));
-    QString localePlus(locale().positiveSign());
-    if (localePlus != asciiPlus) {
-        input.replace(localePlus, asciiPlus);
-    }
-
-    // workaround for improper handling of plus sign
-    // in Building US unit system
-    // https://github.com/FreeCAD/FreeCAD/issues/11345
-    QString asciiMinusMinus(QStringLiteral("--"));
-    input.replace(asciiPlus, asciiMinusMinus);
-}
-
 QValidator::State InputField::validate(QString& input, int& pos) const
 {
     Q_UNUSED(pos);
-    try {
-        Quantity res;
-        QString text = input;
-        fixup(text);
-        res = Quantity::parse(text.toStdString());
-
-        double factor;
-        std::string unitStr;
-        res.getUserString(factor, unitStr);
-        double value = res.getValue() / factor;
-        // disallow one to enter numbers out of range
-        if (value > this->Maximum || value < this->Minimum) {
-            return QValidator::Invalid;
-        }
+    App::QuantityConstraints constraints;
+    if (actUnit != Unit::One) {
+        constraints.requiredUnit = actUnit;
     }
-    catch (Base::Exception&) {
-        // Actually invalid input but the newInput slot gives
-        // some feedback
-        return QValidator::Intermediate;
-    }
-
-    return QValidator::Acceptable;
+    constraints.minimum = Minimum;
+    constraints.maximum = Maximum;
+    const auto result = App::interpretQuantityInput(
+        input.toUtf8().toStdString(),
+        isBound() ? App::QuantityInputGrammar::Expression : App::QuantityInputGrammar::Quantity,
+        getPath(),
+        actUnit,
+        Gui::numericLocaleContextFor(locale()),
+        App::InputPhase::Editing,
+        constraints
+    );
+    return result.status == App::InputStatus::Acceptable ? QValidator::Acceptable
+                                                         : QValidator::Intermediate;
 }
 
 // --------------------------------------------------------------------
@@ -832,11 +821,6 @@ InputValidator::InputValidator(InputField* parent)
 {}
 
 InputValidator::~InputValidator() = default;
-
-void InputValidator::fixup(QString& input) const
-{
-    dptr->fixup(input);
-}
 
 QValidator::State InputValidator::validate(QString& input, int& pos) const
 {

--- a/src/Gui/InputField.h
+++ b/src/Gui/InputField.h
@@ -210,6 +210,7 @@ protected Q_SLOTS:
 
 protected:
     void showEvent(QShowEvent* event) override;
+    void changeEvent(QEvent* event) override;
     void focusInEvent(QFocusEvent* event) override;
     void focusOutEvent(QFocusEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;

--- a/src/Gui/InputField.h
+++ b/src/Gui/InputField.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <QValidator>
+#include <App/QuantityInput.h>
 #include <Base/Parameter.h>
 
 #include "ExpressionBinding.h"
@@ -161,8 +162,6 @@ public:
     /// set the number portion selected (use after setValue())
     void selectNumber();
     /// input validation
-    void fixup(QString& input) const;
-    /// input validation
     QValidator::State validate(QString& input, int& pos) const;
 
     /** @name history and default management */
@@ -221,8 +220,10 @@ protected:
 
 private:
     QPixmap getValidationIcon(const char* name, const QSize& size) const;
+    App::QuantityInputResult interpretInput(const QString&, App::InputPhase) const;
     void updateText(const Base::Quantity&);
     void notifyValueChanged();
+    void commitInput();
 
 private:
     QByteArray m_sPrefGrp;

--- a/src/Gui/InputField.h
+++ b/src/Gui/InputField.h
@@ -161,8 +161,6 @@ public:
     /// set the number portion selected (use after setValue())
     void selectNumber();
     /// input validation
-    void fixup(QString& input) const;
-    /// input validation
     QValidator::State validate(QString& input, int& pos) const;
 
     /** @name history and default management */
@@ -223,6 +221,7 @@ private:
     QPixmap getValidationIcon(const char* name, const QSize& size) const;
     void updateText(const Base::Quantity&);
     void notifyValueChanged();
+    void commitInput();
 
 private:
     QByteArray m_sPrefGrp;

--- a/src/Gui/Language/Translator.cpp
+++ b/src/Gui/Language/Translator.cpp
@@ -23,7 +23,6 @@
  ***************************************************************************/
 
 #include <algorithm>
-#include <array>
 #include <QApplication>
 #include <QDir>
 #include <QKeyEvent>
@@ -32,15 +31,14 @@
 #include <QTranslator>
 #include <QWidget>
 
-#include <Base/Tools.h>
+#include <utility>
+
+#include <Base/NumericFormatting.h>
 
 #include <App/Application.h>
 #include <Gui/TextEdit.h>
+#include "../NumericLocale.h"
 #include "Translator.h"
-
-#ifdef FC_OS_WIN32
-# include <windows.h>
-#endif
 
 using namespace Gui;
 
@@ -63,18 +61,38 @@ Translator::LocaleFormattingPreference toLocaleFormattingPreference(const int fo
     }
 }
 
-#ifdef FC_OS_WIN32
-QString getWindowsUserDefaultLocaleName()
+struct ResolvedNumericLocale
 {
-    std::array<wchar_t, LOCALE_NAME_MAX_LENGTH> buffer {};
-    const int written = GetUserDefaultLocaleName(buffer.data(), static_cast<int>(buffer.size()));
-    if (written <= 0) {
-        return {};
+    QLocale qtLocale;
+    Base::NumericLocaleContext numericContext;
+};
+
+ResolvedNumericLocale resolveNumericLocale(const Translator& translator, const std::string& language)
+{
+    QLocale qtLocale;
+    if (Base::isCLocaleName(language)) {
+        qtLocale = QLocale::c();
+    }
+    else {
+        qtLocale = QLocale::system();
+
+        if (!language.empty()) {
+            const std::string localeName = translator.locale(language);
+
+            if (Base::isCLocaleName(localeName)) {
+                qtLocale = QLocale::c();
+            }
+            else if (!localeName.empty()) {
+                const QLocale candidate(QString::fromStdString(localeName));
+                if (candidate.language() != QLocale::C) {
+                    qtLocale = candidate;
+                }
+            }
+        }
     }
 
-    return QString::fromWCharArray(buffer.data());
+    return {qtLocale, Gui::numericLocaleContextFor(qtLocale)};
 }
-#endif
 }  // namespace
 
 /** \defgroup i18n Internationalization with FreeCAD
@@ -372,44 +390,28 @@ void Translator::applyLocaleFormattingPreference() const
 
 void Translator::setLocale(const std::string& language) const
 {
-    const bool isCLocale = Base::Tools::isCLocaleName(language);
-
-    auto loc = QLocale::system();  // Defaulting to OS locale
-#ifdef FC_OS_WIN32
-    if (language.empty()) {
-        // Local Windows development runs can inherit shell state that makes Qt resolve the
-        // system locale differently from the user's regional format.
-        const auto operatingSystemLocale = getWindowsUserDefaultLocaleName();
-        if (!operatingSystemLocale.isEmpty()) {
-            loc = QLocale(operatingSystemLocale);
-        }
-    }
+    // Resolve Qt and the complete numeric-locale context from the same source
+    // so quantity formatting can match what Qt widgets display.
+    const auto resolved = resolveNumericLocale(*this, language);
+    auto nextContext = resolved.numericContext;
+#ifdef FC_DEBUG
+    const auto previousState = Base::currentNumericLocaleContext();
+    const bool localeChanged = previousState != nextContext;
 #endif
-    if (isCLocale) {
-        loc = QLocale::c();
-    }
-    else {
-        auto bcp47 = locale(language);
-        if (!bcp47.empty()) {
-            loc = QLocale(QString::fromStdString(bcp47));
-        }
-    }
-
-    auto icuLocaleId = loc.name().toStdString();
-    if (language.empty()) {
-        // QLocale keeps the effective numeric separators, but loc.name() may still report LANG.
-        const auto operatingSystemNumericLocale = Base::Tools::getOperatingSystemNumericLocale();
-        if (!operatingSystemNumericLocale.empty()) {
-            icuLocaleId = operatingSystemNumericLocale;
-        }
-    }
-    QLocale::setDefault(loc);
-    Base::Tools::setIcuDefaultLocale(isCLocale ? "C" : icuLocaleId);
+    // Complete the fallible ICU operation before publishing Qt and FreeCAD's context. A failure
+    // leaves all three locale consumers unchanged.
+    Base::setIcuDefaultLocale(nextContext.localeId);
+    QLocale::setDefault(resolved.qtLocale);
+    Base::publishNumericLocaleContext(std::move(nextContext));
     updateLocaleChange();
 
 #ifdef FC_DEBUG
-    Base::Console()
-        .log("Locale changed to %s => %s\n", qPrintable(loc.bcp47Name()), qPrintable(loc.name()));
+    if (localeChanged) {
+        const QByteArray bcp47Name = resolved.qtLocale.bcp47Name().toUtf8();
+        const QByteArray localeName = resolved.qtLocale.name().toUtf8();
+        Base::Console()
+            .log("Locale changed to %s => %s\n", bcp47Name.constData(), localeName.constData());
+    }
 #endif
 }
 

--- a/src/Gui/Language/Translator.cpp
+++ b/src/Gui/Language/Translator.cpp
@@ -23,7 +23,6 @@
  ***************************************************************************/
 
 #include <algorithm>
-#include <array>
 #include <QApplication>
 #include <QDir>
 #include <QKeyEvent>
@@ -32,15 +31,14 @@
 #include <QTranslator>
 #include <QWidget>
 
-#include <Base/Tools.h>
+#include <utility>
+
+#include <Base/NumericFormatting.h>
 
 #include <App/Application.h>
 #include <Gui/TextEdit.h>
+#include "../NumericLocale.h"
 #include "Translator.h"
-
-#ifdef FC_OS_WIN32
-# include <windows.h>
-#endif
 
 using namespace Gui;
 
@@ -63,18 +61,44 @@ Translator::LocaleFormattingPreference toLocaleFormattingPreference(const int fo
     }
 }
 
-#ifdef FC_OS_WIN32
-QString getWindowsUserDefaultLocaleName()
+struct ResolvedNumericLocale
 {
-    std::array<wchar_t, LOCALE_NAME_MAX_LENGTH> buffer {};
-    const int written = GetUserDefaultLocaleName(buffer.data(), static_cast<int>(buffer.size()));
-    if (written <= 0) {
-        return {};
+    QLocale qtLocale;
+    Base::NumericLocaleContext numericContext;
+};
+
+std::string toUtf8(const QString& text)
+{
+    const QByteArray utf8 = text.toUtf8();
+    return std::string(utf8.constData(), utf8.size());
+}
+
+ResolvedNumericLocale resolveNumericLocale(const Translator& translator, const std::string& language)
+{
+    QLocale qtLocale;
+    if (Base::isCLocaleName(language)) {
+        qtLocale = QLocale::c();
+    }
+    else {
+        qtLocale = QLocale::system();
+
+        if (!language.empty()) {
+            const std::string localeName = translator.locale(language);
+
+            if (Base::isCLocaleName(localeName)) {
+                qtLocale = QLocale::c();
+            }
+            else if (!localeName.empty()) {
+                const QLocale candidate(QString::fromStdString(localeName));
+                if (candidate.language() != QLocale::C) {
+                    qtLocale = candidate;
+                }
+            }
+        }
     }
 
-    return QString::fromWCharArray(buffer.data());
+    return {qtLocale, Gui::numericLocaleContextFor(qtLocale)};
 }
-#endif
 }  // namespace
 
 /** \defgroup i18n Internationalization with FreeCAD
@@ -371,44 +395,28 @@ void Translator::applyLocaleFormattingPreference() const
 
 void Translator::setLocale(const std::string& language) const
 {
-    const bool isCLocale = Base::Tools::isCLocaleName(language);
-
-    auto loc = QLocale::system();  // Defaulting to OS locale
-#ifdef FC_OS_WIN32
-    if (language.empty()) {
-        // Local Windows development runs can inherit shell state that makes Qt resolve the
-        // system locale differently from the user's regional format.
-        const auto operatingSystemLocale = getWindowsUserDefaultLocaleName();
-        if (!operatingSystemLocale.isEmpty()) {
-            loc = QLocale(operatingSystemLocale);
-        }
-    }
+    // Resolve Qt and the complete numeric-locale context from the same source
+    // so quantity formatting can match what Qt widgets display.
+    const auto resolved = resolveNumericLocale(*this, language);
+    auto nextContext = resolved.numericContext;
+#ifdef FC_DEBUG
+    const auto previousState = Base::currentNumericLocaleContext();
+    const bool localeChanged = previousState != nextContext;
 #endif
-    if (isCLocale) {
-        loc = QLocale::c();
-    }
-    else {
-        auto bcp47 = locale(language);
-        if (!bcp47.empty()) {
-            loc = QLocale(QString::fromStdString(bcp47));
-        }
-    }
-
-    auto icuLocaleId = loc.name().toStdString();
-    if (language.empty()) {
-        // QLocale keeps the effective numeric separators, but loc.name() may still report LANG.
-        const auto operatingSystemNumericLocale = Base::Tools::getOperatingSystemNumericLocale();
-        if (!operatingSystemNumericLocale.empty()) {
-            icuLocaleId = operatingSystemNumericLocale;
-        }
-    }
-    QLocale::setDefault(loc);
-    Base::Tools::setIcuDefaultLocale(isCLocale ? "C" : icuLocaleId);
+    // Complete the fallible ICU operation before publishing Qt and FreeCAD's context. A failure
+    // leaves all three locale consumers unchanged.
+    Base::setIcuDefaultLocale(nextContext.localeId);
+    QLocale::setDefault(resolved.qtLocale);
+    Base::publishNumericLocaleContext(std::move(nextContext));
     updateLocaleChange();
 
 #ifdef FC_DEBUG
-    Base::Console()
-        .log("Locale changed to %s => %s\n", qPrintable(loc.bcp47Name()), qPrintable(loc.name()));
+    if (localeChanged) {
+        const QByteArray bcp47Name = resolved.qtLocale.bcp47Name().toUtf8();
+        const QByteArray localeName = resolved.qtLocale.name().toUtf8();
+        Base::Console()
+            .log("Locale changed to %s => %s\n", bcp47Name.constData(), localeName.constData());
+    }
 #endif
 }
 

--- a/src/Gui/NumericLocale.cpp
+++ b/src/Gui/NumericLocale.cpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "NumericLocale.h"
+
+#include <utility>
+
+#include <QCoreApplication>
+#include <QStringList>
+
+#include <App/QuantityInput.h>
+#include <Base/NumericFormatting.h>
+#include <Base/NumericInput.h>
+
+namespace
+{
+std::string toUtf8(const QString& text)
+{
+    const QByteArray utf8 = text.toUtf8();
+    return std::string(utf8.constData(), utf8.size());
+}
+
+std::pair<int, int> groupingSizes(const QLocale& locale)
+{
+    const QString separator = locale.groupSeparator();
+    const QString formatted = locale.toString(123456789.0, 'f', 0);
+    const auto groups = formatted.split(separator, Qt::KeepEmptyParts);
+    if (separator.isEmpty() || groups.size() < 2) {
+        return {0, 0};
+    }
+
+    const int primary = groups.back().size();
+    const int secondary = groups.size() > 2 ? groups[groups.size() - 2].size() : primary;
+    return {primary, secondary};
+}
+}  // namespace
+
+Base::NumericLocaleContext Gui::numericLocaleContextFor(const QLocale& locale)
+{
+    const auto [primary, secondary] = groupingSizes(locale);
+    const QString localeName = locale.name();
+
+    return {
+        Base::normalizeIcuLocaleId(toUtf8(localeName)),
+        toUtf8(QString(locale.decimalPoint())),
+        toUtf8(QString(locale.groupSeparator())),
+        toUtf8(QString(locale.positiveSign())),
+        toUtf8(QString(locale.negativeSign())),
+        primary,
+        secondary,
+        toUtf8(QString(locale.zeroDigit()))
+    };
+}
+
+int Gui::numericInputSelectionLengthUtf16(const QString& text, const Base::NumericLocaleContext& locale)
+{
+    const QByteArray utf8 = text.toUtf8();
+    const auto result = Base::scanLocalizedNumber(
+        std::string_view {utf8.constData(), static_cast<std::size_t>(utf8.size())},
+        locale,
+        Base::NumericSyntaxContext::Standalone
+    );
+    if (result.consumedBytes == 0) {
+        return 0;
+    }
+
+    return QString::fromUtf8(utf8.constData(), static_cast<int>(result.consumedBytes)).size();
+}
+
+QString Gui::numericInputDiagnosticText(const App::InputDiagnosticKind kind)
+{
+    switch (kind) {
+        case App::InputDiagnosticKind::IncompleteNumber:
+            return QCoreApplication::translate("NumericInput", "Incomplete number");
+        case App::InputDiagnosticKind::MalformedGrouping:
+            return QCoreApplication::translate("NumericInput", "Malformed grouping separator placement");
+        case App::InputDiagnosticKind::InvalidNumber:
+            return QCoreApplication::translate("NumericInput", "Invalid number");
+        case App::InputDiagnosticKind::ExpressionSyntax:
+            return QCoreApplication::translate("NumericInput", "Invalid expression");
+        case App::InputDiagnosticKind::Evaluation:
+            return QCoreApplication::translate("NumericInput", "Expression could not be evaluated");
+        case App::InputDiagnosticKind::IncompatibleUnit:
+            return QCoreApplication::translate("NumericInput", "Incompatible unit");
+        case App::InputDiagnosticKind::OutOfRange:
+            return QCoreApplication::translate("NumericInput", "Value is outside the allowed range");
+    }
+    return {};
+}

--- a/src/Gui/NumericLocale.cpp
+++ b/src/Gui/NumericLocale.cpp
@@ -10,6 +10,7 @@
 #include <App/QuantityInput.h>
 #include <Base/NumericFormatting.h>
 #include <Base/NumericInput.h>
+#include <Base/Quantity.h>
 
 namespace
 {
@@ -49,6 +50,18 @@ Base::NumericLocaleContext Gui::numericLocaleContextFor(const QLocale& locale)
         secondary,
         toUtf8(QString(locale.zeroDigit()))
     };
+}
+
+Base::QuantityFormat Gui::editableQuantityFormat(
+    const Base::QuantityFormat& format,
+    const Base::NumericLocaleContext& locale
+)
+{
+    auto editable = format;
+    if (locale.decimalSeparator != "." && locale.groupingSeparator == ".") {
+        editable.option |= Base::QuantityFormat::OmitGroupSeparator;
+    }
+    return editable;
 }
 
 int Gui::numericInputSelectionLengthUtf16(const QString& text, const Base::NumericLocaleContext& locale)

--- a/src/Gui/NumericLocale.cpp
+++ b/src/Gui/NumericLocale.cpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "NumericLocale.h"
+
+#include <utility>
+
+#include <QCoreApplication>
+#include <QStringList>
+
+#include <App/QuantityInput.h>
+#include <Base/NumericFormatting.h>
+#include <Base/NumericInput.h>
+
+namespace
+{
+std::string toUtf8(const QString& text)
+{
+    const QByteArray utf8 = text.toUtf8();
+    return std::string(utf8.constData(), utf8.size());
+}
+
+std::pair<int, int> groupingSizes(const QLocale& locale)
+{
+    const QString separator = locale.groupSeparator();
+    const QString formatted = locale.toString(123456789.0, 'f', 0);
+    const auto groups = formatted.split(separator, Qt::KeepEmptyParts);
+    if (separator.isEmpty() || groups.size() < 2) {
+        return {0, 0};
+    }
+
+    const int primary = groups.back().size();
+    const int secondary = groups.size() > 2 ? groups[groups.size() - 2].size() : primary;
+    return {primary, secondary};
+}
+}  // namespace
+
+Base::NumericLocaleContext Gui::numericLocaleContextFor(const QLocale& locale)
+{
+    const auto [primary, secondary] = groupingSizes(locale);
+    const QString localeName = locale.name();
+
+    return {
+        Base::normalizeIcuLocaleId(toUtf8(localeName)),
+        toUtf8(QString(locale.decimalPoint())),
+        toUtf8(QString(locale.groupSeparator())),
+        toUtf8(QString(locale.positiveSign())),
+        toUtf8(QString(locale.negativeSign())),
+        primary,
+        secondary,
+        toUtf8(QString(locale.zeroDigit()))
+    };
+}
+
+int Gui::numericInputSelectionLength(const QString& text, const Base::NumericLocaleContext& locale)
+{
+    const QByteArray utf8 = text.toUtf8();
+    const auto result = Base::scanLocalizedNumber(
+        std::string_view {utf8.constData(), static_cast<std::size_t>(utf8.size())},
+        locale,
+        Base::NumericSyntaxContext::Standalone
+    );
+    if (result.consumedBytes == 0) {
+        return 0;
+    }
+
+    return QString::fromUtf8(utf8.constData(), static_cast<int>(result.consumedBytes)).size();
+}
+
+QString Gui::numericInputDiagnosticText(const App::InputDiagnosticKind kind)
+{
+    switch (kind) {
+        case App::InputDiagnosticKind::IncompleteNumber:
+            return QCoreApplication::translate("NumericInput", "Incomplete number");
+        case App::InputDiagnosticKind::MalformedGrouping:
+            return QCoreApplication::translate("NumericInput", "Malformed grouping separator placement");
+        case App::InputDiagnosticKind::InvalidNumber:
+            return QCoreApplication::translate("NumericInput", "Invalid number");
+        case App::InputDiagnosticKind::ExpressionSyntax:
+            return QCoreApplication::translate("NumericInput", "Invalid expression");
+        case App::InputDiagnosticKind::Evaluation:
+            return QCoreApplication::translate("NumericInput", "Expression could not be evaluated");
+        case App::InputDiagnosticKind::IncompatibleUnit:
+            return QCoreApplication::translate("NumericInput", "Incompatible unit");
+        case App::InputDiagnosticKind::OutOfRange:
+            return QCoreApplication::translate("NumericInput", "Value is outside the allowed range");
+    }
+    return {};
+}

--- a/src/Gui/NumericLocale.h
+++ b/src/Gui/NumericLocale.h
@@ -18,6 +18,18 @@ namespace Gui
 /** Build a complete numeric-locale context from this widget's QLocale. */
 GuiExport Base::NumericLocaleContext numericLocaleContextFor(const QLocale& locale);
 
+/**
+ * Return the format safe for displaying a quantity in an editable field.
+ *
+ * A dot grouping separator is ambiguous in a locale whose decimal separator is not a dot:
+ * `1.234` can be either a grouped integer or a canonical decimal. Editable displays must not
+ * emit that ambiguous form.
+ */
+GuiExport Base::QuantityFormat editableQuantityFormat(
+    const Base::QuantityFormat& format,
+    const Base::NumericLocaleContext& locale
+);
+
 /** Return the UTF-16 code-unit length of the numeric token at the start of a line edit. */
 GuiExport int numericInputSelectionLengthUtf16(
     const QString& text,

--- a/src/Gui/NumericLocale.h
+++ b/src/Gui/NumericLocale.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <QLocale>
+#include <QString>
+
+#include <Base/NumericFormatting.h>
+
+namespace App
+{
+enum class InputDiagnosticKind;
+}
+
+namespace Gui
+{
+
+/** Build a complete numeric-locale context from this widget's QLocale. */
+GuiExport Base::NumericLocaleContext numericLocaleContextFor(const QLocale& locale);
+
+/** Return the UTF-16 code-unit length of the numeric token at the start of a line edit. */
+GuiExport int numericInputSelectionLengthUtf16(
+    const QString& text,
+    const Base::NumericLocaleContext& locale
+);
+
+/** Translate an application-level numeric input diagnostic for GUI presentation. */
+GuiExport QString numericInputDiagnosticText(App::InputDiagnosticKind kind);
+
+}  // namespace Gui

--- a/src/Gui/NumericLocale.h
+++ b/src/Gui/NumericLocale.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <QLocale>
+#include <QString>
+
+#include <Base/NumericFormatting.h>
+
+namespace App
+{
+enum class InputDiagnosticKind;
+}
+
+namespace Gui
+{
+
+/** Build a complete numeric-locale context from this widget's QLocale. */
+GuiExport Base::NumericLocaleContext numericLocaleContextFor(const QLocale& locale);
+
+/** Return the UTF-16 length of the numeric token at the start of a line edit. */
+GuiExport int numericInputSelectionLength(const QString& text, const Base::NumericLocaleContext& locale);
+
+/** Translate an application-level numeric input diagnostic for GUI presentation. */
+GuiExport QString numericInputDiagnosticText(App::InputDiagnosticKind kind);
+
+}  // namespace Gui

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -26,8 +26,7 @@
 #include <QFocusEvent>
 #include <QFontMetrics>
 #include <QLineEdit>
-#include <QRegularExpression>
-#include <QRegularExpressionMatch>
+#include <QtCore/QScopedValueRollback>
 #include <QStyle>
 #include <QStyleOptionSpinBox>
 #include <QToolTip>
@@ -38,15 +37,18 @@
 #include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <App/ExpressionParser.h>
+#include <App/QuantityInput.h>
 #include <Base/Exception.h>
+#include <Base/NumericFormatting.h>
+#include <Base/NumericInput.h>
 #include <Base/UnitsApi.h>
-#include <Base/Tools.h>
 #include <Base/UnitsSchema.h>
 
 #include "QuantitySpinBox.h"
 #include "QuantitySpinBox_p.h"
 #include "Command.h"
 #include "Dialogs/DlgExpressionInput.h"
+#include "NumericLocale.h"
 #include "Tools.h"
 #include "Widgets.h"
 
@@ -64,6 +66,7 @@ public:
     QuantitySpinBoxPrivate(QuantitySpinBox* q)
         : validInput(true)
         , pendingEmit(false)
+        , updatingText(false)
         , normalize(true)
         , checkRangeInExpression(false)
         , adjustableWidth(false)
@@ -77,242 +80,56 @@ public:
     {}
     ~QuantitySpinBoxPrivate() = default;
 
-    QString stripped(const QString& t, int* pos) const
-    {
-        QString text = t;
-        const int s = text.size();
-        text = text.trimmed();
-        if (pos) {
-            (*pos) -= (s - text.size());
-        }
-        return text;
-    }
-
-    bool validate(QString& input, Base::Quantity& result, const App::ObjectIdentifier& path) const
+    App::QuantityInputResult interpretInput(
+        const QString& input,
+        const App::ObjectIdentifier& path,
+        const App::QuantityInputGrammar grammar,
+        const App::InputPhase phase
+    ) const
     {
         Q_Q(const QuantitySpinBox);
-
-        // Do not accept empty strings because the parser will consider
-        // " unit" as "1 unit" which is not the desired behaviour (see #0004104)
-        if (input.isEmpty()) {
-            return false;
+        App::QuantityConstraints constraints;
+        if (unit != Base::Unit::One) {
+            constraints.requiredUnit = unit;
         }
-
-        bool success = false;
-        QString tmp = input;
-
-        auto validateInput = [&](QString& tmp) -> QValidator::State {
-            QValidator::State state;
-            Base::Quantity res = validateAndInterpret(tmp, state, path);
-            res.setFormat(quantity.getFormat());
-            if (state == QValidator::Acceptable) {
-                success = true;
-                result = res;
-                input = tmp;
-            }
-            return state;
+        constraints.minimum = minimum;
+        constraints.maximum = maximum;
+        const auto parse = [&](const App::QuantityInputGrammar selectedGrammar) {
+            return App::interpretQuantityInput(
+                input.toUtf8().toStdString(),
+                selectedGrammar,
+                path,
+                unit,
+                Gui::numericLocaleContextFor(q->locale()),
+                phase,
+                constraints
+            );
         };
 
-        QValidator::State state = validateInput(tmp);
-        if (state == QValidator::Intermediate && q->hasExpression()) {
-            // Accept the expression as it is but try to add the right unit string
-            success = true;
-
-            Base::Quantity quantity;
-            double value;
-            if (parseString(input, quantity, value, path)) {
-                quantity.setUnit(unit);
-                result = quantity;
-
-                // Now translate the quantity into its string representation using the user-defined
-                // unit system
-                input = QString::fromStdString(Base::UnitsApi::schemaTranslate(result));
-            }
+        auto result = parse(grammar);
+        // Preserve the quantity parser as the authority for quantity-only syntax, while keeping
+        // the established unbound-field support for arithmetic expressions. A parser failure is
+        // the only case that permits the expression grammar fallback; malformed numbers and
+        // incompatible units must retain their original diagnostics.
+        if (grammar == App::QuantityInputGrammar::Quantity
+            && result.status == App::InputStatus::Invalid && result.diagnostic
+            && result.diagnostic->kind == App::InputDiagnosticKind::ExpressionSyntax) {
+            result = parse(App::QuantityInputGrammar::Expression);
         }
-
-        return success;
-    }
-    bool parseString(
-        const QString& str,
-        Base::Quantity& result,
-        double& value,
-        const App::ObjectIdentifier& path
-    ) const
-    {
-        App::ObjectIdentifier pathtmp = path;
-        try {
-            QString copy = str;
-            copy.remove(locale.groupSeparator());
-
-            // Expression parser
-            std::shared_ptr<Expression> expr(
-                ExpressionParser::parse(path.getDocumentObject(), copy.toUtf8().constData())
-            );
-            if (expr) {
-
-                std::unique_ptr<Expression> res(expr->eval());
-                NumberExpression* n = freecad_cast<NumberExpression*>(res.get());
-                if (n) {
-                    result = n->getQuantity();
-                    value = result.getValue();
-                    return true;
-                }
-            }
-        }
-        catch (Base::Exception&) {
-            return false;
-        }
-        return false;
-    }
-    Base::Quantity validateAndInterpret(
-        QString& input,
-        QValidator::State& state,
-        const App::ObjectIdentifier& path
-    ) const
-    {
-        Base::Quantity res;
-        const double max = this->maximum;
-        const double min = this->minimum;
-
-        QString copy = input;
-        double value = min;
-        bool ok = false;
-
-        QChar plus = QLatin1Char('+'), minus = QLatin1Char('-');
-
-        if (locale.negativeSign() != minus) {
-            copy.replace(locale.negativeSign(), minus);
-        }
-        if (locale.positiveSign() != plus) {
-            copy.replace(locale.positiveSign(), plus);
-        }
-
-        QString reverseUnitStr = unitStr;
-        std::reverse(reverseUnitStr.begin(), reverseUnitStr.end());
-
-        // Prep for expression parser
-        // This regex matches chunks between +,-,$,^ accounting for matching parenthesis.
-        QRegularExpression chunkRe(
-            QStringLiteral("(?<=^|[\\+\\-])((\\((?>[^()]|(?2))*\\))|[^\\+\\-\n])*(?=$|[\\+\\-])")
-        );
-        QRegularExpressionMatchIterator expressionChunk = chunkRe.globalMatch(copy);
-        unsigned int lengthOffset = 0;
-        while (expressionChunk.hasNext()) {
-            QRegularExpressionMatch matchChunk = expressionChunk.next();
-            QString origionalChunk = matchChunk.captured(0);
-            QString copyChunk = origionalChunk;
-            std::reverse(copyChunk.begin(), copyChunk.end());
-
-            // Reused regex patterns
-            static const std::string regexUnits
-                = "sAV|VC|lim|nim|im|hpm|[mf]?bl|°|ged|dar|nog|″|′|rroT[uµm]?|K[uµm]?|A[mkM]?|F["
-                  "pnuµm]?|C|S[uµmkM]?|zH[kMGT]?|H[nuµm]?|mhO[kM]?|J[mk]?|Ve[kM]?|V[mk]?|hWk|sW|"
-                  "lack?|N[mkM]?|g[uµmk]?|lm?|(?<=\\b|[^a-zA-Z])m[nuµmcdk]?|uoht|ni|\"|'|dy|dc|bW|"
-                  "T|t|zo|ts|twc|Wk?|aP[kMG]?|is[pk]|h|G|M|tfc|tfqs|tf|s";
-            static const std::string regexUnitlessFunctions
-                = "soca|nisa|2nata|nata|hsoc|hnis|hnat|soc|nat|nis|pxe|gol|01gol";
-            static const std::string regexConstants = "e|ip|lomm|lom";
-            static const std::string regexNumber = "\\d+\\s*\\.?\\s*\\d*|\\.\\s*\\d+";
-
-            // If expression does not contain /*() or ^, this regex will not find anything
-            if (copy.contains(QLatin1Char('/')) || copy.contains(QLatin1Char('*'))
-                || copy.contains(QLatin1Char('(')) || copy.contains(QLatin1Char(')'))
-                || copy.contains(QLatin1Char('^'))) {
-                // Find units and replace 1/2mm -> 1/2*(1mm), 1^2mm -> 1^2*(1mm)
-                QRegularExpression fixUnits(
-                    QString::fromStdString(
-                        "(" + regexUnits + ")(\\s*\\)|(?:\\*|(?:\\)(?:(?:\\s*(?:" + regexConstants
-                        + "|\\)(?:[^()]|(?R))*\\((?:" + regexUnitlessFunctions + ")|" + regexNumber
-                        + "))|(?R))*\\(|(?:\\s*(?:" + regexConstants
-                        + "|\\)(?:[^()]|(?R))*\\((?:" + regexUnitlessFunctions + ")|" + regexNumber
-                        + "))))+(?:[\\/\\^]|(.*$))(?!(" + regexUnits + ")))"
-                    )
-                );
-                QRegularExpressionMatch fixUnitsMatch = fixUnits.match(copyChunk);
-
-                // 3rd capture group being filled indicates regex bailed out; no match.
-                if (fixUnitsMatch.lastCapturedIndex() == 2
-                    || (fixUnitsMatch.lastCapturedIndex() == 3
-                        && fixUnitsMatch.captured(3).isEmpty())) {
-                    QString matchUnits = fixUnitsMatch.captured(1);
-                    QString matchNumbers = fixUnitsMatch.captured(2);
-                    copyChunk.replace(
-                        matchUnits + matchNumbers,
-                        QStringLiteral(")") + matchUnits + QStringLiteral("1(*") + matchNumbers
-                    );
-                }
-            }
-
-            // Add default units to string if none are present
-            if (!copyChunk.contains(reverseUnitStr)) {  // Fast check
-                QRegularExpression unitsRe(
-                    QString::fromStdString(
-                        "(?<=\\b|[^a-zA-Z])(" + regexUnits
-                        + ")(?=\\b|[^a-zA-Z])|°|″|′|\"|'|\\p{L}\\.\\p{L}|\\[\\p{L}"
-                    )
-                );
-
-                QRegularExpressionMatch match = unitsRe.match(copyChunk);
-                if (!match.hasMatch() && !copyChunk.isEmpty()) {  // If no units are found, use
-                                                                  // default units
-                    copyChunk.prepend(
-                        QStringLiteral(")") + reverseUnitStr + QStringLiteral("1(*")
-                    );  // Add units to the end of chunk *(1unit)
-                }
-            }
-
-            std::reverse(copyChunk.begin(), copyChunk.end());
-
-            copy.replace(
-                matchChunk.capturedStart() + lengthOffset,
-                matchChunk.capturedEnd() - matchChunk.capturedStart(),
-                copyChunk
-            );
-            lengthOffset += copyChunk.length() - origionalChunk.length();
-        }
-
-        ok = parseString(copy, res, value, path);
-
-        // If result does not have unit: add default unit
-        if (res.isDimensionless()) {
-            res.setUnit(unit);
-        }
-
-        if (!ok) {
-            // input may not be finished
-            state = QValidator::Intermediate;
-        }
-        else if (value >= min && value <= max) {
-            state = QValidator::Acceptable;
-        }
-        else if (max == min) {  // when max and min is the same the only non-Invalid input is max
-                                // (or min)
-            state = QValidator::Invalid;
-        }
-        else {
-            if ((value >= 0 && value > max) || (value < 0 && value < min)) {
-                state = QValidator::Invalid;
-            }
-            else {
-                state = QValidator::Intermediate;
-            }
-        }
-        if (state != QValidator::Acceptable) {
-            res.setValue(max > 0 ? min : max);
-        }
-
-        return res;
+        return result;
     }
 
     QLocale locale;
     bool validInput;
     bool pendingEmit;
+    bool updatingText;
     bool normalize;
     bool checkRangeInExpression;
     bool adjustableWidth;
     int maxExpectedDigits;
     bool addIconSpace;
     QString validStr;
+    QString lastRejectedText;
     Base::Quantity quantity;
     Base::Quantity cached;
     Base::Unit unit;
@@ -335,7 +152,6 @@ QuantitySpinBox::QuantitySpinBox(QWidget* parent)
     d_ptr->locale = locale();
     this->setContextMenuPolicy(Qt::DefaultContextMenu);
     connect(lineEdit(), &QLineEdit::textChanged, this, &QuantitySpinBox::userInput);
-    connect(this, &QuantitySpinBox::editingFinished, this, [&] { this->handlePendingEmit(true); });
 }
 
 QuantitySpinBox::~QuantitySpinBox() = default;
@@ -461,20 +277,44 @@ void Gui::QuantitySpinBox::keyPressEvent(QKeyEvent* event)
 
     const auto isEnter = event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return;
 
-    if (d->normalize && isEnter && !isNormalized()) {
-        // ensure that input is up to date
-        handlePendingEmit();
+    if (event->key() == Qt::Key_Escape) {
+        d->pendingEmit = false;
+        d->validInput = true;
+        d->lastRejectedText.clear();
+        QToolTip::hideText();
+        lineEdit()->setToolTip(QString());
+        lineEdit()->setProperty("numericInputInvalid", false);
+        {
+            const QSignalBlocker blocker(lineEdit());
+            updateText(d->quantity);
+        }
+        // Restore the editor here, then leave cancellation to an enclosing task panel.
+        event->ignore();
+        return;
+    }
 
-        normalize();
+    if (isEnter) {
+        validateInput();
+        if (d->validInput && d->normalize && !isNormalized()) {
+            normalize();
+        }
+        if (d->validInput) {
+            // This handler deliberately consumes Return after committing the text. Preserve the
+            // QAbstractSpinBox signal contract for callers that use editingFinished().
+            Q_EMIT returnPressed();
+            Q_EMIT editingFinished();
+            // A successful local commit must not hide Return from an enclosing task panel.
+            event->ignore();
+        }
+        else {
+            // Rejected input must not accept the surrounding task.
+            event->accept();
+        }
         return;
     }
 
     if (!handleKeyEvent(event->text())) {
         QAbstractSpinBox::keyPressEvent(event);
-    }
-
-    if (isEnter) {
-        returnPressed();
     }
 }
 
@@ -493,6 +333,9 @@ void QuantitySpinBox::updateText(const Quantity& quant)
     QString txt = getUserString(quant, dFactor, d->unitStr);
     d->unitValue = quant.getValue() / dFactor;
     updateEdit(txt);
+    d->validStr = txt;
+    d->validInput = true;
+    d->lastRejectedText.clear();
     handlePendingEmit();
 }
 
@@ -506,6 +349,10 @@ void QuantitySpinBox::updateEdit(const QString& text)
     int selLen = edit->selectionLength();
 
     // setText resets cursor/selection so save it and restore it
+    // A schema can intentionally display a precise quantity in a coarser user unit (for
+    // example, 12345.67 mm as 12.35 m). Do not feed that display representation back through
+    // the input parser or the stored quantity will change when the editor updates itself.
+    QScopedValueRollback<bool> updatingGuard(d->updatingText, true);
     edit->setText(text);
 
     int maxPos = qMax(0, edit->displayText().size() - d->unitStr.size());
@@ -526,15 +373,53 @@ void QuantitySpinBox::validateInput()
 {
     Q_D(QuantitySpinBox);
 
-    QValidator::State state;
-    QString text = lineEdit()->text();
+    const QString text = lineEdit()->text();
+    if (d->validInput && !d->pendingEmit && !text.isEmpty() && text == d->validStr) {
+        return;
+    }
     const App::ObjectIdentifier& path = getPath();
-    d->validateAndInterpret(text, state, path);
-    if (state != QValidator::Acceptable) {
-        updateEdit(d->validStr);
+    const auto grammar = isBound() ? App::QuantityInputGrammar::Expression
+                                   : App::QuantityInputGrammar::Quantity;
+    const auto result = d->interpretInput(text, path, grammar, App::InputPhase::Commit);
+    if (result.status == App::InputStatus::Acceptable) {
+        auto quantity = *result.quantity;
+        quantity.setFormat(d->quantity.getFormat());
+        const bool needsEmit = !d->validInput || d->validStr != text || d->pendingEmit;
+        d->cached = quantity;
+        d->pendingEmit = needsEmit;
+        d->validInput = true;
+        d->validStr = text;
+        d->lastRejectedText.clear();
+        lineEdit()->setToolTip(QString());
+        lineEdit()->setProperty("numericInputInvalid", false);
+        handlePendingEmit();
+        return;
     }
 
-    handlePendingEmit();
+    d->pendingEmit = false;
+    d->validInput = false;
+
+    if (!result.diagnostic || d->lastRejectedText == text) {
+        return;
+    }
+
+    const QString message = Gui::numericInputDiagnosticText(result.diagnostic->kind);
+
+    // Input errors use a dedicated line-edit state. The expression icon belongs to the formula
+    // editor and showing it here changes the text margin and leaves stale UI state behind.
+    lineEdit()->setProperty("numericInputInvalid", true);
+    lineEdit()->setToolTip(message);
+    const auto& diagnostic = *result.diagnostic;
+    const QByteArray utf8 = text.toUtf8();
+    const auto offsetBytes = qMin<int>(static_cast<int>(diagnostic.offsetBytes), utf8.size());
+    const auto lengthBytes
+        = qMin<int>(static_cast<int>(diagnostic.lengthBytes), utf8.size() - offsetBytes);
+    const int errorStartUtf16 = QString::fromUtf8(utf8.constData(), offsetBytes).size();
+    const int errorLengthUtf16 = QString::fromUtf8(utf8.mid(offsetBytes, lengthBytes)).size();
+    lineEdit()->setSelection(errorStartUtf16, errorLengthUtf16);
+    QToolTip::showText(lineEdit()->mapToGlobal(QPoint(0, lineEdit()->height())), message, lineEdit());
+    d->lastRejectedText = text;
+    Q_EMIT inputRejected(message, errorStartUtf16, errorLengthUtf16);
 }
 
 Base::Quantity QuantitySpinBox::value() const
@@ -718,42 +603,41 @@ bool QuantitySpinBox::hasValidInput() const
     return d->validInput;
 }
 
-// Gets called after call of 'validateAndInterpret'
+// Parse edits without changing the last committed quantity until the edit is complete.
 void QuantitySpinBox::userInput(const QString& text)
 {
     Q_D(QuantitySpinBox);
-    d->pendingEmit = true;
-
-    QString tmp = text;
-    Base::Quantity res;
-    const App::ObjectIdentifier& path = getPath();
-    if (d->validate(tmp, res, path)) {
-        d->validStr = tmp;
-        d->validInput = true;
-    }
-    else {
-        d->validInput = false;
-
-        // only emit signal to reset EditableDatumLabel if the input is truly empty or has
-        // no meaningful number don't emit for partially typed numbers like "71." which are
-        // temporarily invalid
-        const QString trimmedText = text.trimmed();
-        static const QRegularExpression partialNumberRegex(QStringLiteral(R"([+-]?(\d+)?(\.,\d*)?)"));
-        if (trimmedText.isEmpty() || !trimmedText.contains(partialNumberRegex)) {
-            // we have to emit here signal explicitly as validator will not pass
-            // this value further but we want to check it to disable isSet flag if
-            // it has been set previously
-            Q_EMIT valueChanged(d->quantity.getValue());
-        }
+    if (d->updatingText) {
         return;
     }
 
-    if (keyboardTracking()) {
-        d->cached = res;
-        handlePendingEmit(false);
+    const App::ObjectIdentifier& path = getPath();
+    const auto grammar = isBound() ? App::QuantityInputGrammar::Expression
+                                   : App::QuantityInputGrammar::Quantity;
+    const auto result = d->interpretInput(text, path, grammar, App::InputPhase::Editing);
+    if (text.trimmed().isEmpty()) {
+        Q_EMIT inputCleared();
+    }
+    d->lastRejectedText.clear();
+    QToolTip::hideText();
+    lineEdit()->setToolTip(QString());
+    lineEdit()->setProperty("numericInputInvalid", false);
+
+    if (result.status == App::InputStatus::Acceptable) {
+        auto quantity = *result.quantity;
+        quantity.setFormat(d->quantity.getFormat());
+        d->cached = quantity;
+        d->pendingEmit = true;
+        d->validStr = text;
+        d->validInput = true;
+
+        if (keyboardTracking()) {
+            handlePendingEmit(false);
+        }
     }
     else {
-        d->cached = res;
+        d->pendingEmit = false;
+        d->validInput = false;
     }
 }
 
@@ -808,7 +692,13 @@ void QuantitySpinBox::updateFromCache(bool notify, bool updateUnit /* = true */)
             d->pendingEmit = false;
             Q_EMIT valueChanged(res);
             Q_EMIT valueChanged(res.getValue());
-            Q_EMIT textChanged(text);
+            // While keyboard tracking is active, keep the user's exact text in the line edit.
+            // Re-emitting a schema-formatted string here can switch units at a threshold and
+            // feed a rounded display value back through the parser on the next keystroke.
+            const QString emittedText = updateUnit ? text : lineEdit()->text();
+            d->updatingText = true;
+            Q_EMIT textChanged(emittedText);
+            d->updatingText = false;
         }
     }
 }
@@ -935,26 +825,22 @@ void QuantitySpinBox::clearSchema()
 QString QuantitySpinBox::getUserString(const Base::Quantity& val, double& factor, QString& unitString) const
 {
     Q_D(const QuantitySpinBox);
+    const auto formatting = Gui::numericLocaleContextFor(locale());
+    auto displayQuantity = val;
+    displayQuantity.setFormat(Gui::editableQuantityFormat(val.getFormat(), formatting));
     std::string unitStr;
-    const std::string str = d->scheme ? val.getUserString(d->scheme.get(), factor, unitStr)
-                                      : val.getUserString(factor, unitStr);
+    const std::string str = d->scheme
+        ? d->scheme->translate(displayQuantity, formatting, factor, unitStr)
+        : Base::UnitsApi::schemaTranslate(displayQuantity, formatting, factor, unitStr);
     unitString = QString::fromStdString(unitStr);
     return QString::fromStdString(str);
 }
 
 QString QuantitySpinBox::getUserString(const Base::Quantity& val) const
 {
-    Q_D(const QuantitySpinBox);
-    std::string str;
-    if (d->scheme) {
-        double factor;
-        std::string unitString;
-        str = val.getUserString(d->scheme.get(), factor, unitString);
-    }
-    else {
-        str = val.getUserString();
-    }
-    return QString::fromStdString(str);
+    double factor;
+    QString unitString;
+    return getUserString(val, factor, unitString);
 }
 
 void QuantitySpinBox::setExpression(std::shared_ptr<Expression> expr)
@@ -1133,12 +1019,23 @@ void QuantitySpinBox::focusOutEvent(QFocusEvent* event)
 
     validateInput();
 
-    if (d->normalize) {
+    if (d->validInput && d->normalize) {
         normalize();
     }
 
     QToolTip::hideText();
     QAbstractSpinBox::focusOutEvent(event);
+}
+
+void QuantitySpinBox::changeEvent(QEvent* event)
+{
+    Q_D(QuantitySpinBox);
+    QAbstractSpinBox::changeEvent(event);
+
+    if (event->type() == QEvent::LocaleChange && d->validInput) {
+        const QSignalBlocker blocker(lineEdit());
+        updateText(d->quantity);
+    }
 }
 
 void QuantitySpinBox::clear()
@@ -1148,15 +1045,12 @@ void QuantitySpinBox::clear()
 
 void QuantitySpinBox::selectNumber()
 {
-    QString expr = QStringLiteral("^([%1%2]?[0-9\\%3]*)\\%4?([0-9]+(%5[%1%2]?[0-9]+)?)")
-                       .arg(locale().negativeSign())
-                       .arg(locale().positiveSign())
-                       .arg(locale().groupSeparator())
-                       .arg(locale().decimalPoint())
-                       .arg(locale().exponential());
-    auto rmatch = QRegularExpression(expr).match(lineEdit()->text());
-    if (rmatch.hasMatch()) {
-        lineEdit()->setSelection(0, rmatch.capturedLength());
+    const auto length = Gui::numericInputSelectionLengthUtf16(
+        lineEdit()->text(),
+        Gui::numericLocaleContextFor(locale())
+    );
+    if (length > 0) {
+        lineEdit()->setSelection(0, length);
     }
 }
 
@@ -1173,16 +1067,11 @@ Base::Quantity QuantitySpinBox::valueFromText(const QString& text) const
 {
     Q_D(const QuantitySpinBox);
 
-    QString copy = text;
-    QValidator::State state = QValidator::Acceptable;
     const App::ObjectIdentifier& path = getPath();
-    Base::Quantity quant = d->validateAndInterpret(copy, state, path);
-    if (state != QValidator::Acceptable) {
-        fixup(copy);
-        quant = d->validateAndInterpret(copy, state, path);
-    }
-
-    return quant;
+    const auto grammar = isBound() ? App::QuantityInputGrammar::Expression
+                                   : App::QuantityInputGrammar::Quantity;
+    const auto result = d->interpretInput(text, path, grammar, App::InputPhase::Commit);
+    return result.quantity.value_or(Base::Quantity());
 }
 
 QValidator::State QuantitySpinBox::validate(QString& text, int& pos) const
@@ -1190,17 +1079,13 @@ QValidator::State QuantitySpinBox::validate(QString& text, int& pos) const
     Q_D(const QuantitySpinBox);
     Q_UNUSED(pos)
 
-    QValidator::State state;
     const App::ObjectIdentifier& path = getPath();
-    d->validateAndInterpret(text, state, path);
-    return state;
+    const auto grammar = isBound() ? App::QuantityInputGrammar::Expression
+                                   : App::QuantityInputGrammar::Quantity;
+    const auto result = d->interpretInput(text, path, grammar, App::InputPhase::Editing);
+    return result.status == App::InputStatus::Acceptable ? QValidator::Acceptable
+                                                         : QValidator::Intermediate;
 }
-
-void QuantitySpinBox::fixup(QString& input) const
-{
-    input.remove(locale().groupSeparator());
-}
-
 
 #include "moc_QuantitySpinBox.cpp"
 #include "moc_QuantitySpinBox_p.cpp"

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -26,8 +26,6 @@
 #include <QFocusEvent>
 #include <QFontMetrics>
 #include <QLineEdit>
-#include <QRegularExpression>
-#include <QRegularExpressionMatch>
 #include <QStyle>
 #include <QStyleOptionSpinBox>
 #include <QToolTip>
@@ -38,15 +36,18 @@
 #include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <App/ExpressionParser.h>
+#include <App/QuantityInput.h>
 #include <Base/Exception.h>
+#include <Base/NumericFormatting.h>
+#include <Base/NumericInput.h>
 #include <Base/UnitsApi.h>
-#include <Base/Tools.h>
 #include <Base/UnitsSchema.h>
 
 #include "QuantitySpinBox.h"
 #include "QuantitySpinBox_p.h"
 #include "Command.h"
 #include "Dialogs/DlgExpressionInput.h"
+#include "NumericLocale.h"
 #include "Tools.h"
 #include "Widgets.h"
 
@@ -77,231 +78,29 @@ public:
     {}
     ~QuantitySpinBoxPrivate() = default;
 
-    QString stripped(const QString& t, int* pos) const
-    {
-        QString text = t;
-        const int s = text.size();
-        text = text.trimmed();
-        if (pos) {
-            (*pos) -= (s - text.size());
-        }
-        return text;
-    }
-
-    bool validate(QString& input, Base::Quantity& result, const App::ObjectIdentifier& path) const
+    App::QuantityInputResult interpretInput(
+        const QString& input,
+        const App::ObjectIdentifier& path,
+        const App::QuantityInputGrammar grammar,
+        const App::InputPhase phase
+    ) const
     {
         Q_Q(const QuantitySpinBox);
-
-        // Do not accept empty strings because the parser will consider
-        // " unit" as "1 unit" which is not the desired behaviour (see #0004104)
-        if (input.isEmpty()) {
-            return false;
+        App::QuantityConstraints constraints;
+        if (unit != Base::Unit::One) {
+            constraints.requiredUnit = unit;
         }
-
-        bool success = false;
-        QString tmp = input;
-
-        auto validateInput = [&](QString& tmp) -> QValidator::State {
-            QValidator::State state;
-            Base::Quantity res = validateAndInterpret(tmp, state, path);
-            res.setFormat(quantity.getFormat());
-            if (state == QValidator::Acceptable) {
-                success = true;
-                result = res;
-                input = tmp;
-            }
-            return state;
-        };
-
-        QValidator::State state = validateInput(tmp);
-        if (state == QValidator::Intermediate && q->hasExpression()) {
-            // Accept the expression as it is but try to add the right unit string
-            success = true;
-
-            Base::Quantity quantity;
-            double value;
-            if (parseString(input, quantity, value, path)) {
-                quantity.setUnit(unit);
-                result = quantity;
-
-                // Now translate the quantity into its string representation using the user-defined
-                // unit system
-                input = QString::fromStdString(Base::UnitsApi::schemaTranslate(result));
-            }
-        }
-
-        return success;
-    }
-    bool parseString(
-        const QString& str,
-        Base::Quantity& result,
-        double& value,
-        const App::ObjectIdentifier& path
-    ) const
-    {
-        App::ObjectIdentifier pathtmp = path;
-        try {
-            QString copy = str;
-            copy.remove(locale.groupSeparator());
-
-            // Expression parser
-            std::shared_ptr<Expression> expr(
-                ExpressionParser::parse(path.getDocumentObject(), copy.toUtf8().constData())
-            );
-            if (expr) {
-
-                std::unique_ptr<Expression> res(expr->eval());
-                NumberExpression* n = freecad_cast<NumberExpression*>(res.get());
-                if (n) {
-                    result = n->getQuantity();
-                    value = result.getValue();
-                    return true;
-                }
-            }
-        }
-        catch (Base::Exception&) {
-            return false;
-        }
-        return false;
-    }
-    Base::Quantity validateAndInterpret(
-        QString& input,
-        QValidator::State& state,
-        const App::ObjectIdentifier& path
-    ) const
-    {
-        Base::Quantity res;
-        const double max = this->maximum;
-        const double min = this->minimum;
-
-        QString copy = input;
-        double value = min;
-        bool ok = false;
-
-        QChar plus = QLatin1Char('+'), minus = QLatin1Char('-');
-
-        if (locale.negativeSign() != minus) {
-            copy.replace(locale.negativeSign(), minus);
-        }
-        if (locale.positiveSign() != plus) {
-            copy.replace(locale.positiveSign(), plus);
-        }
-
-        QString reverseUnitStr = unitStr;
-        std::reverse(reverseUnitStr.begin(), reverseUnitStr.end());
-
-        // Prep for expression parser
-        // This regex matches chunks between +,-,$,^ accounting for matching parenthesis.
-        QRegularExpression chunkRe(
-            QStringLiteral("(?<=^|[\\+\\-])((\\((?>[^()]|(?2))*\\))|[^\\+\\-\n])*(?=$|[\\+\\-])")
+        constraints.minimum = minimum;
+        constraints.maximum = maximum;
+        return App::interpretQuantityInput(
+            input.toUtf8().toStdString(),
+            grammar,
+            path,
+            unit,
+            Gui::numericLocaleContextFor(q->locale()),
+            phase,
+            constraints
         );
-        QRegularExpressionMatchIterator expressionChunk = chunkRe.globalMatch(copy);
-        unsigned int lengthOffset = 0;
-        while (expressionChunk.hasNext()) {
-            QRegularExpressionMatch matchChunk = expressionChunk.next();
-            QString origionalChunk = matchChunk.captured(0);
-            QString copyChunk = origionalChunk;
-            std::reverse(copyChunk.begin(), copyChunk.end());
-
-            // Reused regex patterns
-            static const std::string regexUnits
-                = "sAV|VC|lim|nim|im|hpm|[mf]?bl|°|ged|dar|nog|″|′|rroT[uµm]?|K[uµm]?|A[mkM]?|F["
-                  "pnuµm]?|C|S[uµmkM]?|zH[kMGT]?|H[nuµm]?|mhO[kM]?|J[mk]?|Ve[kM]?|V[mk]?|hWk|sW|"
-                  "lack?|N[mkM]?|g[uµmk]?|lm?|(?<=\\b|[^a-zA-Z])m[nuµmcdk]?|uoht|ni|\"|'|dy|dc|bW|"
-                  "T|t|zo|ts|twc|Wk?|aP[kMG]?|is[pk]|h|G|M|tfc|tfqs|tf|s";
-            static const std::string regexUnitlessFunctions
-                = "soca|nisa|2nata|nata|hsoc|hnis|hnat|soc|nat|nis|pxe|gol|01gol";
-            static const std::string regexConstants = "e|ip|lomm|lom";
-            static const std::string regexNumber = "\\d+\\s*\\.?\\s*\\d*|\\.\\s*\\d+";
-
-            // If expression does not contain /*() or ^, this regex will not find anything
-            if (copy.contains(QLatin1Char('/')) || copy.contains(QLatin1Char('*'))
-                || copy.contains(QLatin1Char('(')) || copy.contains(QLatin1Char(')'))
-                || copy.contains(QLatin1Char('^'))) {
-                // Find units and replace 1/2mm -> 1/2*(1mm), 1^2mm -> 1^2*(1mm)
-                QRegularExpression fixUnits(
-                    QString::fromStdString(
-                        "(" + regexUnits + ")(\\s*\\)|(?:\\*|(?:\\)(?:(?:\\s*(?:" + regexConstants
-                        + "|\\)(?:[^()]|(?R))*\\((?:" + regexUnitlessFunctions + ")|" + regexNumber
-                        + "))|(?R))*\\(|(?:\\s*(?:" + regexConstants
-                        + "|\\)(?:[^()]|(?R))*\\((?:" + regexUnitlessFunctions + ")|" + regexNumber
-                        + "))))+(?:[\\/\\^]|(.*$))(?!(" + regexUnits + ")))"
-                    )
-                );
-                QRegularExpressionMatch fixUnitsMatch = fixUnits.match(copyChunk);
-
-                // 3rd capture group being filled indicates regex bailed out; no match.
-                if (fixUnitsMatch.lastCapturedIndex() == 2
-                    || (fixUnitsMatch.lastCapturedIndex() == 3
-                        && fixUnitsMatch.captured(3).isEmpty())) {
-                    QString matchUnits = fixUnitsMatch.captured(1);
-                    QString matchNumbers = fixUnitsMatch.captured(2);
-                    copyChunk.replace(
-                        matchUnits + matchNumbers,
-                        QStringLiteral(")") + matchUnits + QStringLiteral("1(*") + matchNumbers
-                    );
-                }
-            }
-
-            // Add default units to string if none are present
-            if (!copyChunk.contains(reverseUnitStr)) {  // Fast check
-                QRegularExpression unitsRe(
-                    QString::fromStdString(
-                        "(?<=\\b|[^a-zA-Z])(" + regexUnits
-                        + ")(?=\\b|[^a-zA-Z])|°|″|′|\"|'|\\p{L}\\.\\p{L}|\\[\\p{L}"
-                    )
-                );
-
-                QRegularExpressionMatch match = unitsRe.match(copyChunk);
-                if (!match.hasMatch() && !copyChunk.isEmpty()) {  // If no units are found, use
-                                                                  // default units
-                    copyChunk.prepend(
-                        QStringLiteral(")") + reverseUnitStr + QStringLiteral("1(*")
-                    );  // Add units to the end of chunk *(1unit)
-                }
-            }
-
-            std::reverse(copyChunk.begin(), copyChunk.end());
-
-            copy.replace(
-                matchChunk.capturedStart() + lengthOffset,
-                matchChunk.capturedEnd() - matchChunk.capturedStart(),
-                copyChunk
-            );
-            lengthOffset += copyChunk.length() - origionalChunk.length();
-        }
-
-        ok = parseString(copy, res, value, path);
-
-        // If result does not have unit: add default unit
-        if (res.isDimensionless()) {
-            res.setUnit(unit);
-        }
-
-        if (!ok) {
-            // input may not be finished
-            state = QValidator::Intermediate;
-        }
-        else if (value >= min && value <= max) {
-            state = QValidator::Acceptable;
-        }
-        else if (max == min) {  // when max and min is the same the only non-Invalid input is max
-                                // (or min)
-            state = QValidator::Invalid;
-        }
-        else {
-            if ((value >= 0 && value > max) || (value < 0 && value < min)) {
-                state = QValidator::Invalid;
-            }
-            else {
-                state = QValidator::Intermediate;
-            }
-        }
-        if (state != QValidator::Acceptable) {
-            res.setValue(max > 0 ? min : max);
-        }
-
-        return res;
     }
 
     QLocale locale;
@@ -313,6 +112,7 @@ public:
     int maxExpectedDigits;
     bool addIconSpace;
     QString validStr;
+    QString lastRejectedText;
     Base::Quantity quantity;
     Base::Quantity cached;
     Base::Unit unit;
@@ -335,7 +135,6 @@ QuantitySpinBox::QuantitySpinBox(QWidget* parent)
     d_ptr->locale = locale();
     this->setContextMenuPolicy(Qt::DefaultContextMenu);
     connect(lineEdit(), &QLineEdit::textChanged, this, &QuantitySpinBox::userInput);
-    connect(this, &QuantitySpinBox::editingFinished, this, [&] { this->handlePendingEmit(true); });
 }
 
 QuantitySpinBox::~QuantitySpinBox() = default;
@@ -461,20 +260,35 @@ void Gui::QuantitySpinBox::keyPressEvent(QKeyEvent* event)
 
     const auto isEnter = event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return;
 
-    if (d->normalize && isEnter && !isNormalized()) {
-        // ensure that input is up to date
-        handlePendingEmit();
+    if (event->key() == Qt::Key_Escape) {
+        d->pendingEmit = false;
+        d->validInput = true;
+        d->lastRejectedText.clear();
+        QToolTip::hideText();
+        lineEdit()->setToolTip(QString());
+        lineEdit()->setProperty("numericInputInvalid", false);
+        {
+            const QSignalBlocker blocker(lineEdit());
+            updateText(d->quantity);
+        }
+        event->accept();
+        return;
+    }
 
-        normalize();
+    if (isEnter) {
+        validateInput();
+        if (d->validInput && d->normalize && !isNormalized()) {
+            normalize();
+        }
+        if (d->validInput) {
+            Q_EMIT returnPressed();
+        }
+        event->accept();
         return;
     }
 
     if (!handleKeyEvent(event->text())) {
         QAbstractSpinBox::keyPressEvent(event);
-    }
-
-    if (isEnter) {
-        returnPressed();
     }
 }
 
@@ -526,15 +340,48 @@ void QuantitySpinBox::validateInput()
 {
     Q_D(QuantitySpinBox);
 
-    QValidator::State state;
-    QString text = lineEdit()->text();
+    const QString text = lineEdit()->text();
     const App::ObjectIdentifier& path = getPath();
-    d->validateAndInterpret(text, state, path);
-    if (state != QValidator::Acceptable) {
-        updateEdit(d->validStr);
+    const auto grammar = isBound() ? App::QuantityInputGrammar::Expression
+                                   : App::QuantityInputGrammar::Quantity;
+    const auto result = d->interpretInput(text, path, grammar, App::InputPhase::Commit);
+    if (result.status == App::InputStatus::Acceptable) {
+        auto quantity = *result.quantity;
+        quantity.setFormat(d->quantity.getFormat());
+        d->cached = quantity;
+        d->pendingEmit = true;
+        d->validInput = true;
+        d->validStr = text;
+        d->lastRejectedText.clear();
+        lineEdit()->setToolTip(QString());
+        lineEdit()->setProperty("numericInputInvalid", false);
+        handlePendingEmit();
+        return;
     }
 
-    handlePendingEmit();
+    d->pendingEmit = false;
+    d->validInput = false;
+
+    if (!result.diagnostic || d->lastRejectedText == text) {
+        return;
+    }
+
+    const QString message = Gui::numericInputDiagnosticText(result.diagnostic->kind);
+
+    // Input errors use a dedicated line-edit state. The expression icon belongs to the formula
+    // editor and showing it here changes the text margin and leaves stale UI state behind.
+    lineEdit()->setProperty("numericInputInvalid", true);
+    lineEdit()->setToolTip(message);
+    const auto& diagnostic = *result.diagnostic;
+    const QByteArray utf8 = text.toUtf8();
+    const auto offset = qMin<int>(static_cast<int>(diagnostic.offset), utf8.size());
+    const auto length = qMin<int>(static_cast<int>(diagnostic.length), utf8.size() - offset);
+    const int errorStart = QString::fromUtf8(utf8.constData(), offset).size();
+    const int errorLength = QString::fromUtf8(utf8.mid(offset, length)).size();
+    lineEdit()->setSelection(errorStart, errorLength);
+    QToolTip::showText(lineEdit()->mapToGlobal(QPoint(0, lineEdit()->height())), message, lineEdit());
+    d->lastRejectedText = text;
+    Q_EMIT inputRejected(message, errorStart, errorLength);
 }
 
 Base::Quantity QuantitySpinBox::value() const
@@ -571,8 +418,7 @@ bool QuantitySpinBox::isNormalized()
     // 1. We consider every string that does not contain operators as normalized
     // 2. If it does contain operators we check if it differs from normalized input - as some
     //    operators like - can be allowed even in normalized case.
-    return !d->validStr.contains(operators)
-        || d->validStr.toStdString() == d->quantity.getUserString();
+    return !d->validStr.contains(operators) || d->validStr == getUserString(d->quantity);
 }
 
 void QuantitySpinBox::setValue(const Base::Quantity& value)
@@ -657,42 +503,34 @@ bool QuantitySpinBox::hasValidInput() const
     return d->validInput;
 }
 
-// Gets called after call of 'validateAndInterpret'
+// Parse edits without changing the last committed quantity until the edit is complete.
 void QuantitySpinBox::userInput(const QString& text)
 {
     Q_D(QuantitySpinBox);
-    d->pendingEmit = true;
-
-    QString tmp = text;
-    Base::Quantity res;
     const App::ObjectIdentifier& path = getPath();
-    if (d->validate(tmp, res, path)) {
-        d->validStr = tmp;
+    const auto grammar = isBound() ? App::QuantityInputGrammar::Expression
+                                   : App::QuantityInputGrammar::Quantity;
+    const auto result = d->interpretInput(text, path, grammar, App::InputPhase::Editing);
+    d->lastRejectedText.clear();
+    QToolTip::hideText();
+    lineEdit()->setToolTip(QString());
+    lineEdit()->setProperty("numericInputInvalid", false);
+
+    if (result.status == App::InputStatus::Acceptable) {
+        auto quantity = *result.quantity;
+        quantity.setFormat(d->quantity.getFormat());
+        d->cached = quantity;
+        d->pendingEmit = true;
+        d->validStr = text;
         d->validInput = true;
-    }
-    else {
-        d->validInput = false;
 
-        // only emit signal to reset EditableDatumLabel if the input is truly empty or has
-        // no meaningful number don't emit for partially typed numbers like "71." which are
-        // temporarily invalid
-        const QString trimmedText = text.trimmed();
-        static const QRegularExpression partialNumberRegex(QStringLiteral(R"([+-]?(\d+)?(\.,\d*)?)"));
-        if (trimmedText.isEmpty() || !trimmedText.contains(partialNumberRegex)) {
-            // we have to emit here signal explicitly as validator will not pass
-            // this value further but we want to check it to disable isSet flag if
-            // it has been set previously
-            Q_EMIT valueChanged(d->quantity.getValue());
+        if (keyboardTracking()) {
+            handlePendingEmit(false);
         }
-        return;
-    }
-
-    if (keyboardTracking()) {
-        d->cached = res;
-        handlePendingEmit(false);
     }
     else {
-        d->cached = res;
+        d->pendingEmit = false;
+        d->validInput = false;
     }
 }
 
@@ -874,26 +712,20 @@ void QuantitySpinBox::clearSchema()
 QString QuantitySpinBox::getUserString(const Base::Quantity& val, double& factor, QString& unitString) const
 {
     Q_D(const QuantitySpinBox);
+    const auto formatting = Gui::numericLocaleContextFor(locale());
     std::string unitStr;
-    const std::string str = d->scheme ? val.getUserString(d->scheme.get(), factor, unitStr)
-                                      : val.getUserString(factor, unitStr);
+    const std::string str = d->scheme
+        ? d->scheme->translate(val, formatting, factor, unitStr)
+        : Base::UnitsApi::schemaTranslate(val, formatting, factor, unitStr);
     unitString = QString::fromStdString(unitStr);
     return QString::fromStdString(str);
 }
 
 QString QuantitySpinBox::getUserString(const Base::Quantity& val) const
 {
-    Q_D(const QuantitySpinBox);
-    std::string str;
-    if (d->scheme) {
-        double factor;
-        std::string unitString;
-        str = val.getUserString(d->scheme.get(), factor, unitString);
-    }
-    else {
-        str = val.getUserString();
-    }
-    return QString::fromStdString(str);
+    double factor;
+    QString unitString;
+    return getUserString(val, factor, unitString);
 }
 
 void QuantitySpinBox::setExpression(std::shared_ptr<Expression> expr)
@@ -1072,12 +904,23 @@ void QuantitySpinBox::focusOutEvent(QFocusEvent* event)
 
     validateInput();
 
-    if (d->normalize) {
+    if (d->validInput && d->normalize) {
         normalize();
     }
 
     QToolTip::hideText();
     QAbstractSpinBox::focusOutEvent(event);
+}
+
+void QuantitySpinBox::changeEvent(QEvent* event)
+{
+    Q_D(QuantitySpinBox);
+    QAbstractSpinBox::changeEvent(event);
+
+    if (event->type() == QEvent::LocaleChange && d->validInput) {
+        const QSignalBlocker blocker(lineEdit());
+        updateText(d->quantity);
+    }
 }
 
 void QuantitySpinBox::clear()
@@ -1087,15 +930,12 @@ void QuantitySpinBox::clear()
 
 void QuantitySpinBox::selectNumber()
 {
-    QString expr = QStringLiteral("^([%1%2]?[0-9\\%3]*)\\%4?([0-9]+(%5[%1%2]?[0-9]+)?)")
-                       .arg(locale().negativeSign())
-                       .arg(locale().positiveSign())
-                       .arg(locale().groupSeparator())
-                       .arg(locale().decimalPoint())
-                       .arg(locale().exponential());
-    auto rmatch = QRegularExpression(expr).match(lineEdit()->text());
-    if (rmatch.hasMatch()) {
-        lineEdit()->setSelection(0, rmatch.capturedLength());
+    const auto length = Gui::numericInputSelectionLength(
+        lineEdit()->text(),
+        Gui::numericLocaleContextFor(locale())
+    );
+    if (length > 0) {
+        lineEdit()->setSelection(0, length);
     }
 }
 
@@ -1112,16 +952,11 @@ Base::Quantity QuantitySpinBox::valueFromText(const QString& text) const
 {
     Q_D(const QuantitySpinBox);
 
-    QString copy = text;
-    QValidator::State state = QValidator::Acceptable;
     const App::ObjectIdentifier& path = getPath();
-    Base::Quantity quant = d->validateAndInterpret(copy, state, path);
-    if (state != QValidator::Acceptable) {
-        fixup(copy);
-        quant = d->validateAndInterpret(copy, state, path);
-    }
-
-    return quant;
+    const auto grammar = isBound() ? App::QuantityInputGrammar::Expression
+                                   : App::QuantityInputGrammar::Quantity;
+    const auto result = d->interpretInput(text, path, grammar, App::InputPhase::Commit);
+    return result.quantity.value_or(Base::Quantity());
 }
 
 QValidator::State QuantitySpinBox::validate(QString& text, int& pos) const
@@ -1129,17 +964,13 @@ QValidator::State QuantitySpinBox::validate(QString& text, int& pos) const
     Q_D(const QuantitySpinBox);
     Q_UNUSED(pos)
 
-    QValidator::State state;
     const App::ObjectIdentifier& path = getPath();
-    d->validateAndInterpret(text, state, path);
-    return state;
+    const auto grammar = isBound() ? App::QuantityInputGrammar::Expression
+                                   : App::QuantityInputGrammar::Quantity;
+    const auto result = d->interpretInput(text, path, grammar, App::InputPhase::Editing);
+    return result.status == App::InputStatus::Acceptable ? QValidator::Acceptable
+                                                         : QValidator::Intermediate;
 }
-
-void QuantitySpinBox::fixup(QString& input) const
-{
-    input.remove(locale().groupSeparator());
-}
-
 
 #include "moc_QuantitySpinBox.cpp"
 #include "moc_QuantitySpinBox_p.cpp"

--- a/src/Gui/QuantitySpinBox.h
+++ b/src/Gui/QuantitySpinBox.h
@@ -161,7 +161,6 @@ public:
     void stepBy(int steps) override;
     void clear() override;
     QValidator::State validate(QString& input, int& pos) const override;
-    void fixup(QString& str) const override;
 
     /// This is a helper function to determine the size this widget requires to fully display the text
     QSize sizeForText(const QString&) const;
@@ -191,6 +190,7 @@ protected:
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;
     void closeEvent(QCloseEvent* event) override;
+    void changeEvent(QEvent* event) override;
     void focusInEvent(QFocusEvent* event) override;
     void focusOutEvent(QFocusEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
@@ -232,6 +232,15 @@ Q_SIGNALS:
      *  focus out.
      */
     void returnPressed();
+    /** Reports that the user cleared the editor; valueChanged() is reserved for actual values. */
+    void inputCleared();
+    /**
+     * Reports a rejected committed edit and its diagnostic range.
+     *
+     * @a errorStartUtf16 and @a errorLengthUtf16 are QString indices measured in UTF-16 code
+     * units. They identify the text that should be selected or highlighted for the user.
+     */
+    void inputRejected(const QString& message, int errorStartUtf16, int errorLengthUtf16);
 
 private:
     QScopedPointer<QuantitySpinBoxPrivate> d_ptr;

--- a/src/Gui/QuantitySpinBox.h
+++ b/src/Gui/QuantitySpinBox.h
@@ -161,7 +161,6 @@ public:
     void stepBy(int steps) override;
     void clear() override;
     QValidator::State validate(QString& input, int& pos) const override;
-    void fixup(QString& str) const override;
 
     /// This is a helper function to determine the size this widget requires to fully display the text
     QSize sizeForText(const QString&) const;
@@ -191,6 +190,7 @@ protected:
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;
     void closeEvent(QCloseEvent* event) override;
+    void changeEvent(QEvent* event) override;
     void focusInEvent(QFocusEvent* event) override;
     void focusOutEvent(QFocusEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
@@ -232,6 +232,7 @@ Q_SIGNALS:
      *  focus out.
      */
     void returnPressed();
+    void inputRejected(const QString& message, int errorStart, int errorLength);
 
 private:
     QScopedPointer<QuantitySpinBoxPrivate> d_ptr;

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -51,7 +51,6 @@
 #include <Base/Interpreter.h>
 #include <Base/Parameter.h>
 #include <Base/Exception.h>
-#include <Base/Tools.h>
 #include <Gui/Application.h>
 #include <Gui/ProgramInformation.h>
 
@@ -151,11 +150,7 @@ static void displayCritical(const QString& msg, bool preformatted = true)
 int main(int argc, char** argv)
 {
 #if defined(FC_OS_LINUX) || defined(FC_OS_BSD)
-    setlocale(LC_ALL, "");  // use native environment settings
-    // Preserve the resolved numeric locale before forcing LC_NUMERIC=C for XML parsing.
-    if (const char* localeName = setlocale(LC_NUMERIC, nullptr)) {
-        Base::Tools::setOperatingSystemNumericLocale(localeName);
-    }
+    setlocale(LC_ALL, "");       // use native environment settings
     setlocale(LC_NUMERIC, "C");  // except for numbers to not break XML import
     // See https://github.com/FreeCAD/FreeCAD/issues/16724
 

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -51,7 +51,6 @@
 #include <Base/Interpreter.h>
 #include <Base/Parameter.h>
 #include <Base/Exception.h>
-#include <Base/Tools.h>
 #include <Gui/Application.h>
 #include <Gui/ProgramInformation.h>
 
@@ -148,11 +147,7 @@ static void displayCritical(const QString& msg, bool preformatted = true)
 int main(int argc, char** argv)
 {
 #if defined(FC_OS_LINUX) || defined(FC_OS_BSD)
-    setlocale(LC_ALL, "");  // use native environment settings
-    // Preserve the resolved numeric locale before forcing LC_NUMERIC=C for XML parsing.
-    if (const char* localeName = setlocale(LC_NUMERIC, nullptr)) {
-        Base::Tools::setOperatingSystemNumericLocale(localeName);
-    }
+    setlocale(LC_ALL, "");       // use native environment settings
     setlocale(LC_NUMERIC, "C");  // except for numbers to not break XML import
     // See https://github.com/FreeCAD/FreeCAD/issues/16724
 

--- a/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
@@ -25,10 +25,28 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
     def setUp(self):
         super().setUp()
 
+        self.sketcher_tool_params = FreeCAD.ParamGet(
+            "User parameter:BaseApp/Preferences/Mod/Sketcher/Tools"
+        )
+        self.had_ovp_visibility = "OnViewParameterVisibility" in self.sketcher_tool_params.GetInts()
+        self.old_ovp_visibility = self.sketcher_tool_params.GetInt("OnViewParameterVisibility", 1)
+        self.sketcher_tool_params.SetInt("OnViewParameterVisibility", 1)
+
         FreeCADGui.activateWorkbench("SketcherWorkbench")
         self.doc = FreeCAD.newDocument("TestOnViewParameterGui")
         self.sketch = self.doc.addObject("Sketcher::SketchObject", "Sketch")
         self.doc.recompute()
+
+    def tearDown(self):
+        try:
+            if self.had_ovp_visibility:
+                self.sketcher_tool_params.SetInt(
+                    "OnViewParameterVisibility", self.old_ovp_visibility
+                )
+            else:
+                self.sketcher_tool_params.RemInt("OnViewParameterVisibility")
+        finally:
+            super().tearDown()
 
     def pack_color(self, color):
         r, g, b, a = color
@@ -42,6 +60,16 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
     def key_text(self, widget, text):
         for ch in text:
             self.key_click(widget, self.KEYS[ch], ch)
+
+    def active_spinbox(self):
+        widget = QtGui.QApplication.focusWidget()
+        if isinstance(widget, QtGui.QAbstractSpinBox):
+            return widget
+        if isinstance(widget, QtGui.QLineEdit):
+            parent = widget.parent()
+            if isinstance(parent, QtGui.QAbstractSpinBox):
+                return parent
+        return None
 
     def visible_spinboxes(self):
         main_window = FreeCADGui.getMainWindow()
@@ -62,6 +90,9 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
         main_window.activateWindow()
         spinbox.setFocus(QtCore.Qt.OtherFocusReason)
         self.flush_gui()
+
+    def ovp_lock_icon(self, spinbox):
+        return spinbox.findChild(QtGui.QLabel, "onViewParameterLockIcon")
 
     def active_task_dialog(self):
         return FreeCADGui.Control.activeTaskDialog()
@@ -612,6 +643,53 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
             self.sketch.GeometryCount,
             4,
             "Expected the rectangle to be created after accepting both OVPs",
+        )
+
+    def test_clearing_committed_rectangle_ovp_releases_its_lock(self):
+        """A cleared OVP must leave its committed state and resume live geometry input."""
+
+        self.begin_rectangle_with_visible_ovp()
+
+        first_spinbox = self.active_spinbox()
+        self.assertIsNotNone(first_spinbox, "Expected the first rectangle OVP to have focus")
+        self.key_text(first_spinbox, "10")
+        self.key_click(first_spinbox, QtCore.Qt.Key_Tab, "\t")
+
+        lock_icon = self.ovp_lock_icon(first_spinbox)
+        self.assertIsNotNone(lock_icon)
+        self.assertTrue(
+            self.wait_until(lock_icon.isVisible, timeout_ms=1000),
+            "Expected Tab to lock the committed first OVP",
+        )
+
+        first_edit = first_spinbox.findChild(QtGui.QLineEdit)
+        self.assertIsNotNone(first_edit)
+        first_spinbox.setFocus(QtCore.Qt.OtherFocusReason)
+        self.pump(100)
+        self.assertIs(self.active_spinbox(), first_spinbox)
+        first_edit.clear()
+        self.pump(60)
+
+        self.assertTrue(
+            self.wait_until(lambda: not lock_icon.isVisible(), timeout_ms=1000),
+            "Expected clearing the first OVP to release its lock",
+        )
+
+        first_edit.setText("15")
+        self.pump(60)
+        self.key_click(first_spinbox, QtCore.Qt.Key_Tab, "\t")
+
+        self.assertTrue(
+            self.wait_until(
+                lambda: self.active_spinbox() is not None
+                and self.active_spinbox() is not first_spinbox,
+                timeout_ms=1000,
+            ),
+            "Expected a replacement value to recommit the first OVP",
+        )
+        self.assertTrue(
+            self.wait_until(lock_icon.isVisible, timeout_ms=1000),
+            "Expected the replacement value to lock the first OVP again",
         )
 
     def test_rectangle_ovp_escape_resets_tool_without_exiting_sketch(self):

--- a/tests/src/App/CMakeLists.txt
+++ b/tests/src/App/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(App_tests_run
         DocumentObserver.cpp
         Expression.cpp
         ExpressionParser.cpp
+        QuantityInput.cpp
         ElementMap.cpp
         ElementNamingUtils.cpp
         IndexedName.cpp

--- a/tests/src/App/ExpressionParser.cpp
+++ b/tests/src/App/ExpressionParser.cpp
@@ -3,13 +3,17 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#include <cmath>
+
 #include "Base/Quantity.h"
+#include "Base/NumericFormatting.h"
 
 #include "App/Application.h"
 #include "App/Document.h"
 #include "App/DocumentObject.h"
 #include "App/Expression.h"
 #include "App/ExpressionParser.h"
+#include "App/PropertyUnits.h"
 
 #include "src/App/InitApplication.h"
 
@@ -70,7 +74,7 @@ protected:
     {
         docName = App::GetApplication().getUniqueDocumentName("test");
         thisDoc = App::GetApplication().newDocument(docName.c_str(), "testUser");
-        thisObj = thisDoc->addObject("Sketcher::SketchObject", "Sketch");
+        thisObj = thisDoc->addObject("App::GeoFeature", "Sketch");
     }
 
     void TearDown() override
@@ -87,6 +91,15 @@ protected:
     Base::Quantity parse_expression_text_as_quantity(const char* expression_text)
     {
         const auto expression = parse(thisObj, expression_text);
+        return App::any_cast<Base::Quantity>(expression->getValueAsAny());
+    }
+
+    Base::Quantity parse_user_input_as_quantity(
+        const char* expressionText,
+        const Base::NumericLocaleContext& formatting
+    )
+    {
+        const auto expression = parseUserInput(thisObj, expressionText, formatting);
         return App::any_cast<Base::Quantity>(expression->getValueAsAny());
     }
 
@@ -227,6 +240,114 @@ TEST_F(ExpressionParserTest, simpleExpressionsParse)
         << "mixed angle units";
 
     EXPECT_THAT(parseExpr("True mm"), IsQuantity(mm(1))) << "boolean constant treated as scalar";
+}
+
+TEST_F(ExpressionParserTest, expressionUserInputKeepsGroupingSeparateFromDecimals)
+{
+    const Base::NumericLocaleContext deDe {"de_DE", ",", ".", "+", "-", 3, 3, "0"};
+
+    EXPECT_EQ(parse_user_input_as_quantity("1.234 mm", deDe), mm(1.234));
+    EXPECT_EQ(parse_user_input_as_quantity("1,234 mm", deDe), mm(1.234));
+}
+
+TEST_F(ExpressionParserTest, groupedExpressionUsesLocaleGroupingPattern)
+{
+    const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3, "0"};
+    const Base::NumericLocaleContext enIn {"en_IN", ".", ",", "+", "-", 3, 2, "0"};
+
+    EXPECT_EQ(parse_user_input_as_quantity("12,345.67 mm", enUs), mm(12345.67));
+    EXPECT_THROW(parse_user_input_as_quantity("12,34,567 mm", enUs), Base::ParserError);
+    EXPECT_EQ(parse_user_input_as_quantity("12,34,567 mm", enIn), mm(1234567));
+}
+
+TEST_F(ExpressionParserTest, localizedInputPreservesDigitsInsideIdentifiers)
+{
+    const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3, "0"};
+    auto* object = this_doc()->addObject("App::FeaturePython", "Box001");
+    auto* length = freecad_cast<App::PropertyLength*>(
+        object->addDynamicProperty("App::PropertyLength", "Length001")
+    );
+    ASSERT_NE(length, nullptr);
+    length->setValue(3.0);
+
+    EXPECT_EQ(parse_user_input_as_quantity("Box001.Length001 + 2 mm", enUs), mm(5));
+}
+
+TEST_F(ExpressionParserTest, functionArgumentsTakePrecedenceOverGrouping)
+{
+    const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3, "0"};
+    const auto expression = parseUserInput(this_obj(), "pow(1,234)", enUs);
+    const auto simplified = expression->simplify();
+
+    EXPECT_THAT(simplified->getValueAsAny(), IsLong(1));
+}
+
+TEST_F(ExpressionParserTest, commaDecimalLocalesUseSemicolonsForArguments)
+{
+    const Base::NumericLocaleContext deDe {"de_DE", ",", ".", "+", "-", 3, 3, "0"};
+    const auto decimalExpression = parseUserInput(this_obj(), "sqrt(1,234)", deDe);
+    const auto decimal = decimalExpression->simplify();
+    EXPECT_DOUBLE_EQ(App::any_cast<double>(decimal->getValueAsAny()), std::sqrt(1.234));
+
+    const auto decimalThenArgument = parseUserInput(this_obj(), "pow(1,234;2)", deDe);
+    const auto decimalPower = decimalThenArgument->simplify();
+    EXPECT_DOUBLE_EQ(App::any_cast<double>(decimalPower->getValueAsAny()), 1.234 * 1.234);
+
+    const auto argumentsExpression = parseUserInput(this_obj(), "pow(1;234)", deDe);
+    const auto arguments = argumentsExpression->simplify();
+    EXPECT_THAT(arguments->getValueAsAny(), IsLong(1));
+
+    const auto spacedArgumentsExpression = parseUserInput(this_obj(), "pow(1, 234)", deDe);
+    const auto spacedArguments = spacedArgumentsExpression->simplify();
+    EXPECT_THAT(spacedArguments->getValueAsAny(), IsLong(1));
+
+    const Base::NumericLocaleContext frFr {"fr_FR", ",", "\xE2\x80\xAF", "+", "-", 3, 3, "0"};
+    const auto groupedDecimal = parseUserInput(
+                                    this_obj(),
+                                    "pow(1\xE2\x80\xAF"
+                                    "234,5;2)",
+                                    frFr
+    )
+                                    ->simplify();
+    EXPECT_DOUBLE_EQ(App::any_cast<double>(groupedDecimal->getValueAsAny()), 1234.5 * 1234.5);
+}
+
+TEST_F(ExpressionParserTest, groupedParenthesizedExpressionsUseTheLocalePattern)
+{
+    const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3, "0"};
+
+    EXPECT_EQ(parse_user_input_as_quantity("(12,345.67 mm)", enUs), mm(12345.67));
+    const auto nested = parseUserInput(this_obj(), "pow((1,234.5), 2)", enUs)->simplify();
+    EXPECT_DOUBLE_EQ(App::any_cast<double>(nested->getValueAsAny()), 1234.5 * 1234.5);
+}
+
+TEST_F(ExpressionParserTest, spaceGroupingAndSemicolonArgumentsRemainDistinct)
+{
+    const Base::NumericLocaleContext spaceGrouped {"space", ".", " ", "+", "-", 3, 3, "0"};
+
+    const auto expression = parseUserInput(this_obj(), "pow(1 234; 2)", spaceGrouped)->simplify();
+    EXPECT_THAT(expression->getValueAsAny(), IsLong(1522756));
+}
+
+TEST_F(ExpressionParserTest, commaFunctionArgumentsRemainArgumentsWithDecimalText)
+{
+    const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3, "0"};
+    const auto expression = parseUserInput(this_obj(), "pow(1,234.5)", enUs);
+    const auto simplified = expression->simplify();
+
+    EXPECT_THAT(simplified->getValueAsAny(), IsLong(1));
+}
+
+TEST_F(ExpressionParserTest, userInputPreservesOpaqueStringLiterals)
+{
+    const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3, "0"};
+    const auto expression = parseUserInput(this_obj(), "<<(12,345.67 mm)>>", enUs);
+    const auto value = expression->simplify()->getValueAsAny();
+
+    ASSERT_THAT(value, IsString(_));
+    EXPECT_EQ(App::any_cast<std::string>(value), "(12,345.67 mm)");
+
+    EXPECT_THROW(parseUserInput(this_obj(), "<<12,34,567", enUs), Base::ParserError);
 }
 
 TEST_F(ExpressionParserTest, badExpressionsDoNotParse)

--- a/tests/src/App/ExpressionParser.cpp
+++ b/tests/src/App/ExpressionParser.cpp
@@ -4,6 +4,7 @@
 #include <gmock/gmock.h>
 
 #include "Base/Quantity.h"
+#include "Base/NumericFormatting.h"
 
 #include "App/Application.h"
 #include "App/Document.h"
@@ -70,7 +71,7 @@ protected:
     {
         docName = App::GetApplication().getUniqueDocumentName("test");
         thisDoc = App::GetApplication().newDocument(docName.c_str(), "testUser");
-        thisObj = thisDoc->addObject("Sketcher::SketchObject", "Sketch");
+        thisObj = thisDoc->addObject("App::GeoFeature", "Sketch");
     }
 
     void TearDown() override
@@ -87,6 +88,15 @@ protected:
     Base::Quantity parse_expression_text_as_quantity(const char* expression_text)
     {
         const auto expression = parse(thisObj, expression_text);
+        return App::any_cast<Base::Quantity>(expression->getValueAsAny());
+    }
+
+    Base::Quantity parse_user_input_as_quantity(
+        const char* expressionText,
+        const Base::NumericLocaleContext& formatting
+    )
+    {
+        const auto expression = parseUserInput(thisObj, expressionText, formatting);
         return App::any_cast<Base::Quantity>(expression->getValueAsAny());
     }
 
@@ -227,6 +237,96 @@ TEST_F(ExpressionParserTest, simpleExpressionsParse)
         << "mixed angle units";
 
     EXPECT_THAT(parseExpr("True mm"), IsQuantity(mm(1))) << "boolean constant treated as scalar";
+}
+
+TEST_F(ExpressionParserTest, expressionUserInputKeepsGroupingSeparateFromDecimals)
+{
+    const Base::NumericLocaleContext deDe {"de_DE", ",", ".", "+", "-", 3, 3};
+
+    EXPECT_EQ(parse_user_input_as_quantity("1.234 mm", deDe), mm(1.234));
+    EXPECT_EQ(parse_user_input_as_quantity("1,234 mm", deDe), mm(1.234));
+}
+
+TEST_F(ExpressionParserTest, groupedExpressionUsesLocaleGroupingPattern)
+{
+    const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3};
+    const Base::NumericLocaleContext enIn {"en_IN", ".", ",", "+", "-", 3, 2};
+
+    EXPECT_EQ(parse_user_input_as_quantity("12,345.67 mm", enUs), mm(12345.67));
+    EXPECT_THROW(parse_user_input_as_quantity("12,34,567 mm", enUs), Base::ParserError);
+    EXPECT_EQ(parse_user_input_as_quantity("12,34,567 mm", enIn), mm(1234567));
+}
+
+TEST_F(ExpressionParserTest, functionArgumentsTakePrecedenceOverGrouping)
+{
+    const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3};
+    const auto expression = parseUserInput(this_obj(), "pow(1,234)", enUs);
+    const auto simplified = expression->simplify();
+
+    EXPECT_THAT(simplified->getValueAsAny(), IsLong(1));
+}
+
+TEST_F(ExpressionParserTest, commaDecimalLocalesUseSemicolonsForArguments)
+{
+    const Base::NumericLocaleContext deDe {"de_DE", ",", ".", "+", "-", 3, 3};
+    const auto decimalExpression = parseUserInput(this_obj(), "pow(1,234)", deDe);
+    const auto decimal = decimalExpression->simplify();
+    EXPECT_THAT(decimal->getValueAsAny(), IsDouble(1.234));
+
+    const auto argumentsExpression = parseUserInput(this_obj(), "pow(1;234)", deDe);
+    const auto arguments = argumentsExpression->simplify();
+    EXPECT_THAT(arguments->getValueAsAny(), IsLong(1));
+
+    const auto spacedArgumentsExpression = parseUserInput(this_obj(), "pow(1, 234)", deDe);
+    const auto spacedArguments = spacedArgumentsExpression->simplify();
+    EXPECT_THAT(spacedArguments->getValueAsAny(), IsLong(1));
+
+    const Base::NumericLocaleContext frFr {"fr_FR", ",", "\xE2\x80\xAF", "+", "-", 3, 3};
+    const auto groupedDecimal = parseUserInput(
+                                    this_obj(),
+                                    "pow(1\xE2\x80\xAF"
+                                    "234,5;2)",
+                                    frFr
+    )
+                                    ->simplify();
+    EXPECT_DOUBLE_EQ(App::any_cast<double>(groupedDecimal->getValueAsAny()), 1234.5 * 1234.5);
+}
+
+TEST_F(ExpressionParserTest, groupedParenthesizedExpressionsUseTheLocalePattern)
+{
+    const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3};
+
+    EXPECT_EQ(parse_user_input_as_quantity("(12,345.67 mm)", enUs), mm(12345.67));
+    const auto nested = parseUserInput(this_obj(), "pow((1,234.5), 2)", enUs)->simplify();
+    EXPECT_DOUBLE_EQ(App::any_cast<double>(nested->getValueAsAny()), 1234.5 * 1234.5);
+}
+
+TEST_F(ExpressionParserTest, spaceGroupingAndSemicolonArgumentsRemainDistinct)
+{
+    const Base::NumericLocaleContext spaceGrouped {"space", ".", " ", "+", "-", 3, 3};
+
+    EXPECT_EQ(parse_user_input_as_quantity("pow(1 234; 2) mm", spaceGrouped), mm(1522756.0));
+}
+
+TEST_F(ExpressionParserTest, commaFunctionArgumentsRemainArgumentsWithDecimalText)
+{
+    const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3};
+    const auto expression = parseUserInput(this_obj(), "pow(1,234.5)", enUs);
+    const auto simplified = expression->simplify();
+
+    EXPECT_THAT(simplified->getValueAsAny(), IsLong(1));
+}
+
+TEST_F(ExpressionParserTest, userInputPreservesOpaqueStringLiterals)
+{
+    const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3};
+    const auto expression = parseUserInput(this_obj(), "<<(12,345.67 mm)>>", enUs);
+    const auto value = expression->simplify()->getValueAsAny();
+
+    ASSERT_THAT(value, IsString(_));
+    EXPECT_EQ(App::any_cast<std::string>(value), "(12,345.67 mm)");
+
+    EXPECT_THROW(parseUserInput(this_obj(), "<<12,34,567", enUs), Base::ParserError);
 }
 
 TEST_F(ExpressionParserTest, badExpressionsDoNotParse)

--- a/tests/src/App/QuantityInput.cpp
+++ b/tests/src/App/QuantityInput.cpp
@@ -1,0 +1,789 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <App/Expression.h>
+#include <App/ExpressionParser.h>
+#include <App/ObjectIdentifier.h>
+#include <App/Property.h>
+#include "App/QuantityInput.h"
+#include "Base/NumericFormatting.h"
+#include <src/App/InitApplication.h>
+
+namespace
+{
+class ScopedExpressionOwner
+{
+public:
+    ScopedExpressionOwner()
+        : documentName {App::GetApplication().getUniqueDocumentName("quantity_input")}
+        , document {App::GetApplication().newDocument(documentName.c_str(), "testUser")}
+        , object {document->addObject("App::GeoFeature", "Owner")}
+        , property {object->addDynamicProperty("App::PropertyFloat", "Value", "Test")}
+    {}
+
+    ~ScopedExpressionOwner()
+    {
+        App::GetApplication().closeDocument(documentName.c_str());
+    }
+
+    App::ObjectIdentifier path() const
+    {
+        return App::ObjectIdentifier(*property);
+    }
+
+    void setValue(const double value)
+    {
+        freecad_cast<App::PropertyFloat*>(property)->setValue(value);
+    }
+
+private:
+    std::string documentName;
+    App::Document* document;
+    App::DocumentObject* object;
+    App::Property* property;
+};
+}  // namespace
+
+namespace App::QuantityInputTest
+{
+
+const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3, "0"};
+
+TEST(QuantityInput, EditingAndCommitDistinguishIncompleteNumbers)
+{
+    const ObjectIdentifier path;
+    const QuantityConstraints constraints;
+
+    EXPECT_EQ(
+        interpretQuantityInput(
+            "-",
+            QuantityInputGrammar::Quantity,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Editing,
+            constraints
+        )
+            .status,
+        InputStatus::Incomplete
+    );
+    EXPECT_EQ(
+        interpretQuantityInput(
+            "-",
+            QuantityInputGrammar::Quantity,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Commit,
+            constraints
+        )
+            .status,
+        InputStatus::Invalid
+    );
+    EXPECT_EQ(
+        interpretQuantityInput(
+            "1e",
+            QuantityInputGrammar::Quantity,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Editing,
+            constraints
+        )
+            .status,
+        InputStatus::Incomplete
+    );
+    EXPECT_EQ(
+        interpretQuantityInput(
+            "1e",
+            QuantityInputGrammar::Quantity,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Commit,
+            constraints
+        )
+            .status,
+        InputStatus::Invalid
+    );
+
+    for (const auto input : {"", "+", "1e-"}) {
+        EXPECT_EQ(
+            interpretQuantityInput(
+                input,
+                QuantityInputGrammar::Quantity,
+                path,
+                Base::Unit::Length,
+                enUs,
+                InputPhase::Editing,
+                constraints
+            )
+                .status,
+            InputStatus::Incomplete
+        ) << input;
+        EXPECT_EQ(
+            interpretQuantityInput(
+                input,
+                QuantityInputGrammar::Quantity,
+                path,
+                Base::Unit::Length,
+                enUs,
+                InputPhase::Commit,
+                constraints
+            )
+                .status,
+            InputStatus::Invalid
+        ) << input;
+    }
+
+    for (const auto input : {"1,2", "1.2.3"}) {
+        EXPECT_EQ(
+            interpretQuantityInput(
+                input,
+                QuantityInputGrammar::Quantity,
+                path,
+                Base::Unit::Length,
+                enUs,
+                InputPhase::Editing,
+                constraints
+            )
+                .status,
+            InputStatus::Invalid
+        ) << input;
+        EXPECT_EQ(
+            interpretQuantityInput(
+                input,
+                QuantityInputGrammar::Quantity,
+                path,
+                Base::Unit::Length,
+                enUs,
+                InputPhase::Commit,
+                constraints
+            )
+                .status,
+            InputStatus::Invalid
+        ) << input;
+    }
+}
+
+TEST(QuantityInput, TrailingGroupingSeparatorFollowsTheInputPhase)
+{
+    const ObjectIdentifier path;
+    const QuantityConstraints constraints;
+
+    const auto editing = interpretQuantityInput(
+        "12,",
+        QuantityInputGrammar::Quantity,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Editing,
+        constraints
+    );
+    ASSERT_EQ(editing.status, InputStatus::Incomplete);
+    ASSERT_TRUE(editing.diagnostic);
+    EXPECT_EQ(editing.diagnostic->kind, InputDiagnosticKind::IncompleteNumber);
+
+    const auto commit = interpretQuantityInput(
+        "12,",
+        QuantityInputGrammar::Quantity,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(commit.status, InputStatus::Invalid);
+    ASSERT_TRUE(commit.diagnostic);
+    EXPECT_EQ(commit.diagnostic->kind, InputDiagnosticKind::IncompleteNumber);
+}
+
+TEST(QuantityInput, ReportsGroupingAndUnitDiagnostics)
+{
+    const ObjectIdentifier path;
+    const QuantityConstraints constraints;
+
+    const auto malformed = interpretQuantityInput(
+        "12,34,567 mm",
+        QuantityInputGrammar::Quantity,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(malformed.status, InputStatus::Invalid);
+    ASSERT_TRUE(malformed.diagnostic);
+    EXPECT_EQ(malformed.diagnostic->kind, InputDiagnosticKind::MalformedGrouping);
+
+    const auto plainSpace = interpretQuantityInput(
+        "12 345 mm",
+        QuantityInputGrammar::Quantity,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(plainSpace.status, InputStatus::Invalid);
+    ASSERT_TRUE(plainSpace.diagnostic);
+    EXPECT_EQ(plainSpace.diagnostic->kind, InputDiagnosticKind::MalformedGrouping);
+
+    QuantityConstraints restricted;
+    restricted.requiredUnit = Base::Unit::TimeSpan;
+    const auto incompatible = interpretQuantityInput(
+        "10 mm",
+        QuantityInputGrammar::Quantity,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        restricted
+    );
+    ASSERT_EQ(incompatible.status, InputStatus::Invalid);
+    ASSERT_TRUE(incompatible.diagnostic);
+    EXPECT_EQ(incompatible.diagnostic->kind, InputDiagnosticKind::IncompatibleUnit);
+}
+
+TEST(QuantityInput, AcceptsGroupedQuantityAndNormalizesIt)
+{
+    const ObjectIdentifier path;
+    const QuantityConstraints constraints;
+    const auto result = interpretQuantityInput(
+        "12,345.67 mm",
+        QuantityInputGrammar::Quantity,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+
+    ASSERT_EQ(result.status, InputStatus::Acceptable);
+    ASSERT_TRUE(result.quantity);
+    EXPECT_DOUBLE_EQ(result.quantity->getValue(), 12345.67);
+}
+
+TEST(QuantityInput, ReportsExpressionEvaluationAndRangeDiagnostics)
+{
+    tests::initApplication();
+    ScopedExpressionOwner owner;
+    const auto path = owner.path();
+    const QuantityConstraints constraints;
+
+    const auto syntax = interpretQuantityInput(
+        "1 +",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(syntax.status, InputStatus::Invalid);
+    ASSERT_TRUE(syntax.diagnostic);
+    EXPECT_EQ(syntax.diagnostic->kind, InputDiagnosticKind::ExpressionSyntax);
+
+    const auto evaluation = interpretQuantityInput(
+        "str(1)",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(evaluation.status, InputStatus::Invalid);
+    ASSERT_TRUE(evaluation.diagnostic);
+    EXPECT_EQ(evaluation.diagnostic->kind, InputDiagnosticKind::Evaluation);
+
+    QuantityConstraints bounded;
+    bounded.maximum = 10.0;
+    const auto outOfRange = interpretQuantityInput(
+        "11 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        bounded
+    );
+    ASSERT_EQ(outOfRange.status, InputStatus::Invalid);
+    ASSERT_TRUE(outOfRange.diagnostic);
+    EXPECT_EQ(outOfRange.diagnostic->kind, InputDiagnosticKind::OutOfRange);
+}
+
+TEST(QuantityInput, GrammarSelectionIsExplicit)
+{
+    tests::initApplication();
+    ScopedExpressionOwner owner;
+    const auto path = owner.path();
+    const QuantityConstraints constraints;
+
+    const auto quantity = interpretQuantityInput(
+        "1+2 mm",
+        QuantityInputGrammar::Quantity,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    EXPECT_EQ(quantity.status, InputStatus::Invalid);
+
+    const auto expression = interpretQuantityInput(
+        "1+2 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(expression.status, InputStatus::Acceptable);
+    ASSERT_TRUE(expression.quantity);
+    EXPECT_DOUBLE_EQ(expression.quantity->getValue(), 3.0);
+
+    const auto comment = interpretQuantityInput(
+        "1 mm [original input 12,34,567]",
+        QuantityInputGrammar::Quantity,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(comment.status, InputStatus::Acceptable);
+    ASSERT_TRUE(comment.quantity);
+    EXPECT_DOUBLE_EQ(comment.quantity->getValue(), 1.0);
+}
+
+TEST(QuantityInput, PositiveSignsAndCompactAdditionRemainExpressionSyntax)
+{
+    tests::initApplication();
+    ScopedExpressionOwner owner;
+    const auto path = owner.path();
+    const QuantityConstraints constraints;
+
+    const auto positive = interpretQuantityInput(
+        "+1 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(positive.status, InputStatus::Acceptable);
+    ASSERT_TRUE(positive.quantity);
+    EXPECT_DOUBLE_EQ(positive.quantity->getValue(), 1.0);
+
+    const auto compact = interpretQuantityInput(
+        "1+2 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(compact.status, InputStatus::Acceptable);
+    ASSERT_TRUE(compact.quantity);
+    EXPECT_DOUBLE_EQ(compact.quantity->getValue(), 3.0);
+    EXPECT_EQ(compact.quantity->getUnit(), Base::Unit::Length);
+
+    const Base::NumericLocaleContext custom {"custom", ".", ",", "plus", "minus", 3, 3, "0"};
+    const auto localizedPlus = interpretQuantityInput(
+        "plus1 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        custom,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(localizedPlus.status, InputStatus::Acceptable);
+    ASSERT_TRUE(localizedPlus.quantity);
+    EXPECT_DOUBLE_EQ(localizedPlus.quantity->getValue(), 1.0);
+
+    const auto localizedMinus = interpretQuantityInput(
+        "minus1 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        custom,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(localizedMinus.status, InputStatus::Acceptable);
+    ASSERT_TRUE(localizedMinus.quantity);
+    EXPECT_DOUBLE_EQ(localizedMinus.quantity->getValue(), -1.0);
+
+    const Base::NumericLocaleContext persian {"fa_IR", "٫", "٬", "+", "−", 3, 3, "۰"};
+    const auto localizedCompact = interpretQuantityInput(
+        "۱+۲ mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        persian,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(localizedCompact.status, InputStatus::Acceptable);
+    ASSERT_TRUE(localizedCompact.quantity);
+    EXPECT_DOUBLE_EQ(localizedCompact.quantity->getValue(), 3.0);
+
+    for (const auto& [input, expected] :
+         {std::pair {"1-2 mm", -1.0},
+          std::pair {"1+-2 mm", -1.0},
+          std::pair {"1e+2 mm", 100.0},
+          std::pair {"1e-2 mm", 0.01}}) {
+        const auto result = interpretQuantityInput(
+            input,
+            QuantityInputGrammar::Expression,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Commit,
+            constraints
+        );
+        ASSERT_EQ(result.status, InputStatus::Acceptable) << input;
+        ASSERT_TRUE(result.quantity);
+        EXPECT_DOUBLE_EQ(result.quantity->getValue(), expected);
+    }
+
+    for (const auto& [input, expected] :
+         {std::pair {"-(1 mm)", -1.0},
+          std::pair {"+(1 mm)", 1.0},
+          std::pair {"-sqrt(4) * 1 mm", -2.0},
+          std::pair {"-(1 + 2) mm", -3.0}}) {
+        const auto result = interpretQuantityInput(
+            input,
+            QuantityInputGrammar::Expression,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Commit,
+            constraints
+        );
+        ASSERT_EQ(result.status, InputStatus::Acceptable) << input;
+        ASSERT_TRUE(result.quantity);
+        EXPECT_DOUBLE_EQ(result.quantity->getValue(), expected);
+        EXPECT_EQ(result.quantity->getUnit(), Base::Unit::Length);
+    }
+}
+
+TEST(QuantityInput, DefaultUnitAppliesToBareAdditiveTerms)
+{
+    tests::initApplication();
+    ScopedExpressionOwner owner;
+    const auto path = owner.path();
+    const QuantityConstraints constraints;
+
+    for (const auto& [input, expected] :
+         {std::pair {"1 + 2 mm", 3.0},
+          std::pair {"1 mm + 2", 3.0},
+          std::pair {"1 + 2", 3.0},
+          std::pair {"(1 * 2) + 3 mm", 5.0},
+          std::pair {"sqrt(4) + 3 mm", 5.0},
+          std::pair {"1 + (2 + 3 mm)", 6.0},
+          std::pair {"(1 + 2) mm + 3", 6.0},
+          std::pair {"1 mm + (2 + 3)", 6.0},
+          std::pair {"(1 + 2) * 3 mm", 9.0},
+          std::pair {"3 mm * (1 + 2)", 9.0},
+          std::pair {"(4 - 1) / 3 * 6 mm", 6.0}}) {
+        const auto result = interpretQuantityInput(
+            input,
+            QuantityInputGrammar::Expression,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Commit,
+            constraints
+        );
+        ASSERT_EQ(result.status, InputStatus::Acceptable) << input;
+        ASSERT_TRUE(result.quantity);
+        EXPECT_DOUBLE_EQ(result.quantity->getValue(), expected);
+        EXPECT_EQ(result.quantity->getUnit(), Base::Unit::Length);
+    }
+
+    const auto multiplied = interpretQuantityInput(
+        "2 * 3 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(multiplied.status, InputStatus::Acceptable);
+    ASSERT_TRUE(multiplied.quantity);
+    EXPECT_DOUBLE_EQ(multiplied.quantity->getValue(), 6.0);
+    EXPECT_EQ(multiplied.quantity->getUnit(), Base::Unit::Length);
+
+    // A unit-bearing denominator is explicit expression syntax. Both forms are inverse length
+    // and therefore incompatible with this length field.
+    QuantityConstraints lengthConstraints;
+    lengthConstraints.requiredUnit = Base::Unit::Length;
+
+    const auto dividedNumber = interpretQuantityInput(
+        "1 / 2 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        lengthConstraints
+    );
+    EXPECT_EQ(dividedNumber.status, InputStatus::Invalid);
+    ASSERT_TRUE(dividedNumber.diagnostic);
+    EXPECT_EQ(dividedNumber.diagnostic->kind, InputDiagnosticKind::IncompatibleUnit);
+
+    const auto dividedQuantity = interpretQuantityInput(
+        "1 / (2 mm)",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        lengthConstraints
+    );
+    EXPECT_EQ(dividedQuantity.status, InputStatus::Invalid);
+    ASSERT_TRUE(dividedQuantity.diagnostic);
+    EXPECT_EQ(dividedQuantity.diagnostic->kind, InputDiagnosticKind::IncompatibleUnit);
+
+    const auto parenthesized = interpretQuantityInput(
+        "(1 + 2) mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        lengthConstraints
+    );
+    ASSERT_EQ(parenthesized.status, InputStatus::Acceptable);
+    ASSERT_TRUE(parenthesized.quantity);
+    EXPECT_DOUBLE_EQ(parenthesized.quantity->getValue(), 3.0);
+    EXPECT_EQ(parenthesized.quantity->getUnit(), Base::Unit::Length);
+
+    const auto dimensionless = interpretQuantityInput(
+        "1 + 2",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::One,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(dimensionless.status, InputStatus::Acceptable);
+    ASSERT_TRUE(dimensionless.quantity);
+    EXPECT_DOUBLE_EQ(dimensionless.quantity->getValue(), 3.0);
+    EXPECT_EQ(dimensionless.quantity->getUnit(), Base::Unit::One);
+}
+
+TEST(QuantityInput, RejectsMalformedGroupingAfterExpressionOperand)
+{
+    const ObjectIdentifier path;
+    const QuantityConstraints constraints;
+    const auto result = interpretQuantityInput(
+        "1 mm + 12,34,567 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+
+    EXPECT_EQ(result.status, InputStatus::Invalid);
+}
+
+TEST(QuantityInput, DefaultUnitPreservesExpressionDependencies)
+{
+    tests::initApplication();
+    ScopedExpressionOwner owner;
+    owner.setValue(2.0);
+    const auto path = owner.path();
+    const QuantityConstraints constraints;
+
+    const auto result = interpretQuantityInput(
+        "Value + 3 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(result.status, InputStatus::Acceptable);
+    ASSERT_TRUE(result.quantity);
+    ASSERT_TRUE(result.expression);
+    EXPECT_DOUBLE_EQ(result.quantity->getValue(), 5.0);
+    EXPECT_EQ(result.quantity->getUnit(), Base::Unit::Length);
+
+    const auto dependencies = result.expression->getDeps();
+    const auto objectDependencies = dependencies.find(path.getDocumentObject());
+    ASSERT_NE(objectDependencies, dependencies.end());
+    EXPECT_TRUE(objectDependencies->second.contains("Value"));
+
+    owner.setValue(4.0);
+    const auto reevaluated = result.expression->eval();
+    const auto* quantity = freecad_cast<App::NumberExpression*>(reevaluated.get());
+    ASSERT_NE(quantity, nullptr);
+    EXPECT_DOUBLE_EQ(quantity->getValue(), 7.0);
+    EXPECT_EQ(quantity->getUnit(), Base::Unit::Length);
+
+    const auto updatedDependencies = result.expression->getDeps();
+    const auto updatedObjectDependencies = updatedDependencies.find(path.getDocumentObject());
+    ASSERT_NE(updatedObjectDependencies, updatedDependencies.end());
+    EXPECT_TRUE(updatedObjectDependencies->second.contains("Value"));
+}
+
+TEST(QuantityInput, DefaultUnitDoesNotRewriteNestedMultiplicativeSubexpressions)
+{
+    tests::initApplication();
+    ScopedExpressionOwner owner;
+    owner.setValue(2.0);
+    const auto path = owner.path();
+    const QuantityConstraints constraints;
+
+    const auto result = interpretQuantityInput(
+        "(Value + 1) * 3 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(result.status, InputStatus::Acceptable);
+    ASSERT_TRUE(result.quantity);
+    ASSERT_TRUE(result.expression);
+    EXPECT_DOUBLE_EQ(result.quantity->getValue(), 9.0);
+    EXPECT_EQ(result.quantity->getUnit(), Base::Unit::Length);
+
+    const auto dependencies = result.expression->getDeps();
+    const auto objectDependencies = dependencies.find(path.getDocumentObject());
+    ASSERT_NE(objectDependencies, dependencies.end());
+    EXPECT_TRUE(objectDependencies->second.contains("Value"));
+
+    owner.setValue(4.0);
+    const auto reevaluated = result.expression->eval();
+    const auto* quantity = freecad_cast<App::NumberExpression*>(reevaluated.get());
+    ASSERT_NE(quantity, nullptr);
+    EXPECT_DOUBLE_EQ(quantity->getValue(), 15.0);
+    EXPECT_EQ(quantity->getUnit(), Base::Unit::Length);
+}
+
+TEST(QuantityInput, DefaultUnitExpressionsRoundTripThroughSerialization)
+{
+    tests::initApplication();
+    ScopedExpressionOwner owner;
+    owner.setValue(2.0);
+    const auto path = owner.path();
+    const QuantityConstraints constraints;
+
+    for (const auto& [input, expected] :
+         {std::pair {"Value + 3 mm", 5.0}, std::pair {"sqrt(4) + 3 mm", 5.0}}) {
+        const auto result = interpretQuantityInput(
+            input,
+            QuantityInputGrammar::Expression,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Commit,
+            constraints
+        );
+        ASSERT_EQ(result.status, InputStatus::Acceptable) << input;
+        ASSERT_TRUE(result.expression);
+
+        const auto serialized = result.expression->toString();
+        const auto reparsed
+            = App::ExpressionParser::parse(path.getDocumentObject(), serialized.c_str());
+        const auto evaluated = reparsed->eval();
+        const auto* quantity = freecad_cast<App::NumberExpression*>(evaluated.get());
+        ASSERT_NE(quantity, nullptr) << serialized;
+        EXPECT_DOUBLE_EQ(quantity->getValue(), expected) << serialized;
+        EXPECT_EQ(quantity->getUnit(), Base::Unit::Length) << serialized;
+
+        if (std::string_view {input} == "Value + 3 mm") {
+            const auto dependencies = reparsed->getDeps();
+            const auto objectDependencies = dependencies.find(path.getDocumentObject());
+            ASSERT_NE(objectDependencies, dependencies.end());
+            EXPECT_TRUE(objectDependencies->second.contains("Value"));
+        }
+    }
+}
+
+TEST(QuantityInput, EditingAndCommitExposeTheSameInvalidGrouping)
+{
+    const ObjectIdentifier path;
+    const QuantityConstraints constraints;
+    for (const auto phase : {InputPhase::Editing, InputPhase::Commit}) {
+        const auto result = interpretQuantityInput(
+            "12,34,567 mm",
+            QuantityInputGrammar::Expression,
+            path,
+            Base::Unit::Length,
+            enUs,
+            phase,
+            constraints
+        );
+        EXPECT_EQ(result.status, InputStatus::Invalid);
+        ASSERT_TRUE(result.diagnostic);
+        EXPECT_EQ(result.diagnostic->kind, InputDiagnosticKind::MalformedGrouping);
+    }
+}
+
+TEST(QuantityInput, SharedLocalizedInputCorpus)
+{
+    tests::initApplication();
+    ScopedExpressionOwner owner;
+    const ObjectIdentifier quantityPath;
+    const auto expressionPath = owner.path();
+    const QuantityConstraints constraints;
+
+    struct ConsumerCase
+    {
+        std::string_view input;
+        QuantityInputGrammar grammar;
+        ObjectIdentifier path;
+        InputStatus status;
+        std::optional<double> value;
+    };
+
+    const std::vector<ConsumerCase> cases {
+        {"12,345.67 mm", QuantityInputGrammar::Quantity, quantityPath, InputStatus::Acceptable, 12345.67},
+        {"12,34,567 mm", QuantityInputGrammar::Quantity, quantityPath, InputStatus::Invalid, std::nullopt},
+        {"12 345 mm", QuantityInputGrammar::Quantity, quantityPath, InputStatus::Invalid, std::nullopt},
+        {"1+2 mm", QuantityInputGrammar::Expression, expressionPath, InputStatus::Acceptable, 3.0},
+        {"1 + 2 mm", QuantityInputGrammar::Expression, expressionPath, InputStatus::Acceptable, 3.0},
+        {"12,34,567 mm", QuantityInputGrammar::Expression, expressionPath, InputStatus::Invalid, std::nullopt}
+    };
+
+    for (const auto& testCase : cases) {
+        const auto result = interpretQuantityInput(
+            testCase.input,
+            testCase.grammar,
+            testCase.path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Commit,
+            constraints
+        );
+        ASSERT_EQ(result.status, testCase.status) << testCase.input;
+        if (testCase.value) {
+            ASSERT_TRUE(result.quantity);
+            EXPECT_DOUBLE_EQ(result.quantity->getValue(), *testCase.value);
+        }
+    }
+}
+
+}  // namespace App::QuantityInputTest

--- a/tests/src/App/QuantityInput.cpp
+++ b/tests/src/App/QuantityInput.cpp
@@ -1,0 +1,703 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <App/Expression.h>
+#include <App/ExpressionParser.h>
+#include <App/ObjectIdentifier.h>
+#include <App/Property.h>
+#include "App/QuantityInput.h"
+#include "Base/NumericFormatting.h"
+#include <src/App/InitApplication.h>
+
+namespace
+{
+class ScopedExpressionOwner
+{
+public:
+    ScopedExpressionOwner()
+        : documentName {App::GetApplication().getUniqueDocumentName("quantity_input")}
+        , document {App::GetApplication().newDocument(documentName.c_str(), "testUser")}
+        , object {document->addObject("App::GeoFeature", "Owner")}
+        , property {object->addDynamicProperty("App::PropertyFloat", "Value", "Test")}
+    {}
+
+    ~ScopedExpressionOwner()
+    {
+        App::GetApplication().closeDocument(documentName.c_str());
+    }
+
+    App::ObjectIdentifier path() const
+    {
+        return App::ObjectIdentifier(*property);
+    }
+
+    void setValue(const double value)
+    {
+        freecad_cast<App::PropertyFloat*>(property)->setValue(value);
+    }
+
+private:
+    std::string documentName;
+    App::Document* document;
+    App::DocumentObject* object;
+    App::Property* property;
+};
+}  // namespace
+
+namespace App::QuantityInputTest
+{
+
+const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3};
+
+TEST(QuantityInput, EditingAndCommitDistinguishIncompleteNumbers)
+{
+    const ObjectIdentifier path;
+    const QuantityConstraints constraints;
+
+    EXPECT_EQ(
+        interpretQuantityInput(
+            "-",
+            QuantityInputGrammar::Quantity,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Editing,
+            constraints
+        )
+            .status,
+        InputStatus::Incomplete
+    );
+    EXPECT_EQ(
+        interpretQuantityInput(
+            "-",
+            QuantityInputGrammar::Quantity,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Commit,
+            constraints
+        )
+            .status,
+        InputStatus::Invalid
+    );
+    EXPECT_EQ(
+        interpretQuantityInput(
+            "1e",
+            QuantityInputGrammar::Quantity,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Editing,
+            constraints
+        )
+            .status,
+        InputStatus::Incomplete
+    );
+    EXPECT_EQ(
+        interpretQuantityInput(
+            "1e",
+            QuantityInputGrammar::Quantity,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Commit,
+            constraints
+        )
+            .status,
+        InputStatus::Invalid
+    );
+
+    for (const auto input : {"", "+", "1e-"}) {
+        EXPECT_EQ(
+            interpretQuantityInput(
+                input,
+                QuantityInputGrammar::Quantity,
+                path,
+                Base::Unit::Length,
+                enUs,
+                InputPhase::Editing,
+                constraints
+            )
+                .status,
+            InputStatus::Incomplete
+        ) << input;
+        EXPECT_EQ(
+            interpretQuantityInput(
+                input,
+                QuantityInputGrammar::Quantity,
+                path,
+                Base::Unit::Length,
+                enUs,
+                InputPhase::Commit,
+                constraints
+            )
+                .status,
+            InputStatus::Invalid
+        ) << input;
+    }
+
+    for (const auto input : {"1,2", "1.2.3"}) {
+        EXPECT_EQ(
+            interpretQuantityInput(
+                input,
+                QuantityInputGrammar::Quantity,
+                path,
+                Base::Unit::Length,
+                enUs,
+                InputPhase::Editing,
+                constraints
+            )
+                .status,
+            InputStatus::Invalid
+        ) << input;
+        EXPECT_EQ(
+            interpretQuantityInput(
+                input,
+                QuantityInputGrammar::Quantity,
+                path,
+                Base::Unit::Length,
+                enUs,
+                InputPhase::Commit,
+                constraints
+            )
+                .status,
+            InputStatus::Invalid
+        ) << input;
+    }
+}
+
+TEST(QuantityInput, TrailingGroupingSeparatorFollowsTheInputPhase)
+{
+    const ObjectIdentifier path;
+    const QuantityConstraints constraints;
+
+    const auto editing = interpretQuantityInput(
+        "12,",
+        QuantityInputGrammar::Quantity,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Editing,
+        constraints
+    );
+    ASSERT_EQ(editing.status, InputStatus::Incomplete);
+    ASSERT_TRUE(editing.diagnostic);
+    EXPECT_EQ(editing.diagnostic->kind, InputDiagnosticKind::IncompleteNumber);
+
+    const auto commit = interpretQuantityInput(
+        "12,",
+        QuantityInputGrammar::Quantity,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(commit.status, InputStatus::Invalid);
+    ASSERT_TRUE(commit.diagnostic);
+    EXPECT_EQ(commit.diagnostic->kind, InputDiagnosticKind::IncompleteNumber);
+}
+
+TEST(QuantityInput, ReportsGroupingAndUnitDiagnostics)
+{
+    const ObjectIdentifier path;
+    const QuantityConstraints constraints;
+
+    const auto malformed = interpretQuantityInput(
+        "12,34,567 mm",
+        QuantityInputGrammar::Quantity,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(malformed.status, InputStatus::Invalid);
+    ASSERT_TRUE(malformed.diagnostic);
+    EXPECT_EQ(malformed.diagnostic->kind, InputDiagnosticKind::MalformedGrouping);
+
+    const auto plainSpace = interpretQuantityInput(
+        "12 345 mm",
+        QuantityInputGrammar::Quantity,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(plainSpace.status, InputStatus::Invalid);
+    ASSERT_TRUE(plainSpace.diagnostic);
+    EXPECT_EQ(plainSpace.diagnostic->kind, InputDiagnosticKind::MalformedGrouping);
+
+    QuantityConstraints restricted;
+    restricted.requiredUnit = Base::Unit::TimeSpan;
+    const auto incompatible = interpretQuantityInput(
+        "10 mm",
+        QuantityInputGrammar::Quantity,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        restricted
+    );
+    ASSERT_EQ(incompatible.status, InputStatus::Invalid);
+    ASSERT_TRUE(incompatible.diagnostic);
+    EXPECT_EQ(incompatible.diagnostic->kind, InputDiagnosticKind::IncompatibleUnit);
+}
+
+TEST(QuantityInput, AcceptsGroupedQuantityAndNormalizesIt)
+{
+    const ObjectIdentifier path;
+    const QuantityConstraints constraints;
+    const auto result = interpretQuantityInput(
+        "12,345.67 mm",
+        QuantityInputGrammar::Quantity,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+
+    ASSERT_EQ(result.status, InputStatus::Acceptable);
+    ASSERT_TRUE(result.quantity);
+    EXPECT_DOUBLE_EQ(result.quantity->getValue(), 12345.67);
+    EXPECT_EQ(result.normalizedText, "12345.67 mm");
+}
+
+TEST(QuantityInput, ReportsExpressionEvaluationAndRangeDiagnostics)
+{
+    tests::initApplication();
+    ScopedExpressionOwner owner;
+    const auto path = owner.path();
+    const QuantityConstraints constraints;
+
+    const auto syntax = interpretQuantityInput(
+        "1 +",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(syntax.status, InputStatus::Invalid);
+    ASSERT_TRUE(syntax.diagnostic);
+    EXPECT_EQ(syntax.diagnostic->kind, InputDiagnosticKind::ExpressionSyntax);
+
+    const auto evaluation = interpretQuantityInput(
+        "str(1)",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(evaluation.status, InputStatus::Invalid);
+    ASSERT_TRUE(evaluation.diagnostic);
+    EXPECT_EQ(evaluation.diagnostic->kind, InputDiagnosticKind::Evaluation);
+
+    QuantityConstraints bounded;
+    bounded.maximum = 10.0;
+    const auto outOfRange = interpretQuantityInput(
+        "11 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        bounded
+    );
+    ASSERT_EQ(outOfRange.status, InputStatus::Invalid);
+    ASSERT_TRUE(outOfRange.diagnostic);
+    EXPECT_EQ(outOfRange.diagnostic->kind, InputDiagnosticKind::OutOfRange);
+}
+
+TEST(QuantityInput, GrammarSelectionIsExplicit)
+{
+    tests::initApplication();
+    ScopedExpressionOwner owner;
+    const auto path = owner.path();
+    const QuantityConstraints constraints;
+
+    const auto quantity = interpretQuantityInput(
+        "1+2 mm",
+        QuantityInputGrammar::Quantity,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    EXPECT_EQ(quantity.status, InputStatus::Invalid);
+
+    const auto expression = interpretQuantityInput(
+        "1+2 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(expression.status, InputStatus::Acceptable);
+    ASSERT_TRUE(expression.quantity);
+    EXPECT_DOUBLE_EQ(expression.quantity->getValue(), 3.0);
+}
+
+TEST(QuantityInput, PositiveSignsAndCompactAdditionRemainExpressionSyntax)
+{
+    tests::initApplication();
+    ScopedExpressionOwner owner;
+    const auto path = owner.path();
+    const QuantityConstraints constraints;
+
+    const auto positive = interpretQuantityInput(
+        "+1 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(positive.status, InputStatus::Acceptable);
+    ASSERT_TRUE(positive.quantity);
+    EXPECT_DOUBLE_EQ(positive.quantity->getValue(), 1.0);
+
+    const auto compact = interpretQuantityInput(
+        "1+2 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(compact.status, InputStatus::Acceptable);
+    ASSERT_TRUE(compact.quantity);
+    EXPECT_DOUBLE_EQ(compact.quantity->getValue(), 3.0);
+    EXPECT_EQ(compact.quantity->getUnit(), Base::Unit::Length);
+
+    const Base::NumericLocaleContext custom {"custom", ".", ",", "plus", "minus", 3, 3};
+    const auto localizedPlus = interpretQuantityInput(
+        "plus1 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        custom,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(localizedPlus.status, InputStatus::Acceptable);
+    ASSERT_TRUE(localizedPlus.quantity);
+    EXPECT_DOUBLE_EQ(localizedPlus.quantity->getValue(), 1.0);
+
+    const auto localizedMinus = interpretQuantityInput(
+        "minus1 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        custom,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(localizedMinus.status, InputStatus::Acceptable);
+    ASSERT_TRUE(localizedMinus.quantity);
+    EXPECT_DOUBLE_EQ(localizedMinus.quantity->getValue(), -1.0);
+
+    const Base::NumericLocaleContext persian {"fa_IR", "٫", "٬", "+", "−", 3, 3, "۰"};
+    const auto localizedCompact = interpretQuantityInput(
+        "۱+۲ mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        persian,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(localizedCompact.status, InputStatus::Acceptable);
+    ASSERT_TRUE(localizedCompact.quantity);
+    EXPECT_DOUBLE_EQ(localizedCompact.quantity->getValue(), 3.0);
+
+    for (const auto [input, expected] :
+         {std::pair {"1-2 mm", -1.0},
+          std::pair {"1+-2 mm", -1.0},
+          std::pair {"1e+2 mm", 100.0},
+          std::pair {"1e-2 mm", 0.01}}) {
+        const auto result = interpretQuantityInput(
+            input,
+            QuantityInputGrammar::Expression,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Commit,
+            constraints
+        );
+        ASSERT_EQ(result.status, InputStatus::Acceptable) << input;
+        ASSERT_TRUE(result.quantity);
+        EXPECT_DOUBLE_EQ(result.quantity->getValue(), expected);
+    }
+
+    for (const auto [input, expected] :
+         {std::pair {"-(1 mm)", -1.0},
+          std::pair {"+(1 mm)", 1.0},
+          std::pair {"-sqrt(4) * 1 mm", -2.0},
+          std::pair {"-(1 + 2) mm", -3.0}}) {
+        const auto result = interpretQuantityInput(
+            input,
+            QuantityInputGrammar::Expression,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Commit,
+            constraints
+        );
+        ASSERT_EQ(result.status, InputStatus::Acceptable) << input;
+        ASSERT_TRUE(result.quantity);
+        EXPECT_DOUBLE_EQ(result.quantity->getValue(), expected);
+        EXPECT_EQ(result.quantity->getUnit(), Base::Unit::Length);
+    }
+}
+
+TEST(QuantityInput, DefaultUnitAppliesToBareAdditiveTerms)
+{
+    tests::initApplication();
+    ScopedExpressionOwner owner;
+    const auto path = owner.path();
+    const QuantityConstraints constraints;
+
+    for (const auto& [input, expected] :
+         {std::pair {"1 + 2 mm", 3.0},
+          std::pair {"1 mm + 2", 3.0},
+          std::pair {"1 + 2", 3.0},
+          std::pair {"(1 * 2) + 3 mm", 5.0},
+          std::pair {"sqrt(4) + 3 mm", 5.0}}) {
+        const auto result = interpretQuantityInput(
+            input,
+            QuantityInputGrammar::Expression,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Commit,
+            constraints
+        );
+        ASSERT_EQ(result.status, InputStatus::Acceptable) << input;
+        ASSERT_TRUE(result.quantity);
+        EXPECT_DOUBLE_EQ(result.quantity->getValue(), expected);
+        EXPECT_EQ(result.quantity->getUnit(), Base::Unit::Length);
+    }
+
+    const auto multiplied = interpretQuantityInput(
+        "2 * 3 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(multiplied.status, InputStatus::Acceptable);
+    ASSERT_TRUE(multiplied.quantity);
+    EXPECT_DOUBLE_EQ(multiplied.quantity->getValue(), 6.0);
+    EXPECT_EQ(multiplied.quantity->getUnit(), Base::Unit::Length);
+
+    // A unit written in a divisor is explicit expression syntax. The field's default unit is
+    // applied to dimensionless additive operands, not used to reinterpret an explicit denominator.
+    for (const auto input : {"1 / 2 mm", "1 / (2 mm)"}) {
+        const auto result = interpretQuantityInput(
+            input,
+            QuantityInputGrammar::Expression,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Commit,
+            constraints
+        );
+        EXPECT_EQ(result.status, InputStatus::Invalid) << input;
+        ASSERT_TRUE(result.diagnostic);
+        EXPECT_EQ(result.diagnostic->kind, InputDiagnosticKind::IncompatibleUnit);
+    }
+
+    const auto parenthesized = interpretQuantityInput(
+        "(1 + 2) mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(parenthesized.status, InputStatus::Acceptable);
+    ASSERT_TRUE(parenthesized.quantity);
+    EXPECT_DOUBLE_EQ(parenthesized.quantity->getValue(), 3.0);
+    EXPECT_EQ(parenthesized.quantity->getUnit(), Base::Unit::Length);
+
+    const auto dimensionless = interpretQuantityInput(
+        "1 + 2",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::One,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(dimensionless.status, InputStatus::Acceptable);
+    ASSERT_TRUE(dimensionless.quantity);
+    EXPECT_DOUBLE_EQ(dimensionless.quantity->getValue(), 3.0);
+    EXPECT_EQ(dimensionless.quantity->getUnit(), Base::Unit::One);
+}
+
+TEST(QuantityInput, DefaultUnitPreservesExpressionDependencies)
+{
+    tests::initApplication();
+    ScopedExpressionOwner owner;
+    owner.setValue(2.0);
+    const auto path = owner.path();
+    const QuantityConstraints constraints;
+
+    const auto result = interpretQuantityInput(
+        "Value + 3 mm",
+        QuantityInputGrammar::Expression,
+        path,
+        Base::Unit::Length,
+        enUs,
+        InputPhase::Commit,
+        constraints
+    );
+    ASSERT_EQ(result.status, InputStatus::Acceptable);
+    ASSERT_TRUE(result.quantity);
+    ASSERT_TRUE(result.expression);
+    EXPECT_DOUBLE_EQ(result.quantity->getValue(), 5.0);
+    EXPECT_EQ(result.quantity->getUnit(), Base::Unit::Length);
+
+    const auto dependencies = result.expression->getDeps();
+    const auto objectDependencies = dependencies.find(path.getDocumentObject());
+    ASSERT_NE(objectDependencies, dependencies.end());
+    EXPECT_TRUE(objectDependencies->second.contains("Value"));
+
+    owner.setValue(4.0);
+    const auto reevaluated = result.expression->eval();
+    const auto* quantity = freecad_cast<App::UnitExpression*>(reevaluated.get());
+    ASSERT_NE(quantity, nullptr);
+    EXPECT_DOUBLE_EQ(quantity->getValue(), 7.0);
+    EXPECT_EQ(quantity->getUnit(), Base::Unit::Length);
+
+    const auto updatedDependencies = result.expression->getDeps();
+    const auto updatedObjectDependencies = updatedDependencies.find(path.getDocumentObject());
+    ASSERT_NE(updatedObjectDependencies, updatedDependencies.end());
+    EXPECT_TRUE(updatedObjectDependencies->second.contains("Value"));
+}
+
+TEST(QuantityInput, DefaultUnitExpressionsRoundTripThroughSerialization)
+{
+    tests::initApplication();
+    ScopedExpressionOwner owner;
+    owner.setValue(2.0);
+    const auto path = owner.path();
+    const QuantityConstraints constraints;
+
+    for (const auto& [input, expected] :
+         {std::pair {"Value + 3 mm", 5.0}, std::pair {"sqrt(4) + 3 mm", 5.0}}) {
+        const auto result = interpretQuantityInput(
+            input,
+            QuantityInputGrammar::Expression,
+            path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Commit,
+            constraints
+        );
+        ASSERT_EQ(result.status, InputStatus::Acceptable) << input;
+        ASSERT_TRUE(result.expression);
+
+        const auto serialized = result.expression->toString();
+        const auto reparsed
+            = App::ExpressionParser::parse(path.getDocumentObject(), serialized.c_str());
+        const auto evaluated = reparsed->eval();
+        const auto* quantity = freecad_cast<App::UnitExpression*>(evaluated.get());
+        ASSERT_NE(quantity, nullptr) << serialized;
+        EXPECT_DOUBLE_EQ(quantity->getValue(), expected) << serialized;
+        EXPECT_EQ(quantity->getUnit(), Base::Unit::Length) << serialized;
+
+        if (input == "Value + 3 mm") {
+            const auto dependencies = reparsed->getDeps();
+            const auto objectDependencies = dependencies.find(path.getDocumentObject());
+            ASSERT_NE(objectDependencies, dependencies.end());
+            EXPECT_TRUE(objectDependencies->second.contains("Value"));
+        }
+    }
+}
+
+TEST(QuantityInput, EditingAndCommitExposeTheSameInvalidGrouping)
+{
+    const ObjectIdentifier path;
+    const QuantityConstraints constraints;
+    for (const auto phase : {InputPhase::Editing, InputPhase::Commit}) {
+        const auto result = interpretQuantityInput(
+            "12,34,567 mm",
+            QuantityInputGrammar::Expression,
+            path,
+            Base::Unit::Length,
+            enUs,
+            phase,
+            constraints
+        );
+        EXPECT_EQ(result.status, InputStatus::Invalid);
+        ASSERT_TRUE(result.diagnostic);
+        EXPECT_EQ(result.diagnostic->kind, InputDiagnosticKind::MalformedGrouping);
+    }
+}
+
+TEST(QuantityInput, SharedLocalizedInputCorpus)
+{
+    tests::initApplication();
+    ScopedExpressionOwner owner;
+    const ObjectIdentifier quantityPath;
+    const auto expressionPath = owner.path();
+    const QuantityConstraints constraints;
+
+    struct ConsumerCase
+    {
+        std::string_view input;
+        QuantityInputGrammar grammar;
+        ObjectIdentifier path;
+        InputStatus status;
+        std::optional<double> value;
+    };
+
+    const std::vector<ConsumerCase> cases {
+        {"12,345.67 mm", QuantityInputGrammar::Quantity, quantityPath, InputStatus::Acceptable, 12345.67},
+        {"12,34,567 mm", QuantityInputGrammar::Quantity, quantityPath, InputStatus::Invalid, std::nullopt},
+        {"12 345 mm", QuantityInputGrammar::Quantity, quantityPath, InputStatus::Invalid, std::nullopt},
+        {"1+2 mm", QuantityInputGrammar::Expression, expressionPath, InputStatus::Acceptable, 3.0},
+        {"1 + 2 mm", QuantityInputGrammar::Expression, expressionPath, InputStatus::Acceptable, 3.0},
+        {"12,34,567 mm", QuantityInputGrammar::Expression, expressionPath, InputStatus::Invalid, std::nullopt}
+    };
+
+    for (const auto& testCase : cases) {
+        const auto result = interpretQuantityInput(
+            testCase.input,
+            testCase.grammar,
+            testCase.path,
+            Base::Unit::Length,
+            enUs,
+            InputPhase::Commit,
+            constraints
+        );
+        ASSERT_EQ(result.status, testCase.status) << testCase.input;
+        if (testCase.value) {
+            ASSERT_TRUE(result.quantity);
+            EXPECT_DOUBLE_EQ(result.quantity->getValue(), *testCase.value);
+        }
+    }
+}
+
+}  // namespace App::QuantityInputTest

--- a/tests/src/Base/CMakeLists.txt
+++ b/tests/src/Base/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(Base_tests_run
         InputSource.cpp
         Handle.cpp
         Matrix.cpp
+        NumericFormatting.cpp
         Parameter.cpp
         ParameterObserver.cpp
         Placement.cpp

--- a/tests/src/Base/CMakeLists.txt
+++ b/tests/src/Base/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(Base_tests_run
         Handle.cpp
         Matrix.cpp
         NumericFormatting.cpp
+        NumericInput.cpp
         Parameter.cpp
         ParameterObserver.cpp
         Placement.cpp

--- a/tests/src/Base/CMakeLists.txt
+++ b/tests/src/Base/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(Base_tests_run
         InputSource.cpp
         Handle.cpp
         Matrix.cpp
+        NumericInput.cpp
         Parameter.cpp
         ParameterObserver.cpp
         Placement.cpp

--- a/tests/src/Base/CMakeLists.txt
+++ b/tests/src/Base/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(Base_tests_run
         InputSource.cpp
         Handle.cpp
         Matrix.cpp
+        NumericFormatting.cpp
         NumericInput.cpp
         Parameter.cpp
         ParameterObserver.cpp

--- a/tests/src/Base/NumericFormatting.cpp
+++ b/tests/src/Base/NumericFormatting.cpp
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+
+#include <utility>
+
+#include <Base/Exception.h>
+#include <Base/NumericFormatting.h>
+#include <Base/NumericInput.h>
+#include <Base/Quantity.h>
+
+TEST(NumericFormattingTest, createsLocaleSpecificSeparators)
+{
+    const auto enUs = Base::createNumericLocaleContext("en_US");
+    const auto deDe = Base::createNumericLocaleContext("de_DE");
+    const auto enIn = Base::createNumericLocaleContext("en_IN");
+
+    EXPECT_EQ(enUs.localeId, "en_US");
+    EXPECT_EQ(enUs.decimalSeparator, ".");
+    EXPECT_EQ(enUs.groupingSeparator, ",");
+    EXPECT_EQ(enUs.positiveSign, "+");
+    EXPECT_EQ(enUs.negativeSign, "-");
+    EXPECT_EQ(enUs.primaryGroupingSize, 3);
+    EXPECT_EQ(enUs.secondaryGroupingSize, 3);
+    EXPECT_EQ(enUs.zeroDigit, "0");
+
+    EXPECT_EQ(deDe.localeId, "de_DE");
+    EXPECT_EQ(deDe.decimalSeparator, ",");
+    EXPECT_EQ(deDe.groupingSeparator, ".");
+
+    EXPECT_EQ(enIn.localeId, "en_IN");
+    EXPECT_EQ(enIn.decimalSeparator, ".");
+    EXPECT_EQ(enIn.groupingSeparator, ",");
+    EXPECT_EQ(enIn.primaryGroupingSize, 3);
+    EXPECT_EQ(enIn.secondaryGroupingSize, 2);
+}
+
+TEST(NumericFormattingTest, formattedNativeDigitsRoundTripThroughScannerAndQuantity)
+{
+    Base::QuantityFormat fixed(Base::QuantityFormat::Fixed, 1);
+    fixed.option = Base::QuantityFormat::None;
+    Base::QuantityFormat scientific(Base::QuantityFormat::Scientific, 2);
+    scientific.option = Base::QuantityFormat::None;
+
+    for (const auto localeId : {"fa_IR", "ar_EG"}) {
+        const auto locale = Base::createNumericLocaleContext(localeId);
+        for (const auto [value, format] :
+             {std::pair {1234.5, fixed}, std::pair {-1234.5, fixed}, std::pair {1.25e6, scientific}}) {
+            const auto formatted = Base::formatNumericValue(value, format, locale);
+            if (format.format == Base::QuantityFormat::Scientific) {
+                EXPECT_NE(formatted.find('e'), std::string::npos) << localeId << ": " << formatted;
+            }
+            const auto scanned
+                = Base::scanLocalizedNumber(formatted, locale, Base::NumericSyntaxContext::Standalone);
+            ASSERT_EQ(scanned.status, Base::LocalizedNumberResult::Status::Complete)
+                << localeId << ": " << formatted;
+            EXPECT_DOUBLE_EQ(scanned.value, value);
+            if (format.format == Base::QuantityFormat::Scientific) {
+                EXPECT_EQ(scanned.canonicalText, "1.25e6");
+            }
+
+            const auto quantity = Base::Quantity::parseUserInput(formatted + " mm", locale);
+            EXPECT_DOUBLE_EQ(quantity.getValue(), value);
+            EXPECT_EQ(quantity.getUnit(), Base::Unit::Length);
+        }
+    }
+}
+
+TEST(NumericFormattingTest, formatsValuesWithEffectiveSeparators)
+{
+    const Base::NumericLocaleContext formatting {"en_US", ",", "\xC2\xA0", "+", "-", 3, 3};
+
+    Base::QuantityFormat fixed(Base::QuantityFormat::Fixed, 2);
+    fixed.option = Base::QuantityFormat::None;
+    EXPECT_EQ(Base::formatNumericValue(1.5, fixed, formatting), "1,50");
+
+    Base::QuantityFormat grouped(Base::QuantityFormat::Default, 0);
+    grouped.option = Base::QuantityFormat::None;
+    EXPECT_EQ(
+        Base::formatNumericValue(12345.0, grouped, formatting),
+        std::string {"12\xC2\xA0"
+                     "345"}
+    );
+}
+
+TEST(NumericFormattingTest, cLocaleUsesDeterministicFallback)
+{
+    const Base::NumericLocaleContext expected {"en_US_POSIX", ".", ",", "+", "-", 3, 3, "0"};
+    EXPECT_EQ(Base::createNumericLocaleContext("C"), expected);
+}
+
+TEST(NumericFormattingTest, normalizesIcuLocaleIdentifiers)
+{
+    EXPECT_EQ(Base::normalizeIcuLocaleId(""), "en_US_POSIX");
+    EXPECT_EQ(Base::normalizeIcuLocaleId("POSIX"), "en_US_POSIX");
+    EXPECT_EQ(Base::normalizeIcuLocaleId("de_DE"), "de_DE");
+}
+
+TEST(NumericFormattingTest, rejectsBogusIcuLocaleIdentifiers)
+{
+    constexpr auto bogusLocale = "not a locale";
+
+    EXPECT_THROW(Base::normalizeIcuLocaleId(bogusLocale), Base::ValueError);
+    EXPECT_THROW(Base::createNumericLocaleContext(bogusLocale), Base::ValueError);
+    EXPECT_THROW(Base::setIcuDefaultLocale(bogusLocale), Base::ValueError);
+}
+
+TEST(NumericFormattingTest, publishedStateIsACompleteSnapshot)
+{
+    const auto previous = Base::currentNumericLocaleContext();
+    const Base::NumericLocaleContext expected {"en_US", ".", ",", "+", "-", 3, 3, "0"};
+
+    Base::publishNumericLocaleContext(expected);
+
+    EXPECT_EQ(Base::currentNumericLocaleContext(), expected);
+    Base::publishNumericLocaleContext(previous);
+}
+
+TEST(NumericFormattingTest, failedLocaleResolutionDoesNotPublishPartialState)
+{
+    const auto previous = Base::currentNumericLocaleContext();
+    const Base::NumericLocaleContext expected {"en_IN", ".", ",", "+", "-", 3, 2, "0"};
+    Base::publishNumericLocaleContext(expected);
+
+    EXPECT_THROW(Base::createNumericLocaleContext("not a locale"), Base::ValueError);
+    EXPECT_EQ(Base::currentNumericLocaleContext(), expected);
+
+    Base::publishNumericLocaleContext(previous);
+}

--- a/tests/src/Base/NumericInput.cpp
+++ b/tests/src/Base/NumericInput.cpp
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+
+#include <Base/NumericFormatting.h>
+#include <Base/NumericInput.h>
+
+namespace
+{
+Base::NumericLocaleContext locale(
+    const char* localeId,
+    const char* decimal,
+    const char* grouping,
+    int primary = 3,
+    int secondary = 3
+)
+{
+    return {localeId, decimal, grouping, "+", "-", primary, secondary};
+}
+
+void expectComplete(
+    const Base::LocalizedNumberResult& result,
+    double value,
+    std::string_view canonical,
+    std::size_t consumed
+)
+{
+    EXPECT_EQ(result.status, Base::LocalizedNumberResult::Status::Complete);
+    EXPECT_DOUBLE_EQ(result.value, value);
+    EXPECT_EQ(result.canonicalText, canonical);
+    EXPECT_EQ(result.consumedBytes, consumed);
+    EXPECT_FALSE(result.diagnostic.has_value());
+}
+}  // namespace
+
+TEST(NumericInputTest, canonicalAndLocalizedDecimals)
+{
+    const auto de = locale("de_DE", ",", ".");
+    expectComplete(
+        Base::scanLocalizedNumber("1,25 mm", de, Base::NumericSyntaxContext::Standalone),
+        1.25,
+        "1.25",
+        4
+    );
+    expectComplete(
+        Base::scanLocalizedNumber("12.345,67 mm", de, Base::NumericSyntaxContext::Standalone),
+        12345.67,
+        "12345.67",
+        9
+    );
+    expectComplete(
+        Base::scanLocalizedNumber("1.25 mm", de, Base::NumericSyntaxContext::Standalone),
+        1.25,
+        "1.25",
+        4
+    );
+}
+
+TEST(NumericInputTest, westernGroupingAndScientificNotation)
+{
+    const auto en = locale("en_US", ".", ",");
+    expectComplete(
+        Base::scanLocalizedNumber("1,234.5 mm", en, Base::NumericSyntaxContext::Standalone),
+        1234.5,
+        "1234.5",
+        7
+    );
+    expectComplete(
+        Base::scanLocalizedNumber("1,234e5 mm", en, Base::NumericSyntaxContext::Standalone),
+        123400000.0,
+        "1234e5",
+        7
+    );
+}
+
+TEST(NumericInputTest, indianGroupingUsesSecondarySize)
+{
+    const auto enIn = locale("en_IN", ".", ",", 3, 2);
+    expectComplete(
+        Base::scanLocalizedNumber("12,34,567 mm", enIn, Base::NumericSyntaxContext::Standalone),
+        1234567.0,
+        "1234567",
+        9
+    );
+}
+
+TEST(NumericInputTest, malformedGroupingIsInvalid)
+{
+    const auto en = locale("en_US", ".", ",");
+    const auto result
+        = Base::scanLocalizedNumber("12,34,567", en, Base::NumericSyntaxContext::Standalone);
+
+    EXPECT_EQ(result.status, Base::LocalizedNumberResult::Status::Invalid);
+    ASSERT_TRUE(result.diagnostic.has_value());
+    EXPECT_EQ(result.diagnostic->kind, Base::NumericDiagnosticKind::InvalidGrouping);
+}
+
+TEST(NumericInputTest, multipleDecimalsAndIncompleteExponentsAreDiagnosed)
+{
+    const auto en = locale("en_US", ".", ",");
+    const auto multipleDecimals
+        = Base::scanLocalizedNumber("1.2.3", en, Base::NumericSyntaxContext::Standalone);
+    EXPECT_EQ(multipleDecimals.status, Base::LocalizedNumberResult::Status::Invalid);
+
+    const auto incompleteExponent
+        = Base::scanLocalizedNumber("1e", en, Base::NumericSyntaxContext::Standalone);
+    EXPECT_EQ(incompleteExponent.status, Base::LocalizedNumberResult::Status::Incomplete);
+    ASSERT_TRUE(incompleteExponent.diagnostic.has_value());
+    EXPECT_EQ(incompleteExponent.diagnostic->kind, Base::NumericDiagnosticKind::IncompleteExponent);
+
+    for (const auto input : {"1.23,4", "1,234.5,6", "1e1,000", "1,234e1,000"}) {
+        EXPECT_EQ(
+            Base::scanLocalizedNumber(input, en, Base::NumericSyntaxContext::Standalone).status,
+            Base::LocalizedNumberResult::Status::Invalid
+        ) << input;
+    }
+}
+
+TEST(NumericInputTest, DotGroupingAndCanonicalDecimalHaveAnExplicitPolicy)
+{
+    const auto de = locale("de_DE", ",", ".");
+    expectComplete(
+        Base::scanLocalizedNumber("1.234", de, Base::NumericSyntaxContext::Standalone),
+        1.234,
+        "1.234",
+        5
+    );
+    expectComplete(
+        Base::scanLocalizedNumber("1.234,5", de, Base::NumericSyntaxContext::Standalone),
+        1234.5,
+        "1234.5",
+        7
+    );
+    expectComplete(
+        Base::scanLocalizedNumber("1.234.567", de, Base::NumericSyntaxContext::Standalone),
+        1234567.0,
+        "1234567",
+        9
+    );
+    expectComplete(
+        Base::scanLocalizedNumber("12.345 mm", de, Base::NumericSyntaxContext::Standalone),
+        12.345,
+        "12.345",
+        6
+    );
+}
+
+TEST(NumericInputTest, negativeAndLocalizedSigns)
+{
+    const auto en = locale("en_US", ".", ",");
+    expectComplete(
+        Base::scanLocalizedNumber("-1,234.5 mm", en, Base::NumericSyntaxContext::Standalone),
+        -1234.5,
+        "-1234.5",
+        8
+    );
+
+    const Base::NumericLocaleContext
+        fa {"fa_IR", "\xD9\xAB", "\xD9\xAC", "\xEF\xBC\x8B", "\xE2\x88\x92", 3, 3, "\xDB\xB0"};
+    const std::string input = fa.negativeSign + "1" + fa.decimalSeparator + "25 mm";
+    const auto localized = Base::scanLocalizedNumber(input, fa, Base::NumericSyntaxContext::Standalone);
+    EXPECT_EQ(localized.status, Base::LocalizedNumberResult::Status::Complete);
+    EXPECT_DOUBLE_EQ(localized.value, -1.25);
+    EXPECT_EQ(localized.canonicalText, "-1.25");
+}
+
+TEST(NumericInputTest, InvalidUtf8IsNotALocalizedDigit)
+{
+    const Base::NumericLocaleContext locale {"fa_IR", "\xD9\xAB", "\xD9\xAC", "+", "-", 3, 3, "\xDB\xB0"};
+    for (const auto input : {"\xC0\x80", "\xED\xA0\x80", "\xF4\x90\x80\x80"}) {
+        int digit = 0;
+        std::size_t consumed = 0;
+        EXPECT_FALSE(Base::localizedDigitAt(input, 0, locale, digit, consumed)) << input;
+        EXPECT_EQ(consumed, 0U);
+    }
+}
+
+TEST(NumericInputTest, positiveSignsAreAcceptedByCanonicalConversion)
+{
+    const Base::NumericLocaleContext en = locale("en_US", ".", ",");
+    expectComplete(
+        Base::scanLocalizedNumber("+1.25 mm", en, Base::NumericSyntaxContext::Standalone),
+        1.25,
+        "1.25",
+        5
+    );
+
+    const Base::NumericLocaleContext custom {"custom", ".", ",", "plus", "minus", 3, 3};
+    expectComplete(
+        Base::scanLocalizedNumber("plus1.25 mm", custom, Base::NumericSyntaxContext::Standalone),
+        1.25,
+        "1.25",
+        8
+    );
+}
+
+TEST(NumericInputTest, OutOfRangeScientificNotationIsDiagnosed)
+{
+    const Base::NumericLocaleContext en = locale("en_US", ".", ",");
+    const auto result = Base::scanLocalizedNumber("1e999", en, Base::NumericSyntaxContext::Standalone);
+
+    EXPECT_EQ(result.status, Base::LocalizedNumberResult::Status::Invalid);
+    ASSERT_TRUE(result.diagnostic.has_value());
+    EXPECT_EQ(result.diagnostic->kind, Base::NumericDiagnosticKind::OutOfRange);
+}
+
+TEST(NumericInputTest, exactGroupingSymbolsAreRequired)
+{
+    const auto en = locale("en_US", ".", ",");
+    const auto plainSpace
+        = Base::scanLocalizedNumber("12 345", en, Base::NumericSyntaxContext::Standalone);
+    EXPECT_EQ(plainSpace.status, Base::LocalizedNumberResult::Status::Invalid);
+    ASSERT_TRUE(plainSpace.diagnostic.has_value());
+    EXPECT_EQ(plainSpace.diagnostic->kind, Base::NumericDiagnosticKind::UnexpectedSeparator);
+
+    const auto narrowSpace = locale("fr_FR", ",", "\xE2\x80\xAF");
+    expectComplete(
+        Base::scanLocalizedNumber(
+            "12\xE2\x80\xAF"
+            "345",
+            narrowSpace,
+            Base::NumericSyntaxContext::Standalone
+        ),
+        12345.0,
+        "12345",
+        8
+    );
+
+    for (const auto separator : {"\xC2\xA0", " ", "\xE2\x80\x89", "\t", "\n"}) {
+        const auto result = Base::scanLocalizedNumber(
+            std::string {"12"} + separator + "345",
+            narrowSpace,
+            Base::NumericSyntaxContext::Standalone
+        );
+        EXPECT_EQ(result.status, Base::LocalizedNumberResult::Status::Invalid) << separator;
+    }
+
+    auto noBreakSpace = narrowSpace;
+    noBreakSpace.groupingSeparator = "\xC2\xA0";
+    expectComplete(
+        Base::scanLocalizedNumber(
+            "12\xC2\xA0"
+            "345",
+            noBreakSpace,
+            Base::NumericSyntaxContext::Standalone
+        ),
+        12345.0,
+        "12345",
+        7
+    );
+}
+
+TEST(NumericInputTest, FunctionArgumentsTakePrecedenceOverCommaGrouping)
+{
+    const auto en = locale("en_US", ".", ",");
+    const auto firstArgument
+        = Base::scanLocalizedNumber("1,234", en, Base::NumericSyntaxContext::FunctionArgument);
+    expectComplete(firstArgument, 1.0, "1", 1);
+
+    const auto groupedArgument = locale("space", ".", " ");
+    expectComplete(
+        Base::scanLocalizedNumber("1 234; 2", groupedArgument, Base::NumericSyntaxContext::FunctionArgument),
+        1234.0,
+        "1234",
+        5
+    );
+
+    const auto de = locale("de_DE", ",", ".");
+    expectComplete(
+        Base::scanLocalizedNumber("1,234; 2", de, Base::NumericSyntaxContext::FunctionArgument),
+        1.234,
+        "1.234",
+        5
+    );
+}
+
+TEST(NumericInputTest, GroupingPlacementMutationsFollowLocalePattern)
+{
+    const auto en = locale("en_US", ".", ",");
+    for (const auto input : {"1,234", "12,345", "123,456"}) {
+        EXPECT_EQ(
+            Base::scanLocalizedNumber(input, en, Base::NumericSyntaxContext::Standalone).status,
+            Base::LocalizedNumberResult::Status::Complete
+        );
+    }
+    for (const auto input : {"1234,567", "1,23,456", "1,,234", ",123", "1,234,"}) {
+        const auto result
+            = Base::scanLocalizedNumber(input, en, Base::NumericSyntaxContext::Standalone);
+        EXPECT_NE(result.status, Base::LocalizedNumberResult::Status::Complete) << input;
+    }
+
+    const auto enIn = locale("en_IN", ".", ",", 3, 2);
+    for (const auto input : {"1,23,456", "12,34,567", "1,23,45,678"}) {
+        EXPECT_EQ(
+            Base::scanLocalizedNumber(input, enIn, Base::NumericSyntaxContext::Standalone).status,
+            Base::LocalizedNumberResult::Status::Complete
+        );
+    }
+    for (const auto input : {"123,45,678", "1,234,567", "1,2,345"}) {
+        EXPECT_EQ(
+            Base::scanLocalizedNumber(input, enIn, Base::NumericSyntaxContext::Standalone).status,
+            Base::LocalizedNumberResult::Status::Invalid
+        );
+    }
+}

--- a/tests/src/Base/NumericInput.cpp
+++ b/tests/src/Base/NumericInput.cpp
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+
+#include <Base/NumericFormatting.h>
+#include <Base/NumericInput.h>
+#include <Base/Quantity.h>
+
+namespace
+{
+Base::NumericLocaleContext locale(
+    const char* localeId,
+    const char* decimal,
+    const char* grouping,
+    int primary = 3,
+    int secondary = 3
+)
+{
+    return {localeId, decimal, grouping, "+", "-", primary, secondary};
+}
+
+void expectComplete(
+    const Base::LocalizedNumberResult& result,
+    double value,
+    std::string_view canonical,
+    std::size_t consumed
+)
+{
+    EXPECT_EQ(result.status, Base::LocalizedNumberResult::Status::Complete);
+    EXPECT_DOUBLE_EQ(result.value, value);
+    EXPECT_EQ(result.canonicalText, canonical);
+    EXPECT_EQ(result.consumedBytes, consumed);
+    EXPECT_FALSE(result.diagnostic.has_value());
+}
+}  // namespace
+
+TEST(NumericInputTest, canonicalAndLocalizedDecimals)
+{
+    const auto de = locale("de_DE", ",", ".");
+    expectComplete(
+        Base::scanLocalizedNumber("1,25 mm", de, Base::NumericSyntaxContext::Standalone),
+        1.25,
+        "1.25",
+        4
+    );
+    expectComplete(
+        Base::scanLocalizedNumber("12.345,67 mm", de, Base::NumericSyntaxContext::Standalone),
+        12345.67,
+        "12345.67",
+        9
+    );
+    expectComplete(
+        Base::scanLocalizedNumber("1.25 mm", de, Base::NumericSyntaxContext::Standalone),
+        1.25,
+        "1.25",
+        4
+    );
+}
+
+TEST(NumericInputTest, westernGroupingAndScientificNotation)
+{
+    const auto en = locale("en_US", ".", ",");
+    expectComplete(
+        Base::scanLocalizedNumber("1,234.5 mm", en, Base::NumericSyntaxContext::Standalone),
+        1234.5,
+        "1234.5",
+        7
+    );
+    expectComplete(
+        Base::scanLocalizedNumber("1,234e5 mm", en, Base::NumericSyntaxContext::Standalone),
+        123400000.0,
+        "1234e5",
+        7
+    );
+}
+
+TEST(NumericInputTest, indianGroupingUsesSecondarySize)
+{
+    const auto enIn = locale("en_IN", ".", ",", 3, 2);
+    expectComplete(
+        Base::scanLocalizedNumber("12,34,567 mm", enIn, Base::NumericSyntaxContext::Standalone),
+        1234567.0,
+        "1234567",
+        9
+    );
+}
+
+TEST(NumericInputTest, malformedGroupingIsInvalid)
+{
+    const auto en = locale("en_US", ".", ",");
+    const auto result
+        = Base::scanLocalizedNumber("12,34,567", en, Base::NumericSyntaxContext::Standalone);
+
+    EXPECT_EQ(result.status, Base::LocalizedNumberResult::Status::Invalid);
+    ASSERT_TRUE(result.diagnostic.has_value());
+    EXPECT_EQ(result.diagnostic->kind, Base::NumericDiagnosticKind::InvalidGrouping);
+}
+
+TEST(NumericInputTest, multipleDecimalsAndIncompleteExponentsAreDiagnosed)
+{
+    const auto en = locale("en_US", ".", ",");
+    const auto multipleDecimals
+        = Base::scanLocalizedNumber("1.2.3", en, Base::NumericSyntaxContext::Standalone);
+    EXPECT_EQ(multipleDecimals.status, Base::LocalizedNumberResult::Status::Invalid);
+
+    const auto incompleteExponent
+        = Base::scanLocalizedNumber("1e", en, Base::NumericSyntaxContext::Standalone);
+    EXPECT_EQ(incompleteExponent.status, Base::LocalizedNumberResult::Status::Incomplete);
+    ASSERT_TRUE(incompleteExponent.diagnostic.has_value());
+    EXPECT_EQ(incompleteExponent.diagnostic->kind, Base::NumericDiagnosticKind::IncompleteExponent);
+
+    for (const auto input : {"1.23,4", "1,234.5,6", "1e1,000", "1,234e1,000"}) {
+        EXPECT_EQ(
+            Base::scanLocalizedNumber(input, en, Base::NumericSyntaxContext::Standalone).status,
+            Base::LocalizedNumberResult::Status::Invalid
+        ) << input;
+    }
+}
+
+TEST(NumericInputTest, DotGroupingAndCanonicalDecimalHaveAnExplicitPolicy)
+{
+    const auto de = locale("de_DE", ",", ".");
+    expectComplete(
+        Base::scanLocalizedNumber("1.234", de, Base::NumericSyntaxContext::Standalone),
+        1.234,
+        "1.234",
+        5
+    );
+    expectComplete(
+        Base::scanLocalizedNumber("1.234,5", de, Base::NumericSyntaxContext::Standalone),
+        1234.5,
+        "1234.5",
+        7
+    );
+    expectComplete(
+        Base::scanLocalizedNumber("1.234.567", de, Base::NumericSyntaxContext::Standalone),
+        1234567.0,
+        "1234567",
+        9
+    );
+    expectComplete(
+        Base::scanLocalizedNumber("12.345 mm", de, Base::NumericSyntaxContext::Standalone),
+        12.345,
+        "12.345",
+        6
+    );
+}
+
+TEST(NumericInputTest, negativeAndLocalizedSigns)
+{
+    const auto en = locale("en_US", ".", ",");
+    expectComplete(
+        Base::scanLocalizedNumber("-1,234.5 mm", en, Base::NumericSyntaxContext::Standalone),
+        -1234.5,
+        "-1234.5",
+        8
+    );
+
+    auto fa = Base::createNumericLocaleContext("fa_IR");
+    const std::string input = fa.negativeSign + "1" + fa.decimalSeparator + "25 mm";
+    const auto localized = Base::scanLocalizedNumber(input, fa, Base::NumericSyntaxContext::Standalone);
+    EXPECT_EQ(localized.status, Base::LocalizedNumberResult::Status::Complete);
+    EXPECT_DOUBLE_EQ(localized.value, -1.25);
+    EXPECT_EQ(localized.canonicalText, "-1.25");
+}
+
+TEST(NumericInputTest, formattedNativeDigitsAreAccepted)
+{
+    for (const auto localeId : {"fa_IR", "ar_EG"}) {
+        const auto localized = Base::createNumericLocaleContext(localeId);
+        const auto formatted = Base::formatNumericValue(
+            1234.5,
+            Base::QuantityFormat(Base::QuantityFormat::Fixed, 1),
+            localized
+        );
+        const auto result
+            = Base::scanLocalizedNumber(formatted, localized, Base::NumericSyntaxContext::Standalone);
+        expectComplete(result, 1234.5, "1234.5", formatted.size());
+    }
+}
+
+TEST(NumericInputTest, InvalidUtf8IsNotALocalizedDigit)
+{
+    const auto locale = Base::createNumericLocaleContext("fa_IR");
+    for (const auto input : {"\xC0\x80", "\xED\xA0\x80", "\xF4\x90\x80\x80"}) {
+        int digit = 0;
+        std::size_t consumed = 0;
+        EXPECT_FALSE(Base::localizedDigitAt(input, 0, locale, digit, consumed)) << input;
+        EXPECT_EQ(consumed, 0U);
+    }
+}
+
+TEST(NumericInputTest, positiveSignsAreAcceptedByFromChars)
+{
+    const Base::NumericLocaleContext en = locale("en_US", ".", ",");
+    expectComplete(
+        Base::scanLocalizedNumber("+1.25 mm", en, Base::NumericSyntaxContext::Standalone),
+        1.25,
+        "1.25",
+        5
+    );
+
+    const Base::NumericLocaleContext custom {"custom", ".", ",", "plus", "minus", 3, 3};
+    expectComplete(
+        Base::scanLocalizedNumber("plus1.25 mm", custom, Base::NumericSyntaxContext::Standalone),
+        1.25,
+        "1.25",
+        8
+    );
+}
+
+TEST(NumericInputTest, exactGroupingSymbolsAreRequired)
+{
+    const auto en = locale("en_US", ".", ",");
+    const auto plainSpace
+        = Base::scanLocalizedNumber("12 345", en, Base::NumericSyntaxContext::Standalone);
+    EXPECT_EQ(plainSpace.status, Base::LocalizedNumberResult::Status::Invalid);
+    ASSERT_TRUE(plainSpace.diagnostic.has_value());
+    EXPECT_EQ(plainSpace.diagnostic->kind, Base::NumericDiagnosticKind::UnexpectedSeparator);
+
+    const auto narrowSpace = locale("fr_FR", ",", "\xE2\x80\xAF");
+    expectComplete(
+        Base::scanLocalizedNumber(
+            "12\xE2\x80\xAF"
+            "345",
+            narrowSpace,
+            Base::NumericSyntaxContext::Standalone
+        ),
+        12345.0,
+        "12345",
+        8
+    );
+
+    for (const auto separator : {"\xC2\xA0", " ", "\xE2\x80\x89", "\t", "\n"}) {
+        const auto result = Base::scanLocalizedNumber(
+            std::string {"12"} + separator + "345",
+            narrowSpace,
+            Base::NumericSyntaxContext::Standalone
+        );
+        EXPECT_EQ(result.status, Base::LocalizedNumberResult::Status::Invalid) << separator;
+    }
+
+    auto noBreakSpace = narrowSpace;
+    noBreakSpace.groupingSeparator = "\xC2\xA0";
+    expectComplete(
+        Base::scanLocalizedNumber(
+            "12\xC2\xA0"
+            "345",
+            noBreakSpace,
+            Base::NumericSyntaxContext::Standalone
+        ),
+        12345.0,
+        "12345",
+        7
+    );
+}
+
+TEST(NumericInputTest, FunctionArgumentsTakePrecedenceOverCommaGrouping)
+{
+    const auto en = locale("en_US", ".", ",");
+    const auto firstArgument
+        = Base::scanLocalizedNumber("1,234", en, Base::NumericSyntaxContext::FunctionArgument);
+    expectComplete(firstArgument, 1.0, "1", 1);
+
+    const auto groupedArgument = locale("space", ".", " ");
+    expectComplete(
+        Base::scanLocalizedNumber("1 234; 2", groupedArgument, Base::NumericSyntaxContext::FunctionArgument),
+        1234.0,
+        "1234",
+        5
+    );
+
+    const auto de = locale("de_DE", ",", ".");
+    expectComplete(
+        Base::scanLocalizedNumber("1,234; 2", de, Base::NumericSyntaxContext::FunctionArgument),
+        1.234,
+        "1.234",
+        5
+    );
+}
+
+TEST(NumericInputTest, GroupingPlacementMutationsFollowLocalePattern)
+{
+    const auto en = locale("en_US", ".", ",");
+    for (const auto input : {"1,234", "12,345", "123,456"}) {
+        EXPECT_EQ(
+            Base::scanLocalizedNumber(input, en, Base::NumericSyntaxContext::Standalone).status,
+            Base::LocalizedNumberResult::Status::Complete
+        );
+    }
+    for (const auto input : {"1234,567", "1,23,456", "1,,234", ",123", "1,234,"}) {
+        const auto result
+            = Base::scanLocalizedNumber(input, en, Base::NumericSyntaxContext::Standalone);
+        EXPECT_NE(result.status, Base::LocalizedNumberResult::Status::Complete) << input;
+    }
+
+    const auto enIn = locale("en_IN", ".", ",", 3, 2);
+    for (const auto input : {"1,23,456", "12,34,567", "1,23,45,678"}) {
+        EXPECT_EQ(
+            Base::scanLocalizedNumber(input, enIn, Base::NumericSyntaxContext::Standalone).status,
+            Base::LocalizedNumberResult::Status::Complete
+        );
+    }
+    for (const auto input : {"123,45,678", "1,234,567", "1,2,345"}) {
+        EXPECT_EQ(
+            Base::scanLocalizedNumber(input, enIn, Base::NumericSyntaxContext::Standalone).status,
+            Base::LocalizedNumberResult::Status::Invalid
+        );
+    }
+}

--- a/tests/src/Base/Quantity.cpp
+++ b/tests/src/Base/Quantity.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <Base/Exception.h>
+#include <Base/NumericFormatting.h>
 #include <Base/Quantity.h>
 #include "Base/UnitsApi.h"
 #include <QLocale>
@@ -26,6 +27,32 @@ TEST(BaseQuantity, TestParse)
     constexpr auto val {1.2340};
     EXPECT_EQ(q1, Quantity(val, Unit::Mass));
     EXPECT_THROW(auto rew [[maybe_unused]] = Quantity::parse("1,234,500.12 kg"), ParserError);
+}
+
+TEST(BaseQuantity, TestLocalizedUserInput)
+{
+    const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3};
+    const Base::NumericLocaleContext enIn {"en_IN", ".", ",", "+", "-", 3, 2};
+
+    EXPECT_EQ(Quantity::parseUserInput("12,345.67 mm", enUs), Quantity(12345.67, Unit::Length));
+    EXPECT_THROW(Quantity::parseUserInput("12,34,567 mm", enUs), ParserError);
+    EXPECT_EQ(Quantity::parseUserInput("12,34,567 mm", enIn), Quantity(1234567, Unit::Length));
+}
+
+TEST(BaseQuantity, TestLocalizedUserInputPreservesComments)
+{
+    const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3};
+
+    EXPECT_EQ(
+        Quantity::parseUserInput("1 mm [original input 12,34,567]", enUs),
+        Quantity(1, Unit::Length)
+    );
+    EXPECT_EQ(Quantity::parseUserInput("1 mm [original input 12 345]", enUs), Quantity(1, Unit::Length));
+    EXPECT_EQ(
+        Quantity::parseUserInput("1 mm [original input 1.234,5]", enUs),
+        Quantity(1, Unit::Length)
+    );
+    EXPECT_THROW(Quantity::parseUserInput("1 mm [original input 12,34", enUs), ParserError);
 }
 
 TEST(BaseQuantity, TestNoDim)

--- a/tests/src/Base/Quantity.cpp
+++ b/tests/src/Base/Quantity.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <Base/Exception.h>
+#include <Base/NumericFormatting.h>
 #include <Base/Quantity.h>
 #include "Base/UnitsApi.h"
 #include <QLocale>
@@ -26,6 +27,33 @@ TEST(BaseQuantity, TestParse)
     constexpr auto val {1.2340};
     EXPECT_EQ(q1, Quantity(val, Unit::Mass));
     EXPECT_THROW(auto rew [[maybe_unused]] = Quantity::parse("1,234,500.12 kg"), ParserError);
+}
+
+TEST(BaseQuantity, TestLocalizedUserInput)
+{
+    const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3};
+    const Base::NumericLocaleContext enIn {"en_IN", ".", ",", "+", "-", 3, 2};
+
+    EXPECT_EQ(Quantity::parseUserInput("12,345.67 mm", enUs), Quantity(12345.67, Unit::Length));
+    EXPECT_THROW(Quantity::parseUserInput("12,34,567 mm", enUs), ParserError);
+    EXPECT_EQ(Quantity::parseUserInput("12,34,567 mm", enIn), Quantity(1234567, Unit::Length));
+}
+
+TEST(BaseQuantity, TestLocalizedUserInputPreservesComments)
+{
+    const Base::NumericLocaleContext enUs {"en_US", ".", ",", "+", "-", 3, 3};
+
+    EXPECT_EQ(
+        Quantity::parseUserInput("1 mm [original input 12,34,567]", enUs),
+        Quantity(1, Unit::Length)
+    );
+    EXPECT_EQ(Quantity::parseUserInput("1 mm [original input 12 345]", enUs), Quantity(1, Unit::Length));
+    EXPECT_EQ(
+        Quantity::parseUserInput("1 mm [original input 1.234,5]", enUs),
+        Quantity(1, Unit::Length)
+    );
+    EXPECT_THROW(Quantity::parseUserInput("1 mm [original input 12,34", enUs), ParserError);
+    EXPECT_EQ(Quantity::parseUserInput("1 mm", enUs), Quantity(1, Unit::Length));
 }
 
 TEST(BaseQuantity, TestNoDim)

--- a/tests/src/Base/SchemaTests.cpp
+++ b/tests/src/Base/SchemaTests.cpp
@@ -28,13 +28,11 @@
 #include "Base/UnitsApi.h"
 #include "Base/UnitsSchemasData.h"
 #include "Base/UnitsSchemas.h"
+#include <src/LocaleTestHelpers.h>
 #include "TranslationTestHelpers.h"
 
 #include <array>
 #include <string>
-
-#include <unicode/locid.h>
-#include <unicode/utypes.h>
 
 using Base::Quantity;
 using Base::QuantityFormat;
@@ -48,17 +46,6 @@ namespace Tools = Base::Tools;
 class SchemaTest: public testing::Test
 {
 protected:
-    void SetUp() override
-    {
-        // Ensure deterministic decimal separator for tests.
-        UErrorCode status = U_ZERO_ERROR;
-        icu::Locale::setDefault(icu::Locale("en_US_POSIX"), status);
-        ASSERT_TRUE(U_SUCCESS(status));
-    }
-
-    void TearDown() override
-    {}
-
     static std::string set(const std::string& schemaName, const Unit unit, const double value)  // NOLINT
     {
         UnitsApi::setSchema(schemaName);
@@ -112,6 +99,9 @@ protected:
         }
     }
 
+    tests::ScopedLocaleEnvironment localeState {
+        {.formattingLocale = "en_US_POSIX", .icuLocale = "en_US_POSIX"}
+    };
     std::unique_ptr<UnitsSchemas> schemas;  // NOLINT
 };
 
@@ -550,13 +540,12 @@ TEST_F(SchemaTest, imperial_building_special_function_high_precision_rounding)
 
 TEST_F(SchemaTest, imperial_building_special_function_length)
 {
-    GTEST_SKIP() << "QuantityParser::yyparse() is crashing on the >>1' 2\" + 1/4\"<< input, "
-                    "so disable this test";
     constexpr auto val {360.6};
     const auto result = set("ImperialBuilding", Unit::Length, val);
     const auto expect = Tools::escapeQuotesFromString("1' 2\" + 1/4\"");
 
     EXPECT_EQ(result, expect);
+    EXPECT_EQ(Quantity::parse("1' 2\" + 1/4\""), Quantity::parse("1' 2\" 1/4\""));
 }
 
 TEST_F(SchemaTest, imperial_building_special_function_length_neg)

--- a/tests/src/Base/UnitsSchemaFormat.cpp
+++ b/tests/src/Base/UnitsSchemaFormat.cpp
@@ -3,38 +3,12 @@
 #include <Base/Quantity.h>
 #include <Base/UnitsSchema.h>
 
-#include <unicode/locid.h>
-#include <unicode/utypes.h>
+#include <src/LocaleTestHelpers.h>
 
 #include <string>
 
 namespace
 {
-class ScopedIcuLocale
-{
-public:
-    explicit ScopedIcuLocale(const char* name)
-        : previous {icu::Locale::getDefault()}
-    {
-        UErrorCode status = U_ZERO_ERROR;
-        icu::Locale::setDefault(icu::Locale(name), status);
-    }
-
-    ~ScopedIcuLocale()
-    {
-        UErrorCode status = U_ZERO_ERROR;
-        icu::Locale::setDefault(previous, status);
-    }
-
-    ScopedIcuLocale(const ScopedIcuLocale&) = delete;
-    ScopedIcuLocale(ScopedIcuLocale&&) = delete;
-    ScopedIcuLocale& operator=(const ScopedIcuLocale&) = delete;
-    ScopedIcuLocale& operator=(ScopedIcuLocale&&) = delete;
-
-private:
-    icu::Locale previous;
-};
-
 Base::UnitsSchema makeNoTranslationSchema()
 {
     Base::UnitsSchemaSpec spec {};
@@ -56,24 +30,40 @@ std::string translateValue(const double value, const Base::QuantityFormat& fmt)
     std::string unitString;
     return schema.translate(q, factor, unitString);
 }
+
+std::string translateValue(
+    const double value,
+    const Base::QuantityFormat& fmt,
+    const Base::NumericLocaleContext& formatting
+)
+{
+    Base::Quantity q(value);
+    q.setFormat(fmt);
+
+    auto schema = makeNoTranslationSchema();
+    double factor = 0.0;
+    std::string unitString;
+    return schema.translate(q, formatting, factor, unitString);
+}
+
 }  // namespace
 
 TEST(UnitsSchemaFormatTest, fixed_uses_precision_and_trailing_zeroes)
 {
-    ScopedIcuLocale locale("en_US");
-
     Base::QuantityFormat fmt(Base::QuantityFormat::Fixed, 2);
     fmt.option = Base::QuantityFormat::None;
+
+    tests::ScopedLocaleEnvironment localeState {{.formattingLocale = "en_US"}};
 
     EXPECT_EQ(translateValue(123.0, fmt), "123.00");
 }
 
 TEST(UnitsSchemaFormatTest, scientific_uses_exponent_and_precision)
 {
-    ScopedIcuLocale locale("en_US");
-
     Base::QuantityFormat fmt(Base::QuantityFormat::Scientific, 2);
     fmt.option = Base::QuantityFormat::None;
+
+    tests::ScopedLocaleEnvironment localeState {{.formattingLocale = "en_US"}};
 
     const std::string s = translateValue(123.0, fmt);
 
@@ -88,10 +78,10 @@ TEST(UnitsSchemaFormatTest, scientific_uses_exponent_and_precision)
 
 TEST(UnitsSchemaFormatTest, default_matches_qt_general_scientific_thresholds)
 {
-    ScopedIcuLocale locale("en_US");
-
     Base::QuantityFormat fmt(Base::QuantityFormat::Default, 6);
     fmt.option = Base::QuantityFormat::None;
+
+    tests::ScopedLocaleEnvironment localeState {{.formattingLocale = "en_US"}};
 
     EXPECT_EQ(translateValue(1e9, fmt), "1e+09");
     EXPECT_EQ(translateValue(1e6, fmt), "1e+06");
@@ -100,17 +90,66 @@ TEST(UnitsSchemaFormatTest, default_matches_qt_general_scientific_thresholds)
 
 TEST(UnitsSchemaFormatTest, omit_group_separator_option_removes_grouping)
 {
-    ScopedIcuLocale locale("en_US");
-
     Base::QuantityFormat fmtGroup(Base::QuantityFormat::Default, 0);
     fmtGroup.option = Base::QuantityFormat::None;
 
     Base::QuantityFormat fmtNoGroup(Base::QuantityFormat::Default, 0);
     fmtNoGroup.option = Base::QuantityFormat::OmitGroupSeparator;
 
+    tests::ScopedLocaleEnvironment localeState {{.formattingLocale = "en_US"}};
+
     const std::string withGrouping = translateValue(12345.0, fmtGroup);
     const std::string noGrouping = translateValue(12345.0, fmtNoGroup);
 
     EXPECT_NE(withGrouping.find(','), std::string::npos);
     EXPECT_EQ(noGrouping.find(','), std::string::npos);
+}
+
+TEST(UnitsSchemaFormatTest, formatting_state_overrides_icu_default)
+{
+    tests::ScopedLocaleEnvironment localeState {{.formattingLocale = "en_US", .icuLocale = "fr_FR"}};
+
+    Base::QuantityFormat fmt(Base::QuantityFormat::Fixed, 2);
+    fmt.option = Base::QuantityFormat::None;
+
+    EXPECT_EQ(translateValue(1.5, fmt), "1.50");
+}
+
+TEST(UnitsSchemaFormatTest, default_translation_uses_current_numeric_formatting_locale)
+{
+    tests::ScopedLocaleEnvironment localeState {{.formattingLocale = "de_DE", .icuLocale = "en_US"}};
+
+    Base::QuantityFormat fmt(Base::QuantityFormat::Fixed, 2);
+    fmt.option = Base::QuantityFormat::None;
+
+    EXPECT_EQ(translateValue(1.5, fmt), "1,50");
+}
+
+TEST(UnitsSchemaFormatTest, effective_numeric_separators_override_locale_symbols)
+{
+    tests::ScopedLocaleEnvironment localeState {{.formattingLocale = "en_US"}};
+    tests::ScopedNumericLocaleContext separators {{"en_US", ",", "\xC2\xA0", "+", "-", 3, 3}};
+
+    Base::QuantityFormat fmtFixed(Base::QuantityFormat::Fixed, 2);
+    fmtFixed.option = Base::QuantityFormat::None;
+    EXPECT_EQ(translateValue(1.5, fmtFixed), "1,50");
+
+    Base::QuantityFormat fmtGrouped(Base::QuantityFormat::Default, 0);
+    fmtGrouped.option = Base::QuantityFormat::None;
+    EXPECT_EQ(
+        translateValue(12345.0, fmtGrouped),
+        std::string {"12\xC2\xA0"
+                     "345"}
+    );
+}
+
+TEST(UnitsSchemaFormatTest, explicit_formatting_state_does_not_use_published_snapshot)
+{
+    tests::ScopedLocaleEnvironment localeState {{.formattingLocale = "en_US"}};
+
+    Base::QuantityFormat fmt(Base::QuantityFormat::Fixed, 2);
+    fmt.option = Base::QuantityFormat::None;
+    const Base::NumericLocaleContext formatting {"en_US", ",", ".", "+", "-", 3, 3};
+
+    EXPECT_EQ(translateValue(1.5, fmt, formatting), "1,50");
 }

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -19,7 +19,10 @@ add_executable(Gui_tests_run
 
 # Qt tests
 setup_qt_test(ObjectSelection)
+setup_qt_test(TranslatorLocale)
+setup_qt_test(InputField)
 setup_qt_test(QuantitySpinBox)
+setup_qt_test(NumericLocaleConsumers)
 
 target_link_libraries(Gui_tests_run PRIVATE
     GTest::gmock_main

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -18,7 +18,10 @@ add_executable(Gui_tests_run
 )
 
 # Qt tests
+setup_qt_test(TranslatorLocale)
+setup_qt_test(InputField)
 setup_qt_test(QuantitySpinBox)
+setup_qt_test(NumericLocaleConsumers)
 
 target_link_libraries(Gui_tests_run PRIVATE
     GTest::gmock_main

--- a/tests/src/Gui/InputField.cpp
+++ b/tests/src/Gui/InputField.cpp
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <string>
+
+#include <QKeyEvent>
+#include <QLineEdit>
+#include <QSignalSpy>
+#include <QTest>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <App/ObjectIdentifier.h>
+#include <App/Property.h>
+#include <Base/UnitsApi.h>
+
+#include "Gui/InputField.h"
+#include <src/LocaleTestHelpers.h>
+#include <src/App/InitApplication.h>
+
+// NOLINTBEGIN(readability-magic-numbers)
+
+namespace
+{
+class ScopedExpressionOwner
+{
+public:
+    ScopedExpressionOwner()
+        : documentName {App::GetApplication().getUniqueDocumentName("input_field")}
+        , document {App::GetApplication().newDocument(documentName.c_str(), "testUser")}
+        , object {document->addObject("App::VarSet", "VarSet")}
+        , property {object->addDynamicProperty("App::PropertyFloat", "Value", "Test")}
+    {}
+
+    ~ScopedExpressionOwner()
+    {
+        App::GetApplication().closeDocument(documentName.c_str());
+    }
+
+    App::ObjectIdentifier getPath() const
+    {
+        return App::ObjectIdentifier(*property);
+    }
+
+private:
+    std::string documentName;
+    App::Document* document;
+    App::DocumentObject* object;
+    App::Property* property;
+};
+
+class TestInputField: public Gui::InputField
+{
+public:
+    using Gui::InputField::InputField;
+
+    std::string expressionString() const
+    {
+        return getExpressionString(false);
+    }
+};
+
+class KeyEventParent: public QWidget
+{
+public:
+    int returns {};
+    int escapes {};
+
+protected:
+    void keyPressEvent(QKeyEvent* event) override
+    {
+        if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
+            ++returns;
+            event->accept();
+            return;
+        }
+        if (event->key() == Qt::Key_Escape) {
+            ++escapes;
+            event->accept();
+            return;
+        }
+        QWidget::keyPressEvent(event);
+    }
+};
+}  // namespace
+
+class testInputField: public QObject
+{
+    Q_OBJECT
+
+public:
+    testInputField()
+    {
+        tests::initApplication();
+    }
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+        Base::UnitsApi::setSchema("Internal");
+    }
+
+    void test_MismatchedFormatterAndWidgetLocaleEditPreservesEnteredValue()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "da_DK",
+             .formattingLocale = "en_US",
+             .icuLocale = "fr_FR",
+             .useQtSeparators = true}
+        };
+
+        Gui::InputField input;
+        Base::Quantity quantity(10.0, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+
+        input.setValue(quantity);
+        input.show();
+        input.setFocus();
+        input.selectNumber();
+        QTest::keyClicks(&input, "1.010,00");
+        QTest::keyClick(&input, Qt::Key_Return);
+
+        QCOMPARE(input.rawValue(), 1010.0);
+        QCOMPARE(input.text(), QStringLiteral("1.010,00 mm"));
+    }
+
+    void test_NativeDigitRoundTripUsesTheWidgetLocale()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "fa_IR",
+             .formattingLocale = "fa_IR",
+             .icuLocale = "fa_IR",
+             .useQtSeparators = true}
+        };
+
+        Gui::InputField input;
+        input.setLocale(QLocale(QStringLiteral("fa_IR")));
+        input.setUnit(Base::Unit::Length);
+        Base::Quantity quantity(1234.5, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 1);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+        input.setValue(quantity);
+        input.show();
+        const QString formatted = input.text();
+        QVERIFY(formatted.contains(QChar(0x06F1)));
+        input.setText(formatted);
+        input.selectNumber();
+        const int unitStart = formatted.indexOf(QStringLiteral(" mm"));
+        QVERIFY(unitStart > 0);
+        QCOMPARE(input.selectedText(), formatted.left(unitStart));
+        QTest::keyClick(&input, Qt::Key_Return);
+
+        QCOMPARE(input.rawValue(), 1234.5);
+        QVERIFY(input.hasValidInput());
+    }
+
+    void test_LocaleChangeReformatsAndParsesWithTheNewWidgetLocale()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::InputField input;
+        input.setLocale(QLocale(QStringLiteral("en_US")));
+        Base::Quantity quantity(1234.5, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 1);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+        input.setValue(quantity);
+        input.show();
+        QVERIFY(input.text().contains(QStringLiteral("1,234.5")));
+
+        input.setLocale(QLocale(QStringLiteral("de_DE")));
+        QCoreApplication::processEvents();
+        QVERIFY(input.text().contains(QStringLiteral("1234,5")));
+
+        input.setText(QStringLiteral("2.345,6 mm"));
+        QTest::keyClick(&input, Qt::Key_Return);
+        QCOMPARE(input.rawValue(), 2345.6);
+        QVERIFY(input.hasValidInput());
+    }
+
+    void test_DotGroupingDoesNotCorruptEditableInteger()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "de_DE",
+             .formattingLocale = "de_DE",
+             .icuLocale = "de_DE",
+             .useQtSeparators = true}
+        };
+
+        Gui::InputField input;
+        input.setLocale(QLocale(QStringLiteral("de_DE")));
+        Base::Quantity quantity(1234.0, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 0);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+
+        input.setValue(quantity);
+
+        QCOMPARE(input.rawValue(), 1234.0);
+        QVERIFY(!input.text().contains(QStringLiteral("1.234")));
+        QCOMPARE(input.text(), QStringLiteral("1234 mm"));
+
+        QTest::keyClick(&input, Qt::Key_Return);
+        QCOMPARE(input.rawValue(), 1234.0);
+        QVERIFY(input.hasValidInput());
+    }
+
+    void test_UnboundQuantityGrammarPreservesComments()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::InputField input;
+        input.setUnit(Base::Unit::Length);
+        input.setText(QStringLiteral("1 mm [original input 12,34,567]"));
+
+        QVERIFY(input.hasValidInput());
+        QCOMPARE(input.rawValue(), 1.0);
+    }
+
+    void test_UnboundQuantityGrammarFallsBackToArithmetic()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::InputField input;
+        input.setUnit(Base::Unit::Length);
+        input.setText(QStringLiteral("1 + 2 mm"));
+
+        QVERIFY(input.hasValidInput());
+        QCOMPARE(input.rawValue(), 3.0);
+    }
+
+    void test_GroupedLocaleNumberIsNormalizedBeforeParse()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::InputField input;
+        input.setText(QStringLiteral("1,010.00 mm"));
+
+        QCOMPARE(input.getQuantity(), Base::Quantity(1010, "mm"));
+        QCOMPARE(input.rawValue(), 1010.0);
+    }
+
+    void test_FailedBoundEditDoesNotCommitCandidateExpression()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+        ScopedExpressionOwner owner;
+
+        TestInputField input;
+        input.bind(owner.getPath());
+        input.setUnit(Base::Unit::Length);
+        input.setText(QStringLiteral("2 mm"));
+
+        QVERIFY(input.hasValidInput());
+        QCOMPARE(input.rawValue(), 2.0);
+        const auto previousExpression = QString::fromStdString(input.expressionString());
+        QVERIFY(!previousExpression.isEmpty());
+
+        // This parses as an expression but does not evaluate to NumberExpression. It must not
+        // replace the last valid expression or reset the stored quantity to zero.
+        input.setText(QStringLiteral("str(1)"));
+
+        QVERIFY(!input.hasValidInput());
+        QCOMPARE(input.rawValue(), 2.0);
+        QCOMPARE(QString::fromStdString(input.expressionString()), previousExpression);
+    }
+
+    void test_ReturnPressedOnlyFollowsValidCommit()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::InputField input;
+        input.setUnit(Base::Unit::Length);
+        input.setValue(Base::Quantity(10.0, "mm"));
+        input.show();
+        input.setFocus();
+
+        QSignalSpy returnPressed(&input, &QLineEdit::returnPressed);
+        QSignalSpy editingFinished(&input, &QLineEdit::editingFinished);
+        input.setText(QStringLiteral("11 mm"));
+        QTest::keyClick(&input, Qt::Key_Return);
+        QCOMPARE(returnPressed.count(), 1);
+        QCOMPARE(editingFinished.count(), 1);
+
+        input.setText(QStringLiteral("12,34,567 mm"));
+        QSignalSpy parseError(&input, &Gui::InputField::parseError);
+        QTest::keyClick(&input, Qt::Key_Return);
+        QCOMPARE(returnPressed.count(), 1);
+        QCOMPARE(editingFinished.count(), 1);
+        QCOMPARE(parseError.count(), 1);
+    }
+
+    void test_ActionKeysPropagateOnlyAfterSuccessfulHandling()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        KeyEventParent parent;
+        Gui::InputField input(&parent);
+        input.setUnit(Base::Unit::Length);
+        input.setValue(Base::Quantity(10.0, "mm"));
+        parent.show();
+        input.show();
+        input.setFocus();
+
+        input.setText(QStringLiteral("11 mm"));
+        QTest::keyClick(&input, Qt::Key_Return);
+        QCOMPARE(parent.returns, 1);
+
+        input.setText(QStringLiteral("12,34,567 mm"));
+        QTest::keyClick(&input, Qt::Key_Return);
+        QCOMPARE(parent.returns, 1);
+
+        QTest::keyClick(&input, Qt::Key_Escape);
+        QCOMPARE(parent.escapes, 1);
+        QCOMPARE(input.rawValue(), 11.0);
+    }
+
+    void test_CommitPreservesQuantityFormatOnReturnAndFocusLoss()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::InputField input;
+        input.setUnit(Base::Unit::Length);
+        Base::Quantity quantity(10.0, "mm");
+        auto format = quantity.getFormat();
+        format.setPrecision(5);
+        quantity.setFormat(format);
+        input.setValue(quantity);
+        input.show();
+        input.setFocus();
+
+        input.setText(QStringLiteral("11 mm"));
+        QTest::keyClick(&input, Qt::Key_Return);
+        QCOMPARE(input.getPrecision(), 5);
+
+        input.setText(QStringLiteral("12 mm"));
+        QLineEdit other;
+        other.show();
+        other.setFocus();
+        QTRY_COMPARE(input.getPrecision(), 5);
+    }
+};
+
+// NOLINTEND(readability-magic-numbers)
+
+QTEST_MAIN(testInputField)
+
+#include "InputField.moc"

--- a/tests/src/Gui/InputField.cpp
+++ b/tests/src/Gui/InputField.cpp
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <string>
+
+#include <QLineEdit>
+#include <QSignalSpy>
+#include <QTest>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <App/ObjectIdentifier.h>
+#include <App/Property.h>
+
+#include "Gui/InputField.h"
+#include <src/LocaleTestHelpers.h>
+#include <src/App/InitApplication.h>
+
+// NOLINTBEGIN(readability-magic-numbers)
+
+namespace
+{
+class ScopedExpressionOwner
+{
+public:
+    ScopedExpressionOwner()
+        : documentName {App::GetApplication().getUniqueDocumentName("input_field")}
+        , document {App::GetApplication().newDocument(documentName.c_str(), "testUser")}
+        , object {document->addObject("App::VarSet", "VarSet")}
+        , property {object->addDynamicProperty("App::PropertyFloat", "Value", "Test")}
+    {}
+
+    ~ScopedExpressionOwner()
+    {
+        App::GetApplication().closeDocument(documentName.c_str());
+    }
+
+    App::ObjectIdentifier getPath() const
+    {
+        return App::ObjectIdentifier(*property);
+    }
+
+private:
+    std::string documentName;
+    App::Document* document;
+    App::DocumentObject* object;
+    App::Property* property;
+};
+
+class TestInputField: public Gui::InputField
+{
+public:
+    using Gui::InputField::InputField;
+
+    std::string expressionString() const
+    {
+        return getExpressionString(false);
+    }
+};
+}  // namespace
+
+class testInputField: public QObject
+{
+    Q_OBJECT
+
+public:
+    testInputField()
+    {
+        tests::initApplication();
+    }
+
+private Q_SLOTS:
+    void test_MismatchedFormatterAndWidgetLocaleEditPreservesEnteredValue()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "da_DK",
+             .formattingLocale = "en_US",
+             .icuLocale = "fr_FR",
+             .useQtSeparators = true}
+        };
+
+        Gui::InputField input;
+        Base::Quantity quantity(10.0, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+
+        input.setValue(quantity);
+        input.show();
+        input.setFocus();
+        input.selectNumber();
+        QTest::keyClicks(&input, "1.010,00");
+        QTest::keyClick(&input, Qt::Key_Return);
+
+        QCOMPARE(input.rawValue(), 1010.0);
+        QCOMPARE(input.text(), QStringLiteral("1.010,00 mm"));
+    }
+
+    void test_NativeDigitRoundTripUsesTheWidgetLocale()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "fa_IR",
+             .formattingLocale = "fa_IR",
+             .icuLocale = "fa_IR",
+             .useQtSeparators = true}
+        };
+
+        Gui::InputField input;
+        input.setLocale(QLocale(QStringLiteral("fa_IR")));
+        input.setUnit(Base::Unit::Length);
+        Base::Quantity quantity(1234.5, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 1);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+        input.setValue(quantity);
+        input.show();
+        const QString formatted = input.text();
+        QVERIFY(formatted.contains(QChar(0x06F1)));
+        input.setText(formatted);
+        input.selectNumber();
+        const int unitStart = formatted.indexOf(QStringLiteral(" mm"));
+        QVERIFY(unitStart > 0);
+        QCOMPARE(input.selectedText(), formatted.left(unitStart));
+        QTest::keyClick(&input, Qt::Key_Return);
+
+        QCOMPARE(input.rawValue(), 1234.5);
+        QVERIFY(input.hasValidInput());
+    }
+
+    void test_LocaleChangeReformatsAndParsesWithTheNewWidgetLocale()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::InputField input;
+        input.setLocale(QLocale(QStringLiteral("en_US")));
+        Base::Quantity quantity(1234.5, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 1);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+        input.setValue(quantity);
+        input.show();
+        QVERIFY(input.text().contains(QStringLiteral("1,234.5")));
+
+        input.setLocale(QLocale(QStringLiteral("de_DE")));
+        QCoreApplication::processEvents();
+        QVERIFY(input.text().contains(QStringLiteral("1.234,5")));
+
+        input.setText(QStringLiteral("2.345,6 mm"));
+        QTest::keyClick(&input, Qt::Key_Return);
+        QCOMPARE(input.rawValue(), 2345.6);
+        QVERIFY(input.hasValidInput());
+    }
+
+    void test_GroupedLocaleNumberIsNormalizedBeforeParse()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::InputField input;
+        input.setText(QStringLiteral("1,010.00 mm"));
+
+        QCOMPARE(input.getQuantity(), Base::Quantity(1010, "mm"));
+        QCOMPARE(input.rawValue(), 1010.0);
+    }
+
+    void test_FailedBoundEditDoesNotCommitCandidateExpression()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+        ScopedExpressionOwner owner;
+
+        TestInputField input;
+        input.bind(owner.getPath());
+        input.setUnit(Base::Unit::Length);
+        input.setText(QStringLiteral("2 mm"));
+
+        QVERIFY(input.hasValidInput());
+        QCOMPARE(input.rawValue(), 2.0);
+        const auto previousExpression = QString::fromStdString(input.expressionString());
+        QVERIFY(!previousExpression.isEmpty());
+
+        // This parses as an expression but does not evaluate to NumberExpression. It must not
+        // replace the last valid expression or reset the stored quantity to zero.
+        input.setText(QStringLiteral("str(1)"));
+
+        QVERIFY(!input.hasValidInput());
+        QCOMPARE(input.rawValue(), 2.0);
+        QCOMPARE(QString::fromStdString(input.expressionString()), previousExpression);
+    }
+
+    void test_ReturnPressedOnlyFollowsValidCommit()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::InputField input;
+        input.setUnit(Base::Unit::Length);
+        input.setValue(Base::Quantity(10.0, "mm"));
+        input.show();
+        input.setFocus();
+
+        QSignalSpy returnPressed(&input, &QLineEdit::returnPressed);
+        input.setText(QStringLiteral("11 mm"));
+        QTest::keyClick(&input, Qt::Key_Return);
+        QCOMPARE(returnPressed.count(), 1);
+
+        input.setText(QStringLiteral("12,34,567 mm"));
+        QSignalSpy parseError(&input, &Gui::InputField::parseError);
+        QTest::keyClick(&input, Qt::Key_Return);
+        QCOMPARE(returnPressed.count(), 1);
+        QCOMPARE(parseError.count(), 1);
+    }
+
+    void test_CommitPreservesQuantityFormatOnReturnAndFocusLoss()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::InputField input;
+        input.setUnit(Base::Unit::Length);
+        Base::Quantity quantity(10.0, "mm");
+        auto format = quantity.getFormat();
+        format.setPrecision(5);
+        quantity.setFormat(format);
+        input.setValue(quantity);
+        input.show();
+        input.setFocus();
+
+        input.setText(QStringLiteral("11 mm"));
+        QTest::keyClick(&input, Qt::Key_Return);
+        QCOMPARE(input.getPrecision(), 5);
+
+        input.setText(QStringLiteral("12 mm"));
+        QLineEdit other;
+        other.show();
+        other.setFocus();
+        QTRY_COMPARE(input.getPrecision(), 5);
+    }
+};
+
+// NOLINTEND(readability-magic-numbers)
+
+QTEST_MAIN(testInputField)
+
+#include "InputField.moc"

--- a/tests/src/Gui/NumericLocaleConsumers.cpp
+++ b/tests/src/Gui/NumericLocaleConsumers.cpp
@@ -2,7 +2,7 @@
 
 #include <QLineEdit>
 #include <QLocale>
-#include <QTextEdit>
+#include <QPlainTextEdit>
 #include <QTest>
 
 #include <memory>
@@ -80,7 +80,7 @@ private Q_SLOTS:
         std::shared_ptr<const App::Expression> initialExpression(std::move(initial));
         Gui::Dialog::DlgExpressionInput dialog(owner.path(), initialExpression, Base::Unit::Length);
 
-        auto* editor = dialog.findChild<QTextEdit*>(QStringLiteral("expression"));
+        auto* editor = dialog.findChild<QPlainTextEdit*>(QStringLiteral("expression"));
         QVERIFY(editor != nullptr);
         if (!editor) {
             return;

--- a/tests/src/Gui/NumericLocaleConsumers.cpp
+++ b/tests/src/Gui/NumericLocaleConsumers.cpp
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <QLineEdit>
+#include <QLocale>
+#include <QTextEdit>
+#include <QTest>
+
+#include <memory>
+#include <string>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <App/Expression.h>
+#include <App/ExpressionParser.h>
+#include <App/ObjectIdentifier.h>
+#include <App/Property.h>
+
+#include <Base/Quantity.h>
+
+#include "Gui/Dialogs/DlgExpressionInput.h"
+#include "Gui/Dialogs/DlgUnitsCalculatorImp.h"
+#include "Gui/InputField.h"
+#include <src/App/InitApplication.h>
+#include <src/LocaleTestHelpers.h>
+
+namespace
+{
+class ScopedExpressionOwner
+{
+public:
+    ScopedExpressionOwner()
+        : documentName {App::GetApplication().getUniqueDocumentName("numeric_locale_consumers")}
+        , document {App::GetApplication().newDocument(documentName.c_str(), "testUser")}
+        , object {document->addObject("App::GeoFeature", "Owner")}
+        , property {object->addDynamicProperty("App::PropertyFloat", "Value", "Test")}
+    {}
+
+    ~ScopedExpressionOwner()
+    {
+        App::GetApplication().closeDocument(documentName.c_str());
+    }
+
+    App::DocumentObject* objectPtr() const
+    {
+        return object;
+    }
+
+    App::ObjectIdentifier path() const
+    {
+        return App::ObjectIdentifier(*property);
+    }
+
+private:
+    std::string documentName;
+    App::Document* document;
+    App::DocumentObject* object;
+    App::Property* property;
+};
+}  // namespace
+
+class testNumericLocaleConsumers: public QObject
+{
+    Q_OBJECT
+
+public:
+    testNumericLocaleConsumers()
+    {
+        tests::initApplication();
+    }
+
+private Q_SLOTS:
+    void test_ExpressionDialogUsesExpressionWidgetLocale()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "da_DK", .formattingLocale = "de_DE", .icuLocale = "fr_FR"}
+        };
+        ScopedExpressionOwner owner;
+        auto initial = App::ExpressionParser::parse(owner.objectPtr(), "10 mm");
+        std::shared_ptr<const App::Expression> initialExpression(std::move(initial));
+        Gui::Dialog::DlgExpressionInput dialog(owner.path(), initialExpression, Base::Unit::Length);
+
+        auto* editor = dialog.findChild<QTextEdit*>(QStringLiteral("expression"));
+        QVERIFY(editor != nullptr);
+        if (!editor) {
+            return;
+        }
+        editor->setLocale(QLocale(QStringLiteral("en_US")));
+        editor->setPlainText(QStringLiteral("12,345.67 mm"));
+
+        const auto expression = dialog.getExpression();
+        QVERIFY(expression != nullptr);
+        if (!expression) {
+            return;
+        }
+        auto evaluated = expression->eval();
+        auto* number = freecad_cast<App::NumberExpression*>(evaluated.get());
+        QVERIFY(number != nullptr);
+        if (!number) {
+            return;
+        }
+        QCOMPARE(number->getQuantity().getValue(), 12345.67);
+    }
+
+    void test_UnitsCalculatorUsesItsInputWidgetLocale()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "da_DK", .formattingLocale = "de_DE", .icuLocale = "fr_FR"}
+        };
+        Gui::Dialog::DlgUnitsCalculator dialog;
+
+        auto* valueInput = dialog.findChild<Gui::InputField*>(QStringLiteral("ValueInput"));
+        auto* unitInput = dialog.findChild<QLineEdit*>(QStringLiteral("UnitInput"));
+        auto* valueOutput = dialog.findChild<QLineEdit*>(QStringLiteral("ValueOutput"));
+        QVERIFY(valueInput != nullptr);
+        QVERIFY(unitInput != nullptr);
+        QVERIFY(valueOutput != nullptr);
+        if (!valueInput || !unitInput || !valueOutput) {
+            return;
+        }
+
+        valueInput->setLocale(QLocale(QStringLiteral("en_US")));
+        unitInput->setLocale(QLocale(QStringLiteral("en_US")));
+        valueInput->setText(QStringLiteral("12,345.67 mm"));
+        unitInput->setText(QStringLiteral("in"));
+
+        QCOMPARE(valueInput->rawValue(), 12345.67);
+        QVERIFY(!valueOutput->text().contains(QStringLiteral("unknown unit")));
+        QVERIFY(valueOutput->text().contains(QStringLiteral("in")));
+    }
+};
+
+QTEST_MAIN(testNumericLocaleConsumers)
+
+#include "NumericLocaleConsumers.moc"

--- a/tests/src/Gui/QuantitySpinBox.cpp
+++ b/tests/src/Gui/QuantitySpinBox.cpp
@@ -1,13 +1,21 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <QDebug>
+#include <QKeyEvent>
 #include <QLineEdit>
 #include <QTest>
+#include <QSignalSpy>
 
 #include <App/Application.h>
 #include <Base/UnitsApi.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <App/ObjectIdentifier.h>
+#include <App/Property.h>
 
 #include "Gui/QuantitySpinBox.h"
+#include "Gui/PrefWidgets.h"
+#include <src/LocaleTestHelpers.h>
 #include <src/App/InitApplication.h>
 
 // NOLINTBEGIN(readability-magic-numbers)
@@ -27,6 +35,55 @@ const QString standardSchema = QStringLiteral("Internal");
 const QString usCustomarySchema = QStringLiteral("Imperial");
 const QString imperialDecimalSchema = QStringLiteral("ImperialDecimal");
 const QString buildingUsSchema = QStringLiteral("ImperialBuilding");
+class ScopedExpressionOwner
+{
+public:
+    ScopedExpressionOwner()
+        : documentName {App::GetApplication().getUniqueDocumentName("quantity_spinbox")}
+        , document {App::GetApplication().newDocument(documentName.c_str(), "testUser")}
+        , object {document->addObject("App::VarSet", "VarSet")}
+        , property {object->addDynamicProperty("App::PropertyFloat", "Value", "Test")}
+    {}
+
+    ~ScopedExpressionOwner()
+    {
+        App::GetApplication().closeDocument(documentName.c_str());
+    }
+
+    App::ObjectIdentifier getPath() const
+    {
+        return App::ObjectIdentifier(*property);
+    }
+
+private:
+    std::string documentName;
+    App::Document* document;
+    App::DocumentObject* object;
+    App::Property* property;
+};
+
+class KeyEventParent: public QWidget
+{
+public:
+    int returns {};
+    int escapes {};
+
+protected:
+    void keyPressEvent(QKeyEvent* event) override
+    {
+        if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
+            ++returns;
+            event->accept();
+            return;
+        }
+        if (event->key() == Qt::Key_Escape) {
+            ++escapes;
+            event->accept();
+            return;
+        }
+        QWidget::keyPressEvent(event);
+    }
+};
 }  // namespace
 
 class testQuantitySpinBox: public QObject
@@ -42,13 +99,18 @@ public:
 
 private Q_SLOTS:
 
+    void initTestCase()
+    {
+        Base::UnitsApi::setSchema("Internal");
+    }
+
     void init()
     {}
 
     void cleanup()
     {
         // some tests switch the unit schema, the next one has to start from the default again
-        Base::UnitsApi::setSchema(Base::UnitsApi::getDefSchemaNum());
+        Base::UnitsApi::setSchema("Internal");
     }
 
     void test_SimpleBaseUnit()  // NOLINT
@@ -228,6 +290,817 @@ private Q_SLOTS:
         QVERIFY(spinBox->hasValidInput());
 
         QCOMPARE(spinBox->isNormalized(), false);
+    }
+
+    void test_MismatchedFormatterAndWidgetLocaleDoesNotMutateValue()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "da_DK",
+             .formattingLocale = "en_US",
+             .icuLocale = "fr_FR",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setValue(Base::Quantity(10, "mm"));
+
+        QCOMPARE(spinBox.value(), Base::Quantity(10, "mm"));
+        QCOMPARE(spinBox.rawValue(), 10.0);
+    }
+
+    void test_NativeDigitRoundTripUsesTheWidgetLocale()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "fa_IR",
+             .formattingLocale = "fa_IR",
+             .icuLocale = "fa_IR",
+             .useQtSeparators = true}
+        };
+
+        const QLocale persian(QStringLiteral("fa_IR"));
+        Base::Quantity quantity(1234.5, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 1);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+
+        Gui::QuantitySpinBox unbound;
+        unbound.setLocale(persian);
+        unbound.setKeyboardTracking(false);
+        unbound.setValue(quantity);
+        unbound.show();
+        auto* unboundEdit = unbound.findChild<QLineEdit*>();
+        QVERIFY(unboundEdit != nullptr);
+        if (!unboundEdit) {
+            return;
+        }
+        const QString formatted = unbound.text();
+        QVERIFY(formatted.contains(QChar(0x06F1)));
+        unboundEdit->setText(formatted);
+        unbound.selectNumber();
+        const int unitStart = formatted.indexOf(QStringLiteral(" mm"));
+        QVERIFY(unitStart > 0);
+        QCOMPARE(unboundEdit->selectedText(), formatted.left(unitStart));
+        QTest::keyClick(&unbound, Qt::Key_Return);
+        QCOMPARE(unbound.rawValue(), 1234.5);
+        QVERIFY(unbound.hasValidInput());
+
+        ScopedExpressionOwner owner;
+        Gui::QuantitySpinBox bound;
+        bound.setLocale(persian);
+        bound.setKeyboardTracking(false);
+        bound.bind(owner.getPath());
+        bound.setUnit(Base::Unit::Length);
+        bound.setValue(quantity);
+        bound.show();
+        auto* boundEdit = bound.findChild<QLineEdit*>();
+        QVERIFY(boundEdit != nullptr);
+        if (!boundEdit) {
+            return;
+        }
+        boundEdit->setText(formatted);
+        bound.selectNumber();
+        QCOMPARE(boundEdit->selectedText(), formatted.left(unitStart));
+        QTest::keyClick(&bound, Qt::Key_Return);
+        QCOMPARE(bound.rawValue(), 1234.5);
+        QVERIFY(bound.hasValidInput());
+    }
+
+    void test_LocaleChangeReformatsAndParsesWithTheNewWidgetLocale()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setLocale(QLocale(QStringLiteral("en_US")));
+        Base::Quantity quantity(1234.5, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 1);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+        spinBox.setValue(quantity);
+        spinBox.show();
+        QVERIFY(spinBox.text().contains(QStringLiteral("1,234.5")));
+
+        spinBox.setLocale(QLocale(QStringLiteral("de_DE")));
+        QCoreApplication::processEvents();
+        QVERIFY(spinBox.text().contains(QStringLiteral("1234,5")));
+
+        spinBox.findChild<QLineEdit*>()->setText(QStringLiteral("2.345,6 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+        QCOMPARE(spinBox.rawValue(), 2345.6);
+        QVERIFY(spinBox.hasValidInput());
+    }
+
+    void test_DotGroupingDoesNotCorruptEditableInteger()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "de_DE",
+             .formattingLocale = "de_DE",
+             .icuLocale = "de_DE",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setLocale(QLocale(QStringLiteral("de_DE")));
+        Base::Quantity quantity(1234.0, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 0);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+
+        spinBox.setValue(quantity);
+
+        QCOMPARE(spinBox.rawValue(), 1234.0);
+        QVERIFY(!spinBox.text().contains(QStringLiteral("1.234")));
+        QCOMPARE(spinBox.text(), QStringLiteral("1234 mm"));
+
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+        QCOMPARE(spinBox.rawValue(), 1234.0);
+        QVERIFY(spinBox.hasValidInput());
+    }
+
+    void test_SchemaFormattedTextDoesNotReparseExactValue()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Base::UnitsApi::setSchema("Internal");
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setLocale(QLocale(QStringLiteral("en_US")));
+
+        Base::Quantity quantity(12345.67, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+
+        spinBox.setValue(quantity);
+        QCOMPARE(spinBox.text(), QStringLiteral("12.35 m"));
+        QCOMPARE(spinBox.rawValue(), 12345.67);
+
+        spinBox.show();
+        spinBox.setFocus();
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QCOMPARE(spinBox.rawValue(), 12345.67);
+        QVERIFY(spinBox.hasValidInput());
+    }
+
+    void test_TextChangedIsEmittedForKeyboardTrackedEdits()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setValue(Base::Quantity(10.0, "mm"));
+        spinBox.show();
+        QSignalSpy textChanged(&spinBox, &Gui::QuantitySpinBox::textChanged);
+
+        auto* edit = spinBox.findChild<QLineEdit*>();
+        QVERIFY(edit != nullptr);
+        if (!edit) {
+            return;
+        }
+
+        edit->setText(QStringLiteral("11 mm"));
+
+        QCOMPARE(textChanged.count(), 1);
+        QCOMPARE(textChanged.at(0).at(0).toString(), QStringLiteral("11 mm"));
+    }
+
+    void test_UnboundQuantityGrammarPreservesComments()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setUnit(Base::Unit::Length);
+
+        QCOMPARE(
+            spinBox.valueFromText(QStringLiteral("1 mm [original input 12,34,567]")),
+            Base::Quantity(1.0, "mm")
+        );
+    }
+
+    void test_GroupedLocaleNumberIsNormalizedBeforeParse()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "da_DK",
+             .formattingLocale = "en_US",
+             .icuLocale = "fr_FR",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        const auto result = spinBox.valueFromText("1.000,00 mm");
+
+        QCOMPARE(result, Base::Quantity(1000, "mm"));
+    }
+
+    void test_CanonicalDecimalPointRemainsAcceptedInCommaLocale()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "da_DK",
+             .formattingLocale = "en_US",
+             .icuLocale = "fr_FR",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        const auto result = spinBox.valueFromText("10.00 mm");
+
+        QCOMPARE(result, Base::Quantity(10, "mm"));
+    }
+
+    void test_IndianGroupedLocaleNumberIsNormalizedBeforeParse()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_IN",
+             .formattingLocale = "en_IN",
+             .icuLocale = "en_IN",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        const auto result = spinBox.valueFromText("12,34,567 mm");
+
+        QCOMPARE(result, Base::Quantity(1234567, "mm"));
+    }
+
+    void test_GroupedScientificNotationIsNormalizedBeforeParse_data()  // NOLINT
+    {
+        QTest::addColumn<QString>("input");
+        QTest::newRow("lowercase exponent") << QStringLiteral("1,234e5 mm");
+        QTest::newRow("uppercase exponent") << QStringLiteral("1,234E5 mm");
+    }
+
+    void test_GroupedScientificNotationIsNormalizedBeforeParse()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+        QFETCH(QString, input);
+
+        Gui::QuantitySpinBox spinBox;
+        const auto result = spinBox.valueFromText(input);
+
+        QCOMPARE(result, Base::Quantity(123400000, "mm"));
+    }
+
+    void test_GroupedEditDoesNotCorruptRawValue()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        Base::Quantity quantity(10.0, "mm");
+
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+
+        spinBox.setValue(quantity);
+        spinBox.show();
+        spinBox.setFocus();
+        spinBox.selectNumber();
+        QTest::keyClicks(&spinBox, "1,010.00");
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QCOMPARE(spinBox.rawValue(), 1010.0);
+        QCOMPARE(spinBox.text(), QStringLiteral("1,010.00 mm"));
+    }
+
+    void test_BoundPrefSpinBoxGroupedDecimalUsesWidgetLocale()  // NOLINT
+    {
+        // Start aligned so the widget is constructed and initially displayed
+        // using US numeric formatting.
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+        Base::UnitsApi::setSchema("FEM");
+
+        ScopedExpressionOwner owner;
+
+        // Sketcher's datum dialog uses PrefQuantitySpinBox rather than a plain
+        // QuantitySpinBox.
+        Gui::PrefQuantitySpinBox spinBox;
+
+        Base::Quantity quantity(10.0, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+
+        spinBox.setValue(quantity);
+        spinBox.bind(owner.getPath());
+
+        spinBox.show();
+        spinBox.setFocus();
+        spinBox.selectNumber();
+
+        {
+            // Reproduce the suspected real-world mismatch:
+            //
+            //   widget locale:       en_US, decimal ".", grouping ","
+            //   shared parse state:  decimal ",", grouping "."
+            //
+            // The widget still displays and accepts US-style text, but the
+            // current implementation parses through the stale shared state.
+            tests::ScopedNumericLocaleContext staleFormatting {
+                {"en_US", ",", ".", "+", "-", 3, 3, "0"}
+            };
+
+            QTest::keyClicks(&spinBox, "12,345.67");
+            QTest::keyClick(&spinBox, Qt::Key_Return);
+        }
+
+        QCOMPARE(spinBox.hasValidInput(), true);
+        QCOMPARE(spinBox.rawValue(), 12345.67);
+        QCOMPARE(spinBox.text(), QStringLiteral("12,345.67 mm"));
+    }
+
+    void test_BoundGroupedDecimalEditUsesWidgetLocale()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+        Base::UnitsApi::setSchema("FEM");
+        ScopedExpressionOwner owner;
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.bind(owner.getPath());
+        spinBox.setUnit(Base::Unit::Length);
+
+        Base::Quantity quantity(10.0, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+
+        spinBox.setValue(quantity);
+        spinBox.show();
+        spinBox.setFocus();
+        spinBox.selectNumber();
+
+        QTest::keyClicks(&spinBox, "12,345.67");
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QCOMPARE(spinBox.rawValue(), 12345.67);
+    }
+
+    void test_EffectiveSeparatorsOverrideFormattingLocaleId()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "pt_PT", .formattingLocale = "en_US", .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        Base::Quantity quantity(1.5, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+
+        spinBox.setValue(quantity);
+
+        QCOMPARE(spinBox.text(), QStringLiteral("1,50 mm"));
+        QCOMPARE(spinBox.text().at(1), QLocale().decimalPoint());
+    }
+
+    void test_FunctionArgumentSeparatorSurvivesQuantityParsing()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+        ScopedExpressionOwner owner;
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.bind(owner.getPath());
+        spinBox.setUnit(Base::Unit::Length);
+        // Use a non-unit function name here. The helper-level min(1,234) case above still covers
+        // separator preservation for that spelling, but the real parser tokenizes "min" as minute.
+        const auto result = spinBox.valueFromText("pow(1, 234)");
+
+        QCOMPARE(result.getValue(), 1.0);
+    }
+
+    void test_InvalidCommittedGroupingRemainsVisibleAndEscapes()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        Base::Quantity quantity(10.0, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+        spinBox.setValue(quantity);
+        spinBox.show();
+        spinBox.setFocus();
+
+        QSignalSpy rejected(&spinBox, &Gui::QuantitySpinBox::inputRejected);
+        spinBox.findChild<QLineEdit*>()->setText(QStringLiteral("12,34,567 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QCOMPARE(spinBox.text(), QStringLiteral("12,34,567 mm"));
+        QCOMPARE(spinBox.rawValue(), 10.0);
+        QVERIFY(!spinBox.hasValidInput());
+        QCOMPARE(rejected.count(), 1);
+        const auto arguments = rejected.at(0);
+        QVERIFY(arguments.at(0).toString().contains(QStringLiteral("Malformed grouping")));
+        QVERIFY(arguments.at(1).toInt() >= 0);
+        QVERIFY(arguments.at(2).toInt() > 0);
+
+        auto* edit = spinBox.findChild<QLineEdit*>();
+        QVERIFY(edit != nullptr);
+        if (!edit) {
+            return;
+        }
+        QVERIFY(edit->property("numericInputInvalid").toBool());
+
+        QTest::keyClick(&spinBox, Qt::Key_Escape);
+        QCOMPARE(spinBox.text(), QStringLiteral("10.00 mm"));
+        QCOMPARE(spinBox.rawValue(), 10.0);
+        QVERIFY(spinBox.hasValidInput());
+        QVERIFY(!edit->property("numericInputInvalid").toBool());
+    }
+
+    void test_ReturnSignalsMatchCommitResult()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setUnit(Base::Unit::Length);
+        spinBox.setValue(Base::Quantity(10.0, "mm"));
+        spinBox.show();
+        spinBox.setFocus();
+
+        QSignalSpy changed(
+            &spinBox,
+            qOverload<const Base::Quantity&>(&Gui::QuantitySpinBox::valueChanged)
+        );
+        QSignalSpy returnPressed(&spinBox, &Gui::QuantitySpinBox::returnPressed);
+        QSignalSpy editingFinished(&spinBox, &QAbstractSpinBox::editingFinished);
+        QSignalSpy rejected(&spinBox, &Gui::QuantitySpinBox::inputRejected);
+        auto* edit = spinBox.findChild<QLineEdit*>();
+        QVERIFY(edit != nullptr);
+        if (!edit) {
+            return;
+        }
+
+        edit->setText(QStringLiteral("11 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+        QCOMPARE(returnPressed.count(), 1);
+        QCOMPARE(editingFinished.count(), 1);
+        QCOMPARE(rejected.count(), 0);
+        QCOMPARE(changed.count(), 1);
+
+        edit->setText(QStringLiteral("12,34,567 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+        QCOMPARE(returnPressed.count(), 1);
+        QCOMPARE(editingFinished.count(), 1);
+        QCOMPARE(rejected.count(), 1);
+        QCOMPARE(changed.count(), 1);
+    }
+
+    void test_ActionKeysPropagateOnlyAfterSuccessfulHandling()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        KeyEventParent parent;
+        Gui::QuantitySpinBox spinBox(&parent);
+        spinBox.setUnit(Base::Unit::Length);
+        spinBox.setValue(Base::Quantity(10.0, "mm"));
+        parent.show();
+        spinBox.show();
+        spinBox.setFocus();
+
+        auto* edit = spinBox.findChild<QLineEdit*>();
+        QVERIFY(edit != nullptr);
+        edit->setText(QStringLiteral("11 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+        QCOMPARE(parent.returns, 1);
+
+        edit->setText(QStringLiteral("12,34,567 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+        QCOMPARE(parent.returns, 1);
+
+        QTest::keyClick(&spinBox, Qt::Key_Escape);
+        QCOMPARE(parent.escapes, 1);
+        QCOMPARE(spinBox.rawValue(), 11.0);
+    }
+
+    void test_ClearedInputHasAnExplicitTransientState()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setUnit(Base::Unit::Length);
+        spinBox.setValue(Base::Quantity(10.0, "mm"));
+        spinBox.show();
+        auto* edit = spinBox.findChild<QLineEdit*>();
+        QVERIFY(edit != nullptr);
+
+        QSignalSpy changed(&spinBox, qOverload<double>(&Gui::QuantitySpinBox::valueChanged));
+        QSignalSpy cleared(&spinBox, &Gui::QuantitySpinBox::inputCleared);
+
+        edit->setText(QStringLiteral("12 mm"));
+        QCOMPARE(spinBox.rawValue(), 12.0);
+        QCOMPARE(changed.count(), 1);
+
+        QTest::keyClick(edit, Qt::Key_A, Qt::ControlModifier);
+        QCOMPARE(edit->selectedText(), edit->text());
+        QTest::keyClick(edit, Qt::Key_Backspace);
+        QCOMPARE(edit->text(), QString {});
+        QCOMPARE(cleared.count(), 1);
+        QVERIFY(!spinBox.hasValidInput());
+        QCOMPARE(changed.count(), 1);
+        QCOMPARE(spinBox.rawValue(), 12.0);
+
+        edit->setText(QStringLiteral("13 mm"));
+        QVERIFY(spinBox.hasValidInput());
+        QCOMPARE(spinBox.rawValue(), 13.0);
+    }
+
+    void test_MultibyteDiagnosticSelectsTheCompleteSeparator()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "fr_FR",
+             .formattingLocale = "fr_FR",
+             .icuLocale = "fr_FR",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setLocale(QLocale(QStringLiteral("fr_FR")));
+        spinBox.setUnit(Base::Unit::Length);
+        spinBox.setValue(Base::Quantity(10.0, "mm"));
+        spinBox.show();
+        spinBox.setFocus();
+        auto* edit = spinBox.findChild<QLineEdit*>();
+        QVERIFY(edit != nullptr);
+        if (!edit) {
+            return;
+        }
+
+        const QString narrowSpace = QString::fromUtf8("\xE2\x80\xAF");
+        edit->setText(QStringLiteral("12") + narrowSpace + QStringLiteral("34 mm"));
+        QSignalSpy rejected(&spinBox, &Gui::QuantitySpinBox::inputRejected);
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QCOMPARE(rejected.count(), 1);
+        const auto args = rejected.at(0);
+        const int start = args.at(1).toInt();
+        const int length = args.at(2).toInt();
+        QCOMPARE(edit->text().mid(start, length), narrowSpace);
+        QCOMPARE(length, narrowSpace.size());
+        QCOMPARE(length, 1);
+        QVERIFY(!edit->text().contains(QChar::ReplacementCharacter));
+    }
+
+    void test_ValidEditClearsTheInvalidState()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setValue(Base::Quantity(10.0, "mm"));
+        spinBox.show();
+        spinBox.setFocus();
+        auto* edit = spinBox.findChild<QLineEdit*>();
+        QVERIFY(edit != nullptr);
+        if (!edit) {
+            return;
+        }
+
+        QTest::keyClicks(edit, QStringLiteral("12,34,567 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+        QVERIFY(edit->property("numericInputInvalid").toBool());
+
+        edit->setText(QStringLiteral("11 mm"));
+        QVERIFY(!edit->property("numericInputInvalid").toBool());
+        QVERIFY(edit->toolTip().isEmpty());
+        QVERIFY(spinBox.hasValidInput());
+    }
+
+    void test_InvalidFocusLossCommitsOnce()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setValue(Base::Quantity(10.0, "mm"));
+        spinBox.show();
+        spinBox.setFocus();
+
+        QSignalSpy rejected(&spinBox, &Gui::QuantitySpinBox::inputRejected);
+        spinBox.findChild<QLineEdit*>()->setText(QStringLiteral("12,34,567 mm"));
+        QLineEdit other;
+        other.show();
+        other.setFocus();
+
+        QTRY_COMPARE(rejected.count(), 1);
+        QCOMPARE(spinBox.rawValue(), 10.0);
+    }
+
+    void test_ValidFocusLossCommitsOnce()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setKeyboardTracking(false);
+        spinBox.setValue(Base::Quantity(10.0, "mm"));
+        spinBox.show();
+        spinBox.setFocus();
+        QSignalSpy changed(
+            &spinBox,
+            qOverload<const Base::Quantity&>(&Gui::QuantitySpinBox::valueChanged)
+        );
+        QSignalSpy rejected(&spinBox, &Gui::QuantitySpinBox::inputRejected);
+
+        spinBox.findChild<QLineEdit*>()->setText(QStringLiteral("11 mm"));
+        QLineEdit other;
+        other.show();
+        other.setFocus();
+        QTRY_COMPARE(changed.count(), 1);
+        QCOMPARE(rejected.count(), 0);
+
+        QLineEdit another;
+        another.show();
+        another.setFocus();
+        QTest::qWait(0);
+        QCOMPARE(changed.count(), 1);
+    }
+
+    void test_IncompleteEditHasNoTooltipAndDoesNotCommit()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        Base::Quantity quantity(10.0, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+        spinBox.setValue(quantity);
+        spinBox.show();
+        spinBox.setFocus();
+
+        auto* edit = spinBox.findChild<QLineEdit*>();
+        QVERIFY(edit != nullptr);
+        if (!edit) {
+            return;
+        }
+        QSignalSpy rejected(&spinBox, &Gui::QuantitySpinBox::inputRejected);
+
+        edit->setText(QStringLiteral("-"));
+
+        QVERIFY(!spinBox.hasValidInput());
+        QCOMPARE(spinBox.rawValue(), 10.0);
+        QVERIFY(edit->toolTip().isEmpty());
+        QCOMPARE(rejected.count(), 0);
+
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QVERIFY(!spinBox.hasValidInput());
+        QCOMPARE(spinBox.rawValue(), 10.0);
+        QCOMPARE(spinBox.text(), QStringLiteral("-"));
+        QCOMPARE(rejected.count(), 1);
+        QVERIFY(rejected.at(0).at(0).toString().contains(QStringLiteral("Incomplete number")));
+
+        QTest::keyClick(&spinBox, Qt::Key_Escape);
+        QCOMPARE(spinBox.text(), QStringLiteral("10.00 mm"));
+        QVERIFY(spinBox.hasValidInput());
+    }
+
+    void test_IncompatibleUnitAndRangeDiagnosticsRemainVisible()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setUnit(Base::Unit::Length);
+        spinBox.setValue(Base::Quantity(10.0, "mm"));
+        spinBox.show();
+        spinBox.setFocus();
+
+        auto* edit = spinBox.findChild<QLineEdit*>();
+        QVERIFY(edit != nullptr);
+        if (!edit) {
+            return;
+        }
+        QSignalSpy rejected(&spinBox, &Gui::QuantitySpinBox::inputRejected);
+
+        edit->setText(QStringLiteral("1 s"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QVERIFY(!spinBox.hasValidInput());
+        QCOMPARE(spinBox.rawValue(), 10.0);
+        QCOMPARE(rejected.count(), 1);
+        QVERIFY(rejected.at(0).at(0).toString().contains(QStringLiteral("Incompatible unit")));
+
+        QTest::keyClick(&spinBox, Qt::Key_Escape);
+        spinBox.setRange(0.0, 10.0);
+        edit->setText(QStringLiteral("11 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QVERIFY(!spinBox.hasValidInput());
+        QCOMPARE(spinBox.rawValue(), 10.0);
+        QCOMPARE(rejected.count(), 2);
+        QVERIFY(rejected.at(1).at(0).toString().contains(QStringLiteral("outside the allowed range")));
+    }
+
+    void test_ValidGroupedCommitUpdatesQuantity()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+        Base::UnitsApi::setSchema("FEM");
+
+        Gui::QuantitySpinBox spinBox;
+        Base::Quantity quantity(10.0, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+        spinBox.setValue(quantity);
+        spinBox.show();
+        spinBox.setFocus();
+
+        spinBox.findChild<QLineEdit*>()->setText(QStringLiteral("12,345.67 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QCOMPARE(spinBox.text(), QStringLiteral("12,345.67 mm"));
+        QCOMPARE(spinBox.rawValue(), 12345.67);
+        QVERIFY(spinBox.hasValidInput());
     }
 
 private:

--- a/tests/src/Gui/QuantitySpinBox.cpp
+++ b/tests/src/Gui/QuantitySpinBox.cpp
@@ -2,13 +2,51 @@
 
 #include <QDebug>
 #include <QTest>
+#include <QSignalSpy>
+#include <QLineEdit>
 
 #include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <App/ObjectIdentifier.h>
+#include <App/Property.h>
 
 #include "Gui/QuantitySpinBox.h"
+#include "Gui/PrefWidgets.h"
+#include <src/LocaleTestHelpers.h>
 #include <src/App/InitApplication.h>
 
 // NOLINTBEGIN(readability-magic-numbers)
+
+namespace
+{
+class ScopedExpressionOwner
+{
+public:
+    ScopedExpressionOwner()
+        : documentName {App::GetApplication().getUniqueDocumentName("quantity_spinbox")}
+        , document {App::GetApplication().newDocument(documentName.c_str(), "testUser")}
+        , object {document->addObject("App::VarSet", "VarSet")}
+        , property {object->addDynamicProperty("App::PropertyFloat", "Value", "Test")}
+    {}
+
+    ~ScopedExpressionOwner()
+    {
+        App::GetApplication().closeDocument(documentName.c_str());
+    }
+
+    App::ObjectIdentifier getPath() const
+    {
+        return App::ObjectIdentifier(*property);
+    }
+
+private:
+    std::string documentName;
+    App::Document* document;
+    App::DocumentObject* object;
+    App::Property* property;
+};
+}  // namespace
 
 class testQuantitySpinBox: public QObject
 {
@@ -63,6 +101,639 @@ private Q_SLOTS:
         qsb->setValue(3.5);
         auto val2 = qsb->value();
         QCOMPARE(val2.getFormat().getPrecision(), 7);
+    }
+
+    void test_MismatchedFormatterAndWidgetLocaleDoesNotMutateValue()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "da_DK",
+             .formattingLocale = "en_US",
+             .icuLocale = "fr_FR",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setValue(Base::Quantity(10, "mm"));
+
+        QCOMPARE(spinBox.value(), Base::Quantity(10, "mm"));
+        QCOMPARE(spinBox.rawValue(), 10.0);
+    }
+
+    void test_NativeDigitRoundTripUsesTheWidgetLocale()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "fa_IR",
+             .formattingLocale = "fa_IR",
+             .icuLocale = "fa_IR",
+             .useQtSeparators = true}
+        };
+
+        const QLocale persian(QStringLiteral("fa_IR"));
+        Base::Quantity quantity(1234.5, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 1);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+
+        Gui::QuantitySpinBox unbound;
+        unbound.setLocale(persian);
+        unbound.setKeyboardTracking(false);
+        unbound.setValue(quantity);
+        unbound.show();
+        auto* unboundEdit = unbound.findChild<QLineEdit*>();
+        QVERIFY(unboundEdit != nullptr);
+        if (!unboundEdit) {
+            return;
+        }
+        const QString formatted = unbound.text();
+        QVERIFY(formatted.contains(QChar(0x06F1)));
+        unboundEdit->setText(formatted);
+        unbound.selectNumber();
+        const int unitStart = formatted.indexOf(QStringLiteral(" mm"));
+        QVERIFY(unitStart > 0);
+        QCOMPARE(unboundEdit->selectedText(), formatted.left(unitStart));
+        QTest::keyClick(&unbound, Qt::Key_Return);
+        QCOMPARE(unbound.rawValue(), 1234.5);
+        QVERIFY(unbound.hasValidInput());
+
+        ScopedExpressionOwner owner;
+        Gui::QuantitySpinBox bound;
+        bound.setLocale(persian);
+        bound.setKeyboardTracking(false);
+        bound.bind(owner.getPath());
+        bound.setUnit(Base::Unit::Length);
+        bound.setValue(quantity);
+        bound.show();
+        auto* boundEdit = bound.findChild<QLineEdit*>();
+        QVERIFY(boundEdit != nullptr);
+        if (!boundEdit) {
+            return;
+        }
+        boundEdit->setText(formatted);
+        bound.selectNumber();
+        QCOMPARE(boundEdit->selectedText(), formatted.left(unitStart));
+        QTest::keyClick(&bound, Qt::Key_Return);
+        QCOMPARE(bound.rawValue(), 1234.5);
+        QVERIFY(bound.hasValidInput());
+    }
+
+    void test_LocaleChangeReformatsAndParsesWithTheNewWidgetLocale()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setLocale(QLocale(QStringLiteral("en_US")));
+        Base::Quantity quantity(1234.5, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 1);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+        spinBox.setValue(quantity);
+        spinBox.show();
+        QVERIFY(spinBox.text().contains(QStringLiteral("1,234.5")));
+
+        spinBox.setLocale(QLocale(QStringLiteral("de_DE")));
+        QCoreApplication::processEvents();
+        QVERIFY(spinBox.text().contains(QStringLiteral("1.234,5")));
+
+        spinBox.findChild<QLineEdit*>()->setText(QStringLiteral("2.345,6 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+        QCOMPARE(spinBox.rawValue(), 2345.6);
+        QVERIFY(spinBox.hasValidInput());
+    }
+
+    void test_GroupedLocaleNumberIsNormalizedBeforeParse()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "da_DK",
+             .formattingLocale = "en_US",
+             .icuLocale = "fr_FR",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        const auto result = spinBox.valueFromText("1.000,00 mm");
+
+        QCOMPARE(result, Base::Quantity(1000, "mm"));
+    }
+
+    void test_CanonicalDecimalPointRemainsAcceptedInCommaLocale()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "da_DK",
+             .formattingLocale = "en_US",
+             .icuLocale = "fr_FR",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        const auto result = spinBox.valueFromText("10.00 mm");
+
+        QCOMPARE(result, Base::Quantity(10, "mm"));
+    }
+
+    void test_IndianGroupedLocaleNumberIsNormalizedBeforeParse()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_IN",
+             .formattingLocale = "en_IN",
+             .icuLocale = "en_IN",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        const auto result = spinBox.valueFromText("12,34,567 mm");
+
+        QCOMPARE(result, Base::Quantity(1234567, "mm"));
+    }
+
+    void test_GroupedScientificNotationIsNormalizedBeforeParse_data()  // NOLINT
+    {
+        QTest::addColumn<QString>("input");
+        QTest::newRow("lowercase exponent") << QStringLiteral("1,234e5 mm");
+        QTest::newRow("uppercase exponent") << QStringLiteral("1,234E5 mm");
+    }
+
+    void test_GroupedScientificNotationIsNormalizedBeforeParse()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+        QFETCH(QString, input);
+
+        Gui::QuantitySpinBox spinBox;
+        const auto result = spinBox.valueFromText(input);
+
+        QCOMPARE(result, Base::Quantity(123400000, "mm"));
+    }
+
+    void test_GroupedEditDoesNotCorruptRawValue()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        Base::Quantity quantity(10.0, "mm");
+
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+
+        spinBox.setValue(quantity);
+        spinBox.show();
+        spinBox.setFocus();
+        spinBox.selectNumber();
+        QTest::keyClicks(&spinBox, "1,010.00");
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QCOMPARE(spinBox.rawValue(), 1010.0);
+        QCOMPARE(spinBox.text(), QStringLiteral("1,010.00 mm"));
+    }
+
+    void test_BoundPrefSpinBoxGroupedDecimalUsesWidgetLocale()  // NOLINT
+    {
+        // Start aligned so the widget is constructed and initially displayed
+        // using US numeric formatting.
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        ScopedExpressionOwner owner;
+
+        // Sketcher's datum dialog uses PrefQuantitySpinBox rather than a plain
+        // QuantitySpinBox.
+        Gui::PrefQuantitySpinBox spinBox;
+
+        Base::Quantity quantity(10.0, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+
+        spinBox.setValue(quantity);
+        spinBox.bind(owner.getPath());
+
+        spinBox.show();
+        spinBox.setFocus();
+        spinBox.selectNumber();
+
+        {
+            // Reproduce the suspected real-world mismatch:
+            //
+            //   widget locale:       en_US, decimal ".", grouping ","
+            //   shared parse state:  decimal ",", grouping "."
+            //
+            // The widget still displays and accepts US-style text, but the
+            // current implementation parses through the stale shared state.
+            tests::ScopedNumericLocaleContext staleFormatting {{"en_US", ",", ".", "+", "-", 3, 3}};
+
+            QTest::keyClicks(&spinBox, "12,345.67");
+            QTest::keyClick(&spinBox, Qt::Key_Return);
+        }
+
+        QCOMPARE(spinBox.hasValidInput(), true);
+        QCOMPARE(spinBox.rawValue(), 12345.67);
+        QCOMPARE(spinBox.text(), QStringLiteral("12,345.67 mm"));
+    }
+
+    void test_BoundGroupedDecimalEditUsesWidgetLocale()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+        ScopedExpressionOwner owner;
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.bind(owner.getPath());
+        spinBox.setUnit(Base::Unit::Length);
+
+        Base::Quantity quantity(10.0, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+
+        spinBox.setValue(quantity);
+        spinBox.show();
+        spinBox.setFocus();
+        spinBox.selectNumber();
+
+        QTest::keyClicks(&spinBox, "12,345.67");
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QCOMPARE(spinBox.rawValue(), 12345.67);
+    }
+
+    void test_EffectiveSeparatorsOverrideFormattingLocaleId()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "pt_PT", .formattingLocale = "en_US", .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        Base::Quantity quantity(1.5, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+
+        spinBox.setValue(quantity);
+
+        QCOMPARE(spinBox.text(), QStringLiteral("1,50 mm"));
+        QCOMPARE(spinBox.text().at(1), QLocale().decimalPoint());
+    }
+
+    void test_FunctionArgumentSeparatorSurvivesQuantityParsing()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+        ScopedExpressionOwner owner;
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.bind(owner.getPath());
+        spinBox.setUnit(Base::Unit::Length);
+        // Use a non-unit function name here. The helper-level min(1,234) case above still covers
+        // separator preservation for that spelling, but the real parser tokenizes "min" as minute.
+        const auto result = spinBox.valueFromText("pow(1, 234)");
+
+        QCOMPARE(result.getValue(), 1.0);
+    }
+
+    void test_InvalidCommittedGroupingRemainsVisibleAndEscapes()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        Base::Quantity quantity(10.0, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+        spinBox.setValue(quantity);
+        spinBox.show();
+        spinBox.setFocus();
+
+        QSignalSpy rejected(&spinBox, &Gui::QuantitySpinBox::inputRejected);
+        spinBox.findChild<QLineEdit*>()->setText(QStringLiteral("12,34,567 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QCOMPARE(spinBox.text(), QStringLiteral("12,34,567 mm"));
+        QCOMPARE(spinBox.rawValue(), 10.0);
+        QVERIFY(!spinBox.hasValidInput());
+        QCOMPARE(rejected.count(), 1);
+        const auto arguments = rejected.at(0);
+        QVERIFY(arguments.at(0).toString().contains(QStringLiteral("Malformed grouping")));
+        QVERIFY(arguments.at(1).toInt() >= 0);
+        QVERIFY(arguments.at(2).toInt() > 0);
+
+        auto* edit = spinBox.findChild<QLineEdit*>();
+        QVERIFY(edit != nullptr);
+        if (!edit) {
+            return;
+        }
+        QVERIFY(edit->property("numericInputInvalid").toBool());
+
+        QTest::keyClick(&spinBox, Qt::Key_Escape);
+        QCOMPARE(spinBox.text(), QStringLiteral("10.00 mm"));
+        QCOMPARE(spinBox.rawValue(), 10.0);
+        QVERIFY(spinBox.hasValidInput());
+        QVERIFY(!edit->property("numericInputInvalid").toBool());
+    }
+
+    void test_ReturnSignalsMatchCommitResult()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setUnit(Base::Unit::Length);
+        spinBox.setValue(Base::Quantity(10.0, "mm"));
+        spinBox.show();
+        spinBox.setFocus();
+
+        QSignalSpy changed(
+            &spinBox,
+            qOverload<const Base::Quantity&>(&Gui::QuantitySpinBox::valueChanged)
+        );
+        QSignalSpy returnPressed(&spinBox, &Gui::QuantitySpinBox::returnPressed);
+        QSignalSpy rejected(&spinBox, &Gui::QuantitySpinBox::inputRejected);
+        auto* edit = spinBox.findChild<QLineEdit*>();
+        QVERIFY(edit != nullptr);
+        if (!edit) {
+            return;
+        }
+
+        edit->setText(QStringLiteral("11 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+        QCOMPARE(returnPressed.count(), 1);
+        QCOMPARE(rejected.count(), 0);
+        QCOMPARE(changed.count(), 1);
+
+        edit->setText(QStringLiteral("12,34,567 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+        QCOMPARE(returnPressed.count(), 1);
+        QCOMPARE(rejected.count(), 1);
+        QCOMPARE(changed.count(), 1);
+    }
+
+    void test_MultibyteDiagnosticSelectsTheCompleteSeparator()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "fr_FR",
+             .formattingLocale = "fr_FR",
+             .icuLocale = "fr_FR",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setLocale(QLocale(QStringLiteral("fr_FR")));
+        spinBox.setUnit(Base::Unit::Length);
+        spinBox.setValue(Base::Quantity(10.0, "mm"));
+        spinBox.show();
+        spinBox.setFocus();
+        auto* edit = spinBox.findChild<QLineEdit*>();
+        QVERIFY(edit != nullptr);
+        if (!edit) {
+            return;
+        }
+
+        const QString narrowSpace = QString::fromUtf8("\xE2\x80\xAF");
+        edit->setText(QStringLiteral("12") + narrowSpace + QStringLiteral("34 mm"));
+        QSignalSpy rejected(&spinBox, &Gui::QuantitySpinBox::inputRejected);
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QCOMPARE(rejected.count(), 1);
+        const auto args = rejected.at(0);
+        const int start = args.at(1).toInt();
+        const int length = args.at(2).toInt();
+        QCOMPARE(edit->text().mid(start, length), narrowSpace);
+        QCOMPARE(length, narrowSpace.size());
+        QCOMPARE(length, 1);
+        QVERIFY(!edit->text().contains(QChar::ReplacementCharacter));
+    }
+
+    void test_ValidEditClearsTheInvalidState()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setValue(Base::Quantity(10.0, "mm"));
+        spinBox.show();
+        spinBox.setFocus();
+        auto* edit = spinBox.findChild<QLineEdit*>();
+        QVERIFY(edit != nullptr);
+        if (!edit) {
+            return;
+        }
+
+        QTest::keyClicks(edit, QStringLiteral("12,34,567 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+        QVERIFY(edit->property("numericInputInvalid").toBool());
+
+        edit->setText(QStringLiteral("11 mm"));
+        QVERIFY(!edit->property("numericInputInvalid").toBool());
+        QVERIFY(edit->toolTip().isEmpty());
+        QVERIFY(spinBox.hasValidInput());
+    }
+
+    void test_InvalidFocusLossCommitsOnce()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setValue(Base::Quantity(10.0, "mm"));
+        spinBox.show();
+        spinBox.setFocus();
+
+        QSignalSpy rejected(&spinBox, &Gui::QuantitySpinBox::inputRejected);
+        spinBox.findChild<QLineEdit*>()->setText(QStringLiteral("12,34,567 mm"));
+        QLineEdit other;
+        other.show();
+        other.setFocus();
+
+        QTRY_COMPARE(rejected.count(), 1);
+        QCOMPARE(spinBox.rawValue(), 10.0);
+    }
+
+    void test_ValidFocusLossCommitsOnce()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setKeyboardTracking(false);
+        spinBox.setValue(Base::Quantity(10.0, "mm"));
+        spinBox.show();
+        spinBox.setFocus();
+        QSignalSpy changed(
+            &spinBox,
+            qOverload<const Base::Quantity&>(&Gui::QuantitySpinBox::valueChanged)
+        );
+        QSignalSpy rejected(&spinBox, &Gui::QuantitySpinBox::inputRejected);
+
+        spinBox.findChild<QLineEdit*>()->setText(QStringLiteral("11 mm"));
+        QLineEdit other;
+        other.show();
+        other.setFocus();
+        QTRY_COMPARE(changed.count(), 1);
+        QCOMPARE(rejected.count(), 0);
+
+        QLineEdit another;
+        another.show();
+        another.setFocus();
+        QTest::qWait(0);
+        QCOMPARE(changed.count(), 1);
+    }
+
+    void test_IncompleteEditHasNoTooltipAndDoesNotCommit()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        Base::Quantity quantity(10.0, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+        spinBox.setValue(quantity);
+        spinBox.show();
+        spinBox.setFocus();
+
+        auto* edit = spinBox.findChild<QLineEdit*>();
+        QVERIFY(edit != nullptr);
+        if (!edit) {
+            return;
+        }
+        QSignalSpy rejected(&spinBox, &Gui::QuantitySpinBox::inputRejected);
+
+        edit->setText(QStringLiteral("-"));
+
+        QVERIFY(!spinBox.hasValidInput());
+        QCOMPARE(spinBox.rawValue(), 10.0);
+        QVERIFY(edit->toolTip().isEmpty());
+        QCOMPARE(rejected.count(), 0);
+
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QVERIFY(!spinBox.hasValidInput());
+        QCOMPARE(spinBox.rawValue(), 10.0);
+        QCOMPARE(spinBox.text(), QStringLiteral("-"));
+        QCOMPARE(rejected.count(), 1);
+        QVERIFY(rejected.at(0).at(0).toString().contains(QStringLiteral("Incomplete number")));
+
+        QTest::keyClick(&spinBox, Qt::Key_Escape);
+        QCOMPARE(spinBox.text(), QStringLiteral("10.00 mm"));
+        QVERIFY(spinBox.hasValidInput());
+    }
+
+    void test_IncompatibleUnitAndRangeDiagnosticsRemainVisible()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        spinBox.setUnit(Base::Unit::Length);
+        spinBox.setValue(Base::Quantity(10.0, "mm"));
+        spinBox.show();
+        spinBox.setFocus();
+
+        auto* edit = spinBox.findChild<QLineEdit*>();
+        QVERIFY(edit != nullptr);
+        if (!edit) {
+            return;
+        }
+        QSignalSpy rejected(&spinBox, &Gui::QuantitySpinBox::inputRejected);
+
+        edit->setText(QStringLiteral("1 s"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QVERIFY(!spinBox.hasValidInput());
+        QCOMPARE(spinBox.rawValue(), 10.0);
+        QCOMPARE(rejected.count(), 1);
+        QVERIFY(rejected.at(0).at(0).toString().contains(QStringLiteral("Incompatible unit")));
+
+        QTest::keyClick(&spinBox, Qt::Key_Escape);
+        spinBox.setRange(0.0, 10.0);
+        edit->setText(QStringLiteral("11 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QVERIFY(!spinBox.hasValidInput());
+        QCOMPARE(spinBox.rawValue(), 10.0);
+        QCOMPARE(rejected.count(), 2);
+        QVERIFY(rejected.at(1).at(0).toString().contains(QStringLiteral("outside the allowed range")));
+    }
+
+    void test_ValidGroupedCommitUpdatesQuantity()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "en_US",
+             .formattingLocale = "en_US",
+             .icuLocale = "en_US",
+             .useQtSeparators = true}
+        };
+
+        Gui::QuantitySpinBox spinBox;
+        Base::Quantity quantity(10.0, "mm");
+        Base::QuantityFormat format(Base::QuantityFormat::Fixed, 2);
+        format.option = Base::QuantityFormat::None;
+        quantity.setFormat(format);
+        spinBox.setValue(quantity);
+        spinBox.show();
+        spinBox.setFocus();
+
+        spinBox.findChild<QLineEdit*>()->setText(QStringLiteral("12,345.67 mm"));
+        QTest::keyClick(&spinBox, Qt::Key_Return);
+
+        QCOMPARE(spinBox.text(), QStringLiteral("12,345.67 mm"));
+        QCOMPARE(spinBox.rawValue(), 12345.67);
+        QVERIFY(spinBox.hasValidInput());
     }
 
 private:

--- a/tests/src/Gui/TranslatorLocale.cpp
+++ b/tests/src/Gui/TranslatorLocale.cpp
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <QLocale>
+#include <QTest>
+
+#include <App/Application.h>
+#include <Base/NumericFormatting.h>
+
+#include "Gui/Language/Translator.h"
+#include "Gui/NumericLocale.h"
+#include <src/LocaleTestHelpers.h>
+#include <src/App/InitApplication.h>
+
+// NOLINTBEGIN(readability-magic-numbers)
+
+class testTranslatorLocale: public QObject
+{
+    Q_OBJECT
+
+public:
+    testTranslatorLocale()
+    {
+        tests::initApplication();
+    }
+
+private Q_SLOTS:
+    void test_NumericLocaleContextRealignsMismatchedQtAndIcuDefaults()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeEnvironment {
+            {.qtLocale = "da_DK", .formattingLocale = "en_US", .icuLocale = "fr_FR"}
+        };
+
+        QCOMPARE(QLocale().name(), QStringLiteral("da_DK"));
+        QCOMPARE(QString::fromLatin1(icu::Locale::getDefault().getName()), QStringLiteral("fr_FR"));
+        QCOMPARE(
+            QString::fromStdString(Base::currentNumericLocaleContext().localeId),
+            QStringLiteral("en_US")
+        );
+
+        Gui::Translator::instance()->setLocale("German");
+        const auto formattingState = Base::currentNumericLocaleContext();
+
+        QCOMPARE(QLocale().name(), QStringLiteral("de_DE"));
+        QCOMPARE(QLocale().decimalPoint(), QChar(','));
+        QCOMPARE(QLocale().groupSeparator(), QChar('.'));
+        QCOMPARE(QString::fromStdString(formattingState.localeId), QStringLiteral("de_DE"));
+        QCOMPARE(QString::fromStdString(formattingState.decimalSeparator), QStringLiteral(","));
+        QCOMPARE(QString::fromStdString(formattingState.groupingSeparator), QStringLiteral("."));
+        QCOMPARE(QString::fromStdString(formattingState.positiveSign), QStringLiteral("+"));
+        QCOMPARE(QString::fromStdString(formattingState.negativeSign), QStringLiteral("-"));
+        QCOMPARE(formattingState.primaryGroupingSize, 3);
+        QCOMPARE(formattingState.secondaryGroupingSize, 3);
+        QCOMPARE(QString::fromLatin1(icu::Locale::getDefault().getName()), QStringLiteral("de_DE"));
+    }
+
+    void test_WidgetLocaleContextIsCompleteAndIndependentOfPublishedState()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeEnvironment {
+            {.qtLocale = "da_DK", .formattingLocale = "fr_FR", .icuLocale = "fr_FR"}
+        };
+        const QLocale widgetLocale(QStringLiteral("en_IN"));
+
+        const auto context = Gui::numericLocaleContextFor(widgetLocale);
+
+        QCOMPARE(QString::fromStdString(context.localeId), QStringLiteral("en_IN"));
+        QCOMPARE(QString::fromStdString(context.decimalSeparator), QString(widgetLocale.decimalPoint()));
+        QCOMPARE(
+            QString::fromStdString(context.groupingSeparator),
+            QString(widgetLocale.groupSeparator())
+        );
+        QCOMPARE(QString::fromStdString(context.positiveSign), QString(widgetLocale.positiveSign()));
+        QCOMPARE(QString::fromStdString(context.negativeSign), QString(widgetLocale.negativeSign()));
+        QCOMPARE(context.primaryGroupingSize, 3);
+        QCOMPARE(context.secondaryGroupingSize, 2);
+        QVERIFY(context != Base::currentNumericLocaleContext());
+    }
+
+    void test_OperatingSystemFormattingUsesSystemLocaleSeparators()  // NOLINT
+    {
+        auto general = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/General"
+        );
+        const int previousPreference = general->GetInt("UseLocaleFormatting", 0);
+
+        general->SetInt(
+            "UseLocaleFormatting",
+            static_cast<int>(Gui::Translator::LocaleFormattingPreference::OperatingSystem)
+        );
+        Gui::Translator::instance()->applyLocaleFormattingPreference();
+
+        const auto systemLocale = QLocale::system();
+        const auto formatting = Base::currentNumericLocaleContext();
+        QCOMPARE(
+            QString::fromStdString(formatting.decimalSeparator),
+            QString(systemLocale.decimalPoint())
+        );
+        QCOMPARE(
+            QString::fromStdString(formatting.groupingSeparator),
+            QString(systemLocale.groupSeparator())
+        );
+
+        general->SetInt("UseLocaleFormatting", previousPreference);
+    }
+};
+
+// NOLINTEND(readability-magic-numbers)
+
+QTEST_MAIN(testTranslatorLocale)
+
+#include "TranslatorLocale.moc"

--- a/tests/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/tests/src/Gui/propertyeditor/PropertyItem.cpp
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <QDebug>
+#include <QLineEdit>
 #include <QtTest/QTest>
 
 #include <App/Application.h>
+#include <Base/Quantity.h>
 
+#include "Gui/QuantitySpinBox.h"
 #include "Gui/propertyeditor/PropertyItem.h"
 #include <src/App/InitApplication.h>
+#include <src/LocaleTestHelpers.h>
 
 // NOLINTBEGIN(readability-magic-numbers)
 
@@ -37,6 +41,14 @@ protected:
 private:
     QVariant testValue;
     QVariant storedSetValue;
+};
+
+class TestPropertyUnitItem final: public Gui::PropertyEditor::PropertyUnitItem
+{
+public:
+    TestPropertyUnitItem()
+        : PropertyUnitItem()
+    {}
 };
 
 class testPropertyItem: public QObject
@@ -98,6 +110,38 @@ private Q_SLOTS:
     {
         item->setPropertyName(QLatin1String("Box_Length"));
         QCOMPARE(item->propertyName(), QLatin1String("Box_Length"));
+    }
+
+    void test_quantityEditorUsesItsWidgetLocale()  // NOLINT
+    {
+        tests::ScopedLocaleEnvironment localeState {
+            {.qtLocale = "da_DK", .formattingLocale = "de_DE", .icuLocale = "fr_FR"}
+        };
+
+        TestPropertyUnitItem unitItem;
+        QWidget parent;
+        auto* editor = unitItem.createEditor(&parent, [] {});
+        auto* spinBox = qobject_cast<Gui::QuantitySpinBox*>(editor);
+        QVERIFY(spinBox != nullptr);
+        if (!spinBox) {
+            return;
+        }
+
+        spinBox->setLocale(QLocale(QStringLiteral("en_US")));
+        unitItem.setEditorData(spinBox, QVariant::fromValue<Base::Quantity>(Base::Quantity(10.0, "mm")));
+        spinBox->show();
+        spinBox->setFocus();
+
+        auto* lineEdit = spinBox->findChild<QLineEdit*>();
+        QVERIFY(lineEdit != nullptr);
+        if (!lineEdit) {
+            return;
+        }
+        lineEdit->setText(QStringLiteral("12,345.67 mm"));
+        QTest::keyClick(spinBox, Qt::Key_Return);
+
+        QCOMPARE(spinBox->rawValue(), 12345.67);
+        QVERIFY(spinBox->hasValidInput());
     }
 
 private:

--- a/tests/src/LocaleTestHelpers.h
+++ b/tests/src/LocaleTestHelpers.h
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <QLocale>
+#include <QString>
+
+#include <Base/NumericFormatting.h>
+
+#include <unicode/locid.h>
+#include <unicode/utypes.h>
+
+namespace tests
+{
+namespace detail
+{
+inline icu::Locale toIcuLocale(std::string_view localeId)
+{
+    if (Base::isCLocaleName(localeId)) {
+        return icu::Locale("en_US_POSIX");
+    }
+
+    const std::string localeName(localeId);
+    return icu::Locale::createFromName(localeName.c_str());
+}
+
+inline QLocale toQtLocale(std::string_view localeName)
+{
+    return QLocale(QString::fromUtf8(localeName.data(), static_cast<int>(localeName.size())));
+}
+
+inline std::string toUtf8(const QString& text)
+{
+    const QByteArray utf8 = text.toUtf8();
+    return std::string(utf8.constData(), utf8.size());
+}
+}  // namespace detail
+
+class ScopedNumericLocaleContext
+{
+public:
+    explicit ScopedNumericLocaleContext(Base::NumericLocaleContext next)
+        : previous {Base::currentNumericLocaleContext()}
+    {
+        Base::publishNumericLocaleContext(std::move(next));
+    }
+
+    ~ScopedNumericLocaleContext()
+    {
+        Base::publishNumericLocaleContext(previous);
+    }
+
+    ScopedNumericLocaleContext(const ScopedNumericLocaleContext&) = delete;
+    ScopedNumericLocaleContext(ScopedNumericLocaleContext&&) = delete;
+    ScopedNumericLocaleContext& operator=(const ScopedNumericLocaleContext&) = delete;
+    ScopedNumericLocaleContext& operator=(ScopedNumericLocaleContext&&) = delete;
+
+private:
+    Base::NumericLocaleContext previous;
+};
+
+struct LocaleEnvironmentConfig
+{
+    std::optional<std::string_view> qtLocale {};
+    std::optional<std::string_view> formattingLocale {};
+    std::optional<std::string_view> icuLocale {};
+    bool useQtSeparators {false};
+};
+
+class ScopedLocaleEnvironment
+{
+public:
+    explicit ScopedLocaleEnvironment(const LocaleEnvironmentConfig& config = {})
+        : previousQt {QLocale()}
+        , previousIcu {icu::Locale::getDefault()}
+        , previousFormatting {Base::currentNumericLocaleContext()}
+    {
+        std::optional<QLocale> qtLocale;
+        if (config.qtLocale) {
+            qtLocale = detail::toQtLocale(*config.qtLocale);
+            QLocale::setDefault(*qtLocale);
+        }
+
+        if (config.icuLocale) {
+            UErrorCode status = U_ZERO_ERROR;
+            icu::Locale::setDefault(detail::toIcuLocale(*config.icuLocale), status);
+        }
+
+        if (config.formattingLocale || config.useQtSeparators) {
+            auto formatting = config.formattingLocale
+                ? Base::createNumericLocaleContext(*config.formattingLocale)
+                : previousFormatting;
+            if (config.useQtSeparators) {
+                const QLocale& locale = qtLocale ? *qtLocale : QLocale();
+                formatting.decimalSeparator = detail::toUtf8(QString(locale.decimalPoint()));
+                formatting.groupingSeparator = detail::toUtf8(QString(locale.groupSeparator()));
+                formatting.positiveSign = detail::toUtf8(QString(locale.positiveSign()));
+                formatting.negativeSign = detail::toUtf8(QString(locale.negativeSign()));
+                formatting.zeroDigit = detail::toUtf8(QString(locale.zeroDigit()));
+                const auto groups = locale.toString(123456789.0, 'f', 0)
+                                        .split(locale.groupSeparator(), Qt::KeepEmptyParts);
+                if (groups.size() > 1) {
+                    formatting.primaryGroupingSize = groups.back().size();
+                    formatting.secondaryGroupingSize = groups.size() > 2
+                        ? groups[groups.size() - 2].size()
+                        : formatting.primaryGroupingSize;
+                }
+            }
+            Base::publishNumericLocaleContext(std::move(formatting));
+        }
+    }
+
+    ~ScopedLocaleEnvironment()
+    {
+        Base::publishNumericLocaleContext(previousFormatting);
+
+        UErrorCode status = U_ZERO_ERROR;
+        icu::Locale::setDefault(previousIcu, status);
+        QLocale::setDefault(previousQt);
+    }
+
+    ScopedLocaleEnvironment(const ScopedLocaleEnvironment&) = delete;
+    ScopedLocaleEnvironment(ScopedLocaleEnvironment&&) = delete;
+    ScopedLocaleEnvironment& operator=(const ScopedLocaleEnvironment&) = delete;
+    ScopedLocaleEnvironment& operator=(ScopedLocaleEnvironment&&) = delete;
+
+private:
+    QLocale previousQt;
+    icu::Locale previousIcu;
+    Base::NumericLocaleContext previousFormatting;
+};
+
+}  // namespace tests


### PR DESCRIPTION
Fixes #29340

## Problem

Localized quantity input was handled differently across `QuantitySpinBox`, `InputField`, quantity parsing, and expression parsing.

This caused several user-visible issues:

* locale decimal and grouping separators could be interpreted inconsistently
* grouped values could work in quantity fields but fail in expressions
* malformed grouping could be silently stripped or rejected without feedback
* widgets could parse using locale state different from what they displayed
* localized signs, native digits, and scientific notation did not reliably round-trip

## Summary

This PR introduces a shared localized-number scanner and a common App-level quantity-input interpretation path.

The responsibilities are split between:

* `Base`: localized numeric scanning and formatting
* `App`: quantity/expression interpretation and default-unit semantics
* `Gui`: widget locale handling, validation, and user feedback

Canonical parsing APIs remain locale-independent for persistence, scripting, and internal expression syntax.

## Localized numeric input

`Base::scanLocalizedNumber()` recognizes one numeric token using an explicit locale context, including:

* decimal and grouping separators
* Western and secondary grouping patterns
* localized signs and native digits
* scientific notation
* canonical numeric syntax where unambiguous

Grouping must match the locale exactly. For example:

```text
en_US: 1,234.5 mm   -> 1234.5 mm
en_IN: 12,34,567 mm -> 1234567 mm
de_DE: 1.234,5 mm   -> 1234.5 mm
```

Malformed grouping such as `12,34,567 mm` or `12 345 mm` in `en_US` is rejected.

## Quantity and expression input

Localized numbers are normalized before reaching the canonical expression parser.

Function argument separators remain structural, so for example:

```text
en_US: pow(1,234) -> two arguments
de_DE: pow(1,234) -> decimal 1.234
de_DE: pow(1;234) -> two arguments
```

Unbound quantity fields keep the quantity parser as the authority for legacy quantity syntax, with expression parsing used as a fallback for arithmetic. Bound fields use expression syntax directly.

For expression-capable quantity fields, dimensionless additive terms inherit the field's default unit while preserving expression dependencies.

## Editable quantity behavior

`QuantitySpinBox` and `InputField` now parse using their effective widget locale and share the same validation path.

Invalid committed input:

* remains visible
* preserves the previous valid quantity
* reports an error instead of failing silently
* selects the offending range where available
* does not emit Return as a successful commit
* can be restored with Escape

Editable formatting is also required to round-trip to the same quantity. Ambiguous grouping is suppressed in locales where a grouped value such as `1.234` could otherwise be interpreted as a canonical decimal.

## Tests

Regression coverage includes localized grouping and decimals, malformed grouping, function-argument ambiguity, localized signs and digits, locale mismatches, default-unit expressions and dependencies, editable-text round trips, widget signal behavior, and invalid-edit feedback.
