### PR TITLE
Gui: preserve selection order in placement command

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1873,10 +1873,8 @@ StdCmdPlacement::StdCmdPlacement()
 void StdCmdPlacement::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(
-        nullptr,
-        App::GeoFeature::getClassTypeId()
-    );
+    std::vector<Gui::SelectionObject> selection
+        = Gui::Selection().getSelectionEx(nullptr, App::GeoFeature::getClassTypeId());
     auto plm = new Gui::Dialog::TaskPlacement();
     if (!selection.empty()) {
         auto obj = selection.front().getObject();

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1873,23 +1873,16 @@ StdCmdPlacement::StdCmdPlacement()
 void StdCmdPlacement::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    std::vector<App::DocumentObject*> sel = Gui::Selection().getObjectsOfType(
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(
+        nullptr,
         App::GeoFeature::getClassTypeId()
     );
     auto plm = new Gui::Dialog::TaskPlacement();
-    if (!sel.empty()) {
-        App::Property* prop = sel.front()->getPropertyByName("Placement");
+    if (!selection.empty()) {
+        auto obj = selection.front().getObject();
+        App::Property* prop = obj->getPropertyByName("Placement");
         if (prop && prop->is<App::PropertyPlacement>()) {
             plm->setPlacement(static_cast<App::PropertyPlacement*>(prop)->getValue());
-
-            std::vector<Gui::SelectionObject> selection;
-            selection.reserve(sel.size());
-            std::transform(
-                sel.cbegin(),
-                sel.cend(),
-                std::back_inserter(selection),
-                [](App::DocumentObject* obj) { return Gui::SelectionObject(obj); }
-            );
 
             plm->setPropertyName(QLatin1String("Placement"));
             plm->setSelection(selection);


### PR DESCRIPTION
- [ ] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

### Summary
- Preserve user selection order when opening the placement editor
- Use `getSelectionEx()` for the ordered `GeoFeature` selection passed to `TaskPlacement`
- Keep the change local to `Std_Placement` instead of changing shared selection APIs

### Validation
- `git diff --check`
- Secret/config scan before edits and diff secret scan after edits
- Local FreeCAD build not run: no `cmake` or `pixi` executable available in this environment

### AI assistance disclosure
This change was prepared with assistance from GPT-5 Codex on 2026-06-04. The assistant inspected the relevant selection APIs, made the local code edit, and ran the listed checks.

Fixes #30545