### PR TITLE
Revert std::string_view-related PyCXX changes

### DIFF
--- a/src/3rdParty/PyCXX/CXX/Python3/Objects.hxx
+++ b/src/3rdParty/PyCXX/CXX/Python3/Objects.hxx
@@ -2101,7 +2101,7 @@ namespace Py
             validate();
         }
 
-        String( std::string_view utf8 )
+        String( const std::string &utf8 )
         : SeqBase<Char>( PyUnicode_FromStringAndSize( utf8.data(), Py_ssize_t(utf8.size()) ), true )
         {
             validate();
@@ -2130,7 +2130,7 @@ namespace Py
            generic ones are documented.
 
         */
-        String( std::string_view s, const char *encoding, const char *errors=NULL )
+        String( const std::string &s, const char *encoding, const char *errors=NULL )
         : SeqBase<Char>( PyUnicode_Decode( s.data(), Py_ssize_t(s.size()), encoding, errors ), true )
         {
             validate();

--- a/src/App/DocumentObjectPyImp.cpp
+++ b/src/App/DocumentObjectPyImp.cpp
@@ -172,7 +172,7 @@ PyObject* DocumentObjectPy::supportedProperties(PyObject* args)
         Base::BaseClass* data = static_cast<Base::BaseClass*>(it.createInstance());
         if (data) {
             delete data;
-            res.append(Py::String(it.getName()));
+            res.append(Base::toPyString(it.getName()));
         }
     }
     return Py::new_reference_to(res);

--- a/src/App/DocumentPyImp.cpp
+++ b/src/App/DocumentPyImp.cpp
@@ -891,7 +891,7 @@ PyObject* DocumentPy::supportedTypes(PyObject* args)
     Base::Type::getAllDerivedFrom(App::DocumentObject::getClassTypeId(), ary);
     Py::List res;
     for (const auto& it : ary) {
-        res.append(Py::String(it.getName()));
+        res.append(Base::toPyString(it.getName()));
     }
     return Py::new_reference_to(res);
 }

--- a/src/App/LinkBaseExtensionPyImp.cpp
+++ b/src/App/LinkBaseExtensionPyImp.cpp
@@ -176,7 +176,7 @@ PyObject* LinkBaseExtensionPy::getLinkPropertyInfo(PyObject* args)
         for (const auto& info : infos) {
             ret.setItem(i++,
                         Py::TupleN(Py::String(info.name),
-                                   Py::String(info.type.getName()),
+                                   Base::toPyString(info.type.getName()),
                                    Py::String(info.doc)));
         }
         return Py::new_reference_to(ret);
@@ -189,7 +189,7 @@ PyObject* LinkBaseExtensionPy::getLinkPropertyInfo(PyObject* args)
             return nullptr;
         }
         Py::TupleN ret(Py::String(infos[index].name),
-                       Py::String(infos[index].type.getName()),
+                       Base::toPyString(infos[index].type.getName()),
                        Py::String(infos[index].doc));
         return Py::new_reference_to(ret);
     }
@@ -198,7 +198,7 @@ PyObject* LinkBaseExtensionPy::getLinkPropertyInfo(PyObject* args)
     if (PyArg_ParseTuple(args, "s", &name)) {
         for (const auto& info : infos) {
             if (strcmp(info.name, name) == 0) {
-                Py::TupleN ret(Py::String(info.type.getName()), Py::String(info.doc));
+                Py::TupleN ret(Base::toPyString(info.type.getName()), Py::String(info.doc));
                 return Py::new_reference_to(ret);
             }
         }

--- a/src/App/PropertyContainerPyImp.cpp
+++ b/src/App/PropertyContainerPyImp.cpp
@@ -153,7 +153,7 @@ PyObject* PropertyContainerPy::getTypeIdOfProperty(PyObject* args)
         return nullptr;
     }
 
-    Py::String str(prop->getTypeId().getName());
+    Py::String str = Base::toPyString(prop->getTypeId().getName());
     return Py::new_reference_to(str);
 }
 

--- a/src/Base/BaseClassPyImp.cpp
+++ b/src/Base/BaseClassPyImp.cpp
@@ -58,7 +58,7 @@ PyObject* BaseClassPy::getAllDerivedFrom(PyObject* args) const
     Type::getAllDerivedFrom(getBaseClassPtr()->getTypeId(), ary);
     Py::List res;
     for (const auto& it : ary) {
-        res.append(Py::String(it.getName()));
+        res.append(toPyString(it.getName()));
     }
     return Py::new_reference_to(res);
 }

