### PR TITLE
JtReader improvements

### DIFF
--- a/src/Mod/JtReader/App/AppJtReaderPy.cpp
+++ b/src/Mod/JtReader/App/AppJtReaderPy.cpp
@@ -32,6 +32,7 @@
 #include <Base/PyObjectBase.h>
 #include <Mod/Mesh/App/Core/MeshKernel.h>
 #include <Mod/Mesh/App/MeshPy.h>
+#include <Standard_Version.hxx>
 
 #include <CXX/Extensions.hxx>
 
@@ -105,7 +106,36 @@ private:
 
 #ifdef JTREADER_HAVE_TKJT
             JtReaderNS::TKJtReader jtReader;
-            jtReader.open(EncodedName);
+            try {
+                jtReader.open(EncodedName);
+            }
+# if OCC_VERSION_HEX < 0x080000
+            catch (const Standard_Failure& e) {
+                Base::Console().Warning(
+                    "JtReader: error reading '%s': %s\n",
+                    file.fileName().c_str(),
+                    e.GetMessageString()
+                );
+                return Py::None();
+            }
+# endif
+            catch (const std::exception& e) {
+                Base::Console().Warning(
+                    "JtReader: error reading '%s': %s\n",
+                    file.fileName().c_str(),
+                    e.what()
+                );
+                return Py::None();
+            }
+
+            if (jtReader.shapeCount() == 0) {
+                Base::Console().Warning(
+                    "JtReader: no geometry could be imported from '%s'. "
+                    "The file may use unsupported features.\n",
+                    file.fileName().c_str()
+                );
+                return Py::None();
+            }
 
             App::Document* doc = App::GetApplication().newDocument();
             std::string objname = file.fileNamePure();
@@ -143,7 +173,36 @@ private:
 
 #ifdef JTREADER_HAVE_TKJT
             JtReaderNS::TKJtReader jtReader;
