### PR TITLE
Temporarily revert "Toponaming: Improve toponaming support for the python API."

### DIFF
--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -545,8 +545,7 @@ const std::string& TopoShape::shapeName(bool silent) const
 
 PyObject* TopoShape::getPySubShape(const char* Type, bool silent) const
 {
-    TopoShape s(*this);
-    return Py::new_reference_to(shape2pyshape(s.getSubTopoShape(Type, silent)));
+    return Py::new_reference_to(shape2pyshape(getSubShape(Type, silent)));
 }
 
 PyObject* TopoShape::getPyObject()

--- a/src/Mod/Part/App/TopoShapeCache.cpp
+++ b/src/Mod/Part/App/TopoShapeCache.cpp
@@ -41,16 +41,11 @@ bool ShapeRelationKey::operator<(const ShapeRelationKey& other) const
 
 TopoShape TopoShapeCache::Ancestry::_getTopoShape(const TopoShape& parent, int index)
 {
-    TopoShape& foundTS = topoShapes[index - 1];
-    TopoShape ts;
-
-    if (foundTS.isNull()) {
-        ts = shapes.FindKey(index);
+    auto& ts = topoShapes[index - 1];
+    if (ts.isNull()) {
+        ts.setShape(shapes.FindKey(index), true);
         ts.initCache();
         ts._cache->subLocation = ts._Shape.Location();
-    }
-    else {
-        ts = foundTS;
     }
 
     if (ts._Shape.IsEqual(parent._cache->shape)) {
@@ -83,19 +78,13 @@ TopoShape TopoShapeCache::Ancestry::_getTopoShape(const TopoShape& parent, int i
         // in the direct parent shape, while TopoShape::_subLocation is
         // used to accumulate locations in higher ancestors. We
         // separate these two to avoid invalidating cache.
+
         res._subLocation = parent._subLocation * parent._cache->subLocation;
         res._parentCache = parent._parentCache;
     }
     else {
         res._parentCache = owner->shared_from_this();
     }
-
-    // the subelement doesn't have an element map, lets find it by mapping the parent shape onto the
-    // subelement.
-    if (res.elementMap(false) == 0 && res._parentCache->cachedElementMap) {
-        res.flushElementMap();
-    }
-
     return res;
 }
 

--- a/src/Mod/Part/App/TopoShapeCompoundPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeCompoundPyImp.cpp
@@ -73,15 +73,18 @@ int TopoShapeCompoundPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         return -1;
     }
 
-    std::vector<TopoShape> shapes;
+    BRep_Builder builder;
+    TopoDS_Compound Comp;
+    builder.MakeCompound(Comp);
 
     try {
         Py::Sequence list(pcObj);
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type))) {
-                const TopoShape& sh = *(static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr());
-                if (!sh.isNull()) {
-                    shapes.push_back(sh);
+                const TopoDS_Shape& sh
+                    = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->getShape();
+                if (!sh.IsNull()) {
+                    builder.Add(Comp, sh);
                 }
             }
         }
@@ -91,7 +94,7 @@ int TopoShapeCompoundPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         return -1;
     }
 
-    getTopoShapePtr()->makeElementCompound(shapes);
+    getTopoShapePtr()->setShape(Comp);
     return 0;
 }
 
@@ -102,19 +105,16 @@ PyObject* TopoShapeCompoundPy::add(PyObject* args)
         return nullptr;
     }
 
