### PR TITLE
Gui: fix custom toolbar appearing twice after workbench switch

### DIFF
--- a/src/Gui/Dialogs/DlgToolbarsImp.cpp
+++ b/src/Gui/Dialogs/DlgToolbarsImp.cpp
@@ -616,8 +616,10 @@ void DlgCustomToolbarsImp::addCustomToolbar(const QString& name)
     QVariant data = ui->workbenchBox->itemData(ui->workbenchBox->currentIndex(), Qt::UserRole);
     Workbench* w = WorkbenchManager::instance()->active();
     if (w && w->name() == std::string((const char*)data.toByteArray())) {
-        QToolBar* bar = getMainWindow()->addToolBar(name);
+        auto* bar = new ToolBar(getMainWindow());
+        bar->setWindowTitle(name);
         bar->setObjectName(name);
+        getMainWindow()->addToolBar(bar);
     }
 }
 


### PR DESCRIPTION
Fixes #24405.

`ToolBarManager::toolBars()` uses `findChildren<ToolBar*>()`, which only finds FreeCAD's `ToolBar` subclass, not plain `QToolBar`. The old code created a plain `QToolBar`, so on every workbench switch `setup()` could not find it and spawned a duplicate.

Fix: create a `ToolBar` directly, consistent with what `ToolBarManager::setup()` already does.