### PR TITLE
PartDesign: Introducing "Start"

### DIFF
--- a/src/Gui/Inventor/Draggers/Gizmo.cpp
+++ b/src/Gui/Inventor/Draggers/Gizmo.cpp
@@ -25,6 +25,7 @@
 
 #include <cmath>
 #include <QApplication>
+#include <QLineEdit>
 
 #include <Inventor/nodes/SoOrthographicCamera.h>
 #include <Inventor/nodes/SoPerspectiveCamera.h>
@@ -93,6 +94,18 @@ double snapToStep(double value, double step)
     }
 
     return std::round(value / step) * step;
+}
+
+void focusPropertyEditor(QuantitySpinBox* property)
+{
+    if (auto* parent = property->parentWidget()) {
+        for (auto* editor : parent->findChildren<QLineEdit*>()) {
+            editor->deselect();
+        }
+    }
+
+    property->setFocus();
+    property->selectAll();
 }
 }  // namespace
 
@@ -265,6 +278,29 @@ void LinearGizmo::setAddFactor(const double val)
     setDragLength(property->value().getValue());
 }
 
+void LinearGizmo::setBaseStart(const double val)
+{
+    auto* base = SO_GET_PART(dragger, "baseGeom", SoArrowBase);
+    base->startOffset = static_cast<float>(val);
+}
+
+void LinearGizmo::setPointStyle()
+{
+    auto* arrow = SO_GET_PART(dragger, "arrow", SoArrowGeometry);
+    arrow->cylinderHeight = 0.0F;
+    arrow->cylinderRadius = 0.0F;
+    arrow->coneHeight = 0.0F;
+    arrow->coneBottomRadius = 0.0F;
+    arrow->pointRadius = 1.15F;
+
+    dragger->labelVisible = false;
+    dragger->baseGeomVisible = false;
+
+    auto* base = SO_GET_PART(dragger, "baseGeom", SoArrowBase);
+    base->cylinderHeight = 0.0F;
+    base->cylinderRadius = 0.0F;
+}
+
 void LinearGizmo::setVisibility(bool visible)
 {
     this->visible = visible;
@@ -275,6 +311,8 @@ void LinearGizmo::draggingStarted()
 {
     initialValue = property->value().getValue();
     dragger->translationIncrementCount.setValue(0);
+
+    focusPropertyEditor(property);
 
     if (isDelayedUpdateEnabled()) {
         property->blockSignals(true);
@@ -288,8 +326,7 @@ void LinearGizmo::draggingFinished()
         property->valueChanged(property->value().getValue());
     }
 
-    property->setFocus();
-    property->selectAll();
+    focusPropertyEditor(property);
 }
 
 void LinearGizmo::draggingContinued()
@@ -307,9 +344,7 @@ void LinearGizmo::draggingContinued()
         value = snapToStep(value, baseStep * getCoarseLinearSnapMultiplier());
     }
 
-    // TODO: Need to change the lower limit to sudoThis->property->minimum() once the
-    // two direction extrude work gets merged
-    value = std::clamp(value, dragger->translationIncrement.getValue(), property->maximum());
+    value = std::clamp(value, property->minimum(), property->maximum());
 
     property->setValue(value);
     setDragLength(value);
@@ -481,6 +516,8 @@ void RotationGizmo::draggingStarted()
     initialValue = property->value().getValue();
     dragger->rotationIncrementCount.setValue(0);
 
+    focusPropertyEditor(property);
+
     if (isDelayedUpdateEnabled()) {
         property->blockSignals(true);
     }
@@ -493,8 +530,7 @@ void RotationGizmo::draggingFinished()
         property->valueChanged(property->value().getValue());
     }
 
-    property->setFocus();
-    property->selectAll();
+    focusPropertyEditor(property);
 }
 
 void RotationGizmo::draggingContinued()
@@ -639,6 +675,27 @@ void RadialGizmo::setRadius(float radius)
     auto baseGeom = SO_GET_PART(dragger, "baseGeom", SoRotatorBase);
 
     rotator->radius = baseGeom->arcRadius = radius;
+}
+
+void RadialGizmo::setPointStyle()
+{
+    auto* dragger = getDraggerContainer()->getDragger();
+    auto* arrow = SO_GET_PART(dragger, "rotator", SoRotatorArrow);
+    arrow->cylinderHeight = 0.0F;
+    arrow->cylinderRadius = 0.0F;
+    arrow->coneHeight = 0.0F;
+    arrow->coneBottomRadius = 0.0F;
+    arrow->pointRadius = 1.15F;
+    dragger->baseGeomVisible = false;
+}
+
+void RadialGizmo::setBaseAngleRange(const double start, const double end)
+{
+    auto* dragger = getDraggerContainer()->getDragger();
+    auto* base = SO_GET_PART(dragger, "baseGeom", SoRotatorBase);
+    base->startAngle = static_cast<float>(start);
+    base->endAngle = static_cast<float>(end);
+    base->useAngleRange = true;
 }
 
 void RadialGizmo::flipArrow()

--- a/src/Gui/Inventor/Draggers/Gizmo.h
+++ b/src/Gui/Inventor/Draggers/Gizmo.h
@@ -114,6 +114,8 @@ public:
     void setProperty(QuantitySpinBox* property);
     void setMultFactor(const double val);
     void setAddFactor(const double val);
+    void setBaseStart(const double val);
+    void setPointStyle();
     void setVisibility(bool visible);
 
 private:
@@ -203,6 +205,8 @@ public:
     void updateColorTheme();
 
     void setRadius(float radius);
+    void setPointStyle();
+    void setBaseAngleRange(const double start, const double end);
     void flipArrow();
 
 private:

--- a/src/Gui/Inventor/Draggers/SoLinearDraggerGeometry.cpp
+++ b/src/Gui/Inventor/Draggers/SoLinearDraggerGeometry.cpp
@@ -21,11 +21,14 @@
  *                                                                          *
  ***************************************************************************/
 
+#include <cmath>
+
 #include <Inventor/nodes/SoBaseColor.h>
 #include <Inventor/nodes/SoCone.h>
 #include <Inventor/nodes/SoCylinder.h>
 #include <Inventor/nodes/SoLightModel.h>
 #include <Inventor/nodes/SoPickStyle.h>
+#include <Inventor/nodes/SoSphere.h>
 #include <Inventor/nodes/SoTranslation.h>
 
 #include "SoLinearDraggerGeometry.h"
@@ -63,6 +66,7 @@ SoArrowGeometry::SoArrowGeometry()
     SO_KIT_ADD_CATALOG_ENTRY(pickStyle, SoPickStyle, false, separator, "", false);
     SO_KIT_ADD_CATALOG_ENTRY(arrowBody, SoCylinder, false, separator, "", true);
     SO_KIT_ADD_CATALOG_ENTRY(arrowTip, SoCone, false, separator, "", true);
+    SO_KIT_ADD_CATALOG_ENTRY(point, SoSphere, false, separator, "", true);
 
     SO_KIT_ADD_CATALOG_ENTRY(_arrowBodyTranslation, SoTranslation, false, separator, arrowBody, false);
     SO_KIT_ADD_CATALOG_ENTRY(_arrowTipTranslation, SoTranslation, false, separator, arrowTip, false);
@@ -71,6 +75,7 @@ SoArrowGeometry::SoArrowGeometry()
     SO_KIT_ADD_FIELD(coneHeight, (2.5f));
     SO_KIT_ADD_FIELD(cylinderHeight, (10.0f));
     SO_KIT_ADD_FIELD(cylinderRadius, (0.1f));
+    SO_KIT_ADD_FIELD(pointRadius, (0.0f));
 
     SO_KIT_INIT_INSTANCE();
 
@@ -81,6 +86,9 @@ SoArrowGeometry::SoArrowGeometry()
     auto arrowTip = SO_GET_ANY_PART(this, "arrowTip", SoCone);
     arrowTip->height.connectFrom(&coneHeight);
     arrowTip->bottomRadius.connectFrom(&coneBottomRadius);
+
+    auto* point = SO_GET_ANY_PART(this, "point", SoSphere);
+    point->radius.connectFrom(&pointRadius);
 
     auto lightModel = SO_GET_ANY_PART(this, "lightModel", SoLightModel);
     lightModel->model = SoLightModel::BASE_COLOR;
@@ -96,6 +104,10 @@ void SoArrowGeometry::notify(SoNotList* notList)
 {
     SoField* lastField = notList->getLastField();
 
+    if (lastField == &pointRadius && pointRadius.getValue() > 0.0F) {
+        tipPosition = {0, pointRadius.getValue(), 0};
+    }
+
     if (lastField == &cylinderHeight) {
         auto translation = SO_GET_ANY_PART(this, "_arrowBodyTranslation", SoTranslation);
         translation->translation = SbVec3f(0, cylinderHeight.getValue() / 2.0f, 0);
@@ -106,7 +118,9 @@ void SoArrowGeometry::notify(SoNotList* notList)
         translation->translation
             = SbVec3f(0, (cylinderHeight.getValue() + coneHeight.getValue()) / 2.0f, 0);
 
-        tipPosition = {0, cylinderHeight.getValue() + 1.5f * coneHeight.getValue(), 0};
+        if (pointRadius.getValue() <= 0.0F) {
+            tipPosition = {0, cylinderHeight.getValue() + 1.5f * coneHeight.getValue(), 0};
+        }
     }
 }
 
@@ -148,6 +162,7 @@ SoArrowBase::SoArrowBase()
 
     SO_KIT_ADD_FIELD(cylinderHeight, (1.0));
     SO_KIT_ADD_FIELD(cylinderRadius, (0.15));
+    SO_KIT_ADD_FIELD(startOffset, (0.0));
     SO_KIT_ADD_FIELD(color, (0, 0, 1));
 
     SO_KIT_INIT_INSTANCE();
