### PR TITLE
Sketcher: Solve constraints alone when possible

### DIFF
--- a/src/Mod/Sketcher/App/planegcs/Constraints.h
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.h
@@ -134,9 +134,13 @@ public:
     virtual ~Constraint()
     {}
 
-    VEC_pD params()
+    VEC_pD params() const
     {
         return pvec;
+    }
+    VEC_pD origParams() const
+    {
+        return origpvec;
     }
 
     void redirectParams(const MAP_pD_pD& redirectionmap);

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -53,6 +53,7 @@
 #include <iostream>
 #include <limits>
 #include <numbers>
+#include <vector>
 
 #include "GCS.h"
 #include "qp_eq.h"
@@ -99,9 +100,6 @@
 
 #include <Base/Console.h>
 #include <FCConfig.h>
-
-#include <boost/graph/connected_components.hpp>
-#include <boost_graph_adjacency_list.hpp>
 
 using MatrixIndexType = Eigen::FullPivHouseholderQR<Eigen::MatrixXd>::IntDiagSizeVectorType;
 
@@ -456,8 +454,6 @@ void SolverReportingManager::LogMatrix(const std::string str, MatrixIndexType ma
 }
 #endif
 
-
-using Graph = boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS>;
 
 ///////////////////////////////////////
 // Solver
@@ -1763,43 +1759,27 @@ void System::initSolution(Algorithm alg)
     auto [redMap, constraints, params] = computeReductionMap(plist, solvableConstraints(clist));
     reductionMap = redMap;
 
-    auto components = partitionIntoComponents(params, constraints, reductionMap);
-
-    // TODO: Why are the later (constraint-related) items added first?
-    // Adding plist-related items first would simplify as   signment of `i`, but is not a big expense
-    // overall. Leaving as is to avoid any unintended consequences.
-    clists.clear();                 // destroy any lists
-    clists.resize(components.size);  // create empty lists to be filled in
-    for (size_t i = 0; i < constraints.size(); ++i) {
-        int cid = components.constraintComponent(i);
-        clists[cid].push_back(constraints[i]);
-    }
-
-    plists.clear();                 // destroy any lists
-    plists.resize(components.size);  // create empty lists to be filled in
-    for (size_t i = 0; i < params.size(); ++i) {
-        int cid = components.paramComponent(i);
-        plists[cid].push_back(params[i]);
-    }
+    auto subSystemDescriptions = partitionIntoSubSystems(params, constraints, reductionMap);
 
     // calculates subSystems and subSystemsAux from clists, plists
     clearSubSystems();
-    subSystems.resize(clists.size(), nullptr);
-    subSystemsAux.resize(clists.size(), nullptr);
-    for (std::size_t cid = 0; cid < clists.size(); ++cid) {
+    subSystems.resize(subSystemDescriptions.size(), nullptr);
+    subSystemsAux.resize(subSystemDescriptions.size(), nullptr);
+    for (size_t cid = 0; cid < subSystemDescriptions.size(); ++cid) {
+        const auto& subSystemDescription = subSystemDescriptions[cid];
         std::vector<Constraint*> clist0, clist1;
         std::ranges::partition_copy(
-            clists[cid],
+            subSystemDescription.constraints,
             std::back_inserter(clist0),
             std::back_inserter(clist1),
             [](auto constr) { return constr->getTag() >= 0; }
         );
 
         if (!clist0.empty()) {
-            subSystems[cid] = new SubSystem(clist0, plists[cid], reductionMap);
+            subSystems[cid] = new SubSystem(clist0, subSystemDescription.params, reductionMap);
         }
         if (!clist1.empty()) {
-            subSystemsAux[cid] = new SubSystem(clist1, plists[cid], reductionMap);
+            subSystemsAux[cid] = new SubSystem(clist1, subSystemDescription.params, reductionMap);
         }
     }
 
@@ -1820,14 +1800,17 @@ std::vector<Constraint*> System::solvableConstraints(const std::vector<Constrain
     }
     return solvable;
 }
