### PR TITLE
Sketcher: Group Polyline and Line by default

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettings.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.ui
@@ -205,7 +205,7 @@ Requires to re-enter edit mode to take effect.</string>
          <string>Group the polyline and line commands</string>
         </property>
         <property name="checked">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>UnifiedLineCommands</cstring>

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -321,7 +321,7 @@ inline void SketcherAddWorkspaceLines<Gui::ToolBarItem>(Gui::ToolBarItem& geom)
         "User parameter:BaseApp/Preferences/Mod/Sketcher/Commands"
     );
 
-    if (hGrp->GetBool("UnifiedLineCommands", false)) {
+    if (hGrp->GetBool("UnifiedLineCommands", true)) {
         geom << "Sketcher_CompLine";
     }
     else {


### PR DESCRIPTION
Change the default so Polyline and Line tools are grouped.
Preference existed since 1.0 but was off by default, now it should be the default with the new polyline tool as it can replace the line tool with OVP as well.