### PR TITLE
BIM: Change DrawingView LineWidth of Cut Lines object to 2x the default thickness

### DIFF
--- a/src/Mod/BIM/bimcommands/BimDrawingView.py
+++ b/src/Mod/BIM/bimcommands/BimDrawingView.py
@@ -57,7 +57,7 @@ class BIM_DrawingView:
     def Activated(self):
 
         import Draft
-        
+
         default_line_width = view_params.GetInt("DefaultShapeLineWidth", 2)
         thickness_ratio = arch_params.GetFloat("CutLineThickness", 2.0)
         cut_lines_width = default_line_width * thickness_ratio

--- a/src/Mod/BIM/bimcommands/BimDrawingView.py
+++ b/src/Mod/BIM/bimcommands/BimDrawingView.py
@@ -55,6 +55,11 @@ class BIM_DrawingView:
     def Activated(self):
 
         import Draft
+        
+        view_prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View")
+        default_line_width = view_prefs.GetInt("DefaultShapeLineWidth", 2)
+        thickness_ratio = PARAMS.GetFloat("CutAreasLineThicknessRatio", 2.0)
+        cut_lines_width = default_line_width * thickness_ratio
 
         FreeCAD.ActiveDocument.openTransaction(translate("Arch", "Create 2D View"))
         FreeCADGui.addModule("Arch")
@@ -78,7 +83,7 @@ class BIM_DrawingView:
                 FreeCADGui.doCommand("cobj.Label = " + repr(translate("BIM", "Cut lines")))
                 FreeCADGui.doCommand("cobj.InPlace = False")
                 FreeCADGui.doCommand('cobj.ProjectionMode = "Cutfaces"')
-                FreeCADGui.doCommand("cobj.ViewObject.LineWidth = 4")
+                FreeCADGui.doCommand("cobj.ViewObject.LineWidth = " + str(cut_lines_width))
                 FreeCADGui.doCommand("obj.addObject(cobj)")
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()

--- a/src/Mod/BIM/bimcommands/BimDrawingView.py
+++ b/src/Mod/BIM/bimcommands/BimDrawingView.py
@@ -78,6 +78,7 @@ class BIM_DrawingView:
                 FreeCADGui.doCommand("cobj.Label = " + repr(translate("BIM", "Cut lines")))
                 FreeCADGui.doCommand("cobj.InPlace = False")
                 FreeCADGui.doCommand('cobj.ProjectionMode = "Cutfaces"')
+                FreeCADGui.doCommand("cobj.ViewObject.LineWidth = 4")
                 FreeCADGui.doCommand("obj.addObject(cobj)")
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()

--- a/src/Mod/BIM/bimcommands/BimDrawingView.py
+++ b/src/Mod/BIM/bimcommands/BimDrawingView.py
@@ -31,6 +31,8 @@ QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
 translate = FreeCAD.Qt.translate
 
 PARAMS = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM")
+view_params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View")
+arch_params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch")
 
 
 class BIM_DrawingView:
@@ -56,9 +58,8 @@ class BIM_DrawingView:
 
         import Draft
         
-        view_prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View")
-        default_line_width = view_prefs.GetInt("DefaultShapeLineWidth", 4)
-        thickness_ratio = PARAMS.GetFloat("CutAreasLineThicknessRatio", 4.0)
+        default_line_width = view_params.GetInt("DefaultShapeLineWidth", 2)
+        thickness_ratio = arch_params.GetFloat("CutLineThickness", 2.0)
         cut_lines_width = default_line_width * thickness_ratio
 
         FreeCAD.ActiveDocument.openTransaction(translate("Arch", "Create 2D View"))

--- a/src/Mod/BIM/bimcommands/BimDrawingView.py
+++ b/src/Mod/BIM/bimcommands/BimDrawingView.py
@@ -57,8 +57,8 @@ class BIM_DrawingView:
         import Draft
         
         view_prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View")
-        default_line_width = view_prefs.GetInt("DefaultShapeLineWidth", 2)
-        thickness_ratio = PARAMS.GetFloat("CutAreasLineThicknessRatio", 2.0)
+        default_line_width = view_prefs.GetInt("DefaultShapeLineWidth", 4)
+        thickness_ratio = PARAMS.GetFloat("CutAreasLineThicknessRatio", 4.0)
         cut_lines_width = default_line_width * thickness_ratio
 
         FreeCAD.ActiveDocument.openTransaction(translate("Arch", "Create 2D View"))


### PR DESCRIPTION
EDIT: AI was used as an assistant in creating this PR

This PR adds `LineWidth` value of 'Default Line Width' multiplied by 'Cut Areas Line Thickness Ratio' from FreeCAD preferences  to `Cut lines` object create by the `BIM_DrawingView` command.

I tested the PR only by replacing the `.py` file in weekly build and running that. I did not build FreeCAD myself.


## Issues
(https://github.com/FreeCAD/FreeCAD/issues/28474)

Note: the issue was created by myself.