### PR TITLE
[Base] Expose ParameterGrp type to python

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -520,6 +520,10 @@ void Application::setupPythonTypes()
     Base::InterpreterSingleton::addType(&OriginGroupExtensionPy::Type, pAppModule, "OriginGroupExtension");
     Base::InterpreterSingleton::addType(&LinkBaseExtensionPy::Type, pAppModule, "LinkBaseExtension");
 
+    Base::ParameterGrpPy::init_type();
+    Base::InterpreterSingleton::addType(Base::ParameterGrpPy::type_object(),
+        pAppModule, "ParameterGrp");
+
     //insert Base and Console
     Py_INCREF(pBaseModule);
     PyModule_AddObject(pAppModule, "Base", pBaseModule);
@@ -553,10 +557,6 @@ void Application::setupPythonTypes()
     Base::Vector2dPy::init_type();
     Base::InterpreterSingleton::addType(Base::Vector2dPy::type_object(),
         pBaseModule,"Vector2d");
-
-    Base::ParameterGrpPy::init_type();
-    Base::InterpreterSingleton::addType(Base::ParameterGrpPy::type_object(),
-        pBaseModule, "ParameterGrp");
 
     // clang-format on
 }

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -87,7 +87,7 @@
 #include <Base/Interpreter.h>
 #include <Base/MatrixPy.h>
 #include <Base/QuantityPy.h>
-#include <Base/Parameter.h>
+#include <Base/ParameterPy.h>
 #include <Base/Persistence.h>
 #include <Base/PlacementPy.h>
 #include <Base/PrecisionPy.h>
@@ -553,6 +553,11 @@ void Application::setupPythonTypes()
     Base::Vector2dPy::init_type();
     Base::InterpreterSingleton::addType(Base::Vector2dPy::type_object(),
         pBaseModule,"Vector2d");
+
+    Base::ParameterGrpPy::init_type();
+    Base::InterpreterSingleton::addType(Base::ParameterGrpPy::type_object(),
+        pBaseModule, "ParameterGrp");
+
     // clang-format on
 }
 

--- a/src/App/FreeCAD.module.pyi
+++ b/src/App/FreeCAD.module.pyi
@@ -19,26 +19,33 @@ if TYPE_CHECKING:
     from Part import Feature as _PartFeature
 
 _FileTypeModules: TypeAlias = dict[str, str | list[str] | None]
-_LogLevelName: TypeAlias = Literal["Default", "Error", "Warning", "Message", "Log", "Trace"]
+_LogLevelName: TypeAlias = Literal[
+    "Default", "Error", "Warning", "Message", "Log", "Trace"
+]
 GuiUp: int
 ActiveDocument: Document | None
 
 # Parameter and configuration access
-def ParamGet(path: str, /) -> _ParameterGrp:
+def ParamGet(path: str, /) -> ParameterGrp:
     """Return the parameter group rooted at one application preference path."""
     ...
+
 def saveParameter(name: str = "User parameter", /) -> None:
     """Persist one named parameter tree to disk."""
     ...
+
 def Version() -> list[str]:
     """Return the FreeCAD version components as strings."""
     ...
+
 def ConfigGet(key: str, /) -> str:
     """Return one application configuration value by key."""
     ...
+
 def ConfigSet(key: str, value: str, /) -> None:
     """Store one application configuration value by key."""
     ...
+
 def ConfigDump() -> dict[str, str]:
     """Return the current flat application configuration mapping."""
     ...
@@ -47,30 +54,40 @@ def ConfigDump() -> dict[str, str]:
 def addImportType(extension: str, module: str, /) -> None:
     """Register one importer module for a file extension."""
     ...
+
 def changeImportModule(extension: str, old_module: str, new_module: str, /) -> None:
     """Replace one importer module registration for a file extension."""
     ...
+
 @overload
 def getImportType() -> _FileTypeModules:
     """Return the full extension-to-module map for all registered importers."""
     ...
