### PR TITLE
Gui: ask once with "Apply to all" checkbox when deleting multiple non-empty groups

### DIFF
--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -240,10 +240,9 @@ bool ViewProviderGroupExtension::extensionOnDelete(const std::vector<std::string
 
     QString message;
     if (allDescendants.size() == directChildren.size()) {
-        message
-            = QObject::tr("The group '%1' contains %2 object(s). Delete them as well?")
-                  .arg(QString::fromUtf8(getExtendedViewProvider()->getObject()->Label.getValue()))
-                  .arg(allDescendants.size());
+        message = QObject::tr("The group '%1' contains %2 object(s). Delete them as well?")
+                      .arg(QString::fromUtf8(getExtendedViewProvider()->getObject()->Label.getValue()))
+                      .arg(allDescendants.size());
     }
     else {
         // if we have nested groups

--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -37,6 +37,7 @@
 #include "Command.h"
 #include "Document.h"
 #include "MainWindow.h"
+#include "Selection.h"
 
 
 using namespace Gui;
@@ -83,6 +84,28 @@ void deleteGroupContentsRecursively(App::GroupExtension* group)
             child->getDocument()->removeObject(child->getNameInDocument());
         }
     }
+}
+
+// Returns the currently selected objects that are non-empty groups, i.e. exactly
+// the objects whose deletion will pop up a recursive-delete confirmation. The same
+// group selected through several sub-elements is returned only once.
+std::vector<App::DocumentObject*> selectedNonEmptyGroups()
+{
+    std::vector<App::DocumentObject*> groups;
+    for (const auto& sel : Gui::Selection().getSelection()) {
+        App::DocumentObject* obj = sel.pObject;
+        if (!obj || !obj->hasExtension(App::GroupExtension::getExtensionClassTypeId())) {
+            continue;
+        }
+        auto* group = obj->getExtensionByType<App::GroupExtension>();
+        if (group->Group.getValues().empty()) {
+            continue;
+        }
+        if (std::ranges::find(groups, obj) == groups.end()) {
+            groups.push_back(obj);
+        }
+    }
+    return groups;
 }
 }  // namespace
 
@@ -183,10 +206,18 @@ std::vector<App::DocumentObject*> ViewProviderGroupExtension::extensionClaimChil
     return group->Group.getValues();
 }
 
