### PR TITLE
Typing: remove stale Sandbox references from stub smoke checks

### DIFF
--- a/src/Tools/typing/smoke/smoke.py
+++ b/src/Tools/typing/smoke/smoke.py
@@ -29,7 +29,6 @@ import Materials
 import PartDesignGui
 import PathApp
 import QtUnitGui
-import Sandbox
 import SpreadsheetGui
 import TechDrawGui
 from FreeCAD import DocumentObject
@@ -169,7 +168,6 @@ def exercise(
     selection_ex = GuiSelection.getSelectionEx()
     selection_object = GuiSelection.getSelectionObject("Document", "Object", "Edge1")
     stacked_selection = GuiSelection.getSelectionFromStack()
-    protector = cast(Sandbox._DocumentProtector, object())
     unit_test = cast(QtUnitGui._UnitTest, object())
     sheet_view = cast(SpreadsheetGui._SheetView, object())
     page_view = cast(TechDrawGui._MDIViewPage, object())
@@ -501,7 +499,6 @@ def exercise(
     assert_type(viewer.getPickRadius(), float)
     assert_type(viewer.isRedirectedToSceneGraph(), bool)
     assert_type(viewer.isEnabledNaviCube(), bool)
-    protector.recompute()
     unit_test.getUnitTest()
     unit_test.clearErrorList()
     unit_test.insertError("failure", "details")
@@ -561,7 +558,6 @@ def exercise(
     reveal_type(resource)
     reveal_type(selection_filter)
     reveal_type(selection_object)
-    reveal_type(protector)
     reveal_type(unit_test)
     reveal_type(sheet_view)
     reveal_type(page_view)

--- a/src/Tools/typing/stubgen/type_context_rules.py
+++ b/src/Tools/typing/stubgen/type_context_rules.py
@@ -122,16 +122,6 @@ TYPE_CONTEXT_RULES = (
         public_targets=(PublicTypeTarget("FreeCADGui", "_PyResource"),),
     ),
     TypeContextRule(
-        source="src/Mod/Sandbox/App/DocumentProtectorPy.cpp",
-        context_name="DocumentProtectorPy",
-        public_targets=(PublicTypeTarget("Sandbox", "_DocumentProtector"),),
-    ),
-    TypeContextRule(
-        source="src/Mod/Sandbox/App/DocumentProtectorPy.cpp",
-        context_name="DocumentObjectProtectorPy",
-        public_targets=(PublicTypeTarget("Sandbox", "_DocumentObjectProtector"),),
-    ),
-    TypeContextRule(
         source="src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp",
         context_name="SheetViewPy",
         public_targets=(PublicTypeTarget("SpreadsheetGui", "_SheetView"),),


### PR DESCRIPTION
PR #28162 removed the deprecated Sandbox module, but the generated binding stub smoke check still referenced it due to stale CI runs.

This updates the typing smoke-check inputs to match the post-removal module set by:

- removing the `Sandbox` import and `_DocumentProtector` smoke-check usage from `src/Tools/typing/smoke/smoke.py`
- removing the obsolete manual type-context mappings for `DocumentProtectorPy` and `DocumentObjectProtectorPy` from `src/Tools/typing/stubgen/type_context_rules.py`

This fixes the lint failure in the generated binding stubs smoke-check job.
