### PR TITLE
Address several instances where SVG stroke-width format is invalid

### DIFF
--- a/src/Mod/Draft/Resources/patterns/aluminium.svg
+++ b/src/Mod/Draft/Resources/patterns/aluminium.svg
@@ -11,20 +11,20 @@
   </metadata>
   <defs id="defs21" />
   <g id="groupe1">
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 64.0 L 0.0 16.0 " id="Line014_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 64.0 L 0.0 12.8 " id="Line015_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 0.0 L 64.0 12.8 " id="Line013_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 3.2 0.0 L 64.0 60.8 " id="Line001_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 60.8 L 3.2 64.0 " id="Line002_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 35.2 0.0 L 64.0 28.8 " id="Line006_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 44.8 L 19.2 64.0 " id="Line009_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 64.0 48.0 L 16.0 0.0 " id="Line010_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 32.0 L 32.0 64.0 " id="Line003_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 64.0 44.8 L 19.2 0.0 " id="Line011_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 0.0 L 64.0 16.0 " id="Line012_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 28.8 L 35.2 64.0 " id="Line004_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 0.0 L 64.0 32.0 " id="Line005_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 48.0 L 16.0 64.0 " id="Line008_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 64.0 L 0.0 16.0 " id="Line014_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 64.0 L 0.0 12.8 " id="Line015_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 0.0 L 64.0 12.8 " id="Line013_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 3.2 0.0 L 64.0 60.8 " id="Line001_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 60.8 L 3.2 64.0 " id="Line002_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 35.2 0.0 L 64.0 28.8 " id="Line006_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 44.8 L 19.2 64.0 " id="Line009_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 64.0 48.0 L 16.0 0.0 " id="Line010_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 32.0 L 32.0 64.0 " id="Line003_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 64.0 44.8 L 19.2 0.0 " id="Line011_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 0.0 L 64.0 16.0 " id="Line012_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 28.8 L 35.2 64.0 " id="Line004_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 0.0 L 64.0 32.0 " id="Line005_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 48.0 L 16.0 64.0 " id="Line008_w0000" />
   </g>
 </svg>

--- a/src/Mod/Draft/Resources/patterns/cuprous.svg
+++ b/src/Mod/Draft/Resources/patterns/cuprous.svg
@@ -11,64 +11,64 @@
   </metadata>
   <defs id="defs65" />
   <g id="groupe1">
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 19.2 L 16.0 22.4 " id="Line022_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 6.4 L 16.0 9.6 " id="Line023_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 51.2 L 22.4 54.4 " id="Line024_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 25.6 L 22.4 28.8 " id="Line026_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 38.4 L 22.4 41.6 " id="Line025_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 0.0 L 9.6 3.2 " id="Line014_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 19.2 L 3.2 22.4 " id="Line012_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 38.4 L 9.6 41.6 " id="Line016_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 25.6 L 9.6 28.8 " id="Line017_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 44.8 L 16.0 48.0 " id="Line020_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 6.4 L 3.2 9.6 " id="Line013_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 32.0 L 16.0 35.2 " id="Line021_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 32.0 L 3.2 35.2 " id="Line011_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 12.8 L 9.6 16.0 " id="Line018_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 51.2 L 9.6 54.4 " id="Line015_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 57.6 L 16.0 60.8 " id="Line019_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 0.0 L 64.0 12.8 " id="Line008_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 57.6 L 3.2 60.8 " id="Line009_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 44.8 L 3.2 48.0 " id="Line010_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 12.8 L 51.2 64.0 " id="Line001_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 0.0 L 64.0 51.2 " id="Line005_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 38.4 L 25.6 64.0 " id="Line003_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 51.2 L 12.8 64.0 " id="Line004_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 25.6 L 38.4 64.0 " id="Line002_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 0.0 L 64.0 38.4 " id="Line006_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 0.0 L 64.0 25.6 " id="Line007_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 6.4 L 41.6 9.6 " id="Line043_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 25.6 L 48.0 28.8 " id="Line046_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 0.0 L 35.2 3.2 " id="Line034_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 57.6 L 28.8 60.8 " id="Line029_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 32.0 L 28.8 35.2 " id="Line031_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 6.4 L 28.8 9.6 " id="Line033_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 12.8 L 35.2 16.0 " id="Line035_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 19.2 L 41.6 22.4 " id="Line042_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 0.0 L 48.0 3.2 " id="Line044_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 57.6 L 54.4 60.8 " id="Line049_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 44.8 L 28.8 48.0 " id="Line030_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 19.2 L 28.8 22.4 " id="Line032_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 57.6 L 41.6 60.8 " id="Line039_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 12.8 L 48.0 16.0 " id="Line045_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 32.0 L 54.4 35.2 " id="Line051_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 0.0 L 22.4 3.2 " id="Line028_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 44.8 L 41.6 48.0 " id="Line040_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 38.4 L 48.0 41.6 " id="Line047_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 25.6 L 35.2 28.8 " id="Line036_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 32.0 L 41.6 35.2 " id="Line041_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 38.4 L 35.2 41.6 " id="Line037_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 51.2 L 48.0 54.4 " id="Line048_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 51.2 L 35.2 54.4 " id="Line038_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 44.8 L 54.4 48.0 " id="Line050_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 12.8 L 22.4 16.0 " id="Line027_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 19.2 L 54.4 22.4 " id="Line052_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 6.4 L 54.4 9.6 " id="Line053_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 51.2 L 60.8 54.4 " id="Line058_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 12.8 L 60.8 16.0 " id="Line055_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 38.4 L 60.8 41.6 " id="Line057_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 0.0 L 60.8 3.2 " id="Line054_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 25.6 L 60.8 28.8 " id="Line056_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 19.2 L 16.0 22.4 " id="Line022_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 6.4 L 16.0 9.6 " id="Line023_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 51.2 L 22.4 54.4 " id="Line024_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 25.6 L 22.4 28.8 " id="Line026_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 38.4 L 22.4 41.6 " id="Line025_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 0.0 L 9.6 3.2 " id="Line014_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 19.2 L 3.2 22.4 " id="Line012_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 38.4 L 9.6 41.6 " id="Line016_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 25.6 L 9.6 28.8 " id="Line017_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 44.8 L 16.0 48.0 " id="Line020_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 6.4 L 3.2 9.6 " id="Line013_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 32.0 L 16.0 35.2 " id="Line021_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 32.0 L 3.2 35.2 " id="Line011_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 12.8 L 9.6 16.0 " id="Line018_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 51.2 L 9.6 54.4 " id="Line015_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 57.6 L 16.0 60.8 " id="Line019_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 0.0 L 64.0 12.8 " id="Line008_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 57.6 L 3.2 60.8 " id="Line009_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 44.8 L 3.2 48.0 " id="Line010_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 12.8 L 51.2 64.0 " id="Line001_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 0.0 L 64.0 51.2 " id="Line005_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 38.4 L 25.6 64.0 " id="Line003_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 51.2 L 12.8 64.0 " id="Line004_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 25.6 L 38.4 64.0 " id="Line002_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 0.0 L 64.0 38.4 " id="Line006_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 0.0 L 64.0 25.6 " id="Line007_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 6.4 L 41.6 9.6 " id="Line043_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 25.6 L 48.0 28.8 " id="Line046_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 0.0 L 35.2 3.2 " id="Line034_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 57.6 L 28.8 60.8 " id="Line029_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 32.0 L 28.8 35.2 " id="Line031_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 6.4 L 28.8 9.6 " id="Line033_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 12.8 L 35.2 16.0 " id="Line035_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 19.2 L 41.6 22.4 " id="Line042_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 0.0 L 48.0 3.2 " id="Line044_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 57.6 L 54.4 60.8 " id="Line049_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 44.8 L 28.8 48.0 " id="Line030_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 19.2 L 28.8 22.4 " id="Line032_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 57.6 L 41.6 60.8 " id="Line039_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 12.8 L 48.0 16.0 " id="Line045_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 32.0 L 54.4 35.2 " id="Line051_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 0.0 L 22.4 3.2 " id="Line028_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 44.8 L 41.6 48.0 " id="Line040_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 38.4 L 48.0 41.6 " id="Line047_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 25.6 L 35.2 28.8 " id="Line036_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 32.0 L 41.6 35.2 " id="Line041_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 38.4 L 35.2 41.6 " id="Line037_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 51.2 L 48.0 54.4 " id="Line048_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 51.2 L 35.2 54.4 " id="Line038_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 44.8 L 54.4 48.0 " id="Line050_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 12.8 L 22.4 16.0 " id="Line027_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 19.2 L 54.4 22.4 " id="Line052_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 6.4 L 54.4 9.6 " id="Line053_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 51.2 L 60.8 54.4 " id="Line058_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 12.8 L 60.8 16.0 " id="Line055_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 38.4 L 60.8 41.6 " id="Line057_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 0.0 L 60.8 3.2 " id="Line054_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 25.6 L 60.8 28.8 " id="Line056_w0000" />
   </g>
 </svg>

