### PR TITLE
TechDraw: Prioritize X/Y position over snapping

### DIFF
--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -629,6 +629,25 @@ double Preferences::SnapLimitFactor()
 }
 
 
+//! true if dimensions should snap to position
+bool Preferences::SnapDimensions()
+{
+    return getPreferenceGroup("Dimensions")->GetBool("SnapDimensions", true);
+}
+
+//! percentage of dimension text legth to use in deciding to snap dimension text
+double Preferences::SnapDimensionsTextFactor()
+{
+    return getPreferenceGroup("Dimensions")->GetFloat("SnapDimensionsTextFactor", 0.4);
+}
+
+//! percentage of inter-dimension distance (cascade spacing from dimAttributes?) to use in deciding to snap dimension
+double Preferences::SnapDimensionsChainFactor()
+{
+    return getPreferenceGroup("Dimensions")->GetFloat("SnapDimensionsChainFactor", 0.2);
+}
+
+
 //! returns the key combination that simulates multiple selection. Traditionally Ctrl+pick, as that
 //! is how QGraphicsScene implements multiple selection.  This method is likely to only be used by
 //! developers.

--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -635,7 +635,7 @@ bool Preferences::SnapDimensions()
     return getPreferenceGroup("Dimensions")->GetBool("SnapDimensions", true);
 }
 
