### PR TITLE
Sketcher: restore OVP Esc cancel behavior

### DIFF
--- a/src/Gui/TaskView/TaskDialog.cpp
+++ b/src/Gui/TaskView/TaskDialog.cpp
@@ -49,6 +49,7 @@ TaskDialog::TaskDialog()
     , pos(North)
     , escapeButton(true)
     , autoCloseTransaction(false)
+    , autoCloseResetEdit(false)
     , autoCloseDeletedDocument(false)
     , autoCloseClosedView(false)
 {}
@@ -128,6 +129,9 @@ void TaskDialog::closed()
 {}
 
 void TaskDialog::autoClosedOnTransactionChange()
+{}
+
+void TaskDialog::autoClosedOnResetEdit()
 {}
 
 void TaskDialog::autoClosedOnDeletedDocument()

--- a/src/Gui/TaskView/TaskDialog.h
+++ b/src/Gui/TaskView/TaskDialog.h
@@ -113,6 +113,16 @@ public:
         return autoCloseTransaction;
     }
 
+    /// Defines whether a task dialog must be closed if the document exits edit mode.
+    void setAutoCloseOnResetEdit(bool on)
+    {
+        autoCloseResetEdit = on;
+    }
+    bool isAutoCloseOnResetEdit() const
+    {
+        return autoCloseResetEdit;
+    }
+
     /// Defines whether a task dialog must be closed if the document is
     /// deleted.
     void setAutoCloseOnDeletedDocument(bool on)
@@ -192,6 +202,9 @@ public:
     /// changing the active transaction
     virtual void autoClosedOnTransactionChange();
     /// is called by the framework when the dialog is automatically closed due to
+    /// exiting edit mode
+    virtual void autoClosedOnResetEdit();
+    /// is called by the framework when the dialog is automatically closed due to
     /// deleting the document
     virtual void autoClosedOnDeletedDocument();
     /// is called by the framework when the dialog is automatically closed due to
@@ -236,6 +249,7 @@ private:
     const Gui::MDIView* associatedView;
     bool escapeButton;
     bool autoCloseTransaction;
+    bool autoCloseResetEdit;
     bool autoCloseDeletedDocument;
     bool autoCloseClosedView;
 

--- a/src/Gui/TaskView/TaskDialogPython.cpp
+++ b/src/Gui/TaskView/TaskDialogPython.cpp
@@ -451,6 +451,16 @@ void TaskDialogPy::init_type()
         "Checks if the task dialog will be closed when the active transaction has changed -> bool"
     );
     add_varargs_method(
+        "setAutoCloseOnResetEdit",
+        &TaskDialogPy::setAutoCloseOnResetEdit,
+        "Defines whether a task dialog must be closed if the document exits edit mode"
+    );
+    add_varargs_method(
+        "isAutoCloseOnResetEdit",
+        &TaskDialogPy::isAutoCloseOnResetEdit,
+        "Checks if the task dialog will be closed when the document exits edit mode -> bool"
+    );
+    add_varargs_method(
         "setAutoCloseOnDeletedDocument",
         &TaskDialogPy::setAutoCloseOnDeletedDocument,
         "Defines whether a task dialog must be closed if the document is deleted"
@@ -586,6 +596,21 @@ Py::Object TaskDialogPy::isAutoCloseOnTransactionChange(const Py::Tuple& args)
         throw Py::Exception();
     }
     return Py::Boolean(dialog->isAutoCloseOnTransactionChange());
+}
+
+Py::Object TaskDialogPy::setAutoCloseOnResetEdit(const Py::Tuple& args)
+{
+    Py::Boolean value(args[0]);
+    dialog->setAutoCloseOnResetEdit(static_cast<bool>(value));
+    return Py::None();
+}
+
+Py::Object TaskDialogPy::isAutoCloseOnResetEdit(const Py::Tuple& args)
+{
+    if (!PyArg_ParseTuple(args.ptr(), "")) {
+        throw Py::Exception();
+    }
+    return Py::Boolean(dialog->isAutoCloseOnResetEdit());
 }
 
 Py::Object TaskDialogPy::setAutoCloseOnDeletedDocument(const Py::Tuple& args)
