### PR TITLE
Remove "Dump" msg

### DIFF
--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -380,10 +380,6 @@ bool View3DInventor::onMsg(const char* pMsg)
         _viewer->viewSelection(true);
         return true;
     }
-    else if (strncmp("Dump", pMsg, 4) == 0) {
-        dump(pMsg + 5);
-        return true;
-    }
     else if (strcmp("ViewBottom", pMsg) == 0) {
         _viewer->setCameraOrientation(Camera::rotation(Camera::Bottom));
         return true;
@@ -552,9 +548,6 @@ bool View3DInventor::onHasMsg(const char* pMsg) const
         return true;
     }
     else if (strcmp("PerspectiveCamera", pMsg) == 0) {
-        return true;
-    }
-    else if (strncmp("Dump", pMsg, 4) == 0) {
         return true;
     }
     else if (strcmp("AlignToSelection", pMsg) == 0) {


### PR DESCRIPTION
- [x] This PR didn't involve AI during any step.

## Issues

Per #27779. After this PR, there will be no message which works by concatenating the message type with an argument.

Note that Python code can no longer use `Gui.SendMsgToActiveView("Dump ~/test.idk")`, but has to use already existing `Gui.activeView().dump("~/test.idk")`.