### PR TITLE
Feature/copilot integration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.sh text eol=lf
+Dockerfile text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PIXI_VERSION=v0.48.2
+
+ENV PIXI_HOME=/opt/pixi \
+    PATH=/opt/pixi/bin:$PATH \
+    QT_QPA_PLATFORM=offscreen \
+    FREECAD_USER_HOME=/workspace/.freecad
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dbus-x11 \
+        git \
+        novnc \
+        openbox \
+        tini \
+        websockify \
+        xterm \
+        x11vnc \
+        xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://pixi.sh/install.sh | bash -s -- -y --version "${PIXI_VERSION}" \
+    && pixi --version
+
+WORKDIR /workspace/FreeCAD
+
+COPY pixi.toml pixi.lock ./
+RUN pixi install --locked
+
+RUN git config --global --add safe.directory /workspace/FreeCAD
+
+COPY . .
+
+COPY docker/start-novnc.sh /usr/local/bin/start-novnc
+RUN chmod +x /usr/local/bin/start-novnc
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["bash"]

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -23,7 +23,7 @@ docker compose --profile desktop up desktop
 Then open this URL in your browser:
 
 ```text
-http://localhost:8010/vnc.html
+http://localhost:8010/vnc.html?resize=scale&autoconnect=true
 ```
 
 ## What Each Command Does
@@ -83,7 +83,7 @@ Starts the browser-accessible desktop service. This runs Xvfb, x11vnc, noVNC, an
 The service exposes noVNC on host port `8010`, so FreeCAD can be opened at:
 
 ```text
-http://localhost:8010/vnc.html
+http://localhost:8010/vnc.html?resize=scale&autoconnect=true
 ```
 
 Keep this command running while using FreeCAD in the browser. Stop it with `Ctrl + C`.

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -1,0 +1,121 @@
+# Running FreeCAD With Docker
+
+This project includes a Docker setup for building FreeCAD and opening it through a browser-based noVNC desktop.
+
+## Prerequisites
+
+- Docker Desktop installed and running
+- PowerShell or another terminal
+- This repository checked out locally
+
+## Start FreeCAD
+
+Run these commands from PowerShell:
+
+```powershell
+cd "E:\Scratch Pad\MetaCad\FreeCAD"
+docker compose build
+docker compose run --rm configure
+docker compose run --rm build
+docker compose --profile desktop up desktop
+```
+
+Then open this URL in your browser:
+
+```text
+http://localhost:8010/vnc.html
+```
+
+## What Each Command Does
+
+```powershell
+cd "E:\Scratch Pad\MetaCad\FreeCAD"
+```
+
+Moves the terminal into the FreeCAD repository folder. Docker Compose must be run from the folder that contains `docker-compose.yml`.
+
+```powershell
+docker compose build
+```
+
+Builds the local Docker image from the `Dockerfile`. This installs Ubuntu packages, Pixi, and the FreeCAD dependency environment needed to configure and build the project.
+
+```powershell
+docker compose run --rm configure
+```
+
+Runs the FreeCAD CMake configure step inside a temporary container.
+
+Internally, this runs:
+
+```bash
+pixi run configure-debug
+```
+
+It creates the debug build configuration under:
+
+```text
+build/debug
+```
+
+The `--rm` flag removes the temporary container after the command finishes.
+
+```powershell
+docker compose run --rm build
+```
+
+Compiles FreeCAD inside a temporary container.
+
+Internally, this runs:
+
+```bash
+pixi run build-debug
+```
+
+This can take a long time because FreeCAD is a large C++/Qt application. If interrupted, running the same command again usually resumes from the existing build files.
+
+```powershell
+docker compose --profile desktop up desktop
+```
+
+Starts the browser-accessible desktop service. This runs Xvfb, x11vnc, noVNC, and FreeCAD inside the container.
+
+The service exposes noVNC on host port `8010`, so FreeCAD can be opened at:
+
+```text
+http://localhost:8010/vnc.html
+```
+
+Keep this command running while using FreeCAD in the browser. Stop it with `Ctrl + C`.
+
+## When To Use `docker compose down -v`
+
+Use this command only when you want to reset Docker state for this project:
+
+```powershell
+docker compose down -v
+```
+
+It stops Compose services and removes the named Docker volumes used by this setup, including:
+
+- the FreeCAD build volume
+- the Pixi environment cache volume
+- the ccache compiler cache volume
+
+This is useful when:
+
+- the build cache is corrupted
+- CMake or Ninja keeps failing due to stale generated files
+- you want a clean rebuild from scratch
+- you see timestamp-related errors such as `manifest 'build.ninja' still dirty`
+
+It does not delete your source code, but the next build will take longer because Docker must recreate the removed caches.
+
+After running it, start again with:
+
+```powershell
+docker compose build
+docker compose run --rm configure
+docker compose run --rm build
+docker compose --profile desktop up desktop
+```

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -119,3 +119,185 @@ docker compose run --rm configure
 docker compose run --rm build
 docker compose --profile desktop up desktop
 ```
+
+## Faster Development And Testing
+
+You do not need to run every Docker command after every code change.
+
+The full startup sequence is:
+
+```powershell
+docker compose build
+docker compose run --rm configure
+docker compose run --rm build
+docker compose --profile desktop up desktop
+```
+
+Use the full sequence when setting up the project for the first time, after deleting Docker volumes, or after changing major build/dependency configuration.
+
+For day-to-day development, use the smallest command needed for the type of change you made.
+
+### If You Changed Python Code
+
+For most Python-only changes, especially in:
+
+```text
+src/Mod/copilot
+```
+
+you usually do not need to rebuild the Docker image.
+
+Use:
+
+```powershell
+docker compose --profile desktop up desktop
+```
+
+If FreeCAD is already running, stop the desktop service with `Ctrl + C`, then start it again:
+
+```powershell
+docker compose --profile desktop up desktop
+```
+
+This is usually enough because the repository is mounted into the container.
+
+If the changed Python files are copied into FreeCAD's build output by CMake and the change does not appear inside FreeCAD, run:
+
+```powershell
+docker compose run --rm build
+docker compose --profile desktop up desktop
+```
+
+### If You Added Or Removed Python Files
+
+If you add or remove files that are listed in a `CMakeLists.txt`, run configure and build again:
+
+```powershell
+docker compose run --rm configure
+docker compose run --rm build
+docker compose --profile desktop up desktop
+```
+
+Use this for changes such as:
+
+- adding a new file under `src/Mod/copilot`
+- removing a Copilot file
+- updating `src/Mod/copilot/CMakeLists.txt`
+- updating `src/Mod/CMakeLists.txt`
+
+### If You Changed C++ Code
+
+Run only the build step:
+
+```powershell
+docker compose run --rm build
+docker compose --profile desktop up desktop
+```
+
+CMake/Ninja should rebuild only the files affected by your change. It should not rebuild all of FreeCAD unless many shared files changed.
+
+### If You Changed CMake Configuration
+
+Run configure, then build:
+
+```powershell
+docker compose run --rm configure
+docker compose run --rm build
+docker compose --profile desktop up desktop
+```
+
+Use this when you change files such as:
+
+- `CMakeLists.txt`
+- `CMakePresets.json`
+- CMake helper files
+- build options
+- module registration
+
+### If You Changed Docker Configuration
+
+Rebuild the Docker image:
+
+```powershell
+docker compose build
+docker compose --profile desktop up desktop
+```
+
+Use this when you change:
+
+- `Dockerfile`
+- `docker-compose.yml`
+- `.dockerignore`
+- files under `docker/`
+- OS-level packages
+- container startup behavior
+
+If the Docker change also affects the FreeCAD build environment, run:
+
+```powershell
+docker compose build
+docker compose run --rm configure
+docker compose run --rm build
+docker compose --profile desktop up desktop
+```
+
+### If You Changed Pixi Dependencies
+
+Run the full build setup:
+
+```powershell
+docker compose build
+docker compose run --rm configure
+docker compose run --rm build
+docker compose --profile desktop up desktop
+```
+
+Use this when you change:
+
+- `pixi.toml`
+- `pixi.lock`
+- compiler or dependency versions
+
+### Quick Command Guide
+
+Use this table as the normal development guide:
+
+| Change Type | Commands |
+| --- | --- |
+| Start existing built FreeCAD | `docker compose --profile desktop up desktop` |
+| Python-only change | restart desktop service |
+| Python change not appearing | `docker compose run --rm build` then start desktop |
+| Added/removed CMake-listed files | `configure`, then `build`, then start desktop |
+| C++ change | `build`, then start desktop |
+| CMake change | `configure`, then `build`, then start desktop |
+| Dockerfile or startup script change | `docker compose build`, then start desktop |
+| Dependency change | full sequence |
+| Corrupted build/cache | `docker compose down -v`, then full sequence |
+
+### Recommended Copilot Development Loop
+
+For Copilot work, use this loop most of the time:
+
+```powershell
+docker compose --profile desktop up desktop
+```
+
+Make a Python change under:
+
+```text
+src/Mod/copilot
+```
+
+Then restart the desktop service:
+
+```powershell
+Ctrl + C
+docker compose --profile desktop up desktop
+```
+
+If FreeCAD does not pick up the change:
+
+```powershell
+docker compose run --rm build
+docker compose --profile desktop up desktop
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ x-freecad-service: &freecad-service
     DISPLAY: "${DISPLAY:-}"
     FREECAD_USER_HOME: /workspace/.freecad
     CCACHE_DIR: /workspace/.ccache
+    COPILOT_PROVIDER: "${COPILOT_PROVIDER:-local}"
+    OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+    OPENAI_MODEL: "${OPENAI_MODEL:-gpt-4.1-mini}"
   volumes:
     - .:/workspace/FreeCAD
     - freecad-pixi:/workspace/FreeCAD/.pixi
@@ -52,6 +55,9 @@ services:
       DISPLAY: ":1"
       FREECAD_USER_HOME: /workspace/.freecad
       CCACHE_DIR: /workspace/.ccache
+      COPILOT_PROVIDER: "${COPILOT_PROVIDER:-local}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      OPENAI_MODEL: "${OPENAI_MODEL:-gpt-4.1-mini}"
       VNC_RESOLUTION: "${VNC_RESOLUTION:-1280x800x24}"
     ports:
       - "8010:6080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,69 @@
