### PR TITLE
TechDraw: Preserve Draft/Arch Page scale on restore

### DIFF
--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -198,7 +198,7 @@ void DrawView::onChanged(const App::Property* prop)
         }
         if (ScaleType.isValue("Page")) {
             Scale.setStatus(App::Property::ReadOnly, true);
-            if(std::abs(page->Scale.getValue() - getScale()) > std::numeric_limits<float>::epsilon()) {
+            if(std::abs(page->Scale.getValue() - Scale.getValue()) > std::numeric_limits<float>::epsilon()) {
                Scale.setValue(page->Scale.getValue());
             }
         } else if ( ScaleType.isValue("Custom") ) {

--- a/src/Mod/TechDraw/App/DrawViewArch.cpp
+++ b/src/Mod/TechDraw/App/DrawViewArch.cpp
@@ -87,6 +87,16 @@ short DrawViewArch::mustExecute() const
     return DrawViewSymbol::mustExecute();
 }
 
+void DrawViewArch::validateScale()
+{
+    if (ScaleType.isValue("Page")) {
+        // Keep restored Page scale selections instead of demoting stale saved Scale values.
+        checkScale();
+        return;
+    }
+
+    TechDraw::DrawView::validateScale();
+}
 
 App::DocumentObjectExecReturn *DrawViewArch::execute()
 {

--- a/src/Mod/TechDraw/App/DrawViewArch.h
+++ b/src/Mod/TechDraw/App/DrawViewArch.h
@@ -71,6 +71,7 @@ public:
 
 protected:
 /*    virtual void onChanged(const App::Property* prop) override;*/
+    void validateScale() override;
     Base::BoundBox3d bbox;
     std::string getSVGHead();
     std::string getSVGTail();

--- a/src/Mod/TechDraw/App/DrawViewDraft.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDraft.cpp
@@ -73,6 +73,16 @@ short DrawViewDraft::mustExecute() const
     return DrawViewSymbol::mustExecute();
 }
 
+void DrawViewDraft::validateScale()
+{
+    if (ScaleType.isValue("Page")) {
+        // Keep restored Page scale selections instead of demoting stale saved Scale values.
+        checkScale();
+        return;
+    }
+
+    TechDraw::DrawView::validateScale();
+}
 
 
 App::DocumentObjectExecReturn *DrawViewDraft::execute()

--- a/src/Mod/TechDraw/App/DrawViewDraft.h
+++ b/src/Mod/TechDraw/App/DrawViewDraft.h
@@ -67,6 +67,7 @@ public:
 
 protected:
 /*    virtual void onChanged(const App::Property* prop) override;*/
+    void validateScale() override;
     Base::BoundBox3d bbox;
     std::string getSVGHead();
     std::string getSVGTail();

--- a/src/Mod/TechDraw/TDTest/DrawViewScaleRestoreTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawViewScaleRestoreTest.py
@@ -1,0 +1,75 @@
+import os
+import tempfile
+import unittest
+import xml.etree.ElementTree as ElementTree
+import zipfile
+
+import FreeCAD
+
+from .TechDrawTestUtilities import createPageWithSVGTemplate
+
+
+class DrawViewScaleRestoreTest(unittest.TestCase):
+    def setUp(self):
+        FreeCAD.newDocument("TDScaleRestore")
+        FreeCAD.setActiveDocument("TDScaleRestore")
+        FreeCAD.ActiveDocument = FreeCAD.getDocument("TDScaleRestore")
+        self.doc = FreeCAD.ActiveDocument
+        self.page = createPageWithSVGTemplate(self.doc)
+        self.page.Scale = 0.05
+
+    def tearDown(self):
+        for name in list(FreeCAD.listDocuments()):
+            if name.startswith("TDScaleRestore"):
+                FreeCAD.closeDocument(name)
+
+    def rewrite_view_scale(self, file_path, view_name, scale):
+        with zipfile.ZipFile(file_path, "r") as archive:
+            entries = [(info, archive.read(info.filename)) for info in archive.infolist()]
+
+        with zipfile.ZipFile(file_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for info, data in entries:
+                if info.filename == "Document.xml":
+                    root = ElementTree.fromstring(data)
+                    for obj in root.findall(".//Object"):
+                        if obj.get("name") != view_name:
+                            continue
+                        for prop in obj.findall("./Properties/Property"):
+                            if prop.get("name") == "Scale":
+                                prop.find("Float").set("value", f"{scale:.16f}")
+                    data = ElementTree.tostring(root, encoding="utf-8", xml_declaration=True)
+                archive.writestr(info, data)
+
+    def assert_page_scale_survives_restore(self, type_id, view_name):
+        view = self.doc.addObject(type_id, view_name)
+        self.page.addView(view)
+        view.ScaleType = "Page"
+        self.assertAlmostEqual(view.Scale, self.page.Scale)
+
+        temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".FCStd")
+        temp_file.close()
+        reopened = None
+        try:
+            self.doc.saveAs(temp_file.name)
+            self.rewrite_view_scale(temp_file.name, view_name, 1.0)
+
+            reopened = FreeCAD.openDocument(temp_file.name)
+            restored_view = reopened.getObject(view_name)
+            restored_page = reopened.getObject("Page")
+
+            self.assertEqual(restored_view.ScaleType, "Page")
+            self.assertAlmostEqual(restored_view.Scale, restored_page.Scale)
+        finally:
+            if reopened is not None:
+                FreeCAD.closeDocument(reopened.Name)
+            os.unlink(temp_file.name)
+
+    def test_draft_view_page_scale_survives_restore_with_stale_saved_scale(self):
+        self.assert_page_scale_survives_restore("TechDraw::DrawViewDraft", "DraftView")
+
+    def test_arch_view_page_scale_survives_restore_with_stale_saved_scale(self):
+        self.assert_page_scale_survives_restore("TechDraw::DrawViewArch", "BIMView")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/TechDraw/TestTechDrawApp.py
+++ b/src/Mod/TechDraw/TestTechDrawApp.py
@@ -25,6 +25,7 @@ from TDTest.DrawHatchTest import DrawHatchTest  # noqa: F401
 from TDTest.DrawViewAnnotationTest import DrawViewAnnotationTest  # noqa: F401
 from TDTest.DrawViewBalloonTest import DrawViewBalloonTest  # noqa: F401
 from TDTest.DrawViewImageTest import DrawViewImageTest  # noqa: F401
+from TDTest.DrawViewScaleRestoreTest import DrawViewScaleRestoreTest  # noqa: F401
 from TDTest.DrawViewSymbolTest import DrawViewSymbolTest  # noqa: F401
 from TDTest.DrawProjectionGroupTest import DrawProjectionGroupTest  # noqa: F401
 


### PR DESCRIPTION
## Summary
- Fixes #30186.
- Update the stored view `Scale` when a TechDraw view is switched to `Page` scale, comparing against the raw `Scale` value instead of `getScale()`.
- Keep `Page` scale for DraftView and BIM/ArchView during document restore, resyncing stale saved `Scale` values instead of demoting the view to `Custom`.
- Add a TechDraw regression test that rewrites a saved `.FCStd` view scale to match the stale-value shape from the issue and checks DraftView/ArchView restore behavior.

## Validation
- `python -m py_compile src\Mod\TechDraw\TDTest\DrawViewScaleRestoreTest.py src\Mod\TechDraw\TestTechDrawApp.py`
- `git diff --check`
- `git diff --cached --check`
- `git diff --cached | gitleaks detect --pipe --redact --verbose --no-color`

## Not run
- FreeCAD runtime regression test: `FreeCADCmd`, `freecadcmd`, `FreeCAD`, and `freecad` were not available on this Windows machine, and no FreeCAD install was found under common `C:\Program Files\FreeCAD*` paths.

## Notes
- AI-assisted change; I reviewed the code path and validation output before submitting.