### PR TITLE
Gui: add Qt QPA, OpenGL & File/Color dialog info to `ProgramInformation`

### DIFF
--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -480,14 +480,7 @@ void AboutDialog::linkActivated(const QUrl& link)
 
 void AboutDialog::copyToClipboard()
 {
-    const auto& config = App::Application::Config();
-    std::stringstream str;
-    App::ProgramInformation::getVerboseCommonInfo(str, config);
-    Gui::ProgramInformation::getStyleInformation(str);
-    Gui::ProgramInformation::getNavigationStyleInformation(str);
-    Gui::ProgramInformation::getDpiInformation(str);
-    App::ProgramInformation::getVerboseAddOnsInfo(str, config);
-    QString data = QString::fromStdString(str.str());
+    QString data = QString::fromStdString(Gui::ProgramInformation::collect());
 
     QClipboard* cb = QApplication::clipboard();
     cb->setText(data);

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -141,6 +141,18 @@ struct ActionDisabler
 };
 
 
+DialogOptions::Backend DialogOptions::fileDialogBackend()
+{
+    if (dontUseNativeFileDialog()) {
+        return Backend::NonNative;
+    }
+#ifdef FC_OS_WIN32
+    return Backend::ViaWin32;
+#else
+    return Backend::ViaQt;
+#endif
+}
+
 bool DialogOptions::dontUseNativeFileDialog()
 {
 #if defined(USE_QT_DIALOGS)
@@ -155,6 +167,14 @@ bool DialogOptions::dontUseNativeFileDialog()
                                      ->GetGroup("Preferences")
                                      ->GetGroup("Dialog");
     return group->GetBool("DontUseNativeDialog", notNativeDialog);
+}
+
+DialogOptions::Backend DialogOptions::colorDialogBackend()
+{
+    if (dontUseNativeColorDialog()) {
+        return Backend::NonNative;
+    }
+    return Backend::ViaQt;
 }
 
 bool DialogOptions::dontUseNativeColorDialog()

--- a/src/Gui/FileDialog.h
+++ b/src/Gui/FileDialog.h
@@ -47,7 +47,17 @@ namespace Gui
 class GuiExport DialogOptions
 {
 public:
+    enum class Backend : uint8_t
+    {
+        NonNative,
+        ViaQt,
+        ViaWin32,
+    };
+
+    static Backend fileDialogBackend();
     static bool dontUseNativeFileDialog();
+
+    static Backend colorDialogBackend();
     static bool dontUseNativeColorDialog();
 };
 

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -102,6 +102,7 @@
 #include "ModuleIO.h"
 #include "NotificationArea.h"
 #include "OverlayManager.h"
+#include "ProgramInformation.h"
 #include "ProgressBar.h"
 #include "PropertyView.h"
 #include "PythonConsole.h"
@@ -365,14 +366,20 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     d->whatsthis = false;
     d->assistant = new Assistant();
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-    // this forces QT to switch to OpenGL mode, this prevents delay and flickering of the window
-    // after opening project and prevent issues with double initialization of the window
-    //
+    // 1. Force Qt to switch to OpenGL mode, this prevents delay and flickering of the window
+    // after opening project and prevent issues with double initialization of the window.
     // https://stackoverflow.com/questions/76026196/how-to-force-qt-to-use-the-opengl-window-type
-    auto _OpenGLWidget = new QOpenGLWidget(this);
-    _OpenGLWidget->move(QPoint(-100, -100));
-#endif
+    // 2. Grab an OpenGL context for version info reporting.
+    struct OpenGLContextGrabWidget: public QOpenGLWidget
+    {
+        using QOpenGLWidget::QOpenGLWidget;
+        void initializeGL() final override
+        {
+            ProgramInformation::initOpenGLInformation(*this);
+        }
+    };
+    auto openGLWidget = new OpenGLContextGrabWidget(this);
+    openGLWidget->move(QPoint(-100, -100));
 
     // global access
     instance = this;

--- a/src/Gui/ProgramInformation.cpp
+++ b/src/Gui/ProgramInformation.cpp
@@ -21,13 +21,16 @@
  *                                                                         *
  **************************************************************************/
 
-#include <string>
+#include "ProgramInformation.h"
+
 #include <QApplication>
 #include <QScreen>
 #include <QStyle>
 
 #include <App/Application.h>