+name: freecad-dev
+
+x-freecad-service: &freecad-service
+  build:
+    context: .
+    dockerfile: Dockerfile
+  image: freecad-dev:local
+  working_dir: /workspace/FreeCAD
+  environment:
+    QT_QPA_PLATFORM: "${QT_QPA_PLATFORM:-offscreen}"
+    DISPLAY: "${DISPLAY:-}"
+    FREECAD_USER_HOME: /workspace/.freecad
+    CCACHE_DIR: /workspace/.ccache
+    COPILOT_PROVIDER: "${COPILOT_PROVIDER:-local}"
+    OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+    OPENAI_MODEL: "${OPENAI_MODEL:-gpt-4.1-mini}"
+  volumes:
+    - .:/workspace/FreeCAD
+    - freecad-pixi:/workspace/FreeCAD/.pixi
+    - freecad-build:/workspace/FreeCAD/build
+    - freecad-ccache:/workspace/.ccache
+
+services:
+  freecad:
+    <<: *freecad-service
+    stdin_open: true
+    tty: true
+    command: ["bash"]
+
+  configure:
+    <<: *freecad-service
+    profiles: ["build"]
+    command: ["pixi", "run", "configure-debug"]
+
+  build:
+    <<: *freecad-service
+    profiles: ["build"]
+    command: ["pixi", "run", "build-debug"]
+
+  test:
+    <<: *freecad-service
+    profiles: ["test"]
+    command: ["pixi", "run", "xvfb-run", "-a", "build/debug/bin/FreeCAD", "-t", "0"]
+
+  cmd:
+    <<: *freecad-service
+    profiles: ["run"]
+    command: ["pixi", "run", "build/debug/bin/FreeCADCmd", "--help"]
+
+  desktop:
+    <<: *freecad-service
+    profiles: ["desktop"]
+    environment:
+      QT_QPA_PLATFORM: xcb
+      DISPLAY: ":1"
+      FREECAD_USER_HOME: /workspace/.freecad
+      CCACHE_DIR: /workspace/.ccache
+      COPILOT_PROVIDER: "${COPILOT_PROVIDER:-local}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      OPENAI_MODEL: "${OPENAI_MODEL:-gpt-4.1-mini}"
+      VNC_RESOLUTION: "${VNC_RESOLUTION:-1280x800x24}"
+    ports:
+      - "8010:6080"
+    command: ["start-novnc"]
+
+volumes:
+  freecad-build:
+  freecad-pixi:
+  freecad-ccache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ x-freecad-service: &freecad-service
     COPILOT_PROVIDER: "${COPILOT_PROVIDER:-local}"
     OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
     OPENAI_MODEL: "${OPENAI_MODEL:-gpt-4.1-mini}"
+    OPENROUTER_API_KEY: "${OPENROUTER_API_KEY:-}"
+    OPENROUTER_MODEL: "${OPENROUTER_MODEL:-openai/gpt-4o-mini}"
+    OPENROUTER_BASE_URL: "${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}"
+    OPENROUTER_SITE_URL: "${OPENROUTER_SITE_URL:-http://localhost:8010}"
+    OPENROUTER_APP_NAME: "${OPENROUTER_APP_NAME:-MetaCad FreeCAD Copilot}"
   volumes:
     - .:/workspace/FreeCAD
     - freecad-pixi:/workspace/FreeCAD/.pixi
@@ -58,7 +63,12 @@ services:
       COPILOT_PROVIDER: "${COPILOT_PROVIDER:-local}"
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
       OPENAI_MODEL: "${OPENAI_MODEL:-gpt-4.1-mini}"
-      VNC_RESOLUTION: "${VNC_RESOLUTION:-1280x800x24}"
+      OPENROUTER_API_KEY: "${OPENROUTER_API_KEY:-}"
+      OPENROUTER_MODEL: "${OPENROUTER_MODEL:-openai/gpt-4o-mini}"
+      OPENROUTER_BASE_URL: "${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}"
+      OPENROUTER_SITE_URL: "${OPENROUTER_SITE_URL:-http://localhost:8010}"
+      OPENROUTER_APP_NAME: "${OPENROUTER_APP_NAME:-MetaCad FreeCAD Copilot}"
+      VNC_RESOLUTION: "${VNC_RESOLUTION:-1920x1080x24}"
     ports:
       - "8010:6080"
     command: ["start-novnc"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,6 @@ x-freecad-service: &freecad-service
     DISPLAY: "${DISPLAY:-}"
     FREECAD_USER_HOME: /workspace/.freecad
     CCACHE_DIR: /workspace/.ccache
-    COPILOT_PROVIDER: "${COPILOT_PROVIDER:-local}"
-    OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
-    OPENAI_MODEL: "${OPENAI_MODEL:-gpt-4.1-mini}"
   volumes:
     - .:/workspace/FreeCAD
     - freecad-pixi:/workspace/FreeCAD/.pixi
@@ -55,9 +52,6 @@ services:
       DISPLAY: ":1"
       FREECAD_USER_HOME: /workspace/.freecad
       CCACHE_DIR: /workspace/.ccache
-      COPILOT_PROVIDER: "${COPILOT_PROVIDER:-local}"
-      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
-      OPENAI_MODEL: "${OPENAI_MODEL:-gpt-4.1-mini}"
       VNC_RESOLUTION: "${VNC_RESOLUTION:-1280x800x24}"
     ports:
       - "8010:6080"

--- a/docker/start-novnc.sh
+++ b/docker/start-novnc.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DISPLAY="${DISPLAY:-:1}"
+export QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-xcb}"
+export FREECAD_USER_HOME="${FREECAD_USER_HOME:-/workspace/.freecad}"
+
+mkdir -p "${FREECAD_USER_HOME}"
+
+Xvfb "${DISPLAY}" -screen 0 "${VNC_RESOLUTION:-1280x800x24}" -ac +extension GLX +render -noreset &
+xvfb_pid=$!
+
+openbox &
+openbox_pid=$!
+
+x11vnc -display "${DISPLAY}" -forever -shared -nopw -listen 0.0.0.0 -rfbport 5900 &
+x11vnc_pid=$!
+
+websockify --web=/usr/share/novnc/ 0.0.0.0:6080 localhost:5900 &
+websockify_pid=$!
+
+cleanup() {
+  kill "${websockify_pid}" "${x11vnc_pid}" "${openbox_pid}" "${xvfb_pid}" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+if [ -x build/debug/bin/FreeCAD ]; then
+  pixi run build/debug/bin/FreeCAD &
+else
+  xterm -geometry 120x32 -e "echo 'FreeCAD is not built yet.'; echo 'Run: docker compose run --rm configure && docker compose run --rm build'; bash" &
+fi
+
+wait "${websockify_pid}"

--- a/env.example
+++ b/env.example
@@ -1,0 +1,6 @@
+COPILOT_PROVIDER=openrouter
+OPENROUTER_API_KEY=""
+OPENROUTER_MODEL=openai/gpt-4o-mini
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+OPENROUTER_SITE_URL=http://localhost:8010
+OPENROUTER_APP_NAME=MetaCad FreeCAD Copilot

--- a/env.example
+++ b/env.example
@@ -4,3 +4,4 @@ OPENROUTER_MODEL=openai/gpt-4o-mini
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 OPENROUTER_SITE_URL=http://localhost:8010
 OPENROUTER_APP_NAME=MetaCad FreeCAD Copilot
+VNC_RESOLUTION=1920x1080x24

--- a/src/Mod/CMakeLists.txt
+++ b/src/Mod/CMakeLists.txt
@@ -18,6 +18,8 @@ if(BUILD_CLOUD)
     add_subdirectory(Cloud)
 endif(BUILD_CLOUD)
 
+add_subdirectory(copilot)
+
 if(BUILD_DRAFT)
   add_subdirectory(Draft)
 endif(BUILD_DRAFT)

--- a/src/Mod/copilot/CMakeLists.txt
+++ b/src/Mod/copilot/CMakeLists.txt
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+set(Copilot_Scripts
+    Init.py
+    InitGui.py
+    commands.py
+    executor.py
+    panel.py
+    provider.py
+    tests.py
+    Resources/icons/copilot.svg
+)
+
+add_custom_target(CopilotScripts ALL
+    SOURCES ${Copilot_Scripts}
+)
+
+fc_target_copy_resource(CopilotScripts
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_BINARY_DIR}/Mod/copilot
+    ${Copilot_Scripts}
+)
+
+install(
+    FILES
+        Init.py
+        InitGui.py
+        commands.py
+        executor.py
+        panel.py
+        provider.py
+        tests.py
+    DESTINATION
+        Mod/copilot
+)
+
+install(
+    FILES
+        Resources/icons/copilot.svg
+    DESTINATION
+        Mod/copilot/Resources/icons
+)

