### PR TITLE
TechDraw: fix bspline to circle conversion

### DIFF
--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -1615,40 +1615,45 @@ TopoDS_Edge GeometryUtils::asCircle(const TopoDS_Edge& splineEdge, bool& arc)
 {
     double radius{0};
     Base::Vector3d center;
-    bool isArc = false;
-    bool canMakeCircle = GeometryUtils::getCircleParms(splineEdge, radius, center, isArc);
+    bool canMakeCircle = GeometryUtils::getCircleParms(splineEdge, radius, center, arc);
     if (!canMakeCircle) {
-        throw Base::RuntimeError("GU::asCircle received non-circular edge!");
+        throw Base::RuntimeError("GU::asCircle received non-circular spline edge!");
     }
-    arc = isArc;
 
     gp_Pnt gCenter = Base::convertTo<gp_Pnt>(center);
     gp_Dir gNormal{0, 0, 1};
     Handle(Geom_Circle) circleFromParms = GC_MakeCircle(gCenter, gNormal, radius);
 
-    if (!isArc) {
+    if (!arc) {
         return BRepBuilderAPI_MakeEdge(circleFromParms);
     }
 
-    // find the ends of the edge from the underlying curve
+    // find the ends of the arc from the underlying curve
     BRepAdaptor_Curve curveAdapt(splineEdge);
     double firstParam = curveAdapt.FirstParameter();
     double lastParam = curveAdapt.LastParameter();
+
     gp_Pnt startPoint = curveAdapt.Value(firstParam);
     gp_Pnt endPoint = curveAdapt.Value(lastParam);
 
-    double midRange = (lastParam + firstParam) / 2;
-    gp_Pnt midPoint = curveAdapt.Value(midRange);
+    gp_Vec startVec = startPoint.XYZ() - gCenter.XYZ();
+    gp_Vec endVec = endPoint.XYZ() - gCenter.XYZ();
 
-    // this should be using circleFromParms as a base instead of points on the original spline.
-    // could be problems with very small errors??  other versions of GC_MakeArcOfCircle have
-    // poorly explained parameters.
-    GC_MakeArcOfCircle mkArc(startPoint, midPoint, endPoint);
-    auto circleArc = mkArc.Value();
-    if (!mkArc.IsDone()) {
-        throw Base::RuntimeError("GU::asCircle failed to create arc");
-    }
-    return BRepBuilderAPI_MakeEdge(circleArc);
+    double startAngle = std::atan2(startVec.Y(), startVec.X());  // range [-π, +π] radians
+    double endAngle = std::atan2(endVec.Y(), endVec.X());
+
+    // Find the best match of larger and smaller arcs between startAngle and endAngle.
+    // The last parameter here is the OCCT "sense" boolean which is not explained very well,
+    // but has something to do with the parameterization direction of the curve.  Setting
+    // this to false does not seem to change anything.
+    GC_MakeArcOfCircle mkArc1(circleFromParms->Circ(), startAngle, endAngle, true);
+    GC_MakeArcOfCircle mkArc2(circleFromParms->Circ(), endAngle, startAngle, true);
+
+    opencascade::handle< Geom_TrimmedCurve > splineArcHandle =
+            new Geom_TrimmedCurve(curveAdapt.Curve().Curve(), firstParam, lastParam);
+    auto arcToUse = bestFitArc(splineArcHandle, mkArc1.Value(), mkArc2.Value());
+
+    return BRepBuilderAPI_MakeEdge(arcToUse);
 }
 
 bool GeometryUtils::isLine(const TopoDS_Edge& occEdge)
@@ -1896,5 +1901,25 @@ std::string GeometryUtils::getGeomTypeName(GeomType typeEnumValue)
     return "Not Defined";
 }
 
+gp_Pnt GeometryUtils::midPoint(const opencascade::handle<Geom_TrimmedCurve> &curve)
+{
+    double midParam = (curve->FirstParameter() + curve->LastParameter()) / 2;
+    return curve->Value(midParam);
+}
+
+//! Returns the arc of a circle that is a better approximation of a spline.
+opencascade::handle<Geom_TrimmedCurve> GeometryUtils::bestFitArc(opencascade::handle<Geom_TrimmedCurve> splineActual,
+                                                                 opencascade::handle<Geom_TrimmedCurve> circleArc0,
+                                                                 opencascade::handle<Geom_TrimmedCurve> circleArc1)
+{
+    gp_Pnt midActual = midPoint(splineActual);
+    gp_Pnt mid0 = midPoint(circleArc0);
+    gp_Pnt mid1 = midPoint(circleArc1);
+    if (midActual.Distance(mid0) < midActual.Distance(mid1)) {
+        return circleArc0;
+    }
+
+    return circleArc1;
+}
 
 

--- a/src/Mod/TechDraw/App/Geometry.h
+++ b/src/Mod/TechDraw/App/Geometry.h
@@ -35,6 +35,8 @@
 #include <TopoDS_Face.hxx>
 #include <TopoDS_Vertex.hxx>
 #include <TopoDS_Wire.hxx>
+#include <Geom_Curve.hxx>
+#include <Geom_TrimmedCurve.hxx>
 
 #include "Tag.h"
 
@@ -474,6 +476,11 @@ class TechDrawExport GeometryUtils
         static std::vector<int> findNestedFaceIndices(const std::vector<FacePtr>& holes);
 
         static std::string getGeomTypeName(GeomType typeEnumValue);
+        static gp_Pnt midPoint(const opencascade::handle<Geom_TrimmedCurve>& curve);
+        static opencascade::handle<Geom_TrimmedCurve>
+                    bestFitArc(opencascade::handle<Geom_TrimmedCurve> splineActual,
+                               opencascade::handle<Geom_TrimmedCurve> circleArc0,
+                               opencascade::handle<Geom_TrimmedCurve> circleArc1);
 };
 
 } //end namespace TechDraw


### PR DESCRIPTION
This PR implements a fix for issue #30284. The problem occurs during the conversion of a "circle-like" bSpline to actual circle geometry.  The conversion algo was sometimes choosing the wrong arc of the underlying circle.  The algo now generates both arcs and picks the one with the closest match to the bSpline.  

before fix:
<img width="981" height="641" alt="Thread_beforeCircleFix" src="https://github.com/user-attachments/assets/11b81b7b-7a42-43f8-908a-54cc1505cef7" />

after fix:
<img width="679" height="634" alt="Thread_afterCircleFix" src="https://github.com/user-attachments/assets/a109c414-702f-4865-85ae-3c429065840b" />
