### PR TITLE
PartDesign: Pattern: Prevent selection order issue

### DIFF
--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -34,6 +34,8 @@
 
 
 #include <array>
+#include <unordered_map>
+#include <algorithm>
 
 #include <Base/Console.h>
 #include <Base/Exception.h>

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -123,14 +123,8 @@ Part::Feature* Transformed::getBaseObject(bool silent) const
     return rv;
 }
 
-std::vector<App::DocumentObject*> Transformed::getOriginals() const
+std::vector<App::DocumentObject*> Transformed::getSortedOriginals() const
 {
-    auto const mode = static_cast<Mode>(TransformMode.getValue());
-
-    if (mode == Mode::WholeShape) {
-        return {};
-    }
-
     std::vector<DocumentObject*> originals = Originals.getValues();
 
     // Sort originals in chronological order of the body's group history
@@ -148,6 +142,19 @@ std::vector<App::DocumentObject*> Transformed::getOriginals() const
             return idxA < idxB;
         });
     }
+
+    return originals;
+}
+
+std::vector<App::DocumentObject*> Transformed::getOriginals() const
+{
+    auto const mode = static_cast<Mode>(TransformMode.getValue());
+
+    if (mode == Mode::WholeShape) {
+        return {};
+    }
+
+    std::vector<DocumentObject*> originals = getSortedOriginals();
 
     const auto isSuppressed = [](const DocumentObject* obj) {
         auto feature = freecad_cast<Feature*>(obj);

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -131,6 +131,22 @@ std::vector<App::DocumentObject*> Transformed::getOriginals() const
 
     std::vector<DocumentObject*> originals = Originals.getValues();
 
+    // Sort originals in chronological order of the body's group history
+    if (auto body = getFeatureBody()) {
+        const auto& group = body->Group.getValues();
+        std::unordered_map<const DocumentObject*, size_t> indexMap;
+        for (size_t i = 0; i < group.size(); ++i) {
+            indexMap[group[i]] = i;
+        }
+        std::ranges::sort(originals, [&indexMap](const DocumentObject* a, const DocumentObject* b) {
+            auto itA = indexMap.find(a);
+            auto itB = indexMap.find(b);
+            size_t idxA = (itA != indexMap.end()) ? itA->second : std::numeric_limits<size_t>::max();
+            size_t idxB = (itB != indexMap.end()) ? itB->second : std::numeric_limits<size_t>::max();
+            return idxA < idxB;
+        });
+    }
+
     const auto isSuppressed = [](const DocumentObject* obj) {
         auto feature = freecad_cast<Feature*>(obj);
 

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -91,7 +91,7 @@ Part::Feature* Transformed::getBaseObject(bool silent) const
     }
 
     const char* err = nullptr;
-    const std::vector<App::DocumentObject*>& originals = Originals.getValues();
+    const std::vector<App::DocumentObject*>& originals = getOriginals();
     // NOTE: may be here supposed to be last origin but in order to keep the old behaviour keep here
     // first
     App::DocumentObject* firstOriginal = originals.empty() ? nullptr : originals.front();

--- a/src/Mod/PartDesign/App/FeatureTransformed.h
+++ b/src/Mod/PartDesign/App/FeatureTransformed.h
@@ -67,6 +67,10 @@ public:
     Part::Feature* getBaseObject(bool silent = false) const override;
 
     virtual std::vector<App::DocumentObject*> getOriginals() const;
+    /** Returns the list of original features sorted in chronological order of 
+     *  the parent Body's history (retaining suppressed features).
+     */
+    std::vector<App::DocumentObject*> getSortedOriginals() const;
 
     /// Return the sketch of the first original
     App::DocumentObject* getSketchObject() const;

--- a/src/Mod/PartDesign/App/FeatureTransformed.h
+++ b/src/Mod/PartDesign/App/FeatureTransformed.h
@@ -67,7 +67,7 @@ public:
     Part::Feature* getBaseObject(bool silent = false) const override;
 
     virtual std::vector<App::DocumentObject*> getOriginals() const;
-    /** Returns the list of original features sorted in chronological order of 
+    /** Returns the list of original features sorted in chronological order of
      *  the parent Body's history (retaining suppressed features).
      */
     std::vector<App::DocumentObject*> getSortedOriginals() const;

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
@@ -116,12 +116,6 @@ void TaskTransformedParameters::setupUI()
     ui->listWidgetFeatures->addAction(action);
     connect(action, &QAction::triggered, this, &TaskTransformedParameters::onFeatureDeleted);
     ui->listWidgetFeatures->setContextMenuPolicy(Qt::ActionsContextMenu);
-    connect(
-        ui->listWidgetFeatures->model(),
-        &QAbstractListModel::rowsMoved,
-        this,
-        &TaskTransformedParameters::indexesMoved
-    );
 
     connect(ui->checkBoxUpdateView, &QCheckBox::toggled, this, &TaskTransformedParameters::onUpdateView);
 
@@ -146,7 +140,7 @@ void TaskTransformedParameters::setupUI()
             break;
     }
 
-    std::vector<App::DocumentObject*> originals = pcTransformed->Originals.getValues();
+    std::vector<App::DocumentObject*> originals = pcTransformed->getSortedOriginals();
     // Fill data into dialog elements
     for (auto obj : originals) {
         if (obj) {
@@ -232,7 +226,7 @@ bool TaskTransformedParameters::originalSelected(const Gui::SelectionChanges& ms
         if (selectedObject->isDerivedFrom<PartDesign::FeatureAddSub>()) {
 
             // Do the same like in TaskDlgTransformedParameters::accept() but without doCommand
-            std::vector<App::DocumentObject*> originals = pcTransformed->Originals.getValues();
+            std::vector<App::DocumentObject*> originals = pcTransformed->getSortedOriginals();
             const auto or_iter = std::ranges::find(originals, selectedObject);
             if (selectionMode == SelectionMode::AddFeature) {
                 if (or_iter == originals.end()) {
@@ -370,7 +364,7 @@ void TaskTransformedParameters::onButtonRemoveFeature(bool checked)
 void TaskTransformedParameters::onFeatureDeleted()
 {
     PartDesign::Transformed* pcTransformed = getObject();
-    std::vector<App::DocumentObject*> originals = pcTransformed->Originals.getValues();
+    std::vector<App::DocumentObject*> originals = pcTransformed->getSortedOriginals();
     int currentRow = ui->listWidgetFeatures->currentRow();
     if (currentRow < 0) {
         Base::Console().error("PartDesign Pattern: No feature selected for removing.\n");
@@ -584,29 +578,6 @@ void TaskTransformedParameters::addReferenceSelectionGate(AllowSelectionFlags al
         new NoDependentsSelection(getTopTransformedObject())
     );
     Gui::Selection().addSelectionGate(new CombineSelectionFilterGates(gateRefPtr, gateDepPtr));
-}
-
-void TaskTransformedParameters::indexesMoved()
-{
-    auto model = qobject_cast<QAbstractItemModel*>(sender());
-    if (!model) {
-        return;
-    }
-
-    PartDesign::Transformed* pcTransformed = getObject();
-    std::vector<App::DocumentObject*> originals = pcTransformed->Originals.getValues();
-
-    QByteArray name;
-    int rows = model->rowCount();
-    for (int i = 0; i < rows; i++) {
-        QModelIndex index = model->index(i, 0);
-        name = index.data(Qt::UserRole).toByteArray().constData();
-        originals[i] = pcTransformed->getDocument()->getObject(name.constData());
-    }
-
-    setupTransaction();
-    pcTransformed->Originals.setValues(originals);
-    recomputeFeature();
 }
 
 //**************************************************************************

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -172,7 +172,6 @@ private Q_SLOTS:
     void onButtonAddFeature(bool checked);
     void onButtonRemoveFeature(bool checked);
     void onFeatureDeleted();
-    void indexesMoved();
     void onModeChanged(int mode_id);
 
 private:

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.ui
@@ -102,12 +102,6 @@
           <height>120</height>
          </size>
         </property>
-        <property name="toolTip">
-         <string>List can be reordered by dragging</string>
-        </property>
-        <property name="dragDropMode">
-         <enum>QAbstractItemView::InternalMove</enum>
-        </property>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/15668
Fix https://github.com/FreeCAD/FreeCAD/issues/30521

Add a `getSortedOriginals` that returns a chronologically sorted version of Originals.
`getOriginals` now uses this function. Ensuring that the patterns can be correctly generated.

GUI also uses `getSortedOriginals` to correctly sort the objects in the widget (note GUI is not using the getOriginals because that one is filtering out the suppressed features).

The PR also remove the 'drag and drop' capability of the QListWidget since it was here only to fix manually the chronological order. So if we sort automatically then it's unwanted.

Please squash.