### PR TITLE
BIM: Trimex to change Arch objects

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -78,6 +78,84 @@ def _make_projected_horizontal_area_face(projected_faces):
     return fused_face.removeSplitter()
 
 
+def getTrimexDataFromBase(obj, base=None, offset_start=0.0, offset_end=0.0):
+    """Return Trimex data for an object based on an open Draft wire or line.
+
+    The data redirects to an unoffset base. For an offset base, its setter
+    moves the base endpoints so the visible caps match the selected points.
+    """
+    import Part
+
+    if base is None:
+        base = obj.Base
+    base_type = Draft.getType(base)
+    if base_type not in ("Wire", "Part::Line"):
+        return None
+    shape = base.Shape
+    if shape.isNull():
+        return None
+    if base_type == "Wire":
+        wire = shape.Wires[0]
+        if wire.isClosed():
+            return None
+        edges = Part.__sortEdges__(wire.Edges)
+    else:
+        edges = shape.Edges
+
+    placement = obj.Placement
+    axis_start = _trimex_tangent(edges[0], True, placement)
+    axis_end = _trimex_tangent(edges[-1], False, placement)
+    raw_start = placement.multVec(edges[0].Vertexes[0].Point)
+    raw_end = placement.multVec(edges[-1].Vertexes[-1].Point)
+    p_start = raw_start - axis_start * offset_start
+    p_end = raw_end - axis_end * offset_end
+
+    data = {
+        "endpoints": [p_start, p_end],
+        "axes": [axis_start, axis_end],
+    }
+    if offset_start == 0 and offset_end == 0:
+        data["redirect"] = base
+    else:
+        data["set"] = lambda pts: _set_trimex_base_endpoints(
+            base,
+            placement,
+            FreeCAD.Vector(pts[0]) + axis_start * offset_start,
+            FreeCAD.Vector(pts[1]) + axis_end * offset_end,
+        )
+    return data
+
+
+def _trimex_tangent(edge, at_start, placement):
+    """Outward world-space tangent for the given edge endpoint."""
+    parameter = edge.FirstParameter if at_start else edge.LastParameter
+    tangent = edge.tangentAt(parameter)
+    if at_start:
+        tangent = tangent.negative()
+    tangent.normalize()
+    return placement.Rotation.multVec(tangent)
+
+
+def _set_trimex_base_endpoints(base, placement, p_start, p_end):
+    """Set the first and last endpoint of an editable base object."""
+    invpl = placement.inverse()
+    p_start = invpl.multVec(FreeCAD.Vector(p_start))
+    p_end = invpl.multVec(FreeCAD.Vector(p_end))
+    base_type = Draft.getType(base)
+    if base_type == "Part::Line":
+        base.X1 = p_start.x
+        base.Y1 = p_start.y
+        base.Z1 = p_start.z
+        base.X2 = p_end.x
+        base.Y2 = p_end.y
+        base.Z2 = p_end.z
+    else:
+        points = list(base.Points)
+        points[0] = p_start
+        points[-1] = p_end
+        base.Points = points
+
+
 def addToComponent(compobject, addobject, prop):
     """Add an object to a component's property.
 

--- a/src/Mod/BIM/ArchFrame.py
+++ b/src/Mod/BIM/ArchFrame.py
@@ -300,6 +300,10 @@ class _Frame(ArchComponent.Component):
                 obj.Shape = Part.makeCompound(shapes)
                 obj.Placement = pl
 
+    def getTrimexData(self, obj):
+        """Return Trimex data for the endpoints of an open wire or line base."""
+        return ArchComponent.getTrimexDataFromBase(obj)
+
 
 class _ViewProviderFrame(ArchComponent.ViewProviderComponent):
     "A View Provider for the Frame object"

--- a/src/Mod/BIM/ArchPanel.py
+++ b/src/Mod/BIM/ArchPanel.py
@@ -567,6 +567,38 @@ class _Panel(ArchComponent.Component):
                     if not pl.isNull():
                         obj.Placement = pl
 
+    def getTrimexData(self, obj):
+        """Return Trimex data for the two faces created by panel thickness."""
+        if obj.Thickness.Value == 0:
+            return None
+
+        faces = sorted(obj.Shape.Faces, key=lambda face: face.Area, reverse=True)
+        first_face = faces[0]
+        first_normal = first_face.normalAt(*first_face.Surface.parameter(first_face.CenterOfMass))
+        second_face = next(
+            face
+            for face in faces[1:]
+            if first_normal.dot(face.normalAt(*face.Surface.parameter(face.CenterOfMass))) < -0.95
+        )
+        p1 = first_face.CenterOfMass
+        p2 = second_face.CenterOfMass
+        axis = p2.sub(p1).normalize()
+
+        def _set(pts):
+            new_p1 = FreeCAD.Vector(pts[0])
+            new_p2 = FreeCAD.Vector(pts[1])
+            new_length = new_p1.distanceToPoint(new_p2)
+            if new_length == 0:
+                return
+            obj.Placement.Base = obj.Placement.Base + new_p1.sub(p1)
+            obj.Thickness = new_length
+
+        return {
+            "endpoints": [p1, p2],
+            "axes": [FreeCAD.Vector(axis).negative(), axis],
+            "set": _set,
+        }
+
 
 class PanelTaskPanel(ArchComponent.ComponentOptionsTaskPanel):
     """A task panel for Curtain Walls using the generic options task box"""

--- a/src/Mod/BIM/ArchPipe.py
+++ b/src/Mod/BIM/ArchPipe.py
@@ -409,6 +409,44 @@ class _ArchPipe(ArchComponent.Component):
                     p = p.cut(p2)
         return p
 
+    def getTrimexData(self, obj):
+        """Return Trimex data for a straight Pipe.
+
+        Base wires are edited directly unless offsets require updating their
+        endpoints. Baseless pipes update Length and Placement.
+        """
+        pipe_pl = obj.Placement
+        off_start = obj.OffsetStart.Value
+        off_end = obj.OffsetEnd.Value
+        base = obj.Base
+        if base is None:
+            length = obj.Length.Value
+            axis = pipe_pl.Rotation.multVec(FreeCAD.Vector(0, 0, 1))
+            p1 = pipe_pl.multVec(FreeCAD.Vector(0, 0, off_start))
+            p2 = pipe_pl.multVec(FreeCAD.Vector(0, 0, length - off_end))
+
+            def _set(pts):
+                new_p1 = FreeCAD.Vector(pts[0])
+                new_p2 = FreeCAD.Vector(pts[1])
+                new_len = new_p1.distanceToPoint(new_p2) + off_start + off_end
+                if new_len == 0:
+                    return
+                # The path origin sits OffsetStart before the visible cap.
+                obj.Placement.Base = new_p1 - axis * off_start
+                obj.Length = new_len
+
+            return {
+                "endpoints": [p1, p2],
+                "axes": [FreeCAD.Vector(axis).negative(), FreeCAD.Vector(axis)],
+                "set": _set,
+            }
+        return ArchComponent.getTrimexDataFromBase(
+            obj,
+            base,
+            offset_start=off_start,
+            offset_end=off_end,
+        )
+
 
 class _ViewProviderPipe(ArchComponent.ViewProviderComponent):
     "A View Provider for the Pipe object"

--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -1406,6 +1406,63 @@ class _Structure(ArchComponent.Component):
                     )
         return edges
 
+    def getTrimexData(self, obj):
+        """Return Trimex data for a straight structure extrusion.
+
+        Structures with an extrusion path are excluded; their path is the
+        editable object.
+        """
+        if obj.Tool:
+            return None
+
+        if obj.IfcType in ("Beam", "Column") and obj.Length.Value > obj.Height.Value:
+            prop_name = "Length"
+        else:
+            prop_name = "Height"
+
+        # Derive the axis from getExtrusionData so we reuse the exact rules
+        # the executor uses (handles Normal=auto, profile orientation, etc.).
+        extdata = self.getExtrusionData(obj)
+        if not extdata:
+            return None
+        ev = extdata[1]
+        pla = extdata[2]
+        if isinstance(ev, list):
+            if not ev:
+                return None
+            ev = ev[0]
+            pla = pla[0] if isinstance(pla, list) else pla
+        if not isinstance(ev, FreeCAD.Vector):
+            # Tool-wire extrusion: filtered above, but guard anyway.
+            return None
+
+        # The extrusion vector is expressed in ``pla``'s local frame;
+        # ``pla`` itself is relative to obj.Placement.
+        ext_world = obj.Placement.Rotation.multVec(pla.Rotation.multVec(ev))
+        ext_length = ext_world.Length
+        if ext_length == 0:
+            return None
+        axis_world = FreeCAD.Vector(ext_world).multiply(1.0 / ext_length)
+        p1 = obj.Placement.multVec(pla.Base)
+        p2 = p1 + axis_world * ext_length
+
+        def _set(pts):
+            new_p1 = FreeCAD.Vector(pts[0])
+            new_p2 = FreeCAD.Vector(pts[1])
+            new_len = (new_p2 - new_p1).dot(axis_world)
+            if new_len <= 0:
+                return
+            shift = new_p1 - p1
+            shift_axial = shift.dot(axis_world)
+            obj.Placement.Base = obj.Placement.Base + axis_world * shift_axial
+            setattr(obj, prop_name, new_len)
+
+        return {
+            "endpoints": [p1, p2],
+            "axes": [FreeCAD.Vector(axis_world).negative(), FreeCAD.Vector(axis_world)],
+            "set": _set,
+        }
+
 
 class _ViewProviderStructure(ArchComponent.ViewProviderComponent):
     "A View Provider for the Structure object"

--- a/src/Mod/BIM/ArchTruss.py
+++ b/src/Mod/BIM/ArchTruss.py
@@ -405,6 +405,10 @@ class Truss(ArchComponent.Component):
         rod = rod.extrude(p2.sub(p1))
         return rod
 
+    def getTrimexData(self, obj):
+        """Return Trimex data for the endpoints of an open wire or line base."""
+        return ArchComponent.getTrimexDataFromBase(obj)
+
 
 class TrussTaskPanel(ArchComponent.ComponentOptionsTaskPanel):
     """A task panel for Arch Trusses using the generic options box"""

--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -1486,6 +1486,24 @@ class _Wall(ArchComponent.Component):
             return (base, extrusion, placement)
         return None
 
+    def getTrimexData(self, obj):
+        """Return Trimex data for a Wall.
+
+        Wire and line bases are edited directly; baseless walls update their
+        Length and Placement. Sketch-based walls are excluded.
+        """
+        wall_pl = obj.Placement
+        base = obj.Base
+        if base is None:
+            eps = self.calc_endpoints(obj)
+            axis = wall_pl.Rotation.multVec(FreeCAD.Vector(1, 0, 0))
+            return {
+                "endpoints": [FreeCAD.Vector(eps[0]), FreeCAD.Vector(eps[1])],
+                "axes": [FreeCAD.Vector(axis).negative(), FreeCAD.Vector(axis)],
+                "set": lambda pts: self.set_from_endpoints(obj, pts),
+            }
+        return ArchComponent.getTrimexDataFromBase(obj, base)
+
     def calc_endpoints(self, obj):
         """Returns the global start and end points of a baseless wall's centerline."""
         # The wall's shape is centered, so its endpoints in local coordinates
