### PR TITLE
Core/UI/UX: Selection View search clear behavior

### DIFF
--- a/src/Gui/Selection/SelectionView.cpp
+++ b/src/Gui/Selection/SelectionView.cpp
@@ -52,6 +52,64 @@ FC_LOG_LEVEL_INIT("Selection", true, true, true)
 using namespace Gui;
 using namespace Gui::DockWnd;
 
+namespace
+{
+QString selectionItemText(
+    const char* docName,
+    const char* objName,
+    const char* subName,
+    App::DocumentObject* obj
+)
+{
+    QString selObject;
+    QTextStream str(&selObject);
+    str << QString::fromUtf8(docName);
+    str << "#";
+    str << QString::fromUtf8(objName);
+    if (subName != nullptr && subName[0] != 0) {
+        str << ".";
+        /* Original code doesn't take account of histories in subelement names and displays
+         * them inadvertently.  Let's not do that.
+        str << subName;
+        */
+        /* Remove the history from the displayed subelement name */
+        App::ElementNamePair elementName;
+        App::GeoFeature::resolveElement(obj, subName, elementName);
+        str << elementName.oldName.c_str();  // Use the shortened element name not the full one.
+        /* Mark it visually if there was a history as a "tell" for if a given selection has TNP
+         * fixes in it. */
+        if (elementName.newName.size() > 0) {
+            str << " []";
+        }
+        auto subObj = obj->getSubObject(subName);
+        if (subObj) {
+            obj = subObj;
+        }
+    }
+    str << " (";
+    str << QString::fromUtf8(obj->Label.getValue());
+    str << ")";
+    return selObject;
+}
+
+QListWidgetItem* addSelectionItem(
+    QListWidget* view,
+    const char* docName,
+    const char* objName,
+    const char* subName,
+    App::DocumentObject* obj
+)
+{
+    QStringList list;
+    list << QString::fromUtf8(docName);
+    list << QString::fromUtf8(objName);
+
+    auto item = new QListWidgetItem(selectionItemText(docName, objName, subName, obj), view);
+    item->setData(Qt::UserRole, list);
+    return item;
+}
+}  // namespace
+
 
 /* TRANSLATOR Gui::DockWnd::SelectionView */
 
@@ -80,6 +138,7 @@ SelectionView::SelectionView(Gui::Document* pcDocument, QWidget* parent)
     clearButton->setStyleSheet(QStringLiteral("QToolButton {margin-bottom:1px}"));
     clearButton->setIcon(BitmapFactory().pixmap(":/icons/edit-cleartext.svg"));
     clearButton->setToolTip(tr("Clears the search field"));
+    clearButton->setFocusPolicy(Qt::NoFocus);
     clearButton->setAutoRaise(true);
     countLabel = new QLabel(this);
     countLabel->setText(QStringLiteral("0"));
@@ -154,54 +213,10 @@ void SelectionView::onSelectionChanged(const SelectionChanges& Reason)
         }
     }
 
