### PR TITLE
CAM: Adaptive: Fix #30517

### DIFF
--- a/src/Mod/CAM/libarea/Adaptive.cpp
+++ b/src/Mod/CAM/libarea/Adaptive.cpp
@@ -1761,43 +1761,37 @@ std::list<AdaptiveOutput> Adaptive2d::Execute(
     }
 
     // 6) Compute toolBounds = offset(input paths, -(toolRadius + finishingThickness)).
-    // ...but clipper 1 drops Z value when doing offsets, so I need to do the offset per-curve to
-    // preserve Z value
-    Paths toolBounds;
-    for (const Path& path : inputPaths) {
-        bool orientation = Orientation(path);
-        int direction = (getPathNestingLevel(path, inputPaths) % 2 == 1) ? 1 : -1;
-        bool z1 = false;
-        for (const IntPoint& p : path) {
-            if (p.Z == 1) {
-                z1 = true;
-                break;
-            }
+    // Z is used to indicate which paths need a finish pass. Clipper1 doesn't
+    // preserve Z with operations, so convert to Clipper2, perform the offset,
+    // then back to Clipper1 for subsequent operations
+    Clipper2Lib::Paths64 inputPaths2;
+    inputPaths2.reserve(inputPaths.size());
+    for (const auto& path : inputPaths) {
+        Clipper2Lib::Path64 p;
+        p.reserve(path.size());
+        for (const auto& pt : path) {
+            p.emplace_back(pt.X, pt.Y, pt.Z);  // IntPoint -> Point64
         }
-
-        Paths out;
-        clipof.Clear();
-        clipof.AddPath(path, JoinType::jtRound, EndType::etClosedPolygon);
-        clipof.Execute(out, -(toolRadiusScaled + finishPassOffsetScaled) * direction);
-
-        for (Path& p : out) {
-            if (Orientation(p) != orientation) {
-                ReversePath(p);
-            }
-            if (z1) {
-                for (IntPoint& pp : p) {
-                    pp.Z = 1;
-                }
-            }
-            toolBounds.push_back(p);
-        }
+        inputPaths2.emplace_back(p);
     }
-    // these 3 lines should work instead of the above if clipper 1 handled Z-values for offsets,
-    // like clipper 2 does:
-    //
-    // clipof.Clear();
-    // clipof.AddPaths(inputPaths, JoinType::jtRound, EndType::etClosedPolygon);
-    // clipof.Execute(toolBounds, -(toolRadiusScaled + finishPassOffsetScaled));
+    Clipper2Lib::Paths64 toolBounds2 = Clipper2Lib::InflatePaths(
+        inputPaths2,
+        -(toolRadiusScaled + finishPassOffsetScaled),
+        Clipper2Lib::JoinType::Round,
+        Clipper2Lib::EndType::Polygon
+    );
+
+    /* Convert results back to clipper1 */
+    Paths toolBounds;
+    toolBounds.reserve(toolBounds2.size());
+    for (const auto& path : toolBounds2) {
+        Path p;
+        p.reserve(path.size());
+        for (const auto& pt : path) {
+            p.emplace_back(pt.x, pt.y, pt.z);  // Point64 -> IntPoint
+        }
+        toolBounds.emplace_back(p);
+    }
 
     // 7) Loop over connected components using nesting level.
     for (const auto& current : toolBounds) {

--- a/src/Mod/CAM/libarea/Adaptive.hpp
+++ b/src/Mod/CAM/libarea/Adaptive.hpp
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 #include "clipper.hpp"
+#include "clipper2/clipper.h"
 #include <vector>
 #include <list>
 #include <optional>


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/30517

Change is migrating one step of the Adaptive process to use the Clipper2 library, which preserves Z coordinates while Clipper1 does not. The Adaptive operation uses the Z coordinate to flag paths for a finishing pass, and the current workaround to preserve Z coordinates using Clipper1 resulted in the bug indicated above.

The approach taken is as recommended by @davidgilkaufman in that issue.

This does not appear to fix the issue reported on the forums with finishing passes extending to edges beyond the selection. https://forum.freecad.org/viewtopic.php?p=891211

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [ x ] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/30517

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
