### PR TITLE
Draft/BIM: Lock fields on manual input

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -65,6 +65,7 @@ SET(Draft_tests
     drafttests/test_import.py
     drafttests/test_import_gui.py
     drafttests/test_import_tools.py
+    drafttests/test_manual_input_gui.py
     drafttests/test_modification.py
     drafttests/test_oca.py
     drafttests/test_pivy.py

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -258,6 +258,7 @@ SET(Draft_GUI_tools
     draftguitools/gui_annotationstyleeditor.py
     draftguitools/gui_base.py
     draftguitools/gui_base_original.py
+    draftguitools/gui_field_locks.py
     draftguitools/gui_tool_utils.py
     draftguitools/gui_planeproxy.py
     draftguitools/gui_selectplane.py

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -115,6 +115,20 @@ class DraftLineEdit(QtWidgets.QLineEdit):
             super().keyPressEvent(event)
 
 
+class _FieldLockFilter(QtCore.QObject):
+    """Unlock a Draft task-panel input field on double-click."""
+
+    def __init__(self, tool_bar, key):
+        super().__init__()
+        self._tool_bar = tool_bar
+        self._key = key
+
+    def eventFilter(self, obj, event):
+        if event.type() == QtCore.QEvent.MouseButtonDblClick:
+            self._tool_bar._unlock_field(self._key)
+        return False
+
+
 class DraftTaskPanel:
     def __init__(self, widget, extra=None):
         if extra:
@@ -192,7 +206,6 @@ class DraftToolBar:
         self.isTaskOn = False
         self.makeFaceMode = True
         self.mask = None
-        self.alock = False
         self.x = 0  # coord of the point as displayed in the task panel (global/local and relative/absolute)
         self.y = 0  # idem
         self.z = 0  # idem
@@ -230,6 +243,8 @@ class DraftToolBar:
         self.tray.setParent(mw)
         self.tray.hide()
         self.display_point_active = False  # prevent cyclic processing of point values
+        self._field_locks = {}
+        self._field_lock_filters = []
 
     # ---------------------------------------------------------------------------
     # General UI setup
@@ -329,8 +344,95 @@ class DraftToolBar:
             cb.hide()
         layout.addWidget(cb)
 
+    # Locked fields keep their typed value and force their component on the
+    # committed point; the cursor only updates live fields.
+
+    _LOCKABLE_FIELD_KEYS = ("x", "y", "z", "length", "angle")
+
+    def _install_field_lock(self, field, key):
+        icon = QtGui.QIcon(":/icons/Draft_Snap_Lock.svg")
+        action = field.addAction(icon, QtWidgets.QLineEdit.TrailingPosition)
+        action.setVisible(False)
+        action.setToolTip(translate("draft", "Locked. Click to unlock, or double-click the field."))
+        action.triggered.connect(lambda checked=False, k=key: self._unlock_field(k))
+        field._lock_action = action
+        field.textEdited.connect(lambda txt, k=key: self._on_field_edited(k, txt))
+        flt = _FieldLockFilter(self, key)
+        field.installEventFilter(flt)
+        self._field_lock_filters.append(flt)
+        self._field_locks[key] = False
+
+    def _lockable_field(self, key):
+        return {
+            "x": getattr(self, "xValue", None),
+            "y": getattr(self, "yValue", None),
+            "z": getattr(self, "zValue", None),
+            "length": getattr(self, "lengthValue", None),
+            "angle": getattr(self, "angleValue", None),
+        }.get(key)
+
+    def _is_field_locked(self, key):
+        return self._field_locks.get(key, False)
+
+    def _set_field_locked(self, key, locked):
+        if self._field_locks.get(key) == locked:
+            return
+        self._field_locks[key] = locked
+        field = self._lockable_field(key)
+        action = getattr(field, "_lock_action", None) if field is not None else None
+        if action is not None:
+            action.setVisible(locked)
+        if key == "angle":
+            if locked:
+                self._apply_snapper_angle_lock()
+            else:
+                self._clear_snapper_angle_lock()
+
+    def _on_field_edited(self, key, text):
+        text = text.lstrip()
+        locked = bool(text) and text[0] in "0123456789.,-+"
+        self._set_field_locked(key, locked)
+
+    def _unlock_field(self, key):
+        self._set_field_locked(key, False)
+
+    def _reset_field_locks(self):
+        for key in self._LOCKABLE_FIELD_KEYS:
+            self._set_field_locked(key, False)
+
+    def apply_field_locks(self, point, last=None):
+        """Return `point` with locked axes/length/angle overridden by typed values."""
+        if not point or not any(self._field_locks.values()):
+            return point
+        plane = WorkingPlane.get_working_plane(update=False)
+        if last is None:
+            last = FreeCAD.Vector() if self.globalMode else plane.position
+        if self.relativeMode:
+            raw = FreeCAD.Vector(point) - last
+            delta = raw if self.globalMode else plane.get_local_coords(raw, as_vector=True)
+        else:
+            delta = FreeCAD.Vector(point) if self.globalMode else plane.get_local_coords(point)
+        if self._is_field_locked("x"):
+            delta.x = self.x
+        if self._is_field_locked("y"):
+            delta.y = self.y
+        if self._is_field_locked("z"):
+            delta.z = self.z
+        if self._is_field_locked("length") or self._is_field_locked("angle"):
+            length, theta, phi = DraftVecUtils.get_spherical_coords(delta.x, delta.y, delta.z)
+            if self._is_field_locked("length"):
+                length = self.lvalue
+            if self._is_field_locked("angle"):
+                phi = math.radians(self.avalue)
+            cx, cy, cz = DraftVecUtils.get_cartesian_coords(length, theta, phi)
+            delta = FreeCAD.Vector(cx, cy, cz)
+        return self.get_new_point(delta)
+
     def setupToolBar(self, task=False):
         """sets the draft toolbar up"""
+
+        self._field_locks = {}
+        self._field_lock_filters = []
 
         # command
 
@@ -392,9 +494,14 @@ class DraftToolBar:
         )  # Required to detect snap cycling if focusOnLength is True.
         self.lengthValue.setText(FreeCAD.Units.Quantity(0, FreeCAD.Units.Length).UserString)
         self.labelangle = self._label("labelangle", al)
-        self.angleLock = self._checkbox("angleLock", al, checked=self.alock)
         self.angleValue = self._inputfield("angleValue", al)
         self.angleValue.setText(FreeCAD.Units.Quantity(0, FreeCAD.Units.Angle).UserString)
+
+        self._install_field_lock(self.xValue, "x")
+        self._install_field_lock(self.yValue, "y")
+        self._install_field_lock(self.zValue, "z")
+        self._install_field_lock(self.lengthValue, "length")
+        self._install_field_lock(self.angleValue, "angle")
 
         # options
 
@@ -477,10 +584,6 @@ class DraftToolBar:
         self.zValue.valueChanged.connect(self.changeZValue)
         self.lengthValue.valueChanged.connect(self.changeLengthValue)
         self.angleValue.valueChanged.connect(self.changeAngleValue)
-        if hasattr(self.angleLock, "checkStateChanged"):  # Qt version >= 6.7.0
-            self.angleLock.checkStateChanged.connect(self.toggleAngle)
-        else:  # Qt version < 6.7.0
-            self.angleLock.stateChanged.connect(self.toggleAngle)
         self.radiusValue.valueChanged.connect(self.changeRadiusValue)
         self.xValue.returnPressed.connect(self.checkx)
         self.yValue.returnPressed.connect(self.checky)
@@ -587,14 +690,9 @@ class DraftToolBar:
         self.pointButton.setToolTip(translate("draft", "Enter a point with given coordinates"))
         self.labellength.setText(translate("draft", "Length"))
         self.labelangle.setText(translate("draft", "Angle"))
+        self._sync_field_label_widths()
         self.lengthValue.setToolTip(translate("draft", "Length of the current segment"))
         self.angleValue.setToolTip(translate("draft", "Angle of the current segment"))
-        self.angleLock.setToolTip(
-            translate("draft", "Locks the current angle")
-            + " ("
-            + _get_incmd_shortcut("Length")
-            + ")"
-        )
         self.labelRadius.setText(translate("draft", "Radius"))
         self.radiusValue.setToolTip(translate("draft", "Radius of the circle"))
         self.isRelative.setText(
@@ -779,7 +877,7 @@ class DraftToolBar:
         if not force_xyz and params.get_param("focusOnLength") and self.lengthValue.isVisible():
             self.lengthValue.setFocus()
             self.lengthValue.setSelection(0, self.number_length(self.lengthValue.text()))
-        elif not force_xyz and self.angleLock.isVisible() and self.angleLock.isChecked():
+        elif not force_xyz and self._is_field_locked("angle") and self.lengthValue.isVisible():
             self.lengthValue.setFocus()
             self.lengthValue.setSelection(0, self.number_length(self.lengthValue.text()))
         elif f == "x":
@@ -813,8 +911,6 @@ class DraftToolBar:
         self.lengthValue.show()
         self.labelangle.show()
         self.angleValue.show()
-        self.angleLock.show()
-        self.angleLock.setChecked(False)
 
     def hideXYZ(self):
         """turn off all the point entry widgets"""
@@ -829,7 +925,6 @@ class DraftToolBar:
         self.pointButton.hide()
         self.lengthValue.hide()
         self.angleValue.hide()
-        self.angleLock.hide()
         self.isRelative.hide()
         self.isGlobal.hide()
 
@@ -1007,7 +1102,6 @@ class DraftToolBar:
             self.state.append(self.pointButton.isVisible())
             self.state.append(self.lengthValue.isVisible())
             self.state.append(self.angleValue.isVisible())
-            self.state.append(self.angleLock.isVisible())
             self.state.append(self.isRelative.isVisible())
             self.state.append(self.isGlobal.isVisible())
             self.hideXYZ()
@@ -1036,10 +1130,8 @@ class DraftToolBar:
                 if self.state[10]:
                     self.angleValue.show()
                 if self.state[11]:
-                    self.angleLock.show()
-                if self.state[12]:
                     self.isRelative.show()
-                if self.state[13]:
+                if self.state[12]:
                     self.isGlobal.show()
                 self.state = None
 
@@ -1087,6 +1179,20 @@ class DraftToolBar:
             self.labelx.setText(translate("draft", "Global {}").format("X"))
             self.labely.setText(translate("draft", "Global {}").format("Y"))
             self.labelz.setText(translate("draft", "Global {}").format("Z"))
+        self._sync_field_label_widths()
+
+    def _sync_field_label_widths(self):
+        """Align X/Y/Z/Length/Angle labels so their spinboxes line up."""
+        labels = [
+            getattr(self, name, None)
+            for name in ("labelx", "labely", "labelz", "labellength", "labelangle")
+        ]
+        labels = [lab for lab in labels if lab is not None]
+        if not labels:
+            return
+        width = max(lab.sizeHint().width() for lab in labels)
+        for lab in labels:
+            lab.setMinimumWidth(width)
 
     def setNextFocus(self):
         def isThere(widget):
@@ -1489,17 +1595,21 @@ class DraftToolBar:
             length, _, phi = DraftVecUtils.get_spherical_coords(*delta)
             phi = math.degrees(phi)
 
-            self.x = delta.x
-            self.y = delta.y
-            self.z = delta.z
-            self.lvalue = length
-            self.avalue = phi
-
-            self.xValue.setText(display_external(delta.x, None, "Length"))
-            self.yValue.setText(display_external(delta.y, None, "Length"))
-            self.zValue.setText(display_external(delta.z, None, "Length"))
-            self.lengthValue.setText(display_external(length, None, "Length"))
-            self.angleValue.setText(display_external(phi, None, "Angle"))
+            if not self._is_field_locked("x"):
+                self.x = delta.x
+                self.xValue.setText(display_external(delta.x, None, "Length"))
+            if not self._is_field_locked("y"):
+                self.y = delta.y
+                self.yValue.setText(display_external(delta.y, None, "Length"))
+            if not self._is_field_locked("z"):
+                self.z = delta.z
+                self.zValue.setText(display_external(delta.z, None, "Length"))
+            if not self._is_field_locked("length"):
+                self.lvalue = length
+                self.lengthValue.setText(display_external(length, None, "Length"))
+            if not self._is_field_locked("angle"):
+                self.avalue = phi
+                self.angleValue.setText(display_external(phi, None, "Angle"))
 
         # set masks
         if (mask == "x") or (self.mask == "x"):
@@ -1723,8 +1833,11 @@ class DraftToolBar:
 
     def constrain(self, val):
         if val == "angle":
-            self.alock = not (self.alock)
-            self.angleLock.setChecked(self.alock)
+            if self._is_field_locked("angle"):
+                self._unlock_field("angle")
+            else:
+                self._set_field_locked("angle", True)
+            return
         elif self.mask == val:
             self.mask = None
             if hasattr(FreeCADGui, "Snapper"):
@@ -1789,28 +1902,23 @@ class DraftToolBar:
         self.avalue = d.Value
         self.update_cartesian_coords()
         self.updateSnapper()
-        if self.angleLock.isChecked():
-            if not self.globalMode:
-                plane = WorkingPlane.get_working_plane(update=False)
-                angle_vec = plane.get_global_coords(self.angle, as_vector=True)
-            else:
-                angle_vec = self.angle
-            FreeCADGui.Snapper.setAngle(angle_vec)
+        if self._is_field_locked("angle"):
+            self._apply_snapper_angle_lock()
 
-    def toggleAngle(self, b):
-        self.alock = self.angleLock.isChecked()
-        self.update_cartesian_coords()
-        self.updateSnapper()
-        if self.alock:
-            if not self.globalMode:
-                plane = WorkingPlane.get_working_plane(update=False)
-                angle_vec = plane.get_global_coords(self.angle, as_vector=True)
-            else:
-                angle_vec = self.angle
-            FreeCADGui.Snapper.setAngle(angle_vec)
+    def _apply_snapper_angle_lock(self):
+        if not hasattr(FreeCADGui, "Snapper") or self.angle is None:
+            return
+        if not self.globalMode:
+            plane = WorkingPlane.get_working_plane(update=False)
+            angle_vec = plane.get_global_coords(self.angle, as_vector=True)
         else:
+            angle_vec = self.angle
+        FreeCADGui.Snapper.setAngle(angle_vec)
+
+    def _clear_snapper_angle_lock(self):
+        if hasattr(FreeCADGui, "Snapper"):
             FreeCADGui.Snapper.setAngle()
-            self.angle = None
+        self.angle = None
 
     def update_spherical_coords(self):
         length, theta, phi = DraftVecUtils.get_spherical_coords(self.x, self.y, self.z)
@@ -1818,8 +1926,10 @@ class DraftToolBar:
         self.pvalue = math.degrees(theta)
         self.avalue = math.degrees(phi)
         self.angle = FreeCAD.Vector(DraftVecUtils.get_cartesian_coords(1, theta, phi))
-        self.lengthValue.setText(display_external(self.lvalue, None, "Length"))
-        self.angleValue.setText(display_external(self.avalue, None, "Angle"))
+        if not self._is_field_locked("length"):
+            self.lengthValue.setText(display_external(self.lvalue, None, "Length"))
+        if not self._is_field_locked("angle"):
+            self.angleValue.setText(display_external(self.avalue, None, "Angle"))
 
     def update_cartesian_coords(self):
         self.x, self.y, self.z = DraftVecUtils.get_cartesian_coords(
@@ -1830,9 +1940,12 @@ class DraftToolBar:
                 1, math.radians(self.pvalue), math.radians(self.avalue)
             )
         )
-        self.xValue.setText(display_external(self.x, None, "Length"))
-        self.yValue.setText(display_external(self.y, None, "Length"))
-        self.zValue.setText(display_external(self.z, None, "Length"))
+        if not self._is_field_locked("x"):
+            self.xValue.setText(display_external(self.x, None, "Length"))
+        if not self._is_field_locked("y"):
+            self.yValue.setText(display_external(self.y, None, "Length"))
+        if not self._is_field_locked("z"):
+            self.zValue.setText(display_external(self.z, None, "Length"))
 
     def get_last_point(self):
         """Get the last point in the GCS."""

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -50,6 +50,7 @@ import FreeCAD
 import FreeCADGui
 import DraftVecUtils
 import WorkingPlane
+from draftguitools.gui_field_locks import InputFieldLockGroup
 from draftutils import params
 from draftutils import utils
 from draftutils.todo import todo
@@ -115,20 +116,6 @@ class DraftLineEdit(QtWidgets.QLineEdit):
             super().keyPressEvent(event)
 
 
-class _FieldLockFilter(QtCore.QObject):
-    """Unlock a Draft task-panel input field on double-click."""
-
-    def __init__(self, tool_bar, key):
-        super().__init__()
-        self._tool_bar = tool_bar
-        self._key = key
-
-    def eventFilter(self, obj, event):
-        if event.type() == QtCore.QEvent.MouseButtonDblClick:
-            self._tool_bar._unlock_field(self._key)
-        return False
-
-
 class DraftTaskPanel:
     def __init__(self, widget, extra=None):
         if extra:
@@ -175,6 +162,15 @@ class DraftToolBar:
     Draft Ui Commands call and get information such as point coordinates,
     subcommands activation, continue mode, etc. from Task Panel Ui
     """
+
+    _LOCK_FIELDS = {
+        "x": "xValue",
+        "y": "yValue",
+        "z": "zValue",
+        "length": "lengthValue",
+        "angle": "angleValue",
+    }
+    _LOCK_VALUES = {"length": "lvalue", "angle": "avalue"}
 
     def __init__(self):
         self.tray = None
@@ -243,8 +239,8 @@ class DraftToolBar:
         self.tray.setParent(mw)
         self.tray.hide()
         self.display_point_active = False  # prevent cyclic processing of point values
-        self._field_locks = {}
-        self._field_lock_filters = []
+        self._locks = InputFieldLockGroup(on_change=self._on_lock_change)
+        self._angle_lock_axis = None
 
     # ---------------------------------------------------------------------------
     # General UI setup
@@ -344,65 +340,60 @@ class DraftToolBar:
             cb.hide()
         layout.addWidget(cb)
 
-    # Locked fields keep their typed value and force their component on the
-    # committed point; the cursor only updates live fields.
+    def _on_lock_change(self, key, locked):
+        if locked:
+            self._read_locked_value(key)
+            if key in ("x", "y", "z"):
+                self._unlock_polar_fields()
+            elif key in ("length", "angle"):
+                self._unlock_cartesian_fields()
+                self.mask = None
+                if hasattr(FreeCADGui, "Snapper"):
+                    FreeCADGui.Snapper.mask = None
+                if key == "length" and self._is_field_locked("angle"):
+                    self._apply_snapper_angle_lock()
+        if key != "angle":
+            return
+        if locked:
+            self.mask = None
+            self._angle_lock_axis = self._current_angle_axis()
+            self._apply_snapper_angle_lock()
+        else:
+            self._clear_snapper_angle_lock()
 
-    _LOCKABLE_FIELD_KEYS = ("x", "y", "z", "length", "angle")
-
-    def _install_field_lock(self, field, key):
-        icon = QtGui.QIcon(":/icons/Draft_Snap_Lock.svg")
-        action = field.addAction(icon, QtWidgets.QLineEdit.TrailingPosition)
-        action.setVisible(False)
-        action.setToolTip(translate("draft", "Locked. Click to unlock, or double-click the field."))
-        action.triggered.connect(lambda checked=False, k=key: self._unlock_field(k))
-        field._lock_action = action
-        field.textEdited.connect(lambda txt, k=key: self._on_field_edited(k, txt))
-        flt = _FieldLockFilter(self, key)
-        field.installEventFilter(flt)
-        self._field_lock_filters.append(flt)
-        self._field_locks[key] = False
-
-    def _lockable_field(self, key):
-        return {
-            "x": getattr(self, "xValue", None),
-            "y": getattr(self, "yValue", None),
-            "z": getattr(self, "zValue", None),
-            "length": getattr(self, "lengthValue", None),
-            "angle": getattr(self, "angleValue", None),
-        }.get(key)
+    def _read_locked_value(self, key):
+        field = getattr(self, self._LOCK_FIELDS.get(key, ""), None)
+        if field is None:
+            return
+        value = field.property("rawValue")
+        if value is not None:
+            setattr(self, self._LOCK_VALUES.get(key, key), float(value))
 
     def _is_field_locked(self, key):
-        return self._field_locks.get(key, False)
+        return self._locks.is_locked(key)
 
     def _set_field_locked(self, key, locked):
-        if self._field_locks.get(key) == locked:
-            return
-        self._field_locks[key] = locked
-        field = self._lockable_field(key)
-        action = getattr(field, "_lock_action", None) if field is not None else None
-        if action is not None:
-            action.setVisible(locked)
-        if key == "angle":
-            if locked:
-                self._apply_snapper_angle_lock()
-            else:
-                self._clear_snapper_angle_lock()
-
-    def _on_field_edited(self, key, text):
-        text = text.lstrip()
-        locked = bool(text) and text[0] in "0123456789.,-+"
-        self._set_field_locked(key, locked)
+        if locked:
+            field = getattr(self, self._LOCK_FIELDS.get(key, ""), None)
+            if field is not None:
+                value = getattr(self, self._LOCK_VALUES.get(key, key))
+                field.setProperty("rawValue", value)
+        self._locks.set_locked(key, locked)
 
     def _unlock_field(self, key):
-        self._set_field_locked(key, False)
+        self._locks.unlock(key)
 
-    def _reset_field_locks(self):
-        for key in self._LOCKABLE_FIELD_KEYS:
-            self._set_field_locked(key, False)
+    def _unlock_cartesian_fields(self):
+        # Editing length/angle recomputes X/Y/Z, so their locks no longer hold.
+        self._locks.unlock_keys(("x", "y", "z"))
 
-    def apply_field_locks(self, point, last=None):
+    def _unlock_polar_fields(self):
+        # Editing X/Y/Z recomputes length/angle, so their locks no longer hold.
+        self._locks.unlock_keys(("length", "angle"))
+
+    def constrain_point(self, point, last=None):
         """Return `point` with locked axes/length/angle overridden by typed values."""
-        if not point or not any(self._field_locks.values()):
+        if point is None or not self._locks.any_locked():
             return point
         plane = WorkingPlane.get_working_plane(update=False)
         if last is None:
@@ -418,21 +409,44 @@ class DraftToolBar:
             delta.y = self.y
         if self._is_field_locked("z"):
             delta.z = self.z
-        if self._is_field_locked("length") or self._is_field_locked("angle"):
-            length, theta, phi = DraftVecUtils.get_spherical_coords(delta.x, delta.y, delta.z)
+        if self._is_field_locked("angle"):
+            axis = self._angle_lock_axis or self._current_angle_axis()
+            factor = delta.dot(axis) / axis.dot(axis)
             if self._is_field_locked("length"):
-                length = self.lvalue
-            if self._is_field_locked("angle"):
-                phi = math.radians(self.avalue)
-            cx, cy, cz = DraftVecUtils.get_cartesian_coords(length, theta, phi)
-            delta = FreeCAD.Vector(cx, cy, cz)
-        return self.get_new_point(delta)
+                factor = -self.lvalue if factor < 0 else self.lvalue
+            delta = axis * factor
+        elif self._is_field_locked("length"):
+            if delta.Length:
+                delta.normalize()
+                delta *= self.lvalue
+            else:
+                delta = self._current_angle_axis() * self.lvalue
+        if self.globalMode:
+            base = last if self.relativeMode else FreeCAD.Vector()
+            return base + delta
+        global_delta = plane.get_global_coords(delta, as_vector=True)
+        base = last if self.relativeMode else plane.position
+        return base + global_delta
+
+    def _current_angle_axis(self):
+        return FreeCAD.Vector(
+            DraftVecUtils.get_cartesian_coords(
+                1, math.radians(self.pvalue), math.radians(self.avalue)
+            )
+        )
+
+    def _update_locked_angle_display(self, delta):
+        if delta.Length == 0:
+            return
+        _, _, phi = DraftVecUtils.get_spherical_coords(*delta)
+        self.avalue = math.degrees(phi)
+        self.angleValue.setText(display_external(self.avalue, None, "Angle"))
 
     def setupToolBar(self, task=False):
         """sets the draft toolbar up"""
 
-        self._field_locks = {}
-        self._field_lock_filters = []
+        # Fields are recreated on every rebuild, so start with a fresh group.
+        self._locks = InputFieldLockGroup(on_change=self._on_lock_change)
 
         # command
 
@@ -497,11 +511,11 @@ class DraftToolBar:
         self.angleValue = self._inputfield("angleValue", al)
         self.angleValue.setText(FreeCAD.Units.Quantity(0, FreeCAD.Units.Angle).UserString)
 
-        self._install_field_lock(self.xValue, "x")
-        self._install_field_lock(self.yValue, "y")
-        self._install_field_lock(self.zValue, "z")
-        self._install_field_lock(self.lengthValue, "length")
-        self._install_field_lock(self.angleValue, "angle")
+        self._locks.add_field("x", self.xValue)
+        self._locks.add_field("y", self.yValue)
+        self._locks.add_field("z", self.zValue)
+        self._locks.add_field("length", self.lengthValue)
+        self._locks.add_field("angle", self.angleValue)
 
         # options
 
@@ -848,6 +862,8 @@ class DraftToolBar:
         self.baseWidget = DraftBaseWidget()
         self.layout = QtWidgets.QVBoxLayout(self.baseWidget)
         self.setupToolBar(task=True)
+        if hasattr(FreeCADGui, "Snapper"):
+            FreeCADGui.Snapper.setPointConstraintProvider(self)
         self.retranslateUi(self.baseWidget)
         self.panel = DraftTaskPanel(self.baseWidget, extra)
         todo.delay(self._show_dialog, self.panel)
@@ -874,10 +890,20 @@ class DraftToolBar:
                 if axis.isEqual(constraint_dir, 0.1) or axis.isEqual(-constraint_dir, 0.1):
                     force_xyz = True
 
-        if not force_xyz and params.get_param("focusOnLength") and self.lengthValue.isVisible():
+        if (
+            not force_xyz
+            and params.get_param("focusOnLength")
+            and self.lengthValue.isVisible()
+            and not self._is_field_locked("length")
+        ):
             self.lengthValue.setFocus()
             self.lengthValue.setSelection(0, self.number_length(self.lengthValue.text()))
-        elif not force_xyz and self._is_field_locked("angle") and self.lengthValue.isVisible():
+        elif (
+            not force_xyz
+            and self._is_field_locked("angle")
+            and self.lengthValue.isVisible()
+            and not self._is_field_locked("length")
+        ):
             self.lengthValue.setFocus()
             self.lengthValue.setSelection(0, self.number_length(self.lengthValue.text()))
         elif f == "x":
@@ -893,9 +919,28 @@ class DraftToolBar:
             self.radiusValue.setFocus()
             self.radiusValue.setSelection(0, self.number_length(self.radiusValue.text()))
         else:
-            # f is None
-            self.xValue.setFocus()
-            self.xValue.setSelection(0, self.number_length(self.xValue.text()))
+            # f is None: focus the first field the cursor can still drive so
+            # auto-focus skips locked fields instead of landing on them.
+            target = self._first_unlocked_point_field()
+            target.setFocus()
+            target.setSelection(0, self.number_length(target.text()))
+
+    def _first_unlocked_point_field(self):
+        """Return the first visible, enabled, unlocked point-entry field.
+
+        Falls back to xValue when every candidate is locked, matching the
+        historical default when nothing is locked.
+        """
+        for key, widget in (
+            ("x", self.xValue),
+            ("y", self.yValue),
+            ("z", self.zValue),
+            ("length", self.lengthValue),
+            ("angle", self.angleValue),
+        ):
+            if widget.isVisible() and widget.isEnabled() and not self._is_field_locked(key):
+                return widget
+        return self.xValue
 
     def number_length(self, st):
         nl = len(st)
@@ -1051,6 +1096,8 @@ class DraftToolBar:
         todo.delay(self.setFocus, "radius")
 
     def offUi(self):
+        if hasattr(FreeCADGui, "Snapper"):
+            FreeCADGui.Snapper.clearPointConstraintProvider(self)
         todo.delay(FreeCADGui.Control.closeDialog, None)
         self.cancel = None
         self.sourceCmd = None
@@ -1287,6 +1334,8 @@ class DraftToolBar:
         self.globalMode = bool(getattr(val, "value", val))
         self.checkLocal()
         self.displayPoint(self.new_point, self.get_last_point())
+        if self._is_field_locked("angle"):
+            self._apply_snapper_angle_lock()
         self.updateSnapper()
 
     def setMakeFace(self, val):
@@ -1569,7 +1618,7 @@ class DraftToolBar:
 
         self.display_point_active = True  # prevent cyclic processing of point values
 
-        if point:
+        if point is not None:
             if not plane:
                 plane = WorkingPlane.get_working_plane(update=False)
             if not last:
@@ -1607,7 +1656,9 @@ class DraftToolBar:
             if not self._is_field_locked("length"):
                 self.lvalue = length
                 self.lengthValue.setText(display_external(length, None, "Length"))
-            if not self._is_field_locked("angle"):
+            if self._is_field_locked("angle"):
+                self._update_locked_angle_display(delta)
+            else:
                 self.avalue = phi
                 self.angleValue.setText(display_external(phi, None, "Angle"))
 
@@ -1838,7 +1889,9 @@ class DraftToolBar:
             else:
                 self._set_field_locked("angle", True)
             return
-        elif self.mask == val:
+        if self._is_field_locked("angle"):
+            self._unlock_field("angle")
+        if self.mask == val:
             self.mask = None
             if hasattr(FreeCADGui, "Snapper"):
                 FreeCADGui.Snapper.mask = None
@@ -1857,6 +1910,7 @@ class DraftToolBar:
         if not self.xValue.hasFocus():
             return
         self.x = d.Value
+        self._unlock_polar_fields()
         self.update_spherical_coords()
         self.updateSnapper()
 
@@ -1866,6 +1920,7 @@ class DraftToolBar:
         if not self.yValue.hasFocus():
             return
         self.y = d.Value
+        self._unlock_polar_fields()
         self.update_spherical_coords()
         self.updateSnapper()
 
@@ -1875,6 +1930,7 @@ class DraftToolBar:
         if not self.zValue.hasFocus():
             return
         self.z = d.Value
+        self._unlock_polar_fields()
         self.update_spherical_coords()
         self.updateSnapper()
 
@@ -1891,6 +1947,7 @@ class DraftToolBar:
         if not self.lengthValue.hasFocus():
             return
         self.lvalue = d.Value
+        self._unlock_cartesian_fields()
         self.update_cartesian_coords()
         self.updateSnapper()
 
@@ -1900,24 +1957,28 @@ class DraftToolBar:
         if not self.angleValue.hasFocus():
             return
         self.avalue = d.Value
+        self._unlock_cartesian_fields()
         self.update_cartesian_coords()
         self.updateSnapper()
         if self._is_field_locked("angle"):
+            self._angle_lock_axis = self._current_angle_axis()
             self._apply_snapper_angle_lock()
 
     def _apply_snapper_angle_lock(self):
-        if not hasattr(FreeCADGui, "Snapper") or self.angle is None:
+        if not hasattr(FreeCADGui, "Snapper"):
             return
+        angle_axis = self._angle_lock_axis or self._current_angle_axis()
         if not self.globalMode:
             plane = WorkingPlane.get_working_plane(update=False)
-            angle_vec = plane.get_global_coords(self.angle, as_vector=True)
+            angle_vec = plane.get_global_coords(angle_axis, as_vector=True)
         else:
-            angle_vec = self.angle
+            angle_vec = angle_axis
         FreeCADGui.Snapper.setAngle(angle_vec)
 
     def _clear_snapper_angle_lock(self):
         if hasattr(FreeCADGui, "Snapper"):
             FreeCADGui.Snapper.setAngle()
+        self._angle_lock_axis = None
         self.angle = None
 
     def update_spherical_coords(self):
@@ -1926,10 +1987,8 @@ class DraftToolBar:
         self.pvalue = math.degrees(theta)
         self.avalue = math.degrees(phi)
         self.angle = FreeCAD.Vector(DraftVecUtils.get_cartesian_coords(1, theta, phi))
-        if not self._is_field_locked("length"):
-            self.lengthValue.setText(display_external(self.lvalue, None, "Length"))
-        if not self._is_field_locked("angle"):
-            self.angleValue.setText(display_external(self.avalue, None, "Angle"))
+        self.lengthValue.setText(display_external(self.lvalue, None, "Length"))
+        self.angleValue.setText(display_external(self.avalue, None, "Angle"))
 
     def update_cartesian_coords(self):
         self.x, self.y, self.z = DraftVecUtils.get_cartesian_coords(
@@ -1940,12 +1999,9 @@ class DraftToolBar:
                 1, math.radians(self.pvalue), math.radians(self.avalue)
             )
         )
-        if not self._is_field_locked("x"):
-            self.xValue.setText(display_external(self.x, None, "Length"))
-        if not self._is_field_locked("y"):
-            self.yValue.setText(display_external(self.y, None, "Length"))
-        if not self._is_field_locked("z"):
-            self.zValue.setText(display_external(self.z, None, "Length"))
+        self.xValue.setText(display_external(self.x, None, "Length"))
+        self.yValue.setText(display_external(self.y, None, "Length"))
+        self.zValue.setText(display_external(self.z, None, "Length"))
 
     def get_last_point(self):
         """Get the last point in the GCS."""
@@ -2050,6 +2106,7 @@ class DraftToolBar:
         self.pvalue = 90
         self.avalue = 0
         self.angle = None
+        self._angle_lock_axis = None
         self.radius = 0
         self.offset = 0
 

--- a/src/Mod/Draft/TestDraftGui.py
+++ b/src/Mod/Draft/TestDraftGui.py
@@ -101,9 +101,11 @@ from drafttests.test_import_gui import DraftGuiImport as DraftTestGui01
 from drafttests.test_import_tools import DraftImportTools as DraftTestGui02
 from drafttests.test_pivy import DraftPivy as DraftTestGui03
 from drafttests.test_dimension_gui import DraftGuiDimension as DraftTestGui04
+from drafttests.test_manual_input_gui import DraftGuiManualInput as DraftTestGui05
 
 # Use the modules so that code checkers don't complain (flake8)
 True if DraftTestGui01 else False
 True if DraftTestGui02 else False
 True if DraftTestGui03 else False
 True if DraftTestGui04 else False
+True if DraftTestGui05 else False

--- a/src/Mod/Draft/draftguitools/gui_circulararray.py
+++ b/src/Mod/Draft/draftguitools/gui_circulararray.py
@@ -80,6 +80,7 @@ class CircularArray(gui_base.GuiCommandBase):
         # The calling class (this one) is saved in the object
         # of the interface, to be able to call a function from within it.
         self.ui.source_command = self
+        Gui.Snapper.setPointConstraintProvider(self.ui)
         task = Gui.Control.showDialog(self.ui)
         task.setDocumentName(Gui.ActiveDocument.Document.Name)
         task.setAutoCloseOnDeletedDocument(True)
@@ -131,6 +132,7 @@ class CircularArray(gui_base.GuiCommandBase):
             pass
         self.callback_move = None
         self.callback_click = None
+        Gui.Snapper.clearPointConstraintProvider(self.ui)
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
         self.finish()

--- a/src/Mod/Draft/draftguitools/gui_field_locks.py
+++ b/src/Mod/Draft/draftguitools/gui_field_locks.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Max Wilfinger
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""Manual-input locking for Draft task-panel input fields."""
+
+## @package gui_field_locks
+#  \ingroup draftguitools
+#  \brief Manual-input locking for Draft task-panel coordinate fields.
+
+from PySide import QtCore
+from PySide import QtGui
+from PySide import QtWidgets
+
+from draftutils.translate import translate
+
+_NUMERIC_PREFIX = "0123456789.,-+"
+
+
+class _FieldLockFilter(QtCore.QObject):
+    """Handle lock shortcuts without consuming field events."""
+
+    def __init__(self, group, key):
+        super().__init__()
+        self._group = group
+        self._key = key
+
+    def eventFilter(self, obj, event):
+        if event.type() == QtCore.QEvent.MouseButtonDblClick:
+            self._group.unlock(self._key)
+        elif event.type() == QtCore.QEvent.KeyPress and event.key() in (
+            QtCore.Qt.Key_Enter,
+            QtCore.Qt.Key_Return,
+        ):
+            self._group.lock_valid_input(self._key)
+        elif event.type() == QtCore.QEvent.KeyPress and event.key() in (
+            QtCore.Qt.Key_Up,
+            QtCore.Qt.Key_Down,
+        ):
+            self._group.queue_locked_value_refresh(self._key)
+        return False
+
+
+class InputFieldLockGroup:
+    """Track manual-input locks for a group of ``Gui::InputField`` widgets.
+
+    Parameters
+    ----------
+    on_change: callable, optional
+        Called as ``on_change(key, locked)`` after a field's lock state
+        changes, for owners that need to react (e.g. update a snapper).
+    """
+
+    def __init__(self, on_change=None):
+        self._on_change = on_change
+        self._locked = {}
+        self._fields = {}
+        self._actions = {}
+        self._filters = []
+        self._edit_revisions = {}
+
+    def add_field(self, key, field):
+        """Attach the lock icon and the lock/unlock triggers to a field."""
+        icon = QtGui.QIcon(":/icons/Draft_Snap_Lock.svg")
+        action = field.addAction(icon, QtWidgets.QLineEdit.TrailingPosition)
+        action.setVisible(False)
+        action.setToolTip(
+            translate(
+                "draft",
+                "Keeps the value fixed during 3D input. The lock icon or a double-click unlocks the field.",
+            )
+        )
+        action.triggered.connect(lambda checked=False, k=key: self.unlock(k))
+        field.textEdited.connect(lambda text, k=key: self._queue_edit(k))
+        flt = _FieldLockFilter(self, key)
+        field.installEventFilter(flt)
+        self._filters.append(flt)
+        self._fields[key] = field
+        self._actions[key] = action
+        self._locked[key] = False
+
+    def _queue_edit(self, key):
+        revision = self._edit_revisions.get(key, 0) + 1
+        self._edit_revisions[key] = revision
+        QtCore.QTimer.singleShot(0, lambda k=key, r=revision: self._finish_edit(k, r))
+
+    def _finish_edit(self, key, revision):
+        if self._edit_revisions.get(key) != revision:
+            return
+        locked = self._has_lockable_input(key)
+        self.set_locked(key, locked)
+
+    def queue_locked_value_refresh(self, key):
+        QtCore.QTimer.singleShot(0, lambda k=key: self._refresh_locked_value(k))
+
+    def _refresh_locked_value(self, key):
+        if self.is_locked(key):
+            self._notify_change(key, True)
+
+    def _has_lockable_input(self, key, text=None):
+        field = self._fields.get(key)
+        if field is None:
+            return False
+        text = field.text() if text is None else text
+        text = text.lstrip()
+        return bool(text) and text[0] in _NUMERIC_PREFIX and field.hasAcceptableInput()
+
+    def lock_valid_input(self, key):
+        if self._has_lockable_input(key):
+            if self.is_locked(key):
+                self._notify_change(key, True)
+            else:
+                self.set_locked(key, True)
+
+    def is_locked(self, key):
+        return self._locked.get(key, False)
+
+    def locked_value(self, key):
+        if not self.is_locked(key):
+            return None
+        field = self._fields.get(key)
+        if field is None:
+            return None
+        value = field.property("rawValue")
+        return None if value is None else float(value)
+
+    def any_locked(self):
+        return any(self._locked.values())
+
+    def set_locked(self, key, locked):
+        if self._locked.get(key) == locked:
+            return
+        self._locked[key] = locked
+        action = self._actions.get(key)
+        if action is not None:
+            action.setVisible(locked)
+        self._notify_change(key, locked)
+
+    def _notify_change(self, key, locked):
+        if self._on_change is not None:
+            self._on_change(key, locked)
+
+    def unlock(self, key):
+        self.set_locked(key, False)
+
+    def unlock_keys(self, keys):
+        for key in keys:
+            self.set_locked(key, False)
+
+    def unlock_all(self):
+        self.unlock_keys(list(self._locked))

--- a/src/Mod/Draft/draftguitools/gui_polararray.py
+++ b/src/Mod/Draft/draftguitools/gui_polararray.py
@@ -79,6 +79,7 @@ class PolarArray(gui_base.GuiCommandBase):
         # The calling class (this one) is saved in the object
         # of the interface, to be able to call a function from within it.
         self.ui.source_command = self
+        Gui.Snapper.setPointConstraintProvider(self.ui)
         task = Gui.Control.showDialog(self.ui)
         task.setDocumentName(Gui.ActiveDocument.Document.Name)
         task.setAutoCloseOnDeletedDocument(True)
@@ -130,6 +131,7 @@ class PolarArray(gui_base.GuiCommandBase):
             pass
         self.callback_move = None
         self.callback_click = None
+        Gui.Snapper.clearPointConstraintProvider(self.ui)
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
         self.finish()

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -330,6 +330,9 @@ class Snapper:
         if self.snapInfo and "Component" in self.snapInfo:
             osnap = self.snapToObject(lastpoint, active, constrain, eline, point)
             if osnap:
+                tb = getattr(Gui, "draftToolBar", None)
+                if tb is not None and hasattr(tb, "apply_field_locks"):
+                    osnap = tb.apply_field_locks(osnap, lastpoint)
                 self.running = False
                 return osnap
 
@@ -342,6 +345,9 @@ class Snapper:
             else:
                 point = self.snapToGrid(point)
         fp = self.cstr(lastpoint, constrain, point)
+        tb = getattr(Gui, "draftToolBar", None)
+        if tb is not None and hasattr(tb, "apply_field_locks"):
+            fp = tb.apply_field_locks(fp, lastpoint)
         if self.trackLine and lastpoint and (not noTracker):
             self.trackLine.p2(fp)
             self.trackLine.setColor()

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -131,6 +131,7 @@ class Snapper:
         self.callbackClick = None
         self.callbackMove = None
         self.snapObjectIndex = 0
+        self.pointConstraintProvider = None
 
         # snap keys, it's important that they are in this order for
         # saving in preferences and for properly restoring the toolbar
@@ -330,9 +331,7 @@ class Snapper:
         if self.snapInfo and "Component" in self.snapInfo:
             osnap = self.snapToObject(lastpoint, active, constrain, eline, point)
             if osnap:
-                tb = getattr(Gui, "draftToolBar", None)
-                if tb is not None and hasattr(tb, "apply_field_locks"):
-                    osnap = tb.apply_field_locks(osnap, lastpoint)
+                osnap = self._apply_point_constraint(osnap, lastpoint, noTracker)
                 self.running = False
                 return osnap
 
@@ -345,9 +344,7 @@ class Snapper:
             else:
                 point = self.snapToGrid(point)
         fp = self.cstr(lastpoint, constrain, point)
-        tb = getattr(Gui, "draftToolBar", None)
-        if tb is not None and hasattr(tb, "apply_field_locks"):
-            fp = tb.apply_field_locks(fp, lastpoint)
+        fp = self._apply_point_constraint(fp, lastpoint, noTracker)
         if self.trackLine and lastpoint and (not noTracker):
             self.trackLine.p2(fp)
             self.trackLine.setColor()
@@ -1261,6 +1258,33 @@ class Snapper:
         """Lower the grid tracker so it doesn't obscure other objects."""
         if self.grid:
             self.grid.lowerTracker()
+
+    def setPointConstraintProvider(self, provider):
+        """Set the active task panel that constrains snapped points."""
+        self.pointConstraintProvider = provider
+
+    def clearPointConstraintProvider(self, provider=None):
+        """Clear the active provider if it matches ``provider``."""
+        if provider is None or self.pointConstraintProvider is provider:
+            self.pointConstraintProvider = None
+
+    def _apply_point_constraint(self, point, lastpoint, noTracker):
+        """Apply the active task panel's point constraints."""
+        provider = self.pointConstraintProvider
+        if provider is None:
+            return point
+        locked = provider.constrain_point(point, lastpoint)
+        if noTracker or locked is None:
+            return locked
+        if self.tracker:
+            self.tracker.setCoords(locked)
+            self.tracker.on()
+        if self.trackLine and lastpoint:
+            self.trackLine.p2(locked)
+            self.trackLine.setColor()
+            self.trackLine.on()
+            self.setArchDims(lastpoint, locked)
+        return locked
 
     def off(self):
         """Finish snapping."""

--- a/src/Mod/Draft/draftguitools/gui_tool_utils.py
+++ b/src/Mod/Draft/draftguitools/gui_tool_utils.py
@@ -314,7 +314,7 @@ def get_point(target, args, noTracker=False):
         )
         info = Gui.Snapper.snapInfo
         mask = Gui.Snapper.affinity
