### PR TITLE
Assembly: Fix duplicate ground joint on load

### DIFF
--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -2086,6 +2086,10 @@ void AssemblyObject::ensureIdentityPlacements()
 
 void AssemblyObject::syncGroundedJoints()
 {
+    if (App::GetApplication().isRestoring()) {
+        return;
+    }
+
     std::vector<App::DocumentObject*> groundedJoints = getGroundedJoints();
     std::map<App::DocumentObject*, App::DocumentObject*> groundedMap;
     for (auto gJoint : groundedJoints) {


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/30184

The problem was that syncGroundedJoints is being called while the document is loading. And so as the document is not fully loaded yet, it does not find the grounded joint. And so it creates one.

This PR make sure the document is fully loaded in syncGroundedJoints 