### PR TITLE
Use alignToSelection method instead of onMsg

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -4048,15 +4048,21 @@ StdCmdAlignToSelection::StdCmdAlignToSelection()
     eType = Alter3DView;
 }
 
-void StdCmdAlignToSelection::activated(int iMsg)
+void StdCmdAlignToSelection::activated(int /*iMsg*/)
 {
-    Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"AlignToSelection\")");
+    auto view = freecad_cast<View3DInventor*>(getGuiApplication()->activeView());
+    if (view && view->getViewer()) {
+        view->getViewer()->alignToSelection();
+    }
+    else {
+        Base::Console().developerError("StdCmdAlignToSelection", "active view is not a 3D view");
+    }
 }
 
 bool StdCmdAlignToSelection::isActive()
 {
-    return getGuiApplication()->sendHasMsgToActiveView("AlignToSelection");
+    auto view = freecad_cast<View3DInventor*>(getGuiApplication()->activeView());
+    return view && view->getViewer();
 }
 
 //===========================================================================

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -448,10 +448,6 @@ bool View3DInventor::onMsg(const char* pMsg)
         getGuiDocument()->saveCopy();
         return true;
     }
-    else if (strcmp("AlignToSelection", pMsg) == 0) {
-        _viewer->alignToSelection();
-        return true;
-    }
     else if (strcmp("ZoomIn", pMsg) == 0) {
         _viewer->navigationStyle()->zoomIn();
         return true;
@@ -555,9 +551,6 @@ bool View3DInventor::onHasMsg(const char* pMsg) const
         return true;
     }
     else if (strncmp("Dump", pMsg, 4) == 0) {
-        return true;
-    }
-    else if (strcmp("AlignToSelection", pMsg) == 0) {
         return true;
     }
     else if (strcmp("ZoomIn", pMsg) == 0) {


### PR DESCRIPTION
- [x] This PR didn't involve AI at any stage.

## Issues

Per #27779.

Note that Python code can no longer use Gui.SendMsgToActiveView("AlignToSelection"), but has to use already existing AlignToSelection command.