### PR TITLE
Gui: Override for Space key to keep focus in tree view

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1893,6 +1893,13 @@ Qt::DropActions TreeWidget::supportedDropActions() const
 
 bool TreeWidget::event(QEvent* e)
 {
+    if (e->type() == QEvent::ShortcutOverride) {
+        auto ke = static_cast<QKeyEvent*>(e);
+        if (ke->key() == Qt::Key_Space && ke->modifiers() == Qt::NoModifier) {
+            ke->accept();
+            return true;
+        }
+    }
     return QTreeWidget::event(e);
 }
 
@@ -1975,6 +1982,17 @@ void TreeWidget::keyPressEvent(QKeyEvent* event)
             event->accept();
             return;
         }
+    }
+
+    else if (event->key() == Qt::Key_Space && event->modifiers() == Qt::NoModifier) {
+        if (auto* cmd = Gui::Application::Instance->commandManager().getCommandByName(
+                "Std_ToggleVisibility"
+            )) {
+            cmd->invoke(0, Command::TriggerAction);
+        }
+        setFocus();
+        event->accept();
+        return;
     }
 
     QTreeWidget::keyPressEvent(event);


### PR DESCRIPTION
Keeps the keyboard focus on the tree view so you can move up/down between PD features in an active body to toggle visibility quickly.

Fixes https://github.com/FreeCAD/FreeCAD/issues/30216


https://github.com/user-attachments/assets/d452ae58-8e6e-4ebe-84e0-38fac8f8d8cd