@@ -1031,6 +1056,22 @@ void TaskDialogPython::autoClosedOnTransactionChange()
     try {
         if (dlg.hasAttr(std::string("autoClosedOnTransactionChange"))) {
             Py::Callable method(dlg.getAttr(std::string("autoClosedOnTransactionChange")));
+            Py::Tuple args;
+            method.apply(args);
+        }
+    }
+    catch (Py::Exception&) {
+        Base::PyException e;  // extract the Python error text
+        e.reportException();
+    }
+}
+
+void TaskDialogPython::autoClosedOnResetEdit()
+{
+    Base::PyGILStateLocker lock;
+    try {
+        if (dlg.hasAttr(std::string("autoClosedOnResetEdit"))) {
+            Py::Callable method(dlg.getAttr(std::string("autoClosedOnResetEdit")));
             Py::Tuple args;
             method.apply(args);
         }

--- a/src/Gui/TaskView/TaskDialogPython.h
+++ b/src/Gui/TaskView/TaskDialogPython.h
@@ -101,6 +101,8 @@ public:
     /// active transaction.
     Py::Object setAutoCloseOnTransactionChange(const Py::Tuple&);
     Py::Object isAutoCloseOnTransactionChange(const Py::Tuple&);
+    Py::Object setAutoCloseOnResetEdit(const Py::Tuple&);
+    Py::Object isAutoCloseOnResetEdit(const Py::Tuple&);
     Py::Object setAutoCloseOnDeletedDocument(const Py::Tuple&);
     Py::Object isAutoCloseOnDeletedDocument(const Py::Tuple&);
 
@@ -166,6 +168,7 @@ public:
     bool needsFullSpace() const override;
 
     void autoClosedOnTransactionChange() override;
+    void autoClosedOnResetEdit() override;
     void autoClosedOnDeletedDocument() override;
 
 public:

--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -302,6 +302,9 @@ TaskView::TaskView(QWidget* parent)
     connectApplicationInEdit = Gui::Application::Instance->signalInEdit.connect(
         std::bind(&Gui::TaskView::TaskView::slotInEdit, this, sp::_1)
     );
+    connectApplicationResetEdit = Gui::Application::Instance->signalResetEdit.connect(
+        std::bind(&Gui::TaskView::TaskView::slotResetEdit, this, sp::_1)
+    );
     // NOLINTEND
 
     setShowTaskWatcher(hGrp->GetBool("ShowTaskWatcher", true));
@@ -324,6 +327,7 @@ TaskView::~TaskView()
     connectApplicationUndoDocument.disconnect();
     connectApplicationRedoDocument.disconnect();
     connectApplicationInEdit.disconnect();
+    connectApplicationResetEdit.disconnect();
     connectShowTaskWatcherSetting.disconnect();
     Gui::Selection().Detach(this);
 
@@ -502,13 +506,38 @@ void TaskView::slotInEdit(const Gui::ViewProviderDocumentObject& vp)
     }
 }
 
+void TaskView::slotResetEdit(const Gui::ViewProviderDocumentObject& vp)
+{
+    App::Document* doc = vp.getDocument()->getDocument();
+    auto foundTaskInfo = std::ranges::find(taskInfos, doc, &TaskInfo::Document);
+    bool hasDialog = foundTaskInfo != taskInfos.end();
+
+    if (hasDialog && foundTaskInfo->ActiveDialog->isAutoCloseOnResetEdit()) {
+        foundTaskInfo->ActiveDialog->autoClosedOnResetEdit();
+
+        auto refreshedTaskInfo = std::ranges::find(taskInfos, doc, &TaskInfo::Document);
+        if (refreshedTaskInfo != taskInfos.end()) {
+            removeDialog(refreshedTaskInfo);
+        }
+        hasDialog = false;
+    }
+
+    if (!hasDialog) {
+        updateWatcher();
+    }
+}
+
 void TaskView::slotDeletedDocument(const App::Document& doc)
 {
     auto foundTaskInfo = std::ranges::find(taskInfos, &doc, &TaskInfo::Document);
     bool hasDialog = foundTaskInfo != taskInfos.end();
     if (hasDialog && foundTaskInfo->ActiveDialog->isAutoCloseOnDeletedDocument()) {
         foundTaskInfo->ActiveDialog->autoClosedOnDeletedDocument();
-        removeDialog(foundTaskInfo);
+
+        auto refreshedTaskInfo = std::ranges::find(taskInfos, &doc, &TaskInfo::Document);
+        if (refreshedTaskInfo != taskInfos.end()) {
+            removeDialog(refreshedTaskInfo);
+        }
         hasDialog = false;
     }
 
@@ -525,8 +554,13 @@ void TaskView::slotViewClosed(const Gui::MDIView* view)
     bool hasDialog = foundTaskInfo != taskInfos.end();
     // It can happen that only a view is closed an not the document
     if (hasDialog && foundTaskInfo->ActiveDialog->isAutoCloseOnClosedView()) {
+        App::Document* doc = foundTaskInfo->Document;
         foundTaskInfo->ActiveDialog->autoClosedOnClosedView();
-        removeDialog(foundTaskInfo);
+
+        auto refreshedTaskInfo = std::ranges::find(taskInfos, doc, &TaskInfo::Document);
+        if (refreshedTaskInfo != taskInfos.end()) {
+            removeDialog(refreshedTaskInfo);
+        }
         hasDialog = false;
     }
 
@@ -549,8 +583,13 @@ void TaskView::transactionChangeOnDocument(const App::Document& doc, bool undo)
         }
 
         if (foundTaskInfo->ActiveDialog->isAutoCloseOnTransactionChange()) {
+            App::Document* docPtr = foundTaskInfo->Document;
             foundTaskInfo->ActiveDialog->autoClosedOnTransactionChange();
-            removeDialog(foundTaskInfo);
+
+            auto refreshedTaskInfo = std::ranges::find(taskInfos, docPtr, &TaskInfo::Document);
+            if (refreshedTaskInfo != taskInfos.end()) {
+                removeDialog(refreshedTaskInfo);
+            }
             hasDialog = false;
         }
     }

--- a/src/Gui/TaskView/TaskView.h
+++ b/src/Gui/TaskView/TaskView.h
@@ -221,6 +221,7 @@ private:
     void tryRestoreWidth();
     void slotActiveDocument(const App::Document&);
     void slotInEdit(const Gui::ViewProviderDocumentObject&);
