### PR TITLE
Interpreter: Add missing supportGetattr() calls to console classes

### DIFF
--- a/src/Base/Interpreter.cpp
+++ b/src/Base/Interpreter.cpp
@@ -203,6 +203,7 @@ public:
         behaviors().doc("Python standard output");
         add_varargs_method("write", &PythonStdOutput::write, "write()");
         add_varargs_method("flush", &PythonStdOutput::flush, "flush()");
+        behaviors().supportGetattr();
         behaviors().readyType();
     }
 

--- a/src/Gui/PythonConsolePy.cpp
+++ b/src/Gui/PythonConsolePy.cpp
@@ -36,6 +36,7 @@ void PythonStdout::init_type()
     add_varargs_method("write", &PythonStdout::write, "write()");
     add_varargs_method("flush", &PythonStdout::flush, "flush()");
     add_noargs_method("isatty", &PythonStdout::isatty, "isatty()");
+    behaviors().supportGetattr();
     behaviors().readyType();
 }
 
@@ -98,6 +99,7 @@ void PythonStderr::init_type()
     add_varargs_method("write", &PythonStderr::write, "write()");
     add_varargs_method("flush", &PythonStderr::flush, "flush()");
     add_noargs_method("isatty", &PythonStderr::isatty, "isatty()");
+    behaviors().supportGetattr();
     behaviors().readyType();
 }
 
@@ -160,6 +162,7 @@ void OutputStdout::init_type()
     add_varargs_method("write", &OutputStdout::write, "write()");
     add_varargs_method("flush", &OutputStdout::flush, "flush()");
     add_noargs_method("isatty", &OutputStdout::isatty, "isatty()");
+    behaviors().supportGetattr();
     behaviors().readyType();
 }
 
@@ -220,6 +223,7 @@ void OutputStderr::init_type()
     add_varargs_method("write", &OutputStderr::write, "write()");
     add_varargs_method("flush", &OutputStderr::flush, "flush()");
     add_noargs_method("isatty", &OutputStderr::isatty, "isatty()");
+    behaviors().supportGetattr();
     behaviors().readyType();
 }
 

--- a/src/Gui/PythonDebugger.cpp
+++ b/src/Gui/PythonDebugger.cpp
@@ -178,6 +178,7 @@ void PythonDebugStdout::init_type()
     behaviors().supportRepr();
     add_varargs_method("write", &PythonDebugStdout::write, "write to stdout");
     add_varargs_method("flush", &PythonDebugStdout::flush, "flush the output");
+    behaviors().supportGetattr();
     behaviors().readyType();
 }
 
@@ -219,6 +220,7 @@ void PythonDebugStderr::init_type()
     // you must have overwritten the virtual functions
     behaviors().supportRepr();
     add_varargs_method("write", &PythonDebugStderr::write, "write to stderr");
+    behaviors().supportGetattr();
     behaviors().readyType();
 }
 
@@ -255,6 +257,7 @@ void PythonDebugExcept::init_type()
     // you must have overwritten the virtual functions
     behaviors().supportRepr();
     add_varargs_method("fc_excepthook", &PythonDebugExcept::excepthook, "Custom exception handler");
+    behaviors().supportGetattr();
     behaviors().readyType();
 }
 


### PR DESCRIPTION
Fixes #30248 (and any other time you see `'OutputStdout' object has no attribute 'write'`). The switch to calling `readyType()` in all of our `init_type()` methods had unexpected consequences for our console classes. I also need to make sure to call `behaviors().supportGetattr();` *before* the `readyType` in those classes.