### PR TITLE
Fix #15974: Persist Clipping dock geometry and visibility across sess…

### DIFF
--- a/src/Gui/Clipping.cpp
+++ b/src/Gui/Clipping.cpp
@@ -28,7 +28,11 @@
 #include <Inventor/sensors/SoTimerSensor.h>
 #include <QDockWidget>
 #include <QPointer>
+#include <QScreen>
 
+#include <App/Application.h>
+
+#include "Application.h"
 #include "Clipping.h"
 #include "ui_Clipping.h"
 #include "DockWindowManager.h"
@@ -36,6 +40,43 @@
 #include "View3DInventorViewer.h"
 
 using namespace Gui::Dialog;
+
+namespace {
+
+auto getClippingDockParameterGroup()
+{
+    return App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/DockWindows/Clipping"
+    );
+}
+
+QRect getDockSavedGeometry(const ParameterGrp::handle& hGrp)
+{
+    return QRect(
+        static_cast<int>(hGrp->GetInt("GeometryX", 0)),
+        static_cast<int>(hGrp->GetInt("GeometryY", 0)),
+        static_cast<int>(hGrp->GetInt("GeometryW", 0)),
+        static_cast<int>(hGrp->GetInt("GeometryH", 0))
+    );
+}
+
+void restoreDockWidgetGeometry(QDockWidget* dw, const QRect& savedGeom, bool floating)
+{
+    QScreen* targetScreen = nullptr;
+    for (QScreen* screen : QApplication::screens()) {
+        if (screen->availableGeometry().contains(savedGeom)) {
+            targetScreen = screen;
+            break;
+        }
+    }
+
+    if (targetScreen) {
+        dw->setFloating(floating);
+        dw->setGeometry(savedGeom);
+    }
+}
+
+}
 
 class Clipping::Private
 {
@@ -125,7 +166,7 @@ Clipping::Clipping(Gui::View3DInventor* view, QWidget* parent)
     d->ui.dirZ->setSingleStep(0.1f);
     d->ui.dirZ->setValue(1.0f);
 
-    d->view = view;
+     d->view = view;
     View3DInventorViewer* viewer = view->getViewer();
     d->node = static_cast<SoGroup*>(viewer->getSceneGraph());
     d->node->ref();
@@ -192,12 +233,27 @@ Clipping::Clipping(Gui::View3DInventor* view, QWidget* parent)
 
 Clipping* Clipping::makeDockWidget(Gui::View3DInventor* view)
 {
-    // embed this dialog into a QDockWidget
-    auto clipping = new Clipping(view);
+    if (!view)
+        return nullptr;
+
     Gui::DockWindowManager* pDockMgr = Gui::DockWindowManager::instance();
+    if (pDockMgr->getDockContainer("Clipping"))
+        return nullptr;
+
+    auto hGrp = getClippingDockParameterGroup();
+    if (hGrp->GetBoolMap("Visible").empty()) {
+        //if no settings exist, don't create the clipping dialog, it will be created when the user clicks on the menu entry for clipping
+        return nullptr;
+    }
+
+    auto clipping = new Clipping(view);
     QDockWidget* dw = pDockMgr->addDockWindow("Clipping", clipping, Qt::LeftDockWidgetArea);
     dw->setFeatures(QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
-    dw->show();
+
+    QRect savedGeom = getDockSavedGeometry(hGrp);
+    restoreDockWidgetGeometry(dw, savedGeom, hGrp->GetBool("Floating", false));
+
+    dw->setVisible(hGrp->GetBool("Visible", true));
 
     return clipping;
 }
@@ -251,13 +307,63 @@ void Clipping::setupConnections()
     // clang-format on
 }
 
+void Clipping::saveDockSettings(QDockWidget* dw, bool visible)
+{
+    auto hGrp = getClippingDockParameterGroup();
+    const QRect geom = dw->geometry();
+
+    hGrp->SetInt("GeometryX", geom.x());
+    hGrp->SetInt("GeometryY", geom.y());
+    hGrp->SetInt("GeometryW", geom.width());
+    hGrp->SetInt("GeometryH", geom.height());
+    hGrp->SetBool("Floating", dw->isFloating());
+    hGrp->SetBool("Visible", visible);
+}
+
+QRect getDockSavedGeometry(const ParameterGrp::handle& hGrp)
+{
+    return QRect(
+        static_cast<int>(hGrp->GetInt("GeometryX", 0)),
+        static_cast<int>(hGrp->GetInt("GeometryY", 0)),
+        static_cast<int>(hGrp->GetInt("GeometryW", 0)),
+        static_cast<int>(hGrp->GetInt("GeometryH", 0))
+    );
+}
+
+void restoreDockWidgetGeometry(QDockWidget* dw, const QRect& savedGeom, bool floating)
+{
+    QScreen* targetScreen = nullptr;
+    //check if the last saved geometry is still valid on the current screen setup
+    for (QScreen* screen : QApplication::screens()) {
+        if (screen->availableGeometry().contains(savedGeom)) {
+            targetScreen = screen;
+            break;
+        }
+    }
+
+    if (targetScreen) {
+        dw->setFloating(floating);
+        dw->setGeometry(savedGeom);
+    }
+}
+
+void Clipping::setDockVisible(bool visible)
+{
+    getClippingDockParameterGroup()->SetBool("Visible", visible);
+}
+
 void Clipping::reject()
 {
-    QDialog::reject();
     auto dw = qobject_cast<QDockWidget*>(parent());
+    bool closing = Gui::Application::Instance && Gui::Application::Instance->isClosing();
+
     if (dw) {
+        // if clipping exists on closing, save settings as visible
+        saveDockSettings(dw, closing);
         dw->deleteLater();
     }
+
+    QDialog::reject();
 }
 
 void Clipping::onGroupBoxXToggled(bool on)

--- a/src/Gui/Clipping.h
+++ b/src/Gui/Clipping.h
@@ -26,6 +26,8 @@
 #include <QDialog>
 #include <FCGlobal.h>
 
+class QDockWidget;
+
 namespace Gui
 {
 class View3DInventor;
@@ -42,6 +44,7 @@ class GuiExport Clipping: public QDialog
 public:
     static Clipping* makeDockWidget(Gui::View3DInventor*);
     Clipping(Gui::View3DInventor* view, QWidget* parent = nullptr);
+    static void setDockVisible(bool visible);
     ~Clipping() override;
 
 protected:
@@ -67,6 +70,8 @@ public:
     void reject() override;
 
 private:
+    void attachToView(Gui::View3DInventor* view);
+    void saveDockSettings(QDockWidget* dw, bool visible);
     class Private;
     Private* d;
 };

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -59,6 +59,7 @@
 #include "Clipping.h"
 #include "DemoMode.h"
 #include "Dialogs/DlgSettingsImageImp.h"
+#include "DockWindowManager.h"
 #include "Document.h"
 #include "FileDialog.h"
 #include "ImageView.h"
@@ -656,13 +657,18 @@ Action* StdCmdToggleClipPlane::createAction()
 void StdCmdToggleClipPlane::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    static QPointer<Gui::Dialog::Clipping> clipping = nullptr;
-    if (!clipping) {
-        auto view = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
-        if (view) {
-            clipping = Gui::Dialog::Clipping::makeDockWidget(view);
-        }
+    Gui::DockWindowManager* pDockMgr = Gui::DockWindowManager::instance();
+    QDockWidget* dw = pDockMgr->getDockContainer("Clipping");
+    Gui::Dialog::Clipping::setDockVisible(true);
+
+    if (dw) {
+        dw->show();
+        dw->raise();
+        return;
     }
+
+    Gui::Dialog::Clipping::makeDockWidget(
+        qobject_cast<Gui::View3DInventor*>(getMainWindow()->activeWindow()));
 }
 
 bool StdCmdToggleClipPlane::isActive()

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -2275,6 +2275,7 @@ MDIView* Document::createView(const Base::Type& typeId, CreateViewMode mode)
         if (mode != CreateViewMode::Clone) {
             getMainWindow()->addWindow(view3D);
         }
+        view3D->setupClipping();
 
         view3D->getViewer()->redraw();
         return view3D;

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -62,6 +62,7 @@
 #include "Application.h"
 #include "BitmapFactory.h"
 #include "Camera.h"
+#include "Clipping.h"
 #include "Document.h"
 #include "FileDialog.h"
 #include "MainWindow.h"
@@ -75,6 +76,7 @@
 #include "ViewProvider.h"
 #include "ViewProviderDocumentObject.h"
 #include "WaitCursor.h"
+
 
 #include "Utilities.h"
 
@@ -652,6 +654,14 @@ bool View3DInventor::setCamera(const char* pCamera)
     }
 
     return true;
