### PR TITLE
Sketcher: Angle OVP: prevent confusing overriding while typing.

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -616,7 +616,7 @@ void DSHLineController::adaptParameters(Base::Vector2d onSketchPos)
                         Base::Unit::Angle
                     );
                 }
-                else if (vec.Length() > Precision::Confusion()) {
+                else if (fourthParam->hasFinishedEditing && vec.Length() > Precision::Confusion()) {
                     double ovpRange = Base::toRadians(fourthParam->getValue());
                     if (fabs(range - ovpRange) > Precision::Confusion()) {
                         setOnViewParameterValue(

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1966,7 +1966,7 @@ void DSHPolyLineController::adaptParameters(Base::Vector2d onSketchPos)
                 if (!fourthParam->isSet) {
                     setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Unit::Angle);
                 }
-                else if (vec.Length() > Precision::Confusion()) {
+                else if (fourthParam->hasFinishedEditing && vec.Length() > Precision::Confusion()) {
                     double ovpRange = fourthParam->getValue();
 
                     if (fabs(range - ovpRange) > Precision::Confusion()) {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
@@ -513,7 +513,7 @@ void DSHSlotController::adaptParameters(Base::Vector2d onSketchPos)
                     Base::Unit::Angle
                 );
             }
-            else if (vec.Length() > Precision::Confusion()) {
+            else if (fourthParam->hasFinishedEditing && vec.Length() > Precision::Confusion()) {
                 double ovpRange = Base::toRadians(fourthParam->getValue());
 
                 if (fabs(range - ovpRange) > Precision::Confusion()) {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerText.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerText.h
@@ -562,7 +562,7 @@ void DSHTextController::adaptParameters(Base::Vector2d onSketchPos)
                     Base::Unit::Angle
                 );
             }
-            else if (vec.Length() > Precision::Confusion()) {
+            else if (fourthParam->hasFinishedEditing && vec.Length() > Precision::Confusion()) {
                 double ovpRange = Base::toRadians(fourthParam->getValue());
                 if (fabs(range - ovpRange) > Precision::Confusion()) {
                     setOnViewParameterValue(


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/30461

What happens is that this PR : https://github.com/FreeCAD/FreeCAD/pull/20267
Introduced an automatic switch between an angle and its complementary based on mouse position. See the video in the PR.

It was working fine. However since @tetektoza made the behavior change on the OVP, the value are now applied as soon as user type. So this caused the effect we see in #30461 where user start typing something, like 105, but because of its mouse position the automatic switch replace the value by -75 in the middle of the user edition.

So what this PR does is that it disable this automatic switch until the user finishes to edit the value of the OVP.

Please squash