### PR TITLE
Hints priority

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -54,6 +54,7 @@
 #include <QWhatsThis>
 #include <QWindow>
 #include <QPushButton>
+#include <QAbstractButton>
 #include <string>
 
 
@@ -114,6 +115,45 @@
 #include "WaitCursor.h"
 #include "WorkbenchManager.h"
 #include "Workbench.h"
+
+namespace
+{
+constexpr const char* kStatusBarFullTextProperty = "statusBarFullText";
+
+/// Apply ellipsis to text based on available widget width
+void setElidedText(QWidget* widget, const QString& fullText)
+{
+    if (!widget) {
+        return;
+    }
+    const QString text = fullText.simplified();
+    widget->setProperty(kStatusBarFullTextProperty, text);
+    widget->setToolTip(text);
+
+    QFontMetrics fm(widget->font());
+    int availableWidth = std::max(1, widget->width());
+    QString elided = fm.elidedText(text, Qt::ElideMiddle, availableWidth);
+
+    if (auto* label = qobject_cast<QLabel*>(widget)) {
+        label->setText(elided);
+    }
+    else if (auto* button = qobject_cast<QAbstractButton*>(widget)) {
+        button->setText(elided);
+    }
+}
+
+/// Refresh elided text when widget size changes
+void refreshElidedText(QWidget* widget)
+{
+    if (!widget) {
+        return;
+    }
+    const QVariant fullText = widget->property(kStatusBarFullTextProperty);
+    if (fullText.isValid()) {
+        setElidedText(widget, fullText.toString());
+    }
+}
+}  // namespace
 
 #include "MergeDocuments.h"
 #include "ViewProviderExtern.h"
@@ -417,13 +457,24 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     statusBar()->setObjectName(QStringLiteral("statusBar"));
     connect(statusBar(), &QStatusBar::messageChanged, this, &MainWindow::statusMessageChanged);
 
-    // labels and progressbar
     d->status = new StatusBarObserver();
+
+    // High-priority hints (stretch=100): never clipped by other widgets
+    d->hintLabel = new InputHintWidget(statusBar());
+    d->hintLabel->setObjectName(QStringLiteral("hintLabel"));
+    d->hintLabel->setWindowTitle(tr("Input Hints"));
+    statusBar()->addWidget(d->hintLabel, 100);
+
+    // Low-priority preselection (stretch=1): clipped first when space limited
     d->actionLabel = new StatusBarLabel(statusBar());
     d->actionLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    d->sizeLabel = new DimensionWidget(statusBar());
-
+    d->actionLabel->setWindowTitle(tr("Preselection"));
+    d->actionLabel->installEventFilter(this);
     statusBar()->addWidget(d->actionLabel, 1);
+
+    // Size/unit label with resize tracking for ellipsis refresh
+    d->sizeLabel = new DimensionWidget(statusBar());
+    d->sizeLabel->installEventFilter(this);
 
     QProgressBar* progressBar = Gui::SequencerBar::instance()->getProgressBar(statusBar());
     statusBar()->addPermanentWidget(progressBar, 0);
@@ -450,21 +501,13 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     });
     statusBar()->addPermanentWidget(toggleBottomPanelsButton);
 
-    // hint label
-    d->hintLabel = new InputHintWidget(statusBar());
-    d->hintLabel->setObjectName(QStringLiteral("hintLabel"));
-    //: A context menu action used to show or hide the input hints in the status bar
-    d->hintLabel->setWindowTitle(tr("Input Hints"));
-
-    statusBar()->addWidget(d->hintLabel);
-
-    // right side label
+    // Right-side label with ellipsis support (toggleable via context menu)
     d->rightSideLabel = new StatusBarLabel(statusBar(), "QuickMeasureEnabled");
-    d->rightSideLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    statusBar()->addPermanentWidget(d->rightSideLabel);
     d->rightSideLabel->setObjectName(QStringLiteral("rightSideLabel"));
-    //: A context menu action used to enable or disable quick measure in the status bar
+    d->rightSideLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    d->rightSideLabel->installEventFilter(this);
     d->rightSideLabel->setWindowTitle(tr("Quick Measure"));
