### PR TITLE
CAM: Update Job Task Panel GUI

### DIFF
--- a/src/Mod/CAM/Gui/Resources/Path.qrc
+++ b/src/Mod/CAM/Gui/Resources/Path.qrc
@@ -1,5 +1,9 @@
 <RCC>
     <qresource>
+        <file>icons/origin-x.svg</file>
+        <file>icons/origin-y.svg</file>
+        <file>icons/origin-z.svg</file>
+        <file>icons/set-origin.svg</file>
         <file>icons/CAM_Adaptive.svg</file>
         <file>icons/CAM_3DPocket.svg</file>
         <file>icons/CAM_3DSurface.svg</file>
@@ -73,6 +77,18 @@
         <file>icons/CAM_RotarySurface.svg</file>
         <file>icons/CAM_Waterline.svg</file>
         <file>icons/arrow-ccw.svg</file>
+        <file>icons/arrow-ccw-x.svg</file>
+        <file>icons/arrow-ccw-y.svg</file>
+        <file>icons/arrow-ccw-z.svg</file>
+        <file>icons/arrow-cw-x.svg</file>
+        <file>icons/arrow-cw-y.svg</file>
+        <file>icons/arrow-cw-z.svg</file>
+        <file>icons/arrow-down-y.svg</file>
+        <file>icons/arrow-down-z.svg</file>
+        <file>icons/arrow-left-x.svg</file>
+        <file>icons/arrow-right-x.svg</file>
+        <file>icons/arrow-up-y.svg</file>
+        <file>icons/arrow-up-z.svg</file>
         <file>icons/arrow-cw.svg</file>
         <file>icons/arrow-down.svg</file>
         <file>icons/arrow-left-down.svg</file>
@@ -82,6 +98,7 @@
         <file>icons/arrow-right-up.svg</file>
         <file>icons/arrow-right.svg</file>
         <file>icons/arrow-up.svg</file>
+        <file>icons/move-to-origin.svg</file>
         <file>icons/edge-join-miter-not.svg</file>
         <file>icons/edge-join-miter.svg</file>
         <file>icons/edge-join-round-not.svg</file>
@@ -164,5 +181,9 @@
         <file>preferences/Advanced.ui</file>
         <file>preferences/PathDressupHoldingTags.ui</file>
         <file>preferences/PathJob.ui</file>
+        <file>icons/model.svg</file>
+        <file>icons/stock.svg</file>
+        <file>icons/center-in-stock.svg</file>
+        <file>icons/xy-in-stock.svg</file>
     </qresource>
 </RCC>

--- a/src/Mod/CAM/Gui/Resources/Path.qrc
+++ b/src/Mod/CAM/Gui/Resources/Path.qrc
@@ -1,5 +1,9 @@
 <RCC>
     <qresource>
+        <file>icons/origin-x.svg</file>
+        <file>icons/origin-y.svg</file>
+        <file>icons/origin-z.svg</file>
+        <file>icons/set-origin.svg</file>
         <file>icons/CAM_Adaptive.svg</file>
         <file>icons/CAM_3DPocket.svg</file>
         <file>icons/CAM_3DSurface.svg</file>
@@ -81,6 +85,7 @@
         <file>icons/arrow-right-up.svg</file>
         <file>icons/arrow-right.svg</file>
         <file>icons/arrow-up.svg</file>
+        <file>icons/move-to-origin.svg</file>
         <file>icons/edge-join-miter-not.svg</file>
         <file>icons/edge-join-miter.svg</file>
         <file>icons/edge-join-round-not.svg</file>
@@ -163,5 +168,9 @@
         <file>preferences/Advanced.ui</file>
         <file>preferences/PathDressupHoldingTags.ui</file>
         <file>preferences/PathJob.ui</file>
+        <file>icons/model.svg</file>
+        <file>icons/stock.svg</file>
+        <file>icons/center-in-stock.svg</file>
+        <file>icons/xy-in-stock.svg</file>
     </qresource>
 </RCC>