@@ -1501,14 +1519,13 @@ class _Wall(ArchComponent.Component):
 
     def set_from_endpoints(self, obj, pts):
         """Sets the Length and Placement of a baseless wall from two global points."""
-        if len(pts) < 2:
-            return
-
         p1 = pts[0]
         p2 = pts[1]
 
         # Recalculate the wall's properties based on the new endpoints
         new_length = p1.distanceToPoint(p2)
+        if new_length == 0:
+            return
         new_midpoint = (p1 + p2) * 0.5
         new_direction = (p2 - p1).normalize()
 

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -137,6 +137,7 @@ SET(bimcommands_SRCS
     bimcommands/BimEquipment.py
     bimcommands/BimExamples.py
     bimcommands/BimExtrude.py
+    bimcommands/BimExtrudeFace.py
     bimcommands/BimFence.py
     bimcommands/BimFrame.py
     bimcommands/BimFuse.py

--- a/src/Mod/BIM/InitGui.py
+++ b/src/Mod/BIM/InitGui.py
@@ -156,6 +156,7 @@ class BIMWorkbench(Workbench):
             "BIM_ArrayTools",
             "Arch_CutPlane",
             "BIM_Extrude",
+            "BIM_ExtrudeFace",
             "BIM_BooleanTools",
         ]
 