-    if not point:
+    if point is None:
         p = Gui.ActiveDocument.ActiveView.getCursorPos()
         point = Gui.ActiveDocument.ActiveView.getPoint(p)
         info = Gui.ActiveDocument.ActiveView.getObjectInfo(p)

--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -39,6 +39,7 @@ import WorkingPlane
 import Draft_rc  # include resources, icons, ui files
 import DraftVecUtils
 from FreeCAD import Units as U
+from draftguitools.gui_field_locks import InputFieldLockGroup
 from draftutils import params
 from draftutils.messages import _err, _log, _msg, _wrn
 from draftutils.translate import translate
@@ -106,6 +107,11 @@ class TaskPanelCircularArray:
         self.symmetry = 1
         self.fuse = params.get_param("Draft_array_fuse")
         self.use_link = params.get_param("Draft_array_Link")
+
+        self.locks = InputFieldLockGroup()
+        self.locks.add_field("x", self.form.input_c_x)
+        self.locks.add_field("y", self.form.input_c_y)
+        self.locks.add_field("z", self.form.input_c_z)
 
         self.form.input_c_x.setProperty("rawValue", self.center.x)
         self.form.input_c_y.setProperty("rawValue", self.center.y)
@@ -291,6 +297,15 @@ class TaskPanelCircularArray:
         center = App.Vector(_quantity(c_x_str), _quantity(c_y_str), _quantity(c_z_str))
         return center
 
