### PR TITLE
BIM: include external defining sketch geometry in walls

### DIFF
--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -1095,6 +1095,12 @@ class _Wall(ArchComponent.Component):
                         skGeom = obj.Base.GeometryFacadeList
                         skGeomEdges = []
                         skPlacement = obj.Base.Placement  # Get Sketch's placement to restore later
+                        supportedSketchGeometry = (
+                            Part.LineSegment,
+                            Part.Circle,
+                            Part.ArcOfCircle,
+                            Part.Ellipse,
+                        )
                         # Get ArchSketch edges to construct ArchWall
                         # No need to test obj.ArchSketchData ...
                         for ig, geom in enumerate(skGeom):
@@ -1107,12 +1113,18 @@ class _Wall(ArchComponent.Component):
                             ) in obj.ArchSketchEdges:
                                 # support Line, Arc, Circle, Ellipse for Sketch
                                 # as Base at the moment
-                                if isinstance(
-                                    geom.Geometry,
-                                    (Part.LineSegment, Part.Circle, Part.ArcOfCircle, Part.Ellipse),
-                                ):
+                                if isinstance(geom.Geometry, supportedSketchGeometry):
                                     skGeomEdgesI = geom.Geometry.toShape()
                                     skGeomEdges.append(skGeomEdgesI)
+                        if not obj.ArchSketchEdges and obj.Base.ExternalGeometry:
+                            import Sketcher
+
+                            for geom in obj.Base.ExternalGeo:
+                                extGeom = Sketcher.ExternalGeometryFacade(geom)
+                                if not extGeom.testFlag("Defining"):
+                                    continue
+                                if isinstance(geom, supportedSketchGeometry):
+                                    skGeomEdges.append(geom.toShape())
                         for cluster in Part.getSortedClusters(skGeomEdges):
                             clusterTransformed = []
                             for edge in cluster:

--- a/src/Mod/BIM/bimtests/TestArchWall.py
+++ b/src/Mod/BIM/bimtests/TestArchWall.py
@@ -95,6 +95,35 @@ class TestArchWall(TestArchBase.TestArchBase):
                     "Arch Wall with MultiMaterial and 3 alignments failed",
                 )
 
+    def testWallUsesExternalDefiningSketchGeometry(self):
+        operation = "Checking Arch Wall with external defining sketch geometry..."
+        self.printTestMessage(operation)
+
+        source = self.document.addObject("Sketcher::SketchObject", "SourceSketch")
+        source.addGeometry(Part.LineSegment(App.Vector(0, 0, 0), App.Vector(1000, 0, 0)))
+        self.document.recompute()
+
+        target = self.document.addObject("Sketcher::SketchObject", "TargetSketch")
+        target.addGeometry(Part.LineSegment(App.Vector(1000, 0, 0), App.Vector(1000, 1000, 0)))
+        target.addExternal(source.Name, "Edge1", True)
+        self.document.recompute()
+
+        self.assertEqual(
+            len(target.Shape.Edges),
+            2,
+            "Test sketch should expose internal and external defining edges",
+        )
+
+        wall = Arch.makeWall(target, width=100, height=1000)
+        self.document.recompute()
+
+        self.assertAlmostEqual(
+            wall.Shape.Volume,
+            200000000,
+            delta=1e-7,
+            msg="Arch Wall should build from internal and external defining sketch geometry",
+        )
+
     def test_makeWall(self):
         """Test the makeWall function."""
         operation = "Testing makeWall function"


### PR DESCRIPTION
Fixes #28239.

Summary:
- Include external defining sketch geometry when Arch Wall extracts sketch base edges.
- Keep the existing ArchSketchEdges override behavior unchanged.
- Add a BIM wall regression test for external defining sketch geometry.

Validation:
- `pixi run cmake --build build/release --target src/Mod/BIM/all -- -j2`
- `pixi run cmake --build build/release --target TechDraw -- -j2`
- `pixi run ./build/release/bin/FreeCADCmd -t TestArch.TestArchWall.testWallUsesExternalDefiningSketchGeometry`
- Issue attachment smoke test: external defining edge included; wall volume/bbox changed from the old internal-only result to the new external-inclusive result.
- `git diff --check -- src/Mod/BIM/ArchWall.py src/Mod/BIM/bimtests/TestArchWall.py`
- Individual hooks passed: `black`, `trailing-whitespace`, `end-of-file-fixer`, `mixed-line-ending`.