+    void slotResetEdit(const Gui::ViewProviderDocumentObject&);
     void slotDeletedDocument(const App::Document&);
     void slotViewClosed(const Gui::MDIView*);
     void slotUndoDocument(const App::Document&);
@@ -259,6 +260,7 @@ protected:
     Connection connectApplicationUndoDocument;
     Connection connectApplicationRedoDocument;
     Connection connectApplicationInEdit;
+    Connection connectApplicationResetEdit;
     Connection connectShowTaskWatcherSetting;
 };
 

--- a/src/Mod/Sketcher/CMakeLists.txt
+++ b/src/Mod/Sketcher/CMakeLists.txt
@@ -30,6 +30,7 @@ if(BUILD_GUI)
     )
     list (APPEND Sketcher_TestScripts
           SketcherTests/TestConstraintPreselectionGui.py
+          SketcherTests/GuiTestCase.py
           SketcherTests/TestPlacementUpdate.py
           SketcherTests/TestOnViewParameterGui.py
     )

--- a/src/Mod/Sketcher/Gui/DrawSketchController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchController.h
@@ -679,6 +679,11 @@ protected:
                 &Gui::EditableDatumLabel::editingFinished,
                 handleParameterValueChanged
             );
+            QObject::connect(parameter, &Gui::EditableDatumLabel::editingCanceled, [this](double) {
+                if (handler) {
+                    handler->cancelCurrentAction();
+                }
+            });
 
             // this gets triggered whenever user deletes content in OVP, we remove the
             // constraints and unset everything to give user another change to select stuff

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -455,13 +455,18 @@ public:
             this->iterateToNextConstructionMethod();
         }
         else if (key == SoKeyboardEvent::ESCAPE && pressed) {
-            rightButtonOrEsc();
+            cancelCurrentAction();
         }
     }
 
     void pressRightButton(Base::Vector2d onSketchPos) override
     {
         Q_UNUSED(onSketchPos);
+        cancelCurrentAction();
+    }
+
+    void cancelCurrentAction() override
+    {
         rightButtonOrEsc();
     }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -344,20 +344,23 @@ void DrawSketchHandler::preActivated()
     ViewProviderSketchDrawSketchHandlerAttorney::setConstraintSelectability(*sketchgui, false);
 }
 
-void DrawSketchHandler::registerPressedKey(bool pressed, int key)
+void DrawSketchHandler::cancelCurrentAction()
 {
     // the default behaviour is to quit - specific handler categories may
     // override this behaviour, for example to implement a continuous mode
+    quit();
+}
+
+void DrawSketchHandler::registerPressedKey(bool pressed, int key)
+{
     if (key == SoKeyboardEvent::ESCAPE && !pressed) {
-        quit();
+        cancelCurrentAction();
     }
 }
 
 void DrawSketchHandler::pressRightButton(Base::Vector2d /*onSketchPos*/)
 {
-    // the default behaviour is to quit - specific handler categories may
-    // override this behaviour, for example to implement a continuous mode
-    quit();
+    cancelCurrentAction();
 }
 
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -171,6 +171,8 @@ public:
     virtual bool pressButton(Base::Vector2d pos) = 0;
     virtual bool releaseButton(Base::Vector2d pos) = 0;
 
+    /// Cancels the current tool action. Used by Esc, right click, and OVP cancel.
+    virtual void cancelCurrentAction();
     virtual void registerPressedKey(bool pressed, int key);
     virtual void pressRightButton(Base::Vector2d pos);
 

--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
@@ -55,6 +55,7 @@ TaskDlgEditSketch::TaskDlgEditSketch(ViewProviderSketch* sketchView)
         "User parameter:BaseApp/Preferences/Mod/Sketcher"
     );
     setEscapeButtonEnabled(hGrp->GetBool("LeaveSketchWithEscape", true));
+    setAutoCloseOnResetEdit(true);
 
     Content.push_back(Messages);
     Content.push_back(ToolSettings);
@@ -118,28 +119,33 @@ void TaskDlgEditSketch::slotToolChanged(const std::string& toolname)
 void TaskDlgEditSketch::open()
 {}
 
+void TaskDlgEditSketch::closed()
+{}
+
 void TaskDlgEditSketch::clicked(int)
 {}
 
 bool TaskDlgEditSketch::reject()
 {
-    sketchView->editingCancelled = true;
-    deactivate();
-    sketchView->editingCancelled = false;
+    ViewProviderSketch* view = sketchView;
+    std::string document = getDocumentName();  // needed because resetEdit() deletes this instance
+    view->editingCancelled = true;
+    Gui::Command::doCommand(Gui::Command::Gui, "Gui.getDocument('%s').resetEdit()", document.c_str());
+    view->editingCancelled = false;
 
     return true;
 }
 
 bool TaskDlgEditSketch::accept()
 {
-    std::string document = getDocumentName();
-    deactivate();
+    std::string document = getDocumentName();  // needed because resetEdit() deletes this instance
+    Gui::Command::doCommand(Gui::Command::Gui, "Gui.getDocument('%s').resetEdit()", document.c_str());
     Gui::Command::doCommand(Gui::Command::Doc, "App.getDocument('%s').recompute()", document.c_str());
 
     return true;
 }
 