--- a/src/Mod/CAM/Gui/Resources/icons/arrow-ccw-x.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/arrow-ccw-x.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64px" height="64px" id="svg3000" sodipodi:version="0.32" inkscape:version="0.48.5 r10040" sodipodi:docname="arrow-ccw.svg" inkscape:output_extension="org.inkscape.output.svg.inkscape" version="1.1">
+  <defs id="defs3002">
+    <linearGradient id="linearGradient3393">
+      <stop style="stop-color:#a8121c;stop-opacity:1" offset="0" id="stop3395"/>
+      <stop style="stop-color:#f2555f;stop-opacity:1" offset="1" id="stop3397"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3393" id="linearGradient3399" x1="1699.6969" y1="1840.5964" x2="2044.969" y2="1629.2852" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.25534521,-0.95296128,0.96517316,0.25861737,-283.46374,3042.7301)"/>
+    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_z="64 : 32 : 1" inkscape:persp3d-origin="32 : 21.333333 : 1" id="perspective3008"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3393-7" id="linearGradient3399-1" x1="1669.7314" y1="1726.0585" x2="2067.1702" y2="1726.0585" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.98657811,0,0,0.99922078,20.129251,-2.6811697)"/>
+    <linearGradient id="linearGradient3393-7">
+      <stop style="stop-color:#a8121c;stop-opacity:1;" offset="0" id="stop3395-4"/>
+      <stop style="stop-color:#f2555f;stop-opacity:1;" offset="1" id="stop3397-0"/>
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="11.283648" inkscape:cx="11.6776" inkscape:cy="30.967582" inkscape:current-layer="g3405" showgrid="true" inkscape:document-units="px" inkscape:grid-bbox="true" inkscape:window-width="1920" inkscape:window-height="1137" inkscape:window-x="0" inkscape:window-y="27" inkscape:snap-bbox="true" inkscape:snap-nodes="true" inkscape:snap-global="true" inkscape:window-maximized="1">
+    <inkscape:grid type="xygrid" id="grid2990" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
+  </sodipodi:namedview>
+  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
+    <g id="g3405" transform="matrix(0.1369365,0,0,0.1369365,-222.21754,-203.36512)">
+      <path id="path2396" d="m 1880.5373,1902.9135 c 106.1484,-2.3589 189.8111,-89.4894 186.7502,-194.4908 -3.0611,-105.0013 -91.6921,-188.303 -197.8404,-185.9442 -55.9403,1.2433 -105.6257,26.0285 -139.6708,64.565 l -44.1198,-35.1059 -37.4604,176.0561 178.5573,-51.1979 -41.4836,-45.5767 c 22.1039,-24.0141 53.73,-39.3793 89.2346,-40.1684 69.1228,-1.536 126.8308,52.7017 128.824,121.0778 1.9931,68.3762 -52.4788,125.1377 -121.6017,126.6738 -19.7778,0.4394 -38.6039,-3.7029 -55.475,-11.4237 l -31.3948,57.7752 c 26.0336,11.9963 55.1182,18.4389 85.6804,17.7597 z" style="fill:url(#linearGradient3399);fill-opacity:1;fill-rule:evenodd;stroke:#3d0508;stroke-width:14.60531044;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" inkscape:connector-curvature="0" sodipodi:nodetypes="ssscccccsssccs"/>
+      <path id="path2396-9" d="m 1885.0707,1887.6865 c 78.8923,-1.5361 138.9163,-54.9141 161.631,-130.1829 32.4053,-107.38 -55.6977,-196.5384 -121.2835,-214.3605 -100.7263,-27.3711 -169.4379,33.3038 -195.1926,62.9466 l -32.9948,-25.9656 -28.5313,126.5336 130.8309,-37.2342 -36.266,-37.8417 c 59.0149,-55.9052 101.9936,-63.2133 153.0445,-50.3357 52.2393,13.1775 118.2783,78.5389 98.4143,164.5079 -17.2644,74.7179 -82.9486,105.1278 -134.9353,106.5777 -17.3999,2.1436 -33.9339,-2.2822 -47.106,-6.2036 l -17.5742,32.2101 c 20.5378,6.6037 46.0171,9.8144 69.963,9.3483 z" style="fill:none;stroke:#f2555f;stroke-width:14.60530949;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" inkscape:connector-curvature="0" sodipodi:nodetypes="ssscccccsscccs"/>
+    </g>
+  </g>
+  <metadata id="metadata5324">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title/>
+        <cc:license rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html"/>
+        <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[wmayer]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_Rotate.svg</dc:identifier>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description>An arrow in a circular shape with the head curving towards the tail</dc:description>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>curved</rdf:li>
+            <rdf:li>refresh</rdf:li>
+            <rdf:li>rotate</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:title>arrow-ccw-x</dc:title>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/arrow-ccw-y.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/arrow-ccw-y.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64px" height="64px" id="svg3000" sodipodi:version="0.32" inkscape:version="0.48.5 r10040" sodipodi:docname="arrow-ccw.svg" inkscape:output_extension="org.inkscape.output.svg.inkscape" version="1.1">
+  <defs id="defs3002">
+    <linearGradient id="linearGradient3393">
+      <stop style="stop-color:#0f7a1c;stop-opacity:1" offset="0" id="stop3395"/>
+      <stop style="stop-color:#3ad14a;stop-opacity:1" offset="1" id="stop3397"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3393" id="linearGradient3399" x1="1699.6969" y1="1840.5964" x2="2044.969" y2="1629.2852" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.25534521,-0.95296128,0.96517316,0.25861737,-283.46374,3042.7301)"/>
+    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_z="64 : 32 : 1" inkscape:persp3d-origin="32 : 21.333333 : 1" id="perspective3008"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3393-7" id="linearGradient3399-1" x1="1669.7314" y1="1726.0585" x2="2067.1702" y2="1726.0585" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.98657811,0,0,0.99922078,20.129251,-2.6811697)"/>
+    <linearGradient id="linearGradient3393-7">
+      <stop style="stop-color:#0f7a1c;stop-opacity:1;" offset="0" id="stop3395-4"/>
+      <stop style="stop-color:#3ad14a;stop-opacity:1;" offset="1" id="stop3397-0"/>
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="11.283648" inkscape:cx="11.6776" inkscape:cy="30.967582" inkscape:current-layer="g3405" showgrid="true" inkscape:document-units="px" inkscape:grid-bbox="true" inkscape:window-width="1920" inkscape:window-height="1137" inkscape:window-x="0" inkscape:window-y="27" inkscape:snap-bbox="true" inkscape:snap-nodes="true" inkscape:snap-global="true" inkscape:window-maximized="1">
+    <inkscape:grid type="xygrid" id="grid2990" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
+  </sodipodi:namedview>
+  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
+    <g id="g3405" transform="matrix(0.1369365,0,0,0.1369365,-222.21754,-203.36512)">
+      <path id="path2396" d="m 1880.5373,1902.9135 c 106.1484,-2.3589 189.8111,-89.4894 186.7502,-194.4908 -3.0611,-105.0013 -91.6921,-188.303 -197.8404,-185.9442 -55.9403,1.2433 -105.6257,26.0285 -139.6708,64.565 l -44.1198,-35.1059 -37.4604,176.0561 178.5573,-51.1979 -41.4836,-45.5767 c 22.1039,-24.0141 53.73,-39.3793 89.2346,-40.1684 69.1228,-1.536 126.8308,52.7017 128.824,121.0778 1.9931,68.3762 -52.4788,125.1377 -121.6017,126.6738 -19.7778,0.4394 -38.6039,-3.7029 -55.475,-11.4237 l -31.3948,57.7752 c 26.0336,11.9963 55.1182,18.4389 85.6804,17.7597 z" style="fill:url(#linearGradient3399);fill-opacity:1;fill-rule:evenodd;stroke:#05300a;stroke-width:14.60531044;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" inkscape:connector-curvature="0" sodipodi:nodetypes="ssscccccsssccs"/>
+      <path id="path2396-9" d="m 1885.0707,1887.6865 c 78.8923,-1.5361 138.9163,-54.9141 161.631,-130.1829 32.4053,-107.38 -55.6977,-196.5384 -121.2835,-214.3605 -100.7263,-27.3711 -169.4379,33.3038 -195.1926,62.9466 l -32.9948,-25.9656 -28.5313,126.5336 130.8309,-37.2342 -36.266,-37.8417 c 59.0149,-55.9052 101.9936,-63.2133 153.0445,-50.3357 52.2393,13.1775 118.2783,78.5389 98.4143,164.5079 -17.2644,74.7179 -82.9486,105.1278 -134.9353,106.5777 -17.3999,2.1436 -33.9339,-2.2822 -47.106,-6.2036 l -17.5742,32.2101 c 20.5378,6.6037 46.0171,9.8144 69.963,9.3483 z" style="fill:none;stroke:#3ad14a;stroke-width:14.60530949;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" inkscape:connector-curvature="0" sodipodi:nodetypes="ssscccccsscccs"/>
+    </g>
+  </g>
+  <metadata id="metadata5324">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title/>
+        <cc:license rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html"/>
+        <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[wmayer]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_Rotate.svg</dc:identifier>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description>An arrow in a circular shape with the head curving towards the tail</dc:description>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>curved</rdf:li>
+            <rdf:li>refresh</rdf:li>
+            <rdf:li>rotate</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:title>arrow-ccw-y</dc:title>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/arrow-ccw-z.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/arrow-ccw-z.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64px" height="64px" id="svg3000" sodipodi:version="0.32" inkscape:version="0.48.5 r10040" sodipodi:docname="arrow-ccw.svg" inkscape:output_extension="org.inkscape.output.svg.inkscape" version="1.1">
+  <defs id="defs3002">
+    <linearGradient id="linearGradient3393">
+      <stop style="stop-color:#1f4494;stop-opacity:1" offset="0" id="stop3395"/>
+      <stop style="stop-color:#5a8cf0;stop-opacity:1" offset="1" id="stop3397"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3393" id="linearGradient3399" x1="1699.6969" y1="1840.5964" x2="2044.969" y2="1629.2852" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.25534521,-0.95296128,0.96517316,0.25861737,-283.46374,3042.7301)"/>
+    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_z="64 : 32 : 1" inkscape:persp3d-origin="32 : 21.333333 : 1" id="perspective3008"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3393-7" id="linearGradient3399-1" x1="1669.7314" y1="1726.0585" x2="2067.1702" y2="1726.0585" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.98657811,0,0,0.99922078,20.129251,-2.6811697)"/>
+    <linearGradient id="linearGradient3393-7">
+      <stop style="stop-color:#1f4494;stop-opacity:1;" offset="0" id="stop3395-4"/>
+      <stop style="stop-color:#5a8cf0;stop-opacity:1;" offset="1" id="stop3397-0"/>
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="11.283648" inkscape:cx="11.6776" inkscape:cy="30.967582" inkscape:current-layer="g3405" showgrid="true" inkscape:document-units="px" inkscape:grid-bbox="true" inkscape:window-width="1920" inkscape:window-height="1137" inkscape:window-x="0" inkscape:window-y="27" inkscape:snap-bbox="true" inkscape:snap-nodes="true" inkscape:snap-global="true" inkscape:window-maximized="1">
+    <inkscape:grid type="xygrid" id="grid2990" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
+  </sodipodi:namedview>
+  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
+    <g id="g3405" transform="matrix(0.1369365,0,0,0.1369365,-222.21754,-203.36512)">
+      <path id="path2396" d="m 1880.5373,1902.9135 c 106.1484,-2.3589 189.8111,-89.4894 186.7502,-194.4908 -3.0611,-105.0013 -91.6921,-188.303 -197.8404,-185.9442 -55.9403,1.2433 -105.6257,26.0285 -139.6708,64.565 l -44.1198,-35.1059 -37.4604,176.0561 178.5573,-51.1979 -41.4836,-45.5767 c 22.1039,-24.0141 53.73,-39.3793 89.2346,-40.1684 69.1228,-1.536 126.8308,52.7017 128.824,121.0778 1.9931,68.3762 -52.4788,125.1377 -121.6017,126.6738 -19.7778,0.4394 -38.6039,-3.7029 -55.475,-11.4237 l -31.3948,57.7752 c 26.0336,11.9963 55.1182,18.4389 85.6804,17.7597 z" style="fill:url(#linearGradient3399);fill-opacity:1;fill-rule:evenodd;stroke:#0a1a3d;stroke-width:14.60531044;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" inkscape:connector-curvature="0" sodipodi:nodetypes="ssscccccsssccs"/>
+      <path id="path2396-9" d="m 1885.0707,1887.6865 c 78.8923,-1.5361 138.9163,-54.9141 161.631,-130.1829 32.4053,-107.38 -55.6977,-196.5384 -121.2835,-214.3605 -100.7263,-27.3711 -169.4379,33.3038 -195.1926,62.9466 l -32.9948,-25.9656 -28.5313,126.5336 130.8309,-37.2342 -36.266,-37.8417 c 59.0149,-55.9052 101.9936,-63.2133 153.0445,-50.3357 52.2393,13.1775 118.2783,78.5389 98.4143,164.5079 -17.2644,74.7179 -82.9486,105.1278 -134.9353,106.5777 -17.3999,2.1436 -33.9339,-2.2822 -47.106,-6.2036 l -17.5742,32.2101 c 20.5378,6.6037 46.0171,9.8144 69.963,9.3483 z" style="fill:none;stroke:#5a8cf0;stroke-width:14.60530949;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" inkscape:connector-curvature="0" sodipodi:nodetypes="ssscccccsscccs"/>
+    </g>
+  </g>
+  <metadata id="metadata5324">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title/>
+        <cc:license rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html"/>
+        <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[wmayer]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_Rotate.svg</dc:identifier>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description>An arrow in a circular shape with the head curving towards the tail</dc:description>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>curved</rdf:li>
+            <rdf:li>refresh</rdf:li>
+            <rdf:li>rotate</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:title>arrow-ccw-z</dc:title>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/arrow-cw-x.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/arrow-cw-x.svg
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg3000"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="arrow-cw.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs3002">
+    <linearGradient
+       id="linearGradient3393">
+      <stop
+         style="stop-color:#a8121c;stop-opacity:1"
+         offset="0"
+         id="stop3395" />
+      <stop
+         style="stop-color:#f2555f;stop-opacity:1"
+         offset="1"
+         id="stop3397" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3393"
+       id="linearGradient3399"
+       x1="1650.4493"
+       y1="1752.9712"
+       x2="2052.8906"
+       y2="1767.5603"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.25534521,-0.95296128,-0.96517316,0.25861737,3999.0287,3042.7301)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective3008" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3393-7"
+       id="linearGradient3399-1"
+       x1="1669.7314"
+       y1="1726.0585"
+       x2="2067.1702"
+       y2="1726.0585"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98657811,0,0,0.99922078,20.129251,-2.6811697)" />
+    <linearGradient
+       id="linearGradient3393-7">
+      <stop
+         style="stop-color:#a8121c;stop-opacity:1;"
+         offset="0"
+         id="stop3395-4" />
+      <stop
+         style="stop-color:#f2555f;stop-opacity:1;"
+         offset="1"
+         id="stop3397-0" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.989372"
+     inkscape:cx="-14.680107"
+     inkscape:cy="32.691314"
+     inkscape:current-layer="g3405"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="745"
+     inkscape:window-height="464"
+     inkscape:window-x="1173"
+     inkscape:window-y="522"
+     inkscape:snap-bbox="true"
+     inkscape:snap-nodes="true"
+     inkscape:snap-global="true"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2990"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <g
+       id="g3405"
+       transform="matrix(0.1369365,0,0,0.1369365,-222.21754,-203.36512)">
+      <path
+         id="path2396"
+         d="m 1835.0277,1902.9135 c -106.1484,-2.3589 -189.8111,-89.4894 -186.7502,-194.4908 3.0611,-105.0013 91.6921,-188.303 197.8404,-185.9442 55.9403,1.2433 105.6257,26.0285 139.6708,64.565 l 44.1198,-35.1059 37.4604,176.0561 -178.5573,-51.1979 41.4836,-45.5767 c -22.1039,-24.0141 -53.73,-39.3793 -89.2346,-40.1684 -69.1228,-1.536 -126.8308,52.7017 -128.824,121.0778 -1.9931,68.3762 52.4788,125.1377 121.6017,126.6738 19.7778,0.4394 38.6039,-3.7029 55.475,-11.4237 l 31.3948,57.7752 c -26.0336,11.9963 -55.1182,18.4389 -85.6804,17.7597 z"
+         style="fill:url(#linearGradient3399);fill-opacity:1;fill-rule:evenodd;stroke:#3d0508;stroke-width:14.60531044000000000;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssscccccsssccs" />
+      <path
+         id="path2396-9"
+         d="m 1830.4943,1887.6865 c -78.8923,-1.5361 -138.9163,-54.9141 -161.631,-130.1829 -32.4053,-107.38 55.6977,-196.5384 121.2835,-214.3605 100.7263,-27.3711 169.4379,33.3038 195.1926,62.9466 l 32.9948,-25.9656 28.5313,126.5336 -130.8309,-37.2342 36.266,-37.8417 c -59.0149,-55.9052 -101.9936,-63.2133 -153.0445,-50.3357 -52.2393,13.1775 -118.2783,78.5389 -98.4143,164.5079 17.2644,74.7179 82.9486,105.1278 134.9353,106.5777 17.3999,2.1436 33.9339,-2.2822 47.106,-6.2036 l 17.5742,32.2101 c -20.5378,6.6037 -46.0171,9.8144 -69.963,9.3483 z"
+         style="fill:none;stroke:#f2555f;stroke-width:14.60530949;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssscccccsscccs" />
+    </g>
+  </g>
+  <metadata
+     id="metadata5324">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <cc:license
+           rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html" />
+        <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[wmayer]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_Rotate.svg</dc:identifier>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description>An arrow in a circular shape with the head curving towards the tail</dc:description>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>curved</rdf:li>
+            <rdf:li>refresh</rdf:li>
+            <rdf:li>rotate</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:title>arrow-cw-x</dc:title>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/arrow-cw-y.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/arrow-cw-y.svg
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg3000"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="arrow-cw.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs3002">
+    <linearGradient
+       id="linearGradient3393">
+      <stop
+         style="stop-color:#0f7a1c;stop-opacity:1"
+         offset="0"
+         id="stop3395" />
+      <stop
+         style="stop-color:#3ad14a;stop-opacity:1"
+         offset="1"
+         id="stop3397" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3393"
+       id="linearGradient3399"
+       x1="1650.4493"
+       y1="1752.9712"
+       x2="2052.8906"
+       y2="1767.5603"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.25534521,-0.95296128,-0.96517316,0.25861737,3999.0287,3042.7301)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective3008" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3393-7"
+       id="linearGradient3399-1"
+       x1="1669.7314"
+       y1="1726.0585"
+       x2="2067.1702"
+       y2="1726.0585"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98657811,0,0,0.99922078,20.129251,-2.6811697)" />
+    <linearGradient
+       id="linearGradient3393-7">
+      <stop
+         style="stop-color:#0f7a1c;stop-opacity:1;"
+         offset="0"
+         id="stop3395-4" />
+      <stop
+         style="stop-color:#3ad14a;stop-opacity:1;"
+         offset="1"
+         id="stop3397-0" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.989372"
+     inkscape:cx="-14.680107"
+     inkscape:cy="32.691314"
+     inkscape:current-layer="g3405"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="745"
+     inkscape:window-height="464"
+     inkscape:window-x="1173"
+     inkscape:window-y="522"
+     inkscape:snap-bbox="true"
+     inkscape:snap-nodes="true"
+     inkscape:snap-global="true"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2990"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <g
+       id="g3405"
+       transform="matrix(0.1369365,0,0,0.1369365,-222.21754,-203.36512)">
+      <path
+         id="path2396"
+         d="m 1835.0277,1902.9135 c -106.1484,-2.3589 -189.8111,-89.4894 -186.7502,-194.4908 3.0611,-105.0013 91.6921,-188.303 197.8404,-185.9442 55.9403,1.2433 105.6257,26.0285 139.6708,64.565 l 44.1198,-35.1059 37.4604,176.0561 -178.5573,-51.1979 41.4836,-45.5767 c -22.1039,-24.0141 -53.73,-39.3793 -89.2346,-40.1684 -69.1228,-1.536 -126.8308,52.7017 -128.824,121.0778 -1.9931,68.3762 52.4788,125.1377 121.6017,126.6738 19.7778,0.4394 38.6039,-3.7029 55.475,-11.4237 l 31.3948,57.7752 c -26.0336,11.9963 -55.1182,18.4389 -85.6804,17.7597 z"
+         style="fill:url(#linearGradient3399);fill-opacity:1;fill-rule:evenodd;stroke:#05300a;stroke-width:14.60531044000000000;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssscccccsssccs" />
+      <path
+         id="path2396-9"
+         d="m 1830.4943,1887.6865 c -78.8923,-1.5361 -138.9163,-54.9141 -161.631,-130.1829 -32.4053,-107.38 55.6977,-196.5384 121.2835,-214.3605 100.7263,-27.3711 169.4379,33.3038 195.1926,62.9466 l 32.9948,-25.9656 28.5313,126.5336 -130.8309,-37.2342 36.266,-37.8417 c -59.0149,-55.9052 -101.9936,-63.2133 -153.0445,-50.3357 -52.2393,13.1775 -118.2783,78.5389 -98.4143,164.5079 17.2644,74.7179 82.9486,105.1278 134.9353,106.5777 17.3999,2.1436 33.9339,-2.2822 47.106,-6.2036 l 17.5742,32.2101 c -20.5378,6.6037 -46.0171,9.8144 -69.963,9.3483 z"
+         style="fill:none;stroke:#3ad14a;stroke-width:14.60530949;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssscccccsscccs" />
+    </g>
+  </g>
+  <metadata
+     id="metadata5324">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <cc:license
+           rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html" />
+        <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[wmayer]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_Rotate.svg</dc:identifier>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description>An arrow in a circular shape with the head curving towards the tail</dc:description>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>curved</rdf:li>
+            <rdf:li>refresh</rdf:li>
+            <rdf:li>rotate</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:title>arrow-cw-y</dc:title>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/arrow-cw-z.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/arrow-cw-z.svg
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg3000"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="arrow-cw.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs3002">
+    <linearGradient
+       id="linearGradient3393">
+      <stop
+         style="stop-color:#1f4494;stop-opacity:1"
+         offset="0"
+         id="stop3395" />
+      <stop
+         style="stop-color:#5a8cf0;stop-opacity:1"
+         offset="1"
+         id="stop3397" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3393"
+       id="linearGradient3399"
+       x1="1650.4493"
+       y1="1752.9712"
+       x2="2052.8906"
+       y2="1767.5603"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.25534521,-0.95296128,-0.96517316,0.25861737,3999.0287,3042.7301)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective3008" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3393-7"
+       id="linearGradient3399-1"
+       x1="1669.7314"
+       y1="1726.0585"
+       x2="2067.1702"
+       y2="1726.0585"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98657811,0,0,0.99922078,20.129251,-2.6811697)" />
+    <linearGradient
+       id="linearGradient3393-7">
+      <stop
+         style="stop-color:#1f4494;stop-opacity:1;"
+         offset="0"
+         id="stop3395-4" />
+      <stop
+         style="stop-color:#5a8cf0;stop-opacity:1;"
+         offset="1"
+         id="stop3397-0" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.989372"
+     inkscape:cx="-14.680107"
+     inkscape:cy="32.691314"
+     inkscape:current-layer="g3405"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="745"
+     inkscape:window-height="464"
+     inkscape:window-x="1173"
+     inkscape:window-y="522"
+     inkscape:snap-bbox="true"
+     inkscape:snap-nodes="true"
+     inkscape:snap-global="true"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2990"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <g
+       id="g3405"
+       transform="matrix(0.1369365,0,0,0.1369365,-222.21754,-203.36512)">
+      <path
+         id="path2396"
+         d="m 1835.0277,1902.9135 c -106.1484,-2.3589 -189.8111,-89.4894 -186.7502,-194.4908 3.0611,-105.0013 91.6921,-188.303 197.8404,-185.9442 55.9403,1.2433 105.6257,26.0285 139.6708,64.565 l 44.1198,-35.1059 37.4604,176.0561 -178.5573,-51.1979 41.4836,-45.5767 c -22.1039,-24.0141 -53.73,-39.3793 -89.2346,-40.1684 -69.1228,-1.536 -126.8308,52.7017 -128.824,121.0778 -1.9931,68.3762 52.4788,125.1377 121.6017,126.6738 19.7778,0.4394 38.6039,-3.7029 55.475,-11.4237 l 31.3948,57.7752 c -26.0336,11.9963 -55.1182,18.4389 -85.6804,17.7597 z"
+         style="fill:url(#linearGradient3399);fill-opacity:1;fill-rule:evenodd;stroke:#0a1a3d;stroke-width:14.60531044000000000;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssscccccsssccs" />
+      <path
+         id="path2396-9"
+         d="m 1830.4943,1887.6865 c -78.8923,-1.5361 -138.9163,-54.9141 -161.631,-130.1829 -32.4053,-107.38 55.6977,-196.5384 121.2835,-214.3605 100.7263,-27.3711 169.4379,33.3038 195.1926,62.9466 l 32.9948,-25.9656 28.5313,126.5336 -130.8309,-37.2342 36.266,-37.8417 c -59.0149,-55.9052 -101.9936,-63.2133 -153.0445,-50.3357 -52.2393,13.1775 -118.2783,78.5389 -98.4143,164.5079 17.2644,74.7179 82.9486,105.1278 134.9353,106.5777 17.3999,2.1436 33.9339,-2.2822 47.106,-6.2036 l 17.5742,32.2101 c -20.5378,6.6037 -46.0171,9.8144 -69.963,9.3483 z"
+         style="fill:none;stroke:#5a8cf0;stroke-width:14.60530949;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssscccccsscccs" />
+    </g>
+  </g>
+  <metadata
+     id="metadata5324">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <cc:license
+           rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html" />
+        <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[wmayer]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_Rotate.svg</dc:identifier>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description>An arrow in a circular shape with the head curving towards the tail</dc:description>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>curved</rdf:li>
+            <rdf:li>refresh</rdf:li>
+            <rdf:li>rotate</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:title>arrow-cw-z</dc:title>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/arrow-down-y.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/arrow-down-y.svg
@@ -1,0 +1,311 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg6248"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="arrow-down.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs6250">
+    <linearGradient
+       id="linearGradient3806">
+      <stop
+         id="stop3808"
+         offset="0"
+         style="stop-color:#3ad14a;stop-opacity:1" />
+      <stop
+         id="stop3810"
+         offset="1"
+         style="stop-color:#0f7a1c;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3253">
+      <stop
+         style="stop-color:#3ad14a;stop-opacity:1;"
+         offset="0"
+         id="stop3255" />
+      <stop
+         style="stop-color:#0f7a1c;stop-opacity:1;"
+         offset="1"
+         id="stop3257" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253"
+       id="radialGradient3270"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-69.025653,-0.11788499)"
+       cx="10.328116"
+       cy="25.129232"
+       fx="10.328116"
+       fy="25.129232"
+       r="27.986705" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6816">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6818" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop6820" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6781">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop6783" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:0;"
+         offset="1"
+         id="stop6785" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective6256" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6816"
+       id="radialGradient6822"
+       cx="33.369828"
+       cy="51.929391"
+       fx="33.369828"
+       fy="51.929391"
+       r="25.198714"
+       gradientTransform="matrix(1.1581633,0,0,0.6558985,-7.29237,16.126077)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3393"
+       id="linearGradient3399"
+       x1="1669.7314"
+       y1="1726.0585"
+       x2="2067.1702"
+       y2="1726.0585"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)" />
+    <linearGradient
+       id="linearGradient3393">
+      <stop
+         style="stop-color:#0f7a1c;stop-opacity:1;"
+         offset="0"
+         id="stop3395" />
+      <stop
+         style="stop-color:#3ad14a;stop-opacity:1;"
+         offset="1"
+         id="stop3397" />
+    </linearGradient>
+    <linearGradient
+       y2="1726.0585"
+       x2="2067.1702"
+       y1="1726.0585"
+       x1="1669.7314"
+       gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3270"
+       xlink:href="#linearGradient3393"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253"
+       id="radialGradient3293"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-69.025653,-0.11788499)"
+       cx="10.328116"
+       cy="25.129232"
+       fx="10.328116"
+       fy="25.129232"
+       r="27.986705" />
+    <linearGradient
+       id="linearGradient3253-6">
+      <stop
+         style="stop-color:#3ad14a;stop-opacity:1;"
+         offset="0"
+         id="stop3255-8" />
+      <stop
+         style="stop-color:#0f7a1c;stop-opacity:1;"
+         offset="1"
+         id="stop3257-7" />
+    </linearGradient>
+    <radialGradient
+       r="27.986706"
+       fy="25.129232"
+       fx="10.328116"
+       cy="25.129232"
+       cx="10.328116"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-2.1599239,-18.716253)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3337"
+       xlink:href="#linearGradient3253-6"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253-6-5"
+       id="radialGradient3270-0-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2166851,1.0433407,-0.52714011,0.61472119,-73.012055,-80.803852)"
+       cx="83.590195"
+       cy="32.60199"
+       fx="83.590195"
+       fy="32.60199"
+       r="27.986706" />
+    <linearGradient
+       id="linearGradient3253-6-5">
+      <stop
+         style="stop-color:#3ad14a;stop-opacity:1;"
+         offset="0"
+         id="stop3255-8-4" />
+      <stop
+         style="stop-color:#0f7a1c;stop-opacity:1;"
+         offset="1"
+         id="stop3257-7-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,-1.4500001,1.4705882,0,-15.05882,91.45)"
+       y2="36.079998"
+       x2="21.689653"
+       y1="29.279999"
+       x1="56.172409"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3036"
+       xlink:href="#linearGradient3895"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop3897" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="1"
+         id="stop3899" />
+    </linearGradient>
+    <linearGradient
+       y2="29.156361"
+       x2="58.053288"
+       y1="36.080002"
+       x1="21.940434"
+       gradientTransform="matrix(0,1.4500001,-1.4705882,0,79.05882,-27.45)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3012"
+       xlink:href="#linearGradient3806"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.5"
+     inkscape:cx="-39.80793"
+     inkscape:cy="28.947943"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1278"
+     inkscape:window-height="691"
+     inkscape:window-x="640"
+     inkscape:window-y="86"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3011"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata6253">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[WandererFan]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>arrow-down-y</dc:title>
+        <dc:date>2016-11-24</dc:date>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/TechDraw/Gui/Resources/icons/arrow-down.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license
+           rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html">https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>down</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Arrow pointing down</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#05300a;stroke-width:1.99999988000000010;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 57,35 -16.000001,0 0,-32 -18,0 0,32 L 7,35 32,61 z"
+       id="path3343"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
+       inkscape:export-xdpi="4.1683898"
+       inkscape:export-ydpi="4.1683898" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#3ad14a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 52.25713,37 -13.257131,0 0,-32 -14,0 0,32 L 11.710728,37 32,58 z"
+       id="path3343-2"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
+       inkscape:export-xdpi="4.1683898"
+       inkscape:export-ydpi="4.1683898" />
+  </g>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/arrow-down-z.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/arrow-down-z.svg
@@ -1,0 +1,311 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg6248"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="arrow-down.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs6250">
+    <linearGradient
+       id="linearGradient3806">
+      <stop
+         id="stop3808"
+         offset="0"
+         style="stop-color:#5a8cf0;stop-opacity:1" />
+      <stop
+         id="stop3810"
+         offset="1"
+         style="stop-color:#1f4494;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3253">
+      <stop
+         style="stop-color:#5a8cf0;stop-opacity:1;"
+         offset="0"
+         id="stop3255" />
+      <stop
+         style="stop-color:#1f4494;stop-opacity:1;"
+         offset="1"
+         id="stop3257" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253"
+       id="radialGradient3270"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-69.025653,-0.11788499)"
+       cx="10.328116"
+       cy="25.129232"
+       fx="10.328116"
+       fy="25.129232"
+       r="27.986705" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6816">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6818" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop6820" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6781">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop6783" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:0;"
+         offset="1"
+         id="stop6785" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective6256" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6816"
+       id="radialGradient6822"
+       cx="33.369828"
+       cy="51.929391"
+       fx="33.369828"
+       fy="51.929391"
+       r="25.198714"
+       gradientTransform="matrix(1.1581633,0,0,0.6558985,-7.29237,16.126077)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3393"
+       id="linearGradient3399"
+       x1="1669.7314"
+       y1="1726.0585"
+       x2="2067.1702"
+       y2="1726.0585"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)" />
+    <linearGradient
+       id="linearGradient3393">
+      <stop
+         style="stop-color:#1f4494;stop-opacity:1;"
+         offset="0"
+         id="stop3395" />
+      <stop
+         style="stop-color:#5a8cf0;stop-opacity:1;"
+         offset="1"
+         id="stop3397" />
+    </linearGradient>
+    <linearGradient
+       y2="1726.0585"
+       x2="2067.1702"
+       y1="1726.0585"
+       x1="1669.7314"
+       gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3270"
+       xlink:href="#linearGradient3393"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253"
+       id="radialGradient3293"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-69.025653,-0.11788499)"
+       cx="10.328116"
+       cy="25.129232"
+       fx="10.328116"
+       fy="25.129232"
+       r="27.986705" />
+    <linearGradient
+       id="linearGradient3253-6">
+      <stop
+         style="stop-color:#5a8cf0;stop-opacity:1;"
+         offset="0"
+         id="stop3255-8" />
+      <stop
+         style="stop-color:#1f4494;stop-opacity:1;"
+         offset="1"
+         id="stop3257-7" />
+    </linearGradient>
+    <radialGradient
+       r="27.986706"
+       fy="25.129232"
+       fx="10.328116"
+       cy="25.129232"
+       cx="10.328116"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-2.1599239,-18.716253)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3337"
+       xlink:href="#linearGradient3253-6"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253-6-5"
+       id="radialGradient3270-0-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2166851,1.0433407,-0.52714011,0.61472119,-73.012055,-80.803852)"
+       cx="83.590195"
+       cy="32.60199"
+       fx="83.590195"
+       fy="32.60199"
+       r="27.986706" />
+    <linearGradient
+       id="linearGradient3253-6-5">
+      <stop
+         style="stop-color:#5a8cf0;stop-opacity:1;"
+         offset="0"
+         id="stop3255-8-4" />
+      <stop
+         style="stop-color:#1f4494;stop-opacity:1;"
+         offset="1"
+         id="stop3257-7-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,-1.4500001,1.4705882,0,-15.05882,91.45)"
+       y2="36.079998"
+       x2="21.689653"
+       y1="29.279999"
+       x1="56.172409"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3036"
+       xlink:href="#linearGradient3895"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop3897" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="1"
+         id="stop3899" />
+    </linearGradient>
+    <linearGradient
+       y2="29.156361"
+       x2="58.053288"
+       y1="36.080002"
+       x1="21.940434"
+       gradientTransform="matrix(0,1.4500001,-1.4705882,0,79.05882,-27.45)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3012"
+       xlink:href="#linearGradient3806"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.5"
+     inkscape:cx="-39.80793"
+     inkscape:cy="28.947943"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1278"
+     inkscape:window-height="691"
+     inkscape:window-x="640"
+     inkscape:window-y="86"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3011"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata6253">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[WandererFan]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>arrow-down-z</dc:title>
+        <dc:date>2016-11-24</dc:date>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/TechDraw/Gui/Resources/icons/arrow-down.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license
+           rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html">https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>down</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Arrow pointing down</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#0a1a3d;stroke-width:1.99999988000000010;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 57,35 -16.000001,0 0,-32 -18,0 0,32 L 7,35 32,61 z"
+       id="path3343"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
+       inkscape:export-xdpi="4.1683898"
+       inkscape:export-ydpi="4.1683898" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#5a8cf0;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 52.25713,37 -13.257131,0 0,-32 -14,0 0,32 L 11.710728,37 32,58 z"
+       id="path3343-2"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
+       inkscape:export-xdpi="4.1683898"
+       inkscape:export-ydpi="4.1683898" />
+  </g>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/arrow-left-x.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/arrow-left-x.svg
@@ -1,0 +1,311 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg6248"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="arrow-left.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs6250">
+    <linearGradient
+       id="linearGradient3806">
+      <stop
+         id="stop3808"
+         offset="0"
+         style="stop-color:#f2555f;stop-opacity:1" />
+      <stop
+         id="stop3810"
+         offset="1"
+         style="stop-color:#a8121c;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3253">
+      <stop
+         style="stop-color:#f2555f;stop-opacity:1;"
+         offset="0"
+         id="stop3255" />
+      <stop
+         style="stop-color:#a8121c;stop-opacity:1;"
+         offset="1"
+         id="stop3257" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253"
+       id="radialGradient3270"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-69.025653,-0.11788499)"
+       cx="10.328116"
+       cy="25.129232"
+       fx="10.328116"
+       fy="25.129232"
+       r="27.986705" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6816">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6818" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop6820" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6781">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop6783" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:0;"
+         offset="1"
+         id="stop6785" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective6256" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6816"
+       id="radialGradient6822"
+       cx="33.369828"
+       cy="51.929391"
+       fx="33.369828"
+       fy="51.929391"
+       r="25.198714"
+       gradientTransform="matrix(1.1581633,0,0,0.6558985,-7.29237,16.126077)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3393"
+       id="linearGradient3399"
+       x1="1669.7314"
+       y1="1726.0585"
+       x2="2067.1702"
+       y2="1726.0585"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)" />
+    <linearGradient
+       id="linearGradient3393">
+      <stop
+         style="stop-color:#a8121c;stop-opacity:1;"
+         offset="0"
+         id="stop3395" />
+      <stop
+         style="stop-color:#f2555f;stop-opacity:1;"
+         offset="1"
+         id="stop3397" />
+    </linearGradient>
+    <linearGradient
+       y2="1726.0585"
+       x2="2067.1702"
+       y1="1726.0585"
+       x1="1669.7314"
+       gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3270"
+       xlink:href="#linearGradient3393"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253"
+       id="radialGradient3293"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-69.025653,-0.11788499)"
+       cx="10.328116"
+       cy="25.129232"
+       fx="10.328116"
+       fy="25.129232"
+       r="27.986705" />
+    <linearGradient
+       id="linearGradient3253-6">
+      <stop
+         style="stop-color:#f2555f;stop-opacity:1;"
+         offset="0"
+         id="stop3255-8" />
+      <stop
+         style="stop-color:#a8121c;stop-opacity:1;"
+         offset="1"
+         id="stop3257-7" />
+    </linearGradient>
+    <radialGradient
+       r="27.986706"
+       fy="25.129232"
+       fx="10.328116"
+       cy="25.129232"
+       cx="10.328116"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-2.1599239,-18.716253)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3337"
+       xlink:href="#linearGradient3253-6"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253-6-5"
+       id="radialGradient3270-0-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2166851,1.0433407,-0.52714011,0.61472119,-73.012055,-80.803852)"
+       cx="83.590195"
+       cy="32.60199"
+       fx="83.590195"
+       fy="32.60199"
+       r="27.986706" />
+    <linearGradient
+       id="linearGradient3253-6-5">
+      <stop
+         style="stop-color:#f2555f;stop-opacity:1;"
+         offset="0"
+         id="stop3255-8-4" />
+      <stop
+         style="stop-color:#a8121c;stop-opacity:1;"
+         offset="1"
+         id="stop3257-7-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,-1.4500001,1.4705882,0,-15.05882,91.45)"
+       y2="36.079998"
+       x2="21.689653"
+       y1="29.279999"
+       x1="56.172409"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3036"
+       xlink:href="#linearGradient3895"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop3897" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="1"
+         id="stop3899" />
+    </linearGradient>
+    <linearGradient
+       y2="19.265453"
+       x2="40.373039"
+       y1="44.981819"
+       x1="42.755482"
+       gradientTransform="matrix(-1.4500001,0,0,-1.4705882,91.45,79.05882)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3012"
+       xlink:href="#linearGradient3806"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.5"
+     inkscape:cx="-39.80793"
+     inkscape:cy="28.947943"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1278"
+     inkscape:window-height="691"
+     inkscape:window-x="640"
+     inkscape:window-y="86"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3011"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata6253">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[WandererFan]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>arrow-left-x</dc:title>
+        <dc:date>2016-11-24</dc:date>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/TechDraw/Gui/Resources/icons/arrow-left.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license
+           rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html">https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>left</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Arrow pointing left</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#3d0508;stroke-width:1.99999988000000010;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 29,57 0,-16.000001 32,0 0,-18 -32,0 L 29,7 3,32 z"
+       id="path3343"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
+       inkscape:export-xdpi="4.1683898"
+       inkscape:export-ydpi="4.1683898" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#f2555f;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 27,52.25713 0,-13.257131 32,0 0,-14 -32,0 L 27,11.710728 6,32 z"
+       id="path3343-2"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
+       inkscape:export-xdpi="4.1683898"
+       inkscape:export-ydpi="4.1683898" />
+  </g>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/arrow-right-x.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/arrow-right-x.svg
@@ -1,0 +1,311 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg6248"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="arrow-right.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs6250">
+    <linearGradient
+       id="linearGradient3806">
+      <stop
+         id="stop3808"
+         offset="0"
+         style="stop-color:#f2555f;stop-opacity:1" />
+      <stop
+         id="stop3810"
+         offset="1"
+         style="stop-color:#a8121c;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3253">
+      <stop
+         style="stop-color:#f2555f;stop-opacity:1;"
+         offset="0"
+         id="stop3255" />
+      <stop
+         style="stop-color:#a8121c;stop-opacity:1;"
+         offset="1"
+         id="stop3257" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253"
+       id="radialGradient3270"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-69.025653,-0.11788499)"
+       cx="10.328116"
+       cy="25.129232"
+       fx="10.328116"
+       fy="25.129232"
+       r="27.986705" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6816">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6818" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop6820" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6781">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop6783" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:0;"
+         offset="1"
+         id="stop6785" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective6256" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6816"
+       id="radialGradient6822"
+       cx="33.369828"
+       cy="51.929391"
+       fx="33.369828"
+       fy="51.929391"
+       r="25.198714"
+       gradientTransform="matrix(1.1581633,0,0,0.6558985,-7.29237,16.126077)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3393"
+       id="linearGradient3399"
+       x1="1669.7314"
+       y1="1726.0585"
+       x2="2067.1702"
+       y2="1726.0585"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)" />
+    <linearGradient
+       id="linearGradient3393">
+      <stop
+         style="stop-color:#a8121c;stop-opacity:1;"
+         offset="0"
+         id="stop3395" />
+      <stop
+         style="stop-color:#f2555f;stop-opacity:1;"
+         offset="1"
+         id="stop3397" />
+    </linearGradient>
+    <linearGradient
+       y2="1726.0585"
+       x2="2067.1702"
+       y1="1726.0585"
+       x1="1669.7314"
+       gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3270"
+       xlink:href="#linearGradient3393"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253"
+       id="radialGradient3293"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-69.025653,-0.11788499)"
+       cx="10.328116"
+       cy="25.129232"
+       fx="10.328116"
+       fy="25.129232"
+       r="27.986705" />
+    <linearGradient
+       id="linearGradient3253-6">
+      <stop
+         style="stop-color:#f2555f;stop-opacity:1;"
+         offset="0"
+         id="stop3255-8" />
+      <stop
+         style="stop-color:#a8121c;stop-opacity:1;"
+         offset="1"
+         id="stop3257-7" />
+    </linearGradient>
+    <radialGradient
+       r="27.986706"
+       fy="25.129232"
+       fx="10.328116"
+       cy="25.129232"
+       cx="10.328116"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-2.1599239,-18.716253)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3337"
+       xlink:href="#linearGradient3253-6"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253-6-5"
+       id="radialGradient3270-0-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2166851,1.0433407,-0.52714011,0.61472119,-73.012055,-80.803852)"
+       cx="83.590195"
+       cy="32.60199"
+       fx="83.590195"
+       fy="32.60199"
+       r="27.986706" />
+    <linearGradient
+       id="linearGradient3253-6-5">
+      <stop
+         style="stop-color:#f2555f;stop-opacity:1;"
+         offset="0"
+         id="stop3255-8-4" />
+      <stop
+         style="stop-color:#a8121c;stop-opacity:1;"
+         offset="1"
+         id="stop3257-7-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,-1.4500001,1.4705882,0,-15.05882,91.45)"
+       y2="36.079998"
+       x2="21.689653"
+       y1="29.279999"
+       x1="56.172409"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3036"
+       xlink:href="#linearGradient3895"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop3897" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="1"
+         id="stop3899" />
+    </linearGradient>
+    <linearGradient
+       y2="44.610909"
+       x2="42.379307"
+       y1="20.996365"
+       x1="39.996861"
+       gradientTransform="matrix(1.4500001,0,0,1.4705882,-27.45,-15.05882)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3012"
+       xlink:href="#linearGradient3806"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.5"
+     inkscape:cx="-39.80793"
+     inkscape:cy="28.947943"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1278"
+     inkscape:window-height="691"
+     inkscape:window-x="640"
+     inkscape:window-y="86"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3011"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata6253">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[WandererFan]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>arrow-right-x</dc:title>
+        <dc:date>2016-11-24</dc:date>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/TechDraw/Gui/Resources/icons/arrow-right.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license
+           rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html">https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>right</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Arrow pointing right</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#3d0508;stroke-width:1.99999988000000010;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 35,7 0,16.000001 -32,0 0,18 32,0 L 35,57 61,32 z"
+       id="path3343"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
+       inkscape:export-xdpi="4.1683898"
+       inkscape:export-ydpi="4.1683898" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#f2555f;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 37,11.74287 0,13.257131 -32,0 0,14 32,0 0,13.289271 L 58,32 z"
+       id="path3343-2"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
+       inkscape:export-xdpi="4.1683898"
+       inkscape:export-ydpi="4.1683898" />
+  </g>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/arrow-up-y.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/arrow-up-y.svg
@@ -1,0 +1,311 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg6248"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="arrow-up.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs6250">
+    <linearGradient
+       id="linearGradient3806">
+      <stop
+         id="stop3808"
+         offset="0"
+         style="stop-color:#3ad14a;stop-opacity:1" />
+      <stop
+         id="stop3810"
+         offset="1"
+         style="stop-color:#0f7a1c;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3253">
+      <stop
+         style="stop-color:#3ad14a;stop-opacity:1;"
+         offset="0"
+         id="stop3255" />
+      <stop
+         style="stop-color:#0f7a1c;stop-opacity:1;"
+         offset="1"
+         id="stop3257" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253"
+       id="radialGradient3270"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-69.025653,-0.11788499)"
+       cx="10.328116"
+       cy="25.129232"
+       fx="10.328116"
+       fy="25.129232"
+       r="27.986705" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6816">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6818" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop6820" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6781">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop6783" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:0;"
+         offset="1"
+         id="stop6785" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective6256" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6816"
+       id="radialGradient6822"
+       cx="33.369828"
+       cy="51.929391"
+       fx="33.369828"
+       fy="51.929391"
+       r="25.198714"
+       gradientTransform="matrix(1.1581633,0,0,0.6558985,-7.29237,16.126077)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3393"
+       id="linearGradient3399"
+       x1="1669.7314"
+       y1="1726.0585"
+       x2="2067.1702"
+       y2="1726.0585"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)" />
+    <linearGradient
+       id="linearGradient3393">
+      <stop
+         style="stop-color:#0f7a1c;stop-opacity:1;"
+         offset="0"
+         id="stop3395" />
+      <stop
+         style="stop-color:#3ad14a;stop-opacity:1;"
+         offset="1"
+         id="stop3397" />
+    </linearGradient>
+    <linearGradient
+       y2="1726.0585"
+       x2="2067.1702"
+       y1="1726.0585"
+       x1="1669.7314"
+       gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3270"
+       xlink:href="#linearGradient3393"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253"
+       id="radialGradient3293"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-69.025653,-0.11788499)"
+       cx="10.328116"
+       cy="25.129232"
+       fx="10.328116"
+       fy="25.129232"
+       r="27.986705" />
+    <linearGradient
+       id="linearGradient3253-6">
+      <stop
+         style="stop-color:#3ad14a;stop-opacity:1;"
+         offset="0"
+         id="stop3255-8" />
+      <stop
+         style="stop-color:#0f7a1c;stop-opacity:1;"
+         offset="1"
+         id="stop3257-7" />
+    </linearGradient>
+    <radialGradient
+       r="27.986706"
+       fy="25.129232"
+       fx="10.328116"
+       cy="25.129232"
+       cx="10.328116"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-2.1599239,-18.716253)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3337"
+       xlink:href="#linearGradient3253-6"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253-6-5"
+       id="radialGradient3270-0-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2166851,1.0433407,-0.52714011,0.61472119,-73.012055,-80.803852)"
+       cx="83.590195"
+       cy="32.60199"
+       fx="83.590195"
+       fy="32.60199"
+       r="27.986706" />
+    <linearGradient
+       id="linearGradient3253-6-5">
+      <stop
+         style="stop-color:#3ad14a;stop-opacity:1;"
+         offset="0"
+         id="stop3255-8-4" />
+      <stop
+         style="stop-color:#0f7a1c;stop-opacity:1;"
+         offset="1"
+         id="stop3257-7-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,-1.4500001,1.4705882,0,-15.05882,91.45)"
+       y2="36.079998"
+       x2="21.689653"
+       y1="29.279999"
+       x1="56.172409"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3036"
+       xlink:href="#linearGradient3895"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop3897" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="1"
+         id="stop3899" />
+    </linearGradient>
+    <linearGradient
+       y2="34.472725"
+       x2="20.937302"
+       y1="30.763638"
+       x1="56.799366"
+       gradientTransform="matrix(0,-1.4500001,1.4705882,0,-15.05882,91.45)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3012"
+       xlink:href="#linearGradient3806"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.5"
+     inkscape:cx="-39.80793"
+     inkscape:cy="28.947943"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1278"
+     inkscape:window-height="691"
+     inkscape:window-x="640"
+     inkscape:window-y="86"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3011"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata6253">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[WandererFan]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>arrow-up-y</dc:title>
+        <dc:date>2016-11-24</dc:date>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/TechDraw/Gui/Resources/icons/arrow-up.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license
+           rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html">https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>up</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Arrow pointing upwards</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#05300a;stroke-width:1.99999988000000010;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 7,29 16.000001,0 0,32 18,0 0,-32 L 57,29 32,3 z"
+       id="path3343"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
+       inkscape:export-xdpi="4.1683898"
+       inkscape:export-ydpi="4.1683898" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#3ad14a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 11.74287,27 13.257131,0 0,32 14,0 0,-32 13.289271,0 L 32,6 z"
+       id="path3343-2"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
+       inkscape:export-xdpi="4.1683898"
+       inkscape:export-ydpi="4.1683898" />
+  </g>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/arrow-up-z.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/arrow-up-z.svg
@@ -1,0 +1,311 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg6248"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="arrow-up.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs6250">
+    <linearGradient
+       id="linearGradient3806">
+      <stop
+         id="stop3808"
+         offset="0"
+         style="stop-color:#5a8cf0;stop-opacity:1" />
+      <stop
+         id="stop3810"
+         offset="1"
+         style="stop-color:#1f4494;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3253">
+      <stop
+         style="stop-color:#5a8cf0;stop-opacity:1;"
+         offset="0"
+         id="stop3255" />
+      <stop
+         style="stop-color:#1f4494;stop-opacity:1;"
+         offset="1"
+         id="stop3257" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253"
+       id="radialGradient3270"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-69.025653,-0.11788499)"
+       cx="10.328116"
+       cy="25.129232"
+       fx="10.328116"
+       fy="25.129232"
+       r="27.986705" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6816">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6818" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop6820" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6781">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop6783" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:0;"
+         offset="1"
+         id="stop6785" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective6256" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6816"
+       id="radialGradient6822"
+       cx="33.369828"
+       cy="51.929391"
+       fx="33.369828"
+       fy="51.929391"
+       r="25.198714"
+       gradientTransform="matrix(1.1581633,0,0,0.6558985,-7.29237,16.126077)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3393"
+       id="linearGradient3399"
+       x1="1669.7314"
+       y1="1726.0585"
+       x2="2067.1702"
+       y2="1726.0585"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)" />
+    <linearGradient
+       id="linearGradient3393">
+      <stop
+         style="stop-color:#1f4494;stop-opacity:1;"
+         offset="0"
+         id="stop3395" />
+      <stop
+         style="stop-color:#5a8cf0;stop-opacity:1;"
+         offset="1"
+         id="stop3397" />
+    </linearGradient>
+    <linearGradient
+       y2="1726.0585"
+       x2="2067.1702"
+       y1="1726.0585"
+       x1="1669.7314"
+       gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3270"
+       xlink:href="#linearGradient3393"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253"
+       id="radialGradient3293"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-69.025653,-0.11788499)"
+       cx="10.328116"
+       cy="25.129232"
+       fx="10.328116"
+       fy="25.129232"
+       r="27.986705" />
+    <linearGradient
+       id="linearGradient3253-6">
+      <stop
+         style="stop-color:#5a8cf0;stop-opacity:1;"
+         offset="0"
+         id="stop3255-8" />
+      <stop
+         style="stop-color:#1f4494;stop-opacity:1;"
+         offset="1"
+         id="stop3257-7" />
+    </linearGradient>
+    <radialGradient
+       r="27.986706"
+       fy="25.129232"
+       fx="10.328116"
+       cy="25.129232"
+       cx="10.328116"
+       gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-2.1599239,-18.716253)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3337"
+       xlink:href="#linearGradient3253-6"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3253-6-5"
+       id="radialGradient3270-0-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2166851,1.0433407,-0.52714011,0.61472119,-73.012055,-80.803852)"
+       cx="83.590195"
+       cy="32.60199"
+       fx="83.590195"
+       fy="32.60199"
+       r="27.986706" />
+    <linearGradient
+       id="linearGradient3253-6-5">
+      <stop
+         style="stop-color:#5a8cf0;stop-opacity:1;"
+         offset="0"
+         id="stop3255-8-4" />
+      <stop
+         style="stop-color:#1f4494;stop-opacity:1;"
+         offset="1"
+         id="stop3257-7-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,-1.4500001,1.4705882,0,-15.05882,91.45)"
+       y2="36.079998"
+       x2="21.689653"
+       y1="29.279999"
+       x1="56.172409"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3036"
+       xlink:href="#linearGradient3895"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop3897" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="1"
+         id="stop3899" />
+    </linearGradient>
+    <linearGradient
+       y2="34.472725"
+       x2="20.937302"
+       y1="30.763638"
+       x1="56.799366"
+       gradientTransform="matrix(0,-1.4500001,1.4705882,0,-15.05882,91.45)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3012"
+       xlink:href="#linearGradient3806"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.5"
+     inkscape:cx="-39.80793"
+     inkscape:cy="28.947943"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1278"
+     inkscape:window-height="691"
+     inkscape:window-x="640"
+     inkscape:window-y="86"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3011"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata6253">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[WandererFan]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>arrow-up-z</dc:title>
+        <dc:date>2016-11-24</dc:date>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/TechDraw/Gui/Resources/icons/arrow-up.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license
+           rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html">https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>up</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Arrow pointing upwards</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#0a1a3d;stroke-width:1.99999988000000010;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 7,29 16.000001,0 0,32 18,0 0,-32 L 57,29 32,3 z"
+       id="path3343"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
+       inkscape:export-xdpi="4.1683898"
+       inkscape:export-ydpi="4.1683898" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#5a8cf0;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 11.74287,27 13.257131,0 0,32 14,0 0,-32 13.289271,0 L 32,6 z"
+       id="path3343-2"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
+       inkscape:export-xdpi="4.1683898"
+       inkscape:export-ydpi="4.1683898" />
+  </g>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/center-in-stock.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/center-in-stock.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 64 64"
+   version="1.1"
+   id="svg1820"
+   sodipodi:docname="center-in-stock.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1824" />
+  <sodipodi:namedview
+     id="namedview1822"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="5.9445817"
+     inkscape:cx="-9.0839024"
+     inkscape:cy="73.09177"
+     inkscape:window-width="1872"
+     inkscape:window-height="1163"
+     inkscape:window-x="1728"
+     inkscape:window-y="1050"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1820" />
+  <g
+     fill="none"
+     stroke="#111111"
+     stroke-width="4"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g1816"
+     style="stroke-width:3.8;stroke-dasharray:none;stroke:#111111;stroke-opacity:1">
+    <path
+       d="M12 12h10"
+       id="path1792"
+       style="stroke-width:3.8;stroke-dasharray:none;stroke:#111111;stroke-opacity:1" />
+    <path
+       d="M42 12h10"
+       id="path1794"
+       style="stroke-width:3.8;stroke-dasharray:none;stroke:#111111;stroke-opacity:1" />
+    <path
+       d="M12 52h10"
+       id="path1796"
+       style="stroke-width:3.8;stroke-dasharray:none;stroke:#111111;stroke-opacity:1" />
+    <path
+       d="M42 52h10"
+       id="path1798"
+       style="stroke-width:3.8;stroke-dasharray:none;stroke:#111111;stroke-opacity:1" />
+    <path
+       d="M12 12v10"
+       id="path1800"
+       style="stroke-width:3.8;stroke-dasharray:none;stroke:#111111;stroke-opacity:1" />
+    <path
+       d="M52 12v10"
+       id="path1802"
+       style="stroke-width:3.8;stroke-dasharray:none;stroke:#111111;stroke-opacity:1" />
+    <path
+       d="M12 42v10"
+       id="path1804"
+       style="stroke-width:3.8;stroke-dasharray:none;stroke:#111111;stroke-opacity:1" />
+    <path
+       d="M52 42v10"
+       id="path1806"
+       style="stroke-width:3.8;stroke-dasharray:none;stroke:#111111;stroke-opacity:1" />
+    <path
+       d="M32 8v14"
+       id="path1808"
+       style="stroke-width:3.8;stroke-dasharray:none;stroke:#111111;stroke-opacity:1" />
+    <path
+       d="M32 42v14"
+       id="path1810"
+       style="stroke-width:3.8;stroke-dasharray:none;stroke:#111111;stroke-opacity:1" />
+    <path
+       d="M8 32h14"
+       id="path1812"
+       style="stroke-width:3.8;stroke-dasharray:none;stroke:#111111;stroke-opacity:1" />
+    <path
+       d="M42 32h14"
+       id="path1814"
+       style="stroke-width:3.8;stroke-dasharray:none;stroke:#111111;stroke-opacity:1" />
+  </g>
+  <path
+     id="circle1818"
+     style="fill:#111111;fill-opacity:1"
+     d="m 37,32 a 5,5 0 0 1 -5,5 5,5 0 0 1 -5,-5 5,5 0 0 1 5,-5 5,5 0 0 1 5,5 z" />
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/model.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/model.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+	<g fill="none" stroke="#111111" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+		<path d="M32 5L56 18.5V45.5L32 59L8 45.5V18.5L32 5Z"/>
+		<path d="M8 18.5L32 32L56 18.5"/>
+		<path d="M32 32V59"/>
+		<path d="M32 17L45 24.5V39.5L32 47L19 39.5V24.5L32 17Z"/>
+		<path d="M19 24.5L32 32L45 24.5"/>
+		<path d="M32 32V47"/>
+		<path d="M8 45.5L19 39.5"/>
+		<path d="M56 45.5L45 39.5"/>
+		<path d="M32 5V17"/>
+	</g>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/move-to-origin.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/move-to-origin.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 64 64"
+   version="1.1"
+   id="svg1356"
+   sodipodi:docname="move_to_origin.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1360" />
+  <sodipodi:namedview
+     id="namedview1358"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="8.9510127"
+     inkscape:cx="10.613324"
+     inkscape:cy="37.370073"
+     inkscape:window-width="1872"
+     inkscape:window-height="1163"
+     inkscape:window-x="1728"
+     inkscape:window-y="1050"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1356" />
+  <g
+     fill="none"
+     stroke="#111111"
+     stroke-width="4"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g1352">
+    <path
+       style="display:inline"
+       d="m 18,32 c 0,-7.731986 6.268014,-14 14,-14 7.731986,0 14,6.268014 14,14 0,7.731986 -6.268014,14 -14,14"
+       id="circle1338"
+       sodipodi:nodetypes="cssc" />
+    <path
+       d="M 32,6 V 22"
+       id="path1340"
+       style="display:inline"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="M 32,42 V 58"
+       id="path1342"
+       style="display:inline"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="M 6,32 H 22"
+       id="path1344"
+       style="display:inline"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="M 42,32 H 58"
+       id="path1346"
+       style="display:inline"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="M 9,54.999995 23.453197,40.546798"
+       id="path1348"
+       style="display:inline"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="M 18,40 23.453197,40.546798 24,46"
+       id="path1350"
+       inkscape:label="path1350"
+       style="display:inline"
+       sodipodi:nodetypes="ccc" />
+  </g>
+  <path
+     id="circle1354"
+     style="display:inline;fill:#111111;stroke:none;stroke-opacity:1;stroke-width:0.9;stroke-dasharray:none"
+     d="m 37,32 a 5,5 0 0 1 -5,5 5,5 0 0 1 -5,-5 5,5 0 0 1 5,-5 5,5 0 0 1 5,5 z" />
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/origin-x.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/origin-x.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+	<path d="M14 14L50 50M50 14L14 50" fill="none" stroke="#e01f2d" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/origin-y.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/origin-y.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+	<path d="M14 10L32 32L50 10M32 32V56" fill="none" stroke="#18b329" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/origin-z.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/origin-z.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+	<path d="M14 12H50L14 52H50" fill="none" stroke="#2f65d9" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/set-origin.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/set-origin.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 64 64"
+   version="1.1"
+   id="svg390"
+   sodipodi:docname="set_origin.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs394" />
+  <sodipodi:namedview
+     id="namedview392"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="14.359375"
+     inkscape:cx="31.059848"
+     inkscape:cy="32"
+     inkscape:window-width="1872"
+     inkscape:window-height="1163"
+     inkscape:window-x="1728"
+     inkscape:window-y="1050"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg390" />
+  <g
+     fill="none"
+     stroke="#111111"
+     stroke-width="4"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g386">
+    <path
+       id="circle376"
+       d="M 46,32 A 14,14 0 0 1 32,46 14,14 0 0 1 18,32 14,14 0 0 1 32,18 14,14 0 0 1 46,32 Z" />
+    <path
+       d="M 32,6 V 22"
+       id="path378"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="M 32,42 V 58"
+       id="path380"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="M 6,32 H 22"
+       id="path382"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="M 42,32 H 58"
+       id="path384"
+       sodipodi:nodetypes="cc" />
+  </g>
+  <path
+     id="circle388"
+     style="fill:#111111"
+     d="m 37,32 a 5,5 0 0 1 -5,5 5,5 0 0 1 -5,-5 5,5 0 0 1 5,-5 5,5 0 0 1 5,5 z" />
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/stock.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/stock.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+	<g stroke-linejoin="round">
+		<path d="M32 6L54 18.5V45.5L32 58L10 45.5V18.5L32 6Z" fill="#111111" stroke="#111111" stroke-width="4"/>
+		<path d="M10 18.5L32 31L54 18.5" fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round"/>
+		<path d="M32 31V58" fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round"/>
+	</g>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/xy-in-stock.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/xy-in-stock.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+	<g fill="none" stroke="#111111" stroke-width="3.5" stroke-linecap="round">
+		<path d="M14 8v48"/>
+		<path d="M32 8v48"/>
+		<path d="M50 8v48"/>
+		<path d="M8 14h48"/>
+		<path d="M8 32h48"/>
+		<path d="M8 50h48"/>
+	</g>
+	<circle cx="32" cy="32" r="6" fill="#111111"/>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
@@ -298,6 +298,19 @@
               </widget>
              </item>
              <item>
