### PR TITLE
CAM: Preserve comment command names with annotations

### DIFF
--- a/src/Mod/CAM/App/Command.cpp
+++ b/src/Mod/CAM/App/Command.cpp
@@ -150,7 +150,9 @@ std::string Command::toGCode(int precision, bool padzero) const
 
     // Add annotations as a comment if they exist
     if (!Annotations.empty()) {
-        str << " ; ";
+        const bool commentOnly =
+            Parameters.empty() && !Name.empty() && Name.front() == '(' && Name.back() == ')';
+        str << (commentOnly ? "; " : " ; ");
         bool first = true;
         for (const auto& pair : Annotations) {
             if (!first) {
@@ -184,6 +186,7 @@ void Command::setFromGCode(const std::string& str)
     auto comment_pos = str.find("; ");
     if (comment_pos != std::string::npos) {
         gcode_part = str.substr(0, comment_pos);
+        boost::trim_right(gcode_part);
         annotation_part = str.substr(comment_pos + 1);  // length of "; "
     }
 

--- a/src/Mod/CAM/App/Command.cpp
+++ b/src/Mod/CAM/App/Command.cpp
@@ -150,8 +150,8 @@ std::string Command::toGCode(int precision, bool padzero) const
 
     // Add annotations as a comment if they exist
     if (!Annotations.empty()) {
-        const bool commentOnly =
-            Parameters.empty() && !Name.empty() && Name.front() == '(' && Name.back() == ')';
+        const bool commentOnly = Parameters.empty() && !Name.empty() && Name.front() == '('
+            && Name.back() == ')';
         str << (commentOnly ? "; " : " ; ");
         bool first = true;
         for (const auto& pair : Annotations) {

--- a/src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py
+++ b/src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py
@@ -384,7 +384,7 @@ class TestPathCommandAnnotations(PathTestBase):
         c1 = Path.Command("(xx)", {}, {"a": "x"})
         content = c1.dumpContent()
 
-        self.assertIn('gcode="(xx); a:\'x\'"', content)
+        self.assertIn("gcode=\"(xx); a:'x'\"", content)
         self.assertNotIn('gcode="(xx) ;', content)
 
         c2 = Path.Command()

--- a/src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py
+++ b/src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py
@@ -378,3 +378,23 @@ class TestPathCommandAnnotations(PathTestBase):
         self.assertEqual(c1.Parameters["Y"], 5.0)
         self.assertEqual(c1.Annotations["retract"], 15.5)
         self.assertEqual(c1.Annotations["angle"], 30.25)
+
+    def test21(self):
+        """Test comment command save/restore with annotations."""
+        c1 = Path.Command("(xx)", {}, {"a": "x"})
+        content = c1.dumpContent()
+
+        self.assertIn('gcode="(xx); a:\'x\'"', content)
+        self.assertNotIn('gcode="(xx) ;', content)
+
+        c2 = Path.Command()
+        c2.restoreContent(content)
+        self.assertEqual(c2.Name, "(xx)")
+        self.assertEqual(c2.Annotations["a"], "x")
+
+        c2.setFromGCode("(xx) ; a:'x'")
+        self.assertEqual(c2.Name, "(xx)")
+        self.assertEqual(c2.Annotations["a"], "x")
+
+        c3 = Path.Command("G1", {"X": 1.0}, {"a": "x"})
+        self.assertIn(" ; a:", c3.dumpContent())


### PR DESCRIPTION
﻿## Summary
- avoid adding a pre-semicolon space when serializing annotations for parenthesized comment-only `Path.Command` values
- trim the parsed G-code portion before annotation comments so legacy `"(xx) ; ..."` content restores without a trailing space in `Name`
- add CAM annotation regression coverage for new serialization, legacy parsing, and unchanged regular G-code annotation spacing

Fixes #30140.

## Validation
- `python -m py_compile src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py`
- `git diff --check`
- `git diff | gitleaks detect --pipe --redact --verbose --no-color`

Not run: FreeCAD CAM test harness. This local machine does not have the FreeCAD runtime available (`import FreeCAD` raises `ModuleNotFoundError`, and `FreeCADCmd` is not on PATH).

AI-assisted contribution: I reviewed the issue, contribution requirements, diff, and validation results and can explain the change.
