### PR TITLE
Build: Fix Ubuntu CI job

### DIFF
--- a/cMake/FindShiboken6.cmake
+++ b/cMake/FindShiboken6.cmake
@@ -18,7 +18,7 @@ if(NOT Shiboken6_FOUND)
         # The include directory we actually want is part of shiboken6-generator
         find_pip_package(shiboken6_generator)
         if(shiboken6_generator_FOUND)
-            set(SHIBOKEN_INCLUDE_DIR ${shiboken6_generator_INCLUDE_DIRS})
+            set(SHIBOKEN_INCLUDE_DIR ${shiboken6_generator_INCLUDE_DIRS};${shiboken6_generator_INCLUDE_DIRS}/shiboken6)
         endif()
     endif()
 else()


### PR DESCRIPTION
Shiboken 6.11 on Ubuntu changed the organization of the package, and headers are now in a shiboken6 directory in the root shiboken include dir.

@maxwxyz 