+    statusBar()->addPermanentWidget(d->rightSideLabel);
 
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/NotificationArea"
@@ -1206,6 +1249,12 @@ bool MainWindow::event(QEvent* e)
 
 bool MainWindow::eventFilter(QObject* o, QEvent* e)
 {
+    // Refresh elided text when widgets resize to show/hide content appropriately
+    if (o->isWidgetType() && (e->type() == QEvent::Resize || e->type() == QEvent::LayoutRequest)) {
+        if (o == d->actionLabel || o == d->rightSideLabel || o == d->sizeLabel) {
+            refreshElidedText(static_cast<QWidget*>(o));
+        }
+    }
     if (o != this) {
         if (e->type() == QEvent::WindowStateChange) {
             // notify all mdi views when the active view receives a show normal, show minimized
@@ -2599,7 +2648,8 @@ void MainWindow::showMessage(const QString& message, int timeout)
         QApplication::postEvent(this, new CustomMessageEvent(MainWindow::Tmp, message, timeout));
         return;
     }
-    d->actionLabel->setText(message.simplified());
+    // Apply ellipsis to preselection text if it exceeds available width
+    setElidedText(d->actionLabel, message);
     if (timeout) {
         d->actionTimer->setSingleShot(true);
         d->actionTimer->start(timeout);
@@ -2611,7 +2661,7 @@ void MainWindow::showMessage(const QString& message, int timeout)
 
 void MainWindow::setRightSideMessage(const QString& message)
 {
-    d->rightSideLabel->setText(message.simplified());
+    setElidedText(d->rightSideLabel, message);
 }
 
 bool MainWindow::isRightSideMessageVisible() const
@@ -2672,7 +2722,7 @@ void MainWindow::setPaneText(int i, QString text)
         showStatus(MainWindow::Pane, text);
     }
     else if (i == 2) {
-        d->sizeLabel->setText(text);
+        setElidedText(d->sizeLabel, text);
     }
 }
 

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -119,6 +119,7 @@
 namespace
 {
 constexpr const char* kStatusBarFullTextProperty = "statusBarFullText";
+constexpr const char* kInputHintsVisibleProperty = "inputHintsVisible";
 
 /// Apply ellipsis to text based on available widget width
 void setElidedText(QWidget* widget, const QString& fullText)
@@ -153,6 +154,95 @@ void refreshElidedText(QWidget* widget)
         setElidedText(widget, fullText.toString());
     }
 }
+
+enum class InputHintsVisibility
+{
+    Hidden,
+    Visible
+};
+
+bool hasInputHints(const std::list<Gui::InputHint>& hints)
+{
+    return !hints.empty();
+}
+
+// Store the last applied hint visibility
+bool inputHintsVisibilityProperty(const QWidget* widget)
+{
+    if (!widget) {
+        return false;
+    }
+
+    const QVariant value = widget->property(kInputHintsVisibleProperty);
+    if (!value.isValid()) {
+        return widget->isVisible();
+    }
+
+    return value.toBool();
+}
+
+void setInputHintsVisibilityProperty(QWidget* widget, bool visible)
+{
+    if (!widget) {
+        return;
+    }
+
+    widget->setProperty(kInputHintsVisibleProperty, visible);
+}
+
+// Show or hide the input hints widget
+void applyInputHintsVisibility(QWidget* widget, InputHintsVisibility visibility)
+{
+    if (!widget) {
+        return;
+    }
+
+    const bool visible = visibility == InputHintsVisibility::Visible;
+
+    if (inputHintsVisibilityProperty(widget) == visible && widget->isVisible() == visible) {
+        return;
+    }
+
+    setInputHintsVisibilityProperty(widget, visible);
+    widget->setVisible(visible);
+}
+
+void clearInputHints(Gui::InputHintWidget* hintWidget)
+{
+    if (!hintWidget) {
+        return;
+    }
+
+    hintWidget->clearHints();
+}
+
+// Empty hints should not reserve space in the status bar
+void hideInputHints(Gui::InputHintWidget* hintWidget)
+{
+    if (!hintWidget) {
+        return;
+    }
+
+    clearInputHints(hintWidget);
+    applyInputHintsVisibility(hintWidget, InputHintsVisibility::Hidden);
+}
+
+// Keep hints visible only while there is useful hint content to show
+void showInputHints(Gui::InputHintWidget* hintWidget, const std::list<Gui::InputHint>& hints)
+{
+    if (!hintWidget) {
+        return;
+    }
+
+    if (!hasInputHints(hints)) {
+        hideInputHints(hintWidget);
+        return;
+    }
+
+    applyInputHintsVisibility(hintWidget, InputHintsVisibility::Visible);
+    hintWidget->showHints(hints);
+}
+
 }  // namespace
 
 #include "MergeDocuments.h"