--- a/src/Mod/BIM/Resources/Arch.qrc
+++ b/src/Mod/BIM/Resources/Arch.qrc
@@ -106,6 +106,7 @@
         <file>icons/BIM_DimensionHorizontal.svg</file>
         <file>icons/BIM_DimensionVertical.svg</file>
         <file>icons/BIM_Door.svg</file>
+        <file>icons/BIM_ExtrudeFace.svg</file>
         <file>icons/BIM_Glue.svg</file>
         <file>icons/BIM_Hatch.svg</file>
         <file>icons/BIM_Help.svg</file>

--- a/src/Mod/BIM/Resources/icons/BIM_ExtrudeFace.svg
+++ b/src/Mod/BIM/Resources/icons/BIM_ExtrudeFace.svg
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="64px"
+   height="64px"
+   id="svg2682"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2684">
+    <linearGradient
+       id="linearGradient10">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1;"
+         offset="0"
+         id="stop10" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:0;"
+         offset="1"
+         id="stop11" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop3897" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop3899" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3895"
+       id="linearGradient3025-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.82726526,0,0,0.85294121,11.636761,6.2058827)"
+       x1="42.758076"
+       y1="23.526644"
+       x2="45.615246"
+       y2="39.514103" />
+    <linearGradient
+       xlink:href="#linearGradient10"
+       id="linearGradient11"
+       x1="101.00684"
+       y1="34.651367"
+       x2="73"
+       y2="35.145844"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <metadata
+     id="metadata2687">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[wmayer]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:date>2011-10-10</dc:date>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Part/Gui/Resources/icons/Part_Extrude.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       style="fill:none;fill-opacity:1;stroke:#3465a4;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5;stroke-opacity:1"
+       d="M 11.152344,8.0097656 19.140625,23.990234 H 34.648437 L 26.660156,8.0097656 Z"
+       id="path8" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#3465a4;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5;stroke-opacity:1"
+       d="m 19.789062,28.009766 -1.75,27.980468 h 15.972657 l 1.75,-27.980468 z"
+       id="path7" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:5;stroke-opacity:1"
+       d="m 17.900085,26 h 19.999664 l -2,32 H 15.900085 Z"
+       id="path5" />
+    <path
+       id="path1"
+       style="fill:#3465a4;stroke:#0b1521;stroke-width:2;stroke-linejoin:round"
+       transform="rotate(90,51.400238,-5.5997617)"
+       d="m 83,27.900391 -20,10 32,2 20,-10 z" />
+    <path
+       id="path2"
+       style="fill:#3465a4;stroke:#729fcf;stroke-width:2;stroke-linejoin:round"
+       transform="rotate(90,51.400238,-5.5997617)"
+       d="m 83.414062,29.939453 -12.841796,6.419922 24.013671,1.501953 12.841793,-6.419922 z" />
+    <path
+       id="path3023"
+       d="M 27.900085,6.0000003 H 7.9000853 L 5.9000853,38 H 25.900085 Z"
+       style="fill:none;fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path3025"
+       d="m 5.9000853,38 9.9999997,20 h 20 l -10,-20 z"
+       style="fill:none;fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path4"
+       d="M 9.1523438,40.009766 17.140625,55.990234 H 32.648437 L 24.660156,40.009766 Z"
+       style="fill:none;fill-opacity:1;stroke:#3465a4;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:5;stroke-opacity:1"
+       d="M 17.900085,26 7.9000853,6.0000003 H 27.899749 L 37.899749,26 Z"
+       id="path6" />
+    <path
+       id="path3027"
+       style="fill:#729fcf;stroke:#0b1521;stroke-width:2;stroke-linejoin:round"
+       transform="rotate(90,61.40007,4.4000703)"
+       d="m 83,27.900391 -20,10 32,2 20,-10 z" />
+    <path
+       id="path3"
+       d="m 9.7890625,8.0097656 -1.75,27.9804684 H 24.011719 l 1.75,-27.9804684 z"
+       style="fill:none;fill-opacity:1;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path9"
+       style="fill:url(#linearGradient11);stroke:#729fcf;stroke-width:2;stroke-linejoin:miter;fill-opacity:1"
+       transform="rotate(90,61.40007,4.4000703)"
+       d="m 83.414062,29.939453 -12.841796,6.419922 24.013671,1.501953 12.841793,-6.419922 z" />
+  </g>
+  <path
+     id="path3343-3"
+     d="m 48.099945,19 v 8 h -8 v 10 h 8 v 8 l 12,-13 z"
+     style="fill:url(#linearGradient3025-0);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path3343-2-7"
+     d="M 50.140693,24.487021 50.099945,29 h -8 v 6 h 8 l 0.01705,5.130682 7.264191,-8.106576 z"
+     style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+</svg>

--- a/src/Mod/BIM/bimcommands/BimExtrudeFace.py
+++ b/src/Mod/BIM/bimcommands/BimExtrudeFace.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""BIM command for interactive face extrusion."""
+
+import FreeCADGui
+
+from draftguitools.gui_trimex import ExtrudeFace
+
+FreeCADGui.addCommand("BIM_ExtrudeFace", ExtrudeFace())

--- a/src/Mod/Draft/draftguitools/gui_trimex.py
+++ b/src/Mod/Draft/draftguitools/gui_trimex.py
@@ -59,6 +59,28 @@ from draftutils.messages import _msg, _err, _toolmsg
 from draftutils.translate import translate
 
 
+def _get_trimex_data(obj):
+    """Return a Trimex data dict for ``obj``, or None.
+
+    BIM objects opt in by implementing ``obj.Proxy.getTrimexData(obj)``.
+    The returned dict must contain ``endpoints`` (two world-space points
+    bounding the object's editable axis) and ``axes`` (matching outward unit
+    vectors used to identify end faces), plus either:
+
+    - ``redirect``: an object to operate on instead (for example a base wire)
+    - ``set``: callable(list[Vector]) committing new world endpoints
+    """
+    proxy = getattr(obj, "Proxy", None)
+    if proxy is not None and hasattr(proxy, "getTrimexData"):
+        try:
+            adapter = proxy.getTrimexData(obj)
+        except Exception:
+            adapter = None
+        if adapter is not None:
+            return adapter
+    return None
+
+
 class Trimex(gui_base_original.Modifier):
     """Gui Command for the Trimex tool.
 
