### PR TITLE
CAM: Profile - Refactor 2

### DIFF
--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -544,149 +544,141 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         """_preprocessBase(obj) ... returns envelope of selected shapes"""
         shapeTups = []
 
+        self.solids = [base.Shape for base in self.model]
+        self.tol = self.job.GeometryTolerance.Value
+
+        bases = []
+        edgeslist = []
+        horFaces = []
+        vertFaces = []
         for base, subsList in self.baseShapes(obj):
             if subsList == ("",):
                 shapeTups.extend(self._processEachModel(base))
                 continue
-
-            basewires = []
-            edgeslist = []
-            horFacesList = []
-            horFaces = []
-            vertFaces = []
+            if base.Shape.Faces and base not in bases:
+                bases.append(base)
             for subName in subsList:
                 sub = getattr(base.Shape, subName)
                 if isinstance(sub, Part.Edge):
-                    # extract and process edges
                     edgeslist.append(sub)
                 elif isinstance(sub, Part.Face):
                     if Path.Geom.isHorizontal(sub):
-                        # save horizontal faces for regular processing
                         horFaces.append(sub)
                     else:
-                        # save other faces for processing bottom edges
                         vertFaces.append(sub)
 
-            for es in Part.sortEdges(edgeslist):
-                basewires.append((base, Part.Wire(es)))
+        for face in horFaces:
+            for base in bases:
+                if base.Shape.isInside(face.Vertexes[0].Point, self.tol, True):
+                    shapeTups.extend(self._processHorFace(obj, base, face))
+                    break
 
-            if horFaces:  # save faces for returning and processing
-                horFacesList.append((base, horFaces))
+        # extend list of selected edges by bottom edges from vertical faces
+        for face in vertFaces:
+            fzMin = min(e.BoundBox.ZMin for e in face.Edges)
+            bEs = [e for e in face.Edges if Path.Geom.isRoughly(e.BoundBox.ZMax, fzMin)]
+            edgeslist.extend(bEs)
 
-            # get bottom wire from not horizontal faces
-            if vertFaces:
-                bottomEdges = []
-                for f in vertFaces:
-                    fzMin = min(e.BoundBox.ZMin for e in f.Edges)
-                    bEs = [e for e in f.Edges if Path.Geom.isRoughly(e.BoundBox.ZMax, fzMin)]
-                    bottomEdges.extend(bEs)
-                for cluster in Part.getSortedClusters(bottomEdges):
-                    wire = Part.Wire(Part.__sortEdges__(cluster))
-                    edgeslist.extend(cluster)
-                    basewires.append((base, wire))
-
-            if basewires:
-                shapeTups.extend(self._processWires(obj, basewires, edgeslist))
-            if horFacesList:
-                shapeTups.extend(self._processHorFaces(obj, horFacesList))
-
-        return shapeTups
-
-    def _processHorFaces(self, obj, horFacesList):
-        """_processHorFaces(obj, horFacesList) ... returns envelope of horizontal faces"""
-        shapeTups = []
-        for base, facesList in horFacesList:
-            holes = []
-            faces = []
-
-            for face in facesList:
-                faces.append(face)
-                ohash = face.OuterWire.hashCode()
-                for wire in face.Wires:
-                    if wire.hashCode() == ohash:
-                        continue
-                    holes.append((base.Shape, wire))
-
-            for baseShape, wire in holes:
-                f = Part.makeFace(wire, "Part::FaceMakerSimple")
-                drillable = Drillable.isDrillable(baseShape, f, vector=None)
-                Path.Log.debug(drillable)
-                if (obj.processCircles and drillable) or (obj.processHoles and not drillable):
-                    shapeEnv = PathUtils.getEnvelope(
-                        baseShape, subshape=f, depthparams=self.depthparams
-                    )
-                    if shapeEnv:
-                        self._addDebugObject("HoleShapeEnvelope", shapeEnv)
-                        shapeTups.append((shapeEnv, True, "pathProfile"))
-
-            if faces and obj.processPerimeter:
-                for shape in faces:
-                    custDepthparams = self.depthparams
-                    try:
-                        shapeEnv = PathUtils.getEnvelope(shape, depthparams=custDepthparams)
-                    except Exception as ee:
-                        # PathUtils.getEnvelope() failed to return an object.
-                        msg = translate("PathProfile", "Unable to create path for face(s).")
-                        Path.Log.error(msg + "\n{}".format(ee))
-                        shapeEnv = None
-
-                    if shapeEnv:
-                        for shEnv in shapeEnv.Solids:
-                            # divide solids after for 'Individually'
-                            self._addDebugObject("CutShapeEnv", shEnv)
-                            shapeTups.append((shEnv, False, "pathProfile"))
-
-        return shapeTups
-
-    def _processWires(self, obj, basewires, edgeslist):
-        """_processWires(obj, basewires, edgelist) ... returns envelope of all selected edges"""
-        Path.Log.track(basewires)
-        shapeTups = []
-        for base, wire in basewires:
-            if wire.isClosed():
-                origWire, flatWire = self._flattenWire(obj, wire, obj.FinalDepth.Value)
-                f = flatWire.Wires[0]
-                if f:
-                    shapeEnv = PathUtils.getEnvelope(Part.Face(f), depthparams=self.depthparams)
-                    if shapeEnv:
-                        shapeTups.append((shapeEnv, False, "pathProfile"))
+        for se in Part.getSortedClusters(edgeslist):
+            for base in bases:
+                if any(base.Shape.isInside(e.Vertexes[0].Point, self.tol, True) for e in se):
+                    shapeTups.extend(self._processWire(obj, base, se))
+                    break
+            else:
+                wire = Part.Wire(Part.__sortEdges__(se))
+                if wire.isClosed():
+                    shapeTups.extend(self._processWire(obj, None, se))
                 else:
