### PR TITLE
CAM: Linking - Replace Path.fromShape() by cmdsForEdge()

### DIFF
--- a/src/Mod/CAM/Path/Base/Generator/linking.py
+++ b/src/Mod/CAM/Path/Base/Generator/linking.py
@@ -152,24 +152,12 @@ def get_linking_moves(
         if is_travel_collision_free(
             wire, collision_model, tool_shape, tool_diameter, collision_clearance
         ):
-            cmds = Path.fromShape(wire).Commands
-            # Ensure all commands have complete XYZ coordinates
-            # Path.fromShape() may omit coordinates that don't change
-            current_pos = start_position
-            complete_cmds = []
-            for i, cmd in enumerate(cmds):
-                params = dict(cmd.Parameters)
-                # Fill in missing coordinates from current position
-                x = params.get("X", current_pos.x)
-                y = params.get("Y", current_pos.y)
-                # For the last command (plunge to target), use target.z if Z is missing
-                if "Z" not in params and i == len(cmds) - 1:
-                    z = target_position.z
-                else:
-                    z = params.get("Z", current_pos.z)
-                complete_cmds.append(Path.Command("G0", {"X": x, "Y": y, "Z": z}))
-                current_pos = Vector(x, y, z)
-            return complete_cmds
+            commands = []
+            for e in wire.Edges:
+                cmd = Path.Geom.cmdsForEdge(e)[0]
+                cmd.Name = "G0"
+                commands.append(cmd)
+            return commands
 
     raise RuntimeError("No collision-free path found between start and target positions")
 


### PR DESCRIPTION
### Example of problem

Project: [linking_bug.zip](https://github.com/user-attachments/files/28272675/linking_bug.zip)

`X` coordinate of left hole is 0
Linking missed `X` move

<img width="1172" height="358" alt="Screenshot_20260526_184038_hor_lossy" src="https://github.com/user-attachments/assets/9062f8fd-7aa6-45ac-84c3-e96579d88a22" />

---

### Description of the Issue

`Path.fromShape()` and `Path.fromShapes()` contains glitches related to `x = 0` and/or `y = 0` coordinates in initial rapid moves
We already fight with it in `Area.py`

https://github.com/FreeCAD/FreeCAD/blob/b823ead1b92eab085f5f08e19a251034fc6d9940/src/Mod/CAM/Path/Op/Area.py#L394-L398

https://github.com/FreeCAD/FreeCAD/blob/b823ead1b92eab085f5f08e19a251034fc6d9940/src/Mod/CAM/Path/Op/Area.py#L334-L335

---

### Changes

There are not too much commands in linking moves to care about performance and fight with this glitches again
I suggest to replace `Path.fromShape()` by `Path.Geom.cmdsForEdge()`, which works absolutely predictably

---

### Performance

I assumed that `cmdsForEdge()` will be slower, but the result of `timeit(..., number=1000)`
- old code: 0.04 sec
- new code: 0.03 sec

`Path.fromShape()` works 20 times faster than `cmdsForEdge()`,
but post-processing of the result of `Path.fromShape()` is very slow
So in the end `cmdsForEdge()` is faster than `Path.fromShape()`

https://github.com/FreeCAD/FreeCAD/blob/c083a08b9d9ea5d6693ecdcbfc88b6c172502a86/src/Mod/CAM/Path/Base/Generator/linking.py#L155-L171
