### PR TITLE
Expressions: fix (num unit)^pow losing parens on serialization

### DIFF
--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1468,6 +1468,16 @@ void OperatorExpression::_toString(std::ostream &s, bool persistent,int) const
         //else if (!isCommutative())
         //    needsParens = true;
     }
+    // The grammar's unit_exp rule absorbs '^' when the left is a UNIT expression,
+    // so '5 mm ^ 2' re-parses as '5 (mm^2)' instead of '(5 mm) ^ 2'.
+    else if (op == POW && leftOperator == UNIT)
+        needsParens = true;
+    // Same issue with negated unit: '-5 mm ^ 2' re-parses as '-(5 mm^2)'.
+    else if (op == POW && (leftOperator == NEG || leftOperator == POS)) {
+        auto* inner = freecad_cast<OperatorExpression*>(static_cast<OperatorExpression*>(left)->left);
+        if (inner && inner->op == UNIT)
+            needsParens = true;
+    }
 
     switch (op) {
     case NEG:

--- a/tests/src/App/ExpressionParser.cpp
+++ b/tests/src/App/ExpressionParser.cpp
@@ -122,6 +122,25 @@ protected:
         }
     }
 
+    boost::any roundTripExpr(const char* text)
+    {
+        try {
+            const auto expression = parse(thisObj, text);
+            const std::string serialized = expression->toString();
+            const auto reparsed = parse(thisObj, serialized.c_str());
+            ExpressionPtr simplified = reparsed->simplify();
+            return simplified->getValueAsAny();
+        }
+        catch (const Base::ParserError& e) {
+            return e;
+        }
+        catch (const Base::Exception& e) {
+            EXPECT_TRUE(false) << "Unexpected Base::Exception when round-tripping \"" << text
+                               << "\": " << e.what();
+            throw;
+        }
+    }
+
 private:
     std::string docName;
     App::Document* thisDoc {};
@@ -325,6 +344,17 @@ TEST_F(ExpressionParserTest, canParseProperties)
     this_obj()->addDynamicProperty("App::PropertyQuantity", "Bar");
     EXPECT_THAT(parseExpr("Sketch.Bar"), IsQuantity(Base::Quantity()))
         << "PropertyQuantity on object";
+}
+
+// https://github.com/FreeCAD/FreeCAD/issues/12173
+TEST_F(ExpressionParserTest, powWithUnitBaseRoundTrips)
+{
+    EXPECT_THAT(roundTripExpr("(5 mm)^2"), IsQuantity(mm2(25))) << "(num unit)^n round-trip";
+    EXPECT_THAT(roundTripExpr("(5 mm)^2 / 1 mm"), IsQuantity(mm(25)))
+        << "(num unit)^n / unit round-trip";
+    EXPECT_THAT(roundTripExpr("(-5 mm)^2"), IsQuantity(mm2(25))) << "(-num unit)^n round-trip";
+    EXPECT_THAT(roundTripExpr("(-5 mm)^2 / 1 mm"), IsQuantity(mm(25)))
+        << "(-num unit)^n / unit round-trip";
 }
 
 }  // namespace App::ExpressionParser::Test


### PR DESCRIPTION
Fixes #12173

`(5 mm) ^ 2 / 1 mm` was stored without parens as `5 mm ^ 2 / 1 mm`. On re-parse the grammar's `unit_exp '^' integer` rule grabbed the `^` into the unit part, turning `mm ^ 2` into `mm²`, so the expression evaluated to 5 mm instead of 25 mm.

The fix is one extra condition in `OperatorExpression::_toString`: when the operator is `^` and the left side is a unit expression, always wrap it in parens.