### PR TITLE
CAM: avoid padding annotated comment commands

### DIFF
--- a/src/Mod/CAM/App/Command.cpp
+++ b/src/Mod/CAM/App/Command.cpp
@@ -150,7 +150,7 @@ std::string Command::toGCode(int precision, bool padzero) const
 
     // Add annotations as a comment if they exist
     if (!Annotations.empty()) {
-        str << " ; ";
+        str << "; ";
         bool first = true;
         for (const auto& pair : Annotations) {
             if (!first) {

--- a/src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py
+++ b/src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py
@@ -256,6 +256,18 @@ class TestPathCommandAnnotations(PathTestBase):
         self.assertEqual(restored.Name, "G1")
         # Note: Parameters are restored via GCode parsing
 
+    def test_comment_command_annotations_do_not_pad_name(self):
+        """Test comment command names do not gain spaces with annotations."""
+        original = Path.Command("(xx)", {}, {"a": "x"})
+
+        self.assertEqual(original.toGCode(), "(xx); a:'x'")
+
+        restored = Path.Command()
+        restored.restoreContent(original.dumpContent())
+
+        self.assertEqual(restored.Name, "(xx)")
+        self.assertEqual(restored.Annotations, {"a": "x"})
+
     def test12(self):
         """Test save/restore with empty annotations (in-memory)."""
         # Test empty annotations (should work and use compact format)


### PR DESCRIPTION
## Summary

Avoid writing a space before annotation comments in `Path.Command` gcode output. This keeps comment-only command names like `(xx)` from restoring as `(xx) ` after a save/restore round trip.

## Issues

Fixes #30140

## Before and After Images

N/A, CAM serialization only.

## Validation

- `python3 -m py_compile src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py`
- `git diff --check`

Not run: `FreeCADCmd -t CAMTests.TestPathCommandAnnotations.TestPathCommandAnnotations` because `FreeCADCmd` is not available in this local environment.
