### PR TITLE
CAM: Area - Improve offer side

### DIFF
--- a/src/Mod/CAM/Path/Op/Area.py
+++ b/src/Mod/CAM/Path/Op/Area.py
@@ -102,6 +102,10 @@ class ObjectOp(PathOp.ObjectOp):
 
         self.initAreaOp(obj)
 
+    def initAfterBase(self, obj):
+        if hasattr(obj, "Side"):
+            obj.Side = PathOpUtil.getOpSide(obj)
+
     def initAreaOp(self, obj):
         """initAreaOp(obj) ... overwrite if the receiver class needs initialisation.
         Can safely be overwritten by subclasses."""
@@ -133,16 +137,6 @@ class ObjectOp(PathOp.ObjectOp):
         # Path.Log.track(obj.Label, prop)
         if prop in ("AreaParams", "PathParams", "removalshape"):
             obj.setEditorMode(prop, 2)
-
-        if (
-            getattr(self, "init", False)
-            and hasattr(obj, "Side")
-            and prop == "FinalDepth"
-            and obj.Base
-        ):
-            # Offer side only while creating new operation
-            self.init = False
-            self.opSetDefaultSide(obj)
 
         self.areaOpOnChanged(obj, prop)
 
@@ -202,59 +196,11 @@ class ObjectOp(PathOp.ObjectOp):
             )
 
         self.areaOpSetDefaultValues(obj, job)
-        self.init = True  # using for offer 'Side' while creating new operation
 
     def areaOpSetDefaultValues(self, obj, job):
         """areaOpSetDefaultValues(obj, job) ... overwrite to set initial values of operation specific properties.
         Can safely be overwritten by subclasses."""
         pass
-
-    def opSetDefaultSide(self, obj):
-        """setDefaltSide(obj) ...  offer side while creating new operation"""
-        base, subNames = obj.Base[0]
-
-        # find parent boundbox
-        if isinstance(base.Shape, Part.Compound):
-            bbs = [shape.BoundBox for shape in base.Shape.SubShapes]
-        else:
-            bbs = [base.Shape.BoundBox]
-
-        subBb = None
-        if "Face" in subNames[0]:
-            faces = [base.Shape.getElement(sub) for sub in subNames if sub.startswith("Face")]
-            vFaces = [f for f in faces if not Path.Geom.isHorizontal(f)]
-            if vFaces:
-                # check if vertical faces creates a closed area
-                fzMin = min(e.BoundBox.ZMin for f in vFaces for e in f.Edges)
-                bottomEdges = [
-                    e for f in vFaces for e in f.Edges if isRoughly(e.BoundBox.ZMax, fzMin)
-                ]
-                wire = Part.Wire(Part.__sortEdges__(bottomEdges))
-                if not wire.isClosed():
-                    # for open area always offer 'Outside'
-                    obj.Side = "Outside"
-                    return
-            shape = Part.Compound(faces)
-            subBb = shape.BoundBox
-        elif "Edge" in subNames[0]:
-            edges = [base.Shape.getElement(sub) for sub in subNames if sub.startswith("Edge")]
-            wire = Part.Wire(Part.__sortEdges__(edges))
-            if not wire.isClosed():
-                # for open wire always offer 'Outside'
-                obj.Side = "Outside"
-                return
-            else:
-                subBb = wire.BoundBox
-
-        if subBb:
-            for bb in bbs:
-                if not bb.isInside(subBb):
-                    continue
-                if isRoughly(bb.XLength, subBb.XLength) and isRoughly(bb.YLength, subBb.YLength):
-                    obj.Side = "Outside"
-                else:
-                    obj.Side = "Inside"
-                return
 
     def getMiddlePointLongestEdge(self, shape):
         """getMiddlePointLongestEdge(shape) ... return middle point of longest edge from shape."""

