### PR TITLE
CAM: Add missing CAMTests that succeed

### DIFF
--- a/src/Mod/CAM/CAMTests/TestGcodeProcessingUtils.py
+++ b/src/Mod/CAM/CAMTests/TestGcodeProcessingUtils.py
@@ -525,6 +525,7 @@ class TestDeduplicateRepeatedCommands(unittest.TestCase):
         ]
         self.assertEqual(result, expected)
 
+    @unittest.skip("FIXME")
     def test_modal_blockdelete(self):
         """Test that blockdelete prefix is handled correctly."""
         gcode = ["/G1 X10.0", "/G1 X20.0"]

--- a/src/Mod/CAM/CAMTests/TestPathDepthParams.py
+++ b/src/Mod/CAM/CAMTests/TestPathDepthParams.py
@@ -25,7 +25,7 @@ import PathScripts.PathUtils as PathUtils
 import unittest
 
 
-class depthTestCases(unittest.TestCase):
+class TestDepthCases(unittest.TestCase):
     def test00(self):
         """Stepping down to zero"""
         args = {

--- a/src/Mod/CAM/CAMTests/TestPathDressupArray.py
+++ b/src/Mod/CAM/CAMTests/TestPathDressupArray.py
@@ -31,7 +31,7 @@ import Path.Op.Profile as PathProfile
 from CAMTests.PathTestUtils import PathTestBase
 
 
-class TestEngrave:
+class _TestEngrave:
     def __init__(self, path):
         self.Path = Path.Path(path)
         self.ToolController = None  # default tool 5mm
@@ -44,7 +44,7 @@ class TestEngrave:
         return False
 
 
-class TestFeature:
+class _TestFeature:
     def __init__(self):
         self.Path = Path.Path()
         self.Name = ""
@@ -66,8 +66,8 @@ class TestDressupArray(PathTestBase):
 
         expected_gcode = "G0 X0.000000 Y0.000000 Z0.000000\n" "G1 X10.000000 Y10.000000 Z0.000000\n"
 
-        base = TestEngrave(source_gcode)
-        obj = TestFeature()
+        base = _TestEngrave(source_gcode)
+        obj = _TestFeature()
         da = DressupArray(obj, base, None)
         da.execute(obj)
         self.assertTrue(obj.Path.toGCode() == expected_gcode, "Incorrect g-code generated")
@@ -84,8 +84,8 @@ class TestDressupArray(PathTestBase):
             "G1 X22.000000 Y22.000000 Z5.000000\n"
         )
 
-        base = TestEngrave(source_gcode)
-        obj = TestFeature()
+        base = _TestEngrave(source_gcode)
+        obj = _TestFeature()
         da = DressupArray(obj, base, None)
         obj.Copies = 1
         obj.Offset = FreeCAD.Vector(12, 12, 5)
@@ -113,8 +113,8 @@ class TestDressupArray(PathTestBase):
             "G1 X34.000000 Y16.000000 Z0.000000\n"
         )
 
-        base = TestEngrave(source_gcode)
-        obj = TestFeature()
+        base = _TestEngrave(source_gcode)
+        obj = _TestFeature()
         da = DressupArray(obj, base, None)
         obj.Type = "Linear2D"
         obj.Copies = 0

--- a/src/Mod/CAM/CAMTests/TestPathToolAsset.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolAsset.py
@@ -5,7 +5,7 @@ from typing import Any, List, Mapping
 from Path.Tool.assets import Asset, AssetUri
 
 
-class TestAsset(Asset):
+class _TestAsset(Asset):
     asset_type: str = "test_asset"
 
     @classmethod
@@ -30,12 +30,12 @@ class TestPathToolAsset(unittest.TestCase):
             Asset()  # type: ignore
 
     def test_asset_can_be_instantiated_and_has_members(self):
-        asset = TestAsset()
+        asset = _TestAsset()
         self.assertIsInstance(asset, Asset)
         self.assertEqual(asset.asset_type, "test_asset")
         self.assertEqual(asset.to_bytes(), b"dummy_serialized_data")
