### PR TITLE
CAM: stabilize tool controller roundtrip test units

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathToolController.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolController.py
@@ -29,11 +29,21 @@ from CAMTests.PathTestUtils import PathTestBase
 
 class TestPathToolController(PathTestBase):
     def setUp(self):
+        self.units = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Units")
+        self.saved_user_schema = self.units.GetInt("UserSchema", 0)
+        self.saved_decimals = self.units.GetInt("Decimals", 2)
+        self.saved_schema = FreeCAD.Units.getSchema()
+        self.units.SetInt("UserSchema", 6)
+        self.units.SetInt("Decimals", 6)
+        FreeCAD.Units.setSchema(6)
         self.doc = FreeCAD.newDocument("TestPathToolController")
         FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
 
     def tearDown(self):
         FreeCAD.closeDocument(self.doc.Name)
+        self.units.SetInt("UserSchema", self.saved_user_schema)
+        self.units.SetInt("Decimals", self.saved_decimals)
+        FreeCAD.Units.setSchema(self.saved_schema)
         FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     def createTool(self, name="t1", diameter=1.75):


### PR DESCRIPTION
- [ ] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

### Summary
- Make `TestPathToolController` use deterministic metric unit settings during the tool controller template round-trip test
- Save and restore the user's unit schema and decimal preferences around the test
- Keep the production tool controller and toolbit serialization paths unchanged

### Validation
- `python -m py_compile src/Mod/CAM/CAMTests/TestPathToolController.py`
- `git diff --check`
- Secret/config scan before edits and diff secret scan after edits
- Local FreeCAD CAM test run not available in this environment because there is no local FreeCAD runtime/build setup

### AI assistance disclosure
This change was prepared with assistance from GPT-5 Codex on 2026-06-04. The assistant inspected the related CAM test and tool controller serialization path, made the local test edit, and ran the listed checks.

Fixes #18417