+              <spacer name="materialSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>16</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
               <widget class="QLabel" name="materialLabel">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -322,6 +335,67 @@
          </widget>
         </item>
         <item>
+          <layout class="QGridLayout" name="gridLayout_2">
+            <property name="leftMargin">
+              <number>12</number>
+            </property>
+            <property name="topMargin">
+              <number>0</number>
+            </property>
+            <property name="rightMargin">
+              <number>12</number>
+            </property>
+            <item row="0" column="0" colspan="2">
+              <layout class="QHBoxLayout" name="chooseRefLayout">
+                <item>
+                <widget class="QLabel" name="pickTargetLabel">
+                  <property name="text">
+                  <string>Active Component</string>
+                  </property>
+                </widget>
+                </item>
+                <item>
+                <widget class="QPushButton" name="pickTargetModel">
+                  <property name="text">
+                  <string>Model</string>
+                  </property>
+                  <property name="toolTip">
+                  <string>Set selection target to Model (default): origin/axis picks target the Model object.</string>
+                  </property>
+                  <property name="icon">
+                  <iconset resource="../Path.qrc">
+                    <normaloff>:/icons/model.svg</normaloff>:/icons/model.svg</iconset>
+                  </property>
+                  <property name="checkable">
+                  <bool>true</bool>
+                  </property>
+                  <property name="checked">
+                  <bool>true</bool>
+                  </property>
+                </widget>
+                </item>
+                <item>
+                <widget class="QPushButton" name="pickTargetStock">
+                  <property name="text">
+                  <string>Stock</string>
+                  </property>
+                  <property name="toolTip">
+                  <string>Set selection target to Stock: origin/axis picks target the Stock object.</string>
+                  </property>
+                  <property name="icon">
+                  <iconset resource="../Path.qrc">
+                    <normaloff>:/icons/stock.svg</normaloff>:/icons/stock.svg</iconset>
+                  </property>
+                  <property name="checkable">
+                  <bool>true</bool>
+                  </property>
+                </widget>
+                </item>
+              </layout>
+            </item>
+          </layout>
+        </item>
+        <item>
          <widget class="QGroupBox" name="modelAlignGroup">
           <property name="title">
            <string>Alignment</string>
