### PR TITLE
Tools/CI: Fix linter arg passing

### DIFF
--- a/.github/workflows/CI_primary.yml
+++ b/.github/workflows/CI_primary.yml
@@ -65,11 +65,9 @@ jobs:
     with:
       artifactBasename: Lint-${{ github.run_id }}
       changedFiles: ${{ needs.Prepare.outputs.changedFiles }}
-      changedLines: ${{ needs.Prepare.outputs.changedLines }}
       changedCppFiles: ${{ needs.Prepare.outputs.changedCppFiles }}
       changedCppLines: ${{ needs.Prepare.outputs.changedCppLines }}
       changedPythonFiles: ${{ needs.Prepare.outputs.changedPythonFiles }}
-      changedPythonLines: ${{ needs.Prepare.outputs.changedPythonLines }}
 
   WrapUp:
     needs: [

--- a/.github/workflows/sub_lint.yml
+++ b/.github/workflows/sub_lint.yml
@@ -230,7 +230,7 @@ jobs:
         run: |
           python3 tools/lint/generic_checks.py \
             --lineendings-check \
-            --files "${{ inputs.changedFiles }}" \
+            --files ${{ inputs.changedFiles }} \
             --report-file "${{ env.reportdir }}${{ env.reportfilename }}" \
             --log-dir "${{ env.logdir }}"
 
@@ -240,7 +240,7 @@ jobs:
         run: |
           python3 tools/lint/generic_checks.py \
             --whitespace-check \
-            --files "${{ inputs.changedFiles }}" \
+            --files ${{ inputs.changedFiles }} \
             --report-file "${{ env.reportdir }}${{ env.reportfilename }}" \
             --log-dir "${{ env.logdir }}"
 
@@ -250,7 +250,7 @@ jobs:
         run: |
           python3 tools/lint/generic_checks.py \
             --tabs-check \
-            --files "${{ inputs.changedFiles }}" \
+            --files ${{ inputs.changedFiles }} \
             --report-file "${{ env.reportdir }}${{ env.reportfilename }}" \
             --log-dir "${{ env.logdir }}"
 
@@ -270,7 +270,7 @@ jobs:
         continue-on-error: ${{ inputs.pylintFailSilent }}
         run: |
           python3 tools/lint/pylint.py \
-            --files "${{ inputs.changedPythonFiles }}" \
+            --files ${{ inputs.changedPythonFiles }} \
             --disable "${{ inputs.pylintDisable }}" \
             --log-dir "${{ env.logdir }}" \
             --report-file "${{ env.reportdir }}${{ env.reportfilename }}"
@@ -280,7 +280,7 @@ jobs:
         continue-on-error: ${{ inputs.blackFailSilent }}
         run: |
           python3 tools/lint/black.py \
-            --files "${{ inputs.changedPythonFiles }}" \
+            --files ${{ inputs.changedPythonFiles }} \
             --log-dir "${{ env.logdir }}" \
             --report-file "${{ env.reportdir }}${{ env.reportfilename }}"
 
@@ -289,7 +289,6 @@ jobs:
         run: |
           export PATH="$HOME/.local/bin:$PATH"
           python3 tools/lint/python_stubs.py \
-            --files "${{ inputs.changedFiles }}" \
             --log-dir "${{ env.logdir }}" \
             --report-file "${{ env.reportdir }}${{ env.reportfilename }}"
 
@@ -309,7 +308,7 @@ jobs:
         continue-on-error: ${{ inputs.qtConnectionsFailSilent }}
         run: |
           python3 tools/lint/qt_connections.py \
-            --files "${{ inputs.changedFiles }}" \
+            --files ${{ inputs.changedFiles }} \
             --log-dir "${{ env.logdir }}" \
             --report-file "${{ env.reportdir }}${{ env.reportfilename }}"
 
@@ -318,7 +317,7 @@ jobs:
         continue-on-error: ${{ inputs.cpplintFailSilent }}
         run: |
           python3 tools/lint/cpplint.py \
-            --files "${{ inputs.changedCppFiles }}" \
+            --files ${{ inputs.changedCppFiles }} \
             --log-dir "${{ env.logdir }}" \
             --report-file "${{ env.reportdir }}${{ env.reportfilename }}"
 
@@ -327,7 +326,7 @@ jobs:
         continue-on-error: ${{ inputs.clangFormatFailSilent }}
         run: |
           python3 tools/lint/clang_format.py \
-            --files "${{ inputs.changedCppFiles }}" \
+            --files ${{ inputs.changedCppFiles }} \
             --clang-style "${{ inputs.clangStyle }}" \
             --log-dir "${{ env.logdir }}" \
             --report-file "${{ env.reportdir }}${{ env.reportfilename }}"
@@ -348,7 +347,7 @@ jobs:
         continue-on-error: ${{ inputs.clangTidyFailSilent }}
         run: |
           python3 tools/lint/clang_tidy.py \
-            --files "${{ inputs.changedCppFiles }}" \
+            --files ${{ inputs.changedCppFiles }} \
             --line-filter '${{ inputs.changedCppLines }}' \
             --clang-style "${{ inputs.clangStyle }}" \
             --log-dir "${{ env.logdir }}" \
@@ -359,7 +358,7 @@ jobs:
         continue-on-error: ${{ inputs.clazyFailSilent }}
         run: |
           python3 tools/lint/clazy.py \
-            --files "${{ inputs.changedCppFiles }}" \
+            --files ${{ inputs.changedCppFiles }} \
             --clazy-checks "${{ inputs.clazyChecks }}" \
             --log-dir "${{ env.logdir }}" \
             --report-file "${{ env.reportdir }}${{ env.reportfilename }}"
@@ -369,7 +368,7 @@ jobs:
         continue-on-error: ${{ inputs.clazyQT6FailSilent }}
         run: |
           python3 tools/lint/clazy_qt6.py \
-            --files "${{ inputs.changedCppFiles }}" \
+            --files ${{ inputs.changedCppFiles }} \
             --clazy-qt6-checks "${{ inputs.clazyQT6Checks }}" \
             --log-dir "${{ env.logdir }}" \
             --report-file "${{ env.reportdir }}${{ env.reportfilename }}"

--- a/.github/workflows/sub_lint.yml
+++ b/.github/workflows/sub_lint.yml
@@ -21,7 +21,10 @@
 # *                                                                         *
 # ***************************************************************************
 
-# This is the lint workflow for CI of FreeCAD
+# This is the lint workflow for CI of FreeCAD.
+# Formatting checks (black, clang-format, trailing whitespace, line endings,
+# tabs) are handled by pre-commit, so they are intentionally not duplicated
+# here.
 
 name: Lint
 
@@ -34,9 +37,6 @@ on:
       changedFiles:
         type: string
         required: true
-      changedLines:
-        type: string
-        required: false
       changedCppFiles:
         type: string
         required: true
@@ -46,46 +46,11 @@ on:
       changedPythonFiles:
         type: string
         required: true
-      changedPythonLines:
-        type: string
-        required: false
-      checkLineendings:
-        default: false
-        type: boolean
-        required: false
-      lineendingsFailSilent:
-        default: true
-        type: boolean
-        required: false
-      checkWhitespace:
-        default: true
-        type: boolean
-        required: false
-      whitespaceFailSilent:
-        default: true
-        type: boolean
-        required: false
-      checkTabs:
-        default: true
-        type: boolean
-        required: false
-      tabsFailSilent:
-        default: true
-        type: boolean
-        required: false
       checkQtConnections:
         default: true
         type: boolean
         required: false
       qtConnectionsFailSilent:
-        default: true
-        type: boolean
-        required: false
-      checkCpplint:
-        default: true
-        type: boolean
-        required: false
-      cpplintFailSilent:
         default: true
         type: boolean
         required: false
@@ -101,25 +66,9 @@ on:
         default: true
         type: boolean
         required: false
-      checkBlack:
-        default: true
-        type: boolean
-        required: false
-      blackFailSilent:
-        default: true
-        type: boolean
-        required: false
-      checkClangFormat:
-        default: false
-        type: boolean
-        required: false
       clangStyle:
         default: file # for .clang-format file
         type: string
-        required: false
-      clangFormatFailSilent:
-        default: true
-        type: boolean
         required: false
       checkSpelling:
         default: true
@@ -142,34 +91,6 @@ on:
         type: boolean
         required: false
       clangTidyFailSilent:
-        default: true # warnings or notes will never fail the CI, only errors
-        type: boolean
-        required: false
-      checkClazy: # for the Message codes see: https://invent.kde.org/sdk/clazy#list-of-checks
-        default: false
-        type: boolean
-        required: false
-      clazyChecks:
-        default: level2,no-non-pod-global-static,no-copyable-polymorphic
-        type: string
-        required: false
-      clazyFailSilent:
-        default: true # warnings or notes will never fail the CI, only errors
-        type: boolean
-        required: false
-      checkClazyQT6:
-        default: false
-        type: boolean
-        required: false
-      clazyQT6Checks:
-        default: qt6-deprecated-api-fixes,qt6-header-fixes,qt6-qhash-signature,qt6-fwd-fixes,missing-qobject-macro # for QT6 Porting https://invent.kde.org/sdk/clazy#list-of-checks
-        type: string
-        required: false
-      QT6Branch: # branch to check for QT6 Porting
-        default: main
-        type: string
-        required: false
-      clazyQT6FailSilent:
         default: true # warnings or notes will never fail the CI, only errors
         type: boolean
         required: false
@@ -224,36 +145,6 @@ jobs:
       - name: Check File Case Sensitivity
         uses: credfeto/action-case-checker@cb652aeab29ed363bbdb7d9ee1bfcc010c46cac5 # v1.3.0
 
-      - name: Check for non Unix line ending
-        if: inputs.checkLineendings && always()
-        continue-on-error: ${{ inputs.lineendingsFailSilent }}
-        run: |
-          python3 tools/lint/generic_checks.py \
-            --lineendings-check \
-            --files ${{ inputs.changedFiles }} \
-            --report-file "${{ env.reportdir }}${{ env.reportfilename }}" \
-            --log-dir "${{ env.logdir }}"
-
-      - name: Check for trailing whitespaces
-        if: inputs.checkWhitespace && always()
-        continue-on-error: ${{ inputs.whitespaceFailSilent }}
-        run: |
-          python3 tools/lint/generic_checks.py \
-            --whitespace-check \
-            --files ${{ inputs.changedFiles }} \
-            --report-file "${{ env.reportdir }}${{ env.reportfilename }}" \
-            --log-dir "${{ env.logdir }}"
-
-      - name: Check for Tab usage
-        if: inputs.checkTabs && always()
-        continue-on-error: ${{ inputs.tabsFailSilent }}
-        run: |
-          python3 tools/lint/generic_checks.py \
-            --tabs-check \
-            --files ${{ inputs.changedFiles }} \
-            --report-file "${{ env.reportdir }}${{ env.reportfilename }}" \
-            --log-dir "${{ env.logdir }}"
-
     # Python linting steps
 
       - name: Set up pixi for stub smoke checks
@@ -272,15 +163,6 @@ jobs:
           python3 tools/lint/pylint.py \
             --files ${{ inputs.changedPythonFiles }} \
             --disable "${{ inputs.pylintDisable }}" \
-            --log-dir "${{ env.logdir }}" \
-            --report-file "${{ env.reportdir }}${{ env.reportfilename }}"
-
-      - name: Black
-        if: inputs.checkBlack && inputs.changedPythonFiles != '' && always()
-        continue-on-error: ${{ inputs.blackFailSilent }}
-        run: |
-          python3 tools/lint/black.py \
-            --files ${{ inputs.changedPythonFiles }} \
             --log-dir "${{ env.logdir }}" \
             --report-file "${{ env.reportdir }}${{ env.reportfilename }}"
 
@@ -308,26 +190,7 @@ jobs:
         continue-on-error: ${{ inputs.qtConnectionsFailSilent }}
         run: |
           python3 tools/lint/qt_connections.py \
-            --files ${{ inputs.changedFiles }} \
-            --log-dir "${{ env.logdir }}" \
-            --report-file "${{ env.reportdir }}${{ env.reportfilename }}"
-
-      - name: Cpplint
-        if: inputs.checkCpplint && inputs.changedCppFiles != '' && always()
-        continue-on-error: ${{ inputs.cpplintFailSilent }}
-        run: |
-          python3 tools/lint/cpplint.py \
             --files ${{ inputs.changedCppFiles }} \
-            --log-dir "${{ env.logdir }}" \
-            --report-file "${{ env.reportdir }}${{ env.reportfilename }}"
-
-      - name: Clang-format
-        if: inputs.checkClangFormat && inputs.changedCppFiles != '' && always()
-        continue-on-error: ${{ inputs.clangFormatFailSilent }}
-        run: |
-          python3 tools/lint/clang_format.py \
-            --files ${{ inputs.changedCppFiles }} \
-            --clang-style "${{ inputs.clangStyle }}" \
             --log-dir "${{ env.logdir }}" \
             --report-file "${{ env.reportdir }}${{ env.reportfilename }}"
 
@@ -350,26 +213,6 @@ jobs:
             --files ${{ inputs.changedCppFiles }} \
             --line-filter '${{ inputs.changedCppLines }}' \
             --clang-style "${{ inputs.clangStyle }}" \
-            --log-dir "${{ env.logdir }}" \
-            --report-file "${{ env.reportdir }}${{ env.reportfilename }}"
-
-      - name: Clazy
-        if: inputs.checkClazy && inputs.changedCppFiles != '' && always()
-        continue-on-error: ${{ inputs.clazyFailSilent }}
-        run: |
-          python3 tools/lint/clazy.py \
-            --files ${{ inputs.changedCppFiles }} \
-            --clazy-checks "${{ inputs.clazyChecks }}" \
-            --log-dir "${{ env.logdir }}" \
-            --report-file "${{ env.reportdir }}${{ env.reportfilename }}"
-
-      - name: Clazy-QT6
-        if: inputs.checkClazyQT6 && inputs.changedCppFiles != '' && github.ref == inputs.QT6Branch && always()
-        continue-on-error: ${{ inputs.clazyQT6FailSilent }}
-        run: |
-          python3 tools/lint/clazy_qt6.py \
-            --files ${{ inputs.changedCppFiles }} \
-            --clazy-qt6-checks "${{ inputs.clazyQT6Checks }}" \
             --log-dir "${{ env.logdir }}" \
             --report-file "${{ env.reportdir }}${{ env.reportfilename }}"
 

--- a/tools/lint/black.py
+++ b/tools/lint/black.py
@@ -78,7 +78,7 @@ def main():
         "--line-length",
         str(DEFAULT_LINE_LENGTH_LIMIT),
         "--check",
-    ] + args.files.split()
+    ] + args.files
     stdout, stderr, exit_code = run_command(cmd, check=False)
     output = stdout + "\n" + stderr
 

