### PR TITLE
Assembly: Fix insert new part joint creation

### DIFF
--- a/src/Mod/Assembly/UtilsAssembly.py
+++ b/src/Mod/Assembly/UtilsAssembly.py
@@ -1259,7 +1259,11 @@ def getComponentReference(assembly, root_obj, sub_string):
 
         if isLink(obj):
             linkedObj = obj.getLinkedObject()
-            if linkedObj and not isLink(linkedObj) and not linkedObj.isDerivedFrom("App::GeoFeature"):
+            if (
+                linkedObj
+                and not isLink(linkedObj)
+                and not linkedObj.isDerivedFrom("App::GeoFeature")
+            ):
                 continue
         elif not obj.isDerivedFrom("App::GeoFeature"):
             continue

--- a/src/Mod/Assembly/UtilsAssembly.py
+++ b/src/Mod/Assembly/UtilsAssembly.py
@@ -1259,7 +1259,7 @@ def getComponentReference(assembly, root_obj, sub_string):
 
         if isLink(obj):
             linkedObj = obj.getLinkedObject()
-            if linkedObj and not linkedObj.isDerivedFrom("App::GeoFeature"):
+            if linkedObj and not isLink(linkedObj) and not linkedObj.isDerivedFrom("App::GeoFeature"):
                 continue
         elif not obj.isDerivedFrom("App::GeoFeature"):
             continue


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/29974

The bug was happening because joint task addSelection was not adding the empty link to the joint anymore.
The reason is that `getComponentReference` was enforcing "only links to geofeatures" which implied no empty links. I actually did this before in a previous large PR, but without much reason. So it's safe to change this.

To fix the issue we make the rule a bit less strict and enable both empty links and links to geofeatures.

Confidence level that this is the correct fix : 100%