### PR TITLE
Sketcher: Fix 2 OVP focus issue

### DIFF
--- a/src/Gui/EditableDatumLabel.cpp
+++ b/src/Gui/EditableDatumLabel.cpp
@@ -359,7 +359,6 @@ bool EditableDatumLabel::eventFilter(QObject* watched, QEvent* event)
     else if (event->type() == QEvent::FocusOut) {
         if (watched == spinBox) {
             Q_EMIT focusLost();
-            return true;
         }
     }
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/30330

The root cause of the bug was : 
```
    else if (event->type() == QEvent::FocusOut) {
        if (watched == spinBox) {
            Q_EMIT focusLost();
            return true;
        }
    }
```
Because the event filter returns true, the FocusOut event is consumed and never actually reaches the underlying `QLineEdit`/`QSpinBox`
And so it does not clear the hightlight style even though it does not have the focus anymore.