@@ -331,6 +405,16 @@
             <widget class="QPushButton" name="moveToOrigin">
              <property name="text">
               <string>Move to Origin</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/move-to-origin.svg</normaloff>:/icons/move-to-origin.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
              </property>
             </widget>
            </item>
@@ -342,35 +426,49 @@
              <property name="toolTip">
               <string>Sets the model origin to a selected point, either a vertex or the center of the selected face. The picking button controls whether selection targets the stock or the model.</string>
              </property>
-            </widget>
-           </item>
-           <item row="1" column="0" colspan="2">
-            <widget class="QPushButton" name="pickTargetToggle">
-             <property name="text">
-              <string>Picking: Model</string>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/set-origin.svg</normaloff>:/icons/set-origin.svg</iconset>
              </property>
-             <property name="toolTip">
-              <string>Toggle whether origin/axis picks target the Model (default) or the Stock. Useful when Stock and Model overlap and the desired vertex is hidden.</string>
-             </property>
-             <property name="checkable">
-              <bool>true</bool>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
+             <property name="iconSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
+           <item row="1" column="0">
             <widget class="QPushButton" name="centerInStock">
              <property name="text">
               <string>Center in Stock</string>
              </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/center-in-stock.svg</normaloff>:/icons/center-in-stock.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
+             </property>
             </widget>
            </item>
