### PR TITLE
Sketcher: Fix perpendicular autoconstraint

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -612,8 +612,8 @@ bool DrawSketchHandler::seekAlignmentAutoConstraint(
                     candidateConstraint = Sketcher::Parallel;
                 }
                 else if (
-                    std::abs(lineAngle - angle - 2.0 * pi) < angleDevRad
-                    || std::abs(lineAngle - angle + 2.0 * pi) < angleDevRad
+                    std::abs(lineAngle - angle - 0.5 * pi) < angleDevRad
+                    || std::abs(lineAngle - angle + 0.5 * pi) < angleDevRad
                 ) {
                     candidateConstraint = Sketcher::Perpendicular;
                 }


### PR DESCRIPTION
https://github.com/FreeCAD/FreeCAD/pull/29336 added perpendicular autoconstraint. But during syntax fixes, M_PI_2 was replaced by 2.0 * pi. But M_PI_2 is actually 0.5 * pi. So this PR fixes this typo.