### PR TITLE
fixes #30161 do not select entire object when selecting additional items via the tree menu w/ unit test

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -5559,6 +5559,48 @@ void DocumentItem::updateItemSelection(DocumentObjectItem* item)
     if (!selected && !item->selected) {
         return;
     }
+    auto computeObjAndSubname =
+        [](DocumentObjectItem* treeItem, App::DocumentObject*& outObj, std::string& outSubname) {
+            std::ostringstream str;
+            App::DocumentObject* topParent = nullptr;
+            treeItem->getSubName(str, topParent);
+            if (topParent) {
+                if (!outObj->redirectSubName(str, topParent, nullptr)) {
+                    str << outObj->getNameInDocument() << '.';
+                }
+                outObj = topParent;
+            }
+            outSubname = str.str();
+        };
+
+    // do not select the entire object if only a sub-element is
+    // selected ie. see https://github.com/freecad/freecad/issues/30161
+    // it's not the user's intent to select the whole object
+    // when selecting additional items via the tree menu
+    if (selected) {
+        auto guardObj = item->object()->getObject();
+        if (guardObj && guardObj->isAttachedToDocument()) {
+            // compute this item's full subname ie. matching what would be pushed below
+            std::string guardSubname;
+            computeObjAndSubname(item, guardObj, guardSubname);
+            const char* docname = guardObj->getDocument()->getName();
+
+            // Look for any existing selection entry on the same (object, subname-prefix)
+            // that carries an additional sub-element. If found, this Qt item is selected
+            // only as a visual reflection of the sub-element selection — don't re-push
+            // it as a whole-object selection. See #30161.
+            for (const auto& sel : Gui::Selection().getSelection(docname, ResolveMode::NoResolve)) {
+                if (sel.pObject != guardObj || !sel.SubName) {
+                    continue;
+                }
+                std::string_view existing(sel.SubName);
+                if (existing.starts_with(guardSubname) && existing.size() > guardSubname.size()) {
+                    return;
+                }
+            }
+        }
+    }
+
     if (item->selected != -1) {
         item->mySubs.clear();
     }
@@ -5569,18 +5611,10 @@ void DocumentItem::updateItemSelection(DocumentObjectItem* item)
         return;
     }
 
-    std::ostringstream str;
-    App::DocumentObject* topParent = nullptr;
-    item->getSubName(str, topParent);
-    if (topParent) {
-        if (!obj->redirectSubName(str, topParent, nullptr)) {
-            str << obj->getNameInDocument() << '.';
-        }
-        obj = topParent;
-    }
+    std::string subname;
+    computeObjAndSubname(item, obj, subname);
     const char* objname = obj->getNameInDocument();
     const char* docname = obj->getDocument()->getName();
-    const auto& subname = str.str();
 
 #ifdef FC_DEBUG
     if (!subname.empty()) {
@@ -5600,18 +5634,10 @@ void DocumentItem::updateItemSelection(DocumentObjectItem* item)
                     continue;
                 }
 
-                std::ostringstream str2;
-                App::DocumentObject* topParent2 = nullptr;
-                docitem->getSubName(str2, topParent2);
+                std::string subname2;
+                computeObjAndSubname(docitem, obj2, subname2);
 