+
 @overload
 def getImportType(extension: str, /) -> list[str]:
     """Return the importer modules registered for one specific extension."""
     ...
+
 def addExportType(extension: str, module: str, /) -> None:
     """Register one exporter module for a file extension."""
     ...
-def addTranslatableExportType(description: str, extensions: list[str], module: str, /) -> None:
+
+def addTranslatableExportType(
+    description: str, extensions: list[str], module: str, /
+) -> None:
     """Register one exporter together with a translated file-dialog description."""
     ...
+
 def changeExportModule(extension: str, old_module: str, new_module: str, /) -> None:
     """Replace one exporter module registration for a file extension."""
     ...
+
 @overload
 def getExportType() -> _FileTypeModules:
     """Return the full extension-to-module map for all registered exporters."""
     ...
+
 @overload
 def getExportType(extension: str, /) -> list[str]:
     """Return the exporter modules registered for one specific extension."""
@@ -80,27 +97,35 @@ def getExportType(extension: str, /) -> list[str]:
 def getResourceDir() -> str:
     """Return the root resource directory shipped with FreeCAD."""
     ...
+
 def getLibraryDir() -> str:
     """Return the directory that contains FreeCAD shared libraries."""
     ...
+
 def getTempPath() -> str:
     """Return the temporary directory used by FreeCAD."""
     ...
+
 def getUserCachePath() -> str:
     """Return the user cache directory used by FreeCAD."""
     ...
+
 def getUserConfigDir() -> str:
     """Return the user configuration directory."""
     ...
+
 def getUserAppDataDir() -> str:
     """Return the user application-data directory."""
     ...
+
 def getUserMacroDir(actual: bool = False, /) -> str:
     """Return the user macro directory, optionally resolving the effective path."""
     ...
+
 def getHelpDir() -> str:
     """Return the directory that contains bundled help resources."""
     ...
+
 def getHomePath() -> str:
     """Return the current FreeCAD home directory."""
     ...
@@ -109,12 +134,17 @@ def getHomePath() -> str:
 def loadFile(path: str, doc: str = "", module: str = "", /) -> None:
     """Load one file into an existing or inferred document context."""
     ...
+
 def open(name: str, hidden: bool = False, temporary: bool = False, /) -> Document:
     """Open a document file and return the created document."""
     ...
-def openDocument(name: str, hidden: bool = False, temporary: bool = False, /) -> Document:
+
+def openDocument(
+    name: str, hidden: bool = False, temporary: bool = False, /
+) -> Document:
     """Open a document file explicitly through the document loader."""
     ...
