### PR TITLE
TechDraw: fix wrong tolerance value

### DIFF
--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -1687,7 +1687,7 @@ bool GeometryUtils::isLine(const TopoDS_Edge& occEdge)
         lenTotal += (v2-v1).Length();
     }
 
-    return DrawUtil::fpCompare(lenTotal, endPointLength, tolerance);
+    return DrawUtil::fpCompare(lenTotal, endPointLength, EWTOLERANCE);
 }
 
 


### PR DESCRIPTION
This PR implements a fix for issue #30049 where a shallow curve is depicted as a line.

The wrong tolerance value was being used in comparing the length of the edge to the distance 
between endpoints.

Before:
<img width="550" height="677" alt="Con Rod_before" src="https://github.com/user-attachments/assets/d1b41360-8d79-4a45-a248-1d83a40ae8e3" />

After
<img width="467" height="771" alt="Con Rod_after" src="https://github.com/user-attachments/assets/2857ea5b-9c4b-43b8-9631-770c34dd270f" />
