### PR TITLE
App: resolve sanitized document names in closeDocument

### DIFF
--- a/src/App/ApplicationPy.cpp
+++ b/src/App/ApplicationPy.cpp
@@ -26,6 +26,7 @@
 #include <FCConfig.h>
 
 #include <array>
+#include <cstring>
 
 #include <Base/Console.h>
 #include <Base/Exception.h>
@@ -34,6 +35,7 @@
 #include <Base/Parameter.h>
 #include <Base/PyWrapParseTupleAndKeywords.h>
 #include <Base/Sequencer.h>
+#include <Base/Tools.h>
 
 #include "Application.h"
 #include "ApplicationPy.h"
@@ -46,6 +48,47 @@
 // using Base::GetConsole;
 using namespace Base;
 using namespace App;
+
+namespace
+{
+
+enum class DocumentLookupResult
+{
+    NotFound,
+    Found,
+    Ambiguous,
+};
+
+DocumentLookupResult findDocumentByNameOrIdentifier(const char* nameOrIdentifier, Document*& doc)
+{
+    doc = GetApplication().getDocument(nameOrIdentifier);
+    if (doc) {
+        return DocumentLookupResult::Found;
+    }
+
+    std::string identifier = Base::Tools::getIdentifier(nameOrIdentifier);
+    if (identifier == nameOrIdentifier) {
+        return DocumentLookupResult::NotFound;
+    }
+
+    doc = GetApplication().getDocument(identifier.c_str());
+    if (!doc) {
+        return DocumentLookupResult::NotFound;
+    }
+
+    for (auto* document : GetApplication().getDocuments()) {
+        if (std::strcmp(document->Label.getValue(), nameOrIdentifier) != 0) {
+            continue;
+        }
+        if (document != doc) {
+            return DocumentLookupResult::Ambiguous;
+        }
+    }
+
+    return DocumentLookupResult::Found;
+}
+
+}  // namespace
 
 
 //**************************************************************************
@@ -449,18 +492,24 @@ PyObject* ApplicationPy::sCloseDocument(PyObject* /*self*/, PyObject* args)
 {
     char* pstr = nullptr;
     if (PyArg_ParseTuple(args, "s", &pstr)) {
-        Document* doc = GetApplication().getDocument(pstr);
-        if (!doc) {
+        Document* doc = nullptr;
+        auto lookupResult = findDocumentByNameOrIdentifier(pstr, doc);
+        if (lookupResult == DocumentLookupResult::NotFound) {
             PyErr_Format(PyExc_NameError, "Unknown document '%s'", pstr);
             return nullptr;
         }
-        if (!doc->isClosable()) {
-            PyErr_Format(PyExc_RuntimeError, "The document '%s' is not closable for the moment", pstr);
+        if (lookupResult == DocumentLookupResult::Ambiguous) {
+            PyErr_Format(PyExc_NameError, "Ambiguous document label '%s'", pstr);
             return nullptr;
         }
 
-        if (!GetApplication().closeDocument(pstr)) {
-            PyErr_Format(PyExc_RuntimeError, "Closing the document '%s' failed", pstr);
+        if (!doc->isClosable()) {
+            PyErr_Format(PyExc_RuntimeError, "The document '%s' is not closable for the moment", doc->getName());
+            return nullptr;
+        }
+
+        if (!GetApplication().closeDocument(doc)) {
+            PyErr_Format(PyExc_RuntimeError, "Closing the document '%s' failed", doc->getName());
             return nullptr;
         }
 

--- a/tests/src/App/Application.cpp
+++ b/tests/src/App/Application.cpp
@@ -74,8 +74,10 @@ TEST_F(ApplicationTest, closeDocumentPythonAcceptsSanitizedDocumentIdentifier)
         }
     } cleanup;
 
-    Base::Interpreter().runString("import FreeCAD as App\n"
-                                  "App.newDocument('close-document-hyphen-test')\n");
+    Base::Interpreter().runString(
+        "import FreeCAD as App\n"
+        "App.newDocument('close-document-hyphen-test')\n"
+    );
 
     auto* doc = App::GetApplication().getDocument("close_document_hyphen_test");
     ASSERT_NE(doc, nullptr);
@@ -99,9 +101,11 @@ TEST_F(ApplicationTest, closeDocumentPythonAcceptsSanitizedDocumentIdentifierWit
         }
     } cleanup;
 
-    Base::Interpreter().runString("import FreeCAD as App\n"
-                                  "App.newDocument('close-document-custom-label-test', "
-                                  "'Custom document label')\n");
+    Base::Interpreter().runString(
+        "import FreeCAD as App\n"
+        "App.newDocument('close-document-custom-label-test', "
+        "'Custom document label')\n"
+    );
 
     auto* doc = App::GetApplication().getDocument("close_document_custom_label_test");
     ASSERT_NE(doc, nullptr);
@@ -145,9 +149,13 @@ TEST_F(ApplicationTest, closeDocumentPythonRejectsLabelIdentifierConflict)
     EXPECT_STREQ(second->getName(), secondName.c_str());
     EXPECT_STREQ(second->Label.getValue(), "close-document-identifier-conflict");
 
-    EXPECT_THROW(Base::Interpreter().runString("import FreeCAD as App\n"
-                                               "App.closeDocument('close-document-identifier-conflict')\n"),
-                 Base::Exception);
+    EXPECT_THROW(
+        Base::Interpreter().runString(
+            "import FreeCAD as App\n"
+            "App.closeDocument('close-document-identifier-conflict')\n"
+        ),
+        Base::Exception
+    );
     EXPECT_EQ(app.getDocument(firstName.c_str()), first);
     EXPECT_EQ(app.getDocument(secondName.c_str()), second);
 }

--- a/tests/src/App/Application.cpp
+++ b/tests/src/App/Application.cpp
@@ -4,6 +4,9 @@
 #define FC_OS_MACOSX 1
 #include "App/ProgramOptionsUtilities.h"
 
+#include <App/Application.h>
+#include <App/Document.h>
+#include <Base/Interpreter.h>
 #include <src/App/InitApplication.h>
 
 
@@ -57,3 +60,94 @@ TEST_F(ApplicationTest, fCustomSyntaxEmptyIn)
     Spr exp {"", ""};
     EXPECT_EQ(res, exp);
 };