@@ -90,6 +112,14 @@ class Trimex(gui_base_original.Modifier):
         self.linetrack = None
         self.color = None
         self.width = None
+        # Trimex-data protocol state. When a BIM object provides
+        # ``getTrimexData``, the host is re-selected at the end; either the
+        # operation is redirected to ``self.obj`` (a base wire), or it commits
+        # through ``trimexSet`` with the two updated world endpoints.
+        self.trimexHost = None
+        self.trimexSet = None
+        self.trimexEndpoints = None
+        self.lockedActivePoint = None
         if self.ui:
             if not Gui.Selection.getSelection():
                 self.ui.selectUi(on_close_call=self.finish)
@@ -111,6 +141,12 @@ class Trimex(gui_base_original.Modifier):
         sel = Gui.Selection.getSelectionEx("", 0)[0]
 
         import Part
+
+        # BIM integration. If the selected object opts in via getTrimexData
+        # and an end face is pre-selected, route the operation to its base
+        # wire or to a property-update setter instead of face-extrude.
+        if self._setupTrimexData(sel):
+            return
 
         reason = utils.get_trimex_unsupported_reason(self.obj, sel.SubObjects)
         if reason:
@@ -183,6 +219,137 @@ class Trimex(gui_base_original.Modifier):
         _toolmsg(translate("draft", "Pick distance"))
         self.selection_done = True
         self.update_hints()
+
+    def _setupTrimexData(self, sel):
+        """Generic adapter dispatch.
+
+        Resolves BIM ``getTrimexData`` and, if the user pre-selected an end
+        face, routes Trimex to:
+          - the redirected base wire/line (``redirect`` key), or
+          - a property-update setter (``set`` key) driven by a virtual edge.
+
+        Returns True if the operation is fully set up here (set-mode);
+        False otherwise. Side / top / bottom face selections always fall
+        through to the default face-extrude path.
+        """
+        import Part
+
+        adapter = _get_trimex_data(self.obj)
+        if adapter is None:
+            return False
+
+        endpoints = adapter.get("endpoints") or []
+        axes = adapter.get("axes") or []
+        if len(endpoints) < 2 or len(axes) != len(endpoints):
+            return False
+
+        ends = list(zip(endpoints, axes))
+        end_idx = None
+        for sub in sel.SubObjects:
+            if getattr(sub, "ShapeType", None) != "Face":
+                continue
+            match = self._matchEndFace(sub, ends)
+            if match is not None:
+                end_idx = match
+                break
+        if end_idx is None:
+            # Not an end face (side / top / bottom, or no face picked): keep
+            # the default face-extrude behaviour untouched.
+            return False
+
+        redirect = adapter.get("redirect")
+        setter = adapter.get("set")
+        host = self.obj
+
+        if redirect is not None:
+            # Modify the base directly; the host follows on recompute. The
+            # adapter reports two ends (first / last cap), but the wire-mode
+            # vertex list spans every vertex of the base wire, so map the
+            # matched cap to the correct vertex index: 0 -> first, last cap
+            # -> the wire's final vertex (== edge count). Without this a
+            # multi-segment base would move the 2nd vertex instead of the
+            # last when the far end is trimmed.
+            self.trimexHost = host
+            self.obj = redirect
+            if end_idx == 0:
+                self.lockedActivePoint = 0
+            else:
+                # Last cap -> final vertex; its index equals the edge count.
+                self.lockedActivePoint = self._wireEdgeCount(redirect)
+            return False
+
+        if setter is None:
+            return False
+
+        # Property-update mode: drive a virtual single-edge line and commit
+        # the new endpoints through the setter callable.
+        self.trimexHost = host
+        self.trimexSet = setter
+        self.trimexEndpoints = [App.Vector(p) for p in endpoints]
+        self.lockedActivePoint = end_idx
+
+        p1, p2 = self.trimexEndpoints
+        self.edges = [Part.LineSegment(p1, p2).toShape()]
+        self.placement = None
+        self.extrudeMode = False
+        self.ghost = [trackers.lineTracker(scolor=(0.5, 0.5, 0.5), swidth=1)]
+        self.ui.trimUi(title=translate("draft", self.featureName))
+        self.linetrack = trackers.lineTracker()
+        for g in self.ghost:
+            g.on()
+        self.activePoint = 0
+        self.nodes = []
+        self.shift = False
+        self.alt = False
+        self.force = None
+        self.cv = None
+        self.call = self.view.addEventCallback("SoEvent", self.action)
+        _toolmsg(translate("draft", "Pick distance"))
+        return True
+
+    @staticmethod
+    def _wireEdgeCount(obj):
+        """Edge count of ``obj``'s wire, using the same edge selection as the
+        wire-mode setup. The final vertex index of the vertex list equals
+        this count."""
+        import Part
+
+        shape = obj.Shape
+        if shape.Wires:
+            return len(Part.__sortEdges__(shape.Wires[0].Edges))
+        return len(shape.Edges)
+
+    @staticmethod
+    def _matchEndFace(face, ends):
+        """Index of the end whose axis is parallel to ``face``'s normal and
+        whose endpoint lies on the face's plane. ``None`` if the face is not
+        an end face (side, top, bottom, etc.)."""
+        try:
+            u, v = face.Surface.parameter(face.CenterOfMass)
+            normal = face.normalAt(u, v)
+        except Exception:
+            return None
+        if normal.Length < 1e-9:
+            return None
+        normal = App.Vector(normal).normalize()
+        center = face.CenterOfMass
+        best = None
+        best_dot = 0.95  # require strong alignment to discount side/top/bottom faces
+        for i, (endpoint, axis) in enumerate(ends):
+            ax_len = axis.Length
+            if ax_len < 1e-9:
+                continue
+            ax = App.Vector(axis).multiply(1.0 / ax_len)
+            dot = abs(normal.dot(ax))
+            if dot < best_dot:
+                continue
+            # Endpoint must lie on the face's plane (along the normal).
+            offset = abs(normal.dot(endpoint - center))
+            if offset > 1e-3:
+                continue
+            best_dot = dot
+            best = i
+        return best
 
     def action(self, arg):
         """Handle the 3D scene events.
@@ -291,7 +458,12 @@ class Trimex(gui_base_original.Modifier):
         for e in self.edges:
             vlist.append(e.Vertexes[0].Point)
         vlist.append(self.edges[-1].Vertexes[-1].Point)
-        if shift:
+        if self.lockedActivePoint is not None:
+            # An endpoint was pre-selected (e.g. the start/end face of a wall).
+            # Keep it locked so the user's mouse only sets the new position,
+            # not which end moves.
+            npoint = self.lockedActivePoint
+        elif shift:
             npoint = self.activePoint
         else:
             npoint = geo_general.findClosest(point, vlist)
@@ -434,7 +606,18 @@ class Trimex(gui_base_original.Modifier):
             edges = self.redraw(self.point, self.snapped, self.shift, self.alt, real=True)
             newshape = Part.Wire(edges)
             self.doc.openTransaction("Trim/extend")
-            if utils.getType(self.obj) in ["Wire", "BSpline"]:
+            if self.trimexSet is not None:
+                pts = list(self.trimexEndpoints)
+                idx = (
+                    self.lockedActivePoint
+                    if self.lockedActivePoint is not None
+                    else self.activePoint
+                )
+                if idx is None or idx >= len(pts):
+                    idx = min(self.activePoint, len(pts) - 1)
+                pts[idx] = App.Vector(self.newpoint)
+                self.trimexSet(pts)
+            elif utils.getType(self.obj) in ["Wire", "BSpline"]:
                 p = []
                 if self.placement:
                     invpl = self.placement.inverse()
@@ -443,6 +626,18 @@ class Trimex(gui_base_original.Modifier):
                     if self.placement:
                         np = invpl.multVec(np)
                     p.append(np)
+                # When the far endpoint is trimmed, redraw rebuilds the wire
+                # in reverse, which flips the Points order. That is harmless
+                # for a standalone wire but flips direction-sensitive parents
+                # (Arch Truss/Frame, ...) when we trim a redirected base. In
+                # that case keep the original orientation by comparing both
+                # ends against the previous Points.
+                old = self.obj.Points
+                if self.trimexHost is not None and len(p) == len(old) and len(old) >= 2:
+                    same = (p[0] - old[0]).Length + (p[-1] - old[-1]).Length
+                    flipped = (p[0] - old[-1]).Length + (p[-1] - old[0]).Length
+                    if flipped < same:
+                        p.reverse()
                 self.obj.Points = p
             elif utils.getType(self.obj) == "Part::Line":
                 p = []
@@ -582,7 +777,10 @@ class Trimex(gui_base_original.Modifier):
                     self.obj.ViewObject.LineColor = self.color
                 if self.width:
                     self.obj.ViewObject.LineWidth = self.width
-                gui_utils.select(self.obj)
+                # Re-select the original host when we operated on its base
+                # or via its property setter, so the user keeps a meaningful
+                # selection.
+                gui_utils.select(self.trimexHost or self.obj)
         super().finish()
 
     def numericRadius(self, dist):

--- a/src/Mod/Draft/draftguitools/gui_trimex.py
+++ b/src/Mod/Draft/draftguitools/gui_trimex.py
@@ -24,15 +24,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides GUI tools to trim and extend lines.
-
-It also extends closed faces to create solids, that is, it can be used
-to extrude a closed profile.
-
-Make sure the snapping is active so that the extrusion is done following
-the direction of a line, and up to the distance specified
-by the snapping point.
-"""
+"""Provides GUI tools to trim and extend lines and extrude faces."""
 
 ## @package gui_trimex
 # \ingroup draftguitools
