### PR TITLE
Assembly: Fix joint becoming visible again after user selects and hides

### DIFF
--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -1541,7 +1541,9 @@ void ViewProviderAssembly::isolateJointReferences(App::DocumentObject* joint, Is
 
     isolatedJoint = joint;
     isolatedJointVisibilityBackup = joint->Visibility.getValue();
-    joint->Visibility.setValue(true);
+    if (!isolatedJointVisibilityBackup) {
+        joint->Visibility.setValue(true);
+    }
 
     std::set<App::DocumentObject*> isolateSet = {part1, part2};
     isolateComponents(isolateSet, mode);
@@ -1552,7 +1554,9 @@ void ViewProviderAssembly::isolateJointReferences(App::DocumentObject* joint, Is
 void ViewProviderAssembly::clearIsolate()
 {
     if (isolatedJoint) {
-        isolatedJoint->Visibility.setValue(isolatedJointVisibilityBackup);
+        if (!isolatedJointVisibilityBackup) {
+            isolatedJoint->Visibility.setValue(false);
+        }
         isolatedJoint = nullptr;
 
         clearJointElementHighlight();


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/29120


So here is what cause the bug : 
- Initially the joint is **visible** and **unselected**.
- The user clicks on the joint -> isolation starts. It does : 
```
visibility_backup = joint.Visibility (which is true) 
joint.visibility = true
```
- For the user, the joint visibility has not changed. It is still visible.
- Now the user press space : the joint becomes hidden.
- Now the user unselect the joint by clicking on 3dview. This triggers the end of isolation. It does : 
```
joint.visibility = visibility_backup
```
- So the joint becomes visible again! 

To fix the bug, we simply set back the visibility only if the joint was hidden to start with. Why does it work? Because it works in all cases : 
- If the joint was hidden. User selects it. becomes visible. Unselects it : hides the joint. -> ok
- If the joint was hidden. User selects it. becomes visible. Press space : becomes hidden. Unselects it : hides the joint. -> ok
- If the joint was visible. User selects it. nothing happens. Unselects it : nothing happen still visible -> ok
- If the joint was visible. User selects it. nothing happens. press space : hides the joint. Unselects it : nothing happen, the joint is now hidden-> ok