-                if (topParent2) {
-                    if (!obj2->redirectSubName(str2, topParent2, nullptr)) {
-                        str2 << obj2->getNameInDocument() << '.';
-                    }
-                    obj2 = topParent2;
-                }
-
-                if (obj2 == obj && str2.str() == subname) {
+                if (obj2 == obj && subname2 == subname) {
                     keep = true;
                     break;
                 }

--- a/src/Mod/Test/TestTreeSelection.py
+++ b/src/Mod/Test/TestTreeSelection.py
@@ -36,8 +36,10 @@ import FreeCADGui
 from FreeCADGui import Selection
 
 import Draft
+import Part
 
 from PySide6 import QtWidgets
+from PySide6.QtCore import QModelIndex, QItemSelectionModel
 
 
 class TestSelectAllInstances(unittest.TestCase):
@@ -244,4 +246,86 @@ class TestSelectAllInstances(unittest.TestCase):
         count = self._count_tree_selections_by_name("Box")
         self.assertGreaterEqual(
             count, 1, f"Expected at least 1 'Box' instance selected, got {count}."
+        )
+
+    def test_subelement_selection_preserved_on_tree_click(self):
+        """Issue #30161: selecting an Origin plane in the tree must not
+        replace an existing sub-element selection with a whole-object one."""
+
+        # Create Body with Sketch on XZ plane containing a rectangle
+        body = self.doc.addObject("PartDesign::Body", "Body")
+        sketch = body.newObject("Sketcher::SketchObject", "Sketch")
+        sketch.AttachmentSupport = (body.Origin.OutList[2], "")  # XZ
+
+        sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(10, 0, 0)))
+        sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(10, 0, 0), FreeCAD.Vector(10, 10, 0)))
+        sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(10, 10, 0), FreeCAD.Vector(0, 10, 0)))
+        sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(0, 10, 0), FreeCAD.Vector(0, 0, 0)))
+        self.doc.recompute()
+        FreeCADGui.updateGui()
+
+        # step 1:
+        # Select vertex via Selection API (mimics 3D-view selection effect on Gui::Selection)
+        Selection.clearSelection()
+        Selection.addSelection(self.doc.Name, body.Name, "Sketch.Vertex1")
+        FreeCADGui.updateGui()
+
+        # step 2:
+        # re-fetch tree references AFTER selection observers have run.
+        # The selection observers may have recreated DocumentObjectItem nodes,
+        # so any references obtained earlier could be dangling.
+        tree = self._get_tree_widget()
+        self.assertIsNotNone(tree, "Could not find tree widget")
+
+        def find_index(parent_index, label):
+            """Find the QModelIndex of an item with matching label, recursively."""
+            model = tree.model()
+            if parent_index.isValid():
+                rows = model.rowCount(parent_index)
+            else:
+                rows = tree.topLevelItemCount()
+            for i in range(rows):
+                if parent_index.isValid():
+                    idx = model.index(i, 0, parent_index)
+                else:
+                    idx = model.index(i, 0)
+                text = model.data(idx)
+                if text and (text == label or label in text):
+                    return idx
+                found = find_index(idx, label)
+                if found.isValid():
+                    return found
+            return QModelIndex()
+
+        xy_index = find_index(QModelIndex(), "XY-plane")
+        self.assertTrue(xy_index.isValid(), "Could not locate XY-plane tree item")
+
+        # Step 3:
+        # trigger the bug. Qt-selecting the XY-plane item fires
+        # QTreeWidget::itemSelectionChanged → DocumentItem::updateItemSelection.
+        # Before the #30161 fix, this would push the whole Sketch into Gui::Selection.
+        tree.selectionModel().select(xy_index, QItemSelectionModel.Select)
+        FreeCADGui.updateGui()
+
+        # The fix: selection must still contain the vertex sub-element, not whole Sketch
+        sels = Selection.getSelectionEx(self.doc.Name, 0)  # ResolveMode::NoResolve
+        sub_names = []
+        for sel in sels:
+            for sub in sel.SubElementNames or [""]:
+                sub_names.append(sub)
+
+        # No bare "Sketch." (whole-object) entry should appear
+        self.assertNotIn(
+            "Sketch.",
+            sub_names,
+            f"Issue #30161 regression: whole Sketch was selected. Got: {sub_names}",
+        )
+        # The vertex sub-element entry must survive
+        self.assertTrue(
+            any("Vertex" in s for s in sub_names),
+            f"Vertex sub-element selection was lost. Got: {sub_names}",
+        )
+        # XY_Plane should now also be selected (internal name in SubElementNames)
+        self.assertTrue(
+            any("XY_Plane" in s for s in sub_names), f"XY_Plane was not added. Got: {sub_names}"
         )