-           <item row="2" column="1">
+           <item row="1" column="1">
             <widget class="QPushButton" name="centerInStockXY">
              <property name="text">
               <string>XY in Stock</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/xy-in-stock.svg</normaloff>:/icons/xy-in-stock.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
              </property>
             </widget>
            </item>
@@ -394,6 +492,16 @@
              <property name="toolTip">
               <string>Rotates the model so a picked edge becomes the X-axis</string>
              </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/origin-x.svg</normaloff>:/icons/origin-x.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
+             </property>
             </widget>
            </item>
            <item row="0" column="1">
@@ -404,6 +512,16 @@
              <property name="toolTip">
               <string>Rotates the model so a picked edge becomes the Y-axis</string>
              </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/origin-y.svg</normaloff>:/icons/origin-y.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
+             </property>
             </widget>
            </item>
            <item row="0" column="2">
@@ -413,6 +531,16 @@
              </property>
              <property name="toolTip">
               <string>Rotates the model so a picked edge becomes the Z-axis</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/origin-z.svg</normaloff>:/icons/origin-z.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
              </property>
             </widget>
            </item>
@@ -446,7 +574,7 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
+           <item row="2" column="0" colspan="3">
             <widget class="QCheckBox" name="linkStockAndModel">
              <property name="text">
               <string>Link stock and model</string>
@@ -476,8 +604,8 @@
              </property>
              <property name="iconSize">
               <size>
-               <width>32</width>
-               <height>32</height>
+               <width>24</width>
+               <height>24</height>
               </size>
              </property>
             </widget>
@@ -493,8 +621,8 @@
              </property>
              <property name="iconSize">
               <size>
-               <width>32</width>
-               <height>32</height>
+               <width>24</width>
+               <height>24</height>
               </size>
              </property>
             </widget>
@@ -510,8 +638,8 @@
              </property>
              <property name="iconSize">
               <size>
-               <width>32</width>
-               <height>32</height>
+               <width>24</width>
+               <height>24</height>
               </size>
              </property>
             </widget>
@@ -527,22 +655,16 @@
              </property>
              <property name="iconSize">
               <size>
-               <width>32</width>
-               <height>32</height>
+               <width>24</width>
+               <height>24</height>
               </size>
              </property>
             </widget>
            </item>
            <item row="1" column="1">
-            <widget class="QDoubleSpinBox" name="modelMoveValue">
-             <property name="minimum">
-              <double>-1000.000000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>1000.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>1.000000000000000</double>
+            <widget class="Gui::QuantitySpinBox" name="modelMoveValue">
+             <property name="toolTip">
+              <string>Step distance for model move buttons (in document units)</string>
              </property>
             </widget>
            </item>
@@ -557,8 +679,8 @@
              </property>
              <property name="iconSize">
               <size>
-               <width>32</width>
-               <height>32</height>
+               <width>24</width>
+               <height>24</height>
               </size>
              </property>
             </widget>
@@ -574,8 +696,8 @@
              </property>
              <property name="iconSize">
               <size>
-               <width>32</width>
-               <height>32</height>
+               <width>24</width>
+               <height>24</height>
               </size>
              </property>
             </widget>
@@ -591,8 +713,8 @@
              </property>
              <property name="iconSize">
               <size>
-               <width>32</width>
-               <height>32</height>
+               <width>24</width>
+               <height>24</height>
               </size>
              </property>
             </widget>
@@ -608,8 +730,8 @@
              </property>
              <property name="iconSize">
               <size>
-               <width>32</width>
-               <height>32</height>
+               <width>24</width>
+               <height>24</height>
               </size>
              </property>
             </widget>
@@ -643,8 +765,8 @@
              </property>
              <property name="iconSize">
               <size>
-               <width>32</width>
-               <height>32</height>
+               <width>24</width>
+               <height>24</height>
               </size>
              </property>
             </widget>
@@ -708,8 +830,8 @@
              </property>
              <property name="iconSize">
               <size>
-               <width>32</width>
-               <height>32</height>
+               <width>24</width>
+               <height>24</height>
               </size>
              </property>
             </widget>

--- a/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
@@ -298,6 +298,19 @@
               </widget>
              </item>
              <item>
+              <spacer name="materialSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>16</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
               <widget class="QLabel" name="materialLabel">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -322,35 +335,22 @@
          </widget>
         </item>
         <item>
-         <widget class="QGroupBox" name="modelAlignGroup">
+         <widget class="QGroupBox" name="pickTargetGroup">
           <property name="title">
-           <string>Alignment</string>
+           <string>Selection Target</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_2">
-           <item row="0" column="0">
-            <widget class="QPushButton" name="moveToOrigin">
+          <layout class="QHBoxLayout" name="chooseRefLayout">
+           <item>
+            <widget class="QPushButton" name="pickTargetModel">
              <property name="text">
-              <string>Move to Origin</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QPushButton" name="setOrigin">
-             <property name="text">
-              <string>Set Origin</string>
+              <string>Model</string>
              </property>
              <property name="toolTip">
-              <string>Sets the model origin to a selected point, either a vertex or the center of the selected face. The picking button controls whether selection targets the stock or the model.</string>
+              <string>Set selection target to Model; stock becomes unselectable</string>
              </property>
-            </widget>
-           </item>
-           <item row="1" column="0" colspan="2">
-            <widget class="QPushButton" name="pickTargetToggle">
-             <property name="text">
-              <string>Picking: Model</string>
-             </property>
-             <property name="toolTip">
-              <string>Toggle whether origin/axis picks target the Model (default) or the Stock. Useful when Stock and Model overlap and the desired vertex is hidden.</string>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/model.svg</normaloff>:/icons/model.svg</iconset>
              </property>
              <property name="checkable">
               <bool>true</bool>
@@ -360,33 +360,129 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
-            <widget class="QPushButton" name="centerInStock">
+           <item>
+            <widget class="QPushButton" name="pickTargetStock">
              <property name="text">
-              <string>Center in Stock</string>
+              <string>Stock</string>
+             </property>
+             <property name="toolTip">
+              <string>Set selection target to Stock; model becomes unselectable</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/stock.svg</normaloff>:/icons/stock.svg</iconset>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="1">
-            <widget class="QPushButton" name="centerInStockXY">
-             <property name="text">
-              <string>XY in Stock</string>
+           <item>
+            <spacer name="pickTargetSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
              </property>
-            </widget>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
            </item>
           </layout>
          </widget>
         </item>
         <item>
-         <widget class="QGroupBox" name="modelSetGroup">
+         <widget class="QGroupBox" name="modelAlignGroup">
           <property name="title">
-           <string>Origin &amp;&amp; Orientation</string>
+           <string>Origin &amp;&amp; Alignment</string>
           </property>
-          <property name="toolTip">
-           <string>Positions the model so a picked edge defines an axis and a picked vertex zeros the model on that axis. The G54-G59 fixture is set on the output tab.</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_5">
-           <item row="0" column="0">
+          <layout class="QGridLayout" name="gridLayout_2">
+           <item row="0" column="0" colspan="3">
+            <widget class="QPushButton" name="moveToOrigin">
+             <property name="text">
+              <string>Move to Origin</string>
+             </property>
+             <property name="toolTip">
+              <string>Moves the selection to the origin point</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/move-to-origin.svg</normaloff>:/icons/move-to-origin.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="3" colspan="3">
+            <widget class="QPushButton" name="setOrigin">
+             <property name="text">
+              <string>Set Origin</string>
+             </property>
+             <property name="toolTip">
+              <string>Sets the origin point to a selected point: a vertex, the center
+of an edge (or arc center), or the center of the selected face.
+The Selection Target buttons control whether the selection comes
+from the model or the stock.</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/set-origin.svg</normaloff>:/icons/set-origin.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" colspan="3">
+            <widget class="QPushButton" name="centerInStock">
+             <property name="text">
+              <string>Center XYZ in Stock</string>
+             </property>
+             <property name="toolTip">
+              <string>Centers the model in the stock in X, Y and Z</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/center-in-stock.svg</normaloff>:/icons/center-in-stock.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="3" colspan="3">
+            <widget class="QPushButton" name="centerInStockXY">
+             <property name="text">
+              <string>Center XY in Stock</string>
+             </property>
+             <property name="toolTip">
+              <string>Centers the model in the stock in X and Y; Z is unchanged</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/xy-in-stock.svg</normaloff>:/icons/xy-in-stock.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0" colspan="2">
             <widget class="QPushButton" name="modelSetXAxis">
              <property name="text">
               <string>X-Axis</string>
@@ -394,9 +490,19 @@
              <property name="toolTip">
               <string>Rotates the model so a picked edge becomes the X-axis</string>
              </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/origin-x.svg</normaloff>:/icons/origin-x.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
+             </property>
             </widget>
            </item>
-           <item row="0" column="1">
+           <item row="2" column="2" colspan="2">
             <widget class="QPushButton" name="modelSetYAxis">
              <property name="text">
               <string>Y-Axis</string>
@@ -404,9 +510,19 @@
              <property name="toolTip">
               <string>Rotates the model so a picked edge becomes the Y-axis</string>
              </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/origin-y.svg</normaloff>:/icons/origin-y.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
+             </property>
             </widget>
            </item>
-           <item row="0" column="2">
+           <item row="2" column="4" colspan="2">
             <widget class="QPushButton" name="modelSetZAxis">
              <property name="text">
               <string>Z-Axis</string>
@@ -414,9 +530,19 @@
              <property name="toolTip">
               <string>Rotates the model so a picked edge becomes the Z-axis</string>
              </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/origin-z.svg</normaloff>:/icons/origin-z.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
+             </property>
             </widget>
            </item>
-           <item row="1" column="0">
+           <item row="3" column="0" colspan="2">
             <widget class="QPushButton" name="modelSetX0">
              <property name="text">
               <string>X=0</string>
@@ -426,7 +552,7 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
+           <item row="3" column="2" colspan="2">
             <widget class="QPushButton" name="modelSetY0">
              <property name="text">
               <string>Y=0</string>
@@ -436,7 +562,7 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="2">
+           <item row="3" column="4" colspan="2">
             <widget class="QPushButton" name="modelSetZ0">
              <property name="text">
               <string>Z=0</string>
@@ -446,13 +572,15 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
+           <item row="4" column="0" colspan="6">
             <widget class="QCheckBox" name="linkStockAndModel">
              <property name="text">
               <string>Link stock and model</string>
              </property>
              <property name="toolTip">
-              <string>When checked, stock follows model translations and rotations performed in this dialog. When unchecked, stock can be positioned independently of the model.</string>
+              <string>When checked, stock follows model translations and rotations
+performed in this dialog. When unchecked, stock can be
+positioned independently of the model.</string>
              </property>
             </widget>
            </item>
@@ -462,257 +590,522 @@
         <item>
          <widget class="QGroupBox" name="modelMoveGroup">
           <property name="title">
-           <string>Move - XY</string>
+           <string>Transform</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_3">
-           <item row="0" column="0">
-            <widget class="QPushButton" name="modelMoveLeftUp">
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-left-up.svg</normaloff>:/icons/arrow-left-up.svg</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>32</width>
-               <height>32</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QPushButton" name="modelMoveUp">
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-up.svg</normaloff>:/icons/arrow-up.svg</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>32</width>
-               <height>32</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="2">
-            <widget class="QPushButton" name="modelMoveRightUp">
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-right-up.svg</normaloff>:/icons/arrow-right-up.svg</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>32</width>
-               <height>32</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QPushButton" name="modelMoveLeft">
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-left.svg</normaloff>:/icons/arrow-left.svg</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>32</width>
-               <height>32</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QDoubleSpinBox" name="modelMoveValue">
-             <property name="minimum">
-              <double>-1000.000000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>1000.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>1.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="2">
-            <widget class="QPushButton" name="modelMoveRight">
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-right.svg</normaloff>:/icons/arrow-right.svg</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>32</width>
-               <height>32</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QPushButton" name="modelMoveLeftDown">
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-left-down.svg</normaloff>:/icons/arrow-left-down.svg</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>32</width>
-               <height>32</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QPushButton" name="modelMoveDown">
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-down.svg</normaloff>:/icons/arrow-down.svg</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>32</width>
-               <height>32</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="2">
-            <widget class="QPushButton" name="modelMoveRightDown">
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-right-down.svg</normaloff>:/icons/arrow-right-down.svg</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>32</width>
-               <height>32</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="modelRotateGroup">
-          <property name="title">
-           <string>Rotate around Z</string>
-          </property>
-          <property name="toolTip">
-           <string>Rotates the model about the Z-axis. When the compound checkbox is enabled, rotations stack cumulatively.</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_6">
-           <item row="0" column="0">
-            <widget class="QPushButton" name="modelRotateLeft">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-ccw.svg</normaloff>:/icons/arrow-ccw.svg</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>32</width>
-               <height>32</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <layout class="QVBoxLayout" name="verticalLayout_18">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
+          <layout class="QVBoxLayout" name="verticalLayout_modelMove">
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <property name="leftMargin">
+            <number>8</number>
+           </property>
+           <property name="topMargin">
+            <number>6</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>4</number>
+           </property>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_transform">
+             <property name="spacing">
               <number>0</number>
              </property>
              <item>
-              <widget class="QDoubleSpinBox" name="modelRotateValue">
-               <property name="minimum">
-                <double>-180.000000000000000</double>
+              <spacer name="transformLeftSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
                </property>
-               <property name="maximum">
-                <double>360.000000000000000</double>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
                </property>
-               <property name="value">
-                <double>90.000000000000000</double>
-               </property>
-              </widget>
+              </spacer>
              </item>
              <item>
-              <widget class="QCheckBox" name="modelRotateCompound">
-               <property name="text">
-                <string>Compound</string>
+              <layout class="QVBoxLayout" name="verticalLayout_transformInner">
+               <property name="spacing">
+                <number>6</number>
                </property>
