### PR TITLE
Gui/Draft: block clarify selection while picking points

### DIFF
--- a/src/Gui/FreeCADGui._View3DInventorViewer.pyi
+++ b/src/Gui/FreeCADGui._View3DInventorViewer.pyi
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import Any, overload
 
 from FreeCAD import Matrix, Vector
+from FreeCADGui import ViewerInputClaimKind
 
 class _View3DInventorViewer:
     """Low-level Coin viewer wrapper behind the 3D view."""
@@ -93,6 +94,30 @@ class _View3DInventorViewer:
 
     def isRedirectedToSceneGraph(self) -> bool:
         """Return whether rendering is redirected to the scene graph."""
+        ...
+
+    def beginInputClaim(
+        self,
+        owner: str,
+        kind: ViewerInputClaimKind,
+        /,
+    ) -> int:
+        """Claim viewer input and return a claim id.
+
+        The kind value is a ``FreeCADGui.ViewerInputClaimKind`` member.
+        """
+        ...
+
+    def endInputClaim(self, claim_id: int, /) -> None:
+        """Release a viewer input claim."""
+        ...
+
+    def hasInputClaim(self) -> bool:
+        """Return whether any viewer input claim is active."""
+        ...
+
+    def canStartSelection(self) -> bool:
+        """Return whether selection may start."""
         ...
 
     def grabFramebuffer(self) -> Any:

--- a/src/Gui/FreeCADGui.module.pyi
+++ b/src/Gui/FreeCADGui.module.pyi
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import FreeCAD as App
 from collections.abc import Sequence
-from enum import IntEnum
+from enum import Enum, IntEnum
 from typing import Any, ClassVar, Literal, Protocol, TypeAlias, overload
 
 from FreeCAD import DocumentObject
@@ -168,6 +168,13 @@ class UserInput(IntEnum):
     MouseScrollDown = ...
 
 _InputSequence: TypeAlias = UserInput | tuple[UserInput, ...]
+
+class ViewerInputClaimKind(str, Enum):
+    """Viewer input interaction kinds accepted by 3D viewer input claims."""
+
+    PointPick = "PointPick"
+    DragInteraction = "DragInteraction"
+    SelectionMenu = "SelectionMenu"
 
 class _WorkbenchBackend(Protocol):
     """Protocol for the mutable backend object behind one GUI workbench."""

--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -93,6 +93,12 @@ class ToggleVisibilityMode(Enum):
     NoToggleVisibility = "NoToggleVisibility"
 
 
+class ViewerInputClaimKind(str, Enum):
+    PointPick = "PointPick"
+    DragInteraction = "DragInteraction"
+    SelectionMenu = "SelectionMenu"
+
+
 def _isCommandActive(name: str) -> bool:
     cmd = Gui.Command.get(name)
     return bool(cmd and cmd.isActive())
@@ -103,6 +109,7 @@ Gui.listCommands = Gui.Command.listAll
 Gui.isCommandActive = _isCommandActive
 Gui.Selection.SelectionStyle = SelectionStyle
 Gui.Selection.SelectionActionMode = SelectionActionMode
+Gui.ViewerInputClaimKind = ViewerInputClaimKind
 
 
 # Important definitions

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -2191,7 +2191,7 @@ void NavigationStyle::openPopupMenu(const SbVec2s& position)
     const SoPickedPointList& pplist = rp.getPickedPointList();
     QAction* pickAction = nullptr;
 
