### PR TITLE
Sketcher: Point-on-Line Constrain is now also possible along the line for AutoConstrain, and Hint line is available.

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -102,6 +102,14 @@ inline void ViewProviderSketchDrawSketchHandlerAttorney::drawLineExtensionAutoCo
     vp.drawLineExtensionAutoConstraintHint(HintCurve);
 }
 
+inline bool ViewProviderSketchDrawSketchHandlerAttorney::isLineExtensionAutoConstraintHintVisible(
+    const ViewProviderSketch& vp,
+    const std::vector<Base::Vector2d>& HintCurve
+)
+{
+    return vp.isLineExtensionAutoConstraintHintVisible(HintCurve);
+}
+
 inline void ViewProviderSketchDrawSketchHandlerAttorney::drawEditMarkers(
     ViewProviderSketch& vp,
     const std::vector<Base::Vector2d>& EditMarkers,
@@ -597,11 +605,15 @@ bool DrawSketchHandler::seekLineExtensionAutoConstraint(
 
     for (int geoId = 0; geoId <= getHighestCurveIndex(); ++geoId) {
         const Part::Geometry* geo = obj->getGeometry(geoId);
-        if (!geo || !geo->isDerivedFrom<Part::GeomLineSegment>()) {
+        if (!geo) {
             continue;
         }
 
-        auto* line = static_cast<const Part::GeomLineSegment*>(geo);
+        const auto* line = freecad_cast<const Part::GeomLineSegment*>(geo);
+        if (!line) {
+            continue;
+        }
+
         const Base::Vector2d startPoint = toVector2d(line->getStartPoint());
         const Base::Vector2d endPoint = toVector2d(line->getEndPoint());
         const Base::Vector2d lineDirection = endPoint - startPoint;
@@ -636,6 +648,10 @@ bool DrawSketchHandler::seekLineExtensionAutoConstraint(
         return false;
     }
 
+    if (!isLineExtensionAutoConstraintHintVisible(bestAnchor, bestProjection)) {
+        return false;
+    }
+
     AutoConstraint constr;
     constr.Type = Sketcher::PointOnObject;
     constr.GeoId = bestGeoId;
@@ -664,6 +680,14 @@ void DrawSketchHandler::renderLineExtensionAutoConstraintHint() const
     drawLineExtensionAutoConstraintHint(
         {lineExtensionAutoConstraintHint.start, lineExtensionAutoConstraintHint.end}
     );
+}
+
+bool DrawSketchHandler::isLineExtensionAutoConstraintHintVisible(
+    const Base::Vector2d& start,
+    const Base::Vector2d& end
+) const
+{
+    return isLineExtensionAutoConstraintHintVisible(std::vector<Base::Vector2d> {start, end});
 }
 
 bool DrawSketchHandler::seekAlignmentAutoConstraint(
@@ -1301,6 +1325,16 @@ void DrawSketchHandler::drawLineExtensionAutoConstraintHint(
 ) const
 {
     ViewProviderSketchDrawSketchHandlerAttorney::drawLineExtensionAutoConstraintHint(
+        *sketchgui,
+        HintCurve
+    );
+}
+
+bool DrawSketchHandler::isLineExtensionAutoConstraintHintVisible(
+    const std::vector<Base::Vector2d>& HintCurve
+) const
+{
+    return ViewProviderSketchDrawSketchHandlerAttorney::isLineExtensionAutoConstraintHintVisible(
         *sketchgui,
         HintCurve
     );

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -94,6 +94,14 @@ inline void ViewProviderSketchDrawSketchHandlerAttorney::drawEdit(
     vp.drawEdit(list);
 }
 
+inline void ViewProviderSketchDrawSketchHandlerAttorney::drawLineExtensionAutoConstraintHint(
+    ViewProviderSketch& vp,
+    const std::vector<Base::Vector2d>& HintCurve
+)
+{
+    vp.drawLineExtensionAutoConstraintHint(HintCurve);
+}
+
 inline void ViewProviderSketchDrawSketchHandlerAttorney::drawEditMarkers(
     ViewProviderSketch& vp,
     const std::vector<Base::Vector2d>& EditMarkers,
@@ -332,6 +340,7 @@ void DrawSketchHandler::deactivate()
     // clear temporary Curve and Markers from the scenograph
     clearEdit();
     clearEditMarkers();
+    clearLineExtensionAutoConstraintHintDrawing();
     resetPositionText();
     setAngleSnapping(false);
 
@@ -551,6 +560,112 @@ void DrawSketchHandler::seekPreselectionAutoConstraint(
     }
 }
 
+double DrawSketchHandler::getAutoConstraintSearchDistance() const
+{
+    return 0.1 * sketchgui->getScaleFactor();
+}
+
+bool DrawSketchHandler::seekLineExtensionAutoConstraint(
+    std::vector<AutoConstraint>& suggestedConstraints,
+    const Base::Vector2d& Pos,
+    AutoConstraint::TargetType type
+)
+{
+    if (type != AutoConstraint::VERTEX && type != AutoConstraint::VERTEX_NO_TANGENCY) {
+        return false;
+    }
+
+    for (const auto& constraint : suggestedConstraints) {
+        if (constraint.Type == Sketcher::Coincident || constraint.Type == Sketcher::PointOnObject
+            || constraint.Type == Sketcher::Symmetric) {
+            return false;
+        }
+    }
+
+    SketchObject* obj = sketchgui->getSketchObject();
+    if (!obj) {
+        return false;
+    }
+
+    constexpr double segmentStartParameter = 0.0;
+    constexpr double segmentEndParameter = 1.0;
+
+    double bestDistance = getAutoConstraintSearchDistance();
+    int bestGeoId = GeoEnum::GeoUndef;
+    Base::Vector2d bestAnchor;
+    Base::Vector2d bestProjection;
+
+    for (int geoId = 0; geoId <= getHighestCurveIndex(); ++geoId) {
+        const Part::Geometry* geo = obj->getGeometry(geoId);
+        if (!geo || !geo->isDerivedFrom<Part::GeomLineSegment>()) {
+            continue;
+        }
+
+        auto* line = static_cast<const Part::GeomLineSegment*>(geo);
+        const Base::Vector2d startPoint = toVector2d(line->getStartPoint());
+        const Base::Vector2d endPoint = toVector2d(line->getEndPoint());
+        const Base::Vector2d lineDirection = endPoint - startPoint;
+        const double lineLengthSquared = lineDirection.Sqr();
+
+        if (lineLengthSquared <= Precision::SquareConfusion()) {
+            continue;
+        }
+
+        const Base::Vector2d cursorFromStart = Pos - startPoint;
+        const double parameter = (cursorFromStart.x * lineDirection.x
+                                  + cursorFromStart.y * lineDirection.y)
+            / lineLengthSquared;
+
+        if (parameter >= segmentStartParameter && parameter <= segmentEndParameter) {
+            continue;
+        }
+
+        const Base::Vector2d projection = startPoint + parameter * lineDirection;
+        const double distance = (Pos - projection).Length();
+        if (distance > bestDistance) {
+            continue;
+        }
+
+        bestDistance = distance;
+        bestGeoId = geoId;
+        bestAnchor = parameter < segmentStartParameter ? startPoint : endPoint;
+        bestProjection = projection;
+    }
+
+    if (bestGeoId == GeoEnum::GeoUndef) {
+        return false;
+    }
+
+    AutoConstraint constr;
+    constr.Type = Sketcher::PointOnObject;
+    constr.GeoId = bestGeoId;
+    constr.PosId = PointPos::none;
+    suggestedConstraints.push_back(constr);
+
+    lineExtensionAutoConstraintHint.isValid = true;
+    lineExtensionAutoConstraintHint.start = bestAnchor;
+    lineExtensionAutoConstraintHint.end = bestProjection;
+
+    return true;
+}
+
+void DrawSketchHandler::resetLineExtensionAutoConstraintHint()
+{
+    lineExtensionAutoConstraintHint = LineExtensionAutoConstraintHint();
+}
+
+void DrawSketchHandler::renderLineExtensionAutoConstraintHint() const
+{
+    if (!lineExtensionAutoConstraintHint.isValid) {
+        clearLineExtensionAutoConstraintHintDrawing();
+        return;
+    }
+
+    drawLineExtensionAutoConstraintHint(
+        {lineExtensionAutoConstraintHint.start, lineExtensionAutoConstraintHint.end}
+    );
+}
+
 bool DrawSketchHandler::seekAlignmentAutoConstraint(
     std::vector<AutoConstraint>& suggestedConstraints,
     const Base::Vector2d& Pos,
@@ -679,7 +794,7 @@ bool DrawSketchHandler::seekTangentAutoConstraint(
 
     // Do not consider if distance is more than that.
     // Decrease this value when a candidate is found.
-    double tangDeviation = 0.1 * sketchgui->getScaleFactor();
+    double tangDeviation = getAutoConstraintSearchDistance();
 
     // Get geometry list
     const std::vector<Part::Geometry*> geomlist = obj->getCompleteGeometry();
@@ -902,11 +1017,14 @@ int DrawSketchHandler::seekAutoConstraint(
 {
     suggestedConstraints.clear();
 
+    resetLineExtensionAutoConstraintHint();
+
     if (!sketchgui->Autoconstraints.getValue()) {
         return 0;  // If Autoconstraints property is not set quit
     }
 
     seekPreselectionAutoConstraint(suggestedConstraints, Pos, Dir, type);
+    seekLineExtensionAutoConstraint(suggestedConstraints, Pos, type);
 
     if (Dir.Length() > 1e-8 && type != AutoConstraint::CURVE) {
         bool tangentCreated = false;
@@ -1124,7 +1242,10 @@ int DrawSketchHandler::seekAndRenderAutoConstraint(
     AutoConstraint::TargetType type
 )
 {
-    if (seekAutoConstraint(suggestedConstraints, Pos, Dir, type)) {
+    const int constraintCount = seekAutoConstraint(suggestedConstraints, Pos, Dir, type);
+    renderLineExtensionAutoConstraintHint();
+
+    if (constraintCount) {
         renderSuggestConstraintsCursor(suggestedConstraints);
     }
     else {
@@ -1175,9 +1296,24 @@ void DrawSketchHandler::drawEdit(const std::vector<Part::Geometry*>& geometries)
     drawEdit(list);
 }
 
+void DrawSketchHandler::drawLineExtensionAutoConstraintHint(
+    const std::vector<Base::Vector2d>& HintCurve
+) const
+{
+    ViewProviderSketchDrawSketchHandlerAttorney::drawLineExtensionAutoConstraintHint(
+        *sketchgui,
+        HintCurve
+    );
+}
+
 void DrawSketchHandler::clearEdit() const
 {
     drawEdit(std::vector<Base::Vector2d>());
+}
+
+void DrawSketchHandler::clearLineExtensionAutoConstraintHintDrawing() const
+{
+    drawLineExtensionAutoConstraintHint(std::vector<Base::Vector2d>());
 }
 
 void DrawSketchHandler::clearEditMarkers() const

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -598,7 +598,8 @@ bool DrawSketchHandler::seekLineExtensionAutoConstraint(
     constexpr double segmentStartParameter = 0.0;
     constexpr double segmentEndParameter = 1.0;
 
-    double bestDistance = getAutoConstraintSearchDistance();
+    const double searchDistance = getAutoConstraintSearchDistance();
+    double bestDistanceSquared = searchDistance * searchDistance;
     int bestGeoId = GeoEnum::GeoUndef;
     Base::Vector2d bestAnchor;
     Base::Vector2d bestProjection;
@@ -633,12 +634,12 @@ bool DrawSketchHandler::seekLineExtensionAutoConstraint(
         }
 
         const Base::Vector2d projection = startPoint + parameter * lineDirection;
-        const double distance = (Pos - projection).Length();
-        if (distance > bestDistance) {
+        const double distanceSquared = (Pos - projection).Sqr();
+        if (distanceSquared > bestDistanceSquared) {
             continue;
         }
 
-        bestDistance = distance;
+        bestDistanceSquared = distanceSquared;
         bestGeoId = geoId;
         bestAnchor = parameter < segmentStartParameter ? startPoint : endPoint;
         bestProjection = projection;
@@ -688,6 +689,16 @@ bool DrawSketchHandler::isLineExtensionAutoConstraintHintVisible(
 ) const
 {
     return isLineExtensionAutoConstraintHintVisible(std::vector<Base::Vector2d> {start, end});
+}
+
+bool DrawSketchHandler::getLineExtensionAutoConstraintSnapPoint(Base::Vector2d& point) const
+{
+    if (!lineExtensionAutoConstraintHint.isValid) {
+        return false;
+    }
+
+    point = lineExtensionAutoConstraintHint.end;
+    return true;
 }
 
 bool DrawSketchHandler::seekAlignmentAutoConstraint(

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -109,6 +109,10 @@ private:
         ViewProviderSketch& vp,
         const std::list<std::vector<Base::Vector2d>>& list
     );
+    static inline void drawLineExtensionAutoConstraintHint(
+        ViewProviderSketch& vp,
+        const std::vector<Base::Vector2d>& HintCurve
+    );
     static inline void drawEditMarkers(
         ViewProviderSketch& vp,
         const std::vector<Base::Vector2d>& EditMarkers,
@@ -271,12 +275,14 @@ protected:
     void drawEdit(const std::vector<Base::Vector2d>& EditCurve) const;
     void drawEdit(const std::list<std::vector<Base::Vector2d>>& list) const;
     void drawEdit(const std::vector<Part::Geometry*>& geometries) const;
+    void drawLineExtensionAutoConstraintHint(const std::vector<Base::Vector2d>& HintCurve) const;
     void drawEditMarkers(
         const std::vector<Base::Vector2d>& EditMarkers,
         unsigned int augmentationlevel = 0
     ) const;
 
     void clearEdit() const;
+    void clearLineExtensionAutoConstraintHintDrawing() const;
     void clearEditMarkers() const;
 
     void setAxisPickStyle(bool on);
@@ -315,7 +321,17 @@ protected:
         Base::Vector3d hitShapeDir = Base::Vector3d(0, 0, 0);
         bool isLine = false;
     };
+
+    struct LineExtensionAutoConstraintHint
+    {
+        bool isValid = false;
+        Base::Vector2d start;
+        Base::Vector2d end;
+    };
+
     PreselectionData getPreselectionData() const;
+
+    double getAutoConstraintSearchDistance() const;
 
     void seekPreselectionAutoConstraint(
         std::vector<AutoConstraint>& constraints,
@@ -323,6 +339,15 @@ protected:
         const Base::Vector2d& Dir,
         AutoConstraint::TargetType type
     );
+
+    bool seekLineExtensionAutoConstraint(
+        std::vector<AutoConstraint>& constraints,
+        const Base::Vector2d& Pos,
+        AutoConstraint::TargetType type
+    );
+
+    void resetLineExtensionAutoConstraintHint();
+    void renderLineExtensionAutoConstraintHint() const;
 
     bool isLineCenterAutoConstraint(int GeoId, const Base::Vector2d& Pos) const;
 
@@ -352,6 +377,7 @@ protected:
 
     QWidget* toolwidget;
     int currentTransactionID {0};
+    LineExtensionAutoConstraintHint lineExtensionAutoConstraintHint;
 };
 
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -113,6 +113,10 @@ private:
         ViewProviderSketch& vp,
         const std::vector<Base::Vector2d>& HintCurve
     );
+    static inline bool isLineExtensionAutoConstraintHintVisible(
+        const ViewProviderSketch& vp,
+        const std::vector<Base::Vector2d>& HintCurve
+    );
     static inline void drawEditMarkers(
         ViewProviderSketch& vp,
         const std::vector<Base::Vector2d>& EditMarkers,
@@ -276,6 +280,7 @@ protected:
     void drawEdit(const std::list<std::vector<Base::Vector2d>>& list) const;
     void drawEdit(const std::vector<Part::Geometry*>& geometries) const;
     void drawLineExtensionAutoConstraintHint(const std::vector<Base::Vector2d>& HintCurve) const;
+    bool isLineExtensionAutoConstraintHintVisible(const std::vector<Base::Vector2d>& HintCurve) const;
     void drawEditMarkers(
         const std::vector<Base::Vector2d>& EditMarkers,
         unsigned int augmentationlevel = 0
@@ -349,6 +354,11 @@ protected:
     void resetLineExtensionAutoConstraintHint();
     void renderLineExtensionAutoConstraintHint() const;
 
+    bool isLineExtensionAutoConstraintHintVisible(
+        const Base::Vector2d& start,
+        const Base::Vector2d& end
+    ) const;
+
     bool isLineCenterAutoConstraint(int GeoId, const Base::Vector2d& Pos) const;
 
     bool seekAlignmentAutoConstraint(
@@ -377,6 +387,8 @@ protected:
 
     QWidget* toolwidget;
     int currentTransactionID {0};
+
+private:
     LineExtensionAutoConstraintHint lineExtensionAutoConstraintHint;
 };
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -358,6 +358,7 @@ protected:
         const Base::Vector2d& start,
         const Base::Vector2d& end
     ) const;
+    bool getLineExtensionAutoConstraintSnapPoint(Base::Vector2d& point) const;
 
     bool isLineCenterAutoConstraint(int GeoId, const Base::Vector2d& Pos) const;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -102,24 +102,28 @@ private:
     {
         switch (state()) {
             case SelectMode::SeekFirst: {
-                toolWidgetManager.drawPositionAtCursor(onSketchPos);
-
-                startPoint = onSketchPos;
-
                 seekAndRenderAutoConstraint(sugConstraints[0], onSketchPos, Base::Vector2d(0.f, 0.f));
+
+                Base::Vector2d snapPoint;
+                startPoint = getLineExtensionAutoConstraintSnapPoint(snapPoint) ? snapPoint
+                                                                                : onSketchPos;
+
+                toolWidgetManager.drawPositionAtCursor(startPoint);
             } break;
             case SelectMode::SeekSecond: {
-                toolWidgetManager.drawDirectionAtCursor(onSketchPos, startPoint);
+                seekAndRenderAutoConstraint(sugConstraints[1], onSketchPos, onSketchPos - startPoint);
 
-                endPoint = onSketchPos;
+                Base::Vector2d snapPoint;
+                endPoint = getLineExtensionAutoConstraintSnapPoint(snapPoint) ? snapPoint
+                                                                              : onSketchPos;
+
+                toolWidgetManager.drawDirectionAtCursor(endPoint, startPoint);
 
                 try {
                     CreateAndDrawShapeGeometry();
                 }
                 catch (const Base::ValueError&) {
                 }  // equal points while hovering raise an objection that can be safely ignored
-
-                seekAndRenderAutoConstraint(sugConstraints[1], onSketchPos, onSketchPos - startPoint);
             } break;
             default:
                 break;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -79,11 +79,13 @@ private:
     {
         switch (state()) {
             case SelectMode::SeekFirst: {
-                toolWidgetManager.drawPositionAtCursor(onSketchPos);
-
-                editPoint = onSketchPos;
-
                 seekAndRenderAutoConstraint(sugConstraints[0], onSketchPos, Base::Vector2d(0.f, 0.f));
+
+                Base::Vector2d snapPoint;
+                editPoint = getLineExtensionAutoConstraintSnapPoint(snapPoint) ? snapPoint
+                                                                               : onSketchPos;
+
+                toolWidgetManager.drawPositionAtCursor(editPoint);
             } break;
             default:
                 break;

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -647,6 +647,49 @@ void EditModeCoinManager::drawEdit(
     editModeScenegraphNodes.EditCurvesMaterials->diffuseColor.finishEditing();
 }
 
+void EditModeCoinManager::drawLineExtensionAutoConstraintHint(
+    const std::vector<Base::Vector2d>& HintCurve
+)
+{
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintSet->numVertices.setNum(1);
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintCoordinate->point.setNum(HintCurve.size());
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintMaterials->diffuseColor.setNum(
+        HintCurve.size()
+    );
+
+    SbVec3f* verts
+        = editModeScenegraphNodes.LineExtensionAutoConstraintHintCoordinate->point.startEditing();
+    int32_t* index
+        = editModeScenegraphNodes.LineExtensionAutoConstraintHintSet->numVertices.startEditing();
+    SbColor* color = editModeScenegraphNodes.LineExtensionAutoConstraintHintMaterials->diffuseColor
+                         .startEditing();
+
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintDrawStyle->lineWidth
+        = editModeScenegraphNodes.InformationDrawStyle->lineWidth;
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintDrawStyle->linePattern
+        = editModeScenegraphNodes.CurvesConstructionDrawStyle->linePattern;
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintDrawStyle->linePatternScaleFactor
+        = editModeScenegraphNodes.CurvesConstructionDrawStyle->linePatternScaleFactor;
+
+    int i = 0;
+    for (const auto& point : HintCurve) {
+        verts[i].setValue(
+            point.x,
+            point.y,
+            ViewProviderSketchCoinAttorney::getViewOrientationFactor(viewProvider)
+                * drawingParameters.zEdit
+        );
+        color[i] = drawingParameters.InformationColor;
+        ++i;
+    }
+
+    index[0] = HintCurve.size();
+
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintCoordinate->point.finishEditing();
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintSet->numVertices.finishEditing();
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintMaterials->diffuseColor.finishEditing();
+}
+
 void EditModeCoinManager::setPositionText(const Base::Vector2d& Pos, const SbString& text)
 {
     editModeScenegraphNodes.textX->string = text;
@@ -971,6 +1014,45 @@ void EditModeCoinManager::createEditModeInventorNodes()
     editModeScenegraphNodes.EditCurveSet = new SoLineSet;
     editModeScenegraphNodes.EditCurveSet->setName("EditCurveLineSet");
     editCurvesRoot->addChild(editModeScenegraphNodes.EditCurveSet);
+
+    SoSeparator* autoConstraintExtensionHintRoot = new SoSeparator;
+    editModeScenegraphNodes.EditRoot->addChild(autoConstraintExtensionHintRoot);
+
+    SoPickStyle* autoConstraintExtensionHintPickStyle = new SoPickStyle;
+    autoConstraintExtensionHintPickStyle->style = SoPickStyle::UNPICKABLE;
+    autoConstraintExtensionHintRoot->addChild(autoConstraintExtensionHintPickStyle);
+
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintMaterials = new SoMaterial;
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintMaterials->setName(
+        "LineExtensionAutoConstraintHintMaterials"
+    );
+    autoConstraintExtensionHintRoot->addChild(
+        editModeScenegraphNodes.LineExtensionAutoConstraintHintMaterials
+    );
+
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintCoordinate = new SoCoordinate3;
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintCoordinate->setName(
+        "LineExtensionAutoConstraintHintCoordinate"
+    );
+    autoConstraintExtensionHintRoot->addChild(
+        editModeScenegraphNodes.LineExtensionAutoConstraintHintCoordinate
+    );
+
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintDrawStyle = new SoDrawStyle;
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintDrawStyle->setName(
+        "LineExtensionAutoConstraintHintDrawStyle"
+    );
+    autoConstraintExtensionHintRoot->addChild(
+        editModeScenegraphNodes.LineExtensionAutoConstraintHintDrawStyle
+    );
+
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintSet = new SoLineSet;
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintSet->setName(
+        "LineExtensionAutoConstraintHintLineSet"
+    );
+    autoConstraintExtensionHintRoot->addChild(
+        editModeScenegraphNodes.LineExtensionAutoConstraintHintSet
+    );
 
     // stuff for the EditMarkers +++++++++++++++++++++++++++++++++++++++
     SoSeparator* editMarkersRoot = new SoSeparator;

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -651,18 +651,14 @@ void EditModeCoinManager::drawLineExtensionAutoConstraintHint(
     const std::vector<Base::Vector2d>& HintCurve
 )
 {
-    editModeScenegraphNodes.LineExtensionAutoConstraintHintSet->numVertices.setNum(1);
-    editModeScenegraphNodes.LineExtensionAutoConstraintHintCoordinate->point.setNum(HintCurve.size());
-    editModeScenegraphNodes.LineExtensionAutoConstraintHintMaterials->diffuseColor.setNum(
-        HintCurve.size()
-    );
+    const int hintCurveSize = static_cast<int>(HintCurve.size());
 
-    SbVec3f* verts
-        = editModeScenegraphNodes.LineExtensionAutoConstraintHintCoordinate->point.startEditing();
-    int32_t* index
-        = editModeScenegraphNodes.LineExtensionAutoConstraintHintSet->numVertices.startEditing();
-    SbColor* color = editModeScenegraphNodes.LineExtensionAutoConstraintHintMaterials->diffuseColor
-                         .startEditing();
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintSet->numVertices.setNum(1);
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintSet->numVertices.set1Value(0, hintCurveSize);
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintCoordinate->point.setNum(hintCurveSize);
+    editModeScenegraphNodes.LineExtensionAutoConstraintHintMaterials->diffuseColor.setNum(
+        hintCurveSize
+    );
 
     editModeScenegraphNodes.LineExtensionAutoConstraintHintDrawStyle->lineWidth
         = editModeScenegraphNodes.InformationDrawStyle->lineWidth;
@@ -673,21 +669,23 @@ void EditModeCoinManager::drawLineExtensionAutoConstraintHint(
 
     int i = 0;
     for (const auto& point : HintCurve) {
-        verts[i].setValue(
-            point.x,
-            point.y,
-            ViewProviderSketchCoinAttorney::getViewOrientationFactor(viewProvider)
-                * drawingParameters.zEdit
+        editModeScenegraphNodes.LineExtensionAutoConstraintHintCoordinate->point.set1Value(
+            i,
+            SbVec3f(
+                static_cast<float>(point.x),
+                static_cast<float>(point.y),
+                static_cast<float>(
+                    ViewProviderSketchCoinAttorney::getViewOrientationFactor(viewProvider)
+                    * drawingParameters.zEdit
+                )
+            )
         );
-        color[i] = drawingParameters.InformationColor;
+        editModeScenegraphNodes.LineExtensionAutoConstraintHintMaterials->diffuseColor.set1Value(
+            i,
+            drawingParameters.InformationColor
+        );
         ++i;
     }
-
-    index[0] = HintCurve.size();
-
-    editModeScenegraphNodes.LineExtensionAutoConstraintHintCoordinate->point.finishEditing();
-    editModeScenegraphNodes.LineExtensionAutoConstraintHintSet->numVertices.finishEditing();
-    editModeScenegraphNodes.LineExtensionAutoConstraintHintMaterials->diffuseColor.finishEditing();
 }
 
 void EditModeCoinManager::setPositionText(const Base::Vector2d& Pos, const SbString& text)
@@ -1015,18 +1013,18 @@ void EditModeCoinManager::createEditModeInventorNodes()
     editModeScenegraphNodes.EditCurveSet->setName("EditCurveLineSet");
     editCurvesRoot->addChild(editModeScenegraphNodes.EditCurveSet);
 
-    SoSeparator* autoConstraintExtensionHintRoot = new SoSeparator;
-    editModeScenegraphNodes.EditRoot->addChild(autoConstraintExtensionHintRoot);
+    SoSeparator* lineExtensionAutoConstraintHintRoot = new SoSeparator;
+    editModeScenegraphNodes.EditRoot->addChild(lineExtensionAutoConstraintHintRoot);
 
-    SoPickStyle* autoConstraintExtensionHintPickStyle = new SoPickStyle;
-    autoConstraintExtensionHintPickStyle->style = SoPickStyle::UNPICKABLE;
-    autoConstraintExtensionHintRoot->addChild(autoConstraintExtensionHintPickStyle);
+    SoPickStyle* lineExtensionAutoConstraintHintPickStyle = new SoPickStyle;
+    lineExtensionAutoConstraintHintPickStyle->style = SoPickStyle::UNPICKABLE;
+    lineExtensionAutoConstraintHintRoot->addChild(lineExtensionAutoConstraintHintPickStyle);
 
     editModeScenegraphNodes.LineExtensionAutoConstraintHintMaterials = new SoMaterial;
     editModeScenegraphNodes.LineExtensionAutoConstraintHintMaterials->setName(
         "LineExtensionAutoConstraintHintMaterials"
     );
-    autoConstraintExtensionHintRoot->addChild(
+    lineExtensionAutoConstraintHintRoot->addChild(
         editModeScenegraphNodes.LineExtensionAutoConstraintHintMaterials
     );
 
@@ -1034,7 +1032,7 @@ void EditModeCoinManager::createEditModeInventorNodes()
     editModeScenegraphNodes.LineExtensionAutoConstraintHintCoordinate->setName(
         "LineExtensionAutoConstraintHintCoordinate"
     );
-    autoConstraintExtensionHintRoot->addChild(
+    lineExtensionAutoConstraintHintRoot->addChild(
         editModeScenegraphNodes.LineExtensionAutoConstraintHintCoordinate
     );
 
@@ -1042,7 +1040,7 @@ void EditModeCoinManager::createEditModeInventorNodes()
     editModeScenegraphNodes.LineExtensionAutoConstraintHintDrawStyle->setName(
         "LineExtensionAutoConstraintHintDrawStyle"
     );
-    autoConstraintExtensionHintRoot->addChild(
+    lineExtensionAutoConstraintHintRoot->addChild(
         editModeScenegraphNodes.LineExtensionAutoConstraintHintDrawStyle
     );
 
@@ -1050,7 +1048,7 @@ void EditModeCoinManager::createEditModeInventorNodes()
     editModeScenegraphNodes.LineExtensionAutoConstraintHintSet->setName(
         "LineExtensionAutoConstraintHintLineSet"
     );
-    autoConstraintExtensionHintRoot->addChild(
+    lineExtensionAutoConstraintHintRoot->addChild(
         editModeScenegraphNodes.LineExtensionAutoConstraintHintSet
     );
 

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -213,6 +213,7 @@ public:
     void drawEditMarkers(const std::vector<Base::Vector2d>& EditMarkers, unsigned int augmentationlevel);
     void drawEdit(const std::vector<Base::Vector2d>& EditCurve, GeometryCreationMode mode);
     void drawEdit(const std::list<std::vector<Base::Vector2d>>& list, GeometryCreationMode mode);
+    void drawLineExtensionAutoConstraintHint(const std::vector<Base::Vector2d>& HintCurve);
     void setPositionText(const Base::Vector2d& Pos, const SbString& txt);
     void setPositionText(const Base::Vector2d& Pos);
     void resetPositionText();

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -447,6 +447,14 @@ struct EditModeScenegraphNodes
     SoPickStyle* pickStyleAxes;
     //@}
 
+    /** @name Line-extension auto-constraint hint nodes */
+    //@{
+    SoMaterial* LineExtensionAutoConstraintHintMaterials;
+    SoCoordinate3* LineExtensionAutoConstraintHintCoordinate;
+    SoLineSet* LineExtensionAutoConstraintHintSet;
+    SoDrawStyle* LineExtensionAutoConstraintHintDrawStyle;
+    //@}
+
     /** @name Temporal edit markers nodes- For operation rendering, such as trimming green circles*/
     //@{
     SoMaterial* EditMarkersMaterials;

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3370,6 +3370,13 @@ void ViewProviderSketch::drawEdit(const std::list<std::vector<Base::Vector2d>>& 
     editCoinManager->drawEdit(list, currentGeometryCreationMode());
 }
 
+void ViewProviderSketch::drawLineExtensionAutoConstraintHint(
+    const std::vector<Base::Vector2d>& HintCurve
+)
+{
+    editCoinManager->drawLineExtensionAutoConstraintHint(HintCurve);
+}
+
 void ViewProviderSketch::drawEditMarkers(const std::vector<Base::Vector2d>& EditMarkers,
                                          unsigned int augmentationlevel)
 {

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3377,6 +3377,40 @@ void ViewProviderSketch::drawLineExtensionAutoConstraintHint(
     editCoinManager->drawLineExtensionAutoConstraintHint(HintCurve);
 }
 
+bool ViewProviderSketch::isLineExtensionAutoConstraintHintVisible(
+    const std::vector<Base::Vector2d>& HintCurve
+) const
+{
+    Gui::MDIView* mdi = this->getActiveView();
+    Gui::View3DInventor* view = qobject_cast<Gui::View3DInventor*>(mdi);
+    if (!view || !isInEditMode()) {
+        return false;
+    }
+
+    Gui::View3DInventorViewer* viewer = view->getViewer();
+    if (!viewer || !viewer->getGLWidget()) {
+        return false;
+    }
+
+    const int width = viewer->getGLWidget()->width();
+    const int height = viewer->getGLWidget()->height();
+    if (width <= 0 || height <= 0) {
+        return false;
+    }
+
+    for (const auto& point : HintCurve) {
+        const SbVec2f screenCoordinates = getScreenCoordinates(
+            SbVec2f(static_cast<float>(point.x), static_cast<float>(point.y))
+        );
+        if (screenCoordinates[0] < 0.0F || screenCoordinates[0] > width
+            || screenCoordinates[1] < 0.0F || screenCoordinates[1] > height) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 void ViewProviderSketch::drawEditMarkers(const std::vector<Base::Vector2d>& EditMarkers,
                                          unsigned int augmentationlevel)
 {

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -957,6 +957,7 @@ private:
     /// draw the edit curve
     void drawEdit(const std::vector<Base::Vector2d>& EditCurve);
     void drawEdit(const std::list<std::vector<Base::Vector2d>>& list);
+    void drawLineExtensionAutoConstraintHint(const std::vector<Base::Vector2d>& HintCurve);
     /// draw the edit markers
     void drawEditMarkers(
         const std::vector<Base::Vector2d>& EditMarkers,

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -958,6 +958,7 @@ private:
     void drawEdit(const std::vector<Base::Vector2d>& EditCurve);
     void drawEdit(const std::list<std::vector<Base::Vector2d>>& list);
     void drawLineExtensionAutoConstraintHint(const std::vector<Base::Vector2d>& HintCurve);
+    bool isLineExtensionAutoConstraintHintVisible(const std::vector<Base::Vector2d>& HintCurve) const;
     /// draw the edit markers
     void drawEditMarkers(
         const std::vector<Base::Vector2d>& EditMarkers,


### PR DESCRIPTION
Point-on-line constraint is normally possible along the line, but autoconstraint can only be applied above the line. This PR allows it to be applied along the line as well, and it also adds a hint line for clarity. The hint line's properties are derived from InformationColor (which is probably the most logical variable) in terms of color and from ConstructionPattern in terms of properties. I thought it would be better if it were a bit different from other auto constraints because of the hint line. Also, this hint geometry is a pretty good idea, it can be expanded, but it's probably the most functional one.

@PaddleStroke, could you please take a look?

Honestly, I didn't think I'd get something like this so easily. I think it turned out great; it's a feature everyone will enjoy.

I consulted ChatGPT 5.5 while conducting this PR.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/78e031dc-3ffb-4faf-aeb2-db20b06c31ca

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