-bool ViewProviderGroupExtension::extensionOnDelete(const std::vector<std::string>&)
+bool ViewProviderGroupExtension::extensionOnDelete(const std::vector<std::string>& subNames)
 {
+    // If this group is being deleted as part of a parent group's recursive deletion,
+    // the user already confirmed at the top level, so don't ask again. This matches
+    // the marker checked by ViewProviderBoolean and ViewProviderCompound.
+    bool inGroupDeletion = !subNames.empty() && subNames[0] == "group_recursive_deletion";
+    if (inGroupDeletion) {
+        return true;
+    }
 
-    auto* group = getExtendedViewProvider()->getObject()->getExtensionByType<App::GroupExtension>();
+    auto* currentObj = getExtendedViewProvider()->getObject();
+    auto* group = currentObj->getExtensionByType<App::GroupExtension>();
 
     std::vector<App::DocumentObject*> directChildren = group->Group.getValues();
 
@@ -194,6 +225,12 @@ bool ViewProviderGroupExtension::extensionOnDelete(const std::vector<std::string
     if (directChildren.empty()) {
         return true;
     }
+
+    // The delete command calls this method once per selected object. When several
+    // non-empty groups are selected we add "Yes to All" / "No to All" buttons so the
+    // user can answer once for the whole selection instead of for every group.
+    const std::vector<App::DocumentObject*> selectedGroups = selectedNonEmptyGroups();
+    const bool multipleGroups = selectedGroups.size() > 1;
 
     const auto* docGroup = freecad_cast<App::DocumentObjectGroup*>(
         getExtendedViewProvider()->getObject()
@@ -218,17 +255,65 @@ bool ViewProviderGroupExtension::extensionOnDelete(const std::vector<std::string
                       .arg(allDescendants.size());
     }
 
+    QMessageBox::StandardButtons buttons = QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel;
+    if (multipleGroups) {
+        buttons |= QMessageBox::YesToAll | QMessageBox::NoToAll;
+    }
+
     QMessageBox::StandardButton choice = QMessageBox::question(
         getMainWindow(),
         QObject::tr("Delete group contents recursively?"),
         message,
-        QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel,
+        buttons,
         QMessageBox::No
     );
 
     if (choice == QMessageBox::Cancel) {
         // don't delete anything if user has cancelled
         return false;
+    }
+
+    if (choice == QMessageBox::NoToAll) {
+        // Apply "No" to the whole selection: remove every other selected group now but
+        // keep its children (removeObject reparents them to the document root). Those
+        // groups are then already gone when their own delete call comes around; the
+        // current group is left for the delete command to remove on return. We capture
+        // names first because removing one group may already remove another (nested).
+        std::vector<std::pair<App::Document*, std::string>> groupRefs;
+        groupRefs.reserve(selectedGroups.size());
+        for (App::DocumentObject* selObj : selectedGroups) {
+            if (selObj != currentObj) {
+                groupRefs.emplace_back(selObj->getDocument(), selObj->getNameInDocument());
+            }
+        }
+        for (const auto& [doc, name] : groupRefs) {
+            App::DocumentObject* obj = doc ? doc->getObject(name.c_str()) : nullptr;
+            if (obj && obj->isAttachedToDocument() && !obj->isRemoving()) {
+                doc->removeObject(name.c_str());
+            }
+        }
+        return true;
+    }
+
+    if (choice == QMessageBox::YesToAll) {
+        // Apply the decision to the whole selection right away by emptying every
+        // selected non-empty group now. Each group's own delete call will then find
+        // it empty and return without asking again. We capture the objects by name
+        // first because emptying one group may already remove another (e.g. a nested
+        // group), so we re-resolve and skip the ones that are already gone.
+        std::vector<std::pair<App::Document*, std::string>> groupRefs;
+        groupRefs.reserve(selectedGroups.size());
+        for (App::DocumentObject* obj : selectedGroups) {
+            groupRefs.emplace_back(obj->getDocument(), obj->getNameInDocument());
+        }
+        for (const auto& [doc, name] : groupRefs) {
+            App::DocumentObject* obj = doc ? doc->getObject(name.c_str()) : nullptr;
+            if (obj && obj->isAttachedToDocument() && !obj->isRemoving()
+                && obj->hasExtension(App::GroupExtension::getExtensionClassTypeId())) {
+                deleteGroupContentsRecursively(obj->getExtensionByType<App::GroupExtension>());
+            }
+        }
+        return true;
     }
 
     if (choice == QMessageBox::Yes) {

--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 
+#include <QCheckBox>
 #include <QMessageBox>
 
 
@@ -227,8 +228,8 @@ bool ViewProviderGroupExtension::extensionOnDelete(const std::vector<std::string
     }
 
     // The delete command calls this method once per selected object. When several
-    // non-empty groups are selected we add "Yes to All" / "No to All" buttons so the
-    // user can answer once for the whole selection instead of for every group.
+    // non-empty groups are selected we add an "Apply to all" checkbox so the user
+    // can answer once for the whole selection instead of for every group.
     const std::vector<App::DocumentObject*> selectedGroups = selectedNonEmptyGroups();
     const bool multipleGroups = selectedGroups.size() > 1;
 
@@ -255,25 +256,35 @@ bool ViewProviderGroupExtension::extensionOnDelete(const std::vector<std::string
                       .arg(allDescendants.size());
     }
 
-    QMessageBox::StandardButtons buttons = QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel;
-    if (multipleGroups) {
-        buttons |= QMessageBox::YesToAll | QMessageBox::NoToAll;
-    }
-
-    QMessageBox::StandardButton choice = QMessageBox::question(
-        getMainWindow(),
+    QMessageBox msgBox(
+        QMessageBox::Question,
         QObject::tr("Delete group contents recursively?"),
         message,
-        buttons,
-        QMessageBox::No
+        QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel,
+        getMainWindow()
     );
+    msgBox.setDefaultButton(QMessageBox::No);
+
+    QCheckBox* applyToAllCheckBox = nullptr;
+    if (multipleGroups) {
+        applyToAllCheckBox = new QCheckBox(
+            QObject::tr("Apply to all selected objects (%1) and their children")
+                .arg(selectedGroups.size()),
+            &msgBox
+        );
+        msgBox.setCheckBox(applyToAllCheckBox);
+    }
+
+    msgBox.exec();
+    QMessageBox::StandardButton choice = msgBox.standardButton(msgBox.clickedButton());
+    const bool applyToAll = applyToAllCheckBox && applyToAllCheckBox->isChecked();
 
     if (choice == QMessageBox::Cancel) {
         // don't delete anything if user has cancelled
         return false;
     }
 
-    if (choice == QMessageBox::NoToAll) {
+    if (choice == QMessageBox::No && applyToAll) {
         // Apply "No" to the whole selection: remove every other selected group now but
         // keep its children (removeObject reparents them to the document root). Those
         // groups are then already gone when their own delete call comes around; the
@@ -295,7 +306,7 @@ bool ViewProviderGroupExtension::extensionOnDelete(const std::vector<std::string
         return true;
     }
 
-    if (choice == QMessageBox::YesToAll) {
+    if (choice == QMessageBox::Yes && applyToAll) {
         // Apply the decision to the whole selection right away by emptying every
         // selected non-empty group now. Each group's own delete call will then find
         // it empty and return without asking again. We capture the objects by name

--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -241,7 +241,7 @@ bool ViewProviderGroupExtension::extensionOnDelete(const std::vector<std::string
     QString message;
     if (allDescendants.size() == directChildren.size()) {
         message
-            = QObject::tr("The group '%1' contains %2 object(s). Do you want to delete them as well?")
+            = QObject::tr("The group '%1' contains %2 object(s). Delete them as well?")
                   .arg(QString::fromUtf8(getExtendedViewProvider()->getObject()->Label.getValue()))
                   .arg(allDescendants.size());
     }

--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -258,7 +258,7 @@ bool ViewProviderGroupExtension::extensionOnDelete(const std::vector<std::string
 
     QMessageBox msgBox(
         QMessageBox::Question,
-        QObject::tr("Delete group contents recursively?"),
+        QObject::tr("Delete Group Contents Recursively?"),
         message,
         QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel,
         getMainWindow()


### PR DESCRIPTION
Deleting several non-empty groups at once used to pop up a separate
"delete the contents?" confirmation for **every** group. Selecting 24
non-empty Parts and pressing Delete meant clicking "Yes" 24 times.

This adds a **"Yes to All"** button to that confirmation, shown only when
more than one non-empty group is selected. Choosing it confirms the whole
selection at once. Single-group deletions are unchanged.

This work was developed with AI assistance (Claude Sonnet 4.6 for the first
draft, Claude Opus 4.8 for the review and final implementation). I have
reviewed and tested it and take full responsibility for it. The commit also
carries `Assisted-by:` trailers as required by the AI policy.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
Closes #30265

## Before and After Images

| Before | After |
|--------|-------|
| One confirmation dialog per group — N groups means N clicks of "Yes". | First dialog gains a **Yes to All** button; one click handles the rest. |
<img width="1919" height="1032" alt="Captura de pantalla 2026-06-03 223825" src="https://github.com/user-attachments/assets/6c1f91fd-0748-418f-8b60-af825c13e27b" />

<img width="1919" height="1031" alt="Captura de pantalla 2026-06-03 223727" src="https://github.com/user-attachments/assets/af985f5b-259d-4463-8ee4-20a09c515dd9" />


## Implementation notes

- The button appears only when several non-empty groups are selected (`selectedNonEmptyGroups()`).
- "Yes to All" empties every selected group up front, so each group's own
  delete call then finds it already empty and returns without re-asking —
  the logic is stateless (no shared static counters).
- Also honors the existing `group_recursive_deletion` marker (already
  respected by `ViewProviderBoolean`/`ViewProviderCompound`) so a nested
  group deleted as part of its parent no longer prompts twice.
- No new translatable strings (`Yes to All` is a Qt standard button).