@@ -72,10 +64,7 @@ def _get_trimex_data(obj):
     """
     proxy = getattr(obj, "Proxy", None)
     if proxy is not None and hasattr(proxy, "getTrimexData"):
-        try:
-            adapter = proxy.getTrimexData(obj)
-        except Exception:
-            adapter = None
+        adapter = proxy.getTrimexData(obj)
         if adapter is not None:
             return adapter
     return None
@@ -84,12 +73,13 @@ def _get_trimex_data(obj):
 class Trimex(gui_base_original.Modifier):
     """Gui Command for the Trimex tool.
 
-    This tool trims or extends lines, wires and arcs,
-    or extrudes single faces.
+    This tool trims or extends lines, wires, arcs and supported BIM objects.
 
-    SHIFT constrains to the last point
-    or extrudes in direction to the face normal.
+    SHIFT constrains to the active endpoint.
     """
+
+    command_name = "Trimex"
+    selection_message = "Select objects to trim or extend"
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -98,32 +88,29 @@ class Trimex(gui_base_original.Modifier):
             "Pixmap": "Draft_Trimex",
             "Accel": "T, R",
             "MenuText": QT_TRANSLATE_NOOP("Draft_Trimex", "Trimex"),
-            "ToolTip": QT_TRANSLATE_NOOP(
-                "Draft_Trimex", "Trims or extends the selected object, or extrudes single faces"
-            ),
+            "ToolTip": QT_TRANSLATE_NOOP("Draft_Trimex", "Trims or extends the selected object"),
         }
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name="Trimex")
+        super().Activated(name=self.command_name)
         self.edges = []
         self.placement = None
         self.ghost = []
         self.linetrack = None
         self.color = None
         self.width = None
-        # Trimex-data protocol state. When a BIM object provides
-        # ``getTrimexData``, the host is re-selected at the end; either the
-        # operation is redirected to ``self.obj`` (a base wire), or it commits
-        # through ``trimexSet`` with the two updated world endpoints.
         self.trimexHost = None
         self.trimexSet = None
         self.trimexEndpoints = None
         self.lockedActivePoint = None
+        self.extrudeMode = False
+        self.extrudeBase = None
+        self.extrudeShape = None
         if self.ui:
             if not Gui.Selection.getSelection():
                 self.ui.selectUi(on_close_call=self.finish)
-                _msg(translate("draft", "Select objects to trim or extend"))
+                _msg(translate("draft", self.selection_message))
                 self.call = self.view.addEventCallback("SoEvent", gui_tool_utils.selectObject)
             else:
                 self.proceed()
@@ -140,69 +127,54 @@ class Trimex(gui_base_original.Modifier):
         self.obj = sel[0]
         sel = Gui.Selection.getSelectionEx("", 0)[0]
 
-        import Part
-
         # BIM integration. If the selected object opts in via getTrimexData
         # and an end face is pre-selected, route the operation to its base
-        # wire or to a property-update setter instead of face-extrude.
+        # wire or to a property-update setter.
         if self._setupTrimexData(sel):
             return
 
-        reason = utils.get_trimex_unsupported_reason(self.obj, sel.SubObjects)
+        reason = utils.get_trimex_unsupported_reason(self.obj)
         if reason:
             self.obj = None
             self.finish()
             _err(reason)
             return
+        self._startWireTrimex()
+
+    def _startWireTrimex(self):
+        """Set up the common trim/extend interaction for editable edges."""
+        import Part
+
         self.ui.trimUi(title=translate("draft", self.featureName))
         self.linetrack = trackers.lineTracker()
         if hasattr(self.obj, "Placement"):
             self.placement = self.obj.Placement
-        if self.obj.Shape.Faces:
-            self.obj = sel.Object
-            if len(self.obj.Shape.Faces) == 1:
-                # simple extrude mode, the object itself is extruded
-                pass
-            elif len(sel.SubObjects) == 1 and sel.SubObjects[0].ShapeType == "Face":
-                # face extrude mode, a new object is created
-                self.obj = self.doc.addObject("Part::Feature", "Face")
-                self.obj.Shape = sel.SubObjects[0]
-            else:
+        if self.obj.Shape.Wires:
+            self.edges = self.obj.Shape.Wires[0].Edges
+            self.edges = Part.__sortEdges__(self.edges)
+        else:
+            self.edges = self.obj.Shape.Edges
+        for edge in self.edges:
+            if isinstance(edge.Curve, (Part.BSplineCurve, Part.BezierCurve)):
                 self.obj = None
                 self.finish()
-                _err(translate("draft", "Only a single face can be extruded"))
+                _err(translate("draft", "Trimex does not support this object type"))
                 return
-            self.extrudeMode = True
-            self.normal = self.obj.Shape.Faces[0].normalAt(0.5, 0.5)
-            self.ghost = [trackers.ghostTracker([self.obj]), trackers.lineTracker(dotted=True)]
-            self.ghost += [trackers.lineTracker() for _ in self.obj.Shape.Vertexes]
-        else:
-            # normal wire trimex mode
-            self.color = self.obj.ViewObject.LineColor
-            self.width = self.obj.ViewObject.LineWidth
-            if self.obj.Shape.Wires:
-                self.edges = self.obj.Shape.Wires[0].Edges
-                self.edges = Part.__sortEdges__(self.edges)
+        self.color = self.obj.ViewObject.LineColor
+        self.width = self.obj.ViewObject.LineWidth
+        self.obj.ViewObject.LineColor = (0.5, 0.5, 0.5)
+        self.obj.ViewObject.LineWidth = 1
+        self.ghost = []
+        line_color = (self.color[0], self.color[1], self.color[2])
+        for edge in self.edges:
+            if geo_general.geomType(edge) == "Line":
+                self.ghost.append(trackers.lineTracker(scolor=line_color, swidth=self.width))
             else:
-                self.edges = self.obj.Shape.Edges
-            for e in self.edges:
-                if isinstance(e.Curve, (Part.BSplineCurve, Part.BezierCurve)):
-                    self.obj = None
-                    self.finish()
-                    _err(translate("draft", "Trimex does not support this object type"))
-                    return
-            self.obj.ViewObject.LineColor = (0.5, 0.5, 0.5)
-            self.obj.ViewObject.LineWidth = 1
-            self.extrudeMode = False
-            self.ghost = []
-            lc = self.color
-            sc = (lc[0], lc[1], lc[2])
-            sw = self.width
-            for e in self.edges:
-                if geo_general.geomType(e) == "Line":
-                    self.ghost.append(trackers.lineTracker(scolor=sc, swidth=sw))
-                else:
-                    self.ghost.append(trackers.arcTracker(scolor=sc, swidth=sw))
+                self.ghost.append(trackers.arcTracker(scolor=line_color, swidth=self.width))
+        self._startInteraction()
+
+    def _startInteraction(self):
+        """Start the shared point-picking interaction for the active mode."""
         if not self.ghost:
             self.obj = None
             self.finish()
@@ -220,18 +192,37 @@ class Trimex(gui_base_original.Modifier):
         self.selection_done = True
         self.update_hints()
 
+    def _startFaceExtrude(self, sel):
+        """Set up face extrusion without creating document objects yet."""
+        source = sel.Object
+        if not hasattr(source, "Shape"):
+            self.obj = None
+            self.finish()
+            _err(translate("draft", "Select a single face to extrude"))
+            return
+        shape = source.Shape
+        if len(shape.Faces) == 1:
+            self.extrudeBase = source
+            self.extrudeShape = shape
+        elif len(sel.SubObjects) == 1 and sel.SubObjects[0].ShapeType == "Face":
+            self.extrudeShape = sel.SubObjects[0]
+        else:
+            self.obj = None
+            self.finish()
+            _err(translate("draft", "Only a single face can be extruded"))
+            return
+
+        self.obj = source
+        self.extrudeMode = True
+        self.normal = self.extrudeShape.Faces[0].normalAt(0.5, 0.5)
+        self.ghost = [trackers.ghostTracker(self.extrudeShape), trackers.lineTracker(dotted=True)]
+        self.ghost += [trackers.lineTracker() for _ in self.extrudeShape.Vertexes]
+        self.ui.trimUi(title=translate("draft", self.featureName))
+        self.linetrack = trackers.lineTracker()
+        self._startInteraction()
+
     def _setupTrimexData(self, sel):
-        """Generic adapter dispatch.
-
-        Resolves BIM ``getTrimexData`` and, if the user pre-selected an end
-        face, routes Trimex to:
-          - the redirected base wire/line (``redirect`` key), or
-          - a property-update setter (``set`` key) driven by a virtual edge.
-
-        Returns True if the operation is fully set up here (set-mode);
-        False otherwise. Side / top / bottom face selections always fall
-        through to the default face-extrude path.
-        """
+        """Set up a BIM object that exposes Trimex data."""
         import Part
 
         adapter = _get_trimex_data(self.obj)
@@ -240,7 +231,7 @@ class Trimex(gui_base_original.Modifier):
 
         endpoints = adapter.get("endpoints") or []
         axes = adapter.get("axes") or []
-        if len(endpoints) < 2 or len(axes) != len(endpoints):
+        if len(endpoints) != 2 or len(axes) != 2:
             return False
 
         ends = list(zip(endpoints, axes))
@@ -253,8 +244,6 @@ class Trimex(gui_base_original.Modifier):
                 end_idx = match
                 break
         if end_idx is None:
-            # Not an end face (side / top / bottom, or no face picked): keep
-            # the default face-extrude behaviour untouched.
             return False
 
         redirect = adapter.get("redirect")
@@ -262,27 +251,17 @@ class Trimex(gui_base_original.Modifier):
         host = self.obj
 
         if redirect is not None:
-            # Modify the base directly; the host follows on recompute. The
-            # adapter reports two ends (first / last cap), but the wire-mode
-            # vertex list spans every vertex of the base wire, so map the
-            # matched cap to the correct vertex index: 0 -> first, last cap
-            # -> the wire's final vertex (== edge count). Without this a
-            # multi-segment base would move the 2nd vertex instead of the
-            # last when the far end is trimmed.
             self.trimexHost = host
             self.obj = redirect
             if end_idx == 0:
                 self.lockedActivePoint = 0
             else:
-                # Last cap -> final vertex; its index equals the edge count.
                 self.lockedActivePoint = self._wireEdgeCount(redirect)
             return False
 
         if setter is None:
             return False
 
-        # Property-update mode: drive a virtual single-edge line and commit
-        # the new endpoints through the setter callable.
         self.trimexHost = host
         self.trimexSet = setter
         self.trimexEndpoints = [App.Vector(p) for p in endpoints]
@@ -295,23 +274,12 @@ class Trimex(gui_base_original.Modifier):
         self.ghost = [trackers.lineTracker(scolor=(0.5, 0.5, 0.5), swidth=1)]
         self.ui.trimUi(title=translate("draft", self.featureName))
         self.linetrack = trackers.lineTracker()
-        for g in self.ghost:
-            g.on()
-        self.activePoint = 0
-        self.nodes = []
-        self.shift = False
-        self.alt = False
-        self.force = None
-        self.cv = None
-        self.call = self.view.addEventCallback("SoEvent", self.action)
-        _toolmsg(translate("draft", "Pick distance"))
+        self._startInteraction()
         return True
 
     @staticmethod
     def _wireEdgeCount(obj):
-        """Edge count of ``obj``'s wire, using the same edge selection as the
-        wire-mode setup. The final vertex index of the vertex list equals
-        this count."""
+        """Return the index of a wire's final vertex."""
         import Part
 
         shape = obj.Shape
