### PR TITLE
Sketcher: fix line style dropdowns being empty

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -364,7 +364,7 @@ SketcherSettingsGrid::~SketcherSettingsGrid()
 
 bool SketcherSettingsGrid::event(QEvent* event)
 {
-    if (event->type() == QEvent::PaletteChange) {
+    if (event->type() == QEvent::StyleChange) {
         PreferencePage::event(event);
         const qreal dpr = devicePixelRatioF();
         const QBrush brush = palette().windowText();
@@ -598,7 +598,7 @@ SketcherSettingsAppearance::~SketcherSettingsAppearance()
 
 bool SketcherSettingsAppearance::event(QEvent* event)
 {
-    if (event->type() == QEvent::PaletteChange) {
+    if (event->type() == QEvent::StyleChange) {
         PreferencePage::event(event);
         const qreal dpr = devicePixelRatioF();
         const QBrush brush = palette().windowText();


### PR DESCRIPTION
* Fixes #30132

FreeCAD classic has no QStyleSheet, and for some reason this means `QEvent::PaletteChange` never gets fired, but `QEvent::StyleChange` does and by that point the palette has already been set up in both QSS and non-QSS themes.