-void TaskDlgEditSketch::deactivate()
+void TaskDlgEditSketch::saveDialogState() const
 {
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Sketcher"
@@ -148,18 +154,16 @@ void TaskDlgEditSketch::deactivate()
     hGrp->SetBool("ExpandedSolverAdvancedWidget", SolverAdvanced->isGroupVisible());
     hGrp->SetBool("ExpandedConstraintsWidget", Constraints->isGroupVisible());
     hGrp->SetBool("ExpandedElementsWidget", Elements->isGroupVisible());
-
-    if (sketchView && sketchView->getSketchMode() != ViewProviderSketch::STATUS_NONE) {
-        sketchView->purgeHandler();
-    }
-
-    std::string document = getDocumentName();  // needed because resetEdit() deletes this instance
-    Gui::Command::doCommand(Gui::Command::Gui, "Gui.getDocument('%s').resetEdit()", document.c_str());
 }
 
 QDialogButtonBox::StandardButtons TaskDlgEditSketch::getStandardButtons() const
 {
     return QDialogButtonBox::Ok | QDialogButtonBox::Cancel;
+}
+
+void TaskDlgEditSketch::autoClosedOnResetEdit()
+{
+    saveDialogState();
 }
 
 void TaskDlgEditSketch::autoClosedOnClosedView()