-System::ReductionOutput System::computeReductionMap(const std::vector<double*>& params, const std::vector<Constraint*>& constraints)
+System::ReductionOutput System::computeReductionMap(
+    const std::vector<double*>& params,
+    const std::vector<Constraint*>& constraints
+)
 {
     std::map<double*, int> paramToIndex = buildParamToIndex(params);
     VEC_pD reducedParams = params;
     std::vector<Constraint*> remainingConstraints;
     std::map<double*, double*> reductionMap;
     std::vector<double*> remainingParams;
-    
+
     for (const auto& constr : constraints) {
         if (!(constr->getTag() >= 0 && constr->getTypeId() == Equal)) {
             remainingConstraints.push_back(constr);
@@ -1836,8 +1819,8 @@ System::ReductionOutput System::computeReductionMap(const std::vector<double*>& 
         const auto it1 = paramToIndex.find(constr->params()[0]);
         const auto it2 = paramToIndex.find(constr->params()[1]);
         if (it1 == paramToIndex.end() || it2 == paramToIndex.end()) {
-          remainingConstraints.push_back(constr);
-          continue;
+            remainingConstraints.push_back(constr);
+            continue;
         }
         double* p_kept = reducedParams[it1->second];
         double* p_replaced = reducedParams[it2->second];
@@ -1846,73 +1829,170 @@ System::ReductionOutput System::computeReductionMap(const std::vector<double*>& 
     for (size_t i = 0; i < params.size(); ++i) {
         if (params[i] != reducedParams[i]) {
             reductionMap[params[i]] = reducedParams[i];
-        } else {
+        }
+        else {
             remainingParams.push_back(params[i]);
         }
     }
 
     return ReductionOutput {
-                .reductionMap=reductionMap, 
-                .constraints=remainingConstraints, 
-                .params=remainingParams
-            };
+        .reductionMap = reductionMap,
+        .constraints = remainingConstraints,
+        .params = remainingParams
+    };
 }
-System::Components System::partitionIntoComponents(const std::vector<double*>& params, const std::vector<Constraint*>& constraints, const std::map<double*, double*>& reductionMap)
+
+void fillComponent(
+    int vertexIndex,
+    const std::vector<std::vector<size_t>>& adjacencyList,
+    std::vector<bool>& visited,
+    std::vector<size_t>& component
+)
 {
-    // partitioning into decoupled components
+    visited[vertexIndex] = true;
+    component.push_back(vertexIndex);
+
+    for (int adjVertex : adjacencyList[vertexIndex]) {
+        if (!visited[adjVertex]) {
+            fillComponent(adjVertex, adjacencyList, visited, component);
+        }
+    }
+}
+
+std::vector<System::SubSystemDescription> System::partitionIntoSubSystems(
+    const std::vector<double*>& params,
+    std::vector<Constraint*> constraints,
+    const std::map<double*, double*>& reductionMap
+)
+{
     std::map<double*, int> paramToIndex = buildParamToIndex(params);
 
-    Graph g;
-    
-    auto reducedParameters = [&](std::vector<double*> cparams) {
-        bool anyReduction = false;
+    // We sort by constraint type because we know
+    // equality and difference constraint have more chances
+    // to be solved singled out, so we edge our bet to have
+    // other, more complex constraints be reduced to 1 parameter
+    std::ranges::sort(constraints, [](Constraint* a, Constraint* b) -> bool {
+        return a->getTypeId() < b->getTypeId();
+    });
+
+    // This is used to find parameter indices for constraints parameters, it
+    // 1. Follows reduction indirection
+    // 2. Ensures uniqueness (no duplicate parameters)
+    // 3. Maps parameters to their index in the `params` vector
+    auto reduceParameters = [&](std::vector<double*> cparams) -> std::vector<size_t> {
         std::ranges::transform(cparams, cparams.begin(), [&](double* cparam) {
             auto foundReduction = reductionMap.find(cparam);
             if (foundReduction != reductionMap.end()) {
                 cparam = foundReduction->second;
-                anyReduction = true;
             }
             return cparam;
         });
 
-
-        if (!anyReduction) {
-            return cparams;
-        }
         std::ranges::sort(cparams);
         std::ranges::unique(cparams);
-        return cparams;
-    };
-
-    for (size_t i = 0; i < params.size() + constraints.size(); i++) {
-        boost::add_vertex(g);
-    }
-
-    int cvtid = int(params.size());
-    for (const auto constr : constraints) {
-        VEC_pD cparams = reducedParameters(c2p[constr]);
-    
-        for (auto param : cparams) {            
-            auto it = paramToIndex.find(param);
-            if (it != paramToIndex.end()) {
-                boost::add_edge(cvtid, it->second, g);
+        std::vector<size_t> paramIndices;
+        paramIndices.reserve(cparams.size());
+        for (auto param : cparams) {
+            auto foundIndex = paramToIndex.find(param);
+            if (foundIndex != paramToIndex.end()) {
+                paramIndices.push_back(foundIndex->second);
             }
         }
-        ++cvtid;
-    }
 
-    VEC_I components(boost::num_vertices(g));
-    int componentsSize = 0;
-    if (!components.empty()) {
-        componentsSize = boost::connected_components(g, &components[0]);
-    }
-
-    return Components {
-        .components = components,
-        .nParams = params.size(),
-        .size = componentsSize
+        return paramIndices;
     };
+
+    // Build an index
+    std::vector<std::pair<size_t, std::vector<size_t>>> constraintToParams;
+    for (size_t i = 0; i < constraints.size(); ++i) {
+        auto indices = reduceParameters(constraints[i]->origParams());
+        // if (indices.size() == 1) {
+        //     paramToIndex.erase(params[indices[0]]); // Will make simple systems discovery faster
+        //     later
+        // }
+        constraintToParams.push_back(std::make_pair(i, indices));
+    }
+
+    // Build the adjacency list. Every constraint and every parameter
+    // has a position in the vector. Each vector position contains
+    // a vector of indices to the adjacency list vector this represent
+    // adjacent vertices
+    // In practice, there should never be an edge between 2 constraints
+    // or between 2 parameters. Constraints occupy the first index range
+    // [0, constraints.size()[ and parameters occupy the second
+    // [constraints.size(), constraints.size() + params.size()[
+    std::vector<std::vector<size_t>> adjacencyList(constraints.size() + params.size());
+    for (size_t i = 0; i < constraints.size(); ++i) {
+        for (size_t paramInd : constraintToParams[i].second) {
+            size_t paramAdjInd = constraints.size() + paramInd;
+            adjacencyList[i].push_back(paramAdjInd);
+            adjacencyList[paramAdjInd].push_back(i);
+        }
+    }
+
+    // This cleanly removes a parameter from the adjacency list,
+    // severing every edge to or from it
+    // to preserve indexing, it does not actualy remove the parameter's
+    // position in the adjacencyList, but we can later test for
+    // vertices with no outgoing edge and refuse to make a subsystem
+    // from it
+    auto removeParam = [&](size_t paramAdjIndex) {
+        for (auto constrIndex : adjacencyList[paramAdjIndex]) {
+            std::erase(adjacencyList[constrIndex], paramAdjIndex);
+        }
+        adjacencyList[paramAdjIndex].clear();
+    };
+    std::vector<SubSystemDescription> subSystems;
+
+    bool retrySmallSystems = true;
+    size_t numSmallSystems = 0;
+    while (retrySmallSystems) {
+        retrySmallSystems = false;
+        for (size_t i = 0; i < constraints.size(); ++i) {
+            if (adjacencyList[i].size() != 1 || constraints[i]->getTag() < 0) {
+                continue;
+            }
+            size_t paramAdjIndex = adjacencyList[i][0];
+
+            subSystems.push_back(
+                SubSystemDescription {
+                    .constraints = {constraints[i]},
+                    .params = {params[paramAdjIndex - constraints.size()]}
+                }
+            );
+            removeParam(paramAdjIndex);
+            numSmallSystems++;
+            retrySmallSystems = true;
+        }
+    }
+
+    // Builds a subsystem description from constraints & parameters
+    // indices, it pulls from the `constraints` and `params` vectors
+    auto componentToSubsystem = [&](const std::vector<size_t>& component) -> SubSystemDescription {
+        System::SubSystemDescription desc;
+        for (size_t vertex : component) {
+            if (vertex < constraints.size()) {
+                desc.constraints.push_back(constraints[vertex]);
+            }
+            else {
+                desc.params.push_back(params[vertex - constraints.size()]);
+            }
+        }
+        return desc;
+    };
+
+    // Find every remaining connected components
+    std::vector<bool> visited(adjacencyList.size(), false);
+    for (size_t i = 0; i < constraints.size(); i++) {
+        if (!visited[i] && !adjacencyList[i].empty()) {
+            std::vector<size_t> component;
+            fillComponent(i, adjacencyList, visited, component);
+            subSystems.push_back(componentToSubsystem(component));
+        }
+    }
+    return subSystems;
 }
+
 std::map<double*, int> System::buildParamToIndex(const std::vector<double*> params)
 {
     std::map<double*, int> paramToIndex;
@@ -2124,6 +2204,7 @@ int System::solve_BFGS(SubSystem* subsys, bool /*isFine*/, bool isRedundantsolvi
     }
 
     subsys->revertParams();
+    subsys->applySolution();
 
     if (err <= smallF) {
         return Success;
@@ -2309,6 +2390,7 @@ int System::solve_LM(SubSystem* subsys, bool isRedundantsolving)
     }
 
     subsys->revertParams();
+    subsys->applySolution();
 
     return (stop == 1) ? Success : Failed;
 }
@@ -2517,6 +2599,7 @@ int System::solve_DL(SubSystem* subsys, bool isRedundantsolving)
     }
 
     subsys->revertParams();
+    subsys->applySolution();
 
     if (debugMode == IterationLevel) {
         std::stringstream stream;
@@ -4739,6 +4822,9 @@ int System::solve(SubSystem* subsysA, SubSystem* subsysB, bool /*isFine*/, bool 
 
     subsysA->revertParams();
     subsysB->revertParams();
+
+    subsysA->applySolution();
+    subsysB->applySolution();
     return ret;
 }
 

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -520,7 +520,6 @@ void System::clear()
 {
     plist.clear();
     pdrivenlist.clear();
-    pIndex.clear();
     pDependentParameters.clear();
     pDependentParametersGroups.clear();
     hasUnknowns = false;
@@ -1722,10 +1721,6 @@ void System::rescaleConstraint(int id, double coeff)
 void System::declareUnknowns(VEC_pD& params)
 {
     plist = params;
-    pIndex.clear();
-    for (int i = 0; i < int(plist.size()); ++i) {
-        pIndex[plist[i]] = i;
-    }
     hasUnknowns = true;
 }
 
@@ -1765,93 +1760,29 @@ void System::initSolution(Algorithm alg)
         return;
     }
 
-    std::vector<Constraint*> clistR;
-    if (!redundant.empty()) {
-        std::ranges::copy_if(clist, std::back_inserter(clistR), [this](auto constr) {
-            return this->redundant.count(constr) == 0 && constr->isDriving();
-        });
-    }
-    else {
-        std::ranges::copy_if(clist, std::back_inserter(clistR), [](auto constr) {
-            return constr->isDriving();
-        });
-    }
+    auto [redMap, constraints, params] = computeReductionMap(plist, solvableConstraints(clist));
+    reductionMap = redMap;
 
-    // partitioning into decoupled components
-    Graph g;
-    for (int i = 0; i < int(plist.size() + clistR.size()); i++) {
-        boost::add_vertex(g);
-    }
-
-    int cvtid = int(plist.size());
-    for (const auto constr : clistR) {
-        VEC_pD& cparams = c2p[constr];
-        for (const auto param : cparams) {
-            MAP_pD_I::const_iterator it = pIndex.find(param);
-            if (it != pIndex.end()) {
-                boost::add_edge(cvtid, it->second, g);
-            }
-        }
-        ++cvtid;
-    }
-
-    VEC_I components(boost::num_vertices(g));
-    int componentsSize = 0;
-    if (!components.empty()) {
-        componentsSize = boost::connected_components(g, &components[0]);
-    }
-
-    // identification of equality constraints and parameter reduction
-    std::set<Constraint*> reducedConstrs;  // constraints that will be eliminated through reduction
-    reductionmaps.clear();                 // destroy any maps
-    reductionmaps.resize(componentsSize);  // create empty maps to be filled in
-    {
-        VEC_pD reducedParams = plist;
-
-        for (const auto& constr : clistR) {
-            if (!(constr->getTag() >= 0 && constr->getTypeId() == Equal)) {
-                continue;
-            }
-            const auto it1 = pIndex.find(constr->params()[0]);
-            const auto it2 = pIndex.find(constr->params()[1]);
-            if (it1 == pIndex.end() || it2 == pIndex.end()) {
-                continue;
-            }
-            reducedConstrs.insert(constr);
-            double* p_kept = reducedParams[it1->second];
-            double* p_replaced = reducedParams[it2->second];
-            std::ranges::replace(reducedParams, p_replaced, p_kept);
-        }
-        for (size_t i = 0; i < plist.size(); ++i) {
-            if (plist[i] != reducedParams[i]) {
-                int cid = components[i];
-                reductionmaps[cid][plist[i]] = reducedParams[i];
-            }
-        }
-    }
+    auto components = partitionIntoComponents(params, constraints, reductionMap);
 
     // TODO: Why are the later (constraint-related) items added first?
-    // Adding plist-related items first would simplify assignment of `i`, but is not a big expense
+    // Adding plist-related items first would simplify as   signment of `i`, but is not a big expense
     // overall. Leaving as is to avoid any unintended consequences.
     clists.clear();                 // destroy any lists
-    clists.resize(componentsSize);  // create empty lists to be filled in
-    size_t i = plist.size();
-    for (const auto& constr : clistR) {
-        if (reducedConstrs.count(constr) == 0) {
-            int cid = components[i];
-            clists[cid].push_back(constr);
-        }
-        ++i;
+    clists.resize(components.size);  // create empty lists to be filled in
+    for (size_t i = 0; i < constraints.size(); ++i) {
+        int cid = components.constraintComponent(i);
+        clists[cid].push_back(constraints[i]);
     }
 
     plists.clear();                 // destroy any lists
-    plists.resize(componentsSize);  // create empty lists to be filled in
-    for (size_t i = 0; i < plist.size(); ++i) {
-        int cid = components[i];
-        plists[cid].push_back(plist[i]);
+    plists.resize(components.size);  // create empty lists to be filled in
+    for (size_t i = 0; i < params.size(); ++i) {
+        int cid = components.paramComponent(i);
+        plists[cid].push_back(params[i]);
     }
 
-    // calculates subSystems and subSystemsAux from clists, plists and reductionmaps
+    // calculates subSystems and subSystemsAux from clists, plists
     clearSubSystems();
     subSystems.resize(clists.size(), nullptr);
     subSystemsAux.resize(clists.size(), nullptr);
@@ -1865,14 +1796,130 @@ void System::initSolution(Algorithm alg)
         );
 
         if (!clist0.empty()) {
-            subSystems[cid] = new SubSystem(clist0, plists[cid], reductionmaps[cid]);
+            subSystems[cid] = new SubSystem(clist0, plists[cid], reductionMap);
         }
         if (!clist1.empty()) {
-            subSystemsAux[cid] = new SubSystem(clist1, plists[cid], reductionmaps[cid]);
+            subSystemsAux[cid] = new SubSystem(clist1, plists[cid], reductionMap);
         }
     }
 
     isInit = true;
+}
+std::vector<Constraint*> System::solvableConstraints(const std::vector<Constraint*>& constraints)
+{
+    std::vector<Constraint*> solvable;
+    if (!redundant.empty()) {
+        std::ranges::copy_if(constraints, std::back_inserter(solvable), [this](auto constr) {
+            return this->redundant.count(constr) == 0 && constr->isDriving();
+        });
+    }
+    else {
+        std::ranges::copy_if(constraints, std::back_inserter(solvable), [](auto constr) {
+            return constr->isDriving();
+        });
+    }
+    return solvable;
+}
+System::ReductionOutput System::computeReductionMap(const std::vector<double*>& params, const std::vector<Constraint*>& constraints)
+{
+    std::map<double*, int> paramToIndex = buildParamToIndex(params);
+    VEC_pD reducedParams = params;
+    std::vector<Constraint*> remainingConstraints;
+    std::map<double*, double*> reductionMap;
+    std::vector<double*> remainingParams;
+    
+    for (const auto& constr : constraints) {
+        if (!(constr->getTag() >= 0 && constr->getTypeId() == Equal)) {
+            remainingConstraints.push_back(constr);
+            continue;
+        }
+        const auto it1 = paramToIndex.find(constr->params()[0]);
+        const auto it2 = paramToIndex.find(constr->params()[1]);
+        if (it1 == paramToIndex.end() || it2 == paramToIndex.end()) {
+          remainingConstraints.push_back(constr);
+          continue;
+        }
+        double* p_kept = reducedParams[it1->second];
+        double* p_replaced = reducedParams[it2->second];
+        std::ranges::replace(reducedParams, p_replaced, p_kept);
+    }
+    for (size_t i = 0; i < params.size(); ++i) {
+        if (params[i] != reducedParams[i]) {
+            reductionMap[params[i]] = reducedParams[i];
+        } else {
+            remainingParams.push_back(params[i]);
+        }
+    }
+
+    return ReductionOutput {
+                .reductionMap=reductionMap, 
+                .constraints=remainingConstraints, 
+                .params=remainingParams
+            };
+}
+System::Components System::partitionIntoComponents(const std::vector<double*>& params, const std::vector<Constraint*>& constraints, const std::map<double*, double*>& reductionMap)
+{
+    // partitioning into decoupled components
+    std::map<double*, int> paramToIndex = buildParamToIndex(params);
+
+    Graph g;
+    
+    auto reducedParameters = [&](std::vector<double*> cparams) {
+        bool anyReduction = false;
+        std::ranges::transform(cparams, cparams.begin(), [&](double* cparam) {
+            auto foundReduction = reductionMap.find(cparam);
+            if (foundReduction != reductionMap.end()) {
+                cparam = foundReduction->second;
+                anyReduction = true;
+            }
+            return cparam;
+        });
+
+
+        if (!anyReduction) {
+            return cparams;
+        }
+        std::ranges::sort(cparams);
+        std::ranges::unique(cparams);
+        return cparams;
+    };
+
+    for (size_t i = 0; i < params.size() + constraints.size(); i++) {
+        boost::add_vertex(g);
+    }
+
+    int cvtid = int(params.size());
+    for (const auto constr : constraints) {
+        VEC_pD cparams = reducedParameters(c2p[constr]);
+    
+        for (auto param : cparams) {            
+            auto it = paramToIndex.find(param);
+            if (it != paramToIndex.end()) {
+                boost::add_edge(cvtid, it->second, g);
+            }
+        }
+        ++cvtid;
+    }
+
+    VEC_I components(boost::num_vertices(g));
+    int componentsSize = 0;
+    if (!components.empty()) {
+        componentsSize = boost::connected_components(g, &components[0]);
+    }
+
+    return Components {
+        .components = components,
+        .nParams = params.size(),
+        .size = componentsSize
+    };
+}
+std::map<double*, int> System::buildParamToIndex(const std::vector<double*> params)
+{
+    std::map<double*, int> paramToIndex;
+    for (size_t i = 0; i < params.size(); ++i) {
+        paramToIndex[params[i]] = static_cast<int>(i);
+    }
+    return paramToIndex;
 }
 
 void System::setReference()
@@ -4704,11 +4751,9 @@ void System::applySolution()
         if (subSystems[cid]) {
             subSystems[cid]->applySolution();
         }
-        for (MAP_pD_pD::const_iterator it = reductionmaps[cid].begin();
-             it != reductionmaps[cid].end();
-             ++it) {
-            *(it->first) = *(it->second);
-        }
+    }
+    for (auto reduced : reductionMap) {
+        *(reduced.first) = *(reduced.second);
     }
     evaluateDrivenConstraints();
 }

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <Eigen/QR>
+#include <vector>
 
 #include "../../SketcherGlobal.h"
 #include "SubSystem.h"
@@ -110,7 +111,6 @@ class SketcherExport System
 private:
     VEC_pD plist;        // list of the unknown parameters
     VEC_pD pdrivenlist;  // list of parameters of driven constraints
-    MAP_pD_I pIndex;
 
     VEC_pD pDependentParameters;  // list of dependent parameters by the system
 
@@ -133,7 +133,7 @@ private:
     std::vector<VEC_pD> plists;  // partitioned plist except equality constraints
     // partitioned clist except equality constraints
     std::vector<std::vector<Constraint*>> clists;
-    std::vector<MAP_pD_pD> reductionmaps;  // for simplification of equality constraints
+    MAP_pD_pD reductionMap;  // for simplification of equality constraints
 
     int dofs;
     std::set<Constraint*> redundant;
@@ -688,6 +688,37 @@ protected:
             return constraint->getTag() == tagID;
         });
     }
