### PR TITLE
BIM: fix ArchMaterial issue with Building US unit system

### DIFF
--- a/src/Mod/BIM/ArchMaterial.py
+++ b/src/Mod/BIM/ArchMaterial.py
@@ -1001,7 +1001,8 @@ class _ArchMultiMaterialTaskPanel:
         try:
             return float(text) * pref_factor
         except ValueError:
-            return FreeCAD.Units.Quantity(text).Value
+            # Workaround for Building US unit system bug (Version 1.1, 2026):
+            return FreeCAD.Units.Quantity(text.replace("+", "--")).Value
 
     def recalcThickness(self, item=None):
         prefix = translate("Arch", "Total thickness") + ": "


### PR DESCRIPTION
Fixes #29563.

Using the well known workaround again: `replace("+", "--")`.