--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
@@ -43,7 +43,6 @@ TaskDlgEditSketch::TaskDlgEditSketch(ViewProviderSketch* sketchView)
     , sketchView(sketchView)
 {
     assert(sketchView);
-    roleOnEscape = QDialogButtonBox::ButtonRole::AcceptRole;
 
     ToolSettings = new TaskSketcherTool(sketchView);
     Constraints = new TaskSketcherConstraints(sketchView);

--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.h
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.h
@@ -58,17 +58,19 @@ public:
 public:
     /// is called the TaskView when the dialog is opened
     void open() override;
+    /// is called by the framework when the dialog is closed
+    void closed() override;
     /// is called by the framework if an button is clicked which has no accept or reject role
     void clicked(int) override;
     /// is called by the framework if the dialog is accepted (Ok)
     bool accept() override;
     /// is called by the framework if the dialog is rejected (Cancel)
     bool reject() override;
-    void deactivate() override;
     bool isAllowedAlterDocument() const override
     {
         return false;
     }
+    void autoClosedOnResetEdit() override;
     void autoClosedOnClosedView() override;
 
     QDialogButtonBox::StandardButtons getStandardButtons() const override;
@@ -86,6 +88,7 @@ protected:
 
 private:
     void slotToolChanged(const std::string& toolname);
+    void saveDialogState() const;
 
 protected:
     ViewProviderSketch* sketchView;

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -4268,8 +4268,6 @@ void ViewProviderSketch::unsetEdit(int ModNum)
     connectSolverUpdate.disconnect();
     connectConstraintAdded.disconnect();
 
-    // when pressing ESC make sure to close the dialog
-    Gui::Control().closeDialog();
     unsetupActiveAndInEdit();
 
     // visibility automation

--- a/src/Mod/Sketcher/SketcherTests/GuiTestCase.py
+++ b/src/Mod/Sketcher/SketcherTests/GuiTestCase.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+import FreeCAD
+
+try:
+    import FreeCADGui
+
+    GUI_MODULE_AVAILABLE = True
+except ImportError:
+    FreeCADGui = None
+    GUI_MODULE_AVAILABLE = False
+
+try:
+    from PySide import QtCore, QtGui
+
+    QT_MODULE_AVAILABLE = True
+except ImportError:
+    QtCore = None
+    QtGui = None
+    QT_MODULE_AVAILABLE = False
+
+
+def gui_available():
+    if not GUI_MODULE_AVAILABLE:
+        return False
+
+    try:
+        return FreeCADGui.getMainWindow() is not None
+    except (AttributeError, RuntimeError):
+        return False
+
+
+class SketcherGuiTestCase(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        if not gui_available():
+            self.skipTest("GUI not available")
+
+    def tearDown(self):
+        try:
+            self.cleanup_gui_document(getattr(self, "doc", None))
+        finally:
+            super().tearDown()
+
+    def pump(self, timeout_ms=50):
+        if not QT_MODULE_AVAILABLE:
+            return
+
+        loop = QtCore.QEventLoop()
+        QtCore.QTimer.singleShot(timeout_ms, loop.quit)
+        loop.exec_()
+
+    def flush_gui(self, timeout_ms=0):
+        if not gui_available():
+            return
+
+        if QT_MODULE_AVAILABLE:
+            QtGui.QApplication.processEvents()
+
+        FreeCADGui.updateGui()
+
+        if timeout_ms:
+            self.pump(timeout_ms)
+
+    def cleanup_gui_document(self, doc, timeout_ms=80):
+        if not gui_available():
+            return
+
+        gui_doc = FreeCADGui.ActiveDocument
+        if gui_doc is not None:
+            gui_doc.resetEdit()
+            self.flush_gui(timeout_ms)
+
+        if FreeCADGui.Control.activeDialog() is not None:
+            FreeCADGui.Control.closeDialog()
+            self.flush_gui(timeout_ms)
+
+        if doc is not None and doc.Name in FreeCAD.listDocuments():
+            FreeCAD.closeDocument(doc.Name)
+            self.flush_gui(timeout_ms)
+
+    def wait_until(self, predicate, timeout_ms=1000, step_ms=50):
+        remaining = timeout_ms
+        while remaining > 0:
+            if predicate():
+                return True
+            self.flush_gui(step_ms)
+            remaining -= step_ms
+        return predicate()
+
+    def send_mouse(self, widget, event_type, pos, button, buttons):
+        global_pos = widget.mapToGlobal(pos)
+        event = QtGui.QMouseEvent(
+            event_type,
+            pos,
+            global_pos,
+            button,
+            buttons,
+            QtCore.Qt.NoModifier,
+        )
+        QtGui.QApplication.sendEvent(widget, event)
+
+    def click(self, widget, pos):
+        self.send_mouse(
+            widget,
+            QtCore.QEvent.MouseButtonPress,
+            pos,
+            QtCore.Qt.LeftButton,
+            QtCore.Qt.LeftButton,
+        )
+        self.send_mouse(
+            widget,
+            QtCore.QEvent.MouseButtonRelease,
+            pos,
+            QtCore.Qt.LeftButton,
+            QtCore.Qt.NoButton,
+        )
+        self.pump(120)
+
+    def right_click(self, widget, pos):
+        self.send_mouse(
+            widget,
+            QtCore.QEvent.MouseButtonPress,
+            pos,
+            QtCore.Qt.RightButton,
+            QtCore.Qt.RightButton,
+        )
+        self.send_mouse(
+            widget,
+            QtCore.QEvent.MouseButtonRelease,
+            pos,
+            QtCore.Qt.RightButton,
+            QtCore.Qt.NoButton,
+        )
+        self.pump(120)
+
+    def move(self, widget, pos):
+        self.send_mouse(
+            widget,
+            QtCore.QEvent.MouseMove,
+            pos,
+            QtCore.Qt.NoButton,
+            QtCore.Qt.NoButton,
+        )
+        self.pump(80)
+
+    def key_click(self, widget, key, text=""):
+        press = QtGui.QKeyEvent(QtCore.QEvent.KeyPress, key, QtCore.Qt.NoModifier, text)
+        release = QtGui.QKeyEvent(QtCore.QEvent.KeyRelease, key, QtCore.Qt.NoModifier, text)
+        QtGui.QApplication.sendEvent(widget, press)
+        QtGui.QApplication.sendEvent(widget, release)
+        self.pump(60)
+
+    def clamp_to_widget(self, widget, pos, margin=10):
+        rect = widget.rect()
+        return QtCore.QPoint(
+            max(margin, min(pos.x(), rect.right() - margin)),
+            max(margin, min(pos.y(), rect.bottom() - margin)),
+        )

--- a/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
@@ -1,20 +1,11 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import unittest
-
 import FreeCAD
-
-try:
-    import FreeCADGui
-
-    GUI_AVAILABLE = FreeCADGui.getMainWindow() is not None
-except (ImportError, AttributeError):
-    GUI_AVAILABLE = False
-
 from PySide import QtCore, QtGui
+from SketcherTests.GuiTestCase import FreeCADGui, SketcherGuiTestCase
 
 
-class TestOnViewParameterGui(unittest.TestCase):
+class TestOnViewParameterGui(SketcherGuiTestCase):
     KEYS = {
         "0": QtCore.Qt.Key_0,
         "1": QtCore.Qt.Key_1,
@@ -32,24 +23,12 @@ class TestOnViewParameterGui(unittest.TestCase):
     }
 
     def setUp(self):
-        if not GUI_AVAILABLE:
-            self.skipTest("GUI not available")
+        super().setUp()
 
         FreeCADGui.activateWorkbench("SketcherWorkbench")
         self.doc = FreeCAD.newDocument("TestOnViewParameterGui")
         self.sketch = self.doc.addObject("Sketcher::SketchObject", "Sketch")
         self.doc.recompute()
-
-    def tearDown(self):
-        if not GUI_AVAILABLE:
-            return
-
-        gui_doc = FreeCADGui.ActiveDocument
-        if gui_doc is not None:
-            gui_doc.resetEdit()
-
-        if self.doc.Name in FreeCAD.listDocuments():
-            FreeCAD.closeDocument(self.doc.Name)
 
     def pack_color(self, color):
         r, g, b, a = color
@@ -59,66 +38,6 @@ class TestOnViewParameterGui(unittest.TestCase):
             | int(b * 255.0 + 0.5) << 8
             | int(a * 255.0 + 0.5)
         )
-
-    def pump(self, timeout_ms=50):
-        loop = QtCore.QEventLoop()
-        QtCore.QTimer.singleShot(timeout_ms, loop.quit)
-        loop.exec_()
-
-    def wait_until(self, predicate, timeout_ms=1000, step_ms=50):
-        remaining = timeout_ms
-        while remaining > 0:
-            if predicate():
-                return True
-            self.pump(step_ms)
-            remaining -= step_ms
-        return predicate()
-
-    def send_mouse(self, widget, event_type, pos, button, buttons):
-        global_pos = widget.mapToGlobal(pos)
-        event = QtGui.QMouseEvent(
-            event_type,
-            pos,
-            global_pos,
-            button,
-            buttons,
-            QtCore.Qt.NoModifier,
-        )
-        QtGui.QApplication.sendEvent(widget, event)
-
-    def click(self, widget, pos):
-        self.send_mouse(
-            widget,
-            QtCore.QEvent.MouseButtonPress,
-            pos,
-            QtCore.Qt.LeftButton,
-            QtCore.Qt.LeftButton,
-        )
-        self.send_mouse(
-            widget,
-            QtCore.QEvent.MouseButtonRelease,
-            pos,
-            QtCore.Qt.LeftButton,
-            QtCore.Qt.NoButton,
-        )
-        self.pump(120)
-
-    def move(self, widget, pos):
-        self.send_mouse(
-            widget,
-            QtCore.QEvent.MouseMove,
-            pos,
-            QtCore.Qt.NoButton,
-            QtCore.Qt.NoButton,
-        )
-        self.pump(80)
-
-    def key_click(self, widget, key, text=""):
-        press = QtGui.QKeyEvent(QtCore.QEvent.KeyPress, key, QtCore.Qt.NoModifier, text)
-        release = QtGui.QKeyEvent(QtCore.QEvent.KeyRelease, key, QtCore.Qt.NoModifier, text)
-        QtGui.QApplication.sendEvent(widget, press)
-        QtGui.QApplication.sendEvent(widget, release)
-        self.pump(60)
 
     def key_text(self, widget, text):
         for ch in text:
@@ -142,17 +61,31 @@ class TestOnViewParameterGui(unittest.TestCase):
             if spinbox.isVisible()
         ]
 
