### PR TITLE
Part: Fix face selection filter not accepting sketch internal faces

### DIFF
--- a/src/Mod/Part/Gui/CommandFilter.cpp
+++ b/src/Mod/Part/Gui/CommandFilter.cpp
@@ -252,7 +252,12 @@ PartCmdFaceSelection::PartCmdFaceSelection()
 void PartCmdFaceSelection::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.Selection.addSelectionGate('SELECT Part::Feature SUBELEMENT Face SELECT App::Link SUBELEMENT Face')");
+    doCommand(
+        Command::Gui,
+        "Gui.Selection.addSelectionGate('SELECT Part::Feature SUBELEMENT Face "
+        "SELECT App::Link SUBELEMENT Face "
+        "SELECT Part::Part2DObject SUBELEMENT InternalFace')"
+    );
 }
 
 


### PR DESCRIPTION
Fixes #23570

Sketch faces have subelement names like `InternalFace1`. The face selection filter was only accepting subelements starting with `Face`, so sketch faces were always blocked.

The fix adds `SELECT Part::Part2DObject SUBELEMENT InternalFace` to the gate string, which covers `SketchObject` since it derives from `Part::Part2DObject`.