### PR TITLE
Feature: Model Tree search enhancements (Wildcards, Global search, History)

### DIFF
--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -803,6 +803,7 @@ SET(Dock_Windows_CPP_SRCS
     Selection/SelectionView.cpp
     ToolBox.cpp
     Tree.cpp
+    TreeSearchUtil.cpp
     TreeView.cpp
     DAGView/DAGView.cpp
     DAGView/DAGModel.cpp
@@ -817,6 +818,7 @@ SET(Dock_Windows_HPP_SRCS
     Selection/SelectionView.h
     ToolBox.h
     Tree.h
+    TreeSearchUtil.h
     TreeView.h
     DAGView/DAGView.h
     DAGView/DAGModel.h

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -92,12 +92,15 @@ using Gui::TreeSearchUtil::wildcardToRegex;
 namespace
 {
 
-class UnfilteredCompleter : public QCompleter {
+class UnfilteredCompleter: public QCompleter
+{
 public:
-    UnfilteredCompleter(QAbstractItemModel *model, QObject *parent = nullptr)
-        : QCompleter(model, parent) {}
+    UnfilteredCompleter(QAbstractItemModel* model, QObject* parent = nullptr)
+        : QCompleter(model, parent)
+    {}
 
-    QStringList splitPath(const QString &) const override {
+    QStringList splitPath(const QString&) const override
+    {
         return QStringList("");
     }
 };
@@ -4270,8 +4273,10 @@ TreePanel::TreePanel(const char* name, QWidget* parent)
     this->searchBox = new QLineEdit(this);
     this->searchBox->setPlaceholderText(tr("Search"));
     this->searchBox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-    this->searchBox->setToolTip(tr("Searches the model tree.\n"
-                                   "Uses * for any sequence, ? for a single character."));
+    this->searchBox->setToolTip(
+        tr("Searches the model tree.\n"
+           "Uses * for any sequence, ? for a single character.")
+    );
     this->searchBox->installEventFilter(this);
 
     QStringListModel* listModel = new QStringListModel(this);
@@ -4285,13 +4290,17 @@ TreePanel::TreePanel(const char* name, QWidget* parent)
     this->historyBtn->setAutoRaise(true);
     this->historyBtn->setPopupMode(QToolButton::InstantPopup);
     this->historyBtn->setMenu(historyMenu);
-    this->historyBtn->setToolTip(tr("<b>Search History</b> (Alt+Down)<br>Accesses recent searches from this session."));
+    this->historyBtn->setToolTip(
+        tr("<b>Search History</b> (Alt+Down)<br>Accesses recent searches from this session.")
+    );
     this->historyBtn->setEnabled(false);
     this->historyBtn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
     this->historyBtn->setFixedWidth(15);
 
     this->globalBtn = new QCheckBox(tr("Global"), searchRow);
-    this->globalBtn->setToolTip(tr("<b>Global Search</b><br>Enables searching in the tree models of all open documents."));
+    this->globalBtn->setToolTip(
+        tr("<b>Global Search</b><br>Enables searching in the tree models of all open documents.")
+    );
     this->globalBtn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
     this->globalBtn->setChecked(true);
 
@@ -4304,8 +4313,7 @@ TreePanel::TreePanel(const char* name, QWidget* parent)
 
     connect(this->searchBox, &QLineEdit::returnPressed, this, &TreePanel::accept);
     connect(this->searchBox, &QLineEdit::textEdited, this, &TreePanel::itemSearch);
-    connect(this->historyMenu, &QMenu::triggered,
-            this, &TreePanel::onHistoryActionTriggered);
+    connect(this->historyMenu, &QMenu::triggered, this, &TreePanel::onHistoryActionTriggered);
 
     connect(this->globalBtn, &QCheckBox::toggled, this, [this](bool on) {
         const QString text = searchBox->text();
@@ -4441,7 +4449,8 @@ void TreePanel::saveSearchHistory(const QString& term)
     QAction* newAct = new QAction(term, this);
     if (this->historyMenu->isEmpty()) {
         this->historyMenu->addAction(newAct);
-    } else {
+    }
+    else {
         this->historyMenu->insertAction(this->historyMenu->actions().first(), newAct);
     }
 

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -38,6 +38,10 @@
 #include <QTimer>
 #include <QToolTip>
 #include <QVBoxLayout>
+#include <QToolButton>
+#include <QCheckBox>
+#include <QStringListModel>
+#include <QCompleter>
 
 
 #include <Base/Console.h>
@@ -59,11 +63,11 @@
 #include "BitmapFactory.h"
 #include "Command.h"
 #include "Document.h"
-#include "ExpressionCompleter.h"
 #include "Macro.h"
 #include "MainWindow.h"
 #include "MenuManager.h"
 #include "TreeParams.h"
+#include "TreeSearchUtil.h"
 #include "View3DInventor.h"
 #include "ViewProviderDocumentObject.h"
 #include "Widgets.h"
@@ -82,6 +86,47 @@ FC_LOG_LEVEL_INIT("Tree", false, true, true)
 
 using namespace Gui;
 namespace sp = std::placeholders;
+using Gui::TreeSearchUtil::regexMatches;
+using Gui::TreeSearchUtil::wildcardToRegex;
+
+namespace
+{
+
+class UnfilteredCompleter : public QCompleter {
+public:
+    UnfilteredCompleter(QAbstractItemModel *model, QObject *parent = nullptr)
+        : QCompleter(model, parent) {}
+
+    QStringList splitPath(const QString &) const override {
+        return QStringList("");
+    }
+};
+
+class TreeUpdatesBlocker
+{
+public:
+    explicit TreeUpdatesBlocker(QTreeWidget* tree)
+        : tree(tree)
+        , updatesEnabled(tree && tree->updatesEnabled())
+    {
+        if (tree) {
+            tree->setUpdatesEnabled(false);
+        }
+    }
+
+    ~TreeUpdatesBlocker()
+    {
+        if (tree) {
+            tree->setUpdatesEnabled(updatesEnabled);
+        }
+    }
+
+private:
+    QTreeWidget* tree;
+    bool updatesEnabled;
+};
+
+}
 
 /////////////////////////////////////////////////////////////////////////////////
 
@@ -967,8 +1012,27 @@ void TreeWidget::checkTopParent(App::DocumentObject*& obj, std::string& subname)
     }
 }
 
+QStringList TreeWidget::getHighlightedNames() const
+{
+    QStringList names;
+    for (const auto& highlight : searchHighlights) {
+        if (highlight.first) {
+            names << highlight.first->text(0);
+        }
+    }
+    names.removeDuplicates();
+    return names;
+}
+
 void TreeWidget::resetItemSearch()
 {
+    for (const auto& [item, brush] : searchHighlights) {
+        if (item) {
+            item->setBackground(0, brush);
+        }
+    }
+    searchHighlights.clear();
+
     if (!searchObject) {
         return;
     }
@@ -986,8 +1050,40 @@ void TreeWidget::resetItemSearch()
     searchObject = nullptr;
 }
 
+void TreeWidget::searchInDocumentItem(
+    QTreeWidgetItem* node,
+    const QRegularExpression& re,
+    QTreeWidgetItem*& firstHit,
+    int& hitCount
+)
+{
+    if (!node || hitCount >= kSearchHitCap) {
+        return;
+    }
+
+    const QString label = node->text(0);
+    if (regexMatches(re, label)) {
+        ++hitCount;
+        if (!firstHit) {
+            firstHit = node;
+        }
+        for (QTreeWidgetItem* parent = node->parent(); parent; parent = parent->parent()) {
+            parent->setExpanded(true);
+        }
+        node->setExpanded(true);
+        searchHighlights.emplace_back(node, node->background(0));
+        node->setBackground(0, QColor(255, 255, 0, 100));
+    }
+
+    for (int i = 0, count = node->childCount(); i < count && hitCount < kSearchHitCap; ++i) {
+        searchInDocumentItem(node->child(i), re, firstHit, hitCount);
+    }
+}
+
 void TreeWidget::startItemSearch(QLineEdit* edit)
 {
+    Q_UNUSED(edit);
+
     resetItemSearch();
     searchDoc = nullptr;
     searchContextDoc = nullptr;
@@ -1005,112 +1101,108 @@ void TreeWidget::startItemSearch(QLineEdit* edit)
     else {
         searchDoc = Application::Instance->activeDocument();
     }
-
-    App::DocumentObject* obj = nullptr;
-    if (searchContextDoc && !searchContextDoc->getDocument()->getObjects().empty()) {
-        obj = searchContextDoc->getDocument()->getObjects().front();
-    }
-    else if (searchDoc && !searchDoc->getDocument()->getObjects().empty()) {
-        obj = searchDoc->getDocument()->getObjects().front();
-    }
-
-    if (obj) {
-        static_cast<ExpressionLineEdit*>(edit)->setDocumentObject(obj);
-    }
 }
 
-void TreeWidget::itemSearch(const QString& text, bool select)
+bool TreeWidget::itemSearch(const QString& text, bool select, bool global)
 {
     resetItemSearch();
 
-    auto docItem = getDocumentItem(searchDoc);
-    if (!docItem) {
-        docItem = getDocumentItem(Application::Instance->activeDocument());
-        if (!docItem) {
-            FC_TRACE("item search no document");
-            resetItemSearch();
-            return;
+    const QString searchText = text.trimmed();
+    if (searchText.isEmpty()) {
+        return false;
+    }
+
+    const QRegularExpression re = wildcardToRegex(searchText);
+    if (!re.isValid()) {
+        FC_TRACE("invalid item search pattern " << searchText.toUtf8().constData());
+        return false;
+    }
+
+    std::vector<DocumentItem*> docItems;
+    if (global) {
+        auto docs = App::GetApplication().getDocuments();
+        auto activeDoc = App::GetApplication().getActiveDocument();
+        for (auto it = docs.begin(); activeDoc && it != docs.end(); ++it) {
+            if (*it == activeDoc) {
+                docs.erase(it);
+                docs.insert(docs.begin(), activeDoc);
+                break;
+            }
+        }
+        for (auto appDoc : docs) {
+            if (!appDoc || appDoc->getObjects().empty()) {
+                continue;
+            }
+            auto guiDoc = Application::Instance->getDocument(appDoc);
+            if (auto docItem = getDocumentItem(guiDoc)) {
+                docItems.push_back(docItem);
+            }
+        }
+    }
+    else {
+        auto guiDoc = searchDoc ? searchDoc : Application::Instance->activeDocument();
+        if (auto docItem = getDocumentItem(guiDoc)) {
+            if (!docItem->document()->getDocument()->getObjects().empty()) {
+                docItems.push_back(docItem);
+            }
         }
     }
 
-    auto doc = docItem->document()->getDocument();
-    const auto& objs = doc->getObjects();
-    if (objs.empty()) {
-        FC_TRACE("item search no objects");
-        return;
+    if (docItems.empty()) {
+        FC_TRACE("item search no document");
+        return false;
     }
-    std::string txt(text.toUtf8().constData());
+
+    QTreeWidgetItem* firstHit = nullptr;
+    int hitCount = 0;
+    {
+        TreeUpdatesBlocker updates(this);
+        for (auto docItem : docItems) {
+            searchInDocumentItem(docItem, re, firstHit, hitCount);
+            if (hitCount >= kSearchHitCap) {
+                break;
+            }
+        }
+    }
+
+    if (hitCount == 0 || !firstHit) {
+        FC_TRACE("item " << searchText.toUtf8().constData() << " not found");
+        return false;
+    }
+    if (hitCount >= kSearchHitCap) {
+        FC_TRACE("item search hit cap reached");
+    }
+
+    scrollToItem(firstHit);
+    if (firstHit->type() != ObjectType) {
+        FC_TRACE("found item " << searchText.toUtf8().constData());
+        return true;
+    }
+
+    auto item = static_cast<DocumentObjectItem*>(firstHit);
+    auto* vp = item->object();
+    auto obj = vp ? vp->getObject() : nullptr;
+    if (!obj) {
+        resetItemSearch();
+        return false;
+    }
+
+    std::ostringstream subname;
+    App::DocumentObject* parent = nullptr;
+    item->getSubName(subname, parent);
+    if (parent) {
+        if (!obj->redirectSubName(subname, parent, nullptr)) {
+            subname << obj->getNameInDocument() << '.';
+        }
+        obj = parent;
+    }
+    const std::string subnameText = subname.str();
+
     try {
-        if (txt.empty()) {
-            return;
-        }
-        if (txt.find("<<") == std::string::npos) {
-            auto pos = txt.find('.');
-            if (pos == std::string::npos) {
-                txt += '.';
-            }
-            else if (pos != txt.size() - 1) {
-                txt.insert(pos + 1, "<<");
-                if (txt.back() != '.') {
-                    txt += '.';
-                }
-                txt += ">>.";
-            }
-        }
-        else if (txt.back() != '.') {
-            txt += '.';
-        }
-        txt += "_self";
-        auto path = App::ObjectIdentifier::parse(objs.front(), txt);
-        if (path.getPropertyName() != "_self") {
-            FC_TRACE("Object " << txt << " not found in " << doc->getName());
-            return;
-        }
-        auto obj = path.getDocumentObject();
-        if (!obj) {
-            FC_TRACE("Object " << txt << " not found in " << doc->getName());
-            return;
-        }
-        std::string subname = path.getSubObjectName();
-        App::DocumentObject* parent = nullptr;
-        if (searchContextDoc) {
-            auto it = DocumentMap.find(searchContextDoc);
-            if (it != DocumentMap.end()) {
-                parent = it->second->getTopParent(obj, subname);
-                if (parent) {
-                    obj = parent;
-                    docItem = it->second;
-                    doc = docItem->document()->getDocument();
-                }
-            }
-        }
-        if (!parent) {
-            parent = docItem->getTopParent(obj, subname);
-            while (!parent) {
-                if (docItem->document()->getDocument() == obj->getDocument()) {
-                    // this shouldn't happen
-                    FC_LOG("Object " << txt << " not found in " << doc->getName());
-                    return;
-                }
-                auto it = DocumentMap.find(Application::Instance->getDocument(obj->getDocument()));
-                if (it == DocumentMap.end()) {
-                    return;
-                }
-                docItem = it->second;
-                parent = docItem->getTopParent(obj, subname);
-            }
-            obj = parent;
-        }
-        auto item = docItem->findItemByObject(true, obj, subname.c_str());
-        if (!item) {
-            FC_TRACE("item " << txt << " not found in " << doc->getName());
-            return;
-        }
-        scrollToItem(item);
         Selection().setPreselect(
             obj->getDocument()->getName(),
             obj->getNameInDocument(),
-            subname.c_str(),
+            subnameText.c_str(),
             0,
             0,
             0,
@@ -1122,19 +1214,22 @@ void TreeWidget::itemSearch(const QString& text, bool select)
             Gui::Selection().addSelection(
                 obj->getDocument()->getName(),
                 obj->getNameInDocument(),
-                subname.c_str()
+                subnameText.c_str()
             );
             Gui::Selection().selStackPush();
         }
         else {
             searchObject = item->object()->getObject();
-            item->setBackground(0, QColor(255, 255, 0, 100));
         }
-        FC_TRACE("found item " << txt);
+        FC_TRACE("found item " << searchText.toUtf8().constData());
+        return true;
     }
     catch (...) {
-        FC_TRACE("item " << txt << " search exception in " << doc->getName());
+        FC_TRACE("item " << searchText.toUtf8().constData() << " search exception");
+        resetItemSearch();
+        return false;
     }
+    return false;
 }
 
 Gui::Document* TreeWidget::selectedDocument()
@@ -4167,25 +4262,85 @@ TreePanel::TreePanel(const char* name, QWidget* parent)
     pLayout->addWidget(this->treeWidget);
     connect(this->treeWidget, &TreeWidget::emitSearchObjects, this, &TreePanel::showEditor);
 
-    this->searchBox = new Gui::ExpressionLineEdit(this, true);
-    static_cast<ExpressionLineEdit*>(this->searchBox)
-        ->setExactMatch(Gui::ExpressionParameter::instance()->isExactMatch());
-    pLayout->addWidget(this->searchBox);
-    this->searchBox->hide();
-    this->searchBox->installEventFilter(this);
+    searchRow = new QWidget(this);
+    auto* rowLayout = new QHBoxLayout(searchRow);
+    rowLayout->setContentsMargins(0, 0, 0, 0);
+    rowLayout->setSpacing(2);
+
+    this->searchBox = new QLineEdit(this);
     this->searchBox->setPlaceholderText(tr("Search"));
+    this->searchBox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    this->searchBox->setToolTip(tr("Searches the model tree.\n"
+                                   "Uses * for any sequence, ? for a single character."));
+    this->searchBox->installEventFilter(this);
+
+    QStringListModel* listModel = new QStringListModel(this);
+    UnfilteredCompleter* completer = new UnfilteredCompleter(listModel, this);
+    completer->setCompletionMode(QCompleter::PopupCompletion);
+    completer->setCaseSensitivity(Qt::CaseInsensitive);
+    this->searchBox->setCompleter(completer);
+
+    historyMenu = new QMenu(this);
+    this->historyBtn = new QToolButton(searchRow);
+    this->historyBtn->setAutoRaise(true);
+    this->historyBtn->setPopupMode(QToolButton::InstantPopup);
+    this->historyBtn->setMenu(historyMenu);
+    this->historyBtn->setToolTip(tr("<b>Search History</b> (Alt+Down)<br>Accesses recent searches from this session."));
+    this->historyBtn->setEnabled(false);
+    this->historyBtn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+    this->historyBtn->setFixedWidth(15);
+
+    this->globalBtn = new QCheckBox(tr("Global"), searchRow);
+    this->globalBtn->setToolTip(tr("<b>Global Search</b><br>Enables searching in the tree models of all open documents."));
+    this->globalBtn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+    this->globalBtn->setChecked(true);
+
+    rowLayout->addWidget(searchBox);
+    rowLayout->addWidget(historyBtn);
+    rowLayout->addWidget(globalBtn);
+
+    pLayout->addWidget(searchRow);
+    searchRow->hide();
+
     connect(this->searchBox, &QLineEdit::returnPressed, this, &TreePanel::accept);
-    connect(this->searchBox, &QLineEdit::textChanged, this, &TreePanel::itemSearch);
+    connect(this->searchBox, &QLineEdit::textEdited, this, &TreePanel::itemSearch);
+    connect(this->historyMenu, &QMenu::triggered,
+            this, &TreePanel::onHistoryActionTriggered);
+
+    connect(this->globalBtn, &QCheckBox::toggled, this, [this](bool on) {
+        const QString text = searchBox->text();
+        if (!text.trimmed().isEmpty()) {
+            treeWidget->itemSearch(text, false, on);
+        }
+    });
+
+    connect(this->historyMenu, &QMenu::hovered, this, [this](QAction* action) {
+        if (action) {
+            this->treeWidget->itemSearch(action->text(), false, this->globalBtn->isChecked());
+        }
+    });
+
+    connect(this->historyMenu, &QMenu::aboutToHide, this, [this]() {
+        this->treeWidget->itemSearch(this->searchBox->text(), false, this->globalBtn->isChecked());
+    });
 }
 
 TreePanel::~TreePanel() = default;
 
 void TreePanel::accept()
 {
-    QString text = this->searchBox->text();
-    hideEditor();
-    this->treeWidget->setFocus();
-    this->treeWidget->itemSearch(text, true);
+    QString text = this->searchBox->text().trimmed();
+    if (text.isEmpty()) {
+        hideEditor();
+        return;
+    }
+
+    const bool matched = treeWidget->itemSearch(text, true, globalBtn->isChecked());
+    if (matched) {
+        saveSearchHistory(text);
+        hideEditor();
+        this->treeWidget->setFocus();
+    }
 }
 
 bool TreePanel::eventFilter(QObject* obj, QEvent* ev)
@@ -4196,7 +4351,17 @@ bool TreePanel::eventFilter(QObject* obj, QEvent* ev)
 
     if (ev->type() == QEvent::KeyPress) {
         bool consumed = false;
-        int key = static_cast<QKeyEvent*>(ev)->key();
+        auto* keyEvent = static_cast<QKeyEvent*>(ev);
+        int key = keyEvent->key();
+
+        bool altPressed = (keyEvent->modifiers() & Qt::AltModifier);
+        if (key == Qt::Key_Down && this->historyBtn->isEnabled()) {
+            if (altPressed || this->searchBox->text().isEmpty()) {
+                this->historyBtn->showMenu();
+                return true;
+            }
+        }
+
         switch (key) {
             case Qt::Key_Escape:
                 hideEditor();
@@ -4216,16 +4381,15 @@ bool TreePanel::eventFilter(QObject* obj, QEvent* ev)
 
 void TreePanel::showEditor()
 {
-    this->searchBox->show();
+    this->searchRow->show();
     this->searchBox->setFocus();
     this->treeWidget->startItemSearch(searchBox);
 }
 
 void TreePanel::hideEditor()
 {
-    static_cast<ExpressionLineEdit*>(this->searchBox)->setDocumentObject(nullptr);
     this->searchBox->clear();
-    this->searchBox->hide();
+    this->searchRow->hide();
     this->treeWidget->resetItemSearch();
     auto sels = this->treeWidget->selectedItems();
     if (!sels.empty()) {
@@ -4235,7 +4399,59 @@ void TreePanel::hideEditor()
 
 void TreePanel::itemSearch(const QString& text)
 {
-    this->treeWidget->itemSearch(text, false);
+    this->treeWidget->itemSearch(text, false, this->globalBtn->isChecked());
+
+    QStringList results;
+    if (!text.isEmpty()) {
+        results = this->treeWidget->getHighlightedNames();
+    }
+
+    if (QCompleter* comp = this->searchBox->completer()) {
+        if (auto model = qobject_cast<QStringListModel*>(comp->model())) {
+            model->setStringList(results);
+        }
+    }
+}
+
+void TreePanel::onHistoryActionTriggered(QAction* action)
+{
+    const QString term = action->text();
+    {
+        QSignalBlocker block(this->searchBox);
+        this->searchBox->setText(term);
+    }
+    this->treeWidget->itemSearch(term, false, this->globalBtn->isChecked());
+    this->searchBox->setFocus();
+    this->searchBox->selectAll();
+}
+
+void TreePanel::saveSearchHistory(const QString& term)
+{
+    if (term.trimmed().isEmpty()) {
+        return;
+    }
+
+    for (QAction* act : this->historyMenu->actions()) {
+        if (act->text() == term) {
+            this->historyMenu->removeAction(act);
+            act->deleteLater();
+        }
+    }
+
+    QAction* newAct = new QAction(term, this);
+    if (this->historyMenu->isEmpty()) {
+        this->historyMenu->addAction(newAct);
+    } else {
+        this->historyMenu->insertAction(this->historyMenu->actions().first(), newAct);
+    }
+
+    while (this->historyMenu->actions().size() > kMaxHistory) {
+        QAction* lastAct = this->historyMenu->actions().last();
+        this->historyMenu->removeAction(lastAct);
+        lastAct->deleteLater();
+    }
+
+    this->historyBtn->setEnabled(true);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -24,6 +24,9 @@
 #pragma once
 
 #include <unordered_map>
+#include <utility>
+#include <vector>
+#include <QBrush>
 #include <QTimer>
 #include <QElapsedTimer>
 #include <QStyledItemDelegate>
@@ -38,6 +41,10 @@
 #include <Gui/TreeItemMode.h>
 
 class QLineEdit;
+class QToolButton;
+class QMenu;
+class QCheckBox;
+class QRegularExpression;
 
 namespace Gui
 {
@@ -133,7 +140,8 @@ public:
 
     void resetItemSearch();
     void startItemSearch(QLineEdit*);
-    void itemSearch(const QString& text, bool select);
+    bool itemSearch(const QString& text, bool select, bool global = false);
+    QStringList getHighlightedNames() const;
 
     static void synchronizeSelectionCheckBoxes();
     static void updateVisibilityIcons();
@@ -204,6 +212,13 @@ private:
     void selectAllDocumentLevel();
     void selectAllGroupLevel(const QTreeWidgetItem* targetNode, bool isGroup);
     void clearSelectAllContext();
+    void searchInDocumentItem(
+        QTreeWidgetItem* node,
+        const QRegularExpression& re,
+        QTreeWidgetItem*& firstHit,
+        int& hitCount
+    );
+    static constexpr int kSearchHitCap = 500;
 
 protected Q_SLOTS:
     void onCreateGroup();
@@ -283,6 +298,7 @@ private:
     Command* skipRecomputeCommand;
     QTreeWidgetItem* contextItem;
     App::DocumentObject* searchObject;
+    std::vector<std::pair<QTreeWidgetItem*, QBrush>> searchHighlights;
     Gui::Document* searchDoc;
     Gui::Document* searchContextDoc;
     DocumentObjectItem* editingItem;
@@ -588,10 +604,18 @@ private Q_SLOTS:
     void showEditor();
     void hideEditor();
     void itemSearch(const QString& text);
+    void onHistoryActionTriggered(QAction* action);
 
 private:
-    QLineEdit* searchBox;
-    TreeWidget* treeWidget;
+    TreeWidget*              treeWidget  = nullptr;
+    QWidget*                 searchRow   = nullptr;
+    QLineEdit*               searchBox   = nullptr;
+    QToolButton*             historyBtn  = nullptr;
+    QCheckBox*               globalBtn   = nullptr;
+    QMenu*                   historyMenu = nullptr;
+
+    void saveSearchHistory(const QString& term);
+    static constexpr int kMaxHistory = 10;
 };
 
 /**

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -607,12 +607,12 @@ private Q_SLOTS:
     void onHistoryActionTriggered(QAction* action);
 
 private:
-    TreeWidget*              treeWidget  = nullptr;
-    QWidget*                 searchRow   = nullptr;
-    QLineEdit*               searchBox   = nullptr;
-    QToolButton*             historyBtn  = nullptr;
-    QCheckBox*               globalBtn   = nullptr;
-    QMenu*                   historyMenu = nullptr;
+    TreeWidget* treeWidget = nullptr;
+    QWidget* searchRow = nullptr;
+    QLineEdit* searchBox = nullptr;
+    QToolButton* historyBtn = nullptr;
+    QCheckBox* globalBtn = nullptr;
+    QMenu* historyMenu = nullptr;
 
     void saveSearchHistory(const QString& term);
     static constexpr int kMaxHistory = 10;

--- a/src/Gui/TreeSearchUtil.cpp
+++ b/src/Gui/TreeSearchUtil.cpp
@@ -27,8 +27,7 @@ namespace Gui::TreeSearchUtil
 
 QRegularExpression wildcardToRegex(const QString& pattern)
 {
-    const bool hasWildcard = pattern.contains(QLatin1Char('*'))
-        || pattern.contains(QLatin1Char('?'));
+    const bool hasWildcard = pattern.contains(QLatin1Char('*')) || pattern.contains(QLatin1Char('?'));
     const QString effectivePattern = hasWildcard ? pattern : QStringLiteral("*%1*").arg(pattern);
 
     QString rx;
@@ -56,4 +55,4 @@ bool regexMatches(const QRegularExpression& re, const QString& haystack)
     return re.isValid() && re.match(haystack).hasMatch();
 }
 
-}
+}  // namespace Gui::TreeSearchUtil

--- a/src/Gui/TreeSearchUtil.cpp
+++ b/src/Gui/TreeSearchUtil.cpp
@@ -1,0 +1,59 @@
+/***************************************************************************
+ *   Copyright (c) 2026 The FreeCAD Project Association AISBL              *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "TreeSearchUtil.h"
+
+namespace Gui::TreeSearchUtil
+{
+
+QRegularExpression wildcardToRegex(const QString& pattern)
+{
+    const bool hasWildcard = pattern.contains(QLatin1Char('*'))
+        || pattern.contains(QLatin1Char('?'));
+    const QString effectivePattern = hasWildcard ? pattern : QStringLiteral("*%1*").arg(pattern);
+
+    QString rx;
+    rx.reserve(effectivePattern.size() * 2 + 2);
+    rx += QLatin1Char('^');
+
+    for (const QChar ch : effectivePattern) {
+        if (ch == QLatin1Char('*')) {
+            rx += QStringLiteral(".*");
+        }
+        else if (ch == QLatin1Char('?')) {
+            rx += QLatin1Char('.');
+        }
+        else {
+            rx += QRegularExpression::escape(QString(ch));
+        }
+    }
+
+    rx += QLatin1Char('$');
+    return QRegularExpression(rx, QRegularExpression::CaseInsensitiveOption);
+}
+
+bool regexMatches(const QRegularExpression& re, const QString& haystack)
+{
+    return re.isValid() && re.match(haystack).hasMatch();
+}
+
+}

--- a/src/Gui/TreeSearchUtil.h
+++ b/src/Gui/TreeSearchUtil.h
@@ -25,7 +25,7 @@
 #include <QString>
 #include <QRegularExpression>
 
-#include "GuiExport.h"
+#include <FCGlobal.h>
 
 namespace Gui::TreeSearchUtil
 {

--- a/src/Gui/TreeSearchUtil.h
+++ b/src/Gui/TreeSearchUtil.h
@@ -25,11 +25,13 @@
 #include <QString>
 #include <QRegularExpression>
 
+#include "GuiExport.h"
+
 namespace Gui::TreeSearchUtil
 {
 
 // Internal GUI utility for model tree search; not part of the public API.
-QRegularExpression wildcardToRegex(const QString& pattern);
-bool regexMatches(const QRegularExpression& re, const QString& haystack);
+GuiExport QRegularExpression wildcardToRegex(const QString& pattern);
+GuiExport bool regexMatches(const QRegularExpression& re, const QString& haystack);
 
 }  // namespace Gui::TreeSearchUtil

--- a/src/Gui/TreeSearchUtil.h
+++ b/src/Gui/TreeSearchUtil.h
@@ -1,0 +1,35 @@
+/***************************************************************************
+ *   Copyright (c) 2026 The FreeCAD Project Association AISBL              *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include <QString>
+#include <QRegularExpression>
+
+namespace Gui::TreeSearchUtil
+{
+
+// Internal GUI utility for model tree search; not part of the public API.
+QRegularExpression wildcardToRegex(const QString& pattern);
+bool regexMatches(const QRegularExpression& re, const QString& haystack);
+
+}

--- a/src/Gui/TreeSearchUtil.h
+++ b/src/Gui/TreeSearchUtil.h
@@ -32,4 +32,4 @@ namespace Gui::TreeSearchUtil
 QRegularExpression wildcardToRegex(const QString& pattern);
 bool regexMatches(const QRegularExpression& re, const QString& haystack);
 
-}
+}  // namespace Gui::TreeSearchUtil

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(Gui_tests_run
         Assistant.cpp
         Camera.cpp
         FileDialog.cpp
+        TreeSearchUtil.cpp
         StyleParameters/StyleParametersApplicationTest.cpp
         StyleParameters/ParserTest.cpp
         StyleParameters/ParameterManagerTest.cpp

--- a/tests/src/Gui/TreeSearchUtil.cpp
+++ b/tests/src/Gui/TreeSearchUtil.cpp
@@ -16,7 +16,7 @@ bool matches(const QString& pattern, const QString& haystack)
     return Gui::TreeSearchUtil::regexMatches(re, haystack);
 }
 
-}
+}  // namespace
 
 TEST(TreeSearchUtil, PlainTextSearchMatchesSubstrings)
 {

--- a/tests/src/Gui/TreeSearchUtil.cpp
+++ b/tests/src/Gui/TreeSearchUtil.cpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+
+#include <QRegularExpression>
+
+#include <Gui/TreeSearchUtil.h>
+
+namespace
+{
+
+bool matches(const QString& pattern, const QString& haystack)
+{
+    const auto re = Gui::TreeSearchUtil::wildcardToRegex(pattern);
+    EXPECT_TRUE(re.isValid());
+    return Gui::TreeSearchUtil::regexMatches(re, haystack);
+}
+
+}
+
+TEST(TreeSearchUtil, PlainTextSearchMatchesSubstrings)
+{
+    EXPECT_TRUE(matches(QStringLiteral("Cube"), QStringLiteral("Cube")));
+    EXPECT_TRUE(matches(QStringLiteral("Cube"), QStringLiteral("Cube001")));
+    EXPECT_TRUE(matches(QStringLiteral("Cube"), QStringLiteral("MyCube")));
+}
+
+TEST(TreeSearchUtil, MatchingIsCaseInsensitive)
+{
+    EXPECT_TRUE(matches(QStringLiteral("cube"), QStringLiteral("CUBE001")));
+}
+
+TEST(TreeSearchUtil, PrefixWildcardIsAnchored)
+{
+    EXPECT_TRUE(matches(QStringLiteral("Cube*"), QStringLiteral("Cube")));
+    EXPECT_TRUE(matches(QStringLiteral("Cube*"), QStringLiteral("Cube001")));
+    EXPECT_FALSE(matches(QStringLiteral("Cube*"), QStringLiteral("MyCube")));
+}
+
+TEST(TreeSearchUtil, SuffixWildcardIsAnchored)
+{
+    EXPECT_TRUE(matches(QStringLiteral("*Cube"), QStringLiteral("MyCube")));
+    EXPECT_TRUE(matches(QStringLiteral("*Cube"), QStringLiteral("Cube")));
+    EXPECT_FALSE(matches(QStringLiteral("*Cube"), QStringLiteral("Cube001Extra")));
+}
+
+TEST(TreeSearchUtil, MiddleWildcardIsAnchored)
+{
+    EXPECT_TRUE(matches(QStringLiteral("C*e"), QStringLiteral("Cube")));
+    EXPECT_TRUE(matches(QStringLiteral("C*e"), QStringLiteral("C123e")));
+    EXPECT_TRUE(matches(QStringLiteral("C*e"), QStringLiteral("Ce")));
+    EXPECT_FALSE(matches(QStringLiteral("C*e"), QStringLiteral("ACube")));
+}
+
+TEST(TreeSearchUtil, QuestionMarkMatchesExactlyOneCharacter)
+{
+    EXPECT_TRUE(matches(QStringLiteral("Cube???"), QStringLiteral("Cube001")));
+    EXPECT_FALSE(matches(QStringLiteral("Cube???"), QStringLiteral("Cube01")));
+    EXPECT_FALSE(matches(QStringLiteral("Cube???"), QStringLiteral("Cube0001")));
+}
+
+TEST(TreeSearchUtil, SingleWildcardsHandleEmptyAndSingleCharacters)
+{
+    EXPECT_TRUE(matches(QStringLiteral("*"), QStringLiteral("")));
+    EXPECT_TRUE(matches(QStringLiteral("*"), QStringLiteral("anything")));
+    EXPECT_TRUE(matches(QStringLiteral("?"), QStringLiteral("A")));
+    EXPECT_FALSE(matches(QStringLiteral("?"), QStringLiteral("")));
+    EXPECT_FALSE(matches(QStringLiteral("?"), QStringLiteral("AB")));
+}
+
+TEST(TreeSearchUtil, StarAndQuestionMarkCanBeCombined)
+{
+    EXPECT_TRUE(matches(QStringLiteral("Part*??"), QStringLiteral("Part001")));
+    EXPECT_TRUE(matches(QStringLiteral("P?rt*1"), QStringLiteral("Part001")));
+    EXPECT_FALSE(matches(QStringLiteral("Part*??"), QStringLiteral("Part1")));
+    EXPECT_FALSE(matches(QStringLiteral("P?rt*1"), QStringLiteral("Port002")));
+}
+
+TEST(TreeSearchUtil, RegexMetacharactersAreEscaped)
+{
+    EXPECT_TRUE(matches(QStringLiteral("a.b+c"), QStringLiteral("a.b+c")));
+    EXPECT_FALSE(matches(QStringLiteral("a.b+c"), QStringLiteral("aXbXc")));
+}
+
+TEST(TreeSearchUtil, IncompleteRegexSyntaxIsTreatedLiterally)
+{
+    EXPECT_TRUE(matches(QStringLiteral("["), QStringLiteral("[")));
+    EXPECT_FALSE(matches(QStringLiteral("["), QStringLiteral("x")));
+}
+
+TEST(TreeSearchUtil, EmptyPatternProducesValidRegex)
+{
+    const auto re = Gui::TreeSearchUtil::wildcardToRegex(QString {});
+
+    EXPECT_TRUE(re.isValid());
+}
+
+TEST(TreeSearchUtil, RegexMatchesRejectsInvalidRegex)
+{
+    const QRegularExpression invalid(QStringLiteral("["));
+
+    EXPECT_FALSE(invalid.isValid());
+    EXPECT_FALSE(Gui::TreeSearchUtil::regexMatches(invalid, QStringLiteral("anything")));
+}


### PR DESCRIPTION
This PR implements the search enhancements for the Model Tree as discussed in #29473. It improves navigation for power users while strictly preserving the legacy substring search behavior for standard queries.

### Key Features & Architectural Choices
* **Wildcard Support:** Added wildcard-aware tree search supporting `*` and `?`. Plain text searches remain standard substring searches (fully backwards compatible). When explicit wildcards are used, the pattern is treated as an anchored glob (using `^` and `$`). Matching is case-insensitive and regex metacharacters are safely treated literally.
* **Search History:** A dedicated dropdown menu (`QMenu` accessible via button or `Alt+Down`) stores recent successful searches.
* **Global Search Toggle:** A new checkbox allows searching across all open documents.
* **Architecture:** Replaced the math-based `ExpressionLineEdit` with a clean, native `QLineEdit` to avoid conflicts with wildcard characters. Introduced an `UnfilteredCompleter` adopting a Single Source of Truth (SSOT) approach: the dropdown now strictly mirrors the exact items highlighted by the tree's search logic. Separated the wildcard regex logic into `TreeSearchUtil` with full `gtest` coverage.

## Issues
Closes #29473

## Video

https://github.com/user-attachments/assets/f8fe38b7-0bde-48f0-9caa-65bdfde84ceb

