### PR TITLE
TechDraw: Add Paper/Screen Mode preference for vertex and edge rendering

### DIFF
--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
@@ -816,7 +816,7 @@ for ProjectionGroups</string>
       <string>View Defaults</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_9">
-      <item row="1" column="0">
+      <item row="2" column="0">
        <layout class="QVBoxLayout" name="verticalLayout_7">
         <item>
          <widget class="Gui::PrefCheckBox" name="cb_useCameraDirection">
@@ -847,7 +847,7 @@ for ProjectionGroups</string>
         </item>
        </layout>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="Gui::PrefComboBox" name="cb_viewFramesVisibility">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Control when the view boundary frames and labels are displayed.&lt;/p&gt;&lt;p&gt;Auto: Show on hover, On: Always show, Off: Never show.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -880,11 +880,41 @@ for ProjectionGroups</string>
         </item>
        </widget>
       </item>
-      <item row="0" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="label_15">
         <property name="text">
          <string>View frames mode</string>
         </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_16">
+        <property name="text">
+         <string>Screen mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::PrefComboBox" name="cb_screenMode">
+        <property name="toolTip">
+         <string>In screen mode, vertex markers and edge lines are displayed at a constant size regardless of zoom level. In paper mode (default), all elements scale with the view as they would appear on the printed page.</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ScreenMode</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/TechDraw/General</cstring>
+        </property>
+        <item>
+         <property name="text">
+          <string>Paper mode</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Screen mode</string>
+         </property>
+        </item>
        </widget>
       </item>
      </layout>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneralImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneralImp.cpp
@@ -81,6 +81,7 @@ void DlgPrefsTechDrawGeneralImp::saveSettings()
     ui->cbMultiSelection->onSave();
 
     ui->cb_viewFramesVisibility->onSave();
+    ui->cb_screenMode->onSave();
     ui->cb_useCameraDirection->onSave();
     ui->cb_SnapViews->onSave();
     ui->psb_SnapFactor->onSave();
@@ -129,6 +130,7 @@ void DlgPrefsTechDrawGeneralImp::loadSettings()
     ui->cbMultiSelection->onRestore();
 
     ui->cb_viewFramesVisibility->onRestore();
+    ui->cb_screenMode->onRestore();
     ui->cb_useCameraDirection->onRestore();
 
     ui->cb_SnapViews->onRestore();

--- a/src/Mod/TechDraw/Gui/PreferencesGui.cpp
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.cpp
@@ -316,3 +316,8 @@ ViewFrameMode PreferencesGui::getViewFrameMode()
     return static_cast<ViewFrameMode>(temp);
 }
 
+PreferencesGui::ViewSizeMode PreferencesGui::screenMode()
+{
+    int temp = Preferences::getPreferenceGroup("General")->GetInt("ScreenMode", 0);
+    return static_cast<ViewSizeMode>(temp);
+}

--- a/src/Mod/TechDraw/Gui/PreferencesGui.h
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.h
@@ -100,7 +100,11 @@ static int          get3dMarkerSize();
 static ViewFrameMode getViewFrameMode();
 static void setViewFrameMode(ViewFrameMode newMode);
 
-
+enum class ViewSizeMode {
+    Paper = 0,
+    Screen = 1
+};
+static ViewSizeMode screenMode();
 };
 
 } //end namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
@@ -23,6 +23,7 @@
 # include <cassert>
 
 # include <QGraphicsScene>
+#include <QGraphicsView>
 # include <QGraphicsSceneHoverEvent>
 # include <QPainter>
 # include <QStyleOptionGraphicsItem>
@@ -282,13 +283,19 @@ void QGIPrimPath::setFillColor(QColor c)
     m_colNormalFill = c;
 }
 
-void QGIPrimPath::paint ( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget) {
+void QGIPrimPath::paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget) {
     QStyleOptionGraphicsItem myOption(*option);
     myOption.state &= ~QStyle::State_Selected;
 
-    setPen(m_pen);
+    QPen displayPen = m_pen;
+    auto* parentView = dynamic_cast<QGIView*>(parentItem());
+    bool exporting = parentView ? parentView->isExporting() : false;
+    if (PreferencesGui::screenMode() == PreferencesGui::ViewSizeMode::Screen && !exporting) {
+        displayPen.setCosmetic(true);
+    }
+    setPen(displayPen);
     setBrush(m_brush);
 
-    QGraphicsPathItem::paint (painter, &myOption, widget);
+    QGraphicsPathItem::paint(painter, &myOption, widget);
 }
 

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -522,6 +522,9 @@ void QGIViewPart::drawAllVertexes()
                 item->setNormalColor(vertexColor);
                 item->setFillColor(vertexColor);
                 item->setRadius(getVertexSize());
+                if (PreferencesGui::screenMode() == PreferencesGui::ViewSizeMode::Screen && !isExporting()) {
+                    item->setFlag(QGraphicsItem::ItemIgnoresTransformations, true);
+                }
                 item->setPrettyNormal();
                 item->setZValue(ZVALUE::VERTEX);
                 item->setVisible(shouldShowFrame());


### PR DESCRIPTION
This PR implements implements constant screen size vertices and view edges and adds a preference to TechDraw for switching between Paper Mode (the current behaviour) and Screen Mode (new behaviour).

This PR is being marked as draft, as I think there is a lot of refinement needed. But I hope this will spark a conversation on how we would best like this feature to be implemented.

Note that paper mode is always used for exporting of the page.

Some ideas:
1) Should switching between the modes be a preference? Or should it be toggled with a toolbar command, or perhaps a content menu?
2) With the current implementation, when switching to screen mode, vertices and edges can look quite thick. @WandererFan any ideas on how to handle having the paper and screen mode look the same when the page fits the screen (ie when V + F key-shortcut pressed). 
3) Worth noting there is an existing preference for vertex size, and should fit in with this paper/screen mode.

Things to do next:
1) Add screen mode to template rendering and annotations

## Issues
Adds #25114
Probably fixes this #27773


## Before and After Images
https://github.com/user-attachments/assets/4fff71c4-0bde-42d8-8873-befddeff4091