-    TopoShape& comp = *(getTopoShapePtr());
-    std::vector<TopoShape> shapes;
+    BRep_Builder builder;
+    TopoDS_Shape comp = getTopoShapePtr()->getShape();
+    if (comp.IsNull()) {
+        builder.MakeCompound(TopoDS::Compound(comp));
+    }
 
     try {
-        if (comp.shapeType() == TopAbs_COMPOUND) {
-            for (const TopoShape& childShape : comp.getSubTopoShapes()) {
-                shapes.push_back(childShape);
-            }
-        }
-
-        const TopoShape& sh = *(static_cast<TopoShapePy*>(obj)->getTopoShapePtr());
-        if (!sh.isNull()) {
-            shapes.push_back(sh);
+        const TopoDS_Shape& sh = static_cast<TopoShapePy*>(obj)->getTopoShapePtr()->getShape();
+        if (!sh.IsNull()) {
+            builder.Add(comp, sh);
         }
     }
     catch (Standard_Failure& e) {
@@ -123,7 +123,7 @@ PyObject* TopoShapeCompoundPy::add(PyObject* args)
         return nullptr;
     }
 
-    getTopoShapePtr()->makeElementCompound(shapes);
+    getTopoShapePtr()->setShape(comp);
 
     Py_Return;
 }

--- a/src/Mod/Part/App/TopoShapeEdgePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeEdgePyImp.cpp
@@ -161,7 +161,7 @@ int TopoShapeEdgePy::PyInit(PyObject* args, PyObject* /*kwd*/)
     if (PyArg_ParseTuple(args, "O!", &(Part::TopoShapePy::Type), &pcObj)) {
         TopoShape* shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr();
         if (shape && !shape->getShape().IsNull() && shape->getShape().ShapeType() == TopAbs_EDGE) {
-            this->getTopoShapePtr()->setShape((*shape));
+            this->getTopoShapePtr()->setShape(shape->getShape());
             return 0;
         }
         else {

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -1002,7 +1002,7 @@ void TopoShape::mapSubElement(const TopoShape& other, const char* op, bool force
                 ss.str("");
 
                 ensureElementMap()->encodeElementName(shapetype[0], name, ss, &sids, Tag, op, other.Tag);
-                ensureElementMap()->setElementName(element, name, Tag, &sids);
+                elementMap()->setElementName(element, name, Tag, &sids);
             }
         }
     }

