### PR TITLE
Fix auto-task behavior when in transparent overlay mode

### DIFF
--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -1699,7 +1699,7 @@ void OverlayManager::onTaskViewUpdate()
             || it->second->tabWidget->getAutoMode() != OverlayTabWidget::AutoMode::TaskShow) {
             return;
         }
-        d->onToggleDockWidget(dock, taskview->isEmpty() ? -2 : 2);
+        d->onToggleDockWidget(dock, taskview->isEmpty(false) ? -2 : 2);
     }
 }
 

--- a/src/Gui/OverlayWidgets.cpp
+++ b/src/Gui/OverlayWidgets.cpp
@@ -1250,6 +1250,9 @@ bool OverlayTabWidget::checkAutoHide() const
     }
 
     if (autoMode == AutoMode::TaskShow) {
+        if (isTransparent()) {
+          return false;
+        }
         return (!Control().taskPanel() || Control().taskPanel()->isEmpty(false));
     }
 

--- a/src/Gui/OverlayWidgets.cpp
+++ b/src/Gui/OverlayWidgets.cpp
@@ -1251,7 +1251,7 @@ bool OverlayTabWidget::checkAutoHide() const
 
     if (autoMode == AutoMode::TaskShow) {
         if (isTransparent()) {
-          return false;
+            return false;
         }
         return (!Control().taskPanel() || Control().taskPanel()->isEmpty(false));
     }

--- a/src/Gui/OverlayWidgets.cpp
+++ b/src/Gui/OverlayWidgets.cpp
@@ -1250,7 +1250,7 @@ bool OverlayTabWidget::checkAutoHide() const
     }
 
     if (autoMode == AutoMode::TaskShow) {
-        return (!Control().taskPanel() || Control().taskPanel()->isEmpty());
+        return (!Control().taskPanel() || Control().taskPanel()->isEmpty(false));
     }
 
     if (autoMode == AutoMode::EditHide && activeDocInEdit) {

--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -201,7 +201,7 @@ void TaskBox::hideGroupBox()
 
 bool TaskBox::isGroupVisible() const
 {
-    return myGroup->isVisible();
+    return myGroup->isVisible() || m_foldDirection == 1;
 }
 
 void TaskBox::actionEvent(QActionEvent* e)

--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -855,6 +855,7 @@ void TaskView::addTaskWatcher()
 {
     if (!showTaskWatcher) {
         setShownTaskInfo(-1);  // Switch to the empty taskwatcher panel
+        Q_EMIT taskUpdate();
         return;
     }
     // add all widgets for all watcher to the task view

--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -201,7 +201,7 @@ void TaskBox::hideGroupBox()
 
 bool TaskBox::isGroupVisible() const
 {
-    return myGroup->isVisible() || m_foldDirection == 1;
+    return !myGroup->isHidden() || m_foldDirection == 1;
 }
 
 void TaskBox::actionEvent(QActionEvent* e)

--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -195,7 +195,7 @@ void TaskBox::hideGroupBox()
     myGroup->hide();
 
     m_foldPixmap = QPixmap();
-    setFixedHeight(myHeader->height());
+    setFixedHeight(myScheme->headerSize);
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
 }
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
This PR resolves an issue where the auto-task view does not correctly hide and unhide the task panel when the transparent overlay is active.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->

Assisted-by: Claude Sonnet 4.6
I used this tool only to search the codebase for the context of the issue.  It made no commits, and wrote no part of any of the messages or descriptions.  It suggested lots of incorrect and unnecessarily complex ways to fix the problem which ultimately led me to this very simple change.

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

closes #17274

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

Before:

https://private-user-images.githubusercontent.com/11936535/532720291-7d905cc6-cbd5-4511-8f48-6f6910249b4e.mp4

After:

https://private-user-images.githubusercontent.com/11936535/601254091-4bce6dc2-e03b-4190-a966-2ad7cd310583.mp4

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
-->
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
    They have not
<!--
  - If the PR affects the GUI, did the contributor include before/after images?
    Yes

  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
-->
  - Does the change include tests?
    No, I was unsure how to do this as I'm not sure how much test coverage there is for this part of the GUI.  I looked around in the tests and there's no mention of the overlay functionality that I could see.

  - Is the PR rebased on the current main branch with unnecessary commits squashed?
    ~It is not currently.  I will do this and update the PR after it's opened.~ This is done

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
    It has not, although the linked issue does impact the current stable release
  - Have the release notes been considered/updated?
    No, I can do that if necessary.

