### PR TITLE
PartDesign: fuse preview shape when AddSubShape has multiple solids

### DIFF
--- a/src/Mod/PartDesign/App/FeatureAddSub.cpp
+++ b/src/Mod/PartDesign/App/FeatureAddSub.cpp
@@ -140,6 +140,26 @@ void FeatureAddSub::updatePreviewShape()
         }
     }
 
+    // Fuse multiple solids in AddSubShape (e.g. from overlapping sketch profiles)
+    // so the preview matches the final result.
+    if (addSubType == Additive) {
+        const TopoShape& addSubShape = AddSubShape.getShape();
+        if (!addSubShape.isNull() && addSubShape.countSubShapes(TopAbs_SOLID) > 1) {
+            try {
+                TopoShape fused;
+                fused.makeElementFuse(addSubShape.getSubTopoShapes(TopAbs_SOLID));
+                PreviewShape.setValue(fused);
+                return;
+            }
+            catch (Standard_Failure& e) {
+                notifyWarning(QString::fromUtf8(e.GetMessageString()));
+            }
+            catch (Base::Exception& e) {
+                notifyWarning(QString::fromStdString(e.getMessage()));
+            }
+        }
+    }
+
     PreviewShape.setValue(AddSubShape.getShape());
 }
 


### PR DESCRIPTION
When a sketch contains overlapping closed profiles (e.g. intersecting circles), the face maker produces multiple solids in AddSubShape. The preview was displaying this raw compound, which looked different from the final fused result. Fuse the solids before setting PreviewShape so the preview matches the confirmed output.


<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
Fixes https://github.com/FreeCAD/FreeCAD/issues/26412


<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
