### PR TITLE
Gui: Fix HiDPI issues

### DIFF
--- a/src/Gui/EditableDatumLabel.cpp
+++ b/src/Gui/EditableDatumLabel.cpp
@@ -21,6 +21,7 @@
  *                                                                          *
  ***************************************************************************/
 
+#include <cmath>
 #include <limits>
 #include <Inventor/sensors/SoNodeSensor.h>
 #include <Inventor/nodes/SoAnnotation.h>
@@ -109,7 +110,10 @@ EditableDatumLabel::EditableDatumLabel(
     label->ref();
     label->string = " ";
     setDeactivatedColor();
-    label->size.setValue(17);
+    // Scale the font size by the device pixelratio so the on-view-parameter value keeps a constant
+    // perceived size on HiDPI displays (SoDatumLabel renders the text in physical pixels).
+    const double dpr = view ? view->devicePixelRatio() : 1.0;
+    label->size.setValue(static_cast<int>(std::lround(17 * dpr)));
     label->lineWidth = 2.0;
     label->useAntialiasing = false;
     label->datumtype = SoDatumLabel::DISTANCE;

--- a/src/Gui/Inventor/SoAxisCrossKit.cpp
+++ b/src/Gui/Inventor/SoAxisCrossKit.cpp
@@ -61,6 +61,7 @@
 
 #include "SoAxisCrossKit.h"
 #include "SoDevicePixelRatioElement.h"
+#include <SoTextLabel.h>
 
 using namespace Gui;
 
@@ -285,7 +286,7 @@ SoRegPoint::SoRegPoint()
     auto sub = new SoSeparator();
     sub->addChild(col);
     sub->addChild(font);
-    sub->addChild(new SoText2());
+    sub->addChild(new SoFCText2());
     root->addChild(sub);
 }
 

--- a/src/Gui/Inventor/SoFCBoundingBox.cpp
+++ b/src/Gui/Inventor/SoFCBoundingBox.cpp
@@ -32,6 +32,7 @@
 #include <Inventor/nodes/SoTransform.h>
 
 #include "SoFCBoundingBox.h"
+#include <SoTextLabel.h>
 
 
 using namespace Gui;
@@ -81,7 +82,7 @@ SoFCBoundingBox::SoFCBoundingBox()
         auto temp = new SoSeparator();
         auto trans = new SoTransform();
         temp->addChild(trans);
-        auto text = new SoText2();
+        auto text = new SoFCText2();
         text->justification.setValue(SoText2::CENTER);
         temp->addChild(text);
         textSep->addChild(temp);
@@ -93,7 +94,7 @@ SoFCBoundingBox::SoFCBoundingBox()
         auto temp = new SoSeparator();
         auto trans = new SoTransform();
         temp->addChild(trans);
-        auto text = new SoText2();
+        auto text = new SoFCText2();
         text->justification.setValue(SoText2::CENTER);
         temp->addChild(text);
         dimSep->addChild(temp);

--- a/src/Gui/SoFCColorLegend.cpp
+++ b/src/Gui/SoFCColorLegend.cpp
@@ -33,6 +33,7 @@
 
 
 #include "SoFCColorLegend.h"
+#include "SoTextLabel.h"
 #include "ViewProvider.h"
 
 
