### PR TITLE
Gui: Keep focus in tree view after using keyboard to delete item in tree view

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1497,6 +1497,8 @@ void StdCmdDelete::activated(int iMsg)
     Q_UNUSED(iMsg);
 
     int tid = 0;
+    QPointer<QWidget> focusBefore;
+
     try {
         std::set<App::Document*> docs;
         std::vector<App::TransactionLocker> tlocks;
@@ -1511,6 +1513,13 @@ void StdCmdDelete::activated(int iMsg)
             // commitCommand();
             return;
         }
+
+        // Snapshot focus before any popup can steal it. After the delete
+        // completes and any modal dialogs close, restore focus so keyboard
+        // navigation continues from where the user was working.
+        // Fixes https://github.com/FreeCAD/FreeCAD/issues/23798
+        focusBefore = QApplication::focusWidget();
+
         // Ensure that the document from which we send the command
         // can undo it (e.g delete a subobject of an assembly
         // from the assembly file)
@@ -1667,6 +1676,16 @@ void StdCmdDelete::activated(int iMsg)
     App::GetApplication().commitTransaction(tid);
     Gui::getMainWindow()->setUpdatesEnabled(true);
     Gui::getMainWindow()->update();
+
+    // Restore focus to the widget the user was working in.
+    if (focusBefore) {
+        QPointer<QWidget> target = focusBefore;
+        QTimer::singleShot(0, target, [target]() {
+            if (target && target->isVisible() && target->isEnabled()) {
+                target->setFocus(Qt::OtherFocusReason);
+            }
+        });
+    }
 }
 
 bool StdCmdDelete::isActive()

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1499,6 +1499,17 @@ void StdCmdDelete::activated(int iMsg)
     int tid = 0;
     QPointer<QWidget> focusBefore;
 
+    // Restore focus to the widget the user was working in before the
+    // command opened any modal popup. Using a scope guard ensures the
+    // restore runs on every exit path: normal return, early return,
+    // and exception unwinding.
+    // Fixes https://github.com/FreeCAD/FreeCAD/issues/23798
+    auto focusGuard = qScopeGuard([&focusBefore]() {
+        if (focusBefore && focusBefore->isVisible() && focusBefore->isEnabled()) {
+            focusBefore->setFocus(Qt::OtherFocusReason);
+        }
+    });
+
     try {
         std::set<App::Document*> docs;
         std::vector<App::TransactionLocker> tlocks;
@@ -1676,16 +1687,6 @@ void StdCmdDelete::activated(int iMsg)
     App::GetApplication().commitTransaction(tid);
     Gui::getMainWindow()->setUpdatesEnabled(true);
     Gui::getMainWindow()->update();
-
-    // Restore focus to the widget the user was working in.
-    if (focusBefore) {
-        QPointer<QWidget> target = focusBefore;
-        QTimer::singleShot(0, target, [target]() {
-            if (target && target->isVisible() && target->isEnabled()) {
-                target->setFocus(Qt::OtherFocusReason);
-            }
-        });
-    }
 }
 
 bool StdCmdDelete::isActive()

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1449,13 +1449,12 @@ void MainWindow::setActiveWindow(MDIView* view)
     // switching from a 3d view to a spreadsheet using the "Windows..." dialog or when docking a
     // spreadsheet that was in top-level/fullscreen mode. Why this could only be reproduced with a
     // spreadsheet remains a mystery.
-
-
-    // However, unconditionally stealing focus here also stomps focus that the user
-    // has placed on a dock widget (e.g. the tree view). Closing a modal popup
-    // triggers ActivationChange -> setActiveSubWindow -> setActiveWindow with the
-    // same view that is already active, which has no real reason to take focus.
-    // Only force focus to the view when the active view is actually changing.
+    //
+    // However, only do this when the active view is actually changing. Calling setFocus
+    // unconditionally also stomps focus that the user has placed on a dock widget (e.g. the
+    // tree view): closing a modal popup triggers ActivationChange -> setActiveSubWindow ->
+    // setActiveWindow with the same view that is already active, which has no real reason
+    // to take focus.
     // Fixes https://github.com/FreeCAD/FreeCAD/issues/23798
     if (view != d->activeView) {
         view->setFocus();

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1440,7 +1440,6 @@ void MainWindow::setActiveWindow(MDIView* view)
     if (!view) {
         return;
     }
-
     // always update the focus and active sub window
 
     // We need the explicit call to setFocus because it seems the focus window and the
@@ -1451,7 +1450,16 @@ void MainWindow::setActiveWindow(MDIView* view)
     // spreadsheet that was in top-level/fullscreen mode. Why this could only be reproduced with a
     // spreadsheet remains a mystery.
 
-    view->setFocus();
+
+    // However, unconditionally stealing focus here also stomps focus that the user
+    // has placed on a dock widget (e.g. the tree view). Closing a modal popup
+    // triggers ActivationChange -> setActiveSubWindow -> setActiveWindow with the
+    // same view that is already active, which has no real reason to take focus.
+    // Only force focus to the view when the active view is actually changing.
+    // Fixes https://github.com/FreeCAD/FreeCAD/issues/23798
+    if (view != d->activeView) {
+        view->setFocus();
+    }
 
     auto subwindow = qobject_cast<QMdiSubWindow*>(view->parentWidget());
     if (subwindow) {
@@ -1459,7 +1467,6 @@ void MainWindow::setActiveWindow(MDIView* view)
     }
 
     // if active view changed, notify rest of the application
-
     if (view == d->activeView) {
         return;
     }


### PR DESCRIPTION
when a user is navigating with their keyboard in the tree view and usese the delete key to delete an item that presents a popup / modal, ie. an assembly the focus to the tree is lost and is restored to the "scene graph" / gl context. so when a user continues pressing the arrow keys on their keyboard the camera view is moved in 3d space. with this PR after a user deletes an item in the tree view focus is restore to the tree so the user can keep navigating the tree with their keyboard.

i have a debug branch with my log statements for those who are interested.

https://github.com/ipatch/FreeCAD/tree/ipatch.tshoot.23798-dbg

Assisted-by: claude (opus 4.7 adapative)

fixes #23798

## Issues

- https://github.com/freecad/freecad/issues/23798