+
 def newDocument(
     name: str | None = None,
     label: str | None = None,
@@ -124,6 +154,7 @@ def newDocument(
 ) -> Document:
     """Create and return a new document."""
     ...
+
 def closeDocument(document: str | Document, /) -> None:
     """Close one document by name or object."""
     ...
@@ -132,18 +163,23 @@ def closeDocument(document: str | Document, /) -> None:
 def activeDocument() -> Document | None:
     """Return the current active document, if any."""
     ...
+
 def setActiveDocument(name: str, /) -> None:
     """Make one named document the active document."""
     ...
+
 def getDocument(name: str, /) -> Document:
     """Return one loaded document by name."""
     ...
+
 def listDocuments(sort: bool = False, /) -> dict[str, Document]:
     """Return the currently loaded documents keyed by name."""
     ...
+
 def addDocumentObserver(observer: object, /) -> None:
     """Register one document observer object."""
     ...
+
 def removeDocumentObserver(observer: object, /) -> None:
     """Unregister one document observer object."""
     ...
@@ -152,12 +188,15 @@ def removeDocumentObserver(observer: object, /) -> None:
 def setLogLevel(tag: str, level: _LogLevelName | int, /) -> None:
     """Set one named log channel to a numeric or named level."""
     ...
+
 def getLogLevel(tag: str, /) -> int:
     """Return the numeric level of one named log channel."""
     ...
+
 def checkLinkDepth(depth: int, /) -> int:
     """Clamp or validate one proposed link depth value."""
     ...
+
 def getLinksTo(
     obj: DocumentObject | None = None,
     options: int = 0,
@@ -166,6 +205,7 @@ def getLinksTo(
 ) -> tuple[DocumentObject, ...]:
     """Return objects that link to the given object."""
     ...
+
 def getDependentObjects(
     obj: DocumentObject | Sequence[DocumentObject],
     options: int = 0,
@@ -173,18 +213,23 @@ def getDependentObjects(
 ) -> tuple[DocumentObject, ...]:
     """Return objects that depend on one object or object sequence."""
     ...
+
 def setActiveTransaction(name: str, persist: bool = False, /) -> int:
     """Start or select the active transaction and return its identifier."""
     ...
+
 def getActiveTransaction() -> tuple[str, int] | None:
     """Return the current transaction name and identifier, if any."""
     ...
+
 def closeActiveTransaction(abort: bool = False, id: int = 0, /) -> None:
     """Close or abort the current transaction."""
     ...
+
 def isRestoring() -> bool:
     """Return whether FreeCAD is currently restoring document state."""
     ...
+
 def checkAbort() -> None:
     """Raise if the current long-running operation has been asked to abort."""
     ...

--- a/src/Base/FreeCAD.ParameterGrp.pyi
+++ b/src/Base/FreeCAD.ParameterGrp.pyi
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-"""Typed public method signatures for the ``FreeCAD._ParameterGrp`` PyCXX type."""
+"""Typed public method signatures for the ``FreeCAD.ParameterGrp`` PyCXX type."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ class _ParameterObserver(Protocol):
 
     def onChange(
         self,
-        group: _ParameterGrp,
+        group: ParameterGrp,
         param_type: str,
         name: str,
         value: str,
@@ -29,7 +29,7 @@ class _ParameterManagerObserver(Protocol):
 
     def slotParamChanged(
         self,
-        group: _ParameterGrp,
+        group: ParameterGrp,
         param_type: str,
         name: str,
         value: str,
@@ -38,10 +38,10 @@ class _ParameterManagerObserver(Protocol):
         """Handle one manager-level parameter change notification."""
         ...
 
-class _ParameterGrp:
+class ParameterGrp:
     """Hierarchical parameter-group wrapper used for FreeCAD preferences."""
 
-    def GetGroup(self, name: str, /) -> _ParameterGrp:
+    def GetGroup(self, name: str, /) -> ParameterGrp:
         """Return one child parameter group by name."""
         ...
 
@@ -65,15 +65,15 @@ class _ParameterGrp:
         """Rename one child parameter group."""
         ...
 
-    def CopyTo(self, group: _ParameterGrp, /) -> None:
+    def CopyTo(self, group: ParameterGrp, /) -> None:
         """Copy this group's contents into another parameter group."""
         ...
 
-    def Manager(self) -> _ParameterGrp | None:
+    def Manager(self) -> ParameterGrp | None:
         """Return the manager group for this parameter group, if any."""
         ...
 
-    def Parent(self) -> _ParameterGrp | None:
+    def Parent(self) -> ParameterGrp | None:
         """Return the parent group, if any."""
         ...
 

--- a/src/Base/ParameterPy.cpp
+++ b/src/Base/ParameterPy.cpp
@@ -37,9 +37,9 @@
 # include <unistd.h>
 #endif
 
-#include "Parameter.h"
+#include "ParameterPy.h"
+
 #include "Exception.h"
-#include "Interpreter.h"
 
 #include <Tools.h>
 
@@ -101,83 +101,6 @@ private:
 };
 
 using ParameterGrpObserverList = std::list<ParameterGrpObserver*>;
-
-class ParameterGrpPy: public Py::PythonExtension<ParameterGrpPy>  // NOLINT
-{
-public:
-    static void init_type();  // announce properties and methods
-
-    explicit ParameterGrpPy(const Base::Reference<ParameterGrp>& rcParamGrp);
-    ~ParameterGrpPy() override;
-
-    Py::Object repr() override;
-
-    // NOLINTBEGIN
-    Py::Object getGroup(const Py::Tuple&);
-    Py::Object getGroupName(const Py::Tuple&);
-    Py::Object getGroups(const Py::Tuple&);
-    Py::Object remGroup(const Py::Tuple&);
-    Py::Object hasGroup(const Py::Tuple&);
-    Py::Object renameGroup(const Py::Tuple&);
-    Py::Object copyTo(const Py::Tuple&);
-
-    Py::Object getManager(const Py::Tuple&);
-    Py::Object getParent(const Py::Tuple&);
-
-    Py::Object isEmpty(const Py::Tuple&);
-    Py::Object clear(const Py::Tuple&);
-
-    Py::Object attach(const Py::Tuple&);
-    Py::Object attachManager(const Py::Tuple& args);
-    Py::Object detach(const Py::Tuple&);
-    Py::Object notify(const Py::Tuple&);
-    Py::Object notifyAll(const Py::Tuple&);
-
-    Py::Object setBool(const Py::Tuple&);
-    Py::Object getBool(const Py::Tuple&);
-    Py::Object getBools(const Py::Tuple&);
-    Py::Object remBool(const Py::Tuple&);
-
-    Py::Object setInt(const Py::Tuple&);
-    Py::Object getInt(const Py::Tuple&);
-    Py::Object getInts(const Py::Tuple&);
-    Py::Object remInt(const Py::Tuple&);
-
-    Py::Object setUnsigned(const Py::Tuple&);
-    Py::Object getUnsigned(const Py::Tuple&);
-    Py::Object getUnsigneds(const Py::Tuple&);
-    Py::Object remUnsigned(const Py::Tuple&);
-
-    Py::Object setFloat(const Py::Tuple&);
-    Py::Object getFloat(const Py::Tuple&);
-    Py::Object getFloats(const Py::Tuple&);
-    Py::Object remFloat(const Py::Tuple&);
-
-    Py::Object setString(const Py::Tuple&);
-    Py::Object getString(const Py::Tuple&);
-    Py::Object getStrings(const Py::Tuple&);
-    Py::Object remString(const Py::Tuple&);
-
-    Py::Object importFrom(const Py::Tuple&);
-    Py::Object insert(const Py::Tuple&);
-    Py::Object exportTo(const Py::Tuple&);
-
-    Py::Object getContents(const Py::Tuple&);
-    // NOLINTEND
-
-private:
-    void tryCall(
-        ParameterGrpObserver* obs,
-        ParameterGrp* Param,
-        ParameterGrp::ParamType Type,
-        const char* Name,
-        const char* Value
-    );
-
-private:
-    ParameterGrp::handle _cParamGrp;
-    ParameterGrpObserverList _observers;
-};
 
 // ---------------------------------------------------------
 
@@ -951,11 +874,5 @@ Py::Object ParameterGrpPy::getContents(const Py::Tuple& args)
  */
 PyObject* GetPyObject(const Base::Reference<ParameterGrp>& hcParamGrp)
 {
-    static bool init = false;
-    if (!init) {
-        init = true;
-        Base::ParameterGrpPy::init_type();
-    }
-
     return new Base::ParameterGrpPy(hcParamGrp);
 }

--- a/src/Base/ParameterPy.cpp
+++ b/src/Base/ParameterPy.cpp
@@ -868,6 +868,11 @@ Py::Object ParameterGrpPy::getContents(const Py::Tuple& args)
     return list;  // NOLINT
 }
 
+PyTypeObject* ParameterGrpPy::type_object()
+{
+    return Py::PythonExtension<ParameterGrpPy>::type_object();
+}
+
 }  // namespace Base
 
 /** python wrapper function

--- a/src/Base/ParameterPy.h
+++ b/src/Base/ParameterPy.h
@@ -39,6 +39,7 @@ class ParameterGrpPy: public Py::PythonExtension<ParameterGrpPy>  // NOLINT
 {
 public:
     static void init_type();  // announce properties and methods
+    static PyTypeObject* type_object();
 
     explicit ParameterGrpPy(const Base::Reference<ParameterGrp>& rcParamGrp);
     ~ParameterGrpPy() override;

--- a/src/Base/ParameterPy.h
+++ b/src/Base/ParameterPy.h
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Library General Public License (LGPL)   *
+ *   as published by the Free Software Foundation; either version 2 of     *
+ *   the License, or (at your option) any later version.                   *
+ *   for detail see the LICENCE text file.                                 *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful,            *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with FreeCAD; if not, write to the Free Software        *
+ *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+ *   USA                                                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <list>
+
+#include "Parameter.h"
+#include "Interpreter.h"
+
+
+namespace Base
+{
+class ParameterGrpObserver;
+
+using ParameterGrpObserverList = std::list<ParameterGrpObserver*>;
+
+class ParameterGrpPy: public Py::PythonExtension<ParameterGrpPy>  // NOLINT
+{
+public:
+    static void init_type();  // announce properties and methods
+
+    explicit ParameterGrpPy(const Base::Reference<ParameterGrp>& rcParamGrp);
+    ~ParameterGrpPy() override;
+
+    Py::Object repr() override;
+
+    // NOLINTBEGIN
+    Py::Object getGroup(const Py::Tuple&);
+    Py::Object getGroupName(const Py::Tuple&);
+    Py::Object getGroups(const Py::Tuple&);
+    Py::Object remGroup(const Py::Tuple&);
+    Py::Object hasGroup(const Py::Tuple&);
+    Py::Object renameGroup(const Py::Tuple&);
+    Py::Object copyTo(const Py::Tuple&);
+
+    Py::Object getManager(const Py::Tuple&);
+    Py::Object getParent(const Py::Tuple&);
+
+    Py::Object isEmpty(const Py::Tuple&);
+    Py::Object clear(const Py::Tuple&);
+
+    Py::Object attach(const Py::Tuple&);
+    Py::Object attachManager(const Py::Tuple& args);
+    Py::Object detach(const Py::Tuple&);
+    Py::Object notify(const Py::Tuple&);
+    Py::Object notifyAll(const Py::Tuple&);
+
+    Py::Object setBool(const Py::Tuple&);
+    Py::Object getBool(const Py::Tuple&);
+    Py::Object getBools(const Py::Tuple&);
+    Py::Object remBool(const Py::Tuple&);
+
+    Py::Object setInt(const Py::Tuple&);
+    Py::Object getInt(const Py::Tuple&);
+    Py::Object getInts(const Py::Tuple&);
+    Py::Object remInt(const Py::Tuple&);
+
+    Py::Object setUnsigned(const Py::Tuple&);
+    Py::Object getUnsigned(const Py::Tuple&);
+    Py::Object getUnsigneds(const Py::Tuple&);
+    Py::Object remUnsigned(const Py::Tuple&);
+
+    Py::Object setFloat(const Py::Tuple&);
+    Py::Object getFloat(const Py::Tuple&);
+    Py::Object getFloats(const Py::Tuple&);
+    Py::Object remFloat(const Py::Tuple&);
+
+    Py::Object setString(const Py::Tuple&);
+    Py::Object getString(const Py::Tuple&);
+    Py::Object getStrings(const Py::Tuple&);
+    Py::Object remString(const Py::Tuple&);
+
+    Py::Object importFrom(const Py::Tuple&);
+    Py::Object insert(const Py::Tuple&);
+    Py::Object exportTo(const Py::Tuple&);
+
+    Py::Object getContents(const Py::Tuple&);
+    // NOLINTEND
+
+private:
+    void tryCall(
+        ParameterGrpObserver* obs,
+        ParameterGrp* Param,
+        ParameterGrp::ParamType Type,
+        const char* Name,
+        const char* Value
+    );
+
+private:
+    ParameterGrp::handle _cParamGrp;
+    ParameterGrpObserverList _observers;
+};
+
+}  // namespace Base

--- a/src/Base/ParameterPy.h
+++ b/src/Base/ParameterPy.h
@@ -35,7 +35,7 @@ class ParameterGrpObserver;
 
 using ParameterGrpObserverList = std::list<ParameterGrpObserver*>;
 
-class ParameterGrpPy: public Py::PythonExtension<ParameterGrpPy>  // NOLINT
+class BaseExport ParameterGrpPy: public Py::PythonExtension<ParameterGrpPy>  // NOLINT
 {
 public:
     static void init_type();  // announce properties and methods

--- a/src/Tools/typing/smoke/smoke.py
+++ b/src/Tools/typing/smoke/smoke.py
@@ -31,7 +31,7 @@ import PathApp
 import QtUnitGui
 import SpreadsheetGui
 import TechDrawGui
-from FreeCAD import DocumentObject
+from FreeCAD import DocumentObject, ParameterGrp
 from FreeCAD.Base import (
     Axis,
     BoundBox,
@@ -61,7 +61,7 @@ class ParameterObserver:
 
     def onChange(
         self,
-        group: FreeCAD._ParameterGrp,
+        group: ParameterGrp,
         param_type: str,
         name: str,
         value: str,
@@ -75,7 +75,7 @@ class ParameterManagerObserver:
 
     def slotParamChanged(
         self,
-        group: FreeCAD._ParameterGrp,
+        group: ParameterGrp,
         param_type: str,
         name: str,
         value: str,
@@ -337,13 +337,13 @@ def exercise(
     ui_loader.addPluginPath("/tmp")
     ui_loader.setLanguageChangeEnabled(True)
     ui_loader.setWorkingDirectory("/tmp")
-    assert_type(child_parameters, FreeCAD._ParameterGrp)
+    assert_type(child_parameters, ParameterGrp)
     assert_type(parameters.GetGroupName(), str)
     assert_type(parameters.GetGroups(), list[str])
     assert_type(parameters.HasGroup("Preferences"), bool)
     assert_type(parameters.RenameGroup("old", "new"), bool)
-    assert_type(parameters.Manager(), FreeCAD._ParameterGrp | None)
-    assert_type(parameters.Parent(), FreeCAD._ParameterGrp | None)
+    assert_type(parameters.Manager(), ParameterGrp | None)
+    assert_type(parameters.Parent(), ParameterGrp | None)
     assert_type(parameters.IsEmpty(), bool)
     assert_type(parameters.GetBool("flag", 0), bool)
     assert_type(parameters.GetBools(), list[str])

--- a/src/Tools/typing/stubgen/type_context_rules.py
+++ b/src/Tools/typing/stubgen/type_context_rules.py
@@ -79,7 +79,7 @@ TYPE_CONTEXT_RULES = (
     TypeContextRule(
         source="src/Base/ParameterPy.cpp",
         context_name="ParameterGrp",
-        public_targets=(PublicTypeTarget("FreeCAD", "_ParameterGrp"),),
+        public_targets=(PublicTypeTarget("FreeCAD", "ParameterGrp"),),
     ),
     TypeContextRule(
         source="src/Gui/MainWindowPy.cpp",


### PR DESCRIPTION
Expose `FreeCAD.ParameterGrp` as proper python type. In current codebase, instances of this type are returned by `ParamGet` function, but the type itself is not exposed, so python functions accepting or returning it cannot be property type hinted.

Old:
```python
import FreeCAD as App
def func(grp: App.ParameterGrp):   # Error
  ...
```

New:
```python
import FreeCAD as App
def func(grp: App.ParameterGrp):   # Ok
  ...
```