--- a/src/Mod/Part/App/TopoShapeFacePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeFacePyImp.cpp
@@ -139,23 +139,22 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
     PyObject* pW;
     if (PyArg_ParseTuple(args, "O!", &(Part::TopoShapePy::Type), &pW)) {
         try {
-            const TopoShape& sh = *(static_cast<Part::TopoShapePy*>(pW)->getTopoShapePtr());
-            if (sh.isNull()) {
+            const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(pW)->getTopoShapePtr()->getShape();
+            if (sh.IsNull()) {
                 PyErr_SetString(PartExceptionOCCError, "cannot create face out of empty wire");
                 return -1;
             }
 
-            if (sh.shapeType() == TopAbs_WIRE) {
-                BRepBuilderAPI_MakeFace mkFace(TopoDS::Wire(sh.getShape()));
+            if (sh.ShapeType() == TopAbs_WIRE) {
+                BRepBuilderAPI_MakeFace mkFace(TopoDS::Wire(sh));
                 if (!mkFace.IsDone()) {
                     PyErr_SetString(PartExceptionOCCError, "Failed to create face from wire");
                     return -1;
                 }
                 getTopoShapePtr()->setShape(mkFace.Face());
-                getTopoShapePtr()->mapSubElement(sh);
                 return 0;
             }
-            else if (sh.shapeType() == TopAbs_FACE) {
+            else if (sh.ShapeType() == TopAbs_FACE) {
                 getTopoShapePtr()->setShape(sh);
                 return 0;
             }
@@ -177,27 +176,27 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
             &wire
         )) {
         try {
-            const TopoShape& f = *(static_cast<Part::TopoShapePy*>(face)->getTopoShapePtr());
-            if (f.isNull()) {
+            const TopoDS_Shape& f
+                = static_cast<Part::TopoShapePy*>(face)->getTopoShapePtr()->getShape();
+            if (f.IsNull()) {
                 PyErr_SetString(PartExceptionOCCError, "cannot create face out of empty support face");
                 return -1;
             }
-            const TopoShape& w = *(static_cast<Part::TopoShapePy*>(wire)->getTopoShapePtr());
-            if (w.isNull()) {
+            const TopoDS_Shape& w
+                = static_cast<Part::TopoShapePy*>(wire)->getTopoShapePtr()->getShape();
+            if (w.IsNull()) {
                 PyErr_SetString(PartExceptionOCCError, "cannot create face out of empty boundary wire");
                 return -1;
             }
 
-            const TopoDS_Face& supportFace = TopoDS::Face(f.getShape());
-            const TopoDS_Wire& boundaryWire = TopoDS::Wire(w.getShape());
+            const TopoDS_Face& supportFace = TopoDS::Face(f);
+            const TopoDS_Wire& boundaryWire = TopoDS::Wire(w);
             BRepBuilderAPI_MakeFace mkFace(supportFace, boundaryWire);
             if (!mkFace.IsDone()) {
                 PyErr_SetString(PartExceptionOCCError, "Failed to create face from wire");
                 return -1;
             }
             getTopoShapePtr()->setShape(mkFace.Face());
-            getTopoShapePtr()->mapSubElement(f);
-            getTopoShapePtr()->mapSubElement(w);
             return 0;
         }
         catch (Standard_Failure& e) {
@@ -224,20 +223,20 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 PyErr_SetString(PyExc_TypeError, "geometry is not a valid surface");
                 return -1;
             }
-            const TopoShape& w = *(static_cast<Part::TopoShapePy*>(wire)->getTopoShapePtr());
-            if (w.isNull()) {
+            const TopoDS_Shape& w
+                = static_cast<Part::TopoShapePy*>(wire)->getTopoShapePtr()->getShape();
+            if (w.IsNull()) {
                 PyErr_SetString(PartExceptionOCCError, "cannot create face out of empty boundary wire");
                 return -1;
             }
 
-            const TopoDS_Wire& boundaryWire = TopoDS::Wire(w.getShape());
+            const TopoDS_Wire& boundaryWire = TopoDS::Wire(w);
             BRepBuilderAPI_MakeFace mkFace(S, boundaryWire);
             if (!mkFace.IsDone()) {
                 PyErr_SetString(PartExceptionOCCError, "Failed to create face from wire");
                 return -1;
             }
             getTopoShapePtr()->setShape(mkFace.Face());
-            getTopoShapePtr()->mapSubElement(w);
             return 0;
         }
         catch (Standard_Failure& e) {
@@ -258,19 +257,16 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 return -1;
             }
 
-            std::vector<TopoShape> wires;
             BRepBuilderAPI_MakeFace mkFace(S, Precision::Confusion());
             if (bound) {
                 Py::List list(bound);
                 for (Py::List::iterator it = list.begin(); it != list.end(); ++it) {
                     PyObject* item = (*it).ptr();
                     if (PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
-                        const TopoShape& sh = *(
-                            static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()
-                        );
-                        if (sh.shapeType() == TopAbs_WIRE) {
-                            wires.push_back(sh);
-                            mkFace.Add(TopoDS::Wire(sh.getShape()));
+                        const TopoDS_Shape& sh
+                            = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape();
+                        if (sh.ShapeType() == TopAbs_WIRE) {
+                            mkFace.Add(TopoDS::Wire(sh));
                         }
                         else {
                             PyErr_SetString(PyExc_TypeError, "shape is not a wire");
@@ -285,7 +281,6 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
             }
 
             getTopoShapePtr()->setShape(mkFace.Face());
-            getTopoShapePtr()->mapSubElement(wires);
             return 0;
         }
         catch (Standard_Failure& e) {
@@ -297,14 +292,15 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
     PyErr_Clear();
     if (PyArg_ParseTuple(args, "O!", &(PyList_Type), &bound)) {
         try {
-            std::vector<TopoShape> wires;
+            std::vector<TopoDS_Wire> wires;
             Py::List list(bound);
             for (Py::List::iterator it = list.begin(); it != list.end(); ++it) {
                 PyObject* item = (*it).ptr();
                 if (PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
-                    const TopoShape& sh = *(static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr());
-                    if (sh.shapeType() == TopAbs_WIRE) {
-                        wires.push_back(sh);
+                    const TopoDS_Shape& sh
+                        = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape();
+                    if (sh.ShapeType() == TopAbs_WIRE) {
+                        wires.push_back(TopoDS::Wire(sh));
                     }
                     else {
                         throw Standard_Failure("shape is not a wire");
@@ -316,7 +312,7 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
             }
 
             if (!wires.empty()) {
-                BRepBuilderAPI_MakeFace mkFace(TopoDS::Wire(wires.front().getShape()));
+                BRepBuilderAPI_MakeFace mkFace(wires.front());
                 if (!mkFace.IsDone()) {
                     switch (mkFace.Error()) {
                         case BRepBuilderAPI_NoFace:
@@ -336,11 +332,11 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
                             break;
                     }
                 }
-                for (std::size_t i = 1; i < wires.size(); i++) {
-                    mkFace.Add(TopoDS::Wire(wires[i].getShape()));
+                for (std::vector<TopoDS_Wire>::iterator it = wires.begin() + 1; it != wires.end();
+                     ++it) {
+                    mkFace.Add(*it);
                 }
                 getTopoShapePtr()->setShape(mkFace.Face());
-                getTopoShapePtr()->mapSubElement(wires);
                 return 0;
             }
             else {

--- a/src/Mod/Part/App/TopoShapeMapper.h
+++ b/src/Mod/Part/App/TopoShapeMapper.h
@@ -186,9 +186,6 @@ struct PartExport ShapeMapper: TopoShape::Mapper
             expand(d.getShape(), dstShapes);
         }
         insert(status, src.getShape(), dstShapes);
-        if (shapeSet.insert(src.getShape()).second) {
-            shapes.push_back(src);
-        }
     }
 
     /** Expand a shape into faces, edges and vertices

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -980,9 +980,9 @@ PyObject* TopoShapePy::ancestorsOfType(PyObject* args) const
     }
 
     try {
-        const TopoShape& model = *getTopoShapePtr();
+        const TopoDS_Shape& model = getTopoShapePtr()->getShape();
         const TopoDS_Shape& shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
-        if (model.isNull() || shape.IsNull()) {
+        if (model.IsNull() || shape.IsNull()) {
             PyErr_SetString(PyExc_ValueError, "Shape is null");
             return nullptr;
         }
@@ -994,18 +994,22 @@ PyObject* TopoShapePy::ancestorsOfType(PyObject* args) const
             return nullptr;
         }
 
-        std::vector<int> foundIndices = model.findAncestors(shape, shapetype);
-        std::unordered_set<int> appendedIndices = {};
+        TopTools_IndexedDataMapOfShapeListOfShape mapOfShapeShape;
+        TopExp::MapShapesAndAncestors(model, shape.ShapeType(), shapetype, mapOfShapeShape);
+        const TopTools_ListOfShape& ancestors = mapOfShapeShape.FindFromKey(shape);
 
         Py::List list;
-        for (int idx : foundIndices) {
-            if (appendedIndices.count(idx)) {
-                continue;
+        std::set<Standard_Integer> hashes;
+        TopTools_ListIteratorOfListOfShape it(ancestors);
+        for (; it.More(); it.Next()) {
+            // make sure to avoid duplicates
+            Standard_Integer code = ShapeMapHasher {}(it.Value());
+            if (hashes.find(code) == hashes.end()) {
+                list.append(shape2pyshape(it.Value()));
+                hashes.insert(code);
             }
-
-            list.append(shape2pyshape(model.getSubTopoShape(shapetype, idx)));
-            appendedIndices.emplace(idx);
         }
+
         return Py::new_reference_to(list);
     }
     catch (Standard_Failure& e) {

--- a/src/Mod/Part/App/TopoShapeWirePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeWirePyImp.cpp
@@ -92,16 +92,16 @@ int TopoShapeWirePy::PyInit(PyObject* args, PyObject* /*kwd*/)
     PyObject* pcObj;
     if (PyArg_ParseTuple(args, "O!", &(Part::TopoShapePy::Type), &pcObj)) {
         BRepBuilderAPI_MakeWire mkWire;
-        const TopoShape& sh = *(static_cast<Part::TopoShapePy*>(pcObj)->getTopoShapePtr());
-        if (sh.isNull()) {
+        const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
+        if (sh.IsNull()) {
             PyErr_SetString(PyExc_TypeError, "given shape is invalid");
             return -1;
         }
-        if (sh.shapeType() == TopAbs_EDGE) {
-            mkWire.Add(TopoDS::Edge(sh.getShape()));
+        if (sh.ShapeType() == TopAbs_EDGE) {
+            mkWire.Add(TopoDS::Edge(sh));
         }
-        else if (sh.shapeType() == TopAbs_WIRE) {
-            mkWire.Add(TopoDS::Wire(sh.getShape()));
+        else if (sh.ShapeType() == TopAbs_WIRE) {
+            mkWire.Add(TopoDS::Wire(sh));
         }
         else {
             PyErr_SetString(PyExc_TypeError, "shape is neither edge nor wire");
@@ -110,7 +110,6 @@ int TopoShapeWirePy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
         try {
             getTopoShapePtr()->setShape(mkWire.Wire());
-            getTopoShapePtr()->mapSubElement(sh);
             return 0;
         }
         catch (Standard_Failure& e) {
@@ -127,28 +126,27 @@ int TopoShapeWirePy::PyInit(PyObject* args, PyObject* /*kwd*/)
             return -1;
         }
 
-        std::vector<TopoShape> shapes;
         BRepBuilderAPI_MakeWire mkWire;
         Py::Sequence list(pcObj);
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             PyObject* item = (*it).ptr();
             if (PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
-                const TopoShape& sh = *(static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr());
-                if (sh.isNull()) {
+                const TopoDS_Shape& sh
+                    = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape();
+                if (sh.IsNull()) {
                     PyErr_SetString(PyExc_TypeError, "given shape is invalid");
                     return -1;
                 }
-                if (sh.shapeType() == TopAbs_EDGE) {
-                    mkWire.Add(TopoDS::Edge(sh.getShape()));
+                if (sh.ShapeType() == TopAbs_EDGE) {
+                    mkWire.Add(TopoDS::Edge(sh));
                 }
-                else if (sh.shapeType() == TopAbs_WIRE) {
-                    mkWire.Add(TopoDS::Wire(sh.getShape()));
+                else if (sh.ShapeType() == TopAbs_WIRE) {
+                    mkWire.Add(TopoDS::Wire(sh));
                 }
                 else {
                     PyErr_SetString(PyExc_TypeError, "shape is neither edge nor wire");
                     return -1;
                 }
-                shapes.push_back(sh);
             }
             else {
                 PyErr_SetString(PyExc_TypeError, "item is not a shape");
@@ -158,7 +156,6 @@ int TopoShapeWirePy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
         try {
             getTopoShapePtr()->setShape(mkWire.Wire());
-            getTopoShapePtr()->mapSubElement(shapes);
             return 0;
         }
         catch (Standard_Failure& e) {


### PR DESCRIPTION
This is a temporary revert until the bug in X is fixed; will be reapplied afterward.
OP and maintainer who merged it approves of it.
OP will look into fixing the issue, afterwards we can retest and restore and remerge the PR

Reverts FreeCAD/FreeCAD#24632