### PR TITLE
CAM: Job - Fix toggle freeze

### DIFF
--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -822,6 +822,10 @@ class ObjectOp(object):
         """
         Path.Log.track()
 
+        job = getattr(self, "job", None) or PathUtils.findParentJob(obj)
+        if job and "freezed" in job.getStatusString().casefold():
+            return
+
         if not obj.Active:
             path = Path.Path("(inactive operation)")
             obj.Path = path


### PR DESCRIPTION
This is another implementation of #29510
Allows to skip recomputes for all operations, if **Job** in `Freezed` state

<img width="596" height="370" alt="Screenshot_20260517_193249_hor_lossy" src="https://github.com/user-attachments/assets/37b731d1-a28e-4f24-8863-a15a67a207fa" />