-//! percentage of dimension text legth to use in deciding to snap dimension text
+//! percentage of dimension text length to use in deciding to snap dimension text
 double Preferences::SnapDimensionsTextFactor()
 {
     return getPreferenceGroup("Dimensions")->GetFloat("SnapDimensionsTextFactor", 0.4);

--- a/src/Mod/TechDraw/App/Preferences.h
+++ b/src/Mod/TechDraw/App/Preferences.h
@@ -147,6 +147,11 @@ public:
     static bool SnapViews();
     static double SnapLimitFactor();
 
+    static bool SnapDimensions();
+    static double SnapDimensionsTextFactor();
+    static double SnapDimensionsChainFactor();
+
+
     static Qt::KeyboardModifiers multiselectModifiers();
 
     static Qt::KeyboardModifiers balloonDragModifiers();

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>495</width>
-    <height>692</height>
+    <height>748</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -377,7 +377,7 @@ Multiplier of 'Font size'</string>
         <item row="4" column="1">
          <spacer name="horizontalSpacer">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -584,14 +584,172 @@ This affects only the toolbar; all tools remain available via the menu and short
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="gbSnap">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Snapping</string>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0">
+        <item row="0" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbSnapDims">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>198</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <family>Ubuntu</family>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this is checked, new dimensions will be set to snap to position.  If not checked, new dimensions will not snap.  Snapping for individual dimensions may be adjusted with the &amp;quot;AllowSnapping&amp;quot; property.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Snap dimensions</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SnapDimensions</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="dsbTextFactor">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>174</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Change this value to control how close the dimension text should be to the centered position before snapping.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.400000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SnapDimensionsTextFactor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Dimension text factor</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Chain factor</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="dsbChainFactor">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Change this value to control how close dimensions need to be to snap as chain or ordinate dimensions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.200000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SnapDimensionsChainFactor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_7">
+        <property name="font">
+         <font>
+          <pointsize>10</pointsize>
+          <italic>true</italic>
+         </font>
+        </property>
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Snapping settings for views are on the general tab.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>20</height>
+       <height>40</height>
       </size>
      </property>
     </spacer>
@@ -603,11 +761,6 @@ This affects only the toolbar; all tools remain available via the menu and short
    <class>Gui::QuantitySpinBox</class>
    <extends>QWidget</extends>
    <header>Gui/QuantitySpinBox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
    <class>Gui::PrefCheckBox</class>
@@ -632,6 +785,11 @@ This affects only the toolbar; all tools remain available via the menu and short
   <customwidget>
    <class>Gui::PrefUnitSpinBox</class>
    <extends>Gui::QuantitySpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefSpinBox</class>
+   <extends>QSpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
@@ -655,7 +655,7 @@ This affects only the toolbar; all tools remain available via the menu and short
            </size>
           </property>
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Change this value to control how close the dimension text should be to the centered position before snapping.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fraction of the dimension text length within which the text snaps to its centered position.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="singleStep">
            <double>0.100000000000000</double>
@@ -694,7 +694,7 @@ This affects only the toolbar; all tools remain available via the menu and short
            </sizepolicy>
           </property>
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Change this value to control how close dimensions need to be to snap as chain or ordinate dimensions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fraction of the spacing between dimensions within which they snap as chain or ordinate dimensions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="singleStep">
            <double>0.100000000000000</double>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensionsImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensionsImp.cpp
@@ -66,6 +66,9 @@ void DlgPrefsTechDrawDimensionsImp::saveSettings()
     ui->pdsbGapISO->onSave();
     ui->pdsbGapASME->onSave();
     ui->pdsbLineSpacingFactorISO->onSave();
+    ui->cbSnapDims->onSave();
+    ui->dsbTextFactor->onSave();
+    ui->dsbChainFactor->onSave();
 
     enum
     {
@@ -186,6 +189,10 @@ void DlgPrefsTechDrawDimensionsImp::loadSettings()
     bool Radius = hGrp->GetBool("DimensioningRadius", true);
     index = Diameter ? (Radius ? 0 : 1) : 2;
     ui->radiusDiameterMode->setCurrentIndex(index);
+
+    ui->cbSnapDims->onRestore();
+    ui->dsbTextFactor->onRestore();
+    ui->dsbChainFactor->onRestore();
 }
 
 void DlgPrefsTechDrawDimensionsImp::dimensioningModeChanged(int index)

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
@@ -907,7 +907,7 @@ for ProjectionGroups</string>
         <item row="1" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="psb_SnapFactor">
           <property name="toolTip">
-           <string>When dragging a view, if it is within this fraction of view size of the correct alignment, it will snap into alignment.</string>
+           <string>Snaps a view into its aligned position when it is within this fraction of the view size from the alignment target.</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
@@ -1032,7 +1032,7 @@ for ProjectionGroups</string>
            </font>
           </property>
           <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note:  Snapping settings for dimensions are on the dimensions tab.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Snapping settings for dimensions are on the dimensions tab.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
@@ -893,7 +893,7 @@ for ProjectionGroups</string>
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -903,7 +903,33 @@ for ProjectionGroups</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_9">
       <item>
-       <layout class="QGridLayout" name="gridLayout_8" columnstretch="1,0,2">
+       <layout class="QGridLayout" name="gridLayout_8" columnstretch="1,0,0">
+        <item row="1" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="psb_SnapFactor">
+          <property name="toolTip">
+           <string>When dragging a view, if it is within this fraction of view size of the correct alignment, it will snap into alignment.</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+          </property>
+          <property name="value">
+           <double>0.050000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SnapLimitFactor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_14">
+          <property name="text">
+           <string>Highlight snapping factor</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="0">
          <widget class="Gui::PrefCheckBox" name="cb_SnapViews">
           <property name="toolTip">
@@ -942,49 +968,10 @@ for ProjectionGroups</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="psb_SnapFactor">
-          <property name="toolTip">
-           <string>When dragging a view, if it is within this fraction of view size of the correct alignment, it will snap into alignment.</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <double>0.050000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SnapLimitFactor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <spacer name="horizontalSpacer_4">
-          <property name="orientation">
-           <enum>Qt::Orientation::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
         <item row="1" column="0">
          <widget class="QLabel" name="label_3">
           <property name="text">
            <string>View snapping factor</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_14">
-          <property name="text">
-           <string>Highlight snapping factor</string>
           </property>
          </widget>
         </item>
@@ -1004,6 +991,48 @@ for ProjectionGroups</string>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label_16">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>10</pointsize>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note:  Snapping settings for dimensions are on the dimensions tab.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>
@@ -1050,19 +1079,9 @@ for ProjectionGroups</string>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Gui::FileChooser</class>
-   <extends>QWidget</extends>
-   <header>Gui/FileDialog.h</header>
-  </customwidget>
-  <customwidget>
    <class>Gui::QuantitySpinBox</class>
    <extends>QWidget</extends>
    <header>Gui/QuantitySpinBox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefFileChooser</class>
-   <extends>Gui::FileChooser</extends>
-   <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
    <class>Gui::PrefCheckBox</class>
@@ -1085,13 +1104,23 @@ for ProjectionGroups</string>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>Gui::PrefFontBox</class>
-   <extends>QFontComboBox</extends>
+   <class>Gui::PrefUnitSpinBox</class>
+   <extends>Gui::QuantitySpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>Gui::PrefUnitSpinBox</class>
-   <extends>Gui::QuantitySpinBox</extends>
+   <class>Gui::FileChooser</class>
+   <extends>QWidget</extends>
+   <header>Gui/FileDialog.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefFileChooser</class>
+   <extends>Gui::FileChooser</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefFontBox</class>
+   <extends>QFontComboBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>

--- a/src/Mod/TechDraw/Gui/QGIDatumLabel.cpp
+++ b/src/Mod/TechDraw/Gui/QGIDatumLabel.cpp
@@ -129,13 +129,6 @@ QVariant QGIDatumLabel::itemChange(GraphicsItemChange change, const QVariant& va
 
 void QGIDatumLabel::snapPosition(QPointF& pos)
 {
-    if (!Preferences::SnapViews()) {
-        return;
-    }
-
-    qreal snapPercent = 0.4;
-    double dimSpacing = Rez::guiX(activeDimAttributes.getCascadeSpacing());
-
     auto* qgivd = dynamic_cast<QGIViewDimension*>(parentItem());
     if (!qgivd) {
         return;
@@ -150,6 +143,14 @@ void QGIDatumLabel::snapPosition(QPointF& pos)
     if(type != "Distance" && type != "DistanceX" && type != "DistanceY") {
         return;
     }
+
+    auto* vp = freecad_cast<ViewProviderDimension*>(Gui::Application::Instance->getViewProvider(dim));
+    if (!vp || !vp->AllowSnap.getValue()) {
+        return;
+    }
+
+    qreal snapTextPercent = Preferences::SnapDimensionsTextFactor();
+    double dimSpacing = Rez::guiX(activeDimAttributes.getCascadeSpacing());
 
     // 1 - We try to snap the label to its center position.
     pointPair pp = dim->getLinearPoints();
@@ -179,18 +180,18 @@ void QGIDatumLabel::snapPosition(QPointF& pos)
     projPnt.ProjectToLine(posV - mid, normal);
     projPnt = projPnt + mid;
 
-    if ((projPnt - posV).Length() < dimSpacing * snapPercent) {
+    if ((projPnt - posV).Length() < dimSpacing * snapTextPercent) {
         posV = projPnt;
         pos.setX(posV.x - toCenter.x);
         pos.setY(posV.y - toCenter.y);
     }
 
     // 2 - We check for coord/chain dimensions to offer proper snapping
+    double snapChainPercent = Preferences::SnapDimensionsChainFactor();
     auto* qgiv = dynamic_cast<QGIView*>(qgivd->parentItem());
     if (qgiv) {
         auto* dvp = dynamic_cast<TechDraw::DrawViewPart*>(qgiv->getViewObject());
         if (dvp) {
-            snapPercent = 0.2;
             std::vector<TechDraw::DrawViewDimension*> dims = dvp->getDimensions();
             for (auto& d : dims) {
                 if (d == dim) { continue; }
@@ -234,13 +235,13 @@ void QGIDatumLabel::snapPosition(QPointF& pos)
                 projPnt2.ProjectToLine(posV - posVi, idir);
                 projPnt2 = projPnt2 + posVi;
 
-                if ((projPnt2 - posV).Length() < dimSpacing * snapPercent) {
+                if ((projPnt2 - posV).Length() < dimSpacing * snapChainPercent) {
                     posV = projPnt2;
                     pos.setX(posV.x - toCenter.x);
                     pos.setY(posV.y - toCenter.y);
                     break;
                 }
-                else if (fabs((projPnt2 - posV).Length() - fabs(dimSpacing)) < dimSpacing * snapPercent) {
+                else if (fabs((projPnt2 - posV).Length() - fabs(dimSpacing)) < dimSpacing * snapChainPercent) {
                     posV = projPnt2 + (posV - projPnt2).Normalize() * dimSpacing;
                     pos.setX(posV.x - toCenter.x);
                     pos.setY(posV.y - toCenter.y);

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -84,7 +84,8 @@ QGIView::QGIView()
     m_label(new QGCustomLabel()),
     m_border(new QGCustomBorder()),
     m_caption(new QGICaption()),
-    m_lock(new QGCustomImage())
+    m_lock(new QGCustomImage()),
+    m_inhibitSnapOnPosChange(false)
 {
     setCacheMode(QGraphicsItem::NoCache);
     setHandlesChildEvents(false);
@@ -185,7 +186,10 @@ QVariant QGIView::itemChange(GraphicsItemChange change, const QVariant &value)
         else {
             // For general views we check if we need to snap to a position
             if (!(QApplication::keyboardModifiers() & Qt::AltModifier)) {
-                snapPosition(newPos);
+                if (!m_inhibitSnapOnPosChange) {
+                    snapPosition(newPos);
+                }
+                m_inhibitSnapOnPosChange = false;
             }
         }
 
@@ -273,6 +277,10 @@ void QGIView::dragFinished()
 //! position, otherwise it is the position within the ProjectionGroup.
 void QGIView::snapPosition(QPointF& newPosition)
 {
+    if (m_inhibitSnapOnPosChange) {
+        return;
+    }
+
     if (!Preferences::SnapViews()) {
         return;
     }

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -558,19 +558,15 @@ void QGIView::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
     drawBorder();
 }
 
-//sets position in /Gui(graphics), not /App
-void QGIView::setPosition(qreal xPos, qreal yPos)
+//! get the X&Y position from the feature in Page coords (could be parent coords?), convert to Qt coords and update
+//! this graphic item's scene position.
+void QGIView::updatePositionFromFeatureXY()
 {
-    double newX = xPos;
-    double newY = -yPos;
-    double oldX = pos().x();
-    double oldY = pos().y();
-
-    if (TechDraw::DrawUtil::fpCompare(newX, oldX) &&
-        TechDraw::DrawUtil::fpCompare(newY, oldY)) {
-        return;
-    } else {
-        setPos(newX, newY);
+    if (getViewObject()) {
+        m_inhibitSnapOnPosChange = true;
+        double xFeat = Rez::guiX(getViewObject()->X.getValue());
+        double yFeat = Rez::guiX(getViewObject()->Y.getValue());
+        setPos(xFeat, -yFeat);
     }
 }
 
@@ -587,14 +583,10 @@ QGIViewClip* QGIView::getClipGroup()
     return parentView;
 }
 
+//! called from ViewProvider when feature properties change.
 void QGIView::updateView(bool forceUpdate)
 {
     setMovableFlag();
-
-    if (getViewObject() && forceUpdate) {
-        setPosition(Rez::guiX(getViewObject()->X.getValue()),
-                    Rez::guiX(getViewObject()->Y.getValue()));
-    }
 
     double appRotation = getViewObject()->Rotation.getValue();
     double guiRotation = rotation();
@@ -666,14 +658,6 @@ void QGIView::toggleCache(bool state)
 
 void QGIView::draw()
 {
-    double xFeat, yFeat;
-    if (getViewObject()) {
-        xFeat = Rez::guiX(getViewObject()->X.getValue());
-        yFeat = Rez::guiX(getViewObject()->Y.getValue());
-        if (!getViewObject()->LockPosition.getValue()) {
-            setPosition(xFeat, yFeat);
-        }
-    }
     if (isVisible()) {
         show();
     } else {

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -232,7 +232,7 @@ private:
     QPen m_decorPen;
     double m_lockWidth;
     double m_lockHeight;
-    int m_zOrder;
+    int m_zOrder{0};
 
     bool m_snapped{false};
 

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -127,11 +127,11 @@ public:
 
     /** Methods to ensure that Y-Coordinates are orientated correctly.
      * @{ */
-    void setPosition(qreal xPos, qreal yPos);
     inline qreal getY() { return y() * -1; }
     bool isInnerView() const { return m_innerView; }
     void isInnerView(bool state) { m_innerView = state; }
     QGIViewClip* getClipGroup();
+    void updatePositionFromFeatureXY();
 
     bool isSnapping() { return snapping; }
     void snapPosition(QPointF& position);

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -243,6 +243,8 @@ private:
                        QPointF& outCaptionPos,
                        QPointF& outLabelPos,
                        QPointF& outLockPos) const;
+
+    bool m_inhibitSnapOnPosChange{false};
 };
 
 } // namespace

--- a/src/Mod/TechDraw/Gui/QGIViewClip.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewClip.cpp
@@ -133,7 +133,7 @@ void QGIViewClip::drawClip()
                 qgiv->isInnerView(true);
                 double x = Rez::guiX(qgiv->getViewObject()->X.getValue());
                 double y = Rez::guiX(qgiv->getViewObject()->Y.getValue());
-                qgiv->setPosition(clipOrigin.x() + x, clipOrigin.y() + y);
+                setPositionInClip(qgiv, clipOrigin.x() + x, clipOrigin.y() + y);
                 qgiv->show();
             }
         } else {
@@ -217,4 +217,9 @@ bool QGIViewClip::forwardEventToSelection(QGIView* qview, QEvent* event) const
     return qview->pseudoEventFilter(qview, event);
 }
 
-
+void QGIViewClip::setPositionInClip(QGIView* qgiv, qreal xPos, qreal yPos)
+{
+    double newX = xPos;
+    double newY = -yPos;
+    qgiv->setPos(newX, newY);
+}

--- a/src/Mod/TechDraw/Gui/QGIViewClip.h
+++ b/src/Mod/TechDraw/Gui/QGIViewClip.h
@@ -56,6 +56,8 @@ public:
     QGCustomRect* getFrame() {return m_frame;}
     QGCustomClip* getClipArea() {return m_cliparea;}
 
+    void setPositionInClip(QGIView* qgiv, qreal xPos, qreal yPos);
+
 protected:
     void drawClip();
 

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -439,6 +439,10 @@ bool QGSPage::attachView(App::DocumentObject* obj)
         return true;
     }
 
+    if (qview) {
+        qview->updatePositionFromFeatureXY();
+    }
+
     return (qview != nullptr);
 }
 
@@ -558,7 +562,6 @@ QGIView* QGSPage::addDrawViewClip(TechDraw::DrawViewClip* view)
     auto qview(new QGIViewClip);
     qview->setViewFeature(view);
     addItemToScene(qview);
-    qview->setPosition(Rez::guiX(view->X.getValue()), Rez::guiX(view->Y.getValue()));
     qview->installSceneEventFilter(qview);
     return qview;
 }

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -303,34 +303,6 @@ std::vector<QGIView*> QGSPage::getViews() const
     return result;
 }
 
-int QGSPage::addQView(QGIView* view)
-{
-    QGIView* existing = getQGIVByName(view->getViewName());
-    if (!existing) { //don't add twice!
-        addItem(view);
-
-        TechDraw::DrawView *viewObj = view->getViewObject();
-        // Preserve the desired position, as addToGroup() adjusts the child view's position
-        QPointF viewPos(Rez::guiX(viewObj->X.getValue()), -Rez::guiX(viewObj->Y.getValue()));
-        // Find if it belongs to a parent
-        QGIView *parent = findParent(view);
-        if (parent) {
-            parent->addToGroup(view);
-        }
-        view->setPos(viewPos);
-
-        auto viewProvider = dynamic_cast<ViewProviderDrawingView *>(QGIView::getViewProvider(viewObj));
-        if (viewProvider) {
-            view->setZValue(viewProvider->StackOrder.getValue());
-        }
-
-        view->updateView(true);
-    } else {
-        Base::Console().message("QGSP::addQView - qview already exists\n");
-    }
-    return 0;
-}
-
 int QGSPage::removeQView(QGIView* view)
 {
     if (view) {

--- a/src/Mod/TechDraw/Gui/QGSPage.h
+++ b/src/Mod/TechDraw/Gui/QGSPage.h
@@ -119,7 +119,6 @@ public:
 
     std::vector<QGIView*> getViews() const;
 
-    int addQView(QGIView* view);
     int removeQView(QGIView* view);
     int removeQViewByName(const char* name);
     void removeQViewFromScene(QGIView* view);

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -108,6 +108,8 @@ ViewProviderDimension::ViewProviderDimension()
     ADD_PROPERTY_TYPE(LineSpacingFactorISO, (Preferences::LineSpacingISO()), group, App::Prop_None,
                       "Adjusts the gap between dimension line and dimension text");
 
+    ADD_PROPERTY_TYPE(AllowSnap, (Preferences::SnapDimensions()), group, App::Prop_None,
+                      "Dimension will snap to position if true");
    StackOrder.setValue(ZVALUE::DIMENSION);
 }
 
@@ -234,7 +236,8 @@ void ViewProviderDimension::onChanged(const App::Property* prop)
         (prop == &FlipArrowheads) ||
         (prop == &GapFactorASME) ||
         (prop == &GapFactorISO) ||
-        prop == &LineSpacingFactorISO)  {
+        prop == &LineSpacingFactorISO ||
+        prop == &AllowSnap)  {
         auto* qgiv = getQView();
         if (qgiv) {
             qgiv->updateView(true);

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.h
@@ -48,6 +48,7 @@ public:
     App::PropertyEnumeration  ArrowStyle;
     App::PropertyLength LineWidth;
     App::PropertyColor  Color;
+    App::PropertyBool   AllowSnap;
 
     static const int STD_STYLE_ISO_ORIENTED     = 0;
     static const int STD_STYLE_ISO_REFERENCING  = 1;

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -59,7 +59,6 @@ PROPERTY_SOURCE(TechDrawGui::ViewProviderDrawingView, Gui::ViewProviderDocumentO
 ViewProviderDrawingView::ViewProviderDrawingView() :
     m_myName(std::string())
 {
-//    Base::Console().message("VPDV::VPDV\n");
     initExtension(this);
 
     sPixmap = "TechDraw_TreeView";

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -186,10 +186,38 @@ QGIView* ViewProviderDrawingView::getQView()
 
     QGSPage* page = vpp->getQGSPage();
     if (page) {
-        return dynamic_cast<QGIView *>(page->findQViewForDocObj(getViewObject()));
+        return page->findQViewForDocObj(getViewObject());
     }
 
     return nullptr;
+}
+
+//! Returns the parent graphics item of the passed item or nullptr if the passed item has no parent item.  The parent/child
+//! relationship is based on TD features, not the QGraphicsScene.
+//! this is just qgiv->parentItem() with extra steps??
+QGIView* ViewProviderDrawingView::getOwnerQView(const QGIView* qgiv)
+{
+    auto page = dynamic_cast<QGSPage *>(qgiv->scene());
+    if (!page) {
+        return nullptr;
+    }
+
+    TechDraw::DrawView* obj = qgiv->getViewObject();
+    if (!obj) {
+        return nullptr;
+    }
+
+    App::PropertyLink* ownerProp = obj->getOwnerProperty();
+    if (!ownerProp) {
+        return nullptr;
+    }
+
+    auto* owner = dynamic_cast<TechDraw::DrawView *>(ownerProp->getValue());
+    if (!owner) {
+        return nullptr;
+    }
+
+    return page->getQGIVByName(owner->getNameInDocument());
 }
 
 bool ViewProviderDrawingView::isShow() const
@@ -216,46 +244,44 @@ void ViewProviderDrawingView::finishRestoring()
 
 void ViewProviderDrawingView::updateData(const App::Property* prop)
 {
-    TechDraw::DrawView *obj = getViewObject();
-    App::PropertyLink *ownerProp = obj->getOwnerProperty();
+    QGIView* qgiv = getQView();
+    if (!qgiv)  {
+        return;
+    }
+
+    TechDraw::DrawView* obj = getViewObject();
+    if (!obj) {
+        return;
+    }
+
+    App::PropertyLink* ownerProp = obj->getOwnerProperty();
 
     //only move the view on X, Y change
-    if (prop == &obj->X
-        || prop == &obj->Y) {
-        QGIView* qgiv = getQView();
-        if (qgiv && !qgiv->isSnapping()) {
-            qgiv->QGIView::updateView(true);
+    if (prop == &obj->X ||
+        prop == &obj->Y) {
 
-            // Update also the owner/parent view, if there is any
-            if (ownerProp) {
-                auto owner = dynamic_cast<TechDraw::DrawView *>(ownerProp->getValue());
-                if (owner) {
-                    auto page = dynamic_cast<QGSPage *>(qgiv->scene());
-                    if (page) {
-                        QGIView *ownerView = page->getQGIVByName(owner->getNameInDocument());
-                        if (ownerView) {
-                            ownerView->updateView();
-                        }
-                    }
-                }
-            }
+        if (qgiv->isSnapping() ||
+            obj->LockPosition.getValue()) {
+            Gui::ViewProviderDocumentObject::updateData(prop);
+            return;
         }
+
+        qgiv->updatePositionFromFeatureXY();
+
+        // Update also the owner/parent view, if there is any
+        QGIView* ownerView = getOwnerQView(qgiv);
+        if (ownerView) {
+            ownerView->updateView();
+        }
+
+        Gui::ViewProviderDocumentObject::updateData(prop);
+        return;
     }
-    else if (ownerProp && prop == ownerProp) {
-        QGIView* qgiv = getQView();
-        if (qgiv) {
-            QGIView *ownerView = nullptr;
-            auto owner = dynamic_cast<TechDraw::DrawView *>(ownerProp->getValue());
-            if (owner) {
-                auto page = dynamic_cast<QGSPage *>(qgiv->scene());
-                if (page) {
-                    ownerView = page->getQGIVByName(owner->getNameInDocument());
-                }
-            }
 
-            qgiv->switchParentItem(ownerView);
-            qgiv->updateView();
-        }
+    if (ownerProp && prop == ownerProp) {
+        QGIView* ownerView = getOwnerQView(qgiv);  // ownerView is allowed to be null here
+        qgiv->switchParentItem(ownerView);
+        qgiv->updateView();
     }
 
     Gui::ViewProviderDocumentObject::updateData(prop);

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.h
@@ -72,6 +72,8 @@ public:
     void updateData(const App::Property*) override;
 
     QGIView* getQView();
+    static QGIView* getOwnerQView(const QGIView* qgiv);
+
     MDIViewPage* getMDIViewPage() const;
     Gui::MDIView *getMDIView() const override;
     ViewProviderPage* getViewProviderPage() const;

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.h
@@ -69,7 +69,7 @@ public:
     void dropObject(App::DocumentObject* docObj) override;
 
     void onChanged(const App::Property *prop) override;
-    void updateData(const App::Property*) override;
+    void updateData(const App::Property* prop) override;
 
     QGIView* getQView();
     static QGIView* getOwnerQView(const QGIView* qgiv);

--- a/src/Mod/TechDraw/Gui/ViewProviderProjGroupItem.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderProjGroupItem.cpp
@@ -52,7 +52,7 @@ ViewProviderProjGroupItem::~ViewProviderProjGroupItem()
 
 void ViewProviderProjGroupItem::updateData(const App::Property* prop)
 {
-    Gui::ViewProviderDocumentObject::updateData(prop);
+    ViewProviderViewPart::updateData(prop);
 
     //TODO: Once we know that ProjType is valid, sPixMap = "Proj" + projType
 


### PR DESCRIPTION
This PR implements a solution for issue #28732.  Previously, a manual update to a view or dimension X/Y property would be overridden by the position snapping logic.

The solution includes:
- new preferences for dimension snapping
- hard coded dimension snapping parameters replaced by preference values
- changes to dimension text positioning/snapping
- changes to dimension to dimension snapping (ex chain dimensions)
- changes to view to view dimension snapping
- minor code clean ups and corrections.

This PR also includes a serendipitous partial fix for issue #17226 (TechDraw: Too many unnecessary redraws which ultimately impact  performance), by eliminating 2 unnecessary graphics redraws on position changes.

New section for dimension snapping parameters:
<img width="1054" height="959" alt="NewDimSnappingPrefs" src="https://github.com/user-attachments/assets/7da770bc-da53-4962-bb80-42eb95c3918e" />