@@ -464,6 +554,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     d->hintLabel->setObjectName(QStringLiteral("hintLabel"));
     d->hintLabel->setWindowTitle(tr("Input Hints"));
     statusBar()->addWidget(d->hintLabel, 100);
+    applyInputHintsVisibility(d->hintLabel, InputHintsVisibility::Hidden);
 
     // Low-priority preselection (stretch=1): clipped first when space limited
     d->actionLabel = new StatusBarLabel(statusBar());
@@ -2707,12 +2798,12 @@ void MainWindow::showStatus(int type, const QString& message)
 
 void MainWindow::showHints(const std::list<InputHint>& hints)
 {
-    d->hintLabel->showHints(hints);
+    showInputHints(d->hintLabel, hints);
 }
 
 void MainWindow::hideHints()
 {
-    d->hintLabel->clearHints();
+    hideInputHints(d->hintLabel);
 }
 
 // set text to the pane

--- a/src/Mod/Draft/draftutils/init_draft_statusbar.py
+++ b/src/Mod/Draft/draftutils/init_draft_statusbar.py
@@ -252,7 +252,7 @@ def init_draft_statusbar_scale():
     scale_widget.scaleLabel = scaleLabel
 
     # add scale widget to the statusbar
-    sb.insertPermanentWidget(3, scale_widget)
+    sb.addPermanentWidget(scale_widget)
     scale_widget.show()
 
 
@@ -290,7 +290,7 @@ def init_draft_statusbar_snap():
     snap_widget.setWindowTitle(text)
     snap_widget.setOrientation(QtCore.Qt.Orientation.Horizontal)
     snap_widget.setIconSize(QtCore.QSize(16, 16))
-    sb.insertPermanentWidget(2, snap_widget)
+    sb.addPermanentWidget(snap_widget)
 
     # grid button:
     snap_widget.addAction(Gui.Command.get("Draft_ToggleGrid").getAction()[0])
@@ -343,7 +343,7 @@ def show_draft_statusbar_scale():
     else:
         scale_widget = mw.findChild(QtWidgets.QToolBar, "draft_scale_widget")
         if scale_widget:
-            sb.insertPermanentWidget(3, scale_widget)
+            sb.addPermanentWidget(scale_widget)
             scale_widget.show()
         else:
             init_draft_statusbar_scale()
@@ -363,7 +363,7 @@ def show_draft_statusbar_snap():
     else:
         snap_widget = mw.findChild(QtWidgets.QToolBar, "draft_snap_widget")
         if snap_widget:
-            sb.insertPermanentWidget(2, snap_widget)
+            sb.addPermanentWidget(snap_widget)
             snap_widget.setOrientation(QtCore.Qt.Orientation.Horizontal)
             snap_widget.show()
         else:

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(Gui_tests_run
         StyleParameters/YamlParameterSourceTest.cpp
         InputHintTest.cpp
         SelectionTest.cpp
+        StatusBarHintsPriorityTest.cpp
 )
 
 # Qt tests

