### PR TITLE
Fix DXF text import scale multiplier

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -4985,6 +4985,10 @@ class DxfDraftPostProcessor:
                             ViewProviderDraft(obj.ViewObject)
                     elif proxy_name == "Text":
                         if hasattr(obj, "DxfTextHeight"):
+                            # DXF TEXT heights are already drawing values, so the active
+                            # Draft annotation scale multiplier must not resize imported text.
+                            if hasattr(obj.ViewObject, "ScaleMultiplier"):
+                                obj.ViewObject.ScaleMultiplier = 1.0
                             obj.ViewObject.FontSize = obj.DxfTextHeight * TEXTSCALING
                 except Exception as e:
                     FCC.PrintWarning(f"Failed to set ViewProvider for {obj.Name}: {e}\n")


### PR DESCRIPTION
﻿## Summary
- Prevent imported DXF `TEXT` placeholders from inheriting the active Draft annotation `ScaleMultiplier`.
- Keep the imported text height based on `DxfTextHeight`, while neutralizing only the scale multiplier for DXF text objects.

## Issues
Fixes #30043

## Before and After Images
Not attached. I do not have a local FreeCAD GUI/runtime available in this environment.

## Validation
- `gh issue view 30043 --repo FreeCAD/FreeCAD --json number,state,title,assignees,labels,url`
- `gh pr list --repo FreeCAD/FreeCAD --state open --search "30043 DXF Import Scale Multiplier text objects" --json number,title,headRefName,author,url`
- `python -m py_compile src/Mod/Draft/importDXF.py`
- `git diff --check`
- `git diff --cached --check`
- `git diff --cached | gitleaks detect --pipe --redact --verbose --no-color`

Not run: GUI DXF import smoke test, because `FreeCADCmd`/`FreeCAD` is not available on this machine.

AI-assisted work: I reviewed the source path and validation results before submitting this PR.
