### PR TITLE
BIM: remove nudge shortcuts conflicting with tree view

### DIFF
--- a/src/Mod/BIM/bimcommands/BimNudge.py
+++ b/src/Mod/BIM/bimcommands/BimNudge.py
@@ -151,7 +151,6 @@ class BIM_Nudge_Up(BIM_Nudge):
     def GetResources(self):
         return {
             "MenuText": QT_TRANSLATE_NOOP("BIM_Nudge_Up", "Nudge Up"),
-            "Accel": "Alt+Up",
         }
 
     def Activated(self):
@@ -171,7 +170,6 @@ class BIM_Nudge_Down(BIM_Nudge):
     def GetResources(self):
         return {
             "MenuText": QT_TRANSLATE_NOOP("BIM_Nudge_Down", "Nudge Down"),
-            "Accel": "Alt+Down",
         }
 
     def Activated(self):
@@ -191,7 +189,6 @@ class BIM_Nudge_Left(BIM_Nudge):
     def GetResources(self):
         return {
             "MenuText": QT_TRANSLATE_NOOP("BIM_Nudge_Left", "Nudge Left"),
-            "Accel": "Alt+Left",
         }
 
     def Activated(self):
@@ -211,7 +208,6 @@ class BIM_Nudge_Right(BIM_Nudge):
     def GetResources(self):
         return {
             "MenuText": QT_TRANSLATE_NOOP("BIM_Nudge_Right", "Nudge Right"),
-            "Accel": "Alt+Right",
         }
 
     def Activated(self):


### PR DESCRIPTION
- [ ] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

This removes the default `Alt+Arrow` accelerators from the BIM nudge direction commands because those shortcuts conflict with Tree View navigation shortcuts.

The nudge commands remain registered and available from the BIM workbench command/menu/toolbar paths; this only removes the conflicting default keyboard accelerators.

AI assistance disclosure: this change was assisted by GPT-5 Codex. The commit also includes the required `Assisted-by` trailer.

## Issues

Fixes #30506

## Before and After Images

No GUI layout changes.

## Tests

- `python -m py_compile src/Mod/BIM/bimcommands/BimNudge.py` using bundled Python
- `git diff --check`
- Conflict search confirmed `Alt+Up`, `Alt+Down`, `Alt+Left`, and `Alt+Right` are no longer assigned in `BimNudge.py`

## Security / confidential information check

- Full repo token-pattern scan completed locally with no hits.
- Full repo env/key-file scan completed locally with no hits.
- PR diff token-pattern scan completed locally with no hits.