### PR TITLE
BIM: clamp IFC multicore preference when disabled

### DIFF
--- a/src/Mod/BIM/importers/importIFCHelper.py
+++ b/src/Mod/BIM/importers/importIFCHelper.py
@@ -105,7 +105,7 @@ def getPreferences():
         "FITVIEW_ONIMPORT": params.get_param_arch("ifcFitViewOnImport"),
         "ALLOW_INVALID": params.get_param_arch("ifcAllowInvalid"),
         "REPLACE_PROJECT": params.get_param_arch("ifcReplaceProject"),
-        "MULTICORE": params.get_param_arch("ifcMulticore"),
+        "MULTICORE": max(1, params.get_param_arch("ifcMulticore")),
         "IMPORT_LAYER": params.get_param_arch("ifcImportLayer"),
     }
 

--- a/src/Mod/BIM/nativeifc/ifc_generator.py
+++ b/src/Mod/BIM/nativeifc/ifc_generator.py
@@ -419,7 +419,7 @@ def get_geom_iterator(ifcfile, elements, brep_mode):
         else:
             # We print a debug message but we continue
             print("DEBUG: ifc_tools.get_geom_iterator: Iterator could not be set up correctly")
-    cores = multiprocessing.cpu_count()
+    cores = max(1, multiprocessing.cpu_count() - 1)
     iterator = ifcopenshell.geom.iterator(settings, ifcfile, cores, include=elements)
     if not iterator.initialize():
         print("DEBUG: ifc_tools.get_geom_iterator: Invalid iterator")


### PR DESCRIPTION
## Summary
- normalize the IFC multicore preference to a non-negative integer
- treat `0` as "multicore disabled" before creating the IfcOpenShell geometry iterator

Closes #27401