--- a/tools/lint/clang_format.py
+++ b/tools/lint/clang_format.py
@@ -59,10 +59,13 @@ def main():
     args = parser.parse_args()
     init_environment(args)
 
-    cmd = (
-        f"clang-format --dry-run --ferror-limit=1 --verbose "
-        f"--style={args.clang_style} {args.files}"
-    )
+    cmd = [
+        "clang-format",
+        "--dry-run",
+        "--ferror-limit=1",
+        "--verbose",
+        f"--style={args.clang_style}",
+    ] + args.files
     stdout, stderr, _ = run_command(cmd)
     output = stdout + "\n" + stderr
 

--- a/tools/lint/clang_tidy.py
+++ b/tools/lint/clang_tidy.py
@@ -47,9 +47,7 @@ def generate_markdown_report(
     report_lines.append("````")
     report_lines.append("</details>")
     report_lines.append("")
-    report_lines.append(
-        "<details><summary>:information_source: Enabled checks</summary>"
-    )
+    report_lines.append("<details><summary>:information_source: Enabled checks</summary>")
     report_lines.append("")
     report_lines.append("````")
     report_lines.append(enabled_checks_content)

--- a/tools/lint/clang_tidy.py
+++ b/tools/lint/clang_tidy.py
@@ -104,7 +104,7 @@ def main():
     clang_cmd = clang_tidy_base_cmd
     if args.line_filter:
         clang_cmd = clang_cmd + [f"--line-filter={args.line_filter}"]
-    clang_cmd = clang_cmd + args.files.split()
+    clang_cmd = clang_cmd + args.files
     print("clang_cmd = ", clang_cmd)
     clang_stdout, clang_stderr, _ = run_command(clang_cmd)
     clang_tidy_output = clang_stdout + clang_stderr

--- a/tools/lint/clazy.py
+++ b/tools/lint/clazy.py
@@ -57,7 +57,8 @@ def main():
     parser.add_argument(
         "--files",
         required=True,
-        help="A space-separated list (or glob-expanded string) of C++ files to check.",
+        nargs="+",
+        help="List of C++ files to check.",
     )
     parser.add_argument(
         "--clazy-checks",
@@ -80,9 +81,7 @@ def main():
     fix_file = "clazy.yaml"
 
     output = ""
-    file_list = args.files.split()
-
-    for file in file_list:
+    for file in args.files:
         cmd = [
             "clazy-standalone",
             f"--export-fixes={fix_file}",

--- a/tools/lint/clazy.py
+++ b/tools/lint/clazy.py
@@ -104,9 +104,7 @@ def main():
     warnings_count = len(re.findall(warning_pattern, output, re.MULTILINE))
     notes_count = len(re.findall(note_pattern, output, re.MULTILINE))
 
-    logging.info(
-        f"Found {errors_count} errors, {warnings_count} warnings, {notes_count} notes"
-    )
+    logging.info(f"Found {errors_count} errors, {warnings_count} warnings, {notes_count} notes")
 
     report = generate_markdown_report(output, errors_count, warnings_count, notes_count)
     append_file(args.report_file, report + "\n")

--- a/tools/lint/clazy_qt6.py
+++ b/tools/lint/clazy_qt6.py
@@ -107,9 +107,7 @@ def main():
     warnings_count = count_occurrences(warning_pattern, output)
     notes_count = count_occurrences(note_pattern, output)
 
-    logging.info(
-        f"Found {errors_count} errors, {warnings_count} warnings, {notes_count} notes"
-    )
+    logging.info(f"Found {errors_count} errors, {warnings_count} warnings, {notes_count} notes")
 
     report = generate_markdown_report(output, errors_count, warnings_count, notes_count)
     append_file(args.report_file, report + "\n")

--- a/tools/lint/clazy_qt6.py
+++ b/tools/lint/clazy_qt6.py
@@ -59,7 +59,8 @@ def main():
     parser.add_argument(
         "--files",
         required=True,
-        help="A space-separated list (or glob-expanded string) of C++ files to check.",
+        nargs="+",
+        help="List of C++ files to check.",
     )
     parser.add_argument(
         "--clazy-qt6-checks",
@@ -90,7 +91,7 @@ def main():
         f"-checks={args.clazy_qt6_checks}",
         "-p",
         build_dir,
-    ] + args.files.split()
+    ] + args.files
 
     stdout, stderr, _ = run_command(cmd)
     output = stdout + stderr

--- a/tools/lint/codespell.py
+++ b/tools/lint/codespell.py
@@ -54,35 +54,18 @@ def main():
     parser = argparse.ArgumentParser(
         description="Run codespell on files and append a Markdown report."
     )
-    parser.add_argument(
-        "--files",
-        nargs="+",
-        required=True,
-        help="List of files to spell check."
-    )
+    parser.add_argument("--files", nargs="+", required=True, help="List of files to spell check.")
     parser.add_argument(
         "--ignore-words",
         required=True,
         help="Comma-separated list of words to ignore (from codespellignore).",
     )
-    parser.add_argument(
-        "--log-dir",
-        required=True,
-        help="Directory to store the log file."
-    )
-    parser.add_argument(
-        "--report-file",
-        required=True,
-        help="Name of the report file."
-    )
+    parser.add_argument("--log-dir", required=True, help="Directory to store the log file.")
+    parser.add_argument("--report-file", required=True, help="Name of the report file.")
     parser.add_argument(
         "--skip", required=True, help="Comma-separated list of file patterns to skip."
     )
-    parser.add_argument(
-        "--verbose",
-        action='store_true',
-        help="Use verbose output."
-    )
+    parser.add_argument("--verbose", action="store_true", help="Use verbose output.")
     args = parser.parse_args()
     init_environment(args)
 

--- a/tools/lint/codespell.py
+++ b/tools/lint/codespell.py
@@ -19,7 +19,7 @@ def download_dictionary(url, dest):
     try:
         urllib.request.urlretrieve(url, dest)
     except Exception as e:
-        logging.error(f"Error downloading dictionary: {e}", file=sys.stderr)
+        logging.error(f"Error downloading dictionary: {e}")
         sys.exit(1)
 
 
@@ -56,7 +56,6 @@ def main():
     )
     parser.add_argument(
         "--files",
-        action="extend",
         nargs="+",
         required=True,
         help="List of files to spell check."

--- a/tools/lint/cpplint.py
+++ b/tools/lint/cpplint.py
@@ -16,12 +16,19 @@ from utils import (
 DEFAULT_LINE_LENGTH_LIMIT = 100
 
 
-def load_cpplint_filters(conf_file="cpplint.cfg"):
-    """Load cpplint filters from a configuration file."""
+def load_cpplint_filters(conf_file=None):
+    """Load cpplint filters from a configuration file.
+
+    The config file lists one filter per line. Lines are stripped, blanks are
+    dropped, and any trailing commas are removed before joining everything into
+    a single comma-separated string suitable for cpplint's --filters= flag.
+    """
+    if conf_file is None:
+        conf_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "cpplint.cfg")
     try:
         with open(conf_file, "r", encoding="utf-8") as f:
-            filters = f.read().strip()
-            return filters
+            entries = [line.strip().rstrip(",") for line in f]
+        return ",".join(entry for entry in entries if entry)
     except Exception as e:
         logging.warning(f"Could not load {conf_file}: {e}")
         return ""
@@ -65,17 +72,15 @@ def main():
 
     run_command(["pip", "install", "-q", "cpplint"], check=True)
 
-    cpplint_filters = load_cpplint_filters("cpplint.cfg")
+    cpplint_filters = load_cpplint_filters()
+
+    base_cmd = ["cpplint", f"--linelength={DEFAULT_LINE_LENGTH_LIMIT}"]
+    if cpplint_filters:
+        base_cmd.insert(1, f"--filters={cpplint_filters}")
 
     aggregated_output = ""
     for file in args.files:
-        cmd = [
-            "cpplint",
-            f"--filters={cpplint_filters}",
-            f"--linelength={DEFAULT_LINE_LENGTH_LIMIT}",
-            file,
-        ]
-        stdout, stderr, _ = run_command(cmd)
+        stdout, stderr, _ = run_command(base_cmd + [file])
         aggregated_output += stdout + stderr + "\n"
 
     cpplint_log = os.path.join(args.log_dir, "cpplint.log")

--- a/tools/lint/cpplint.py
+++ b/tools/lint/cpplint.py
@@ -64,7 +64,7 @@ def main():
     cpplint_filters = load_cpplint_filters("cpplint.cfg")
 
     aggregated_output = ""
-    for file in args.files.split():
+    for file in args.files:
         cmd = [
             "cpplint",
             f"--filters={cpplint_filters}",

--- a/tools/lint/cpplint.py
+++ b/tools/lint/cpplint.py
@@ -15,6 +15,7 @@ from utils import (
 
 DEFAULT_LINE_LENGTH_LIMIT = 100
 
+
 def load_cpplint_filters(conf_file="cpplint.cfg"):
     """Load cpplint filters from a configuration file."""
     try:
@@ -25,12 +26,14 @@ def load_cpplint_filters(conf_file="cpplint.cfg"):
         logging.warning(f"Could not load {conf_file}: {e}")
         return ""
 
+
 def count_cpplint_errors(log_text: str) -> int:
     """
     Count the number of cpplint error/warning lines.
     """
     matches = re.findall(r"\[[0-9]+\]$", log_text, re.MULTILINE)
     return len(matches)
+
 
 def generate_markdown_report(aggregated_output: str, errors_count: int) -> str:
     """Generate a Markdown report section based on cpplint output and error count."""
@@ -50,6 +53,7 @@ def generate_markdown_report(aggregated_output: str, errors_count: int) -> str:
     report_lines.append("</details>")
     report_lines.append("")
     return "\n".join(report_lines)
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -85,6 +89,7 @@ def main():
     append_file(args.report_file, report)
 
     sys.exit(0 if errors_count == 0 else 1)
+
 
 if __name__ == "__main__":
     main()

--- a/tools/lint/generic_checks.py
+++ b/tools/lint/generic_checks.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 from utils import (
     add_common_arguments,
     init_environment,
@@ -106,6 +107,7 @@ def main():
     file_list = [f for f in args.files if os.path.isfile(f)]
 
     report_sections = []
+    total_issues = 0
 
     # Check non-Unix line endings.
     if args.lineendings_check:
@@ -113,6 +115,7 @@ def main():
         for file, detail in le_issues.items():
             print(f"::warning file={file},title={file}::{detail}")
         report_sections.append(format_report("Non-Unix Line Endings", le_issues))
+        total_issues += len(le_issues)
 
     # Check trailing whitespace.
     if args.whitespace_check:
@@ -133,6 +136,7 @@ def main():
                 ws_log_file, "grepMatcherWarning.json", "grepMatcher-warning"
             )
         report_sections.append(format_report("Trailing Whitespace", ws_issues))
+        total_issues += len(ws_issues)
 
     # Check tab usage.
     if args.tabs_check:
@@ -153,10 +157,13 @@ def main():
                 tab_log_file, "grepMatcherWarning.json", "grepMatcher-warning"
             )
         report_sections.append(format_report("Tab Usage", tab_issues))
+        total_issues += len(tab_issues)
 
     report_content = "\n".join(report_sections)
     write_file(args.report_file, report_content)
     print("Lint report generated at:", args.report_file)
+
+    sys.exit(0 if total_issues == 0 else 1)
 
 
 if __name__ == "__main__":

--- a/tools/lint/generic_checks.py
+++ b/tools/lint/generic_checks.py
@@ -37,9 +37,7 @@ def check_trailing_whitespace(file_paths):
             with open(path, "r", encoding="utf-8") as f:
                 lines = f.read().splitlines()
                 error_lines = [
-                    idx
-                    for idx, line in enumerate(lines, start=1)
-                    if line != line.rstrip()
+                    idx for idx, line in enumerate(lines, start=1) if line != line.rstrip()
                 ]
                 if error_lines:
                     issues[path] = error_lines
@@ -58,9 +56,7 @@ def check_tabs(file_paths):
         try:
             with open(path, "r", encoding="utf-8") as f:
                 lines = f.read().splitlines()
-                tab_lines = [
-                    idx for idx, line in enumerate(lines, start=1) if "\t" in line
-                ]
+                tab_lines = [idx for idx, line in enumerate(lines, start=1) if "\t" in line]
                 if tab_lines:
                     issues[path] = tab_lines
         except Exception as e:
@@ -132,9 +128,7 @@ def main():
 
             ws_log_file = os.path.join(args.log_dir, "whitespace.log")
             write_file(ws_log_file, ws_output)
-            emit_problem_matchers(
-                ws_log_file, "grepMatcherWarning.json", "grepMatcher-warning"
-            )
+            emit_problem_matchers(ws_log_file, "grepMatcherWarning.json", "grepMatcher-warning")
         report_sections.append(format_report("Trailing Whitespace", ws_issues))
         total_issues += len(ws_issues)
 
@@ -153,9 +147,7 @@ def main():
 
             tab_log_file = os.path.join(args.log_dir, "tabs.log")
             write_file(tab_log_file, tab_output)
-            emit_problem_matchers(
-                tab_log_file, "grepMatcherWarning.json", "grepMatcher-warning"
-            )
+            emit_problem_matchers(tab_log_file, "grepMatcherWarning.json", "grepMatcher-warning")
         report_sections.append(format_report("Tab Usage", tab_issues))
         total_issues += len(tab_issues)
 

--- a/tools/lint/generic_checks.py
+++ b/tools/lint/generic_checks.py
@@ -1,5 +1,4 @@
 import argparse
-import glob
 import os
 from utils import (
     add_common_arguments,
@@ -104,8 +103,7 @@ def main():
     args = parser.parse_args()
     init_environment(args)
 
-    file_list = glob.glob(args.files, recursive=True)
-    file_list = [f for f in file_list if os.path.isfile(f)]
+    file_list = [f for f in args.files if os.path.isfile(f)]
 
     report_sections = []
 

--- a/tools/lint/pylint.py
+++ b/tools/lint/pylint.py
@@ -22,10 +22,10 @@ def get_enabled_checks(log_dir: str) -> str:
     return enabled_log_path
 
 
-def run_pylint(files: str, disable: str, log_dir: str) -> str:
+def run_pylint(files: list, disable: str, log_dir: str) -> str:
     """Run pylint on the provided files and log the output."""
     pylint_log_path = os.path.join(log_dir, "pylint.log")
-    cmd = ["pylint", f"--disable={disable}"] + files.split()
+    cmd = ["pylint", f"--disable={disable}"] + files
     stdout, stderr, _ = run_command(cmd, check=False)
     combined_output = stdout + "\n" + stderr
     write_file(pylint_log_path, combined_output)

--- a/tools/lint/pylint.py
+++ b/tools/lint/pylint.py
@@ -63,9 +63,7 @@ def parse_pylint_output(log_path: str) -> dict:
     }
 
 
-def generate_markdown_report(
-    pylint_counts: dict, enabled_checks_log: str, pylint_log: str
-) -> str:
+def generate_markdown_report(pylint_counts: dict, enabled_checks_log: str, pylint_log: str) -> str:
     """Generate a Markdown-formatted report based on pylint results and logs."""
 
     def generate_summary(counts: dict) -> str:
@@ -102,9 +100,7 @@ def generate_markdown_report(
     summary = generate_summary(pylint_counts)
     report_lines.append(f"<details><summary>{summary}</summary>")
     report_lines.append("")
-    report_lines.append(
-        "<details><summary>:information_source: Enabled checks</summary>"
-    )
+    report_lines.append("<details><summary>:information_source: Enabled checks</summary>")
     report_lines.append("")
     report_lines.append("````")
     report_lines.append(read_file_contents(enabled_checks_log))

--- a/tools/lint/python_stubs.py
+++ b/tools/lint/python_stubs.py
@@ -6,7 +6,7 @@ import shlex
 import subprocess
 import sys
 
-from utils import add_common_arguments, append_file, init_environment
+from utils import append_file, init_environment
 
 
 def run_check_command(log_dir: str, repo_root: str) -> int:
@@ -46,7 +46,15 @@ def main():
     parser = argparse.ArgumentParser(
         description="Run the Python binding stub generator and smoke type checks."
     )
-    add_common_arguments(parser)
+    parser.add_argument(
+        "--log-dir", required=True, help="Directory where log files will be written."
+    )
+    parser.add_argument(
+        "--report-file",
+        required=True,
+        help="Path to the Markdown report file to append results.",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose output.")
     args = parser.parse_args()
     init_environment(args)
 

--- a/tools/lint/python_stubs.py
+++ b/tools/lint/python_stubs.py
@@ -69,9 +69,17 @@ def main():
     report = [
         f"<details><summary>{section_title}</summary>",
         "",
-        report_section("Stub generation", "Stub generation", os.path.join(args.log_dir, "python-stubs-generate.log")),
-        report_section("Pyright smoke check", "Pyright", os.path.join(args.log_dir, "python-stubs-pyright.log")),
-        report_section("Pyrefly smoke check", "Pyrefly", os.path.join(args.log_dir, "python-stubs-pyrefly.log")),
+        report_section(
+            "Stub generation",
+            "Stub generation",
+            os.path.join(args.log_dir, "python-stubs-generate.log"),
+        ),
+        report_section(
+            "Pyright smoke check", "Pyright", os.path.join(args.log_dir, "python-stubs-pyright.log")
+        ),
+        report_section(
+            "Pyrefly smoke check", "Pyrefly", os.path.join(args.log_dir, "python-stubs-pyrefly.log")
+        ),
         "</details>",
         "",
     ]

--- a/tools/lint/qt_connections.py
+++ b/tools/lint/qt_connections.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import logging
 import os
 import re
 import sys

--- a/tools/lint/qt_connections.py
+++ b/tools/lint/qt_connections.py
@@ -12,6 +12,8 @@ from utils import (
     emit_problem_matchers,
 )
 
+CPP_EXTENSIONS = (".cpp", ".cxx", ".cc", ".c", ".hpp", ".hxx", ".hh", ".h")
+
 
 def check_qt_connections(file_path):
     """
@@ -55,6 +57,8 @@ def main():
 
     all_matches = []
     for file_path in args.files:
+        if not file_path.lower().endswith(CPP_EXTENSIONS):
+            continue
         logging.debug(f"Checking file: {file_path}")
         matches = check_qt_connections(file_path)
         all_matches.extend(matches)

--- a/tools/lint/qt_connections.py
+++ b/tools/lint/qt_connections.py
@@ -53,7 +53,7 @@ def main():
     init_environment(args)
 
     all_matches = []
-    for file_path in args.files.split():
+    for file_path in args.files:
         logging.debug(f"Checking file: {file_path}")
         matches = check_qt_connections(file_path)
         all_matches.extend(matches)

--- a/tools/lint/utils.py
+++ b/tools/lint/utils.py
@@ -69,7 +69,8 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
     parser.add_argument(
         "--files",
         required=True,
-        help="A space-separated list or glob pattern of files to check.",
+        nargs="+",
+        help="List of files to check.",
     )
     parser.add_argument(
         "--log-dir", required=True, help="Directory where log files will be written."


### PR DESCRIPTION
While investigating a strange recent linter failure, I discovered that actually our current linter scripts aren't being called correctly (basically, in most cases, we're passing in a string that contains a bunch of concatenated quoted substrings, but then the call itself is adding *another* set of quotes. The ultimate effect varies from linter to linter, but in some cases, like the clang-format linter, they were basically not being run at all. To resolve this issue, switch to actually passing a list of args instead of a single string by adding `nargs="+"` to all of the linter calls. Note that the single exception is that `codespell` was being called this way already, so no change was needed there.

ETA: And as long as I'm cleaning up those linter error messages, I've added a few other fixes (in separate commits).

ETA2: And we had several linter checks either disabled or redundant (e.g. Black), so those are removed from the run entirely now. The scripts are retained in case they are useful in the future.


~~NOTE: Obviously we need to drop the [DUMMY CHANGE TO TRIGGER C++ CI](https://github.com/FreeCAD/FreeCAD/pull/30145/commits/9eb2a55caa7fb9a02ffc9f0bdd2e08ec9f3d69ca) commit before merging...~~ Update: dropped