@@ -324,28 +292,15 @@ class Trimex(gui_base_original.Modifier):
         """Index of the end whose axis is parallel to ``face``'s normal and
         whose endpoint lies on the face's plane. ``None`` if the face is not
         an end face (side, top, bottom, etc.)."""
-        try:
-            u, v = face.Surface.parameter(face.CenterOfMass)
-            normal = face.normalAt(u, v)
-        except Exception:
-            return None
-        if normal.Length < 1e-9:
-            return None
-        normal = App.Vector(normal).normalize()
         center = face.CenterOfMass
+        normal = face.normalAt(*face.Surface.parameter(center)).normalize()
         best = None
         best_dot = 0.95  # require strong alignment to discount side/top/bottom faces
         for i, (endpoint, axis) in enumerate(ends):
-            ax_len = axis.Length
-            if ax_len < 1e-9:
-                continue
-            ax = App.Vector(axis).multiply(1.0 / ax_len)
-            dot = abs(normal.dot(ax))
+            dot = abs(normal.dot(axis))
             if dot < best_dot:
                 continue
-            # Endpoint must lie on the face's plane (along the normal).
-            offset = abs(normal.dot(endpoint - center))
-            if offset > 1e-3:
+            if abs(normal.dot(endpoint - center)) > face.Tolerance:
                 continue
             best_dot = dot
             best = i