-               <property name="toolTip">
-                <string>When checked, rotations stack: each press rotates by the value above relative to the current orientation. When unchecked, each press resets and rotates from the original orientation.</string>
+               <item>
+                <layout class="QGridLayout" name="gridLayout_3">
+                 <property name="horizontalSpacing">
+                  <number>6</number>
+                 </property>
+                 <property name="verticalSpacing">
+                  <number>6</number>
+                 </property>
+                 <property name="columnStretch">
+                  <string notr="true">0,0,0,0,0,1</string>
+                 </property>
+                 <item row="0" column="0" alignment="Qt::AlignLeft|Qt::AlignTop">
+                  <widget class="QLabel" name="modelMoveLabel">
+                   <property name="text">
+                    <string>X/Y</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="4" alignment="Qt::AlignHCenter|Qt::AlignTop">
+                  <widget class="QLabel" name="modelMoveZLabel">
+                   <property name="text">
+                    <string>Z</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="4" rowspan="3">
+                  <layout class="QVBoxLayout" name="verticalLayout_modelMoveZ">
+                   <property name="spacing">
+                    <number>6</number>
+                   </property>
+                   <item>
+                   <spacer name="modelMoveZTopSpacer">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </spacer>
+                   </item>
+                   <item>
+                   <widget class="QPushButton" name="modelMoveZUp">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="maximumSize">
+                     <size>
+                      <width>40</width>
+                      <height>28</height>
+                     </size>
+                    </property>
+                    <property name="toolTip">
+                     <string>Moves the selection along the +Z axis by the step distance</string>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../Path.qrc">
+                      <normaloff>:/icons/arrow-up-z.svg</normaloff>:/icons/arrow-up-z.svg</iconset>
+                    </property>
+                    <property name="iconSize">
+                     <size>
+                      <width>18</width>
+                      <height>18</height>
+                     </size>
+                    </property>
+                   </widget>
+                   </item>
+                   <item>
+                   <widget class="QPushButton" name="modelMoveZDown">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="maximumSize">
+                     <size>
+                      <width>40</width>
+                      <height>28</height>
+                     </size>
+                    </property>
+                    <property name="toolTip">
+                     <string>Moves the selection along the -Z axis by the step distance</string>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../Path.qrc">
+                      <normaloff>:/icons/arrow-down-z.svg</normaloff>:/icons/arrow-down-z.svg</iconset>
+                    </property>
+                    <property name="iconSize">
+                     <size>
+                      <width>18</width>
+                      <height>18</height>
+                     </size>
+                    </property>
+                   </widget>
+                   </item>
+                   <item>
+                   <spacer name="modelMoveZBottomSpacer">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </spacer>
+                   </item>
+                  </layout>
+                 </item>
+                 <item row="0" column="1" alignment="Qt::AlignHCenter">
+                  <widget class="QPushButton" name="modelMoveUp">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>40</width>
+                     <height>28</height>
+                    </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Moves the selection along the +Y axis by the step distance</string>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="icon">
+                    <iconset resource="../Path.qrc">
+                     <normaloff>:/icons/arrow-up-y.svg</normaloff>:/icons/arrow-up-y.svg</iconset>
+                   </property>
+                   <property name="iconSize">
+                    <size>
+                     <width>18</width>
+                     <height>18</height>
+                    </size>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QPushButton" name="modelMoveLeft">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>40</width>
+                     <height>28</height>
+                    </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Moves the selection along the -X axis by the step distance</string>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="icon">
+                    <iconset resource="../Path.qrc">
+                     <normaloff>:/icons/arrow-left-x.svg</normaloff>:/icons/arrow-left-x.svg</iconset>
+                   </property>
+                   <property name="iconSize">
+                    <size>
+                     <width>18</width>
+                     <height>18</height>
+                    </size>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1" alignment="Qt::AlignHCenter">
+                  <widget class="Gui::QuantitySpinBox" name="modelMoveValue">
+                   <property name="maximumSize">
+                    <size>
+                     <width>90</width>
+                     <height>28</height>
+                    </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Step distance for model move buttons (in document units)</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="2">
+                  <widget class="QPushButton" name="modelMoveRight">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>40</width>
+                     <height>28</height>
+                    </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Moves the selection along the +X axis by the step distance</string>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="icon">
+                    <iconset resource="../Path.qrc">
+                     <normaloff>:/icons/arrow-right-x.svg</normaloff>:/icons/arrow-right-x.svg</iconset>
+                   </property>
+                   <property name="iconSize">
+                    <size>
+                     <width>18</width>
+                     <height>18</height>
+                    </size>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="1" alignment="Qt::AlignHCenter">
+                  <widget class="QPushButton" name="modelMoveDown">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>40</width>
+                     <height>28</height>
+                    </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Moves the selection along the -Y axis by the step distance</string>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="icon">
+                    <iconset resource="../Path.qrc">
+                     <normaloff>:/icons/arrow-down-y.svg</normaloff>:/icons/arrow-down-y.svg</iconset>
+                   </property>
+                   <property name="iconSize">
+                    <size>
+                     <width>18</width>
+                     <height>18</height>
+                    </size>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="3">
+                  <spacer name="modelMoveZSpacer">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeType">
+                    <enum>QSizePolicy::Fixed</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>16</width>
+                     <height>4</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <widget class="Line" name="modelTransformLine">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="frameShape">
+                  <enum>QFrame::HLine</enum>
+                 </property>
+                 <property name="frameShadow">
+                  <enum>QFrame::Sunken</enum>
+                 </property>
+                 <property name="lineWidth">
+                  <number>1</number>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="modelRotateLabel">
+                 <property name="text">
+                 <string>Rotate</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <layout class="QGridLayout" name="gridLayout_6">
+                 <property name="horizontalSpacing">
+                  <number>6</number>
+                 </property>
+                 <property name="verticalSpacing">
+                  <number>6</number>
+                 </property>
+                 <property name="columnStretch">
+                  <string notr="true">0,0,0,0,1</string>
+                 </property>
+                 <item row="0" column="0">
+                  <widget class="QPushButton" name="modelRotateLeft">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>40</width>
+                     <height>28</height>
+                    </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Rotates the selection counter-clockwise around the selected axis</string>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="icon">
+                    <iconset resource="../Path.qrc">
+                     <normaloff>:/icons/arrow-ccw.svg</normaloff>:/icons/arrow-ccw.svg</iconset>
+                   </property>
+                   <property name="iconSize">
+                    <size>
+                     <width>18</width>
+                     <height>18</height>
+                    </size>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QComboBox" name="modelRotateAxis">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>90</width>
+                     <height>28</height>
+                    </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Axis the model is rotated around</string>
+                   </property>
+                   <item>
+                    <property name="text">
+                     <string>X Axis</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Y Axis</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Z Axis</string>
+                    </property>
+                   </item>
+                   <property name="currentIndex">
+                    <number>2</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="2">
+                  <widget class="QDoubleSpinBox" name="modelRotateValue">
+                   <property name="maximumSize">
+                    <size>
+                     <width>90</width>
+                     <height>28</height>
+                    </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Rotation angle applied by each press of the rotate buttons</string>
+                   </property>
+                   <property name="suffix">
+                    <string>°</string>
+                   </property>
+                   <property name="minimum">
+                    <double>-180.000000000000000</double>
+                   </property>
+                   <property name="maximum">
+                    <double>360.000000000000000</double>
+                   </property>
+                   <property name="value">
+                    <double>90.000000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="3">
+                  <widget class="QPushButton" name="modelRotateRight">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>40</width>
+                     <height>28</height>
+                    </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Rotates the selection clockwise around the selected axis</string>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="icon">
+                    <iconset resource="../Path.qrc">
+                     <normaloff>:/icons/arrow-cw.svg</normaloff>:/icons/arrow-cw.svg</iconset>
+                   </property>
+                   <property name="iconSize">
+                    <size>
+                     <width>18</width>
+                     <height>18</height>
+                    </size>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0" colspan="4">
+                  <widget class="QCheckBox" name="modelRotateCompound">
+                   <property name="text">
+                    <string>Compound</string>
+                   </property>
+                   <property name="toolTip">
+                    <string>Only has an effect when more than one object is selected.
+When checked, all selected objects rotate together around
+the center of their combined bounding box. When unchecked,
+each object rotates around its own center.</string>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <spacer name="transformRightSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
                </property>
-               <property name="checked">
-                <bool>true</bool>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
                </property>
-              </widget>
+              </spacer>
              </item>
             </layout>
-           </item>
-           <item row="0" column="2">
-            <widget class="QPushButton" name="modelRotateRight">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-cw.svg</normaloff>:/icons/arrow-cw.svg</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>32</width>
-               <height>32</height>
-              </size>
-             </property>
-            </widget>
            </item>
           </layout>
          </widget>

--- a/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
@@ -335,73 +335,71 @@
          </widget>
         </item>
         <item>
-          <layout class="QGridLayout" name="gridLayout_2">
-            <property name="leftMargin">
-              <number>12</number>
-            </property>
-            <property name="topMargin">
-              <number>0</number>
-            </property>
-            <property name="rightMargin">
-              <number>12</number>
-            </property>
-            <item row="0" column="0" colspan="2">
-              <layout class="QHBoxLayout" name="chooseRefLayout">
-                <item>
-                <widget class="QLabel" name="pickTargetLabel">
-                  <property name="text">
-                  <string>Active Component</string>
-                  </property>
-                </widget>
-                </item>
-                <item>
-                <widget class="QPushButton" name="pickTargetModel">
-                  <property name="text">
-                  <string>Model</string>
-                  </property>
-                  <property name="toolTip">
-                  <string>Set selection target to Model (default): origin/axis picks target the Model object.</string>
-                  </property>
-                  <property name="icon">
-                  <iconset resource="../Path.qrc">
-                    <normaloff>:/icons/model.svg</normaloff>:/icons/model.svg</iconset>
-                  </property>
-                  <property name="checkable">
-                  <bool>true</bool>
-                  </property>
-                  <property name="checked">
-                  <bool>true</bool>
-                  </property>
-                </widget>
-                </item>
-                <item>
-                <widget class="QPushButton" name="pickTargetStock">
-                  <property name="text">
-                  <string>Stock</string>
-                  </property>
-                  <property name="toolTip">
-                  <string>Set selection target to Stock: origin/axis picks target the Stock object.</string>
-                  </property>
-                  <property name="icon">
-                  <iconset resource="../Path.qrc">
-                    <normaloff>:/icons/stock.svg</normaloff>:/icons/stock.svg</iconset>
-                  </property>
-                  <property name="checkable">
-                  <bool>true</bool>
-                  </property>
-                </widget>
-                </item>
-              </layout>
-            </item>
+         <widget class="QGroupBox" name="pickTargetGroup">
+          <property name="title">
+           <string>Select From</string>
+          </property>
+          <layout class="QHBoxLayout" name="chooseRefLayout">
+           <item>
+            <widget class="QPushButton" name="pickTargetModel">
+             <property name="text">
+              <string>Model</string>
+             </property>
+             <property name="toolTip">
+              <string>Set selection target to Model (default): origin/axis picks target the Model object.</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/model.svg</normaloff>:/icons/model.svg</iconset>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pickTargetStock">
+             <property name="text">
+              <string>Stock</string>
+             </property>
+             <property name="toolTip">
+              <string>Set selection target to Stock: origin/axis picks target the Stock object.</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/stock.svg</normaloff>:/icons/stock.svg</iconset>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="pickTargetSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
           </layout>
+         </widget>
         </item>
         <item>
          <widget class="QGroupBox" name="modelAlignGroup">
           <property name="title">
-           <string>Alignment</string>
+           <string>Origin &amp;&amp; Alignment</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_2">
-           <item row="0" column="0">
+           <item row="0" column="0" colspan="3">
             <widget class="QPushButton" name="moveToOrigin">
              <property name="text">
               <string>Move to Origin</string>
@@ -418,7 +416,7 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
+           <item row="0" column="3" colspan="3">
             <widget class="QPushButton" name="setOrigin">
              <property name="text">
               <string>Set Origin</string>
@@ -438,10 +436,10 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="0">
+           <item row="1" column="0" colspan="3">
             <widget class="QPushButton" name="centerInStock">
              <property name="text">
-              <string>Center in Stock</string>
+              <string>Center XYZ in Stock</string>
              </property>
              <property name="icon">
               <iconset resource="../Path.qrc">
@@ -455,10 +453,10 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
+           <item row="1" column="3" colspan="3">
             <widget class="QPushButton" name="centerInStockXY">
              <property name="text">
-              <string>XY in Stock</string>
+              <string>Center XY in Stock</string>
              </property>
              <property name="icon">
               <iconset resource="../Path.qrc">
@@ -472,19 +470,7 @@
              </property>
             </widget>
            </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="modelSetGroup">
-          <property name="title">
-           <string>Origin &amp;&amp; Orientation</string>
-          </property>
-          <property name="toolTip">
-           <string>Positions the model so a picked edge defines an axis and a picked vertex zeros the model on that axis. The G54-G59 fixture is set on the output tab.</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_5">
-           <item row="0" column="0">
+           <item row="2" column="0" colspan="2">
             <widget class="QPushButton" name="modelSetXAxis">
              <property name="text">
               <string>X-Axis</string>
@@ -504,7 +490,7 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
+           <item row="2" column="2" colspan="2">
             <widget class="QPushButton" name="modelSetYAxis">
              <property name="text">
               <string>Y-Axis</string>
@@ -524,7 +510,7 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="2">
+           <item row="2" column="4" colspan="2">
             <widget class="QPushButton" name="modelSetZAxis">
              <property name="text">
               <string>Z-Axis</string>
@@ -544,7 +530,7 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="0">
+           <item row="3" column="0" colspan="2">
             <widget class="QPushButton" name="modelSetX0">
              <property name="text">
               <string>X=0</string>
@@ -554,7 +540,7 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
+           <item row="3" column="2" colspan="2">
             <widget class="QPushButton" name="modelSetY0">
              <property name="text">
               <string>Y=0</string>
@@ -564,7 +550,7 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="2">
+           <item row="3" column="4" colspan="2">
             <widget class="QPushButton" name="modelSetZ0">
              <property name="text">
               <string>Z=0</string>
@@ -574,7 +560,7 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="0" colspan="3">
+           <item row="4" column="0" colspan="6">
             <widget class="QCheckBox" name="linkStockAndModel">
              <property name="text">
               <string>Link stock and model</string>
@@ -590,25 +576,17 @@
         <item>
          <widget class="QGroupBox" name="modelMoveGroup">
           <property name="title">
-           <string>Move - XY</string>
+           <string>Transform</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_3">
+          <layout class="QVBoxLayout" name="verticalLayout_modelMove">
+           <property name="spacing"><number>6</number></property>
+           <property name="leftMargin"><number>0</number></property>
+           <property name="topMargin"><number>6</number></property>
+           <property name="rightMargin"><number>0</number></property>
+           <property name="bottomMargin"><number>6</number></property>
+           <item>
+            <layout class="QGridLayout" name="gridLayout_3">
            <item row="0" column="0">
-            <widget class="QPushButton" name="modelMoveLeftUp">
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-left-up.svg</normaloff>:/icons/arrow-left-up.svg</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>24</width>
-               <height>24</height>
-              </size>
-             </property>
-            </widget>
            </item>
            <item row="0" column="1">
             <widget class="QPushButton" name="modelMoveUp">
@@ -628,13 +606,13 @@
             </widget>
            </item>
            <item row="0" column="2">
-            <widget class="QPushButton" name="modelMoveRightUp">
+            <widget class="QPushButton" name="modelMoveZUp">
              <property name="text">
               <string/>
              </property>
              <property name="icon">
               <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-right-up.svg</normaloff>:/icons/arrow-right-up.svg</iconset>
+               <normaloff>:/icons/arrow-up.svg</normaloff>:/icons/arrow-up.svg</iconset>
              </property>
              <property name="iconSize">
               <size>
@@ -686,21 +664,6 @@
             </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QPushButton" name="modelMoveLeftDown">
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-left-down.svg</normaloff>:/icons/arrow-left-down.svg</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>24</width>
-               <height>24</height>
-              </size>
-             </property>
-            </widget>
            </item>
            <item row="2" column="1">
             <widget class="QPushButton" name="modelMoveDown">
@@ -720,13 +683,13 @@
             </widget>
            </item>
            <item row="2" column="2">
-            <widget class="QPushButton" name="modelMoveRightDown">
+            <widget class="QPushButton" name="modelMoveZDown">
              <property name="text">
               <string/>
              </property>
              <property name="icon">
               <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-right-down.svg</normaloff>:/icons/arrow-right-down.svg</iconset>
+               <normaloff>:/icons/arrow-down.svg</normaloff>:/icons/arrow-down.svg</iconset>
              </property>
              <property name="iconSize">
               <size>
@@ -737,17 +700,9 @@
             </widget>
            </item>
           </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="modelRotateGroup">
-          <property name="title">
-           <string>Rotate around Z</string>
-          </property>
-          <property name="toolTip">
-           <string>Rotates the model about the Z-axis. When the compound checkbox is enabled, rotations stack cumulatively.</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_6">
+           </item>
+           <item>
+            <layout class="QGridLayout" name="gridLayout_6">
            <item row="0" column="0">
             <widget class="QPushButton" name="modelRotateLeft">
              <property name="sizePolicy">
@@ -835,6 +790,8 @@
               </size>
              </property>
             </widget>
+           </item>
+          </layout>
            </item>
           </layout>
          </widget>

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -38,6 +38,7 @@ import Path.Main.Job as PathJob
 import Path.Main.Stock as PathStock
 import Path.Tool.Gui.Controller as PathToolControllerGui
 import PathScripts.PathUtils as PathUtils
+from Path.Tool.docobject.ui.docobject import _get_label_text as _format_label
 from Path.Tool.toolbit.ui.selector import ToolBitSelector
 from Machine.models import MachineFactory
 from Machine.ui.editor import MachineEditorDialog
@@ -413,7 +414,6 @@ class MaterialDialog(QtWidgets.QDialog):
 
     def onMaterial(self, uuid):
         try:
-            print("Selected '{0}'".format(uuid))
             self.uuid = uuid
         except Exception as e:
             print(e)
@@ -882,7 +882,7 @@ class TaskPanel:
             return
         _, name = self._currentStockMaterial()
         if name:
-            label.setText(name)
+            label.setText(_format_label(name, keep_case=True))
             label.setStyleSheet("")
         else:
             label.setText(translate("CAM_Job", "(none assigned)"))
@@ -1400,7 +1400,7 @@ class TaskPanel:
                                 Draft.move(self.obj.Stock, offset)
 
     def modelMove(self, axis):
-        scale = self.form.modelMoveValue.value()
+        scale = self.form.modelMoveValue.property("rawValue")
         with selectionEx() as selection:
             for sel in selection:
                 offset = axis * scale
@@ -1457,20 +1457,25 @@ class TaskPanel:
         except Exception as e:
             Path.Log.error("Failed to open Machine Editor: %s" % e)
 
-    def togglePickTarget(self, checked):
-        """Toggle whether origin/axis picks target the Stock or the Model.
-        When checked (Picking: Model): model selectable, stock non-selectable.
-        When unchecked (Picking: Stock): stock selectable, model non-selectable."""
+    def togglePickTarget(self, modelTarget):
+        """Set whether origin/axis picks target the Model or the Stock.
+        When modelTarget is True: model selectable, stock non-selectable.
+        When modelTarget is False: stock selectable, model non-selectable."""
         stock = self.obj.Stock
         if stock and stock.ViewObject:
-            stock.ViewObject.Selectable = not checked
+            stock.ViewObject.Selectable = not modelTarget
         for base in self.obj.Model.Group:
             if base and base.ViewObject:
-                base.ViewObject.Selectable = checked
-        if checked:
-            self.form.pickTargetToggle.setText(translate("CAM_Job", "Picking: Model"))
-        else:
-            self.form.pickTargetToggle.setText(translate("CAM_Job", "Picking: Stock"))
+                base.ViewObject.Selectable = modelTarget
+        self.form.pickTargetModel.setChecked(modelTarget)
+        self.form.pickTargetStock.setChecked(not modelTarget)
+        # Apply explicit highlight so the active button is visible regardless of theme.
+        pal = self.form.pickTargetModel.palette()
+        hl_color = pal.highlight().color().name()
+        hl_text = pal.highlightedText().color().name()
+        active_style = f"background-color: {hl_color}; color: {hl_text};"
+        self.form.pickTargetModel.setStyleSheet(active_style if modelTarget else "")
+        self.form.pickTargetStock.setStyleSheet("" if modelTarget else active_style)
 
     def alignSetOrigin(self):
         obj, by = self.alignMoveToOrigin()
@@ -1572,6 +1577,7 @@ class TaskPanel:
 
     def refreshStock(self):
         self.updateStockEditor(self.form.stock.currentIndex(), True)
+        self.togglePickTarget(self.form.pickTargetModel.isChecked())
 
     def alignCenterInStock(self):
         bbs = self.obj.Stock.Shape.BoundBox
@@ -1759,8 +1765,17 @@ class TaskPanel:
 
         self.form.setOrigin.clicked.connect(self.alignSetOrigin)
         self.form.moveToOrigin.clicked.connect(self.alignMoveToOrigin)