+
+public:
+    struct Components {
+        std::vector<int> components;
+        size_t nParams;
+        int size;
+    
+        int constraintComponent(size_t constraintIndex)
+        {
+            return components[constraintIndex + nParams];
+        }
+        int paramComponent(size_t paramIndex)
+        {
+            return components[paramIndex];
+        }
+    };
+    struct ReductionOutput {
+        std::map<double*, double*> reductionMap;
+        std::vector<Constraint*> constraints;
+        std::vector<double*> params;
+    };
+    struct IsolateConstraintsOutput {
+        std::vector<Constraint*> singleConstraints; // Constraints that can be solved individually
+        std::vector<Constraint*> groupConstraints; // Constraints that could not be isolated
+    };
+private:
+    static std::map<double*, int> buildParamToIndex(const std::vector<double*> params);
+    std::vector<Constraint*> solvableConstraints(const std::vector<Constraint*>& constraints);
+    ReductionOutput computeReductionMap(const std::vector<double*>& params, const std::vector<Constraint*>& constraints);
+    IsolateConstraintsOutput isolateConstraints();
+    Components partitionIntoComponents(const std::vector<double*>& params, const std::vector<Constraint*>& constraints, const std::map<double*, double*>& reductionMap);
 };
 
 

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -690,11 +690,12 @@ protected:
     }
 
 public:
