### PR TITLE
Sketcher: Polyline: Fix errors when arc invalid

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1068,6 +1068,10 @@ private:
             // We create the geometry first.
             createShape(false);
 
+            if (ShapeGeometry.empty()) {
+                return false;
+            }
+
             commandAddShapeGeometryAndConstraints();
 
             int geoId = getHighestCurveIndex();
@@ -1543,12 +1547,7 @@ private:
             double radius = getArcCenter(center, prevCursorPos);
 
             if (radius == 0.0) {
-                // fall back to a line
-                addLineToShapeGeometry(
-                    toVector3d(points[points.size() - 1]),
-                    toVector3d(prevCursorPos),
-                    isConstructionMode()
-                );
+                return;
             }
 
             double rx = lastPoint.x - center.x;


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/30323

When in arc mode, when the mouse goes around and goes on the previous line, then the behavior was bad. It was trying to fallback to a line, but was then still adding the bad arc. I don't think that falling back to a line makes sense anyway so I removed it instead. Now if you move to somewhere where the arc can't be made, it just does nothing. And clicking also does nothing.

https://github.com/user-attachments/assets/97290053-94da-4f75-96dd-226858ed5136

