### PR TITLE
CAM: Linking - list of heights

### DIFF
--- a/src/Mod/CAM/CAMTests/TestLinkingGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestLinkingGenerator.py
@@ -21,8 +21,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
     def setUp(self):
         self.start = FreeCAD.Vector(0, 0, 0)
         self.target = FreeCAD.Vector(10, 0, 0)
-        self.local_clearance = 2.0
-        self.global_clearance = 5.0
+        self.heights_clearance = (2.0, 5.0)
         self.tooldiameter = 2
         self.tool = Part.makeCylinder(self.tooldiameter / 2, 5)
 
@@ -30,8 +29,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
         cmds = generator.get_linking_moves(
             start_position=self.start,
             target_position=self.target,
-            local_clearance=self.local_clearance,
-            global_clearance=self.global_clearance,
+            heights_clearance=self.heights_clearance,
             solids=[],
         )
         self.assertGreater(len(cmds), 0)
@@ -41,8 +39,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
         cmds = generator.get_linking_moves(
             start_position=self.start,
             target_position=self.start,
-            local_clearance=self.local_clearance,
-            global_clearance=self.global_clearance,
+            heights_clearance=self.heights_clearance,
             solids=[],
         )
         self.assertEqual(len(cmds), 0)
@@ -52,18 +49,8 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             generator.get_linking_moves(
                 start_position=self.start,
                 target_position=self.target,
-                local_clearance=self.local_clearance,
-                global_clearance=self.global_clearance,
+                heights_clearance=self.heights_clearance,
                 retract_height_offset=-1,
-            )
-
-    def test_clearance_violation_raises(self):
-        with self.assertRaises(ValueError):
-            generator.get_linking_moves(
-                start_position=self.start,
-                target_position=self.target,
-                local_clearance=10.0,
-                global_clearance=5.0,
             )
 
     def test_path_blocked_by_solid(self):
@@ -73,8 +60,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             generator.get_linking_moves(
                 start_position=self.start,
                 target_position=self.target,
-                local_clearance=self.local_clearance,
-                global_clearance=self.global_clearance,
+                heights_clearance=self.heights_clearance,
                 solids=[blocking_box],
                 tool_diameter=0,
             )
