### PR TITLE
Draft: Add task dialog widget for Draft_Edit

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1050,8 +1050,8 @@ class DraftToolBar:
     def selectUi(self, extra=None, on_close_call=None):
         self.makeDumbTask(extra, on_close_call)
 
-    def editUi(self):
-        self.makeDumbTask(on_close_call=self.finish)
+    def editUi(self, extra=None):
+        self.makeDumbTask(extra=extra, on_close_call=self.finish)
 
     def extUi(self):
         if params.get_param("UsePartPrimitives"):

--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -294,7 +294,10 @@ class Edit(gui_base_original.Modifier):
             # https://github.com/FreeCAD/FreeCAD/issues/27308
             QtCore.QTimer.singleShot(300, self.proceed)
         else:
-            self.ui.selectUi(on_close_call=self.finish)
+            self.ui.selectUi(
+                extra=self.create_task_panel_widget("select_object"),
+                on_close_call=self.finish,
+            )
             App.Console.PrintMessage(translate("draft", "Select a Draft object to edit") + "\n")
             self.register_selection_callback()
 
@@ -311,10 +314,14 @@ class Edit(gui_base_original.Modifier):
         Gui.Selection.clearSelection()
         Gui.Snapper.setSelectMode(True)
 
-        self.ui.editUi()
-
+        edit_points_by_obj = []
         for obj in self.edited_objects:
-            self.setTrackers(obj, self.getEditPoints(obj))
+            edit_points_by_obj.append((obj, self.getEditPoints(obj)))
+
+        self.ui.editUi(extra=self.create_task_panel_widget("select_point"))
+
+        for obj, edit_points in edit_points_by_obj:
+            self.setTrackers(obj, edit_points)
 
         App.addDocumentObserver(self)
         self.register_editing_callbacks()
@@ -500,7 +507,13 @@ class Edit(gui_base_original.Modifier):
 
         App.Console.PrintMessage(obj.Name + ": editing node number " + str(node_idx) + "\n")
 
-        self.ui.lineUi(title=translate("draft", "Edit Node"), icon="Draft_Edit")
+        self.ui.lineUi(
+            title=translate("draft", "Edit Node"),
+            extra=self.create_task_panel_widget(
+                "set_position", selected_obj=obj, selected_node=node_idx
+            ),
+            icon="Draft_Edit",
+        )
         self.ui.continueCmd.hide()
         self.editing = node_idx
         self.trackers[obj.Name][node_idx].off()
@@ -538,11 +551,39 @@ class Edit(gui_base_original.Modifier):
             self.trackers[obj.Name][nodeIndex].set(v)
         self.update(obj, nodeIndex, v)
         self.alt_edit_mode = 0
-        self.ui.editUi()
+        self.ui.editUi(extra=self.create_task_panel_widget("select_point"))
         self.node = []
         self.editing = None
         self.showTrackers()
         gui_tool_utils.redraw_3d_view()
+
+    def create_task_panel_widget(self, state, selected_obj=None, selected_node=None):
+        """Create the Draft Edit task panel section for the current state."""
+        widget = QtWidgets.QWidget()
+        widget.setWindowTitle(translate("draft", "Draft Edit"))
+        widget.setWindowIcon(Gui.getIcon(":/icons/Draft_Edit.svg"))
+
+        layout = QtWidgets.QVBoxLayout(widget)
+
+        status_label = QtWidgets.QLabel()
+        status_label.setWordWrap(True)
+        status_label.setText(self.get_task_panel_status(state, selected_obj, selected_node))
+        layout.addWidget(status_label)
+
+        return widget
+
+    def get_task_panel_status(self, state, selected_obj=None, selected_node=None):
+        """Return the status text for the Draft Edit task panel."""
+        if state == "select_object":
+            return translate("draft", "Select an editable object.")
+        if state == "select_point":
+            return translate("draft", "Select a point to edit.")
+        if state == "set_position":
+            return translate(
+                "draft",
+                "Set the position for point {point} of {object}.",
+            ).format(point=selected_node + 1, object=selected_obj.Label)
+        return ""
 
     # -------------------------------------------------------------------------
     # EDIT TRACKERS functions


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Adds a task dialog widget to the otherwise empty task dialog which only shows a Close button.
- Asks to select an object if no object was chosen
- Asks to select a point if an object is selected or was pre-selected
- Displays the point and object which is edited


In combination with the PR for the status bar hints it should be clear how this tool works.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
- Fixes https://github.com/FreeCAD/FreeCAD/issues/19650
## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
### Before
<img width="1183" height="654" alt="grafik" src="https://github.com/user-attachments/assets/b864e64a-1543-4ed9-9650-2ae32f8c6813" />


### After


https://github.com/user-attachments/assets/8e7f0cd8-39a8-43ee-8892-41bc0c1aa014


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
