### PR TITLE
Cloud: use DocumentInitFlags instead of boolean in newDocument call

### DIFF
--- a/src/Mod/Cloud/App/AppCloud.cpp
+++ b/src/Mod/Cloud/App/AppCloud.cpp
@@ -1481,10 +1481,12 @@ void Cloud::Module::LinkXSetValue(std::string filename)
     // Starting from here the Document doesn't exist we must create it
     // and make it the active Document before Restoring
     App::Document* newDoc;
+    App::DocumentInitFlags newInitFlags;
     string newName;
     Document* currentDoc = GetApplication().getActiveDocument();
     newName = GetApplication().getUniqueDocumentName("unnamed");
-    newDoc = GetApplication().newDocument(newName.c_str(), (const char*)path.c_str(), true);
+    newInitFlags.createView = true;
+    newDoc = GetApplication().newDocument(newName.c_str(), (const char*)path.c_str(), newInitFlags);
     GetApplication().setActiveDocument(newDoc);
     this->cloudRestore((const char*)path.c_str());
     GetApplication().setActiveDocument(currentDoc);


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
The current FreeCAD failed to build for linux on gcc-15 with -std=c++20 and -DBUILD_CLOUD=ON:
`freecad/src/Mod/Cloud/App/AppCloud.cpp:1487:87: error: cannot convert 'bool' to 'App::DocumentInitFlags'`


with the patch, it fixes the issue.

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
No related open issue

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
No changes to GUI

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
