### PR TITLE
CAM: Custom - Select source from task panel

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PageOpCustomEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpCustomEdit.ui
@@ -14,7 +14,7 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+   <item row="0" column="0">
     <widget class="QFrame" name="frame_2">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
@@ -44,7 +44,7 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
+       <widget class="QLabel" name="label_2">
         <property name="text">
          <string>Coolant mode</string>
         </property>
@@ -63,35 +63,93 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>G-Code</string>
-     </property>
+   <item row="1" column="0">
+    <widget class="QWidget" name="widget">
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>G-code source</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="source">
+        <property name="toolTip">
+         <string>Select source of the G-code</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Text</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>File</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item>
-    <widget class="QTextEdit" name="txtGCode">
-     <property name="lineWrapMode">
-      <enum>QTextEdit::NoWrap</enum>
-     </property>
-     <property name="acceptRichText">
-      <bool>false</bool>
-     </property>
+   <item row="2" column="0">
+    <widget class="QWidget" name="txtGCodeBox">
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QTextEdit" name="txtGCode">
+        <property name="lineWrapMode">
+         <enum>QTextEdit::NoWrap</enum>
+        </property>
+        <property name="acceptRichText">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
+   <item row="3" column="0">
+    <widget class="QWidget" name="fileNameBox">
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QLineEdit" name="fileName">
+        <property name="toolTip">
+         <string>Enter the filename containing the G-code</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QToolButton" name="setFileName">
+        <property name="text">
+         <string notr="true">…</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QWidget" name="verticalSpacerBox">
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="0">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/Mod/CAM/Path/Op/Gui/Custom.py
+++ b/src/Mod/CAM/Path/Op/Gui/Custom.py
@@ -26,12 +26,17 @@ import FreeCADGui
 import Path.Op.Custom as PathCustom
 import Path.Op.Gui.Base as PathOpGui
 
+from PySide import QtGui
 from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import os
 
 __title__ = "CAM Custom Operation UI"
 __author__ = "sliptonic (Brad Collette)"
 __url__ = "https://www.freecad.org"
 __doc__ = "Custom operation page controller and command implementation."
+
+translate = FreeCAD.Qt.translate
 
 
 class TaskPanelOpPage(PathOpGui.TaskPanelPage):
@@ -39,29 +44,79 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def getForm(self):
         """getForm() ... returns UI"""
-        return FreeCADGui.PySideUic.loadUi(":/panels/PageOpCustomEdit.ui")
+        form = FreeCADGui.PySideUic.loadUi(":/panels/PageOpCustomEdit.ui")
+
+        comboToPropertyMap = [("source", "Source")]
+        enumTups = PathCustom.ObjectCustom.propertyEnumerations(dataType="raw")
+
+        self.populateCombobox(form, enumTups, comboToPropertyMap)
+        return form
 
     def getFields(self, obj):
         """getFields(obj) ... transfers values from UI to obj's properties"""
         self.updateToolController(obj, self.form.toolController)
         self.updateCoolant(obj, self.form.coolantController)
+        if obj.Source != str(self.form.source.currentData()):
+            obj.Source = str(self.form.source.currentData())
+        if obj.GcodeFile != str(self.form.fileName.text()):
+            obj.GcodeFile = str(self.form.fileName.text())
+        if obj.Gcode != str(self.form.txtGCode.toPlainText().split("\n")):
+            obj.Gcode = self.form.txtGCode.toPlainText().split("\n")
 
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
         self.setupToolController(obj, self.form.toolController)
-        self.form.txtGCode.setText("\n".join(obj.Gcode))
         self.setupCoolant(obj, self.form.coolantController)
+        self.selectInComboBox(obj.Source, self.form.source)
+        self.form.fileName.setText(obj.GcodeFile)
+        self.form.txtGCode.setText("\n".join(obj.Gcode))
+
+        self.updateVisibility()
 
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
         signals = []
         signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.coolantController.currentIndexChanged)
-        self.form.txtGCode.textChanged.connect(self.setGCode)
+        signals.append(self.form.source.currentIndexChanged)
+        signals.append(self.form.fileName.editingFinished)
+        signals.append(self.form.txtGCode.textChanged)
+
         return signals
 
-    def setGCode(self):
-        self.obj.Gcode = self.form.txtGCode.toPlainText().split("\n")
+    def updateVisibility(self):
+        source = self.obj.getEnumerationsOfProperty("Source")[self.form.source.currentIndex()]
+        if source == "File":
+            self.form.fileNameBox.show()
+            self.form.verticalSpacerBox.show()
+            self.form.txtGCodeBox.hide()
+        else:
+            self.form.txtGCodeBox.show()
+            self.form.fileNameBox.hide()
+            self.form.verticalSpacerBox.hide()
+
+    def registerSignalHandlers(self, obj):
+        self.form.source.currentIndexChanged.connect(self.updateVisibility)
+        self.form.setFileName.clicked.connect(self.setFileName)
+
+    def setFileName(self):
+        dirname = os.path.dirname(self.obj.GcodeFile)
+        if not dirname:
+            dirname = os.path.dirname(FreeCAD.activeDocument().FileName)
+        filter1 = "All Files (*)"
+        filter2 = "Text files (*.cnc *.g *.gc *.gco *.gcode *.nc *.ncc *.ngc *.tap *.txt)"
+        filters = translate("CAM_Custom", ";;".join((filter1, filter2)))
+        selected_filter = translate("CAM_Custom", filter2)
+        filename = QtGui.QFileDialog.getOpenFileName(
+            self.form,
+            translate("CAM_Custom", "Select file containing the gcode"),
+            dirname,
+            filters,
+            selected_filter,
+        )
+        if filename and filename[0]:
+            self.obj.GcodeFile = str(filename[0])
+            self.setFields(self.obj)
 
 
 Command = PathOpGui.SetupOperation(


### PR DESCRIPTION
### Description

https://github.com/FreeCAD/FreeCAD/pull/21509#issuecomment-2996660860

> Task panel doesn't work as expected. With source set to 'File' the task panel still shows the text input. There's also no way to switch source from the task panel.

---

### Changes

- Added field `G-code source` to select source of the G-code from **Task panel**
- Field to enter text stretches to full window height

---

### Before

<img width="359" height="344" alt="Screenshot_20260602_093308_lossy" src="https://github.com/user-attachments/assets/685771f8-be25-430a-9921-f41364752d61" />

---

### After

<img width="728" height="562" alt="Screenshot_20260602_121249_hor" src="https://github.com/user-attachments/assets/cc4fed7d-e44e-4002-a5d8-785943705c1e" />