--- a/src/Mod/Draft/Resources/patterns/general_steel.svg
+++ b/src/Mod/Draft/Resources/patterns/general_steel.svg
@@ -11,14 +11,14 @@
   </metadata>
   <defs id="defs15" />
   <g id="aaaa">
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 12.8 L 51.2 64.0 " id="Line001_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 25.6 L 38.4 64.0 " id="Line002_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 0.0 L 64.0 51.2 " id="Line005_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 0.0 L 64.0 12.8 " id="Line008_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 0.0 L 64.0 25.6 " id="Line007_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 51.2 L 12.8 64.0 " id="Line004_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 38.4 L 25.6 64.0 " id="Line003_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 0.0 L 64.0 38.4 " id="Line006_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 12.8 L 51.2 64.0 " id="Line001_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 25.6 L 38.4 64.0 " id="Line002_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 0.0 L 64.0 51.2 " id="Line005_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 0.0 L 64.0 12.8 " id="Line008_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 0.0 L 64.0 25.6 " id="Line007_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 51.2 L 12.8 64.0 " id="Line004_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 38.4 L 25.6 64.0 " id="Line003_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 0.0 L 64.0 38.4 " id="Line006_w0000" />
   </g>
 </svg>

--- a/src/Mod/Draft/Resources/patterns/glass.svg
+++ b/src/Mod/Draft/Resources/patterns/glass.svg
@@ -11,85 +11,85 @@
   </metadata>
   <defs id="defs3637" />
   <g id="groupe1">
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 41.6 57.6 L 44.8 60.8 " id="Line605_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 35.2 0.0 L 38.4 3.2 " id="Line090_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 41.6 6.4 L 44.8 9.6 " id="Line091_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 32.0 L 51.2 35.2 " id="Line075_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 54.4 38.4 L 57.6 41.6 " id="Line076_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 60.8 44.8 L 64.0 48.0 " id="Line077_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 25.6 L 60.8 28.8 " id="Line089_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 54.4 19.2 L 57.6 22.4 " id="Line093_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 60.8 25.6 L 64.0 28.8 " id="Line094_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 12.8 L 51.2 16.0 " id="Line092_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 60.8 L 9.6 57.6 " id="Line354_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 0.0 L 35.2 3.2 " id="Line085_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 54.4 L 3.2 51.2 " id="Line355_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 6.4 L 28.8 9.6 " id="Line079_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 12.8 L 48.0 16.0 " id="Line087_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 19.2 L 54.4 22.4 " id="Line088_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 25.6 L 28.8 28.8 " id="Line054_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 19.2 L 22.4 22.4 " id="Line053_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 12.8 L 35.2 16.0 " id="Line080_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 0.0 L 22.4 3.2 " id="Line078_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 6.4 L 41.6 9.6 " id="Line086_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 28.8 25.6 L 32.0 28.8 " id="Line064_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 60.8 12.8 L 64.0 16.0 " id="Line097_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 54.4 6.4 L 57.6 9.6 " id="Line096_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 0.0 L 3.2 3.2 " id="Line000_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 6.4 L 9.6 9.6 " id="Line051_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 51.2 L 41.6 54.4 " id="Line049_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 57.6 L 48.0 60.8 " id="Line050_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 57.6 L 60.8 60.8 " id="Line059_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 12.8 L 16.0 16.0 " id="Line052_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 22.4 6.4 L 25.6 9.6 " id="Line071_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 28.8 12.8 L 32.0 16.0 " id="Line072_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 35.2 32.0 L 38.4 35.2 " id="Line065_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 35.2 19.2 L 38.4 22.4 " id="Line073_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 28.8 57.6 L 32.0 60.8 " id="Line353_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 32.0 L 35.2 35.2 " id="Line055_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 38.4 L 41.6 41.6 " id="Line056_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 44.8 L 48.0 48.0 " id="Line057_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 22.4 19.2 L 25.6 22.4 " id="Line063_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 51.2 L 54.4 54.4 " id="Line058_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 16.0 12.8 L 19.2 16.0 " id="Line062_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 41.6 38.4 L 44.8 41.6 " id="Line066_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 0.0 L 54.4 3.2 " id="Line098_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 9.6 6.4 L 12.8 9.6 " id="Line061_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 44.8 L 51.2 48.0 " id="Line067_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 54.4 51.2 L 57.6 54.4 " id="Line068_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 16.0 0.0 L 19.2 3.2 " id="Line070_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 60.8 57.6 L 64.0 60.8 " id="Line069_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 3.2 0.0 L 6.4 3.2 " id="Line060_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 22.4 51.2 L 25.6 54.4 " id="Line352_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 25.6 L 48.0 28.8 " id="Line082_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 57.6 L 28.8 60.8 " id="Line027_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 44.8 L 3.2 48.0 " id="Line020_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 19.2 L 41.6 22.4 " id="Line081_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 57.6 L 16.0 60.8 " id="Line022_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 51.2 L 22.4 54.4 " id="Line026_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 32.0 L 54.4 35.2 " id="Line083_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 41.6 25.6 L 44.8 28.8 " id="Line074_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 38.4 L 60.8 41.6 " id="Line084_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 19.2 L 9.6 22.4 " id="Line044_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 51.2 L 9.6 54.4 " id="Line021_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 38.4 L 9.6 41.6 " id="Line024_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 32.0 L 3.2 35.2 " id="Line023_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 44.8 L 16.0 48.0 " id="Line025_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 0.0 L 51.2 3.2 " id="Line095_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 6.4 L 60.8 9.6 " id="Line099_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 32.0 L 22.4 35.2 " id="Line046_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 12.8 L 3.2 16.0 " id="Line043_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 25.6 L 16.0 28.8 " id="Line045_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 38.4 L 28.8 41.6 " id="Line047_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 44.8 L 35.2 48.0 " id="Line048_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 35.2 51.2 L 38.4 54.4 " id="Line604_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 9.6 38.4 L 12.8 41.6 " id="Line350_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 3.2 32.0 L 6.4 35.2 " id="Line349_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 16.0 44.8 L 19.2 48.0 " id="Line351_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 28.8 44.8 L 32.0 48.0 " id="Line603_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 3.2 19.2 L 6.4 22.4 " id="Line599_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 22.4 38.4 L 25.6 41.6 " id="Line602_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 16.0 32.0 L 19.2 35.2 " id="Line601_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 9.6 25.6 L 12.8 28.8 " id="Line600_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 41.6 57.6 L 44.8 60.8 " id="Line605_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 35.2 0.0 L 38.4 3.2 " id="Line090_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 41.6 6.4 L 44.8 9.6 " id="Line091_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 32.0 L 51.2 35.2 " id="Line075_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 54.4 38.4 L 57.6 41.6 " id="Line076_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 60.8 44.8 L 64.0 48.0 " id="Line077_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 25.6 L 60.8 28.8 " id="Line089_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 54.4 19.2 L 57.6 22.4 " id="Line093_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 60.8 25.6 L 64.0 28.8 " id="Line094_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 12.8 L 51.2 16.0 " id="Line092_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 60.8 L 9.6 57.6 " id="Line354_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 0.0 L 35.2 3.2 " id="Line085_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 54.4 L 3.2 51.2 " id="Line355_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 6.4 L 28.8 9.6 " id="Line079_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 12.8 L 48.0 16.0 " id="Line087_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 19.2 L 54.4 22.4 " id="Line088_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 25.6 L 28.8 28.8 " id="Line054_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 19.2 L 22.4 22.4 " id="Line053_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 12.8 L 35.2 16.0 " id="Line080_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 0.0 L 22.4 3.2 " id="Line078_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 6.4 L 41.6 9.6 " id="Line086_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 28.8 25.6 L 32.0 28.8 " id="Line064_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 60.8 12.8 L 64.0 16.0 " id="Line097_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 54.4 6.4 L 57.6 9.6 " id="Line096_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 0.0 L 3.2 3.2 " id="Line000_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 6.4 L 9.6 9.6 " id="Line051_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 51.2 L 41.6 54.4 " id="Line049_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 57.6 L 48.0 60.8 " id="Line050_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 57.6 L 60.8 60.8 " id="Line059_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 12.8 L 16.0 16.0 " id="Line052_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 22.4 6.4 L 25.6 9.6 " id="Line071_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 28.8 12.8 L 32.0 16.0 " id="Line072_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 35.2 32.0 L 38.4 35.2 " id="Line065_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 35.2 19.2 L 38.4 22.4 " id="Line073_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 28.8 57.6 L 32.0 60.8 " id="Line353_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 32.0 L 35.2 35.2 " id="Line055_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 38.4 L 41.6 41.6 " id="Line056_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 44.8 L 48.0 48.0 " id="Line057_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 22.4 19.2 L 25.6 22.4 " id="Line063_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 51.2 L 54.4 54.4 " id="Line058_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 16.0 12.8 L 19.2 16.0 " id="Line062_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 41.6 38.4 L 44.8 41.6 " id="Line066_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 0.0 L 54.4 3.2 " id="Line098_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 9.6 6.4 L 12.8 9.6 " id="Line061_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 44.8 L 51.2 48.0 " id="Line067_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 54.4 51.2 L 57.6 54.4 " id="Line068_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 16.0 0.0 L 19.2 3.2 " id="Line070_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 60.8 57.6 L 64.0 60.8 " id="Line069_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 3.2 0.0 L 6.4 3.2 " id="Line060_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 22.4 51.2 L 25.6 54.4 " id="Line352_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 25.6 L 48.0 28.8 " id="Line082_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 57.6 L 28.8 60.8 " id="Line027_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 44.8 L 3.2 48.0 " id="Line020_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 19.2 L 41.6 22.4 " id="Line081_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 57.6 L 16.0 60.8 " id="Line022_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 51.2 L 22.4 54.4 " id="Line026_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 32.0 L 54.4 35.2 " id="Line083_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 41.6 25.6 L 44.8 28.8 " id="Line074_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 38.4 L 60.8 41.6 " id="Line084_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 19.2 L 9.6 22.4 " id="Line044_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 51.2 L 9.6 54.4 " id="Line021_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 38.4 L 9.6 41.6 " id="Line024_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 32.0 L 3.2 35.2 " id="Line023_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 44.8 L 16.0 48.0 " id="Line025_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 0.0 L 51.2 3.2 " id="Line095_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 6.4 L 60.8 9.6 " id="Line099_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 32.0 L 22.4 35.2 " id="Line046_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 12.8 L 3.2 16.0 " id="Line043_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 25.6 L 16.0 28.8 " id="Line045_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 38.4 L 28.8 41.6 " id="Line047_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 44.8 L 35.2 48.0 " id="Line048_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 35.2 51.2 L 38.4 54.4 " id="Line604_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 9.6 38.4 L 12.8 41.6 " id="Line350_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 3.2 32.0 L 6.4 35.2 " id="Line349_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 16.0 44.8 L 19.2 48.0 " id="Line351_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 28.8 44.8 L 32.0 48.0 " id="Line603_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 3.2 19.2 L 6.4 22.4 " id="Line599_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 22.4 38.4 L 25.6 41.6 " id="Line602_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 16.0 32.0 L 19.2 35.2 " id="Line601_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 9.6 25.6 L 12.8 28.8 " id="Line600_w0000" />
   </g>
 </svg>

