### PR TITLE
Fix: spreadsheet expression "10 mm ^ 3" gains spurious parens on save

### DIFF
--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1532,7 +1532,8 @@ void OperatorExpression::_toString(std::ostream &s, bool persistent,int) const
     needsParens = false;
     if (freecad_cast<OperatorExpression*>(right))
         rightOperator = static_cast<OperatorExpression*>(right)->op;
-    if (right->priority() < priority()) // Check on operator priority first
+    // unit_exp '^' integer is unambiguous without outer parens (e.g. "10 mm ^ 3").
+    if (right->priority() < priority() && !(op == UNIT && rightOperator == POW))
         needsParens = true;
     else if (rightOperator == op) { // Same operator ?
         if (!isRightAssociative())

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1574,7 +1574,8 @@ void OperatorExpression::_toString(std::ostream &s, bool persistent,int) const
     needsParens = false;
     if (freecad_cast<OperatorExpression*>(right))
         rightOperator = static_cast<OperatorExpression*>(right)->op;
-    if (right->priority() < priority()) // Check on operator priority first
+    // unit_exp '^' integer is unambiguous without outer parens (e.g. "10 mm ^ 3").
+    if (right->priority() < priority() && !(op == UNIT && rightOperator == POW))
         needsParens = true;
     else if (rightOperator == op) { // Same operator ?
         if (!isRightAssociative())

--- a/tests/src/App/Expression.cpp
+++ b/tests/src/App/Expression.cpp
@@ -23,13 +23,18 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+
 #include <src/App/InitApplication.h>
+
+#include "Base/Quantity.h"
 
 #include "App/Document.h"
 #include "App/DocumentObject.h"
 #include "App/Expression.h"
 #include "App/ExpressionParser.h"
 #include "App/ExpressionTokenizer.h"
+#include "App/ObjectIdentifier.h"
 
 // +------------------------------------------------+
 // | Note: For more expression related tests, see:  |
@@ -329,6 +334,58 @@ TEST_F(Expression, test_e_rad)
     auto op = std::make_unique<App::OperatorExpression>(nullptr, constant.get(), App::OperatorExpression::UNIT, unit.get());
     EXPECT_EQ(op->toString(), "e rad");
     op.release();
+}
+
+static std::string reserialize(const char* text)
+{
+    return App::ExpressionParser::parse(nullptr, text)->toString();
+}
+
+static Base::Quantity valueOf(const char* text)
+{
+    const auto expression = App::ExpressionParser::parse(nullptr, text);
+    return App::any_cast<Base::Quantity>(expression->getValueAsAny());
+}
+
+// The grammar binds '^' more tightly than the number/unit juxtaposition, so "10 mm ^ 3" is
+// unambiguous and must not be wrapped in parentheses when serialized.
+// https://github.com/FreeCAD/FreeCAD/issues/24884
+TEST_F(Expression, serializeUnitPower)
+{
+    EXPECT_EQ(reserialize("10 mm ^ 3"), "10 mm ^ 3");
+    EXPECT_EQ(reserialize("10 mm ^ -3"), "10 mm ^ -3");
+    EXPECT_EQ(reserialize("10 (mm ^ 3)"), "10 mm ^ 3");
+    EXPECT_EQ(reserialize("pi rad ^ 2"), "pi rad ^ 2");
+    EXPECT_EQ(reserialize("10 (mm / s) ^ 2"), "10 (mm / s) ^ 2");
+}
+
+// Juxtaposition binds more tightly than '*' and '/', so "10 (mm / s)" and "10 mm / s" are
+// different parse trees and those parentheses must survive serialization.
+TEST_F(Expression, serializeUnitProductKeepsParens)
+{
+    EXPECT_EQ(reserialize("10 (mm / s)"), "10 (mm / s)");
+    EXPECT_EQ(reserialize("10 (mm * s)"), "10 (mm * s)");
+    EXPECT_EQ(reserialize("10 mm / s"), "10 mm / s");
+}
+
+// Serializing must be idempotent and value preserving: saving and reloading a document may
+// not perturb the expression.
+TEST_F(Expression, serializeUnitPowerRoundTrip)
+{
+    for (const char* text : {"10 mm ^ 3", "10 mm ^ -3", "10 (mm ^ 3)", "pi rad ^ 2",
+                             "10 (mm / s) ^ 2", "10 (mm / s)", "10 mm / s"}) {
+        const std::string once = reserialize(text);
+        EXPECT_EQ(reserialize(once.c_str()), once) << "not idempotent: " << text;
+        EXPECT_EQ(valueOf(once.c_str()), valueOf(text)) << "value changed: " << text;
+    }
+}
+
+// Guards the resolution of the shift/reduce conflict the serializer now relies on: '^' binds
+// to the unit, not to the quantity, so "10 mm ^ 3" is ten cubic millimetres.
+TEST_F(Expression, unitPowerAppliesToUnitOnly)
+{
+    EXPECT_EQ(valueOf("10 mm ^ 3"), Base::Quantity(10, Base::Unit::Volume));
+    EXPECT_EQ(valueOf("(10 mm) ^ 3"), Base::Quantity(1000, Base::Unit::Volume));
 }
 
 class Evaluate: public ::testing::Test


### PR DESCRIPTION
POW priority (5) < UNIT priority (6) caused the serializer to wrap "mm ^ 3" in parens on every save/reload. The grammar rule unit_exp '^' integer is unambiguous without outer parens, so skip paren-wrapping for UNIT+POW.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

Fixes https://github.com/FreeCAD/FreeCAD/issues/24884
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