--- a/src/Mod/copilot/CMakeLists.txt
+++ b/src/Mod/copilot/CMakeLists.txt
@@ -4,6 +4,7 @@ set(Copilot_Scripts
     Init.py
     InitGui.py
     commands.py
+    constants.py
     executor.py
     panel.py
     provider.py
@@ -26,6 +27,7 @@ install(
         Init.py
         InitGui.py
         commands.py
+        constants.py
         executor.py
         panel.py
         provider.py

--- a/src/Mod/copilot/Init.py
+++ b/src/Mod/copilot/Init.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""FreeCAD Copilot module bootstrap."""
+
+import FreeCAD as App
+
+App.Console.PrintLog("Loading Copilot module... done\n")

--- a/src/Mod/copilot/InitGui.py
+++ b/src/Mod/copilot/InitGui.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Graphical bootstrap for the Copilot workbench."""
+
+import os
+
+import FreeCAD as App
+import FreeCADGui as Gui
+
+
+class CopilotWorkbench(Gui.Workbench):
+    """Workbench that exposes a natural-language CAD assistant."""
+
+    def __init__(self):
+        self.__class__.Icon = os.path.join(
+            App.getResourceDir(), "Mod", "copilot", "Resources", "icons", "copilot.svg"
+        )
+        self.__class__.MenuText = "Copilot"
+        self.__class__.ToolTip = "Create and edit CAD models with text prompts"
+
+    def Initialize(self):
+        import commands
+
+        self.appendToolbar("Copilot", ["Copilot_ShowPanel"])
+        self.appendMenu("Copilot", ["Copilot_ShowPanel"])
+        App.Console.PrintLog("Loading Copilot workbench... done\n")
+
+    def Activated(self):
+        try:
+            from panel import show_panel
+
+            show_panel()
+        except Exception as err:
+            App.Console.PrintError("Failed to open Copilot panel: {0}\n".format(err))
+
+    def GetClassName(self):
+        return "Gui::PythonWorkbench"
+
+
+Gui.addWorkbench(CopilotWorkbench())

--- a/src/Mod/copilot/Resources/icons/copilot.svg
+++ b/src/Mod/copilot/Resources/icons/copilot.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect x="8" y="8" width="48" height="48" rx="6" fill="#2f5e8e"/>
+  <path d="M20 42V24l12-7 12 7v18l-12 7-12-7z" fill="#f2f6fa" stroke="#16324f" stroke-width="2"/>
+  <path d="M20 24l12 7 12-7M32 31v18" fill="none" stroke="#2f5e8e" stroke-width="2"/>
+  <circle cx="46" cy="18" r="6" fill="#43b883" stroke="#16324f" stroke-width="2"/>
+</svg>

--- a/src/Mod/copilot/commands.py
+++ b/src/Mod/copilot/commands.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""FreeCAD GUI commands for Copilot."""
+
+import FreeCAD as App
+import FreeCADGui as Gui
+
+
+class ShowCopilotPanelCommand:
+    """Open the Copilot dock panel."""
+
+    def GetResources(self):
+        return {
+            "MenuText": "Open Copilot",
+            "ToolTip": "Open the Copilot prompt panel",
+            "Pixmap": "applications-python",
+        }
+
+    def Activated(self):
+        from panel import show_panel
+
+        show_panel()
+
+    def IsActive(self):
+        return True
+
+
+Gui.addCommand("Copilot_ShowPanel", ShowCopilotPanelCommand())

--- a/src/Mod/copilot/constants.py
+++ b/src/Mod/copilot/constants.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Shared constants for the Copilot module."""
+
+# Maximum image size (bytes) for reference images
+MAX_IMAGE_SIZE_BYTES = 8 * 1024 * 1024
+
+# Color palette (RGB tuples, 0.0-1.0)
+COLORS = {
+    "red": (1.0, 0.0, 0.0),
+    "green": (0.0, 0.8, 0.0),
+    "blue": (0.0, 0.2, 1.0),
+    "yellow": (1.0, 0.9, 0.0),
+    "orange": (1.0, 0.45, 0.0),
+    "white": (1.0, 1.0, 1.0),
+    "black": (0.0, 0.0, 0.0),
+    "gray": (0.45, 0.45, 0.45),
+    "grey": (0.45, 0.45, 0.45),
+}
+
+# Default primitive dimensions
+DEFAULTS = {
+    "box_size": 10.0,
+    "cylinder_radius": 5.0,
+    "cylinder_height": 10.0,
+    "sphere_radius": 5.0,
+    "cone_radius1": 5.0,
+    "cone_radius2": 0.0,
+    "cone_height": 10.0,
+    "torus_radius1": 10.0,
+    "torus_radius2": 2.0,
+    "rotation_angle": 90.0,
+    "scale_factor": 1.0,
+}
+
+# Allowed actions for plan validation
+ALLOWED_ACTIONS = {
+    "create_box",
+    "create_cylinder",
+    "create_sphere",
+    "create_cone",
+    "create_torus",
+    "move_selected",
+    "rotate_selected",
+    "scale_selected",
+    "select_by_name",
+    "delete_selected",
+    "set_color",
+    "boolean_fuse",
+    "boolean_cut",
+    "fit_view",
+    "save",
+    "open",
+}

--- a/src/Mod/copilot/executor.py
+++ b/src/Mod/copilot/executor.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Apply Copilot command plans to FreeCAD documents."""
+
+import os
+
+import FreeCAD as App
+
+try:
+    import FreeCADGui as Gui
+except ImportError:
+    Gui = None
+
+
+class CopilotExecutor:
+    """Execute the small command language produced by provider.py."""
+
+    def run(self, plan):
+        results = []
+        for step in plan:
+            action = step.get("action")
+            handler = getattr(self, "_{0}".format(action), None)
+            if handler is None:
+                raise ValueError("Unsupported action: {0}".format(action))
+            results.append(handler(step))
+        return results
+
+    def _document(self):
+        doc = App.ActiveDocument
+        if doc is None:
+            doc = App.newDocument("CopilotModel")
+        return doc
+
+    def _selection(self):
+        if Gui is None:
+            return []
+        return list(Gui.Selection.getSelection())
+
+    def _create_box(self, step):
+        doc = self._document()
+        obj = doc.addObject("Part::Box", step.get("name", "CopilotBox"))
+        obj.Length = float(step.get("length", 10.0))
+        obj.Width = float(step.get("width", 10.0))
+        obj.Height = float(step.get("height", 10.0))
+        doc.recompute()
+        self._select(obj)
+        return "Created box {0}".format(obj.Label)
+
+    def _create_cylinder(self, step):
+        doc = self._document()
+        obj = doc.addObject("Part::Cylinder", step.get("name", "CopilotCylinder"))
+        obj.Radius = float(step.get("radius", 5.0))
+        obj.Height = float(step.get("height", 10.0))
+        doc.recompute()
+        self._select(obj)
+        return "Created cylinder {0}".format(obj.Label)
+
+    def _create_sphere(self, step):
+        doc = self._document()
+        obj = doc.addObject("Part::Sphere", step.get("name", "CopilotSphere"))
+        obj.Radius = float(step.get("radius", 5.0))
+        doc.recompute()
+        self._select(obj)
+        return "Created sphere {0}".format(obj.Label)
+
+    def _create_cone(self, step):
+        doc = self._document()
+        obj = doc.addObject("Part::Cone", step.get("name", "CopilotCone"))
+        obj.Radius1 = float(step.get("radius1", 5.0))
+        obj.Radius2 = float(step.get("radius2", 0.0))
+        obj.Height = float(step.get("height", 10.0))
+        doc.recompute()
+        self._select(obj)
+        return "Created cone {0}".format(obj.Label)
+
+    def _move_selected(self, step):
+        objects = self._require_selection()
+        vector = App.Vector(float(step.get("x", 0.0)), float(step.get("y", 0.0)), float(step.get("z", 0.0)))
+        for obj in objects:
+            obj.Placement.Base = obj.Placement.Base + vector
+        App.ActiveDocument.recompute()
+        return "Moved {0} selected object(s)".format(len(objects))
+
+    def _rotate_selected(self, step):
+        objects = self._require_selection()
+        axis_name = step.get("axis", "z").lower()
+        axis = {"x": App.Vector(1, 0, 0), "y": App.Vector(0, 1, 0), "z": App.Vector(0, 0, 1)}.get(axis_name)
+        if axis is None:
+            raise ValueError("Axis must be x, y, or z.")
+        angle = float(step.get("angle", 90.0))
+        for obj in objects:
+            obj.Placement.rotate(App.Vector(0, 0, 0), axis, angle)
+        App.ActiveDocument.recompute()
+        return "Rotated {0} selected object(s)".format(len(objects))
+
+    def _scale_selected(self, step):
+        objects = self._require_selection()
+        factor = float(step.get("factor", 1.0))
+        if factor <= 0:
+            raise ValueError("Scale factor must be greater than zero.")
+        for obj in objects:
+            obj.Placement.Base = obj.Placement.Base.multiply(factor)
+            for prop in ("Length", "Width", "Height", "Radius", "Radius1", "Radius2"):
+                if hasattr(obj, prop):
+                    setattr(obj, prop, getattr(obj, prop) * factor)
+        App.ActiveDocument.recompute()
+        return "Scaled {0} selected object(s)".format(len(objects))
+
+    def _delete_selected(self, step):
+        objects = self._require_selection()
+        doc = App.ActiveDocument
+        for obj in objects:
+            doc.removeObject(obj.Name)
+        doc.recompute()
+        return "Deleted {0} selected object(s)".format(len(objects))
+
+    def _set_color(self, step):
+        objects = self._require_selection()
+        color = tuple(float(part) for part in step.get("color", [0.8, 0.8, 0.8]))
+        for obj in objects:
+            if hasattr(obj, "ViewObject"):
+                obj.ViewObject.ShapeColor = color
+        return "Colored {0} selected object(s)".format(len(objects))
+
+    def _fit_view(self, step):
+        if Gui is not None:
+            Gui.SendMsgToActiveView("ViewFit")
+        return "Fit active view"
+
+    def _save(self, step):
+        doc = self._document()
+        path = step.get("path")
+        if not path:
+            if doc.FileName:
+                doc.save()
+                return "Saved {0}".format(doc.FileName)
+            raise ValueError("Please provide a path, for example: save as /workspace/FreeCAD/model.FCStd")
+        path = os.path.abspath(os.path.expanduser(path))
+        doc.saveAs(path)
+        return "Saved {0}".format(path)
+
+    def _open(self, step):
+        path = step.get("path")
+        if not path:
+            raise ValueError("Please provide a file path to open.")
+        App.openDocument(os.path.abspath(os.path.expanduser(path)))
+        return "Opened {0}".format(path)
+
+    def _require_selection(self):
+        objects = self._selection()
+        if not objects:
+            raise ValueError("Select one or more objects first.")
+        return objects
+
+    def _select(self, obj):
+        if Gui is not None:
+            Gui.Selection.clearSelection()
+            Gui.Selection.addSelection(obj)
+            Gui.SendMsgToActiveView("ViewFit")

--- a/src/Mod/copilot/executor.py
+++ b/src/Mod/copilot/executor.py
@@ -4,7 +4,6 @@
 import os
 
 import FreeCAD as App
-
 try:
     import FreeCADGui as Gui
 except ImportError:
@@ -41,6 +40,7 @@ class CopilotExecutor:
         obj.Length = float(step.get("length", 10.0))
         obj.Width = float(step.get("width", 10.0))
         obj.Height = float(step.get("height", 10.0))
+        self._apply_placement(obj, step)
         doc.recompute()
         self._select(obj)
         return "Created box {0}".format(obj.Label)
@@ -50,6 +50,7 @@ class CopilotExecutor:
         obj = doc.addObject("Part::Cylinder", step.get("name", "CopilotCylinder"))
         obj.Radius = float(step.get("radius", 5.0))
         obj.Height = float(step.get("height", 10.0))
+        self._apply_placement(obj, step)
         doc.recompute()
         self._select(obj)
         return "Created cylinder {0}".format(obj.Label)
@@ -58,6 +59,7 @@ class CopilotExecutor:
         doc = self._document()
         obj = doc.addObject("Part::Sphere", step.get("name", "CopilotSphere"))
         obj.Radius = float(step.get("radius", 5.0))
+        self._apply_placement(obj, step)
         doc.recompute()
         self._select(obj)
         return "Created sphere {0}".format(obj.Label)
@@ -68,9 +70,20 @@ class CopilotExecutor:
         obj.Radius1 = float(step.get("radius1", 5.0))
         obj.Radius2 = float(step.get("radius2", 0.0))
         obj.Height = float(step.get("height", 10.0))
+        self._apply_placement(obj, step)
         doc.recompute()
         self._select(obj)
         return "Created cone {0}".format(obj.Label)
+
+    def _create_torus(self, step):
+        doc = self._document()
+        obj = doc.addObject("Part::Torus", step.get("name", "CopilotTorus"))
+        obj.Radius1 = float(step.get("radius1", 10.0))
+        obj.Radius2 = float(step.get("radius2", 2.0))
+        self._apply_placement(obj, step)
+        doc.recompute()
+        self._select(obj)
+        return "Created torus {0}".format(obj.Label)
 
     def _move_selected(self, step):
         objects = self._require_selection()
@@ -114,12 +127,44 @@ class CopilotExecutor:
         return "Deleted {0} selected object(s)".format(len(objects))
 
     def _set_color(self, step):
-        objects = self._require_selection()
-        color = tuple(float(part) for part in step.get("color", [0.8, 0.8, 0.8]))
+        objects = self._objects_from_step(step) or self._require_selection()
+        color = self._coerce_color(step.get("color", [0.8, 0.8, 0.8]))
         for obj in objects:
             if hasattr(obj, "ViewObject"):
                 obj.ViewObject.ShapeColor = color
-        return "Colored {0} selected object(s)".format(len(objects))
+        return "Colored {0} object(s)".format(len(objects))
+
+    def _select_by_name(self, step):
+        name = step.get("name")
+        if not name:
+            raise ValueError("select_by_name requires a name.")
+        obj = self._find_object(name)
+        self._select(obj)
+        return "Selected {0}".format(obj.Label)
+
+    def _boolean_fuse(self, step):
+        doc = self._document()
+        objects = self._objects_from_names(step.get("objects"))
+        if len(objects) < 2:
+            raise ValueError("boolean_fuse requires at least two objects.")
+        obj = doc.addObject("Part::MultiFuse", step.get("name", "CopilotFuse"))
+        obj.Shapes = objects
+        doc.recompute()
+        self._hide(objects)
+        self._select(obj)
+        return "Fused {0} object(s) into {1}".format(len(objects), obj.Label)
+
+    def _boolean_cut(self, step):
+        doc = self._document()
+        base = self._find_object(step.get("base"))
+        tool = self._find_object(step.get("tool"))
+        obj = doc.addObject("Part::Cut", step.get("name", "CopilotCut"))
+        obj.Base = base
+        obj.Tool = tool
+        doc.recompute()
+        self._hide([base, tool])
+        self._select(obj)
+        return "Cut {0} with {1}".format(base.Label, tool.Label)
 
     def _fit_view(self, step):
         if Gui is not None:
@@ -150,6 +195,57 @@ class CopilotExecutor:
         if not objects:
             raise ValueError("Select one or more objects first.")
         return objects
+
+    def _apply_placement(self, obj, step):
+        obj.Placement.Base = App.Vector(
+            float(step.get("x", 0.0)),
+            float(step.get("y", 0.0)),
+            float(step.get("z", 0.0)),
+        )
+
+    def _objects_from_step(self, step):
+        if step.get("name"):
+            return [self._find_object(step.get("name"))]
+        if step.get("objects"):
+            return self._objects_from_names(step.get("objects"))
+        return []
+
+    def _objects_from_names(self, names):
+        if isinstance(names, str):
+            names = [name.strip() for name in names.split(",") if name.strip()]
+        if not isinstance(names, (list, tuple)):
+            raise ValueError("Object names must be a list or comma-separated string.")
+        return [self._find_object(name) for name in names]
+
+    def _find_object(self, name):
+        if not name:
+            raise ValueError("Object name is required.")
+        doc = self._document()
+        for obj in doc.Objects:
+            if obj.Name == name or obj.Label == name:
+                return obj
+        raise ValueError("Object not found: {0}".format(name))
+
+    def _hide(self, objects):
+        for obj in objects:
+            if hasattr(obj, "ViewObject"):
+                obj.ViewObject.Visibility = False
+
+    def _coerce_color(self, color):
+        if isinstance(color, str):
+            colors = {
+                "red": (1.0, 0.0, 0.0),
+                "green": (0.0, 0.8, 0.0),
+                "blue": (0.0, 0.2, 1.0),
+                "yellow": (1.0, 0.9, 0.0),
+                "orange": (1.0, 0.45, 0.0),
+                "white": (1.0, 1.0, 1.0),
+                "black": (0.0, 0.0, 0.0),
+                "gray": (0.45, 0.45, 0.45),
+                "grey": (0.45, 0.45, 0.45),
+            }
+            return colors.get(color.lower(), (0.8, 0.8, 0.8))
+        return tuple(float(part) for part in color)
 
     def _select(self, obj):
         if Gui is not None:

--- a/src/Mod/copilot/executor.py
+++ b/src/Mod/copilot/executor.py
@@ -9,6 +9,8 @@ try:
 except ImportError:
     Gui = None
 
+from constants import COLORS, DEFAULTS
+
 
 class CopilotExecutor:
     """Execute the small command language produced by provider.py."""
@@ -90,7 +92,7 @@ class CopilotExecutor:
         vector = App.Vector(float(step.get("x", 0.0)), float(step.get("y", 0.0)), float(step.get("z", 0.0)))
         for obj in objects:
             obj.Placement.Base = obj.Placement.Base + vector
-        App.ActiveDocument.recompute()
+        self._document().recompute()
         return "Moved {0} selected object(s)".format(len(objects))
 
     def _rotate_selected(self, step):
@@ -99,15 +101,15 @@ class CopilotExecutor:
         axis = {"x": App.Vector(1, 0, 0), "y": App.Vector(0, 1, 0), "z": App.Vector(0, 0, 1)}.get(axis_name)
         if axis is None:
             raise ValueError("Axis must be x, y, or z.")
-        angle = float(step.get("angle", 90.0))
+        angle = float(step.get("angle", DEFAULTS["rotation_angle"]))
         for obj in objects:
             obj.Placement.rotate(App.Vector(0, 0, 0), axis, angle)
-        App.ActiveDocument.recompute()
+        self._document().recompute()
         return "Rotated {0} selected object(s)".format(len(objects))
 
     def _scale_selected(self, step):
         objects = self._require_selection()
-        factor = float(step.get("factor", 1.0))
+        factor = float(step.get("factor", DEFAULTS["scale_factor"]))
         if factor <= 0:
             raise ValueError("Scale factor must be greater than zero.")
         for obj in objects:
@@ -115,7 +117,7 @@ class CopilotExecutor:
             for prop in ("Length", "Width", "Height", "Radius", "Radius1", "Radius2"):
                 if hasattr(obj, prop):
                     setattr(obj, prop, getattr(obj, prop) * factor)
-        App.ActiveDocument.recompute()
+        self._document().recompute()
         return "Scaled {0} selected object(s)".format(len(objects))
 
     def _delete_selected(self, step):
@@ -179,7 +181,7 @@ class CopilotExecutor:
                 doc.save()
                 return "Saved {0}".format(doc.FileName)
             raise ValueError("Please provide a path, for example: save as /workspace/FreeCAD/model.FCStd")
-        path = os.path.abspath(os.path.expanduser(path))
+        path = self._validate_path(path)
         doc.saveAs(path)
         return "Saved {0}".format(path)
 
@@ -187,7 +189,8 @@ class CopilotExecutor:
         path = step.get("path")
         if not path:
             raise ValueError("Please provide a file path to open.")
-        App.openDocument(os.path.abspath(os.path.expanduser(path)))
+        path = self._validate_path(path)
+        App.openDocument(path)
         return "Opened {0}".format(path)
 
     def _require_selection(self):
@@ -233,19 +236,18 @@ class CopilotExecutor:
 
     def _coerce_color(self, color):
         if isinstance(color, str):
-            colors = {
-                "red": (1.0, 0.0, 0.0),
-                "green": (0.0, 0.8, 0.0),
-                "blue": (0.0, 0.2, 1.0),
-                "yellow": (1.0, 0.9, 0.0),
-                "orange": (1.0, 0.45, 0.0),
-                "white": (1.0, 1.0, 1.0),
-                "black": (0.0, 0.0, 0.0),
-                "gray": (0.45, 0.45, 0.45),
-                "grey": (0.45, 0.45, 0.45),
-            }
-            return colors.get(color.lower(), (0.8, 0.8, 0.8))
+            return COLORS.get(color.lower(), (0.8, 0.8, 0.8))
         return tuple(float(part) for part in color)
+
+    def _validate_path(self, path):
+        """Validate and sanitize a file path for save/open operations."""
+        expanded = os.path.abspath(os.path.expanduser(path))
+        # Allow paths within workspace and home; block obviously dangerous ones
+        blocked_prefixes = ("/dev/", "/proc/", "/sys/", "//", "\\", ":")
+        normalized = os.path.normpath(expanded)
+        if any(normalized.startswith(p) for p in blocked_prefixes):
+            raise ValueError("Path is not allowed: {0}".format(path))
+        return expanded
 
     def _select(self, obj):
         if Gui is not None:

--- a/src/Mod/copilot/panel.py
+++ b/src/Mod/copilot/panel.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Qt dock panel for FreeCAD Copilot."""
+
+import traceback
+
+import FreeCAD as App
+import FreeCADGui as Gui
+
+try:
+    from PySide import QtCore, QtGui
+    QtWidgets = QtGui
+except ImportError:
+    from PySide2 import QtCore, QtWidgets
+
+from executor import CopilotExecutor
+from provider import describe_plan, get_provider
+
+
+PANEL_OBJECT_NAME = "CopilotDockPanel"
+
+
+class CopilotPanel(QtWidgets.QDockWidget):
+    """Dockable prompt interface."""
+
+    def __init__(self, parent=None):
+        super(CopilotPanel, self).__init__("Copilot", parent)
+        self.setObjectName(PANEL_OBJECT_NAME)
+        self.provider = get_provider()
+        self.executor = CopilotExecutor()
+        self._build_ui()
+
+    def _build_ui(self):
+        root = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(root)
+
+        self.prompt = QtWidgets.QPlainTextEdit()
+        self.prompt.setPlaceholderText(
+            "Try: create a box length 40 width 20 height 10\n"
+            "Try: move selected x 10 y 0 z 5\n"
+            "Try: color selected blue"
+        )
+        self.prompt.setMinimumHeight(90)
+        layout.addWidget(self.prompt)
+
+        button_row = QtWidgets.QHBoxLayout()
+        self.run_button = QtWidgets.QPushButton("Run")
+        self.plan_button = QtWidgets.QPushButton("Preview Plan")
+        self.clear_button = QtWidgets.QPushButton("Clear")
+        button_row.addWidget(self.run_button)
+        button_row.addWidget(self.plan_button)
+        button_row.addWidget(self.clear_button)
+        layout.addLayout(button_row)
+
+        self.output = QtWidgets.QPlainTextEdit()
+        self.output.setReadOnly(True)
+        self.output.setMinimumHeight(180)
+        layout.addWidget(self.output)
+
+        self.setWidget(root)
+
+        self.run_button.clicked.connect(self.run_prompt)
+        self.plan_button.clicked.connect(self.preview_plan)
+        self.clear_button.clicked.connect(self.output.clear)
+
+    def preview_plan(self):
+        try:
+            plan = self.provider.plan(self.prompt.toPlainText(), _context())
+            self._write(describe_plan(plan))
+        except Exception as err:
+            self._write_error(err)
+
+    def run_prompt(self):
+        try:
+            plan = self.provider.plan(self.prompt.toPlainText(), _context())
+            self._write("Plan:\n{0}".format(describe_plan(plan)))
+            results = self.executor.run(plan)
+            self._write("\nResult:\n{0}".format("\n".join(results)))
+        except Exception as err:
+            self._write_error(err)
+
+    def _write(self, text):
+        self.output.setPlainText(text)
+        App.Console.PrintMessage("{0}\n".format(text))
+
+    def _write_error(self, err):
+        message = "Copilot error: {0}".format(err)
+        self.output.setPlainText(message)
+        App.Console.PrintError("{0}\n{1}\n".format(message, traceback.format_exc()))
+
+
+def show_panel():
+    main_window = Gui.getMainWindow()
+    panel = main_window.findChild(QtWidgets.QDockWidget, PANEL_OBJECT_NAME)
+    if panel is None:
+        panel = CopilotPanel(main_window)
+        main_window.addDockWidget(QtCore.Qt.RightDockWidgetArea, panel)
+    panel.show()
+    panel.raise_()
+    return panel
+
+
+def _context():
+    doc = App.ActiveDocument
+    selection = []
+    try:
+        selection = [obj.Label for obj in Gui.Selection.getSelection()]
+    except Exception:
+        selection = []
+    return {
+        "document": doc.Name if doc else None,
+        "selection": selection,
+    }

--- a/src/Mod/copilot/panel.py
+++ b/src/Mod/copilot/panel.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 """Qt dock panel for FreeCAD Copilot."""
 
+import base64
+import mimetypes
+import os
 import traceback
 
 import FreeCAD as App
@@ -27,6 +30,8 @@ class CopilotPanel(QtWidgets.QDockWidget):
         self.setObjectName(PANEL_OBJECT_NAME)
         self.provider = get_provider()
         self.executor = CopilotExecutor()
+        self.image_path = None
+        self.image_data_url = None
         self._build_ui()
 
     def _build_ui(self):
@@ -37,10 +42,20 @@ class CopilotPanel(QtWidgets.QDockWidget):
         self.prompt.setPlaceholderText(
             "Try: create a box length 40 width 20 height 10\n"
             "Try: move selected x 10 y 0 z 5\n"
-            "Try: color selected blue"
+            "Try: color selected blue\n"
+            "Or attach an image and ask: create this object"
         )
         self.prompt.setMinimumHeight(90)
         layout.addWidget(self.prompt)
+
+        image_row = QtWidgets.QHBoxLayout()
+        self.image_label = QtWidgets.QLabel("No image attached")
+        self.attach_image_button = QtWidgets.QPushButton("Attach Image")
+        self.clear_image_button = QtWidgets.QPushButton("Clear Image")
+        image_row.addWidget(self.image_label, 1)
+        image_row.addWidget(self.attach_image_button)
+        image_row.addWidget(self.clear_image_button)
+        layout.addLayout(image_row)
 
         button_row = QtWidgets.QHBoxLayout()
         self.run_button = QtWidgets.QPushButton("Run")
@@ -61,17 +76,47 @@ class CopilotPanel(QtWidgets.QDockWidget):
         self.run_button.clicked.connect(self.run_prompt)
         self.plan_button.clicked.connect(self.preview_plan)
         self.clear_button.clicked.connect(self.output.clear)
+        self.attach_image_button.clicked.connect(self.attach_image)
+        self.clear_image_button.clicked.connect(self.clear_image)
+
+    def attach_image(self):
+        try:
+            path, _filter = QtWidgets.QFileDialog.getOpenFileName(
+                self,
+                "Attach reference image",
+                "",
+                "Images (*.png *.jpg *.jpeg *.webp *.bmp);;All Files (*)",
+            )
+            if not path:
+                return
+            max_bytes = 8 * 1024 * 1024
+            if os.path.getsize(path) > max_bytes:
+                raise ValueError("Image is larger than 8 MB. Please choose a smaller image.")
+            mime_type = mimetypes.guess_type(path)[0] or "image/png"
+            with open(path, "rb") as image_file:
+                encoded = base64.b64encode(image_file.read()).decode("ascii")
+            self.image_path = path
+            self.image_data_url = "data:{0};base64,{1}".format(mime_type, encoded)
+            self.image_label.setText(os.path.basename(path))
+            self._write("Attached image: {0}".format(path))
+        except Exception as err:
+            self._write_error(err)
+
+    def clear_image(self):
+        self.image_path = None
+        self.image_data_url = None
+        self.image_label.setText("No image attached")
 
     def preview_plan(self):
         try:
-            plan = self.provider.plan(self.prompt.toPlainText(), _context())
+            plan = self.provider.plan(self.prompt.toPlainText(), self._context())
             self._write(describe_plan(plan))
         except Exception as err:
             self._write_error(err)
 
     def run_prompt(self):
         try:
-            plan = self.provider.plan(self.prompt.toPlainText(), _context())
+            plan = self.provider.plan(self.prompt.toPlainText(), self._context())
             self._write("Plan:\n{0}".format(describe_plan(plan)))
             results = self.executor.run(plan)
             self._write("\nResult:\n{0}".format("\n".join(results)))
@@ -86,6 +131,15 @@ class CopilotPanel(QtWidgets.QDockWidget):
         message = "Copilot error: {0}".format(err)
         self.output.setPlainText(message)
         App.Console.PrintError("{0}\n{1}\n".format(message, traceback.format_exc()))
+
+    def _context(self):
+        context = _context()
+        if self.image_data_url:
+            context["image"] = {
+                "path": self.image_path,
+                "data_url": self.image_data_url,
+            }
+        return context
 
 
 def show_panel():

--- a/src/Mod/copilot/panel.py
+++ b/src/Mod/copilot/panel.py
@@ -15,6 +15,7 @@ try:
 except ImportError:
     from PySide2 import QtCore, QtWidgets
 
+from constants import MAX_IMAGE_SIZE_BYTES
 from executor import CopilotExecutor
 from provider import describe_plan, get_provider
 
@@ -28,11 +29,15 @@ class CopilotPanel(QtWidgets.QDockWidget):
     def __init__(self, parent=None):
         super(CopilotPanel, self).__init__("Copilot", parent)
         self.setObjectName(PANEL_OBJECT_NAME)
-        self.provider = get_provider()
         self.executor = CopilotExecutor()
         self.image_path = None
         self.image_data_url = None
         self._build_ui()
+
+    @property
+    def provider(self):
+        """Return a fresh provider instance (environment may change)."""
+        return get_provider()
 
     def _build_ui(self):
         root = QtWidgets.QWidget()
@@ -89,9 +94,8 @@ class CopilotPanel(QtWidgets.QDockWidget):
             )
             if not path:
                 return
-            max_bytes = 8 * 1024 * 1024
-            if os.path.getsize(path) > max_bytes:
-                raise ValueError("Image is larger than 8 MB. Please choose a smaller image.")
+            if os.path.getsize(path) > MAX_IMAGE_SIZE_BYTES:
+                raise ValueError("Image is larger than {0} MB. Please choose a smaller image.".format(MAX_IMAGE_SIZE_BYTES // (1024 * 1024)))
             mime_type = mimetypes.guess_type(path)[0] or "image/png"
             with open(path, "rb") as image_file:
                 encoded = base64.b64encode(image_file.read()).decode("ascii")

--- a/src/Mod/copilot/provider.py
+++ b/src/Mod/copilot/provider.py
@@ -20,6 +20,8 @@ class LocalIntentProvider:
         text = prompt.strip()
         if not text:
             raise ValueError("Enter a modeling request first.")
+        if context and context.get("image"):
+            raise ValueError("Image prompts require COPILOT_PROVIDER=openrouter with a vision-capable model.")
 
         lower = text.lower()
         if _has_any(lower, ["delete", "remove"]) and _has_any(lower, ["selected", "selection"]):
@@ -176,19 +178,15 @@ class OpenRouterIntentProvider:
                     "content": (
                         "You are a FreeCAD CAD planning assistant. Return JSON only, "
                         "with this shape: {\"steps\":[{\"action\":\"...\"}]}. "
-                        "Use only the supported actions. Do not include markdown."
+                        "Use only the supported actions. Do not include markdown. "
+                        "If an image is provided, approximate the visible object as a "
+                        "parametric CAD model by decomposing it into safe primitives, "
+                        "placements, colors, boolean fuses, and cuts. Create multiple "
+                        "steps for complex objects. Use reasonable dimensions when the "
+                        "image has no scale."
                     ),
                 },
-                {
-                    "role": "user",
-                    "content": json.dumps(
-                        {
-                            "request": prompt,
-                            "context": context or {},
-                            "supported_actions": _supported_actions(),
-                        }
-                    ),
-                },
+                _openrouter_user_message(prompt, context or {}),
             ],
             "temperature": 0.1,
             "max_tokens": 800,
@@ -237,15 +235,19 @@ def _response_text(response):
 
 def _supported_actions():
     return [
-        "create_box(length,width,height,name)",
-        "create_cylinder(radius,height,name)",
-        "create_sphere(radius,name)",
-        "create_cone(radius1,radius2,height,name)",
+        "create_box(length,width,height,name,x,y,z)",
+        "create_cylinder(radius,height,name,x,y,z)",
+        "create_sphere(radius,name,x,y,z)",
+        "create_cone(radius1,radius2,height,name,x,y,z)",
+        "create_torus(radius1,radius2,name,x,y,z)",
         "move_selected(x,y,z)",
         "rotate_selected(axis,angle)",
         "scale_selected(factor)",
+        "select_by_name(name)",
         "delete_selected()",
-        "set_color(color)",
+        "set_color(color,name)",
+        "boolean_fuse(objects,name)",
+        "boolean_cut(base,tool,name)",
         "fit_view()",
         "save(path)",
         "open(path)",
@@ -258,11 +260,15 @@ def _validate_plan(plan):
         "create_cylinder",
         "create_sphere",
         "create_cone",
+        "create_torus",
         "move_selected",
         "rotate_selected",
         "scale_selected",
+        "select_by_name",
         "delete_selected",
         "set_color",
+        "boolean_fuse",
+        "boolean_cut",
         "fit_view",
         "save",
         "open",
@@ -317,21 +323,29 @@ def _parse_function_style_step(text):
 def _step_from_function_args(action, args):
     step = {"action": action}
     if action == "create_box":
-        _assign_args(step, args, ["length", "width", "height", "name"])
+        _assign_args(step, args, ["length", "width", "height", "name", "x", "y", "z"])
     elif action == "create_cylinder":
-        _assign_args(step, args, ["radius", "height", "name"])
+        _assign_args(step, args, ["radius", "height", "name", "x", "y", "z"])
     elif action == "create_sphere":
-        _assign_args(step, args, ["radius", "name"])
+        _assign_args(step, args, ["radius", "name", "x", "y", "z"])
     elif action == "create_cone":
-        _assign_args(step, args, ["radius1", "radius2", "height", "name"])
+        _assign_args(step, args, ["radius1", "radius2", "height", "name", "x", "y", "z"])
+    elif action == "create_torus":
+        _assign_args(step, args, ["radius1", "radius2", "name", "x", "y", "z"])
     elif action == "move_selected":
         _assign_args(step, args, ["x", "y", "z"])
     elif action == "rotate_selected":
         _assign_args(step, args, ["axis", "angle"])
     elif action == "scale_selected":
         _assign_args(step, args, ["factor"])
+    elif action == "select_by_name":
+        _assign_args(step, args, ["name"])
     elif action == "set_color":
-        _assign_args(step, args, ["color"])
+        _assign_args(step, args, ["color", "name"])
+    elif action == "boolean_fuse":
+        _assign_args(step, args, ["objects", "name"])
+    elif action == "boolean_cut":
+        _assign_args(step, args, ["base", "tool", "name"])
     elif action in ("delete_selected", "fit_view"):
         pass
     elif action in ("save", "open"):
@@ -366,6 +380,38 @@ def _literal_arg(node):
 
 def _has_any(text, words):
     return any(word in text for word in words)
+
+
+def _openrouter_user_message(prompt, context):
+    image = context.get("image") or {}
+    request_context = dict(context)
+    if "image" in request_context:
+        request_context["image"] = {"path": image.get("path"), "attached": True}
+
+    text = json.dumps(
+        {
+            "request": prompt,
+            "context": request_context,
+            "supported_actions": _supported_actions(),
+            "output_rules": [
+                "Return only JSON.",
+                "Use {\"steps\": [...]} as the top-level shape.",
+                "Each step must use an exact supported action name, not prose.",
+                "Prefer multiple simple primitives for complex image objects.",
+                "Set x, y, z placement fields when parts should not overlap.",
+            ],
+        }
+    )
+    data_url = image.get("data_url")
+    if not data_url:
+        return {"role": "user", "content": text}
+    return {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": data_url}},
+        ],
+    }
 
 
 def _quoted(text):

--- a/src/Mod/copilot/provider.py
+++ b/src/Mod/copilot/provider.py
@@ -12,6 +12,8 @@ import ast
 import urllib.error
 import urllib.request
 
+from constants import ALLOWED_ACTIONS, COLORS, DEFAULTS
+
 
 class LocalIntentProvider:
     """Parse simple English prompts without any network dependency."""
@@ -39,7 +41,7 @@ class LocalIntentProvider:
 
         color = _color(lower)
         if color and _has_any(lower, ["selected", "selection"]):
-            return [{"action": "set_color", "target": "selected", "color": color}]
+            return [{"action": "set_color", "target": "selected", "color": list(color)}]
 
         transform = _transform(lower)
         if transform:
@@ -149,8 +151,8 @@ class OpenAIIntentProvider:
             with urllib.request.urlopen(request, timeout=45) as response:
                 body = response.read().decode("utf-8")
         except urllib.error.HTTPError as err:
-            detail = err.read().decode("utf-8", errors="replace")
-            raise ValueError("OpenAI request failed: {0} {1}".format(err.code, detail))
+            detail = _sanitize_error(err.read().decode("utf-8", errors="replace"))
+            raise ValueError("OpenAI request failed: HTTP {0}".format(err.code))
         parsed = json.loads(body)
         plan_text = _response_text(parsed)
         plan = json.loads(plan_text)
@@ -212,12 +214,44 @@ class OpenRouterIntentProvider:
             with urllib.request.urlopen(request, timeout=45) as response:
                 body = response.read().decode("utf-8")
         except urllib.error.HTTPError as err:
-            detail = err.read().decode("utf-8", errors="replace")
-            raise ValueError("OpenRouter request failed: {0} {1}".format(err.code, detail))
+            detail = _sanitize_error(err.read().decode("utf-8", errors="replace"))
+            raise ValueError("OpenRouter request failed: HTTP {0}".format(err.code))
         parsed = json.loads(body)
-        content = parsed["choices"][0]["message"]["content"]
+        content = _get_openrouter_content(parsed)
         plan = json.loads(content)
         return _validate_plan(plan.get("steps", []))
+
+
+def _sanitize_error(text):
+    """Remove sensitive fields from API error responses."""
+    if not text:
+        return ""
+    try:
+        parsed = json.loads(text)
+        for key in ("api_key", "token", "access_token", "secret", "key"):
+            if key in parsed:
+                parsed[key] = "<redacted>"
+        return json.dumps(parsed)
+    except (ValueError, TypeError):
+        # If not JSON, redact common patterns inline
+        redacted = re.sub(r'(api[_-]?key|token|secret)\s*[:=]\s*[^\s&]+', r'\1=<redacted>', text, flags=re.IGNORECASE)
+        return redacted[:500]
+
+
+def _get_openrouter_content(parsed):
+    """Safely extract content from OpenRouter response."""
+    if not isinstance(parsed, dict):
+        raise ValueError("Invalid OpenRouter response format.")
+    choices = parsed.get("choices")
+    if not choices or not isinstance(choices, list):
+        raise ValueError("OpenRouter response missing choices.")
+    message = choices[0].get("message")
+    if not isinstance(message, dict):
+        raise ValueError("OpenRouter response missing message.")
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise ValueError("OpenRouter response missing content text.")
+    return content
 
 
 def _response_text(response):
@@ -255,24 +289,7 @@ def _supported_actions():
 
 
 def _validate_plan(plan):
-    allowed = {
-        "create_box",
-        "create_cylinder",
-        "create_sphere",
-        "create_cone",
-        "create_torus",
-        "move_selected",
-        "rotate_selected",
-        "scale_selected",
-        "select_by_name",
-        "delete_selected",
-        "set_color",
-        "boolean_fuse",
-        "boolean_cut",
-        "fit_view",
-        "save",
-        "open",
-    }
+    allowed = ALLOWED_ACTIONS
     if not isinstance(plan, list) or not plan:
         raise ValueError("Planner returned no steps.")
     plan = [_normalize_step(step) for step in plan]
@@ -302,8 +319,16 @@ def _normalize_step(step):
 
 
 def _parse_function_style_step(text):
+    stripped = text.strip()
+    if not stripped:
+        return {"action": text}
+
+    # Safety: only allow simple identifier calls with literal args
+    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*\s*\(", stripped):
+        return {"action": text}
+
     try:
-        expression = ast.parse(text.strip(), mode="eval").body
+        expression = ast.parse(stripped, mode="eval").body
     except SyntaxError:
         return {"action": text}
 
@@ -311,9 +336,14 @@ def _parse_function_style_step(text):
         return {"action": text}
 
     action = expression.func.id
+    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", action):
+        return {"action": text}
+
     step = _step_from_function_args(action, [_literal_arg(arg) for arg in expression.args])
     for keyword in expression.keywords:
         if keyword.arg:
+            if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", keyword.arg):
+                continue
             value = _literal_arg(keyword.value)
             if value is not _PLACEHOLDER:
                 step[keyword.arg] = value
@@ -495,18 +525,7 @@ def _transform(text):
 
 
 def _color(text):
-    colors = {
-        "red": [1.0, 0.0, 0.0],
-        "green": [0.0, 0.8, 0.0],
-        "blue": [0.0, 0.2, 1.0],
-        "yellow": [1.0, 0.9, 0.0],
-        "orange": [1.0, 0.45, 0.0],
-        "white": [1.0, 1.0, 1.0],
-        "black": [0.0, 0.0, 0.0],
-        "gray": [0.45, 0.45, 0.45],
-        "grey": [0.45, 0.45, 0.45],
-    }
-    for name, rgb in colors.items():
+    for name, rgb in COLORS.items():
         if name in text:
             return rgb
     return None

--- a/src/Mod/copilot/provider.py
+++ b/src/Mod/copilot/provider.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Intent provider interfaces for Copilot.
+
+The default provider is local and deterministic. It converts common CAD prompts
+into a small command language that executor.py applies to the active document.
+"""
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+
+
+class LocalIntentProvider:
+    """Parse simple English prompts without any network dependency."""
+
+    def plan(self, prompt, context=None):
+        text = prompt.strip()
+        if not text:
+            raise ValueError("Enter a modeling request first.")
+
+        lower = text.lower()
+        if _has_any(lower, ["delete", "remove"]) and _has_any(lower, ["selected", "selection"]):
+            return [{"action": "delete_selected"}]
+
+        if _has_any(lower, ["fit", "zoom"]) and "view" in lower:
+            return [{"action": "fit_view"}]
+
+        if lower.startswith("save") or " save " in " {0} ".format(lower):
+            path = _quoted(text) or _path_after_keyword(text, "as")
+            return [{"action": "save", "path": path}]
+
+        if lower.startswith("open "):
+            return [{"action": "open", "path": _quoted(text) or text[5:].strip()}]
+
+        color = _color(lower)
+        if color and _has_any(lower, ["selected", "selection"]):
+            return [{"action": "set_color", "target": "selected", "color": color}]
+
+        transform = _transform(lower)
+        if transform:
+            return [transform]
+
+        primitive = _primitive(lower)
+        if primitive:
+            return [primitive]
+
+        raise ValueError(
+            "I can create boxes, cylinders, spheres, and cones; move, rotate, scale, "
+            "color, delete selected objects; fit the view; and save/open files."
+        )
+
+
+def get_provider():
+    """Return the configured provider.
+
+    COPILOT_PROVIDER=openai uses OpenAI's Responses API when OPENAI_API_KEY is
+    present. The local provider keeps this module usable inside offline FreeCAD
+    containers.
+    """
+
+    provider_name = os.environ.get("COPILOT_PROVIDER", "local").strip().lower()
+    if provider_name == "local":
+        return LocalIntentProvider()
+    if provider_name == "openai":
+        return OpenAIIntentProvider()
+    raise ValueError("Unsupported COPILOT_PROVIDER: {0}".format(provider_name))
+
+
+def describe_plan(plan):
+    return json.dumps(plan, indent=2, sort_keys=True)
+
+
+class OpenAIIntentProvider:
+    """Use OpenAI to translate prompts into the same safe action plan."""
+
+    endpoint = "https://api.openai.com/v1/responses"
+
+    def __init__(self):
+        self.api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+        self.model = os.environ.get("OPENAI_MODEL", "gpt-4.1-mini").strip()
+        if not self.api_key:
+            raise ValueError("OPENAI_API_KEY is required when COPILOT_PROVIDER=openai.")
+
+    def plan(self, prompt, context=None):
+        payload = {
+            "model": self.model,
+            "instructions": (
+                "You are a FreeCAD CAD planning assistant. Convert the user request "
+                "into JSON only. Use only supported actions. Prefer selected-object "
+                "edit actions when the user says selected or selection. Do not invent "
+                "unsupported operations."
+            ),
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": json.dumps(
+                                {
+                                    "request": prompt,
+                                    "context": context or {},
+                                    "supported_actions": _supported_actions(),
+                                }
+                            ),
+                        }
+                    ],
+                }
+            ],
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "name": "freecad_copilot_plan",
+                    "strict": False,
+                    "schema": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["steps"],
+                        "properties": {
+                            "steps": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {"type": "object"},
+                            }
+                        },
+                    },
+                }
+            },
+            "max_output_tokens": 800,
+        }
+        data = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            self.endpoint,
+            data=data,
+            headers={
+                "Authorization": "Bearer {0}".format(self.api_key),
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=45) as response:
+                body = response.read().decode("utf-8")
+        except urllib.error.HTTPError as err:
+            detail = err.read().decode("utf-8", errors="replace")
+            raise ValueError("OpenAI request failed: {0} {1}".format(err.code, detail))
+        parsed = json.loads(body)
+        plan_text = _response_text(parsed)
+        plan = json.loads(plan_text)
+        return _validate_plan(plan.get("steps", []))
+
+
+def _response_text(response):
+    chunks = []
+    for item in response.get("output", []):
+        for content in item.get("content", []):
+            if content.get("type") == "output_text" and "text" in content:
+                chunks.append(content["text"])
+    if chunks:
+        return "".join(chunks)
+    if "output_text" in response:
+        return response["output_text"]
+    raise ValueError("OpenAI response did not include output text.")
+
+
+def _supported_actions():
+    return [
+        "create_box(length,width,height,name)",
+        "create_cylinder(radius,height,name)",
+        "create_sphere(radius,name)",
+        "create_cone(radius1,radius2,height,name)",
+        "move_selected(x,y,z)",
+        "rotate_selected(axis,angle)",
+        "scale_selected(factor)",
+        "delete_selected()",
+        "set_color(color)",
+        "fit_view()",
+        "save(path)",
+        "open(path)",
+    ]
+
+
+def _validate_plan(plan):
+    allowed = {
+        "create_box",
+        "create_cylinder",
+        "create_sphere",
+        "create_cone",
+        "move_selected",
+        "rotate_selected",
+        "scale_selected",
+        "delete_selected",
+        "set_color",
+        "fit_view",
+        "save",
+        "open",
+    }
+    if not isinstance(plan, list) or not plan:
+        raise ValueError("Planner returned no steps.")
+    for step in plan:
+        if not isinstance(step, dict):
+            raise ValueError("Planner returned an invalid step.")
+        action = step.get("action")
+        if action not in allowed:
+            raise ValueError("Planner returned unsupported action: {0}".format(action))
+    return plan
+
+
+def _has_any(text, words):
+    return any(word in text for word in words)
+
+
+def _quoted(text):
+    match = re.search(r"['\"]([^'\"]+)['\"]", text)
+    return match.group(1) if match else None
+
+
+def _path_after_keyword(text, keyword):
+    match = re.search(r"\b{0}\b\s+(.+)$".format(re.escape(keyword)), text, re.IGNORECASE)
+    return match.group(1).strip() if match else None
+
+
+def _number_after(text, names, default):
+    for name in names:
+        match = re.search(r"\b{0}\b\s*[:=]?\s*(-?\d+(?:\.\d+)?)".format(re.escape(name)), text)
+        if match:
+            return float(match.group(1))
+    return default
+
+
+def _first_number(text, default):
+    match = re.search(r"-?\d+(?:\.\d+)?", text)
+    return float(match.group(0)) if match else default
+
+
+def _primitive(text):
+    if "box" in text or "cube" in text:
+        size = _first_number(text, 10.0)
+        return {
+            "action": "create_box",
+            "name": "CopilotBox",
+            "length": _number_after(text, ["length", "x", "width"], size),
+            "width": _number_after(text, ["width", "y", "depth"], size),
+            "height": _number_after(text, ["height", "z"], size),
+        }
+
+    if "cylinder" in text:
+        radius = _number_after(text, ["radius", "r"], 5.0)
+        height = _number_after(text, ["height", "h"], 10.0)
+        return {"action": "create_cylinder", "name": "CopilotCylinder", "radius": radius, "height": height}
+
+    if "sphere" in text or "ball" in text:
+        radius = _number_after(text, ["radius", "r"], _first_number(text, 5.0))
+        return {"action": "create_sphere", "name": "CopilotSphere", "radius": radius}
+
+    if "cone" in text:
+        radius1 = _number_after(text, ["radius1", "bottom", "base"], 5.0)
+        radius2 = _number_after(text, ["radius2", "top"], 0.0)
+        height = _number_after(text, ["height", "h"], 10.0)
+        return {
+            "action": "create_cone",
+            "name": "CopilotCone",
+            "radius1": radius1,
+            "radius2": radius2,
+            "height": height,
+        }
+
+    return None
+
+
+def _transform(text):
+    if "move" in text or "translate" in text:
+        return {
+            "action": "move_selected",
+            "x": _number_after(text, ["x", "dx"], 0.0),
+            "y": _number_after(text, ["y", "dy"], 0.0),
+            "z": _number_after(text, ["z", "dz"], 0.0),
+        }
+
+    if "rotate" in text:
+        axis = "z"
+        for candidate in ("x", "y", "z"):
+            if " around {0}".format(candidate) in text or " {0} axis".format(candidate) in text:
+                axis = candidate
+        return {"action": "rotate_selected", "axis": axis, "angle": _first_number(text, 90.0)}
+
+    if "scale" in text:
+        return {"action": "scale_selected", "factor": _first_number(text, 1.0)}
+
+    return None
+
+
+def _color(text):
+    colors = {
+        "red": [1.0, 0.0, 0.0],
+        "green": [0.0, 0.8, 0.0],
+        "blue": [0.0, 0.2, 1.0],
+        "yellow": [1.0, 0.9, 0.0],
+        "orange": [1.0, 0.45, 0.0],
+        "white": [1.0, 1.0, 1.0],
+        "black": [0.0, 0.0, 0.0],
+        "gray": [0.45, 0.45, 0.45],
+        "grey": [0.45, 0.45, 0.45],
+    }
+    for name, rgb in colors.items():
+        if name in text:
+            return rgb
+    return None

--- a/src/Mod/copilot/provider.py
+++ b/src/Mod/copilot/provider.py
@@ -8,6 +8,7 @@ into a small command language that executor.py applies to the active document.
 import json
 import os
 import re
+import ast
 import urllib.error
 import urllib.request
 
@@ -65,6 +66,8 @@ def get_provider():
         return LocalIntentProvider()
     if provider_name == "openai":
         return OpenAIIntentProvider()
+    if provider_name == "openrouter":
+        return OpenRouterIntentProvider()
     raise ValueError("Unsupported COPILOT_PROVIDER: {0}".format(provider_name))
 
 
@@ -152,6 +155,73 @@ class OpenAIIntentProvider:
         return _validate_plan(plan.get("steps", []))
 
 
+class OpenRouterIntentProvider:
+    """Use OpenRouter's OpenAI-compatible Chat Completions API."""
+
+    def __init__(self):
+        self.api_key = os.environ.get("OPENROUTER_API_KEY", "").strip()
+        self.model = os.environ.get("OPENROUTER_MODEL", "openai/gpt-4o-mini").strip()
+        self.base_url = os.environ.get("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1").rstrip("/")
+        self.site_url = os.environ.get("OPENROUTER_SITE_URL", "http://localhost:8010").strip()
+        self.app_name = os.environ.get("OPENROUTER_APP_NAME", "MetaCad FreeCAD Copilot").strip()
+        if not self.api_key:
+            raise ValueError("OPENROUTER_API_KEY is required when COPILOT_PROVIDER=openrouter.")
+
+    def plan(self, prompt, context=None):
+        payload = {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a FreeCAD CAD planning assistant. Return JSON only, "
+                        "with this shape: {\"steps\":[{\"action\":\"...\"}]}. "
+                        "Use only the supported actions. Do not include markdown."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": json.dumps(
+                        {
+                            "request": prompt,
+                            "context": context or {},
+                            "supported_actions": _supported_actions(),
+                        }
+                    ),
+                },
+            ],
+            "temperature": 0.1,
+            "max_tokens": 800,
+            "response_format": {"type": "json_object"},
+        }
+        data = json.dumps(payload).encode("utf-8")
+        headers = {
+            "Authorization": "Bearer {0}".format(self.api_key),
+            "Content-Type": "application/json",
+        }
+        if self.site_url:
+            headers["HTTP-Referer"] = self.site_url
+        if self.app_name:
+            headers["X-Title"] = self.app_name
+
+        request = urllib.request.Request(
+            "{0}/chat/completions".format(self.base_url),
+            data=data,
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=45) as response:
+                body = response.read().decode("utf-8")
+        except urllib.error.HTTPError as err:
+            detail = err.read().decode("utf-8", errors="replace")
+            raise ValueError("OpenRouter request failed: {0} {1}".format(err.code, detail))
+        parsed = json.loads(body)
+        content = parsed["choices"][0]["message"]["content"]
+        plan = json.loads(content)
+        return _validate_plan(plan.get("steps", []))
+
+
 def _response_text(response):
     chunks = []
     for item in response.get("output", []):