+
+TEST_F(ApplicationTest, closeDocumentPythonAcceptsSanitizedDocumentIdentifier)
+{
+    struct Cleanup
+    {
+        ~Cleanup()
+        {
+            auto& app = App::GetApplication();
+            if (auto* doc = app.getDocument("close_document_hyphen_test")) {
+                app.closeDocument(doc);
+            }
+        }
+    } cleanup;
+
+    Base::Interpreter().runString("import FreeCAD as App\n"
+                                  "App.newDocument('close-document-hyphen-test')\n");
+
+    auto* doc = App::GetApplication().getDocument("close_document_hyphen_test");
+    ASSERT_NE(doc, nullptr);
+    EXPECT_STREQ(doc->Label.getValue(), "close-document-hyphen-test");
+
+    Base::Interpreter().runString("App.closeDocument('close-document-hyphen-test')\n");
+
+    EXPECT_EQ(App::GetApplication().getDocument("close_document_hyphen_test"), nullptr);
+}
+
+TEST_F(ApplicationTest, closeDocumentPythonAcceptsSanitizedDocumentIdentifierWithCustomLabel)
+{
+    struct Cleanup
+    {
+        ~Cleanup()
+        {
+            auto& app = App::GetApplication();
+            if (auto* doc = app.getDocument("close_document_custom_label_test")) {
+                app.closeDocument(doc);
+            }
+        }
+    } cleanup;
+
+    Base::Interpreter().runString("import FreeCAD as App\n"
+                                  "App.newDocument('close-document-custom-label-test', "
+                                  "'Custom document label')\n");
+
+    auto* doc = App::GetApplication().getDocument("close_document_custom_label_test");
+    ASSERT_NE(doc, nullptr);
+    EXPECT_STREQ(doc->Label.getValue(), "Custom document label");
+
+    Base::Interpreter().runString("App.closeDocument('close-document-custom-label-test')\n");
+
+    EXPECT_EQ(App::GetApplication().getDocument("close_document_custom_label_test"), nullptr);
+}
+
+TEST_F(ApplicationTest, closeDocumentPythonRejectsLabelIdentifierConflict)
+{
+    const std::string firstName {"close_document_identifier_conflict"};
+    const std::string secondName {"close_document_identifier_conflict001"};
+
+    struct Cleanup
+    {
+        const std::string& firstName;
+        const std::string& secondName;
+
+        ~Cleanup()
+        {
+            auto& app = App::GetApplication();
+            if (auto* doc = app.getDocument(firstName.c_str())) {
+                app.closeDocument(doc);
+            }
+            if (auto* doc = app.getDocument(secondName.c_str())) {
+                app.closeDocument(doc);
+            }
+        }
+    } cleanup {firstName, secondName};
+
+    auto& app = App::GetApplication();
+    auto* first = app.newDocument(firstName.c_str(), "existing-label");
+    auto* second = app.newDocument("close-document-identifier-conflict");
+
+    ASSERT_NE(first, nullptr);
+    ASSERT_NE(second, nullptr);
+    ASSERT_NE(first, second);
+    EXPECT_STREQ(first->getName(), firstName.c_str());
+    EXPECT_STREQ(second->getName(), secondName.c_str());
+    EXPECT_STREQ(second->Label.getValue(), "close-document-identifier-conflict");
+
+    EXPECT_THROW(Base::Interpreter().runString("import FreeCAD as App\n"
+                                               "App.closeDocument('close-document-identifier-conflict')\n"),
+                 Base::Exception);
+    EXPECT_EQ(app.getDocument(firstName.c_str()), first);
+    EXPECT_EQ(app.getDocument(secondName.c_str()), second);
+}


### PR DESCRIPTION
## Summary
- Resolve `FreeCAD.closeDocument(str)` by exact internal document name first, then by the sanitized identifier produced from the requested name.
- Refuse to close when the requested string also matches a different document label, so ambiguous label-vs-identifier cases do not close the wrong document.
- Add regression coverage for the default-label case, a custom-label case, and the conflict guard.

## Issues
Fixes #15966

## Validation
- `git -c core.whitespace=blank-at-eof,space-before-tab,cr-at-eol diff --check`
- Attempted `cmake --build . --target App_tests_run --config Release -j 2`, but this checkout has no configured CMake build cache, so the local test binary could not be run here.

## AI assistance
I used AI-assisted tooling as an assistive aid while preparing this patch. The resulting code and tests were reviewed and revised for the specific document-name behavior, including the collision case where a requested name's sanitized identifier and visible label can refer to different open documents.