### PR TITLE
PartDesign: add clone body to active part

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -548,6 +548,13 @@ void CmdPartDesignClone::activated(int iMsg)
         Gui::cmdAppObject(cloneObj, std::stringstream() << "Placement = " << objCmd << ".Placement");
         Gui::cmdAppObject(cloneObj, std::stringstream() << "setEditorMode('Placement', 0)");
 
+        if (auto* activePart = PartDesignGui::getActivePart()) {
+            Gui::cmdAppObject(
+                activePart,
+                std::stringstream() << "addObject(" << getObjectCmd(bodyObj) << ")"
+            );
+        }
+
         updateActive();
         copyVisual(cloneObj, "ShapeAppearance", obj);
         copyVisual(cloneObj, "LineColor", obj);

--- a/src/Mod/PartDesign/PartDesignTests/TestActiveObject.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestActiveObject.py
@@ -61,5 +61,27 @@ class TestActiveObject(unittest.TestCase):
 
         FreeCADGui.updateGui()
 
+    def testPartDesignCloneUsesActivePart(self):
+        part = self.doc.addObject("App::Part", "Part")
+        FreeCADGui.activateView("Gui::View3DInventor", True)
+        FreeCADGui.activeView().setActiveObject("part", part)
+
+        body = self.doc.addObject("PartDesign::Body", "Body")
+        part.addObject(body)
+
+        FreeCADGui.Selection.clearSelection()
+        FreeCADGui.Selection.addSelection(body)
+        FreeCADGui.runCommand("PartDesign_Clone")
+        self.doc.recompute()
+        FreeCADGui.updateGui()
+
+        clone_bodies = [
+            obj
+            for obj in self.doc.Objects
+            if obj.TypeId == "PartDesign::Body" and obj.Name != body.Name
+        ]
+        self.assertEqual(len(clone_bodies), 1)
+        self.assertIn(clone_bodies[0], part.Group)
+
     def tearDown(self):
         FreeCAD.closeDocument("PartDesignTestSketch")


### PR DESCRIPTION
Fixes #30013.

## Summary
- add the new PartDesign clone body to the active App::Part when one is active
- keep the existing root-document behavior when no active part is set
- add a regression test for the active-part clone path

## Verification
- git diff --check
- python3 -m py_compile src/Mod/PartDesign/PartDesignTests/TestActiveObject.py

I could not run the FreeCAD GUI test suite in this local environment because no FreeCAD executable is installed.