### PR TITLE
Part: Accept Sketch internals as projecting face

### DIFF
--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
@@ -48,6 +48,7 @@
 
 
 #include <App/Document.h>
+#include <Mod/Part/App/PartFeature.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/CommandT.h>
 #include <Gui/MainWindow.h>
@@ -90,7 +91,7 @@ public:
             return false;
         }
 
-        auto subShape = aPart->Shape.getShape().getSubShape(sSubName, true);
+        auto subShape = Part::Feature::getShape(aPart, Part::ShapeOption::NeedSubElement, sSubName);
         if (subShape.IsNull()) {
             return false;
         }
@@ -123,7 +124,7 @@ public:
             return false;
         }
 
-        auto subShape = aPart->Shape.getShape().getSubShape(sSubName, true);
+        auto subShape = Part::Feature::getShape(aPart, Part::ShapeOption::NeedSubElement, sSubName);
         if (subShape.IsNull()) {
             return false;
         }
@@ -451,7 +452,11 @@ void PartGui::DlgProjectionOnSurface::store_current_selected_parts(
                 if (!it->getSubNames().empty()) {
                     auto parentShape = currentShapeStore.inputShape;
                     for (const auto& itName : selObj.front().getSubNames()) {
-                        auto currentShape = aPart->Shape.getShape().getSubShape(itName.c_str(), true);
+                        auto currentShape = Part::Feature::getShape(
+                            aPart,
+                            Part::ShapeOption::NeedSubElement,
+                            itName.c_str()
+                        );
                         if (currentShape.IsNull()) {
                             continue;
                         }

--- a/src/Mod/Part/TestPartGui.py
+++ b/src/Mod/Part/TestPartGui.py
@@ -29,6 +29,7 @@ import FreeCAD
 import FreeCADGui
 import Part
 import PartGui
+import Sketcher
 from PySide import QtWidgets
 
 
@@ -84,6 +85,53 @@ class PartGuiViewProviderTestCases(unittest.TestCase):
     def tearDown(self):
         # closing doc
         FreeCAD.closeDocument("PartGuiTest")
+
+
+class ProjectionOnSurfaceTestCases(unittest.TestCase):
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("ProjectionOnSurface")
+
+    def testSketchInternalFaceAsSupportFace(self):
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        sketch.MakeInternals = True
+        sketch.addGeometry(
+            [
+                Part.LineSegment(FreeCAD.Vector(0, 0), FreeCAD.Vector(10, 0)),
+                Part.LineSegment(FreeCAD.Vector(10, 0), FreeCAD.Vector(10, 10)),
+                Part.LineSegment(FreeCAD.Vector(10, 10), FreeCAD.Vector(0, 10)),
+                Part.LineSegment(FreeCAD.Vector(0, 10), FreeCAD.Vector(0, 0)),
+            ],
+            False,
+        )
+        self.Doc.recompute()
+
+        FreeCADGui.activateWorkbench("PartWorkbench")
+        FreeCADGui.updateGui()
+        FreeCADGui.runCommand("Part_ProjectionOnSurface")
+        FreeCADGui.updateGui()
+
+        taskDialog = FreeCADGui.Control.activeTaskDialog()
+        self.assertIsNotNone(taskDialog)
+        supportButton = None
+        for widget in taskDialog.getDialogContent():
+            supportButton = widget.findChild(QtWidgets.QPushButton, "pushButtonAddProjFace")
+            if supportButton:
+                break
+        self.assertIsNotNone(supportButton)
+        supportButton.click()
+        FreeCADGui.Selection.addSelection(sketch, "InternalFace1")
+
+        projection = self.Doc.getObject("Projection")
+        self.assertIsNotNone(projection)
+        self.assertEqual(projection.SupportFace[0], sketch)
+        self.assertEqual(projection.SupportFace[1], ["InternalFace1"])
+
+    def tearDown(self):
+        FreeCADGui.Selection.clearSelection()
+        guiDocument = FreeCADGui.getDocument("ProjectionOnSurface")
+        if FreeCADGui.Control.activeDialog(guiDocument):
+            FreeCADGui.Control.closeDialog(guiDocument)
+        FreeCAD.closeDocument("ProjectionOnSurface")
 
 
 class SectionCutTestCases(unittest.TestCase):


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
The project on surface command in Part WB can have faces, wires or edges as input. When faces is selected, Sketch faces (make internals) is not a valid input. Until now.
Allows to project internal sketch faces onto surfaces.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

<img width="1513" height="559" alt="Bildschirmfoto 2026-05-26 um 21 02 46" src="https://github.com/user-attachments/assets/7004c4e0-cb30-46fc-9ca0-6ba8aefd45ea" />



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
