### PR TITLE
CAM: Array op - Fix 360

### DIFF
--- a/src/Mod/CAM/Path/Op/Gui/Array.py
+++ b/src/Mod/CAM/Path/Op/Gui/Array.py
@@ -277,7 +277,7 @@ class ObjectArray:
             obj.Offset,
             obj.CopiesX,
             obj.CopiesY,
-            obj.Angle,
+            obj.Angle.Value,
             obj.Centre,
             obj.SwapDirection,
             jitterMagnitude,
@@ -478,12 +478,17 @@ class PathArray:
 
     def getPolarArray(self, commands):
         """Array type Polar"""
-        for i in range(self.copies):
-            ang = 360
-            if self.copies > 0:
-                ang = self.polarAngle / self.copies * (1 + i)
+        if not self.copies:
+            return
 
+        if Path.Geom.isRoughly(self.polarAngle, 360):
+            stepAng = self.polarAngle / (self.copies + 1)
+        else:
+            stepAng = self.polarAngle / self.copies
+
+        for i in range(self.copies):
             # prepare placement for polar pattern
+            ang = stepAng * (i + 1)
             pl = FreeCAD.Placement()
             pl.rotate(self.polarCentre, FreeCAD.Vector(0, 0, 1), ang)
 


### PR DESCRIPTION
### Description of issue

To get repeats for full circle need to calculate angle for last repeat
Can not just enter 360

### Changes
Changed logic if set `Angle` 360 to be similar with `Polar Array` from **Draft** workbench

https://github.com/FreeCAD/FreeCAD/blob/781714fcc92b1ccc234c53ebb7c4f285cfbbffeb/src/Mod/Draft/draftobjects/array.py#L509-L512

<img width="780" height="540" alt="Screenshot_20260523_174558_hor" src="https://github.com/user-attachments/assets/fb977398-33ae-4aaa-a096-9550bb93abcb" />
