### PR TITLE
TechDraw: allow horizontal/vertical dimensions between circle edges

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -863,6 +863,8 @@ pointPair DrawViewDimension::getPointsOneEdge(ReferenceVector references)
 
 pointPair DrawViewDimension::getPointsTwoEdges(ReferenceVector references)
 {
+    constexpr bool UseProjectionCS{true};
+    constexpr bool UsePaperCS{false};
     App::DocumentObject* refObject = references.front().getObject();
     int iSubelement0 = DrawUtil::getIndexFromName(references.at(0).getSubName());
     int iSubelement1 = DrawUtil::getIndexFromName(references.at(1).getSubName());
@@ -876,6 +878,9 @@ pointPair DrawViewDimension::getPointsTwoEdges(ReferenceVector references)
             ssMessage << getNameInDocument() << " can not find geometry for 2d reference (2)";
             throw Base::RuntimeError(ssMessage.str());
         }
+        if (isCircleSpecialCase(geom0->getOCCEdge(), geom1->getOCCEdge())) {
+            return getPointsTwoCircles(geom0->getOCCEdge(), geom1->getOCCEdge(), UsePaperCS);
+        }
         return closestPoints(geom0->getOCCEdge(), geom1->getOCCEdge());
     }
 
@@ -887,11 +892,96 @@ pointPair DrawViewDimension::getPointsTwoEdges(ReferenceVector references)
         throw Base::RuntimeError("Geometry for dimension reference is null.");
     }
 
+    TopoDS_Edge edge0 = TopoDS::Edge(geometry0);
+    TopoDS_Edge edge1 = TopoDS::Edge(geometry1);
     pointPair pts = closestPoints(geometry0, geometry1);
+    if (isCircleSpecialCase(edge0, edge1)) {
+        pts = getPointsTwoCircles(edge0, edge1, UseProjectionCS);
+    }
     pts.move(getViewPart()->getCurrentCentroid());
     pts.project(getViewPart());
     return pts;
 }
