### PR TITLE
Sketcher: fix AutoColor not updating colors immediately

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3457,6 +3457,7 @@ void ViewProviderSketch::onChanged(const App::Property* prop)
 
     if (prop == &AutoColor) {
         updateColorPropertiesVisibility();
+        updateAutomaticColorProperties();
         return;
     }
 
@@ -3490,6 +3491,17 @@ void SketcherGui::ViewProviderSketch::updateColorPropertiesVisibility()
     ShapeAppearance.setStatus(App::Property::Hidden, usesAutomaticColors);
 }
 
+void SketcherGui::ViewProviderSketch::updateAutomaticColorProperties()
+{
+    if (!AutoColor.getValue()) {
+        return;
+    }
+
+    pObserver->updateFromParameter("SketchEdgeColor");
+    pObserver->updateFromParameter("SketchVertexColor");
+    pObserver->updateFromParameter("SketchFaceColor");
+}
+
 void SketcherGui::ViewProviderSketch::startRestoring()
 {
     // small hack: before restoring mark AutoColor property as non-touched
@@ -3516,9 +3528,7 @@ void SketcherGui::ViewProviderSketch::finishRestoring()
 
     if (AutoColor.getValue()) {
         // update colors according to current user preferences
-        pObserver->updateFromParameter("SketchEdgeColor");
-        pObserver->updateFromParameter("SketchVertexColor");
-        pObserver->updateFromParameter("SketchFaceColor");
+        updateAutomaticColorProperties();
 
         updateColorPropertiesVisibility();
     }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -882,6 +882,7 @@ private:
     void slotToolWidgetChanged(QWidget* newwidget);
 
     void updateColorPropertiesVisibility();
+    void updateAutomaticColorProperties();
 
     /** @name Attorney functions*/
     //@{

--- a/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
@@ -3,6 +3,7 @@
 import unittest
 
 import FreeCAD
+import Part
 
 try:
     import FreeCADGui
@@ -50,6 +51,15 @@ class TestOnViewParameterGui(unittest.TestCase):
 
         if self.doc.Name in FreeCAD.listDocuments():
             FreeCAD.closeDocument(self.doc.Name)
+
+    def pack_color(self, color):
+        r, g, b, a = color
+        return (
+            int(r * 255.0 + 0.5) << 24
+            | int(g * 255.0 + 0.5) << 16
+            | int(b * 255.0 + 0.5) << 8
+            | int(a * 255.0 + 0.5)
+        )
 
     def pump(self, timeout_ms=50):
         loop = QtCore.QEventLoop()
@@ -132,6 +142,31 @@ class TestOnViewParameterGui(unittest.TestCase):
             for spinbox in main_window.findChildren(QtGui.QAbstractSpinBox)
             if spinbox.isVisible()
         ]
+
+    @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
+    def test_auto_color_restores_line_color_from_preferences(self):
+        self.sketch.addGeometry(
+            Part.LineSegment(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(10, 0, 0)),
+            False,
+        )
+        self.doc.recompute()
+
+        params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View")
+        old_color = params.GetUnsigned("SketchEdgeColor", 0xFFFFFFFF)
+        manual_color = 0x112233FF
+        preference_color = 0x44AA88FF
+
+        try:
+            view = self.sketch.ViewObject
+            view.AutoColor = False
+            view.LineColor = manual_color
+            params.SetUnsigned("SketchEdgeColor", preference_color)
+
+            view.AutoColor = True
+
+            self.assertEqual(self.pack_color(view.LineColor), preference_color)
+        finally:
+            params.SetUnsigned("SketchEdgeColor", old_color)
 
     @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
     def test_rectangle_ovp_enter_finishes_without_crash(self):


### PR DESCRIPTION
 When `AutoColor` is set to `true`, colors are now immediately updated from user preferences instead of requiring a document reload.