### PR TITLE
Assembly simulation playback: make buttons bigger and more distinguishable

### DIFF
--- a/src/Mod/Assembly/Gui/Resources/panels/TaskAssemblyCreateSimulation.ui
+++ b/src/Mod/Assembly/Gui/Resources/panels/TaskAssemblyCreateSimulation.ui
@@ -215,7 +215,7 @@
            </sizepolicy>
           </property>
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
          </widget>
         </item>
@@ -244,13 +244,35 @@
       </item>
       <item row="2" column="0">
        <layout class="QHBoxLayout" name="controls_layout">
+        <property name="topMargin">
+         <number>20</number>
+        </property>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
         <item>
          <widget class="QToolButton" name="StepBackwardButton">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>60</width>
+            <height>60</height>
+           </size>
           </property>
           <property name="toolTip">
            <string>Step backward</string>
@@ -262,15 +284,27 @@
            <iconset resource="Icons/resource.qrc">
            <normaloff>:/icons/media-playback-step-back.svg</normaloff>:/icons/media-playback-step-back.svg</iconset>
           </property>
+          <property name="iconSize">
+           <size>
+            <width>18</width>
+            <height>18</height>
+           </size>
+          </property>
          </widget>
         </item>
         <item>
          <widget class="QToolButton" name="PlayBackwardButton">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>60</width>
+            <height>60</height>
+           </size>
           </property>
           <property name="toolTip">
            <string>Play backward</string>
@@ -279,18 +313,36 @@
            <string/>
           </property>
           <property name="icon">
-           <iconset resource="Icons/resource.qrc">
-           <normaloff>:/icons/media-playback-start-back.svg</normaloff>:/icons/media-playback-start-back.svg</iconset>
+           <iconset>
+            <normaloff>:/icons/media-playback-start-back.svg</normaloff>:/icons/media-playback-start-back.svg</iconset>
+          </property>
+          <property name="iconSize">
+           <size>
+            <width>18</width>
+            <height>18</height>
+           </size>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QToolButton" name="StopButton">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>60</width>
+            <height>60</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>60</width>
+            <height>60</height>
+           </size>
           </property>
           <property name="toolTip">
            <string>Stop</string>
@@ -302,15 +354,27 @@
            <iconset resource="Icons/resource.qrc">
            <normaloff>:/icons/media-playback-stop.svg</normaloff>:/icons/media-playback-stop.svg</iconset>
           </property>
+          <property name="iconSize">
+           <size>
+            <width>25</width>
+            <height>25</height>
+           </size>
+          </property>
          </widget>
         </item>
         <item>
          <widget class="QToolButton" name="PlayForwardButton">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>60</width>
+            <height>60</height>
+           </size>
           </property>
           <property name="toolTip">
            <string>Play forward</string>
@@ -322,15 +386,27 @@
            <iconset resource="Icons/resource.qrc">
            <normaloff>:/icons/media-playback-start.svg</normaloff>:/icons/media-playback-start.svg</iconset>
           </property>
+          <property name="iconSize">
+           <size>
+            <width>18</width>
+            <height>18</height>
+           </size>
+          </property>
          </widget>
         </item>
         <item>
          <widget class="QToolButton" name="StepForwardButton">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>60</width>
+            <height>60</height>
+           </size>
           </property>
           <property name="toolTip">
            <string>Step forward</string>
@@ -342,7 +418,26 @@
            <iconset resource="Icons/resource.qrc">
            <normaloff>:/icons/media-playback-step.svg</normaloff>:/icons/media-playback-step.svg</iconset>
           </property>
+          <property name="iconSize">
+           <size>
+            <width>18</width>
+            <height>18</height>
+           </size>
+          </property>
          </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
       </item>


### PR DESCRIPTION
Purely visual change. I noticed that the play and step buttons looked very similar because 1. They are small 2. The vertical bar is too close to the triangle.


## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

Before :disappointed: 
<img width="505" height="510" alt="sim_before" src="https://github.com/user-attachments/assets/129cdf19-1085-4483-b57e-4f3d8619f155" />


After :sunglasses: 
<img width="564" height="518" alt="sim_after" src="https://github.com/user-attachments/assets/c053b37d-f5a4-459e-8aa5-a1e70412bc5a" />