### PR TITLE
CAM: EngraveBase - Fix opFinalDepth complicated shapes

### DIFF
--- a/src/Mod/CAM/Path/Op/EngraveBase.py
+++ b/src/Mod/CAM/Path/Op/EngraveBase.py
@@ -192,8 +192,10 @@ class ObjectOp(PathOp.ObjectOp):
                 obj.OpFinalDepth = job.Stock.Shape.BoundBox.ZMax
 
             if obj.Base:
-                obj.OpFinalDepth = obj.Base[0][0].Shape.BoundBox.ZMax
+                obj.OpFinalDepth = max(
+                    sh.BoundBox.ZMax for base, sub in obj.Base for sh in base.getSubObject(sub)
+                )
             elif obj.BaseShapes:
-                obj.OpFinalDepth = obj.BaseShapes[0].Shape.BoundBox.ZMax
+                obj.OpFinalDepth = max(base.Shape.BoundBox.ZMax for base in obj.BaseShapes)
 
             obj.OpStartDepth = max(obj.OpStartDepth, obj.OpFinalDepth)


### PR DESCRIPTION
### Changes
Use Z max from all selected sub elements, instead of whole model
 
<img width="1116" height="401" alt="Screenshot_20260524_201123_hor" src="https://github.com/user-attachments/assets/643e98cd-1eed-442a-b996-f2efb47ea2a1" />
