### PR TITLE
[TD]fix build failure on openSuse

### DIFF
--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -1879,8 +1879,8 @@ std::vector<int> GeometryUtils::findNestedFaceIndices(const std::vector<FacePtr>
     return nestedFaceIndices;
 }
 
-//! get a description for a GeomType.  Do not add a default case, as we want to
-//! ensure that we are always in sync with the GeomType enum.
+//! get a description for a GeomType.  Needs to always be in sync with the
+//! GeomType enum.
 std::string GeometryUtils::getGeomTypeName(GeomType typeEnumValue)
 {
     switch (typeEnumValue) {
@@ -1893,6 +1893,8 @@ std::string GeometryUtils::getGeomTypeName(GeomType typeEnumValue)
         case GeomType::BSPLINE: return "B-spline Curve";
         case GeomType::GENERIC: return "Line";
     }
+
+    return "Not Defined";
 }
 
 


### PR DESCRIPTION
This PR implements a fix for issue #30193.

The failure occurs with certain build flags (see issue).

A return statement is added for the situation where an invalid GeomType is passed.   