-    QString selObject;
-    QTextStream str(&selObject);
-
-    auto getSelectionName = [](QTextStream& str,
-                               const char* docName,
-                               const char* objName,
-                               const char* subName,
-                               App::DocumentObject* obj) {
-        str << QString::fromUtf8(docName);
-        str << "#";
-        str << QString::fromUtf8(objName);
-        if (subName != 0 && subName[0] != 0) {
-            str << ".";
-            /* Original code doesn't take account of histories in subelement names and displays
-             * them inadvertently.  Let's not do that.
-            str << subName;
-            */
-            /* Remove the history from the displayed subelement name */
-            App::ElementNamePair elementName;
-            App::GeoFeature::resolveElement(obj, subName, elementName);
-            str << elementName.oldName.c_str();  // Use the shortened element name not the full one.
-            /* Mark it visually if there was a history as a "tell" for if a given selection has TNP
-             * fixes in it. */
-            if (elementName.newName.size() > 0) {
-                str << " []";
-            }
-            auto subObj = obj->getSubObject(subName);
-            if (subObj) {
-                obj = subObj;
-            }
-        }
-        str << " (";
-        str << QString::fromUtf8(obj->Label.getValue());
-        str << ")";
-    };
-
     if (Reason.Type == SelectionChanges::AddSelection) {
-        // save as user data
-        QStringList list;
-        list << QString::fromUtf8(Reason.pDocName);
-        list << QString::fromUtf8(Reason.pObjectName);
         App::Document* doc = App::GetApplication().getDocument(Reason.pDocName);
         App::DocumentObject* obj = doc->getObject(Reason.pObjectName);
-        getSelectionName(str, Reason.pDocName, Reason.pObjectName, Reason.pSubName, obj);
-
-        // insert the selection as item
-        QListWidgetItem* item = new QListWidgetItem(selObject, selectionView);
-        item->setData(Qt::UserRole, list);
+        addSelectionItem(selectionView, Reason.pDocName, Reason.pObjectName, Reason.pSubName, obj);
     }
     else if (Reason.Type == SelectionChanges::ClrSelection) {
         if (!Reason.pDocName[0]) {
@@ -210,6 +225,8 @@ void SelectionView::onSelectionChanged(const SelectionChanges& Reason)
         }
         else {
             // build name
+            QString selObject;
+            QTextStream str(&selObject);
             str << Reason.pDocName;
             str << "#";
             // remove all items
@@ -222,7 +239,8 @@ void SelectionView::onSelectionChanged(const SelectionChanges& Reason)
     else if (Reason.Type == SelectionChanges::RmvSelection) {
         App::Document* doc = App::GetApplication().getDocument(Reason.pDocName);
         App::DocumentObject* obj = doc->getObject(Reason.pObjectName);
-        getSelectionName(str, Reason.pDocName, Reason.pObjectName, Reason.pSubName, obj);
+        const QString selObject
+            = selectionItemText(Reason.pDocName, Reason.pObjectName, Reason.pSubName, obj);
         // remove all items
         QList<QListWidgetItem*> l = selectionView->findItems(selObject, Qt::MatchStartsWith);
         if (l.size() == 1) {
@@ -235,17 +253,9 @@ void SelectionView::onSelectionChanged(const SelectionChanges& Reason)
         std::vector<SelectionSingleton::SelObj> objs
             = Gui::Selection().getSelection(Reason.pDocName, ResolveMode::NoResolve);
         for (const auto& it : objs) {
-            // save as user data
-            QStringList list;
-            list << QString::fromUtf8(it.DocName);
-            list << QString::fromUtf8(it.FeatName);
-
             App::Document* doc = App::GetApplication().getDocument(it.DocName);
             App::DocumentObject* obj = doc->getObject(it.FeatName);
-            getSelectionName(str, it.DocName, it.FeatName, it.SubName, obj);
-            QListWidgetItem* item = new QListWidgetItem(selObject, selectionView);
-            item->setData(Qt::UserRole, list);
-            selObject.clear();
+            addSelectionItem(selectionView, it.DocName, it.FeatName, it.SubName, obj);
         }
     }
     else if (Reason.Type == SelectionChanges::PickedListChanged) {
@@ -265,15 +275,14 @@ void SelectionView::onSelectionChanged(const SelectionChanges& Reason)
                     continue;
                 }
 
-                QString selObject;
-                QTextStream str(&selObject);
-                getSelectionName(str, sel.DocName, sel.FeatName, sel.SubName, obj);
-
                 this->x = sel.x;
                 this->y = sel.y;
                 this->z = sel.z;
 
-                new QListWidgetItem(selObject, pickList);
+                new QListWidgetItem(
+                    selectionItemText(sel.DocName, sel.FeatName, sel.SubName, obj),
+                    pickList
+                );
             }
         }
     }
