### PR TITLE
Build: Add Qt5 deprecation notice

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupQt.cmake
+++ b/cMake/FreeCAD_Helpers/SetupQt.cmake
@@ -1,6 +1,17 @@
 # -------------------------------- Qt --------------------------------
 
 set(FREECAD_QT_COMPONENTS Core Concurrent Network Xml)
+
+if (FREECAD_QT_MAJOR_VERSION EQUAL 5)
+    message(WARNING [[
+
+     ******************************************************************
+        Qt5 support is deprecated: please update your builds to Qt6.
+                  Support will be removed in August 2026.
+     ******************************************************************
+    ]])
+endif()
+
 if (FREECAD_QT_MAJOR_VERSION EQUAL 6)
     set (Qt6Core_MOC_EXECUTABLE Qt6::moc)
 endif()


### PR DESCRIPTION
As promised at today's developer meeting, this simply adds a warning-level notice during configuration that Qt5 support is being removed. I set the date as August, but of course we can make it whatever we want.

It looks like this:
```
...
-- swig runtime API version: 5
-- pivy runtime API version: 5
-- swig binary version building freecad: 4.5.0
CMake Warning at cMake/FreeCAD_Helpers/SetupQt.cmake:6 (message):


       ******************************************************************
          Qt5 support is deprecated: please update your builds to Qt6.
                    Support will be removed in August 2026.
       ******************************************************************
      
Call Stack (most recent call first):
  CMakeLists.txt:134 (include)


-- Set up to compile with ...
```