+                    Path.Log.warning("Skipped open wire without base solid model")
+
+        return shapeTups
+
+    def _processHorFace(self, obj, base, face):
+        """_processHorFace(obj, base, face) ... returns envelope of horizontal face"""
+        shapeTups = []
+
+        ohash = face.OuterWire.hashCode()
+        holes = [wire for wire in face.Wires if wire.hashCode() != ohash]
+
+        for wire in holes:
+            f = Part.makeFace(wire, "Part::FaceMakerSimple")
+            drillable = Drillable.isDrillable(base.Shape, f, vector=None)
+            Path.Log.debug(drillable)
+            if (obj.processCircles and drillable) or (obj.processHoles and not drillable):
+                shapeEnv = PathUtils.getEnvelope(
+                    base.Shape, subshape=f, depthparams=self.depthparams
+                )
+                if shapeEnv:
+                    self._addDebugObject("HoleShapeEnvelope", shapeEnv)
+                    shapeTups.append((shapeEnv, True, "pathProfile"))
+
+        if obj.processPerimeter:
+            try:
+                shapeEnv = PathUtils.getEnvelope(face, depthparams=self.depthparams)
+            except Exception as ee:
+                # PathUtils.getEnvelope() failed to return an object.
+                msg = translate("PathProfile", "Unable to create path for face(s).")
+                Path.Log.error(msg + "\n{}".format(ee))
+                shapeEnv = None
+
+            if shapeEnv:
+                for shEnv in shapeEnv.Solids:
+                    # divide solids after for 'Individually'
+                    self._addDebugObject("CutShapeEnv", shEnv)
+                    shapeTups.append((shEnv, False, "pathProfile"))
+
+        return shapeTups
+
+    def _processWire(self, obj, base, edges):
+        """_processWires(obj, base, edges) ... returns envelope of edges forms the wire"""
+        Path.Log.track(base)
+        shapeTups = []
+        wire = Part.Wire(Part.__sortEdges__(edges))
+        if wire.isClosed():
+            origWire, flatWire = self._flattenWire(obj, wire, obj.FinalDepth.Value)
+            f = flatWire.Wires[0]
+            if f:
+                shape = Part.Face(f)
+                shapeEnv = PathUtils.getEnvelope(shape, depthparams=self.depthparams)
+                if shapeEnv:
+                    shapeTups.append((shapeEnv, False, "pathProfile"))
+            else:
+                Path.Log.error(self.inaccessibleMsg)
+        else:  # open wire
+            if self.JOB.GeometryTolerance.Value == 0.0:
+                msg = self.JOB.Label + ".GeometryTolerance = 0.0. "
+                msg += "Please set to an acceptable value greater than zero."
+                Path.Log.error(msg)
+            else:
+                flattened = self._flattenWire(obj, wire, wire.BoundBox.Center.z)
+                if not flattened:
                     Path.Log.error(self.inaccessibleMsg)