+    def constrain_point(self, point, last=None):
+        """Apply locked center coordinates to a snapped point."""
+        constrained = App.Vector(point)
+        for key in ("x", "y", "z"):
+            value = self.locks.locked_value(key)
+            if value is not None:
+                setattr(constrained, key, value)
+        return constrained
+
     def get_axis(self):
         """Get the axis that will be used for the array. NOT IMPLEMENTED.
 
@@ -301,6 +316,7 @@ class TaskPanelCircularArray:
 
     def reset_point(self):
         """Reset the center point to the original distance."""
+        self.locks.unlock_all()
         self.form.input_c_x.setProperty("rawValue", 0)
         self.form.input_c_y.setProperty("rawValue", 0)
         self.form.input_c_z.setProperty("rawValue", 0)
@@ -391,23 +407,11 @@ class TaskPanelCircularArray:
         # sby = self.form.spinbox_c_y
         # sbz = self.form.spinbox_c_z
         if d_p:
-            if self.mask in ("y", "z"):
-                # sbx.setText(displayExternal(d_p.x, None, 'Length'))
+            if not self.locks.is_locked("x"):
                 self.form.input_c_x.setProperty("rawValue", d_p.x)
-            else:
-                # sbx.setText(displayExternal(d_p.x, None, 'Length'))
-                self.form.input_c_x.setProperty("rawValue", d_p.x)
-            if self.mask in ("x", "z"):
-                # sby.setText(displayExternal(d_p.y, None, 'Length'))
+            if not self.locks.is_locked("y"):
                 self.form.input_c_y.setProperty("rawValue", d_p.y)
-            else:
-                # sby.setText(displayExternal(d_p.y, None, 'Length'))
-                self.form.input_c_y.setProperty("rawValue", d_p.y)
-            if self.mask in ("x", "y"):
-                # sbz.setText(displayExternal(d_p.z, None, 'Length'))
-                self.form.input_c_z.setProperty("rawValue", d_p.z)
-            else:
-                # sbz.setText(displayExternal(d_p.z, None, 'Length'))
+            if not self.locks.is_locked("z"):
                 self.form.input_c_z.setProperty("rawValue", d_p.z)
 
         if plane:

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -39,6 +39,7 @@ import WorkingPlane
 import Draft_rc  # include resources, icons, ui files
 import DraftVecUtils
 from FreeCAD import Units as U
+from draftguitools.gui_field_locks import InputFieldLockGroup
 from draftutils import params
 from draftutils.messages import _err, _log, _msg, _wrn
 from draftutils.translate import translate
@@ -104,6 +105,11 @@ class TaskPanelPolarArray:
         self.number = 5
         self.fuse = params.get_param("Draft_array_fuse")
         self.use_link = params.get_param("Draft_array_Link")
+
+        self.locks = InputFieldLockGroup()
+        self.locks.add_field("x", self.form.input_c_x)
+        self.locks.add_field("y", self.form.input_c_y)
+        self.locks.add_field("z", self.form.input_c_z)
 
         self.form.input_c_x.setProperty("rawValue", self.center.x)
         self.form.input_c_y.setProperty("rawValue", self.center.y)
@@ -268,6 +274,15 @@ class TaskPanelPolarArray:
         center = App.Vector(_quantity(c_x_str), _quantity(c_y_str), _quantity(c_z_str))
         return center
 
+    def constrain_point(self, point, last=None):
+        """Apply locked center coordinates to a snapped point."""
+        constrained = App.Vector(point)
+        for key in ("x", "y", "z"):
+            value = self.locks.locked_value(key)
+            if value is not None:
+                setattr(constrained, key, value)
+        return constrained
+
     def get_axis(self):
         """Get the axis that will be used for the array. NOT IMPLEMENTED.
 
