### PR TITLE
Part: Revert #28299 and clarify documentation

### DIFF
--- a/src/Mod/Part/App/TopoShape.pyi
+++ b/src/Mod/Part/App/TopoShape.pyi
@@ -472,13 +472,15 @@ class TopoShape(ComplexGeoData):
         self, matrix: Matrix, copy: bool = False, checkScale: bool = False, /
     ) -> TopoShape:
         """
-        Apply transformation on a shape without changing the underlying geometry.
+        Apply a transformation on this shape in place and return self.
         transformShape(Matrix, [boolean copy=False, checkScale=False]) -> shape
         --
-        If copy is True, returns a transformed copy and leaves the original unchanged.
-        If copy is False, transforms this shape in place and returns itself.
-        If checkScale is True, it will use transformGeometry if non-uniform
-        scaling is detected.
+        If copy is True the underlying geometry is duplicated and the transformation is baked into
+        it. If copy is False the transformation is applied as a location change without modifying
+        the underlying geometry (no bake-in). Note that scaling, mirroring, and non-uniform
+        transformations may force a copy regardless of this flag. If checkScale is True,
+        transformGeometry is used when non-uniform scaling is detected. To obtain a transformed copy
+        while leaving this shape untouched, use transformed() instead.
         """
         ...
 
@@ -487,8 +489,10 @@ class TopoShape(ComplexGeoData):
         self, matrix: Matrix, *, copy: bool = False, checkScale: bool = False, op: str = None
     ) -> TopoShape:
         """
-        Create a new transformed shape
-        transformed(Matrix,copy=False,checkScale=False,op=None) -> shape
+        Return a new shape with the transformation applied; leave self unchanged.
+        transformed(Matrix, copy=False, checkScale=False, op=None) -> shape
+        --
+        The copy and checkScale arguments have the same meaning as in transformShape().
         """
         ...
 

--- a/src/Mod/Part/App/TopoShape.pyi
+++ b/src/Mod/Part/App/TopoShape.pyi
@@ -473,7 +473,6 @@ class TopoShape(ComplexGeoData):
     ) -> TopoShape:
         """
         Apply a transformation on this shape in place and return self.
-        transformShape(Matrix, [boolean copy=False, checkScale=False]) -> shape
         --
         If copy is True the underlying geometry is duplicated and the transformation is baked into
         it. If copy is False the transformation is applied as a location change without modifying
@@ -490,9 +489,9 @@ class TopoShape(ComplexGeoData):
     ) -> TopoShape:
         """
         Return a new shape with the transformation applied; leave self unchanged.
-        transformed(Matrix, copy=False, checkScale=False, op=None) -> shape
         --
-        The copy and checkScale arguments have the same meaning as in transformShape().
+        The copy and checkScale arguments have the same meaning as in transformShape(). op is
+        unused.
         """
         ...
 

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -1093,17 +1093,9 @@ PyObject* TopoShapePy::transformShape(PyObject* args)
     }
 
     Base::Matrix4D mat = static_cast<Base::MatrixPy*>(obj)->value();
-    bool doCopy = Base::asBoolean(copy);
-    bool doCheckScale = Base::asBoolean(checkScale);
     PY_TRY
     {
-        if (doCopy) {
-            TopoShape s(*getTopoShapePtr());
-            s.transformShape(mat, false, doCheckScale);
-            return Py::new_reference_to(shape2pyshape(s));
-        }
-
-        this->getTopoShapePtr()->transformShape(mat, false, doCheckScale);
+        this->getTopoShapePtr()->transformShape(mat, Base::asBoolean(copy), Base::asBoolean(checkScale));
         return IncRef();
     }
     PY_CATCH_OCC

--- a/src/Mod/Part/parttests/regression_tests.py
+++ b/src/Mod/Part/parttests/regression_tests.py
@@ -185,22 +185,39 @@ class RegressionTests(unittest.TestCase):
         for name, pos, normal, xaxis in expected_planes:
             check_plane(name, pos, normal, xaxis)
 
-    def test_transformShape_copy_returns_independent_shape(self):
-        shp = Part.makeBox(1, 2, 3)
+    def test_issue_29733_transformShape_bakes_in_transformation(self):
+        """
+        29733: transformShape(matrix, True) must bake the transformation into the
+        underlying geometry, leaving the shape's Placement untouched. Part Explode
+        Compound and many third-party addons depend on this behavior.
+        """
+        sphere = Part.makeSphere(5.0)
+        move = FreeCAD.Placement(FreeCAD.Vector(10, 0, 0), FreeCAD.Rotation()).toMatrix()
 
-        # Regression: copy=True must return an independent shape object, even for identity transform.
-        cloned = shp.transformShape(FreeCAD.Matrix(), True)
-        self.assertIsNot(cloned, shp)
-        self.assertFalse(cloned.isEqual(shp))
-        self.assertAlmostEqual(shp.BoundBox.XMin, 0.0)
+        returned = sphere.transformShape(move, True)
 
-        # Transforming the returned copy must not affect the original.
-        moved = cloned.transformShape(
-            FreeCAD.Placement(FreeCAD.Vector(5, 0, 0), FreeCAD.Rotation()).toMatrix(), False
-        )
-        self.assertIs(moved, cloned)
-        self.assertAlmostEqual(shp.BoundBox.XMin, 0.0)
-        self.assertAlmostEqual(cloned.BoundBox.XMin, 5.0)
+        self.assertIs(returned, sphere)
+        self.assertAlmostEqual(sphere.Placement.Base.x, 0.0)
+        self.assertAlmostEqual(sphere.Placement.Base.y, 0.0)
+        self.assertAlmostEqual(sphere.Placement.Base.z, 0.0)
+        self.assertAlmostEqual(sphere.CenterOfGravity.x, 10.0, places=5)
+        self.assertAlmostEqual(sphere.CenterOfGravity.y, 0.0, places=5)
+        self.assertAlmostEqual(sphere.CenterOfGravity.z, 0.0, places=5)
+
+    def test_transformed_returns_independent_baked_in_copy(self):
+        """
+        transformed() must return a new shape with the transformation baked into
+        the geometry, leaving the original shape unchanged.
+        """
+        sphere = Part.makeSphere(5.0)
+        move = FreeCAD.Placement(FreeCAD.Vector(10, 0, 0), FreeCAD.Rotation()).toMatrix()
+
+        moved = sphere.transformed(move, copy=True)
+
+        self.assertIsNot(moved, sphere)
+        self.assertAlmostEqual(sphere.CenterOfGravity.x, 0.0, places=5)
+        self.assertAlmostEqual(moved.Placement.Base.x, 0.0)
+        self.assertAlmostEqual(moved.CenterOfGravity.x, 10.0, places=5)
 
     def test_issue_15716_AttacherEngine_sync(self):
         """


### PR DESCRIPTION
PR #28299 made what seemed at the time a logical change, handling a previously-unhandled `copy` argument. Unfortunately, it wasn't a `copy` argument at all, at least not the way a normal dev would read it. This was a case where we have a confusing parameter name, and mistaken documentation, leading to a change that shouldn't have been made. And in fact, even in the ensuing discussion, none of us realized that the method to do what was proposed already existed, with another not-quite-clear name. “There are only two hard things in Computer Science: cache invalidation and naming things.”

So, here's a go at some (maybe?!?!) clearer documentation strings. And basically just a code reversion to the original. Fixes #29733 among other things.