+}
+
+void View3DInventor::setupClipping()
+{   
+    //wait for the document to be fully loaded before creating the clipping dialog
+    QTimer::singleShot(0, this, [this]() {
+        Gui::Dialog::Clipping::makeDockWidget(this);
+    });
 }
 
 void View3DInventor::toggleClippingPlane()

--- a/src/Gui/View3DInventor.h
+++ b/src/Gui/View3DInventor.h
@@ -122,6 +122,7 @@ public:
     void setCurrentViewMode(ViewMode b) override;
     RayPickInfo getObjInfoRay(Base::Vector3d* startvec, Base::Vector3d* dirvec);
     bool setCamera(const char* pCamera);
+    void setupClipping();
     void toggleClippingPlane();
     bool hasClippingPlane() const;
 


### PR DESCRIPTION

Changes made:

Gui/Clipping.cpp and Gui/Clipping.h:

- Added saveDockSettings(QDockWidget*, bool visible) which persists the dock's geometry, floating state, and visibility to
User parameter:BaseApp/Preferences/DockWindows/Clipping
- makeDockWidget now restores saved geometry and floating state on creation. Before applying a saved position it validates that the geometry is fully contained within one of the currently connected screens, preventing the dock from restoring in a position where it can’t be dragged or closed.
- makeDockWidget now guards against creating duplicate dock instances.
- reject() saves dock state on close. On manual close, visibility is saved as false so the dock stays closed next session. On application shutdown, visibility is saved as true so the dock reopens next session (if it was open).
- Added setDockVisible(bool) static helper used by CommandView.cpp to mark the dock as visible when the user explicitly opens it.

