### PR TITLE
CAM: Probe - Limit area by shape

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/ZCorrect.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/ZCorrect.py
@@ -149,16 +149,26 @@ class ObjectDressup:
             return
 
         cols = list(zip(*pointlist))
-        yindex = list(sorted(set(cols[1])))
+        xlist = list(sorted(set(cols[0])))
+        ylist = list(sorted(set(cols[1])))
 
         Path.Log.debug(pointlist)
         Path.Log.debug("cols: {}".format(cols))
-        Path.Log.debug("yindex: {}".format(yindex))
+        Path.Log.debug("yindex: {}".format(ylist))
 
-        array = []
-        for y in yindex:
-            points = sorted([p for p in pointlist if p[1] == y])
-            array.append([FreeCAD.Vector(p[0], p[1], p[2]) for p in points])
+        array = [[None for xi in range(len(xlist))] for yi in range(len(ylist))]
+        for yi in range(len(ylist)):
+            for xi in range(len(xlist)):
+                for p in pointlist:
+                    if xlist[xi] == p[0] and ylist[yi] == p[1]:
+                        array[yi][xi] = FreeCAD.Vector(p[0], p[1], p[2])
+                        break
+            if None in array[yi]:  # fill missed probe positions
+                zlist = [p.z for p in array[yi] if p]
+                averageZ = sum(zlist) / len(zlist)
+                for xi in range(len(xlist)):
+                    if array[yi][xi] is None:
+                        array[yi][xi] = FreeCAD.Vector(xlist[xi], ylist[yi], averageZ)
 
         intSurf = Part.BSplineSurface()
         try:

--- a/src/Mod/CAM/Path/Op/Probe.py
+++ b/src/Mod/CAM/Path/Op/Probe.py
@@ -80,6 +80,27 @@ class ObjectProbing(PathOp.ObjectOp):
                 "App::Property", "The output location for the probe data to be written"
             ),
         )
+        obj.addProperty(
+            "App::PropertyLink",
+            "BaseShape",
+            "Probe",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Limit probe area by shape. Point should be inside shape at final depth",
+            ),
+        )
+
+    def opOnDocumentRestored(self, obj):
+        if not hasattr(obj, "BaseShape"):
+            obj.addProperty(
+                "App::PropertyLink",
+                "BaseShape",
+                "Probe",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Limit probe area by shape. Point should be inside shape at final depth",
+                ),
+            )
 
     def nextpoint(self, startpoint=0.0, endpoint=0.0, count=3):
         curstep = 0
@@ -87,6 +108,15 @@ class ObjectProbing(PathOp.ObjectOp):
         while curstep <= count - 1:
             yield startpoint + (curstep * dist)
             curstep += 1
+
+    def isValidPoint(self, base, x, y, z):
+        if not base:
+            return True
+        point = FreeCAD.Vector(x, y, z)
+        if base.isDerivedFrom("Part::Feature"):
+            return base.Shape.isInside(point, 0.1, True)
+
+        return False
 
     def opExecute(self, obj):
         """opExecute(obj) ... generate probe locations."""
@@ -103,12 +133,17 @@ class ObjectProbing(PathOp.ObjectOp):
         )
 
         stock = PathUtils.findParentJob(obj).Stock
-        bb = stock.Shape.BoundBox
+        if obj.BaseShape and obj.BaseShape.isDerivedFrom("Part::Feature"):
+            bb = obj.BaseShape.Shape.BoundBox
+        else:
+            bb = stock.Shape.BoundBox
 
         self.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeight.Value}))
 
         for y in self.nextpoint(bb.YMin, bb.YMax, obj.PointCountY):
             for x in self.nextpoint(bb.XMin, bb.XMax, obj.PointCountX):
+                if not self.isValidPoint(obj.BaseShape, x, y, obj.FinalDepth.Value):
+                    continue
                 self.commandlist.append(
                     Path.Command(
                         "G0",
@@ -152,5 +187,5 @@ def Create(name, obj=None, parentJob=None):
     """Create(name) ... Creates and returns a Probing operation."""
     if obj is None:
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
-    proxy = ObjectProbing(obj, name, parentJob)
+    obj.Proxy = ObjectProbing(obj, name, parentJob)
     return obj


### PR DESCRIPTION
https://forum.freecad.org/viewtopic.php?t=105728

Changes:
- Use `BoundBox` of the selected shape to define probe area
- Skip points which not inside shape
- Added changes to `ZCorrect.py` to fill empty probe positions

<img width="1276" height="313" alt="Screenshot_20260609_100804_hor" src="https://github.com/user-attachments/assets/063719a3-0d5c-439e-8393-e82321cc3fa3" />
