### PR TITLE
Enable FREECAD_WARN_ERROR in release and not debug

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -226,13 +226,7 @@
         "inherits": [
           "debug",
           "conda"
-        ],
-        "cacheVariables": {
-            "FREECAD_WARN_ERROR": {
-            "type": "BOOL",
-            "value": "ON"
-          }
-        }
+        ]
       },
       {
         "name": "conda-release",
@@ -242,7 +236,13 @@
         "inherits": [
           "release",
           "conda"
-        ]
+        ],
+        "cacheVariables": {
+            "FREECAD_WARN_ERROR": {
+            "type": "BOOL",
+            "value": "ON"
+          }
+        }
       },
       {
         "name": "conda-linux-debug",

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultWidgetController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultWidgetController.h
@@ -252,7 +252,7 @@ public:
     {}
 
     /// function to create constraints based on control information for infinite DSH (polyline).
-    virtual void addStepConstraints()
+    void addStepConstraints() override
     {}
 
     /// function to configure the default widget.

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -927,9 +927,9 @@ public:
         , resetEdge(true)
         , fillet(false)
         , previousDirectionAngle(0.0)
+        , dirChangeAngle(0.0)
         , startAngle(0.0)
         , range(0.0)
-        , dirChangeAngle(0.0)
         , angleToPrevious(0.0)
         , pos(PointPos::end)
         , capturedDirection(0.0, 0.0) {};

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1506,8 +1506,6 @@ private:
                 angleToPrevious = std::round(angleToPrevious / (pi * 0.5)) * (pi * 0.5);
             }
 
-            Base::Vector2d Tangent = getCurrentInitialDirection();
-            double theta = Tangent.GetAngle(currentDir);
             double radius = getArcCenter(center, prevCursorPos);
 
             if (radius == 0.0) {

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -594,7 +594,7 @@ void SketcherSettingsDisplay::onFontNameChanged(const QFont& font)
     auto testChars = QString::fromUtf8(RequiredCharacters).toUcs4();
 
     QString missingChars;
-    for (uint testChar : testChars) {
+    for (char32_t testChar : testChars) {
         if (!metrics.inFontUcs4(testChar)) {
             missingChars += QString::fromUtf8("  ");
             missingChars += QString::fromUcs4(&testChar, 1);

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -586,6 +586,8 @@ QGIViewClip* QGIView::getClipGroup()
 //! called from ViewProvider when feature properties change.
 void QGIView::updateView(bool forceUpdate)
 {
+    Q_UNUSED(forceUpdate);
+
     setMovableFlag();
 
     double appRotation = getViewObject()->Rotation.getValue();


### PR DESCRIPTION
Fixes up https://github.com/FreeCAD/FreeCAD/pull/30228 : -Werror was mistakenly added to the debug preset instead of the release preset, breaking people's debug builds. This correctly enables -Werror for release builds run in CI.

Note to maintainers: after merging this, please rebase all future PRs on `main` before merging them to avoid introducing failures in the `main` branch.