@@ -417,7 +372,7 @@ class Trimex(gui_base_original.Modifier):
 
     def extrude(self, shift=False, real=False):
         """Redraw the ghost in extrude mode."""
-        self.newpoint = self.obj.Shape.Faces[0].CenterOfMass
+        self.newpoint = self.extrudeShape.Faces[0].CenterOfMass
         dvec = self.point.sub(self.newpoint)
         if not shift:
             delta = DraftVecUtils.project(dvec, self.normal)
@@ -437,7 +392,7 @@ class Trimex(gui_base_original.Modifier):
         self.ghost[1].p2(self.newpoint + dvec)
         # Update the vertex lineTrackers:
         for i in range(2, len(self.ghost)):
-            base = self.obj.Shape.Vertexes[i - 2].Point
+            base = self.extrudeShape.Vertexes[i - 2].Point
             self.ghost[i].p1(base)
             self.ghost[i].p2(base + delta)
         return delta.Length
@@ -459,9 +414,6 @@ class Trimex(gui_base_original.Modifier):
             vlist.append(e.Vertexes[0].Point)
         vlist.append(self.edges[-1].Vertexes[-1].Point)
         if self.lockedActivePoint is not None:
-            # An endpoint was pre-selected (e.g. the start/end face of a wall).
-            # Keep it locked so the user's mouse only sets the new position,
-            # not which end moves.
             npoint = self.lockedActivePoint
         elif shift:
             npoint = self.activePoint
@@ -596,10 +548,13 @@ class Trimex(gui_base_original.Modifier):
 
         if self.extrudeMode:
             delta = self.extrude(self.shift, real=True)
