### PR TITLE
Gui: preserve referenced expressions with implied units

### DIFF
--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -591,6 +591,9 @@ void DlgExpressionInput::applyImpliedUnit()
     if (!numberExpr || !numberExpr->getQuantity().isDimensionless()) {
         return;
     }
+    if (!expression->getIdentifiers().empty()) {
+        return;
+    }
 
     double factor = 1.0;
     std::string unitString;

--- a/tests/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/tests/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -115,6 +115,34 @@ private Q_SLOTS:
         QVERIFY(std::abs(quantity.getValue() - Base::Quantity::parse("2 mm").getValue()) < 1e-12);
     }
 
+    void test_ImpliedUnitIgnoresDimensionlessReference()
+    {
+        Base::UnitsApi::setSchema("Internal");
+
+        docName = App::GetApplication().getUniqueDocumentName("test");
+        App::Document* doc = App::GetApplication().newDocument(docName.c_str(), "testUser");
+        App::DocumentObject* obj = doc->addObject("App::VarSet", "VarSet");
+        QVERIFY(obj != nullptr);
+
+        App::Property* source = obj->addDynamicProperty("App::PropertyFloat", "Source");
+        QVERIFY(source != nullptr);
+        source->setPathValue(App::ObjectIdentifier(*source), 10.0);
+
+        App::Property* length = obj->addDynamicProperty("App::PropertyLength", "Length");
+        QVERIFY(length != nullptr);
+        App::ObjectIdentifier lengthPath(*length);
+
+        auto expr = App::Expression::parse(obj, "Source");
+        auto exprShared = std::shared_ptr<const App::Expression>(expr.release());
+
+        Gui::Dialog::DlgExpressionInput dlg(lengthPath, exprShared, Base::Unit::Length);
+        dlg.accept();
+
+        auto accepted = dlg.getExpression();
+        QVERIFY(accepted != nullptr);
+        QCOMPARE(accepted->toString(), std::string("Source"));
+    }
+
 private:
     std::string docName;
 };


### PR DESCRIPTION
- [ ] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

### Summary
- Keep referenced expressions unchanged when the expression editor has an implied unit
- Continue applying implied units to literal dimensionless input such as `1/10`
- Add a Qt regression test for dimensionless references accepted into a length property

### Root cause
`DlgExpressionInput::applyImpliedUnit()` wrapped any dimensionless result with the target property's implied unit. That is correct for literal numeric expressions, but it also affected expressions that reference another property. For a spreadsheet alias like `Spreadsheet.Length`, the accepted expression became equivalent to `Spreadsheet.Length mm`, which cannot be parsed when the GUI applies it through `setExpression()`.

### Validation
- `git diff --check`
- Secret/config scan before edits and diff secret scan after edits
- Local Qt C++ test run not available in this environment because there is no `cmake`, `ctest`, or local FreeCAD build directory

### AI assistance disclosure
This change was prepared with assistance from GPT-5 Codex on 2026-06-04. The assistant inspected the expression dialog path, made the local code/test edit, and ran the listed checks.

Fixes #30549