### PR TITLE
CAM: Profile: Add proof of concept naive profile mode

### DIFF
--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -225,6 +225,20 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                     "\nManual: uses order of shapes selection",
                 ),
             ),
+            (
+                "App::PropertyBool",
+                "NaiveOffset",
+                "Profile",
+                QT_TRANSLATE_NOOP(
+                    "App::Property", "Use naive offset instead of inside/outside based on model"
+                ),
+            ),
+            (
+                "App::PropertyBool",
+                "FlipNaiveOffsetDirection",
+                "Profile",
+                QT_TRANSLATE_NOOP("App::Property", "Flip naive offset direction"),
+            ),
         ]
 
     @classmethod
@@ -294,6 +308,8 @@ class ObjectProfile(PathAreaOp.ObjectOp):
             "processPerimeter": True,
             "Stepover": 0,
             "NumPasses": (1, 1, 99999, 1),
+            "NaiveOffset": False,
+            "FlipNaiveOffsetDirection": False,
         }
 
     def areaOpApplyPropertyDefaults(self, obj, job, propList):
@@ -675,18 +691,33 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                     ][::-1]
                     openWires = []
                     for po in passOffsets:
-                        cutWireObjs = False
-                        self.ofstRadius = po
-                        cutShp = self._getCutAreaCrossSection(obj, base, origWire, flatWire)
-                        if cutShp:
-                            cutWireObjs = self._extractPathWire(obj, base, flatWire, cutShp)
-
-                        if cutWireObjs:
-                            for cW in cutWireObjs:
-                                openWires.append(cW)
+                        if obj.NaiveOffset:
+                            if obj.FlipNaiveOffsetDirection:
+                                po *= -1
+                            try:
+                                # NOTE: This outputs... BSplines instead of circles/ellipses
+                                projface = Path.Geom.makeBoundBoxFace(
+                                    wire.BoundBox, offset=1, zHeight=0
+                                )
+                                pw = projface.makeParallelProjection(wire, FreeCAD.Vector(0, 0, 1))
+                                openWires.append(pw.makeOffset2D(po, openResult=True))
+                            except:
+                                Path.Log.error(f"Offset barf, wire length: {flatWire.Length}")
+                                Part.show(flatWire, "flatWire")
                         else:
-                            Path.Log.error(self.inaccessibleMsg)
-                    shapeTups.append((openWires[0], openWires, "OpenEdge"))
+                            cutWireObjs = False
+                            self.ofstRadius = po
+                            cutShp = self._getCutAreaCrossSection(obj, base, origWire, flatWire)
+                            if cutShp:
+                                cutWireObjs = self._extractPathWire(obj, base, flatWire, cutShp)
+
+                            if cutWireObjs:
+                                for cW in cutWireObjs:
+                                    openWires.append(cW)
+                            else:
+                                Path.Log.error(self.inaccessibleMsg)
+                    if openWires:
+                        shapeTups.append((openWires[0], openWires, "OpenEdge"))
 
         return shapeTups
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
**NOTE: This is mostly for discussion and really isn't intended for merging as-is- it's only gently tested and I'm sure could be significantly improved.**

This is a proof-of-concept adding an option for a "naive" profile operation- "just offset the curves I've selected by the amount I tell you in the direction I specify".

The issue this tries to address is that the profile operation tries to be too smart about figuring out which side is the "inside" and which is the "outside". Sometimes this fails, often in unintuitive ways. This is a long-running issue with many, many bugs and unexpected behaviors resulting from it. The end result of this is you can get incorrect (or no!) toolpaths for operations that should be simple. Adding a "manual override" option at least would allow the user to force the operation to what they want without cluttering the model with helper geometry.

As an example, the image below is the profile generated for the edges selected in blue- it's apparently actually following some contour partway up the face (which will cut into the selected profile below), and doesn't extend along the entire path selected:

<img width="936" height="547" alt="Screenshot_2026-06-06_13-04-10" src="https://github.com/user-attachments/assets/52e13a29-f178-442c-834f-5aff1d0fa763" />


With the naive option, it blindly offsets the curves selected and behaves as intended:
<img width="878" height="551" alt="Screenshot_2026-06-06_13-02-23" src="https://github.com/user-attachments/assets/3b8e203a-decb-4b01-9b86-0d6728d8de24" />


Is this something the developers think is worth putting more time into implementing better and testing more thoroughly?


<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
This would at least work around https://github.com/FreeCAD/FreeCAD/issues/30635

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
