### PR TITLE
Core: Save toolbar layout after toolbar drag

### DIFF
--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -1142,6 +1142,8 @@ void ToolBarManager::onToggleStatusBarWidget(QWidget* widget, bool visible)
 
 bool ToolBarManager::eventFilter(QObject* source, QEvent* ev)
 {
+    static QPointer<QToolBar> movedToolBar;
+
     bool res = false;
     switch (ev->type()) {
         case QEvent::Show:
@@ -1153,6 +1155,13 @@ bool ToolBarManager::eventFilter(QObject* source, QEvent* ev)
                 }
             }
             break;
+        case QEvent::MouseButtonPress: {
+            auto mev = static_cast<QMouseEvent*>(ev);
+            if (mev->button() == Qt::LeftButton) {
+                movedToolBar.clear();
+            }
+            break;
+        }
         case QEvent::MouseButtonRelease: {
             auto mev = static_cast<QMouseEvent*>(ev);
             if (mev->button() == Qt::RightButton) {
@@ -1160,11 +1169,25 @@ bool ToolBarManager::eventFilter(QObject* source, QEvent* ev)
                     return true;
                 }
             }
+            if (mev->button() == Qt::LeftButton) {
+                auto toolbar = qobject_cast<QToolBar*>(source);
+                if (toolbar && movedToolBar == toolbar) {
+                    getMainWindow()->saveWindowSettings(true);
+                }
+                movedToolBar.clear();
+            }
         }
         // fall through
-        case QEvent::MouseMove:
-            res = addToolBarToArea(source, static_cast<QMouseEvent*>(ev));
+        case QEvent::MouseMove: {
+            auto mev = static_cast<QMouseEvent*>(ev);
+            if ((mev->buttons() & Qt::LeftButton) != 0) {
+                if (auto toolbar = qobject_cast<QToolBar*>(source)) {
+                    movedToolBar = toolbar;
+                }
+            }
+            res = addToolBarToArea(source, mev);
             break;
+        }
         case QEvent::ParentChange:
             if (auto toolbar = qobject_cast<QToolBar*>(source)) {
                 resizingToolbars[toolbar] = toolbar;


### PR DESCRIPTION
While working in FreeCAD it was noticed that toolbar which are move to new locations are not always saved. This change implements an approach to save the window state after a toolbar has been moved.

Since QToolBar does not provide a `location changed` event, this is detected by implementing this logic:

- left mouse press clears any stale toolbar drag state
- left mouse move on a toolbar marks that toolbar as moved
- left mouse release on the same toolbar schedules `saveWindowSettings(true)`

This avoids saving on ordinary left-click releases while still persisting toolbar placement changes.


- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

AI assistance disclosure: OpenAI-gpt-5.5


## Issues

#21662
#14525

## Before and After Images

No screenshots included. The change affects persistence of toolbar layout after restart rather than the immediate visual appearance.

## Validation

- Full build (Linux)
- Tested the behavior in FreeCAD by moving toolbars to new locations and restarting to ensure the toolbar location is preserved.