@@ -174,12 +189,15 @@ void SoArrowBase::notify(SoNotList* notList)
 {
     SoField* lastField = notList->getLastField();
 
-    if (lastField == &cylinderHeight || lastField == &translation) {
+    if (lastField == &cylinderHeight || lastField == &translation || lastField == &startOffset) {
         auto cylinder = SO_GET_ANY_PART(this, "cylinder", SoCylinder);
-        cylinder->height = cylinderHeight.getValue() * translation.getValue()[1];
+        const float start = startOffset.getValue();
+        const float end = translation.getValue()[1];
+        const float length = end - start;
+        cylinder->height = cylinderHeight.getValue() * std::fabs(length);
 
         auto cylinderTranslation = SO_GET_ANY_PART(this, "_cylinderTranslation", SoTranslation);
-        cylinderTranslation->translation = {0, cylinder->height.getValue() / 2, 0};
+        cylinderTranslation->translation = {0, start + length / 2, 0};
     }
     else if (lastField == &cylinderRadius || lastField == &geometryScale) {
         auto cylinder = SO_GET_ANY_PART(this, "cylinder", SoCylinder);

--- a/src/Gui/Inventor/Draggers/SoLinearDraggerGeometry.h
+++ b/src/Gui/Inventor/Draggers/SoLinearDraggerGeometry.h
@@ -61,6 +61,7 @@ class GuiExport SoArrowGeometry: public SoLinearGeometryKit
     SO_KIT_CATALOG_ENTRY_HEADER(pickStyle);
     SO_KIT_CATALOG_ENTRY_HEADER(arrowBody);
     SO_KIT_CATALOG_ENTRY_HEADER(arrowTip);
+    SO_KIT_CATALOG_ENTRY_HEADER(point);
 
     SO_KIT_CATALOG_ENTRY_HEADER(_arrowBodyTranslation);
     SO_KIT_CATALOG_ENTRY_HEADER(_arrowTipTranslation);
@@ -73,6 +74,7 @@ public:
     SoSFFloat coneHeight;
     SoSFFloat cylinderHeight;
     SoSFFloat cylinderRadius;
+    SoSFFloat pointRadius;
 
 protected:
     ~SoArrowGeometry() override = default;
@@ -119,6 +121,7 @@ public:
 
     SoSFFloat cylinderHeight;
     SoSFFloat cylinderRadius;
+    SoSFFloat startOffset;
     SoSFColor color;
 
 protected:

--- a/src/Gui/Inventor/Draggers/SoRotationDragger.cpp
+++ b/src/Gui/Inventor/Draggers/SoRotationDragger.cpp
@@ -115,6 +115,9 @@ SoRotationDragger::SoRotationDragger()
 
     this->setUpConnections(TRUE, TRUE);
 
+    auto* sw = SO_GET_ANY_PART(this, "baseGeomSwitch", SoToggleSwitch);
+    sw->on.connectFrom(&baseGeomVisible);
+
     FC_SET_TOGGLE_SWITCH("activeSwitch", false);
 }
 

--- a/src/Gui/Inventor/Draggers/SoRotationDraggerGeometry.cpp
+++ b/src/Gui/Inventor/Draggers/SoRotationDraggerGeometry.cpp
@@ -33,6 +33,7 @@
 #include <Inventor/nodes/SoLightModel.h>
 #include <Inventor/nodes/SoLineSet.h>
 #include <Inventor/nodes/SoPickStyle.h>
+#include <Inventor/nodes/SoSeparator.h>
 #include <Inventor/nodes/SoSphere.h>
 #include <Inventor/nodes/SoTransform.h>
 #include <Inventor/nodes/SoTranslation.h>
@@ -219,6 +220,9 @@ SoRotatorArrow::SoRotatorArrow()
     SO_KIT_ADD_CATALOG_ENTRY(pickStyle, SoPickStyle, false, separator, "", false);
     SO_KIT_ADD_CATALOG_ENTRY(arrowBody, SoCylinder, false, separator, "", true);
     SO_KIT_ADD_CATALOG_ENTRY(arrowTip, SoCone, false, separator, "", true);
+    SO_KIT_ADD_CATALOG_ENTRY(pointSeparator, SoSeparator, false, separator, arrowBody, true);
+    SO_KIT_ADD_CATALOG_ENTRY(pointTransform, SoTransform, false, pointSeparator, "", true);
+    SO_KIT_ADD_CATALOG_ENTRY(point, SoSphere, false, pointSeparator, "", true);
 
     SO_KIT_ADD_CATALOG_ENTRY(_arrowTransform, SoTransform, false, separator, arrowBody, false);
     SO_KIT_ADD_CATALOG_ENTRY(_arrowBodyTranslation, SoTranslation, false, separator, arrowBody, false);
@@ -228,6 +232,7 @@ SoRotatorArrow::SoRotatorArrow()
     SO_KIT_ADD_FIELD(coneHeight, (2.5));
     SO_KIT_ADD_FIELD(cylinderHeight, (3.0));
     SO_KIT_ADD_FIELD(cylinderRadius, (0.2));
+    SO_KIT_ADD_FIELD(pointRadius, (0.0));
     SO_KIT_ADD_FIELD(radius, (8.0));
     SO_KIT_ADD_FIELD(minRadius, (8.0));
 
@@ -246,6 +251,9 @@ SoRotatorArrow::SoRotatorArrow()
     auto arrowTip = SO_GET_ANY_PART(this, "arrowTip", SoCone);
     arrowTip->height.connectFrom(&coneHeight);
     arrowTip->bottomRadius.connectFrom(&coneBottomRadius);
+
+    auto* point = SO_GET_ANY_PART(this, "point", SoSphere);
+    point->radius.connectFrom(&pointRadius);
 
     auto transform = SO_GET_ANY_PART(this, "_arrowTransform", SoTransform);
     transform->rotation = SbRotation({1, 0, 0}, std::numbers::pi)
@@ -279,6 +287,9 @@ void SoRotatorArrow::notify(SoNotList* notList)
             std::max(minRadius.getValue(), radius.getValue() / geometryScale.getValue()[1]),
             0
         );
+
+        auto* pointTransform = SO_GET_ANY_PART(this, "pointTransform", SoTransform);
+        pointTransform->translation = pivotPosition;
     }
 
     if (lastField == &coneHeight || lastField == &cylinderHeight) {
@@ -327,6 +338,9 @@ SoRotatorBase::SoRotatorBase()
     SO_KIT_ADD_FIELD(minArcRadius, (8.0));
     SO_KIT_ADD_FIELD(arcRadius, (8.0));
     SO_KIT_ADD_FIELD(arcThickness, (2.0));
+    SO_KIT_ADD_FIELD(startAngle, (0.0));
+    SO_KIT_ADD_FIELD(endAngle, (0.0));
+    SO_KIT_ADD_FIELD(useAngleRange, (false));
     SO_KIT_ADD_FIELD(color, (0.214, 0.560, 0.930));
 
     SO_KIT_INIT_INSTANCE();
@@ -359,21 +373,34 @@ void SoRotatorBase::notify(SoNotList* notList)
     SoField* lastField = notList->getLastField();
 
     if (lastField == &arcRadius || lastField == &minArcRadius || lastField == &rotation
-        || lastField == &geometryScale) {
+        || lastField == &geometryScale || lastField == &startAngle || lastField == &endAngle
+        || lastField == &useAngleRange) {
         SbVec3f axis;
-        float angle;
-        rotation.getValue(axis, angle);
+        float rotAngle;
+        rotation.getValue(axis, rotAngle);
+
+        float start = 0.0F;
+        float end = rotAngle;
+        if (useAngleRange.getValue()) {
+            start = startAngle.getValue();
+            end = endAngle.getValue();
+        }
+
+        const float sweep = end - start;
         float radius
             = std::max(minArcRadius.getValue() * geometryScale.getValue()[0], arcRadius.getValue());
 
         auto coordinates = SO_GET_ANY_PART(this, "arcCoords", SoCoordinate3);
-        float angleIncrement = angle / static_cast<float>(segments);
-        SbRotation rotation(axis, angleIncrement);
+        float angleIncrement = sweep / static_cast<float>(segments);
+        SbRotation startRotation(axis, start);
+        SbRotation stepRotation(axis, angleIncrement);
         SbVec3f point(0.0, radius, 0.0);
+        startRotation.multVec(point, point);
+
         coordinates->point.set1Value(0, {0.0, 0.0, 0.0});
         for (int index = 0; index <= segments; ++index) {
             coordinates->point.set1Value(index + 1, point);
-            rotation.multVec(point, point);
+            stepRotation.multVec(point, point);
         }
         coordinates->point.set1Value(segments + 2, {0.0, 0.0, 0.0});
     }

--- a/src/Gui/Inventor/Draggers/SoRotationDraggerGeometry.h
+++ b/src/Gui/Inventor/Draggers/SoRotationDraggerGeometry.h
@@ -130,6 +130,9 @@ class GuiExport SoRotatorArrow: public SoRotatorGeometryKit
     SO_KIT_CATALOG_ENTRY_HEADER(pickStyle);
     SO_KIT_CATALOG_ENTRY_HEADER(arrowBody);
     SO_KIT_CATALOG_ENTRY_HEADER(arrowTip);
+    SO_KIT_CATALOG_ENTRY_HEADER(pointSeparator);
+    SO_KIT_CATALOG_ENTRY_HEADER(pointTransform);
+    SO_KIT_CATALOG_ENTRY_HEADER(point);
 
     SO_KIT_CATALOG_ENTRY_HEADER(_arrowTransform);
     SO_KIT_CATALOG_ENTRY_HEADER(_arrowBodyTranslation);
@@ -143,6 +146,7 @@ public:
     SoSFFloat coneHeight;
     SoSFFloat cylinderHeight;
     SoSFFloat cylinderRadius;
+    SoSFFloat pointRadius;
     SoSFFloat radius;
     SoSFFloat minRadius;
 
@@ -196,6 +200,9 @@ public:
     SoSFFloat arcRadius;
     SoSFFloat minArcRadius;
     SoSFFloat arcThickness;
+    SoSFFloat startAngle;
+    SoSFFloat endAngle;
+    SoSFBool useAngleRange;
     SoSFColor color;
 
 protected:

--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -22,6 +22,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <algorithm>
 #include <limits>
 #include <Mod/Part/App/FCBRepAlgoAPI_Fuse.h>
 #include <BRep_Builder.hxx>
@@ -56,6 +57,14 @@ App::PropertyQuantityConstraint::Constraints FeatureExtrude::signedLengthConstra
     = {-std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), 1.0};
 double FeatureExtrude::maxAngle = 90 - Base::toDegrees<double>(Precision::Angular());
 App::PropertyAngle::Constraints FeatureExtrude::floatAngle = {-maxAngle, maxAngle, 1.0};
+
+namespace
+{
+bool isDimensionMethod(const std::string& method)
+{
+    return method == "Length" || method == "LengthFromOrigin";
+}
+}  // namespace
 
 FeatureExtrude::FeatureExtrude() = default;
 