-            jtReader.open(EncodedName);
+            try {
+                jtReader.open(EncodedName);
+            }
+# if OCC_VERSION_HEX < 0x080000
+            catch (const Standard_Failure& e) {
+                Base::Console().Warning(
+                    "JtReader: error reading '%s': %s\n",
+                    file.fileName().c_str(),
+                    e.GetMessageString()
+                );
+                return Py::None();
+            }
+# endif
+            catch (const std::exception& e) {
+                Base::Console().Warning(
+                    "JtReader: error reading '%s': %s\n",
+                    file.fileName().c_str(),
+                    e.what()
+                );
+                return Py::None();
+            }
+
+            if (jtReader.shapeCount() == 0) {
+                Base::Console().Warning(
+                    "JtReader: no geometry could be imported from '%s'. "
+                    "The file may use unsupported features.\n",
+                    file.fileName().c_str()
+                );
+                return Py::None();
+            }
 
             std::string objname = file.fileNamePure();
             auto iv = dynamic_cast<App::InventorObject*>(

--- a/src/Mod/JtReader/App/TKJtReader.cpp
+++ b/src/Mod/JtReader/App/TKJtReader.cpp
@@ -41,6 +41,8 @@ const Handle(Standard_Type) Type_JtNode_RangeLOD                = STANDARD_TYPE(
 const Handle(Standard_Type) Type_JtNode_Shape_Base              = STANDARD_TYPE(JtNode_Shape_Base);
 const Handle(Standard_Type) Type_JtNode_Shape_Vertex            = STANDARD_TYPE(JtNode_Shape_Vertex);
 const Handle(Standard_Type) Type_JtNode_Shape_TriStripSet       = STANDARD_TYPE(JtNode_Shape_TriStripSet);
+const Handle(Standard_Type) Type_JtElement_ShapeLOD_PolygonSet  = STANDARD_TYPE(JtElement_ShapeLOD_PolygonSet);
+const Handle(Standard_Type) Type_JtElement_ShapeLOD_PolylineSet = STANDARD_TYPE(JtElement_ShapeLOD_PolylineSet);
 // clang-format on
 }  // namespace
 
@@ -52,11 +54,14 @@ void TKJtReader::clear()
 {
     result.str(std::string());
     result.clear();
+    myShapeCount = 0;
+    myFileName.clear();
 }
 
 void TKJtReader::open(const std::string& filename)
 {
     clear();
+    myFileName = filename;
 
     Base::FileInfo file(filename);
     jtDir = TCollection_ExtendedString(TCollection_AsciiString((file.dirPath() + '/').c_str()));
@@ -85,6 +90,16 @@ void TKJtReader::open(const std::string& filename)
 std::string TKJtReader::getOutput() const
 {
     return result.str();
+}
+
+int TKJtReader::shapeCount() const
+{
+    return myShapeCount;
+}
+
+std::string TKJtReader::fileName() const
+{
+    return myFileName;
 }
 
 void TKJtReader::readMaterialAttribute(const Handle(JtAttribute_Material) & aMaterial)
@@ -151,7 +166,19 @@ void TKJtReader::readShapeVertex(const Handle(JtNode_Shape_Vertex) & aShape)
                 aLOD = Handle(JtElement_ShapeLOD_TriStripSet)::DownCast(anObject);
             if (!aLOD.IsNull()) {
                 getTriangleStripSet(aLOD);
+                continue;
             }
+        }
+        if (anObject->IsKind(Type_JtElement_ShapeLOD_PolygonSet)) {
+            Handle(JtElement_ShapeLOD_PolygonSet)
+                aPolyLOD = Handle(JtElement_ShapeLOD_PolygonSet)::DownCast(anObject);
+            getPolygonSet(aPolyLOD);
+            continue;
+        }
+        if (anObject->IsKind(Type_JtElement_ShapeLOD_PolylineSet)) {
+            Handle(JtElement_ShapeLOD_PolylineSet)
+                aLineLOD = Handle(JtElement_ShapeLOD_PolylineSet)::DownCast(anObject);
+            getPolylineSet(aLineLOD);
         }
     }
 }
@@ -177,6 +204,53 @@ void TKJtReader::getTriangleStripSet(const Handle(JtElement_ShapeLOD_TriStripSet
     // NOLINTEND
     builder.addNode(Base::Coordinate3Item {points});
     builder.addNode(Base::FaceSetItem {faces});
+    ++myShapeCount;
+}
+
+void TKJtReader::getPolygonSet(const Handle(JtElement_ShapeLOD_PolygonSet) & aLOD)
+{
+    // Polygon set: vertices are already flat triangles via the same Indices/Vertices layout
+    // as TriStripSet — treat identically (indices are already triangle-indexed after decode).
+    const int pointsPerFace = 3;
+    std::vector<Base::Vector3f> points;
+    std::vector<int> faces;
+    const JtElement_ShapeLOD_Vertex::VertexData& vertices = aLOD->Vertices();
+    const JtElement_ShapeLOD_Vertex::IndicesVec& indices = aLOD->Indices();
+    float* data = vertices.Data();
+    // NOLINTBEGIN
+    for (int index = 0; index < indices.Count(); index += 3) {
+        int coordIndex = indices[index] * 3;
+        points.emplace_back(data[coordIndex], data[coordIndex + 1], data[coordIndex + 2]);
+        coordIndex = indices[index + 1] * 3;
+        points.emplace_back(data[coordIndex], data[coordIndex + 1], data[coordIndex + 2]);
+        coordIndex = indices[index + 2] * 3;
+        points.emplace_back(data[coordIndex], data[coordIndex + 1], data[coordIndex + 2]);
+        faces.push_back(pointsPerFace);
+    }
+    // NOLINTEND
+    builder.addNode(Base::Coordinate3Item {points});
+    builder.addNode(Base::FaceSetItem {faces});
+    ++myShapeCount;
+}
+
+void TKJtReader::getPolylineSet(const Handle(JtElement_ShapeLOD_PolylineSet) & aLOD)
+{
+    // Polyline set: emit each indexed vertex as a point in a line set.
+    std::vector<Base::Vector3f> points;
+    const JtElement_ShapeLOD_Vertex::VertexData& vertices = aLOD->Vertices();
+    const JtElement_ShapeLOD_Vertex::IndicesVec& indices = aLOD->Indices();
+    float* data = vertices.Data();
+    // NOLINTBEGIN
+    for (int index = 0; index < indices.Count(); ++index) {
+        int coordIndex = indices[index] * 3;
+        points.emplace_back(data[coordIndex], data[coordIndex + 1], data[coordIndex + 2]);
+    }
+    // NOLINTEND
+    if (!points.empty()) {
+        builder.addNode(Base::Coordinate3Item {points});
+        builder.addNode(Base::LineSetItem {});
+        ++myShapeCount;
+    }
 }
 
 void TKJtReader::readPartition(const Handle(JtNode_Partition) & aPart)

--- a/src/Mod/JtReader/App/TKJtReader.h
+++ b/src/Mod/JtReader/App/TKJtReader.h
@@ -27,15 +27,20 @@
 # include <JtAttribute_GeometricTransform.hxx>
 # include <JtAttribute_Material.hxx>
 # include <JtData_Model.hxx>
+# include <JtElement_ShapeLOD_PolygonSet.hxx>
+# include <JtElement_ShapeLOD_PolylineSet.hxx>
 # include <JtElement_ShapeLOD_TriStripSet.hxx>
 # include <JtNode_Instance.hxx>
 # include <JtNode_Partition.hxx>
 # include <JtNode_RangeLOD.hxx>
 # include <JtNode_Shape_TriStripSet.hxx>
 # include <JtNode_Shape_Vertex.hxx>
+# include <Standard_Failure.hxx>
 # include <TCollection_AsciiString.hxx>
 # include <TCollection_ExtendedString.hxx>
+# include <list>
 # include <Base/Builder3D.h>
+# include <Base/Matrix.h>
 
 namespace JtReaderNS
 {
@@ -47,6 +52,8 @@ public:
     void open(const std::string& filename);
     void clear();
     std::string getOutput() const;
+    int shapeCount() const;
+    std::string fileName() const;
 
 private:
     void traverseGraph(const Handle(JtNode_Base) & aNode);
@@ -59,6 +66,8 @@ private:
     void readInstance(const Handle(JtNode_Instance) & anInstance);
     void readAttributes(const JtData_Object::VectorOfObjects& attr);
     void getTriangleStripSet(const Handle(JtElement_ShapeLOD_TriStripSet) & aLOD);
+    void getPolygonSet(const Handle(JtElement_ShapeLOD_PolygonSet) & aLOD);
+    void getPolylineSet(const Handle(JtElement_ShapeLOD_PolylineSet) & aLOD);
 
 private:
     TCollection_ExtendedString jtDir;
@@ -66,6 +75,8 @@ private:
     std::stringstream result;
     Base::InventorBuilder builder;
     std::list<Base::Matrix4D> transformations;
+    std::string myFileName;
+    int myShapeCount {0};
 };
 
 };  // namespace JtReaderNS


### PR DESCRIPTION
Cherry-picks from Simon Frechette

- Add includes for JtElement_ShapeLOD_PolygonSet/PolylineSet
- readShapeVertex now dispatches to getPolygonSet/getPolylineSet in addition to the existing getTriangleStripSet path
- getPolygonSet: same indexed triangle rendering as TriStripSet
- getPolylineSet: emits Coordinate3+LineSet for wireframe polylines
- Track shape count across getTriangleStripSet, getPolygonSet, getPolylineSet
- In open() and importer(): catch Standard_Failure and std::exception from TKJT/OCCT and emit a Console warning with the error message
- If no geometry is decoded (silent failure, unsupported features), emit a Console warning instead of silently creating an empty document object