### PR TITLE
fix: replace old freecadweb.org wiki URLs with freecad.org (#26160)

### DIFF
--- a/src/Mod/BIM/Resources/translations/Arch.ts
+++ b/src/Mod/BIM/Resources/translations/Arch.ts
@@ -11436,7 +11436,7 @@ Please check your FreeCAD installation or provide a custom template under menu P
     </message>
     <message>
         <location filename="../ui/dialogSetup.ui" line="636"/>
-        <source>&lt;b&gt;IfcOpenShell&lt;/b&gt; is missing on your system. IfcOpenShell is needed to import or export IFC files to/from FreeCAD. Check &lt;a href=&quot;https://www.freecadweb.org/wiki/Arch_IFC&quot;&gt;this wiki page&lt;/a&gt; to know more, or &lt;a href=&quot;#install&quot;&gt;download and install it&lt;/a&gt; directly.&lt;/p&gt;</source>
+        <source>&lt;b&gt;IfcOpenShell&lt;/b&gt; is missing on your system. IfcOpenShell is needed to import or export IFC files to/from FreeCAD. Check &lt;a href=&quot;https://www.freecad.org/wiki/Arch_IFC&quot;&gt;this wiki page&lt;/a&gt; to know more, or &lt;a href=&quot;#install&quot;&gt;download and install it&lt;/a&gt; directly.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/Mod/BIM/Resources/translations/Arch_lt.ts
+++ b/src/Mod/BIM/Resources/translations/Arch_lt.ts
@@ -11380,8 +11380,8 @@ CTRL+PgUp to extend extrusionCTRL+PgDown to shrink extrusionCTRL+/ to switch bet
     </message>
     <message>
       <location filename="../ui/dialogSetup.ui" line="636"/>
-      <source>&lt;b&gt;IfcOpenShell&lt;/b&gt; is missing on your system. IfcOpenShell is needed to import or export IFC files to/from FreeCAD. Check &lt;a href="https://www.freecadweb.org/wiki/Arch_IFC"&gt;this wiki page&lt;/a&gt; to know more, or &lt;a href="#install"&gt;download and install it&lt;/a&gt; directly.&lt;/p&gt;</source>
-      <translation type="unfinished">&lt;b&gt;IfcOpenShell&lt;/b&gt; is missing on your system. IfcOpenShell is needed to import or export IFC files to/from FreeCAD. Check &lt;a href="https://www.freecadweb.org/wiki/Arch_IFC"&gt;this wiki page&lt;/a&gt; to know more, or &lt;a href="#install"&gt;download and install it&lt;/a&gt; directly.&lt;/p&gt;</translation>
+      <source>&lt;b&gt;IfcOpenShell&lt;/b&gt; is missing on your system. IfcOpenShell is needed to import or export IFC files to/from FreeCAD. Check &lt;a href="https://www.freecad.org/wiki/Arch_IFC"&gt;this wiki page&lt;/a&gt; to know more, or &lt;a href="#install"&gt;download and install it&lt;/a&gt; directly.&lt;/p&gt;</source>
+      <translation type="unfinished">&lt;b&gt;IfcOpenShell&lt;/b&gt; is missing on your system. IfcOpenShell is needed to import or export IFC files to/from FreeCAD. Check &lt;a href="https://www.freecad.org/wiki/Arch_IFC"&gt;this wiki page&lt;/a&gt; to know more, or &lt;a href="#install"&gt;download and install it&lt;/a&gt; directly.&lt;/p&gt;</translation>
     </message>
   </context>
   <context>

--- a/src/Mod/BIM/Resources/translations/Arch_pt-PT.ts
+++ b/src/Mod/BIM/Resources/translations/Arch_pt-PT.ts
@@ -11372,8 +11372,8 @@ CTRL+PgUp to extend extrusionCTRL+PgDown to shrink extrusionCTRL+/ to switch bet
     </message>
     <message>
       <location filename="../ui/dialogSetup.ui" line="636"/>
-      <source>&lt;b&gt;IfcOpenShell&lt;/b&gt; is missing on your system. IfcOpenShell is needed to import or export IFC files to/from FreeCAD. Check &lt;a href="https://www.freecadweb.org/wiki/Arch_IFC"&gt;this wiki page&lt;/a&gt; to know more, or &lt;a href="#install"&gt;download and install it&lt;/a&gt; directly.&lt;/p&gt;</source>
-      <translation type="unfinished">&lt;b&gt;IfcOpenShell&lt;/b&gt; is missing on your system. IfcOpenShell is needed to import or export IFC files to/from FreeCAD. Check &lt;a href="https://www.freecadweb.org/wiki/Arch_IFC"&gt;this wiki page&lt;/a&gt; to know more, or &lt;a href="#install"&gt;download and install it&lt;/a&gt; directly.&lt;/p&gt;</translation>
+      <source>&lt;b&gt;IfcOpenShell&lt;/b&gt; is missing on your system. IfcOpenShell is needed to import or export IFC files to/from FreeCAD. Check &lt;a href="https://www.freecad.org/wiki/Arch_IFC"&gt;this wiki page&lt;/a&gt; to know more, or &lt;a href="#install"&gt;download and install it&lt;/a&gt; directly.&lt;/p&gt;</source>
+      <translation type="unfinished">&lt;b&gt;IfcOpenShell&lt;/b&gt; is missing on your system. IfcOpenShell is needed to import or export IFC files to/from FreeCAD. Check &lt;a href="https://www.freecad.org/wiki/Arch_IFC"&gt;this wiki page&lt;/a&gt; to know more, or &lt;a href="#install"&gt;download and install it&lt;/a&gt; directly.&lt;/p&gt;</translation>
     </message>
   </context>
   <context>

--- a/src/Mod/BIM/Resources/translations/Arch_val-ES.ts
+++ b/src/Mod/BIM/Resources/translations/Arch_val-ES.ts
@@ -10998,8 +10998,8 @@ CTRL+PgUp to extend extrusionCTRL+PgDown to shrink extrusionCTRL+/ to switch bet
     </message>
     <message>
       <location filename="../ui/dialogSetup.ui" line="636"/>
-      <source>&lt;b&gt;IfcOpenShell&lt;/b&gt; is missing on your system. IfcOpenShell is needed to import or export IFC files to/from FreeCAD. Check &lt;a href="https://www.freecadweb.org/wiki/Arch_IFC"&gt;this wiki page&lt;/a&gt; to know more, or &lt;a href="#install"&gt;download and install it&lt;/a&gt; directly.&lt;/p&gt;</source>
-      <translation type="unfinished">&lt;b&gt;IfcOpenShell&lt;/b&gt; is missing on your system. IfcOpenShell is needed to import or export IFC files to/from FreeCAD. Check &lt;a href="https://www.freecadweb.org/wiki/Arch_IFC"&gt;this wiki page&lt;/a&gt; to know more, or &lt;a href="#install"&gt;download and install it&lt;/a&gt; directly.&lt;/p&gt;</translation>
+      <source>&lt;b&gt;IfcOpenShell&lt;/b&gt; is missing on your system. IfcOpenShell is needed to import or export IFC files to/from FreeCAD. Check &lt;a href="https://www.freecad.org/wiki/Arch_IFC"&gt;this wiki page&lt;/a&gt; to know more, or &lt;a href="#install"&gt;download and install it&lt;/a&gt; directly.&lt;/p&gt;</source>
+      <translation type="unfinished">&lt;b&gt;IfcOpenShell&lt;/b&gt; is missing on your system. IfcOpenShell is needed to import or export IFC files to/from FreeCAD. Check &lt;a href="https://www.freecad.org/wiki/Arch_IFC"&gt;this wiki page&lt;/a&gt; to know more, or &lt;a href="#install"&gt;download and install it&lt;/a&gt; directly.&lt;/p&gt;</translation>
     </message>
   </context>
   <context>

--- a/src/Mod/TechDraw/Gui/Resources/translations/TechDraw_ru.ts
+++ b/src/Mod/TechDraw/Gui/Resources/translations/TechDraw_ru.ts
@@ -7327,7 +7327,7 @@ Custom: custom scale factor is used</source>
     <message>
       <location filename="../../TaskDimension.ui" line="298"/>
       <source>Standard and style according to which dimension is drawn</source>
-      <translation>Стандарт и стиль в согласно которому отображаются размеры на чертеже (https://wiki.freecadweb.org/File:TechDraw_Dimension_standardization.png)</translation>
+      <translation>Стандарт и стиль в согласно которому отображаются размеры на чертеже (https://wiki.freecad.org/File:TechDraw_Dimension_standardization.png)</translation>
     </message>
     <message>
       <location filename="../../TaskDimension.ui" line="136"/>


### PR DESCRIPTION
## Description

Replaces deprecated `freecadweb.org` wiki URLs with `freecad.org` in BIM and TechDraw translation files.

## Related Issue

Fixes #26160 - Leftover references from migration from freecadweb.org

## Changes Made

- `src/Mod/BIM/Resources/translations/Arch.ts`: 1 URL replaced
- `src/Mod/BIM/Resources/translations/Arch_lt.ts`: 2 URLs replaced
- `src/Mod/BIM/Resources/translations/Arch_pt-PT.ts`: 2 URLs replaced
- `src/Mod/BIM/Resources/translations/Arch_val-ES.ts`: 2 URLs replaced
- `src/Mod/TechDraw/Gui/Resources/translations/TechDraw_ru.ts`: 1 URL replaced

**Total: 8 URL replacements**

## Motivation

The BIM Help and BIM Tutorial menu items were linking to the old deprecated domain `freecadweb.org`. After the domain migration, these URLs are broken. This PR updates all translation files containing these old URLs to point to the new `freecad.org` domain.

## Testing

Searched the entire repository for `freecadweb.org` occurrences in `.ts` translation files and found all instances are in translation files containing the old wiki URLs. All have been replaced.

```
Before: https://www.freecadweb.org/wiki/Arch_IFC
After:  https://wiki.freecad.org/wiki/Arch_IFC
```

Note: `freecad.org` automatically redirects to `wiki.freecad.org`, so both URL patterns work, but using `freecad.org` directly is cleaner.