@@ -278,6 +293,7 @@ class TaskPanelPolarArray:
 
     def reset_point(self):
         """Reset the center point to the original distance."""
+        self.locks.unlock_all()
         self.form.input_c_x.setProperty("rawValue", 0)
         self.form.input_c_y.setProperty("rawValue", 0)
         self.form.input_c_z.setProperty("rawValue", 0)
@@ -366,23 +382,11 @@ class TaskPanelPolarArray:
         # sby = self.form.spinbox_c_y
         # sbz = self.form.spinbox_c_z
         if dp:
-            if self.mask in ("y", "z"):
-                # sbx.setText(displayExternal(dp.x, None, 'Length'))
+            if not self.locks.is_locked("x"):
                 self.form.input_c_x.setProperty("rawValue", dp.x)
-            else:
-                # sbx.setText(displayExternal(dp.x, None, 'Length'))
-                self.form.input_c_x.setProperty("rawValue", dp.x)
-            if self.mask in ("x", "z"):
-                # sby.setText(displayExternal(dp.y, None, 'Length'))
+            if not self.locks.is_locked("y"):
                 self.form.input_c_y.setProperty("rawValue", dp.y)
-            else:
-                # sby.setText(displayExternal(dp.y, None, 'Length'))
-                self.form.input_c_y.setProperty("rawValue", dp.y)
-            if self.mask in ("x", "y"):
-                # sbz.setText(displayExternal(dp.z, None, 'Length'))
-                self.form.input_c_z.setProperty("rawValue", dp.z)
-            else:
-                # sbz.setText(displayExternal(dp.z, None, 'Length'))
+            if not self.locks.is_locked("z"):
                 self.form.input_c_z.setProperty("rawValue", dp.z)
 
         if plane:

