### PR TITLE
CAM: add probe annotation for filename

### DIFF
--- a/src/Mod/CAM/Path/Op/Probe.py
+++ b/src/Mod/CAM/Path/Op/Probe.py
@@ -95,13 +95,12 @@ class ObjectProbing(PathOp.ObjectOp):
             Path.Log.warning("No suitable probe tool found")
             return
 
-        self.commandlist.append(Path.Command("(Begin Probing)"))
+        # annotation so the PP has canonical signal for open/close, and gets the filename
+        self.commandlist.append(Path.Command(f"(Begin Probing {obj.OutputFileName})", {}, {"probe_open" : obj.OutputFileName}))
 
         stock = PathUtils.findParentJob(obj).Stock
         bb = stock.Shape.BoundBox
 
-        openstring = "(PROBEOPEN {})".format(obj.OutputFileName)
-        self.commandlist.append(Path.Command(openstring))
         self.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeight.Value}))
 
         for y in self.nextpoint(bb.YMin, bb.YMax, obj.PointCountY):
@@ -127,7 +126,8 @@ class ObjectProbing(PathOp.ObjectOp):
                 )
                 self.commandlist.append(Path.Command("G0", {"Z": obj.SafeHeight.Value}))
 
-        self.commandlist.append(Path.Command("(PROBECLOSE)"))
+        # annotation so the PP has canonical signal for open/close
+        self.commandlist.append(Path.Command("(PROBECLOSE)", {}, {"probe_close" : ""}))
 
     def opSetDefaultValues(self, obj, job):
         """opSetDefaultValues(obj, job) ... set default value for RetractHeight"""

--- a/src/Mod/CAM/Path/Op/Probe.py
+++ b/src/Mod/CAM/Path/Op/Probe.py
@@ -96,7 +96,11 @@ class ObjectProbing(PathOp.ObjectOp):
             return
 
         # annotation so the PP has canonical signal for open/close, and gets the filename
-        self.commandlist.append(Path.Command(f"(Begin Probing {obj.OutputFileName})", {}, {"probe_open" : obj.OutputFileName}))
+        self.commandlist.append(
+            Path.Command(
+                f"(Begin Probing {obj.OutputFileName})", {}, {"probe_open": obj.OutputFileName}
+            )
+        )
 
         stock = PathUtils.findParentJob(obj).Stock
         bb = stock.Shape.BoundBox
@@ -127,7 +131,7 @@ class ObjectProbing(PathOp.ObjectOp):
                 self.commandlist.append(Path.Command("G0", {"Z": obj.SafeHeight.Value}))
 
         # annotation so the PP has canonical signal for open/close
-        self.commandlist.append(Path.Command("(PROBECLOSE)", {}, {"probe_close" : ""}))
+        self.commandlist.append(Path.Command("(PROBECLOSE)", {}, {"probe_close": ""}))
 
     def opSetDefaultValues(self, obj, job):
         """opSetDefaultValues(obj, job) ... set default value for RetractHeight"""

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -1954,16 +1954,16 @@ class PostProcessor:
 
         # Comments
         if command_name.startswith("("):
-            gcode = [ self._convert_comment(command) ]
+            gcode = [self._convert_comment(command)]
 
             # We use comments for some sequence signals (Probe, etc.)
-            if 'probe_open' in command.Annotations:
-                gcode.append( self._convert_probe_open(command) )
-            elif 'probe_close' in command.Annotations:
-                gcode.append( self._convert_probe_close(command) )
+            if "probe_open" in command.Annotations:
+                gcode.append(self._convert_probe_open(command))
+            elif "probe_close" in command.Annotations:
+                gcode.append(self._convert_probe_close(command))
 
             # drop None/""
-            return "\n".join( [l for l in gcode if l] )
+            return "\n".join([l for l in gcode if l])
 
         # Rapid moves
         if command_name in Constants.GCODE_MOVE_RAPID:

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -1907,6 +1907,9 @@ class PostProcessor:
     def convert_command_to_gcode(self, command: Path.Command) -> str:
         """
         Converts a single-line command to gcode.
+        Return one-string
+            use "\n" to join multiple-lines
+        Return None or "" for nothing.
 
         This method dispatches to specialized hook methods based on command type.
         Derived postprocessors can override individual hook methods to customize
@@ -1951,7 +1954,16 @@ class PostProcessor:
 
         # Comments
         if command_name.startswith("("):
-            return self._convert_comment(command)
+            gcode = [ self._convert_comment(command) ]
+
+            # We use comments for some sequence signals (Probe, etc.)
+            if 'probe_open' in command.Annotations:
+                gcode.append( self._convert_probe_open(command) )
+            elif 'probe_close' in command.Annotations:
+                gcode.append( self._convert_probe_close(command) )
+
+            # drop None/""
+            return "\n".join( [l for l in gcode if l] )
 
         # Rapid moves
         if command_name in Constants.GCODE_MOVE_RAPID:
@@ -2238,10 +2250,30 @@ class PostProcessor:
     def _convert_probe(self, command: Path.Command) -> str:
         """
         Converts a probe command to gcode.
+        _convert_probe_open(command) is called to start the sequence
+        _convert_probe_close(command) is called to end the sequence
 
         This method can be overridden by derived postprocessors to customize probe handling.
         """
         return self._convert_move(command)
+
+    def _convert_probe_open(self, command: Path.Command) -> str:
+        """Probe sequence is starting, do your prefix
+            command is a comment, already processed as a comment.
+            command.Annotations["probe_open"] has the filename from the operation
+                if the filename is "", generate something from the section_name, Postable.Name, "probe", and count
+
+        This method can be overridden by derived postprocessors to customize handling.
+        """
+        return None
+
+    def _convert_probe_close(self, command: Path.Command) -> str:
+        """Probe sequence is ended, do your postfix
+            command is a comment, already processed as a comment.
+
+        This method can be overridden by derived postprocessors to customize handling.
+        """
+        return None
 
     def _convert_dwell(self, command: Path.Command) -> str:
         """


### PR DESCRIPTION
Add the Probe operation's filename as an annotation, and use as signal.

Most PP's will want the filename, and signals for open/close (start/end) for the probe sequence. E.g. opensbp will need that.

Demonstrates adding and using such information. Something similar is anticipated for tool-change (tool-name, etc. for better error messages).

## Issues

Part of #29282