### PR TITLE
Sketcher: fix AutoColor not updating colors immediately when enabled

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3457,6 +3457,7 @@ void ViewProviderSketch::onChanged(const App::Property* prop)
 
     if (prop == &AutoColor) {
         updateColorPropertiesVisibility();
+        updateAutomaticColorProperties();
         return;
     }
 
@@ -3490,6 +3491,17 @@ void SketcherGui::ViewProviderSketch::updateColorPropertiesVisibility()
     ShapeAppearance.setStatus(App::Property::Hidden, usesAutomaticColors);
 }
 
+void SketcherGui::ViewProviderSketch::updateAutomaticColorProperties()
+{
+    if (!AutoColor.getValue()) {
+        return;
+    }
+
+    pObserver->updateFromParameter("SketchEdgeColor");
+    pObserver->updateFromParameter("SketchVertexColor");
+    pObserver->updateFromParameter("SketchFaceColor");
+}
+
 void SketcherGui::ViewProviderSketch::startRestoring()
 {
     // small hack: before restoring mark AutoColor property as non-touched
@@ -3516,9 +3528,7 @@ void SketcherGui::ViewProviderSketch::finishRestoring()
 
     if (AutoColor.getValue()) {
         // update colors according to current user preferences
-        pObserver->updateFromParameter("SketchEdgeColor");
-        pObserver->updateFromParameter("SketchVertexColor");
-        pObserver->updateFromParameter("SketchFaceColor");
+        updateAutomaticColorProperties();
 
         updateColorPropertiesVisibility();
     }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -882,6 +882,7 @@ private:
     void slotToolWidgetChanged(QWidget* newwidget);
 
     void updateColorPropertiesVisibility();
+    void updateAutomaticColorProperties();
 
     /** @name Attorney functions*/
     //@{

--- a/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
@@ -51,6 +51,15 @@ class TestOnViewParameterGui(unittest.TestCase):
         if self.doc.Name in FreeCAD.listDocuments():
             FreeCAD.closeDocument(self.doc.Name)
 
+    def pack_color(self, color):
+        r, g, b, a = color
+        return (
+            int(r * 255.0 + 0.5) << 24
+            | int(g * 255.0 + 0.5) << 16
+            | int(b * 255.0 + 0.5) << 8
+            | int(a * 255.0 + 0.5)
+        )
+
     def pump(self, timeout_ms=50):
         loop = QtCore.QEventLoop()
         QtCore.QTimer.singleShot(timeout_ms, loop.quit)
@@ -198,3 +207,33 @@ class TestOnViewParameterGui(unittest.TestCase):
             4,
             "Expected the rectangle to be created after accepting both OVPs",
         )
+
+    @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
+    def test_auto_color_restores_line_color_from_preferences(self):
+        view_params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View")
+        color_key = "SketchEdgeColor"
+        had_color = color_key in view_params.GetUnsigneds()
+        old_color = view_params.GetUnsigned(color_key, 0)
+
+        try:
+            manual_color = 0x112233FF
+            preference_color = 0x44AA88FF
+
+            view = self.sketch.ViewObject
+            view.AutoColor = False
+            view.LineColor = manual_color
+            self.assertEqual(self.pack_color(view.LineColor), manual_color)
+
+            view_params.SetUnsigned(color_key, preference_color)
+            self.pump(100)
+            self.assertEqual(self.pack_color(view.LineColor), manual_color)
+
+            view.AutoColor = True
+            self.pump(100)
+
+            self.assertEqual(self.pack_color(view.LineColor), preference_color)
+        finally:
+            if had_color:
+                view_params.SetUnsigned(color_key, old_color)
+            else:
+                view_params.RemUnsigned(color_key)


### PR DESCRIPTION
Fixes #25231

When `AutoColor` was toggled to `true`, `onChanged` only called `updateColorPropertiesVisibility()` (which shows/hides properties in the UI) but never applied the preference colors to `LineColor`/`PointColor`/`ShapeAppearance`. That apply step only happened in `finishRestoring()`, which is why save+reopen fixed it.

The fix extracts the color-apply logic into `updateAutomaticColorProperties()` and calls it from `onChanged` when `AutoColor` changes to `true`. A test is added that reproduces the exact scenario from the bug report.