### PR TITLE
CAM: cleanup annotation building (more amenable to tool)

### DIFF
--- a/src/Mod/CAM/Path/Base/Generator/rotary_wrap.py
+++ b/src/Mod/CAM/Path/Base/Generator/rotary_wrap.py
@@ -171,9 +171,7 @@ def _apply_rezero(commands, axis_letter):
         params[axis_letter] = relative
         new_cmd = _clone(cmd, params)
         if crossed:
-            ann = dict(getattr(new_cmd, "Annotations", {}) or {})
-            ann["rotary_rezero"] = axis_letter
-            new_cmd.Annotations = ann
+            new_cmd.addAnnotations({"rotary_rezero": axis_letter})
         out.append(new_cmd)
 
     return out

--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -397,10 +397,7 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
 
             # Set RetractMode annotation for each command
             for command in drillcommands:
-                annotations = command.Annotations
-                annotations["RetractMode"] = mode
-                annotations["operation"] = "drilling"
-                command.Annotations = annotations
+                command.addAnnotations({"RetractMode": mode, "operation": "drilling"})
                 self.commandlist.append(command)
                 machinestate.addCommand(command)
 
@@ -532,10 +529,7 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
 
             # Set RetractMode annotation for each command
             for command in tappingcommands:
-                annotations = command.Annotations
-                annotations["RetractMode"] = mode
-                annotations["operation"] = "tapping"
-                command.Annotations = annotations
+                command.addAnnotations({"RetractMode": mode, "operation": "tapping"})
                 self.commandlist.append(command)
                 machinestate.addCommand(command)
 


### PR DESCRIPTION
Use addAnnotations() instead of round-about building & reassigning.

Allows better output from static-analysis tools to find Annotations (see next comment).
Probably @sliptonic did before .addAnnotations

## Issues

None. Code-quality