### PR TITLE
CMake: Copy preference packs only once

### DIFF
--- a/src/Gui/PreferencePacks/CMakeLists.txt
+++ b/src/Gui/PreferencePacks/CMakeLists.txt
@@ -13,8 +13,6 @@ ADD_CUSTOM_TARGET(PreferencePacks_data ALL
         SOURCES ${PreferencePacks_Files} ${PreferencePacks_Directories}
 )
 
-FILE(COPY ${PreferencePacks_Files} ${PreferencePacks_Directories} DESTINATION "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Gui/PreferencePacks")
-
 fc_copy_sources(PreferencePacks_data "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Gui/PreferencePacks"
         ${PreferencePacks_Files}
         ${PreferencePacks_Directories})


### PR DESCRIPTION
Preference pack data was copied twice, once by `fc_copy_source` and once by `COPY(FILE ..)`. This broke the 'clean' cmake target. 'cmake --build X --target clean' now runs without failing.

