### PR TITLE
[Sketcher]Replace TopTools_ListIteratorOfListOfShape.hxx with TopTools_ListOfListOfShape.hxx for OCCT 8.0 compatibility

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -96,7 +96,7 @@
 #include <TopExp.hxx>
 #include <TopTools_IndexedDataMapOfShapeListOfShape.hxx>
 #include <TopTools_IndexedMapOfShape.hxx>
-#include <TopTools_ListIteratorOfListOfShape.hxx>
+#include <TopTools_ListOfListOfShape.hxx>
 
 #include <Mod/Part/Gui/SoFCShapeObject.h>
 


### PR DESCRIPTION
Replace TopTools_ListIteratorOfListOfShape.hxx with TopTools_ListOfListOfShape.hxx for OCCT 8.0 compatibility. TopTools_ListIteratorOfListOfShape is deprecated in OCCT 8.0.