### PR TITLE
TechDraw: keep DraftView/ArchView ScaleType "Page" across save and reload

### DIFF
--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -198,11 +198,6 @@ void DrawView::onChanged(const App::Property* prop)
         }
         if (ScaleType.isValue("Page")) {
             Scale.setStatus(App::Property::ReadOnly, true);
-            // Compare the raw Scale property, not getScale(): while ScaleType is
-            // "Page" getScale() already returns page->Scale, so the test compared
-            // the page scale to itself and never wrote it to the stored Scale. The
-            // stale value then made validateScale() flip back to Custom on reload
-            // for views (Draft/Arch) that default ScaleType to Custom (#30186).
             if (std::abs(page->Scale.getValue() - Scale.getValue())
                 > std::numeric_limits<float>::epsilon()) {
                 Scale.setValue(page->Scale.getValue());

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -198,8 +198,14 @@ void DrawView::onChanged(const App::Property* prop)
         }
         if (ScaleType.isValue("Page")) {
             Scale.setStatus(App::Property::ReadOnly, true);
-            if(std::abs(page->Scale.getValue() - getScale()) > std::numeric_limits<float>::epsilon()) {
-               Scale.setValue(page->Scale.getValue());
+            // Compare the raw Scale property, not getScale(): while ScaleType is
+            // "Page" getScale() already returns page->Scale, so the test compared
+            // the page scale to itself and never wrote it to the stored Scale. The
+            // stale value then made validateScale() flip back to Custom on reload
+            // for views (Draft/Arch) that default ScaleType to Custom (#30186).
+            if (std::abs(page->Scale.getValue() - Scale.getValue())
+                > std::numeric_limits<float>::epsilon()) {
+                Scale.setValue(page->Scale.getValue());
             }
         } else if ( ScaleType.isValue("Custom") ) {
             //don't change Scale

--- a/src/Mod/TechDraw/CMakeLists.txt
+++ b/src/Mod/TechDraw/CMakeLists.txt
@@ -186,6 +186,7 @@ SET(TDTest_SRCS
     TDTest/DrawViewSectionTest.py
     TDTest/DrawViewBalloonTest.py
     TDTest/DrawViewDetailTest.py
+    TDTest/DrawViewScaleTypeTest.py
     TDTest/TechDrawTestUtilities.py
 )
 

--- a/src/Mod/TechDraw/TDTest/DrawViewScaleTypeTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawViewScaleTypeTest.py
@@ -19,10 +19,6 @@ class DrawViewScaleTypeTest(unittest.TestCase):
     def setUp(self):
         self.document = FreeCAD.newDocument("TDScaleType")
         self.page = createPageWithSVGTemplate(self.document)
-        # A page scale other than the view's default Scale of 1.0 is what makes a
-        # missing Scale sync observable: validateScale() on reload compares the
-        # stored Scale against the page scale and downgrades Page -> Custom on a
-        # mismatch.
         self.page.Scale = 0.05
         self.savedFile = None
 
@@ -38,9 +34,6 @@ class DrawViewScaleTypeTest(unittest.TestCase):
         with codecs.open(path + "/TestSymbol.svg", "r", encoding="utf-8") as f:
             sym.Symbol = f.read()
         self.page.addView(sym)
-        # DrawViewSymbol (like DraftView / ArchView) defaults ScaleType to Custom,
-        # so checkScale() at addView() leaves the stored Scale untouched. Switching
-        # to Page is the path that must sync the stored Scale to the page scale.
         sym.ScaleType = "Page"
         return sym
 

--- a/src/Mod/TechDraw/TDTest/DrawViewScaleTypeTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawViewScaleTypeTest.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import codecs
+import os
+import tempfile
+import unittest
+
+import FreeCAD
+
+from .TechDrawTestUtilities import createPageWithSVGTemplate
+
+
+class DrawViewScaleTypeTest(unittest.TestCase):
+    """Regression test for issue #30186: a symbol-style view (DrawViewSymbol and
+    its DraftView / ArchView subclasses) whose ScaleType is set to 'Page' must
+    keep that ScaleType across a save/reload cycle instead of reverting to
+    'Custom'."""
+
+    def setUp(self):
+        self.document = FreeCAD.newDocument("TDScaleType")
+        self.page = createPageWithSVGTemplate(self.document)
+        # A page scale other than the view's default Scale of 1.0 is what makes a
+        # missing Scale sync observable: validateScale() on reload compares the
+        # stored Scale against the page scale and downgrades Page -> Custom on a
+        # mismatch.
+        self.page.Scale = 0.05
+        self.savedFile = None
+
+    def tearDown(self):
+        for name in list(FreeCAD.listDocuments().keys()):
+            FreeCAD.closeDocument(name)
+        if self.savedFile and os.path.exists(self.savedFile):
+            os.remove(self.savedFile)
+
+    def _addPageSymbol(self):
+        sym = self.document.addObject("TechDraw::DrawViewSymbol", "ScaleSym")
+        path = os.path.dirname(os.path.abspath(__file__))
+        with codecs.open(path + "/TestSymbol.svg", "r", encoding="utf-8") as f:
+            sym.Symbol = f.read()
+        self.page.addView(sym)
+        # DrawViewSymbol (like DraftView / ArchView) defaults ScaleType to Custom,
+        # so checkScale() at addView() leaves the stored Scale untouched. Switching
+        # to Page is the path that must sync the stored Scale to the page scale.
+        sym.ScaleType = "Page"
+        return sym
+
+    def testScaleTypePageSyncsStoredScale(self):
+        """Setting ScaleType to 'Page' must write the page scale into the stored
+        Scale property rather than leaving it at the default."""
+        sym = self._addPageSymbol()
+        self.assertEqual(sym.ScaleType, "Page")
+        self.assertAlmostEqual(sym.Scale, self.page.Scale)
+
+    def testScaleTypePagePersistsOnReload(self):
+        """ScaleType 'Page' must survive a save / close / reopen cycle (#30186)."""
+        self._addPageSymbol()
+        self.document.recompute()
+
+        self.savedFile = os.path.join(tempfile.gettempdir(), "td_scaletype_30186.FCStd")
+        self.document.saveAs(self.savedFile)
+        FreeCAD.closeDocument(self.document.Name)
+
+        reloaded = FreeCAD.openDocument(self.savedFile)
+        sym = reloaded.getObject("ScaleSym")
+        self.assertEqual(sym.ScaleType, "Page")
+        self.assertAlmostEqual(sym.Scale, reloaded.getObject("Page").Scale)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/TechDraw/TestTechDrawApp.py
+++ b/src/Mod/TechDraw/TestTechDrawApp.py
@@ -27,4 +27,5 @@ from TDTest.DrawViewBalloonTest import DrawViewBalloonTest  # noqa: F401
 from TDTest.DrawViewImageTest import DrawViewImageTest  # noqa: F401
 from TDTest.DrawViewSymbolTest import DrawViewSymbolTest  # noqa: F401
 from TDTest.DrawProjectionGroupTest import DrawProjectionGroupTest  # noqa: F401
+from TDTest.DrawViewScaleTypeTest import DrawViewScaleTypeTest  # noqa: F401
 


### PR DESCRIPTION
Fixes #30186.

If you set the Scale of a DraftView or ArchView to "Page", it goes back to "Custom" after you save the file and open it again.

These views default their ScaleType to "Custom", so the usual place that copies the page scale into the view's Scale (checkScale(), called when the view is added to the page) never runs for them, because it only acts on "Page" views. The other place that should keep them in sync is the "Page" branch of DrawView::onChanged(), but it was comparing page->Scale against getScale(). Since getScale() already returns page->Scale when ScaleType is "Page", that comparison is always equal, so the stored Scale never got updated and stayed at its default of 1.0. When the file is loaded again, validateScale() sees the stored Scale doesn't match the page scale and switches ScaleType back to "Custom".

The fix compares the raw Scale property instead, the same thing checkScale() already does. With that, setting ScaleType to "Page" writes the page scale into Scale, so it still matches after a reload and the setting sticks.

I tested it with the sample file from the issue: set both views to Page, refresh, save, close and reopen, and they stay on Page. I also added a small test (DrawViewScaleTypeTest) that checks the Scale gets synced when you pick "Page" and that the setting survives a save and reload.

AI disclosure: I developed this fix with AI assistance. The investigation, the code change, and the unit test. I reviewed the changes, ran the TechDraw test suite, and verified the reported behaviour with the sample file from the issue (set both views to Page, save, close, reopen; ScaleType stays Page). I understand it and take responsibility for it.

## AFTER
https://github.com/user-attachments/assets/aa757643-8da4-4442-a8c6-5658827b2a3b