-        self.form.pickTargetToggle.toggled.connect(self.togglePickTarget)
-        self.togglePickTarget(self.form.pickTargetToggle.isChecked())
+        self.form.pickTargetModel.clicked.connect(lambda: self.togglePickTarget(True))
+        self.form.pickTargetStock.clicked.connect(lambda: self.togglePickTarget(False))
+        self.togglePickTarget(True)  # default: Model
+
+        _moveUnit = FreeCAD.Units.Quantity(1, FreeCAD.Units.Length).getUserPreferred()[2]
+        if _moveUnit in ("in", '"'):
+            self.form.modelMoveValue.setProperty("unit", "in")
+            self.form.modelMoveValue.setProperty("rawValue", 2.54)  # 0.100"
+        else:
+            self.form.modelMoveValue.setProperty("unit", "mm")
+            self.form.modelMoveValue.setProperty("rawValue", 1.0)
 
         self.form.modelMoveLeftUp.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(-1, 1, 0)))
         self.form.modelMoveLeft.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(-1, 0, 0)))
@@ -1797,6 +1812,64 @@ class TaskPanel:
             self.form.setCurrentIndex(4)
 
         self.form.currentChanged.connect(self.tabPageChanged)
+
+        self._applyButtonIcons()
+
+    def _applyButtonIcons(self):
+        """Set button icons with original SVG colors, adapting monochrome icons to the
+        current theme (white on dark, black on light).  The XYZ axis buttons always
+        keep their fixed Red / Green / Blue stroke colors."""
+
+        theme = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/MainWindow").GetString(
+            "Theme", ""
+        )
+        if theme:
+            is_dark = "dark" in theme.lower()
+
+        def _adaptive_icon(resource_path, size=16):
+            """Load a monochrome SVG icon (#111111 stroke/fill) and invert to white
+            when running under a dark theme. Also sets a proper disabled pixmap for button tinting.
+            """
+
+            from PySide import QtSvg
+
+            f = QtCore.QFile(resource_path)
+            if not f.open(QtCore.QFile.ReadOnly):
+                return QtGui.QIcon(resource_path)
+            content = bytes(f.readAll())
+            f.close()
+
+            if is_dark:
+                # #d33d3d is a placehole color to avoid #111111 -> #ffffff replacement affecting the original black strokes in the SVG
+                content = content.replace(b"#111111", b"#d33d3d")
+                content = content.replace(b"#ffffff", b"#111111")
+                content = content.replace(b"#d33d3d", b"#ffffff")
+
+            ba = QtCore.QByteArray(content)
+            renderer = QtSvg.QSvgRenderer(ba)
+            pixmap = QtGui.QPixmap(size, size)
+            pixmap.fill(QtCore.Qt.transparent)
+            painter = QtGui.QPainter(pixmap)
+            renderer.render(painter)
+            painter.end()
+
+            icon = QtGui.QIcon(pixmap)
+            # Disabled pixmap: faded version of the already-correct color
+            disabled_pixmap = pixmap.copy()
+            painter = QtGui.QPainter(disabled_pixmap)
+            painter.setCompositionMode(QtGui.QPainter.CompositionMode_DestinationIn)
+            painter.fillRect(disabled_pixmap.rect(), QtGui.QColor(0, 0, 0, 100))
+            painter.end()
+            icon.addPixmap(disabled_pixmap, QtGui.QIcon.Disabled, QtGui.QIcon.Off)
+            return icon
+
+        # Monochrome (theme-adaptive) icons
+        self.form.moveToOrigin.setIcon(_adaptive_icon(":/icons/move-to-origin.svg"))
+        self.form.setOrigin.setIcon(_adaptive_icon(":/icons/set-origin.svg"))
+        self.form.pickTargetModel.setIcon(_adaptive_icon(":/icons/model.svg"))
+        self.form.pickTargetStock.setIcon(_adaptive_icon(":/icons/stock.svg"))
+        self.form.centerInStock.setIcon(_adaptive_icon(":/icons/center-in-stock.svg"))
+        self.form.centerInStockXY.setIcon(_adaptive_icon(":/icons/xy-in-stock.svg"))
 
     def open(self):
         FreeCADGui.Selection.addObserver(self)

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -43,6 +43,7 @@ import Path.Tool.Gui.Controller as PathToolControllerGui
 # tool updates on open, which must happen before any document opens.
 import Path.Tool.Gui.UpdateDocumentToolsDlg as PathUpdateToolsGui
 import PathScripts.PathUtils as PathUtils
+from Path.Tool.docobject.ui.docobject import _get_label_text as _format_label
 from Path.Tool.toolbit.ui.selector import ToolBitSelector
 from Machine.models import MachineFactory
 from Machine.ui.editor import MachineEditorDialog
@@ -427,7 +428,6 @@ class MaterialDialog(QtWidgets.QDialog):
 
     def onMaterial(self, uuid):
         try:
-            print("Selected '{0}'".format(uuid))
             self.uuid = uuid
         except Exception as e:
             print(e)
@@ -896,7 +896,7 @@ class TaskPanel:
             return
         _, name = self._currentStockMaterial()
         if name:
-            label.setText(name)
+            label.setText(_format_label(name, keep_case=True))
             label.setStyleSheet("")
         else:
             label.setText(translate("CAM_Job", "(none assigned)"))
@@ -918,12 +918,15 @@ class TaskPanel:
         Path.Log.track()
         FreeCADGui.Selection.removeObserver(self)
         # Restore natural selectability: model selectable, stock non-selectable
+        # and reset transparency after leaving the task panel.
         stock = self.obj.Stock
         if stock and stock.ViewObject:
             stock.ViewObject.Selectable = False
+            stock.ViewObject.Transparency = 85
         for base in self.obj.Model.Group:
             if base and base.ViewObject:
                 base.ViewObject.Selectable = True
+                # base.ViewObject.Transparency = 0
         self.vproxy.resetEditVisibility(self.obj)
         self.vproxy.resetTaskPanel()
 
@@ -1468,13 +1471,26 @@ class TaskPanel:
                                 Draft.move(self.obj.Stock, offset)
 
     def modelMove(self, axis):
-        scale = self.form.modelMoveValue.value()
+        scale = self.form.modelMoveValue.property("rawValue")
         with selectionEx() as selection:
             for sel in selection:
                 offset = axis * scale
                 Draft.move(sel.Object, offset)
 
-    def modelRotate(self, axis):
+    def modelRotateAxis(self):
+        """Returns the unit vector of the rotation axis selected in the axis combo."""
+        axes = [
+            FreeCAD.Vector(1, 0, 0),
+            FreeCAD.Vector(0, 1, 0),
+            FreeCAD.Vector(0, 0, 1),
+        ]
+        index = self.form.modelRotateAxis.currentIndex()
+        if index < 0 or index >= len(axes):
+            index = 2  # default to Z
+        return axes[index]
+
+    def modelRotate(self, direction):
+        axis = self.modelRotateAxis() * direction
         angle = self.form.modelRotateValue.value()
         with selectionEx() as selection:
             if self.form.modelRotateCompound.isChecked() and len(selection) > 1:
@@ -1525,20 +1541,27 @@ class TaskPanel:
         except Exception as e:
             Path.Log.error("Failed to open Machine Editor: %s" % e)
 
-    def togglePickTarget(self, checked):
-        """Toggle whether origin/axis picks target the Stock or the Model.
-        When checked (Picking: Model): model selectable, stock non-selectable.
-        When unchecked (Picking: Stock): stock selectable, model non-selectable."""
+    def togglePickTarget(self, modelTarget):
+        """Set whether origin/axis picks target the Model or the Stock.
+        When modelTarget is True: model selectable, stock non-selectable.
+        When modelTarget is False: stock selectable, model non-selectable."""
         stock = self.obj.Stock
         if stock and stock.ViewObject:
-            stock.ViewObject.Selectable = not checked
+            stock.ViewObject.Selectable = not modelTarget
+            stock.ViewObject.Transparency = 95 if modelTarget else 85
         for base in self.obj.Model.Group:
             if base and base.ViewObject:
-                base.ViewObject.Selectable = checked
-        if checked:
-            self.form.pickTargetToggle.setText(translate("CAM_Job", "Picking: Model"))
-        else:
-            self.form.pickTargetToggle.setText(translate("CAM_Job", "Picking: Stock"))
+                base.ViewObject.Selectable = modelTarget
+                # base.ViewObject.Transparency = 0 if modelTarget else 95
+        self.form.pickTargetModel.setChecked(modelTarget)
+        self.form.pickTargetStock.setChecked(not modelTarget)
+        # Apply explicit highlight so the active button is visible regardless of theme.
+        pal = self.form.pickTargetModel.palette()
+        hl_color = pal.highlight().color().name()
+        hl_text = pal.highlightedText().color().name()
+        active_style = f"background-color: {hl_color}; color: {hl_text};"
+        self.form.pickTargetModel.setStyleSheet(active_style if modelTarget else "")
+        self.form.pickTargetStock.setStyleSheet("" if modelTarget else active_style)
 
     def alignSetOrigin(self):
         obj, by = self.alignMoveToOrigin()
@@ -1567,7 +1590,11 @@ class TaskPanel:
                 if "Vertex" == sub.ShapeType:
                     p = FreeCAD.Vector() - sub.Point
                 if "Edge" == sub.ShapeType:
-                    p = FreeCAD.Vector() - sub.Curve.Location
+                    if isinstance(sub.Curve, Part.Circle):
+                        p = FreeCAD.Vector() - sub.Curve.Location
+                    else:
+                        mid = sub.valueAt((sub.FirstParameter + sub.LastParameter) / 2)
+                        p = FreeCAD.Vector() - mid
                 if "Face" == sub.ShapeType:
                     p = FreeCAD.Vector() - sub.BoundBox.Center
 
@@ -1640,6 +1667,7 @@ class TaskPanel:
 
     def refreshStock(self):
         self.updateStockEditor(self.form.stock.currentIndex(), True)
+        self.togglePickTarget(self.form.pickTargetModel.isChecked())
 
     def alignCenterInStock(self):
         bbs = self.obj.Stock.Shape.BoundBox
@@ -1658,8 +1686,6 @@ class TaskPanel:
 
     def isValidDatumSelection(self, sel):
         if sel.ShapeType in ["Vertex", "Edge", "Face"]:
-            if hasattr(sel, "Curve") and not isinstance(sel.Curve, Part.Circle):
-                return False
             return True
 
         # no valid selection
@@ -1711,14 +1737,16 @@ class TaskPanel:
             self.form.modelSetY0.setEnabled(True)
             self.form.modelSetZ0.setEnabled(True)
             self.form.modelMoveGroup.setEnabled(True)
-            self.form.modelRotateGroup.setEnabled(True)
-            self.form.modelRotateCompound.setEnabled(len(sel) > 1)
+            # self.form.modelRotateGroup.setEnabled(True)
+            # Compound only has an effect with multiple objects selected, but keep it
+            # clickable so the setting can be made before the selection is complete.
+            self.form.modelRotateCompound.setEnabled(True)
         else:
             self.form.modelSetX0.setEnabled(False)
             self.form.modelSetY0.setEnabled(False)
             self.form.modelSetZ0.setEnabled(False)
             self.form.modelMoveGroup.setEnabled(False)
-            self.form.modelRotateGroup.setEnabled(False)
+            # self.form.modelRotateGroup.setEnabled(False)
 
     def jobModelEdit(self):
         dialog = PathJobDlg.JobCreate()
@@ -1827,28 +1855,36 @@ class TaskPanel:
 
         self.form.setOrigin.clicked.connect(self.alignSetOrigin)
         self.form.moveToOrigin.clicked.connect(self.alignMoveToOrigin)
-        self.form.pickTargetToggle.toggled.connect(self.togglePickTarget)
-        self.togglePickTarget(self.form.pickTargetToggle.isChecked())
+        self.form.pickTargetModel.clicked.connect(lambda: self.togglePickTarget(True))
+        self.form.pickTargetStock.clicked.connect(lambda: self.togglePickTarget(False))
+        self.togglePickTarget(True)  # default: Model
 
-        self.form.modelMoveLeftUp.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(-1, 1, 0)))
+        _moveUnit = FreeCAD.Units.Quantity(1, FreeCAD.Units.Length).getUserPreferred()[2]
+        if _moveUnit in ("in", '"'):
+            self.form.modelMoveValue.setProperty("unit", "in")
+            self.form.modelMoveValue.setProperty("rawValue", 2.54)  # 0.100"
+        else:
+            self.form.modelMoveValue.setProperty("unit", "mm")
+            self.form.modelMoveValue.setProperty("rawValue", 1.0)
+
+        # self.form.modelMoveLeftUp.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(-1, 1, 0)))
         self.form.modelMoveLeft.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(-1, 0, 0)))
-        self.form.modelMoveLeftDown.clicked.connect(
-            lambda: self.modelMove(FreeCAD.Vector(-1, -1, 0))
-        )
+        # self.form.modelMoveLeftDown.clicked.connect(
+        #    lambda: self.modelMove(FreeCAD.Vector(-1, -1, 0))
+        # )
 
         self.form.modelMoveUp.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(0, 1, 0)))
         self.form.modelMoveDown.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(0, -1, 0)))
 
-        self.form.modelMoveRightUp.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(1, 1, 0)))
+        self.form.modelMoveZUp.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(0, 0, 1)))
         self.form.modelMoveRight.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(1, 0, 0)))
-        self.form.modelMoveRightDown.clicked.connect(
-            lambda: self.modelMove(FreeCAD.Vector(1, -1, 0))
-        )
+        self.form.modelMoveZDown.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(0, 0, -1)))
 
-        self.form.modelRotateLeft.clicked.connect(lambda: self.modelRotate(FreeCAD.Vector(0, 0, 1)))
-        self.form.modelRotateRight.clicked.connect(
-            lambda: self.modelRotate(FreeCAD.Vector(0, 0, -1))
-        )
+        self.form.modelRotateAxis.setCurrentIndex(2)  # default: Z
+        self.form.modelRotateAxis.currentIndexChanged.connect(self._updateRotateIcons)
+        self._updateRotateIcons()
+        self.form.modelRotateLeft.clicked.connect(lambda: self.modelRotate(1))
+        self.form.modelRotateRight.clicked.connect(lambda: self.modelRotate(-1))
 
         self.updateSelection()
 
@@ -1865,6 +1901,69 @@ class TaskPanel:
             self.form.setCurrentIndex(4)
 
         self.form.currentChanged.connect(self.tabPageChanged)
+
+        self._applyButtonIcons()
+
+    def _updateRotateIcons(self):
+        """Color the rotate arrows to match the axis selected in the axis combo."""
+        axis = ["x", "y", "z"][max(0, min(2, self.form.modelRotateAxis.currentIndex()))]
+        self.form.modelRotateLeft.setIcon(QtGui.QIcon(":/icons/arrow-ccw-%s.svg" % axis))
+        self.form.modelRotateRight.setIcon(QtGui.QIcon(":/icons/arrow-cw-%s.svg" % axis))
+
+    def _applyButtonIcons(self):
+        """Set button icons with original SVG colors, adapting monochrome icons to the
+        current theme (white on dark, black on light).  The XYZ axis buttons always
+        keep their fixed Red / Green / Blue stroke colors."""
+
+        theme = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/MainWindow").GetString(
+            "Theme", ""
+        )
+        is_dark = "dark" in theme.lower() if theme else False
+
+        def _adaptive_icon(resource_path, size=16):
+            """Load a monochrome SVG icon (#111111 stroke/fill) and invert to white
+            when running under a dark theme. Also sets a proper disabled pixmap for button tinting.
+            """
+
+            from PySide import QtSvg
+
+            f = QtCore.QFile(resource_path)
+            if not f.open(QtCore.QFile.ReadOnly):
+                return QtGui.QIcon(resource_path)
+            content = bytes(f.readAll())
+            f.close()
+
+            if is_dark:
+                # #d33d3d is a placehole color to avoid #111111 -> #ffffff replacement affecting the original black strokes in the SVG
+                content = content.replace(b"#111111", b"#d33d3d")
+                content = content.replace(b"#ffffff", b"#111111")
+                content = content.replace(b"#d33d3d", b"#ffffff")
+
+            ba = QtCore.QByteArray(content)
+            renderer = QtSvg.QSvgRenderer(ba)
+            pixmap = QtGui.QPixmap(size, size)
+            pixmap.fill(QtCore.Qt.transparent)
+            painter = QtGui.QPainter(pixmap)
+            renderer.render(painter)
+            painter.end()
+
+            icon = QtGui.QIcon(pixmap)
+            # Disabled pixmap: faded version of the already-correct color
+            disabled_pixmap = pixmap.copy()
+            painter = QtGui.QPainter(disabled_pixmap)
+            painter.setCompositionMode(QtGui.QPainter.CompositionMode_DestinationIn)
+            painter.fillRect(disabled_pixmap.rect(), QtGui.QColor(0, 0, 0, 100))
+            painter.end()
+            icon.addPixmap(disabled_pixmap, QtGui.QIcon.Disabled, QtGui.QIcon.Off)
+            return icon
+
+        # Monochrome (theme-adaptive) icons
+        self.form.moveToOrigin.setIcon(_adaptive_icon(":/icons/move-to-origin.svg"))
+        self.form.setOrigin.setIcon(_adaptive_icon(":/icons/set-origin.svg"))
+        self.form.pickTargetModel.setIcon(_adaptive_icon(":/icons/model.svg"))
+        self.form.pickTargetStock.setIcon(_adaptive_icon(":/icons/stock.svg"))
+        self.form.centerInStock.setIcon(_adaptive_icon(":/icons/center-in-stock.svg"))
+        self.form.centerInStockXY.setIcon(_adaptive_icon(":/icons/xy-in-stock.svg"))
 
     def open(self):
         FreeCADGui.Selection.addObserver(self)

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -904,12 +904,15 @@ class TaskPanel:
         Path.Log.track()
         FreeCADGui.Selection.removeObserver(self)
         # Restore natural selectability: model selectable, stock non-selectable
