### PR TITLE
CAM: DressupTag - Allow open base wires

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -707,12 +707,7 @@ class PathData:
             and Path.Geom.isRoughly(e.Vertexes[1].Point.z, minZ)
         ]
         self.bottomEdges = Part.sortEdges(bottom)
-        wires = []
-        for edgesSorted in self.bottomEdges:
-            wire = Part.Wire(edgesSorted)
-            if wire.isClosed():
-                wires.append(wire)
-        return wires
+        return [Part.Wire(se) for se in self.bottomEdges]
 
     def supportsTagGeneration(self):
         return self.baseWires is not None


### PR DESCRIPTION
This PR removes limitation, that bottom wires should be closed

> [!NOTE]
> I do not know the reason for this limitation
> Simple tests did not show any regressions

<img width="698" height="286" alt="Screenshot_20260520_211850_lossy" src="https://github.com/user-attachments/assets/05e68970-8b4c-48c4-b61e-cf45fb8ad38b" />

---

Also this allows to apply `DressupTag` to `DressupLeadInOut`

<img width="937" height="352" alt="Screenshot_20260612_222744_lossy" src="https://github.com/user-attachments/assets/aa2468e0-bb1a-4fe5-aecf-0893090147ad" />