-#include "ProgramInformation.h"
+#include <App/ProgramInformation.h>
+
+#include "FileDialog.h"
 
 using namespace Gui;
 
@@ -88,4 +91,40 @@ void ProgramInformation::getDpiInformation(std::stringstream& str)
         << QApplication::primaryScreen()->logicalDotsPerInch() << "/"
         << QApplication::primaryScreen()->physicalDotsPerInch() << "/"
         << QApplication::primaryScreen()->devicePixelRatio() << "\n";
+}
+
+void ProgramInformation::getQtBackendInformation(std::stringstream& str)
+{
+    constexpr auto dialogBackendToString = [](DialogOptions::Backend backend) {
+        switch (backend) {
+            case DialogOptions::Backend::NonNative:
+                return "non-native";
+            case DialogOptions::Backend::ViaQt:
+                return "via Qt";
+            case DialogOptions::Backend::ViaWin32:
+                return "via Win32";
+            default:
+                return "?";
+        }
+    };
+    str << "QPA/File dialog/Color dialog: " << QApplication::platformName().toStdString() << "/"
+        << dialogBackendToString(DialogOptions::fileDialogBackend()) << "/"
+        << dialogBackendToString(DialogOptions::colorDialogBackend()) << "\n";
+}
+
+std::string ProgramInformation::collect(const std::map<std::string, std::string>& config)
+{
+    std::stringstream str;
+    App::ProgramInformation::getVerboseCommonInfo(str, config);
+    Gui::ProgramInformation::getStyleInformation(str);
+    Gui::ProgramInformation::getQtBackendInformation(str);
+    Gui::ProgramInformation::getNavigationStyleInformation(str);
+    Gui::ProgramInformation::getDpiInformation(str);
+    App::ProgramInformation::getVerboseAddOnsInfo(str, config);
+    return str.str();
+}
+
+std::string ProgramInformation::collect()
+{
+    return collect(App::Application::Config());
 }

--- a/src/Gui/ProgramInformation.cpp
+++ b/src/Gui/ProgramInformation.cpp
@@ -24,6 +24,8 @@
 #include "ProgramInformation.h"
 
 #include <QApplication>
+#include <QOpenGLFunctions>
+#include <QOpenGLWidget>
 #include <QScreen>
 #include <QStyle>
 
@@ -112,6 +114,29 @@ void ProgramInformation::getQtBackendInformation(std::stringstream& str)
         << dialogBackendToString(DialogOptions::colorDialogBackend()) << "\n";
 }
 
+static std::string openGLInfo = "";
+
+// Expects to be called from within initializeGL() of the passed QOpenGLWidget.
+void ProgramInformation::initOpenGLInformation(QOpenGLWidget& widget)
+{
+    std::stringstream str;
+    auto* const funcs = widget.context()->functions();
+    const char* glVersion = reinterpret_cast<const char*>(funcs->glGetString(GL_VERSION));
+    str << (glVersion ? glVersion : "<unavailable>") << '/';
+    const char* glVendor = reinterpret_cast<const char*>(funcs->glGetString(GL_VENDOR));
+    str << (glVendor ? glVendor : "<unavailable>") << '/';
+    const char* glRenderer = reinterpret_cast<const char*>(funcs->glGetString(GL_RENDERER));
+    str << (glRenderer ? glRenderer : "<unavailable>");
+    openGLInfo = str.str();
+}
+
+void ProgramInformation::getOpenGLInformation(std::stringstream& str)
+{
+    if (!openGLInfo.empty()) {
+        str << "OpenGL version/vendor/renderer: " << openGLInfo << "\n";
+    }
+}
+
 std::string ProgramInformation::collect(const std::map<std::string, std::string>& config)
 {
     std::stringstream str;
@@ -120,6 +145,7 @@ std::string ProgramInformation::collect(const std::map<std::string, std::string>
     Gui::ProgramInformation::getQtBackendInformation(str);
     Gui::ProgramInformation::getNavigationStyleInformation(str);
     Gui::ProgramInformation::getDpiInformation(str);
+    Gui::ProgramInformation::getOpenGLInformation(str);
     App::ProgramInformation::getVerboseAddOnsInfo(str, config);
     return str.str();
 }

--- a/src/Gui/ProgramInformation.h
+++ b/src/Gui/ProgramInformation.h
@@ -24,7 +24,10 @@
 #pragma once
 
 #include <FCGlobal.h>
+
+#include <map>
 #include <sstream>
+#include <string>
 
 namespace Gui
 {
@@ -35,6 +38,10 @@ public:
     static void getStyleInformation(std::stringstream& str);
     static void getNavigationStyleInformation(std::stringstream& str);
     static void getDpiInformation(std::stringstream& str);
+    static void getQtBackendInformation(std::stringstream& str);
+
+    static std::string collect(const std::map<std::string, std::string>& config);
+    static std::string collect();
 };
 
 }  // namespace Gui