@@ -155,7 +156,7 @@ void SoFCColorLegend::setMarkerLabel(const SoMFString& label)
         for (int i = 0; i < num; i++) {
             auto trans = new SoTransform;
             auto color = new SoBaseColor;
-            auto text2 = new SoText2;
+            auto text2 = new SoFCText2;
 
             trans->translation.setValue(pos[i + 1]);
             color->rgb.setValue(0, 0, 0);
@@ -182,7 +183,7 @@ void SoFCColorLegend::setMarkerValue(const SoMFString& value)
         for (int i = 0; i < num; i++) {
             auto trans = new SoTransform;
             auto color = new SoBaseColor;
-            auto text2 = new SoText2;
+            auto text2 = new SoFCText2;
 
             trans->translation.setValue(pos[i + 1]);
             color->rgb.setValue(0, 0, 0);

--- a/src/Gui/SoFCDB.cpp
+++ b/src/Gui/SoFCDB.cpp
@@ -137,6 +137,7 @@ void Gui::SoFCDB::init()
     SoSelectionElementAction ::initClass();
     SoVRMLAction ::initClass();
     SoSkipBoundingGroup ::initClass();
+    SoFCText2 ::initClass();
     SoTextLabel ::initClass();
     SoDatumLabel ::initClass();
     SoColorBarLabel ::initClass();

--- a/src/Gui/SoTextLabel.cpp
+++ b/src/Gui/SoTextLabel.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include <algorithm>
+#include <cmath>
 
 #include <QFontMetrics>
 #include <QOpenGLContext>
@@ -47,6 +48,7 @@
 #include <Inventor/draggers/SoTranslate2Dragger.h>
 #include <Inventor/elements/SoCullElement.h>
 #include <Inventor/elements/SoFontNameElement.h>
+#include <Inventor/elements/SoFontSizeElement.h>
 #include <Inventor/elements/SoGLTextureEnabledElement.h>
 #include <Inventor/elements/SoModelMatrixElement.h>
 #include <Inventor/elements/SoProjectionMatrixElement.h>
@@ -56,6 +58,7 @@
 #include <Inventor/elements/SoMultiTextureEnabledElement.h>
 
 #include "SoTextLabel.h"
+#include "SoDevicePixelRatioElement.h"
 #include "SoFCInteractiveElement.h"
 #include "Tools.h"
 
@@ -63,11 +66,59 @@
 using namespace Gui;
 
 
+SO_NODE_SOURCE(SoFCText2)
+
+void SoFCText2::initClass()
+{
+    SO_NODE_INIT_CLASS(SoFCText2, SoText2, "Text2");
+}
+
+SoFCText2::SoFCText2()
+{
+    SO_NODE_CONSTRUCTOR(SoFCText2);
+}
+
+namespace
+{
+// Multiply the current font size element by the device pixel ratio so screen-space
+// text keeps a constant perceived size on HiDPI displays. SoDevicePixelRatioElement
+// is only enabled for the GL render action, so guard against other actions (e.g.
+// bounding box) where reading it would trip the element-enabled assertion.
+void scaleFontSizeByDevicePixelRatio(SoState* state, SoNode* node)
+{
+    if (!state->isElementEnabled(SoDevicePixelRatioElement::getClassStackIndex())) {
+        return;
+    }
+    const float dpr = SoDevicePixelRatioElement::get(state);
+    SoFontSizeElement::set(state, node, SoFontSizeElement::get(state) * dpr);
+}
+}  // namespace
+
+void SoFCText2::GLRender(SoGLRenderAction* action)
+{
+    SoState* state = action->getState();
+    state->push();
+    scaleFontSizeByDevicePixelRatio(state, this);
+    inherited::GLRender(action);
+    state->pop();
+}
+
+void SoFCText2::computeBBox(SoAction* action, SbBox3f& box, SbVec3f& center)
+{
+    SoState* state = action->getState();
+    state->push();
+    scaleFontSizeByDevicePixelRatio(state, this);
+    inherited::computeBBox(action, box, center);
+    state->pop();
+}
+
+// ------------------------------------------------------
+
 SO_NODE_SOURCE(SoTextLabel)
 
 void SoTextLabel::initClass()
 {
-    SO_NODE_INIT_CLASS(SoTextLabel, SoText2, "Text2");
+    SO_NODE_INIT_CLASS(SoTextLabel, SoFCText2, "FCText2");
 }
 
 SoTextLabel::SoTextLabel()
@@ -230,7 +281,7 @@ SO_NODE_SOURCE(SoColorBarLabel)
 
 void SoColorBarLabel::initClass()
 {
-    SO_NODE_INIT_CLASS(SoColorBarLabel, SoText2, "Text2");
+    SO_NODE_INIT_CLASS(SoColorBarLabel, SoFCText2, "FCText2");
 }
 
 SoColorBarLabel::SoColorBarLabel()
@@ -415,7 +466,13 @@ void SoFrameLabel::drawImage()
         return;
     }
 
-    QFont font(QString::fromLatin1(QByteArray(name.getValue())), size.getValue());
+    // Render the image at the active device pixel ratio so it stays crisp and
+    // keeps a constant perceived size on HiDPI displays (SoImage blits the image
+    // one texel per physical framebuffer pixel).
+    const float dpr = renderDpr;
+
+    QFont font(QString::fromLatin1(QByteArray(name.getValue())), -1);
+    font.setPointSizeF(size.getValue() * dpr);
     QFontMetrics fm(font);
     int w = 0;
     int h = fm.height() * num;
@@ -425,7 +482,7 @@ void SoFrameLabel::drawImage()
     const SbColor& t = textColor.getValue();
     QColor front;
     front.setRgbF(t[0], t[1], t[2]);
-    const QPen borderPen(QColor(0, 0, 127), 2, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
+    const QPen borderPen(QColor(0, 0, 127), 2 * dpr, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
 
     QStringList lines;
     for (int i = 0; i < num; i++) {
@@ -434,7 +491,7 @@ void SoFrameLabel::drawImage()
         lines << line;
     }
 
-    int padding = 5;
+    int padding = std::lround(5 * dpr);
 
     bool drawIcon = false;
     QImage iconImg;
@@ -443,6 +500,17 @@ void SoFrameLabel::drawImage()
     if (!iconPixmap.isNull()) {
         drawIcon = true;
         iconImg = iconPixmap.toImage();
+        // The icon pixmap may already carry a HiDPI device pixel ratio (e.g. it
+        // was rendered by pixmapFromSvg at size * dpr). Render it at its
+        // device-independent size times the label's device pixel ratio so it
+        // matches the text scaling, fills its slot and stays centered. The ratio
+        // is reset to 1 so the resulting pixels are taken at face value.
+        const qreal iconDpr = iconImg.devicePixelRatio();
+        const int targetWidth = std::lround(iconImg.width() / iconDpr * dpr);
+        const int targetHeight = std::lround(iconImg.height() / iconDpr * dpr);
+        iconImg.setDevicePixelRatio(1.0);
+        iconImg
+            = iconImg.scaled(targetWidth, targetHeight, Qt::KeepAspectRatio, Qt::SmoothTransformation);
         widthIcon = iconImg.width() + 2 * padding;
         heightIcon = iconImg.height() + 2 * padding;
     }
@@ -466,7 +534,8 @@ void SoFrameLabel::drawImage()
         painter.setBrush(QBrush(drawFrame ? backgroundBrush : Qt::transparent));
 
         QRectF rectangle(0.0, 0.0, widthTotal, heightTotal);
-        painter.drawRoundedRect(rectangle, 5, 5);
+        const qreal radius = 5 * dpr;
+        painter.drawRoundedRect(rectangle, radius, radius);
     }
 
     if (drawIcon) {
@@ -500,6 +569,13 @@ void SoFrameLabel::drawImage()
  */
 void SoFrameLabel::GLRender(SoGLRenderAction* action)
 {
+    // Re-render the label image whenever the device pixel ratio changes (e.g. the
+    // window moves to another monitor) so it matches the current display density.
+    const float dpr = SoDevicePixelRatioElement::get(action->getState());
+    if (dpr != this->renderDpr) {
+        this->renderDpr = dpr;
+        drawImage();
+    }
 
     if (backgroundUseBaseColor.getValue()) {
         SoState* state = action->getState();

--- a/src/Gui/SoTextLabel.h
+++ b/src/Gui/SoTextLabel.h
@@ -40,12 +40,34 @@ namespace Gui
 {
 
 /**
+ * A screen-space text node that scales its font size by the device pixel ratio so
+ * that the text keeps a constant perceived size on HiDPI displays instead of being
+ * rendered at half size in physical framebuffer pixels.
+ * @author Werner Mayer
+ */
+class GuiExport SoFCText2: public SoText2
+{
+    using inherited = SoText2;
+
+    SO_NODE_HEADER(SoFCText2);
+
+public:
+    static void initClass();
+    SoFCText2();
+
+protected:
+    ~SoFCText2() override = default;
+    void GLRender(SoGLRenderAction* action) override;
+    void computeBBox(SoAction* action, SbBox3f& box, SbVec3f& center) override;
+};
+
+/**
  * A text label with a background color.
  * @author Werner Mayer
  */
-class GuiExport SoTextLabel: public SoText2
+class GuiExport SoTextLabel: public SoFCText2
 {
-    using inherited = SoText2;
+    using inherited = SoFCText2;
 
     SO_NODE_HEADER(SoTextLabel);
 
@@ -66,9 +88,9 @@ protected:
  * A text label for the color bar.
  * @author Werner Mayer
  */
-class GuiExport SoColorBarLabel: public SoText2
+class GuiExport SoColorBarLabel: public SoFCText2
 {
-    using inherited = SoText2;
+    using inherited = SoFCText2;
 
     SO_NODE_HEADER(SoColorBarLabel);
 
@@ -138,6 +160,11 @@ protected:
 
 private:
     void drawImage();
+
+    // Device pixel ratio the current image was rendered at. The image is
+    // re-rendered at the active ratio so the text stays crisp and keeps a
+    // constant perceived size on HiDPI displays.
+    float renderDpr {1.0F};
 };
 
 class GuiExport TranslateManip: public SoTransformManip

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -4475,9 +4475,12 @@ void View3DInventorViewer::drawAxisCross()
 
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glPixelZoom((float)axiscrossSize / 30, (float)axiscrossSize / 30);  // 30 = 3 (character pixmap
-                                                                        // ratio) * 10 (default
-                                                                        // axiscrossSize)
+    // The viewport above is sized in physical framebuffer pixels, so the bitmap
+    // letters must be zoomed by the device pixel ratio to keep the same perceived
+    // size as the cross on HiDPI displays.
+    // 30 = 3 (character pixmap ratio) * 10 (default axiscrossSize)
+    const float letterZoom = (float)axiscrossSize / 30 * (float)devicePixelRatio();
+    glPixelZoom(letterZoom, letterZoom);
     glRasterPos2d(xpos[0], xpos[1]);
     glDrawPixels(XPM_WIDTH, XPM_HEIGHT, GL_RGBA, GL_UNSIGNED_BYTE, XPM_pixel_data);
     glRasterPos2d(ypos[0], ypos[1]);

--- a/src/Gui/ViewProviderAnnotation.cpp
+++ b/src/Gui/ViewProviderAnnotation.cpp
@@ -33,7 +33,6 @@
 #include <Inventor/nodes/SoCoordinate3.h>
 #include <Inventor/nodes/SoDrawStyle.h>
 #include <Inventor/nodes/SoFont.h>
-#include <Inventor/nodes/SoImage.h>
 #include <Inventor/nodes/SoLineSet.h>
 #include <Inventor/nodes/SoPointSet.h>
 #include <Inventor/nodes/SoRotationXYZ.h>
@@ -53,6 +52,7 @@
 #include "BitmapFactory.h"
 #include "Document.h"
 #include "SoFCSelection.h"
+#include "SoTextLabel.h"
 #include "Tools.h"
 #include "Window.h"
 
@@ -87,7 +87,7 @@ ViewProviderAnnotation::ViewProviderAnnotation()
 
     pFont = new SoFont();
     pFont->ref();
-    pLabel = new SoText2();
+    pLabel = new SoFCText2();
     pLabel->ref();
     pLabel3d = new SoAsciiText();
     pLabel3d->ref();
@@ -284,7 +284,7 @@ ViewProviderAnnotationLabel::ViewProviderAnnotationLabel()
     pTextTranslation->ref();
     pCoords = new SoCoordinate3();
     pCoords->ref();
-    pImage = new SoImage();
+    pImage = new SoFrameLabel();
     pImage->ref();
 
     BackgroundColor.touch();
@@ -435,60 +435,27 @@ void ViewProviderAnnotationLabel::dragMotionCallback(void* data, SoDragger* drag
 void ViewProviderAnnotationLabel::drawImage(const std::vector<std::string>& s)
 {
     if (s.empty()) {
-        pImage->image = SoSFImage();
+        pImage->string.setNum(0);
         this->hide();
         return;
     }
 
-    QFont font(QString::fromLatin1(this->FontName.getValue()), (int)this->FontSize.getValue());
-    QFontMetrics fm(font);
-    int w = 0;
-    int h = fm.height() * s.size();
-    const Base::Color& b = this->BackgroundColor.getValue();
-    QColor brush;
-    brush.setRgbF(b.r, b.g, b.b);
+    // Delegate the actual rendering to SoFrameLabel, which renders the text into
+    // an image at the active device pixel ratio so the label stays crisp and keeps
+    // a constant perceived size on HiDPI displays.
     const Base::Color& t = this->TextColor.getValue();
-    QColor front;
-    front.setRgbF(t.r, t.g, t.b);
+    pImage->textColor.setValue(t.r, t.g, t.b);
+    const Base::Color& b = this->BackgroundColor.getValue();
+    pImage->backgroundColor.setValue(b.r, b.g, b.b);
+    pImage->name = this->FontName.getValue();
+    pImage->size = (int)this->FontSize.getValue();
+    pImage->justification = this->Justification.getValue();
+    const bool drawFrame = this->Frame.getValue();
+    pImage->frame = drawFrame;
+    pImage->border = drawFrame;
 
-    QStringList lines;
-    for (const auto& it : s) {
-        QString line = QString::fromUtf8(it.c_str());
-        w = std::max<int>(w, QtTools::horizontalAdvance(fm, line));
-        lines << line;
+    pImage->string.setNum((int)s.size());
+    for (std::size_t i = 0; i < s.size(); i++) {
+        pImage->string.set1Value((int)i, SbString(s[i].c_str()));
     }
-
-    QImage image(w + 10, h + 10, QImage::Format_ARGB32_Premultiplied);
-    image.fill(0x00000000);
-    QPainter painter(&image);
-    painter.setRenderHint(QPainter::Antialiasing);
-
-    bool drawFrame = this->Frame.getValue();
-    if (drawFrame) {
-        painter.setPen(QPen(QColor(0, 0, 127), 2, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
-        painter.setBrush(QBrush(brush, Qt::SolidPattern));
-        QRectF rectangle(0.0, 0.0, w + 10, h + 10);
-        painter.drawRoundedRect(rectangle, 5, 5);
-    }
-
-    painter.setPen(front);
-
-    Qt::Alignment align = Qt::AlignVCenter;
-    if (Justification.getValue() == 0) {
-        align = Qt::AlignVCenter | Qt::AlignLeft;
-    }
-    else if (Justification.getValue() == 1) {
-        align = Qt::AlignVCenter | Qt::AlignRight;
-    }
-    else {
-        align = Qt::AlignVCenter | Qt::AlignHCenter;
-    }
-    QString text = lines.join(QLatin1String("\n"));
-    painter.setFont(font);
-    painter.drawText(5, 5, w, h, align, text);
-    painter.end();
-
-    SoSFImage sfimage;
-    Gui::BitmapFactory().convert(image, sfimage);
-    pImage->image = sfimage;
 }

--- a/src/Gui/ViewProviderAnnotation.h
+++ b/src/Gui/ViewProviderAnnotation.h
@@ -34,7 +34,6 @@ class SoBaseColor;
 class SoTranslation;
 class SoTransform;
 class SoRotationXYZ;
-class SoImage;
 class SoCoordinate3;
 
 namespace Gui
@@ -117,7 +116,7 @@ private:
 
 private:
     SoCoordinate3* pCoords;
-    SoImage* pImage;
+    SoFrameLabel* pImage;
     SoBaseColor* pColor;
     SoTranslation* pBaseTranslation;
     TranslateManip* pTextTranslation;

--- a/src/Mod/Measure/App/Preferences.cpp
+++ b/src/Mod/Measure/App/Preferences.cpp
@@ -75,7 +75,7 @@ Base::Color Preferences::defaultTextBackgroundColor()
 
 int Preferences::defaultFontSize()
 {
-    return getPreferenceGroup("Appearance")->GetInt("DefaultFontSize", 18);
+    return getPreferenceGroup("Appearance")->GetInt("DefaultFontSize", 16);
 }
 
 int Preferences::defaultArrowRadius()

--- a/src/Mod/Measure/Gui/DlgPrefsMeasureAppearanceImp.ui
+++ b/src/Mod/Measure/Gui/DlgPrefsMeasureAppearanceImp.ui
@@ -79,7 +79,7 @@
            <number>1</number>
           </property>
           <property name="value">
-           <number>18</number>
+           <number>16</number>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>DefaultFontSize</cstring>

--- a/src/Mod/PartDesign/Gui/ViewProviderDatumCS.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatumCS.cpp
@@ -36,6 +36,7 @@
 
 #include <App/Application.h>
 #include <Gui/Inventor/SoAutoZoomTranslation.h>
+#include <Gui/SoTextLabel.h>
 #include <Mod/Part/Gui/SoBrepEdgeSet.h>
 
 #include "ViewProviderDatumCS.h"
@@ -181,17 +182,17 @@ void ViewProviderDatumCoordinateSystem::setupLabels()
 
     // Transformation for axis labels are relative so no need in separators
     labelGroup->addChild(axisLabelXTrans);
-    auto* t = new SoText2();
+    auto* t = new Gui::SoFCText2();
     t->string = "X";
     labelGroup->addChild(t);
 
     labelGroup->addChild(axisLabelXToYTrans);
-    t = new SoText2();
+    t = new Gui::SoFCText2();
     t->string = "Y";
     labelGroup->addChild(t);
 
     labelGroup->addChild(axisLabelYToZTrans);
-    t = new SoText2();
+    t = new Gui::SoFCText2();
     t->string = "Z";
     labelGroup->addChild(t);
 }


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Fixes HiDPI issues for 3D view overlays such as axis cross, labels, transform dragger, PD pattern OVPs, measurements,... which made most labels and text illegible on HiDPI screens.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: Opus 4.8
<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
- Fixes  https://github.com/FreeCAD/FreeCAD/issues/23741

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
<img width="1570" height="1052" alt="Bildschirmfoto 2026-05-30 um 21 32 40" src="https://github.com/user-attachments/assets/314f4f0c-6943-4c11-a19c-b42ccb97196d" />

<img width="1570" height="1056" alt="Bildschirmfoto 2026-05-30 um 21 32 13" src="https://github.com/user-attachments/assets/26594ed8-9953-487e-9159-ca0f3e94b775" />


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