--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -640,6 +640,12 @@ class ObjectOp(object):
         Should be overwritten by subclasses."""
         pass
 
+    def initAfterBase(self, obj):
+        """initAfterBase(obj) ... implement to execute extra commands
+        while create new operation after add all base geometry.
+        Should be overwritten by subclasses."""
+        pass
+
     def opOnDocumentRestored(self, obj):
         """opOnDocumentRestored(obj) ... implement if an op needs special handling like migrating the data model.
         Should be overwritten by subclasses."""

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -1589,6 +1589,8 @@ class TaskPanel(object):
                 if getattr(page, "InitBase", True) and hasattr(page, "addBase"):
                     page.clearBase()
                     page.addBaseGeometry(sel)
+            if hasattr(self.obj.Proxy, "initAfterBase"):
+                self.obj.Proxy.initAfterBase(self.obj)
 
         # Update properties based upon expressions in case expression value has changed
         for prp, expr in self.obj.ExpressionEngine:

--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -575,3 +575,76 @@ def getClearedAreas(currentOp, bbox):
         opPath = _stripRotaryAxes(op.Path) if rotated else op.Path
         clearedAreas.append(opPath.getClearedArea(diameter, z + dz, bbox))
     return clearedAreas
+
+
+def getOpSide(obj, default="Outside"):
+    """getOpSide(obj) ...  offer side for op base"""
+
+    def getVerticalFaces(edges, shape):
+        """Returns vertical faces (wall around) that contains given edges
+        Excludes faces which is longer than common edges"""
+        vFaces = []
+        for f in shape.Faces:
+            if len(vFaces) == len(edges):
+                break
+            if isHorizontal(f):
+                continue
+            for hEdge in edges:
+                hsh = hEdge.hashCode()
+                if any(hsh == e.hashCode() for e in f.Edges) and all(
+                    e.Length < hEdge.Length or isRoughly(hEdge.Length, e.Length)
+                    for e in f.Edges
+                    if isHorizontal(e)
+                ):
+                    vFaces.append(f)
+                    edges.remove(hEdge)
+                    break
+        return vFaces
+
+    if not obj.Base:
+        return default
+    isRoughly = Path.Geom.isRoughly
+    isHorizontal = Path.Geom.isHorizontal
+    base, subNames = obj.Base[0]
+    if "Face" in subNames[0]:
+        faces = [base.Shape.getElement(sub) for sub in subNames if sub.startswith("Face")]
+        vFaces = []
+        hFaces = []
+        for face in faces:
+            if isHorizontal(face):
+                hFaces.append(face)
+            else:
+                vFaces.append(face)
+        if vFaces:
+            volume = Part.Compound(vFaces).Volume
+            if volume > 0 or isRoughly(volume, 0):
+                return "Outside"
+            # check if vertical faces creates a closed area
+            fzMin = min(e.BoundBox.ZMin for f in vFaces for e in f.Edges)
+            bEdges = [e for f in vFaces for e in f.Edges if isRoughly(e.BoundBox.ZMax, fzMin)]
+            wire = Part.Wire(Part.__sortEdges__(bEdges))
+            if not wire.isClosed():  # for open area always offer 'Outside'
+                return "Outside"
+            if volume < 0 and not isRoughly(volume, 0):  # negative volume forms inner area
+                return "Inside"
+        if hFaces:
+            vFaces = getVerticalFaces(hFaces[0].OuterWire.Edges, base.Shape)
+            volume = Part.Compound(vFaces).Volume
+            if volume < 0 and not isRoughly(volume, 0):  # negative volume forms inner area
+                return "Inside"
+            else:
+                return "Outside"
+    elif "Edge" in subNames[0]:
+        edges = [base.Shape.getElement(sub) for sub in subNames if sub.startswith("Edge")]
+        cluster = Part.getSortedClusters(edges)[0]
+        wire = Part.Wire(Part.__sortEdges__(cluster))
+        if not wire.isClosed():  # for open wire always offer 'Outside'
+            return "Outside"
+        vFaces = getVerticalFaces(edges, base.Shape)
+        volume = Part.Compound(vFaces).Volume
+        if volume < 0 and not isRoughly(volume, 0):  # negative volume forms inner area
+            return "Inside"
+        else:
+            return "Outside"
+
+    return default


### PR DESCRIPTION
### Changes

- Added common method `initAfterBase()` to `Path.Op.Base`, which runs once after created new op after added all base geometry

- Move method `opSetDefaultSide()` from `Path.Op.Area` to `Path.Op.Util`
Will be used in #30977

- Using `BoundBox` to define side works correct only in simple cases
Suggest to use `Volume` instead

---

Test project: [side.zip](https://github.com/user-attachments/files/29750132/side.zip)

<img width="1182" height="397" alt="Screenshot_20260619_093237_hor_lossy" src="https://github.com/user-attachments/assets/b069398d-f668-40b6-bb0a-36e2f041e811" />

https://github.com/user-attachments/assets/04f2b576-0c4c-433c-ad07-92556c641a36