### PR TITLE
BIM: preserve report spreadsheet alignments

### DIFF
--- a/src/Mod/BIM/ArchReport.py
+++ b/src/Mod/BIM/ArchReport.py
@@ -710,11 +710,16 @@ class _ArchReport:
         # Save column widths before clearing so user adjustments survive recomputes.
         used_range = sp.getUsedRange()
         saved_widths = {}
+        saved_alignments = {}
         if used_range:
             first_col = ord(used_range[0].rstrip("0123456789"))
             last_col = ord(used_range[1].rstrip("0123456789"))
             for col in range(first_col, last_col + 1):
                 saved_widths[chr(col)] = sp.getColumnWidth(chr(col))
+            for cell in sp.getUsedCells():
+                alignment = sp.getAlignment(cell)
+                if alignment:
+                    saved_alignments[cell] = alignment
             sp.clear(f"{used_range[0]}:{used_range[1]}")
 
         # Reset the row counter for a new report build.
@@ -739,6 +744,8 @@ class _ArchReport:
 
         for col, width in saved_widths.items():
             sp.setColumnWidth(col, width)
+        for cell, alignment in saved_alignments.items():
+            sp.setAlignment(cell, alignment)
         sp.recompute()
         sp.purgeTouched()
 

--- a/src/Mod/BIM/TestArch.py
+++ b/src/Mod/BIM/TestArch.py
@@ -48,5 +48,5 @@ from bimtests.TestArchSchedule import TestArchSchedule
 from bimtests.TestArchTruss import TestArchTruss
 from bimtests.TestArchComponent import TestArchComponent
 from bimtests.TestWebGLExport import TestWebGLExport
-from bimtests.TestArchReport import TestArchReport
+from bimtests.TestArchReport import TestArchReport, TestArchReportSpreadsheetFormatting
 from bimtests.TestArchCovering import TestArchCovering

--- a/src/Mod/BIM/bimtests/TestArchReport.py
+++ b/src/Mod/BIM/bimtests/TestArchReport.py
@@ -2154,3 +2154,21 @@ class TestArchReport(TestArchBase.TestArchBase):
             custom_width,
             "Column width should be preserved after recompute.",
         )
+
+
+class TestArchReportSpreadsheetFormatting(TestArchBase.TestArchBase):
+
+    def test_cell_alignments_preserved_across_recompute(self):
+        """Cell alignments set by the user should survive a report recompute."""
+        report = Arch.makeReport()
+        report.Proxy.live_statements[0].query_string = "SELECT Label FROM document"
+        report.Proxy.commit_statements()
+        self.document.recompute()
+
+        sp = report.Target
+        sp.setAlignment("A1", "center")
+        sp.setAlignment("A2", "right")
+        self.document.recompute()
+
+        self.assertEqual(sp.getAlignment("A1"), {"center"})
+        self.assertEqual(sp.getAlignment("A2"), {"right"})


### PR DESCRIPTION
Fixes #26251.

Summary:
- Preserve existing spreadsheet cell alignments before clearing and rebuilding BIM report output.
- Restore saved alignments after report recompute, matching the existing column-width preservation behavior.
- Add regression coverage for user-set report spreadsheet alignments across recompute.

Validation:
- `git diff --check -- src/Mod/BIM/ArchReport.py src/Mod/BIM/TestArch.py src/Mod/BIM/bimtests/TestArchReport.py`
- `pixi run cmake --build build/release --target src/Mod/BIM/all -- -j2`
- `pixi run ./build/release/bin/FreeCADCmd -t TestArch.TestArchReportSpreadsheetFormatting`
- Individual hooks passed: `black`, `trailing-whitespace`, `end-of-file-fixer`, `mixed-line-ending`.