@@ -199,6 +269,7 @@ def _validate_plan(plan):
     }
     if not isinstance(plan, list) or not plan:
         raise ValueError("Planner returned no steps.")
+    plan = [_normalize_step(step) for step in plan]
     for step in plan:
         if not isinstance(step, dict):
             raise ValueError("Planner returned an invalid step.")
@@ -206,6 +277,91 @@ def _validate_plan(plan):
         if action not in allowed:
             raise ValueError("Planner returned unsupported action: {0}".format(action))
     return plan
+
+
+def _normalize_step(step):
+    if isinstance(step, str):
+        return _parse_function_style_step(step)
+    if not isinstance(step, dict):
+        return step
+
+    action = step.get("action")
+    if isinstance(action, str) and "(" in action and action.endswith(")"):
+        parsed = _parse_function_style_step(action)
+        for key, value in step.items():
+            if key != "action":
+                parsed[key] = value
+        return parsed
+    return step
+
+
+def _parse_function_style_step(text):
+    try:
+        expression = ast.parse(text.strip(), mode="eval").body
+    except SyntaxError:
+        return {"action": text}
+
+    if not isinstance(expression, ast.Call) or not isinstance(expression.func, ast.Name):
+        return {"action": text}
+
+    action = expression.func.id
+    step = _step_from_function_args(action, [_literal_arg(arg) for arg in expression.args])
+    for keyword in expression.keywords:
+        if keyword.arg:
+            value = _literal_arg(keyword.value)
+            if value is not _PLACEHOLDER:
+                step[keyword.arg] = value
+    return step
+
+
+def _step_from_function_args(action, args):
+    step = {"action": action}
+    if action == "create_box":
+        _assign_args(step, args, ["length", "width", "height", "name"])
+    elif action == "create_cylinder":
+        _assign_args(step, args, ["radius", "height", "name"])
+    elif action == "create_sphere":
+        _assign_args(step, args, ["radius", "name"])
+    elif action == "create_cone":
+        _assign_args(step, args, ["radius1", "radius2", "height", "name"])
+    elif action == "move_selected":
+        _assign_args(step, args, ["x", "y", "z"])
+    elif action == "rotate_selected":
+        _assign_args(step, args, ["axis", "angle"])
+    elif action == "scale_selected":
+        _assign_args(step, args, ["factor"])
+    elif action == "set_color":
+        _assign_args(step, args, ["color"])
+    elif action in ("delete_selected", "fit_view"):
+        pass
+    elif action in ("save", "open"):
+        _assign_args(step, args, ["path"])
+    return step
+
+
+def _assign_args(step, args, names):
+    for index, name in enumerate(names):
+        if index < len(args) and args[index] is not _PLACEHOLDER:
+            step[name] = args[index]
+
+
+_PLACEHOLDER = object()
+
+
+def _literal_arg(node):
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        value = _literal_arg(node.operand)
+        if isinstance(value, (int, float)):
+            return -value
+    if isinstance(node, ast.List):
+        values = [_literal_arg(item) for item in node.elts]
+        return [value for value in values if value is not _PLACEHOLDER]
+    if isinstance(node, ast.Tuple):
+        values = [_literal_arg(item) for item in node.elts]
+        return tuple(value for value in values if value is not _PLACEHOLDER)
+    return _PLACEHOLDER
 
 
 def _has_any(text, words):

