### PR TITLE
Sketcher: Use old Polyline shortcut for new tool

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -236,7 +236,6 @@ CmdSketcherCreatePolylineLegacy::CmdSketcherCreatePolylineLegacy()
     sWhatsThis = "Sketcher_CreatePolylineLegacy";
     sStatusTip = sToolTipText;
     sPixmap = "Sketcher_CreatePolyline";
-    sAccel = "G, M";
     eType = ForEdit;
 }
 
@@ -266,7 +265,7 @@ CmdSketcherCreatePolyline::CmdSketcherCreatePolyline()
     sWhatsThis = "Sketcher_CreatePolyline";
     sStatusTip = sToolTipText;
     sPixmap = "Sketcher_CreatePolyline";
-    sAccel = "L";
+    sAccel = "G, M";
     eType = ForEdit;
 }
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Use the original `G, M` shortcut for the new polyline tool, as `L` is conflicting and already used for dimensioning length.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/30367
