### PR TITLE
CAM: Fix comment round-trip save/load. issue #30140

### DIFF
--- a/src/Mod/CAM/App/Command.cpp
+++ b/src/Mod/CAM/App/Command.cpp
@@ -150,7 +150,7 @@ std::string Command::toGCode(int precision, bool padzero) const
 
     // Add annotations as a comment if they exist
     if (!Annotations.empty()) {
-        str << " ; ";
+        str << "; ";
         bool first = true;
         for (const auto& pair : Annotations) {
             if (!first) {

--- a/src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py
+++ b/src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py
@@ -254,31 +254,41 @@ class TestPathCommandAnnotations(PathTestBase):
 
         # Verify GCode parameters were also restored correctly
         self.assertEqual(restored.Name, "G1")
-        self.assertEqual(restored.Parameters["X"], 10.0, "as float") # ensures it wasn't string'ified etc.
+        self.assertEqual(
+            restored.Parameters["X"], 10.0, "as float"
+        )  # ensures it wasn't string'ified etc.
         # Note: Parameters are restored via GCode parsing
 
     def test11_comment_roundtrip(self):
         """Test that comments w/annotations make round-trip
-            Comments are handled slightly differently than G/M codes.
+        Comments are handled slightly differently than G/M codes.
         """
-        for comment_text, annotation in [ 
+        for comment_text, annotation in [
             # (gcode, annotation)
-            ("(A Comment)",None),
-            ("(A Comment)",{}),
+            ("(A Comment)", None),
+            ("(A Comment)", {}),
             # Comments and actual G/M codes seem to be handled differently
-            ("(A Comment)",{"annotkey":"somevalue"}),
-            ("G1", {"annotkey":"somevalue"}),
+            ("(A Comment)", {"annotkey": "somevalue"}),
+            ("G1", {"annotkey": "somevalue"}),
         ]:
-            comment = Path.Command(comment_text) if annotation is None else Path.Command(comment_text, {}, annotation)
+            comment = (
+                Path.Command(comment_text)
+                if annotation is None
+                else Path.Command(comment_text, {}, annotation)
+            )
 
             dumped = comment.dumpContent()
             restored = Path.Command()
-            restored.restoreContent( dumped )
-            self.assertEqual( comment.Name, restored.Name, f"for dumpContent() round trip: {comment.toGCode()}" )
+            restored.restoreContent(dumped)
+            self.assertEqual(
+                comment.Name, restored.Name, f"for dumpContent() round trip: {comment.toGCode()}"
+            )
 
             gcode = comment.toGCode()
             parsed = Path.Command(gcode)
-            self.assertEqual( comment.Name, parsed.Name, f"for toGCode() round trip: {comment.toGCode()}" )
+            self.assertEqual(
+                comment.Name, parsed.Name, f"for toGCode() round trip: {comment.toGCode()}"
+            )
 
     def test12(self):
         """Test save/restore with empty annotations (in-memory)."""

--- a/src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py
+++ b/src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py
@@ -254,7 +254,31 @@ class TestPathCommandAnnotations(PathTestBase):
 
         # Verify GCode parameters were also restored correctly
         self.assertEqual(restored.Name, "G1")
+        self.assertEqual(restored.Parameters["X"], 10.0, "as float") # ensures it wasn't string'ified etc.
         # Note: Parameters are restored via GCode parsing
+
+    def test11_comment_roundtrip(self):
+        """Test that comments w/annotations make round-trip
+            Comments are handled slightly differently than G/M codes.
+        """
+        for comment_text, annotation in [ 
+            # (gcode, annotation)
+            ("(A Comment)",None),
+            ("(A Comment)",{}),
+            # Comments and actual G/M codes seem to be handled differently
+            ("(A Comment)",{"annotkey":"somevalue"}),
+            ("G1", {"annotkey":"somevalue"}),
+        ]:
+            comment = Path.Command(comment_text) if annotation is None else Path.Command(comment_text, {}, annotation)
+
+            dumped = comment.dumpContent()
+            restored = Path.Command()
+            restored.restoreContent( dumped )
+            self.assertEqual( comment.Name, restored.Name, f"for dumpContent() round trip: {comment.toGCode()}" )
+
+            gcode = comment.toGCode()
+            parsed = Path.Command(gcode)
+            self.assertEqual( comment.Name, parsed.Name, f"for toGCode() round trip: {comment.toGCode()}" )
 
     def test12(self):
         """Test save/restore with empty annotations (in-memory)."""


### PR DESCRIPTION
Remove extra space before ";". Caused comments w/annotation to get a suffix'd space on load/save.

Was incidentally ignored for non-comments, didn't happen for comments w/o annotation.

Does not attempt to handle already-saved comments with a space.

Tests created (failed before fix), and pass after fix.

Fixes #30140