### PR TITLE
Sketcher: improve overlap picking in sketch edit mode

### DIFF
--- a/src/Gui/Quarter/EventFilter.cpp
+++ b/src/Gui/Quarter/EventFilter.cpp
@@ -46,6 +46,19 @@
 
 namespace SIM { namespace Coin3D { namespace Quarter {
 
+namespace {
+
+QPointF getLocalPosition(const QMouseEvent* event)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  return event->position();
+#else
+  return event->localPos();
+#endif
+}
+
+}
+
 class EventFilterP {
 public:
   QList<InputDevice *> devices;
@@ -72,9 +85,10 @@ public:
     this->globalmousepos = event->globalPos();
 #endif
 
-    SbVec2s mousepos(event->pos().x(), this->windowsize[1] - event->pos().y() - 1);
-    // the following corrects for high-dpi displays (e.g. mac retina)
-    mousepos *= quarterwidget->devicePixelRatio();
+    SbVec2s mousepos = InputDevice::toDevicePixelPosition(
+        getLocalPosition(event),
+        this->windowsize,
+        quarterwidget->devicePixelRatio());
     Q_FOREACH(InputDevice * device, this->devices) {
       device->setMousePosition(mousepos);
     }

--- a/src/Gui/Quarter/InputDevice.cpp
+++ b/src/Gui/Quarter/InputDevice.cpp
@@ -34,7 +34,12 @@
 #pragma warning(disable : 4267)
 #endif
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 #include <QInputEvent>
+#include <QPointF>
 #include <Inventor/events/SoEvents.h>
 
 #include "devices/InputDevice.h"
@@ -53,6 +58,25 @@ InputDevice::InputDevice(QuarterWidget* quarter) :
     quarter(quarter)
 {
   this->mousepos = SbVec2s(0, 0);
+}
+
+SbVec2s
+InputDevice::toDevicePixelPosition(
+    const QPointF& logicalPosition,
+    const SbVec2s& logicalWindowSize,
+    qreal devicePixelRatio
+)
+{
+  int xpos = static_cast<int>(std::lround(logicalPosition.x() * devicePixelRatio));
+  int ypos = static_cast<int>(
+      std::lround((logicalWindowSize[1] - logicalPosition.y() - 1.0) * devicePixelRatio));
+
+  constexpr int ShortMin = std::numeric_limits<short>::min();
+  constexpr int ShortMax = std::numeric_limits<short>::max();
+  xpos = std::clamp(xpos, ShortMin, ShortMax);
+  ypos = std::clamp(ypos, ShortMin, ShortMax);
+
+  return SbVec2s(static_cast<short>(xpos), static_cast<short>(ypos));
 }
 
 /*!

--- a/src/Gui/Quarter/Mouse.cpp
+++ b/src/Gui/Quarter/Mouse.cpp
@@ -91,6 +91,28 @@ using namespace SIM::Coin3D::Quarter;
 #define PRIVATE(obj) obj->pimpl
 #define PUBLIC(obj) obj->publ
 
+namespace {
+
+QPointF getLocalPosition(const QMouseEvent* event)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  return event->position();
+#else
+  return event->localPos();
+#endif
+}
+
+QPointF getLocalPosition(const QWheelEvent* event)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  return event->position();
+#else
+  return event->posF();
+#endif
+}
+
+}
+
 Mouse::Mouse(QuarterWidget* quarter) :
   InputDevice(quarter)
 {
@@ -141,9 +163,10 @@ MouseP::mouseMoveEvent(QMouseEvent * event)
   PUBLIC(this)->setModifiers(this->location2, event);
 
   assert(this->windowsize[1] != -1);
-  SbVec2s pos(event->pos().x(), this->windowsize[1] - event->pos().y() - 1);
-  // the following corrects for high-dpi displays (e.g. mac retina)
-  pos *= publ->quarter->devicePixelRatio();
+  SbVec2s pos = InputDevice::toDevicePixelPosition(
+      getLocalPosition(event),
+      this->windowsize,
+      publ->quarter->devicePixelRatio());
   this->location2->setPosition(pos);
   this->mousebutton->setPosition(pos);
   return this->location2;
@@ -153,10 +176,10 @@ const SoEvent *
 MouseP::mouseWheelEvent(QWheelEvent * event)
 {
   PUBLIC(this)->setModifiers(this->wheel, event);
-  QPoint pnt = event->position().toPoint();
-  SbVec2s pos(pnt.x(), PUBLIC(this)->windowsize[1] - pnt.y() - 1);
-  // the following corrects for high-dpi displays (e.g. mac retina)
-  pos *= publ->quarter->devicePixelRatio();
+  SbVec2s pos = InputDevice::toDevicePixelPosition(
+      getLocalPosition(event),
+      PUBLIC(this)->windowsize,
+      publ->quarter->devicePixelRatio());
   this->location2->setPosition(pos); //I don't know why location2 is assigned here, I assumed it important  --DeepSOIC
   this->wheel->setPosition(pos);
 
@@ -175,9 +198,10 @@ const SoEvent *
 MouseP::mouseButtonEvent(QMouseEvent * event)
 {
   PUBLIC(this)->setModifiers(this->mousebutton, event);
-  SbVec2s pos(event->pos().x(), PUBLIC(this)->windowsize[1] - event->pos().y() - 1);
-  // the following corrects for high-dpi displays (e.g. mac retina)
-  pos *= publ->quarter->devicePixelRatio();
+  SbVec2s pos = InputDevice::toDevicePixelPosition(
+      getLocalPosition(event),
+      PUBLIC(this)->windowsize,
+      publ->quarter->devicePixelRatio());
   this->location2->setPosition(pos);
   this->mousebutton->setPosition(pos);
 

--- a/src/Gui/Quarter/devices/InputDevice.h
+++ b/src/Gui/Quarter/devices/InputDevice.h
@@ -38,6 +38,7 @@
 class QEvent;
 class SoEvent;
 class QInputEvent;
+class QPointF;
 
 namespace SIM { namespace Coin3D { namespace Quarter {
 
@@ -53,6 +54,12 @@ public:
     handling
   */
   virtual const SoEvent * translateEvent(QEvent * event) = 0;
+
+  static SbVec2s toDevicePixelPosition(
+      const QPointF& logicalPosition,
+      const SbVec2s& logicalWindowSize,
+      qreal devicePixelRatio
+  );
 
   void setMousePosition(const SbVec2s & pos);
   void setWindowSize(const SbVec2s & size);

--- a/src/Mod/Sketcher/CMakeLists.txt
+++ b/src/Mod/Sketcher/CMakeLists.txt
@@ -29,6 +29,7 @@ if(BUILD_GUI)
           TestSketcherGui.py
     )
     list (APPEND Sketcher_TestScripts
+          SketcherTests/TestConstraintPreselectionGui.py
           SketcherTests/TestPlacementUpdate.py
           SketcherTests/TestOnViewParameterGui.py
     )

--- a/src/Mod/Sketcher/Gui/AppSketcherGui.cpp
+++ b/src/Mod/Sketcher/Gui/AppSketcherGui.cpp
@@ -26,9 +26,12 @@
 #include <Base/Console.h>
 #include <Base/Interpreter.h>
 #include <Base/PyObjectBase.h>
+#include <App/Document.h>
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
+#include <Gui/Document.h>
 #include <Gui/Language/Translator.h>
+#include <Gui/View3DInventor.h>
 #include <Gui/WidgetFactory.h>
 
 #include "PropertyConstraintListItem.h"
@@ -67,6 +70,15 @@ public:
     Module()
         : Py::ExtensionModule<Module>("SketcherGui")
     {
+        add_varargs_method(
+            "getActiveSketchPreselection",
+            &Module::getActiveSketchPreselection,
+            "getActiveSketchPreselection(tuple(int,int)) -> dictionary or None\n"
+            "\n"
+            "Return the Sketcher edit-mode preselection candidate at viewport coordinates.\n"
+            "The tuple uses the same coordinate system as Gui.ActiveDocument.ActiveView"
+            ".getPointOnViewport().\n"
+        );
         initialize("This module is the SketcherGui module.");  // register with Python
     }
 
@@ -74,6 +86,69 @@ public:
     {}
 
 private:
+    Py::Object getActiveSketchPreselection(const Py::Tuple& args)
+    {
+        PyObject* object;
+        if (!PyArg_ParseTuple(args.ptr(), "O", &object)) {
+            throw Py::Exception();
+        }
+
+        const Py::Tuple tuple(object);
+        Py::Long x(tuple[0]);
+        Py::Long y(tuple[1]);
+
+        auto* editDoc = Gui::Application::Instance->editDocument();
+        if (!editDoc) {
+            return Py::None();
+        }
+
+        auto* sketchViewProvider = freecad_cast<SketcherGui::ViewProviderSketch*>(editDoc->getInEdit());
+        if (!sketchViewProvider) {
+            return Py::None();
+        }
+
+        auto* view = dynamic_cast<Gui::View3DInventor*>(
+            editDoc->getEditingViewOfViewProvider(sketchViewProvider)
+        );
+        if (!view) {
+            return Py::None();
+        }
+
+        std::vector<std::string> subElementNames;
+        Base::Vector3d pickedPoint;
+        if (!sketchViewProvider->getPreselectionAtViewportPos(
+                SbVec2s(static_cast<short>((long)x), static_cast<short>((long)y)),
+                view->getViewer(),
+                subElementNames,
+                pickedPoint
+            )) {
+            return Py::None();
+        }
+
+        auto* sketchObject = sketchViewProvider->getObject();
+        if (!sketchObject) {
+            return Py::None();
+        }
+
+        Py::List pySubElementNames;
+        for (const auto& subElementName : subElementNames) {
+            pySubElementNames.append(Py::String(subElementName));
+        }
+
+        Py::List pyPickedPoints;
+        Py::Tuple pyPoint(3);
+        pyPoint.setItem(0, Py::Float(pickedPoint.x));
+        pyPoint.setItem(1, Py::Float(pickedPoint.y));
+        pyPoint.setItem(2, Py::Float(pickedPoint.z));
+        pyPickedPoints.append(pyPoint);
+
+        Py::Dict result;
+        result.setItem("DocumentName", Py::String(sketchObject->getDocument()->getName()));
+        result.setItem("ObjectName", Py::String(sketchObject->getNameInDocument()));
+        result.setItem("SubElementNames", pySubElementNames);
+        result.setItem("PickedPoints", pyPickedPoints);
+        return result;
+    }
 };
 
 PyObject* initModule()

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -46,9 +46,11 @@
 #include <Inventor/nodes/SoText2.h>
 #include <Inventor/nodes/SoTranslation.h>
 
+#include <Base/Converter.h>
 #include <Base/Exception.h>
 #include <Gui/Inventor/MarkerBitmaps.h>
 #include <Gui/Inventor/SoFCBoundingBox.h>
+#include <Gui/Utilities.h>
 #include <Mod/Part/App/Geometry.h>
 #include <Mod/Sketcher/App/Constraint.h>
 #include <Mod/Sketcher/App/GeoList.h>
@@ -285,12 +287,13 @@ struct GeometryScreenPreselector
                     result.clear();
                     result.Kind = SketcherGui::EditModeCoinManager::PreselectionResult::HitKind::Edge;
                     result.GeoIndex = geoIndex;
-                    result.PickedPoint = Base::Vector3d(
-                        startPoint[0] + (endPoint[0] - startPoint[0]) * interpolation,
-                        startPoint[1] + (endPoint[1] - startPoint[1]) * interpolation,
-                        startPoint[2] + (endPoint[2] - startPoint[2]) * interpolation
+                    result.setPickedPoint(
+                        Base::Vector3d(
+                            startPoint[0] + (endPoint[0] - startPoint[0]) * interpolation,
+                            startPoint[1] + (endPoint[1] - startPoint[1]) * interpolation,
+                            startPoint[2] + (endPoint[2] - startPoint[2]) * interpolation
+                        )
                     );
-                    result.HasPickedPoint = true;
                     bestDistanceSquared = bestCurveDistanceSquared;
                     found = true;
                 }
@@ -337,12 +340,13 @@ private:
         result.clear();
         result.Kind = SketcherGui::EditModeCoinManager::PreselectionResult::HitKind::Point;
         result.PointIndex = coinMapping.getPointVertexId(pointIndex, layerIndex);
-        result.PickedPoint = Base::Vector3d(
-            pointValues[pointIndex][0],
-            pointValues[pointIndex][1],
-            pointValues[pointIndex][2]
+        result.setPickedPoint(
+            Base::Vector3d(
+                pointValues[pointIndex][0],
+                pointValues[pointIndex][1],
+                pointValues[pointIndex][2]
+            )
         );
-        result.HasPickedPoint = true;
         return true;
     }
 
@@ -402,11 +406,14 @@ private:
 };
 }  // namespace
 
+void EditModeCoinManager::PreselectionResult::setPickedPoint(const Base::Vector3d& point)
+{
+    PickedPoint = point;
+}
+
 void EditModeCoinManager::PreselectionResult::setPickedPoint(const SoPickedPoint* point)
 {
-    const SbVec3f pickedPoint = point->getPoint();
-    PickedPoint = Base::Vector3d(pickedPoint[0], pickedPoint[1], pickedPoint[2]);
-    HasPickedPoint = true;
+    setPickedPoint(Base::convertTo<Base::Vector3d>(point->getPoint()));
 }
 
 //**************************** ParameterObserver nested class ******************************
@@ -477,6 +484,8 @@ void EditModeCoinManager::ParameterObserver::initParameters()
         {"MarkerSize", [this](const std::string&) { Client.updateElementSizeParameters(); }},
         {"EditSketcherFontName", [this](const std::string&) { Client.updateElementSizeParameters(); }},
         {"EditSketcherFontSize", [this](const std::string&) { Client.updateElementSizeParameters(); }},
+        {"ConstraintIconHitPadding",
+         [this](const std::string&) { Client.updateElementSizeParameters(); }},
         {"EdgeWidth",
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
              updateWidth(drawingParameters.CurveWidth, param, 2);
@@ -1045,8 +1054,7 @@ EditModeCoinManager::PreselectionResult EditModeCoinManager::detectConstraintPre
         = pEditModeConstraintCoinManager->detectPreselectionConstr(cursorPos, &pickedPoint);
     if (!result.ConstrIndices.empty()) {
         result.Kind = PreselectionResult::HitKind::Constraint;
-        result.PickedPoint = pickedPoint;
-        result.HasPickedPoint = true;
+        result.setPickedPoint(pickedPoint);
         return result;
     }
 
@@ -1659,6 +1667,7 @@ void EditModeCoinManager::updateElementSizeParameters()
 
     int sketcherfontSize = hGrp->GetInt("EditSketcherFontSize", defaultFontSizePixels);
     int constraintSymbolSizePref = hGrp->GetInt("ConstraintSymbolSize", defaultFontSizePixels);
+    drawingParameters.constraintIconHitPaddingPx = hGrp->GetInt("ConstraintIconHitPadding", 3);
 
     double dpi = getApplicationLogicalDPIX();
     double devicePixelRatio = getDevicePixelRatio();

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -26,6 +26,7 @@
 
 #include <Inventor/SbVec3f.h>
 #include <Inventor/SoPickedPoint.h>
+#include <Inventor/lists/SoPickedPointList.h>
 #include <Inventor/details/SoDetail.h>
 #include <Inventor/details/SoLineDetail.h>
 #include <Inventor/details/SoPointDetail.h>
@@ -58,6 +59,13 @@
 
 using namespace SketcherGui;
 using namespace Sketcher;
+
+void EditModeCoinManager::PreselectionResult::setPickedPoint(const SoPickedPoint* point)
+{
+    const SbVec3f pickedPoint = point->getPoint();
+    PickedPoint = Base::Vector3d(pickedPoint[0], pickedPoint[1], pickedPoint[2]);
+    HasPickedPoint = true;
+}
 
 //**************************** ParameterObserver nested class ******************************
 EditModeCoinManager::ParameterObserver::ParameterObserver(EditModeCoinManager& client)
@@ -683,81 +691,188 @@ void EditModeCoinManager::setAxisPickStyle(bool on)
     }
 }
 