+        # and reset transparency after leaving the task panel.
         stock = self.obj.Stock
         if stock and stock.ViewObject:
             stock.ViewObject.Selectable = False
+            stock.ViewObject.Transparency = 85
         for base in self.obj.Model.Group:
             if base and base.ViewObject:
                 base.ViewObject.Selectable = True
+                # base.ViewObject.Transparency = 0
         self.vproxy.resetEditVisibility(self.obj)
         self.vproxy.resetTaskPanel()
 
@@ -1464,9 +1467,11 @@ class TaskPanel:
         stock = self.obj.Stock
         if stock and stock.ViewObject:
             stock.ViewObject.Selectable = not modelTarget
+            stock.ViewObject.Transparency = 95 if modelTarget else 85
         for base in self.obj.Model.Group:
             if base and base.ViewObject:
                 base.ViewObject.Selectable = modelTarget
+                # base.ViewObject.Transparency = 0 if modelTarget else 95
         self.form.pickTargetModel.setChecked(modelTarget)
         self.form.pickTargetStock.setChecked(not modelTarget)
         # Apply explicit highlight so the active button is visible regardless of theme.
@@ -1504,7 +1509,11 @@ class TaskPanel:
                 if "Vertex" == sub.ShapeType:
                     p = FreeCAD.Vector() - sub.Point
                 if "Edge" == sub.ShapeType:
-                    p = FreeCAD.Vector() - sub.Curve.Location
+                    if isinstance(sub.Curve, Part.Circle):
+                        p = FreeCAD.Vector() - sub.Curve.Location
+                    else:
+                        mid = sub.valueAt((sub.FirstParameter + sub.LastParameter) / 2)
+                        p = FreeCAD.Vector() - mid
                 if "Face" == sub.ShapeType:
                     p = FreeCAD.Vector() - sub.BoundBox.Center
 
@@ -1596,8 +1605,6 @@ class TaskPanel:
 
     def isValidDatumSelection(self, sel):
         if sel.ShapeType in ["Vertex", "Edge", "Face"]:
-            if hasattr(sel, "Curve") and not isinstance(sel.Curve, Part.Circle):
-                return False
             return True
 
         # no valid selection
@@ -1649,14 +1656,14 @@ class TaskPanel:
             self.form.modelSetY0.setEnabled(True)
             self.form.modelSetZ0.setEnabled(True)
             self.form.modelMoveGroup.setEnabled(True)
-            self.form.modelRotateGroup.setEnabled(True)
+            # self.form.modelRotateGroup.setEnabled(True)
             self.form.modelRotateCompound.setEnabled(len(sel) > 1)
         else:
             self.form.modelSetX0.setEnabled(False)
             self.form.modelSetY0.setEnabled(False)
             self.form.modelSetZ0.setEnabled(False)
             self.form.modelMoveGroup.setEnabled(False)
-            self.form.modelRotateGroup.setEnabled(False)
+            # self.form.modelRotateGroup.setEnabled(False)
 
     def jobModelEdit(self):
         dialog = PathJobDlg.JobCreate()
@@ -1777,20 +1784,18 @@ class TaskPanel:
             self.form.modelMoveValue.setProperty("unit", "mm")
             self.form.modelMoveValue.setProperty("rawValue", 1.0)
 
-        self.form.modelMoveLeftUp.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(-1, 1, 0)))
+        # self.form.modelMoveLeftUp.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(-1, 1, 0)))
         self.form.modelMoveLeft.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(-1, 0, 0)))
-        self.form.modelMoveLeftDown.clicked.connect(
-            lambda: self.modelMove(FreeCAD.Vector(-1, -1, 0))
-        )
+        # self.form.modelMoveLeftDown.clicked.connect(
+        #    lambda: self.modelMove(FreeCAD.Vector(-1, -1, 0))
+        # )
 
         self.form.modelMoveUp.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(0, 1, 0)))
         self.form.modelMoveDown.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(0, -1, 0)))
 
-        self.form.modelMoveRightUp.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(1, 1, 0)))
+        self.form.modelMoveZUp.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(0, 0, 1)))
         self.form.modelMoveRight.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(1, 0, 0)))
-        self.form.modelMoveRightDown.clicked.connect(
-            lambda: self.modelMove(FreeCAD.Vector(1, -1, 0))
-        )
+        self.form.modelMoveZDown.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(0, 0, -1)))
 
         self.form.modelRotateLeft.clicked.connect(lambda: self.modelRotate(FreeCAD.Vector(0, 0, 1)))
         self.form.modelRotateRight.clicked.connect(

--- a/src/Mod/CAM/Path/Main/Job.py
+++ b/src/Mod/CAM/Path/Main/Job.py
@@ -89,10 +89,10 @@ def createResourceClone(obj, orig, name, icon):
         Path.Base.Gui.IconViewProvider.Attach(clone.ViewObject, icon)
         clone.ViewObject.Visibility = False
         clone.ViewObject.DisplayMode = "Flat Lines"
-        clone.ViewObject.ShapeColor = (0.447, 0.475, 0.502)
+        # clone.ViewObject.ShapeColor = (0.447, 0.475, 0.502)
         clone.ViewObject.Transparency = 0
-        clone.ViewObject.LineColor = (0.310, 0.333, 0.357)
-        clone.ViewObject.ShapeMaterial.Shininess = 0.85
+        # clone.ViewObject.LineColor = (0.310, 0.333, 0.357)
+        # clone.ViewObject.ShapeMaterial.Shininess = 0.85
     obj.Document.recompute()  # necessary to create the clone shape
     return clone
 
@@ -396,9 +396,11 @@ class ObjectJob:
                 obj.Stock = PathStock.CreateFromTemplate(obj, json.loads(stockTemplate))
             if not obj.Stock:
                 obj.Stock = PathStock.CreateFromBase(obj)
-        PathStock.ApplyStockViewDefaults(obj.Stock)
-        if obj.Stock and obj.Stock.ViewObject:
-            obj.Stock.ViewObject.Visibility = True
+        # I think this is dedundant code, and is handled in SetupStockObject,
+        # but leaving here for now just in case
+        # PathStock.ApplyStockViewDefaults(obj.Stock)
+        # if obj.Stock and obj.Stock.ViewObject:
+        #     obj.Stock.ViewObject.Visibility = True
 
     def removeBase(self, obj, base, removeFromModel):
         if isResourceClone(obj, base, None):
@@ -601,6 +603,23 @@ class ObjectJob:
 
         for n in self.propertyEnumerations():
             setattr(obj, n[0], n[1])
+
+        # Re-apply view defaults for older documents that may be missing them.
+        # These are safe to always apply since they restore intended CAM visual behaviour
+        # (stock non-selectable/transparent/dotted, model clones hidden with correct style).
+        if FreeCAD.GuiUp:
+            if getattr(obj, "Stock", None) and obj.Stock.ViewObject:
+                PathStock.ApplyStockViewDefaults(obj.Stock)
+
+            if getattr(obj, "Model", None) and getattr(obj.Model, "Group", None):
+                for base in obj.Model.Group:
+                    if isResourceClone(obj, base, "Model") and base.ViewObject:
+                        # base.ViewObject.Visibility = False
+                        base.ViewObject.DisplayMode = "Flat Lines"
+                        # base.ViewObject.ShapeColor = (0.447, 0.475, 0.502)
+                        base.ViewObject.Transparency = 0
+                        # base.ViewObject.LineColor = (0.310, 0.333, 0.357)
+                        # base.ViewObject.ShapeMaterial.Shininess = 0.85
 
     def onChanged(self, obj, prop):
         if prop == "PostProcessor" and obj.PostProcessor:

--- a/src/Mod/CAM/Path/Main/Job.py
+++ b/src/Mod/CAM/Path/Main/Job.py
@@ -89,10 +89,10 @@ def createResourceClone(obj, orig, name, icon):
         Path.Base.Gui.IconViewProvider.Attach(clone.ViewObject, icon)
         clone.ViewObject.Visibility = False
         clone.ViewObject.DisplayMode = "Flat Lines"
-        clone.ViewObject.ShapeColor = (0.447, 0.475, 0.502)
+        # clone.ViewObject.ShapeColor = (0.447, 0.475, 0.502)
         clone.ViewObject.Transparency = 0
-        clone.ViewObject.LineColor = (0.310, 0.333, 0.357)
-        clone.ViewObject.ShapeMaterial.Shininess = 0.85
+        # clone.ViewObject.LineColor = (0.310, 0.333, 0.357)
+        # clone.ViewObject.ShapeMaterial.Shininess = 0.85
     obj.Document.recompute()  # necessary to create the clone shape
     return clone
 
@@ -396,9 +396,11 @@ class ObjectJob:
                 obj.Stock = PathStock.CreateFromTemplate(obj, json.loads(stockTemplate))
             if not obj.Stock:
                 obj.Stock = PathStock.CreateFromBase(obj)
-        PathStock.ApplyStockViewDefaults(obj.Stock)
-        if obj.Stock and obj.Stock.ViewObject:
-            obj.Stock.ViewObject.Visibility = True
+        # I think this is redundant code, and is handled in SetupStockObject,
+        # but leaving here for now just in case
+        # PathStock.ApplyStockViewDefaults(obj.Stock)
+        # if obj.Stock and obj.Stock.ViewObject:
+        #     obj.Stock.ViewObject.Visibility = True
 
     def removeBase(self, obj, base, removeFromModel):
         if isResourceClone(obj, base, None):
@@ -601,6 +603,23 @@ class ObjectJob:
 
         for n in self.propertyEnumerations():
             setattr(obj, n[0], n[1])
+
+        # Re-apply view defaults for older documents that may be missing them.
+        # These are safe to always apply since they restore intended CAM visual behaviour
+        # (stock non-selectable/transparent/dotted, model clones hidden with correct style).
+        if FreeCAD.GuiUp:
+            if getattr(obj, "Stock", None) and obj.Stock.ViewObject:
+                PathStock.ApplyStockViewDefaults(obj.Stock)
+
+            if getattr(obj, "Model", None) and getattr(obj.Model, "Group", None):
+                for base in obj.Model.Group:
+                    if isResourceClone(obj, base, "Model") and base.ViewObject:
+                        # base.ViewObject.Visibility = False
+                        base.ViewObject.DisplayMode = "Flat Lines"
+                        # base.ViewObject.ShapeColor = (0.447, 0.475, 0.502)
+                        base.ViewObject.Transparency = 0
+                        # base.ViewObject.LineColor = (0.310, 0.333, 0.357)
+                        # base.ViewObject.ShapeMaterial.Shininess = 0.85
 
     def onChanged(self, obj, prop):
         if prop == "PostProcessor" and obj.PostProcessor:

--- a/src/Mod/CAM/Path/Main/Stock.py
+++ b/src/Mod/CAM/Path/Main/Stock.py
@@ -173,12 +173,14 @@ class StockFromBase(Stock):
         )
 
         obj.Base = base
-        obj.ExtXneg = 1.0
-        obj.ExtXpos = 1.0
-        obj.ExtYneg = 1.0
-        obj.ExtYpos = 1.0
-        obj.ExtZneg = 1.0
-        obj.ExtZpos = 1.0
+        _ext_unit = FreeCAD.Units.Quantity(1, FreeCAD.Units.Length).getUserPreferred()[2]
+        _default_ext = 3.175 if _ext_unit in ("in", '"') else 1.0  # 0.125" or 1mm
+        obj.ExtXneg = _default_ext
+        obj.ExtXpos = _default_ext
+        obj.ExtYneg = _default_ext
+        obj.ExtYpos = _default_ext
+        obj.ExtZneg = _default_ext
+        obj.ExtZpos = _default_ext
 
         # placement is only tracked on creation
         bb = shapeBoundBox(base.Group) if base else None

--- a/src/Mod/CAM/Path/Main/Stock.py
+++ b/src/Mod/CAM/Path/Main/Stock.py
@@ -349,9 +349,15 @@ def SetupStockObject(obj, stockType):
         import Path.Base.Gui.IconViewProvider as PathIconViewProvider
 
         PathIconViewProvider.ViewProvider(obj.ViewObject, "Stock")
-        obj.ViewObject.Transparency = 90
-        obj.ViewObject.PointSize = 5
-        obj.ViewObject.DisplayMode = "Wireframe"
+        obj.ViewObject.ShapeColor = (0.792, 0.718, 0.537)
+        obj.ViewObject.Transparency = 95
+        obj.ViewObject.LineColor = (0.553, 0.502, 0.376)
+        obj.ViewObject.PointColor = (0.553, 0.502, 0.376)
+        obj.ViewObject.DrawStyle = "Dotted"
+        obj.ViewObject.DisplayMode = "Flat Lines"
+        obj.ViewObject.PointSize = 1
+        obj.ViewObject.LineWidth = 1
+        obj.ViewObject.Selectable = False
 
 
 class FakeJob(object):

--- a/src/Mod/CAM/Path/Main/Stock.py
+++ b/src/Mod/CAM/Path/Main/Stock.py
@@ -173,12 +173,14 @@ class StockFromBase(Stock):
         )
 
         obj.Base = base
-        obj.ExtXneg = 1.0
-        obj.ExtXpos = 1.0
-        obj.ExtYneg = 1.0
-        obj.ExtYpos = 1.0
-        obj.ExtZneg = 1.0
-        obj.ExtZpos = 1.0
+        _ext_unit = FreeCAD.Units.Quantity(1, FreeCAD.Units.Length).getUserPreferred()[2]
+        _default_ext = 3.175 if _ext_unit in ("in", '"') else 1.0  # 0.125" or 1mm
+        obj.ExtXneg = _default_ext
+        obj.ExtXpos = _default_ext
+        obj.ExtYneg = _default_ext
+        obj.ExtYpos = _default_ext
+        obj.ExtZneg = _default_ext
+        obj.ExtZpos = _default_ext
 
         # placement is only tracked on creation
         bb = shapeBoundBox(base.Group) if base else None
@@ -369,9 +371,15 @@ def SetupStockObject(obj, stockType):
         import Path.Base.Gui.IconViewProvider as PathIconViewProvider
 
         PathIconViewProvider.ViewProvider(obj.ViewObject, "Stock")
-        obj.ViewObject.Transparency = 90
-        obj.ViewObject.PointSize = 5
-        obj.ViewObject.DisplayMode = "Wireframe"
+        obj.ViewObject.ShapeColor = (0.792, 0.718, 0.537)
+        obj.ViewObject.Transparency = 95
+        obj.ViewObject.LineColor = (0.553, 0.502, 0.376)
+        obj.ViewObject.PointColor = (0.553, 0.502, 0.376)
+        obj.ViewObject.DrawStyle = "Dotted"
+        obj.ViewObject.DisplayMode = "Flat Lines"
+        obj.ViewObject.PointSize = 1
+        obj.ViewObject.LineWidth = 1
+        obj.ViewObject.Selectable = False
 
 
 class FakeJob(object):


### PR DESCRIPTION
This PR updates the Job Task Panel GUI

* Turns the Picking Stock / Model into two interlinked toggle buttons.
* Added SVG icons to key buttons (move to origin, set origin, center/xy in stock, model, stock, XYZ axes).
* Resized the arrow icons from 32x32 to 24x24
* Switched model move step to use Gui::QuantitySpinBox for better unit handling defaults 0.1000 for imperial, kept 1.0 mm for metric.
* Set default stock boundary extension to 0.125" (3.175 mm) for imperial units, kept original 1.0 mm for metric.
* Added an axis selector so rotation can be around X, Y or Z (defaults to Z).
* Moved the Z up/down buttons beside the X/Y pad.
* Color coded the arrows to the axis they control.

Fixes #29402
Fixes #26337

InActive Buttons
| Open Dark | Open Light |
|---|---|
| <img width="421" height="962" alt="Screenshot from 2026-08-22 16-50-24" src="https://github.com/user-attachments/assets/b5d2be6a-cbf7-4886-aa52-53cefa04e7e3" />|<img width="421" height="962" alt="Screenshot from 2026-08-22 16-51-04" src="https://github.com/user-attachments/assets/04c20b7c-52df-4a64-8e78-155324f821c6" />|

Active Buttons
| Open Dark | Open Light |
|---|---|
|<img width="421" height="962" alt="Screenshot from 2026-08-22 16-50-30" src="https://github.com/user-attachments/assets/b7a4b5b7-dab1-42ae-a441-08925adb149a" />|<img width="421" height="962" alt="Screenshot from 2026-08-22 16-51-11" src="https://github.com/user-attachments/assets/fc27a5b0-a1f0-4a2d-9bac-fc5f784d1390" />|

InActive Buttons
| FreeCAD Dark | FreeCAD  Light |
|---|---|
|<img width="462" height="962" alt="Screenshot from 2026-08-22 17-00-14" src="https://github.com/user-attachments/assets/37336142-fde5-41d2-9216-b622152eaf26" />|<img width="462" height="962" alt="Screenshot from 2026-08-22 17-00-48" src="https://github.com/user-attachments/assets/09b313d4-5c5a-47ee-981f-61f2259a9dea" />|

Active Buttons
| FreeCAD Dark | FreeCAD  Light |
|---|---|
|<img width="462" height="962" alt="Screenshot from 2026-08-22 17-00-09" src="https://github.com/user-attachments/assets/df763ebf-1173-4dea-a718-f54dab680943" />|<img width="462" height="962" alt="Screenshot from 2026-08-22 17-00-53" src="https://github.com/user-attachments/assets/a86acc79-23ee-4da2-a466-ac6715cbe262" />|

Fixes #29402
Fixes #26337