@@ -224,10 +233,11 @@ void FeatureExtrude::updateProperties()
                                        bool& upToShapeEnabled,
                                        bool& localAlongSketchNormal,
                                        bool& localOffset) {
-        if (method == "Length") {
+        if (isDimensionMethod(method)) {
             lengthEnabled = true;
             taperVisible = true;
             localAlongSketchNormal = true;
+            localOffset = true;
         }
         else if (method == "UpToFace") {
             upToFaceEnabled = true;
@@ -336,18 +346,48 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
     std::string method2(Type2.getValueAsString());
 
     // Validate parameters
+    const bool dimension1 = isDimensionMethod(method);
+    const bool dimension2 = Sidemethod == "Two sides" && isDimensionMethod(method2);
+    double start1 = dimension1 ? Offset.getValue() : 0.0;
+    double start2 = dimension2 ? Offset2.getValue() : 0.0;
+
     double L = method == "ThroughAll" ? getThroughAllLength()
-        : method == "Length"          ? Length.getValue()
+        : dimension1                  ? Length.getValue()
                                       : 0.0;
     double L2 = Sidemethod == "Two sides" ? method2 == "ThroughAll" ? getThroughAllLength()
-            : method2 == "Length"                                   ? Length2.getValue()
+            : dimension2                                            ? Length2.getValue()
                                                                     : 0.0
                                           : 0.0;
 
-    if ((Sidemethod == "One side" && method == "Length")
-        || (Sidemethod == "Two sides" && method == "Length" && method2 == "Length")) {
+    double span1 = dimension1 && method == "LengthFromOrigin" ? L - start1 : L;
+    double span2 = dimension2 && method2 == "LengthFromOrigin" ? L2 - start2 : L2;
+    const double end1 = start1 + span1;
+    const double end2 = start2 + span2;
 
-        if (std::abs(L + L2) < Precision::Confusion()) {
+    if (Sidemethod == "Symmetric" && dimension1
+        && (start1 < -Precision::Confusion() || end1 < -Precision::Confusion())) {
+        return new App::DocumentObjectExecReturn(
+            QT_TRANSLATE_NOOP("Exception", "Start and end must not be negative in symmetric mode.")
+        );
+    }
+
+    if (Sidemethod == "Two sides" && dimension1 && dimension2) {
+        const double minSide1 = std::min(start1, end1);
+        const double minSide2 = std::min(start2, end2);
+        if (minSide1 + minSide2 < -Precision::Confusion()) {
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+                "Exception",
+                "Start and end must not cross beyond the nearest value on the opposite side."
+            ));
+        }
+    }
+
+    if (((Sidemethod == "One side" || Sidemethod == "Symmetric") && dimension1)
+        || (Sidemethod == "Two sides" && dimension1 && dimension2)) {
+        const double totalSpan = Sidemethod == "Two sides" ? std::abs(span1) + std::abs(span2)
+                                                           : std::abs(span1);
+
+        if (totalSpan < Precision::Confusion()) {
             if (addSubType == Type::Additive) {
                 return new App::DocumentObjectExecReturn(
                     QT_TRANSLATE_NOOP("Exception", "Cannot create a pad with a total length of zero.")
@@ -447,7 +487,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
         // to make dir as long that its projection to the SketchVector
         // equals the SketchVector.
         // This is the scalar product of both vectors.
-        // Since the pad length cannot be negative, the factor must not be negative.
+        // Negative dimension spans are handled by reversing the extrusion direction.
 
         double factor = fabs(dir * gp_Dir(SketchVector.x, SketchVector.y, SketchVector.z));
 
@@ -463,6 +503,10 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
         if (AlongSketchNormal.getValue()) {
             L = L / factor;
             L2 = L2 / factor;
+            start1 = start1 / factor;
+            start2 = start2 / factor;
+            span1 = span1 / factor;
+            span2 = span2 / factor;
         }
 
         // explicitly set the Direction so that the dialog shows also the used direction
@@ -483,13 +527,26 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
 
         std::vector<TopoShape> prisms;  // Stores prisms, all in global CS
         double taper1 = TaperAngle.getValue();
-        double offset1 = Offset.getValue();
+        double offset1 = dimension1 ? 0.0 : Offset.getValue();
+
+        auto movedSketchForStart =
+            [](const TopoShape& sourceSketch, double start, const gp_Dir& sideDir) {
+                if (std::fabs(start) <= Precision::Confusion()) {
+                    return sourceSketch;
+                }
+
+                TopoShape movedSketch = sourceSketch.makeElementCopy();
+                gp_Trsf startTransform;
+                startTransform.SetTranslation(gp_Vec(sideDir) * start);
+                movedSketch.move(startTransform);
+                return movedSketch;
+            };
 
         if (Sidemethod == "One side") {
             TopoShape prism1 = generateSingleExtrusionSide(
-                sketchshape,
+                movedSketchForStart(sketchshape, start1, dir),
                 method,
-                L,
+                dimension1 ? span1 : L,
                 taper1,
                 UpToFace,
                 UpToShape,
@@ -504,7 +561,48 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
         else if (Sidemethod == "Symmetric") {
             // For Length mode, we are not doing a mirror, but we extrude along the same axis
             // in both directions as it is what users expect.
-            if (method == "Length") {
+            // LengthFromOrigin behaves the same.
+            if (dimension1 && std::fabs(start1) >= Precision::Confusion()) {
+                gp_Dir dir2 = dir;
+                dir2.Reverse();
+                const double symmetricStart = start1 / 2.0;
+                const double symmetricSpan = span1 / 2.0;
+
+                TopoShape prism1 = generateSingleExtrusionSide(
+                    movedSketchForStart(sketchshape, symmetricStart, dir),
+                    method,
+                    symmetricSpan,
+                    taper1,
+                    UpToFace,
+                    UpToShape,
+                    dir,
+                    offset1,
+                    makeface,
+                    base,
+                    invObjLoc
+                );
+                if (!prism1.isNull() && !prism1.getShape().IsNull()) {
+                    prisms.push_back(prism1);
+                }
+
+                TopoShape prism2 = generateSingleExtrusionSide(
+                    movedSketchForStart(sketchshape, symmetricStart, dir2),
+                    method,
+                    symmetricSpan,
+                    taper1,
+                    UpToFace,
+                    UpToShape,
+                    dir2,
+                    offset1,
+                    makeface,
+                    base,
+                    invObjLoc
+                );
+                if (!prism2.isNull() && !prism2.getShape().IsNull()) {
+                    prisms.push_back(prism2);
+                }
+            }
+            else if (dimension1) {
                 if (std::fabs(taper1) > Precision::Angular()) {
                     // TAPERED case: We must create two separate prisms and fuse them
                     // to ensure the taper originates correctly from the sketch plane in both
@@ -607,15 +705,20 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
         }
         else if (Sidemethod == "Two sides") {
             double taper2 = TaperAngle2.getValue();
-            double offset2 = Offset2.getValue();
+            double offset2 = dimension2 ? 0.0 : Offset2.getValue();
             gp_Dir dir2 = dir;
             dir2.Reverse();
             bool noTaper = std::fabs(taper1) < Precision::Angular()
                 && std::fabs(taper2) < Precision::Angular();
-            bool method1LengthBased = method == "Length" || method == "ThroughAll";
-            bool method2LengthBased = method2 == "Length" || method2 == "ThroughAll";
+            bool method1LengthBased = dimension1 || method == "ThroughAll";
+            bool method2LengthBased = dimension2 || method2 == "ThroughAll";
+            const bool hasDimensionStart = (dimension1 && std::fabs(start1) > Precision::Confusion())
+                || (dimension2 && std::fabs(start2) > Precision::Confusion());
+            const bool nonNegativeSpans = (!dimension1 || span1 >= 0.0)
+                && (!dimension2 || span2 >= 0.0);
 
-            if (method1LengthBased && method2 != "UpToFirst" && noTaper) {
+            if (!hasDimensionStart && nonNegativeSpans && method1LengthBased
+                && method2 != "UpToFirst" && noTaper) {
                 gp_Trsf start_transform;
                 start_transform.SetTranslation(gp_Vec(dir) * L);
 
@@ -638,7 +741,10 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
                     prisms.push_back(prism);
                 }
             }
-            else if (method2LengthBased && method != "UpToFirst" && noTaper) {
+            else if (
+                !hasDimensionStart && nonNegativeSpans && method2LengthBased
+                && method != "UpToFirst" && noTaper
+            ) {
                 gp_Trsf start_transform;
                 start_transform.SetTranslation(gp_Vec(dir).Reversed() * L2);
 
@@ -663,9 +769,9 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
             }
             else {
                 TopoShape prism1 = generateSingleExtrusionSide(
-                    sketchshape.makeElementCopy(),
+                    movedSketchForStart(sketchshape, start1, dir),
                     method,
-                    L,
+                    dimension1 ? span1 : L,
                     taper1,
                     UpToFace,
                     UpToShape,
@@ -681,9 +787,9 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
 
                 // Side 2
                 TopoShape prism2 = generateSingleExtrusionSide(
-                    sketchshape.makeElementCopy(),
+                    movedSketchForStart(sketchshape, start2, dir2),
                     method2,
-                    L2,
+                    dimension2 ? span2 : L2,
                     taper2,
                     UpToFace2,
                     UpToShape2,
@@ -908,8 +1014,16 @@ TopoShape FeatureExtrude::generateSingleExtrusionSide(
             }
         }
     }
-    else if (method == "Length" || method == "ThroughAll") {
+    else if (isDimensionMethod(method) || method == "ThroughAll") {
         using std::numbers::pi;
+
+        if (isDimensionMethod(method) && std::fabs(length) < Precision::Confusion()) {
+            return TopoShape(0);
+        }
+        if (length < 0.0) {
+            dir.Reverse();
+            length = -length;
+        }
 
         Part::ExtrusionParameters params;
         params.taperAngleFwd = Base::toRadians(taperAngleDeg);

--- a/src/Mod/PartDesign/App/FeatureGroove.cpp
+++ b/src/Mod/PartDesign/App/FeatureGroove.cpp
@@ -32,7 +32,7 @@ namespace PartDesign
 /* TRANSLATOR PartDesign::Groove */
 
 const char* Groove::TypeEnums[]
-    = {"Angle", "ThroughAll", "UpToFirst", "UpToFace", "TwoAngles", nullptr};
+    = {"Angle", "ThroughAll", "UpToFirst", "UpToFace", "TwoAngles", "AngleFromOrigin", nullptr};
 
 PROPERTY_SOURCE(PartDesign::Groove, PartDesign::Revolved)
 
@@ -58,7 +58,9 @@ Groove::Groove()
         App::PropertyType(App::Prop_ReadOnly | App::Prop_Hidden),
         "Axis"
     );
+    ADD_PROPERTY_TYPE(StartAngle, (emptyAngle), "Groove", App::Prop_None, "Start angle");
     ADD_PROPERTY_TYPE(Angle, (fullAngle), "Groove", App::Prop_None, "Angle");
+    ADD_PROPERTY_TYPE(StartAngle2, (emptyAngle), "Groove", App::Prop_None, "Start angle in 2nd direction");
     ADD_PROPERTY_TYPE(Angle2, (emptyAngle), "Groove", App::Prop_None, "Groove length in 2nd direction");
     ADD_PROPERTY_TYPE(UpToFace, (nullptr), "Groove", App::Prop_None, "Face where groove will end");
     ADD_PROPERTY_TYPE(ReferenceAxis, (nullptr), "Groove", (App::Prop_None), "Reference axis of groove");

--- a/src/Mod/PartDesign/App/FeaturePad.cpp
+++ b/src/Mod/PartDesign/App/FeaturePad.cpp
@@ -42,8 +42,16 @@ using namespace PartDesign;
 // because the files store the enum index. So it is not possible to migrate files if the
 // enum entry is removed (see #23612). In the distant future, when all files are reasonably
 // migrated we can drop this.
-const char* Pad::TypeEnums[]
-    = {"Length", "UpToLast", "UpToFirst", "UpToFace", "?TwoLengths", "UpToShape", nullptr};
+const char* Pad::TypeEnums[] = {
+    "Length",
+    "UpToLast",
+    "UpToFirst",
+    "UpToFace",
+    "?TwoLengths",
+    "UpToShape",
+    "LengthFromOrigin",
+    nullptr
+};
 
 PROPERTY_SOURCE(PartDesign::Pad, PartDesign::FeatureExtrude)
 

--- a/src/Mod/PartDesign/App/FeaturePocket.cpp
+++ b/src/Mod/PartDesign/App/FeaturePocket.cpp
@@ -43,8 +43,16 @@ using namespace PartDesign;
 // because the files store the enum index. So it is not possible to migrate files if the
 // enum entry is removed (see #23612). In the distant future, when all files are reasonably
 // migrated we can drop this.
-const char* Pocket::TypeEnums[]
-    = {"Length", "ThroughAll", "UpToFirst", "UpToFace", "?TwoLengths", "UpToShape", nullptr};
+const char* Pocket::TypeEnums[] = {
+    "Length",
+    "ThroughAll",
+    "UpToFirst",
+    "UpToFace",
+    "?TwoLengths",
+    "UpToShape",
+    "LengthFromOrigin",
+    nullptr
+};
 
 PROPERTY_SOURCE(PartDesign::Pocket, PartDesign::FeatureExtrude)
 

--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -34,7 +34,7 @@ namespace PartDesign
 /* TRANSLATOR PartDesign::Revolution */
 
 const char* Revolution::TypeEnums[]
-    = {"Angle", "UpToLast", "UpToFirst", "UpToFace", "TwoAngles", nullptr};
+    = {"Angle", "UpToLast", "UpToFirst", "UpToFace", "TwoAngles", "AngleFromOrigin", nullptr};
 
 const char* Revolution::FuseOrderEnums[] = {"BaseFirst", "FeatureFirst", nullptr};
 
@@ -62,7 +62,15 @@ Revolution::Revolution()
         App::PropertyType(App::Prop_ReadOnly | App::Prop_Hidden),
         "Axis"
     );
+    ADD_PROPERTY_TYPE(StartAngle, (emptyAngle), "Revolution", App::Prop_None, "Start angle");
     ADD_PROPERTY_TYPE(Angle, (fullAngle), "Revolution", App::Prop_None, "Angle");
+    ADD_PROPERTY_TYPE(
+        StartAngle2,
+        (emptyAngle),
+        "Revolution",
+        App::Prop_None,
+        "Start angle in 2nd direction"
+    );
     ADD_PROPERTY_TYPE(
         Angle2,
         (emptyAngle),

--- a/src/Mod/PartDesign/App/FeatureRevolved.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolved.cpp
@@ -48,12 +48,15 @@ Revolved::Revolved()
 {
     Angle.setConstraints(&floatAngle);
     Angle2.setConstraints(&floatAngle);
+    StartAngle.setConstraints(&floatAngle);
+    StartAngle2.setConstraints(&floatAngle);
 }
 
 short Revolved::mustExecute() const
 {
     if (Placement.isTouched() || ReferenceAxis.isTouched() || Axis.isTouched() || Base.isTouched()
-        || UpToFace.isTouched() || Angle.isTouched() || Angle2.isTouched()) {
+        || UpToFace.isTouched() || Angle.isTouched() || Angle2.isTouched() || StartAngle.isTouched()
+        || StartAngle2.isTouched()) {
         return 1;
     }
     return ProfileBased::mustExecute();
@@ -90,22 +93,43 @@ App::DocumentObjectExecReturn* Revolved::tryExecuteRevolved(Part::RevolMode revo
     const auto method = static_cast<RevolMethod>(Type.getValue());
 
     // Validate parameters
+    double startAngleDeg = 0.0;
+    double startAngle2Deg = 0.0;
     double angleDeg = Angle.getValue();
-    if (angleDeg > maxDegree) {
+    double angle2Deg = Angle2.getValue();
+
+    if (method == RevolMethod::Angle || method == RevolMethod::AngleFromOrigin
+        || method == RevolMethod::TwoAngles) {
+        startAngleDeg = StartAngle.getValue();
+        if (method != RevolMethod::AngleFromOrigin) {
+            angleDeg += startAngleDeg;
+        }
+    }
+    if (method == RevolMethod::TwoAngles) {
+        startAngle2Deg = StartAngle2.getValue();
+        angle2Deg += startAngle2Deg;
+    }
+
+    if (startAngleDeg > maxDegree || startAngle2Deg > maxDegree || angleDeg > maxDegree
+        || angle2Deg > maxDegree) {
         return new App::DocumentObjectExecReturn(
             QT_TRANSLATE_NOOP("Exception", "Angle of revolution too large")
         );
     }
 
     auto angle = Base::toRadians<double>(angleDeg);
-    if (angle < Precision::Angular() && method == RevolMethod::Angle) {
+    const auto startAngle = Base::toRadians<double>(startAngleDeg);
+    if (angle - startAngle < Precision::Angular()
+        && (method == RevolMethod::Angle || method == RevolMethod::AngleFromOrigin)) {
         return new App::DocumentObjectExecReturn(
             QT_TRANSLATE_NOOP("Exception", "Angle of revolution too small")
         );
     }
 
-    double angle2 = Base::toRadians(Angle2.getValue());
-    if (std::fabs(angle + angle2) < Precision::Angular() && method == RevolMethod::TwoAngles) {
+    double angle2 = Base::toRadians<double>(angle2Deg);
+    const auto startAngle2 = Base::toRadians<double>(startAngle2Deg);
+    if (std::fabs(angle - startAngle + angle2 - startAngle2) < Precision::Angular()
+        && method == RevolMethod::TwoAngles) {
         return new App::DocumentObjectExecReturn(
             QT_TRANSLATE_NOOP("Exception", "Angles of revolution nullify each other")
         );
@@ -185,7 +209,18 @@ App::DocumentObjectExecReturn* Revolved::tryExecuteRevolved(Part::RevolMode revo
     else {
         bool midplane = Midplane.getValue();
         bool reversed = Reversed.getValue();
-        generateRevolution(result, sketchshape, gp_Ax1(pnt, dir), angle, angle2, midplane, reversed, method);
+        generateRevolution(
+            result,
+            sketchshape,
+            gp_Ax1(pnt, dir),
+            angle,
+            angle2,
+            startAngle,
+            startAngle2,
+            midplane,
+            reversed,
+            method
+        );
     }
 
     setResult(base, result);
@@ -316,13 +351,83 @@ void Revolved::generateRevolution(
     const gp_Ax1& axis,
     double angle,
     double angle2,
+    double startAngle,
+    double startAngle2,
     bool midplane,
     bool reversed,
     RevolMethod method
 )
 {
-    if (method == RevolMethod::Angle || method == RevolMethod::TwoAngles
-        || method == RevolMethod::ThroughAll) {
+    const bool hasStart = std::fabs(startAngle) >= Precision::Angular();
+    const bool hasStart2 = std::fabs(startAngle2) >= Precision::Angular();
+    const bool needsSeparatedSegments = method == RevolMethod::TwoAngles ? hasStart || hasStart2
+                                                                         : midplane && hasStart
+            && (method == RevolMethod::Angle || method == RevolMethod::AngleFromOrigin);
+
+    if (needsSeparatedSegments) {
+        gp_Ax1 revolAx(axis);
+        if (reversed) {
+            revolAx.Reverse();
+        }
+
+        auto makeRevolutionSegment = [&](const gp_Ax1& segmentAxis, double start, double end) {
+            const double angleTotal = end - start;
+            if (std::fabs(angleTotal) < Precision::Angular()) {
+                return TopoShape(0);
+            }
+
+            TopoShape from = sketchshape;
+            gp_Trsf movement;
+            movement.SetRotation(segmentAxis, start);
+            from.move(TopLoc_Location(movement));
+
+            // BRepPrimAPI is the only option that allows use of this shape for patterns.
+            // See https://forum.freecad.org/viewtopic.php?f=8&t=70185&p=611673#p611673.
+            TopoShape segment = from.makeElementRevolve(segmentAxis, angleTotal);
+            segment.Tag = -getID();
+            return segment;
+        };
+
+        auto combineSegments = [&](const TopoShape& first, const TopoShape& second) {
+            std::vector<TopoShape> segments;
+            if (!first.isNull() && !first.getShape().IsNull()) {
+                segments.push_back(first);
+            }
+            if (!second.isNull() && !second.getShape().IsNull()) {
+                segments.push_back(second);
+            }
+
+            if (segments.empty()) {
+                throw Base::ValueError("Cannot create a revolution with zero angle.");
+            }
+            if (segments.size() == 1) {
+                revol = segments.front();
+            }
+            else {
+                revol.makeElementFuse(segments);
+                revol.Tag = -getID();
+            }
+        };
+
+        gp_Ax1 revolAx2(revolAx);
+        revolAx2.Reverse();
+        if (method == RevolMethod::TwoAngles) {
+            combineSegments(
+                makeRevolutionSegment(revolAx, startAngle, angle),
+                makeRevolutionSegment(revolAx2, startAngle2, angle2)
+            );
+        }
+        else {
+            combineSegments(
+                makeRevolutionSegment(revolAx, startAngle / 2.0, angle / 2.0),
+                makeRevolutionSegment(revolAx2, startAngle / 2.0, angle / 2.0)
+            );
+        }
+        return;
+    }
+
+    if (method == RevolMethod::Angle || method == RevolMethod::AngleFromOrigin
+        || method == RevolMethod::TwoAngles || method == RevolMethod::ThroughAll) {
         double angleTotal = angle;
         double angleOffset = 0.;
 
@@ -338,6 +443,10 @@ void Revolved::generateRevolution(
             // Rotate the face by half the angle to get Revolution symmetric to sketch plane
             angleOffset = -angle / 2;
         }
+        else {
+            angleTotal -= startAngle;
+            angleOffset = startAngle;
+        }
 
         if (std::fabs(angleTotal) < Precision::Angular()) {
             throw Base::ValueError("Cannot create a revolution with zero angle.");
@@ -349,11 +458,10 @@ void Revolved::generateRevolution(
         }
 
         TopoShape from = sketchshape;
-        if (method == RevolMethod::TwoAngles || midplane) {
+        if (std::fabs(angleOffset) >= Precision::Angular()) {
             gp_Trsf mov;
             mov.SetRotation(revolAx, angleOffset);
-            TopLoc_Location loc(mov);
-            from.move(loc);
+            from.move(TopLoc_Location(mov));
         }
 
         // revolve the face to a solid
@@ -407,13 +515,17 @@ void Revolved::updateProperties(RevolMethod method)
 {
     // disable settings that are not valid on the current method
     // disable everything unless we are sure we need it
+    bool isStartAngleEnabled = false;
     bool isAngleEnabled = false;
+    bool isStartAngle2Enabled = false;
     bool isAngle2Enabled = false;
     bool isMidplaneEnabled = false;
     bool isReversedEnabled = false;
     bool isUpToFaceEnabled = false;
     switch (method) {
         case RevolMethod::Angle:
+        case RevolMethod::AngleFromOrigin:
+            isStartAngleEnabled = true;
             isAngleEnabled = true;
             isMidplaneEnabled = true;
             isReversedEnabled = !Midplane.getValue();
@@ -430,13 +542,17 @@ void Revolved::updateProperties(RevolMethod method)
             isUpToFaceEnabled = true;
             break;
         case RevolMethod::TwoAngles:
+            isStartAngleEnabled = true;
             isAngleEnabled = true;
+            isStartAngle2Enabled = true;
             isAngle2Enabled = true;
             isReversedEnabled = true;
             break;
     }
 
+    StartAngle.setReadOnly(!isStartAngleEnabled);
     Angle.setReadOnly(!isAngleEnabled);
+    StartAngle2.setReadOnly(!isStartAngle2Enabled);
     Angle2.setReadOnly(!isAngle2Enabled);
     Midplane.setReadOnly(!isMidplaneEnabled);
     Reversed.setReadOnly(!isReversedEnabled);

--- a/src/Mod/PartDesign/App/FeatureRevolved.h
+++ b/src/Mod/PartDesign/App/FeatureRevolved.h
@@ -47,6 +47,8 @@ public:
     App::PropertyVector Axis;
     App::PropertyAngle Angle;
     App::PropertyAngle Angle2;
+    App::PropertyAngle StartAngle;
+    App::PropertyAngle StartAngle2;
 
     /** if this property is set to a valid link, both Axis and Base properties
      *  are calculated according to the linked line
@@ -68,7 +70,8 @@ public:
         ToLast = ThroughAll,
         ToFirst,
         ToFace,
-        TwoAngles
+        TwoAngles,
+        AngleFromOrigin
     };
 
 protected:
@@ -111,6 +114,8 @@ private:
         const gp_Ax1& ax1,
         double angle,
         double angle2,
+        double startAngle,
+        double startAngle2,
         bool midplane,
         bool reversed,
         RevolMethod method

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -25,6 +25,9 @@
 #include <QSignalBlocker>
 #include <QAction>
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
 
 #include <App/Document.h>
 #include <Base/Tools.h>
@@ -48,6 +51,11 @@ using namespace Gui;
 
 /* TRANSLATOR PartDesignGui::TaskExtrudeParameters */
 
+namespace
+{
+constexpr double minimumLinearDistance = 1.0e-6;
+}  // namespace
+
 TaskExtrudeParameters::TaskExtrudeParameters(
     ViewProviderExtrude* SketchBasedView,
     QWidget* parent,
@@ -69,6 +77,58 @@ TaskExtrudeParameters::TaskExtrudeParameters(
     group->setExclusive(true);
 
     this->groupLayout()->addWidget(proxy);
+}
+
+bool TaskExtrudeParameters::isDimensionMode(Mode mode)
+{
+    return mode == Mode::Dimension || mode == Mode::DimensionFromOrigin;
+}
+
+bool TaskExtrudeParameters::isDimensionFromStartMode(Mode mode)
+{
+    return mode == Mode::Dimension;
+}
+
+TaskExtrudeParameters::Mode TaskExtrudeParameters::modeFromPropertyType(
+    const App::PropertyEnumeration& type
+)
+{
+    const std::string value = type.getValueAsString();
+    if (value == "LengthFromOrigin") {
+        return Mode::DimensionFromOrigin;
+    }
+    if (value == "ThroughAll" || value == "UpToLast") {
+        return Mode::ThroughAll;
+    }
+    if (value == "UpToFirst") {
+        return Mode::ToFirst;
+    }
+    if (value == "UpToFace") {
+        return Mode::ToFace;
+    }
+    if (value == "UpToShape") {
+        return Mode::ToShape;
+    }
+    return Mode::Dimension;
+}
+
+int TaskExtrudeParameters::propertyTypeIndexFromMode(Mode mode)
+{
+    switch (mode) {
+        case Mode::Dimension:
+            return 0;
+        case Mode::DimensionFromOrigin:
+            return 6;
+        case Mode::ThroughAll:
+            return 1;
+        case Mode::ToFirst:
+            return 2;
+        case Mode::ToFace:
+            return 3;
+        case Mode::ToShape:
+            return 5;
+    }
+    return 0;
 }
 
 void TaskExtrudeParameters::setupDialog()
@@ -130,13 +190,10 @@ void TaskExtrudeParameters::setupSideDialog(SideController& side)
     Base::Quantity length = side.Length->getQuantityValue();
     Base::Quantity offset = side.Offset->getQuantityValue();
     Base::Quantity taper = side.TaperAngle->getQuantityValue();
-    int typeIndex = side.Type->getValue();
     // The Type/Type2 properties are stuck with the deprecated 'TwoLength' mode.
     // Because enums do not store text just an index. So this create
     // a inconsistence between the UI and the property.
-    if (typeIndex > static_cast<int>(Mode::ToShape)) {
-        typeIndex--;
-    }
+    int typeIndex = static_cast<int>(modeFromPropertyType(*side.Type));
 
     // --- Set up UI widgets with initial values ---
     side.lengthEdit->setValue(length);
@@ -264,6 +321,7 @@ void TaskExtrudeParameters::readValuesFromHistory()
     ui->taperEdit->selectNumber();
     ui->taperEdit2->setToLastUsedValue();
     ui->taperEdit2->selectNumber();
+    syncDimensionLimits();
 }
 
 void TaskExtrudeParameters::connectSlots()
@@ -636,14 +694,168 @@ std::vector<std::string> PartDesignGui::TaskExtrudeParameters::getShapeFaces(
 
 void TaskExtrudeParameters::onLengthChanged(double len, Side side)
 {
-    getSideController(side).Length->setValue(len);
+    auto& sideController = getSideController(side);
+    sideController.Length->setValue(len);
+    syncDimensionLimits();
     tryRecomputeFeature();
+    setGizmoPositions();
 }
 
 void TaskExtrudeParameters::onOffsetChanged(double len, Side side)
 {
-    getSideController(side).Offset->setValue(len);
+    auto& sideController = getSideController(side);
+    sideController.Offset->setValue(len);
+    syncDimensionLimits();
     tryRecomputeFeature();
+    setGizmoPositions();
+}
+
+bool TaskExtrudeParameters::sideUsesDimension(Side side) const
+{
+    const auto& sideController = side == Side::First ? m_side1 : m_side2;
+    return isDimensionMode(modeFromPropertyType(*sideController.Type));
+}
+
+bool TaskExtrudeParameters::sideUsesDistanceFromStart(Side side) const
+{
+    const auto& sideController = side == Side::First ? m_side1 : m_side2;
+    return isDimensionFromStartMode(modeFromPropertyType(*sideController.Type));
+}
+
+double TaskExtrudeParameters::sideEndPosition(const SideController& side) const
+{
+    const double start = side.offsetEdit->value().getValue();
+    const double distance = side.lengthEdit->value().getValue();
+    return isDimensionFromStartMode(modeFromPropertyType(*side.Type)) ? start + distance : distance;
+}
+
+double TaskExtrudeParameters::sideSpan(const SideController& side) const
+{
+    return std::abs(sideEndPosition(side) - side.offsetEdit->value().getValue());
+}
+
+void TaskExtrudeParameters::syncDimensionLimits()
+{
+    auto syncSide = [this](
+                        SideController& side,
+                        bool dimensionMode,
+                        bool distanceFromStart,
+                        double rangeMinimum,
+                        bool forceNonZeroDistance
+                    ) {
+        QSignalBlocker startBlock(side.offsetEdit);
+        QSignalBlocker distanceBlock(side.lengthEdit);
+
+        const double startPropertyMinimum = side.Offset->getMinimum();
+        const double startPropertyMaximum = side.Offset->getMaximum();
+        const double distancePropertyMinimum = side.Length->getConstraints()
+            ? side.Length->getMinimum()
+            : -std::numeric_limits<double>::max();
+        const double distancePropertyMaximum = side.Length->getMaximum();
+
+        side.offsetEdit->setMinimum(startPropertyMinimum);
+        side.offsetEdit->setMaximum(startPropertyMaximum);
+        side.lengthEdit->setMinimum(distancePropertyMinimum);
+        side.lengthEdit->setMaximum(distancePropertyMaximum);
+
+        if (!dimensionMode) {
+            return;
+        }
+
+        const double coordinateMaximum = std::min(startPropertyMaximum, distancePropertyMaximum);
+        const double coordinateMinimum
+            = std::min(coordinateMaximum, std::max(rangeMinimum, startPropertyMinimum));
+
+        double start
+            = std::clamp(side.offsetEdit->value().getValue(), coordinateMinimum, startPropertyMaximum);
+        double distance = side.lengthEdit->value().getValue();
+        double end = distanceFromStart ? start + distance : distance;
+
+        if (distanceFromStart) {
+            const double distanceMinimum = std::max(distancePropertyMinimum, coordinateMinimum - start);
+            const double distanceMaximum = std::min(distancePropertyMaximum, coordinateMaximum - start);
+            distance = std::clamp(distance, distanceMinimum, distanceMaximum);
+            end = start + distance;
+        }
+        else {
+            end = std::clamp(end, coordinateMinimum, coordinateMaximum);
+            distance = end;
+        }
+
+        if (forceNonZeroDistance && std::fabs(end - start) < minimumLinearDistance) {
+            double adjustedEnd = start + minimumLinearDistance;
+            if (adjustedEnd > coordinateMaximum) {
+                adjustedEnd = start - minimumLinearDistance;
+            }
+            end = std::clamp(adjustedEnd, coordinateMinimum, coordinateMaximum);
+            distance = distanceFromStart ? end - start : end;
+        }
+
+        side.offsetEdit->setValue(start);
+        side.lengthEdit->setValue(distance);
+        side.Offset->setValue(start);
+        side.Length->setValue(distance);
+
+        if (distanceFromStart) {
+            const double distanceMinimum = std::max(distancePropertyMinimum, coordinateMinimum - start);
+            const double distanceMaximum = std::min(distancePropertyMaximum, coordinateMaximum - start);
+            const double startMinimum = std::max(coordinateMinimum, coordinateMinimum - distance);
+            const double startMaximum = std::min(startPropertyMaximum, coordinateMaximum - distance);
+
+            side.offsetEdit->setMinimum(std::min(startMinimum, startMaximum));
+            side.offsetEdit->setMaximum(std::max(startMinimum, startMaximum));
+            side.lengthEdit->setMinimum(std::min(distanceMinimum, distanceMaximum));
+            side.lengthEdit->setMaximum(std::max(distanceMinimum, distanceMaximum));
+        }
+        else {
+            side.offsetEdit->setMinimum(coordinateMinimum);
+            side.offsetEdit->setMaximum(startPropertyMaximum);
+            side.lengthEdit->setMinimum(std::max(distancePropertyMinimum, coordinateMinimum));
+            side.lengthEdit->setMaximum(std::min(distancePropertyMaximum, coordinateMaximum));
+        }
+    };
+
+    const auto sidesMode = static_cast<SidesMode>(ui->sidesMode->currentIndex());
+    const bool side1Dimension = sideUsesDimension(Side::First);
+    const bool side2Dimension = sidesMode == SidesMode::TwoSides && sideUsesDimension(Side::Second);
+
+    double side1RangeMinimum = m_side1.Offset->getMinimum();
+    double side2RangeMinimum = m_side2.Offset->getMinimum();
+
+    if (sidesMode == SidesMode::Symmetric) {
+        side1RangeMinimum = std::max(0.0, side1RangeMinimum);
+    }
+    else if (sidesMode == SidesMode::TwoSides) {
+        if (side2Dimension) {
+            const double side2Start = m_side2.offsetEdit->value().getValue();
+            const double side2End = sideEndPosition(m_side2);
+            side1RangeMinimum = std::max(side1RangeMinimum, -std::min(side2Start, side2End));
+        }
+        syncSide(m_side1, side1Dimension, sideUsesDistanceFromStart(Side::First), side1RangeMinimum, false);
+
+        if (side1Dimension) {
+            const double side1Start = m_side1.offsetEdit->value().getValue();
+            const double side1End = sideEndPosition(m_side1);
+            side2RangeMinimum = std::max(side2RangeMinimum, -std::min(side1Start, side1End));
+        }
+        syncSide(m_side2, side2Dimension, sideUsesDistanceFromStart(Side::Second), side2RangeMinimum, false);
+
+        if (side1Dimension && side2Dimension) {
+            const double side1Start = m_side1.offsetEdit->value().getValue();
+            const double side1End = sideEndPosition(m_side1);
+            const double side2Start = m_side2.offsetEdit->value().getValue();
+            const double side2End = sideEndPosition(m_side2);
+            const bool side1Zero = std::fabs(side1End - side1Start) < minimumLinearDistance;
+            const bool side2Zero = std::fabs(side2End - side2Start) < minimumLinearDistance;
+            if (side1Zero && side2Zero) {
+                syncSide(m_side1, true, sideUsesDistanceFromStart(Side::First), side1RangeMinimum, true);
+            }
+        }
+        return;
+    }
+
+    syncSide(m_side1, side1Dimension, sideUsesDistanceFromStart(Side::First), side1RangeMinimum, true);
+    syncSide(m_side2, false, false, side2RangeMinimum, false);
 }
 
 void TaskExtrudeParameters::onTaperChanged(double angle, Side side)
@@ -781,7 +993,8 @@ void TaskExtrudeParameters::updateWholeUI(Type type, Side side)
     // Side 2 is only visible if in TwoSides mode, and we pass whether it should receive focus.
     updateSideUI(m_side2, type, mode2, isSide2GroupVisible, (side == Side::Second));
 
-    ui->checkBoxReversed->setEnabled(sidesMode != SidesMode::Symmetric || mode1 != Mode::Dimension);
+    ui->checkBoxReversed->setEnabled(sidesMode != SidesMode::Symmetric || !isDimensionMode(mode1));
+    syncDimensionLimits();
 }
 
 void TaskExtrudeParameters::updateSideUI(
@@ -792,6 +1005,13 @@ void TaskExtrudeParameters::updateSideUI(
     bool setFocus
 )
 {
+    const bool dimensionMode = isDimensionMode(sideMode);
+
+    if (dimensionMode) {
+        s.labelOffset->setText(tr("Start"));
+        s.offsetEdit->setToolTip(tr("Start position"));
+    }
+
     // Default states for all controls for this side
     bool isLengthVisible = false;
     bool isOffsetVisible = false;
@@ -800,8 +1020,9 @@ void TaskExtrudeParameters::updateSideUI(
     bool isShapeVisible = false;
 
     // This logic block is a direct translation of the original 'if/else if' chain
-    if (sideMode == Mode::Dimension) {
+    if (dimensionMode) {
         isLengthVisible = true;
+        isOffsetVisible = true;
         isTaperVisible = true;
         if (setFocus) {
             s.lengthEdit->selectNumber();
@@ -811,14 +1032,7 @@ void TaskExtrudeParameters::updateSideUI(
     else if (sideMode == Mode::ThroughAll && featureType == Type::Pocket) {
         isTaperVisible = true;
     }
-    else if (sideMode == Mode::ToLast && featureType == Type::Pad) {
-        isOffsetVisible = true;
-    }
-    else if (sideMode == Mode::ToFirst) {
-        isOffsetVisible = true;
-    }
     else if (sideMode == Mode::ToFace) {
-        isOffsetVisible = true;
         isFaceVisible = true;
         if (setFocus) {
             QMetaObject::invokeMethod(s.lineFaceName, "setFocus", Qt::QueuedConnection);
@@ -1282,6 +1496,8 @@ void TaskExtrudeParameters::saveHistory()
 
 void TaskExtrudeParameters::applyParameters()
 {
+    syncDimensionLimits();
+
     auto obj = getObject();
 
     QString facename = QStringLiteral("None");
@@ -1294,14 +1510,8 @@ void TaskExtrudeParameters::applyParameters()
     }
 
     // Handle deprecated 'TwoLength' mode.
-    int type1 = getMode();
-    if (static_cast<Mode>(type1) == Mode::ToShape) {
-        type1++;
-    }
-    int type2 = getMode2();
-    if (static_cast<Mode>(type2) == Mode::ToShape) {
-        type2++;
-    }
+    int type1 = propertyTypeIndexFromMode(static_cast<Mode>(getMode()));
+    int type2 = propertyTypeIndexFromMode(static_cast<Mode>(getMode2()));
 
     ui->lengthEdit->apply();
     ui->lengthEdit2->apply();
@@ -1342,6 +1552,7 @@ void TaskExtrudeParameters::onSidesModeChanged(int index)
             break;
     }
 
+    syncDimensionLimits();
     recomputeFeature();
 }
 
@@ -1380,7 +1591,9 @@ void TaskExtrudeParameters::setupGizmos()
         return;
     }
 
+    startGizmo1 = new Gui::LinearGizmo(ui->offsetEdit);
     lengthGizmo1 = new Gui::LinearGizmo(ui->lengthEdit);
+    startGizmo2 = new Gui::LinearGizmo(ui->offsetEdit2);
     lengthGizmo2 = new Gui::LinearGizmo(ui->lengthEdit2);
     taperAngleGizmo1 = new Gui::RotationGizmo(ui->taperEdit);
     taperAngleGizmo2 = new Gui::RotationGizmo(ui->taperEdit2);
@@ -1390,9 +1603,12 @@ void TaskExtrudeParameters::setupGizmos()
     });
 
     gizmoContainer = GizmoContainer::create(
-        {lengthGizmo1, lengthGizmo2, taperAngleGizmo1, taperAngleGizmo2},
+        {startGizmo1, lengthGizmo1, startGizmo2, lengthGizmo2, taperAngleGizmo1, taperAngleGizmo2},
         vp
     );
+
+    startGizmo1->setPointStyle();
+    startGizmo2->setPointStyle();
 
     setGizmoPositions();
     showDraggerHints();
@@ -1418,14 +1634,12 @@ void TaskExtrudeParameters::setGizmoPositions()
     std::string extrudeType2 = std::string(extrude->Type2.getValueAsString());
     double dir = extrude->Reversed.getValue() ? -1 : 1;
 
-    lengthGizmo1->Gizmo::setDraggerPlacement(center, extrude->Direction.getValue() * dir);
-    lengthGizmo1->setVisibility(extrudeType == "Length");
-    taperAngleGizmo1->placeOverLinearGizmo(lengthGizmo1);
-    taperAngleGizmo1->setVisibility(extrudeType == "Length");
-    lengthGizmo2->Gizmo::setDraggerPlacement(center, -extrude->Direction.getValue() * dir);
-    lengthGizmo2->setVisibility(sideType == "Two sides" && extrudeType2 == "Length");
-    taperAngleGizmo2->placeOverLinearGizmo(lengthGizmo2);
-    taperAngleGizmo2->setVisibility(sideType == "Two sides" && extrudeType2 == "Length");
+    const bool isDimension1 = extrudeType == "Length" || extrudeType == "LengthFromOrigin";
+    const bool isDimension2 = extrudeType2 == "Length" || extrudeType2 == "LengthFromOrigin";
+    const bool showStartGizmo1 = isDimension1;
+    const bool showStartGizmo2 = sideType == "Two sides" && isDimension2;
+    const bool distanceFromStart1 = extrudeType == "Length";
+    const bool distanceFromStart2 = extrudeType2 == "Length";
 
     Base::Vector3d padDir = extrude->Direction.getValue().Normalized();
     Base::Vector3d sketchDir = extrude->getProfileNormal().Normalized();
@@ -1437,13 +1651,64 @@ void TaskExtrudeParameters::setGizmoPositions()
     // and symmetric option influence the multFactor. If some custom gizmos changes
     // it then that also should be handled properly here
     if (extrude->AlongSketchNormal.getValue()) {
+        startGizmo1->setMultFactor(multFactor / lengthFactor);
         lengthGizmo1->setMultFactor(multFactor / lengthFactor);
+        startGizmo2->setMultFactor(multFactor / lengthFactor);
         lengthGizmo2->setMultFactor(multFactor / lengthFactor);
     }
     else {
+        startGizmo1->setMultFactor(multFactor);
         lengthGizmo1->setMultFactor(multFactor);
+        startGizmo2->setMultFactor(multFactor);
         lengthGizmo2->setMultFactor(multFactor);
     }
+
+    auto setLinearGizmoRange = [](Gui::LinearGizmo* startGizmo,
+                                  Gui::LinearGizmo* distanceGizmo,
+                                  const Base::Vector3d& center,
+                                  const Base::Vector3d& direction,
+                                  double start,
+                                  double factor,
+                                  bool distanceFromStart) {
+        startGizmo->Gizmo::setDraggerPlacement(center, direction);
+
+        Base::Vector3d distanceBase = center;
+        if (distanceFromStart) {
+            Base::Vector3d unitDirection = direction;
+            unitDirection.Normalize();
+            distanceBase += unitDirection * start * factor;
+        }
+        distanceGizmo->Gizmo::setDraggerPlacement(distanceBase, direction);
+        distanceGizmo->setBaseStart(distanceFromStart ? 0.0 : start * factor);
+    };
+
+    setLinearGizmoRange(
+        startGizmo1,
+        lengthGizmo1,
+        center,
+        extrude->Direction.getValue() * dir,
+        ui->offsetEdit->value().getValue(),
+        multFactor,
+        distanceFromStart1
+    );
+    startGizmo1->setVisibility(showStartGizmo1);
+    lengthGizmo1->setVisibility(isDimension1);
+    taperAngleGizmo1->placeOverLinearGizmo(lengthGizmo1);
+    taperAngleGizmo1->setVisibility(isDimension1);
+
+    setLinearGizmoRange(
+        startGizmo2,
+        lengthGizmo2,
+        center,
+        -extrude->Direction.getValue() * dir,
+        ui->offsetEdit2->value().getValue(),
+        multFactor,
+        distanceFromStart2
+    );
+    startGizmo2->setVisibility(showStartGizmo2);
+    lengthGizmo2->setVisibility(sideType == "Two sides" && isDimension2);
+    taperAngleGizmo2->placeOverLinearGizmo(lengthGizmo2);
+    taperAngleGizmo2->setVisibility(sideType == "Two sides" && isDimension2);
 
     gizmoContainer->calculateScaleAndOrientation();
 }

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.h
@@ -98,6 +98,7 @@ public:
     enum class Mode
     {
         Dimension,
+        DimensionFromOrigin,
         ThroughAll,
         ToLast = ThroughAll,
         ToFirst,
@@ -188,10 +189,17 @@ private Q_SLOTS:
     void onReversedChanged(bool);
 
 private:
+    static Mode modeFromPropertyType(const App::PropertyEnumeration& type);
+    static int propertyTypeIndexFromMode(Mode mode);
+
     void onModeChanged_Side1(int index);
     void onModeChanged_Side2(int index);
     void onLengthChanged(double len, Side side);
     void onOffsetChanged(double len, Side side);
+    bool sideUsesDimension(Side side) const;
+    bool sideUsesDistanceFromStart(Side side) const;
+    double sideEndPosition(const SideController& side) const;
+    void syncDimensionLimits();
     void onTaperChanged(double angle, Side side);
     void onSelectFaceToggle(bool checked, Side side);
 
@@ -202,6 +210,10 @@ private:
     void onUnselectShapeFacesTrigger(Side side);
 
 protected:
+    static bool isDimensionMode(Mode mode);
+    static bool isDimensionFromStartMode(Mode mode);
+    double sideSpan(const SideController& side) const;
+
     void updateWholeUI(Type type, Side side);
     void updateSideUI(
         const SideController& s,
@@ -262,7 +274,9 @@ private:
     void createSideControllers();
 
     std::unique_ptr<Gui::GizmoContainer> gizmoContainer;
+    Gui::LinearGizmo* startGizmo1 = nullptr;
     Gui::LinearGizmo* lengthGizmo1 = nullptr;
+    Gui::LinearGizmo* startGizmo2 = nullptr;
     Gui::LinearGizmo* lengthGizmo2 = nullptr;
     Gui::RotationGizmo* taperAngleGizmo1 = nullptr;
     Gui::RotationGizmo* taperAngleGizmo2 = nullptr;

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
@@ -70,7 +70,8 @@ TaskPadParameters::~TaskPadParameters() = default;
 void TaskPadParameters::translateModeList(QComboBox* box, int index)
 {
     box->clear();
-    box->addItem(tr("Dimension"));
+    box->addItem(tr("Dimension from start"));
+    box->addItem(tr("Dimension from origin"));
     box->addItem(tr("To last"));
     box->addItem(tr("To first"));
     box->addItem(tr("Up to face"));
@@ -92,16 +93,19 @@ void TaskPadParameters::onModeChanged(int index, Side side)
 
     switch (static_cast<Mode>(index)) {
         case Mode::Dimension:
-            sideCtrl.Type->setValue("Length");
+        case Mode::DimensionFromOrigin:
+            sideCtrl.Type->setValue(
+                isDimensionFromStartMode(static_cast<Mode>(index)) ? "Length" : "LengthFromOrigin"
+            );
             if (side == Side::First) {
                 // Avoid error message
-                double L = sideCtrl.lengthEdit->value().getValue();
+                double L = sideSpan(sideCtrl);
                 Side otherSide = side == Side::First ? Side::Second : Side::First;
                 auto& sideCtrl2 = getSideController(otherSide);
                 double L2 = static_cast<SidesMode>(getSidesMode()) == SidesMode::TwoSides
-                    ? sideCtrl2.lengthEdit->value().getValue()
+                    ? sideSpan(sideCtrl2)
                     : 0;
-                if (std::abs(L + L2) < Precision::Confusion()) {
+                if (L + L2 < Precision::Confusion()) {
                     sideCtrl.lengthEdit->setValue(5.0);
                 }
             }

--- a/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
@@ -79,14 +79,14 @@
       </widget>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="labelLength">
+      <widget class="QLabel" name="labelOffset">
        <property name="text">
-        <string>Length</string>
+        <string>Offset to face</string>
        </property>
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="Gui::PrefQuantitySpinBox" name="lengthEdit" native="true">
+      <widget class="Gui::PrefQuantitySpinBox" name="offsetEdit" native="true">
        <property name="keyboardTracking" stdset="0">
         <bool>false</bool>
        </property>
@@ -96,14 +96,14 @@
       </widget>
      </item>
      <item row="4" column="0">
-      <widget class="QLabel" name="labelOffset">
+      <widget class="QLabel" name="labelLength">
        <property name="text">
-        <string>Offset to face</string>
+        <string>Length</string>
        </property>
       </widget>
      </item>
      <item row="4" column="1">
-      <widget class="Gui::PrefQuantitySpinBox" name="offsetEdit" native="true">
+      <widget class="Gui::PrefQuantitySpinBox" name="lengthEdit" native="true">
        <property name="keyboardTracking" stdset="0">
         <bool>false</bool>
        </property>
@@ -308,14 +308,14 @@
       <widget class="QComboBox" name="changeMode2"/>
      </item>
      <item row="10" column="0">
-      <widget class="QLabel" name="labelLength2">
+      <widget class="QLabel" name="labelOffset2">
        <property name="text">
-        <string>Length</string>
+        <string>Offset to face</string>
        </property>
       </widget>
      </item>
      <item row="10" column="1">
-      <widget class="Gui::PrefQuantitySpinBox" name="lengthEdit2" native="true">
+      <widget class="Gui::PrefQuantitySpinBox" name="offsetEdit2" native="true">
        <property name="keyboardTracking" stdset="0">
         <bool>false</bool>
        </property>
@@ -325,14 +325,14 @@
       </widget>
      </item>
      <item row="11" column="0">
-      <widget class="QLabel" name="labelOffset2">
+      <widget class="QLabel" name="labelLength2">
        <property name="text">
-        <string>Offset to face</string>
+        <string>Length</string>
        </property>
       </widget>
      </item>
      <item row="11" column="1">
-      <widget class="Gui::PrefQuantitySpinBox" name="offsetEdit2" native="true">
+      <widget class="Gui::PrefQuantitySpinBox" name="lengthEdit2" native="true">
        <property name="keyboardTracking" stdset="0">
         <bool>false</bool>
        </property>

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
@@ -74,7 +74,8 @@ TaskPocketParameters::~TaskPocketParameters() = default;
 void TaskPocketParameters::translateModeList(QComboBox* box, int index)
 {
     box->clear();
-    box->addItem(tr("Dimension"));
+    box->addItem(tr("Dimension from start"));
+    box->addItem(tr("Dimension from origin"));
     box->addItem(tr("Through all"));
     box->addItem(tr("To first"));
     box->addItem(tr("Up to face"));
@@ -96,16 +97,19 @@ void TaskPocketParameters::onModeChanged(int index, Side side)
 
     switch (static_cast<Mode>(index)) {
         case Mode::Dimension:
-            sideCtrl.Type->setValue("Length");
+        case Mode::DimensionFromOrigin:
+            sideCtrl.Type->setValue(
+                isDimensionFromStartMode(static_cast<Mode>(index)) ? "Length" : "LengthFromOrigin"
+            );
             if (side == Side::First) {
                 // Avoid error message
-                double L = sideCtrl.lengthEdit->value().getValue();
+                double L = sideSpan(sideCtrl);
                 Side otherSide = side == Side::First ? Side::Second : Side::First;
                 auto& sideCtrl2 = getSideController(otherSide);
                 double L2 = static_cast<SidesMode>(getSidesMode()) == SidesMode::TwoSides
-                    ? sideCtrl2.lengthEdit->value().getValue()
+                    ? sideSpan(sideCtrl2)
                     : 0;
-                if (std::abs(L + L2) < Precision::Confusion()) {
+                if (L + L2 < Precision::Confusion()) {
                     sideCtrl.lengthEdit->setValue(5.0);
                 }
             }

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
@@ -22,6 +22,12 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <QSignalBlocker>
+
+#include <algorithm>
+
+#include <Inventor/SbRotation.h>
+
 #include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <App/Origin.h>
@@ -50,6 +56,61 @@ using namespace Gui;
 
 /* TRANSLATOR PartDesignGui::TaskRevolutionParameters */
 
+namespace
+{
+constexpr double minimumRevolveAngle = 1.0e-7;
+
+bool isSingleAngleMethod(PartDesign::Revolution::RevolMethod mode)
+{
+    return mode == PartDesign::Revolution::RevolMethod::Angle
+        || mode == PartDesign::Revolution::RevolMethod::AngleFromOrigin;
+}
+
+bool isAngleFromStartMethod(PartDesign::Revolution::RevolMethod mode)
+{
+    return mode == PartDesign::Revolution::RevolMethod::Angle
+        || mode == PartDesign::Revolution::RevolMethod::TwoAngles;
+}
+
+PartDesign::Revolution::RevolMethod modeFromUiIndex(int index)
+{
+    switch (index) {
+        case 1:
+            return PartDesign::Revolution::RevolMethod::AngleFromOrigin;
+        case 2:
+            return PartDesign::Revolution::RevolMethod::ThroughAll;
+        case 3:
+            return PartDesign::Revolution::RevolMethod::ToFirst;
+        case 4:
+            return PartDesign::Revolution::RevolMethod::ToFace;
+        case 5:
+            return PartDesign::Revolution::RevolMethod::TwoAngles;
+        default:
+            return PartDesign::Revolution::RevolMethod::Angle;
+    }
+}
+
+int uiIndexFromMode(PartDesign::Revolution::RevolMethod mode)
+{
+    switch (mode) {
+        case PartDesign::Revolution::RevolMethod::AngleFromOrigin:
+            return 1;
+        case PartDesign::Revolution::RevolMethod::ThroughAll:
+            return 2;
+        case PartDesign::Revolution::RevolMethod::ToFirst:
+            return 3;
+        case PartDesign::Revolution::RevolMethod::ToFace:
+            return 4;
+        case PartDesign::Revolution::RevolMethod::TwoAngles:
+            return 5;
+        case PartDesign::Revolution::RevolMethod::Angle:
+        default:
+            return 0;
+    }
+}
+
+}  // namespace
+
 TaskRevolutionParameters::TaskRevolutionParameters(
     PartDesignGui::ViewProvider* RevolutionView,
     const char* pixname,
@@ -70,13 +131,17 @@ TaskRevolutionParameters::TaskRevolutionParameters(
     // bind property mirrors
     if (auto rev = getObject<PartDesign::Revolved>()) {
         isGroove = rev->getAddSubType() == PartDesign::Revolved::Subtractive;
+        this->propStartAngle = &(rev->StartAngle);
         this->propAngle = &(rev->Angle);
+        this->propStartAngle2 = &(rev->StartAngle2);
         this->propAngle2 = &(rev->Angle2);
         this->propMidPlane = &(rev->Midplane);
         this->propReferenceAxis = &(rev->ReferenceAxis);
         this->propReversed = &(rev->Reversed);
         this->propUpToFace = &(rev->UpToFace);
+        ui->revolveStartAngle->bind(rev->StartAngle);
         ui->revolveAngle->bind(rev->Angle);
+        ui->revolveStartAngle2->bind(rev->StartAngle2);
         ui->revolveAngle2->bind(rev->Angle2);
     }
     else {
@@ -123,6 +188,10 @@ void TaskRevolutionParameters::setupDialog()
     ui->checkBoxMidplane->setChecked(propMidPlane->getValue());
     ui->checkBoxReversed->setChecked(propReversed->getValue());
 
+    ui->revolveStartAngle->setValue(propStartAngle->getValue());
+    ui->revolveStartAngle->setMaximum(propStartAngle->getMaximum());
+    ui->revolveStartAngle->setMinimum(propStartAngle->getMinimum());
+
     ui->revolveAngle->setValue(propAngle->getValue());
     ui->revolveAngle->setMaximum(propAngle->getMaximum());
     ui->revolveAngle->setMinimum(propAngle->getMinimum());
@@ -160,19 +229,26 @@ void TaskRevolutionParameters::setupDialog()
     int index = 0;
 
     auto rev = getObject<PartDesign::Revolved>();
+    ui->revolveStartAngle2->setValue(propStartAngle2->getValue());
+    ui->revolveStartAngle2->setMaximum(propStartAngle2->getMaximum());
+    ui->revolveStartAngle2->setMinimum(propStartAngle2->getMinimum());
+
     ui->revolveAngle2->setValue(propAngle2->getValue());
     ui->revolveAngle2->setMaximum(propAngle2->getMaximum());
     ui->revolveAngle2->setMinimum(propAngle2->getMinimum());
 
-    index = int(rev->Type.getValue());
-
+    index = uiIndexFromMode(static_cast<PartDesign::Revolution::RevolMethod>(rev->Type.getValue()));
     translateModeList(index);
+
+    syncAngleLimits(false);
+    syncAngleLimits(true);
 }
 
 void TaskRevolutionParameters::translateModeList(int index)
 {
     ui->changeMode->clear();
-    ui->changeMode->addItem(tr("Angle"));
+    ui->changeMode->addItem(tr("Angle from start"));
+    ui->changeMode->addItem(tr("Angle from origin"));
     if (!isGroove) {
         ui->changeMode->addItem(tr("To last"));
     }
@@ -281,7 +357,7 @@ void TaskRevolutionParameters::setCheckboxes(PartDesign::Revolution::RevolMethod
     bool isReversedEnabled = false;
     bool isFaceEditEnabled = false;
 
-    if (mode == PartDesign::Revolution::RevolMethod::Angle) {
+    if (isSingleAngleMethod(mode)) {
         isRevolveAngleVisible = true;
         ui->revolveAngle->selectNumber();
         QMetaObject::invokeMethod(ui->revolveAngle, "setFocus", Qt::QueuedConnection);
@@ -313,9 +389,17 @@ void TaskRevolutionParameters::setCheckboxes(PartDesign::Revolution::RevolMethod
         isReversedEnabled = true;
     }
 
+    ui->revolveStartAngle->setVisible(isRevolveAngleVisible);
+    ui->revolveStartAngle->setEnabled(isRevolveAngleVisible);
+    ui->labelStartAngle->setVisible(isRevolveAngleVisible);
+
     ui->revolveAngle->setVisible(isRevolveAngleVisible);
     ui->revolveAngle->setEnabled(isRevolveAngleVisible);
     ui->labelAngle->setVisible(isRevolveAngleVisible);
+
+    ui->revolveStartAngle2->setVisible(isRevolveAngle2Visible);
+    ui->revolveStartAngle2->setEnabled(isRevolveAngle2Visible);
+    ui->labelStartAngle2->setVisible(isRevolveAngle2Visible);
 
     ui->revolveAngle2->setVisible(isRevolveAngle2Visible);
     ui->revolveAngle2->setEnabled(isRevolveAngle2Visible);
@@ -333,13 +417,20 @@ void TaskRevolutionParameters::setCheckboxes(PartDesign::Revolution::RevolMethod
     if (!isFaceEditEnabled) {
         ui->buttonFace->setChecked(false);
     }
+
+    syncAngleLimits(false);
+    syncAngleLimits(true);
 }
 
 void TaskRevolutionParameters::connectSignals()
 {
     // clang-format off
+    connect(ui->revolveStartAngle, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
+            this, &TaskRevolutionParameters::onStartAngleChanged);
     connect(ui->revolveAngle, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
             this, &TaskRevolutionParameters::onAngleChanged);
+    connect(ui->revolveStartAngle2, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
+            this, &TaskRevolutionParameters::onStartAngle2Changed);
     connect(ui->revolveAngle2, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
             this, &TaskRevolutionParameters::onAngle2Changed);
     connect(ui->axis, qOverload<int>(&QComboBox::activated),
@@ -367,7 +458,89 @@ void TaskRevolutionParameters::updateUI(int index)
 
     Base::StateLocker lock(getUpdateBlockRef(), true);
     fillAxisCombo();
-    setCheckboxes(static_cast<PartDesign::Revolution::RevolMethod>(index));
+    setCheckboxes(modeFromUiIndex(index));
+}
+
+void TaskRevolutionParameters::syncAngleLimits(bool secondSide)
+{
+    auto* startEdit = secondSide ? ui->revolveStartAngle2 : ui->revolveStartAngle;
+    auto* angleEdit = secondSide ? ui->revolveAngle2 : ui->revolveAngle;
+    auto* startProperty = secondSide ? propStartAngle2 : propStartAngle;
+    auto* angleProperty = secondSide ? propAngle2 : propAngle;
+
+    QSignalBlocker startBlock(startEdit);
+    QSignalBlocker angleBlock(angleEdit);
+
+    const double startMinimum = startProperty->getMinimum();
+    const double startMaximum = startProperty->getMaximum();
+    const double angleMinimum = angleProperty->getMinimum();
+    const double angleMaximum = angleProperty->getMaximum();
+
+    startEdit->setMinimum(startMinimum);
+    startEdit->setMaximum(startMaximum);
+    angleEdit->setMinimum(angleMinimum);
+    angleEdit->setMaximum(angleMaximum);
+
+    const auto mode = modeFromUiIndex(ui->changeMode->currentIndex());
+    const bool active = secondSide
+        ? mode == PartDesign::Revolution::RevolMethod::TwoAngles
+        : isSingleAngleMethod(mode) || mode == PartDesign::Revolution::RevolMethod::TwoAngles;
+    if (!active) {
+        return;
+    }
+
+    const bool angleFromStart = secondSide || isAngleFromStartMethod(mode);
+    const bool forceNonZero = mode != PartDesign::Revolution::RevolMethod::TwoAngles;
+
+    double start = startEdit->value().getValue();
+    double angle = angleEdit->value().getValue();
+
+    if (angleFromStart) {
+        const double endMaximum = std::min(startMaximum, angleMaximum);
+        const double spanMinimum = forceNonZero ? std::max(angleMinimum, minimumRevolveAngle)
+                                                : angleMinimum;
+        const double startUpper
+            = std::max(startMinimum, std::min(startMaximum, endMaximum - spanMinimum));
+
+        start = std::clamp(start, startMinimum, startUpper);
+        const double spanMaximum = std::max(spanMinimum, std::min(angleMaximum, endMaximum - start));
+        angle = std::clamp(angle, spanMinimum, spanMaximum);
+
+        const double dynamicStartMaximum
+            = std::max(startMinimum, std::min(startMaximum, endMaximum - angle));
+        const double dynamicAngleMaximum
+            = std::max(spanMinimum, std::min(angleMaximum, endMaximum - start));
+
+        startEdit->setValue(start);
+        angleEdit->setValue(angle);
+        startProperty->setValue(start);
+        angleProperty->setValue(angle);
+
+        startEdit->setMaximum(dynamicStartMaximum);
+        angleEdit->setMinimum(spanMinimum);
+        angleEdit->setMaximum(dynamicAngleMaximum);
+        return;
+    }
+
+    const double endMinimum = angleMinimum;
+    const double endMaximum = angleMaximum;
+    const double spanMinimum = minimumRevolveAngle;
+    const double startUpper = std::max(startMinimum, std::min(startMaximum, endMaximum - spanMinimum));
+
+    start = std::clamp(start, startMinimum, startUpper);
+    const double dynamicEndMinimum = std::min(endMaximum, std::max(endMinimum, start + spanMinimum));
+    angle = std::clamp(angle, dynamicEndMinimum, endMaximum);
+
+    const double dynamicStartMaximum
+        = std::max(startMinimum, std::min(startMaximum, angle - spanMinimum));
+
+    startEdit->setValue(start);
+    angleEdit->setValue(angle);
+    startProperty->setValue(start);
+    angleProperty->setValue(angle);
+
+    startEdit->setMaximum(dynamicStartMaximum);
+    angleEdit->setMinimum(dynamicEndMinimum);
 }
 
 void TaskRevolutionParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
@@ -483,23 +656,47 @@ void TaskRevolutionParameters::clearFaceName()
     ui->lineFaceName->setProperty("FaceName", QVariant());
 }
 
-void TaskRevolutionParameters::onAngleChanged(double len)
+void TaskRevolutionParameters::onStartAngleChanged(double start)
 {
     if (getObject()) {
-        propAngle->setValue(len);
+        propStartAngle->setValue(start);
+        syncAngleLimits(false);
         exitSelectionMode();
         recomputeFeature();
+        setGizmoPositions();
     }
 }
 
-void TaskRevolutionParameters::onAngle2Changed(double len)
+void TaskRevolutionParameters::onAngleChanged(double angle)
 {
     if (getObject()) {
-        if (propAngle2) {
-            propAngle2->setValue(len);
-        }
+        propAngle->setValue(angle);
+        syncAngleLimits(false);
         exitSelectionMode();
         recomputeFeature();
+        setGizmoPositions();
+    }
+}
+
+void TaskRevolutionParameters::onStartAngle2Changed(double start)
+{
+    if (getObject()) {
+        propStartAngle2->setValue(start);
+        syncAngleLimits(true);
+        exitSelectionMode();
+        recomputeFeature();
+        setGizmoPositions();
+    }
+}
+
+void TaskRevolutionParameters::onAngle2Changed(double angle)
+{
+    if (getObject()) {
+        propAngle2->setValue(angle);
+        syncAngleLimits(true);
+        exitSelectionMode();
+        recomputeFeature();
+        setGizmoPositions();
     }
 }
 
@@ -598,12 +795,16 @@ void TaskRevolutionParameters::onReversed(bool on)
 void TaskRevolutionParameters::onModeChanged(int index)
 {
     App::PropertyEnumeration* propEnum = &(getObject<PartDesign::Revolved>()->Type);
+    const auto mode = modeFromUiIndex(index);
 
-    switch (static_cast<PartDesign::Revolution::RevolMethod>(index)) {
+    switch (mode) {
         case PartDesign::Revolution::RevolMethod::Angle:
             propEnum->setValue("Angle");
             break;
-        case PartDesign::Revolution::RevolMethod::ToLast:
+        case PartDesign::Revolution::RevolMethod::AngleFromOrigin:
+            propEnum->setValue("AngleFromOrigin");
+            break;
+        case PartDesign::Revolution::RevolMethod::ThroughAll:
             propEnum->setValue(isGroove ? "ThroughAll" : "UpToLast");
             break;
         case PartDesign::Revolution::RevolMethod::ToFirst:
@@ -614,6 +815,8 @@ void TaskRevolutionParameters::onModeChanged(int index)
             break;
         case PartDesign::Revolution::RevolMethod::TwoAngles:
             propEnum->setValue("TwoAngles");
+            break;
+        default:
             break;
     }
 
@@ -686,7 +889,9 @@ void TaskRevolutionParameters::changeEvent(QEvent* event)
 void TaskRevolutionParameters::apply()
 {
     // Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Revolution changed"));
+    ui->revolveStartAngle->apply();
     ui->revolveAngle->apply();
+    ui->revolveStartAngle2->apply();
     ui->revolveAngle2->apply();
     std::vector<std::string> sub;
     App::DocumentObject* obj {};
@@ -696,11 +901,10 @@ void TaskRevolutionParameters::apply()
     FCMD_OBJ_CMD(tobj, "ReferenceAxis = " << axis);
     FCMD_OBJ_CMD(tobj, "Midplane = " << (getMidplane() ? 1 : 0));
     FCMD_OBJ_CMD(tobj, "Reversed = " << (getReversed() ? 1 : 0));
-    int mode = ui->changeMode->currentIndex();
-    FCMD_OBJ_CMD(tobj, "Type = " << mode);
+    const auto mode = modeFromUiIndex(ui->changeMode->currentIndex());
+    FCMD_OBJ_CMD(tobj, "Type = " << static_cast<int>(mode));
     QString facename = QStringLiteral("None");
-    if (static_cast<PartDesign::Revolution::RevolMethod>(mode)
-        == PartDesign::Revolution::RevolMethod::ToFace) {
+    if (mode == PartDesign::Revolution::RevolMethod::ToFace) {
         facename = getFaceName();
     }
     FCMD_OBJ_CMD(tobj, "UpToFace = " << facename.toLatin1().data());
@@ -712,12 +916,19 @@ void TaskRevolutionParameters::setupGizmos(ViewProvider* vp)
         return;
     }
 
+    startRotationGizmo = new Gui::RadialGizmo(ui->revolveStartAngle);
     rotationGizmo = new Gui::RadialGizmo(ui->revolveAngle);
+    startRotationGizmo2 = new Gui::RadialGizmo(ui->revolveStartAngle2);
     rotationGizmo2 = new Gui::RadialGizmo(ui->revolveAngle2);
 
-    gizmoContainer = GizmoContainer::create({rotationGizmo, rotationGizmo2}, vp);
+    gizmoContainer = GizmoContainer::create(
+        {startRotationGizmo, rotationGizmo, startRotationGizmo2, rotationGizmo2},
+        vp
+    );
     rotationGizmo->flipArrow();
     rotationGizmo2->flipArrow();
+    startRotationGizmo->setPointStyle();
+    startRotationGizmo2->setPointStyle();
 
     defaultGizmoMultFactor = rotationGizmo->getMultFactor();
 
@@ -736,7 +947,7 @@ void TaskRevolutionParameters::setGizmoPositions()
     Base::Vector3d axisDir;
     bool reversed = false;
     bool symmetric = false;
-    std::string sideType;
+    PartDesign::Revolution::RevolMethod mode = PartDesign::Revolution::RevolMethod::Angle;
 
     auto getFeatureProps = [&](auto* feature) {
         if (!feature || feature->isError()) {
@@ -749,7 +960,7 @@ void TaskRevolutionParameters::setGizmoPositions()
         axisDir = feature->Axis.getValue();
         reversed = feature->Reversed.getValue();
         symmetric = feature->Midplane.getValue();
-        sideType = std::string(feature->Type.getValueAsString());
+        mode = static_cast<PartDesign::Revolution::RevolMethod>(feature->Type.getValue());
         return true;
     };
 
@@ -775,20 +986,54 @@ void TaskRevolutionParameters::setGizmoPositions()
         axisDir = -axisDir;
     }
 
-    rotationGizmo->Gizmo::setDraggerPlacement(basePos + axisComp, normalComp);
-    rotationGizmo->getDraggerContainer()->setArcNormalDirection(Base::convertTo<SbVec3f>(axisDir));
-    rotationGizmo->setVisibility(sideType == "Angle" || sideType == "TwoAngles");
+    const double firstSideMultFactor = isSingleAngleMethod(mode) && symmetric
+        ? defaultGizmoMultFactor / 2.0
+        : defaultGizmoMultFactor;
+    startRotationGizmo->setMultFactor(firstSideMultFactor);
+    rotationGizmo->setMultFactor(firstSideMultFactor);
+    startRotationGizmo2->setMultFactor(defaultGizmoMultFactor);
+    rotationGizmo2->setMultFactor(defaultGizmoMultFactor);
 
-    rotationGizmo2->Gizmo::setDraggerPlacement(basePos + axisComp, normalComp);
-    rotationGizmo2->getDraggerContainer()->setArcNormalDirection(Base::convertTo<SbVec3f>(-axisDir));
-    rotationGizmo2->setVisibility(sideType == "TwoAngles");
+    const double startAngleRad = ui->revolveStartAngle->rawValue() * firstSideMultFactor;
+    const double angleRad = ui->revolveAngle->rawValue() * firstSideMultFactor;
+    const double startAngle2Rad = ui->revolveStartAngle2->rawValue() * defaultGizmoMultFactor;
+    const double angle2Rad = ui->revolveAngle2->rawValue() * defaultGizmoMultFactor;
+    const bool angleFromStart = isAngleFromStartMethod(mode);
 
-    if (sideType == "TwoAngles" || !symmetric) {
-        rotationGizmo->setMultFactor(defaultGizmoMultFactor);
+    const SbVec3f basePosition = Base::convertTo<SbVec3f>(basePos + axisComp);
+    const SbVec3f firstAxis = Base::convertTo<SbVec3f>(axisDir);
+    const SbVec3f secondAxis = Base::convertTo<SbVec3f>(-axisDir);
+    const SbVec3f baseDirection = Base::convertTo<SbVec3f>(normalComp);
+    SbVec3f firstAngleDirection = baseDirection;
+    SbVec3f secondAngleDirection = baseDirection;
+    if (angleFromStart) {
+        SbRotation(firstAxis, static_cast<float>(startAngleRad))
+            .multVec(baseDirection, firstAngleDirection);
     }
-    else {
-        rotationGizmo->setMultFactor(defaultGizmoMultFactor / 2.0);
-    }
+    SbRotation(secondAxis, static_cast<float>(startAngle2Rad))
+        .multVec(baseDirection, secondAngleDirection);
+
+    startRotationGizmo->setDraggerPlacement(basePosition, baseDirection);
+    startRotationGizmo->getDraggerContainer()->setArcNormalDirection(firstAxis);
+    startRotationGizmo->setVisibility(
+        isSingleAngleMethod(mode) || mode == PartDesign::Revolution::RevolMethod::TwoAngles
+    );
+
+    rotationGizmo->setDraggerPlacement(basePosition, firstAngleDirection);
+    rotationGizmo->getDraggerContainer()->setArcNormalDirection(firstAxis);
+    rotationGizmo->setBaseAngleRange(angleFromStart ? 0.0 : startAngleRad, angleRad);
+    rotationGizmo->setVisibility(
+        isSingleAngleMethod(mode) || mode == PartDesign::Revolution::RevolMethod::TwoAngles
+    );
+
+    startRotationGizmo2->setDraggerPlacement(basePosition, baseDirection);
+    startRotationGizmo2->getDraggerContainer()->setArcNormalDirection(secondAxis);
+    startRotationGizmo2->setVisibility(mode == PartDesign::Revolution::RevolMethod::TwoAngles);
+
+    rotationGizmo2->setDraggerPlacement(basePosition, secondAngleDirection);
+    rotationGizmo2->getDraggerContainer()->setArcNormalDirection(secondAxis);
+    rotationGizmo2->setBaseAngleRange(0.0, angle2Rad);
+    rotationGizmo2->setVisibility(mode == PartDesign::Revolution::RevolMethod::TwoAngles);
 }
 
 //**************************************************************************

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.h
@@ -79,7 +79,9 @@ public:
     );
 
 private Q_SLOTS:
+    void onStartAngleChanged(double);
     void onAngleChanged(double);
+    void onStartAngle2Changed(double);
     void onAngle2Changed(double);
     void onAxisChanged(int);
     void onMidplane(bool);
@@ -101,7 +103,9 @@ protected:
 private:
     // mirrors of revolution's or groove's properties
     // should have been done by inheriting revolution and groove from common class...
+    App::PropertyAngle* propStartAngle;
     App::PropertyAngle* propAngle;
+    App::PropertyAngle* propStartAngle2;
     App::PropertyAngle* propAngle2;
     App::PropertyBool* propReversed;
     App::PropertyBool* propMidPlane;
@@ -112,6 +116,7 @@ private:
     void connectSignals();
     void updateUI(int index);
     void translateModeList(int index);
+    void syncAngleLimits(bool secondSide);
     // TODO: This is common with extrude. Maybe send to superclass.
     void translateFaceName();
     void clearFaceName();
@@ -135,7 +140,9 @@ private:
     std::vector<std::unique_ptr<App::PropertyLinkSub>> axesInList;
 
     std::unique_ptr<Gui::GizmoContainer> gizmoContainer;
+    Gui::RadialGizmo* startRotationGizmo = nullptr;
     Gui::RadialGizmo* rotationGizmo = nullptr;
+    Gui::RadialGizmo* startRotationGizmo2 = nullptr;
     Gui::RadialGizmo* rotationGizmo2 = nullptr;
     void setupGizmos(ViewProvider* vp);
     void setGizmoPositions();

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.ui
@@ -80,6 +80,39 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutStartAngle">
+     <item>
+      <widget class="QLabel" name="labelStartAngle">
+       <property name="text">
+        <string>Start</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::QuantitySpinBox" name="revolveStartAngle">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">deg</string>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>360.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>10.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>0.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QLabel" name="labelAngle">
@@ -107,6 +140,39 @@
        </property>
        <property name="value">
         <double>360.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutStartAngle2">
+     <item>
+      <widget class="QLabel" name="labelStartAngle2">
+       <property name="text">
+        <string>2nd start</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::QuantitySpinBox" name="revolveStartAngle2">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">deg</string>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>360.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>10.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>0.000000000000000</double>
        </property>
       </widget>
      </item>
@@ -207,7 +273,10 @@
  </customwidgets>
  <tabstops>
   <tabstop>axis</tabstop>
+  <tabstop>revolveStartAngle</tabstop>
   <tabstop>revolveAngle</tabstop>
+  <tabstop>revolveStartAngle2</tabstop>
+  <tabstop>revolveAngle2</tabstop>
   <tabstop>checkBoxMidplane</tabstop>
   <tabstop>checkBoxReversed</tabstop>
   <tabstop>checkBoxUpdateView</tabstop>


### PR DESCRIPTION
With the new sketch faces, the master sketch concept has been greatly enhanced. To strengthen this, it adds a start field that determines where the relevant feature begins. If the start is not changed, nothing changes. The end must always be greater than the start, and the star must always be smaller than the end. Additionally, the start has a spherical drager.

This feature is actually very small, but because they did it four times, the PR got a bit bigger. And of course, the Dragggers also needed to be adjusted. Probably the most difficult part was setting up the dragers. Just adding the start feature for the pad takes around 100 lines without dragers.

This feature differs somewhat from the NXs system I was inspired by, unfortunately, in the NXs system, start can be larger than end. It still covers the spaces between them. However, achieving this requires fundamentally changing the system, which I don't want to go into now, but it could be done in the future, at least for the pad. But I'm thinking of moving on to another NX feature.

I consulted ChatGPT 5.5 while conducting this PR.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

https://github.com/user-attachments/assets/c3cd9b7d-62ab-4224-95bd-ad4203b4d73a



https://github.com/user-attachments/assets/2f13c705-e491-4af2-a861-6b15c85b68dc



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
