### PR TITLE
Enable FREECAD_WARN_ERROR on Conda release preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -226,7 +226,13 @@
         "inherits": [
           "debug",
           "conda"
-        ]
+        ],
+        "cacheVariables": {
+            "FREECAD_WARN_ERROR": {
+            "type": "BOOL",
+            "value": "ON"
+          }
+        }
       },
       {
         "name": "conda-release",

--- a/src/Base/Builder3D.cpp
+++ b/src/Base/Builder3D.cpp
@@ -1269,7 +1269,7 @@ BaseExport Vector3f stringToVector(std::string str)
     view.remove_prefix(1);
     view.remove_suffix(1);
 
-    str = view;
+    str = std::string {view};
 
     boost::char_separator<char> sep(" ,");
     boost::tokenizer<boost::char_separator<char>> tokens(str, sep);

--- a/src/Mod/CAM/App/Area.cpp
+++ b/src/Mod/CAM/App/Area.cpp
@@ -1213,21 +1213,17 @@ struct WireJoiner
 
         std::vector<VertexInfo> adjacentList;
         std::set<EdgeInfo*> edgesToVisit;
-        int count = 0;
         int skips = 0;
 
         for (auto& info : edges) {
             info.reset();
         }
 
-        int rcount = 0;
-
         for (auto& info : edges) {
             if (BRep_Tool::IsClosed(info.edge)) {
                 auto wire = BRepBuilderAPI_MakeWire(info.edge).Wire();
                 Area::showShape(wire, "closed");
                 builder.Add(comp, wire);
-                ++count;
                 continue;
             }
             gp_Pnt pt[2];
@@ -1242,7 +1238,6 @@ struct WireJoiner
                 // populate adjacent list
                 constexpr int intMax = std::numeric_limits<int>::max();
                 for (auto vit = vmap.qbegin(bgi::nearest(pt[i], intMax)); vit != vmap.qend(); ++vit) {
-                    ++rcount;
                     if (vit->pt().SquareDistance(pt[i]) > tol) {
                         break;
                     }
@@ -1376,7 +1371,6 @@ struct WireJoiner
                     }
                     Area::showShape(wire, "joined");
                     builder.Add(comp, wire);
-                    ++count;
                 }
                 break;
             }

--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.h
@@ -55,7 +55,7 @@ namespace CAMSimulator
 
 // use short declaration as using 'include' causes a header loop
 class MillSimulation;
-class MillSimulationState;
+struct MillSimulationState;
 struct Vertex;
 class ViewCAMSimulator;
 class GuiDisplay;

--- a/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/GuiDisplay.cpp
@@ -168,7 +168,8 @@ void GuiDisplay::on_stockModelButton_clicked()
     // stock -> base -> both
     //   ^---------------'
 
-    bool sv, bv;
+    bool sv = false;
+    bool bv = false;
 
     if (stockVisible == baseVisible) {
         sv = true;

--- a/src/Mod/CAM/PathSimulator/AppGL/MillPathSegment.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillPathSegment.cpp
@@ -39,11 +39,6 @@ constexpr auto pi = std::numbers::pi_v<float>;
 #define PY 1
 #define PZ 2
 
-// Maximum ratio of radius to chord length for treating arc as curved
-// Ratios above this indicate the arc is essentially a straight line
-// and should be treated as linear to avoid numerical precision issues
-constexpr float ARC_LINEARIZATION_THRESHOLD = 100000.0f;
-
 namespace CAMSimulator
 {
 

--- a/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.cpp
@@ -548,8 +548,8 @@ void SimDisplay::UpdateCameraProjection(const SoCamera& camera)
 
 #else
 
-    float nearDistance;
-    float farDistance;
+    float nearDistance = 0.0;
+    float farDistance = 0.0;
 
 #endif
 

--- a/src/Mod/Measure/Gui/TaskMassProperties.cpp
+++ b/src/Mod/Measure/Gui/TaskMassProperties.cpp
@@ -1146,7 +1146,7 @@ void TaskMassProperties::tryUpdate()
         && referenceDatum->isDerivedFrom<App::Line>();
 
     const auto infoSnapshot = currentInfo;
-    QTimer::singleShot(0, this, [this, infoSnapshot, hasAxisSelection]() {
+    QTimer::singleShot(0, this, [infoSnapshot, hasAxisSelection]() {
         App::Document* doc = App::GetApplication().getActiveDocument();
         if (!doc) {
             return;

--- a/src/Mod/Measure/Gui/TaskMassProperties.h
+++ b/src/Mod/Measure/Gui/TaskMassProperties.h
@@ -57,7 +57,7 @@ public:
     bool accept() override;
     bool reject() override;
 
-    void onSelectionChanged(const Gui::SelectionChanges& msg);
+    void onSelectionChanged(const Gui::SelectionChanges& msg) override;
     void update(const Gui::SelectionChanges& msg);
     void tryUpdate();
 

--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.h
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.h
@@ -64,7 +64,7 @@ public:
     bool accept() override;
     /// is called by the framework if the dialog is rejected (Cancel)
     bool reject() override;
-    void deactivate();
+    void deactivate() override;
     bool isAllowedAlterDocument() const override
     {
         return false;

--- a/src/Mod/Spreadsheet/App/Cell.cpp
+++ b/src/Mod/Spreadsheet/App/Cell.cpp
@@ -374,7 +374,7 @@ void Cell::setContent(const char* value)
                             }
                         }
                     }
-                    else if (const auto number = freecad_cast<NumberExpression*>(parsedExpr.get())) {
+                    else if (freecad_cast<NumberExpression*>(parsedExpr.get())) {
                         // NumbersExpressions can accept more than can be parsed with strtod.
                         //   Example: 12.34 and 12,34 are both valid NumberExpressions
                         newExpr = std::move(parsedExpr);


### PR DESCRIPTION
Fix warnings necessary to build with `FREECAD_WARN_ERROR` on CI, and enable it in the `conda-release` preset.

Why not enable it on all presets? On debug builds, when developing new features, it can be cumbersome to have the build fail on any compiler warning. On non-conda release builds, we don't manage compiler version and environments, so there could be different warnings causing build failures, which we want to avoid.

Pixi jobs for this branch passed on my fork with yesterday's `main`: https://github.com/Lgt2x/FreeCAD/actions/runs/25974360560

This will catch early new compiler warnings before PRs are merged. When/if this is merge, please make sure all PRs merged after this one are rebased on latest `main` and pass CI, to avoid introducing build errors on the `main` branch`.

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

Fix https://github.com/FreeCAD/FreeCAD/issues/30192

FYI @3x380V 