### PR TITLE
Base: prefer inches for US customary lengths

### DIFF
--- a/src/Base/UnitsSchemasData.h
+++ b/src/Base/UnitsSchemasData.h
@@ -625,7 +625,6 @@ inline const UnitsSchemaSpec s7
     {
         { "Length", {
             { 0.00000254      , "in"       , in                },
-            { 2.54            , "thou"     , in / 1000         },
             { 304.8           , "\""       , in                },
             { 914.4           , "'"        , ft                },
             { 1'609'344.0     , "yd"       , yd                },

--- a/tests/src/Base/SchemaTests.cpp
+++ b/tests/src/Base/SchemaTests.cpp
@@ -342,9 +342,30 @@ TEST_F(SchemaTest, imperial_decimal_20_mm_precision_0)
 TEST_F(SchemaTest, imperial_1_mm_precision_0)
 {
     const std::string result = setWithPrecision("Imperial", 1.0, Unit::Length, 0);
-    const auto expect {"39 thou"};
+    const auto expect {"0 in"};
 
     EXPECT_EQ(result, expect);
+}
+
+TEST_F(SchemaTest, imperial_1_mm_prefers_inches)
+{
+    UnitsApi::setSchema("Imperial");
+    Quantity quantity {1.0, Unit::Length};
+
+    double factor {};
+    std::string unitString;
+    quantity.getUserString(factor, unitString);
+
+    EXPECT_EQ(unitString, "in");
+    EXPECT_EQ(factor, Quantity::Inch.getValue());
+}
+
+TEST_F(SchemaTest, imperial_still_parses_thou)
+{
+    const auto quantity = Quantity::parse("1 thou");
+
+    EXPECT_DOUBLE_EQ(quantity.getValue(), Quantity::Thou.getValue());
+    EXPECT_EQ(quantity.getUnit(), Unit::Length);
 }
 
 TEST_F(SchemaTest, imperial_0_mm_precision_0)
@@ -1281,9 +1302,7 @@ TEST_F(SchemaTest, sweep_imperial)
     UnitsApi::setDecimals(6);
     sweepCheck({
         // Length
-        {"1 thou",
-         "10 thou",
-         "1\"",
+        {"1\"",
          "10\"",
          "1'",
          "2'",


### PR DESCRIPTION
- [ ] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

This updates the US Customary (`Imperial`) unit schema so small length values are no longer automatically preferred as `thou`. The schema now keeps using inches for preferred display, which matches the unit system description and the expectation in #30476.

`thou` parsing support is unchanged; the tests now cover that separately from preferred display-unit selection.

AI assistance disclosure: this change was assisted by GPT-5 Codex. The commit also includes the required `Assisted-by` trailer.

## Issues

Fixes #30476

## Before and After Images

No GUI changes.

## Tests

- `git diff --check`
- Not run: C++ unit tests. This local environment does not have `cmake` or `pixi` installed.

## Security / confidential information check

- Full repo token-pattern scan completed locally with no hits.
- Full repo env/key-file scan completed locally with no hits.
- PR diff token-pattern scan completed locally with no hits.