### PR TITLE
CAM: Add c++ based TSP Solver for pairs

### DIFF
--- a/src/Mod/CAM/App/tsp_solver.cpp
+++ b/src/Mod/CAM/App/tsp_solver.cpp
@@ -798,6 +798,9 @@ std::vector<TSPPair> TSPSolver::solvePairs(
         );
     }
     else {
+        // No start point specified; use the machine origin (0,0,0) as a neutral
+        // reference so the nearest-neighbour pass still has a valid starting
+        // position without biasing the route toward any particular area of the job.
         pairs.insert(pairs.begin(), TSPPair(0.0, 0.0, 0.0, 0.0));
     }
 
@@ -850,8 +853,6 @@ std::vector<TSPPair> TSPSolver::solvePairs(
     }
 
     // STEP 4: Additional improvement of the route
-    // Note: 10e-6 == 1e-5 (matches Python source exactly)
-    constexpr double epsilon = 10e-6;
     size_t limitReorderI = route.size() - 2;
     if (routeEndPoint) {
         limitReorderI -= 1;
@@ -874,6 +875,9 @@ std::vector<TSPPair> TSPSolver::solvePairs(
                 double subRouteLengthCurrentPart = std::sqrt(
                     std::pow(route[i].x - route[i + 1].x, 2) + std::pow(route[i].y - route[i + 1].y, 2)
                 );
+                if (i + 3 >= limitReorderJ) {
+                    continue;  // No valid j for this i; route[i+3] would be out of bounds
+                }
                 for (size_t j = i + 3; j < limitReorderJ; ++j) {
                     double subRouteLengthCurrent = subRouteLengthCurrentPart
                         + std::sqrt(std::pow(route[j - 1].x - route[j].x, 2)
@@ -886,7 +890,7 @@ std::vector<TSPPair> TSPSolver::solvePairs(
                         std::pow(route[i].x - route[j - 1].x, 2)
                         + std::pow(route[i].y - route[j - 1].y, 2)
                     );
-                    subRouteLengthNew += epsilon;
+                    subRouteLengthNew += Base::Precision::Confusion();
                     if (subRouteLengthNew < subRouteLengthCurrent) {
                         // Reverse the order of pairs between i-th and j-th pair
                         std::reverse(route.begin() + i + 1, route.begin() + j);
@@ -908,7 +912,7 @@ std::vector<TSPPair> TSPSolver::solvePairs(
                         std::pow(route[i].x - route[limitReorderJ - 1].x, 2)
                         + std::pow(route[i].y - route[limitReorderJ - 1].y, 2)
                     );
-                    subRouteLengthNew += epsilon;
+                    subRouteLengthNew += Base::Precision::Confusion();
                     if (subRouteLengthNew < subRouteLengthCurrent) {
                         // Reverse the order of pairs after i-th to the last pair
                         std::reverse(route.begin() + i + 1, route.begin() + limitReorderJ);
@@ -937,7 +941,7 @@ std::vector<TSPPair> TSPSolver::solvePairs(
                     std::pow(route[i - 1].x - route[i + 1].x, 2)
                     + std::pow(route[i - 1].y - route[i + 1].y, 2)
                 );
-                subRouteLengthNewPart += epsilon;
+                subRouteLengthNewPart += Base::Precision::Confusion();
 
                 // Relocate backward
                 for (size_t j = 0; j + 2 < i; ++j) {
@@ -964,7 +968,7 @@ std::vector<TSPPair> TSPSolver::solvePairs(
                             std::pow(route[i - 1].x - route[i + 1].x, 2)
                             + std::pow(route[i - 1].y - route[i + 1].y, 2)
                         );
-                        subRouteLengthNewPart += epsilon;
+                        subRouteLengthNewPart += Base::Precision::Confusion();
                         improvementFound = true;
                         lastImprovementAtStep = 2;
                     }
@@ -995,7 +999,7 @@ std::vector<TSPPair> TSPSolver::solvePairs(
                             std::pow(route[i - 1].x - route[i + 1].x, 2)
                             + std::pow(route[i - 1].y - route[i + 1].y, 2)
                         );
-                        subRouteLengthNewPart += epsilon;
+                        subRouteLengthNewPart += Base::Precision::Confusion();
                         improvementFound = true;
                         lastImprovementAtStep = 2;
                     }
@@ -1020,7 +1024,7 @@ std::vector<TSPPair> TSPSolver::solvePairs(
                         std::pow(route[route.size() - 1].x - route[j + 1].x, 2)
                         + std::pow(route[route.size() - 1].y - route[j + 1].y, 2)
                     );
-                    subRouteLengthNew += epsilon;
+                    subRouteLengthNew += Base::Precision::Confusion();
                     if (subRouteLengthNew < subRouteLengthCurrent) {
                         // Relocate the last pair after j-th pair
                         std::rotate(route.begin() + j + 1, route.end() - 1, route.end());
@@ -1053,7 +1057,7 @@ std::vector<TSPPair> TSPSolver::solvePairs(
                     std::pow(route[i - 1].x - route[i + 1].x, 2)
                     + std::pow(route[i - 1].y - route[i + 1].y, 2)
                 );
-                subRouteLengthNewPart += epsilon;
+                subRouteLengthNewPart += Base::Precision::Confusion();
 
                 // Relocate backward with alternative point
                 for (size_t j = 0; j + 2 < i; ++j) {
@@ -1083,7 +1087,7 @@ std::vector<TSPPair> TSPSolver::solvePairs(
                             std::pow(route[i - 1].x - route[i + 1].x, 2)
                             + std::pow(route[i - 1].y - route[i + 1].y, 2)
                         );
-                        subRouteLengthNewPart += epsilon;
+                        subRouteLengthNewPart += Base::Precision::Confusion();
                         improvementFound = true;
                         lastImprovementAtStep = 3;
                     }
@@ -1116,7 +1120,7 @@ std::vector<TSPPair> TSPSolver::solvePairs(
                             std::pow(route[i - 1].x - route[i + 1].x, 2)
                             + std::pow(route[i - 1].y - route[i + 1].y, 2)
                         );
-                        subRouteLengthNewPart += epsilon;
+                        subRouteLengthNewPart += Base::Precision::Confusion();
                         improvementFound = true;
                         lastImprovementAtStep = 3;
                     }
@@ -1150,7 +1154,7 @@ std::vector<TSPPair> TSPSolver::solvePairs(
                             std::pow(route[i - 1].x - route[i + 1].x, 2)
                             + std::pow(route[i - 1].y - route[i + 1].y, 2)
                         );
-                        subRouteLengthNewPart += epsilon;
+                        subRouteLengthNewPart += Base::Precision::Confusion();
                         improvementFound = true;
                         lastImprovementAtStep = 3;
                     }
@@ -1175,7 +1179,7 @@ std::vector<TSPPair> TSPSolver::solvePairs(
                         std::pow(route[route.size() - 1].xAlt - route[j + 1].x, 2)
                         + std::pow(route[route.size() - 1].yAlt - route[j + 1].y, 2)
                     );
-                    subRouteLengthNew += epsilon;
+                    subRouteLengthNew += Base::Precision::Confusion();
                     if (subRouteLengthNew < subRouteLengthCurrent) {
                         route.back().flipped = !route.back().flipped;
                         std::swap(route.back().x, route.back().xAlt);

--- a/src/Mod/CAM/App/tsp_solver.cpp
+++ b/src/Mod/CAM/App/tsp_solver.cpp
@@ -774,3 +774,437 @@ std::vector<TSPTunnel> TSPSolver::solveTunnels(
 
     return route;
 }
+
+std::vector<TSPPair> TSPSolver::solvePairs(
+    std::vector<TSPPair> pairs,
+    const TSPPoint* routeStartPoint,
+    const TSPPoint* routeEndPoint
+)
+{
+    if (pairs.empty()) {
+        return pairs;
+    }
+
+    // Set original indices
+    for (size_t i = 0; i < pairs.size(); ++i) {
+        pairs[i].index = static_cast<int>(i);
+    }
+
+    // STEP 1: Add the routeStartPoint (will be deleted at the end)
+    if (routeStartPoint) {
+        pairs.insert(
+            pairs.begin(),
+            TSPPair(routeStartPoint->x, routeStartPoint->y, routeStartPoint->x, routeStartPoint->y)
+        );
+    }
+    else {
+        pairs.insert(pairs.begin(), TSPPair(0.0, 0.0, 0.0, 0.0));
+    }
+
+    // STEP 2: Apply nearest neighbor algorithm
+    std::vector<TSPPair> potentialNeighbours(pairs.begin() + 1, pairs.end());
+    std::vector<TSPPair> route;
+    route.reserve(pairs.size());
+    route.push_back(pairs[0]);
+
+    while (!potentialNeighbours.empty()) {
+        double costCurrent = std::numeric_limits<double>::max();
+        bool toBeFlipped = false;
+        auto nearestNeighbour = potentialNeighbours.begin();
+
+        // Check both primary and alternative orientations in a single pass
+        for (auto it = potentialNeighbours.begin(); it != potentialNeighbours.end(); ++it) {
+            double dx = route.back().x - it->x;
+            double dy = route.back().y - it->y;
+            double costNew = dx * dx + dy * dy;
+            if (costNew < costCurrent) {
+                costCurrent = costNew;
+                toBeFlipped = false;
+                nearestNeighbour = it;
+            }
+            double dxAlt = route.back().x - it->xAlt;
+            double dyAlt = route.back().y - it->yAlt;
+            double costNewAlt = dxAlt * dxAlt + dyAlt * dyAlt;
+            if (costNewAlt < costCurrent) {
+                costCurrent = costNewAlt;
+                toBeFlipped = true;
+                nearestNeighbour = it;
+            }
+        }
+
+        if (toBeFlipped) {
+            nearestNeighbour->flipped = !nearestNeighbour->flipped;
+            std::swap(nearestNeighbour->x, nearestNeighbour->xAlt);
+            std::swap(nearestNeighbour->y, nearestNeighbour->yAlt);
+        }
+
+        route.push_back(*nearestNeighbour);
+        potentialNeighbours.erase(nearestNeighbour);
+    }
+
+    // STEP 3: Add the routeEndPoint (will be deleted at the end)
+    if (routeEndPoint) {
+        route.push_back(
+            TSPPair(routeEndPoint->x, routeEndPoint->y, routeEndPoint->x, routeEndPoint->y)
+        );
+    }
+
+    // STEP 4: Additional improvement of the route
+    // Note: 10e-6 == 1e-5 (matches Python source exactly)
+    constexpr double epsilon = 10e-6;
+    size_t limitReorderI = route.size() - 2;
+    if (routeEndPoint) {
+        limitReorderI -= 1;
+    }
+    size_t limitReorderJ = route.size();
+    size_t limitRelocationI = route.size() - 1;
+    size_t limitRelocationJ = route.size() - 1;
+    int lastImprovementAtStep = 0;
+
+    while (true) {
+
+        // STEP 4.1: Apply 2-opt
+        if (lastImprovementAtStep == 1) {
+            break;
+        }
+        bool improvementFound = true;
+        while (improvementFound) {
+            improvementFound = false;
+            for (size_t i = 0; i < limitReorderI; ++i) {
+                double subRouteLengthCurrentPart = std::sqrt(
+                    std::pow(route[i].x - route[i + 1].x, 2) + std::pow(route[i].y - route[i + 1].y, 2)
+                );
+                for (size_t j = i + 3; j < limitReorderJ; ++j) {
+                    double subRouteLengthCurrent = subRouteLengthCurrentPart
+                        + std::sqrt(std::pow(route[j - 1].x - route[j].x, 2)
+                                    + std::pow(route[j - 1].y - route[j].y, 2));
+                    double subRouteLengthNew = std::sqrt(
+                        std::pow(route[i + 1].x - route[j].x, 2)
+                        + std::pow(route[i + 1].y - route[j].y, 2)
+                    );
+                    subRouteLengthNew += std::sqrt(
+                        std::pow(route[i].x - route[j - 1].x, 2)
+                        + std::pow(route[i].y - route[j - 1].y, 2)
+                    );
+                    subRouteLengthNew += epsilon;
+                    if (subRouteLengthNew < subRouteLengthCurrent) {
+                        // Reverse the order of pairs between i-th and j-th pair
+                        std::reverse(route.begin() + i + 1, route.begin() + j);
+                        subRouteLengthCurrentPart = std::sqrt(
+                            std::pow(route[i].x - route[i + 1].x, 2)
+                            + std::pow(route[i].y - route[i + 1].y, 2)
+                        );
+                        improvementFound = true;
+                        lastImprovementAtStep = 1;
+                    }
+                }
+                // Open route: can reverse from i to end
+                if (!routeEndPoint) {
+                    double subRouteLengthCurrent = std::sqrt(
+                        std::pow(route[i].x - route[i + 1].x, 2)
+                        + std::pow(route[i].y - route[i + 1].y, 2)
+                    );
+                    double subRouteLengthNew = std::sqrt(
+                        std::pow(route[i].x - route[limitReorderJ - 1].x, 2)
+                        + std::pow(route[i].y - route[limitReorderJ - 1].y, 2)
+                    );
+                    subRouteLengthNew += epsilon;
+                    if (subRouteLengthNew < subRouteLengthCurrent) {
+                        // Reverse the order of pairs after i-th to the last pair
+                        std::reverse(route.begin() + i + 1, route.begin() + limitReorderJ);
+                        improvementFound = true;
+                        lastImprovementAtStep = 1;
+                    }
+                }
+            }
+        }
+
+        // STEP 4.2: Apply relocation
+        if (lastImprovementAtStep == 2) {
+            break;
+        }
+        improvementFound = true;
+        while (improvementFound) {
+            improvementFound = false;
+            for (size_t i = 1; i < limitRelocationI; ++i) {
+                double subRouteLengthCurrentPart = std::sqrt(
+                    std::pow(route[i - 1].x - route[i].x, 2) + std::pow(route[i - 1].y - route[i].y, 2)
+                );
+                subRouteLengthCurrentPart += std::sqrt(
+                    std::pow(route[i].x - route[i + 1].x, 2) + std::pow(route[i].y - route[i + 1].y, 2)
+                );
+                double subRouteLengthNewPart = std::sqrt(
+                    std::pow(route[i - 1].x - route[i + 1].x, 2)
+                    + std::pow(route[i - 1].y - route[i + 1].y, 2)
+                );
+                subRouteLengthNewPart += epsilon;
+
+                // Relocate backward
+                for (size_t j = 0; j + 2 < i; ++j) {
+                    double subRouteLengthCurrent = subRouteLengthCurrentPart
+                        + std::sqrt(std::pow(route[j].x - route[j + 1].x, 2)
+                                    + std::pow(route[j].y - route[j + 1].y, 2));
+                    double subRouteLengthNew = subRouteLengthNewPart
+                        + std::sqrt(std::pow(route[j].x - route[i].x, 2)
+                                    + std::pow(route[j].y - route[i].y, 2))
+                        + std::sqrt(std::pow(route[i].x - route[j + 1].x, 2)
+                                    + std::pow(route[i].y - route[j + 1].y, 2));
+                    if (subRouteLengthNew < subRouteLengthCurrent) {
+                        // Relocate the i-th pair backward (after j-th pair)
+                        std::rotate(route.begin() + j + 1, route.begin() + i, route.begin() + i + 1);
+                        subRouteLengthCurrentPart = std::sqrt(
+                            std::pow(route[i - 1].x - route[i].x, 2)
+                            + std::pow(route[i - 1].y - route[i].y, 2)
+                        );
+                        subRouteLengthCurrentPart += std::sqrt(
+                            std::pow(route[i].x - route[i + 1].x, 2)
+                            + std::pow(route[i].y - route[i + 1].y, 2)
+                        );
+                        subRouteLengthNewPart = std::sqrt(
+                            std::pow(route[i - 1].x - route[i + 1].x, 2)
+                            + std::pow(route[i - 1].y - route[i + 1].y, 2)
+                        );
+                        subRouteLengthNewPart += epsilon;
+                        improvementFound = true;
+                        lastImprovementAtStep = 2;
+                    }
+                }
+
+                // Relocate forward
+                for (size_t j = i + 1; j < limitRelocationJ; ++j) {
+                    double subRouteLengthCurrent = subRouteLengthCurrentPart
+                        + std::sqrt(std::pow(route[j].x - route[j + 1].x, 2)
+                                    + std::pow(route[j].y - route[j + 1].y, 2));
+                    double subRouteLengthNew = subRouteLengthNewPart
+                        + std::sqrt(std::pow(route[j].x - route[i].x, 2)
+                                    + std::pow(route[j].y - route[i].y, 2))
+                        + std::sqrt(std::pow(route[i].x - route[j + 1].x, 2)
+                                    + std::pow(route[i].y - route[j + 1].y, 2));
+                    if (subRouteLengthNew < subRouteLengthCurrent) {
+                        // Relocate the i-th pair forward (after j-th pair)
+                        std::rotate(route.begin() + i, route.begin() + i + 1, route.begin() + j + 1);
+                        subRouteLengthCurrentPart = std::sqrt(
+                            std::pow(route[i - 1].x - route[i].x, 2)
+                            + std::pow(route[i - 1].y - route[i].y, 2)
+                        );
+                        subRouteLengthCurrentPart += std::sqrt(
+                            std::pow(route[i].x - route[i + 1].x, 2)
+                            + std::pow(route[i].y - route[i + 1].y, 2)
+                        );
+                        subRouteLengthNewPart = std::sqrt(
+                            std::pow(route[i - 1].x - route[i + 1].x, 2)
+                            + std::pow(route[i - 1].y - route[i + 1].y, 2)
+                        );
+                        subRouteLengthNewPart += epsilon;
+                        improvementFound = true;
+                        lastImprovementAtStep = 2;
+                    }
+                }
+            }
+
+            // Open route: relocate last pair
+            if (!routeEndPoint) {
+                double subRouteLengthCurrentPart = std::sqrt(
+                    std::pow(route[route.size() - 2].x - route[route.size() - 1].x, 2)
+                    + std::pow(route[route.size() - 2].y - route[route.size() - 1].y, 2)
+                );
+                for (size_t j = 0; j + 2 < route.size(); ++j) {
+                    double subRouteLengthCurrent = subRouteLengthCurrentPart
+                        + std::sqrt(std::pow(route[j].x - route[j + 1].x, 2)
+                                    + std::pow(route[j].y - route[j + 1].y, 2));
+                    double subRouteLengthNew = std::sqrt(
+                        std::pow(route[j].x - route[route.size() - 1].x, 2)
+                        + std::pow(route[j].y - route[route.size() - 1].y, 2)
+                    );
+                    subRouteLengthNew += std::sqrt(
+                        std::pow(route[route.size() - 1].x - route[j + 1].x, 2)
+                        + std::pow(route[route.size() - 1].y - route[j + 1].y, 2)
+                    );
+                    subRouteLengthNew += epsilon;
+                    if (subRouteLengthNew < subRouteLengthCurrent) {
+                        // Relocate the last pair after j-th pair
+                        std::rotate(route.begin() + j + 1, route.end() - 1, route.end());
+                        subRouteLengthCurrentPart = std::sqrt(
+                            std::pow(route[route.size() - 2].x - route[route.size() - 1].x, 2)
+                            + std::pow(route[route.size() - 2].y - route[route.size() - 1].y, 2)
+                        );
+                        improvementFound = true;
+                        lastImprovementAtStep = 2;
+                    }
+                }
+            }
+        }
+
+        // STEP 4.3: Apply relocation with alternative point
+        if (lastImprovementAtStep == 3) {
+            break;
+        }
+        improvementFound = true;
+        while (improvementFound) {
+            improvementFound = false;
+            for (size_t i = 1; i < limitRelocationI; ++i) {
+                double subRouteLengthCurrentPart = std::sqrt(
+                    std::pow(route[i - 1].x - route[i].x, 2) + std::pow(route[i - 1].y - route[i].y, 2)
+                );
+                subRouteLengthCurrentPart += std::sqrt(
+                    std::pow(route[i].x - route[i + 1].x, 2) + std::pow(route[i].y - route[i + 1].y, 2)
+                );
+                double subRouteLengthNewPart = std::sqrt(
+                    std::pow(route[i - 1].x - route[i + 1].x, 2)
+                    + std::pow(route[i - 1].y - route[i + 1].y, 2)
+                );
+                subRouteLengthNewPart += epsilon;
+
+                // Relocate backward with alternative point
+                for (size_t j = 0; j + 2 < i; ++j) {
+                    double subRouteLengthCurrent = subRouteLengthCurrentPart
+                        + std::sqrt(std::pow(route[j].x - route[j + 1].x, 2)
+                                    + std::pow(route[j].y - route[j + 1].y, 2));
+                    double subRouteLengthNew = subRouteLengthNewPart
+                        + std::sqrt(std::pow(route[j].x - route[i].xAlt, 2)
+                                    + std::pow(route[j].y - route[i].yAlt, 2))
+                        + std::sqrt(std::pow(route[i].xAlt - route[j + 1].x, 2)
+                                    + std::pow(route[i].yAlt - route[j + 1].y, 2));
+                    if (subRouteLengthNew < subRouteLengthCurrent) {
+                        route[i].flipped = !route[i].flipped;
+                        std::swap(route[i].x, route[i].xAlt);
+                        std::swap(route[i].y, route[i].yAlt);
+                        // Relocate the i-th pair backward (after j-th pair)
+                        std::rotate(route.begin() + j + 1, route.begin() + i, route.begin() + i + 1);
+                        subRouteLengthCurrentPart = std::sqrt(
+                            std::pow(route[i - 1].x - route[i].x, 2)
+                            + std::pow(route[i - 1].y - route[i].y, 2)
+                        );
+                        subRouteLengthCurrentPart += std::sqrt(
+                            std::pow(route[i].x - route[i + 1].x, 2)
+                            + std::pow(route[i].y - route[i + 1].y, 2)
+                        );
+                        subRouteLengthNewPart = std::sqrt(
+                            std::pow(route[i - 1].x - route[i + 1].x, 2)
+                            + std::pow(route[i - 1].y - route[i + 1].y, 2)
+                        );
+                        subRouteLengthNewPart += epsilon;
+                        improvementFound = true;
+                        lastImprovementAtStep = 3;
+                    }
+                }
+
+                // When j = i - 1: try alternative point only (no relocation), no epsilon
+                {
+                    double subRouteLengthCurrent = subRouteLengthCurrentPart;
+                    double subRouteLengthNew = std::sqrt(
+                        std::pow(route[i - 1].x - route[i].xAlt, 2)
+                        + std::pow(route[i - 1].y - route[i].yAlt, 2)
+                    );
+                    subRouteLengthNew += std::sqrt(
+                        std::pow(route[i].xAlt - route[i + 1].x, 2)
+                        + std::pow(route[i].yAlt - route[i + 1].y, 2)
+                    );
+                    if (subRouteLengthNew < subRouteLengthCurrent) {
+                        route[i].flipped = !route[i].flipped;
+                        std::swap(route[i].x, route[i].xAlt);
+                        std::swap(route[i].y, route[i].yAlt);
+                        subRouteLengthCurrentPart = std::sqrt(
+                            std::pow(route[i - 1].x - route[i].x, 2)
+                            + std::pow(route[i - 1].y - route[i].y, 2)
+                        );
+                        subRouteLengthCurrentPart += std::sqrt(
+                            std::pow(route[i].x - route[i + 1].x, 2)
+                            + std::pow(route[i].y - route[i + 1].y, 2)
+                        );
+                        subRouteLengthNewPart = std::sqrt(
+                            std::pow(route[i - 1].x - route[i + 1].x, 2)
+                            + std::pow(route[i - 1].y - route[i + 1].y, 2)
+                        );
+                        subRouteLengthNewPart += epsilon;
+                        improvementFound = true;
+                        lastImprovementAtStep = 3;
+                    }
+                }
+
+                // Relocate forward with alternative point
+                for (size_t j = i + 1; j < limitRelocationJ; ++j) {
+                    double subRouteLengthCurrent = subRouteLengthCurrentPart
+                        + std::sqrt(std::pow(route[j].x - route[j + 1].x, 2)
+                                    + std::pow(route[j].y - route[j + 1].y, 2));
+                    double subRouteLengthNew = subRouteLengthNewPart
+                        + std::sqrt(std::pow(route[j].x - route[i].xAlt, 2)
+                                    + std::pow(route[j].y - route[i].yAlt, 2))
+                        + std::sqrt(std::pow(route[i].xAlt - route[j + 1].x, 2)
+                                    + std::pow(route[i].yAlt - route[j + 1].y, 2));
+                    if (subRouteLengthNew < subRouteLengthCurrent) {
+                        route[i].flipped = !route[i].flipped;
+                        std::swap(route[i].x, route[i].xAlt);
+                        std::swap(route[i].y, route[i].yAlt);
+                        // Relocate the i-th pair forward (after j-th pair)
+                        std::rotate(route.begin() + i, route.begin() + i + 1, route.begin() + j + 1);
+                        subRouteLengthCurrentPart = std::sqrt(
+                            std::pow(route[i - 1].x - route[i].x, 2)
+                            + std::pow(route[i - 1].y - route[i].y, 2)
+                        );
+                        subRouteLengthCurrentPart += std::sqrt(
+                            std::pow(route[i].x - route[i + 1].x, 2)
+                            + std::pow(route[i].y - route[i + 1].y, 2)
+                        );
+                        subRouteLengthNewPart = std::sqrt(
+                            std::pow(route[i - 1].x - route[i + 1].x, 2)
+                            + std::pow(route[i - 1].y - route[i + 1].y, 2)
+                        );
+                        subRouteLengthNewPart += epsilon;
+                        improvementFound = true;
+                        lastImprovementAtStep = 3;
+                    }
+                }
+            }
+
+            // Open route: relocate last pair with alternative point
+            if (!routeEndPoint) {
+                double subRouteLengthCurrentPart = std::sqrt(
+                    std::pow(route[route.size() - 2].x - route[route.size() - 1].x, 2)
+                    + std::pow(route[route.size() - 2].y - route[route.size() - 1].y, 2)
+                );
+                for (size_t j = 0; j + 2 < route.size(); ++j) {
+                    double subRouteLengthCurrent = subRouteLengthCurrentPart
+                        + std::sqrt(std::pow(route[j].x - route[j + 1].x, 2)
+                                    + std::pow(route[j].y - route[j + 1].y, 2));
+                    double subRouteLengthNew = std::sqrt(
+                        std::pow(route[j].x - route[route.size() - 1].xAlt, 2)
+                        + std::pow(route[j].y - route[route.size() - 1].yAlt, 2)
+                    );
+                    subRouteLengthNew += std::sqrt(
+                        std::pow(route[route.size() - 1].xAlt - route[j + 1].x, 2)
+                        + std::pow(route[route.size() - 1].yAlt - route[j + 1].y, 2)
+                    );
+                    subRouteLengthNew += epsilon;
+                    if (subRouteLengthNew < subRouteLengthCurrent) {
+                        route.back().flipped = !route.back().flipped;
+                        std::swap(route.back().x, route.back().xAlt);
+                        std::swap(route.back().y, route.back().yAlt);
+                        // Relocate the last pair after j-th pair
+                        std::rotate(route.begin() + j + 1, route.end() - 1, route.end());
+                        subRouteLengthCurrentPart = std::sqrt(
+                            std::pow(route[route.size() - 2].x - route.back().x, 2)
+                            + std::pow(route[route.size() - 2].y - route.back().y, 2)
+                        );
+                        improvementFound = true;
+                        lastImprovementAtStep = 3;
+                    }
+                }
+            }
+        }
+
+        if (lastImprovementAtStep == 0) {
+            break;  // No additional improvements could be made
+        }
+    }
+
+    // STEP 5: Delete temporary start and end points
+    if (!route.empty()) {
+        route.erase(route.begin());  // Remove temp start
+    }
+    if (routeEndPoint && !route.empty()) {
+        route.pop_back();  // Remove temp end
+    }
+
+    return route;
+}

--- a/src/Mod/CAM/App/tsp_solver.h
+++ b/src/Mod/CAM/App/tsp_solver.h
@@ -55,6 +55,23 @@ struct TSPTunnel
     {}
 };
 
+struct TSPPair
+{
+    double x, y;        // Primary point (current orientation, may be swapped)
+    double xAlt, yAlt;  // Alternative point (current orientation, may be swapped)
+    bool flipped;       // Whether the pair has been flipped from its original orientation
+    int index;          // Original index in input array
+
+    TSPPair(double x_, double y_, double xAlt_, double yAlt_)
+        : x(x_)
+        , y(y_)
+        , xAlt(xAlt_)
+        , yAlt(yAlt_)
+        , flipped(false)
+        , index(-1)
+    {}
+};
+
 class TSPSolver
 {
 public:
@@ -73,6 +90,16 @@ public:
     static std::vector<TSPTunnel> solveTunnels(
         std::vector<TSPTunnel> tunnels,
         bool allowFlipping = false,
+        const TSPPoint* routeStartPoint = nullptr,
+        const TSPPoint* routeEndPoint = nullptr
+    );
+
+    // Solves TSP for pairs (each element has a primary and alternative entry point)
+    // Each pair has (x,y) and (xAlt,yAlt); the solver picks whichever entry point produces
+    // a shorter route, swapping the pair's coordinates in-place when the alt is chosen.
+    // Returns vector of pairs in optimized order (pairs may be flipped)
+    static std::vector<TSPPair> solvePairs(
+        std::vector<TSPPair> pairs,
         const TSPPoint* routeStartPoint = nullptr,
         const TSPPoint* routeEndPoint = nullptr
     );

--- a/src/Mod/CAM/App/tsp_solver_pybind.cpp
+++ b/src/Mod/CAM/App/tsp_solver_pybind.cpp
@@ -97,6 +97,100 @@ std::vector<int> tspSolvePy(
     return TSPSolver::solve(pts, pStartPoint, pEndPoint);
 }
 
+// Python wrapper for solvePairs function
+std::vector<py::dict> tspSolvePairsPy(
+    const std::vector<py::dict>& pairs,
+    const py::object& routeStartPoint = py::none(),
+    const py::object& routeEndPoint = py::none()
+)
+{
+    std::vector<TSPPair> cppPairs;
+
+    // Convert Python dictionaries to C++ TSPPair objects
+    for (size_t i = 0; i < pairs.size(); ++i) {
+        const auto& pair = pairs[i];
+        double x = py::cast<double>(pair["x"]);
+        double y = py::cast<double>(pair["y"]);
+        // xAlt/yAlt default to x/y if not provided (closed wires have same start/end)
+        double xAlt = pair.contains("xAlt") ? py::cast<double>(pair["xAlt"]) : x;
+        double yAlt = pair.contains("yAlt") ? py::cast<double>(pair["yAlt"]) : y;
+
+        TSPPair cppPair(x, y, xAlt, yAlt);
+        cppPair.index = static_cast<int>(i);
+        cppPairs.emplace_back(cppPair);
+    }
+
+    // Handle optional start point
+    TSPPoint* pStartPoint = nullptr;
+    TSPPoint startPointObj(0, 0);
+    if (!routeStartPoint.is_none()) {
+        try {
+            auto sp = routeStartPoint.cast<std::vector<double>>();
+            if (sp.size() >= 2) {
+                startPointObj.x = sp[0];
+                startPointObj.y = sp[1];
+                pStartPoint = &startPointObj;
+            }
+        }
+        catch (py::cast_error&) {
+            try {
+                if (py::len(routeStartPoint) >= 2) {
+                    startPointObj.x = py::cast<double>(routeStartPoint.attr("__getitem__")(0));
+                    startPointObj.y = py::cast<double>(routeStartPoint.attr("__getitem__")(1));
+                    pStartPoint = &startPointObj;
+                }
+            }
+            catch (py::error_already_set&) {
+            }
+        }
+    }
+
+    // Handle optional end point
+    TSPPoint* pEndPoint = nullptr;
+    TSPPoint endPointObj(0, 0);
+    if (!routeEndPoint.is_none()) {
+        try {
+            auto ep = routeEndPoint.cast<std::vector<double>>();
+            if (ep.size() >= 2) {
+                endPointObj.x = ep[0];
+                endPointObj.y = ep[1];
+                pEndPoint = &endPointObj;
+            }
+        }
+        catch (py::cast_error&) {
+            try {
+                if (py::len(routeEndPoint) >= 2) {
+                    endPointObj.x = py::cast<double>(routeEndPoint.attr("__getitem__")(0));
+                    endPointObj.y = py::cast<double>(routeEndPoint.attr("__getitem__")(1));
+                    pEndPoint = &endPointObj;
+                }
+            }
+            catch (py::error_already_set&) {
+            }
+        }
+    }
+
+    // Solve the pair TSP
+    auto result = TSPSolver::solvePairs(cppPairs, pStartPoint, pEndPoint);
+
+    // Convert result back to Python dictionaries, preserving extra keys from input
+    std::vector<py::dict> pyResult;
+    for (const auto& pair : result) {
+        // Start with a copy of the original input dict to preserve extra keys
+        py::dict pairDict = py::dict(pairs[pair.index]);
+        // Update with solver results (may have changed due to flipping)
+        pairDict["x"] = pair.x;
+        pairDict["y"] = pair.y;
+        pairDict["xAlt"] = pair.xAlt;
+        pairDict["yAlt"] = pair.yAlt;
+        pairDict["flipped"] = pair.flipped;
+        pairDict["index"] = pair.index;
+        pyResult.push_back(pairDict);
+    }
+
+    return pyResult;
+}
+
 // Python wrapper for solveTunnels function
 std::vector<py::dict> tspSolveTunnelsPy(
     const std::vector<py::dict>& tunnels,
@@ -227,5 +321,20 @@ PYBIND11_MODULE(tsp_solver, m)
         "- routeStartPoint: Optional [x, y] point where route should start\n"
         "- routeEndPoint: Optional [x, y] point where route should end\n"
         "Returns: List of tunnel dictionaries in optimized order with flipped status"
+    );
+
+    m.def(
+        "solvePairs",
+        &tspSolvePairsPy,
+        py::arg("pairs"),
+        py::arg("routeStartPoint") = py::none(),
+        py::arg("routeEndPoint") = py::none(),
+        "Solve TSP for pairs (each element has a primary and alternative entry point).\n"
+        "Arguments:\n"
+        "- pairs: List of dictionaries with keys: x, y, xAlt, yAlt\n"
+        "- routeStartPoint: Optional [x, y] point where route should start\n"
+        "- routeEndPoint: Optional [x, y] point where route should end\n"
+        "Returns: List of pair dictionaries in optimized order; x/y reflect chosen entry point,\n"
+        "         flipped=True when xAlt/yAlt was selected as the entry point"
     );
 }

--- a/src/Mod/CAM/CAMTests/TestTSPSolver.py
+++ b/src/Mod/CAM/CAMTests/TestTSPSolver.py
@@ -442,6 +442,193 @@ class TestTSPSolver(PathTestBase):
             elif tunnel["index"] == 1:
                 self.assertEqual(tunnel["notes"], "high precision")
 
+    def print_pairs(self, pairs, title):
+        """Helper function to print pair information."""
+        if not self.DEBUG:
+            return
+        print(f"\n{title}:")
+        for i, pair in enumerate(pairs):
+            orig_idx = pair.get("index", "N/A")
+            flipped = pair.get("flipped", False)
+            print(
+                f"  {i} (orig {orig_idx}): ({pair['x']:.2f},{pair['y']:.2f})"
+                f" alt=({pair.get('xAlt', pair['x']):.2f},{pair.get('yAlt', pair['y']):.2f})"
+                f" flipped={flipped}"
+            )
+
+    def test_10_pairs_empty(self):
+        """Test that an empty pairs list returns an empty list."""
+        result = tsp_solver.solvePairs([])
+        self.assertEqual(result, [])
+
+    def test_11_pairs_single(self):
+        """Test that a single pair is returned unchanged (not flipped)."""
+        pairs = [{"x": 5.0, "y": 3.0, "xAlt": 10.0, "yAlt": 3.0}]
+        result = tsp_solver.solvePairs(pairs)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["index"], 0)
+        self.assertFalse(result[0]["flipped"])
+        self.assertRoughly(result[0]["x"], 5.0)
+        self.assertRoughly(result[0]["y"], 3.0)
+
+    def test_12_pairs_basic_ordering(self):
+        """Test that pairs are ordered by nearest-neighbor distance.
+
+        Four symmetric pairs (xAlt == x) arranged on a horizontal line but given
+        in shuffled order.  The temp start point is (0, 0), so the solver should
+        visit them left-to-right: indices 2 → 1 → 3 → 0.
+        """
+        pairs = [
+            {"x": 30.0, "y": 0.0, "xAlt": 30.0, "yAlt": 0.0},  # index 0
+            {"x": 10.0, "y": 0.0, "xAlt": 10.0, "yAlt": 0.0},  # index 1
+            {"x": 0.0, "y": 0.0, "xAlt": 0.0, "yAlt": 0.0},  # index 2
+            {"x": 20.0, "y": 0.0, "xAlt": 20.0, "yAlt": 0.0},  # index 3
+        ]
+        self.print_pairs(pairs, "Input pairs (basic ordering)")
+        result = tsp_solver.solvePairs(pairs)
+        self.print_pairs(result, "Sorted pairs (basic ordering)")
+
+        self.assertEqual(len(result), 4)
+        self.assertEqual(sorted([p["index"] for p in result]), [0, 1, 2, 3])
+        self.assertEqual([p["index"] for p in result], [2, 1, 3, 0])
+        for pair in result:
+            self.assertFalse(pair["flipped"])
+
+    def test_13_pairs_flipping(self):
+        """Test that the solver flips a pair when the alternative endpoint is closer.
+
+        Pair 1 has x=20 (far from previous) and xAlt=5 (close to previous).
+        The solver should flip it so that x=5 becomes the approach point.
+        """
+        pairs = [
+            {"x": 0.0, "y": 0.0, "xAlt": 0.0, "yAlt": 0.0},  # index 0
+            {"x": 20.0, "y": 0.0, "xAlt": 5.0, "yAlt": 0.0},  # index 1 — should flip
+            {"x": 10.0, "y": 0.0, "xAlt": 10.0, "yAlt": 0.0},  # index 2
+        ]
+        self.print_pairs(pairs, "Input pairs (flipping)")
+        result = tsp_solver.solvePairs(pairs)
+        self.print_pairs(result, "Sorted pairs (flipping)")
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual(sorted([p["index"] for p in result]), [0, 1, 2])
+        self.assertEqual([p["index"] for p in result], [0, 1, 2])
+
+        # Pair 0: not flipped, coords unchanged
+        self.assertFalse(result[0]["flipped"])
+        self.assertRoughly(result[0]["x"], 0.0)
+        self.assertRoughly(result[0]["y"], 0.0)
+
+        # Pair 1: should be flipped — x/xAlt swapped
+        self.assertTrue(result[1]["flipped"])
+        self.assertRoughly(result[1]["x"], 5.0)
+        self.assertRoughly(result[1]["xAlt"], 20.0)
+
+        # Pair 2: not flipped
+        self.assertFalse(result[2]["flipped"])
+
+    def test_14_pairs_start_point(self):
+        """Test that the pair nearest to routeStartPoint is visited first."""
+        pairs = [
+            {"x": 0.0, "y": 0.0, "xAlt": 0.0, "yAlt": 0.0},  # index 0
+            {"x": 10.0, "y": 0.0, "xAlt": 10.0, "yAlt": 0.0},  # index 1
+            {"x": 20.0, "y": 0.0, "xAlt": 20.0, "yAlt": 0.0},  # index 2
+            {"x": 30.0, "y": 0.0, "xAlt": 30.0, "yAlt": 0.0},  # index 3
+        ]
+        self.print_pairs(pairs, "Input pairs (start point)")
+        result = tsp_solver.solvePairs(pairs, routeStartPoint=[30.0, 0.0])
+        self.print_pairs(result, "Sorted pairs (start point)")
+
+        self.assertEqual(len(result), 4)
+        self.assertEqual(sorted([p["index"] for p in result]), [0, 1, 2, 3])
+        self.assertEqual(result[0]["index"], 3)
+
+    def test_15_pairs_end_point(self):
+        """Test that the pair nearest to routeEndPoint is visited last."""
+        pairs = [
+            {"x": 0.0, "y": 0.0, "xAlt": 0.0, "yAlt": 0.0},  # index 0
+            {"x": 10.0, "y": 0.0, "xAlt": 10.0, "yAlt": 0.0},  # index 1
+            {"x": 20.0, "y": 0.0, "xAlt": 20.0, "yAlt": 0.0},  # index 2
+            {"x": 30.0, "y": 0.0, "xAlt": 30.0, "yAlt": 0.0},  # index 3
+        ]
+        self.print_pairs(pairs, "Input pairs (end point)")
+        # End point is beyond the rightmost pair; pair 3 should end up last.
+        result = tsp_solver.solvePairs(pairs, routeEndPoint=[35.0, 0.0])
+        self.print_pairs(result, "Sorted pairs (end point)")
+
+        self.assertEqual(len(result), 4)
+        self.assertEqual(sorted([p["index"] for p in result]), [0, 1, 2, 3])
+        self.assertEqual(result[-1]["index"], 3)
+
+    def test_16_pairs_start_end_points(self):
+        """Test that both start and end constraints are respected simultaneously."""
+        pairs = [
+            {"x": 0.0, "y": 0.0, "xAlt": 0.0, "yAlt": 0.0},  # index 0
+            {"x": 10.0, "y": 0.0, "xAlt": 10.0, "yAlt": 0.0},  # index 1
+            {"x": 20.0, "y": 0.0, "xAlt": 20.0, "yAlt": 0.0},  # index 2
+            {"x": 30.0, "y": 0.0, "xAlt": 30.0, "yAlt": 0.0},  # index 3
+        ]
+        self.print_pairs(pairs, "Input pairs (start+end)")
+        result = tsp_solver.solvePairs(
+            pairs, routeStartPoint=[-5.0, 0.0], routeEndPoint=[35.0, 0.0]
+        )
+        self.print_pairs(result, "Sorted pairs (start+end)")
+
+        self.assertEqual(len(result), 4)
+        self.assertEqual(sorted([p["index"] for p in result]), [0, 1, 2, 3])
+        self.assertEqual(result[0]["index"], 0)
+        self.assertEqual(result[-1]["index"], 3)
+
+    def test_17_pairs_extra_data_passthrough(self):
+        """Test that extra keys in input dicts are preserved in the output."""
+        pairs = [
+            {"x": 10.0, "y": 0.0, "xAlt": 10.0, "yAlt": 0.0, "op_id": "B", "feed": 500},
+            {"x": 0.0, "y": 0.0, "xAlt": 0.0, "yAlt": 0.0, "op_id": "A", "feed": 300},
+            {"x": 20.0, "y": 0.0, "xAlt": 20.0, "yAlt": 0.0, "op_id": "C", "feed": 400},
+        ]
+        self.print_pairs(pairs, "Input pairs (extra data)")
+        result = tsp_solver.solvePairs(pairs)
+        self.print_pairs(result, "Sorted pairs (extra data preserved)")
+
+        self.assertEqual(len(result), 3)
+        for pair in result:
+            # Solver-added keys must be present
+            self.assertIn("x", pair)
+            self.assertIn("y", pair)
+            self.assertIn("xAlt", pair)
+            self.assertIn("yAlt", pair)
+            self.assertIn("flipped", pair)
+            self.assertIn("index", pair)
+            # Extra keys must survive
+            self.assertIn("op_id", pair)
+            self.assertIn("feed", pair)
+            # Values must match the original pair
+            original = pairs[pair["index"]]
+            self.assertEqual(pair["op_id"], original["op_id"])
+            self.assertEqual(pair["feed"], original["feed"])
+
+    def test_18_pairs_no_alt_coords(self):
+        """Test that pairs without xAlt/yAlt default correctly (no flipping)."""
+        # xAlt/yAlt are omitted; the C++ wrapper defaults them to x/y.
+        # Since both orientations are identical, no pair should be flipped.
+        pairs = [
+            {"x": 5.0, "y": 0.0},  # index 0
+            {"x": 0.0, "y": 0.0},  # index 1
+            {"x": 10.0, "y": 0.0},  # index 2
+        ]
+        self.print_pairs(pairs, "Input pairs (no alt coords)")
+        result = tsp_solver.solvePairs(pairs)
+        self.print_pairs(result, "Sorted pairs (no alt coords)")
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual(sorted([p["index"] for p in result]), [0, 1, 2])
+        # Nearest-neighbor from (0,0): pair 1 → pair 0 → pair 2
+        self.assertEqual([p["index"] for p in result], [1, 0, 2])
+        for pair in result:
+            self.assertFalse(pair["flipped"])
+            # xAlt/yAlt should have been added by the solver, matching x/y
+            self.assertRoughly(pair["xAlt"], pair["x"])
+            self.assertRoughly(pair["yAlt"], pair["y"])
+
 
 if __name__ == "__main__":
     import unittest

--- a/src/Mod/CAM/CAMTests/TestTSPSolver.py
+++ b/src/Mod/CAM/CAMTests/TestTSPSolver.py
@@ -190,7 +190,7 @@ class TestTSPSolver(PathTestBase):
         self.print_tunnels(tunnels, "Input tunnels")
 
         # Test without flipping
-        sorted_tunnels_no_flip = PathUtils.sort_tunnels_tsp(tunnels, allowFlipping=False)
+        sorted_tunnels_no_flip = tsp_solver.solveTunnels(tunnels, allowFlipping=False)
         self.print_tunnels(sorted_tunnels_no_flip, "Sorted tunnels (no flipping)")
 
         self.assertEqual(len(sorted_tunnels_no_flip), 7)
@@ -199,7 +199,7 @@ class TestTSPSolver(PathTestBase):
             self.assertFalse(tunnel["flipped"])
 
         # Test with flipping allowed
-        sorted_tunnels_with_flip = PathUtils.sort_tunnels_tsp(tunnels, allowFlipping=True)
+        sorted_tunnels_with_flip = tsp_solver.solveTunnels(tunnels, allowFlipping=True)
         self.print_tunnels(sorted_tunnels_with_flip, "Sorted tunnels (flipping allowed)")
 
         self.assertEqual(len(sorted_tunnels_with_flip), 7)
@@ -260,10 +260,11 @@ class TestTSPSolver(PathTestBase):
         ]
 
         # Test 1: No start/end constraints
-        print("\n=== Pentagram Test: No start/end constraints ===")
+        if self.DEBUG:
+            print("\n=== Pentagram Test: No start/end constraints ===")
         self.print_tunnels(tunnels, "Input pentagram tunnels")
 
-        sorted_no_constraints = PathUtils.sort_tunnels_tsp(tunnels, allowFlipping=True)
+        sorted_no_constraints = tsp_solver.solveTunnels(tunnels, allowFlipping=True)
         self.print_tunnels(sorted_no_constraints, "Sorted (no constraints)")
         self.assertEqual(len(sorted_no_constraints), 5)
 
@@ -271,8 +272,9 @@ class TestTSPSolver(PathTestBase):
         start_point = [pentagram_points[0][0], pentagram_points[0][1]]  # Start at point 0
         end_point = [pentagram_points[2][0], pentagram_points[2][1]]  # End at point 2
 
-        print(f"\n=== Pentagram Test: Start at {start_point}, End at {end_point} ===")
-        sorted_with_start_end = PathUtils.sort_tunnels_tsp(
+        if self.DEBUG:
+            print(f"\n=== Pentagram Test: Start at {start_point}, End at {end_point} ===")
+        sorted_with_start_end = tsp_solver.solveTunnels(
             tunnels,
             allowFlipping=True,
             routeStartPoint=start_point,
@@ -282,8 +284,9 @@ class TestTSPSolver(PathTestBase):
         self.assertEqual(len(sorted_with_start_end), 5)
 
         # Test 3: With just start point
-        print(f"\n=== Pentagram Test: Start at {start_point}, no end constraint ===")
-        sorted_with_start_only = PathUtils.sort_tunnels_tsp(
+        if self.DEBUG:
+            print(f"\n=== Pentagram Test: Start at {start_point}, no end constraint ===")
+        sorted_with_start_only = tsp_solver.solveTunnels(
             tunnels, allowFlipping=True, routeStartPoint=start_point
         )
         self.print_tunnels(sorted_with_start_only, "Sorted (start only constraint)")
@@ -352,11 +355,12 @@ class TestTSPSolver(PathTestBase):
             },  # 3 -> 5 (diagonal)
         ]
 
-        print("\n=== Complex Wire Test: End at (25, 10), no start constraint ===")
+        if self.DEBUG:
+            print("\n=== Complex Wire Test: End at (25, 10), no start constraint ===")
         self.print_tunnels(tunnels, "Input complex wire tunnels")
 
         end_point = [25.0, 10.0]  # End at point 4
-        sorted_tunnels = PathUtils.sort_tunnels_tsp(
+        sorted_tunnels = tsp_solver.solveTunnels(
             tunnels, allowFlipping=False, routeEndPoint=end_point
         )
         self.print_tunnels(sorted_tunnels, "Sorted (end only constraint)")
@@ -405,7 +409,7 @@ class TestTSPSolver(PathTestBase):
         self.print_tunnels(tunnels, "Input tunnels with extra data")
 
         # Test with flipping allowed to ensure extra data survives optimization
-        result = PathUtils.sort_tunnels_tsp(tunnels, allowFlipping=True)
+        result = tsp_solver.solveTunnels(tunnels, allowFlipping=True)
 
         self.print_tunnels(result, "Sorted tunnels with extra data preserved")
 

--- a/src/Mod/CAM/PathScripts/PathUtils.py
+++ b/src/Mod/CAM/PathScripts/PathUtils.py
@@ -636,36 +636,6 @@ def sort_locations_tsp(locations, keys, attractors=None, startPoint=None, endPoi
     return [locations[i] for i in order]
 
 
-def sort_tunnels_tsp(tunnels, allowFlipping=False, routeStartPoint=None, routeEndPoint=None):
-    """
-    Python wrapper for the C++ TSP tunnel solver. Takes a list of dicts (tunnels),
-    a list of keys for start/end coordinates, and optional parameters.
-
-    Parameters:
-    - tunnels: List of dictionaries with tunnel data. Each tunnel dictionary should contain:
-        - startX: X-coordinate of the tunnel start point
-        - startY: Y-coordinate of the tunnel start point
-        - endX: X-coordinate of the tunnel end point
-        - endY: Y-coordinate of the tunnel end point
-        - isOpen: Boolean indicating if the tunnel is open (optional, defaults to True)
-    - allowFlipping: Whether tunnels can be reversed (entry becomes exit)
-    - routeStartPoint: Optional starting point [x, y] for the entire route
-    - routeEndPoint: Optional ending point [x, y] for the entire route
-
-    Returns the sorted list of tunnels in TSP order. Each returned tunnel dictionary
-    will include the original keys plus:
-    - flipped: Boolean indicating if the tunnel was reversed during optimization
-    - index: Original index of the tunnel in the input list
-    """
-    # Call C++ TSP tunnel solver directly - it handles all the processing
-    return tsp_solver.solveTunnels(
-        tunnels=tunnels,
-        allowFlipping=allowFlipping,
-        routeStartPoint=routeStartPoint,
-        routeEndPoint=routeEndPoint,
-    )
-
-
 def guessDepths(objshape, subs=None):
     """
     takes an object shape and optional list of subobjects and returns a depth_params


### PR DESCRIPTION
Takes a list of pairs and reorders them to create efficient route for the router
a pair consists of two points - the route must go through ONE of the point
    
It uses nearest neighbour algorithm, further improved with 2-opt,
relocations and relocations with alternative point
    
routeStartPoint and routeEndPoint are optional and specifiy
where ROUGHLY the route should start and end
if 'routeStartPoint' is 'None', uses (0,0) start point
if 'routeEndPoint' is 'None', seach optimal end point
    
Tests have been included

Also remove pointless sort_tunnels_tsp() python wrapper as we can call direct