--- a/src/Mod/Draft/Resources/patterns/plastic.svg
+++ b/src/Mod/Draft/Resources/patterns/plastic.svg
@@ -11,19 +11,19 @@
   </metadata>
   <defs id="defs8742" />
   <g id="aaaa">
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 51.2 L 12.8 64.0 " id="Line_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 12.8 L 51.2 64 " id="Line003_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 38.4 L 25.6 64 " id="Line001_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 0.0 L 64 64 " id="Line004_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 25.6 L 38.4 64 " id="Line002_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 0.0 L 64 51.2 " id="Line005_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 0.0 L 64 38.4 " id="Line006_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 0.0 L 64 25.6 " id="Line007_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 0.0 L 64 12.8 " id="Line008_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 51.2 L 64 51.2 " id="Line010_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 64 L 64 64 " id="Line009_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 38.4 L 64 38.4 " id="Line011_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 25.6 L 64 25.6 " id="Line012_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 12.8 L 64 12.8 " id="Line013_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 51.2 L 12.8 64.0 " id="Line_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 12.8 L 51.2 64 " id="Line003_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 38.4 L 25.6 64 " id="Line001_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 0.0 L 64 64 " id="Line004_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 25.6 L 38.4 64 " id="Line002_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 0.0 L 64 51.2 " id="Line005_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 0.0 L 64 38.4 " id="Line006_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 0.0 L 64 25.6 " id="Line007_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 0.0 L 64 12.8 " id="Line008_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 51.2 L 64 51.2 " id="Line010_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 64 L 64 64 " id="Line009_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 38.4 L 64 38.4 " id="Line011_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 25.6 L 64 25.6 " id="Line012_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 12.8 L 64 12.8 " id="Line013_w0000" />
   </g>
 </svg>

