### PR TITLE
Sketcher: Fix DSH shortcuts not working anymore

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchKeyboardManager.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchKeyboardManager.cpp
@@ -64,7 +64,7 @@ bool DrawSketchKeyboardManager::eventFilter(QObject* object, QEvent* event)
     if (!vpViewer) {
         return false;
     }
-    if (event->type() == QEvent::KeyPress) {
+    if (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease) {
         // Here we decide if we redirect the input the viewer
         auto keyEvent = static_cast<QKeyEvent*>(event);
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/30340

@alfrix the bug was caused because your PR removed the KeyRelease from the event handler.
Can you please advise if this change was voluntary and if yes why? 
Restoring the KeyRelease fixes the regression.