-        self.assertEqual(TestAsset.dependencies(b"some_data"), [])
-        self.assertEqual(TestAsset.from_bytes(b"some_data", "some_id", {}), "dummy_object")
+        self.assertEqual(_TestAsset.dependencies(b"some_data"), [])
+        self.assertEqual(_TestAsset.from_bytes(b"some_data", "some_id", {}), "dummy_object")
         self.assertEqual(asset.get_id(), "dummy_id")
 
 

--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -541,6 +541,7 @@ SET(Tests_SRCS
     CAMTests/TestGenericPlasma.py
     CAMTests/TestGrblPost.py
     CAMTests/TestLinuxCNCPost.py
+    CAMTests/TestLinuxCNCLegacyPost.py
     CAMTests/TestLinkingGenerator.py
     CAMTests/TestMachine.py
     CAMTests/TestMach3Mach4LegacyPost.py

--- a/src/Mod/CAM/TestCAMApp.py
+++ b/src/Mod/CAM/TestCAMApp.py
@@ -117,7 +117,7 @@ from CAMTests.TestPathToolLibrarySerializer import (
 )
 from CAMTests.TestPathToolChangeGenerator import TestPathToolChangeGenerator
 from CAMTests.TestPathToolController import TestPathToolController
-from CAMTests.TestPathUtil import TestPathUtil,TestCompass
+from CAMTests.TestPathUtil import TestPathUtil, TestCompass
 from CAMTests.TestPathVcarve import TestPathVcarve
 from CAMTests.TestPathVoronoi import TestPathVoronoi
 

--- a/src/Mod/CAM/TestCAMApp.py
+++ b/src/Mod/CAM/TestCAMApp.py
@@ -30,17 +30,18 @@ from CAMTests.TestMachine import (
     TestMachineDataclass,
     TestMachineFactory,
     TestToolhead,
+    TestProcessingOptions,
 )
 from CAMTests.TestPathProfile import TestPathProfile
 
 from CAMTests.TestPathAdaptive import TestPathAdaptive
 from CAMTests.TestPathCommandAnnotations import TestPathCommandAnnotations
 from CAMTests.TestPathCore import TestPathCore
-from CAMTests.TestPathDepthParams import depthTestCases
+from CAMTests.TestPathDepthParams import TestDepthCases
 from CAMTests.TestPathDressupDogboneII import TestDressupDogboneII
-from CAMTests.TestPathDressupHoldingTags import TestHoldingTags
 from CAMTests.TestPathDrillable import TestPathDrillable
 from CAMTests.TestPathDrillGenerator import TestPathDrillGenerator
+from CAMTests.TestPathDressupHoldingTags import TestHoldingTags
 from CAMTests.TestDrillCycleExpander import TestDrillCycleExpander
 from CAMTests.TestPathFacingGenerator import TestPathFacingGenerator
 from CAMTests.TestPathGeneratorDogboneII import TestGeneratorDogboneII
@@ -112,10 +113,11 @@ from CAMTests.TestPathToolLibrary import TestPathToolLibrary
 from CAMTests.TestPathToolLibrarySerializer import (
     TestCamoticsLibrarySerializer,
     TestLinuxCNCLibrarySerializer,
+    TestPathToolLibrarySerializerBase,
 )
 from CAMTests.TestPathToolChangeGenerator import TestPathToolChangeGenerator
 from CAMTests.TestPathToolController import TestPathToolController
-from CAMTests.TestPathUtil import TestPathUtil
+from CAMTests.TestPathUtil import TestPathUtil,TestCompass
 from CAMTests.TestPathVcarve import TestPathVcarve
 from CAMTests.TestPathVoronoi import TestPathVoronoi
 
@@ -148,4 +150,5 @@ from CAMTests.TestGcodeProcessingUtils import (
     TestSuppressRedundantAxesWords,
     TestFilterInefficientMoves,
     TestNumberGenerator,
+    TestDeduplicateRepeatedCommands,
 )


### PR DESCRIPTION
Tests exist in CAMTests that aren't run, because they are missing from TestCAMApp.py and CMakeLists.txt.

Wrote code to find missing tests.
Tried missing tests, added working ones.
Marked one test that needs repair.
Fixed class names that aren't tests.
Fixed class name that is test.

## Issues

part of code-quality improvements #29843