--- a/src/Mod/Draft/Resources/patterns/titanium.svg
+++ b/src/Mod/Draft/Resources/patterns/titanium.svg
@@ -11,60 +11,60 @@
   </metadata>
   <defs id="defs10843" />
   <g id="groue">
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 6.4 L 60.8 9.6 " id="Line055_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 41.6 38.4 L 44.8 41.6 " id="Line008_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 0.0 L 64.0 25.6 " id="Line040_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 54.4 0.0 L 64.0 9.6 " id="Line042_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 12.8 L 3.2 16.0 " id="Line029_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 60.8 L 35.2 64.0 " id="Line028_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 6.4 L 28.8 9.6 " id="Line044_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 57.6 L 48.0 60.8 " id="Line036_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 32.0 L 54.4 35.2 " id="Line048_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 48.0 L 16.0 64.0 " id="Line015_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 25.6 L 16.0 28.8 " id="Line031_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 32.0 L 32.0 64.0 " id="Line016_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 51.2 L 41.6 54.4 " id="Line035_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 41.6 L 22.4 64.0 " id="Line014_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 60.8 57.6 L 64.0 60.8 " id="Line011_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 57.6 L 6.4 64.0 " id="Line012_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 48.0 L 22.4 51.2 " id="Line026_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 54.4 L 28.8 57.6 " id="Line027_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 19.2 L 9.6 22.4 " id="Line030_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 44.8 L 51.2 48.0 " id="Line009_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 32.0 L 22.4 35.2 " id="Line032_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 38.4 L 28.8 41.6 " id="Line033_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 54.4 51.2 L 57.6 54.4 " id="Line010_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 44.8 L 35.2 48.0 " id="Line034_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 16.0 0.0 L 64.0 48.0 " id="Line037_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 22.4 0.0 L 64.0 41.6 " id="Line038_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 0.0 L 64.0 32.0 " id="Line039_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 0.0 L 64.0 16.0 " id="Line041_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 0.0 L 22.4 3.2 " id="Line043_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 12.8 L 35.2 16.0 " id="Line045_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 19.2 L 41.6 22.4 " id="Line046_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 25.6 L 48.0 28.8 " id="Line047_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 38.4 L 60.8 41.6 " id="Line049_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 3.2 L 41.6 6.4 " id="Line050_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 22.4 L 60.8 25.6 " id="Line053_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 0.0 L 54.4 3.2 " id="Line054_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 9.6 L 48.0 12.8 " id="Line051_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 16.0 L 54.4 19.2 " id="Line052_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 16.0 L 48.0 64.0 " id="Line018_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 3.2 0.0 L 6.4 3.2 " id="Line002_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 25.6 L 38.4 64.0 " id="Line017_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 9.6 L 54.4 64.0 " id="Line019_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 44.8 L 3.2 48.0 " id="Line020_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 51.2 L 9.6 54.4 " id="Line021_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 57.6 L 16.0 60.8 " id="Line022_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 28.8 L 3.2 32.0 " id="Line023_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 35.2 L 9.6 38.4 " id="Line024_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 41.6 L 16.0 44.8 " id="Line025_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 0.0 L 64.0 57.6 " id="Line001_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 9.6 6.4 L 12.8 9.6 " id="Line003_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 22.4 19.2 L 25.6 22.4 " id="Line005_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 16.0 12.8 L 19.2 16.0 " id="Line004_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 28.8 25.6 L 32.0 28.8 " id="Line006_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 35.2 32.0 L 38.4 35.2 " id="Line007_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 6.4 L 60.8 9.6 " id="Line055_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 41.6 38.4 L 44.8 41.6 " id="Line008_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 0.0 L 64.0 25.6 " id="Line040_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 54.4 0.0 L 64.0 9.6 " id="Line042_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 12.8 L 3.2 16.0 " id="Line029_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 60.8 L 35.2 64.0 " id="Line028_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 6.4 L 28.8 9.6 " id="Line044_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 57.6 L 48.0 60.8 " id="Line036_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 32.0 L 54.4 35.2 " id="Line048_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 48.0 L 16.0 64.0 " id="Line015_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 25.6 L 16.0 28.8 " id="Line031_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 32.0 L 32.0 64.0 " id="Line016_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 51.2 L 41.6 54.4 " id="Line035_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 41.6 L 22.4 64.0 " id="Line014_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 60.8 57.6 L 64.0 60.8 " id="Line011_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 57.6 L 6.4 64.0 " id="Line012_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 48.0 L 22.4 51.2 " id="Line026_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 54.4 L 28.8 57.6 " id="Line027_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 19.2 L 9.6 22.4 " id="Line030_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 44.8 L 51.2 48.0 " id="Line009_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 32.0 L 22.4 35.2 " id="Line032_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 38.4 L 28.8 41.6 " id="Line033_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 54.4 51.2 L 57.6 54.4 " id="Line010_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 44.8 L 35.2 48.0 " id="Line034_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 16.0 0.0 L 64.0 48.0 " id="Line037_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 22.4 0.0 L 64.0 41.6 " id="Line038_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 0.0 L 64.0 32.0 " id="Line039_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 0.0 L 64.0 16.0 " id="Line041_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 0.0 L 22.4 3.2 " id="Line043_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 12.8 L 35.2 16.0 " id="Line045_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 19.2 L 41.6 22.4 " id="Line046_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 25.6 L 48.0 28.8 " id="Line047_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 38.4 L 60.8 41.6 " id="Line049_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 3.2 L 41.6 6.4 " id="Line050_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 22.4 L 60.8 25.6 " id="Line053_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 0.0 L 54.4 3.2 " id="Line054_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 9.6 L 48.0 12.8 " id="Line051_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 16.0 L 54.4 19.2 " id="Line052_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 16.0 L 48.0 64.0 " id="Line018_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 3.2 0.0 L 6.4 3.2 " id="Line002_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 25.6 L 38.4 64.0 " id="Line017_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 9.6 L 54.4 64.0 " id="Line019_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 44.8 L 3.2 48.0 " id="Line020_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 51.2 L 9.6 54.4 " id="Line021_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 57.6 L 16.0 60.8 " id="Line022_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 28.8 L 3.2 32.0 " id="Line023_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 35.2 L 9.6 38.4 " id="Line024_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 41.6 L 16.0 44.8 " id="Line025_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 0.0 L 64.0 57.6 " id="Line001_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 9.6 6.4 L 12.8 9.6 " id="Line003_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 22.4 19.2 L 25.6 22.4 " id="Line005_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 16.0 12.8 L 19.2 16.0 " id="Line004_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 28.8 25.6 L 32.0 28.8 " id="Line006_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 35.2 32.0 L 38.4 35.2 " id="Line007_w0000" />
   </g>
 </svg>

--- a/src/Mod/Draft/Resources/patterns/zinc.svg
+++ b/src/Mod/Draft/Resources/patterns/zinc.svg
@@ -11,23 +11,23 @@
   </metadata>
   <defs id="defs7379" />
   <g id="Groupe">
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 64.0 L 64.0 0.0 " id="Line_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6000003815 0.0 L 64.0 38.4000015259 " id="Line016_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4000015259 0.0 L 64.0 25.6000003815 " id="Line017_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2000007629 0.0 L 64.0 12.8000001907 " id="Line018_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 51.2 L 51.2 0.0 " id="Line007_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 38.4 L 38.4 0.0 " id="Line008_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 12.8 L 12.8 0.0 " id="Line010_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 64.0 L 64.0 38.4 " id="Line006_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.186683624983 12.6133165359 L 51.2000007629 64.0 " id="Line011_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.108462266624 51.0915374756 L 12.8503952026 63.9496040344 " id="Line014_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 64.0 L 64.0 51.2 " id="Line005_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 64.0 L 64.0 25.6 " id="Line003_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line001_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 64.0 L 64.0 12.8 " id="Line002_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.141254857183 25.4587459564 L 38.4251213074 63.9748802185 " id="Line012_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 25.6 L 25.6 0.0 " id="Line009_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0958266854286 38.3041763306 L 25.6377563477 63.9622421265 " id="Line013_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.7872076035 0.0127922063693 L 64.0 51.2000007629 " id="Line015_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 64.0 L 64.0 0.0 " id="Line_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6000003815 0.0 L 64.0 38.4000015259 " id="Line016_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4000015259 0.0 L 64.0 25.6000003815 " id="Line017_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2000007629 0.0 L 64.0 12.8000001907 " id="Line018_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 51.2 L 51.2 0.0 " id="Line007_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 38.4 L 38.4 0.0 " id="Line008_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 12.8 L 12.8 0.0 " id="Line010_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 64.0 L 64.0 38.4 " id="Line006_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.186683624983 12.6133165359 L 51.2000007629 64.0 " id="Line011_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.108462266624 51.0915374756 L 12.8503952026 63.9496040344 " id="Line014_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 64.0 L 64.0 51.2 " id="Line005_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 64.0 L 64.0 25.6 " id="Line003_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line001_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 64.0 L 64.0 12.8 " id="Line002_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.141254857183 25.4587459564 L 38.4251213074 63.9748802185 " id="Line012_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 25.6 L 25.6 0.0 " id="Line009_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0958266854286 38.3041763306 L 25.6377563477 63.9622421265 " id="Line013_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.7872076035 0.0127922063693 L 64.0 51.2000007629 " id="Line015_w0000" />
   </g>
 </svg>