-            # print("delta", delta)
             self.doc.openTransaction("Extrude")
             Gui.addModule("Draft")
-            obj = extrude.extrude(self.obj, delta, solid=True)
+            base = self.extrudeBase
+            if base is None:
+                base = self.doc.addObject("Part::Feature", "Face")
+                base.Shape = self.extrudeShape
+            obj = extrude.extrude(base, delta, solid=True)
             self.doc.commitTransaction()
             self.obj = obj
         else:
@@ -608,14 +563,7 @@ class Trimex(gui_base_original.Modifier):
             self.doc.openTransaction("Trim/extend")
             if self.trimexSet is not None:
                 pts = list(self.trimexEndpoints)
-                idx = (
-                    self.lockedActivePoint
-                    if self.lockedActivePoint is not None
-                    else self.activePoint
-                )
-                if idx is None or idx >= len(pts):
-                    idx = min(self.activePoint, len(pts) - 1)
-                pts[idx] = App.Vector(self.newpoint)
+                pts[self.lockedActivePoint] = App.Vector(self.newpoint)
                 self.trimexSet(pts)
             elif utils.getType(self.obj) in ["Wire", "BSpline"]:
                 p = []
@@ -626,12 +574,6 @@ class Trimex(gui_base_original.Modifier):
                     if self.placement:
                         np = invpl.multVec(np)
                     p.append(np)
-                # When the far endpoint is trimmed, redraw rebuilds the wire
-                # in reverse, which flips the Points order. That is harmless
-                # for a standalone wire but flips direction-sensitive parents
-                # (Arch Truss/Frame, ...) when we trim a redirected base. In
-                # that case keep the original orientation by comparing both
-                # ends against the previous Points.
                 old = self.obj.Points
                 if self.trimexHost is not None and len(p) == len(old) and len(old) >= 2:
                     same = (p[0] - old[0]).Length + (p[-1] - old[-1]).Length
@@ -777,9 +719,6 @@ class Trimex(gui_base_original.Modifier):
                     self.obj.ViewObject.LineColor = self.color
                 if self.width:
                     self.obj.ViewObject.LineWidth = self.width
-                # Re-select the original host when we operated on its base
-                # or via its property setter, so the user keeps a meaningful
-                # selection.
                 gui_utils.select(self.trimexHost or self.obj)
         super().finish()
 
@@ -810,6 +749,34 @@ class Trimex(gui_base_original.Modifier):
                 Gui.InputHint(translate("draft", "Hold %1 invert trim direction"), alt_key)
             )
         return hints + gui_tool_utils._get_hint_mod_snap()
+
+
+class ExtrudeFace(Trimex):
+    """BIM-only face extrusion command sharing Trimex's interaction tools."""
+
+    command_name = "Extrude face"
+    selection_message = "Select a face to extrude"
+    multi_object_selection = False
+
+    def GetResources(self):
+        return {
+            "Pixmap": "BIM_ExtrudeFace",
+            "MenuText": QT_TRANSLATE_NOOP("BIM_ExtrudeFace", "Extrude Face"),
+            "ToolTip": QT_TRANSLATE_NOOP(
+                "BIM_ExtrudeFace", "Extrudes a selected face into a solid"
+            ),
+        }
+
+    def proceed(self):
+        """Start the face-extrude interaction from exactly one selection."""
+        if self.call:
+            self.view.removeEventCallback("SoEvent", self.call)
+        selected = Gui.Selection.getSelection()
+        if len(selected) != 1:
+            self.finish()
+            _err(translate("draft", "Select a single face to extrude"))
+            return
+        self._startFaceExtrude(Gui.Selection.getSelectionEx("", 0)[0])
 
 
 Gui.addCommand("Draft_Trimex", Trimex())

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -350,7 +350,7 @@ def get_type(obj):
 getType = get_type
 
 
-def get_trimex_unsupported_reason(obj, subobjects=None):
+def get_trimex_unsupported_reason(obj):
     """Return a translated Trimex error message for unsupported objects.
 
     Parameters
@@ -380,15 +380,7 @@ def get_trimex_unsupported_reason(obj, subobjects=None):
 
     shape = obj.Shape
     if shape.Faces:
-        if len(shape.Faces) == 1:
-            return None
-        if (
-            subobjects
-            and len(subobjects) == 1
-            and getattr(subobjects[0], "ShapeType", None) == "Face"
-        ):
-            return None
-        return translate("draft", "Only a single face can be extruded")
+        return translate("draft", "Trimex does not support this object type")
 
     if obj.isDerivedFrom("Sketcher::SketchObject"):
         return translate("draft", "Trimex does not support this object type")


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Trimex currently creates new objects based on the selected face, so you cannot shorten a wall by picking its end faces.

This PR changes the Trimex behavior so it changes the underlying base features or properties of arch objects:

- Wall, wire/line-based: edits the base wire's endpoint. Baseless: updates Length + Placement. Sketch-based: unchanged (face-extrude).
- Pipe, wire/line-based: edits the base wire's endpoint. Baseless: updates Length + Placement so local +Z aligns with the new endpoints.
- Structure (Beam / Column / Slab): top/bottom end cap updates Length (Beam-mode, length > height) or Height. Skipped when Tool (path) is set.
- Frame: redirects to base wire; trimming an open-end cap moves the matching base endpoint.
- Truss: redirects to its single-edge base wire.
- Panel: baseless only; top/bottom face updates Thickness.



Trimex asks the selected object "do you have a length axis I can trim?" via obj.Proxy.trimex_axis(obj).
The object replys with two endpoints + outward axes, plus either a redirect (an object to trim instead, e.g. the base wire) or a set callable (commits new endpoints into properties, e.g. Length, Placement, Thickness).
Trimex matches the preselected face against those endpoints/axes to decide if it's an end face. If not, it falls through to the existing "extrude the selected face" path.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
- Fixes https://github.com/FreeCAD/FreeCAD/issues/18730
- Fixes https://github.com/FreeCAD/FreeCAD/issues/5608


## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

https://github.com/user-attachments/assets/40d82bdc-5f7d-41f8-bae5-33b417d701d3




Assisted-by: Opus 4.7