### PR TITLE
CAM: Helix - Fix Operation Defaults

### DIFF
--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -298,6 +298,9 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             ),
         )
 
+        for n in self.helixOpPropertyEnumerations():
+            setattr(obj, n[0], n[1])
+
         self.opSetEditorModes(obj)
 
     def opOnChanged(self, obj, prop):
@@ -317,9 +320,6 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         obj.setEditorMode("SingleHelix", 2)  # hide
 
     def opSetDefaultValues(self, obj, job):
-        for n in self.helixOpPropertyEnumerations():
-            setattr(obj, n[0], n[1])
-
         obj.CutMode = "Conventional"
         obj.FinishHelixCircle = True
         obj.FinishSpiralCircle = True
@@ -919,9 +919,22 @@ def SetupProperties():
     """Returns property names for which the "Setup Sheet" should provide defaults."""
     setup = PathOp.SetupPropertiesLinking()
     setup.append("CutMode")
+    setup.append("Direction")
+    setup.append("FinishHelixCircle")
+    setup.append("FinishSpiralCircle")
+    setup.append("HelixConeAngle")
+    setup.append("HelixMaxPitch")
+    setup.append("HelixMaxRampAngle")
+    setup.append("OverrideArcFeedRate")
+    setup.append("RadialStockToLeaveInner")
+    setup.append("RadialStockToLeaveOuter")
+    setup.append("RetractFromWall")
+    setup.append("RotationAngle")
+    setup.append("Side")
+    setup.append("SingleHelix")
+    setup.append("SpiralMill")
     setup.append("StartAt")
     setup.append("StepOver")
-    setup.append("RadialStockToLeaveInner")
     return setup
 
 


### PR DESCRIPTION
### Changes:

- Fix error while set **Operation Defaults**: `StartAt` and `CutMode`
Moved enumerations to `init` block

- Allow set default value for all properties
   <img width="846" height="682" alt="1_hor_lossy" src="https://github.com/user-attachments/assets/06537a91-dd80-44f4-b8ca-9f3e02095a1a" />