--- a/src/Base/PyObjectBase.h
+++ b/src/Base/PyObjectBase.h
@@ -102,6 +102,16 @@ inline bool asBoolean(PyObject *obj) {
     return PyObject_IsTrue(obj) != 0;
 }
 
+/**
+ * @brief Make a Py::String out of a std::string_view.
+ */
+// If upstream PyCXX ever gets an std::string_view constructor for Py::String,
+// this can be trivially swapped out for that constructor.
+inline Py::String toPyString(std::string_view utf8)
+{
+    return { utf8.data(), Py_ssize_t(utf8.size()) };
+}
+
 }
 
 /*------------------------------

--- a/src/Base/TypePyImp.cpp
+++ b/src/Base/TypePyImp.cpp
@@ -219,7 +219,7 @@ PyObject* TypePy::createInstance(PyObject* args)
         return nullptr;
     }
 
-    Py::String name(getBaseTypePtr()->getName());
+    Py::String name = toPyString(getBaseTypePtr()->getName());
     Py::TupleN tuple(name);
 
     return createInstanceByName(tuple.ptr());

--- a/src/Gui/MDIViewPy.cpp
+++ b/src/Gui/MDIViewPy.cpp
@@ -101,7 +101,7 @@ Py::Object MDIViewPy::repr()
         throw Py::RuntimeError("Cannot print representation of deleted object");
     }
 
-    return Py::String(_view->getTypeId().getName());
+    return Base::toPyString(_view->getTypeId().getName());
 }
 
 Py::Object MDIViewPy::printView(const Py::Tuple& args)

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -1150,7 +1150,7 @@ Py::Object View3DInventorPy::getCamera()
         else {
             buffer[0] = '\0';
         }
-        return Py::String(std::string_view {buffer});
+        return Base::toPyString(std::string_view {buffer});
     }
     catch (const Base::Exception& e) {
         throw Py::RuntimeError(e.what());
@@ -1850,7 +1850,7 @@ Py::Object View3DInventorPy::listNavigationTypes()
     Py::List styles;
     Base::Type::getAllDerivedFrom(UserNavigationStyle::getClassTypeId(), types);
     for (auto it = types.begin() + 1; it != types.end(); ++it) {
-        styles.append(Py::String(it->getName()));
+        styles.append(Base::toPyString(it->getName()));
     }
     return styles;
 }
@@ -1858,7 +1858,7 @@ Py::Object View3DInventorPy::listNavigationTypes()
 Py::Object View3DInventorPy::getNavigationType()
 {
     const auto name = getView3DInventorPtr()->getViewer()->navigationStyle()->getTypeId().getName();
-    return Py::String(name);
+    return Base::toPyString(name);
 }
 
 Py::Object View3DInventorPy::setNavigationType(const Py::Tuple& args)

--- a/src/Gui/ViewProviderPyImp.cpp
+++ b/src/Gui/ViewProviderPyImp.cpp
@@ -148,7 +148,7 @@ PyObject* ViewProviderPy::supportedProperties(PyObject* args)
         auto data = static_cast<Base::BaseClass*>(it.createInstance());
         if (data) {
             delete data;
-            res.append(Py::String(it.getName()));
+            res.append(Base::toPyString(it.getName()));
         }
     }
     return Py::new_reference_to(res);

--- a/src/Mod/Part/App/AttachEnginePyImp.cpp
+++ b/src/Mod/Part/App/AttachEnginePyImp.cpp
@@ -326,7 +326,7 @@ PyObject* AttachEnginePy::getModeInfo(PyObject* args)
             Py::Object submod(module.getAttr("AttachEngineResources"));
             Py::Callable method(submod.getAttr("getModeStrings"));
             Py::Tuple arg(2);
-            arg.setItem(0, Py::String(this->getAttachEnginePtr()->getTypeId().getName()));
+            arg.setItem(0, Base::toPyString(this->getAttachEnginePtr()->getTypeId().getName()));
             arg.setItem(1, Py::Long(mmode));
             Py::List strs = method.apply(arg);
             assert(strs.size() == 2);


### PR DESCRIPTION
This broke builds with `FREECAD_USE_EXTERNAL_PYCXX=ON` since #30008.

* Fixes #30210