-    @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
-    def test_rectangle_ovp_enter_finishes_without_crash(self):
-        """
-        Reproduce the rectangle OVP acceptance flow from PR #29201 review:
-        click first point, type width, Tab, type height, Enter.
+    def active_task_dialog(self):
+        return FreeCADGui.Control.activeTaskDialog()
 
-        If the process survives, the rectangle should be created in the sketch.
-        """
+    def assert_sketch_edit_active(self):
+        edit = FreeCADGui.ActiveDocument.getInEdit()
+        self.assertIsNotNone(edit, "Expected sketch edit mode to remain active")
+        self.assertTrue(
+            edit.isDerivedFrom("SketcherGui::ViewProviderSketch"),
+            "Expected a Sketcher view provider to remain in edit mode",
+        )
 
+    def assert_sketch_edit_inactive(self):
+        self.assertIsNone(
+            FreeCADGui.ActiveDocument.getInEdit(),
+            "Expected sketch edit mode to be inactive",
+        )
+
+    def begin_sketch_edit_with_task_dialog(self):
         FreeCADGui.ActiveDocument.setEdit(self.sketch.Name)
         self.pump(200)
+        self.assert_sketch_edit_active()
+        self.assertIsNotNone(self.active_task_dialog(), "Expected the Sketcher task dialog to open")
+
+    def begin_rectangle_with_visible_ovp(self):
+        self.begin_sketch_edit_with_task_dialog()
 
         view = FreeCADGui.ActiveDocument.ActiveView
         view.viewTop()
@@ -165,9 +98,10 @@ class TestOnViewParameterGui(unittest.TestCase):
             f"Expected {first_point} to fall inside the sketch viewport {viewport.rect()}",
         )
 
-        move_target = QtCore.QPoint(first_point.x() + 80, first_point.y() - 60)
-        move_target.setX(max(10, min(move_target.x(), viewport.rect().right() - 10)))
-        move_target.setY(max(10, min(move_target.y(), viewport.rect().bottom() - 10)))
+        move_target = self.clamp_to_widget(
+            viewport,
+            QtCore.QPoint(first_point.x() + 80, first_point.y() - 60),
+        )
 
         FreeCADGui.runCommand("Sketcher_CreateRectangle")
         self.pump(250)
@@ -180,6 +114,51 @@ class TestOnViewParameterGui(unittest.TestCase):
             self.wait_until(lambda: len(self.visible_spinboxes()) == 2, timeout_ms=1000),
             "Expected the rectangle OVPs to become visible after the first click",
         )
+
+        return viewport, first_point
+
+    def test_reset_edit_closes_sketch_task_dialog(self):
+        self.begin_sketch_edit_with_task_dialog()
+
+        FreeCADGui.ActiveDocument.resetEdit()
+
+        self.assertTrue(
+            self.wait_until(lambda: self.active_task_dialog() is None, timeout_ms=1000),
+            "Expected resetEdit() to close the Sketcher task dialog",
+        )
+        self.assert_sketch_edit_inactive()
+
+    def test_task_dialog_reject_exits_sketch_edit(self):
+        self.begin_sketch_edit_with_task_dialog()
+
+        self.active_task_dialog().reject()
+
+        self.assertTrue(
+            self.wait_until(lambda: self.active_task_dialog() is None, timeout_ms=1000),
+            "Expected reject() to close the Sketcher task dialog",
+        )
+        self.assert_sketch_edit_inactive()
+
+    def test_task_dialog_accept_exits_sketch_edit(self):
+        self.begin_sketch_edit_with_task_dialog()
+
+        self.active_task_dialog().accept()
+
+        self.assertTrue(
+            self.wait_until(lambda: self.active_task_dialog() is None, timeout_ms=1000),
+            "Expected accept() to close the Sketcher task dialog",
+        )
+        self.assert_sketch_edit_inactive()
+
+    def test_rectangle_ovp_enter_finishes_without_crash(self):
+        """
+        Reproduce the rectangle OVP acceptance flow from PR #29201 review:
+        click first point, type width, Tab, type height, Enter.
+
+        If the process survives, the rectangle should be created in the sketch.
+        """
+
+        self.begin_rectangle_with_visible_ovp()
 
         first_spinbox = self.active_spinbox()
         self.assertIsNotNone(first_spinbox, "Expected the first rectangle OVP to have focus")