### PR DESCRIPTION
**updated jun 22** updated changes in `Tree.cpp` to use lambda per code review suggestions below.

this pr fixes the following freecad issue #30161

Assisted-by: cluade opus 4.7

run the below command **without** the fix applied to `Tree.cpp`

```
/opt/code/fcgit/installs/issue.tshooting.qt6.py313/bin/FreeCAD \
-t TestTreeSelection.TestSelectAllInstances
```

```
FreeCAD 1.2.0, Libs: 1.2.0devR46990 (Git)
(C) 2001-2026 FreeCAD contributors
FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.

test_select_all_instances_basic (TestTreeSelection.TestSelectAllInstances.test_select_all_instances_basic)
Test basic 'Select all instances' with single object in group. ... ok
test_select_all_instances_with_cuts (TestTreeSelection.TestSelectAllInstances.test_select_all_instances_with_cuts)
Test that 'Select all instances' selects objects used in Part::Cut operations. ... ok
test_select_all_instances_with_mirror (TestTreeSelection.TestSelectAllInstances.test_select_all_instances_with_mirror)
Test that 'Select all instances' selects objects under Mirror objects. ... ok
test_subelement_selection_preserved_on_tree_click (TestTreeSelection.TestSelectAllInstances.test_subelement_selection_preserved_on_tree_click)
Issue #30161: selecting an Origin plane in the tree must not ... FAIL

======================================================================
FAIL: test_subelement_selection_preserved_on_tree_click (TestTreeSelection.TestSelectAllInstances.test_subelement_selection_preserved_on_tree_click)
Issue #30161: selecting an Origin plane in the tree must not
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/code/git/github/forks/freecad-git/installs/issue.tshooting.qt6.py313/Mod/Test/TestTreeSelection.py", line 330, in test_subelement_selection_preserved_on_tree_click
    self.assertNotIn(
    ~~~~~~~~~~~~~~~~^
        "Sketch.",
        ^^^^^^^^^^
        sub_names,
        ^^^^^^^^^^
        f"Issue #30161 regression: whole Sketch was selected. Got: {sub_names}",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
AssertionError: 'Sketch.' unexpectedly found in ['Sketch.;g1v1;SKT.Vertex1', 'Sketch.', 'Origin.XY_Plane.'] : Issue #30161 regression: whole Sketch was selected. Got: ['Sketch.;g1v1;SKT.Vertex1', 'Sketch.', 'Origin.XY_Plane.']

----------------------------------------------------------------------
Ran 4 tests in 3.352s

FAILED (failures=1)
System exit
```

**with** the fix applied to `Tree.cpp`

```
╰─λ /opt/code/fcgit/installs/issue.tshooting.qt6.py313/bin/FreeCAD -t TestTreeSelection.TestSelectAllInstances
FreeCAD 1.2.0, Libs: 1.2.0devR46990 (Git)
(C) 2001-2026 FreeCAD contributors
FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.

test_select_all_instances_basic (TestTreeSelection.TestSelectAllInstances.test_select_all_instances_basic)
Test basic 'Select all instances' with single object in group. ... ok
test_select_all_instances_with_cuts (TestTreeSelection.TestSelectAllInstances.test_select_all_instances_with_cuts)
Test that 'Select all instances' selects objects used in Part::Cut operations. ... ok
test_select_all_instances_with_mirror (TestTreeSelection.TestSelectAllInstances.test_select_all_instances_with_mirror)
Test that 'Select all instances' selects objects under Mirror objects. ... ok
test_subelement_selection_preserved_on_tree_click (TestTreeSelection.TestSelectAllInstances.test_subelement_selection_preserved_on_tree_click)
Issue #30161: selecting an Origin plane in the tree must not ... ok

----------------------------------------------------------------------
Ran 4 tests in 3.251s

OK
System exit
```

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/30161

## Before and After Images

