### PR TITLE
App: fix shared CopyOnChangeGroup deletion when copied link is removed

### DIFF
--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -54,6 +54,28 @@ namespace sp = std::placeholders;
 
 using CharRange = boost::iterator_range<const char*>;
 
+namespace
+{
+bool isCopyOnChangeGroupShared(const LinkBaseExtension& owner, const DocumentObject* group)
+{
+    if (!group || !group->isAttachedToDocument() || !group->getDocument()) {
+        return false;
+    }
+
+    auto ownerObject = owner.getContainer();
+    for (auto obj : group->getDocument()->getObjects()) {
+        if (!obj || obj == ownerObject || obj->isRemoving()) {
+            continue;
+        }
+        auto ext = obj->getExtensionByType<LinkBaseExtension>(true);
+        if (ext && ext->getLinkCopyOnChangeGroupValue() == group) {
+            return true;
+        }
+    }
+    return false;
+}
+}
+
 ////////////////////////////////////////////////////////////////////////
 
 /*[[[cog
@@ -560,6 +582,9 @@ void LinkBaseExtension::syncCopyOnChange()
     LinkGroup* copyOnChangeGroup = nullptr;
     if (auto prop = getLinkCopyOnChangeGroupProperty()) {
         copyOnChangeGroup = freecad_cast<LinkGroup*>(prop->getValue());
+        if (copyOnChangeGroup && isCopyOnChangeGroupShared(*this, copyOnChangeGroup)) {
+            copyOnChangeGroup = nullptr;
+        }
         if (!copyOnChangeGroup) {
             // Create the LinkGroup if not exist
             auto group = new LinkGroup;
@@ -903,6 +928,15 @@ void LinkBaseExtension::checkCopyOnChange(App::DocumentObject* parent, const App
         return;
     }
 
+    if ((getLinkCopyOnChangeValue() == CopyOnChangeOwned
+         || (getLinkCopyOnChangeValue() == CopyOnChangeTracking
+             && linked != getLinkCopyOnChangeSourceValue()))
+        && isCopyOnChangeGroupShared(*this, getLinkCopyOnChangeGroupValue())) {
+        if (auto copied = makeCopyOnChange()) {
+            linked = copied;
+        }
+    }
+
     if (getLinkCopyOnChangeValue() == CopyOnChangeOwned
         || (getLinkCopyOnChangeValue() == CopyOnChangeTracking
             && linked != getLinkCopyOnChangeSourceValue())) {
@@ -965,7 +999,8 @@ App::DocumentObject* LinkBaseExtension::makeCopyOnChange()
 
     if (auto prop = getLinkCopyOnChangeGroupProperty()) {
         if (auto obj = prop->getValue()) {
-            if (obj->isAttachedToDocument() && obj->getDocument()) {
+            if (obj->isAttachedToDocument() && obj->getDocument()
+                && !isCopyOnChangeGroupShared(*this, obj)) {
                 obj->getDocument()->removeObject(obj->getNameInDocument());
             }
         }
@@ -1642,7 +1677,8 @@ void LinkBaseExtension::onExtendedUnsetupObject()
     }
     detachElements();
     if (auto obj = getLinkCopyOnChangeGroupValue()) {
-        if (obj->isAttachedToDocument() && !obj->isRemoving()) {
+        if (obj->isAttachedToDocument() && !obj->isRemoving()
+            && !isCopyOnChangeGroupShared(*this, obj)) {
             obj->getDocument()->removeObject(obj->getNameInDocument());
         }
     }

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -651,6 +651,44 @@ class DocumentBasicCases(unittest.TestCase):
         self.assertIn("Test", self.Doc.Python.PropertiesList)
         self.assertIn("Test", self.Doc.Link.PropertiesList)
 
+    def testCopiedOwnedLinkKeepsPrivateCopyOnChangeGroup(self):
+        source = self.Doc.addObject("App::FeaturePython", "Source")
+        source.addProperty("App::PropertyInteger", "Config")
+        source.Config = 1
+        source.setPropertyStatus("Config", "CopyOnChange")
+
+        link = self.Doc.addObject("App::Link", "Link")
+        link.LinkedObject = source
+        link.LinkCopyOnChange = "Owned"
+        self.Doc.recompute()
+
+        copiedLink = self.Doc.copyObject(link, False)
+        self.Doc.recompute()
+
+        self.assertIs(link.LinkCopyOnChangeGroup, copiedLink.LinkCopyOnChangeGroup)
+        self.Doc.removeObject(copiedLink.Name)
+        self.Doc.recompute()
+
+        self.assertIsNotNone(link.LinkedObject)
+        self.assertEqual(link.LinkedObject.Config, 1)
+
+        copiedLink = self.Doc.copyObject(link, False)
+        self.Doc.recompute()
+
+        copiedLink.Config = 2
+        self.Doc.recompute()
+
+        self.assertIsNot(link.LinkedObject, copiedLink.LinkedObject)
+        self.assertIsNot(link.LinkCopyOnChangeGroup, copiedLink.LinkCopyOnChangeGroup)
+        self.assertEqual(link.LinkedObject.Config, 1)
+        self.assertEqual(copiedLink.LinkedObject.Config, 2)
+
+        self.Doc.removeObject(copiedLink.Name)
+        self.Doc.recompute()
+
+        self.assertIsNotNone(link.LinkedObject)
+        self.assertEqual(link.LinkedObject.Config, 1)
+
     def testNoProxy(self):
         test = self.Doc.addObject("App::DocumentObject", "Object")
         test.addProperty("App::PropertyPythonObject", "Dictionary")


### PR DESCRIPTION
When a link with `CopyOnChange = Owned` is copied without dependencies, both the original and the copy share the same `CopyOnChangeGroup`. Deleting the copy would destroy that shared group and break the original link.

Fix adds `isCopyOnChangeGroupShared()` to detect this case and guards four call sites: skip deletion if another link still uses the group, create a new private group instead of reusing a shared one, and fork a private copy before applying property changes.

Regression test covers immediate delete and edit-then-delete scenarios.

Fixes #25847.