### PR TITLE
Gui: Add custom CS mode to transform dragger

### DIFF
--- a/src/Gui/Inventor/SoFCPlacementIndicatorKit.cpp
+++ b/src/Gui/Inventor/SoFCPlacementIndicatorKit.cpp
@@ -68,6 +68,9 @@ SoFCPlacementIndicatorKit::SoFCPlacementIndicatorKit()
     SO_NODE_ADD_FIELD(axisLength, (axisLengthDefault));
     SO_NODE_ADD_FIELD(parts, (AxisCross));
     SO_NODE_ADD_FIELD(axes, (AllAxes));
+    SO_NODE_ADD_FIELD(axisLabels, ("X"));
+    axisLabels.set1Value(1, "Y");
+    axisLabels.set1Value(2, "Z");
 
     SO_NODE_DEFINE_ENUM_VALUE(Part, Axes);
     SO_NODE_DEFINE_ENUM_VALUE(Part, ArrowHeads);
@@ -99,7 +102,7 @@ void SoFCPlacementIndicatorKit::notify(SoNotList* l)
 {
     SoField* field = l->getLastField();
 
-    if (field == &parts || field == &axes || field == &axisLength) {
+    if (field == &parts || field == &axes || field == &axisLength || field == &axisLabels) {
         // certainly this is not the fastest way to recompute the geometry as it does recreate
         // everything from the scratch. It is however very easy to implement and this node should
         // not really change too often so the performance penalty is better than making code that
@@ -245,25 +248,38 @@ SoSeparator* SoFCPlacementIndicatorKit::createAxes()
 
     auto sep = new SoSeparator;
 
+    auto labelAt = [&](int i, const char* fallback) -> const char* {
+        return axisLabels.getNum() > i ? axisLabels[i].getString() : fallback;
+    };
+
     if (axes.getValue() & X) {
-        sep->addChild(
-            createAxis("X", Base::Vector3d::UnitX, ViewParams::instance()->getAxisXColor(), xyOffset)
-        );
+        sep->addChild(createAxis(
+            labelAt(0, "X"),
+            Base::Vector3d::UnitX,
+            ViewParams::instance()->getAxisXColor(),
+            xyOffset
+        ));
     }
 
     if (axes.getValue() & Y) {
-        sep->addChild(
-            createAxis("Y", Base::Vector3d::UnitY, ViewParams::instance()->getAxisYColor(), xyOffset)
-        );
+        sep->addChild(createAxis(
+            labelAt(1, "Y"),
+            Base::Vector3d::UnitY,
+            ViewParams::instance()->getAxisYColor(),
+            xyOffset
+        ));
     }
 
     if (axes.getValue() & Z) {
         double zOffset = (parts.getValue() & PlaneIndicator) ? planeIndicatorMargin
                                                              : axisMargin + additionalAxisMargin;
 
-        sep->addChild(
-            createAxis("Z", Base::Vector3d::UnitZ, ViewParams::instance()->getAxisZColor(), zOffset)
-        );
+        sep->addChild(createAxis(
+            labelAt(2, "Z"),
+            Base::Vector3d::UnitZ,
+            ViewParams::instance()->getAxisZColor(),
+            zOffset
+        ));
     }
 
     return sep;

--- a/src/Gui/Inventor/SoFCPlacementIndicatorKit.cpp
+++ b/src/Gui/Inventor/SoFCPlacementIndicatorKit.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 
 #include <sstream>
+#include <optional>
 
 #include <Inventor/nodes/SoBaseColor.h>
 #include <Inventor/nodes/SoComplexity.h>
@@ -248,13 +249,16 @@ SoSeparator* SoFCPlacementIndicatorKit::createAxes()
 
     auto sep = new SoSeparator;
 
-    auto labelAt = [&](int i, const char* fallback) -> const char* {
-        return axisLabels.getNum() > i ? axisLabels[i].getString() : fallback;
+    auto labelAt = [&](int i) -> std::optional<const char*> {
+        if (axisLabels.getNum() <= i) {
+            return std::nullopt;
+        }
+        return axisLabels[i].getString();
     };
 
     if (axes.getValue() & X) {
         sep->addChild(createAxis(
-            labelAt(0, "X"),
+            labelAt(0).value_or("X"),
             Base::Vector3d::UnitX,
             ViewParams::instance()->getAxisXColor(),
             xyOffset
@@ -263,7 +267,7 @@ SoSeparator* SoFCPlacementIndicatorKit::createAxes()
 
     if (axes.getValue() & Y) {
         sep->addChild(createAxis(
-            labelAt(1, "Y"),
+            labelAt(1).value_or("Y"),
             Base::Vector3d::UnitY,
             ViewParams::instance()->getAxisYColor(),
             xyOffset
@@ -275,7 +279,7 @@ SoSeparator* SoFCPlacementIndicatorKit::createAxes()
                                                              : axisMargin + additionalAxisMargin;
 
         sep->addChild(createAxis(
-            labelAt(2, "Z"),
+            labelAt(2).value_or("Z"),
             Base::Vector3d::UnitZ,
             ViewParams::instance()->getAxisZColor(),
             zOffset

--- a/src/Gui/Inventor/SoFCPlacementIndicatorKit.h
+++ b/src/Gui/Inventor/SoFCPlacementIndicatorKit.h
@@ -25,6 +25,7 @@
 
 #include <Inventor/nodekits/SoBaseKit.h>
 
+#include <Inventor/fields/SoMFString.h>
 #include <Inventor/fields/SoSFBool.h>
 #include <Inventor/fields/SoSFEnum.h>
 #include <Inventor/fields/SoSFFloat.h>
@@ -92,6 +93,7 @@ public:
     SoSFBool coloredAxis;
     SoSFFloat scaleFactor;
     SoSFFloat axisLength;
+    SoMFString axisLabels;
 
 private:
     void recomputeGeometry();

--- a/src/Gui/TaskTransform.cpp
+++ b/src/Gui/TaskTransform.cpp
@@ -30,6 +30,7 @@
 #include <App/Document.h>
 #include <App/GeoFeature.h>
 #include <App/Services.h>
+#include <Base/Exception.h>
 #include <Base/Precision.h>
 #include <Base/ServiceProvider.h>
 #include <Base/Tools.h>
@@ -191,6 +192,9 @@ void TaskTransform::loadPositionModeItems() const
     ui->positionModeComboBox->clear();
     ui->positionModeComboBox->addItem(tr("Local"), QVariant::fromValue(PositionMode::Local));
     ui->positionModeComboBox->addItem(tr("Global"), QVariant::fromValue(PositionMode::Global));
+    if (subObjectPlacementProvider) {
+        ui->positionModeComboBox->addItem(tr("Custom"), QVariant::fromValue(PositionMode::Custom));
+    }
 }
 
 void TaskTransform::setupGui()
@@ -203,6 +207,7 @@ void TaskTransform::setupGui()
     loadPositionModeItems();
 
     ui->referencePickerWidget->hide();
+    ui->customCSPickerWidget->hide();
     ui->alignRotationCheckBox->hide();
 
     for (auto positionSpinBox :
@@ -251,6 +256,12 @@ void TaskTransform::setupGui()
         this,
         &TaskTransform::onPickTransformOrigin
     );
+    connect(
+        ui->pickCoordinateSystemReferenceButton,
+        &QPushButton::clicked,
+        this,
+        &TaskTransform::onPickCoordinateSystemReference
+    );
     connect(ui->alignToOtherObjectButton, &QPushButton::clicked, this, &TaskTransform::onAlignToOtherObject);
     connect(ui->moveOptionsButton, &QPushButton::toggled, ui->frameMoveOptions, &QWidget::setVisible);
     connect(ui->translateCheckbox, &QCheckBox::toggled, this, [this](bool translateChecked) {
@@ -287,7 +298,8 @@ void TaskTransform::setupGui()
         {ui->absolutePositionLayout,
          ui->absoluteRotationLayout,
          ui->transformOriginLayout,
-         ui->referencePickerLayout}
+         ui->referencePickerLayout,
+         ui->customCSPickerLayout}
     );
 
     loadPreferences();
@@ -377,7 +389,7 @@ void TaskTransform::updateInputLabels() const
 
 void TaskTransform::updateDraggerLabels() const
 {
-    auto coordinateSystem = isDraggerAlignedToCoordinateSystem() ? globalCoordinateSystem()
+    auto coordinateSystem = isDraggerAlignedToCoordinateSystem() ? currentCoordinateSystem()
                                                                  : localCoordinateSystem();
 
     auto [xLabel, yLabel, zLabel] = coordinateSystem.labels;
@@ -405,6 +417,7 @@ void TaskTransform::setSelectionMode(SelectionMode mode)
 
     ui->pickTransformOriginButton->setText(tr("Pick Reference"));
     ui->alignToOtherObjectButton->setText(tr("Move to Other Object"));
+    ui->pickCoordinateSystemReferenceButton->setText(tr("Pick Reference"));
 
     switch (mode) {
         case SelectionMode::SelectTransformOrigin:
@@ -420,6 +433,14 @@ void TaskTransform::setSelectionMode(SelectionMode mode)
             draggerPickStyle->setOverride(true);
             ui->alignToOtherObjectButton->setText(tr("Cancel"));
             blockSelection(false);
+            break;
+
+        case SelectionMode::SelectCustomCS:
+            draggerPickStyle->style = SoPickStyle::UNPICKABLE;
+            draggerPickStyle->setOverride(true);
+            blockSelection(false);
+            ui->customCSLineEdit->setText(tr("Select object…"));
+            ui->pickCoordinateSystemReferenceButton->setText(tr("Cancel"));
             break;
 
         case SelectionMode::None:
@@ -455,10 +476,25 @@ TaskTransform::CoordinateSystem TaskTransform::globalCoordinateSystem() const
     return {{"X", "Y", "Z"}, globalOrigin};
 }
 
+TaskTransform::CoordinateSystem TaskTransform::customCoordinateSystem() const
+{
+    if (!customCoordinateSystemPlacement.has_value()) {
+        return globalCoordinateSystem();
+    }
+    return {{"X′", "Y′", "Z′"}, globalOrigin * (*customCoordinateSystemPlacement)};
+}
+
 TaskTransform::CoordinateSystem TaskTransform::currentCoordinateSystem() const
 {
-    return ui->positionModeComboBox->currentIndex() == 0 ? localCoordinateSystem()
-                                                         : globalCoordinateSystem();
+    switch (positionMode) {
+        case PositionMode::Local:
+            return localCoordinateSystem();
+        case PositionMode::Global:
+            return globalCoordinateSystem();
+        case PositionMode::Custom:
+            return customCoordinateSystem();
+    }
+    return localCoordinateSystem();
 }
 
 Base::Rotation::EulerSequence TaskTransform::eulerSequence() const
@@ -473,6 +509,56 @@ void TaskTransform::onSelectionChanged(const SelectionChanges& msg)
         || msg.Type == SelectionChanges::SetPreselect;
 
     if (!isSupportedMessage) {
+        return;
+    }
+
+    if (selectionMode == SelectionMode::SelectCustomCS && msg.Type == SelectionChanges::AddSelection) {
+        auto doc = Application::Instance->getDocument(msg.pDocName);
+        auto obj = doc->getDocument()->getObject(msg.pObjectName);
+        if (!obj) {
+            return;
+        }
+
+        Base::Placement refPlacement;
+        QString label;
+
+        if (msg.pOriginalMsg && subObjectPlacementProvider) {
+            auto orgDoc = Application::Instance->getDocument(msg.pOriginalMsg->pDocName);
+            auto orgObj = orgDoc->getDocument()->getObject(msg.pOriginalMsg->pObjectName);
+            auto gp = App::GeoFeature::getGlobalPlacement(obj, orgObj, msg.pOriginalMsg->pSubName);
+            auto localPlacement = App::GeoFeature::getPlacementFromProp(obj, "Placement");
+            try {
+                refPlacement = gp * subObjectPlacementProvider->calculate(msg.Object, localPlacement);
+            }
+            catch (const Base::Exception&) {
+                // Shape type unsupported for attacher (e.g. Solid): fall back to the
+                // link-aware placement already resolved above, preserving link-instance transforms.
+                refPlacement = gp;
+            }
+            label = QStringLiteral("%1#%2.%3")
+                        .arg(
+                            QLatin1String(msg.pOriginalMsg->pObjectName),
+                            QLatin1String(msg.pObjectName),
+                            QLatin1String(msg.pSubName)
+                        );
+        }
+        else if (obj->getDocument() == vp->getObject()->getDocument()) {
+            // Tree-view pick without link resolution: only accept same-document objects
+            // to avoid treating cross-document placements as if they were in this document's space.
+            refPlacement = App::GeoFeature::getGlobalPlacement(obj);
+            label = QString::fromLatin1(obj->Label.getValue());
+        }
+        else {
+            return;
+        }
+
+        customCoordinateSystemPlacement = refPlacement;
+        ui->customCSLineEdit->setText(label);
+        setSelectionMode(SelectionMode::None);
+        updateInputLabels();
+        updatePositionAndRotationUi();
+        updateTransformOrigin();
+        updateDraggerLabels();
         return;
     }
 
@@ -634,6 +720,14 @@ void TaskTransform::onPickTransformOrigin()
     );
 }
 
+void TaskTransform::onPickCoordinateSystemReference()
+{
+    setSelectionMode(
+        selectionMode == SelectionMode::SelectCustomCS ? SelectionMode::None
+                                                       : SelectionMode::SelectCustomCS
+    );
+}
+
 void TaskTransform::onPlacementModeChange([[maybe_unused]] int index)
 {
     placementMode = ui->placementComboBox->currentData().value<PlacementMode>();
@@ -669,7 +763,7 @@ void TaskTransform::updateTransformOrigin()
     auto transformOrigin = getTransformOrigin(placementMode);
     if (isDraggerAlignedToCoordinateSystem()) {
         transformOrigin.setRotation(
-            (vp->getObjectPlacement().inverse() * globalCoordinateSystem().origin).getRotation()
+            (vp->getObjectPlacement().inverse() * currentCoordinateSystem().origin).getRotation()
         );
     }
 
@@ -712,7 +806,7 @@ void TaskTransform::resetReferenceRotation()
 
 bool TaskTransform::isDraggerAlignedToCoordinateSystem() const
 {
-    return positionMode == PositionMode::Global && ui->alignRotationCheckBox->isChecked();
+    return positionMode != PositionMode::Local && ui->alignRotationCheckBox->isChecked();
 }
 
 void TaskTransform::onTransformOriginReset()
@@ -722,13 +816,22 @@ void TaskTransform::onTransformOriginReset()
 
 void TaskTransform::onCoordinateSystemChange([[maybe_unused]] int mode)
 {
+    if (selectionMode == SelectionMode::SelectCustomCS) {
+        setSelectionMode(SelectionMode::None);
+    }
+
     positionMode = ui->positionModeComboBox->currentData().value<PositionMode>();
 
     ui->alignRotationCheckBox->setVisible(positionMode != PositionMode::Local);
+    ui->customCSPickerWidget->setVisible(positionMode == PositionMode::Custom);
 
     updateInputLabels();
     updatePositionAndRotationUi();
     updateTransformOrigin();
+
+    if (positionMode == PositionMode::Custom && !customCoordinateSystemPlacement.has_value()) {
+        setSelectionMode(SelectionMode::SelectCustomCS);
+    }
 }
 
 void TaskTransform::onPositionChange()

--- a/src/Gui/TaskTransform.cpp
+++ b/src/Gui/TaskTransform.cpp
@@ -47,7 +47,14 @@
 #include "TaskTransform.h"
 #include "ui_TaskTransform.h"
 
+#include "Inventor/SoFCPlacementIndicatorKit.h"
+#include "Inventor/So3DAnnotation.h"
+#include "View3DInventor.h"
+
 #include <Inventor/nodes/SoPickStyle.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoTransform.h>
+#include <Inventor/nodes/SoGroup.h>
 
 using namespace Gui;
 
@@ -111,6 +118,8 @@ TaskTransform::TaskTransform(
 
 TaskTransform::~TaskTransform()
 {
+    hideCoordinateSystemIndicator();
+
     Gui::Application::Instance->commandManager()
         .getCommandByName("Std_OrthographicCamera")
         ->setEnabled(true);
@@ -555,6 +564,7 @@ void TaskTransform::onSelectionChanged(const SelectionChanges& msg)
         customCoordinateSystemPlacement = refPlacement;
         ui->customCSLineEdit->setText(label);
         setSelectionMode(SelectionMode::None);
+        showCoordinateSystemIndicator();
         updateInputLabels();
         updatePositionAndRotationUi();
         updateTransformOrigin();
@@ -809,6 +819,69 @@ bool TaskTransform::isDraggerAlignedToCoordinateSystem() const
     return positionMode != PositionMode::Local && ui->alignRotationCheckBox->isChecked();
 }
 
+void TaskTransform::showCoordinateSystemIndicator()
+{
+    auto* view3d = dynamic_cast<View3DInventor*>(vp->getDocument()->getEditingViewOfViewProvider(vp));
+    if (!view3d) {
+        return;
+    }
+
+    auto* editingRoot = dynamic_cast<SoGroup*>(view3d->getViewer()->getEditingRoot());
+    if (!editingRoot) {
+        return;
+    }
+
+    hideCoordinateSystemIndicator();
+
+    auto* transform = new SoTransform();
+    csIndicatorTransform = transform;
+
+    auto* indicator = new SoFCPlacementIndicatorKit();
+    if (positionMode == PositionMode::Custom) {
+        indicator->axisLabels.set1Value(0, "X\xe2\x80\xb2");
+        indicator->axisLabels.set1Value(1, "Y\xe2\x80\xb2");
+        indicator->axisLabels.set1Value(2, "Z\xe2\x80\xb2");
+    }
+
+    auto* annotation = new So3DAnnotation();
+    annotation->addChild(transform);
+    annotation->addChild(indicator);
+
+    auto* root = new SoSeparator();
+    root->addChild(annotation);
+    csIndicatorRoot = root;
+
+    editingRoot->addChild(csIndicatorRoot);
+
+    updateCoordinateSystemIndicator();
+}
+
+void TaskTransform::hideCoordinateSystemIndicator()
+{
+    if (!csIndicatorRoot) {
+        return;
+    }
+
+    auto* view3d = dynamic_cast<View3DInventor*>(vp->getDocument()->getEditingViewOfViewProvider(vp));
+    if (view3d) {
+        auto* editingRoot = dynamic_cast<SoGroup*>(view3d->getViewer()->getEditingRoot());
+        if (editingRoot) {
+            editingRoot->removeChild(csIndicatorRoot);
+        }
+    }
+
+    csIndicatorRoot = nullptr;
+    csIndicatorTransform = nullptr;
+}
+
+void TaskTransform::updateCoordinateSystemIndicator()
+{
+    if (!csIndicatorTransform) {
+        return;
+    }
+    ViewProviderDragger::updateTransform(currentCoordinateSystem().origin, csIndicatorTransform);
+}
+
 void TaskTransform::onTransformOriginReset()
 {
     vp->resetTransformOrigin();
@@ -824,6 +897,16 @@ void TaskTransform::onCoordinateSystemChange([[maybe_unused]] int mode)
 
     ui->alignRotationCheckBox->setVisible(positionMode != PositionMode::Local);
     ui->customCSPickerWidget->setVisible(positionMode == PositionMode::Custom);
+
+    if (positionMode == PositionMode::Local) {
+        hideCoordinateSystemIndicator();
+    }
+    else if (
+        positionMode == PositionMode::Global
+        || (positionMode == PositionMode::Custom && customCoordinateSystemPlacement.has_value())
+    ) {
+        showCoordinateSystemIndicator();
+    }
 
     updateInputLabels();
     updatePositionAndRotationUi();

--- a/src/Gui/TaskTransform.cpp
+++ b/src/Gui/TaskTransform.cpp
@@ -83,6 +83,20 @@ void alignGridLayoutColumns(const std::list<QGridLayout*>& layouts, unsigned col
     }
 }
 
+constexpr std::array<const char*, 3> customCoordinateSystemLabels {"X′", "Y′", "Z′"};
+
+QString linkedSelectionLabel(const SelectionChanges& msg)
+{
+    assert(msg.pOriginalMsg);
+
+    return QStringLiteral("%1#%2.%3")
+        .arg(
+            QLatin1String(msg.pOriginalMsg->pObjectName),
+            QLatin1String(msg.pObjectName),
+            QLatin1String(msg.pSubName)
+        );
+}
+
 }  // namespace
 
 TaskTransform::TaskTransform(
@@ -215,7 +229,9 @@ void TaskTransform::setupGui()
     loadPlacementModeItems();
     loadPositionModeItems();
 
+    ui->referenceLabel->hide();
     ui->referencePickerWidget->hide();
+    ui->customCSReferenceLabel->hide();
     ui->customCSPickerWidget->hide();
     ui->alignRotationCheckBox->hide();
 
@@ -307,8 +323,7 @@ void TaskTransform::setupGui()
         {ui->absolutePositionLayout,
          ui->absoluteRotationLayout,
          ui->transformOriginLayout,
-         ui->referencePickerLayout,
-         ui->customCSPickerLayout}
+         ui->coordinateSystemLayout}
     );
 
     loadPreferences();
@@ -490,7 +505,8 @@ TaskTransform::CoordinateSystem TaskTransform::customCoordinateSystem() const
     if (!customCoordinateSystemPlacement.has_value()) {
         return globalCoordinateSystem();
     }
-    return {{"X′", "Y′", "Z′"}, globalOrigin * (*customCoordinateSystemPlacement)};
+    auto [xLabel, yLabel, zLabel] = customCoordinateSystemLabels;
+    return {{xLabel, yLabel, zLabel}, globalOrigin * (*customCoordinateSystemPlacement)};
 }
 
 TaskTransform::CoordinateSystem TaskTransform::currentCoordinateSystem() const
@@ -522,53 +538,7 @@ void TaskTransform::onSelectionChanged(const SelectionChanges& msg)
     }
 
     if (selectionMode == SelectionMode::SelectCustomCS && msg.Type == SelectionChanges::AddSelection) {
-        auto doc = Application::Instance->getDocument(msg.pDocName);
-        auto obj = doc->getDocument()->getObject(msg.pObjectName);
-        if (!obj) {
-            return;
-        }
-
-        Base::Placement refPlacement;
-        QString label;
-
-        if (msg.pOriginalMsg && subObjectPlacementProvider) {
-            auto orgDoc = Application::Instance->getDocument(msg.pOriginalMsg->pDocName);
-            auto orgObj = orgDoc->getDocument()->getObject(msg.pOriginalMsg->pObjectName);
-            auto gp = App::GeoFeature::getGlobalPlacement(obj, orgObj, msg.pOriginalMsg->pSubName);
-            auto localPlacement = App::GeoFeature::getPlacementFromProp(obj, "Placement");
-            try {
-                refPlacement = gp * subObjectPlacementProvider->calculate(msg.Object, localPlacement);
-            }
-            catch (const Base::Exception&) {
-                // Shape type unsupported for attacher (e.g. Solid): fall back to the
-                // link-aware placement already resolved above, preserving link-instance transforms.
-                refPlacement = gp;
-            }
-            label = QStringLiteral("%1#%2.%3")
-                        .arg(
-                            QLatin1String(msg.pOriginalMsg->pObjectName),
-                            QLatin1String(msg.pObjectName),
-                            QLatin1String(msg.pSubName)
-                        );
-        }
-        else if (obj->getDocument() == vp->getObject()->getDocument()) {
-            // Tree-view pick without link resolution: only accept same-document objects
-            // to avoid treating cross-document placements as if they were in this document's space.
-            refPlacement = App::GeoFeature::getGlobalPlacement(obj);
-            label = QString::fromLatin1(obj->Label.getValue());
-        }
-        else {
-            return;
-        }
-
-        customCoordinateSystemPlacement = refPlacement;
-        ui->customCSLineEdit->setText(label);
-        setSelectionMode(SelectionMode::None);
-        showCoordinateSystemIndicator();
-        updateInputLabels();
-        updatePositionAndRotationUi();
-        updateTransformOrigin();
-        updateDraggerLabels();
+        setCustomCoordinateSystemFromSelection(msg);
         return;
     }
 
@@ -605,12 +575,7 @@ void TaskTransform::onSelectionChanged(const SelectionChanges& msg)
         selectedObjectPlacement.setPosition(rootLocalSnapPos);
     }
 
-    auto label = QStringLiteral("%1#%2.%3")
-                     .arg(
-                         QLatin1String(msg.pOriginalMsg->pObjectName),
-                         QLatin1String(msg.pObjectName),
-                         QLatin1String(msg.pSubName)
-                     );
+    auto label = linkedSelectionLabel(msg);
 
     switch (selectionMode) {
         case SelectionMode::SelectTransformOrigin: {
@@ -643,6 +608,52 @@ void TaskTransform::onSelectionChanged(const SelectionChanges& msg)
             // no-op
             break;
     }
+}
+
+void TaskTransform::setCustomCoordinateSystemFromSelection(const SelectionChanges& msg)
+{
+    auto doc = Application::Instance->getDocument(msg.pDocName);
+    auto obj = doc->getDocument()->getObject(msg.pObjectName);
+    if (!obj) {
+        return;
+    }
+
+    Base::Placement refPlacement;
+    QString label;
+
+    if (msg.pOriginalMsg && subObjectPlacementProvider) {
+        auto orgDoc = Application::Instance->getDocument(msg.pOriginalMsg->pDocName);
+        auto orgObj = orgDoc->getDocument()->getObject(msg.pOriginalMsg->pObjectName);
+        auto gp = App::GeoFeature::getGlobalPlacement(obj, orgObj, msg.pOriginalMsg->pSubName);
+        auto localPlacement = App::GeoFeature::getPlacementFromProp(obj, "Placement");
+        try {
+            refPlacement = gp * subObjectPlacementProvider->calculate(msg.Object, localPlacement);
+        }
+        catch (const Base::Exception&) {
+            // Shape type unsupported for attacher (e.g. Solid): fall back to the
+            // link-aware placement already resolved above, preserving link-instance transforms.
+            refPlacement = gp;
+        }
+        label = linkedSelectionLabel(msg);
+    }
+    else if (obj->getDocument() == vp->getObject()->getDocument()) {
+        // Tree-view pick without link resolution: only accept same-document objects
+        // to avoid treating cross-document placements as if they were in this document's space.
+        refPlacement = App::GeoFeature::getGlobalPlacement(obj);
+        label = QString::fromUtf8(obj->Label.getValue());
+    }
+    else {
+        return;
+    }
+
+    customCoordinateSystemPlacement = refPlacement;
+    ui->customCSLineEdit->setText(label);
+    setSelectionMode(SelectionMode::None);
+    showCoordinateSystemIndicator();
+    updateInputLabels();
+    updatePositionAndRotationUi();
+    updateTransformOrigin();
+    updateDraggerLabels();
 }
 
 void TaskTransform::onAlignRotationChanged()
@@ -763,7 +774,9 @@ void TaskTransform::updateTransformOrigin()
         }
     };
 
-    ui->referencePickerWidget->setVisible(placementMode == PlacementMode::Custom);
+    const bool showReference = (placementMode == PlacementMode::Custom);
+    ui->referenceLabel->setVisible(showReference);
+    ui->referencePickerWidget->setVisible(showReference);
 
     if (placementMode == PlacementMode::Custom && !customTransformOrigin.has_value()) {
         setSelectionMode(SelectionMode::SelectTransformOrigin);
@@ -819,32 +832,40 @@ bool TaskTransform::isDraggerAlignedToCoordinateSystem() const
     return positionMode != PositionMode::Local && ui->alignRotationCheckBox->isChecked();
 }
 
+static SoGroup* findActiveEditingRoot(Gui::Document* doc)
+{
+    const auto views = doc->getMDIViewsOfType(View3DInventor::getClassTypeId());
+    for (auto* mdi : views) {
+        auto* view3d = static_cast<View3DInventor*>(mdi);
+        View3DInventorViewer* viewer = view3d->getViewer();
+        if (viewer->isEditingViewProvider()) {
+            return dynamic_cast<SoGroup*>(viewer->getEditingRoot());
+        }
+    }
+    return nullptr;
+}
+
 void TaskTransform::showCoordinateSystemIndicator()
 {
-    auto* view3d = dynamic_cast<View3DInventor*>(vp->getDocument()->getEditingViewOfViewProvider(vp));
-    if (!view3d) {
-        return;
-    }
-
-    auto* editingRoot = dynamic_cast<SoGroup*>(view3d->getViewer()->getEditingRoot());
+    auto* editingRoot = findActiveEditingRoot(vp->getDocument());
     if (!editingRoot) {
         return;
     }
 
     hideCoordinateSystemIndicator();
 
-    auto* transform = new SoTransform();
-    csIndicatorTransform = transform;
+    csIndicatorTransform = new SoTransform();
 
     auto* indicator = new SoFCPlacementIndicatorKit();
     if (positionMode == PositionMode::Custom) {
-        indicator->axisLabels.set1Value(0, "X\xe2\x80\xb2");
-        indicator->axisLabels.set1Value(1, "Y\xe2\x80\xb2");
-        indicator->axisLabels.set1Value(2, "Z\xe2\x80\xb2");
+        auto [xLabel, yLabel, zLabel] = customCoordinateSystemLabels;
+        indicator->axisLabels.set1Value(0, xLabel);
+        indicator->axisLabels.set1Value(1, yLabel);
+        indicator->axisLabels.set1Value(2, zLabel);
     }
 
     auto* annotation = new So3DAnnotation();
-    annotation->addChild(transform);
+    annotation->addChild(csIndicatorTransform);
     annotation->addChild(indicator);
 
     auto* root = new SoSeparator();
@@ -862,12 +883,9 @@ void TaskTransform::hideCoordinateSystemIndicator()
         return;
     }
 
-    auto* view3d = dynamic_cast<View3DInventor*>(vp->getDocument()->getEditingViewOfViewProvider(vp));
-    if (view3d) {
-        auto* editingRoot = dynamic_cast<SoGroup*>(view3d->getViewer()->getEditingRoot());
-        if (editingRoot) {
-            editingRoot->removeChild(csIndicatorRoot);
-        }
+    auto* editingRoot = findActiveEditingRoot(vp->getDocument());
+    if (editingRoot) {
+        editingRoot->removeChild(csIndicatorRoot);
     }
 
     csIndicatorRoot = nullptr;
@@ -896,6 +914,7 @@ void TaskTransform::onCoordinateSystemChange([[maybe_unused]] int mode)
     positionMode = ui->positionModeComboBox->currentData().value<PositionMode>();
 
     ui->alignRotationCheckBox->setVisible(positionMode != PositionMode::Local);
+    ui->customCSReferenceLabel->setVisible(positionMode == PositionMode::Custom);
     ui->customCSPickerWidget->setVisible(positionMode == PositionMode::Custom);
 
     if (positionMode == PositionMode::Local) {

--- a/src/Gui/TaskTransform.h
+++ b/src/Gui/TaskTransform.h
@@ -34,6 +34,10 @@
 #include <App/Application.h>
 #include <App/Services.h>
 
+#include <array>
+#include <optional>
+#include <string>
+
 class SoDragger;
 class SoTransform;
 
@@ -143,6 +147,7 @@ private:
 
     void resetReferencePlacement();
     void resetReferenceRotation();
+    void setCustomCoordinateSystemFromSelection(const SelectionChanges& msg);
 
     ViewProviderDragger::DraggerComponents getRelevantComponents();
     void moveObjectToDragger(
@@ -162,7 +167,7 @@ private:
 
     CoinPtr<SoTransformDragger> dragger;
     CoinPtr<SoSeparator> csIndicatorRoot;
-    SoTransform* csIndicatorTransform {nullptr};
+    CoinPtr<SoTransform> csIndicatorTransform;
 
     Ui_TaskTransformDialog* ui;
 

--- a/src/Gui/TaskTransform.h
+++ b/src/Gui/TaskTransform.h
@@ -27,12 +27,15 @@
 #include "TaskView/TaskView.h"
 #include "ViewProviderDragger.h"
 
+#include <Inventor/nodes/SoSeparator.h>
+
 #include <Base/ServiceProvider.h>
 
 #include <App/Application.h>
 #include <App/Services.h>
 
 class SoDragger;
+class SoTransform;
 
 namespace Gui
 {
@@ -148,12 +151,18 @@ private:
 
     bool isDraggerAlignedToCoordinateSystem() const;
 
+    void showCoordinateSystemIndicator();
+    void hideCoordinateSystemIndicator();
+    void updateCoordinateSystemIndicator();
+
     ViewProviderDragger* vp;
 
     const App::SubObjectPlacementProvider* subObjectPlacementProvider;
     const App::CenterOfMassProvider* centerOfMassProvider;
 
     CoinPtr<SoTransformDragger> dragger;
+    CoinPtr<SoSeparator> csIndicatorRoot;
+    SoTransform* csIndicatorTransform {nullptr};
 
     Ui_TaskTransformDialog* ui;
 

--- a/src/Gui/TaskTransform.h
+++ b/src/Gui/TaskTransform.h
@@ -52,7 +52,8 @@ public:
     {
         None,
         SelectTransformOrigin,
-        SelectAlignTarget
+        SelectAlignTarget,
+        SelectCustomCS
     };
     enum class PlacementMode
     {
@@ -63,7 +64,8 @@ public:
     enum class PositionMode
     {
         Local,
-        Global
+        Global,
+        Custom
     };
 
     struct CoordinateSystem
@@ -94,6 +96,7 @@ private Q_SLOTS:
     void onPlacementModeChange(int index);
 
     void onPickTransformOrigin();
+    void onPickCoordinateSystemReference();
     void onTransformOriginReset();
     void onAlignRotationChanged();
 
@@ -115,6 +118,7 @@ private:
 
     CoordinateSystem globalCoordinateSystem() const;
     CoordinateSystem localCoordinateSystem() const;
+    CoordinateSystem customCoordinateSystem() const;
     CoordinateSystem currentCoordinateSystem() const;
 
     Base::Rotation::EulerSequence eulerSequence() const;
@@ -158,6 +162,7 @@ private:
     PositionMode positionMode {PositionMode::Local};
 
     std::optional<Base::Placement> customTransformOrigin {};
+    std::optional<Base::Placement> customCoordinateSystemPlacement {};
     Base::Placement referencePlacement {};
     Base::Placement globalOrigin {};
     Base::Rotation referenceRotation {};

--- a/src/Gui/TaskTransform.ui
+++ b/src/Gui/TaskTransform.ui
@@ -45,7 +45,7 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <property name="topMargin">
       <number>0</number>
@@ -59,7 +59,7 @@
      </item>
     </layout>
    </item>
-   <item row="7" column="0">
+   <item row="8" column="0">
     <spacer name="vSpacer">
      <property name="orientation">
       <enum>Qt::Orientation::Vertical</enum>
@@ -88,7 +88,58 @@
      </property>
     </spacer>
    </item>
-   <item row="4" column="0">
+   <item row="3" column="0">
+    <widget class="QWidget" name="customCSPickerWidget" native="true">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="customCSPickerLayout" columnstretch="0,1">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="customCSReferenceLabel">
+        <property name="minimumSize">
+         <size>
+          <width>68</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Reference</string>
+        </property>
+        <property name="buddy">
+         <cstring>customCSLineEdit</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="customCSLineEdit">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="pickCoordinateSystemReferenceButton">
+        <property name="text">
+         <string>Pick Reference</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="0">
     <widget class="QGroupBox" name="positionGroupBox">
      <property name="title">
       <string>Translation</string>
@@ -187,7 +238,7 @@
      </layout>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Utilities</string>
@@ -607,7 +658,7 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QGroupBox" name="rotationGroupBox">
      <property name="title">
       <string>Rotation</string>
@@ -723,6 +774,8 @@
   <tabstop>translationIncrementSpinBox</tabstop>
   <tabstop>rotationIncrementSpinBox</tabstop>
   <tabstop>positionModeComboBox</tabstop>
+  <tabstop>customCSLineEdit</tabstop>
+  <tabstop>pickCoordinateSystemReferenceButton</tabstop>
   <tabstop>alignRotationCheckBox</tabstop>
   <tabstop>xPositionSpinBox</tabstop>
   <tabstop>yPositionSpinBox</tabstop>

--- a/src/Gui/TaskTransform.ui
+++ b/src/Gui/TaskTransform.ui
@@ -15,35 +15,97 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="2" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,1">
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Coordinate system</string>
-       </property>
-       <property name="buddy">
-        <cstring>positionModeComboBox</cstring>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="positionModeComboBox">
-       <item>
+    <widget class="QWidget" name="coordinateSystemWidget" native="true">
+     <layout class="QGridLayout" name="coordinateSystemLayout" columnstretch="0,1">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Local coordinate system</string>
+         <string>Coordinate system</string>
         </property>
-       </item>
-       <item>
+        <property name="buddy">
+         <cstring>positionModeComboBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="positionModeComboBox">
+        <item>
+         <property name="text">
+          <string>Local coordinate system</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Global coordinate system</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="customCSReferenceLabel">
+        <property name="visible">
+         <bool>false</bool>
+        </property>
         <property name="text">
-         <string>Global coordinate system</string>
+         <string>Reference</string>
         </property>
-       </item>
-      </widget>
-     </item>
-    </layout>
+        <property name="buddy">
+         <cstring>customCSLineEdit</cstring>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QWidget" name="customCSPickerWidget" native="true">
+        <property name="visible">
+         <bool>false</bool>
+        </property>
+        <layout class="QVBoxLayout" name="customCSPickerLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLineEdit" name="customCSLineEdit">
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pickCoordinateSystemReferenceButton">
+           <property name="text">
+            <string>Pick Reference</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item row="4" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_4">
@@ -87,57 +149,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item row="3" column="0">
-    <widget class="QWidget" name="customCSPickerWidget" native="true">
-     <property name="visible">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="customCSPickerLayout" columnstretch="0,1">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="customCSReferenceLabel">
-        <property name="minimumSize">
-         <size>
-          <width>68</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Reference</string>
-        </property>
-        <property name="buddy">
-         <cstring>customCSLineEdit</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="customCSLineEdit">
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="pickCoordinateSystemReferenceButton">
-        <property name="text">
-         <string>Pick Reference</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
    </item>
    <item row="5" column="0">
     <widget class="QGroupBox" name="positionGroupBox">
@@ -565,12 +576,22 @@
         </property>
        </spacer>
       </item>
-      <item row="1" column="0" colspan="2">
+      <item row="1" column="0">
+       <widget class="QLabel" name="referenceLabel">
+        <property name="text">
+         <string>Reference</string>
+        </property>
+        <property name="buddy">
+         <cstring>referenceLineEdit</cstring>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
        <widget class="QWidget" name="referencePickerWidget" native="true">
-        <layout class="QGridLayout" name="referencePickerLayout" columnstretch="0,1">
-         <property name="sizeConstraint">
-          <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
-         </property>
+        <layout class="QVBoxLayout" name="referencePickerLayout">
          <property name="leftMargin">
           <number>0</number>
          </property>
@@ -583,33 +604,17 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="referenceLabel">
-           <property name="minimumSize">
-            <size>
-             <width>68</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Reference</string>
-           </property>
-           <property name="buddy">
-            <cstring>referenceLineEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QPushButton" name="pickTransformOriginButton">
-           <property name="text">
-            <string>Pick Reference</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
+         <item>
           <widget class="QLineEdit" name="referenceLineEdit">
            <property name="readOnly">
             <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pickTransformOriginButton">
+           <property name="text">
+            <string>Pick Reference</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Adds a custom coordinate system mode to view and adjust the transform in any picked coordinate system + alignment of the dragger to the selected CS. It allows any object with placement as input for the custom coordinate system, so not only LCS but also Bodies, shapes, Part container,...

When custom is chosen, another reference field is shown (as with custom dragger mode) where the user can select objects and LCS from the tree view or 3D view and the custom coordinate system / placement of the selection is used for u,v,w coordinates but it is displayed as X' Y' Z' as described in the issue. 

🤖 AI helped

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/19278

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

https://github.com/user-attachments/assets/2704e85a-1c66-4203-90ba-8b5819b80f73




<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
