### PR TITLE
Core: buffer embedded file save and restore (performance improvement)

### DIFF
--- a/src/App/PropertyFile.cpp
+++ b/src/App/PropertyFile.cpp
@@ -45,7 +45,7 @@ using namespace std;
 
 namespace {
 
-constexpr std::size_t includedFileRestoreBufferSize = 64 * 1024;
+constexpr std::size_t includedFileBufferSize = 64 * 1024;
 
 }
 
@@ -481,10 +481,26 @@ void PropertyFileIncluded::SaveDocFile(Base::Writer& writer) const
     }
 
     // copy plain data
-    unsigned char c;
+    std::array<char, includedFileBufferSize> buffer {};
     std::ostream& to = writer.Stream();
-    while (from.get((char&)c)) {
-        to.put((char)c);
+    while (from) {
+        from.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        const std::streamsize count = from.gcount();
+        if (count > 0) {
+            to.write(buffer.data(), count);
+            if (!to) {
+                std::stringstream str;
+                str << "PropertyFileIncluded::SaveDocFile(): "
+                    << "File '" << _cValue << "' in transient directory cannot be written.";
+                throw Base::FileSystemError(str.str());
+            }
+        }
+    }
+    if (from.bad()) {
+        std::stringstream str;
+        str << "PropertyFileIncluded::SaveDocFile(): "
+            << "File '" << _cValue << "' in transient directory cannot be read.";
+        throw Base::FileSystemError(str.str());
     }
 }
 
@@ -506,7 +522,7 @@ void PropertyFileIncluded::RestoreDocFile(Base::Reader& reader)
 
     // copy plain data
     aboutToSetValue();
-    std::array<char, includedFileRestoreBufferSize> buffer {};
+    std::array<char, includedFileBufferSize> buffer {};
     while (reader) {
         reader.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
         const std::streamsize count = reader.gcount();
@@ -519,6 +535,12 @@ void PropertyFileIncluded::RestoreDocFile(Base::Reader& reader)
                 throw Base::FileSystemError(str.str());
             }
         }
+    }
+    if (reader.bad()) {
+        std::stringstream str;
+        str << "PropertyFileIncluded::RestoreDocFile(): "
+            << "File '" << _cValue << "' in transient directory cannot be read.";
+        throw Base::FileSystemError(str.str());
     }
     to.close();
     if (!to) {

--- a/src/App/PropertyFile.cpp
+++ b/src/App/PropertyFile.cpp
@@ -31,6 +31,8 @@
 #include <Base/Uuid.h>
 #include <Base/Tools.h>
 
+#include <array>
+
 #include "PropertyFile.h"
 #include "Document.h"
 #include "DocumentObject.h"
@@ -40,6 +42,12 @@
 using namespace App;
 using namespace Base;
 using namespace std;
+
+namespace {
+
+constexpr std::size_t includedFileRestoreBufferSize = 64 * 1024;
+
+}
 
 
 namespace
@@ -498,11 +506,27 @@ void PropertyFileIncluded::RestoreDocFile(Base::Reader& reader)
 
     // copy plain data
     aboutToSetValue();
-    unsigned char c;
-    while (reader.get((char&)c)) {
-        to.put((char)c);
+    std::array<char, includedFileRestoreBufferSize> buffer {};
+    while (reader) {
+        reader.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        const std::streamsize count = reader.gcount();
+        if (count > 0) {
+            to.write(buffer.data(), count);
+            if (!to) {
+                std::stringstream str;
+                str << "PropertyFileIncluded::RestoreDocFile(): "
+                    << "File '" << _cValue << "' in transient directory cannot be written.";
+                throw Base::FileSystemError(str.str());
+            }
+        }
     }
     to.close();
+    if (!to) {
+        std::stringstream str;
+        str << "PropertyFileIncluded::RestoreDocFile(): "
+            << "File '" << _cValue << "' in transient directory cannot be closed.";
+        throw Base::FileSystemError(str.str());
+    }
 
     // set read-only after restoring the file
     fi.setPermissions(Base::FileInfo::ReadOnly);

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -1914,7 +1914,7 @@ class DocumentFileIncludeCases(unittest.TestCase):
         self.assertTrue(os.path.exists(L7.File))
         FreeCAD.closeDocument("Doc2")
 
-    def testBinaryRestore(self):
+    def testBinarySaveRestore(self):
         payload = bytes((i % 251 for i in range(150000))) + b"\x00FreeCAD\x00restore\x00"
         source_path = os.path.join(tempfile.gettempdir(), "FileIncludeBinarySource.bin")
         doc_path = os.path.join(tempfile.gettempdir(), "FileIncludeTests.FCStd")

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -1914,6 +1914,26 @@ class DocumentFileIncludeCases(unittest.TestCase):
         self.assertTrue(os.path.exists(L7.File))
         FreeCAD.closeDocument("Doc2")
 
+    def testBinaryRestore(self):
+        payload = bytes((i % 251 for i in range(150000))) + b"\x00FreeCAD\x00restore\x00"
+        source_path = os.path.join(tempfile.gettempdir(), "FileIncludeBinarySource.bin")
+        doc_path = os.path.join(tempfile.gettempdir(), "FileIncludeTests.FCStd")
+
+        with open(source_path, "wb") as file:
+            file.write(payload)
+
+        obj = self.Doc.addObject("App::DocumentObjectFileIncluded", "BinaryFile")
+        obj.File = (source_path, "BinaryPayload.bin")
+        self.Doc.saveAs(doc_path)
+
+        FreeCAD.closeDocument("FileIncludeTests")
+        self.Doc = FreeCAD.open(doc_path)
+        obj = self.Doc.getObject("BinaryFile")
+
+        with open(obj.File, "rb") as file:
+            self.assertEqual(file.read(), payload)
+        self.assertEqual(obj.File.split("/")[-1], "BinaryPayload.bin")
+
     def tearDown(self):
         # closing doc
         FreeCAD.closeDocument("FileIncludeTests")


### PR DESCRIPTION
This issue was found by profiling performance issues when opening a model which included images used to trace and outline to sketches.

It was found that embedded files are read one character at a time, resulting in slow loading due to excessive kernel calls to read the data.

This change converts the read/write to a buffered read and write (from the FreeCAD file to the transient folder) in fixed chunks.

This keeps the model restore and save behavior unchanged while improving performance. 

A regression test was added to test file load byte integrity.


- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

- AI assistance disclosure: OpenAI GPT-5 Codex


## Issues

None.


## Before and After Images

Not applicable; this PR does not affect the GUI.


## Tests

```sh
cmake --build build/debug --target FreeCADApp App_tests_run -j2
```

```sh
bin/FreeCADCmd -t -t Document.DocumentFileIncludeCases.testBinarySaveRestore
```

The FreeCAD model this issue was discovered on and some samples model were re-opened to check that no regression was introduced and the performance improved.