### PR TITLE
Toponaming: fix assert raising on sketch internal faces creation

### DIFF
--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -545,7 +545,8 @@ const std::string& TopoShape::shapeName(bool silent) const
 
 PyObject* TopoShape::getPySubShape(const char* Type, bool silent) const
 {
-    return Py::new_reference_to(shape2pyshape(getSubShape(Type, silent)));
+    TopoShape s(*this);
+    return Py::new_reference_to(shape2pyshape(s.getSubTopoShape(Type, silent)));
 }
 
 PyObject* TopoShape::getPyObject()

--- a/src/Mod/Part/App/TopoShapeCache.cpp
+++ b/src/Mod/Part/App/TopoShapeCache.cpp
@@ -41,16 +41,16 @@ bool ShapeRelationKey::operator<(const ShapeRelationKey& other) const
 
 TopoShape TopoShapeCache::Ancestry::_getTopoShape(const TopoShape& parent, int index)
 {
-    TopoShape& foundTS = topoShapes[index - 1];
     TopoShape ts;
 
-    if (foundTS.isNull()) {
+    if (int(topoShapes.size()) >= index) {
+        ts = topoShapes[index - 1];
+    }
+
+    if (ts.isNull()) {
         ts = shapes.FindKey(index);
         ts.initCache();
         ts._cache->subLocation = ts._Shape.Location();
-    }
-    else {
-        ts = foundTS;
     }
 
     if (ts._Shape.IsEqual(parent._cache->shape)) {

--- a/src/Mod/Part/App/TopoShapeCompoundPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeCompoundPyImp.cpp
@@ -73,18 +73,15 @@ int TopoShapeCompoundPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         return -1;
     }
 
-    BRep_Builder builder;
-    TopoDS_Compound Comp;
-    builder.MakeCompound(Comp);
+    std::vector<TopoShape> shapes;
 
     try {
         Py::Sequence list(pcObj);
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type))) {
-                const TopoDS_Shape& sh
-                    = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->getShape();
-                if (!sh.IsNull()) {
-                    builder.Add(Comp, sh);
+                const TopoShape& sh = *(static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr());
+                if (!sh.isNull()) {
+                    shapes.push_back(sh);
                 }
             }
         }
@@ -94,7 +91,7 @@ int TopoShapeCompoundPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         return -1;
     }
 
-    getTopoShapePtr()->setShape(Comp);
+    getTopoShapePtr()->makeElementCompound(shapes);
     return 0;
 }
 
@@ -105,16 +102,19 @@ PyObject* TopoShapeCompoundPy::add(PyObject* args)
         return nullptr;
     }
 
-    BRep_Builder builder;
-    TopoDS_Shape comp = getTopoShapePtr()->getShape();
-    if (comp.IsNull()) {
-        builder.MakeCompound(TopoDS::Compound(comp));
-    }
+    TopoShape& comp = *(getTopoShapePtr());
+    std::vector<TopoShape> shapes;
 
     try {
-        const TopoDS_Shape& sh = static_cast<TopoShapePy*>(obj)->getTopoShapePtr()->getShape();
-        if (!sh.IsNull()) {
-            builder.Add(comp, sh);
+        if (comp.shapeType() == TopAbs_COMPOUND) {
+            for (const TopoShape& childShape : comp.getSubTopoShapes()) {
+                shapes.push_back(childShape);
+            }
+        }
+
+        const TopoShape& sh = *(static_cast<TopoShapePy*>(obj)->getTopoShapePtr());
+        if (!sh.isNull()) {
+            shapes.push_back(sh);
         }
     }
     catch (Standard_Failure& e) {
@@ -123,7 +123,7 @@ PyObject* TopoShapeCompoundPy::add(PyObject* args)
         return nullptr;
     }
 
-    getTopoShapePtr()->setShape(comp);
+    getTopoShapePtr()->makeElementCompound(shapes);
 
     Py_Return;
 }

--- a/src/Mod/Part/App/TopoShapeEdgePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeEdgePyImp.cpp
@@ -161,7 +161,7 @@ int TopoShapeEdgePy::PyInit(PyObject* args, PyObject* /*kwd*/)
     if (PyArg_ParseTuple(args, "O!", &(Part::TopoShapePy::Type), &pcObj)) {
         TopoShape* shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr();
         if (shape && !shape->getShape().IsNull() && shape->getShape().ShapeType() == TopAbs_EDGE) {
-            this->getTopoShapePtr()->setShape(shape->getShape());
+            this->getTopoShapePtr()->setShape((*shape));
             return 0;
         }
         else {

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -1002,7 +1002,7 @@ void TopoShape::mapSubElement(const TopoShape& other, const char* op, bool force
                 ss.str("");
 
                 ensureElementMap()->encodeElementName(shapetype[0], name, ss, &sids, Tag, op, other.Tag);
-                elementMap()->setElementName(element, name, Tag, &sids);
+                ensureElementMap()->setElementName(element, name, Tag, &sids);
             }
         }
     }