@@ -208,7 +187,132 @@ class TestOnViewParameterGui(unittest.TestCase):
             "Expected the rectangle to be created after accepting both OVPs",
         )
 
-    @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
+    def test_rectangle_ovp_escape_resets_tool_without_exiting_sketch(self):
+        viewport, first_point = self.begin_rectangle_with_visible_ovp()
+
+        first_spinbox = self.active_spinbox()
+        self.assertIsNotNone(first_spinbox, "Expected the first rectangle OVP to have focus")
+        self.key_click(first_spinbox, QtCore.Qt.Key_Escape)
+
+        self.assertTrue(
+            self.wait_until(lambda: len(self.visible_spinboxes()) == 0, timeout_ms=1000),
+            "Expected Esc to close the rectangle OVPs",
+        )
+        self.assertEqual(self.sketch.GeometryCount, 0)
+        self.assert_sketch_edit_active()
+
+        restart_point = self.clamp_to_widget(
+            viewport,
+            QtCore.QPoint(first_point.x() + 120, first_point.y() + 50),
+        )
+        restart_move = self.clamp_to_widget(
+            viewport,
+            QtCore.QPoint(restart_point.x() + 70, restart_point.y() - 40),
+        )
+
+        self.move(viewport, restart_point)
+        self.click(viewport, restart_point)
+        self.move(viewport, restart_move)
+
+        self.assertTrue(
+            self.wait_until(lambda: len(self.visible_spinboxes()) == 2, timeout_ms=1000),
+            "Expected Esc to reset the rectangle tool back to its first stage",
+        )
+        self.assertEqual(self.sketch.GeometryCount, 0)
+        self.assertIsNotNone(self.active_spinbox())
+
+    def test_rectangle_ovp_escape_then_right_click_exits_tool(self):
+        viewport, first_point = self.begin_rectangle_with_visible_ovp()
+
+        first_spinbox = self.active_spinbox()
+        self.assertIsNotNone(first_spinbox, "Expected the first rectangle OVP to have focus")
+        self.key_click(first_spinbox, QtCore.Qt.Key_Escape)
+
+        self.assertTrue(
+            self.wait_until(lambda: len(self.visible_spinboxes()) == 0, timeout_ms=1000),
+            "Expected Esc to close the rectangle OVPs",
+        )
+        self.assertEqual(self.sketch.GeometryCount, 0)
+        self.assert_sketch_edit_active()
+
+        cancel_point = self.clamp_to_widget(
+            viewport,
+            QtCore.QPoint(first_point.x() + 120, first_point.y() + 50),
+        )
+        retry_move = self.clamp_to_widget(
+            viewport,
+            QtCore.QPoint(cancel_point.x() + 70, cancel_point.y() - 40),
+        )
+
+        self.right_click(viewport, cancel_point)
+        self.assertTrue(
+            self.wait_until(lambda: len(self.visible_spinboxes()) == 0, timeout_ms=400),
+            "Expected right click to keep the rectangle OVPs closed after canceling",
+        )
+        self.assertEqual(self.sketch.GeometryCount, 0)
+        self.assert_sketch_edit_active()
+
+        self.move(viewport, cancel_point)
+        self.click(viewport, cancel_point)
+        self.move(viewport, retry_move)
+
+        self.assertFalse(
+            self.wait_until(lambda: len(self.visible_spinboxes()) == 2, timeout_ms=500),
+            "Expected right click to exit the rectangle tool after OVP Esc",
+        )
+        self.assertEqual(self.sketch.GeometryCount, 0)
+
+    def test_rectangle_ovp_escape_then_escape_then_escape_exits_sketch(self):
+        viewport, first_point = self.begin_rectangle_with_visible_ovp()
+
+        first_spinbox = self.active_spinbox()
+        self.assertIsNotNone(first_spinbox, "Expected the first rectangle OVP to have focus")
+        self.key_click(first_spinbox, QtCore.Qt.Key_Escape)
+
+        self.assertTrue(
+            self.wait_until(lambda: len(self.visible_spinboxes()) == 0, timeout_ms=1000),
+            "Expected the first Esc to close the rectangle OVPs",
+        )
+        self.assertEqual(self.sketch.GeometryCount, 0)
+        self.assert_sketch_edit_active()
+
+        view = FreeCADGui.ActiveDocument.ActiveView
+        graphics_view = view.graphicsView()
+        graphics_view.setFocus(QtCore.Qt.OtherFocusReason)
+        self.pump(100)
+
+        self.key_click(graphics_view, QtCore.Qt.Key_Escape)
+        self.assert_sketch_edit_active()
+
+        cancel_point = self.clamp_to_widget(
+            viewport,
+            QtCore.QPoint(first_point.x() + 120, first_point.y() + 50),
+        )
+        retry_move = self.clamp_to_widget(
+            viewport,
+            QtCore.QPoint(cancel_point.x() + 70, cancel_point.y() - 40),
+        )
+
+        self.move(viewport, cancel_point)
+        self.click(viewport, cancel_point)
+        self.move(viewport, retry_move)
+
+        self.assertFalse(
+            self.wait_until(lambda: len(self.visible_spinboxes()) == 2, timeout_ms=500),
+            "Expected the second Esc to exit the rectangle tool",
+        )
+        self.assertEqual(self.sketch.GeometryCount, 0)
+
+        graphics_view.setFocus(QtCore.Qt.OtherFocusReason)
+        self.pump(100)
+        self.key_click(graphics_view, QtCore.Qt.Key_Escape)
+
+        self.assertTrue(
+            self.wait_until(lambda: self.active_task_dialog() is None, timeout_ms=1000),
+            "Expected the third Esc to close the Sketcher task dialog",
+        )
+        self.assert_sketch_edit_inactive()
+
     def test_auto_color_restores_line_color_from_preferences(self):
         view_params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View")
         color_key = "SketchEdgeColor"