-    struct Components {
+    struct Components
+    {
         std::vector<int> components;
         size_t nParams;
         int size;
-    
+
         int constraintComponent(size_t constraintIndex)
         {
             return components[constraintIndex + nParams];
@@ -704,21 +705,38 @@ public:
             return components[paramIndex];
         }
     };
-    struct ReductionOutput {
+
+    struct SubSystemDescription
+    {
+        std::vector<Constraint*> constraints;
+        std::vector<double*> params;
+    };
+
+    struct ReductionOutput
+    {
         std::map<double*, double*> reductionMap;
         std::vector<Constraint*> constraints;
         std::vector<double*> params;
     };
-    struct IsolateConstraintsOutput {
-        std::vector<Constraint*> singleConstraints; // Constraints that can be solved individually
-        std::vector<Constraint*> groupConstraints; // Constraints that could not be isolated
+    struct IsolateConstraintsOutput
+    {
+        std::vector<Constraint*> singleConstraints;  // Constraints that can be solved individually
+        std::vector<Constraint*> groupConstraints;   // Constraints that could not be isolated
     };
+
 private:
     static std::map<double*, int> buildParamToIndex(const std::vector<double*> params);
     std::vector<Constraint*> solvableConstraints(const std::vector<Constraint*>& constraints);
-    ReductionOutput computeReductionMap(const std::vector<double*>& params, const std::vector<Constraint*>& constraints);
+    ReductionOutput computeReductionMap(
+        const std::vector<double*>& params,
+        const std::vector<Constraint*>& constraints
+    );
+    std::vector<SubSystemDescription> partitionIntoSubSystems(
+        const std::vector<double*>& params,
+        std::vector<Constraint*> constraints,
+        const std::map<double*, double*>& reductionMap
+    );
     IsolateConstraintsOutput isolateConstraints();
-    Components partitionIntoComponents(const std::vector<double*>& params, const std::vector<Constraint*>& constraints, const std::map<double*, double*>& reductionMap);
 };
 
 

--- a/src/Mod/Sketcher/App/planegcs/SubSystem.cpp
+++ b/src/Mod/Sketcher/App/planegcs/SubSystem.cpp
@@ -55,50 +55,27 @@ SubSystem::~SubSystem()
 void SubSystem::initialize(VEC_pD& params, MAP_pD_pD& reductionmap)
 {
     csize = static_cast<int>(clist.size());
+    plist = params;
 
-    // tmpplist will contain the subset of parameters from params that are
-    // relevant for the constraints listed in clist
-    VEC_pD tmpplist;
-    {
-        SET_pD s1(params.begin(), params.end());
-        SET_pD s2;
-        for (std::vector<Constraint*>::iterator constr = clist.begin(); constr != clist.end();
-             ++constr) {
-            (*constr)->revertParams();  // ensure that the constraint points to the original parameters
-            VEC_pD constr_params = (*constr)->params();
-            s2.insert(constr_params.begin(), constr_params.end());
-        }
-        std::set_intersection(s1.begin(), s1.end(), s2.begin(), s2.end(), std::back_inserter(tmpplist));
-    }
-
-    plist.clear();
+    MAP_pD_I pindex;
     MAP_pD_I rindex;
-    if (!reductionmap.empty()) {
-        int i = 0;
-        MAP_pD_I pindex;
-        for (VEC_pD::const_iterator itt = tmpplist.begin(); itt != tmpplist.end(); ++itt) {
-            MAP_pD_pD::const_iterator itr = reductionmap.find(*itt);
-            if (itr != reductionmap.end()) {
-                MAP_pD_I::const_iterator itp = pindex.find(itr->second);
-                if (itp == pindex.end()) {  // the reduction target is not in plist yet, so add it now
-                    plist.push_back(itr->second);
-                    rindex[itr->first] = i;
-                    pindex[itr->second] = i;
-                    i++;
-                }
-                else {  // the reduction target is already in plist, just inform rindex
-                    rindex[itr->first] = itp->second;
-                }
-            }
-            else if (pindex.find(*itt) == pindex.end()) {  // not in plist yet, so add it now
-                plist.push_back(*itt);
-                pindex[*itt] = i;
-                i++;
-            }
-        }
+
+    for (size_t i = 0; i < params.size(); ++i) {
+        pindex[params[i]] = i;
     }
-    else {
-        plist = tmpplist;
+    for (const auto& constr : clist) {
+        for (const auto& param : constr->origParams()) {
+            if (rindex.find(param) != rindex.end()) {
+                continue; // Already in index
+            }
+            auto foundReduction = reductionmap.find(param);
+            if (foundReduction == reductionmap.end()) {
+                continue;
+            }
+            auto foundParam = pindex.find(foundReduction->second);
+            assert(foundParam != pindex.end());
+            rindex[param] = foundParam->second;
+        }
     }
 
     psize = static_cast<int>(plist.size());

--- a/src/Mod/Sketcher/App/planegcs/SubSystem.cpp
+++ b/src/Mod/Sketcher/App/planegcs/SubSystem.cpp
@@ -43,7 +43,11 @@ SubSystem::SubSystem(const std::vector<Constraint*>& clist_, const VEC_pD& param
     initialize(params, dummymap);
 }
 
-SubSystem::SubSystem(const std::vector<Constraint*>& clist_, const VEC_pD& params, const MAP_pD_pD& reductionmap)
+SubSystem::SubSystem(
+    const std::vector<Constraint*>& clist_,
+    const VEC_pD& params,
+    const MAP_pD_pD& reductionmap
+)
     : clist(clist_)
 {
     initialize(params, reductionmap);
@@ -66,7 +70,7 @@ void SubSystem::initialize(const VEC_pD& params, const MAP_pD_pD& reductionmap)
     for (const auto& constr : clist) {
         for (const auto& param : constr->origParams()) {
             if (rindex.find(param) != rindex.end()) {
-                continue; // Already in index
+                continue;  // Already in index
             }
             auto foundReduction = reductionmap.find(param);
             if (foundReduction == reductionmap.end()) {

--- a/src/Mod/Sketcher/App/planegcs/SubSystem.cpp
+++ b/src/Mod/Sketcher/App/planegcs/SubSystem.cpp
@@ -36,14 +36,14 @@ namespace GCS
 {
 
 // SubSystem
-SubSystem::SubSystem(std::vector<Constraint*>& clist_, VEC_pD& params)
+SubSystem::SubSystem(const std::vector<Constraint*>& clist_, const VEC_pD& params)
     : clist(clist_)
 {
     MAP_pD_pD dummymap;
     initialize(params, dummymap);
 }
 
-SubSystem::SubSystem(std::vector<Constraint*>& clist_, VEC_pD& params, MAP_pD_pD& reductionmap)
+SubSystem::SubSystem(const std::vector<Constraint*>& clist_, const VEC_pD& params, const MAP_pD_pD& reductionmap)
     : clist(clist_)
 {
     initialize(params, reductionmap);
@@ -52,7 +52,7 @@ SubSystem::SubSystem(std::vector<Constraint*>& clist_, VEC_pD& params, MAP_pD_pD
 SubSystem::~SubSystem()
 {}
 
-void SubSystem::initialize(VEC_pD& params, MAP_pD_pD& reductionmap)
+void SubSystem::initialize(const VEC_pD& params, const MAP_pD_pD& reductionmap)
 {
     csize = static_cast<int>(clist.size());
     plist = params;
@@ -73,7 +73,9 @@ void SubSystem::initialize(VEC_pD& params, MAP_pD_pD& reductionmap)
                 continue;
             }
             auto foundParam = pindex.find(foundReduction->second);
-            assert(foundParam != pindex.end());
+            if (foundParam == pindex.end()) {
+                continue;
+            }
             rindex[param] = foundParam->second;
         }
     }

--- a/src/Mod/Sketcher/App/planegcs/SubSystem.h
+++ b/src/Mod/Sketcher/App/planegcs/SubSystem.h
@@ -46,10 +46,10 @@ private:
                      //        JacobianMatrix jacobi;  // jacobi matrix of the residuals
     std::map<Constraint*, VEC_pD> c2p;                // constraint to parameter adjacency list
     std::map<double*, std::vector<Constraint*>> p2c;  // parameter to constraint adjacency list
-    void initialize(VEC_pD& params, MAP_pD_pD& reductionmap);  // called by the constructors
+    void initialize(const VEC_pD& params, const MAP_pD_pD& reductionmap);  // called by the constructors
 public:
-    SubSystem(std::vector<Constraint*>& clist_, VEC_pD& params);
-    SubSystem(std::vector<Constraint*>& clist_, VEC_pD& params, MAP_pD_pD& reductionmap);
+    SubSystem(const std::vector<Constraint*>& clist_, const VEC_pD& params);
+    SubSystem(const std::vector<Constraint*>& clist_, const VEC_pD& params, const MAP_pD_pD& reductionmap);
     ~SubSystem();
 
     int pSize()


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

The goal of this PR is to solve unary (1 constraint + 1 parameter) subsystems when it is possible.

This is not unlike what solvespace does, see https://github.com/solvespace/solvespace/blob/08fdb3596922dc93837578a8cd8cda32e3c83f23/src/system.cpp#L472
But here we try to find such systems recursively 

## Flip

It can improve flip stability in some cases but is absolutely not generalized

For instance this does not flip anymore because we can find unary systems for the whole shape width going up to the origin

https://github.com/user-attachments/assets/73c50c92-9011-43c7-9e06-cb3e6eae4ece

But this still flips because we can't do these substitutions in the same axis as the changed constraint

https://github.com/user-attachments/assets/382c62cd-a3f4-4c88-aabf-a9261cd143f9

## Performance

This should improve performance since the solve is a O(n^3) algorithm so smaller subsystems should be solved faster, but I am looking for a good way to benchmark it

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues

Removes boost dependency for planegcs: #26882

<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->




<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