@@ -283,36 +292,45 @@ void SelectionView::onSelectionChanged(const SelectionChanges& Reason)
 
 void SelectionView::search(const QString& text)
 {
-    if (!text.isEmpty()) {
+    if (text.isEmpty()) {
         searchList.clear();
-        App::Document* doc = App::GetApplication().getActiveDocument();
-        std::vector<App::DocumentObject*> objects;
-        if (doc) {
-            objects = doc->getObjects();
-            selectionView->clear();
-            for (auto it : objects) {
-                QString label = QString::fromUtf8(it->Label.getValue());
-                if (label.contains(text, Qt::CaseInsensitive)) {
-                    searchList.push_back(it);
-                    // save as user data
-                    QString selObject;
-                    QTextStream str(&selObject);
-                    QStringList list;
-                    list << QString::fromUtf8(doc->getName());
-                    list << QString::fromUtf8(it->getNameInDocument());
-                    // build name
-                    str << QString::fromUtf8(doc->Label.getValue());
-                    str << "#";
-                    str << it->getNameInDocument();
-                    str << " (";
-                    str << label;
-                    str << ")";
-                    QListWidgetItem* item = new QListWidgetItem(selObject, selectionView);
-                    item->setData(Qt::UserRole, list);
-                }
-            }
-            countLabel->setText(QString::number(selectionView->count()));
+        selectionView->clear();
+        const auto selection = Gui::Selection().getSelection("*", ResolveMode::NoResolve);
+        for (const auto& it : selection) {
+            addSelectionItem(selectionView, it.DocName, it.FeatName, it.SubName, it.pObject);
         }
+        countLabel->setText(QString::number(selectionView->count()));
+        return;
+    }
+
+    searchList.clear();
+    App::Document* doc = App::GetApplication().getActiveDocument();
+    std::vector<App::DocumentObject*> objects;
+    if (doc) {
+        objects = doc->getObjects();
+        selectionView->clear();
+        for (auto it : objects) {
+            QString label = QString::fromUtf8(it->Label.getValue());
+            if (label.contains(text, Qt::CaseInsensitive)) {
+                searchList.push_back(it);
+                // save as user data
+                QString selObject;
+                QTextStream str(&selObject);
+                QStringList list;
+                list << QString::fromUtf8(doc->getName());
+                list << QString::fromUtf8(it->getNameInDocument());
+                // build name
+                str << QString::fromUtf8(doc->Label.getValue());
+                str << "#";
+                str << it->getNameInDocument();
+                str << " (";
+                str << label;
+                str << ")";
+                QListWidgetItem* item = new QListWidgetItem(selObject, selectionView);
+                item->setData(Qt::UserRole, list);
+            }
+        }
+        countLabel->setText(QString::number(selectionView->count()));
     }
 }
 

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(Gui_tests_run
 
 # Qt tests
 setup_qt_test(QuantitySpinBox)
+setup_qt_test(SelectionView)
 
 target_link_libraries(Gui_tests_run PRIVATE
     GTest::gtest_main

--- a/tests/src/Gui/SelectionView.cpp
+++ b/tests/src/Gui/SelectionView.cpp
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <memory>
+
+#include <QLineEdit>
+#include <QListWidget>
+#include <QTest>
+#include <QToolButton>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <Gui/Application.h>
+#include <Gui/MainWindow.h>
+#include <Gui/Selection/Selection.h>
+#include <Gui/Selection/SelectionView.h>
+#include <src/App/InitApplication.h>
+
+class SelectionCommandLogGuard
+{
+public:
+    SelectionCommandLogGuard()
+    {
+        Gui::Selection().disableCommandLog();
+    }
+
+    ~SelectionCommandLogGuard()
+    {
+        Gui::Selection().enableCommandLog(true);
+    }
+};
+
+class testSelectionView final: public QObject
+{
+    Q_OBJECT
+
+public:
+    testSelectionView()
+    {
+        tests::initApplication();
+        if (!Gui::Application::Instance) {
+            guiApplication = std::make_unique<Gui::Application>(false);
+        }
+        if (!Gui::getMainWindow()) {
+            mainWindow = std::make_unique<Gui::MainWindow>();
+        }
+    }
+
+private Q_SLOTS:
+    void init()  // NOLINT
+    {
+        App::DocumentInitFlags createFlags;
+        createFlags.createView = false;
+        docName = App::GetApplication().getUniqueDocumentName("selection_view_test");
+        doc = App::GetApplication().newDocument(docName.c_str(), "testUser", createFlags);
+
+        alpha = doc->addObject("App::FeatureTest", "AlphaObject");
+        alpha->Label.setValue("Alpha target");
+        beta = doc->addObject("App::FeatureTest", "BetaObject");
+        beta->Label.setValue("Beta target");
+    }
+
+    void cleanup()  // NOLINT
+    {
+        SelectionCommandLogGuard guard;
+        Gui::Selection().clearSelection(docName.c_str());
+        if (App::GetApplication().getDocument(docName.c_str())) {
+            App::GetApplication().closeDocument(docName.c_str());
+        }
+        doc = nullptr;
+        alpha = nullptr;
+        beta = nullptr;
+    }
+
+    void clearingSearchRestoresCurrentSelection()  // NOLINT
+    {
+        Gui::DockWnd::SelectionView view(nullptr);
+        view.show();
+        QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+        selectTestObjects();
+        QCOMPARE(view.selectionView->count(), 2);
+
+        auto searchBox = view.findChild<QLineEdit*>();
+        QVERIFY(searchBox);
+
+        searchBox->setText(QStringLiteral("Alpha"));
+        QCOMPARE(view.selectionView->count(), 1);
+
+        searchBox->clear();
+        QCOMPARE(view.selectionView->count(), 2);
+        QCOMPARE(Gui::Selection().getSelection(docName.c_str(), Gui::ResolveMode::NoResolve).size(), 2U);
+
+        searchBox->clearFocus();
+        QCoreApplication::processEvents();
+    }
+
+    void clearButtonDoesNotApplyFilteredSelection()  // NOLINT
+    {
+        Gui::DockWnd::SelectionView view(nullptr);
+        view.show();
+        QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+        selectTestObjects();
+
+        auto searchBox = view.findChild<QLineEdit*>();
+        QVERIFY(searchBox);
+        auto clearButton = view.findChild<QToolButton*>();
+        QVERIFY(clearButton);
+        QCOMPARE(clearButton->focusPolicy(), Qt::NoFocus);
+
+        searchBox->setFocus();
+        searchBox->setText(QStringLiteral("Alpha"));
+        QCOMPARE(view.selectionView->count(), 1);
+
+        QTest::mouseClick(clearButton, Qt::LeftButton);
+        QCOMPARE(searchBox->text(), QString());
+        QCOMPARE(view.selectionView->count(), 2);
+        QCOMPARE(Gui::Selection().getSelection(docName.c_str(), Gui::ResolveMode::NoResolve).size(), 2U);
+
+        searchBox->clearFocus();
+        QCoreApplication::processEvents();
+    }
+
+private:
+    void selectTestObjects()
+    {
+        SelectionCommandLogGuard guard;
+        QVERIFY(Gui::Selection().addSelection(docName.c_str(), alpha->getNameInDocument()));
+        QVERIFY(Gui::Selection().addSelection(docName.c_str(), beta->getNameInDocument()));
+    }
+
+    std::unique_ptr<Gui::Application> guiApplication;
+    std::unique_ptr<Gui::MainWindow> mainWindow;
+    std::string docName;
+    App::Document* doc {};
+    App::DocumentObject* alpha {};
+    App::DocumentObject* beta {};
+};
+
+QTEST_MAIN(testSelectionView)
+
+#include "SelectionView.moc"


### PR DESCRIPTION
Restore the Selection View from the current selection when the search text is cleared, and keep the clear button from applying a filtered selection by taking focus. Add Qt coverage for clearing via text and via the clear
  button.

## Issues

Fixes #30009

## Before and After Images

GUI behavior change only; screenshots are not expected to show the bug clearly.

Before:
- Typing in the Selection View search filters the visible rows.
- Clearing the search text does not restore the full current selection view.
- Clicking the clear button can apply the filtered selection because the button takes focus first.

After:
- Clearing the search text restores the Selection View from the current FreeCAD selection.
- Clicking the clear button keeps the full current selection intact.
- The clear button no longer takes focus before the search is cleared.

## Testing

- Added Qt tests covering:
  - clearing the search text directly
  - clearing via the search field clear button

- Verified with:

```bash
pixi run build -j 2
ctest --test-dir build/debug --output-on-failure -R 'SelectionView_Tests_run|SelectionTest|SelectionPickPolicyTest'
```

- Confirmed manually
  - Entered a search term to get filtered results, and deleted the text to return to the full entity list.
  - Entered a search term to get filtered results, clicked the clear test button to return to the full entity list.


Assisted-by: gpt-5.5
Assisted-by: gpt-5.3-Codex-Spark

[x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