-EditModeCoinManager::PreselectionResult EditModeCoinManager::detectPreselection(SoPickedPoint* Point)
+EditModeCoinManager::PreselectionResult EditModeCoinManager::detectConstraintPreselection(
+    const SoPickedPointList& points,
+    const SbVec2s& cursorPos
+)
 {
-    EditModeCoinManager::PreselectionResult result;
+    PreselectionResult result;
 
-    if (!Point) {
+    for (int i = 0; i < points.getLength(); ++i) {
+        SoPickedPoint* point = points[i];
+        if (!point) {
+            continue;
+        }
+
+        result.ConstrIndices
+            = pEditModeConstraintCoinManager->detectPreselectionConstr(point, cursorPos);
+        if (result.ConstrIndices.empty()) {
+            continue;
+        }
+
+        result.Kind = PreselectionResult::HitKind::Constraint;
+        result.setPickedPoint(point);
         return result;
     }
 
-    // Base::Console().log("Point pick\n");
-    SoPath* path = Point->getPath();
-    SoNode* tail = path->getTail();  // Tail is directly the node containing points and curves
+    return result;
+}
 
-    // checking for a hit on the separate Origin Point
-    if (tail == editModeScenegraphNodes.OriginPointSet) {
-        const SoDetail* point_detail = Point->getDetail(editModeScenegraphNodes.OriginPointSet);
-        if (point_detail && point_detail->getTypeId() == SoPointDetail::getClassTypeId()) {
-            result.PointIndex = -1;  // The logical ID of the origin
-            result.Cross = PreselectionResult::Axes::RootPoint;
-            return result;
+bool EditModeCoinManager::detectOriginPreselection(const SoPickedPoint* point, PreselectionResult& result)
+{
+    SoPath* path = point->getPath();
+    SoNode* tail = path->getTail();
+    if (tail != editModeScenegraphNodes.OriginPointSet) {
+        return false;
+    }
+
+    const SoDetail* pointDetail = point->getDetail(editModeScenegraphNodes.OriginPointSet);
+    if (!pointDetail || pointDetail->getTypeId() != SoPointDetail::getClassTypeId()) {
+        return false;
+    }
+
+    result.Kind = PreselectionResult::HitKind::Axis;
+    result.Cross = PreselectionResult::Axes::RootPoint;
+    result.setPickedPoint(point);
+    return true;
+}
+
+bool EditModeCoinManager::detectPointPreselection(
+    const SoPickedPoint* point,
+    int layerIndex,
+    PreselectionResult& result
+)
+{
+    SoPath* path = point->getPath();
+    SoNode* tail = path->getTail();
+    if (tail != editModeScenegraphNodes.PointSet[layerIndex]) {
+        return false;
+    }
+
+    const SoDetail* pointDetail = point->getDetail(editModeScenegraphNodes.PointSet[layerIndex]);
+    if (!pointDetail || pointDetail->getTypeId() != SoPointDetail::getClassTypeId()) {
+        return false;
+    }
+
+    int pointIndex = static_cast<const SoPointDetail*>(pointDetail)->getCoordinateIndex();
+    result.PointIndex = coinMapping.getPointVertexId(pointIndex, layerIndex);
+    if (result.PointIndex == -1) {
+        result.Kind = PreselectionResult::HitKind::Axis;
+        result.Cross = PreselectionResult::Axes::RootPoint;
+    }
+    else {
+        result.Kind = PreselectionResult::HitKind::Point;
+    }
+
+    result.setPickedPoint(point);
+    return true;
+}
+
+bool EditModeCoinManager::detectCurvePreselection(
+    const SoPickedPoint* point,
+    int layerIndex,
+    PreselectionResult& result
+)
+{
+    SoPath* path = point->getPath();
+    SoNode* tail = path->getTail();
+
+    for (int subLayerIndex = 0; subLayerIndex < geometryLayerParameters.getSubLayerCount();
+         ++subLayerIndex) {
+        if (tail != editModeScenegraphNodes.CurveSet[layerIndex][subLayerIndex]) {
+            continue;
+        }
+
+        const SoDetail* curveDetail = point->getDetail(
+            editModeScenegraphNodes.CurveSet[layerIndex][subLayerIndex]
+        );
+        if (!curveDetail || curveDetail->getTypeId() != SoLineDetail::getClassTypeId()) {
+            return false;
+        }
+
+        int curveIndex = static_cast<const SoLineDetail*>(curveDetail)->getLineIndex();
+        result.GeoIndex = coinMapping.getCurveGeoId(curveIndex, layerIndex, subLayerIndex);
+        result.Kind = PreselectionResult::HitKind::Edge;
+        result.setPickedPoint(point);
+        return true;
+    }
+
+    return false;
+}
+
+bool EditModeCoinManager::detectGeometryPreselection(const SoPickedPoint* point, PreselectionResult& result)
+{
+    for (int layerIndex = 0; layerIndex < geometryLayerParameters.getCoinLayerCount(); ++layerIndex) {
+        if (detectPointPreselection(point, layerIndex, result)) {
+            return true;
+        }
+
+        if (detectCurvePreselection(point, layerIndex, result)) {
+            return true;
         }
     }
 
-    for (int l = 0; l < geometryLayerParameters.getCoinLayerCount(); l++) {
-        // checking for a hit in the points
-        if (tail == editModeScenegraphNodes.PointSet[l]) {
-            const SoDetail* point_detail = Point->getDetail(editModeScenegraphNodes.PointSet[l]);
-            if (point_detail && point_detail->getTypeId() == SoPointDetail::getClassTypeId()) {
-                // get the index
-                int pindex = static_cast<const SoPointDetail*>(point_detail)->getCoordinateIndex();
-                result.PointIndex = coinMapping.getPointVertexId(
-                    pindex,
-                    l
-                );  // returns -1 for root, global VertexId for the rest of vertices.
+    return false;
+}
 
-                if (result.PointIndex == -1) {
-                    result.Cross = PreselectionResult::Axes::RootPoint;
-                }
-
-                return result;
-            }
-        }
-
-        // checking for a hit in the curves
-        for (int t = 0; t < geometryLayerParameters.getSubLayerCount(); t++) {
-            if (tail == editModeScenegraphNodes.CurveSet[l][t]) {
-                const SoDetail* curve_detail = Point->getDetail(editModeScenegraphNodes.CurveSet[l][t]);
-                if (curve_detail && curve_detail->getTypeId() == SoLineDetail::getClassTypeId()) {
-                    // get the index
-                    int curveIndex = static_cast<const SoLineDetail*>(curve_detail)->getLineIndex();
-                    result.GeoIndex = coinMapping.getCurveGeoId(curveIndex, l, t);
-
-                    return result;
-                }
-            }
-        }
+bool EditModeCoinManager::detectAxisPreselection(const SoPickedPoint* point, PreselectionResult& result)
+{
+    SoPath* path = point->getPath();
+    SoNode* tail = path->getTail();
+    if (tail != editModeScenegraphNodes.RootCrossSet) {
+        return false;
     }
-    // checking for a hit in the axes
-    if (tail == editModeScenegraphNodes.RootCrossSet) {
-        const SoDetail* cross_detail = Point->getDetail(editModeScenegraphNodes.RootCrossSet);
-        if (cross_detail && cross_detail->getTypeId() == SoLineDetail::getClassTypeId()) {
-            // get the index (reserve index 0 for root point)
-            int CrossIndex = static_cast<const SoLineDetail*>(cross_detail)->getLineIndex();
 
-            if (CrossIndex == 0) {
-                result.Cross = PreselectionResult::Axes::HorizontalAxis;
-            }
-            else if (CrossIndex == 1) {
-                result.Cross = PreselectionResult::Axes::VerticalAxis;
-            }
-
-            return result;
-        }
+    const SoDetail* crossDetail = point->getDetail(editModeScenegraphNodes.RootCrossSet);
+    if (!crossDetail || crossDetail->getTypeId() != SoLineDetail::getClassTypeId()) {
+        return false;
     }
-    // checking if a constraint is hit
-    result.ConstrIndices = pEditModeConstraintCoinManager->detectPreselectionConstr(Point);
+
+    int crossIndex = static_cast<const SoLineDetail*>(crossDetail)->getLineIndex();
+    if (crossIndex == 0) {
+        result.Cross = PreselectionResult::Axes::HorizontalAxis;
+    }
+    else if (crossIndex == 1) {
+        result.Cross = PreselectionResult::Axes::VerticalAxis;
+    }
+
+    result.Kind = PreselectionResult::HitKind::Axis;
+    result.setPickedPoint(point);
+    return true;
+}
+
+EditModeCoinManager::PreselectionResult EditModeCoinManager::detectPreselection(
+    const SoPickedPointList& points,
+    const SbVec2s& cursorPos
+)
+{
+    PreselectionResult result;
+
+    if (points.getLength() == 0) {
+        return result;
+    }
+
+    result = detectConstraintPreselection(points, cursorPos);
+    if (result.hasWinner()) {
+        return result;
+    }
+
+    SoPickedPoint* point = points[0];
+    if (!point) {
+        return result;
+    }
+
+    if (detectOriginPreselection(point, result)) {
+        return result;
+    }
+
+    if (detectGeometryPreselection(point, result)) {
+        return result;
+    }
+
+    if (detectAxisPreselection(point, result)) {
+        return result;
+    }
 
     return result;
 }

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -800,16 +800,67 @@ bool EditModeCoinManager::detectCurvePreselection(
     return false;
 }
 
-bool EditModeCoinManager::detectGeometryPreselection(const SoPickedPoint* point, PreselectionResult& result)
+bool EditModeCoinManager::detectPointPreselection(
+    const SoPickedPointList& points,
+    PreselectionResult& result
+)
 {
-    for (int layerIndex = 0; layerIndex < geometryLayerParameters.getCoinLayerCount(); ++layerIndex) {
-        if (detectPointPreselection(point, layerIndex, result)) {
-            return true;
+    for (int i = 0; i < points.getLength(); ++i) {
+        SoPickedPoint* point = points[i];
+        if (!point) {
+            continue;
         }
 
-        if (detectCurvePreselection(point, layerIndex, result)) {
-            return true;
+        for (int layerIndex = 0; layerIndex < geometryLayerParameters.getCoinLayerCount();
+             ++layerIndex) {
+            PreselectionResult candidate;
+            if (!detectPointPreselection(point, layerIndex, candidate)) {
+                continue;
+            }
+
+            if (candidate.Kind == PreselectionResult::HitKind::Point) {
+                result = candidate;
+                return true;
+            }
         }
+    }
+
+    return false;
+}
+
+bool EditModeCoinManager::detectCurvePreselection(
+    const SoPickedPointList& points,
+    PreselectionResult& result
+)
+{
+    for (int i = 0; i < points.getLength(); ++i) {
+        SoPickedPoint* point = points[i];
+        if (!point) {
+            continue;
+        }
+
+        for (int layerIndex = 0; layerIndex < geometryLayerParameters.getCoinLayerCount();
+             ++layerIndex) {
+            if (detectCurvePreselection(point, layerIndex, result)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bool EditModeCoinManager::detectGeometryPreselection(
+    const SoPickedPointList& points,
+    PreselectionResult& result
+)
+{
+    if (detectPointPreselection(points, result)) {
+        return true;
+    }
+
+    if (detectCurvePreselection(points, result)) {
+        return true;
     }
 
     return false;
@@ -841,6 +892,42 @@ bool EditModeCoinManager::detectAxisPreselection(const SoPickedPoint* point, Pre
     return true;
 }
 
+bool EditModeCoinManager::detectAxisPreselection(
+    const SoPickedPointList& points,
+    PreselectionResult& result
+)
+{
+    for (int i = 0; i < points.getLength(); ++i) {
+        SoPickedPoint* point = points[i];
+        if (!point) {
+            continue;
+        }
+
+        if (detectOriginPreselection(point, result)) {
+            return true;
+        }
+
+        for (int layerIndex = 0; layerIndex < geometryLayerParameters.getCoinLayerCount();
+             ++layerIndex) {
+            PreselectionResult candidate;
+            if (!detectPointPreselection(point, layerIndex, candidate)) {
+                continue;
+            }
+
+            if (candidate.Kind == PreselectionResult::HitKind::Axis) {
+                result = candidate;
+                return true;
+            }
+        }
+
+        if (detectAxisPreselection(point, result)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 EditModeCoinManager::PreselectionResult EditModeCoinManager::detectPreselection(
     const SoPickedPointList& points,
     const SbVec2s& cursorPos
@@ -857,20 +944,11 @@ EditModeCoinManager::PreselectionResult EditModeCoinManager::detectPreselection(
         return result;
     }
 
-    SoPickedPoint* point = points[0];
-    if (!point) {
+    if (detectGeometryPreselection(points, result)) {
         return result;
     }
 
-    if (detectOriginPreselection(point, result)) {
-        return result;
-    }
-
-    if (detectGeometryPreselection(point, result)) {
-        return result;
-    }
-
-    if (detectAxisPreselection(point, result)) {
+    if (detectAxisPreselection(points, result)) {
         return result;
     }
 

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -697,6 +697,16 @@ EditModeCoinManager::PreselectionResult EditModeCoinManager::detectConstraintPre
 )
 {
     PreselectionResult result;
+    Base::Vector3d pickedPoint;
+
+    result.ConstrIndices
+        = pEditModeConstraintCoinManager->detectPreselectionConstr(cursorPos, &pickedPoint);
+    if (!result.ConstrIndices.empty()) {
+        result.Kind = PreselectionResult::HitKind::Constraint;
+        result.PickedPoint = pickedPoint;
+        result.HasPickedPoint = true;
+        return result;
+    }
 
     for (int i = 0; i < points.getLength(); ++i) {
         SoPickedPoint* point = points[i];

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <functional>
 #include <limits>
 #include <memory>
 
@@ -66,10 +67,13 @@ using namespace Sketcher;
 
 namespace
 {
-constexpr float PointMarkerHitPaddingPx = 5.0F;
-constexpr float EndpointPointHitRadiusBonusPx = 2.0F;
-constexpr float PointHoverHysteresisPx = 2.0F;
-constexpr float EdgeHitPaddingPx = 2.0F;
+struct ScreenPreselectionPolicy
+{
+    static constexpr float PointMarkerHitPaddingPx = 5.0F;
+    static constexpr float EndpointPointHitRadiusBonusPx = 2.0F;
+    static constexpr float PointHoverHysteresisPx = 2.0F;
+    static constexpr float EdgeHitPaddingPx = 2.0F;
+};
 
 float distanceSquaredToSegment(const SbVec2f& point, const SbVec2f& segmentStart, const SbVec2f& segmentEnd)
 {
@@ -93,6 +97,309 @@ float distanceSquaredToSegment(const SbVec2f& point, const SbVec2f& segmentStart
     float dy = point[1] - closestY;
     return dx * dx + dy * dy;
 }
+
+// Screen-space point/edge preselection should be resolved in one place so the fallback policy is
+// explicit and independent of raw Coin hit ordering.
+struct GeometryScreenPreselector
+{
+    GeometryScreenPreselector(
+        const SketcherGui::GeometryLayerParameters& geometryLayerParams,
+        const SketcherGui::EditModeScenegraphNodes& scenegraphNodes,
+        SketcherGui::CoinMapping& coinMap,
+        const SketcherGui::DrawingParameters& drawingParams,
+        const SketcherGui::GeoList& geoListArg,
+        std::function<SbVec2f(const SbVec3f&)> screenProjectorArg
+    )
+        : geometryLayerParameters(geometryLayerParams)
+        , editModeScenegraphNodes(scenegraphNodes)
+        , coinMapping(coinMap)
+        , drawingParameters(drawingParams)
+        , geolist(geoListArg)
+        , projectToScreen(std::move(screenProjectorArg))
+    {}
+
+    bool detectHoveredPointPreselection(
+        int hoveredPointIndex,
+        const SbVec2s& cursorPos,
+        SketcherGui::EditModeCoinManager::PreselectionResult& result
+    )
+    {
+        if (hoveredPointIndex == SketcherGui::EditModeCoinManager::PreselectionResult::InvalidPoint) {
+            return false;
+        }
+
+        SketcherGui::MultiFieldId pointId = coinMapping.getIndexLayer(hoveredPointIndex);
+        if (pointId == SketcherGui::MultiFieldId::Invalid) {
+            return false;
+        }
+
+        float distanceSquared = 0.0F;
+        return detectPointDiskPreselection(
+            pointId.fieldIndex,
+            pointId.layerId,
+            cursorPos,
+            ScreenPreselectionPolicy::PointHoverHysteresisPx,
+            distanceSquared,
+            result
+        );
+    }
+
+    bool detectNearbyPointPreselection(
+        const SbVec2s& cursorPos,
+        SketcherGui::EditModeCoinManager::PreselectionResult& result
+    )
+    {
+        float bestDistanceSquared = std::numeric_limits<float>::max();
+        bool found = false;
+
+        for (int layerIndex = 0; layerIndex < geometryLayerParameters.getCoinLayerCount();
+             ++layerIndex) {
+            SoCoordinate3* coords = editModeScenegraphNodes.PointsCoordinate[layerIndex];
+            if (!coords) {
+                continue;
+            }
+
+            int pointCount = coords->point.getNum();
+            for (int pointIndex = 0; pointIndex < pointCount; ++pointIndex) {
+                int vertexId = coinMapping.getPointVertexId(pointIndex, layerIndex);
+                if (vertexId < 0) {
+                    continue;
+                }
+
+                SketcherGui::EditModeCoinManager::PreselectionResult candidate;
+                float distanceSquared = 0.0F;
+                if (!detectPointDiskPreselection(
+                        pointIndex,
+                        layerIndex,
+                        cursorPos,
+                        0.0F,
+                        distanceSquared,
+                        candidate
+                    )) {
+                    continue;
+                }
+
+                if (distanceSquared > bestDistanceSquared) {
+                    continue;
+                }
+
+                result = candidate;
+                bestDistanceSquared = distanceSquared;
+                found = true;
+            }
+        }
+
+        return found;
+    }
+
+    bool detectNearbyCurvePreselection(
+        const SbVec2s& cursorPos,
+        SketcherGui::EditModeCoinManager::PreselectionResult& result
+    )
+    {
+        float bestDistanceSquared = std::numeric_limits<float>::max();
+        bool found = false;
+        SbVec2f cursorPoint(static_cast<float>(cursorPos[0]), static_cast<float>(cursorPos[1]));
+
+        for (int layerIndex = 0; layerIndex < geometryLayerParameters.getCoinLayerCount();
+             ++layerIndex) {
+            for (int subLayerIndex = 0; subLayerIndex < geometryLayerParameters.getSubLayerCount();
+                 ++subLayerIndex) {
+                if (static_cast<int>(editModeScenegraphNodes.CurvesCoordinate.size()) <= layerIndex
+                    || static_cast<int>(editModeScenegraphNodes.CurvesCoordinate[layerIndex].size())
+                        <= subLayerIndex
+                    || static_cast<int>(editModeScenegraphNodes.CurveSet.size()) <= layerIndex
+                    || static_cast<int>(editModeScenegraphNodes.CurveSet[layerIndex].size())
+                        <= subLayerIndex) {
+                    continue;
+                }
+
+                SoCoordinate3* coords
+                    = editModeScenegraphNodes.CurvesCoordinate[layerIndex][subLayerIndex];
+                SoLineSet* curveSet = editModeScenegraphNodes.CurveSet[layerIndex][subLayerIndex];
+                if (!coords || !curveSet) {
+                    continue;
+                }
+
+                const SbVec3f* curveValues = coords->point.getValues(0);
+                int curveCount = curveSet->numVertices.getNum();
+                if (!curveValues || curveCount <= 0) {
+                    continue;
+                }
+
+                float curveHitRadius = getCurveHitRadius(subLayerIndex);
+                float curveHitRadiusSquared = curveHitRadius * curveHitRadius;
+                int vertexOffset = 0;
+
+                for (int curveIndex = 0; curveIndex < curveCount; ++curveIndex) {
+                    int vertexCount = curveSet->numVertices[curveIndex];
+                    if (!coinMapping.isValidCurveId(curveIndex, layerIndex, subLayerIndex)) {
+                        vertexOffset += std::max(vertexCount, 0);
+                        continue;
+                    }
+
+                    if (vertexCount < 2) {
+                        vertexOffset += std::max(vertexCount, 0);
+                        continue;
+                    }
+
+                    float bestCurveDistanceSquared = std::numeric_limits<float>::max();
+                    int bestSegmentStart = -1;
+                    for (int segmentIndex = 0; segmentIndex < vertexCount - 1; ++segmentIndex) {
+                        int currentVertexIndex = vertexOffset + segmentIndex;
+                        SbVec2f segmentStart = projectToScreen(curveValues[currentVertexIndex]);
+                        SbVec2f segmentEnd = projectToScreen(curveValues[currentVertexIndex + 1]);
+                        float distanceSquared
+                            = distanceSquaredToSegment(cursorPoint, segmentStart, segmentEnd);
+                        if (distanceSquared > curveHitRadiusSquared
+                            || distanceSquared >= bestCurveDistanceSquared) {
+                            continue;
+                        }
+
+                        bestCurveDistanceSquared = distanceSquared;
+                        bestSegmentStart = currentVertexIndex;
+                    }
+
+                    vertexOffset += vertexCount;
+                    if (bestSegmentStart < 0 || bestCurveDistanceSquared >= bestDistanceSquared) {
+                        continue;
+                    }
+
+                    int geoIndex = coinMapping.getCurveGeoId(curveIndex, layerIndex, subLayerIndex);
+                    const SbVec3f& startPoint = curveValues[bestSegmentStart];
+                    const SbVec3f& endPoint = curveValues[bestSegmentStart + 1];
+                    SbVec2f startScreen = projectToScreen(startPoint);
+                    SbVec2f endScreen = projectToScreen(endPoint);
+
+                    float segmentX = endScreen[0] - startScreen[0];
+                    float segmentY = endScreen[1] - startScreen[1];
+                    float segmentLengthSquared = segmentX * segmentX + segmentY * segmentY;
+                    float interpolation = 0.0F;
+                    if (segmentLengthSquared > std::numeric_limits<float>::epsilon()) {
+                        interpolation = ((cursorPoint[0] - startScreen[0]) * segmentX
+                                         + (cursorPoint[1] - startScreen[1]) * segmentY)
+                            / segmentLengthSquared;
+                        interpolation = std::clamp(interpolation, 0.0F, 1.0F);
+                    }
+
+                    result.clear();
+                    result.Kind = SketcherGui::EditModeCoinManager::PreselectionResult::HitKind::Edge;
+                    result.GeoIndex = geoIndex;
+                    result.PickedPoint = Base::Vector3d(
+                        startPoint[0] + (endPoint[0] - startPoint[0]) * interpolation,
+                        startPoint[1] + (endPoint[1] - startPoint[1]) * interpolation,
+                        startPoint[2] + (endPoint[2] - startPoint[2]) * interpolation
+                    );
+                    result.HasPickedPoint = true;
+                    bestDistanceSquared = bestCurveDistanceSquared;
+                    found = true;
+                }
+            }
+        }
+
+        return found;
+    }
+
+private:
+    bool detectPointDiskPreselection(
+        int pointIndex,
+        int layerIndex,
+        const SbVec2s& cursorPos,
+        float extraRadiusPx,
+        float& distanceSquared,
+        SketcherGui::EditModeCoinManager::PreselectionResult& result
+    )
+    {
+        if (!coinMapping.isValidPointId(pointIndex, layerIndex)
+            || static_cast<int>(editModeScenegraphNodes.PointsCoordinate.size()) <= layerIndex) {
+            return false;
+        }
+
+        SoCoordinate3* coords = editModeScenegraphNodes.PointsCoordinate[layerIndex];
+        if (!coords || pointIndex >= coords->point.getNum()) {
+            return false;
+        }
+
+        const SbVec3f* pointValues = coords->point.getValues(0);
+        if (!pointValues) {
+            return false;
+        }
+
+        float pointHitRadius = getPointHitRadius(pointIndex, layerIndex, extraRadiusPx);
+        SbVec2f screenPoint = projectToScreen(pointValues[pointIndex]);
+        float dx = static_cast<float>(cursorPos[0]) - screenPoint[0];
+        float dy = static_cast<float>(cursorPos[1]) - screenPoint[1];
+        distanceSquared = dx * dx + dy * dy;
+        if (distanceSquared > pointHitRadius * pointHitRadius) {
+            return false;
+        }
+
+        result.clear();
+        result.Kind = SketcherGui::EditModeCoinManager::PreselectionResult::HitKind::Point;
+        result.PointIndex = coinMapping.getPointVertexId(pointIndex, layerIndex);
+        result.PickedPoint = Base::Vector3d(
+            pointValues[pointIndex][0],
+            pointValues[pointIndex][1],
+            pointValues[pointIndex][2]
+        );
+        result.HasPickedPoint = true;
+        return true;
+    }
+
+    float getPointHitRadius(int pointIndex, int layerIndex, float extraRadiusPx) const
+    {
+        float markerExtent = static_cast<float>(drawingParameters.markerSize);
+        if (static_cast<int>(editModeScenegraphNodes.PointsDrawStyle.size()) > layerIndex
+            && editModeScenegraphNodes.PointsDrawStyle[layerIndex]) {
+            markerExtent = std::max(
+                markerExtent,
+                editModeScenegraphNodes.PointsDrawStyle[layerIndex]->pointSize.getValue()
+            );
+        }
+
+        int pointGeoId = coinMapping.getPointGeoId(pointIndex, layerIndex);
+        Sketcher::PointPos pointPos = coinMapping.getPointPosId(pointIndex, layerIndex);
+        const Part::Geometry* geometry = geolist.getGeometryFromGeoId(pointGeoId);
+        bool isEndpointOfNonPointGeometry = geometry
+            && geometry->getTypeId() != Part::GeomPoint::getClassTypeId()
+            && (pointPos == Sketcher::PointPos::start || pointPos == Sketcher::PointPos::end);
+
+        float pointHitRadius = markerExtent * 0.5f
+            + ScreenPreselectionPolicy::PointMarkerHitPaddingPx + extraRadiusPx;
+        if (isEndpointOfNonPointGeometry) {
+            pointHitRadius += ScreenPreselectionPolicy::EndpointPointHitRadiusBonusPx;
+        }
+
+        return pointHitRadius;
+    }
+
+    float getCurveHitRadius(int subLayerIndex) const
+    {
+        SoDrawStyle* drawStyle = editModeScenegraphNodes.CurvesDrawStyle;
+        if (geometryLayerParameters.isConstructionSubLayer(subLayerIndex)) {
+            drawStyle = editModeScenegraphNodes.CurvesConstructionDrawStyle;
+        }
+        else if (geometryLayerParameters.isInternalSubLayer(subLayerIndex)) {
+            drawStyle = editModeScenegraphNodes.CurvesInternalDrawStyle;
+        }
+        else if (geometryLayerParameters.isExternalSubLayer(subLayerIndex)) {
+            drawStyle = editModeScenegraphNodes.CurvesExternalDrawStyle;
+        }
+        else if (geometryLayerParameters.isExternalDefiningSubLayer(subLayerIndex)) {
+            drawStyle = editModeScenegraphNodes.CurvesExternalDefiningDrawStyle;
+        }
+
+        float lineWidth = drawStyle ? drawStyle->lineWidth.getValue() : 1.0F;
+        return std::max(3.0F, lineWidth * 0.5F + ScreenPreselectionPolicy::EdgeHitPaddingPx);
+    }
+
+    const SketcherGui::GeometryLayerParameters& geometryLayerParameters;
+    const SketcherGui::EditModeScenegraphNodes& editModeScenegraphNodes;
+    SketcherGui::CoinMapping& coinMapping;
+    const SketcherGui::DrawingParameters& drawingParameters;
+    const SketcherGui::GeoList& geolist;
+    const std::function<SbVec2f(const SbVec3f&)> projectToScreen;
+};
 }  // namespace
 
 void EditModeCoinManager::PreselectionResult::setPickedPoint(const SoPickedPoint* point)
@@ -873,142 +1180,6 @@ bool EditModeCoinManager::detectPointPreselection(
     return false;
 }
 
-bool EditModeCoinManager::detectNearbyPointPreselection(
-    const SbVec2s& cursorPos,
-    PreselectionResult& result
-)
-{
-    float bestDistanceSquared = std::numeric_limits<float>::max();
-    bool found = false;
-
-    for (int layerIndex = 0; layerIndex < geometryLayerParameters.getCoinLayerCount(); ++layerIndex) {
-        SoCoordinate3* coords = editModeScenegraphNodes.PointsCoordinate[layerIndex];
-        if (!coords) {
-            continue;
-        }
-
-        int pointCount = coords->point.getNum();
-        for (int pointIndex = 0; pointIndex < pointCount; ++pointIndex) {
-            int vertexId = coinMapping.getPointVertexId(pointIndex, layerIndex);
-            if (vertexId < 0) {
-                continue;
-            }
-
-            PreselectionResult candidate;
-            float distanceSquared = 0.0F;
-            if (
-                !detectPointDiskPreselection(pointIndex, layerIndex, cursorPos, 0.0F, distanceSquared, candidate)
-            ) {
-                continue;
-            }
-
-            if (distanceSquared > bestDistanceSquared) {
-                continue;
-            }
-
-            result = candidate;
-            bestDistanceSquared = distanceSquared;
-            found = true;
-        }
-    }
-
-    return found;
-}
-
-bool EditModeCoinManager::detectPointDiskPreselection(
-    int pointIndex,
-    int layerIndex,
-    const SbVec2s& cursorPos,
-    float extraRadiusPx,
-    float& distanceSquared,
-    PreselectionResult& result
-)
-{
-    if (!coinMapping.isValidPointId(pointIndex, layerIndex)
-        || static_cast<int>(editModeScenegraphNodes.PointsCoordinate.size()) <= layerIndex) {
-        return false;
-    }
-
-    SoCoordinate3* coords = editModeScenegraphNodes.PointsCoordinate[layerIndex];
-    if (!coords || pointIndex >= coords->point.getNum()) {
-        return false;
-    }
-
-    const SbVec3f* pointValues = coords->point.getValues(0);
-    if (!pointValues) {
-        return false;
-    }
-
-    float markerExtent = static_cast<float>(drawingParameters.markerSize);
-    if (static_cast<int>(editModeScenegraphNodes.PointsDrawStyle.size()) > layerIndex
-        && editModeScenegraphNodes.PointsDrawStyle[layerIndex]) {
-        markerExtent = std::max(
-            markerExtent,
-            editModeScenegraphNodes.PointsDrawStyle[layerIndex]->pointSize.getValue()
-        );
-    }
-
-    int pointGeoId = coinMapping.getPointGeoId(pointIndex, layerIndex);
-    Sketcher::PointPos pointPos = coinMapping.getPointPosId(pointIndex, layerIndex);
-    const GeoList geolist = ViewProviderSketchCoinAttorney::getGeoList(viewProvider);
-    const Part::Geometry* geometry = geolist.getGeometryFromGeoId(pointGeoId);
-    bool isEndpointOfNonPointGeometry = geometry
-        && geometry->getTypeId() != Part::GeomPoint::getClassTypeId()
-        && (pointPos == Sketcher::PointPos::start || pointPos == Sketcher::PointPos::end);
-
-    float pointHitRadius = markerExtent * 0.5f + PointMarkerHitPaddingPx + extraRadiusPx;
-    if (isEndpointOfNonPointGeometry) {
-        pointHitRadius += EndpointPointHitRadiusBonusPx;
-    }
-
-    SbVec2f screenPoint
-        = ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, pointValues[pointIndex]);
-    float dx = static_cast<float>(cursorPos[0]) - screenPoint[0];
-    float dy = static_cast<float>(cursorPos[1]) - screenPoint[1];
-    distanceSquared = dx * dx + dy * dy;
-    if (distanceSquared > pointHitRadius * pointHitRadius) {
-        return false;
-    }
-
-    result.clear();
-    result.Kind = PreselectionResult::HitKind::Point;
-    result.PointIndex = coinMapping.getPointVertexId(pointIndex, layerIndex);
-    result.PickedPoint = Base::Vector3d(
-        pointValues[pointIndex][0],
-        pointValues[pointIndex][1],
-        pointValues[pointIndex][2]
-    );
-    result.HasPickedPoint = true;
-    return true;
-}
-
-bool EditModeCoinManager::detectHoveredPointPreselection(
-    int hoveredPointIndex,
-    const SbVec2s& cursorPos,
-    float extraRadiusPx,
-    PreselectionResult& result
-)
-{
-    if (hoveredPointIndex == PreselectionResult::InvalidPoint) {
-        return false;
-    }
-
-    MultiFieldId pointId = coinMapping.getIndexLayer(hoveredPointIndex);
-    if (pointId == MultiFieldId::Invalid) {
-        return false;
-    }
-
-    float distanceSquared = 0.0F;
-    return detectPointDiskPreselection(
-        pointId.fieldIndex,
-        pointId.layerId,
-        cursorPos,
-        extraRadiusPx,
-        distanceSquared,
-        result
-    );
-}
-
 bool EditModeCoinManager::detectCurvePreselection(
     const SoPickedPointList& points,
     PreselectionResult& result
@@ -1031,139 +1202,6 @@ bool EditModeCoinManager::detectCurvePreselection(
     return false;
 }
 
-bool EditModeCoinManager::detectNearbyCurvePreselection(
-    const SbVec2s& cursorPos,
-    PreselectionResult& result
-)
-{
-    float bestDistanceSquared = std::numeric_limits<float>::max();
-    bool found = false;
-    SbVec2f cursorPoint(static_cast<float>(cursorPos[0]), static_cast<float>(cursorPos[1]));
-
-    auto getCurveHitRadius = [this](int subLayerIndex) {
-        SoDrawStyle* drawStyle = editModeScenegraphNodes.CurvesDrawStyle;
-        if (geometryLayerParameters.isConstructionSubLayer(subLayerIndex)) {
-            drawStyle = editModeScenegraphNodes.CurvesConstructionDrawStyle;
-        }
-        else if (geometryLayerParameters.isInternalSubLayer(subLayerIndex)) {
-            drawStyle = editModeScenegraphNodes.CurvesInternalDrawStyle;
-        }
-        else if (geometryLayerParameters.isExternalSubLayer(subLayerIndex)) {
-            drawStyle = editModeScenegraphNodes.CurvesExternalDrawStyle;
-        }
-        else if (geometryLayerParameters.isExternalDefiningSubLayer(subLayerIndex)) {
-            drawStyle = editModeScenegraphNodes.CurvesExternalDefiningDrawStyle;
-        }
-
-        float lineWidth = drawStyle ? drawStyle->lineWidth.getValue() : 1.0F;
-        return std::max(3.0F, lineWidth * 0.5F + EdgeHitPaddingPx);
-    };
-
-    for (int layerIndex = 0; layerIndex < geometryLayerParameters.getCoinLayerCount(); ++layerIndex) {
-        for (int subLayerIndex = 0; subLayerIndex < geometryLayerParameters.getSubLayerCount();
-             ++subLayerIndex) {
-            if (static_cast<int>(editModeScenegraphNodes.CurvesCoordinate.size()) <= layerIndex
-                || static_cast<int>(editModeScenegraphNodes.CurvesCoordinate[layerIndex].size())
-                    <= subLayerIndex
-                || static_cast<int>(editModeScenegraphNodes.CurveSet.size()) <= layerIndex
-                || static_cast<int>(editModeScenegraphNodes.CurveSet[layerIndex].size())
-                    <= subLayerIndex) {
-                continue;
-            }
-
-            SoCoordinate3* coords = editModeScenegraphNodes.CurvesCoordinate[layerIndex][subLayerIndex];
-            SoLineSet* curveSet = editModeScenegraphNodes.CurveSet[layerIndex][subLayerIndex];
-            if (!coords || !curveSet) {
-                continue;
-            }
-
-            const SbVec3f* curveValues = coords->point.getValues(0);
-            int curveCount = curveSet->numVertices.getNum();
-            if (!curveValues || curveCount <= 0) {
-                continue;
-            }
-
-            float curveHitRadius = getCurveHitRadius(subLayerIndex);
-            float curveHitRadiusSquared = curveHitRadius * curveHitRadius;
-            int vertexOffset = 0;
-
-            for (int curveIndex = 0; curveIndex < curveCount; ++curveIndex) {
-                int vertexCount = curveSet->numVertices[curveIndex];
-                if (!coinMapping.isValidCurveId(curveIndex, layerIndex, subLayerIndex)) {
-                    vertexOffset += std::max(vertexCount, 0);
-                    continue;
-                }
-
-                if (vertexCount < 2) {
-                    vertexOffset += std::max(vertexCount, 0);
-                    continue;
-                }
-
-                float bestCurveDistanceSquared = std::numeric_limits<float>::max();
-                int bestSegmentStart = -1;
-                for (int segmentIndex = 0; segmentIndex < vertexCount - 1; ++segmentIndex) {
-                    int currentVertexIndex = vertexOffset + segmentIndex;
-                    SbVec2f segmentStart = ViewProviderSketchCoinAttorney::getScreenCoordinates(
-                        viewProvider,
-                        curveValues[currentVertexIndex]
-                    );
-                    SbVec2f segmentEnd = ViewProviderSketchCoinAttorney::getScreenCoordinates(
-                        viewProvider,
-                        curveValues[currentVertexIndex + 1]
-                    );
-                    float distanceSquared
-                        = distanceSquaredToSegment(cursorPoint, segmentStart, segmentEnd);
-                    if (distanceSquared > curveHitRadiusSquared
-                        || distanceSquared >= bestCurveDistanceSquared) {
-                        continue;
-                    }
-
-                    bestCurveDistanceSquared = distanceSquared;
-                    bestSegmentStart = currentVertexIndex;
-                }
-
-                vertexOffset += vertexCount;
-                if (bestSegmentStart < 0 || bestCurveDistanceSquared >= bestDistanceSquared) {
-                    continue;
-                }
-
-                int geoIndex = coinMapping.getCurveGeoId(curveIndex, layerIndex, subLayerIndex);
-                const SbVec3f& startPoint = curveValues[bestSegmentStart];
-                const SbVec3f& endPoint = curveValues[bestSegmentStart + 1];
-                SbVec2f startScreen
-                    = ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, startPoint);
-                SbVec2f endScreen
-                    = ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, endPoint);
-
-                float segmentX = endScreen[0] - startScreen[0];
-                float segmentY = endScreen[1] - startScreen[1];
-                float segmentLengthSquared = segmentX * segmentX + segmentY * segmentY;
-                float interpolation = 0.0F;
-                if (segmentLengthSquared > std::numeric_limits<float>::epsilon()) {
-                    interpolation = ((cursorPoint[0] - startScreen[0]) * segmentX
-                                     + (cursorPoint[1] - startScreen[1]) * segmentY)
-                        / segmentLengthSquared;
-                    interpolation = std::clamp(interpolation, 0.0F, 1.0F);
-                }
-
-                result.clear();
-                result.Kind = PreselectionResult::HitKind::Edge;
-                result.GeoIndex = geoIndex;
-                result.PickedPoint = Base::Vector3d(
-                    startPoint[0] + (endPoint[0] - startPoint[0]) * interpolation,
-                    startPoint[1] + (endPoint[1] - startPoint[1]) * interpolation,
-                    startPoint[2] + (endPoint[2] - startPoint[2]) * interpolation
-                );
-                result.HasPickedPoint = true;
-                bestDistanceSquared = bestCurveDistanceSquared;
-                found = true;
-            }
-        }
-    }
-
-    return found;
-}
-
 bool EditModeCoinManager::detectGeometryPreselection(
     const SoPickedPointList& points,
     const SbVec2s& cursorPos,
@@ -1171,19 +1209,33 @@ bool EditModeCoinManager::detectGeometryPreselection(
     PreselectionResult& result
 )
 {
+    const GeoList geolist = ViewProviderSketchCoinAttorney::getGeoList(viewProvider);
+    auto projectToScreen = [this](const SbVec3f& point) {
+        return ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, point);
+    };
+
+    GeometryScreenPreselector screenPreselector {
+        geometryLayerParameters,
+        editModeScenegraphNodes,
+        coinMapping,
+        drawingParameters,
+        geolist,
+        projectToScreen
+    };
+
     if (detectPointPreselection(points, result)) {
         return true;
     }
 
-    if (detectHoveredPointPreselection(hoveredPointIndex, cursorPos, PointHoverHysteresisPx, result)) {
+    if (screenPreselector.detectHoveredPointPreselection(hoveredPointIndex, cursorPos, result)) {
         return true;
     }
 
-    if (detectNearbyPointPreselection(cursorPos, result)) {
+    if (screenPreselector.detectNearbyPointPreselection(cursorPos, result)) {
         return true;
     }
 
-    if (detectNearbyCurvePreselection(cursorPos, result)) {
+    if (screenPreselector.detectNearbyCurvePreselection(cursorPos, result)) {
         return true;
     }
 

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -22,6 +22,9 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
 #include <memory>
 
 #include <Inventor/SbVec3f.h>
@@ -45,6 +48,7 @@
 #include <Base/Exception.h>
 #include <Gui/Inventor/MarkerBitmaps.h>
 #include <Gui/Inventor/SoFCBoundingBox.h>
+#include <Mod/Part/App/Geometry.h>
 #include <Mod/Sketcher/App/Constraint.h>
 #include <Mod/Sketcher/App/GeoList.h>
 
@@ -59,6 +63,37 @@
 
 using namespace SketcherGui;
 using namespace Sketcher;
+
+namespace
+{
+constexpr float PointMarkerHitPaddingPx = 5.0F;
+constexpr float EndpointPointHitRadiusBonusPx = 2.0F;
+constexpr float PointHoverHysteresisPx = 2.0F;
+constexpr float EdgeHitPaddingPx = 2.0F;
+
+float distanceSquaredToSegment(const SbVec2f& point, const SbVec2f& segmentStart, const SbVec2f& segmentEnd)
+{
+    float segmentX = segmentEnd[0] - segmentStart[0];
+    float segmentY = segmentEnd[1] - segmentStart[1];
+    float segmentLengthSquared = segmentX * segmentX + segmentY * segmentY;
+    if (segmentLengthSquared <= std::numeric_limits<float>::epsilon()) {
+        float dx = point[0] - segmentStart[0];
+        float dy = point[1] - segmentStart[1];
+        return dx * dx + dy * dy;
+    }
+
+    float projection = ((point[0] - segmentStart[0]) * segmentX
+                        + (point[1] - segmentStart[1]) * segmentY)
+        / segmentLengthSquared;
+    projection = std::clamp(projection, 0.0F, 1.0F);
+
+    float closestX = segmentStart[0] + projection * segmentX;
+    float closestY = segmentStart[1] + projection * segmentY;
+    float dx = point[0] - closestX;
+    float dy = point[1] - closestY;
+    return dx * dx + dy * dy;
+}
+}  // namespace
 
 void EditModeCoinManager::PreselectionResult::setPickedPoint(const SoPickedPoint* point)
 {
@@ -838,6 +873,142 @@ bool EditModeCoinManager::detectPointPreselection(
     return false;
 }
 
+bool EditModeCoinManager::detectNearbyPointPreselection(
+    const SbVec2s& cursorPos,
+    PreselectionResult& result
+)
+{
+    float bestDistanceSquared = std::numeric_limits<float>::max();
+    bool found = false;
+
+    for (int layerIndex = 0; layerIndex < geometryLayerParameters.getCoinLayerCount(); ++layerIndex) {
+        SoCoordinate3* coords = editModeScenegraphNodes.PointsCoordinate[layerIndex];
+        if (!coords) {
+            continue;
+        }
+
+        int pointCount = coords->point.getNum();
+        for (int pointIndex = 0; pointIndex < pointCount; ++pointIndex) {
+            int vertexId = coinMapping.getPointVertexId(pointIndex, layerIndex);
+            if (vertexId < 0) {
+                continue;
+            }
+
+            PreselectionResult candidate;
+            float distanceSquared = 0.0F;
+            if (
+                !detectPointDiskPreselection(pointIndex, layerIndex, cursorPos, 0.0F, distanceSquared, candidate)
+            ) {
+                continue;
+            }
+
+            if (distanceSquared > bestDistanceSquared) {
+                continue;
+            }
+
+            result = candidate;
+            bestDistanceSquared = distanceSquared;
+            found = true;
+        }
+    }
+
+    return found;
+}
+
+bool EditModeCoinManager::detectPointDiskPreselection(
+    int pointIndex,
+    int layerIndex,
+    const SbVec2s& cursorPos,
+    float extraRadiusPx,
+    float& distanceSquared,
+    PreselectionResult& result
+)
+{
+    if (!coinMapping.isValidPointId(pointIndex, layerIndex)
+        || static_cast<int>(editModeScenegraphNodes.PointsCoordinate.size()) <= layerIndex) {
+        return false;
+    }
+
+    SoCoordinate3* coords = editModeScenegraphNodes.PointsCoordinate[layerIndex];
+    if (!coords || pointIndex >= coords->point.getNum()) {
+        return false;
+    }
+
+    const SbVec3f* pointValues = coords->point.getValues(0);
+    if (!pointValues) {
+        return false;
+    }
+
+    float markerExtent = static_cast<float>(drawingParameters.markerSize);
+    if (static_cast<int>(editModeScenegraphNodes.PointsDrawStyle.size()) > layerIndex
+        && editModeScenegraphNodes.PointsDrawStyle[layerIndex]) {
+        markerExtent = std::max(
+            markerExtent,
+            editModeScenegraphNodes.PointsDrawStyle[layerIndex]->pointSize.getValue()
+        );
+    }
+
+    int pointGeoId = coinMapping.getPointGeoId(pointIndex, layerIndex);
+    Sketcher::PointPos pointPos = coinMapping.getPointPosId(pointIndex, layerIndex);
+    const GeoList geolist = ViewProviderSketchCoinAttorney::getGeoList(viewProvider);
+    const Part::Geometry* geometry = geolist.getGeometryFromGeoId(pointGeoId);
+    bool isEndpointOfNonPointGeometry = geometry
+        && geometry->getTypeId() != Part::GeomPoint::getClassTypeId()
+        && (pointPos == Sketcher::PointPos::start || pointPos == Sketcher::PointPos::end);
+
+    float pointHitRadius = markerExtent * 0.5f + PointMarkerHitPaddingPx + extraRadiusPx;
+    if (isEndpointOfNonPointGeometry) {
+        pointHitRadius += EndpointPointHitRadiusBonusPx;
+    }
+
+    SbVec2f screenPoint
+        = ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, pointValues[pointIndex]);
+    float dx = static_cast<float>(cursorPos[0]) - screenPoint[0];
+    float dy = static_cast<float>(cursorPos[1]) - screenPoint[1];
+    distanceSquared = dx * dx + dy * dy;
+    if (distanceSquared > pointHitRadius * pointHitRadius) {
+        return false;
+    }
+
+    result.clear();
+    result.Kind = PreselectionResult::HitKind::Point;
+    result.PointIndex = coinMapping.getPointVertexId(pointIndex, layerIndex);
+    result.PickedPoint = Base::Vector3d(
+        pointValues[pointIndex][0],
+        pointValues[pointIndex][1],
+        pointValues[pointIndex][2]
+    );
+    result.HasPickedPoint = true;
+    return true;
+}
+
+bool EditModeCoinManager::detectHoveredPointPreselection(
+    int hoveredPointIndex,
+    const SbVec2s& cursorPos,
+    float extraRadiusPx,
+    PreselectionResult& result
+)
+{
+    if (hoveredPointIndex == PreselectionResult::InvalidPoint) {
+        return false;
+    }
+
+    MultiFieldId pointId = coinMapping.getIndexLayer(hoveredPointIndex);
+    if (pointId == MultiFieldId::Invalid) {
+        return false;
+    }
+
+    float distanceSquared = 0.0F;
+    return detectPointDiskPreselection(
+        pointId.fieldIndex,
+        pointId.layerId,
+        cursorPos,
+        extraRadiusPx,
+        distanceSquared,
+        result
+    );
+}
+
 bool EditModeCoinManager::detectCurvePreselection(
     const SoPickedPointList& points,
     PreselectionResult& result
@@ -860,12 +1031,159 @@ bool EditModeCoinManager::detectCurvePreselection(
     return false;
 }
 
+bool EditModeCoinManager::detectNearbyCurvePreselection(
+    const SbVec2s& cursorPos,
+    PreselectionResult& result
+)
+{
+    float bestDistanceSquared = std::numeric_limits<float>::max();
+    bool found = false;
+    SbVec2f cursorPoint(static_cast<float>(cursorPos[0]), static_cast<float>(cursorPos[1]));
+
+    auto getCurveHitRadius = [this](int subLayerIndex) {
+        SoDrawStyle* drawStyle = editModeScenegraphNodes.CurvesDrawStyle;
+        if (geometryLayerParameters.isConstructionSubLayer(subLayerIndex)) {
+            drawStyle = editModeScenegraphNodes.CurvesConstructionDrawStyle;
+        }
+        else if (geometryLayerParameters.isInternalSubLayer(subLayerIndex)) {
+            drawStyle = editModeScenegraphNodes.CurvesInternalDrawStyle;
+        }
+        else if (geometryLayerParameters.isExternalSubLayer(subLayerIndex)) {
+            drawStyle = editModeScenegraphNodes.CurvesExternalDrawStyle;
+        }
+        else if (geometryLayerParameters.isExternalDefiningSubLayer(subLayerIndex)) {
+            drawStyle = editModeScenegraphNodes.CurvesExternalDefiningDrawStyle;
+        }
+
+        float lineWidth = drawStyle ? drawStyle->lineWidth.getValue() : 1.0F;
+        return std::max(3.0F, lineWidth * 0.5F + EdgeHitPaddingPx);
+    };
+
+    for (int layerIndex = 0; layerIndex < geometryLayerParameters.getCoinLayerCount(); ++layerIndex) {
+        for (int subLayerIndex = 0; subLayerIndex < geometryLayerParameters.getSubLayerCount();
+             ++subLayerIndex) {
+            if (static_cast<int>(editModeScenegraphNodes.CurvesCoordinate.size()) <= layerIndex
+                || static_cast<int>(editModeScenegraphNodes.CurvesCoordinate[layerIndex].size())
+                    <= subLayerIndex
+                || static_cast<int>(editModeScenegraphNodes.CurveSet.size()) <= layerIndex
+                || static_cast<int>(editModeScenegraphNodes.CurveSet[layerIndex].size())
+                    <= subLayerIndex) {
+                continue;
+            }
+
+            SoCoordinate3* coords = editModeScenegraphNodes.CurvesCoordinate[layerIndex][subLayerIndex];
+            SoLineSet* curveSet = editModeScenegraphNodes.CurveSet[layerIndex][subLayerIndex];
+            if (!coords || !curveSet) {
+                continue;
+            }
+
+            const SbVec3f* curveValues = coords->point.getValues(0);
+            int curveCount = curveSet->numVertices.getNum();
+            if (!curveValues || curveCount <= 0) {
+                continue;
+            }
+
+            float curveHitRadius = getCurveHitRadius(subLayerIndex);
+            float curveHitRadiusSquared = curveHitRadius * curveHitRadius;
+            int vertexOffset = 0;
+
+            for (int curveIndex = 0; curveIndex < curveCount; ++curveIndex) {
+                int vertexCount = curveSet->numVertices[curveIndex];
+                if (!coinMapping.isValidCurveId(curveIndex, layerIndex, subLayerIndex)) {
+                    vertexOffset += std::max(vertexCount, 0);
+                    continue;
+                }
+
+                if (vertexCount < 2) {
+                    vertexOffset += std::max(vertexCount, 0);
+                    continue;
+                }
+
+                float bestCurveDistanceSquared = std::numeric_limits<float>::max();
+                int bestSegmentStart = -1;
+                for (int segmentIndex = 0; segmentIndex < vertexCount - 1; ++segmentIndex) {
+                    int currentVertexIndex = vertexOffset + segmentIndex;
+                    SbVec2f segmentStart = ViewProviderSketchCoinAttorney::getScreenCoordinates(
+                        viewProvider,
+                        curveValues[currentVertexIndex]
+                    );
+                    SbVec2f segmentEnd = ViewProviderSketchCoinAttorney::getScreenCoordinates(
+                        viewProvider,
+                        curveValues[currentVertexIndex + 1]
+                    );
+                    float distanceSquared
+                        = distanceSquaredToSegment(cursorPoint, segmentStart, segmentEnd);
+                    if (distanceSquared > curveHitRadiusSquared
+                        || distanceSquared >= bestCurveDistanceSquared) {
+                        continue;
+                    }
+
+                    bestCurveDistanceSquared = distanceSquared;
+                    bestSegmentStart = currentVertexIndex;
+                }
+
+                vertexOffset += vertexCount;
+                if (bestSegmentStart < 0 || bestCurveDistanceSquared >= bestDistanceSquared) {
+                    continue;
+                }
+
+                int geoIndex = coinMapping.getCurveGeoId(curveIndex, layerIndex, subLayerIndex);
+                const SbVec3f& startPoint = curveValues[bestSegmentStart];
+                const SbVec3f& endPoint = curveValues[bestSegmentStart + 1];
+                SbVec2f startScreen
+                    = ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, startPoint);
+                SbVec2f endScreen
+                    = ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, endPoint);
+
+                float segmentX = endScreen[0] - startScreen[0];
+                float segmentY = endScreen[1] - startScreen[1];
+                float segmentLengthSquared = segmentX * segmentX + segmentY * segmentY;
+                float interpolation = 0.0F;
+                if (segmentLengthSquared > std::numeric_limits<float>::epsilon()) {
+                    interpolation = ((cursorPoint[0] - startScreen[0]) * segmentX
+                                     + (cursorPoint[1] - startScreen[1]) * segmentY)
+                        / segmentLengthSquared;
+                    interpolation = std::clamp(interpolation, 0.0F, 1.0F);
+                }
+
+                result.clear();
+                result.Kind = PreselectionResult::HitKind::Edge;
+                result.GeoIndex = geoIndex;
+                result.PickedPoint = Base::Vector3d(
+                    startPoint[0] + (endPoint[0] - startPoint[0]) * interpolation,
+                    startPoint[1] + (endPoint[1] - startPoint[1]) * interpolation,
+                    startPoint[2] + (endPoint[2] - startPoint[2]) * interpolation
+                );
+                result.HasPickedPoint = true;
+                bestDistanceSquared = bestCurveDistanceSquared;
+                found = true;
+            }
+        }
+    }
+
+    return found;
+}
+
 bool EditModeCoinManager::detectGeometryPreselection(
     const SoPickedPointList& points,
+    const SbVec2s& cursorPos,
+    int hoveredPointIndex,
     PreselectionResult& result
 )
 {
     if (detectPointPreselection(points, result)) {
+        return true;
+    }
+
+    if (detectHoveredPointPreselection(hoveredPointIndex, cursorPos, PointHoverHysteresisPx, result)) {
+        return true;
+    }
+
+    if (detectNearbyPointPreselection(cursorPos, result)) {
+        return true;
+    }
+
+    if (detectNearbyCurvePreselection(cursorPos, result)) {
         return true;
     }
 
@@ -940,21 +1258,18 @@ bool EditModeCoinManager::detectAxisPreselection(
 
 EditModeCoinManager::PreselectionResult EditModeCoinManager::detectPreselection(
     const SoPickedPointList& points,
-    const SbVec2s& cursorPos
+    const SbVec2s& cursorPos,
+    int hoveredPointIndex
 )
 {
     PreselectionResult result;
-
-    if (points.getLength() == 0) {
-        return result;
-    }
 
     result = detectConstraintPreselection(points, cursorPos);
     if (result.hasWinner()) {
         return result;
     }
 
-    if (detectGeometryPreselection(points, result)) {
+    if (detectGeometryPreselection(points, cursorPos, hoveredPointIndex, result)) {
         return result;
     }
 

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -251,7 +251,11 @@ public:
 
     /** @name handle preselection and selection of points */
     //@{
-    PreselectionResult detectPreselection(const SoPickedPointList& points, const SbVec2s& cursorPos);
+    PreselectionResult detectPreselection(
+        const SoPickedPointList& points,
+        const SbVec2s& cursorPos,
+        int hoveredPointIndex = PreselectionResult::InvalidPoint
+    );
     /// The client is responsible for unref-ing the SoGroup to release the memory.
     SoGroup* getSelectedConstraints();
     //@}
@@ -300,8 +304,29 @@ private:
         const SbVec2s& cursorPos
     );
     bool detectOriginPreselection(const SoPickedPoint* point, PreselectionResult& result);
-    bool detectGeometryPreselection(const SoPickedPointList& points, PreselectionResult& result);
+    bool detectGeometryPreselection(
+        const SoPickedPointList& points,
+        const SbVec2s& cursorPos,
+        int hoveredPointIndex,
+        PreselectionResult& result
+    );
     bool detectPointPreselection(const SoPickedPointList& points, PreselectionResult& result);
+    bool detectNearbyPointPreselection(const SbVec2s& cursorPos, PreselectionResult& result);
+    bool detectPointDiskPreselection(
+        int pointIndex,
+        int layerIndex,
+        const SbVec2s& cursorPos,
+        float extraRadiusPx,
+        float& distanceSquared,
+        PreselectionResult& result
+    );
+    bool detectHoveredPointPreselection(
+        int hoveredPointIndex,
+        const SbVec2s& cursorPos,
+        float extraRadiusPx,
+        PreselectionResult& result
+    );
+    bool detectNearbyCurvePreselection(const SbVec2s& cursorPos, PreselectionResult& result);
     bool detectCurvePreselection(const SoPickedPointList& points, PreselectionResult& result);
     bool detectAxisPreselection(const SoPickedPointList& points, PreselectionResult& result);
     bool detectPointPreselection(const SoPickedPoint* point, int layerIndex, PreselectionResult& result);

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 #include <vector>
 
 #include <App/Application.h>
@@ -207,8 +208,7 @@ public:
                                       // -3,-4,-5,... for external geometry
         Axes Cross = Axes::None;
         std::set<int> ConstrIndices;
-        Base::Vector3d PickedPoint;
-        bool HasPickedPoint = false;
+        std::optional<Base::Vector3d> PickedPoint;
 
         [[nodiscard]] inline bool hasWinner() const
         {
@@ -217,9 +217,15 @@ public:
 
         [[nodiscard]] inline bool hasPickedPoint() const
         {
-            return HasPickedPoint;
+            return PickedPoint.has_value();
         }
 
+        [[nodiscard]] inline const Base::Vector3d& pickedPoint() const
+        {
+            return PickedPoint.value();
+        }
+
+        void setPickedPoint(const Base::Vector3d& point);
         void setPickedPoint(const SoPickedPoint* point);
 
         inline void clear()
@@ -229,8 +235,7 @@ public:
             GeoIndex = InvalidCurve;
             Cross = Axes::None;
             ConstrIndices.clear();
-            PickedPoint = Base::Vector3d();
-            HasPickedPoint = false;
+            PickedPoint.reset();
         }
     };
 

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -311,22 +311,6 @@ private:
         PreselectionResult& result
     );
     bool detectPointPreselection(const SoPickedPointList& points, PreselectionResult& result);
-    bool detectNearbyPointPreselection(const SbVec2s& cursorPos, PreselectionResult& result);
-    bool detectPointDiskPreselection(
-        int pointIndex,
-        int layerIndex,
-        const SbVec2s& cursorPos,
-        float extraRadiusPx,
-        float& distanceSquared,
-        PreselectionResult& result
-    );
-    bool detectHoveredPointPreselection(
-        int hoveredPointIndex,
-        const SbVec2s& cursorPos,
-        float extraRadiusPx,
-        PreselectionResult& result
-    );
-    bool detectNearbyCurvePreselection(const SbVec2s& cursorPos, PreselectionResult& result);
     bool detectCurvePreselection(const SoPickedPointList& points, PreselectionResult& result);
     bool detectAxisPreselection(const SoPickedPointList& points, PreselectionResult& result);
     bool detectPointPreselection(const SoPickedPoint* point, int layerIndex, PreselectionResult& result);

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -300,7 +300,10 @@ private:
         const SbVec2s& cursorPos
     );
     bool detectOriginPreselection(const SoPickedPoint* point, PreselectionResult& result);
-    bool detectGeometryPreselection(const SoPickedPoint* point, PreselectionResult& result);
+    bool detectGeometryPreselection(const SoPickedPointList& points, PreselectionResult& result);
+    bool detectPointPreselection(const SoPickedPointList& points, PreselectionResult& result);
+    bool detectCurvePreselection(const SoPickedPointList& points, PreselectionResult& result);
+    bool detectAxisPreselection(const SoPickedPointList& points, PreselectionResult& result);
     bool detectPointPreselection(const SoPickedPoint* point, int layerIndex, PreselectionResult& result);
     bool detectCurvePreselection(const SoPickedPoint* point, int layerIndex, PreselectionResult& result);
     bool detectAxisPreselection(const SoPickedPoint* point, PreselectionResult& result);

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include <App/Application.h>
+#include <Base/Vector3D.h>
 #include <Mod/Sketcher/App/GeoList.h>
 #include "GeometryCreationMode.h"
 
@@ -35,8 +36,10 @@
 
 
 class SbVec3f;
+class SbVec2s;
 class SoRayPickAction;
 class SoPickedPoint;
+class SoPickedPointList;
 class SbVec3s;
 
 namespace Base
@@ -174,6 +177,15 @@ public:
      */
     struct PreselectionResult
     {
+        enum class HitKind
+        {
+            None = -1,
+            Point = 0,
+            Edge = 1,
+            Axis = 2,
+            Constraint = 3
+        };
+
         enum SpecialValues
         {
             InvalidPoint = -1,
@@ -189,18 +201,36 @@ public:
             VerticalAxis = 2
         };
 
+        HitKind Kind = HitKind::None;
         int PointIndex = InvalidPoint;
         int GeoIndex = InvalidCurve;  // valid values are 0,1,2,... for normal geometry and
                                       // -3,-4,-5,... for external geometry
         Axes Cross = Axes::None;
         std::set<int> ConstrIndices;
+        Base::Vector3d PickedPoint;
+        bool HasPickedPoint = false;
+
+        [[nodiscard]] inline bool hasWinner() const
+        {
+            return Kind != HitKind::None;
+        }
+
+        [[nodiscard]] inline bool hasPickedPoint() const
+        {
+            return HasPickedPoint;
+        }
+
+        void setPickedPoint(const SoPickedPoint* point);
 
         inline void clear()
         {
+            Kind = HitKind::None;
             PointIndex = InvalidPoint;
             GeoIndex = InvalidCurve;
             Cross = Axes::None;
             ConstrIndices.clear();
+            PickedPoint = Base::Vector3d();
+            HasPickedPoint = false;
         }
     };
 
@@ -221,7 +251,7 @@ public:
 
     /** @name handle preselection and selection of points */
     //@{
-    PreselectionResult detectPreselection(SoPickedPoint* Point);
+    PreselectionResult detectPreselection(const SoPickedPointList& points, const SbVec2s& cursorPos);
     /// The client is responsible for unref-ing the SoGroup to release the memory.
     SoGroup* getSelectedConstraints();
     //@}
@@ -265,6 +295,16 @@ public:
     void updateElementSizeParameters();
 
 private:
+    PreselectionResult detectConstraintPreselection(
+        const SoPickedPointList& points,
+        const SbVec2s& cursorPos
+    );
+    bool detectOriginPreselection(const SoPickedPoint* point, PreselectionResult& result);
+    bool detectGeometryPreselection(const SoPickedPoint* point, PreselectionResult& result);
+    bool detectPointPreselection(const SoPickedPoint* point, int layerIndex, PreselectionResult& result);
+    bool detectCurvePreselection(const SoPickedPoint* point, int layerIndex, PreselectionResult& result);
+    bool detectAxisPreselection(const SoPickedPoint* point, PreselectionResult& result);
+
     // This function populates the coin nodes with the information of the current geometry
     void processGeometry(const GeoListFacade& geolistfacade);
 

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -136,9 +136,10 @@ struct DrawingParameters
     int coinFontSize = 17;            // Font size to be used by coin
     int labelFontSize = 17;  // Font size to be used by SoDatumLabel, which uses a QPainter and a
                              // QFont internally
-    static QString labelFontName;  // Font face to be used by SoDatumLabel
-    int constraintIconSize = 15;   // Size of constraint icons
-    int markerSize = 7;            // Size used for markers
+    static QString labelFontName;        // Font face to be used by SoDatumLabel
+    int constraintIconSize = 15;         // Size of constraint icons
+    int constraintIconHitPaddingPx = 3;  // Extra hit padding for constraint icons
+    int markerSize = 7;                  // Size used for markers
 
     int CurveWidth = 2;             // width of normal edges
     int ConstructionWidth = 1;      // width of construction edges

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -78,6 +78,11 @@ using namespace Gui;
 using namespace SketcherGui;
 using namespace Sketcher;
 
+namespace
+{
+constexpr int ConstraintIconHitPaddingPx = 3;
+}
+
 //**************************** EditModeConstraintCoinManager class ******************************
 
 EditModeConstraintCoinManager::EditModeConstraintCoinManager(
@@ -2400,7 +2405,14 @@ std::set<int> EditModeConstraintCoinManager::detectPreselectionIcon(
 
     if (combinedConstrBoxes.count(constrIdsStr)) {
         for (const auto& boxInfo : combinedConstrBoxes.at(constrIdsStr)) {
-            if (boxInfo.first.contains(relativeX, relativeY)) {
+            if (boxInfo.first
+                    .adjusted(
+                        -ConstraintIconHitPaddingPx,
+                        -ConstraintIconHitPaddingPx,
+                        ConstraintIconHitPaddingPx,
+                        ConstraintIconHitPaddingPx
+                    )
+                    .contains(relativeX, relativeY)) {
                 constrIndices.insert(boxInfo.second.begin(), boxInfo.second.end());
             }
         }
@@ -2408,6 +2420,12 @@ std::set<int> EditModeConstraintCoinManager::detectPreselectionIcon(
     }
 
     QRect iconBounds(0, 0, iconSize[0], iconSize[1]);
+    iconBounds.adjust(
+        -ConstraintIconHitPaddingPx,
+        -ConstraintIconHitPaddingPx,
+        ConstraintIconHitPaddingPx,
+        ConstraintIconHitPaddingPx
+    );
     if (iconBounds.contains(relativeX, relativeY)) {
         return parseConstraintIds(constrIdsStr);
     }

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2248,93 +2248,7 @@ std::set<int> EditModeConstraintCoinManager::detectPreselectionConstr(
 
     for (int childIdx = 0; childIdx < sep->getNumChildren(); ++childIdx) {
         if (tail == sep->getChild(childIdx) && dynamic_cast<SoImage*>(tail)) {
-            // The SoInfo node with the ID always follows the SoImage node.
-            if (childIdx + 1 < sep->getNumChildren()) {
-                SoInfo* constrIdsNode = dynamic_cast<SoInfo*>(sep->getChild(childIdx + 1));
-                if (!constrIdsNode) {
-                    continue;
-                }
-
-                QString constrIdsStr = QString::fromLatin1(
-                    constrIdsNode->string.getValue().getString()
-                );
-
-                if (combinedConstrBoxes.count(constrIdsStr)) {
-
-                    // 1. Get the icon group size in device independent pixels.
-                    SbVec3s iconGroupSize = getDisplayedSize(static_cast<SoImage*>(tail));
-
-                    // 2. Get the icon group's absolute world position from its
-                    // SoZoomTranslation node.
-                    SoZoomTranslation* translation = nullptr;
-                    SoNode* firstTransNode = sep->getChild(
-                        static_cast<int>(ConstraintNodePosition::FirstTranslationIndex)
-                    );
-                    if (dynamic_cast<SoZoomTranslation*>(firstTransNode)) {
-                        translation = static_cast<SoZoomTranslation*>(firstTransNode);
-                    }
-                    if (!translation) {
-                        continue;
-                    }
-
-                    SbVec3f absPos = translation->abPos.getValue();
-                    SbVec3f trans = translation->translation.getValue();
-                    float scaleFactor = translation->getScaleFactor();
-
-                    // If this is the second icon in a pair, add its relative translation.
-                    if (int secondIndex = static_cast<int>(ConstraintNodePosition::SecondIconIndex);
-                        secondIndex < sep->getNumChildren()) {
-                        SoNode* secondIconNode = sep->getChild(secondIndex);
-                        if (tail == secondIconNode) {
-                            auto translation2 = static_cast<SoZoomTranslation*>(sep->getChild(
-                                static_cast<int>(ConstraintNodePosition::SecondTranslationIndex)
-                            ));
-                            absPos += translation2->abPos.getValue();
-                            trans += translation2->translation.getValue();
-                            scaleFactor = translation2->getScaleFactor();
-                        }
-                    }
-
-                    // 3. Calculate the icon's center in world coordinates.
-                    SbVec3f iconGroupWorldPos = absPos + scaleFactor * trans;
-
-                    // 4. Project both the icon's center and the picked point to screen coordinates
-                    // (device independent pixels). This is the key: both points are now in the same
-                    // coordinate system.
-                    SbVec2f iconGroupScreenCenter = ViewProviderSketchCoinAttorney::getScreenCoordinates(
-                        viewProvider,
-                        iconGroupWorldPos
-                    );
-
-                    // 5. Calculate cursor position relative to the icon group's top-left corner.
-                    //    - QRect/QImage assumes a top-left origin (Y increases downwards).
-                    //    - Coin3D screen coordinates have a bottom-left origin (Y increases
-                    //    upwards). Cursor coordinates come from the viewport in that same
-                    //    coordinate system, so only the Y flip for QRect is needed here.
-                    int relativeX = static_cast<int>(
-                        cursorScreenPos[0] - iconGroupScreenCenter[0] + iconGroupSize[0] / 2.0f
-                    );
-                    int relativeY = static_cast<int>(
-                        iconGroupScreenCenter[1] - cursorScreenPos[1] + iconGroupSize[1] / 2.0f
-                    );
-
-                    // 6. Perform the hit test on each icon in the group.
-                    for (const auto& boxInfo : combinedConstrBoxes[constrIdsStr]) {
-                        if (boxInfo.first.contains(relativeX, relativeY)) {
-                            constrIndices.insert(boxInfo.second.begin(), boxInfo.second.end());
-                        }
-                    }
-                }
-                else {
-                    // Simple, non-merged icon.
-                    QStringList constrIdStrings = constrIdsStr.split(QStringLiteral(","));
-                    for (const QString& id : constrIdStrings) {
-                        constrIndices.insert(id.toInt());
-                    }
-                }
-
-                return constrIndices;
-            }
+            return detectPreselectionIcon(sep, static_cast<SoImage*>(tail), childIdx, cursorScreenPos);
         }
     }
 
@@ -2346,6 +2260,156 @@ std::set<int> EditModeConstraintCoinManager::detectPreselectionConstr(
                 break;
             }
         }
+    }
+
+    return constrIndices;
+}
+
+std::set<int> EditModeConstraintCoinManager::detectPreselectionConstr(
+    const SbVec2s& cursorScreenPos,
+    Base::Vector3d* pickedPoint
+)
+{
+    std::set<int> constrIndices;
+
+    for (int i = 0; i < editModeScenegraphNodes.constrGroup->getNumChildren(); ++i) {
+        auto* sep = dynamic_cast<SoSeparator*>(editModeScenegraphNodes.constrGroup->getChild(i));
+        if (!sep) {
+            continue;
+        }
+
+        if (int iconIndex = static_cast<int>(ConstraintNodePosition::FirstIconIndex);
+            iconIndex < sep->getNumChildren()) {
+            auto* iconNode = dynamic_cast<SoImage*>(sep->getChild(iconIndex));
+            if (iconNode) {
+                constrIndices
+                    = detectPreselectionIcon(sep, iconNode, iconIndex, cursorScreenPos, pickedPoint);
+                if (!constrIndices.empty()) {
+                    return constrIndices;
+                }
+            }
+        }
+
+        if (int iconIndex = static_cast<int>(ConstraintNodePosition::SecondIconIndex);
+            iconIndex < sep->getNumChildren()) {
+            auto* iconNode = dynamic_cast<SoImage*>(sep->getChild(iconIndex));
+            if (iconNode) {
+                constrIndices
+                    = detectPreselectionIcon(sep, iconNode, iconIndex, cursorScreenPos, pickedPoint);
+                if (!constrIndices.empty()) {
+                    return constrIndices;
+                }
+            }
+        }
+    }
+
+    return constrIndices;
+}
+
+std::set<int> EditModeConstraintCoinManager::parseConstraintIds(const QString& constrIdsStr) const
+{
+    std::set<int> constrIndices;
+    QStringList constrIdStrings = constrIdsStr.split(QStringLiteral(","));
+    for (const QString& id : constrIdStrings) {
+        constrIndices.insert(id.toInt());
+    }
+    return constrIndices;
+}
+
+bool EditModeConstraintCoinManager::resolveIconScreenGeometry(
+    SoSeparator* sep,
+    SoImage* iconNode,
+    int iconIndex,
+    SbVec2f& iconScreenCenter,
+    SbVec3s& iconSize,
+    QString& constrIdsStr,
+    Base::Vector3d* pickedPoint
+) const
+{
+    if (!sep || !iconNode || iconIndex + 1 >= sep->getNumChildren()) {
+        return false;
+    }
+
+    auto* constrIdsNode = dynamic_cast<SoInfo*>(sep->getChild(iconIndex + 1));
+    if (!constrIdsNode) {
+        return false;
+    }
+
+    constrIdsStr = QString::fromLatin1(constrIdsNode->string.getValue().getString());
+    iconSize = getDisplayedSize(iconNode);
+    if (iconSize[0] <= 0 || iconSize[1] <= 0) {
+        return false;
+    }
+
+    auto* firstTransNode = dynamic_cast<SoZoomTranslation*>(
+        sep->getChild(static_cast<int>(ConstraintNodePosition::FirstTranslationIndex))
+    );
+    if (!firstTransNode) {
+        return false;
+    }
+
+    SbVec3f absPos = firstTransNode->abPos.getValue();
+    SbVec3f trans = firstTransNode->translation.getValue();
+    float scaleFactor = firstTransNode->getScaleFactor();
+
+    if (iconIndex == static_cast<int>(ConstraintNodePosition::SecondIconIndex)
+        && static_cast<int>(ConstraintNodePosition::SecondTranslationIndex) < sep->getNumChildren()) {
+        auto* secondTransNode = dynamic_cast<SoZoomTranslation*>(
+            sep->getChild(static_cast<int>(ConstraintNodePosition::SecondTranslationIndex))
+        );
+        if (secondTransNode) {
+            absPos += secondTransNode->abPos.getValue();
+            trans += secondTransNode->translation.getValue();
+            scaleFactor = secondTransNode->getScaleFactor();
+        }
+    }
+
+    SbVec3f iconWorldPos = absPos + scaleFactor * trans;
+    iconScreenCenter = ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, iconWorldPos);
+
+    if (pickedPoint) {
+        *pickedPoint = Base::Vector3d(iconWorldPos[0], iconWorldPos[1], iconWorldPos[2]);
+    }
+
+    return true;
+}
+
+std::set<int> EditModeConstraintCoinManager::detectPreselectionIcon(
+    SoSeparator* sep,
+    SoImage* iconNode,
+    int iconIndex,
+    const SbVec2s& cursorScreenPos,
+    Base::Vector3d* pickedPoint
+) const
+{
+    std::set<int> constrIndices;
+    SbVec2f iconScreenCenter;
+    SbVec3s iconSize;
+    QString constrIdsStr;
+    Base::Vector3d hitPoint;
+    Base::Vector3d* resultPoint = pickedPoint ? pickedPoint : &hitPoint;
+
+    if (
+        !resolveIconScreenGeometry(sep, iconNode, iconIndex, iconScreenCenter, iconSize, constrIdsStr, resultPoint)
+    ) {
+        return constrIndices;
+    }
+
+    int relativeX = static_cast<int>(cursorScreenPos[0] - iconScreenCenter[0] + iconSize[0] / 2.0f);
+    int relativeY = static_cast<int>(iconScreenCenter[1] - cursorScreenPos[1] + iconSize[1] / 2.0f);
+
+    if (combinedConstrBoxes.count(constrIdsStr)) {
+        for (const auto& boxInfo : combinedConstrBoxes.at(constrIdsStr)) {
+            if (boxInfo.first.contains(relativeX, relativeY)) {
+                constrIndices.insert(boxInfo.second.begin(), boxInfo.second.end());
+            }
+        }
+        return constrIndices;
+    }
+
+    QRect iconBounds(0, 0, iconSize[0], iconSize[1]);
+    if (iconBounds.contains(relativeX, relativeY)) {
+        return parseConstraintIds(constrIdsStr);
     }
 
     return constrIndices;

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2229,7 +2229,10 @@ QString EditModeConstraintCoinManager::getPresentationString(
     return fixedValueStr;
 }
 
-std::set<int> EditModeConstraintCoinManager::detectPreselectionConstr(const SoPickedPoint* Point)
+std::set<int> EditModeConstraintCoinManager::detectPreselectionConstr(
+    const SoPickedPoint* Point,
+    const SbVec2s& cursorScreenPos
+)
 {
     std::set<int> constrIndices;
     SoPath* path = Point->getPath();
@@ -2300,19 +2303,14 @@ std::set<int> EditModeConstraintCoinManager::detectPreselectionConstr(const SoPi
                     // coordinate system.
                     SbVec2f iconGroupScreenCenter = ViewProviderSketchCoinAttorney::getScreenCoordinates(
                         viewProvider,
-                        SbVec2f(iconGroupWorldPos[0], iconGroupWorldPos[1])
-                    );
-
-                    SbVec2f cursorScreenPos = ViewProviderSketchCoinAttorney::getScreenCoordinates(
-                        viewProvider,
-                        SbVec2f(Point->getPoint()[0], Point->getPoint()[1])
+                        iconGroupWorldPos
                     );
 
                     // 5. Calculate cursor position relative to the icon group's top-left corner.
                     //    - QRect/QImage assumes a top-left origin (Y increases downwards).
                     //    - Coin3D screen coordinates have a bottom-left origin (Y increases
-                    //    upwards).
-                    //    - We must flip the Y-axis for the check.
+                    //    upwards). Cursor coordinates come from the viewport in that same
+                    //    coordinate system, so only the Y flip for QRect is needed here.
                     int relativeX = static_cast<int>(
                         cursorScreenPos[0] - iconGroupScreenCenter[0] + iconGroupSize[0] / 2.0f
                     );

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -78,11 +78,6 @@ using namespace Gui;
 using namespace SketcherGui;
 using namespace Sketcher;
 
-namespace
-{
-constexpr int ConstraintIconHitPaddingPx = 3;
-}
-
 //**************************** EditModeConstraintCoinManager class ******************************
 
 EditModeConstraintCoinManager::EditModeConstraintCoinManager(
@@ -2373,7 +2368,7 @@ bool EditModeConstraintCoinManager::resolveIconScreenGeometry(
     iconScreenCenter = ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, iconWorldPos);
 
     if (pickedPoint) {
-        *pickedPoint = Base::Vector3d(iconWorldPos[0], iconWorldPos[1], iconWorldPos[2]);
+        *pickedPoint = Base::convertTo<Base::Vector3d>(iconWorldPos);
     }
 
     return true;
@@ -2402,17 +2397,16 @@ std::set<int> EditModeConstraintCoinManager::detectPreselectionIcon(
 
     int relativeX = static_cast<int>(cursorScreenPos[0] - iconScreenCenter[0] + iconSize[0] / 2.0f);
     int relativeY = static_cast<int>(iconScreenCenter[1] - cursorScreenPos[1] + iconSize[1] / 2.0f);
+    const QMargins iconHitPadding(
+        drawingParameters.constraintIconHitPaddingPx,
+        drawingParameters.constraintIconHitPaddingPx,
+        drawingParameters.constraintIconHitPaddingPx,
+        drawingParameters.constraintIconHitPaddingPx
+    );
 
     if (combinedConstrBoxes.count(constrIdsStr)) {
         for (const auto& boxInfo : combinedConstrBoxes.at(constrIdsStr)) {
-            if (boxInfo.first
-                    .adjusted(
-                        -ConstraintIconHitPaddingPx,
-                        -ConstraintIconHitPaddingPx,
-                        ConstraintIconHitPaddingPx,
-                        ConstraintIconHitPaddingPx
-                    )
-                    .contains(relativeX, relativeY)) {
+            if (boxInfo.first.marginsAdded(iconHitPadding).contains(relativeX, relativeY)) {
                 constrIndices.insert(boxInfo.second.begin(), boxInfo.second.end());
             }
         }
@@ -2420,13 +2414,7 @@ std::set<int> EditModeConstraintCoinManager::detectPreselectionIcon(
     }
 
     QRect iconBounds(0, 0, iconSize[0], iconSize[1]);
-    iconBounds.adjust(
-        -ConstraintIconHitPaddingPx,
-        -ConstraintIconHitPaddingPx,
-        ConstraintIconHitPaddingPx,
-        ConstraintIconHitPaddingPx
-    );
-    if (iconBounds.contains(relativeX, relativeY)) {
+    if (iconBounds.marginsAdded(iconHitPadding).contains(relativeX, relativeY)) {
         return parseConstraintIds(constrIdsStr);
     }
 

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
@@ -136,6 +136,10 @@ public:
     //@}
 
     std::set<int> detectPreselectionConstr(const SoPickedPoint* Point, const SbVec2s& cursorScreenPos);
+    std::set<int> detectPreselectionConstr(
+        const SbVec2s& cursorScreenPos,
+        Base::Vector3d* pickedPoint = nullptr
+    );
 
     SoSeparator* getConstraintIdSeparator(int i);
 
@@ -159,6 +163,23 @@ private:
 
     /// Returns the size that Coin should display the indicated image at
     SbVec3s getDisplayedSize(const SoImage*) const;
+    std::set<int> parseConstraintIds(const QString& constrIdsStr) const;
+    bool resolveIconScreenGeometry(
+        SoSeparator* sep,
+        SoImage* iconNode,
+        int iconIndex,
+        SbVec2f& iconScreenCenter,
+        SbVec3s& iconSize,
+        QString& constrIdsStr,
+        Base::Vector3d* pickedPoint = nullptr
+    ) const;
+    std::set<int> detectPreselectionIcon(
+        SoSeparator* sep,
+        SoImage* iconNode,
+        int iconIndex,
+        const SbVec2s& cursorScreenPos,
+        Base::Vector3d* pickedPoint = nullptr
+    ) const;
 
     /** @name Protected helpers for drawing constraint icons*/
     //@{

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
@@ -41,6 +41,7 @@
 
 
 class SbVec3f;
+class SbVec2s;
 class SoRayPickAction;
 class SoPickedPoint;
 class SbVec3s;
@@ -134,7 +135,7 @@ public:
     void setConstraintSelectability(bool enabled = true);
     //@}
 
-    std::set<int> detectPreselectionConstr(const SoPickedPoint* Point);
+    std::set<int> detectPreselectionConstr(const SoPickedPoint* Point, const SbVec2s& cursorScreenPos);
 
     SoSeparator* getConstraintIdSeparator(int i);
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -905,12 +905,14 @@ EditModeCoinManager::PreselectionResult ViewProviderSketch::getPreselectionResul
 ) const
 {
     SoPickedPointList points = getPickedPointsOnRay(pos, viewer);
-    if (points.getLength() == 0) {
-        EditModeCoinManager::PreselectionResult result;
-        return result;
+    int hoveredPointIndex = EditModeCoinManager::PreselectionResult::InvalidPoint;
+    if (viewProviderParameters.hasLastPreselectionResult
+        && viewProviderParameters.lastPreselectionResult.Kind
+            == EditModeCoinManager::PreselectionResult::HitKind::Point) {
+        hoveredPointIndex = viewProviderParameters.lastPreselectionResult.PointIndex;
     }
 
-    return editCoinManager->detectPreselection(points, pos);
+    return editCoinManager->detectPreselection(points, pos, hoveredPointIndex);
 }
 
 void ViewProviderSketch::cachePreselectionResult(

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -844,6 +844,7 @@ void ViewProviderSketch::preselectAtPoint(Base::Vector2d point)
 
         SbVec2s screencoords = viewer->getPointOnViewport(sbpoint);
         auto result = getPreselectionResultAtViewportPos(screencoords, viewer);
+        cachePreselectionResult(screencoords, result);
 
         if (detectAndShowPreselection(result) && sketchHandler) {
             sketchHandler->applyCursor();
@@ -910,6 +911,40 @@ EditModeCoinManager::PreselectionResult ViewProviderSketch::getPreselectionResul
     }
 
     return editCoinManager->detectPreselection(points, pos);
+}
+
+void ViewProviderSketch::cachePreselectionResult(
+    const SbVec2s& pos,
+    const EditModeCoinManager::PreselectionResult& result
+)
+{
+    viewProviderParameters.lastPreselectionCursorPos = pos;
+    viewProviderParameters.lastPreselectionResult = result;
+    viewProviderParameters.hasLastPreselectionResult = result.hasWinner();
+}
+
+EditModeCoinManager::PreselectionResult ViewProviderSketch::resolveClickPreselectionResult(
+    const EditModeCoinManager::PreselectionResult& clickResult,
+    const SbVec2s& cursorPos,
+    const Gui::View3DInventorViewer* viewer
+) const
+{
+    if (!viewer || !viewProviderParameters.hasLastPreselectionResult) {
+        return clickResult;
+    }
+
+    short dx = 0;
+    short dy = 0;
+    (cursorPos - viewProviderParameters.lastPreselectionCursorPos).getValue(dx, dy);
+
+    float distanceSquared = static_cast<float>(dx) * static_cast<float>(dx)
+        + static_cast<float>(dy) * static_cast<float>(dy);
+    float pickRadius = viewer->getPickRadius();
+    if (distanceSquared > pickRadius * pickRadius) {
+        return clickResult;
+    }
+
+    return viewProviderParameters.lastPreselectionResult;
 }
 
 bool ViewProviderSketch::getPreselectionAtViewportPos(
@@ -1121,6 +1156,8 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
     boost::scoped_ptr<SoPickedPoint> pp(this->getPointOnRay(cursorPos, viewer));
     EditModeCoinManager::PreselectionResult clickResult
         = getPreselectionResultAtViewportPos(cursorPos, viewer);
+    EditModeCoinManager::PreselectionResult resolvedClickResult
+        = resolveClickPreselectionResult(clickResult, cursorPos, viewer);
 
     // Radius maximum to allow double click event
     const int dblClickRadius = 5;
@@ -1130,13 +1167,13 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
     SbVec3f pos = point;
     Base::Vector3d selectionPoint(point[0], point[1], point[2]);
 
-    if (clickResult.hasPickedPoint()) {
+    if (resolvedClickResult.hasPickedPoint()) {
         pos = SbVec3f(
-            static_cast<float>(clickResult.PickedPoint.x),
-            static_cast<float>(clickResult.PickedPoint.y),
-            static_cast<float>(clickResult.PickedPoint.z)
+            static_cast<float>(resolvedClickResult.PickedPoint.x),
+            static_cast<float>(resolvedClickResult.PickedPoint.y),
+            static_cast<float>(resolvedClickResult.PickedPoint.z)
         );
-        selectionPoint = clickResult.PickedPoint;
+        selectionPoint = resolvedClickResult.PickedPoint;
     }
     else if (pp) {
         const SoDetail* detail = pp->getDetail();
@@ -1146,7 +1183,7 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
         const SbVec3f pickedPoint = pp->getPoint();
         selectionPoint = Base::Vector3d(pickedPoint[0], pickedPoint[1], pickedPoint[2]);
     }
-    const bool hasSelectionPoint = clickResult.hasPickedPoint() || static_cast<bool>(pp);
+    const bool hasSelectionPoint = resolvedClickResult.hasPickedPoint() || static_cast<bool>(pp);
 
     std::unique_ptr<SnapManager::SnapHandle> snapHandle;
     try {
@@ -1164,9 +1201,9 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
             switch (Mode) {
                 case STATUS_NONE: {
                     bool done = false;
-                    detectAndShowPreselection(clickResult);
+                    detectAndShowPreselection(resolvedClickResult);
 
-                    switch (clickResult.Kind) {
+                    switch (resolvedClickResult.Kind) {
                         case EditModeCoinManager::PreselectionResult::HitKind::Point:
                             setSketchMode(STATUS_SELECT_Point);
                             done = true;
@@ -1375,9 +1412,9 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
             // Do things depending on the mode of the user interaction
             switch (Mode) {
                 case STATUS_NONE: {
-                    detectAndShowPreselection(clickResult);
+                    detectAndShowPreselection(resolvedClickResult);
 
-                    switch (clickResult.Kind) {
+                    switch (resolvedClickResult.Kind) {
                         case EditModeCoinManager::PreselectionResult::HitKind::Point:
                             setSketchMode(STATUS_SELECT_Point);
                             break;
@@ -1727,6 +1764,7 @@ bool ViewProviderSketch::mouseMove(const SbVec2s& cursorPos, Gui::View3DInventor
         && Mode != STATUS_SELECT_Constraint && Mode != STATUS_SKETCH_Drag
         && Mode != STATUS_SKETCH_DragConstraint && Mode != STATUS_SKETCH_UseRubberBand) {
         auto result = getPreselectionResultAtViewportPos(cursorPos, viewer);
+        cachePreselectionResult(cursorPos, result);
         preselectChanged = detectAndShowPreselection(result);
     }
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -28,11 +28,15 @@
 #include <Inventor/SbLine.h>
 #include <Inventor/SbTime.h>
 #include <Inventor/SoPickedPoint.h>
+#include <Inventor/actions/SoRayPickAction.h>
 #include <Inventor/actions/SoGetBoundingBoxAction.h>
 #include <Inventor/details/SoPointDetail.h>
 #include <Inventor/events/SoKeyboardEvent.h>
+#include <Inventor/lists/SoPickedPointList.h>
 #include <Inventor/nodes/SoCamera.h>
 #include <Inventor/nodes/SoShapeHints.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoTransform.h>
 
 #include <QApplication>
 #include <QFontMetricsF>
@@ -50,6 +54,7 @@
 #include <fmt/format.h>
 
 #include <Base/Console.h>
+#include <Base/Converter.h>
 #include <Base/ServiceProvider.h>
 #include <Base/Vector3D.h>
 #include <Gui/Application.h>
@@ -838,10 +843,9 @@ void ViewProviderSketch::preselectAtPoint(Base::Vector2d point)
         SbVec3f sbpoint(static_cast<float>(pnt.x), static_cast<float>(pnt.y), static_cast<float>(pnt.z));
 
         SbVec2s screencoords = viewer->getPointOnViewport(sbpoint);
+        auto result = getPreselectionResultAtViewportPos(screencoords, viewer);
 
-        std::unique_ptr<SoPickedPoint> Point(this->getPointOnRay(screencoords, viewer));
-
-        if (detectAndShowPreselection(Point.get()) && sketchHandler) {
+        if (detectAndShowPreselection(result) && sketchHandler) {
             sketchHandler->applyCursor();
         }
     }
@@ -853,6 +857,120 @@ void ViewProviderSketch::setSketchMode(SketchMode mode)
 {
     Mode = mode;
     Gui::Application::Instance->commandManager().testActive();
+}
+
+SoPickedPointList ViewProviderSketch::getPickedPointsOnRay(
+    const SbVec2s& pos,
+    const Gui::View3DInventorViewer* viewer
+) const
+{
+    SoPickedPointList picks;
+    if (!viewer || !isInEditMode()) {
+        return picks;
+    }
+
+    auto root = new SoSeparator;
+    root->ref();
+    root->addChild(viewer->getSoRenderManager()->getCamera());
+
+    auto trans = new SoTransform;
+    trans->ref();
+    trans->setMatrix(Base::convertTo<SbMatrix>(getDocument()->getEditingTransform()));
+    root->addChild(trans);
+    root->addChild(editCoinManager->getRootEditNode());
+
+    SoRayPickAction rp(viewer->getSoRenderManager()->getViewportRegion());
+    rp.setPickAll(true);
+    rp.setPoint(pos);
+    rp.setRadius(viewer->getPickRadius());
+    rp.apply(root);
+
+    const SoPickedPointList& pickedPoints = rp.getPickedPointList();
+    for (int i = 0; i < pickedPoints.getLength(); ++i) {
+        if (SoPickedPoint* pickedPoint = pickedPoints[i]) {
+            picks.append(new SoPickedPoint(*pickedPoint));
+        }
+    }
+
+    root->unref();
+    trans->unref();
+
+    return picks;
+}
+
+EditModeCoinManager::PreselectionResult ViewProviderSketch::getPreselectionResultAtViewportPos(
+    const SbVec2s& pos,
+    const Gui::View3DInventorViewer* viewer
+) const
+{
+    SoPickedPointList points = getPickedPointsOnRay(pos, viewer);
+    if (points.getLength() == 0) {
+        EditModeCoinManager::PreselectionResult result;
+        return result;
+    }
+
+    return editCoinManager->detectPreselection(points, pos);
+}
+
+bool ViewProviderSketch::getPreselectionAtViewportPos(
+    const SbVec2s& pos,
+    const Gui::View3DInventorViewer* viewer,
+    std::vector<std::string>& subElementNames,
+    Base::Vector3d& pickedPoint
+)
+{
+    subElementNames.clear();
+
+    EditModeCoinManager::PreselectionResult result = getPreselectionResultAtViewportPos(pos, viewer);
+    if (!result.hasWinner() || !result.hasPickedPoint()) {
+        return false;
+    }
+
+    pickedPoint = result.PickedPoint;
+
+    switch (result.Kind) {
+        case EditModeCoinManager::PreselectionResult::HitKind::Point:
+            subElementNames.emplace_back("Vertex" + std::to_string(result.PointIndex + 1));
+            return true;
+        case EditModeCoinManager::PreselectionResult::HitKind::Edge:
+            if (result.GeoIndex >= 0) {
+                subElementNames.emplace_back("Edge" + std::to_string(result.GeoIndex + 1));
+            }
+            else {
+                subElementNames.emplace_back(
+                    "ExternalEdge"
+                    + std::to_string(-result.GeoIndex + Sketcher::GeoEnum::RefExt + 1)
+                );
+            }
+            return true;
+        case EditModeCoinManager::PreselectionResult::HitKind::Axis:
+            switch (result.Cross) {
+                case EditModeCoinManager::PreselectionResult::Axes::RootPoint:
+                    subElementNames.emplace_back("RootPoint");
+                    break;
+                case EditModeCoinManager::PreselectionResult::Axes::HorizontalAxis:
+                    subElementNames.emplace_back("H_Axis");
+                    break;
+                case EditModeCoinManager::PreselectionResult::Axes::VerticalAxis:
+                    subElementNames.emplace_back("V_Axis");
+                    break;
+                case EditModeCoinManager::PreselectionResult::Axes::None:
+                    break;
+            }
+            return !subElementNames.empty();
+        case EditModeCoinManager::PreselectionResult::HitKind::Constraint:
+            subElementNames.reserve(result.ConstrIndices.size());
+            for (int constraintId : result.ConstrIndices) {
+                subElementNames.emplace_back(
+                    Sketcher::PropertyConstraintList::getConstraintName(constraintId)
+                );
+            }
+            return true;
+        case EditModeCoinManager::PreselectionResult::HitKind::None:
+            break;
+    }
+
+    return false;
 }
 
 bool ViewProviderSketch::keyPressed(bool pressed, int key)
@@ -1001,6 +1119,8 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
 
     // use scoped_ptr to make sure that instance gets deleted in all cases
     boost::scoped_ptr<SoPickedPoint> pp(this->getPointOnRay(cursorPos, viewer));
+    EditModeCoinManager::PreselectionResult clickResult
+        = getPreselectionResultAtViewportPos(cursorPos, viewer);
 
     // Radius maximum to allow double click event
     const int dblClickRadius = 5;
@@ -1008,13 +1128,25 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
     double x = std::numeric_limits<double>::quiet_NaN();
     double y = std::numeric_limits<double>::quiet_NaN();
     SbVec3f pos = point;
+    Base::Vector3d selectionPoint(point[0], point[1], point[2]);
 
-    if (pp) {
+    if (clickResult.hasPickedPoint()) {
+        pos = SbVec3f(
+            static_cast<float>(clickResult.PickedPoint.x),
+            static_cast<float>(clickResult.PickedPoint.y),
+            static_cast<float>(clickResult.PickedPoint.z)
+        );
+        selectionPoint = clickResult.PickedPoint;
+    }
+    else if (pp) {
         const SoDetail* detail = pp->getDetail();
         if (detail && detail->getTypeId() == SoPointDetail::getClassTypeId()) {
             pos = pp->getPoint();
         }
+        const SbVec3f pickedPoint = pp->getPoint();
+        selectionPoint = Base::Vector3d(pickedPoint[0], pickedPoint[1], pickedPoint[2]);
     }
+    const bool hasSelectionPoint = clickResult.hasPickedPoint() || static_cast<bool>(pp);
 
     std::unique_ptr<SnapManager::SnapHandle> snapHandle;
     try {
@@ -1032,21 +1164,27 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
             switch (Mode) {
                 case STATUS_NONE: {
                     bool done = false;
-                    if (preselection.isPreselectPointValid()) {
-                        setSketchMode(STATUS_SELECT_Point);
-                        done = true;
-                    }
-                    else if (preselection.isPreselectCurveValid()) {
-                        setSketchMode(STATUS_SELECT_Edge);
-                        done = true;
-                    }
-                    else if (preselection.isCrossPreselected()) {
-                        setSketchMode(STATUS_SELECT_Cross);
-                        done = true;
-                    }
-                    else if (!preselection.PreselectConstraintSet.empty()) {
-                        setSketchMode(STATUS_SELECT_Constraint);
-                        done = true;
+                    detectAndShowPreselection(clickResult);
+
+                    switch (clickResult.Kind) {
+                        case EditModeCoinManager::PreselectionResult::HitKind::Point:
+                            setSketchMode(STATUS_SELECT_Point);
+                            done = true;
+                            break;
+                        case EditModeCoinManager::PreselectionResult::HitKind::Edge:
+                            setSketchMode(STATUS_SELECT_Edge);
+                            done = true;
+                            break;
+                        case EditModeCoinManager::PreselectionResult::HitKind::Axis:
+                            setSketchMode(STATUS_SELECT_Cross);
+                            done = true;
+                            break;
+                        case EditModeCoinManager::PreselectionResult::HitKind::Constraint:
+                            setSketchMode(STATUS_SELECT_Constraint);
+                            done = true;
+                            break;
+                        case EditModeCoinManager::PreselectionResult::HitKind::None:
+                            break;
                     }
 
                     // Double click events variables
@@ -1092,29 +1230,32 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
             // Do things depending on the mode of the user interaction
             switch (Mode) {
                 case STATUS_SELECT_Point:
-                    if (pp) {
+                    if (hasSelectionPoint) {
+                        // Base::Console().log("Select Point:%d\n",this->DragPoint);
                         //  Do selection
                         std::stringstream ss;
                         ss << "Vertex" << preselection.getPreselectionVertexIndex();
 
-                        preselectToSelection(ss, pp, true);
+                        preselectToSelection(ss, selectionPoint, true);
                     }
                     setSketchMode(STATUS_NONE);
                     return true;
                 case STATUS_SELECT_Edge:
-                    if (pp) {
+                    if (hasSelectionPoint) {
+                        // Base::Console().log("Select Point:%d\n",this->DragPoint);
                         std::stringstream ss;
                         if (preselection.isEdge())
                             ss << "Edge" << preselection.getPreselectionEdgeIndex();
                         else// external geometry
                             ss << "ExternalEdge" << preselection.getPreselectionExternalEdgeIndex();
 
-                        preselectToSelection(ss, pp, true);
+                        preselectToSelection(ss, selectionPoint, true);
                     }
                     setSketchMode(STATUS_NONE);
                     return true;
                 case STATUS_SELECT_Cross:
-                    if (pp) {
+                    if (hasSelectionPoint) {
+                        // Base::Console().log("Select Point:%d\n",this->DragPoint);
                         std::stringstream ss;
                         switch (preselection.PreselectCross) {
                             case Preselection::Axes::RootPoint:
@@ -1130,7 +1271,7 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                                 break;
                         }
 
-                        preselectToSelection(ss, pp, true);
+                        preselectToSelection(ss, selectionPoint, true);
                     }
                     setSketchMode(STATUS_NONE);
                     return true;
@@ -1140,13 +1281,13 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                     return true;
                 }
                 case STATUS_SELECT_Constraint: {
-                    if (pp) {
+                    if (hasSelectionPoint) {
                         auto sels = preselection.PreselectConstraintSet;
                         for (int id : sels) {
                             std::stringstream ss;
                             ss << Sketcher::PropertyConstraintList::getConstraintName(id);
 
-                            preselectToSelection(ss, pp, true);
+                            preselectToSelection(ss, selectionPoint, true);
                         }
                     }
                     setSketchMode(STATUS_NONE);
@@ -1234,17 +1375,23 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
             // Do things depending on the mode of the user interaction
             switch (Mode) {
                 case STATUS_NONE: {
-                    if (preselection.isPreselectPointValid()) {
-                        setSketchMode(STATUS_SELECT_Point);
-                    }
-                    else if (preselection.isPreselectCurveValid()) {
-                        setSketchMode(STATUS_SELECT_Edge);
-                    }
-                    else if (preselection.isCrossPreselected()) {
-                        setSketchMode(STATUS_SELECT_Cross);
-                    }
-                    else if (!preselection.PreselectConstraintSet.empty()) {
-                        setSketchMode(STATUS_SELECT_Constraint);
+                    detectAndShowPreselection(clickResult);
+
+                    switch (clickResult.Kind) {
+                        case EditModeCoinManager::PreselectionResult::HitKind::Point:
+                            setSketchMode(STATUS_SELECT_Point);
+                            break;
+                        case EditModeCoinManager::PreselectionResult::HitKind::Edge:
+                            setSketchMode(STATUS_SELECT_Edge);
+                            break;
+                        case EditModeCoinManager::PreselectionResult::HitKind::Axis:
+                            setSketchMode(STATUS_SELECT_Cross);
+                            break;
+                        case EditModeCoinManager::PreselectionResult::HitKind::Constraint:
+                            setSketchMode(STATUS_SELECT_Constraint);
+                            break;
+                        case EditModeCoinManager::PreselectionResult::HitKind::None:
+                            break;
                     }
                     break;
                 }
@@ -1272,18 +1419,20 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                     generateContextMenu();
                     return true;
                 case STATUS_SELECT_Point:
-                    if (pp) {
+                    if (hasSelectionPoint) {
+                        // Base::Console().log("Select Point:%d\n",this->DragPoint);
                         //  Do selection
                         std::stringstream ss;
                         ss << "Vertex" << preselection.getPreselectionVertexIndex();
 
-                        preselectToSelection(ss, pp, false);
+                        preselectToSelection(ss, selectionPoint, false);
                     }
                     setSketchMode(STATUS_NONE);
                     generateContextMenu();
                     return true;
                 case STATUS_SELECT_Edge:
-                    if (pp) {
+                    if (hasSelectionPoint) {
+                        // Base::Console().log("Select Point:%d\n",this->DragPoint);
                         std::stringstream ss;
                         if (preselection.isEdge()) {
                             ss << "Edge" << preselection.getPreselectionEdgeIndex();
@@ -1292,13 +1441,14 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                             ss << "ExternalEdge" << preselection.getPreselectionExternalEdgeIndex();
                         }
 
-                        preselectToSelection(ss, pp, false);
+                        preselectToSelection(ss, selectionPoint, false);
                     }
                     setSketchMode(STATUS_NONE);
                     generateContextMenu();
                     return true;
                 case STATUS_SELECT_Cross:
-                    if (pp) {
+                    if (hasSelectionPoint) {
+                        // Base::Console().log("Select Point:%d\n",this->DragPoint);
                         std::stringstream ss;
                         switch (preselection.PreselectCross) {
                             case Preselection::Axes::RootPoint:
@@ -1314,19 +1464,19 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                                 break;
                         }
 
-                        preselectToSelection(ss, pp, false);
+                        preselectToSelection(ss, selectionPoint, false);
                     }
                     setSketchMode(STATUS_NONE);
                     generateContextMenu();
                     return true;
                 case STATUS_SELECT_Constraint: {
-                    if (pp) {
+                    if (hasSelectionPoint) {
                         auto sels = preselection.PreselectConstraintSet;
                         for (int id : sels) {
                             std::stringstream ss;
                             ss << Sketcher::PropertyConstraintList::getConstraintName(id);
 
-                            preselectToSelection(ss, pp, false);
+                            preselectToSelection(ss, selectionPoint, false);
                         }
                     }
                     setSketchMode(STATUS_NONE);
@@ -1576,10 +1726,8 @@ bool ViewProviderSketch::mouseMove(const SbVec2s& cursorPos, Gui::View3DInventor
     if (Mode != STATUS_SELECT_Point && Mode != STATUS_SELECT_Edge
         && Mode != STATUS_SELECT_Constraint && Mode != STATUS_SKETCH_Drag
         && Mode != STATUS_SKETCH_DragConstraint && Mode != STATUS_SKETCH_UseRubberBand) {
-
-        std::unique_ptr<SoPickedPoint> Point(this->getPointOnRay(cursorPos, viewer));
-
-        preselectChanged = detectAndShowPreselection(Point.get());
+        auto result = getPreselectionResultAtViewportPos(cursorPos, viewer);
+        preselectChanged = detectAndShowPreselection(result);
     }
 
     switch (Mode) {
@@ -2490,7 +2638,9 @@ void ViewProviderSketch::onSelectionChanged(const Gui::SelectionChanges& msg)
     }
 }
 
-bool ViewProviderSketch::detectAndShowPreselection(SoPickedPoint* Point)
+bool ViewProviderSketch::detectAndShowPreselection(
+    const EditModeCoinManager::PreselectionResult& result
+)
 {
     assert(isInEditMode());
 
@@ -2536,17 +2686,17 @@ bool ViewProviderSketch::detectAndShowPreselection(SoPickedPoint* Point)
         }
     };
 
-    if (Point) {
-
-        EditModeCoinManager::PreselectionResult result = editCoinManager->detectPreselection(Point);
-
-        if (result.PointIndex != -1
+    if (result.hasWinner()) {
+        if (result.Kind == EditModeCoinManager::PreselectionResult::HitKind::Point
             && result.PointIndex != preselection.PreselectPoint) {// if a new point is hit
             std::stringstream ss;
             ss << "Vertex" << result.PointIndex + 1;
             bool accepted =
                 setPreselect(
-                    ss.str(), Point->getPoint()[0], Point->getPoint()[1], Point->getPoint()[2])
+                    ss.str(),
+                    result.PickedPoint.x,
+                    result.PickedPoint.y,
+                    result.PickedPoint.z)
                 != 0;
             preselection.blockedPreselection = !accepted;
             if (accepted) {
@@ -2556,39 +2706,47 @@ bool ViewProviderSketch::detectAndShowPreselection(SoPickedPoint* Point)
                 return true;
             }
         }
-        else if (result.GeoIndex != -1
+        else if (result.Kind == EditModeCoinManager::PreselectionResult::HitKind::Edge
                  && result.GeoIndex != preselection.PreselectCurve) {// if a new curve is hit
 
             // If the picked edge is part of a text/group, treat the handle as the preselected item
-            int handleId = getSketchObject()->getGroupHandleIfInGroup(result.GeoIndex);
-            if (handleId != result.GeoIndex) {
+            int geoIndex = result.GeoIndex;
+            int handleId = getSketchObject()->getGroupHandleIfInGroup(geoIndex);
+            if (handleId != geoIndex) {
                 if (handleId == preselection.PreselectCurve) {
+                    if (result.hasPickedPoint()) {
+                        Gui::Selection().setPreselectCoord(
+                            result.PickedPoint.x, result.PickedPoint.y, result.PickedPoint.z);
+                    }
                     return false;
                 }
-                result.GeoIndex = handleId;
+                geoIndex = handleId;
             }
 
             std::stringstream ss;
-            if (result.GeoIndex >= 0)
-                ss << "Edge" << result.GeoIndex + 1;
+            if (geoIndex >= 0)
+                ss << "Edge" << geoIndex + 1;
             else// external geometry
                 ss << "ExternalEdge"
-                   << -result.GeoIndex + Sketcher::GeoEnum::RefExt
+                   << -geoIndex + Sketcher::GeoEnum::RefExt
                         + 1;// convert index start from -3 to 1
             bool accepted =
                 setPreselect(
-                    ss.str(), Point->getPoint()[0], Point->getPoint()[1], Point->getPoint()[2])
+                    ss.str(),
+                    result.PickedPoint.x,
+                    result.PickedPoint.y,
+                    result.PickedPoint.z)
                 != 0;
             preselection.blockedPreselection = !accepted;
             if (accepted) {
                 resetPreselectPoint();
-                preselection.PreselectCurve = result.GeoIndex;
+                preselection.PreselectCurve = geoIndex;
                 updateToolTip(); // Clear tooltip on curve selection
 
                 return true;
             }
         }
-        else if (result.Cross != EditModeCoinManager::PreselectionResult::Axes::None
+        else if (result.Kind == EditModeCoinManager::PreselectionResult::HitKind::Axis
                  && static_cast<int>(result.Cross)
                      != static_cast<int>(preselection.PreselectCross)) {// if a cross line is hit
             std::stringstream ss;
@@ -2607,7 +2765,10 @@ bool ViewProviderSketch::detectAndShowPreselection(SoPickedPoint* Point)
             }
             bool accepted =
                 setPreselect(
-                    ss.str(), Point->getPoint()[0], Point->getPoint()[1], Point->getPoint()[2])
+                    ss.str(),
+                    result.PickedPoint.x,
+                    result.PickedPoint.y,
+                    result.PickedPoint.z)
                 != 0;
             preselection.blockedPreselection = !accepted;
             if (accepted) {
@@ -2622,7 +2783,7 @@ bool ViewProviderSketch::detectAndShowPreselection(SoPickedPoint* Point)
                 return true;
             }
         }
-        else if (!result.ConstrIndices.empty()
+        else if (result.Kind == EditModeCoinManager::PreselectionResult::HitKind::Constraint
                  && result.ConstrIndices
                      != preselection.PreselectConstraintSet) {// if a constraint is hit
             bool accepted = true;
@@ -2634,7 +2795,10 @@ bool ViewProviderSketch::detectAndShowPreselection(SoPickedPoint* Point)
 
                 accepted &=
                     setPreselect(
-                        ss.str(), Point->getPoint()[0], Point->getPoint()[1], Point->getPoint()[2])
+                        ss.str(),
+                        result.PickedPoint.x,
+                        result.PickedPoint.y,
+                        result.PickedPoint.z)
                     != 0;
 
                 preselection.blockedPreselection = !accepted;
@@ -2659,22 +2823,10 @@ bool ViewProviderSketch::detectAndShowPreselection(SoPickedPoint* Point)
                 return true;// Preselection changed
             }
         }
-        else if ((result.PointIndex == -1 && result.GeoIndex == -1
-                  && result.Cross == EditModeCoinManager::PreselectionResult::Axes::None
-                  && result.ConstrIndices.empty())
-                 && (preselection.isPreselectPointValid() || preselection.isPreselectCurveValid()
-                     || preselection.isCrossPreselected()
-                     || !preselection.PreselectConstraintSet.empty()
-                     || preselection.blockedPreselection)) {
-            // we have just left a preselection
-            resetPreselectPoint();
-            preselection.blockedPreselection = false;
-            updateToolTip(); // Clear tooltip when leaving preselection
-
-            return true;
+        if (result.hasPickedPoint()) {
+            Gui::Selection().setPreselectCoord(
+                result.PickedPoint.x, result.PickedPoint.y, result.PickedPoint.z);
         }
-        Gui::Selection().setPreselectCoord(
-            Point->getPoint()[0], Point->getPoint()[1], Point->getPoint()[2]);
     }
     else if (preselection.isPreselectCurveValid() || preselection.isPreselectPointValid()
              || !preselection.PreselectConstraintSet.empty() || preselection.isCrossPreselected()
@@ -4659,13 +4811,17 @@ std::unique_ptr<SoRayPickAction> ViewProviderSketch::getRayPickAction() const
 
 SbVec2f ViewProviderSketch::getScreenCoordinates(SbVec2f sketchcoordinates) const
 {
+    return getScreenCoordinates(SbVec3f(sketchcoordinates[0], sketchcoordinates[1], 0.0f));
+}
 
+SbVec2f ViewProviderSketch::getScreenCoordinates(SbVec3f sketchcoordinates) const
+{
     Base::Placement sketchPlacement = getEditingPlacement();
     Base::Vector3d sketchPos(sketchPlacement.getPosition());
     Base::Rotation sketchRot(sketchPlacement.getRotation());
 
     // get global coordinates from sketcher coordinates
-    Base::Vector3d pos(sketchcoordinates[0], sketchcoordinates[1], 0);
+    Base::Vector3d pos(sketchcoordinates[0], sketchcoordinates[1], sketchcoordinates[2]);
     sketchRot.multVec(pos, pos);
     pos = pos + sketchPos;
 
@@ -5098,7 +5254,7 @@ void ViewProviderSketch::generateContextMenu()
 }
 
 void ViewProviderSketch::preselectToSelection(const std::stringstream& ss,
-                                              boost::scoped_ptr<SoPickedPoint>& pp,
+                                              const Base::Vector3d& pickedPoint,
                                               bool toggle)
 {
     // If toggle true and preselection already selected remove from selection
@@ -5107,7 +5263,7 @@ void ViewProviderSketch::preselectToSelection(const std::stringstream& ss,
     }
     // add to selection
     else {
-        addSelection2(ss.str(), pp->getPoint()[0], pp->getPoint()[1], pp->getPoint()[2]);
+        addSelection2(ss.str(), pickedPoint.x, pickedPoint.y, pickedPoint.z);
         drag.resetIds();
     }
 }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -963,7 +963,7 @@ bool ViewProviderSketch::getPreselectionAtViewportPos(
         return false;
     }
 
-    pickedPoint = result.PickedPoint;
+    pickedPoint = result.pickedPoint();
 
     switch (result.Kind) {
         case EditModeCoinManager::PreselectionResult::HitKind::Point:
@@ -1167,23 +1167,18 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
     double x = std::numeric_limits<double>::quiet_NaN();
     double y = std::numeric_limits<double>::quiet_NaN();
     SbVec3f pos = point;
-    Base::Vector3d selectionPoint(point[0], point[1], point[2]);
+    Base::Vector3d selectionPoint = Base::convertTo<Base::Vector3d>(point);
 
     if (resolvedClickResult.hasPickedPoint()) {
-        pos = SbVec3f(
-            static_cast<float>(resolvedClickResult.PickedPoint.x),
-            static_cast<float>(resolvedClickResult.PickedPoint.y),
-            static_cast<float>(resolvedClickResult.PickedPoint.z)
-        );
-        selectionPoint = resolvedClickResult.PickedPoint;
+        pos = Base::convertTo<SbVec3f>(resolvedClickResult.pickedPoint());
+        selectionPoint = resolvedClickResult.pickedPoint();
     }
     else if (pp) {
         const SoDetail* detail = pp->getDetail();
         if (detail && detail->getTypeId() == SoPointDetail::getClassTypeId()) {
             pos = pp->getPoint();
         }
-        const SbVec3f pickedPoint = pp->getPoint();
-        selectionPoint = Base::Vector3d(pickedPoint[0], pickedPoint[1], pickedPoint[2]);
+        selectionPoint = Base::convertTo<Base::Vector3d>(pp->getPoint());
     }
     const bool hasSelectionPoint = resolvedClickResult.hasPickedPoint() || static_cast<bool>(pp);
 
@@ -1270,7 +1265,6 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
             switch (Mode) {
                 case STATUS_SELECT_Point:
                     if (hasSelectionPoint) {
-                        // Base::Console().log("Select Point:%d\n",this->DragPoint);
                         //  Do selection
                         std::stringstream ss;
                         ss << "Vertex" << preselection.getPreselectionVertexIndex();
@@ -1281,7 +1275,6 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                     return true;
                 case STATUS_SELECT_Edge:
                     if (hasSelectionPoint) {
-                        // Base::Console().log("Select Point:%d\n",this->DragPoint);
                         std::stringstream ss;
                         if (preselection.isEdge())
                             ss << "Edge" << preselection.getPreselectionEdgeIndex();
@@ -1294,7 +1287,6 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                     return true;
                 case STATUS_SELECT_Cross:
                     if (hasSelectionPoint) {
-                        // Base::Console().log("Select Point:%d\n",this->DragPoint);
                         std::stringstream ss;
                         switch (preselection.PreselectCross) {
                             case Preselection::Axes::RootPoint:
@@ -1459,7 +1451,6 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                     return true;
                 case STATUS_SELECT_Point:
                     if (hasSelectionPoint) {
-                        // Base::Console().log("Select Point:%d\n",this->DragPoint);
                         //  Do selection
                         std::stringstream ss;
                         ss << "Vertex" << preselection.getPreselectionVertexIndex();
@@ -1471,7 +1462,6 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                     return true;
                 case STATUS_SELECT_Edge:
                     if (hasSelectionPoint) {
-                        // Base::Console().log("Select Point:%d\n",this->DragPoint);
                         std::stringstream ss;
                         if (preselection.isEdge()) {
                             ss << "Edge" << preselection.getPreselectionEdgeIndex();
@@ -1487,7 +1477,6 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                     return true;
                 case STATUS_SELECT_Cross:
                     if (hasSelectionPoint) {
-                        // Base::Console().log("Select Point:%d\n",this->DragPoint);
                         std::stringstream ss;
                         switch (preselection.PreselectCross) {
                             case Preselection::Axes::RootPoint:
@@ -2729,14 +2718,15 @@ bool ViewProviderSketch::detectAndShowPreselection(
     if (result.hasWinner()) {
         if (result.Kind == EditModeCoinManager::PreselectionResult::HitKind::Point
             && result.PointIndex != preselection.PreselectPoint) {// if a new point is hit
+            const auto& pickedPoint = result.pickedPoint();
             std::stringstream ss;
             ss << "Vertex" << result.PointIndex + 1;
             bool accepted =
                 setPreselect(
                     ss.str(),
-                    result.PickedPoint.x,
-                    result.PickedPoint.y,
-                    result.PickedPoint.z)
+                    pickedPoint.x,
+                    pickedPoint.y,
+                    pickedPoint.z)
                 != 0;
             preselection.blockedPreselection = !accepted;
             if (accepted) {
@@ -2755,8 +2745,9 @@ bool ViewProviderSketch::detectAndShowPreselection(
             if (handleId != geoIndex) {
                 if (handleId == preselection.PreselectCurve) {
                     if (result.hasPickedPoint()) {
+                        const auto& pickedPoint = result.pickedPoint();
                         Gui::Selection().setPreselectCoord(
-                            result.PickedPoint.x, result.PickedPoint.y, result.PickedPoint.z);
+                            pickedPoint.x, pickedPoint.y, pickedPoint.z);
                     }
                     return false;
                 }
@@ -2770,12 +2761,13 @@ bool ViewProviderSketch::detectAndShowPreselection(
                 ss << "ExternalEdge"
                    << -geoIndex + Sketcher::GeoEnum::RefExt
                         + 1;// convert index start from -3 to 1
+            const auto& pickedPoint = result.pickedPoint();
             bool accepted =
                 setPreselect(
                     ss.str(),
-                    result.PickedPoint.x,
-                    result.PickedPoint.y,
-                    result.PickedPoint.z)
+                    pickedPoint.x,
+                    pickedPoint.y,
+                    pickedPoint.z)
                 != 0;
             preselection.blockedPreselection = !accepted;
             if (accepted) {
@@ -2789,6 +2781,7 @@ bool ViewProviderSketch::detectAndShowPreselection(
         else if (result.Kind == EditModeCoinManager::PreselectionResult::HitKind::Axis
                  && static_cast<int>(result.Cross)
                      != static_cast<int>(preselection.PreselectCross)) {// if a cross line is hit
+            const auto& pickedPoint = result.pickedPoint();
             std::stringstream ss;
             switch (result.Cross) {
                 case EditModeCoinManager::PreselectionResult::Axes::RootPoint:
@@ -2806,9 +2799,9 @@ bool ViewProviderSketch::detectAndShowPreselection(
             bool accepted =
                 setPreselect(
                     ss.str(),
-                    result.PickedPoint.x,
-                    result.PickedPoint.y,
-                    result.PickedPoint.z)
+                    pickedPoint.x,
+                    pickedPoint.y,
+                    pickedPoint.z)
                 != 0;
             preselection.blockedPreselection = !accepted;
             if (accepted) {
@@ -2826,6 +2819,7 @@ bool ViewProviderSketch::detectAndShowPreselection(
         else if (result.Kind == EditModeCoinManager::PreselectionResult::HitKind::Constraint
                  && result.ConstrIndices
                      != preselection.PreselectConstraintSet) {// if a constraint is hit
+            const auto& pickedPoint = result.pickedPoint();
             bool accepted = true;
             for (std::set<int>::iterator it = result.ConstrIndices.begin();
                  it != result.ConstrIndices.end();
@@ -2836,9 +2830,9 @@ bool ViewProviderSketch::detectAndShowPreselection(
                 accepted &=
                     setPreselect(
                         ss.str(),
-                        result.PickedPoint.x,
-                        result.PickedPoint.y,
-                        result.PickedPoint.z)
+                        pickedPoint.x,
+                        pickedPoint.y,
+                        pickedPoint.z)
                     != 0;
 
                 preselection.blockedPreselection = !accepted;
@@ -2864,8 +2858,9 @@ bool ViewProviderSketch::detectAndShowPreselection(
             }
         }
         if (result.hasPickedPoint()) {
+            const auto& pickedPoint = result.pickedPoint();
             Gui::Selection().setPreselectCoord(
-                result.PickedPoint.x, result.PickedPoint.y, result.PickedPoint.z);
+                pickedPoint.x, pickedPoint.y, pickedPoint.z);
         }
     }
     else if (preselection.isPreselectCurveValid() || preselection.isPreselectPointValid()
@@ -4871,36 +4866,12 @@ SbVec2f ViewProviderSketch::getScreenCoordinates(SbVec3f sketchcoordinates) cons
         return SbVec2f(0, 0);
 
     Gui::View3DInventorViewer* viewer = view->getViewer();
-
-    SoCamera* pCam = viewer->getSoRenderManager()->getCamera();
-
-    if (!pCam)
+    if (!viewer || !viewer->getSoRenderManager() || !viewer->getSoRenderManager()->getCamera()) {
         return SbVec2f(0, 0);
-
-    SbViewVolume vol = pCam->getViewVolume();
-    Gui::ViewVolumeProjection proj(vol);
-
-    // dimensionless [0 1] (or 1.5 see View3DInventorViewer.cpp )
-    Base::Vector3d screencoords = proj(pos);
-
-    int width = viewer->getGLWidget()->width(), height = viewer->getGLWidget()->height();
-
-    if (width >= height) {
-        // "Landscape" orientation, to square
-        screencoords.x *= height;
-        screencoords.x += (width - height) / 2.0;
-        screencoords.y *= height;
-    }
-    else {
-        // "Portrait" orientation
-        screencoords.x *= width;
-        screencoords.y *= width;
-        screencoords.y += (height - width) / 2.0;
     }
 
-    SbVec2f iconCoords(screencoords.x, screencoords.y);
-
-    return iconCoords;
+    SbVec2s viewportPoint = viewer->getPointOnViewport(Base::convertTo<SbVec3f>(pos));
+    return SbVec2f(static_cast<float>(viewportPoint[0]), static_cast<float>(viewportPoint[1]));
 }
 
 QFont ViewProviderSketch::getApplicationFont() const

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -481,6 +481,9 @@ private:
         bool isShownVirtualSpace = false;  // indicates whether the present virtual space view is the
                                            // Real Space or the Virtual Space (virtual space 1 or 2)
         bool buttonPress = false;
+        bool hasLastPreselectionResult = false;
+        SbVec2s lastPreselectionCursorPos;
+        EditModeCoinManager::PreselectionResult lastPreselectionResult;
 
         int stdCountSegments = 50;  // preferences controlled default geometry sampling for selection
     };
@@ -832,6 +835,15 @@ private:
     ) const;
     EditModeCoinManager::PreselectionResult getPreselectionResultAtViewportPos(
         const SbVec2s& pos,
+        const Gui::View3DInventorViewer* viewer
+    ) const;
+    void cachePreselectionResult(
+        const SbVec2s& pos,
+        const EditModeCoinManager::PreselectionResult& result
+    );
+    EditModeCoinManager::PreselectionResult resolveClickPreselectionResult(
+        const EditModeCoinManager::PreselectionResult& clickResult,
+        const SbVec2s& cursorPos,
         const Gui::View3DInventorViewer* viewer
     ) const;
     /// helper to detect preselection

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -27,6 +27,7 @@
 #include <boost/smart_ptr/scoped_ptr.hpp>
 
 #include <Inventor/SoRenderManager.h>
+#include <Inventor/lists/SoPickedPointList.h>
 #include <Inventor/sensors/SoNodeSensor.h>
 #include <QCoreApplication>
 #include <QMetaObject>
@@ -44,8 +45,8 @@
 #include <Mod/Sketcher/App/GeoList.h>
 #include <Mod/Sketcher/App/GeoEnum.h>
 
+#include "EditModeCoinManager.h"
 #include "PropertyVisualLayerList.h"
-
 #include "ShortcutListener.h"
 #include "Utils.h"
 
@@ -58,6 +59,7 @@ class TopoDS_Face;
 class SoSeparator;
 class SbLine;
 class SbVec2f;
+class SbVec2s;
 class SbVec3f;
 class SoCoordinate3;
 class SoInfo;
@@ -66,6 +68,7 @@ class SoTransform;
 class SoLineSet;
 class SoMarkerSet;
 class SoPickedPoint;
+class SoPickedPointList;
 class SoRayPickAction;
 
 class SoImage;
@@ -730,6 +733,13 @@ public:
     }
     //@}
 
+    bool getPreselectionAtViewportPos(
+        const SbVec2s& pos,
+        const Gui::View3DInventorViewer* viewer,
+        std::vector<std::string>& subElementNames,
+        Base::Vector3d& pickedPoint
+    );
+
     /** @name Attorneys for collaboration with helper classes */
     //@{
     friend class ViewProviderSketchDrawSketchHandlerAttorney;
@@ -816,8 +826,16 @@ private:
 
     /** @name preselection functions */
     //@{
+    SoPickedPointList getPickedPointsOnRay(
+        const SbVec2s& pos,
+        const Gui::View3DInventorViewer* viewer
+    ) const;
+    EditModeCoinManager::PreselectionResult getPreselectionResultAtViewportPos(
+        const SbVec2s& pos,
+        const Gui::View3DInventorViewer* viewer
+    ) const;
     /// helper to detect preselection
-    bool detectAndShowPreselection(SoPickedPoint* Point);
+    bool detectAndShowPreselection(const EditModeCoinManager::PreselectionResult& result);
     int getPreselectPoint() const;
     int getPreselectCurve() const;
     int getPreselectCross() const;
@@ -850,11 +868,7 @@ private:
     void removeSelectPoint(int SelectPoint);
     void clearSelectPoints();
 
-    void preselectToSelection(
-        const std::stringstream& ss,
-        boost::scoped_ptr<SoPickedPoint>& pp,
-        bool toggle
-    );
+    void preselectToSelection(const std::stringstream& ss, const Base::Vector3d& pickedPoint, bool toggle);
     //@}
 
     /** @name miscelanea utilities */
@@ -913,6 +927,7 @@ private:
     std::unique_ptr<SoRayPickAction> getRayPickAction() const;
 
     SbVec2f getScreenCoordinates(SbVec2f sketchcoordinates) const;
+    SbVec2f getScreenCoordinates(SbVec3f sketchcoordinates) const;
 
     QFont getApplicationFont() const;
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketchCoinAttorney.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketchCoinAttorney.h
@@ -97,6 +97,7 @@ private:
 
     static inline float getScaleFactor(const ViewProviderSketch& vp);
     static inline SbVec2f getScreenCoordinates(const ViewProviderSketch& vp, SbVec2f sketchcoordinates);
+    static inline SbVec2f getScreenCoordinates(const ViewProviderSketch& vp, SbVec3f sketchcoordinates);
     static inline QFont getApplicationFont(const ViewProviderSketch& vp);
     static inline double getRotation(const ViewProviderSketch& vp, SbVec3f pos0, SbVec3f pos1);
     static inline int defaultApplicationFontSizePixels(const ViewProviderSketch& vp);
@@ -191,6 +192,14 @@ inline float ViewProviderSketchCoinAttorney::getScaleFactor(const ViewProviderSk
 inline SbVec2f ViewProviderSketchCoinAttorney::getScreenCoordinates(
     const ViewProviderSketch& vp,
     SbVec2f sketchcoordinates
+)
+{
+    return vp.getScreenCoordinates(sketchcoordinates);
+}
+
+inline SbVec2f ViewProviderSketchCoinAttorney::getScreenCoordinates(
+    const ViewProviderSketch& vp,
+    SbVec3f sketchcoordinates
 )
 {
     return vp.getScreenCoordinates(sketchcoordinates);

--- a/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import time
+import unittest
+
+import FreeCAD
+import FreeCADGui
+import Part
+import Sketcher
+import SketcherGui
+from PySide6 import QtCore, QtWidgets
+
+
+class SketcherGuiTestCases(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not FreeCAD.GuiUp:
+            raise unittest.SkipTest("Cannot run GUI tests in a CLI environment.")
+
+        FreeCADGui.getMainWindow().show()
+        cls.pump_gui_events()
+
+    @staticmethod
+    def pump_gui_events(iterations=6, delay=0.01):
+        app = QtWidgets.QApplication.instance()
+        for _ in range(iterations):
+            app.processEvents(QtCore.QEventLoop.AllEvents, int(delay * 1000))
+            if delay > 0.0:
+                time.sleep(delay)
+
+    @staticmethod
+    def build_issue_25840_sketch(sketch):
+        # Mirrors the uploaded repro geometry from issue #25840.
+        first_line = sketch.addGeometry(
+            Part.LineSegment(
+                FreeCAD.Vector(-17.60407066, 31.05172348, 0.0),
+                FreeCAD.Vector(44.00962448, -33.86270142, 0.0),
+            ),
+            False,
+        )
+        second_line = sketch.addGeometry(
+            Part.LineSegment(
+                FreeCAD.Vector(50.4888, 6.2351, 0.0),
+                FreeCAD.Vector(30.973626440922192, -20.12834717, 0.0),
+            ),
+            False,
+        )
+        constraint_id = sketch.addConstraint(
+            Sketcher.Constraint("PointOnObject", second_line, 2, first_line)
+        )
+        return constraint_id, FreeCAD.Vector(30.973626440922192, -20.12834717, 0.0)
+
+    @staticmethod
+    def classify_preselection(info, expected_constraint_name):
+        if not info or not info["ObjectName"]:
+            return "none"
+
+        names = info.get("SubElementNames") or []
+        if expected_constraint_name in names:
+            return "target_constraint"
+        if any(name.startswith("Constraint") for name in names):
+            return "other_constraint"
+        if any(name.startswith("Vertex") for name in names):
+            return "vertex"
+        if any(name.startswith("Edge") for name in names):
+            return "edge"
+        return "other"
+
+    @classmethod
+    def scan_preselection_at_viewport(cls, center_coin, expected_constraint_name, span=16, step=2):
+        counts = {
+            "target_constraint": 0,
+            "other_constraint": 0,
+            "edge": 0,
+            "vertex": 0,
+            "other": 0,
+            "none": 0,
+        }
+
+        for dy in range(-span, span + 1, step):
+            for dx in range(-span, span + 1, step):
+                coin_point = (center_coin[0] + dx, center_coin[1] + dy)
+                info = SketcherGui.getActiveSketchPreselection(coin_point)
+                kind = cls.classify_preselection(info, expected_constraint_name)
+                counts[kind] += 1
+
+        return counts
+
+    @classmethod
+    def find_constraint_probe_viewport_point(
+        cls,
+        view,
+        seed_world_point,
+        expected_constraint_name,
+        span=64,
+        step=8,
+    ):
+        center_coin = tuple(int(value) for value in view.getPointOnViewport(seed_world_point))
+        sum_x = 0
+        sum_y = 0
+        target_count = 0
+
+        for dy in range(-span, span + 1, step):
+            for dx in range(-span, span + 1, step):
+                coin_point = (center_coin[0] + dx, center_coin[1] + dy)
+                info = SketcherGui.getActiveSketchPreselection(coin_point)
+                if cls.classify_preselection(info, expected_constraint_name) != "target_constraint":
+                    continue
+
+                sum_x += coin_point[0]
+                sum_y += coin_point[1]
+                target_count += 1
+
+        if target_count == 0:
+            return None
+
+        return (
+            int(round(sum_x / target_count)),
+            int(round(sum_y / target_count)),
+        )
+
+    @classmethod
+    def configure_view_state(cls, view, tilt=None):
+        view.viewTop()
+        cls.pump_gui_events(2)
+        view.fitAll()
+        cls.pump_gui_events(4)
+
+        if tilt is not None:
+            base_rotation = view.getCameraOrientation()
+            view.setCameraOrientation(tilt.multiply(base_rotation))
+            cls.pump_gui_events(3)
+            view.fitAll()
+            cls.pump_gui_events(4)
+
+    @staticmethod
+    def constraint_share(counts):
+        total_hits = (
+            counts["target_constraint"]
+            + counts["other_constraint"]
+            + counts["edge"]
+            + counts["vertex"]
+            + counts["other"]
+        )
+        if total_hits == 0:
+            return 0.0
+        return counts["target_constraint"] / total_hits
+
+    def setUp(self):
+        self.doc = FreeCAD.newDocument("SketchGuiTest")
+        self.sketch = self.doc.addObject("Sketcher::SketchObject", "Sketch")
+        constraint_id, self.probe_point = self.build_issue_25840_sketch(self.sketch)
+        self.expected_constraint_name = f"Constraint{constraint_id + 1}"
+        self.doc.recompute()
+
+        FreeCADGui.getMainWindow().show()
+        self.pump_gui_events()
+        FreeCADGui.ActiveDocument.setEdit(self.sketch.Name)
+        self.pump_gui_events(6)
+
+        self.view = FreeCADGui.ActiveDocument.ActiveView
+
+    def tearDown(self):
+        FreeCADGui.Selection.clearPreselection()
+        FreeCADGui.Selection.clearSelection()
+        if FreeCADGui.ActiveDocument:
+            FreeCADGui.ActiveDocument.resetEdit()
+        self.pump_gui_events(4, 0.01)
+
+        if self.doc is not None:
+            document_name = self.doc.Name
+            self.doc = None
+            FreeCAD.closeDocument(document_name)
+            self.pump_gui_events(4, 0.01)
+
+    def testPointOnObjectPreselectionMatchesTiltedHitArea(self):
+        tilt_y = FreeCAD.Rotation(FreeCAD.Vector(0, 1, 0), 2.0)
+
+        counts_by_state = {}
+        for name, tilt in {
+            "exact_top": None,
+            "tilt_y_2deg": tilt_y,
+        }.items():
+            self.configure_view_state(self.view, tilt)
+            probe_point = self.find_constraint_probe_viewport_point(
+                self.view,
+                self.probe_point,
+                self.expected_constraint_name,
+            )
+            self.assertIsNotNone(probe_point)
+            counts_by_state[name] = self.scan_preselection_at_viewport(
+                probe_point,
+                self.expected_constraint_name,
+                span=12,
+            )
+
+        exact_top = counts_by_state["exact_top"]
+        tilt_y = counts_by_state["tilt_y_2deg"]
+        max_tilt_hits = tilt_y["target_constraint"]
+        exact_top_share = self.constraint_share(exact_top)
+
+        detail = (
+            f"exact_top={exact_top}, tilt_y_2deg={tilt_y}, "
+            f"constraint_share={exact_top_share:.3f}"
+        )
+
+        self.assertGreater(max_tilt_hits, 0, detail)
+        self.assertGreater(exact_top["target_constraint"], 0, detail)
+        self.assertGreaterEqual(
+            exact_top["target_constraint"],
+            int(max_tilt_hits * 0.8),
+            detail,
+        )
+        self.assertGreaterEqual(
+            exact_top_share,
+            0.20,
+            detail,
+        )

--- a/src/Mod/Sketcher/TestSketcherGui.py
+++ b/src/Mod/Sketcher/TestSketcherGui.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from SketcherTests.TestPlacementUpdate import TestSketchPlacementUpdate
+from SketcherTests.TestConstraintPreselectionGui import SketcherGuiTestCases
 from SketcherTests.TestOnViewParameterGui import TestOnViewParameterGui
+from SketcherTests.TestPlacementUpdate import TestSketchPlacementUpdate
 
 # Use the module so that code checkers don't complain (flake8)
-True if TestSketchPlacementUpdate and TestOnViewParameterGui else False
+True if SketcherGuiTestCases and TestSketchPlacementUpdate and TestOnViewParameterGui else False


### PR DESCRIPTION
Closes #25840.

This improves Sketcher preselection when constraints, points, and edges overlap in sketch edit mode.

The original issue was a constraint-over-geometry regression in exact top view, but the follow-up work here also makes point and edge picking less dependent on raw Coin hit ordering.

## What changed

- constraints are resolved before geometry across all overlapping Coin picks
- merged and regular constraint icons use padded screen-space hit regions
- clicks stay aligned with the currently hovered preselection instead of repicking too eagerly
- points use explicit screen-space hit disks, including when Coin returns no raw point hit
- hovered points get a small hysteresis radius so they do not immediately collapse to an edge on tiny cursor motion
- edges now have an explicit screen-space distance pass against the rendered polyline segments before the legacy raw Coin edge fallback

## Effect

This improves several overlap cases in Sketcher edit mode:

- constraint icons overlapping geometry
- endpoints lying on top of edges
- small point targets that were previously only easy to hit when the cursor was directly on top

## Tests

- existing GUI regression for the uploaded `PointOnObject` repro from #25840 still passes
- additional local probes were used to validate overlapping endpoint and isolated point hit regions
