### PR TITLE
Fix closeDocument for sanitized document names

### DIFF
--- a/src/App/ApplicationPy.cpp
+++ b/src/App/ApplicationPy.cpp
@@ -26,6 +26,7 @@
 #include <FCConfig.h>
 
 #include <array>
+#include <string>
 
 #include <Base/Console.h>
 #include <Base/Exception.h>
@@ -34,6 +35,7 @@
 #include <Base/Parameter.h>
 #include <Base/PyWrapParseTupleAndKeywords.h>
 #include <Base/Sequencer.h>
+#include <Base/Tools.h>
 
 #include "Application.h"
 #include "ApplicationPy.h"
@@ -451,6 +453,12 @@ PyObject* ApplicationPy::sCloseDocument(PyObject* /*self*/, PyObject* args)
     if (PyArg_ParseTuple(args, "s", &pstr)) {
         Document* doc = GetApplication().getDocument(pstr);
         if (!doc) {
+            std::string cleanName = Base::Tools::getIdentifier(pstr);
+            if (cleanName != pstr) {
+                doc = GetApplication().getDocument(cleanName.c_str());
+            }
+        }
+        if (!doc) {
             PyErr_Format(PyExc_NameError, "Unknown document '%s'", pstr);
             return nullptr;
         }
@@ -459,7 +467,7 @@ PyObject* ApplicationPy::sCloseDocument(PyObject* /*self*/, PyObject* args)
             return nullptr;
         }
 
-        if (!GetApplication().closeDocument(pstr)) {
+        if (!GetApplication().closeDocument(doc)) {
             PyErr_Format(PyExc_RuntimeError, "Closing the document '%s' failed", pstr);
             return nullptr;
         }

--- a/src/Mod/Part/parttests/regression_tests.py
+++ b/src/Mod/Part/parttests/regression_tests.py
@@ -259,6 +259,23 @@ class RegressionTests(unittest.TestCase):
             # cluster should contain all edges
             self.assertEqual(len(clusters[0]), i)
 
+    def test_issue_15966_close_document_with_sanitized_name(self):
+        "closeDocument() accepts the original proposed name for sanitized document identifiers"
+        requested_name = "PartRegressionTest-Issue15966"
+        doc = newDocument(requested_name)
+        internal_name = doc.Name
+        try:
+            self.assertNotEqual(internal_name, requested_name)
+            self.assertEqual(internal_name, "PartRegressionTest_Issue15966")
+
+            closeDocument(requested_name)
+
+            self.assertIsNone(FreeCAD.getDocument(internal_name))
+            doc = None
+        finally:
+            if doc and FreeCAD.getDocument(internal_name):
+                closeDocument(internal_name)
+
     def tearDown(self):
         """Clean up our test, optionally preserving the test document"""
         # This flag allows doing something like this:


### PR DESCRIPTION
Summary:

Allow `FreeCAD.closeDocument()` to close a document using the originally requested name when `FreeCAD.newDocument()` sanitized that name into a valid internal document identifier.

Related issue:

Fixes FreeCAD/FreeCAD#15966

What changed:

- Resolve `closeDocument(str)` through `Base::Tools::getIdentifier()` when the exact document name lookup fails.
- Close the resolved document pointer instead of retrying the original unsanitized name.
- Add regression coverage for closing a document created with a hyphenated requested name.

Validation:

- `PYTHONPYCACHEPREFIX=/private/tmp/freecad-issue15966-pycache python3 -m py_compile src/Mod/Part/parttests/regression_tests.py`
- `git -c core.whitespace=cr-at-eol diff --check`
- Attempted local CMake configure with GUI disabled and a minimal module set; configure is blocked in this workspace by missing/incomplete FreeCAD build dependencies, so I could not run the FreeCAD runtime test locally.
