### PR TITLE
Measurement: Fix measurement position

### DIFF
--- a/src/Mod/Part/App/MeasureClient.cpp
+++ b/src/Mod/Part/App/MeasureClient.cpp
@@ -86,22 +86,30 @@ static float getFaceArea(TopoDS_Shape& face)
     return gprops.Mass();
 }
 
-TopoDS_Shape getLocatedShape(const App::SubObjectT& subject, Base::Matrix4D* mat = nullptr)
+TopoDS_Shape getLocatedShape(const App::SubObjectT& subject)
 {
     App::DocumentObject* obj = subject.getSubObjectList().back();
-    if (!obj) {
+    if (!obj || !obj->getNameInDocument()) {
         return {};
     }
+    if (obj->isDerivedFrom<Part::Feature>()) {
+        TopoShape ts = static_cast<const Part::Feature*>(obj)->Shape.getShape();
+        ts.setPlacement(
+            App::GeoFeature::getGlobalPlacement(obj, subject.getObject(), subject.getSubName())
+        );
+        ts = ts.getSubTopoShape(subject.getElementName(), true);
+        if (!ts.isNull()) {
+            return ts.getShape();
+        }
+    }
 
-    TopoDS_Shape shape = Part::Feature::getShape(
+    TopoShape ts = Part::Feature::getTopoShape(
         obj,
         Part::ShapeOption::NeedSubElement | Part::ShapeOption::ResolveLink
             | Part::ShapeOption::Transform,
-        subject.getElementName(),
-        mat
+        subject.getElementName()
     );
-
-    if (shape.IsNull()) {
+    if (ts.isNull()) {
         Base::Console().log(
             "Part::MeasureClient::getLocatedShape: Did not retrieve shape for %s, %s\n",
             obj->getNameInDocument(),
@@ -109,8 +117,10 @@ TopoDS_Shape getLocatedShape(const App::SubObjectT& subject, Base::Matrix4D* mat
         );
         return {};
     }
-
-    return shape;
+    ts.setPlacement(
+        App::GeoFeature::getGlobalPlacement(obj, subject.getObject(), subject.getSubName())
+    );
+    return ts.getShape();
 }
 
 
@@ -246,60 +256,6 @@ bool getShapeFromStrings(TopoDS_Shape& shapeOut, const App::SubObjectT& subject,
     );
     return !shapeOut.IsNull();
 }
-
-
-Part::VectorAdapter buildAdapter(const App::SubObjectT& subject)
-{
-    Base::Matrix4D mat;
-    TopoDS_Shape shape = getLocatedShape(subject, &mat);
-
-    if (shape.IsNull()) {
-        // failure here on loading document with existing measurement.
-        Base::Console().message(
-            "Part::buildAdapter did not retrieve shape for %s, %s\n",
-            subject.getObjectName(),
-            subject.getElementName()
-        );
-        return Part::VectorAdapter();
-    }
-    TopAbs_ShapeEnum shapeType = shape.ShapeType();
-
-    if (shapeType == TopAbs_EDGE) {
-        TopoDS_Edge edge = TopoDS::Edge(shape);
-        // make edge orientation so that end of edge closest to pick is head of vector.
-        TopoDS_Vertex firstVertex = TopExp::FirstVertex(edge, Standard_True);
-        TopoDS_Vertex lastVertex = TopExp::LastVertex(edge, Standard_True);
-        if (firstVertex.IsNull() || lastVertex.IsNull()) {
-            return {};
-        }
-        gp_Vec firstPoint = Part::VectorAdapter::convert(firstVertex);
-        gp_Vec lastPoint = Part::VectorAdapter::convert(lastVertex);
-        Base::Vector3d v(0.0, 0.0, 0.0);  // v(current.x,current.y,current.z);
-        v = mat * v;
-        gp_Vec pickPoint(v.x, v.y, v.z);
-        double firstDistance = (firstPoint - pickPoint).Magnitude();
-        double lastDistance = (lastPoint - pickPoint).Magnitude();
-        if (lastDistance > firstDistance) {
-            if (edge.Orientation() == TopAbs_FORWARD) {
-                edge.Orientation(TopAbs_REVERSED);
-            }
-            else {
-                edge.Orientation(TopAbs_FORWARD);
-            }
-        }
-        return {edge, pickPoint};
-    }
-    if (shapeType == TopAbs_FACE) {
-        TopoDS_Face face = TopoDS::Face(shape);
-        Base::Vector3d vTemp(0.0, 0.0, 0.0);  // v(current.x, current.y, current.z);
-        vTemp = mat * vTemp;
-        gp_Vec pickPoint(vTemp.x, vTemp.y, vTemp.z);
-        return {face, pickPoint};
-    }
-
-    return {};
-}
-
 
 MeasureLengthInfoPtr MeasureLengthHandler(const App::SubObjectT& subject)
 {
@@ -506,29 +462,38 @@ MeasureAngleInfoPtr MeasureAngleHandler(const App::SubObjectT& subject)
 
     TopAbs_ShapeEnum sType = shape.ShapeType();
 
-    Part::VectorAdapter vAdapt = buildAdapter(subject);
-
-    gp_Pnt vec;
-    Base::Vector3d position;
+    gp_Pnt position;
+    Base::Vector3d orientation;
     if (sType == TopAbs_FACE) {
         TopoDS_Face face = TopoDS::Face(shape);
 
         GProp_GProps gprops;
         BRepGProp::SurfaceProperties(face, gprops);
-        vec = gprops.CentreOfMass();
+        position = gprops.CentreOfMass();
+        auto vAdapt = Part::VectorAdapter(face, gp_Vec(0, 0, 0));
+        if (!vAdapt.isValid()) {
+            return std::make_shared<MeasureAngleInfo>();
+        }
+        orientation = (Base::Vector3d)vAdapt;
     }
     else if (sType == TopAbs_EDGE) {
         TopoDS_Edge edge = TopoDS::Edge(shape);
 
         GProp_GProps gprops;
         BRepGProp::LinearProperties(edge, gprops);
-        vec = gprops.CentreOfMass();
+        position = gprops.CentreOfMass();
+        auto vAdapt = Part::VectorAdapter(edge, gp_Vec(0, 0, 0));
+        if (!vAdapt.isValid()) {
+            return std::make_shared<MeasureAngleInfo>();
+        }
+        orientation = (Base::Vector3d)vAdapt;
     }
 
-    position.Set(vec.X(), vec.Y(), vec.Z());
-
-    auto info = std::make_shared<MeasureAngleInfo>(vAdapt.isValid(), (Base::Vector3d)vAdapt, position);
-    return info;
+    return std::make_shared<MeasureAngleInfo>(
+        true,
+        orientation, 
+        Base::Vector3d(position.X(), position.Y(), position.Z())
+    );
 }
 
 

--- a/src/Mod/Part/App/MeasureClient.cpp
+++ b/src/Mod/Part/App/MeasureClient.cpp
@@ -491,7 +491,7 @@ MeasureAngleInfoPtr MeasureAngleHandler(const App::SubObjectT& subject)
 
     return std::make_shared<MeasureAngleInfo>(
         true,
-        orientation, 
+        orientation,
         Base::Vector3d(position.X(), position.Y(), position.Z())
     );
 }

--- a/tests/src/Mod/Measure/App/CMakeLists.txt
+++ b/tests/src/Mod/Measure/App/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 add_executable(Measure_tests_run
         MeasureDistance.cpp
+        MeasurePosition.cpp
 )
 
 target_include_directories(Measure_tests_run PUBLIC

--- a/tests/src/Mod/Measure/App/MeasureDistance.cpp
+++ b/tests/src/Mod/Measure/App/MeasureDistance.cpp
@@ -2,9 +2,14 @@
 
 #include <src/App/InitApplication.h>
 #include <App/Document.h>
+#include <App/Part.h>
+#include <App/GeoFeatureGroupExtension.h>
 #include <App/MeasureManager.h>
 #include <Mod/Measure/App/MeasureDistance.h>
 #include <Mod/Part/App/PartFeature.h>
+#include <Base/Placement.h>
+#include <Base/Rotation.h>
+#include <Base/Vector3D.h>
 #include <gtest/gtest.h>
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <BRepPrimAPI_MakeBox.hxx>
@@ -109,5 +114,60 @@ TEST_F(MeasureDistance, testCircleCircle)
     EXPECT_DOUBLE_EQ(md->DistanceZ.getValue(), 0.0);
     EXPECT_EQ(md->Position1.getValue(), Base::Vector3d(0.0, 0.0, 0.0));
     EXPECT_EQ(md->Position2.getValue(), Base::Vector3d(3.0, 4.0, 0.0));
+}
+
+TEST_F(MeasureDistance, testCircleCircleWithPlacement)
+{
+    // Baseline for issue #30365: distance and the reported positions must respect
+    // each object's own top-level Placement. Worked *before* #30423.
+    App::Document* doc = getDocument();
+    auto p1 = doc->addObject<Part::Feature>("Shape1");
+    p1->Shape.setValue(makeCircle(gp_Pnt(0.0, 0.0, 0.0)));
+    p1->Placement.setValue(Base::Placement(Base::Vector3d(10.0, 0.0, 0.0), Base::Rotation()));
+    auto p2 = doc->addObject<Part::Feature>("Shape2");
+    p2->Shape.setValue(makeCircle(gp_Pnt(0.0, 0.0, 0.0)));
+    p2->Placement.setValue(Base::Placement(Base::Vector3d(10.0, 0.0, 5.0), Base::Rotation()));
+
+    auto md = doc->addObject<Measure::MeasureDistance>("Distance");
+    md->Element1.setValue(p1, {"Edge1"});
+    md->Element2.setValue(p2, {"Edge1"});
+
+    doc->recompute();
+
+    EXPECT_DOUBLE_EQ(md->Distance.getValue(), 5.0);
+    EXPECT_DOUBLE_EQ(md->DistanceX.getValue(), 0.0);
+    EXPECT_DOUBLE_EQ(md->DistanceY.getValue(), 0.0);
+    EXPECT_DOUBLE_EQ(md->DistanceZ.getValue(), 5.0);
+    EXPECT_EQ(md->Position1.getValue(), Base::Vector3d(10.0, 0.0, 0.0));
+    EXPECT_EQ(md->Position2.getValue(), Base::Vector3d(10.0, 0.0, 5.0));
+}
+
+TEST_F(MeasureDistance, testTwoBoxesMovedByContainers)
+{
+    // Regression: https://github.com/FreeCAD/FreeCAD/issues/30365
+    // Mirrors the issue report: two bodies built at the origin and then moved. Requires #30423 fix.
+    App::Document* doc = getDocument();
+
+    auto box1 = doc->addObject<Part::Feature>("Box1");
+    box1->Shape.setValue(BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Solid());
+    auto container1 = doc->addObject<App::Part>("Container1");
+    container1->getExtensionByType<App::GeoFeatureGroupExtension>()->addObject(box1);
+
+    auto box2 = doc->addObject<Part::Feature>("Box2");
+    box2->Shape.setValue(BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Solid());
+    auto container2 = doc->addObject<App::Part>("Container2");
+    container2->Placement.setValue(Base::Placement(Base::Vector3d(50.0, 0.0, 0.0), Base::Rotation()));
+    container2->getExtensionByType<App::GeoFeatureGroupExtension>()->addObject(box2);
+
+    auto md = doc->addObject<Measure::MeasureDistance>("Distance");
+    md->Element1.setValue(container1, {"Box1.Vertex1"});
+    md->Element2.setValue(container2, {"Box2.Vertex1"});
+
+    doc->recompute();
+
+    EXPECT_DOUBLE_EQ(md->Distance.getValue(), 50.0);
+    EXPECT_DOUBLE_EQ(md->DistanceX.getValue(), 50.0);
+    EXPECT_DOUBLE_EQ(md->DistanceY.getValue(), 0.0);
+    EXPECT_DOUBLE_EQ(md->DistanceZ.getValue(), 0.0);
 }
 // NOLINTEND

--- a/tests/src/Mod/Measure/App/MeasurePosition.cpp
+++ b/tests/src/Mod/Measure/App/MeasurePosition.cpp
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <src/App/InitApplication.h>
+#include <App/Document.h>
+#include <App/Part.h>
+#include <App/GeoFeatureGroupExtension.h>
+#include <App/MeasureManager.h>
+#include <Mod/Measure/App/MeasurePosition.h>
+#include <Mod/Part/App/PartFeature.h>
+#include <Base/Placement.h>
+#include <Base/Rotation.h>
+#include <Base/Vector3D.h>
+#include <gtest/gtest.h>
+#include <numbers>
+#include <BRepBuilderAPI_MakeVertex.hxx>
+#include <gp_Pnt.hxx>
+
+class MeasurePosition: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        document = App::GetApplication().newDocument("MeasurePosition");
+    }
+
+    void TearDown() override
+    {
+        App::GetApplication().closeDocument(document->getName());
+    }
+
+    App::Document* getDocument() const
+    {
+        return document;
+    }
+
+    // Create a Part::Feature whose shape is a single vertex at the given local point.
+    Part::Feature* makeVertexFeature(const char* name, const gp_Pnt& point) const
+    {
+        auto feature = document->addObject<Part::Feature>(name);
+        feature->Shape.setValue(BRepBuilderAPI_MakeVertex(point).Vertex());
+        return feature;
+    }
+
+    // Wrap the feature in an App::Part container carrying the given placement. The
+    // container's placement is what distinguishes the leaf object's local frame from
+    // its global frame, which is the situation that regressed in issue #30365.
+    App::Part* makeContainer(
+        const char* name,
+        const Base::Placement& placement,
+        App::DocumentObject* child
+    ) const
+    {
+        auto container = document->addObject<App::Part>(name);
+        container->Placement.setValue(placement);
+        container->getExtensionByType<App::GeoFeatureGroupExtension>()->addObject(child);
+        return container;
+    }
+
+private:
+    App::Document* document {};
+};
+
+// NOLINTBEGIN
+TEST_F(MeasurePosition, testVertexNoPlacement)
+{
+    // Baseline: with an identity placement the measured position is the local point.
+    App::Document* doc = getDocument();
+
+    auto feature = makeVertexFeature("Vertex", gp_Pnt(1.0, 2.0, 3.0));
+    doc->recompute();
+
+    auto mp = doc->addObject<Measure::MeasurePosition>("Position");
+    mp->Element.setValue(feature, {"Vertex1"});
+    doc->recompute();
+
+    EXPECT_EQ(mp->Position.getValue(), Base::Vector3d(1.0, 2.0, 3.0));
+}
+
+TEST_F(MeasurePosition, testVertexWithLocalPlacement)
+{
+    // A top-level object's own Placement must be applied. This path already worked
+    // before the fix (via Part::ShapeOption::Transform); the test guards against a
+    // future regression in the leaf-placement path.
+    App::Document* doc = getDocument();
+
+    auto feature = makeVertexFeature("Vertex", gp_Pnt(1.0, 2.0, 3.0));
+    feature->Placement.setValue(Base::Placement(Base::Vector3d(10.0, 20.0, 30.0), Base::Rotation()));
+    doc->recompute();
+
+    auto mp = doc->addObject<Measure::MeasurePosition>("Position");
+    mp->Element.setValue(feature, {"Vertex1"});
+    doc->recompute();
+
+    EXPECT_EQ(mp->Position.getValue(), Base::Vector3d(11.0, 22.0, 33.0));
+}
+
+TEST_F(MeasurePosition, testVertexInTranslatedContainer)
+{
+    // Regression: https://github.com/FreeCAD/FreeCAD/issues/30365
+    // The vertex feature has an identity placement, but it lives inside a container
+    // (App::Part) that is translated. The measured position must reflect the
+    // container's placement, i.e. the global placement of the leaf. Before the fix
+    // only the leaf's own (identity) placement was applied and the container offset
+    // was lost.
+    App::Document* doc = getDocument();
+
+    auto feature = makeVertexFeature("Leaf", gp_Pnt(1.0, 2.0, 3.0));
+    auto container = makeContainer(
+        "Container",
+        Base::Placement(Base::Vector3d(10.0, 20.0, 30.0), Base::Rotation()),
+        feature
+    );
+    doc->recompute();
+
+    auto mp = doc->addObject<Measure::MeasurePosition>("Position");
+    mp->Element.setValue(container, {"Leaf.Vertex1"});
+    doc->recompute();
+
+    EXPECT_EQ(mp->Position.getValue(), Base::Vector3d(11.0, 22.0, 33.0));
+}
+
+TEST_F(MeasurePosition, testVertexInRotatedContainer)
+{
+    // Regression: https://github.com/FreeCAD/FreeCAD/issues/30365
+    // The container is rotated 90 degrees about Z, which maps the leaf's local
+    // point (1, 0, 0) to the global point (0, 1, 0).
+    App::Document* doc = getDocument();
+
+    auto feature = makeVertexFeature("Leaf", gp_Pnt(1.0, 0.0, 0.0));
+    Base::Rotation rotation(Base::Vector3d(0.0, 0.0, 1.0), std::numbers::pi / 2.0);
+    auto container = makeContainer(
+        "Container",
+        Base::Placement(Base::Vector3d(0.0, 0.0, 0.0), rotation),
+        feature
+    );
+    doc->recompute();
+
+    auto mp = doc->addObject<Measure::MeasurePosition>("Position");
+    mp->Element.setValue(container, {"Leaf.Vertex1"});
+    doc->recompute();
+
+    Base::Vector3d position = mp->Position.getValue();
+    EXPECT_NEAR(position.x, 0.0, 1e-9);
+    EXPECT_NEAR(position.y, 1.0, 1e-9);
+    EXPECT_NEAR(position.z, 0.0, 1e-9);
+}
+
+TEST_F(MeasurePosition, testVertexContainerAndLocalPlacementCombine)
+{
+    // Regression: https://github.com/FreeCAD/FreeCAD/issues/30365
+    // Both the container placement and the leaf's own placement must be composed.
+    // Leaf point (1, 0, 0) + leaf translation (0, 0, 1) = (1, 0, 1), then the
+    // container translation (10, 20, 30) gives (11, 20, 31).
+    App::Document* doc = getDocument();
+
+    auto feature = makeVertexFeature("Leaf", gp_Pnt(1.0, 0.0, 0.0));
+    feature->Placement.setValue(Base::Placement(Base::Vector3d(0.0, 0.0, 1.0), Base::Rotation()));
+    auto container = makeContainer(
+        "Container",
+        Base::Placement(Base::Vector3d(10.0, 20.0, 30.0), Base::Rotation()),
+        feature
+    );
+    doc->recompute();
+
+    auto mp = doc->addObject<Measure::MeasurePosition>("Position");
+    mp->Element.setValue(container, {"Leaf.Vertex1"});
+    doc->recompute();
+
+    EXPECT_EQ(mp->Position.getValue(), Base::Vector3d(11.0, 20.0, 31.0));
+}
+// NOLINTEND


### PR DESCRIPTION
The problem was that the `Part::Feature::getTopoShape` with the `Part::ShapeOption::Transform` does not give the shape in the global transform of the subject. The only way i found to do this was to take some of the functions out of the `Part::Feature::getTopoShape` and in to the `getLocatedShape` function to then transform the shape in to the global transform of the subject before getting the subshape. Then if there is no subshape a call to `Part::Feature::getTopoShape` needs to be made and then transform the shape gotten from this in to the subjects global placement. This happens with internal sketch faces they are derived from `Part::Feature` but they do not have a sub shape so they then have to be found by `Part::Feature::getTopoShape`. 

It may be better to create a overload for `Part::Feature::getTopoShape` that takes in the subject as an argument, but from what I found only this function uses a `App::SubObjectT`, to locate the shape.

## issues
Fixes: https://github.com/FreeCAD/FreeCAD/issues/30365