### PR TITLE
Gui/PD: Toggle body only from 3D view selection

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1893,6 +1893,15 @@ Qt::DropActions TreeWidget::supportedDropActions() const
 
 bool TreeWidget::event(QEvent* e)
 {
+    if (e->type() == QEvent::ShortcutOverride) {
+        auto ke = static_cast<QKeyEvent*>(e);
+        if (ke->key() == Qt::Key_Space && ke->modifiers() == Qt::NoModifier) {
+            // Claim the Space key so Qt does not fire the global
+            // Std_ToggleVisibility
+            ke->accept();
+            return true;
+        }
+    }
     return QTreeWidget::event(e);
 }
 
@@ -1975,6 +1984,29 @@ void TreeWidget::keyPressEvent(QKeyEvent* event)
             event->accept();
             return;
         }
+    }
+
+    else if (event->key() == Qt::Key_Space && event->modifiers() == Qt::NoModifier) {
+        // Toggle each selected feature's own visibility directly
+        for (auto* raw : selectedItems()) {
+            if (raw->type() != ObjectType) {
+                continue;
+            }
+            auto* vp = static_cast<DocumentObjectItem*>(raw)->object();
+            if (!vp || !vp->canToggleVisibility()) {
+                continue;
+            }
+            auto* appObj = vp->getObject();
+            vp->Gui::ViewProvider::toggleVisibility();
+            Selection().updateSelection(
+                vp->isShow(),
+                appObj->getDocument()->getName(),
+                appObj->getNameInDocument()
+            );
+        }
+        setFocus();
+        event->accept();
+        return;
     }
 
     QTreeWidget::keyPressEvent(event);

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -492,14 +492,9 @@ void ViewProvider::toggleVisibility()
         return;
     }
     if (auto* bodyVp = getBodyViewProvider()) {
-        if (bodyVp->isActiveBody()) {
-            // Inside the active body, toggle the feature itself.
-            Gui::ViewProvider::toggleVisibility();
-        }
-        else {
-            // Outside the active body, toggle the whole body.
-            bodyVp->toggleVisibility();
-        }
+        // When toggling via the global Std_ToggleVisibility shortcut (i.e. from
+        // the 3D view), always toggle the whole body
+        bodyVp->toggleVisibility();
         return;
     }
     Gui::ViewProvider::toggleVisibility();


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Supersedes https://github.com/FreeCAD/FreeCAD/pull/30218
PR https://github.com/FreeCAD/FreeCAD/pull/29110 changed that the spacebar always toggled the entire body when selected from the 3D view but that also changed for the space bar when a feature was selected in the tree view. Then, only in an active body, the features were toggled.

This changes the behavior:
- any selection from the 3D view always toggles the body (to fix the initial issue https://github.com/FreeCAD/FreeCAD/pull/29110 fixed)
- any selection from the tree view (e.g. a feature) by mouse or keyboard always toggles the selection

There's a scenario where focus isn't reliable, if the user clicks in the tree to select, then clicks somewhere else in the UI without reselecting, then presses Space. This is very unlikely in normal usage.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/30216
Fixes https://github.com/FreeCAD/FreeCAD/issues/30221

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

https://github.com/user-attachments/assets/e4ed80be-c47e-4f6d-9871-84658223e4a7




<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