--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -325,7 +325,7 @@ def _svg_dimension(
     if not nolines:
         svg += 'fill="none" stroke="'
         svg += stroke + '" '
-        svg += 'stroke-width="' + str(linewidth) + ' px" '
+        svg += 'stroke-width="' + str(linewidth) + 'px" '
         svg += 'style="stroke-width:' + str(linewidth)
         svg += ';stroke-miterlimit:4;stroke-dasharray:none;stroke-linecap:square" '
         svg += 'freecad:basepoint1="' + str(p1.x) + " " + str(p1.y) + '" '
@@ -707,7 +707,7 @@ def get_svg(
                         )
                         svg += '<path d="' + d1 + '" '
                         svg += 'fill="none" stroke="' + stroke + '" '
-                        svg += 'stroke-width="' + str(linewidth) + ' px" '
+                        svg += 'stroke-width="' + str(linewidth) + 'px" '
                         svg += 'style="stroke-width:' + str(linewidth)
                         svg += (
                             ";stroke-miterlimit:4;stroke-dasharray:"
@@ -716,7 +716,7 @@ def get_svg(
                         )
                         svg += '<path d="' + d2 + '" '
                         svg += 'fill="none" stroke="' + stroke + '" '
-                        svg += 'stroke-width="' + str(linewidth) + ' px" '
+                        svg += 'stroke-width="' + str(linewidth) + 'px" '
                         svg += 'style="stroke-width:' + str(linewidth)
                         svg += (
                             ";stroke-miterlimit:4;stroke-dasharray:"

--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -803,7 +803,7 @@ def get_svg(
                 svg_path = "<path "
                 svg_path += 'fill="none" '
                 svg_path += 'stroke="{}" '.format(stroke)
-                svg_path += 'stroke-width="{}" '.format(linewidth)
+                svg_path += 'stroke-width="{}px" '.format(linewidth)
                 svg_path += 'stroke-linecap="square" '
                 svg_path += 'd="{}"'.format(path_dir_str)
                 svg_path += "/>"

--- a/src/Mod/Draft/draftfunctions/svgshapes.py
+++ b/src/Mod/Draft/draftfunctions/svgshapes.py
@@ -289,7 +289,7 @@ def get_circle(plane, fill, stroke, linewidth, lstyle, edge):
     svg += 'stroke="{}" '.format(stroke)
     # Editor: why is stroke-width repeated? Is this really necessary
     # for the generated SVG?
-    svg += 'stroke-width="{} px" '.format(linewidth)
+    svg += 'stroke-width="{}px" '.format(linewidth)
     svg += 'style="'
     svg += "stroke-width:{};".format(linewidth)
     svg += "stroke-miterlimit:4;"
@@ -315,7 +315,7 @@ def get_ellipse(plane, fill, stroke, linewidth, lstyle, edge):
     svg += 'cx="{}" cy="{}" '.format(cen.x, cen.y)
     svg += 'rx="{}" ry="{}" '.format(mar, mir)
     svg += 'stroke="{}" '.format(stroke)
-    svg += 'stroke-width="{} px" '.format(linewidth)
+    svg += 'stroke-width="{}px" '.format(linewidth)
     svg += 'style="'
     svg += "stroke-width:{};".format(linewidth)
     svg += "stroke-miterlimit:4;"
@@ -445,7 +445,7 @@ def get_path(
 
     svg += '" '
     svg += 'stroke="{}" '.format(stroke)
-    svg += 'stroke-width="{} px" '.format(linewidth)
+    svg += 'stroke-width="{}px" '.format(linewidth)
     svg += 'style="'
     svg += "stroke-width:{};".format(linewidth)
     svg += "stroke-miterlimit:4;"

--- a/src/Mod/TechDraw/Patterns/aluminium.svg
+++ b/src/Mod/TechDraw/Patterns/aluminium.svg
@@ -11,20 +11,20 @@
   </metadata>
   <defs id="defs21" />
   <g id="groupe1">
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 64.0 L 0.0 16.0 " id="Line014_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 64.0 L 0.0 12.8 " id="Line015_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 0.0 L 64.0 12.8 " id="Line013_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 3.2 0.0 L 64.0 60.8 " id="Line001_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 60.8 L 3.2 64.0 " id="Line002_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 35.2 0.0 L 64.0 28.8 " id="Line006_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 44.8 L 19.2 64.0 " id="Line009_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 64.0 48.0 L 16.0 0.0 " id="Line010_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 32.0 L 32.0 64.0 " id="Line003_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 64.0 44.8 L 19.2 0.0 " id="Line011_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 0.0 L 64.0 16.0 " id="Line012_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 28.8 L 35.2 64.0 " id="Line004_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 0.0 L 64.0 32.0 " id="Line005_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 48.0 L 16.0 64.0 " id="Line008_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 64.0 L 0.0 16.0 " id="Line014_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 64.0 L 0.0 12.8 " id="Line015_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 0.0 L 64.0 12.8 " id="Line013_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 3.2 0.0 L 64.0 60.8 " id="Line001_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 60.8 L 3.2 64.0 " id="Line002_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 35.2 0.0 L 64.0 28.8 " id="Line006_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 44.8 L 19.2 64.0 " id="Line009_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 64.0 48.0 L 16.0 0.0 " id="Line010_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 32.0 L 32.0 64.0 " id="Line003_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 64.0 44.8 L 19.2 0.0 " id="Line011_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 0.0 L 64.0 16.0 " id="Line012_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 28.8 L 35.2 64.0 " id="Line004_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 0.0 L 64.0 32.0 " id="Line005_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 48.0 L 16.0 64.0 " id="Line008_w0000" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Patterns/cuprous.svg
+++ b/src/Mod/TechDraw/Patterns/cuprous.svg
@@ -11,64 +11,64 @@
   </metadata>
   <defs id="defs65" />
   <g id="groupe1">
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 19.2 L 16.0 22.4 " id="Line022_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 6.4 L 16.0 9.6 " id="Line023_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 51.2 L 22.4 54.4 " id="Line024_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 25.6 L 22.4 28.8 " id="Line026_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 38.4 L 22.4 41.6 " id="Line025_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 0.0 L 9.6 3.2 " id="Line014_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 19.2 L 3.2 22.4 " id="Line012_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 38.4 L 9.6 41.6 " id="Line016_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 25.6 L 9.6 28.8 " id="Line017_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 44.8 L 16.0 48.0 " id="Line020_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 6.4 L 3.2 9.6 " id="Line013_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 32.0 L 16.0 35.2 " id="Line021_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 32.0 L 3.2 35.2 " id="Line011_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 12.8 L 9.6 16.0 " id="Line018_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 51.2 L 9.6 54.4 " id="Line015_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 57.6 L 16.0 60.8 " id="Line019_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 0.0 L 64.0 12.8 " id="Line008_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 57.6 L 3.2 60.8 " id="Line009_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 44.8 L 3.2 48.0 " id="Line010_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 12.8 L 51.2 64.0 " id="Line001_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 0.0 L 64.0 51.2 " id="Line005_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 38.4 L 25.6 64.0 " id="Line003_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 51.2 L 12.8 64.0 " id="Line004_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 25.6 L 38.4 64.0 " id="Line002_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 0.0 L 64.0 38.4 " id="Line006_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 0.0 L 64.0 25.6 " id="Line007_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 6.4 L 41.6 9.6 " id="Line043_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 25.6 L 48.0 28.8 " id="Line046_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 0.0 L 35.2 3.2 " id="Line034_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 57.6 L 28.8 60.8 " id="Line029_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 32.0 L 28.8 35.2 " id="Line031_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 6.4 L 28.8 9.6 " id="Line033_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 12.8 L 35.2 16.0 " id="Line035_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 19.2 L 41.6 22.4 " id="Line042_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 0.0 L 48.0 3.2 " id="Line044_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 57.6 L 54.4 60.8 " id="Line049_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 44.8 L 28.8 48.0 " id="Line030_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 19.2 L 28.8 22.4 " id="Line032_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 57.6 L 41.6 60.8 " id="Line039_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 12.8 L 48.0 16.0 " id="Line045_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 32.0 L 54.4 35.2 " id="Line051_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 0.0 L 22.4 3.2 " id="Line028_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 44.8 L 41.6 48.0 " id="Line040_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 38.4 L 48.0 41.6 " id="Line047_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 25.6 L 35.2 28.8 " id="Line036_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 32.0 L 41.6 35.2 " id="Line041_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 38.4 L 35.2 41.6 " id="Line037_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 51.2 L 48.0 54.4 " id="Line048_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 51.2 L 35.2 54.4 " id="Line038_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 44.8 L 54.4 48.0 " id="Line050_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 12.8 L 22.4 16.0 " id="Line027_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 19.2 L 54.4 22.4 " id="Line052_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 6.4 L 54.4 9.6 " id="Line053_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 51.2 L 60.8 54.4 " id="Line058_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 12.8 L 60.8 16.0 " id="Line055_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 38.4 L 60.8 41.6 " id="Line057_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 0.0 L 60.8 3.2 " id="Line054_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 25.6 L 60.8 28.8 " id="Line056_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 19.2 L 16.0 22.4 " id="Line022_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 6.4 L 16.0 9.6 " id="Line023_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 51.2 L 22.4 54.4 " id="Line024_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 25.6 L 22.4 28.8 " id="Line026_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 38.4 L 22.4 41.6 " id="Line025_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 0.0 L 9.6 3.2 " id="Line014_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 19.2 L 3.2 22.4 " id="Line012_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 38.4 L 9.6 41.6 " id="Line016_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 25.6 L 9.6 28.8 " id="Line017_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 44.8 L 16.0 48.0 " id="Line020_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 6.4 L 3.2 9.6 " id="Line013_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 32.0 L 16.0 35.2 " id="Line021_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 32.0 L 3.2 35.2 " id="Line011_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 12.8 L 9.6 16.0 " id="Line018_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 51.2 L 9.6 54.4 " id="Line015_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 57.6 L 16.0 60.8 " id="Line019_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 0.0 L 64.0 12.8 " id="Line008_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 57.6 L 3.2 60.8 " id="Line009_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 44.8 L 3.2 48.0 " id="Line010_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 12.8 L 51.2 64.0 " id="Line001_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 0.0 L 64.0 51.2 " id="Line005_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 38.4 L 25.6 64.0 " id="Line003_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 51.2 L 12.8 64.0 " id="Line004_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 25.6 L 38.4 64.0 " id="Line002_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 0.0 L 64.0 38.4 " id="Line006_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 0.0 L 64.0 25.6 " id="Line007_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 6.4 L 41.6 9.6 " id="Line043_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 25.6 L 48.0 28.8 " id="Line046_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 0.0 L 35.2 3.2 " id="Line034_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 57.6 L 28.8 60.8 " id="Line029_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 32.0 L 28.8 35.2 " id="Line031_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 6.4 L 28.8 9.6 " id="Line033_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 12.8 L 35.2 16.0 " id="Line035_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 19.2 L 41.6 22.4 " id="Line042_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 0.0 L 48.0 3.2 " id="Line044_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 57.6 L 54.4 60.8 " id="Line049_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 44.8 L 28.8 48.0 " id="Line030_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 19.2 L 28.8 22.4 " id="Line032_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 57.6 L 41.6 60.8 " id="Line039_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 12.8 L 48.0 16.0 " id="Line045_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 32.0 L 54.4 35.2 " id="Line051_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 0.0 L 22.4 3.2 " id="Line028_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 44.8 L 41.6 48.0 " id="Line040_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 38.4 L 48.0 41.6 " id="Line047_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 25.6 L 35.2 28.8 " id="Line036_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 32.0 L 41.6 35.2 " id="Line041_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 38.4 L 35.2 41.6 " id="Line037_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 51.2 L 48.0 54.4 " id="Line048_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 51.2 L 35.2 54.4 " id="Line038_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 44.8 L 54.4 48.0 " id="Line050_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 12.8 L 22.4 16.0 " id="Line027_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 19.2 L 54.4 22.4 " id="Line052_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 6.4 L 54.4 9.6 " id="Line053_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 51.2 L 60.8 54.4 " id="Line058_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 12.8 L 60.8 16.0 " id="Line055_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 38.4 L 60.8 41.6 " id="Line057_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 0.0 L 60.8 3.2 " id="Line054_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 25.6 L 60.8 28.8 " id="Line056_w0000" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Patterns/general_steel.svg
+++ b/src/Mod/TechDraw/Patterns/general_steel.svg
@@ -11,14 +11,14 @@
   </metadata>
   <defs id="defs15" />
   <g id="aaaa">
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 12.8 L 51.2 64.0 " id="Line001_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 25.6 L 38.4 64.0 " id="Line002_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 0.0 L 64.0 51.2 " id="Line005_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 0.0 L 64.0 12.8 " id="Line008_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 0.0 L 64.0 25.6 " id="Line007_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 51.2 L 12.8 64.0 " id="Line004_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 38.4 L 25.6 64.0 " id="Line003_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 0.0 L 64.0 38.4 " id="Line006_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 12.8 L 51.2 64.0 " id="Line001_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 25.6 L 38.4 64.0 " id="Line002_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 0.0 L 64.0 51.2 " id="Line005_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 0.0 L 64.0 12.8 " id="Line008_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 0.0 L 64.0 25.6 " id="Line007_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 51.2 L 12.8 64.0 " id="Line004_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 38.4 L 25.6 64.0 " id="Line003_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 0.0 L 64.0 38.4 " id="Line006_w0000" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Patterns/glass.svg
+++ b/src/Mod/TechDraw/Patterns/glass.svg
@@ -11,85 +11,85 @@
   </metadata>
   <defs id="defs3637" />
   <g id="groupe1">
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 41.6 57.6 L 44.8 60.8 " id="Line605_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 35.2 0.0 L 38.4 3.2 " id="Line090_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 41.6 6.4 L 44.8 9.6 " id="Line091_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 32.0 L 51.2 35.2 " id="Line075_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 54.4 38.4 L 57.6 41.6 " id="Line076_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 60.8 44.8 L 64.0 48.0 " id="Line077_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 25.6 L 60.8 28.8 " id="Line089_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 54.4 19.2 L 57.6 22.4 " id="Line093_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 60.8 25.6 L 64.0 28.8 " id="Line094_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 12.8 L 51.2 16.0 " id="Line092_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 60.8 L 9.6 57.6 " id="Line354_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 0.0 L 35.2 3.2 " id="Line085_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 54.4 L 3.2 51.2 " id="Line355_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 6.4 L 28.8 9.6 " id="Line079_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 12.8 L 48.0 16.0 " id="Line087_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 19.2 L 54.4 22.4 " id="Line088_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 25.6 L 28.8 28.8 " id="Line054_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 19.2 L 22.4 22.4 " id="Line053_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 12.8 L 35.2 16.0 " id="Line080_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 0.0 L 22.4 3.2 " id="Line078_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 6.4 L 41.6 9.6 " id="Line086_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 28.8 25.6 L 32.0 28.8 " id="Line064_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 60.8 12.8 L 64.0 16.0 " id="Line097_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 54.4 6.4 L 57.6 9.6 " id="Line096_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 0.0 L 3.2 3.2 " id="Line000_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 6.4 L 9.6 9.6 " id="Line051_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 51.2 L 41.6 54.4 " id="Line049_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 57.6 L 48.0 60.8 " id="Line050_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 57.6 L 60.8 60.8 " id="Line059_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 12.8 L 16.0 16.0 " id="Line052_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 22.4 6.4 L 25.6 9.6 " id="Line071_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 28.8 12.8 L 32.0 16.0 " id="Line072_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 35.2 32.0 L 38.4 35.2 " id="Line065_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 35.2 19.2 L 38.4 22.4 " id="Line073_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 28.8 57.6 L 32.0 60.8 " id="Line353_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 32.0 L 35.2 35.2 " id="Line055_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 38.4 L 41.6 41.6 " id="Line056_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 44.8 L 48.0 48.0 " id="Line057_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 22.4 19.2 L 25.6 22.4 " id="Line063_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 51.2 L 54.4 54.4 " id="Line058_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 16.0 12.8 L 19.2 16.0 " id="Line062_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 41.6 38.4 L 44.8 41.6 " id="Line066_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 0.0 L 54.4 3.2 " id="Line098_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 9.6 6.4 L 12.8 9.6 " id="Line061_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 44.8 L 51.2 48.0 " id="Line067_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 54.4 51.2 L 57.6 54.4 " id="Line068_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 16.0 0.0 L 19.2 3.2 " id="Line070_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 60.8 57.6 L 64.0 60.8 " id="Line069_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 3.2 0.0 L 6.4 3.2 " id="Line060_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 22.4 51.2 L 25.6 54.4 " id="Line352_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 25.6 L 48.0 28.8 " id="Line082_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 57.6 L 28.8 60.8 " id="Line027_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 44.8 L 3.2 48.0 " id="Line020_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 19.2 L 41.6 22.4 " id="Line081_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 57.6 L 16.0 60.8 " id="Line022_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 51.2 L 22.4 54.4 " id="Line026_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 32.0 L 54.4 35.2 " id="Line083_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 41.6 25.6 L 44.8 28.8 " id="Line074_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 38.4 L 60.8 41.6 " id="Line084_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 19.2 L 9.6 22.4 " id="Line044_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 51.2 L 9.6 54.4 " id="Line021_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 38.4 L 9.6 41.6 " id="Line024_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 32.0 L 3.2 35.2 " id="Line023_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 44.8 L 16.0 48.0 " id="Line025_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 0.0 L 51.2 3.2 " id="Line095_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 6.4 L 60.8 9.6 " id="Line099_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 32.0 L 22.4 35.2 " id="Line046_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 12.8 L 3.2 16.0 " id="Line043_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 25.6 L 16.0 28.8 " id="Line045_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 38.4 L 28.8 41.6 " id="Line047_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 44.8 L 35.2 48.0 " id="Line048_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 35.2 51.2 L 38.4 54.4 " id="Line604_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 9.6 38.4 L 12.8 41.6 " id="Line350_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 3.2 32.0 L 6.4 35.2 " id="Line349_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 16.0 44.8 L 19.2 48.0 " id="Line351_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 28.8 44.8 L 32.0 48.0 " id="Line603_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 3.2 19.2 L 6.4 22.4 " id="Line599_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 22.4 38.4 L 25.6 41.6 " id="Line602_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 16.0 32.0 L 19.2 35.2 " id="Line601_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 9.6 25.6 L 12.8 28.8 " id="Line600_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 41.6 57.6 L 44.8 60.8 " id="Line605_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 35.2 0.0 L 38.4 3.2 " id="Line090_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 41.6 6.4 L 44.8 9.6 " id="Line091_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 32.0 L 51.2 35.2 " id="Line075_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 54.4 38.4 L 57.6 41.6 " id="Line076_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 60.8 44.8 L 64.0 48.0 " id="Line077_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 25.6 L 60.8 28.8 " id="Line089_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 54.4 19.2 L 57.6 22.4 " id="Line093_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 60.8 25.6 L 64.0 28.8 " id="Line094_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 12.8 L 51.2 16.0 " id="Line092_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 60.8 L 9.6 57.6 " id="Line354_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 0.0 L 35.2 3.2 " id="Line085_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 54.4 L 3.2 51.2 " id="Line355_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 6.4 L 28.8 9.6 " id="Line079_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 12.8 L 48.0 16.0 " id="Line087_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 19.2 L 54.4 22.4 " id="Line088_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 25.6 L 28.8 28.8 " id="Line054_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 19.2 L 22.4 22.4 " id="Line053_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 12.8 L 35.2 16.0 " id="Line080_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 0.0 L 22.4 3.2 " id="Line078_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 6.4 L 41.6 9.6 " id="Line086_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 28.8 25.6 L 32.0 28.8 " id="Line064_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 60.8 12.8 L 64.0 16.0 " id="Line097_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 54.4 6.4 L 57.6 9.6 " id="Line096_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 0.0 L 3.2 3.2 " id="Line000_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 6.4 L 9.6 9.6 " id="Line051_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 51.2 L 41.6 54.4 " id="Line049_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 57.6 L 48.0 60.8 " id="Line050_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 57.6 L 60.8 60.8 " id="Line059_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 12.8 L 16.0 16.0 " id="Line052_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 22.4 6.4 L 25.6 9.6 " id="Line071_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 28.8 12.8 L 32.0 16.0 " id="Line072_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 35.2 32.0 L 38.4 35.2 " id="Line065_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 35.2 19.2 L 38.4 22.4 " id="Line073_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 28.8 57.6 L 32.0 60.8 " id="Line353_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 32.0 L 35.2 35.2 " id="Line055_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 38.4 L 41.6 41.6 " id="Line056_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 44.8 L 48.0 48.0 " id="Line057_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 22.4 19.2 L 25.6 22.4 " id="Line063_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 51.2 L 54.4 54.4 " id="Line058_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 16.0 12.8 L 19.2 16.0 " id="Line062_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 41.6 38.4 L 44.8 41.6 " id="Line066_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 0.0 L 54.4 3.2 " id="Line098_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 9.6 6.4 L 12.8 9.6 " id="Line061_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 44.8 L 51.2 48.0 " id="Line067_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 54.4 51.2 L 57.6 54.4 " id="Line068_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 16.0 0.0 L 19.2 3.2 " id="Line070_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 60.8 57.6 L 64.0 60.8 " id="Line069_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 3.2 0.0 L 6.4 3.2 " id="Line060_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 22.4 51.2 L 25.6 54.4 " id="Line352_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 25.6 L 48.0 28.8 " id="Line082_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 57.6 L 28.8 60.8 " id="Line027_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 44.8 L 3.2 48.0 " id="Line020_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 19.2 L 41.6 22.4 " id="Line081_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 57.6 L 16.0 60.8 " id="Line022_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 51.2 L 22.4 54.4 " id="Line026_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 32.0 L 54.4 35.2 " id="Line083_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 41.6 25.6 L 44.8 28.8 " id="Line074_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 38.4 L 60.8 41.6 " id="Line084_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 19.2 L 9.6 22.4 " id="Line044_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 51.2 L 9.6 54.4 " id="Line021_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 38.4 L 9.6 41.6 " id="Line024_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 32.0 L 3.2 35.2 " id="Line023_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 44.8 L 16.0 48.0 " id="Line025_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 0.0 L 51.2 3.2 " id="Line095_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 6.4 L 60.8 9.6 " id="Line099_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 32.0 L 22.4 35.2 " id="Line046_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 12.8 L 3.2 16.0 " id="Line043_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 25.6 L 16.0 28.8 " id="Line045_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 38.4 L 28.8 41.6 " id="Line047_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 44.8 L 35.2 48.0 " id="Line048_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 35.2 51.2 L 38.4 54.4 " id="Line604_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 9.6 38.4 L 12.8 41.6 " id="Line350_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 3.2 32.0 L 6.4 35.2 " id="Line349_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 16.0 44.8 L 19.2 48.0 " id="Line351_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 28.8 44.8 L 32.0 48.0 " id="Line603_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 3.2 19.2 L 6.4 22.4 " id="Line599_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 22.4 38.4 L 25.6 41.6 " id="Line602_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 16.0 32.0 L 19.2 35.2 " id="Line601_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 9.6 25.6 L 12.8 28.8 " id="Line600_w0000" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Patterns/plastic.svg
+++ b/src/Mod/TechDraw/Patterns/plastic.svg
@@ -11,19 +11,19 @@
   </metadata>
   <defs id="defs8742" />
   <g id="aaaa">
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 51.2 L 12.8 64.0 " id="Line_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 12.8 L 51.2 64 " id="Line003_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 38.4 L 25.6 64 " id="Line001_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 0.0 L 64 64 " id="Line004_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 25.6 L 38.4 64 " id="Line002_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 0.0 L 64 51.2 " id="Line005_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 0.0 L 64 38.4 " id="Line006_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 0.0 L 64 25.6 " id="Line007_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 0.0 L 64 12.8 " id="Line008_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 51.2 L 64 51.2 " id="Line010_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 64 L 64 64 " id="Line009_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 38.4 L 64 38.4 " id="Line011_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 25.6 L 64 25.6 " id="Line012_w0000" />
-    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 12.8 L 64 12.8 " id="Line013_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 51.2 L 12.8 64.0 " id="Line_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 12.8 L 51.2 64 " id="Line003_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 38.4 L 25.6 64 " id="Line001_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 0.0 L 64 64 " id="Line004_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 25.6 L 38.4 64 " id="Line002_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 0.0 L 64 51.2 " id="Line005_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 0.0 L 64 38.4 " id="Line006_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 0.0 L 64 25.6 " id="Line007_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 0.0 L 64 12.8 " id="Line008_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 51.2 L 64 51.2 " id="Line010_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 64 L 64 64 " id="Line009_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 38.4 L 64 38.4 " id="Line011_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 25.6 L 64 25.6 " id="Line012_w0000" />
+    <path style="stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 12.8 L 64 12.8 " id="Line013_w0000" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Patterns/titanium.svg
+++ b/src/Mod/TechDraw/Patterns/titanium.svg
@@ -11,60 +11,60 @@
   </metadata>
   <defs id="defs10843" />
   <g id="groue">
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 6.4 L 60.8 9.6 " id="Line055_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 41.6 38.4 L 44.8 41.6 " id="Line008_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 0.0 L 64.0 25.6 " id="Line040_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 54.4 0.0 L 64.0 9.6 " id="Line042_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 12.8 L 3.2 16.0 " id="Line029_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 60.8 L 35.2 64.0 " id="Line028_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 6.4 L 28.8 9.6 " id="Line044_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 57.6 L 48.0 60.8 " id="Line036_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 32.0 L 54.4 35.2 " id="Line048_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 48.0 L 16.0 64.0 " id="Line015_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 25.6 L 16.0 28.8 " id="Line031_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 32.0 L 32.0 64.0 " id="Line016_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 51.2 L 41.6 54.4 " id="Line035_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 41.6 L 22.4 64.0 " id="Line014_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 60.8 57.6 L 64.0 60.8 " id="Line011_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 57.6 L 6.4 64.0 " id="Line012_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 48.0 L 22.4 51.2 " id="Line026_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 54.4 L 28.8 57.6 " id="Line027_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 19.2 L 9.6 22.4 " id="Line030_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 44.8 L 51.2 48.0 " id="Line009_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 32.0 L 22.4 35.2 " id="Line032_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 38.4 L 28.8 41.6 " id="Line033_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 54.4 51.2 L 57.6 54.4 " id="Line010_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 44.8 L 35.2 48.0 " id="Line034_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 16.0 0.0 L 64.0 48.0 " id="Line037_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 22.4 0.0 L 64.0 41.6 " id="Line038_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 0.0 L 64.0 32.0 " id="Line039_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 48.0 0.0 L 64.0 16.0 " id="Line041_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 19.2 0.0 L 22.4 3.2 " id="Line043_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 32.0 12.8 L 35.2 16.0 " id="Line045_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 19.2 L 41.6 22.4 " id="Line046_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 25.6 L 48.0 28.8 " id="Line047_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 38.4 L 60.8 41.6 " id="Line049_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 3.2 L 41.6 6.4 " id="Line050_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 57.6 22.4 L 60.8 25.6 " id="Line053_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 0.0 L 54.4 3.2 " id="Line054_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 44.8 9.6 L 48.0 12.8 " id="Line051_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 16.0 L 54.4 19.2 " id="Line052_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 16.0 L 48.0 64.0 " id="Line018_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 3.2 0.0 L 6.4 3.2 " id="Line002_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 25.6 L 38.4 64.0 " id="Line017_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 9.6 L 54.4 64.0 " id="Line019_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 44.8 L 3.2 48.0 " id="Line020_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 51.2 L 9.6 54.4 " id="Line021_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 57.6 L 16.0 60.8 " id="Line022_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 28.8 L 3.2 32.0 " id="Line023_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 35.2 L 9.6 38.4 " id="Line024_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 41.6 L 16.0 44.8 " id="Line025_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 6.4 0.0 L 64.0 57.6 " id="Line001_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 9.6 6.4 L 12.8 9.6 " id="Line003_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 22.4 19.2 L 25.6 22.4 " id="Line005_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 16.0 12.8 L 19.2 16.0 " id="Line004_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 28.8 25.6 L 32.0 28.8 " id="Line006_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 35.2 32.0 L 38.4 35.2 " id="Line007_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 6.4 L 60.8 9.6 " id="Line055_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 41.6 38.4 L 44.8 41.6 " id="Line008_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 0.0 L 64.0 25.6 " id="Line040_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 54.4 0.0 L 64.0 9.6 " id="Line042_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 12.8 L 3.2 16.0 " id="Line029_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 60.8 L 35.2 64.0 " id="Line028_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 6.4 L 28.8 9.6 " id="Line044_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 57.6 L 48.0 60.8 " id="Line036_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 32.0 L 54.4 35.2 " id="Line048_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 48.0 L 16.0 64.0 " id="Line015_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 25.6 L 16.0 28.8 " id="Line031_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 32.0 L 32.0 64.0 " id="Line016_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 51.2 L 41.6 54.4 " id="Line035_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 41.6 L 22.4 64.0 " id="Line014_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 60.8 57.6 L 64.0 60.8 " id="Line011_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 57.6 L 6.4 64.0 " id="Line012_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 48.0 L 22.4 51.2 " id="Line026_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 54.4 L 28.8 57.6 " id="Line027_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 19.2 L 9.6 22.4 " id="Line030_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 44.8 L 51.2 48.0 " id="Line009_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 32.0 L 22.4 35.2 " id="Line032_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 38.4 L 28.8 41.6 " id="Line033_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 54.4 51.2 L 57.6 54.4 " id="Line010_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 44.8 L 35.2 48.0 " id="Line034_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 16.0 0.0 L 64.0 48.0 " id="Line037_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 22.4 0.0 L 64.0 41.6 " id="Line038_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 0.0 L 64.0 32.0 " id="Line039_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 48.0 0.0 L 64.0 16.0 " id="Line041_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 19.2 0.0 L 22.4 3.2 " id="Line043_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 32.0 12.8 L 35.2 16.0 " id="Line045_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 19.2 L 41.6 22.4 " id="Line046_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 25.6 L 48.0 28.8 " id="Line047_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 38.4 L 60.8 41.6 " id="Line049_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 3.2 L 41.6 6.4 " id="Line050_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 57.6 22.4 L 60.8 25.6 " id="Line053_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 0.0 L 54.4 3.2 " id="Line054_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 44.8 9.6 L 48.0 12.8 " id="Line051_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 16.0 L 54.4 19.2 " id="Line052_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 16.0 L 48.0 64.0 " id="Line018_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 3.2 0.0 L 6.4 3.2 " id="Line002_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 25.6 L 38.4 64.0 " id="Line017_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 9.6 L 54.4 64.0 " id="Line019_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 44.8 L 3.2 48.0 " id="Line020_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 51.2 L 9.6 54.4 " id="Line021_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 57.6 L 16.0 60.8 " id="Line022_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 28.8 L 3.2 32.0 " id="Line023_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 35.2 L 9.6 38.4 " id="Line024_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 41.6 L 16.0 44.8 " id="Line025_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 6.4 0.0 L 64.0 57.6 " id="Line001_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 9.6 6.4 L 12.8 9.6 " id="Line003_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 22.4 19.2 L 25.6 22.4 " id="Line005_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 16.0 12.8 L 19.2 16.0 " id="Line004_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 28.8 25.6 L 32.0 28.8 " id="Line006_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 35.2 32.0 L 38.4 35.2 " id="Line007_w0000" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Patterns/zinc.svg
+++ b/src/Mod/TechDraw/Patterns/zinc.svg
@@ -11,23 +11,23 @@
   </metadata>
   <defs id="defs7379" />
   <g id="Groupe">
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 64.0 L 64.0 0.0 " id="Line_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6000003815 0.0 L 64.0 38.4000015259 " id="Line016_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4000015259 0.0 L 64.0 25.6000003815 " id="Line017_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2000007629 0.0 L 64.0 12.8000001907 " id="Line018_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 51.2 L 51.2 0.0 " id="Line007_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 38.4 L 38.4 0.0 " id="Line008_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 12.8 L 12.8 0.0 " id="Line010_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 38.4 64.0 L 64.0 38.4 " id="Line006_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.186683624983 12.6133165359 L 51.2000007629 64.0 " id="Line011_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.108462266624 51.0915374756 L 12.8503952026 63.9496040344 " id="Line014_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 51.2 64.0 L 64.0 51.2 " id="Line005_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 25.6 64.0 L 64.0 25.6 " id="Line003_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line001_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.8 64.0 L 64.0 12.8 " id="Line002_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.141254857183 25.4587459564 L 38.4251213074 63.9748802185 " id="Line012_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0 25.6 L 25.6 0.0 " id="Line009_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 0.0958266854286 38.3041763306 L 25.6377563477 63.9622421265 " id="Line013_w0000" />
-    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35 px" stroke="#000000" d="M 12.7872076035 0.0127922063693 L 64.0 51.2000007629 " id="Line015_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 64.0 L 64.0 0.0 " id="Line_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6000003815 0.0 L 64.0 38.4000015259 " id="Line016_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4000015259 0.0 L 64.0 25.6000003815 " id="Line017_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2000007629 0.0 L 64.0 12.8000001907 " id="Line018_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 51.2 L 51.2 0.0 " id="Line007_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 38.4 L 38.4 0.0 " id="Line008_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 12.8 L 12.8 0.0 " id="Line010_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 38.4 64.0 L 64.0 38.4 " id="Line006_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.186683624983 12.6133165359 L 51.2000007629 64.0 " id="Line011_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.108462266624 51.0915374756 L 12.8503952026 63.9496040344 " id="Line014_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 51.2 64.0 L 64.0 51.2 " id="Line005_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 25.6 64.0 L 64.0 25.6 " id="Line003_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 0.0 L 64.0 64.0 " id="Line001_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.8 64.0 L 64.0 12.8 " id="Line002_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.141254857183 25.4587459564 L 38.4251213074 63.9748802185 " id="Line012_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0 25.6 L 25.6 0.0 " id="Line009_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 0.0958266854286 38.3041763306 L 25.6377563477 63.9622421265 " id="Line013_w0000" />
+    <path style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd" stroke-width="0.35px" stroke="#000000" d="M 12.7872076035 0.0127922063693 L 64.0 51.2000007629 " id="Line015_w0000" />
   </g>
 </svg>


### PR DESCRIPTION
There should be no space between the value and the unit.

https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeWidth