### PR TITLE
Tree: reset expandIndicatorPressed at start of mousePressEvent

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -2015,6 +2015,7 @@ void TreeWidget::keyPressEvent(QKeyEvent* event)
 void TreeWidget::mousePressEvent(QMouseEvent* event)
 {
     expandIndicatorPressed = false;
+    visibilityIconPressed = false;
     if (isVisibilityIconEnabled()) {
         QTreeWidgetItem* item = itemAt(event->pos());
         if (item && item->type() == TreeWidget::ObjectType && event->button() == Qt::LeftButton) {
@@ -2064,6 +2065,7 @@ void TreeWidget::mousePressEvent(QMouseEvent* event)
                     obj->Visibility.setValue(!visible);
                 }
                 visibilityIconDoubleClickTimer.start();
+                visibilityIconPressed = true;
 
                 // to prevent selection of the item via QTreeWidget::mousePressEvent
                 event->accept();
@@ -2088,7 +2090,7 @@ void TreeWidget::mousePressEvent(QMouseEvent* event)
 
 void TreeWidget::mouseMoveEvent(QMouseEvent* event)
 {
-    if (expandIndicatorPressed) {
+    if (expandIndicatorPressed || visibilityIconPressed) {
         return;
     }
     QTreeWidget::mouseMoveEvent(event);
@@ -2097,6 +2099,11 @@ void TreeWidget::mouseMoveEvent(QMouseEvent* event)
 void TreeWidget::mouseReleaseEvent(QMouseEvent* event)
 {
     expandIndicatorPressed = false;
+    if (visibilityIconPressed) {
+        visibilityIconPressed = false;
+        event->accept();
+        return;
+    }
     QTreeWidget::mouseReleaseEvent(event);
 }
 

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -299,6 +299,7 @@ private:
     QTimer visibilityIconDoubleClickTimer;
 
     bool expandIndicatorPressed = false;
+    bool visibilityIconPressed = false;
 
     static std::unique_ptr<QPixmap> documentPixmap;
     static std::unique_ptr<QPixmap> documentPartialPixmap;


### PR DESCRIPTION
## Summary

Addresses a remaining issue reported by @maxwxyz in #29687.

**Commit 1:** `expandIndicatorPressed` was not reset when the visibility icon path triggered an early return in `mousePressEvent`. Moved the reset to the top of the function so it is unconditionally cleared on every new press.

**Commit 2:** Clicking the visibility icon on a parent item (one with children) could still trigger range selection. The press was accepted and the base class was bypassed, but any subsequent mouse movement (even slight) would cause Qt to drag-select because `mouseMoveEvent` suppression was not active. Fix: set `expandIndicatorPressed = true` after a visibility icon click so mouse moves are suppressed until release, the same way expand indicator presses are handled.

@maxwxyz could you test this and check if it resolves the issue you reported?