### PR TITLE
BIM: Update BIM Classification Download URL

### DIFF
--- a/src/Mod/BIM/Resources/ui/dialogClassification.ui
+++ b/src/Mod/BIM/Resources/ui/dialogClassification.ui
@@ -209,7 +209,7 @@
    <item>
     <widget class="QLabel" name="labelDownload">
      <property name="text">
-      <string>XML or IFC files of several classification systems can be downloaded from &lt;a href=&quot;https://github.com/Moult/IfcClassification&quot;&gt;https://github.com/Moult/IfcClassification&lt;/a&gt; and placed in %s</string>
+      <string>XML or IFC files of several classification systems can be downloaded from &lt;a href=&quot;https://github.com/IfcOpenShell/IfcOpenShell/tree/v0.8.0/src/bonsai/bonsai/bim/data/classifications&quot;&gt;https://github.com/IfcOpenShell/IfcOpenShell/tree/v0.8.0/src/bonsai/bonsai/bim/data/classifications&lt;/a&gt; and placed in %s</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>


### PR DESCRIPTION
This PR updates BIM Classification URL text in the `BIM_Classification` tool dialogue. The change points users to more up to date set of classifications.

It is done as per this comment: https://github.com/FreeCAD/FreeCAD/issues/19185#issuecomment-2609330059
But it does not close the issue as the discussion there went into other direction.

I did not test the PR by building FreeCAD myself, as I am not able to do that. The change should not be problematic though.