### PR TITLE
CAM: avoid padding command names when annotations round-trip

### DIFF
--- a/src/Mod/CAM/App/Command.cpp
+++ b/src/Mod/CAM/App/Command.cpp
@@ -104,7 +104,7 @@ bool Command::has(const std::string& attr) const
     return Parameters.contains(a);
 }
 
-std::string Command::toGCode(int precision, bool padzero) const
+std::string Command::toGCode(int precision, bool padzero, bool includeAnnotations) const
 {
     std::stringstream str;
     str.fill('0');
@@ -149,7 +149,7 @@ std::string Command::toGCode(int precision, bool padzero) const
     }
 
     // Add annotations as a comment if they exist
-    if (!Annotations.empty()) {
+    if (includeAnnotations && !Annotations.empty()) {
         str << " ; ";
         bool first = true;
         for (const auto& pair : Annotations) {
@@ -184,7 +184,8 @@ void Command::setFromGCode(const std::string& str)
     auto comment_pos = str.find("; ");
     if (comment_pos != std::string::npos) {
         gcode_part = str.substr(0, comment_pos);
-        annotation_part = str.substr(comment_pos + 1);  // length of "; "
+        boost::trim_right(gcode_part);
+        annotation_part = str.substr(comment_pos + 2);  // length of "; "
     }
 
     std::string mode = "none";
@@ -479,7 +480,7 @@ unsigned int Command::getMemSize() const
 void Command::Save(Base::Writer& writer) const
 {
     // this will only get used if saved as XML (probably never)
-    writer.Stream() << writer.ind() << "<Command gcode=\"" << toGCode() << "\"";
+    writer.Stream() << writer.ind() << "<Command gcode=\"" << toGCode(6, true, false) << "\"";
 
     if (!Annotations.empty()) {
         writer.Stream() << " annotations=\"";

--- a/src/Mod/CAM/App/Command.h
+++ b/src/Mod/CAM/App/Command.h
@@ -65,7 +65,8 @@ public:
     );  // sets the center coordinates and the command name
     std::string toGCode(
         int precision = 6,
-        bool padzero = true
+        bool padzero = true,
+        bool includeAnnotations = true
     ) const;                                // returns a GCode string representation of the command
     void setFromGCode(const std::string&);  // sets the parameters from the contents of the given
                                             // GCode string

--- a/src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py
+++ b/src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py
@@ -378,3 +378,22 @@ class TestPathCommandAnnotations(PathTestBase):
         self.assertEqual(c1.Parameters["Y"], 5.0)
         self.assertEqual(c1.Annotations["retract"], 15.5)
         self.assertEqual(c1.Annotations["angle"], 30.25)
+
+    def test21(self):
+        """Test comment command names are not padded when annotations round-trip."""
+        original = Path.Command("(xx)", {}, {"a": "x"})
+
+        content = original.dumpContent()
+        restored = Path.Command()
+        restored.restoreContent(content)
+
+        self.assertEqual(restored.Name, "(xx)")
+        self.assertEqual(restored.Annotations, {"a": "x"})
+
+    def test22(self):
+        """Test parsing annotation comments does not include the separator space in the name."""
+        command = Path.Command()
+        command.setFromGCode("(xx) ; a:'x'")
+
+        self.assertEqual(command.Name, "(xx)")
+        self.assertEqual(command.Annotations, {"a": "x"})


### PR DESCRIPTION
## Summary
- keep serialized `Path.Command` gcode free of duplicate annotation comments when an `annotations` attribute is also written
- trim the command portion before parsing semicolon annotations so comment-only command names do not keep the separator space
- add regression coverage for `(xx)` command annotations through save/restore and direct parsing

Fixes #30140

## Root Cause
`Command::Save()` wrote annotations through both `toGCode()` and the separate `annotations` XML attribute. When the gcode string was later parsed, `setFromGCode()` split at the annotation separator but left the trailing space in the command portion, so a comment command like `(xx)` restored as `(xx) `.

## Validation
- `git diff --check HEAD~1..HEAD`
- `pixi install --frozen`
- `pixi run configure-release`
- `pixi run cmake --build build/release --target FreeCADCmd Path -- -j2`
- `pixi run cmake --build build/release --target PathScripts Tests lazy_loader -- -j2`
- `FreeCADCmd -t CAMTests.TestPathCommandAnnotations.TestPathCommandAnnotations` (23 tests OK)