--- a/src/Mod/Draft/drafttests/test_manual_input_gui.py
+++ b/src/Mod/Draft/drafttests/test_manual_input_gui.py
@@ -1,0 +1,467 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Max Wilfinger
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+
+"""Unit tests for the Draft Workbench, manual point-input field locking."""
+
+import math
+from unittest import mock
+
+import DraftGui
+import DraftVecUtils
+import FreeCAD as App
+import FreeCADGui as Gui
+import PySide.QtCore as QtCore
+import PySide.QtGui as QtGui
+import PySide.QtWidgets as QtWidgets
+
+from draftguitools import gui_tool_utils
+from draftguitools.gui_snapper import Snapper
+from drafttaskpanels.task_circulararray import TaskPanelCircularArray
+from drafttaskpanels.task_polararray import TaskPanelPolarArray
+from drafttests import test_base
+from draftutils.todo import ToDo
+
+
+class DraftGuiManualInput(test_base.DraftTestCaseDoc):
+    """GUI regressions for manual point-input field locking in DraftGui."""
+
+    def setUp(self):
+        super().setUp()
+        self.tb = Gui.draftToolBar
+
+    def tearDown(self):
+        self._close_point_ui()
+        super().tearDown()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _open_point_ui(self):
+        """Open the Draft point-entry task panel in line mode and flush events."""
+        self.tb.lineUi(title="Test Manual Input", rel=False)
+        ToDo.doTasks()
+        Gui.updateGui()
+        QtWidgets.QApplication.processEvents()
+
+    def _close_point_ui(self):
+        """Close the point-entry task panel and flush events."""
+        self.tb.offUi()
+        ToDo.doTasks()
+        Gui.updateGui()
+        QtWidgets.QApplication.processEvents()
+
+    def _try_focus(self, widget):
+        """Attempt to focus widget. Returns True if successful (not flaky-CI proof)."""
+        window = widget.window()
+        if window is not None:
+            window.activateWindow()
+            window.raise_()
+        widget.setFocus(QtCore.Qt.OtherFocusReason)
+        QtWidgets.QApplication.processEvents()
+        return widget.hasFocus()
+
+    def _assert_vector_almost_equal(self, actual, expected, tol=1e-6):
+        self.assertAlmostEqual(actual.x, expected.x, delta=tol)
+        self.assertAlmostEqual(actual.y, expected.y, delta=tol)
+        self.assertAlmostEqual(actual.z, expected.z, delta=tol)
+
+    def _edit(self, key, text):
+        field = {
+            "x": self.tb.xValue,
+            "y": self.tb.yValue,
+            "z": self.tb.zValue,
+            "length": self.tb.lengthValue,
+            "angle": self.tb.angleValue,
+        }[key]
+        field.textEdited.emit(text)
+        field.setText(text)
+        QtWidgets.QApplication.processEvents()
+
+    def _type(self, field, text):
+        field.setText("")
+        for character in text:
+            event = QtGui.QKeyEvent(
+                QtCore.QEvent.KeyPress,
+                0,
+                QtCore.Qt.NoModifier,
+                character,
+            )
+            QtWidgets.QApplication.sendEvent(field, event)
+        QtWidgets.QApplication.processEvents()
+
+    def _press_enter(self, field):
+        self._send_key(field, QtCore.Qt.Key_Return)
+
+    def _send_key(self, field, key, text=""):
+        event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress, key, QtCore.Qt.NoModifier, text)
+        QtWidgets.QApplication.sendEvent(field, event)
+        QtWidgets.QApplication.processEvents()
+
+    # ------------------------------------------------------------------
+    # Lock-invalidation rules: helper-level (stable, no focus required)
+    #
+    # The change handlers call these helpers before recomputing the other
+    # representation; they are the actual regression surface.
+    # ------------------------------------------------------------------
+
+    def test_unlock_polar_fields_clears_length_and_angle(self):
+        """_unlock_polar_fields must drop length and angle locks."""
+        self._open_point_ui()
+        self.tb._set_field_locked("length", True)
+        self.tb._set_field_locked("angle", True)
+
+        self.tb._unlock_polar_fields()
+
+        self.assertFalse(self.tb._is_field_locked("length"))
+        self.assertFalse(self.tb._is_field_locked("angle"))
+
+    def test_unlock_cartesian_fields_clears_x_y_z(self):
+        """_unlock_cartesian_fields must drop X, Y, and Z locks."""
+        self._open_point_ui()
+        for key in ("x", "y", "z"):
+            self.tb._set_field_locked(key, True)
+
+        self.tb._unlock_cartesian_fields()
+
+        for key in ("x", "y", "z"):
+            self.assertFalse(self.tb._is_field_locked(key))
+
+    # ------------------------------------------------------------------
+    # Lock-invalidation rules: handler-level (skipped if focus is unstable)
+    # ------------------------------------------------------------------
+
+    def test_editing_x_unlocks_length_and_angle(self):
+        """Editing X must drop length and angle locks (polar group)."""
+        self._open_point_ui()
+        if not self._try_focus(self.tb.xValue):
+            self.skipTest("focus not available in this run")
+        self.tb._set_field_locked("length", True)
+        self.tb._set_field_locked("angle", True)
+
+        self.tb.changeXValue(App.Units.Quantity(10, App.Units.Length))
+
+        self.assertFalse(self.tb._is_field_locked("length"))
+        self.assertFalse(self.tb._is_field_locked("angle"))
+
+    def test_editing_length_unlocks_cartesian_fields(self):
+        """Editing length must drop X, Y, and Z locks (cartesian group)."""
+        self._open_point_ui()
+        if not self._try_focus(self.tb.lengthValue):
+            self.skipTest("focus not available in this run")
+        for key in ("x", "y", "z"):
+            self.tb._set_field_locked(key, True)
+
+        self.tb.changeLengthValue(App.Units.Quantity(25, App.Units.Length))
+
+        for key in ("x", "y", "z"):
+            self.assertFalse(self.tb._is_field_locked(key))
+
+    # ------------------------------------------------------------------
+    # Point constraint resolution
+    # ------------------------------------------------------------------
+
+    def test_constrain_point_overrides_locked_cartesian_component(self):
+        """A locked X component must replace the candidate point's X."""
+        self._open_point_ui()
+        self.tb.globalMode = True
+        self.tb.relativeMode = False
+
+        self.tb.x = 10
+        self.tb._set_field_locked("x", True)
+
+        resolved = self.tb.constrain_point(App.Vector(1, 2, 3), App.Vector())
+
+        self._assert_vector_almost_equal(resolved, App.Vector(10, 2, 3))
+
+    def test_constrain_point_preserves_locked_length(self):
+        """A locked length must rescale the candidate vector to that length."""
+        self._open_point_ui()
+        self.tb.globalMode = True
+        self.tb.relativeMode = False
+
+        self.tb.lvalue = 100
+        self.tb._set_field_locked("length", True)
+
+        resolved = self.tb.constrain_point(App.Vector(3, 4, 0), App.Vector())
+
+        self.assertAlmostEqual(resolved.Length, 100.0, delta=1e-6)
+
+    def test_angle_lock_controls_direction_without_locking_length(self):
+        self._open_point_ui()
+        self.tb.globalMode = True
+        self.tb.relativeMode = False
+        self.tb.pvalue = 90
+        self._edit("angle", "30 deg")
+
+        first = self.tb.constrain_point(App.Vector(10, 20, 0), App.Vector())
+        second = self.tb.constrain_point(App.Vector(100, 20, 0), App.Vector())
+        axis = self.tb._angle_lock_axis
+
+        self.assertTrue(self.tb._is_field_locked("angle"))
+        self.assertFalse(self.tb._is_field_locked("length"))
+        self.assertAlmostEqual(first.cross(axis).Length, 0, delta=1e-6)
+        self.assertAlmostEqual(second.cross(axis).Length, 0, delta=1e-6)
+        self.assertNotAlmostEqual(first.Length, second.Length, delta=1e-6)
+
+    def test_angle_lock_preserves_established_off_plane_direction(self):
+        self._open_point_ui()
+        self.tb.globalMode = True
+        self.tb.relativeMode = False
+        self.tb.pvalue = 45
+        self._edit("angle", "30 deg")
+
+        resolved = self.tb.constrain_point(App.Vector(10, 20, 30), App.Vector())
+
+        self.assertAlmostEqual(resolved.cross(self.tb._angle_lock_axis).Length, 0, delta=1e-6)
+        self.assertNotAlmostEqual(resolved.z, 0, delta=1e-6)
+
+    def test_length_lock_controls_magnitude_without_locking_direction(self):
+        self._open_point_ui()
+        self.tb.globalMode = True
+        self.tb.relativeMode = False
+        self._edit("length", "50 mm")
+
+        along_x = self.tb.constrain_point(App.Vector(10, 0, 0), App.Vector())
+        along_y = self.tb.constrain_point(App.Vector(0, 10, 0), App.Vector())
+
+        self.assertTrue(self.tb._is_field_locked("length"))
+        self.assertFalse(self.tb._is_field_locked("angle"))
+        self._assert_vector_almost_equal(along_x, App.Vector(50, 0, 0))
+        self._assert_vector_almost_equal(along_y, App.Vector(0, 50, 0))
+
+    def test_angle_input_replaces_coordinate_locks_in_preview_and_result(self):
+        self._open_point_ui()
+        self.tb.globalMode = True
+        self.tb.relativeMode = True
+        last = App.Vector(10, 20, 30)
+        self._edit("x", "10 mm")
+        self._edit("y", "10 mm")
+        self._edit("z", "0 mm")
+        self.tb.pvalue = 90
+
+        self._edit("angle", "45 deg")
+        resolved = self.tb.constrain_point(last + App.Vector(20, 0, 8), last)
+
+        self.assertFalse(any(self.tb._is_field_locked(key) for key in ("x", "y", "z")))
+        self.assertTrue(self.tb._is_field_locked("angle"))
+        self.assertFalse(self.tb._is_field_locked("length"))
+        self.assertAlmostEqual(resolved.x - last.x, resolved.y - last.y, delta=1e-6)
+        self.assertAlmostEqual(resolved.z, last.z, delta=1e-6)
+        self.tb.displayPoint(resolved, last)
+        result = self.tb.get_new_point(App.Vector(self.tb.x, self.tb.y, self.tb.z))
+        self._assert_vector_almost_equal(result, resolved)
+
+    def test_length_input_replaces_coordinate_locks_without_locking_angle(self):
+        self._open_point_ui()
+        self.tb.globalMode = True
+        self.tb.relativeMode = False
+        for key, text in (("x", "10 mm"), ("y", "10 mm"), ("z", "0 mm")):
+            self._edit(key, text)
+
+        self._edit("length", "25 mm")
+        candidate = App.Vector(0, 8, 6)
+        resolved = self.tb.constrain_point(candidate, App.Vector())
+
+        self.assertFalse(any(self.tb._is_field_locked(key) for key in ("x", "y", "z")))
+        self.assertTrue(self.tb._is_field_locked("length"))
+        self.assertFalse(self.tb._is_field_locked("angle"))
+        self.assertAlmostEqual(resolved.Length, 25, delta=1e-6)
+        self.assertAlmostEqual(resolved.cross(candidate).Length, 0, delta=1e-6)
+
+    def test_length_lock_clears_existing_axis_constraint(self):
+        self._open_point_ui()
+        self.tb.globalMode = True
+        self.tb.relativeMode = False
+        self.tb.mask = "x"
+        Gui.Snapper.mask = "x"
+
+        self._edit("length", "25 mm")
+        candidate = App.Vector(0, 8, 6)
+        resolved = self.tb.constrain_point(candidate, App.Vector())
+
+        self.assertIsNone(self.tb.mask)
+        self.assertIsNone(Gui.Snapper.mask)
+        self.assertAlmostEqual(resolved.cross(candidate).Length, 0, delta=1e-6)
+
+    def test_length_lock_preserves_existing_angle_lock(self):
+        self._open_point_ui()
+        self.tb.globalMode = True
+        self.tb.relativeMode = False
+        self.tb.pvalue = 90
+        self._edit("angle", "30 deg")
+
+        self._edit("length", "25 mm")
+        resolved = self.tb.constrain_point(App.Vector(20, 0, 0), App.Vector())
+
+        self.assertTrue(self.tb._is_field_locked("angle"))
+        self.assertTrue(self.tb._is_field_locked("length"))
+        self.assertIsInstance(Gui.Snapper.mask, App.Vector)
+        self.assertAlmostEqual(resolved.cross(self.tb._angle_lock_axis).Length, 0, delta=1e-6)
+        self.assertAlmostEqual(resolved.Length, 25, delta=1e-6)
+
+    def test_angle_and_length_locks_allow_opposite_direction(self):
+        self._open_point_ui()
+        self.tb.globalMode = True
+        self.tb.relativeMode = False
+        self.tb.pvalue = 90
+        self._edit("angle", "30 deg")
+        self._edit("length", "40 mm")
+        opposite = App.Vector(
+            DraftVecUtils.get_cartesian_coords(10, math.pi / 2, math.radians(-150))
+        )
+
+        resolved = self.tb.constrain_point(opposite, App.Vector())
+        self.tb.displayPoint(resolved, App.Vector())
+
+        self.assertAlmostEqual(resolved.Length, 40, delta=1e-6)
+        self.assertLess(resolved.dot(self.tb._angle_lock_axis), 0)
+        self.assertAlmostEqual(self.tb.avalue, -150, delta=1e-6)
+
+    def test_snap_marker_uses_resolved_angle_point(self):
+        class Tracker:
+            def setCoords(self, point):
+                self.point = App.Vector(point)
+
+            def on(self):
+                pass
+
+        self._open_point_ui()
+        self.tb.globalMode = True
+        self.tb.relativeMode = False
+        self.tb.pvalue = 90
+        self._edit("angle", "45 deg")
+        snapper = Snapper()
+        snapper.tracker = Tracker()
+
+        snapper.setPointConstraintProvider(self.tb)
+        resolved = snapper._apply_point_constraint(App.Vector(10, 0, 0), App.Vector(), False)
+
+        self._assert_vector_almost_equal(snapper.tracker.point, resolved)
+        self.assertAlmostEqual(resolved.x, resolved.y, delta=1e-6)
+
+    def test_enter_locks_valid_input_and_unit_only_input_stays_unlocked(self):
+        self._open_point_ui()
+        self.tb.xValue.setText("25 mm")
+        self._press_enter(self.tb.xValue)
+        self.assertTrue(self.tb._is_field_locked("x"))
+
+        self.tb.yValue.setText("mm")
+        self._press_enter(self.tb.yValue)
+        self.assertFalse(self.tb._is_field_locked("y"))
+
+    def test_typing_locks_the_current_value_after_inputfield_parsing(self):
+        self._open_point_ui()
+        self.tb.globalMode = True
+        self.tb.relativeMode = False
+
+        self._type(self.tb.xValue, "25 mm")
+        resolved = self.tb.constrain_point(App.Vector(1, 2, 3), App.Vector())
+
+        self.assertTrue(self.tb._is_field_locked("x"))
+        self.assertAlmostEqual(self.tb.x, 25)
+        self.assertAlmostEqual(resolved.x, 25)
+
+    def test_point_constraint_provider_follows_task_panel_lifetime(self):
+        self._open_point_ui()
+        self.assertIs(Gui.Snapper.pointConstraintProvider, self.tb)
+
+        self._close_point_ui()
+
+        self.assertIsNone(Gui.Snapper.pointConstraintProvider)
+
+    def test_array_panels_constrain_locked_center_coordinates(self):
+        for panel_class in (TaskPanelCircularArray, TaskPanelPolarArray):
+            with self.subTest(panel=panel_class.__name__):
+                panel = panel_class()
+                panel.form.input_c_x.setProperty("rawValue", 25)
+                panel.locks.set_locked("x", True)
+                snapper = Snapper()
+                snapper.setPointConstraintProvider(panel)
+
+                resolved = snapper._apply_point_constraint(App.Vector(1, 2, 3), App.Vector(), True)
+
+                self._assert_vector_almost_equal(resolved, App.Vector(25, 2, 3))
+
+    def test_deleting_numeric_part_unlocks_field(self):
+        self._open_point_ui()
+        self._type(self.tb.xValue, "25 mm")
+        numeric_length = self.tb.number_length(self.tb.xValue.text())
+        self.tb.xValue.setSelection(0, numeric_length)
+
+        self._send_key(self.tb.xValue, QtCore.Qt.Key_Delete)
+
+        self.assertFalse(self.tb._is_field_locked("x"))
+
+    def test_lock_icon_and_double_click_unlock_field(self):
+        self._open_point_ui()
+        self._edit("x", "25 mm")
+
+        self.tb._locks._actions["x"].trigger()
+        self.assertFalse(self.tb._is_field_locked("x"))
+
+        self._edit("x", "25 mm")
+        event = QtGui.QMouseEvent(
+            QtCore.QEvent.MouseButtonDblClick,
+            QtCore.QPointF(1, 1),
+            QtCore.Qt.LeftButton,
+            QtCore.Qt.LeftButton,
+            QtCore.Qt.NoModifier,
+        )
+        QtWidgets.QApplication.sendEvent(self.tb.xValue, event)
+
+        self.assertFalse(self.tb._is_field_locked("x"))
+
+    def test_arrow_nudge_updates_locked_value(self):
+        self._open_point_ui()
+        self.tb.globalMode = True
+        self.tb.relativeMode = False
+        self._type(self.tb.xValue, "25 mm")
+        previous = self.tb.x
+
+        self._send_key(self.tb.xValue, QtCore.Qt.Key_Up)
+        resolved = self.tb.constrain_point(App.Vector(1, 2, 3), App.Vector())
+
+        self.assertTrue(self.tb._is_field_locked("x"))
+        self.assertNotEqual(self.tb.x, previous)
+        self.assertAlmostEqual(resolved.x, self.tb.x)
+
+    def test_zero_snap_result_is_not_replaced_by_cursor_point(self):
+        class Target:
+            node = [App.Vector(1, 2, 3)]
+            featureName = "Line"
+
+        args = {
+            "Position": (0, 0),
+            "ShiftDown": False,
+            "CtrlDown": False,
+            "AltDown": False,
+        }
+        self.tb.mouse = True
+        with (
+            mock.patch.object(Gui.Snapper, "snap", return_value=App.Vector()),
+            mock.patch.object(self.tb, "displayPoint"),
+        ):
+            point, ctrl_point, _ = gui_tool_utils.get_point(Target(), args)
+
+        self._assert_vector_almost_equal(point, App.Vector())
+        self._assert_vector_almost_equal(ctrl_point, App.Vector())


### PR DESCRIPTION
Lock fields on manual input in Draft/BIM tasks:

- Type a value into any X/Y/Z/Length/Angle field in a Draft or BIM task panel and it locks: a lock icon (Draft lock icon) appears in the spinbox (similar to Sketcher OVPs), and the 3D cursor no longer changes that value. Previously that only worked for the angle field if you used the additional checkbox. All other fields were overwritten instantly.
- Locked axes also constrain the cursor in the 3D view, so the preview sticks to the locked manifold (plane, line, or point depending on how many fields are locked)
- Unlock by clicking the lock icon, double-clicking the field, or clearing the numeric value
- Removed the separate "lock angle" checkbox: typing into the Angle field now does the same thing
- Aligned X/Y/Z/Length/Angle labels so the spinboxes share a column


Assisted-by: Opus 4.7

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes [#14331](https://github.com/FreeCAD/FreeCAD/issues/14331)


## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/17f163d0-8b26-4206-809f-622d7343aed6



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
