### PR TITLE
PartDesign: suppress false warning when AllowCompound is enabled

### DIFF
--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -440,8 +440,13 @@ App::DocumentObjectExecReturn* Transformed::execute()
 
     supportShape = refineShapeIfActive((supportShape));
 
-    this->Shape.setValue(getSolid(supportShape));  // picking the first solid
-    rejected = getRemainingSolids(supportShape.getShape());
+    this->Shape.setValue(getSolid(supportShape));
+    if (singleSolidRuleMode() == SingleSolidRuleMode::Enforced) {
+        rejected = getRemainingSolids(supportShape.getShape());
+    }
+    else {
+        rejected.Nullify();
+    }
 
     return App::DocumentObject::StdReturn;
 }


### PR DESCRIPTION
Fixes #26370. When `AllowCompound` is enabled on a body, the "One transformed shape does not intersect the support" warning was incorrectly shown. When compound solids are allowed, `getSolid()` already returns the full compound shape, so nothing is actually rejected - `rejected` is now nullified in that case.