### PR TITLE
Gui: Remove TreeActions group command from toolbar

### DIFF
--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -868,7 +868,7 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     auto view = new ToolBarItem(root);
     view->setCommand("View");
     *view << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_ViewGroup" << "Std_AlignToSelection"
-          << "Separator" << "Std_DrawStyle" << "Std_TreeViewActions" << "Separator"
+          << "Separator" << "Std_DrawStyle" << "Separator"
           << "Std_Measure" << "Std_MassProperties";
 
     // Individual views

--- a/src/Mod/Part/Gui/WorkbenchManipulator.cpp
+++ b/src/Mod/Part/Gui/WorkbenchManipulator.cpp
@@ -45,9 +45,10 @@ void WorkbenchManipulator::addSelectionFilter(Gui::ToolBarItem* toolBar)
     if (auto view = toolBar->findItem("View")) {
         auto add = new Gui::ToolBarItem();  // NOLINT
         add->setCommand("Part_SelectFilter");
-        auto item = view->findItem("Std_TreeViewActions");
-        if (item) {
-            view->insertItem(item, add);
+        auto items = view->getItems();
+        auto drawStyleIdx = items.indexOf(view->findItem("Std_DrawStyle"));
+        if (drawStyleIdx >= 0 && drawStyleIdx + 1 < items.size()) {
+            view->insertItem(items.at(drawStyleIdx + 1), add);
         }
         else {
             view->appendItem(add);


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Remove confusing TreeActions group command from toolbar. It is still in the menu and context menu and shortcuts do work.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/14712
## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

<img width="2516" height="442" alt="grafik" src="https://github.com/user-attachments/assets/c8df03da-92d7-480b-acdc-f433b54ee2bb" />


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
