### PR TITLE
Build: require PySide6 QtSvgWidgets for GUI builds

### DIFF
--- a/cMake/FindPySide6.cmake
+++ b/cMake/FindPySide6.cmake
@@ -37,6 +37,39 @@ if(PySide6_FOUND)
         message(STATUS "PySide/Qt version check passed (${_pyside6_major_minor})")
     endif()
 
+    set(_pyside6_qtsvgwidgets_consumers)
+    if(BUILD_BIM)
+        list(APPEND _pyside6_qtsvgwidgets_consumers BUILD_BIM)
+    endif()
+    if(BUILD_MATERIAL)
+        list(APPEND _pyside6_qtsvgwidgets_consumers BUILD_MATERIAL)
+    endif()
+
+    if(BUILD_GUI AND _pyside6_qtsvgwidgets_consumers)
+        execute_process(
+            COMMAND ${Python3_EXECUTABLE} -c "import PySide6.QtSvgWidgets"
+            RESULT_VARIABLE PYSIDE6_QTSVGWIDGETS_IMPORT_FAILED
+            ERROR_VARIABLE PYSIDE6_QTSVGWIDGETS_IMPORT_ERROR
+            OUTPUT_QUIET
+        )
+
+        if(PYSIDE6_QTSVGWIDGETS_IMPORT_FAILED)
+            list(JOIN _pyside6_qtsvgwidgets_consumers ", " _pyside6_qtsvgwidgets_consumer_list)
+            string(STRIP "${PYSIDE6_QTSVGWIDGETS_IMPORT_ERROR}" PYSIDE6_QTSVGWIDGETS_IMPORT_ERROR)
+            message(FATAL_ERROR
+" --------------------------------------------------------
+ PySide6.QtSvgWidgets Python module not found.
+ This configuration enables modules that require it: ${_pyside6_qtsvgwidgets_consumer_list}
+ BIM and Material use it for SVG previews.
+ Install python3-pyside6.qtsvgwidgets or provide a PySide6 installation
+ that includes QtSvgWidgets.
+ Python executable: ${Python3_EXECUTABLE}
+ Import error: ${PYSIDE6_QTSVGWIDGETS_IMPORT_ERROR}
+ --------------------------------------------------------"
+            )
+        endif()
+    endif()
+
     if(NOT PySide6_INCLUDE_DIRS AND TARGET PySide6::pyside6)
         get_property(PySide6_INCLUDE_DIRS TARGET PySide6::pyside6 PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
     endif()

--- a/package/ubuntu/install-apt-packages.sh
+++ b/package/ubuntu/install-apt-packages.sh
@@ -69,6 +69,7 @@ packages=(
   python3-pyside6.qtgui
   python3-pyside6.qtnetwork
   python3-pyside6.qtsvg
+  python3-pyside6.qtsvgwidgets
   python3-pyside6.qtwidgets
   qt6-base-dev
   qt6-l10n-tools


### PR DESCRIPTION
Require the `PySide6.QtSvgWidgets` Python module at configure time for GUI builds, and add the matching Ubuntu package to the apt bootstrap script.

## Problem

On split-package PySide6 setups, CMake could find PySide6 successfully while the runtime Python module `PySide6.QtSvgWidgets` was still missing.

That let FreeCAD configure and build, but later fail at runtime when BIM or Material code imported `from PySide import QtSvgWidgets` to create SVG preview widgets.

## Changes

- add a configure-time import check for `PySide6.QtSvgWidgets` in `FindPySide6.cmake`
- fail early with a clear error message when `BUILD_GUI` is enabled and the module is missing
- add `python3-pyside6.qtsvgwidgets` to `package/ubuntu/install-apt-packages.sh`

## Why this approach

BIM currently depends on `QtSvgWidgets` for SVG previews, so this is a real GUI runtime dependency rather than an optional module. It is better to reject incomplete environments during configure than to allow a successful build that later crashes at runtime.