--- a/src/Gui/ProgramInformation.h
+++ b/src/Gui/ProgramInformation.h
@@ -29,6 +29,8 @@
 #include <sstream>
 #include <string>
 
+class QOpenGLWidget;
+
 namespace Gui
 {
 
@@ -39,6 +41,8 @@ public:
     static void getNavigationStyleInformation(std::stringstream& str);
     static void getDpiInformation(std::stringstream& str);
     static void getQtBackendInformation(std::stringstream& str);
+    static void initOpenGLInformation(QOpenGLWidget&);
+    static void getOpenGLInformation(std::stringstream& str);
 
     static std::string collect(const std::map<std::string, std::string>& config);
     static std::string collect();

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -287,16 +287,7 @@ int main(int argc, char** argv)
     catch (const Base::ProgramInformation& e) {
         QApplication app(argc, argv);
         if (std::strcmp(e.what(), App::ProgramInformation::verboseVersionEmitMessage) == 0) {
-            std::stringstream str;
-            const std::map<std::string, std::string> config = App::Application::Config();
-
-            App::ProgramInformation::getVerboseCommonInfo(str, config);
-            Gui::ProgramInformation::getStyleInformation(str);
-            Gui::ProgramInformation::getNavigationStyleInformation(str);
-            Gui::ProgramInformation::getDpiInformation(str);
-            App::ProgramInformation::getVerboseAddOnsInfo(str, config);
-
-            displayInfo(str.str());
+            displayInfo(Gui::ProgramInformation::collect());
         }
         else {
             displayInfo(e.what());


### PR DESCRIPTION
## Issues
No specific issue, but a help to diagnose them.

As expressed [in a previous Discord message of mine](https://discord.com/channels/870877411049357352/1099444468895199232/1504437128359051335), there exists a number of issues related to file dialogs for which it is hard or impossible to visually distinguish if the dialog in use is the FreeCAD-specific `FileDialog` derived from Qt's, or the system native dialog that just so happens to also be Qt (e.g. KDE, LXQt, any other DE with Qt XDG Desktop Portal, etc).

There also exists vendor or driver-specific graphical issues for which having OpenGL information would be useful out of the box to figure out the specificity thereof.

## Before and After Images
Adds 2 lines to the version info obtainable from the About dialog:
* `QPA/File dialog/Color dialog: {windows,cocoa,xcb,wayland}/{non-native,via {Qt,Win32}}/{non-native,via Qt}`
* `OpenGL version/vendor/renderer: .../.../...`

e.g. changing the version info like this

```diff
 OS: Void Linux (KDE/wayland)
 Architecture: x86_64
 Version: 1.2.0dev.46839 (Git)
 Build date: 2026/05/15 01:04:05
 Build type: Debug
 Branch: feat/extra-version-info
 Hash: 0f9e316e1bb4d5cd469594b1c14d94c4373390e9
 Python 3.14.4, Qt 6.10.2, Coin 4.0.3, Vtk 9.5.0, boost 1_90, Eigen3 3.4.0, PySide 6.10.2
 shiboken 6.10.2, SMESH 7.7.1.0, xerces-c 3.2.5, OCC 7.9.3
 Locale: English/United Kingdom (en_GB)
 Stylesheet/Theme/QtStyle: FreeCAD.qss/FreeCAD Dark/
+QPA/File dialog/Color dialog: wayland/non-native/via Qt
 Navigation Style/Orbit Style/Rotation Mode: CAD/Rounded Arcball/Drag at cursor
 Logical DPI/Physical DPI/Pixel Ratio: 96/92.6073/1
+OpenGL version/vendor/renderer: 4.6 (Compatibility Profile) Mesa 26.0.6/Intel/Mesa Intel(R) Arc(tm) B580 Graphics (BMG G21)
 Installed mods:
   * Curves workbench 0.6.71
```