Gui/CommandView.cpp (StdCmdToggleClipPlane::activated):

- Calls Clipping::setDockVisible(true) when opening the dock to correctly update the persisted visibility flag.
- Guards against opening a duplicate dock if one already exists.

Gui/View3DInventor.cpp (setupClipping):

- Defers dock creation via QTimer::singleShot(0) to ensure the main window is fully initialized before the dock and its spinboxes are created.

Manual testing performed (Linux Ubuntu 24.04):

- Open Clipping from View menu on a fresh start: dock opens normally and is immediately usable.
- Move and resize the floating dock, restart FreeCAD: dock restores at the saved position and size.
- Dock the panel (non-floating), restart: dock restores in the docked state.
- Close the dock manually, restart: dock does not reopen.
- Close FreeCAD with the dock open, restart: dock reopens automatically.
- Trigger View > Clipping while the dock is already open: no duplicate dock is created.
- Set off-screen values in Edit Parameters: dock falls back to default docked position instead of restoring off-screen.
- Move dock to a second monitor, restart with both monitors connected: dock restores on the second monitor.
- Move dock to a second monitor, disconnect monitor, restart: dock falls back to primary screen.

A possible future improvement would be to maintain one set of clipping planes per view, saving and restoring each view's clipping state independently when the active view changes. This was considered out of scope for this fix but seems feasible as a separate issue.