-            else:  # open wire
-                if self.JOB.GeometryTolerance.Value == 0.0:
-                    msg = self.JOB.Label + ".GeometryTolerance = 0.0. "
-                    msg += "Please set to an acceptable value greater than zero."
-                    Path.Log.error(msg)
-                else:
-                    flattened = self._flattenWire(obj, wire, wire.BoundBox.Center.z)
-                    if not flattened:
+                    return []
+                origWire, flatWire = flattened
+                diffDepth = self._getOpenProfileDiffDepth(base, edges)
+                # translate wire in Z to get correct cross-section with model
+                flatWire.translate(FreeCAD.Vector(0, 0, diffDepth))
+                self._addDebugObject("FlatWire", flatWire)
+
+                openWires = []
+                params = self.areaOpAreaParams(obj, False)
+                passOffsets = [
+                    self.ofstRadius + i * abs(params["Stepover"])
+                    for i in range(params["ExtraPass"] + 1)
+                ][::-1]
+                for po in passOffsets:
+                    cutWireObjs = False
+                    self.ofstRadius = po
+                    cutShp = self._getCutAreaCrossSection(obj, base, origWire, flatWire)
+                    if cutShp:
+                        cutWireObjs = self._extractPathWire(obj, base, flatWire, cutShp)
+
+                    if cutWireObjs:
+                        for cW in cutWireObjs:
+                            openWires.append(cW)
+                    else:
                         Path.Log.error(self.inaccessibleMsg)
-                        continue
-                    origWire, flatWire = flattened
-                    diffDepth = self._getOpenProfileDiffDepth(base, edgeslist)
-                    # translate wire in Z to get correct cross-section with model
-                    flatWire.translate(FreeCAD.Vector(0, 0, diffDepth))
-                    self._addDebugObject("FlatWire", flatWire)
-
-                    params = self.areaOpAreaParams(obj, False)
-                    passOffsets = [
-                        self.ofstRadius + i * abs(params["Stepover"])
-                        for i in range(params["ExtraPass"] + 1)
-                    ][::-1]
-                    openWires = []
-                    for po in passOffsets:
-                        cutWireObjs = False
-                        self.ofstRadius = po
-                        cutShp = self._getCutAreaCrossSection(obj, base, origWire, flatWire)
-                        if cutShp:
-                            cutWireObjs = self._extractPathWire(obj, base, flatWire, cutShp)
-
-                        if cutWireObjs:
-                            for cW in cutWireObjs:
-                                openWires.append(cW)
-                        else:
-                            Path.Log.error(self.inaccessibleMsg)
-                    shapeTups.append((openWires[0], openWires, "OpenEdge"))
+                shapeTups.append((openWires[0], openWires, "OpenEdge"))
 
         return shapeTups
 


### PR DESCRIPTION
### Description

Fixes #12643

Another refactor of `areaOpShapes()`, which continues changes from #27236

---

### Changes

**Before**:
Each base shape processing independently

**After**:
Collect sub elements from all base shapes and processing together
This allows to select auxiliary shapes, which can extend base geometry
This ability already present in **PocketShape** operation

---

<img width="1124" height="399" alt="Screenshot_20260519_214846_hor" src="https://github.com/user-attachments/assets/c3b0e876-d044-40ef-a3a2-f53527eaf4f3" />

https://github.com/user-attachments/assets/a4310cbe-3566-478b-86ca-03f2919ee060
