### PR TITLE
Sync zoom with spacemouse Z movement in perspective rendering and restore functionality of middle-click to center rotation when using drag at cursor

### DIFF
--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -2381,7 +2381,7 @@ SbBool NavigationStyle::processMotionEvent(const SoMotion3Event* const ev)
     }
 
     if (camera->getTypeId().isDerivedFrom(SoOrthographicCamera::getClassTypeId())) {
-        static_cast<SoOrthographicCamera*>(camera)->scaleHeight(1.0 + zoom);
+        static_cast<SoOrthographicCamera*>(camera)->scaleHeight(zoomFactor);
     }
 
     // Use the active navigation rotation center mode for SpaceMouse rotations

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -2375,6 +2375,10 @@ SbBool NavigationStyle::processMotionEvent(const SoMotion3Event* const ev)
 
     const float zoom = dir[2] * 0.0001;
     dir[2] = 0.0;
+    float zoomFactor = 1.0 + zoom;
+    if (zoomFactor < 0.1F) {
+        zoomFactor = 0.1F;
+    }
 
     if (camera->getTypeId().isDerivedFrom(SoOrthographicCamera::getClassTypeId())) {
         static_cast<SoOrthographicCamera*>(camera)->scaleHeight(1.0 + zoom);
@@ -2419,10 +2423,6 @@ SbBool NavigationStyle::processMotionEvent(const SoMotion3Event* const ev)
 
     if (camera->getTypeId().isDerivedFrom(SoPerspectiveCamera::getClassTypeId())) {
         const SbVec3f zoomPivot = useMotionRotationCenter ? motionRotationCenter : center;
-        float zoomFactor = 1.0 + zoom;
-        if (zoomFactor < 0.1F) {
-            zoomFactor = 0.1F;
-        }
         newPosition = zoomPivot + (newPosition - zoomPivot) * zoomFactor;
         camera->focalDistance.setValue(camera->focalDistance.getValue() * zoomFactor);
     }

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -596,8 +596,9 @@ void NavigationStyle::lookAtPoint(const SbVec2s screenpos)
 
 void NavigationStyle::lookAtPoint(const SbVec3f& position)
 {
-    this->rotationCenterFound = false;
     translateCamera(position - viewer->getFocalPoint());
+    this->rotationCenter = position;
+    this->rotationCenterFound = true;
 }
 
 SoCamera* NavigationStyle::getCamera() const
@@ -2372,10 +2373,11 @@ SbBool NavigationStyle::processMotionEvent(const SoMotion3Event* const ev)
 
     SbVec3f dir = ev->getTranslation();
 
+    const float zoom = dir[2] * 0.0001;
+    dir[2] = 0.0;
+
     if (camera->getTypeId().isDerivedFrom(SoOrthographicCamera::getClassTypeId())) {
-        auto oCam = static_cast<SoOrthographicCamera*>(camera);
-        oCam->scaleHeight(1.0 + (dir[2] * 0.0001));
-        dir[2] = 0.0;  // don't move the cam for z translation.
+        static_cast<SoOrthographicCamera*>(camera)->scaleHeight(1.0 + zoom);
     }
 
     // Use the active navigation rotation center mode for SpaceMouse rotations
@@ -2413,6 +2415,16 @@ SbBool NavigationStyle::processMotionEvent(const SoMotion3Event* const ev)
     else {
         newRotation.multVec(SbVec3f(0.0, 0.0, -1.0), newDirection);
         newPosition = center - (newDirection * camera->focalDistance.getValue());
+    }
+
+    if (camera->getTypeId().isDerivedFrom(SoPerspectiveCamera::getClassTypeId())) {
+        const SbVec3f zoomPivot = useMotionRotationCenter ? motionRotationCenter : center;
+        float zoomFactor = 1.0 + zoom;
+        if (zoomFactor < 0.1F) {
+            zoomFactor = 0.1F;
+        }
+        newPosition = zoomPivot + (newPosition - zoomPivot) * zoomFactor;
+        camera->focalDistance.setValue(camera->focalDistance.getValue() * zoomFactor);
     }
 
     newRotation.multVec(dir, dir);


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
This PR does two things related to spacemousee support on Linux, based on the recent addition of https://github.com/FreeCAD/FreeCAD/pull/29998

* Restore functionality of (mostly undocumented) middle-click to force rotational center at point when in "Drag at cursor" mode (Preferences -> Display -> Navigation -> Rotation Mode)
  * previous lookAtPoint behavior set rotationCenterFound = false
* Relates Z movement of spacemouse to zoom in perspective mode (was already like that in orthographic mode) to avoid zoom becoming stuck at closest or furthest point when it is used alongside spacemouse Z .  This can be tuned with the float on line 2021 and exposed in the GUI, but it can also be adjusted with the spaceball motion sensitivity slider so I didn't think this was necessary.  It just needed to be a sufficiently small number to avoid feeling different than the current behavior so I didn't change it.
  * perspective and orthographic cameras behave the same with respect to Z movement.
  * Because we are relating zoom to Z movement a side effect is that middle clicking to force rotation center no longer jumps the view dramatically closer or further away.

If the community thinks this should be two PRs I can do that, but they are closely related and together provide a significant improvement in my opinion.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->
Assisted-by: Claude Opus 4.8
Used to identify the location and scope of the cause and to help me more rapidly understand the current layout of spacemouse support on Linux.

In the interest of honesty however I will say that without this tool I do not feel that I am at the level of understanding of C++ or of the codebase required to develop features for FreeCAD.  Therefor I choose to only submit PRs for very small scope issues that I have a personal interest in and use it as a learning tool.  I do not submit anything I haven't taken the time to understand.

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
partially addresses: https://github.com/FreeCAD/FreeCAD/issues/9543

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

In the below videos I roughly (as much as possible anyway) followed this script.  Take note of the zoom distance in the toolbar in the bottom right of the screen .  Particularly while I'm showing what zooming with the scroll wheel does to spacemouse movement.  With the changes in this PR zoom moves WITH the spacemouse Z axis so it does not become disorienting to use both together.

In the first video you can see that zoom does not move at all with Z.  In the second Zoom stays synchronized as Z moves.
```
Show rotation center offset vs non offset:
drag at cursor
rotate
move Z
rotate again

then middle click
rotate
move Z
rotate again

Show middle click zoom missmatch:
middle click
push out Z
zoomw with wheel
reverse

show jumping zoom vs synchronized when middle clicking after set rotation:
middle click
move Z in
middle click again
```

Before screencapture:


https://github.com/user-attachments/assets/b936ba4b-1fb5-4e1b-affe-96d038f3b24d

After screencapture:


https://github.com/user-attachments/assets/7091432c-6ae4-454e-b96f-c77bbb0b3a35




<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
