### PR TITLE
Ubuntu build: improve package install script

### DIFF
--- a/package/ubuntu/install-apt-packages.sh
+++ b/package/ubuntu/install-apt-packages.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-set -euo pipefail
+set -euox pipefail
+
+# Update package lists quietly
+sudo apt-get update -qq
+sudo apt-get install -y --no-install-recommends wget gpg ca-certificates
 
 # Add the KDE Neon repository for up-to-date and matching Qt6 and PySide packages
 # Ubuntu 24.04 does not have PySide6 packages available
@@ -8,13 +12,13 @@ if [ -z "$KEY" ]; then
   echo "Failed to download KDE Neon GPG key" >&2
   exit 1
 fi
-echo "$KEY" | sudo gpg --dearmor -o /usr/share/keyrings/neon-keyring.gpg
+echo "$KEY" | sudo gpg --yes --dearmor -o /usr/share/keyrings/neon-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/neon-keyring.gpg] http://archive.neon.kde.org/user noble main" | sudo tee /etc/apt/sources.list.d/neon-qt.list
 
-# Update package lists quietly
 sudo apt-get update -qq
 
 packages=(
+  build-essential
   ccache
   cmake
   doxygen
@@ -58,6 +62,7 @@ packages=(
   pyside6-tools
   python3-cxx-dev
   python3-av
+  python-is-python3
   python3-dev
   python3-defusedxml
   python3-git
@@ -65,6 +70,7 @@ packages=(
   python3-markdown
   python3-matplotlib
   python3-packaging
+  python3-pip
   python3-pivy
   python3-ply
   python3-pybind11


### PR DESCRIPTION
When working on build errors (https://github.com/FreeCAD/FreeCAD/pull/30394 in my case), it's always handy to use the bundled `install-apt-packages.sh` script to install dependencies required to build FC. Unfortunately, it does not run out of the box on a new container. It assumes that a few packages, installed by default on GH action runners, are already there, namely `wget`, `gpg`, `pip` and `build-essential` (gcc, make).

Also add `set -x` to identify scripts failures more easily, and `gpg --yes` to overwrite the keyring and run the script multiple times if needed.

Now, one can do this to get a FC container ready to build:
```
podman run --it --rm ubuntu:24.04
$ apt update && apt install sudo
$ /fc/package/ubuntu/install-apt-packages.sh
$ cmake -S /fc -B /build -GNinja
...
```