--- a/src/Mod/copilot/tests.py
+++ b/src/Mod/copilot/tests.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Lightweight tests for the local Copilot planner."""
+
+import unittest
+
+from provider import LocalIntentProvider
+
+
+class CopilotProviderTest(unittest.TestCase):
+    def setUp(self):
+        self.provider = LocalIntentProvider()
+
+    def test_create_box(self):
+        plan = self.provider.plan("create a box length 40 width 20 height 10")
+        self.assertEqual(plan[0]["action"], "create_box")
+        self.assertEqual(plan[0]["length"], 40)
+        self.assertEqual(plan[0]["width"], 20)
+        self.assertEqual(plan[0]["height"], 10)
+
+    def test_move_selected(self):
+        plan = self.provider.plan("move selected x 5 y -2 z 1")
+        self.assertEqual(plan[0]["action"], "move_selected")
+        self.assertEqual(plan[0]["x"], 5)
+        self.assertEqual(plan[0]["y"], -2)
+        self.assertEqual(plan[0]["z"], 1)
+
+    def test_color_selected(self):
+        plan = self.provider.plan("make selected blue")
+        self.assertEqual(plan[0]["action"], "set_color")
+        self.assertEqual(plan[0]["color"], [0.0, 0.2, 1.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/copilot/tests.py
+++ b/src/Mod/copilot/tests.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from provider import LocalIntentProvider
+from provider import LocalIntentProvider, _validate_plan
 
 
 class CopilotProviderTest(unittest.TestCase):
@@ -28,6 +28,37 @@ class CopilotProviderTest(unittest.TestCase):
         plan = self.provider.plan("make selected blue")
         self.assertEqual(plan[0]["action"], "set_color")
         self.assertEqual(plan[0]["color"], [0.0, 0.2, 1.0])
+
+    def test_validate_openrouter_style_plan(self):
+        plan = _validate_plan([{"action": "create_sphere", "radius": 12}])
+        self.assertEqual(plan[0]["action"], "create_sphere")
+
+    def test_validate_function_style_action(self):
+        plan = _validate_plan([{"action": "create_box(40,30,20,'Box')"}])
+        self.assertEqual(plan[0]["action"], "create_box")
+        self.assertEqual(plan[0]["length"], 40)
+        self.assertEqual(plan[0]["width"], 30)
+        self.assertEqual(plan[0]["height"], 20)
+        self.assertEqual(plan[0]["name"], "Box")
+
+    def test_validate_function_style_step_string(self):
+        plan = _validate_plan(["move_selected(10, 0, 5)"])
+        self.assertEqual(plan[0]["action"], "move_selected")
+        self.assertEqual(plan[0]["x"], 10)
+        self.assertEqual(plan[0]["y"], 0)
+        self.assertEqual(plan[0]["z"], 5)
+
+    def test_validate_keyword_function_style_action(self):
+        plan = _validate_plan([{"action": "create_cylinder(radius=15,height=20,name='Cylinder')"}])
+        self.assertEqual(plan[0]["action"], "create_cylinder")
+        self.assertEqual(plan[0]["radius"], 15)
+        self.assertEqual(plan[0]["height"], 20)
+        self.assertEqual(plan[0]["name"], "Cylinder")
+
+    def test_validate_placeholder_function_style_action(self):
+        plan = _validate_plan([{"action": "create_box(length,width,height,name)"}])
+        self.assertEqual(plan[0]["action"], "create_box")
+        self.assertNotIn("length", plan[0])
 
 
 if __name__ == "__main__":

--- a/src/Mod/copilot/tests.py
+++ b/src/Mod/copilot/tests.py
@@ -60,6 +60,19 @@ class CopilotProviderTest(unittest.TestCase):
         self.assertEqual(plan[0]["action"], "create_box")
         self.assertNotIn("length", plan[0])
 
+    def test_validate_complex_actions(self):
+        plan = _validate_plan(
+            [
+                "create_torus(20, 4, 'Wheel', 0, 0, 5)",
+                {"action": "set_color('blue','Wheel')"},
+                {"action": "boolean_fuse", "objects": ["Wheel", "Hub"], "name": "WheelAssembly"},
+            ]
+        )
+        self.assertEqual(plan[0]["action"], "create_torus")
+        self.assertEqual(plan[0]["x"], 0)
+        self.assertEqual(plan[1]["color"], "blue")
+        self.assertEqual(plan[2]["action"], "boolean_fuse")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Title
feat(copilot): Add AI-powered natural-language CAD assistant workbench

## Description
This PR introduces a new **Copilot** workbench that enables users to create and edit FreeCAD models using natural language prompts, with optional vision support for image-to-CAD generation.

### What's New

#### Copilot Workbench (`src/Mod/copilot/`)
- **Natural Language Interface** — Type prompts like *"create a box length 40 width 20 height 10"* or *"move selected x 10 y 0 z 5"* and watch the model update instantly.
- **Qt Dock Panel** — Integrated right-side panel with prompt input, image attachment, plan preview, and execution output.
- **Command Executor** — Safe, deterministic execution of a small command language for:
  - Primitives: `box`, `cylinder`, `sphere`, `cone`, `torus`
  - Transforms: `move`, `rotate`, `scale`, `color`, `delete`
  - Booleans: `fuse`, `cut`
  - View & file ops: `fit_view`, `save`, `open`
- **Image-to-CAD** — Attach a reference image and prompt *"create this object"*; the vision provider decomposes the image into parametric primitives.

#### Provider Architecture
| Provider | Requires API Key | Supports Images | Description |
|---|---|---|---|
| `local` (default) | No | No | Deterministic regex-based parser for common CAD prompts |
| `openai` | `OPENAI_API_KEY` | No | OpenAI Responses API with JSON schema enforcement |
| `openrouter` | `OPENROUTER_API_KEY` | Yes | OpenRouter Chat Completions with vision model support |

#### Docker Integration
- All provider env vars are injected via [docker-compose.yml](cci:7://file:///e:/Scratch%20Pad/MetaCad/FreeCAD/docker-compose.yml:0:0-0:0) and `.env`
- VNC desktop resolution configurable via `VNC_RESOLUTION` (default: `1920x1080x24`)
- noVNC auto-scales to fit the browser window (`resize=scale`)

#### Security Hardening
- API error responses are sanitized to prevent leaking keys/tokens
- File path validation blocks writes to `/dev/`, `/proc/`, `/sys/`, etc.
- AST parsing of function-style steps is pre-validated with regex to prevent injection
- Provider instances are refreshed per-call to respect runtime env changes

### Configuration
Copy [env.example](cci:7://file:///e:/Scratch%20Pad/MetaCad/FreeCAD/env.example:0:0-0:0) to `.env` and set your provider:

```bash
COPILOT_PROVIDER=openrouter
OPENROUTER_API_KEY="sk-or-v1-..."
OPENROUTER_MODEL=openai/gpt-4o-mini

<img width="1740" height="976" alt="image" src="https://github.com/user-attachments/assets/78117fe9-b28b-46cf-8adf-d6823f5e35da" />