--- a/tests/src/Gui/StatusBarHintsPriorityTest.cpp
+++ b/tests/src/Gui/StatusBarHintsPriorityTest.cpp
@@ -39,7 +39,8 @@ TEST_F(StatusBarHintsPriorityTest, TextSimplification)
 // Test that QString contains() and length() work
 TEST_F(StatusBarHintsPriorityTest, StringProcessing)
 {
-    QString longText = "This is a very long text that should be ellipsed when the widget is too narrow";
+    QString longText
+        = "This is a very long text that should be ellipsed when the widget is too narrow";
     EXPECT_GT(longText.length(), 50);
 
     QString shortText = "Short";

--- a/tests/src/Gui/StatusBarHintsPriorityTest.cpp
+++ b/tests/src/Gui/StatusBarHintsPriorityTest.cpp
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <gtest/gtest.h>
+#include "MainWindow.h"
+#include <QWidget>
+#include <QApplication>
 #include <QString>
 #include <algorithm>
 
@@ -48,4 +51,23 @@ TEST_F(StatusBarHintsPriorityTest, PropertyNameConstant)
 {
     constexpr const char* kStatusBarFullTextProperty = "statusBarFullText";
     EXPECT_STREQ(kStatusBarFullTextProperty, "statusBarFullText");
+}
+
+// Test that an empty hints list hides the input hints widget
+TEST_F(StatusBarHintsPriorityTest, EmptyHintsHideInputHintsWidget)
+{
+    ASSERT_NE(qApp, nullptr) << "This test requires a QApplication instance.";
+    Gui::MainWindow mainWindow;
+
+    auto* hintWidget = mainWindow.findChild<QWidget*>(QStringLiteral("hintLabel"));
+    ASSERT_NE(hintWidget, nullptr);
+
+    // Simulate a previously visible hints widget
+    hintWidget->show();
+    ASSERT_FALSE(hintWidget->isHidden());
+
+    // An empty hints list should clear and hide the high-priority hints widget
+    mainWindow.showHints({});
+
+    EXPECT_TRUE(hintWidget->isHidden());
 }

--- a/tests/src/Gui/StatusBarHintsPriorityTest.cpp
+++ b/tests/src/Gui/StatusBarHintsPriorityTest.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+#include <QString>
+#include <algorithm>
+
+class StatusBarHintsPriorityTest: public ::testing::Test
+{
+protected:
+    StatusBarHintsPriorityTest() = default;
+};
+
+// Test that ellipsis logic with std::max works correctly
+TEST_F(StatusBarHintsPriorityTest, MinimumWidthCalculation)
+{
+    // Simulate the std::max(1, widget->width()) logic from setElidedText
+    int widgetWidth = 0;
+    int availableWidth = std::max(1, widgetWidth);
+    EXPECT_EQ(availableWidth, 1);
+
+    widgetWidth = 50;
+    availableWidth = std::max(1, widgetWidth);
+    EXPECT_EQ(availableWidth, 50);
+}
+
+// Test that QString simplification works
+TEST_F(StatusBarHintsPriorityTest, TextSimplification)
+{
+    QString text = "  Multiple   spaces   and   newlines  \n  ";
+    QString simplified = text.simplified();
+
+    EXPECT_EQ(simplified, "Multiple spaces and newlines");
+    EXPECT_FALSE(simplified.contains("  "));
+}
+
+// Test that QString contains() and length() work
+TEST_F(StatusBarHintsPriorityTest, StringProcessing)
+{
+    QString longText = "This is a very long text that should be ellipsed when the widget is too narrow";
+    EXPECT_GT(longText.length(), 50);
+
+    QString shortText = "Short";
+    EXPECT_LT(shortText.length(), longText.length());
+}
+
+// Test property name constant
+TEST_F(StatusBarHintsPriorityTest, PropertyNameConstant)
+{
+    constexpr const char* kStatusBarFullTextProperty = "statusBarFullText";
+    EXPECT_STREQ(kStatusBarFullTextProperty, "statusBarFullText");
+}


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
## Issues
Fixes #29632

## Summary

This patch prioritizes tool hints in the status bar over less relevant widgets such as preselection text. Hints now have a high stretch factor and are never clipped, while preselection text gets ellipsis when space is limited, with the full text preserved in a tooltip for accessibility. Draft status bar widgets were also changed from `insertPermanentWidget()` to `addPermanentWidget()` to prevent unintended reordering.

A follow-up extension hides the hints widget entirely when there are no active hints, preventing empty high-priority space from being reserved unnecessarily. When hints become active again, the widget is restored.

C++ tests were added to validate the ellipsis logic, text handling, and the empty hints regression case.

Signed-off-by: Tomás Mendes <tomasmendes02@tecnico.ulisboa.pt>
Co-authored-by: Beatriz Reis <beatriz.reis@tecnico.ulisboa.pt>