### PR TITLE
Fix HiDPI issues in Python WBs

### DIFF
--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -54,6 +54,7 @@ if FreeCAD.GuiUp:
     from PySide import QtGui, QtCore
     from PySide.QtCore import QT_TRANSLATE_NOOP
     import FreeCADGui
+    from draftutils import gui_utils
     from draftutils.translate import translate
 else:
     # \cond
@@ -261,7 +262,7 @@ def makeSolarDiagram(longitude, latitude, scale=1, complete=False, tz=None):
         for w in item.Edges:
             hoursep.addChild(toNode(w))
     for p in circlepos:
-        text = coin.SoText2()
+        text = gui_utils.make_hidpi_text2()
         s = p[0] - 90
         s = -s
         if s > 360:
@@ -288,7 +289,7 @@ def makeSolarDiagram(longitude, latitude, scale=1, complete=False, tz=None):
         item.addChild(text)
         numsep.addChild(item)
     for p in hourpos:
-        text = coin.SoText2()
+        text = gui_utils.make_hidpi_text2()
         s = str(p[0])
         text.string = s
         text.justification = coin.SoText2.CENTER
@@ -2225,7 +2226,7 @@ class _ViewProviderSite:
                 if hasattr(vobj, "ShowHourLabels") and vobj.ShowHourLabels:
                     if vobj.ShowHourLabels and (hour_float in [9.0, 12.0, 15.0]):
                         # Create a text node for the label
-                        text_node = coin.SoText2()
+                        text_node = gui_utils.make_hidpi_text2()
                         text_node.string = f"{int(hour_float)}h"
 
                         # Create a transform to position the text slightly offset from the marker

--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -58,6 +58,21 @@ if App.GuiUp:
     # from PySide import QtSvg  # for load_texture
 
 
+def make_hidpi_text2():
+    """Return a HiDPI-aware screen-space text node (``Gui::SoFCText2``).
+
+    ``SoFCText2`` is a ``SoText2`` subclass that scales its font size by the
+    device pixel ratio at render time, so the text keeps a constant perceived
+    size on HiDPI displays instead of being rendered at half size in physical
+    framebuffer pixels. Falls back to a plain ``coin.SoText2`` if the FreeCAD
+    node type is not registered (e.g. when running without the GUI).
+    """
+    node_type = coin.SoType.fromName("SoFCText2")
+    if node_type.isBad():
+        return coin.SoText2()
+    return node_type.createInstance()
+
+
 def get_3d_view():
     """Return the current 3D view.
 

--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -241,7 +241,7 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
         self.textcolor = coin.SoBaseColor()
         self.font = coin.SoFont()
         self.text_wld = coin.SoAsciiText()  # World orientation. Can be oriented in 3D space.
-        self.text_scr = coin.SoText2()  # Screen orientation. Always faces the camera.
+        self.text_scr = gui_utils.make_hidpi_text2()  # Screen orientation. Always faces the camera.
 
         # The text string needs to be initialized to something,
         # otherwise it may cause a crash of the system
@@ -825,7 +825,7 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
         self.textcolor = coin.SoBaseColor()
         self.font = coin.SoFont()
         self.text_wld = coin.SoAsciiText()  # World orientation. Can be oriented in 3D space.
-        self.text_scr = coin.SoText2()  # Screen orientation. Always faces the camera.
+        self.text_scr = gui_utils.make_hidpi_text2()  # Screen orientation. Always faces the camera.
 
         # The text string needs to be initialized to something,
         # otherwise it may cause a crash of the system

--- a/src/Mod/Draft/draftviewproviders/view_label.py
+++ b/src/Mod/Draft/draftviewproviders/view_label.py
@@ -122,7 +122,7 @@ class ViewProviderLabel(ViewProviderDraftAnnotation):
         self.textpos = coin.SoTransform()
         self.font = coin.SoFont()
         self.text_wld = coin.SoAsciiText()  # World orientation. Can be oriented in 3D space.
-        self.text_scr = coin.SoText2()  # Screen orientation. Always faces the camera.
+        self.text_scr = gui_utils.make_hidpi_text2()  # Screen orientation. Always faces the camera.
 
         self.fcoords = coin.SoCoordinate3()
         self.frame = coin.SoType.fromName("SoBrepEdgeSet").createInstance()

--- a/src/Mod/Draft/draftviewproviders/view_text.py
+++ b/src/Mod/Draft/draftviewproviders/view_text.py
@@ -73,7 +73,7 @@ class ViewProviderText(ViewProviderDraftAnnotation):
         self.mattext = coin.SoMaterial()
         self.font = coin.SoFont()
         self.text_wld = coin.SoAsciiText()  # World orientation. Can be oriented in 3D space.
-        self.text_scr = coin.SoText2()  # Screen orientation. Always faces the camera.
+        self.text_scr = gui_utils.make_hidpi_text2()  # Screen orientation. Always faces the camera.
 
         textdrawstyle = coin.SoDrawStyle()
         textdrawstyle.style = coin.SoDrawStyle.FILLED

--- a/src/Mod/Fem/CreateLabels.py
+++ b/src/Mod/Fem/CreateLabels.py
@@ -32,6 +32,21 @@ __url__ = "https://www.freecad.org"
 import FreeCADGui
 from pivy import coin
 
+
+def _make_hidpi_text2():
+    """Return a HiDPI-aware screen-space text node (``Gui::SoFCText2``).
+
+    ``SoFCText2`` is a ``SoText2`` subclass that scales its font size by the
+    device pixel ratio at render time, so the label keeps a constant perceived
+    size on HiDPI displays. Falls back to a plain ``coin.SoText2`` if the FreeCAD
+    node type is not registered.
+    """
+    node_type = coin.SoType.fromName("SoFCText2")
+    if node_type.isBad():
+        return coin.SoText2()
+    return node_type.createInstance()
+
+
 """
 Place Label on the screen with an optional image.
 positions on screen:
@@ -61,7 +76,7 @@ class createLabel:
         self.size = 20  # 24
         self.myFont.size.setValue(self.size)
 
-        self.SoText2 = coin.SoText2()
+        self.SoText2 = _make_hidpi_text2()
         self.SoText2.string = text
 
         self.textSep.addChild(self.cam)


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Follow up and to be merged after https://github.com/FreeCAD/FreeCAD/pull/30524

Some labels in the 3D view are drawn with `SoText2` which are not DPR aware.
This switches the workbenches to SoFCText2 (SoText2 DRP aware subclass from https://github.com/FreeCAD/FreeCAD/pull/30524)
There is no device pixel ratio code in the workbenches: they only create the node, which reads the single value already in core.

Affected (labels that are always screen space):
* FEM result labels
* Arch Site solar diagram labels

Left out: the Draft annotations and the Arch objects use `SoAsciiText` in their default `World` display mode, which is sized in model units and is already resolution independent.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: Opus 4.8
<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->

