### PR TITLE
Part: Fix copying visual properties

### DIFF
--- a/src/Mod/Part/Gui/Mirroring.cpp
+++ b/src/Mod/Part/Gui/Mirroring.cpp
@@ -50,7 +50,7 @@
 #include <App/Part.h>
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
-#include <Gui/Command.h>
+#include <Gui/CommandT.h>
 #include <Gui/Document.h>
 #include <Gui/Selection/Selection.h>
 #include <Gui/Utilities.h>
@@ -383,11 +383,13 @@ bool Mirroring::accept()
                            .arg(basey)
                            .arg(basez)
                            .arg(selectionString);
-        Gui::Command::runCommand(Gui::Command::App, code.toLatin1());
-        QByteArray from = shape.toLatin1();
-        Gui::Command::copyVisual("ActiveObject", "ShapeAppearance", from);
-        Gui::Command::copyVisual("ActiveObject", "LineColor", from);
-        Gui::Command::copyVisual("ActiveObject", "PointColor", from);
+        Gui::Command::runCommand(Gui::Command::App, code.toUtf8());
+        QByteArray from = shape.toUtf8();
+        auto dst = activeDoc->getActiveObject();
+        auto src = activeDoc->getObject(from);
+        Gui::copyVisualT(dst, "ShapeAppearance", src);
+        Gui::copyVisualT(dst, "LineColor", src);
+        Gui::copyVisualT(dst, "PointColor", src);
     }
 
     activeDoc->commitTransaction();


### PR DESCRIPTION
Cherry-pick from https://codeberg.org/wwmayer/FreeCAD11/commits/branch/fix_copy_visual

Fix copying face, edge and vertex colors in Mirroring dialog.
Reported in https://forum.freecad.org/viewtopic.php?t=105518
