### PR TITLE
CI: Add "Status: Needs triage" label to all new PRs

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -106,6 +106,16 @@
 - changed-files:
   - any-glob-to-any-file:  ['src/3rdParty/**/*']
 
+# 'Language' related labels
+
+"Language: C++":
+- changed-files:
+  - any-glob-to-any-file: ['**/*.cpp', '**/*.cxx', '**/*.cc', '**/*.h', '**/*.hpp', '**/*.hxx']
+
+"Language: Python":
+- changed-files:
+  - any-glob-to-any-file: ['**/*.py']
+
 # 'Topic' related labels
 
 "Topic: Stylesheets":

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -25,6 +25,17 @@ jobs:
       with:
         egress-policy: audit
 
+    - name: 'Add "Status: Needs triage" label'
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      with:
+        script: |
+          await github.rest.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.payload.pull_request.number,
+            labels: ['Status: Needs triage']
+          });
+
     - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR adds new labels to the PRs in automatized fashion:

 - `Language: Python` and `Language: C++` for PRs with given language (so we know that some PRs from CAM for example need attention from C++ guys)
 - `Status: Needs triage` to all new PRs so we know that we need to determine what reviews they require.
 
This PR does not update CONTRIBUTING.md with explanation of the label, but I may do that if asked.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