--- a/src/Mod/Part/App/TopoShapeFacePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeFacePyImp.cpp
@@ -139,22 +139,23 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
     PyObject* pW;
     if (PyArg_ParseTuple(args, "O!", &(Part::TopoShapePy::Type), &pW)) {
         try {
-            const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(pW)->getTopoShapePtr()->getShape();
-            if (sh.IsNull()) {
+            const TopoShape& sh = *(static_cast<Part::TopoShapePy*>(pW)->getTopoShapePtr());
+            if (sh.isNull()) {
                 PyErr_SetString(PartExceptionOCCError, "cannot create face out of empty wire");
                 return -1;
             }
 
-            if (sh.ShapeType() == TopAbs_WIRE) {
-                BRepBuilderAPI_MakeFace mkFace(TopoDS::Wire(sh));
+            if (sh.shapeType() == TopAbs_WIRE) {
+                BRepBuilderAPI_MakeFace mkFace(TopoDS::Wire(sh.getShape()));
                 if (!mkFace.IsDone()) {
                     PyErr_SetString(PartExceptionOCCError, "Failed to create face from wire");
                     return -1;
                 }
                 getTopoShapePtr()->setShape(mkFace.Face());
+                getTopoShapePtr()->mapSubElement(sh);
                 return 0;
             }
-            else if (sh.ShapeType() == TopAbs_FACE) {
+            else if (sh.shapeType() == TopAbs_FACE) {
                 getTopoShapePtr()->setShape(sh);
                 return 0;
             }
@@ -176,27 +177,27 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
             &wire
         )) {
         try {
-            const TopoDS_Shape& f
-                = static_cast<Part::TopoShapePy*>(face)->getTopoShapePtr()->getShape();
-            if (f.IsNull()) {
+            const TopoShape& f = *(static_cast<Part::TopoShapePy*>(face)->getTopoShapePtr());
+            if (f.isNull()) {
                 PyErr_SetString(PartExceptionOCCError, "cannot create face out of empty support face");
                 return -1;
             }
-            const TopoDS_Shape& w
-                = static_cast<Part::TopoShapePy*>(wire)->getTopoShapePtr()->getShape();
-            if (w.IsNull()) {
+            const TopoShape& w = *(static_cast<Part::TopoShapePy*>(wire)->getTopoShapePtr());
+            if (w.isNull()) {
                 PyErr_SetString(PartExceptionOCCError, "cannot create face out of empty boundary wire");
                 return -1;
             }
 
-            const TopoDS_Face& supportFace = TopoDS::Face(f);
-            const TopoDS_Wire& boundaryWire = TopoDS::Wire(w);
+            const TopoDS_Face& supportFace = TopoDS::Face(f.getShape());
+            const TopoDS_Wire& boundaryWire = TopoDS::Wire(w.getShape());
             BRepBuilderAPI_MakeFace mkFace(supportFace, boundaryWire);
             if (!mkFace.IsDone()) {
                 PyErr_SetString(PartExceptionOCCError, "Failed to create face from wire");
                 return -1;
             }
             getTopoShapePtr()->setShape(mkFace.Face());
+            getTopoShapePtr()->mapSubElement(f);
+            getTopoShapePtr()->mapSubElement(w);
             return 0;
         }
         catch (Standard_Failure& e) {
@@ -223,20 +224,20 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 PyErr_SetString(PyExc_TypeError, "geometry is not a valid surface");
                 return -1;
             }
-            const TopoDS_Shape& w
-                = static_cast<Part::TopoShapePy*>(wire)->getTopoShapePtr()->getShape();
-            if (w.IsNull()) {
+            const TopoShape& w = *(static_cast<Part::TopoShapePy*>(wire)->getTopoShapePtr());
+            if (w.isNull()) {
                 PyErr_SetString(PartExceptionOCCError, "cannot create face out of empty boundary wire");
                 return -1;
             }
 
-            const TopoDS_Wire& boundaryWire = TopoDS::Wire(w);
+            const TopoDS_Wire& boundaryWire = TopoDS::Wire(w.getShape());
             BRepBuilderAPI_MakeFace mkFace(S, boundaryWire);
             if (!mkFace.IsDone()) {
                 PyErr_SetString(PartExceptionOCCError, "Failed to create face from wire");
                 return -1;
             }
             getTopoShapePtr()->setShape(mkFace.Face());
+            getTopoShapePtr()->mapSubElement(w);
             return 0;
         }
         catch (Standard_Failure& e) {
@@ -257,16 +258,19 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 return -1;
             }
 
+            std::vector<TopoShape> wires;
             BRepBuilderAPI_MakeFace mkFace(S, Precision::Confusion());
             if (bound) {
                 Py::List list(bound);
                 for (Py::List::iterator it = list.begin(); it != list.end(); ++it) {
                     PyObject* item = (*it).ptr();
                     if (PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
-                        const TopoDS_Shape& sh
-                            = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape();
-                        if (sh.ShapeType() == TopAbs_WIRE) {
-                            mkFace.Add(TopoDS::Wire(sh));
+                        const TopoShape& sh = *(
+                            static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()
+                        );
+                        if (sh.shapeType() == TopAbs_WIRE) {
+                            wires.push_back(sh);
+                            mkFace.Add(TopoDS::Wire(sh.getShape()));
                         }
                         else {
                             PyErr_SetString(PyExc_TypeError, "shape is not a wire");
@@ -281,6 +285,7 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
             }
 
             getTopoShapePtr()->setShape(mkFace.Face());
+            getTopoShapePtr()->mapSubElement(wires);
             return 0;
         }
         catch (Standard_Failure& e) {
@@ -292,15 +297,14 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
     PyErr_Clear();
     if (PyArg_ParseTuple(args, "O!", &(PyList_Type), &bound)) {
         try {
-            std::vector<TopoDS_Wire> wires;
+            std::vector<TopoShape> wires;
             Py::List list(bound);
             for (Py::List::iterator it = list.begin(); it != list.end(); ++it) {
                 PyObject* item = (*it).ptr();
                 if (PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
-                    const TopoDS_Shape& sh
-                        = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape();
-                    if (sh.ShapeType() == TopAbs_WIRE) {
-                        wires.push_back(TopoDS::Wire(sh));
+                    const TopoShape& sh = *(static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr());
+                    if (sh.shapeType() == TopAbs_WIRE) {
+                        wires.push_back(sh);
                     }
                     else {
                         throw Standard_Failure("shape is not a wire");
@@ -312,7 +316,7 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
             }
 
             if (!wires.empty()) {
-                BRepBuilderAPI_MakeFace mkFace(wires.front());
+                BRepBuilderAPI_MakeFace mkFace(TopoDS::Wire(wires.front().getShape()));
                 if (!mkFace.IsDone()) {
                     switch (mkFace.Error()) {
                         case BRepBuilderAPI_NoFace:
@@ -332,11 +336,11 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
                             break;
                     }
                 }
-                for (std::vector<TopoDS_Wire>::iterator it = wires.begin() + 1; it != wires.end();
-                     ++it) {
-                    mkFace.Add(*it);
+                for (std::size_t i = 1; i < wires.size(); i++) {
+                    mkFace.Add(TopoDS::Wire(wires[i].getShape()));
                 }
                 getTopoShapePtr()->setShape(mkFace.Face());
+                getTopoShapePtr()->mapSubElement(wires);
                 return 0;
             }
             else {

--- a/src/Mod/Part/App/TopoShapeMapper.h
+++ b/src/Mod/Part/App/TopoShapeMapper.h
@@ -186,6 +186,9 @@ struct PartExport ShapeMapper: TopoShape::Mapper
             expand(d.getShape(), dstShapes);
         }
         insert(status, src.getShape(), dstShapes);
+        if (shapeSet.insert(src.getShape()).second) {
+            shapes.push_back(src);
+        }
     }
 
     /** Expand a shape into faces, edges and vertices

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -980,9 +980,9 @@ PyObject* TopoShapePy::ancestorsOfType(PyObject* args) const
     }
 
     try {
-        const TopoDS_Shape& model = getTopoShapePtr()->getShape();
+        const TopoShape& model = *getTopoShapePtr();
         const TopoDS_Shape& shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
-        if (model.IsNull() || shape.IsNull()) {
+        if (model.isNull() || shape.IsNull()) {
             PyErr_SetString(PyExc_ValueError, "Shape is null");
             return nullptr;
         }
@@ -994,22 +994,18 @@ PyObject* TopoShapePy::ancestorsOfType(PyObject* args) const
             return nullptr;
         }
 
-        TopTools_IndexedDataMapOfShapeListOfShape mapOfShapeShape;
-        TopExp::MapShapesAndAncestors(model, shape.ShapeType(), shapetype, mapOfShapeShape);
-        const TopTools_ListOfShape& ancestors = mapOfShapeShape.FindFromKey(shape);
+        std::vector<int> foundIndices = model.findAncestors(shape, shapetype);
+        std::unordered_set<int> appendedIndices = {};
 
         Py::List list;
-        std::set<Standard_Integer> hashes;
-        TopTools_ListIteratorOfListOfShape it(ancestors);
-        for (; it.More(); it.Next()) {
-            // make sure to avoid duplicates
-            Standard_Integer code = ShapeMapHasher {}(it.Value());
-            if (hashes.find(code) == hashes.end()) {
-                list.append(shape2pyshape(it.Value()));
-                hashes.insert(code);
+        for (int idx : foundIndices) {
+            if (appendedIndices.count(idx)) {
+                continue;
             }
-        }
 
+            list.append(shape2pyshape(model.getSubTopoShape(shapetype, idx)));
+            appendedIndices.emplace(idx);
+        }
         return Py::new_reference_to(list);
     }
     catch (Standard_Failure& e) {


### PR DESCRIPTION
Add a length guard on the `topoShapes` vector.

Fix #30444
Fix #30459 

Ping @drwho495 for review.