@@ -86,8 +72,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             generator.get_linking_moves(
                 start_position=self.start,
                 target_position=self.target,
-                local_clearance=5,
-                global_clearance=11,
+                heights_clearance=(5, 11),
                 collision_clearance=1.1,
                 solids=[blocking_box],
                 tool_diameter=0,
@@ -101,8 +86,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
         cmds = generator.get_linking_moves(
             start_position=start,
             target_position=target,
-            local_clearance=self.local_clearance,
-            global_clearance=self.global_clearance,
+            heights_clearance=self.heights_clearance,
             solids=[],
         )
 
@@ -134,8 +118,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
         cmds = generator.get_linking_moves(
             start_position=start,
             target_position=target,
-            local_clearance=self.local_clearance,
-            global_clearance=self.global_clearance,
+            heights_clearance=self.heights_clearance,
             solids=[],
         )
 
@@ -159,8 +142,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
         cmds = generator.get_linking_moves(
             start_position=self.start,
             target_position=self.target,
-            local_clearance=self.local_clearance,
-            global_clearance=self.global_clearance,
+            heights_clearance=self.heights_clearance,
             tool_diameter=self.tooldiameter,
             collision_clearance=0.001,
             solids=[blocking_box1, blocking_box2],
@@ -174,8 +156,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             generator.get_linking_moves(
                 start_position=self.start,
                 target_position=self.target,
-                local_clearance=self.local_clearance,
-                global_clearance=self.global_clearance,
+                heights_clearance=self.heights_clearance,
                 tool_diameter=self.tooldiameter,
                 collision_clearance=0.001,
                 solids=[blocking_box1, blocking_box2],
@@ -192,8 +173,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
         cmds = generator.get_linking_moves(
             start_position=self.start,
             target_position=self.target,
-            local_clearance=self.local_clearance,
-            global_clearance=self.global_clearance,
+            heights_clearance=self.heights_clearance,
             tool_diameter=self.tooldiameter,
             collision_clearance=0.001,
             solids=[blocking_box1, blocking_box2],
@@ -207,8 +187,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             generator.get_linking_moves(
                 start_position=self.start,
                 target_position=self.target,
-                local_clearance=self.local_clearance,
-                global_clearance=self.global_clearance,
+                heights_clearance=self.heights_clearance,
                 tool_shape=self.tool,
                 collision_clearance=0.001,
                 solids=[blocking_box1, blocking_box2],
@@ -219,8 +198,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
         cmds = generator.get_linking_moves(
             start_position=self.start,
             target_position=self.target,
-            local_clearance=self.local_clearance,
-            global_clearance=self.global_clearance,
+            heights_clearance=self.heights_clearance,
             tool_shape=Part.Shape(),
             collision_clearance=0.001,
             solids=[Part.Shape()],
@@ -232,8 +210,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
         cmds = generator.get_linking_moves(
             start_position=self.start,
             target_position=FreeCAD.Vector(10, 0, 5),
-            local_clearance=self.local_clearance,
-            global_clearance=self.global_clearance,
+            heights_clearance=self.heights_clearance,
             retract_height_offset=0,
         )
         self.assertTrue(any(cmd for cmd in cmds if cmd.Parameters.get("Z") == self.local_clearance))

--- a/src/Mod/CAM/Path/Base/Generator/linking.py
+++ b/src/Mod/CAM/Path/Base/Generator/linking.py
@@ -95,8 +95,7 @@ def check_collision(
 def get_linking_moves(
     start_position: Vector,
     target_position: Vector,
-    local_clearance: float,
-    global_clearance: float,
+    heights_clearance: list[float],
     tool_shape: Optional[Part.Shape] = None,
     tool_diameter: Optional[float] = None,
     solids: Optional[List[Part.Shape]] = None,
@@ -124,9 +123,6 @@ def get_linking_moves(
         if not check_collision(start_position, target_position, solids):
             return []
 
-    if local_clearance > global_clearance:
-        raise ValueError("Local clearance must not exceed global clearance")
-
     if retract_height_offset is not None and retract_height_offset < 0:
         raise ValueError("Retract offset must be positive")
 
@@ -140,7 +136,10 @@ def get_linking_moves(
             collision_model = Part.makeCompound(solids)
 
     # Determine candidate heights
-    candidate_heights = {local_clearance, global_clearance}
+    if isinstance(heights_clearance, (float, int)):
+        candidate_heights = {heights_clearance}
+    else:
+        candidate_heights = set(heights_clearance)
     if retract_height_offset is not None:
         retract_height = max(start_position.z, target_position.z) + retract_height_offset
         candidate_heights.add(retract_height)
@@ -150,8 +149,8 @@ def get_linking_moves(
     collision_clearance = max(collision_clearance, 0) or 1
 
     # Try each height
-    for height in heights:
-        wire = make_linking_wire(start_position, target_position, height)
+    for i in range(len(heights)):
+        wire = make_linking_wire(start_position, target_position, heights[: i + 1])
         if is_travel_collision_free(
             wire, collision_model, tool_shape, tool_diameter, collision_clearance
         ):
@@ -165,14 +164,16 @@ def get_linking_moves(
     raise RuntimeError("No collision-free path found between start and target positions")
 
 
-def make_linking_wire(start: Vector, target: Vector, z: float) -> Part.Wire:
+def make_linking_wire(start: Vector, target: Vector, heights: list) -> Part.Wire:
     """Returns a wire connecting start and target points"""
-    p1 = Vector(start.x, start.y, z)
-    p2 = Vector(target.x, target.y, z)
+    top_z = heights[-1]
+    plunge_heights = reversed([target.z] + heights[:-1])
+    p1 = Vector(start.x, start.y, top_z)
+    p2 = Vector(target.x, target.y, top_z)
     edges = []
 
-    # Only add retract edge if there's actual movement
-    if not Path.Geom.pointsCoincide(start, p1):
+    # Only add retract edge if there's actual movement and p1 not on vertical line with p2
+    if not Path.Geom.pointsCoincide(start, p1) and not Path.Geom.pointsCoincide(p1, p2):
         edges.append(Part.makeLine(start, p1))
 
     # Only add traverse edge if there's actual movement
@@ -181,7 +182,12 @@ def make_linking_wire(start: Vector, target: Vector, z: float) -> Part.Wire:
 
     # Only add plunge edge if there's actual movement
     if not Path.Geom.pointsCoincide(p2, target):
-        edges.append(Part.makeLine(p2, target))
+        last = p2
+        for z in plunge_heights:
+            p = Vector(target.x, target.y, z)
+            if not Path.Geom.pointsCoincide(p, last):
+                edges.append(Part.makeLine(last, p))
+                last = p
 
     return Part.Wire(edges) if edges else Part.Wire([Part.makeLine(start, target)])
 

--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -298,15 +298,14 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
         linkingArgs = {
             "start_position": None,
             "target_position": None,
-            "local_clearance": safe_height,
-            "global_clearance": obj.ClearanceHeight.Value,
+            "heights_clearance": (safe_height, obj.ClearanceHeight.Value),
             "solids": None,
             "tool_shape": None,
             "tool_diameter": None,
             "collision_clearance": obj.CollisionClearance.Value,
         }
         if obj.CollisionAvoidanceStrategy == "Clearance Height":
-            linkingArgs["local_clearance"] = obj.ClearanceHeight.Value
+            linkingArgs["heights_clearance"] = obj.ClearanceHeight.Value
         elif obj.CollisionAvoidanceStrategy == "Retract Height":
             pass
         elif obj.CollisionAvoidanceStrategy == "Line of Sight":

--- a/src/Mod/CAM/Path/Op/EngraveBase.py
+++ b/src/Mod/CAM/Path/Op/EngraveBase.py
@@ -76,15 +76,14 @@ class ObjectOp(PathOp.ObjectOp):
         linking_kwargs = {
             "start_position": None,
             "target_position": None,
-            "local_clearance": obj.SafeHeight.Value,
-            "global_clearance": obj.ClearanceHeight.Value,
+            "heights_clearance": (obj.SafeHeight.Value, obj.ClearanceHeight.Value),
             "solids": None,
             "tool_shape": None,
             "tool_diameter": None,
             "collision_clearance": obj.CollisionClearance.Value,
         }
         if obj.CollisionAvoidanceStrategy == "Clearance Height":
-            linking_kwargs["local_clearance"] = obj.ClearanceHeight.Value
+            linking_kwargs["heights_clearance"] = obj.ClearanceHeight.Value
         elif obj.CollisionAvoidanceStrategy == "Retract Height":
             pass
         elif obj.CollisionAvoidanceStrategy == "Line of Sight":
@@ -169,10 +168,8 @@ class ObjectOp(PathOp.ObjectOp):
                         # Add gcode for edge
                         self.appendCommand(cmd, z, relZ, self.horizFeed)
 
-                # Track tool position for the next entry move.
-                # Use SafeHeight so the linking check only evaluates the horizontal
-                # traverse, not the retract from cutting depth through the stock.
-                tool_pos = FreeCAD.Vector(lastPoint.x, lastPoint.y, obj.SafeHeight.Value)
+                # Track tool position for the next entry move
+                tool_pos = FreeCAD.Vector(lastPoint.x, lastPoint.y, z)
 
                 if biDir and not wire.isClosed():
                     reverseDir = not reverseDir

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -593,15 +593,14 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         linkingArgs = {
             "start_position": None,
             "target_position": None,
-            "local_clearance": safeHeight,
-            "global_clearance": clearanceHeight,
+            "heights_clearance": (safeHeight, clearanceHeight),
             "solids": None,
             "tool_shape": None,
             "tool_diameter": None,
             "collision_clearance": obj.CollisionClearance.Value,
         }
         if obj.CollisionAvoidanceStrategy == "Clearance Height":
-            linkingArgs["local_clearance"] = clearanceHeight
+            linkingArgs["heights_clearance"] = clearanceHeight
         elif obj.CollisionAvoidanceStrategy == "Retract Height":
             pass
         elif obj.CollisionAvoidanceStrategy == "Line of Sight":

--- a/src/Mod/CAM/Path/Op/MillFacing.py
+++ b/src/Mod/CAM/Path/Op/MillFacing.py
@@ -278,15 +278,14 @@ class ObjectMillFacing(PathOp.ObjectOp):
         linkingArgs = {
             "start_position": None,
             "target_position": None,
-            "local_clearance": obj.SafeHeight.Value,
-            "global_clearance": obj.ClearanceHeight.Value,
+            "heights_clearance": (obj.SafeHeight.Value, obj.ClearanceHeight.Value),
             "solids": None,
             "tool_shape": None,
             "tool_diameter": None,
             "collision_clearance": obj.CollisionClearance.Value,
         }
         if obj.CollisionAvoidanceStrategy == "Clearance Height":
-            linkingArgs["local_clearance"] = obj.ClearanceHeight.Value
+            linkingArgs["heights_clearance"] = obj.ClearanceHeight.Value
         elif obj.CollisionAvoidanceStrategy == "Retract Height":
             pass
         elif obj.CollisionAvoidanceStrategy == "Line of Sight":


### PR DESCRIPTION
### Description 

It does not make sense to use named arguments `local_clearance` and `global_clearance` for heights, because this values will be sorted
Also this limits number of values

https://github.com/FreeCAD/FreeCAD/blob/f54ba894a04b75bf4d5f2ae8cc766da45f0f46d4/src/Mod/CAM/Path/Base/Generator/linking.py#L140

https://github.com/FreeCAD/FreeCAD/blob/f54ba894a04b75bf4d5f2ae8cc766da45f0f46d4/src/Mod/CAM/Path/Base/Generator/linking.py#L145


I trying to implement linking inside one area to safely replace `RetractThreshold` in Area.py, so I need more than two values to check collision
Also need simple way to split plunge by rapid and feed moves 

- #30402

<img width="915" height="548" alt="600271263-c33e5d36-d9f6-464b-85bd-324735df2422" src="https://github.com/user-attachments/assets/dc6d8281-609b-443a-8cb2-4a49991195c2" />

---

### Changes

- Replace `local_clearance` and `global_clearance` by list of values
- For plunge move add edge to each height lower than current