### PR TITLE
Fem: Switch TaskCreateElementSet to use C++ file writing

### DIFF
--- a/src/Mod/Fem/Gui/TaskCreateElementSet.cpp
+++ b/src/Mod/Fem/Gui/TaskCreateElementSet.cpp
@@ -20,7 +20,10 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <fstream>
+
 #include <boost/algorithm/string.hpp>
+#include <fmt/ostream.h>
 
 #include <Inventor/events/SoMouseButtonEvent.h>
 #include <Inventor/nodes/SoCamera.h>
@@ -394,23 +397,23 @@ void writeToFile(
     elType3D[15] = "C3D15";  // 15 node pentahedron
     elType3D[20] = "C3D20";  // 20 node hexahedron
                              // no pyramid elements
-    FILE* fptr = fopen(fileName.c_str(), "w");
-    if (fptr == NULL) {
+    std::ofstream out(fileName);
+    if (!out) {
         return;
     }
-    fprintf(fptr, "** written by Erase Elements inp file writer for CalculiX,Abaqus meshes\n");
-    fprintf(fptr, "** all mesh elements.\n");
+    fmt::print(out, "** written by Erase Elements inp file writer for CalculiX,Abaqus meshes\n");
+    fmt::print(out, "** all mesh elements.\n");
 
-    fprintf(fptr, "\n");
-    fprintf(fptr, "\n");
-    fprintf(fptr, "** Nodes\n");
-    fprintf(fptr, "*Node, NSET=Nall\n");
+    fmt::print(out, "\n");
+    fmt::print(out, "\n");
+    fmt::print(out, "** Nodes\n");
+    fmt::print(out, "*Node, NSET=Nall\n");
 
     for (int i = 1; i < rows + 1; i++) {
         if (nodeNumbers[i] > 0) {
-            fprintf(
-                fptr,
-                "%d, %e, %e, %e\n",
+            fmt::print(
+                out,
+                "{}, {:e}, {:e}, {:e}\n",
                 nodeNumbers[i],
                 nodeCoords[i][0],
                 nodeCoords[i][1],
@@ -439,41 +442,38 @@ void writeToFile(
 
         if (numberNodes != elem->NbNodes()) {
             if (requiredType == 4) {
-                fprintf(fptr, "\n");
-                fprintf(fptr, "\n");
-                fprintf(fptr, "%s", "** Volume elements\n");
-                fprintf(fptr, "*Element, TYPE=%s, ELSET=Evolumes\n", elType3D[elem->NbNodes()].c_str());
+                fmt::print(out, "\n");
+                fmt::print(out, "\n");
+                fmt::print(out, "** Volume elements\n");
+                fmt::print(out, "*Element, TYPE={}, ELSET=Evolumes\n", elType3D[elem->NbNodes()]);
             }
             else if (requiredType == 3) {
-                fprintf(fptr, "%s", "** Face elements\n");
-                fprintf(fptr, "*Element, TYPE=%s, ELSET=Efaces\n", elType2D[elem->NbNodes()].c_str());
+                fmt::print(out, "** Face elements\n");
+                fmt::print(out, "*Element, TYPE={}, ELSET=Efaces\n", elType2D[elem->NbNodes()]);
             }
             numberNodes = elem->NbNodes();
         }
         SMDS_ElemIteratorPtr nIt = elem->nodesIterator();
-        fprintf(fptr, "%d", EID);
+        fmt::print(out, "{}", EID);
         while (nIt->more()) {
             nSrc = static_cast<const SMDS_MeshNode*>(nIt->next());
             NID = nSrc->GetID();
-            fprintf(fptr, ", %d", NID);
+            fmt::print(out, ", {}", NID);
         }
-        fprintf(fptr, "\n");
+        fmt::print(out, "\n");
     }  // while print
     if (requiredType == 4) {
-        fprintf(fptr, "\n");
-        fprintf(fptr, "\n");
-        fprintf(fptr, "%s", "** Define element set Eall\n");
-        fprintf(fptr, "%s", "*ELSET, ELSET=Eall\n");
-        fprintf(fptr, "%s", "Evolumes\n");
+        fmt::print(out, "\n");
+        fmt::print(out, "\n");
+        fmt::print(out, "** Define element set Eall\n");
+        fmt::print(out, "*ELSET, ELSET=Eall\n");
+        fmt::print(out, "Evolumes\n");
     }
     else if (requiredType == 3) {
-        fprintf(fptr, "%s", "** Define element set Eall\n");
-        fprintf(fptr, "%s", "*ELSET, ELSET=Eall\n");
-        fprintf(fptr, "%s", "Efaces\n");
+        fmt::print(out, "** Define element set Eall\n");
+        fmt::print(out, "*ELSET, ELSET=Eall\n");
+        fmt::print(out, "Efaces\n");
     }
-
-    fclose(fptr);
-    return;
 }
 }  // namespace
 


### PR DESCRIPTION
With `libfmt::print` available to us now, a one-to-one mapping of old-style `printf` to new-style `fmt::print` is possible. This gets us two things:
1) Fixes the file access permissions (they were too broad, giving `0666` instead of the more conventional `0644`)
2) RAII cleans up the file closing

Technically it's probably ever so slightly faster as well, but it's neither important nor measurable in this particular case.