### PR TITLE
Lock down file permissions

### DIFF
--- a/src/Base/FileLock.cpp
+++ b/src/Base/FileLock.cpp
@@ -188,6 +188,7 @@ bool FileLock::isLocked() const
 # include <cerrno>
 
 # include <fcntl.h>
+# include <sys/stat.h>
 # include <unistd.h>
 
 using namespace Base;
@@ -224,7 +225,7 @@ bool FileLock::tryLock(int timeoutMs)
     }
 
     if (_fd < 0) {
-        _fd = ::open(_path.c_str(), O_RDWR | O_CREAT, 0666);
+        _fd = ::open(_path.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
         if (_fd < 0) {
             return false;
         }

--- a/src/Gui/SoFCOffscreenRenderer.cpp
+++ b/src/Gui/SoFCOffscreenRenderer.cpp
@@ -37,6 +37,10 @@
 
 #if defined(FC_OS_WIN32)
 # include <windows.h>
+#else
+# include <fcntl.h>
+# include <sys/stat.h>
+# include <unistd.h>
 #endif
 
 #if !defined(FC_OS_MACOSX)
@@ -217,8 +221,19 @@ void SoFCOffscreenRenderer::writeToImageFile(
 #ifdef FC_OS_WIN32
             FILE* fd = _wfopen(file.toStdWString().c_str(), L"w");
 #else
-            FILE* fd = fopen(filename, "w");
+            const int rawFd = ::open(
+                filename,
+                O_WRONLY | O_CREAT | O_TRUNC,
+                S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH
+            );
+            FILE* fd = rawFd >= 0 ? ::fdopen(rawFd, "w") : nullptr;
+            if (!fd && rawFd >= 0) {
+                ::close(rawFd);
+            }
 #endif
+            if (!fd) {
+                throw Base::FileException("Cannot open file for writing", filename);
+            }
             bool ok = writeToPostScript(fd);
             fclose(fd);
             if (!ok) {
@@ -230,8 +245,19 @@ void SoFCOffscreenRenderer::writeToImageFile(
 #ifdef FC_OS_WIN32
             FILE* fd = _wfopen(file.toStdWString().c_str(), L"w");
 #else
-            FILE* fd = fopen(filename, "w");
+            const int rawFd = ::open(
+                filename,
+                O_WRONLY | O_CREAT | O_TRUNC,
+                S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH
+            );
+            FILE* fd = rawFd >= 0 ? ::fdopen(rawFd, "w") : nullptr;
+            if (!fd && rawFd >= 0) {
+                ::close(rawFd);
+            }
 #endif
+            if (!fd) {
+                throw Base::FileException("Cannot open file for writing", filename);
+            }
             bool ok = writeToRGB(fd);
             fclose(fd);
             if (!ok) {


### PR DESCRIPTION
Per the StepSecurity scanner, there were a few places in our codebase where we were inadvertently creating world-writable files. This fixes those (and adds a small `nullptr` check to the screenshot code).

These can only be tested on Linux or macOS, the Windows path is untouched (except for the `nullptr` check, which is pretty safe...).

To test the lockfile fix you will probably have to delete your *existing* lockfile to ensure the permissions get reset. Then just look at the new lock that gets created and make sure it's `-rw-------`.

The Coin stuff, on the other hand, is a bit academic, because at least on my system the code already crashes (without this patch). So although you can validate that the file's permissions are correct, you're going to crash FreeCAD doing it :). On the Python console, run:
```
Gui.activeDocument().activeView().saveImage("/tmp/test.eps", 800, 600, "Current")
```

You can verify that the zero-byte "/tmp/test.eps" exists with `-rw-r--r-` permissions. But at least on my system, nothing was written to the file. I get the same thing if I test "rgb" (one of the other Coin-only output formats). I note that this is a similar backtrace to that reported in #13356, but I *am* running this in the Gui, so it's not clear if it's actually related.