-    if (pplist.getLength() > 0) {
+    if (pplist.getLength() > 0 && viewer->canStartSelection()) {
         separator = true;
         if (auto cmd
             = Application::Instance->commandManager().getCommandByName("Std_ClarifySelection")) {

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -37,6 +37,8 @@
 
 #include <fmt/format.h>
 
+#include <utility>
+
 #include <Inventor/SbBox.h>
 #include <Inventor/SoEventManager.h>
 #include <Inventor/SoPickedPoint.h>
@@ -191,12 +193,17 @@ public:
 private:
     void triggerClarifySelection()
     {
+        if (!currentViewer || !currentViewer->canStartSelection()
+            || (Base::Sequencer().isRunning() && Base::Sequencer().isBlocking())) {
+            longPressTimer->stop();
+            currentViewer = nullptr;
+            return;
+        }
+
         // reset navigation state so button1down doesn't stay stuck ie. gh issue #29090
         // (the blocking QMenu::exec in ClarifySelection steals the LMB release)
-        if (currentViewer) {
-            if (auto* nav = currentViewer->navigationStyle()) {
-                nav->resetButtonState();
-            }
+        if (auto* nav = currentViewer->navigationStyle()) {
+            nav->resetButtonState();
         }
         Gui::Command::runCommand(Gui::Command::Gui, "Gui.runCommand('Std_ClarifySelection')");
     }
@@ -207,6 +214,10 @@ private:
                            .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
                            ->GetBool("EnableLongPressClarifySelection", true);
         if (!enabled) {
+            return false;
+        }
+
+        if (!viewer->canStartSelection()) {
             return false;
         }
 
@@ -2061,6 +2072,35 @@ void View3DInventorViewer::setSelectionEnabled(bool enable)
 bool View3DInventorViewer::isSelectionEnabled() const
 {
     return this->selectionRoot->selectionEnabled.getValue();  // NOLINT
+}
+
+View3DInventorViewer::ViewerInputClaimId View3DInventorViewer::beginInputClaim(
+    std::string owner,
+    ViewerInputClaimKind kind
+)
+{
+    const auto id = nextInputClaimId++;
+    inputClaims.emplace(id, ViewerInputClaim {std::move(owner), kind});
+    return id;
+}
+
+void View3DInventorViewer::endInputClaim(ViewerInputClaimId id)
+{
+    inputClaims.erase(id);
+}
+
+bool View3DInventorViewer::hasInputClaim() const
+{
+    return !inputClaims.empty();
+}
+
+bool View3DInventorViewer::canStartSelection() const
+{
+    if (Gui::Selection().isClarifySelectionActive()) {
+        return false;
+    }
+
+    return !hasInputClaim();
 }
 
 SbVec2f View3DInventorViewer::screenCoordsOfPath(SoPath* path) const

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -23,10 +23,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <list>
 #include <map>
 #include <memory>
 #include <set>
+#include <string>
 #include <vector>
 
 #include <QCursor>
@@ -119,6 +121,14 @@ public:
         BoxZoom = 3,    /**< Perform a box zoom. */
         Clip = 4,       /**< Clip objects using a lasso. */
     };
+    enum class ViewerInputClaimKind
+    {
+        PointPick,
+        DragInteraction,
+        SelectionMenu,
+    };
+    using ViewerInputClaimId = std::uint64_t;
+
     /** @name Modus handling of the viewer
      * Here you can switch several features on/off
      * and modes of the Viewer
@@ -355,6 +365,10 @@ public:
     {
         return this->allowredir;
     }
+    ViewerInputClaimId beginInputClaim(std::string owner, ViewerInputClaimKind kind);
+    void endInputClaim(ViewerInputClaimId id);
+    bool hasInputClaim() const;
+    bool canStartSelection() const;
     //@}
 
     /** @name Pick actions */
@@ -630,6 +644,13 @@ private:
     SoEventCallback* pEventCallback;
     NavigationStyle* navigation;
     SoFCUnifiedSelection* selectionRoot;
+    struct ViewerInputClaim
+    {
+        std::string owner;
+        ViewerInputClaimKind kind;
+    };
+    std::map<ViewerInputClaimId, ViewerInputClaim> inputClaims;
+    ViewerInputClaimId nextInputClaimId {1};
 
     SoClipPlane* pcClipPlane;
 

--- a/src/Gui/View3DViewerPy.cpp
+++ b/src/Gui/View3DViewerPy.cpp
@@ -35,6 +35,26 @@
 
 using namespace Gui;
 
+namespace
+{
+View3DInventorViewer::ViewerInputClaimKind parseViewerInputClaimKind(const char* kind)
+{
+    const std::string kindName(kind);
+    if (kindName == "PointPick") {
+        return View3DInventorViewer::ViewerInputClaimKind::PointPick;
+    }
+    if (kindName == "DragInteraction") {
+        return View3DInventorViewer::ViewerInputClaimKind::DragInteraction;
+    }
+    if (kindName == "SelectionMenu") {
+        return View3DInventorViewer::ViewerInputClaimKind::SelectionMenu;
+    }
+
+    throw Py::ValueError("Unknown viewer input claim kind: " + kindName);
+}
+
+}  // namespace
+
 
 void View3DInventorViewerPy::init_type()
 {
@@ -151,6 +171,27 @@ void View3DInventorViewerPy::init_type()
         "isRedirectedToSceneGraph",
         &View3DInventorViewerPy::isRedirectedToSceneGraph,
         "isRedirectedToSceneGraph() -> bool: check whether event redirection is enabled."
+    );
+    add_varargs_method(
+        "beginInputClaim",
+        &View3DInventorViewerPy::beginInputClaim,
+        "beginInputClaim(owner, kind) -> int: claim viewer input. "
+        "kind is a Gui.ViewerInputClaimKind value."
+    );
+    add_varargs_method(
+        "endInputClaim",
+        &View3DInventorViewerPy::endInputClaim,
+        "endInputClaim(claim_id): release a viewer input claim."
+    );
+    add_varargs_method(
+        "hasInputClaim",
+        &View3DInventorViewerPy::hasInputClaim,
+        "hasInputClaim() -> bool: check whether any viewer input claim is active."
+    );
+    add_varargs_method(
+        "canStartSelection",
+        &View3DInventorViewerPy::canStartSelection,
+        "canStartSelection() -> bool: check whether selection may start."
     );
     add_varargs_method(
         "grabFramebuffer",
@@ -683,6 +724,47 @@ Py::Object View3DInventorViewerPy::isRedirectedToSceneGraph(const Py::Tuple& arg
     }
     bool ok = _viewer->isRedirectedToSceneGraph();
     return Py::Boolean(ok);
+}
+
+Py::Object View3DInventorViewerPy::beginInputClaim(const Py::Tuple& args)
+{
+    const char* owner = nullptr;
+    const char* kind = nullptr;
+    if (!PyArg_ParseTuple(args.ptr(), "ss", &owner, &kind)) {
+        throw Py::Exception();
+    }
+
+    const auto claimId = _viewer->beginInputClaim(owner, parseViewerInputClaimKind(kind));
+    return Py::Object(PyLong_FromUnsignedLongLong(static_cast<unsigned long long>(claimId)), true);
+}
+
+Py::Object View3DInventorViewerPy::endInputClaim(const Py::Tuple& args)
+{
+    unsigned long long claimId = 0;
+    if (!PyArg_ParseTuple(args.ptr(), "K", &claimId)) {
+        throw Py::Exception();
+    }
+
+    _viewer->endInputClaim(static_cast<View3DInventorViewer::ViewerInputClaimId>(claimId));
+    return Py::None();
+}
+
+Py::Object View3DInventorViewerPy::hasInputClaim(const Py::Tuple& args)
+{
+    if (!PyArg_ParseTuple(args.ptr(), "")) {
+        throw Py::Exception();
+    }
+
+    return Py::Boolean(_viewer->hasInputClaim());
+}
+
+Py::Object View3DInventorViewerPy::canStartSelection(const Py::Tuple& args)
+{
+    if (!PyArg_ParseTuple(args.ptr(), "")) {
+        throw Py::Exception();
+    }
+
+    return Py::Boolean(_viewer->canStartSelection());
 }
 
 Py::Object View3DInventorViewerPy::grabFramebuffer(const Py::Tuple& args)

--- a/src/Gui/View3DViewerPy.h
+++ b/src/Gui/View3DViewerPy.h
@@ -73,6 +73,10 @@ public:
     Py::Object setBackgroundColor(const Py::Tuple& args);
     Py::Object setRedirectToSceneGraph(const Py::Tuple& args);
     Py::Object isRedirectedToSceneGraph(const Py::Tuple& args);
+    Py::Object beginInputClaim(const Py::Tuple& args);
+    Py::Object endInputClaim(const Py::Tuple& args);
+    Py::Object hasInputClaim(const Py::Tuple& args);
+    Py::Object canStartSelection(const Py::Tuple& args);
     Py::Object grabFramebuffer(const Py::Tuple& args);
 
     Py::Object setOverrideMode(const Py::Tuple& args);

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -130,6 +130,7 @@ class Snapper:
         self.running = False
         self.callbackClick = None
         self.callbackMove = None
+        self._inputClaims = []
         self.snapObjectIndex = 0
 
         # snap keys, it's important that they are in this order for
@@ -1258,6 +1259,7 @@ class Snapper:
 
     def off(self):
         """Finish snapping."""
+        self._end_all_input_claims()
         if self.tracker:
             self.tracker.off()
         if self.trackLine:
@@ -1395,6 +1397,31 @@ class Snapper:
         if self.constrainLine:
             self.constrainLine.off()
 
+    def _begin_input_claim(self):
+        viewer = self.view.getViewer()
+        claim_id = viewer.beginInputClaim("Draft.Snapper", Gui.ViewerInputClaimKind.PointPick)
+        input_claim = (viewer, claim_id)
+        self._inputClaims.append(input_claim)
+        return input_claim
+
+    def _end_input_claim(self, input_claim):
+        viewer, claim_id = input_claim
+
+        for index, (active_viewer, active_claim_id) in enumerate(self._inputClaims):
+            if active_claim_id != claim_id or active_viewer is not viewer:
+                continue
+
+            del self._inputClaims[index]
+            try:
+                viewer.endInputClaim(claim_id)
+            except RuntimeError:
+                pass
+            return
+
+    def _end_all_input_claims(self):
+        for input_claim in self._inputClaims[:]:
+            self._end_input_claim(input_claim)
+
     def getPoint(
         self, last=None, callback=None, movecallback=None, extradlg=None, title=None, mode="point"
     ):
@@ -1451,6 +1478,7 @@ class Snapper:
             pass
         self.callbackClick = None
         self.callbackMove = None
+        self._end_all_input_claims()
 
         def move(event_cb):
             if not self.ui.mouse:
@@ -1505,15 +1533,21 @@ class Snapper:
             self.callbackMove = None
             Gui.Snapper.off()
             self.ui.offUi()
-            if callback:
-                if len(inspect.getfullargspec(callback).args) > 1:
-                    obj = None
-                    if self.snapInfo and ("Object" in self.snapInfo) and self.snapInfo["Object"]:
-                        obj = App.ActiveDocument.getObject(self.snapInfo["Object"])
-                    callback(self.pt, obj)
-                else:
-                    callback(self.pt)
-            self.pt = None
+            try:
+                if callback:
+                    if len(inspect.getfullargspec(callback).args) > 1:
+                        obj = None
+                        if (
+                            self.snapInfo
+                            and ("Object" in self.snapInfo)
+                            and self.snapInfo["Object"]
+                        ):
+                            obj = App.ActiveDocument.getObject(self.snapInfo["Object"])
+                        callback(self.pt, obj)
+                    else:
+                        callback(self.pt)
+            finally:
+                self.pt = None
 
         def cancel():
             try:
@@ -1549,18 +1583,27 @@ class Snapper:
         else:
             interface = self.ui.pointUi
         if callback:
-            if title:
-                interface(
-                    title=title, cancel=cancel, getcoords=getcoords, extra=extradlg, rel=bool(last)
+            input_claim = self._begin_input_claim()
+            try:
+                if title:
+                    interface(
+                        title=title,
+                        cancel=cancel,
+                        getcoords=getcoords,
+                        extra=extradlg,
+                        rel=bool(last),
+                    )
+                else:
+                    interface(cancel=cancel, getcoords=getcoords, extra=extradlg, rel=bool(last))
+                self.callbackClick = self.view.addEventCallbackPivy(
+                    coin.SoMouseButtonEvent.getClassTypeId(), click
                 )
-            else:
-                interface(cancel=cancel, getcoords=getcoords, extra=extradlg, rel=bool(last))
-            self.callbackClick = self.view.addEventCallbackPivy(
-                coin.SoMouseButtonEvent.getClassTypeId(), click
-            )
-            self.callbackMove = self.view.addEventCallbackPivy(
-                coin.SoLocation2Event.getClassTypeId(), move
-            )
+                self.callbackMove = self.view.addEventCallbackPivy(
+                    coin.SoLocation2Event.getClassTypeId(), move
+                )
+            except Exception:
+                self._end_input_claim(input_claim)
+                raise
 
     def get_snap_toolbar(self):
         """Get the snap toolbar."""


### PR DESCRIPTION
This adds a small viewer-level input-claim API so tools that temporarily own 3D view input can make that state explicit. Draft Snapper now claims point-pick input while `getPoint()` is active, and clarify selection checks the viewer policy before opening from long-press or the context menu.

The intent is to avoid special-casing Draft/BIM inside clarify selection. Instead, the viewer becomes the arbitration point: active tools declare that they own input, and selection features ask whether they may start.

- Add a small `View3DInventorViewer` input-claim API so active tools can claim viewer input.
- Gate long-press and context-menu clarify selection through `canStartSelection()`.
- Make Draft Snapper claim point-pick input while `getPoint()` is active, and release it during Snapper teardown.

Fixes #27982.

Assisted-by: GPT-5.5
