### PR TITLE
Gui: Add icon and shortcut for the "clear" in PythonConsole's context menu

### DIFF
--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -491,12 +491,13 @@ PythonConsole::PythonConsole(QWidget* parent)
     connect(flusher, &QTimer::timeout, this, &PythonConsole::flushOutput);
     flusher->start(100);
 
-    clearAction = addAction(QIcon(QStringLiteral(":/icons/edit-delete.svg")),
-                            tr("Clear Console"),
-                            QKeySequence(Qt::CTRL | Qt::Key_L));
+    clearAction = addAction(
+        QIcon(QStringLiteral(":/icons/edit-delete.svg")),
+        tr("Clear Console"),
+        QKeySequence(Qt::CTRL | Qt::Key_L)
+    );
     clearAction->setShortcutContext(Qt::WidgetShortcut);
-    QObject::connect(clearAction, &QAction::triggered,
-                     this, &PythonConsole::onClearConsole);
+    QObject::connect(clearAction, &QAction::triggered, this, &PythonConsole::onClearConsole);
 }
 
 /** Destroys the object and frees any allocated resources */

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -490,6 +490,13 @@ PythonConsole::PythonConsole(QWidget* parent)
     flusher = new QTimer(this);
     connect(flusher, &QTimer::timeout, this, &PythonConsole::flushOutput);
     flusher->start(100);
+
+    clearAction = addAction(QIcon(QStringLiteral(":/icons/edit-delete.svg")),
+                            tr("Clear Console"),
+                            QKeySequence(Qt::CTRL | Qt::Key_L));
+    clearAction->setShortcutContext(Qt::WidgetShortcut);
+    QObject::connect(clearAction, &QAction::triggered,
+                     this, &PythonConsole::onClearConsole);
 }
 
 /** Destroys the object and frees any allocated resources */
@@ -1366,8 +1373,8 @@ void PythonConsole::contextMenuEvent(QContextMenuEvent* e)
     a->setShortcut(QKeySequence(QStringLiteral("CTRL+A")));
     a->setEnabled(!document()->isEmpty());
 
-    a = menu.addAction(tr("Clear Console"), this, &PythonConsole::onClearConsole);
-    a->setEnabled(!document()->isEmpty());
+    clearAction->setEnabled(!document()->isEmpty());
+    menu.addAction(clearAction);
 
     menu.addSeparator();
     menu.addAction(tr("Insert File Name…"), this, &PythonConsole::onInsertFileName);

--- a/src/Gui/PythonConsole.h
+++ b/src/Gui/PythonConsole.h
@@ -170,7 +170,7 @@ private:
     QString* _sourceDrain {nullptr};
     QString _historyFile;
     QTimer* flusher {nullptr};
-    QAction *clearAction;
+    QAction* clearAction;
 
     friend class PythonStdout;
     friend class PythonStderr;

--- a/src/Gui/PythonConsole.h
+++ b/src/Gui/PythonConsole.h
@@ -170,6 +170,7 @@ private:
     QString* _sourceDrain {nullptr};
     QString _historyFile;
     QTimer* flusher {nullptr};
+    QAction *clearAction;
 
     friend class PythonStdout;
     friend class PythonStderr;


### PR DESCRIPTION
Closes #21753. This commit also adds the icon to the action.