### PR TITLE
CI: Lock down workflow permissions to minimum

### DIFF
--- a/.github/workflows/CI_approved.yml
+++ b/.github/workflows/CI_approved.yml
@@ -48,11 +48,12 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   Gate:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}
     steps:

--- a/.github/workflows/CI_cleanup.yml
+++ b/.github/workflows/CI_cleanup.yml
@@ -46,6 +46,9 @@ on:
 env:
   dryrun: false
 
+permissions:
+  contents: read
+
 concurrency:
   group: FC-CI-cleaner
   cancel-in-progress: false
@@ -54,6 +57,8 @@ jobs:
 
   CachesCleanup:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     env:
       logdir: /tmp/log/
     steps:

--- a/.github/workflows/CI_primary.yml
+++ b/.github/workflows/CI_primary.yml
@@ -40,6 +40,8 @@ on:
     types: [opened, synchronize, reopened]
   merge_group: ~
 
+permissions:
+  contents: read
 
 concurrency:
   group: FC-CI-primary-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,13 +6,15 @@ on:
     branches: [main, releases/*]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   backport:
     name: Create backport pull request
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     # Run the action if a PR is merged with backport labels
     # OR

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  actions: write
+  contents: read
 
 concurrency:
   group: build-release-${{ github.event_name }}
@@ -18,6 +17,9 @@ jobs:
   upload_src:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'FreeCAD'
+    permissions:
+      contents: write
+      actions: write
     outputs:
       build_tag: ${{ steps.get_tag.outputs.build_tag }}
     steps:
@@ -106,6 +108,8 @@ jobs:
 
   build:
     needs: upload_src
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:

--- a/.github/workflows/fetch_crowdin_translations.yml
+++ b/.github/workflows/fetch_crowdin_translations.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 0 * * 1"
 
+# Writes happen via the GH_TOKEN_FOR_CROWDIN_SYNC secret; GITHUB_TOKEN stays read-only.
+permissions:
+  contents: read
+
 jobs:
   update-crowdin:
     runs-on: ubuntu-latest

--- a/.github/workflows/push_crowdin_translations.yml
+++ b/.github/workflows/push_crowdin_translations.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 0 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   update-crowdin:
     runs-on: ubuntu-latest

--- a/.github/workflows/sub_buildPixi.yml
+++ b/.github/workflows/sub_buildPixi.yml
@@ -52,6 +52,9 @@ on:
       reportFile:
         value: ${{ jobs.Build.outputs.reportFile }}
 
+permissions:
+  contents: read
+
 jobs:
   build_with_pixi:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/sub_buildUbuntu.yml
+++ b/.github/workflows/sub_buildUbuntu.yml
@@ -48,6 +48,9 @@ on:
       reportFile:
         value: ${{ jobs.Build.outputs.reportFile }}
 
+permissions:
+  contents: read
+
 jobs:
 
   Build:

--- a/.github/workflows/sub_buildWindows.yml
+++ b/.github/workflows/sub_buildWindows.yml
@@ -58,6 +58,9 @@ on:
       reportFile:
         value: ${{ jobs.Build.outputs.reportFile }}
 
+permissions:
+  contents: read
+
 jobs:
   Build:
     runs-on: windows-latest

--- a/.github/workflows/sub_prepare.yml
+++ b/.github/workflows/sub_prepare.yml
@@ -61,6 +61,9 @@ on:
       changedCppLines:
         value: ${{ jobs.Prepare.outputs.changedCppLines }}
 
+permissions:
+  contents: read
+
 jobs:
 
   Prepare:

--- a/.github/workflows/weekly-compare-link.yml
+++ b/.github/workflows/weekly-compare-link.yml
@@ -15,11 +15,13 @@ on:
         default: false
 
 permissions:
-  contents: write        # required to PATCH the release body
+  contents: read
 
 jobs:
   update-notes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write        # required to PATCH the release body
     steps:
       - name: Inject compare link into weekly release notes
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0


### PR DESCRIPTION
The security scanning bot has been yelling about these since we installed it... finally fix them. No actual changes expected from this, it's purely defensive permissions lockdown.