### PR TITLE
Core: Avoid recursive removal of objects

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3472,6 +3472,11 @@ void Document::removeObject(const char* sName)
         return;
     }
 
+    if (pos->second->testStatus(ObjectStatus::Remove)) {
+        FC_LOG("Avoid recursive deletion of " << pos->second->getFullName());
+        return;
+    }
+
     if (pos->second->testStatus(ObjectStatus::PendingRecompute)) {
         // TODO: shall we allow removal if there is active undo transaction?
         FC_MSG("pending remove of " << sName << " after recomputing document " << getName());
@@ -3495,6 +3500,7 @@ void Document::_removeObject(DocumentObject* pcObject, RemoveObjectOptions optio
     auto pos = d->objectMap.find(pcObject->getNameInDocument());
     if (pos == d->objectMap.end()) {
         FC_ERR("Internal error, could not find " << pcObject->getFullName() << " to remove");
+        return;
     }
 
     if (options.testFlag(RemoveObjectOption::PreserveChildrenVisibility)

--- a/src/Mod/Test/GuiDocument.py
+++ b/src/Mod/Test/GuiDocument.py
@@ -114,6 +114,35 @@ class TestGuiDocument(unittest.TestCase):
         expected_root_objects = [group1, group2, obj1, part1]
         self.assertEqual(set(root_objects), set(expected_root_objects))
 
+    def testIssue30418(self):
+        class ViewProvider:
+            def __init__(self, vobj):
+                vobj.Proxy = self
+
+            def attach(self, vobj):
+                self.ViewObject = vobj
+                self.Object = vobj.Object
+
+            def setEdit(self, vobj, mode):
+                return True
+
+            def unsetEdit(self, vobj, mode):
+                obj = vobj.Object
+                doc = obj.Document
+                doc.removeObject(obj.Name)
+                return True
+
+        gui = FreeCADGui.getDocument(self.doc)
+
+        self.doc.openTransaction("Add object")
+        obj = self.doc.addObject("App::FeaturePython", "Object")
+        ViewProvider(obj.ViewObject)
+        self.doc.commitTransaction()
+        gui.setEdit(obj, 0)
+        self.doc.undo()
+
+        self.assertTrue(True)
+
     def testViewObjectRequiresMainThread(self):
         obj = self.doc.addObject("App::FeaturePython", "ThreadGuard")
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Cherry-picked from https://codeberg.org/xwzCAD/FreeCAD/pulls/212

This fixes https://github.com/FreeCAD/FreeCAD/issues/30418

The about to be deleted object emits the signal 'signalDeletedObject'
the notifies its view provider. The view provider may explicitly call
the method removeObject() which will leads to a crash.

To avoid this explicitly check if the 'Remove' flag is set and abort the
operation.

