### PR TITLE
PartDesign: preserve nested up-to-face references

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -164,7 +164,15 @@ void TaskExtrudeParameters::setupSideDialog(SideController& side)
     }
 
     if (faceObj && PartDesign::Feature::isDatum(faceObj)) {
-        side.lineFaceName->setText(QString::fromUtf8(faceObj->Label.getValue()));
+        if (upToFaceName.empty()) {
+            side.lineFaceName->setText(QString::fromUtf8(faceObj->Label.getValue()));
+        }
+        else {
+            side.lineFaceName->setText(
+                QString::fromUtf8(faceObj->getNameInDocument()) + QStringLiteral(":")
+                + QString::fromStdString(upToFaceName)
+            );
+        }
         side.lineFaceName->setProperty("FeatureName", QByteArray(faceObj->getNameInDocument()));
     }
     else if (faceObj && faceId >= 0) {

--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
@@ -199,7 +199,16 @@ QVariant TaskSketchBasedParameters::setUpToFace(const QString& text)
         return {};
     }
 
-    if (obj->isDerivedFrom<Part::Datum>()) {
+    if (obj->isDerivedFrom<Part::Datum>() || obj->isDerivedFrom<App::DatumElement>()) {
+        if (parts.length() >= 2 && !parts[1].isEmpty()) {
+            std::vector<std::string> upToFaces(1, parts[1].toStdString());
+            auto sketchBased = getObject<PartDesign::ProfileBased>();
+            sketchBased->UpToFace.setValue(obj, upToFaces);
+            recomputeFeature();
+
+            return QByteArray(upToFaces.front().c_str());
+        }
+
         // it's up to the document to check that the datum plane is in the same body
         return {};
     }


### PR DESCRIPTION
Summary:
- Preserve nested datum references, such as `LCS:XY_Plane001`, when reopening Pad/Pocket task dialogs.
- Parse datum-element references with subelements so the dialog writes the original `(object, subelement)` `UpToFace` value instead of dropping the nested plane.

Related issue:
- Fixes FreeCAD/FreeCAD#30373

What changed:
- `TaskExtrudeParameters` now restores the visible line edit text with the nested datum subelement when one is stored.
- `TaskSketchBasedParameters::setUpToFace()` now accepts `App::DatumElement` references with a subelement and updates `UpToFace` accordingly.

Validation:
- Confirmed there are no open PRs currently referencing #30373.
- Ran a CRLF-aware trailing-whitespace check on the modified files.
- Confirmed only two PartDesign GUI source files changed; no translation, generated, or documentation files were touched.
- Attempted a local CMake configure with the existing Homebrew Qt6/Coin/OpenCASCADE setup. Configure did not complete because the local Homebrew PySide6 package references a missing `/opt/homebrew/typesystems` path before build files are generated.