--- a/src/Mod/Sketcher/SketcherTests/TestPlacementUpdate.py
+++ b/src/Mod/Sketcher/SketcherTests/TestPlacementUpdate.py
@@ -2,21 +2,13 @@
 # regression test for sketch placement updates during edit mode
 # when sketcher workbench is active and has not be closed / exited
 
-import unittest
 import FreeCAD
 
-# check if GUI is available
-try:
-    import FreeCADGui
-
-    GUI_AVAILABLE = FreeCADGui.getMainWindow() is not None
-except (ImportError, AttributeError):
-    GUI_AVAILABLE = False
-
 from FreeCAD import Base
+from SketcherTests.GuiTestCase import FreeCADGui, SketcherGuiTestCase
 
 
-class TestSketchPlacementUpdate(unittest.TestCase):
+class TestSketchPlacementUpdate(SketcherGuiTestCase):
     """
     test that sketch placement/attachment changes update the 3D view
     when the sketch is in edit mode.
@@ -36,8 +28,7 @@ class TestSketchPlacementUpdate(unittest.TestCase):
         then attach a sketch to the cylinder to the bottom round face of the
         cylinder.
         """
-        if not GUI_AVAILABLE:
-            self.skipTest("GUI not available")
+        super().setUp()
 
         self.doc = FreeCAD.newDocument("TestPlacementUpdate")
 
@@ -73,12 +64,6 @@ class TestSketchPlacementUpdate(unittest.TestCase):
 
         self.doc.recompute()
 
-    def tearDown(self):
-        """clean up the test document"""
-        if GUI_AVAILABLE:
-            FreeCAD.closeDocument(self.doc.Name)
-
-    @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
     def test_attachment_offset_updates_in_edit_mode(self):
         """
         test that changing AttachmentOffset while editing updates the transform.
@@ -110,10 +95,6 @@ class TestSketchPlacementUpdate(unittest.TestCase):
             "Editing transform should update when AttachmentOffset changes",
         )
 
-        # exit edit mode
-        FreeCADGui.ActiveDocument.resetEdit()
-
-    @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
     def test_multiple_attachment_offset_updates(self):
         """
         test that multiple AttachmentOffset changes in edit mode all update correctly.
@@ -142,10 +123,6 @@ class TestSketchPlacementUpdate(unittest.TestCase):
                     f"Transform {i} should differ from transform {i-1}",
                 )
 
-        # exit edit mode
-        FreeCADGui.ActiveDocument.resetEdit()
-
-    @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
     def test_no_update_when_not_editing(self):
         """
         verify that attachment offset changes don't cause issues when sketch is not in edit mode.
@@ -163,7 +140,6 @@ class TestSketchPlacementUpdate(unittest.TestCase):
         )
         self.assertEqual(self.sketch.MapMode, "FlatFace", "Sketch should still be attached")
 
-    @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
     def test_unattached_sketch_placement_updates(self):
         """
         test that unattached sketches also work correctly.
@@ -195,6 +171,3 @@ class TestSketchPlacementUpdate(unittest.TestCase):
             updated_transform,
             "Editing transform should update when Placement changes for unattached sketch",
         )
-
-        # exit edit mode
-        FreeCADGui.ActiveDocument.resetEdit()


### PR DESCRIPTION
Closes #30439

## Summary

- restore Sketcher tool cancellation when `Esc` is pressed inside an active on-view parameter
- add an explicit `DrawSketchHandler::cancelCurrentAction()` entry point
- route handler `Esc`, right-click, and OVP cancel through the same cancel path

## Problem

Pressing `Esc` while editing an on-view parameter closed the spinbox but did not cancel the active Sketcher draw tool. That left the tool active with focus returned to the view, so subsequent numpad input could affect camera navigation instead of the remaining OVP fields.

## Root Cause

`EditableDatumLabel` consumes `Esc` locally and emits `editingCanceled`, but Sketcher did not connect that signal back into the draw-handler cancel flow.

## Fix

- connect `EditableDatumLabel::editingCanceled` to the handler cancel path
- introduce `DrawSketchHandler::cancelCurrentAction()` as the explicit semantic cancel API
- keep default draw handlers mapping keyboard `Esc` and right-click to the existing `rightButtonOrEsc()` behavior