+
+
+//! true if this is a circle to circle dimension that requires special handling
+bool DrawViewDimension::isCircleSpecialCase(const TopoDS_Edge& edge0, const TopoDS_Edge& edge1)
+{
+    BRepAdaptor_Curve adapt0(edge0);
+    BRepAdaptor_Curve adapt1(edge1);
+    if (adapt0.GetType() != GeomAbs_Circle ||
+        adapt1.GetType() != GeomAbs_Circle) {
+        return false;
+    }
+    return Type.isValue("DistanceX") || Type.isValue("DistanceY");
+}
+
+
+//! Specialization for circle to circle horizontal or vertical dimensions
+pointPair DrawViewDimension::getPointsTwoCircles(const TopoDS_Edge& edge0, const TopoDS_Edge& edge1, bool is3d)
+{
+    BRepAdaptor_Curve adapt0(edge0);
+    BRepAdaptor_Curve adapt1(edge1);
+
+    gp_Ax2 projectionCS = getViewPart()->getProjectionCS();
+    if (!is3d) {
+        // edges are on the XY plane already so use OXYZ as the projectionCS
+        projectionCS = gp_Ax2();
+    }
+
+    gp_Dir alignmentDir = projectionCS.XDirection();
+    if (Type.isValue("DistanceY")) {
+        alignmentDir = projectionCS.YDirection();
+    }
+
+    gp_Circ circle0 = adapt0.Circle();
+    gp_Pnt shift0 = alignmentDir.XYZ() * circle0.Radius();
+    gp_Pnt point0 = circle0.Location();
+
+    gp_Circ circle1 = adapt1.Circle();
+    gp_Pnt point1 = circle1.Location();
+    gp_Pnt shift1 = alignmentDir.XYZ() * circle1.Radius();
+
+    gp_Ax3 projectionCS3{projectionCS};
+    gp_Ax3 OXYZ;
+    gp_Trsf xToProjectionCS;
+    xToProjectionCS.SetTransformation(OXYZ, projectionCS3);
+
+    gp_Pnt center0Local = point0;
+    gp_Pnt center1Local = point1;
+    if (is3d) {
+        center0Local = point0.Transformed(xToProjectionCS);
+        center1Local = point1.Transformed(xToProjectionCS);
+    }
+
+    gp_Dir centerDir = center1Local.XYZ() - center0Local.XYZ();
+    double dot = centerDir.Dot(alignmentDir);
+
+    if (dot > 0) {
+        point0 = point0.XYZ() + shift0.XYZ();
+        point1 = point1.XYZ() - shift1.XYZ();
+        auto point0Out = Base::convertTo<Base::Vector3d>(point0);
+        auto point1Out = Base::convertTo<Base::Vector3d>(point1);
+        return {point0Out, point1Out};
+    }
+
+    if (dot < 0) {
+        point0 = point0.XYZ() - shift0.XYZ();
+        point1 = point1.XYZ() + shift1.XYZ();
+        auto point0Out = Base::convertTo<Base::Vector3d>(point0);
+        auto point1Out = Base::convertTo<Base::Vector3d>(point1);
+        return {point0Out, point1Out};
+    }
+
+    // dot == 0 means alignmentDir and centerDir are at 90* and the separation of the two circles along aligmentDir will
+    // be zero.  Dimension will have zero value until user changes DistanceX to DistanY, or vv.
+    if (dot == 0) {
+        Base::Console().log("DVD::getPointsTwoCircles - %s dot is zero\n", Label.getValue());
+    }
+
+    return closestPoints(edge0, edge1);
+}
+
 
 pointPair DrawViewDimension::getPointsTwoVerts(ReferenceVector references)
 {

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -957,29 +957,26 @@ pointPair DrawViewDimension::getPointsTwoCircles(const TopoDS_Edge& edge0, const
     gp_Dir centerDir = center1Local.XYZ() - center0Local.XYZ();
     double dot = centerDir.Dot(alignmentDir);
 
+    if (dot == 0) {
+        // dot == 0 means alignmentDir and centerDir are at 90* and the separation of the two circles along aligmentDir will
+        // be zero.  Dimension will have zero value until user changes DistanceX to DistanY, or vv.
+        Base::Console().log("DVD::getPointsTwoCircles - %s dot is zero\n", Label.getValue());
+        return closestPoints(edge0, edge1);
+    }
+
     if (dot > 0) {
         point0 = point0.XYZ() + shift0.XYZ();
         point1 = point1.XYZ() - shift1.XYZ();
-        auto point0Out = Base::convertTo<Base::Vector3d>(point0);
-        auto point1Out = Base::convertTo<Base::Vector3d>(point1);
-        return {point0Out, point1Out};
     }
 
     if (dot < 0) {
         point0 = point0.XYZ() - shift0.XYZ();
         point1 = point1.XYZ() + shift1.XYZ();
-        auto point0Out = Base::convertTo<Base::Vector3d>(point0);
-        auto point1Out = Base::convertTo<Base::Vector3d>(point1);
-        return {point0Out, point1Out};
     }
 
-    // dot == 0 means alignmentDir and centerDir are at 90* and the separation of the two circles along aligmentDir will
-    // be zero.  Dimension will have zero value until user changes DistanceX to DistanY, or vv.
-    if (dot == 0) {
-        Base::Console().log("DVD::getPointsTwoCircles - %s dot is zero\n", Label.getValue());
-    }
-
-    return closestPoints(edge0, edge1);
+    auto point0Out = Base::convertTo<Base::Vector3d>(point0);
+    auto point1Out = Base::convertTo<Base::Vector3d>(point1);
+    return {point0Out, point1Out};
 }
 
 

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -250,6 +250,9 @@ protected:
 
     virtual areaPoint getAreaParameters(ReferenceVector references);
 
+    bool isCircleSpecialCase(const TopoDS_Edge& edge0, const TopoDS_Edge& edge1);
+    pointPair getPointsTwoCircles(const TopoDS_Edge& edge0, const TopoDS_Edge& edge1, bool is3d);
+
     double
     dist2Segs(Base::Vector3d s1, Base::Vector3d e1, Base::Vector3d s2, Base::Vector3d e2) const;
     pointPair closestPoints(const TopoDS_Shape& s1, const TopoDS_Shape& s2) const;

--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -1658,7 +1658,10 @@ void execDistanceX(Gui::Command* cmd)
     //Define the geometric configuration required for a length dimension
     StringVector acceptableGeometry({"Edge", "Vertex"});
     std::vector<int> minimumCounts({1, 2});
-    std::vector<DimensionGeometry> acceptableDimensionGeometrys({DimensionGeometry::isHorizontal, DimensionGeometry::isDiagonal, DimensionGeometry::isHybrid});
+    std::vector<DimensionGeometry> acceptableDimensionGeometrys({DimensionGeometry::isHorizontal,
+                                                                 DimensionGeometry::isDiagonal,
+                                                                 DimensionGeometry::isHybrid,
+                                                                 DimensionGeometry::isMultiEdge});
 
     execDim(cmd, "DistanceX", acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
 }
@@ -1706,7 +1709,10 @@ void execDistanceY(Gui::Command* cmd)
     //Define the geometric configuration required for a length dimension
     StringVector acceptableGeometry({"Edge", "Vertex"});
     std::vector<int> minimumCounts({1, 2});
-    std::vector<DimensionGeometry> acceptableDimensionGeometrys({DimensionGeometry::isVertical, DimensionGeometry::isDiagonal, DimensionGeometry::isHybrid});
+    std::vector<DimensionGeometry> acceptableDimensionGeometrys({DimensionGeometry::isVertical,
+                                                                 DimensionGeometry::isDiagonal,
+                                                                 DimensionGeometry::isHybrid,
+                                                                 DimensionGeometry::isMultiEdge});
 
     execDim(cmd, "DistanceY", acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
 }


### PR DESCRIPTION
This PR implements a fix for issue #28223.  It corrects a situation where edge-edge 
dimensions were always treated as Distance dimensions even if DistanceX or DistanceY
were requested.

This PR also includes a fix to correct a situation where 3d edge-edge dimension requests
were falsely rejected.

Before:
<img width="1394" height="602" alt="edgeEdgeCircleBefore" src="https://github.com/user-attachments/assets/7d922be7-c19e-4bae-a643-402520a0da8c" />

After:
<img width="1310" height="729" alt="edgeEdgeCirclesAfter" src="https://github.com/user-attachments/assets/fc39327f-872b-425f-9576-45c870b31452" />
