### PR TITLE
Measurement: Added delta results to the task panel

### DIFF
--- a/src/App/MeasureManager.cpp
+++ b/src/App/MeasureManager.cpp
@@ -155,7 +155,7 @@ Py::Tuple MeasureManager::getSelectionPy(const App::MeasureSelection& selection)
 
 
 std::vector<MeasureType*> MeasureManager::getValidMeasureTypes(App::MeasureSelection selection,
-                                                               std::string mode)
+                                                               std::string modeIdentifier)
 {
     Base::PyGILStateLocker lock;
 
@@ -170,7 +170,7 @@ std::vector<MeasureType*> MeasureManager::getValidMeasureTypes(App::MeasureSelec
     // Loop through measure types and check if they work with given selection
     for (App::MeasureType* mType : getMeasureTypes()) {
 
-        if (mode != "" && mType->label != mode) {
+        if (!modeIdentifier.empty() && mType->identifier != modeIdentifier) {
             continue;
         }
 

--- a/src/App/MeasureManager.h
+++ b/src/App/MeasureManager.h
@@ -121,7 +121,7 @@ public:
     static const std::vector<MeasureType*> getMeasureTypes();
     static Py::Tuple getSelectionPy(const App::MeasureSelection& selection);
     static std::vector<MeasureType*> getValidMeasureTypes(App::MeasureSelection selection,
-                                                          std::string mode);
+                                                          std::string modeIdentifier);
 
 
 private:

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -2,6 +2,7 @@
 
 /***************************************************************************
  *   Copyright (c) 2023 David Friedli <david[at]friedli-be.ch>             *
+ *   Copyright (c) 2026 Loke S. Haugsnes <lokesh[at]live.no>               *
  *                                                                         *
  *   This file is part of FreeCAD.                                         *
  *                                                                         *
@@ -41,7 +42,6 @@
 
 using enum Gui::InputHint::UserInput;
 
-#include <QFormLayout>
 #include <QVBoxLayout>
 #include <QPushButton>
 #include <QSettings>
@@ -199,7 +199,7 @@ TaskMeasure::TaskMeasure()
     modeSwitch->addItem(tr("Auto"));
 
     for (App::MeasureType* mType : App::MeasureManager::getMeasureTypes()) {
-        modeSwitch->addItem(tr(mType->label.c_str()));
+        modeSwitch->addItem(tr(mType->label.c_str()), QString::fromStdString(mType->identifier));
     }
 
     // Connect dropdown's change signal to our onModeChange slot
@@ -217,7 +217,7 @@ TaskMeasure::TaskMeasure()
     // Main layout
     QBoxLayout* layout = taskbox->groupLayout();
 
-    QFormLayout* formLayout = new QFormLayout();
+    formLayout = new QFormLayout();
     formLayout->setHorizontalSpacing(10);
     formLayout->setVerticalSpacing(6);
     // Note: How can the split between columns be kept in the middle?
@@ -370,7 +370,10 @@ void TaskMeasure::tryUpdate()
         }
     }
 
-    valueResult->setText(QString::asprintf("-"));
+    valueResult->setText(QLatin1String("-"));
+    if (typeInfo) {
+        typeInfo->resetUIState();
+    }
 
     std::string mode = explicitMode ? modeSwitch->currentText().toStdString() : "";
 
@@ -398,6 +401,7 @@ void TaskMeasure::tryUpdate()
         // Reset measure object
         if (!explicitMode) {
             setModeSilent(nullptr);
+            createTypeInfo("");
         }
         removeObject();
         enableAnnotateButton(false);
@@ -414,6 +418,7 @@ void TaskMeasure::tryUpdate()
         // we don't already have a measureobject or it isn't the same type as the new one
         removeObject();
         createObject(measureType);
+        createTypeInfo(measureType->identifier);
     }
 
     // we have a valid measure object so we can enable the annotate button
@@ -480,6 +485,9 @@ void TaskMeasure::refreshResult()
     valueResult->setText(
         QString::fromStdString(Base::UnitsApi::toUnicodeSuperscript(_mMeasureObject->getResultString()))
     );
+    if (typeInfo) {
+        typeInfo->update(*_mMeasureObject);
+    }
 }
 
 
@@ -722,6 +730,11 @@ void TaskMeasure::onModeChanged(int index)
 {
     explicitMode = (index != 0);
 
+    if (explicitMode) {
+        std::string type = modeSwitch->itemData(index).toString().toStdString();
+        createTypeInfo(type);
+    }
+
     this->update();
 }
 
@@ -810,4 +823,22 @@ App::MeasureType* TaskMeasure::getMeasureType()
         }
     }
     return nullptr;
+}
+
+void TaskMeasure::createTypeInfo(const std::string& type)
+{
+    typeInfo.reset();
+}
+
+
+TaskMeasureTypeInfo::TaskMeasureTypeInfo(QFormLayout& parentFormLayout)
+    : _parentFormLayout(parentFormLayout)
+    , _container(new QWidget())
+{
+    _parentFormLayout.addRow(_container);
+}
+
+TaskMeasureTypeInfo::~TaskMeasureTypeInfo()
+{
+    _parentFormLayout.removeRow(_container);
 }

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -143,9 +143,9 @@ TaskMeasure::TaskMeasure()
     setupShortcuts(taskbox);
 
     QSettings settings;
-    settings.beginGroup(QLatin1String(taskMeasureSettingsGroup));
-    mAutoSave = settings.value(QLatin1String(taskMeasureAutoSaveSettingsName), mAutoSave).toBool();
-    mGreedySelection = settings.value(QLatin1String(taskMeasureGreedySelection), false).toBool();
+    settings.beginGroup(taskMeasureSettingsGroup);
+    mAutoSave = settings.value(taskMeasureAutoSaveSettingsName, mAutoSave).toBool();
+    mGreedySelection = settings.value(taskMeasureGreedySelection, false).toBool();
     settings.endGroup();
 
     autoSaveAction = new QAction(tr("Auto Save"));
@@ -191,7 +191,10 @@ TaskMeasure::TaskMeasure()
     modeSwitch->addItem(tr("Auto"));
 
     for (App::MeasureType* mType : App::MeasureManager::getMeasureTypes()) {
-        modeSwitch->addItem(tr(mType->label.c_str()), QString::fromStdString(mType->identifier));
+        modeSwitch->addItem(
+            qApp->translate("TaskMeasure", mType->label.c_str()),
+            QString::fromStdString(mType->identifier)
+        );
     }
 
     // Connect dropdown's change signal to our onModeChange slot
@@ -353,12 +356,13 @@ void TaskMeasure::tryUpdate()
         }
     }
 
-    valueResult->setText(QLatin1String("-"));
+    valueResult->setText("-");
     if (typeInfo) {
         typeInfo->resetUIState();
     }
 
-    std::string mode = explicitMode ? modeSwitch->currentText().toStdString() : "";
+    std::string modeIdentifier = explicitMode ? modeSwitch->currentData().toString().toStdString()
+                                              : "";
 
     App::MeasureSelection selection;
     for (auto s : Gui::Selection().getSelection(doc->getName(), Gui::ResolveMode::NoResolve)) {
@@ -370,7 +374,7 @@ void TaskMeasure::tryUpdate()
 
     // Get valid measure type
     App::MeasureType* measureType = nullptr;
-    auto measureTypes = App::MeasureManager::getValidMeasureTypes(selection, mode);
+    auto measureTypes = App::MeasureManager::getValidMeasureTypes(selection, modeIdentifier);
     if (!measureTypes.empty()) {
         measureType = measureTypes.front();
     }
@@ -761,7 +765,7 @@ void TaskMeasure::setModeSilent(App::MeasureType* mode)
         modeSwitch->setCurrentIndex(0);
     }
     else {
-        modeSwitch->setCurrentText(QString::fromLatin1(mode->label.c_str()));
+        modeSwitch->setCurrentIndex(modeSwitch->findData(QString::fromStdString(mode->identifier)));
     }
     modeSwitch->blockSignals(false);
 }
@@ -807,8 +811,8 @@ TaskMeasureDistanceInfo::TaskMeasureDistanceInfo(
     : TaskMeasureTypeInfo(formLayout, std::move(measureObjectGetter))
 {
     QSettings settings;
-    settings.beginGroup(QLatin1String(taskMeasureSettingsGroup));
-    _delta = settings.value(QLatin1String(taskMeasureShowDeltaSettingsName), _delta).toBool();
+    settings.beginGroup(taskMeasureSettingsGroup);
+    _delta = settings.value(taskMeasureShowDeltaSettingsName, _delta).toBool();
     settings.endGroup();
 
     _showDelta = new QCheckBox();
@@ -823,7 +827,8 @@ TaskMeasureDistanceInfo::TaskMeasureDistanceInfo(
     showDeltaLayout->setContentsMargins(0, 0, 0, 0);
     showDeltaLayout->setSpacing(8);
     showDeltaLayout->addWidget(_showDelta, 0, Qt::AlignVCenter | Qt::AlignLeft);
-    showDeltaLayout->addWidget(new QLabel(tr("Show Delta")), 0, Qt::AlignVCenter | Qt::AlignLeft);
+    showDeltaLayout
+        ->addWidget(new QLabel(TaskMeasure::tr("Show Delta")), 0, Qt::AlignVCenter | Qt::AlignLeft);
     showDeltaLayout->addStretch(1);
 
     _deltaXResult = new QLineEdit();
@@ -848,9 +853,9 @@ TaskMeasureDistanceInfo::TaskMeasureDistanceInfo(
 
 void TaskMeasureDistanceInfo::resetUIState()
 {
-    _deltaXResult->setText(QLatin1String("-"));
-    _deltaYResult->setText(QLatin1String("-"));
-    _deltaZResult->setText(QLatin1String("-"));
+    _deltaXResult->setText("-");
+    _deltaYResult->setText("-");
+    _deltaZResult->setText("-");
 }
 
 void TaskMeasureDistanceInfo::update()
@@ -910,8 +915,8 @@ void TaskMeasureDistanceInfo::showDeltaChanged(int checkState)
     _delta = checkState == Qt::CheckState::Checked;
 
     QSettings settings;
-    settings.beginGroup(QLatin1String(taskMeasureSettingsGroup));
-    settings.setValue(QLatin1String(taskMeasureShowDeltaSettingsName), _delta);
+    settings.beginGroup(taskMeasureSettingsGroup);
+    settings.setValue(taskMeasureShowDeltaSettingsName, _delta);
     settings.endGroup();
     settings.sync();  // immediate write to the settings file
 

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -54,6 +54,7 @@ using enum Gui::InputHint::UserInput;
 #include <Base/Quantity.h>
 #include <Base/UnitsApi.h>
 #include <array>
+#include <utility>
 
 using namespace MeasureGui;
 
@@ -143,19 +144,10 @@ TaskMeasure::TaskMeasure()
 
     QSettings settings;
     settings.beginGroup(QLatin1String(taskMeasureSettingsGroup));
-    delta = settings.value(QLatin1String(taskMeasureShowDeltaSettingsName), true).toBool();
     mAutoSave = settings.value(QLatin1String(taskMeasureAutoSaveSettingsName), mAutoSave).toBool();
     mGreedySelection = settings.value(QLatin1String(taskMeasureGreedySelection), false).toBool();
     settings.endGroup();
 
-    showDelta = new QCheckBox();
-    showDelta->setChecked(delta);
-    showDeltaLabel = new QLabel(tr("Show Delta"));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
-    connect(showDelta, &QCheckBox::checkStateChanged, this, &TaskMeasure::showDeltaChanged);
-#else
-    connect(showDelta, &QCheckBox::stateChanged, this, &TaskMeasure::showDeltaChanged);
-#endif
     autoSaveAction = new QAction(tr("Auto Save"));
     autoSaveAction->setCheckable(true);
     autoSaveAction->setChecked(mAutoSave);
@@ -222,7 +214,7 @@ TaskMeasure::TaskMeasure()
     formLayout->setVerticalSpacing(6);
     // Note: How can the split between columns be kept in the middle?
     // formLayout->setFieldGrowthPolicy(QFormLayout::FieldGrowthPolicy::ExpandingFieldsGrow);
-    formLayout->setFormAlignment(Qt::AlignCenter);
+    formLayout->setFormAlignment(Qt::AlignTop);
 
     auto* settingsLayout = new QHBoxLayout();
     settingsLayout->addItem(new QSpacerItem(0, 0, QSizePolicy::Expanding));
@@ -230,20 +222,11 @@ TaskMeasure::TaskMeasure()
     formLayout->addRow(QLatin1String(), settingsLayout);
     formLayout->addRow(tr("Mode"), modeSwitch);
 
-    auto* deltaLayout = new QHBoxLayout();
-    deltaLayout->setContentsMargins(0, 0, 0, 0);
-    deltaLayout->setSpacing(8);
-    deltaLayout->addWidget(showDelta, 0, Qt::AlignVCenter | Qt::AlignLeft);
-    deltaLayout->addWidget(showDeltaLabel, 0, Qt::AlignVCenter | Qt::AlignLeft);
-    deltaLayout->addStretch(1);
-
-
     auto* resultLayout = new QHBoxLayout();
     resultLayout->setSpacing(8);
     resultLayout->addWidget(valueResult, 65);
     resultLayout->addWidget(unitSwitch, 30);
     formLayout->addRow(tr("Result"), resultLayout);
-    formLayout->addRow(deltaLayout);
     layout->addLayout(formLayout);
 
     Content.emplace_back(taskbox);
@@ -430,9 +413,7 @@ void TaskMeasure::tryUpdate()
 
         syncDisplayUnit();
         refreshResult();
-
-        // Initialite the measurement's viewprovider
-        initViewObject(_mMeasureObject);
+        updateAnnotation();
     }
     _mMeasureObject->purgeTouched();
 }
@@ -485,36 +466,26 @@ void TaskMeasure::refreshResult()
     valueResult->setText(
         QString::fromStdString(Base::UnitsApi::toUnicodeSuperscript(_mMeasureObject->getResultString()))
     );
+
     if (typeInfo) {
-        typeInfo->update(*_mMeasureObject);
+        typeInfo->update();
     }
 }
 
-
-void TaskMeasure::initViewObject(Measure::MeasureBase* measure)
+void MeasureGui::TaskMeasure::updateAnnotation()
 {
     Gui::Document* guiDoc = Gui::Application::Instance->activeDocument();
     if (!guiDoc) {
         return;
     }
 
-    Gui::ViewProvider* viewObject = guiDoc->getViewProvider(measure);
+    Gui::ViewProvider* viewObject = guiDoc->getViewProvider(_mMeasureObject);
     if (!viewObject) {
         return;
     }
 
-    // Init the position of the annotation
-    dynamic_cast<MeasureGui::ViewProviderMeasureBase*>(viewObject)->positionAnno(measure);
-
-    // Set the ShowDelta Property if it exists on the measurements view object
-    auto* prop = viewObject->getPropertyByName<App::PropertyBool>("ShowDelta");
-    setDeltaPossible(prop != nullptr);
-    if (prop) {
-        prop->setValue(showDelta->isChecked());
-        viewObject->update(prop);
-    }
+    dynamic_cast<MeasureGui::ViewProviderMeasureBase*>(viewObject)->positionAnno(_mMeasureObject);
 }
-
 
 void TaskMeasure::closeDialog()
 {
@@ -720,12 +691,6 @@ void TaskMeasure::onObjectDeleted(const App::DocumentObject& obj)
     }
 }
 
-void TaskMeasure::setDeltaPossible(bool possible)
-{
-    showDelta->setVisible(possible);
-    showDeltaLabel->setVisible(possible);
-}
-
 void TaskMeasure::onModeChanged(int index)
 {
     explicitMode = (index != 0);
@@ -743,19 +708,6 @@ void TaskMeasure::onUnitChanged(int index)
     Q_UNUSED(index);
     syncDisplayUnit();
     refreshResult();
-}
-
-void TaskMeasure::showDeltaChanged(int checkState)
-{
-    delta = checkState == Qt::CheckState::Checked;
-
-    QSettings settings;
-    settings.beginGroup(QLatin1String(taskMeasureSettingsGroup));
-    settings.setValue(QLatin1String(taskMeasureShowDeltaSettingsName), delta);
-    settings.endGroup();
-    settings.sync();  // immediate write to the settings file
-
-    this->update();
 }
 
 void TaskMeasure::autoSaveChanged(bool checked)
@@ -814,26 +766,26 @@ void TaskMeasure::setModeSilent(App::MeasureType* mode)
     modeSwitch->blockSignals(false);
 }
 
-// Get explicitly set measure type from the mode switch
-App::MeasureType* TaskMeasure::getMeasureType()
-{
-    for (App::MeasureType* mType : App::MeasureManager::getMeasureTypes()) {
-        if (mType->label.c_str() == modeSwitch->currentText().toLatin1()) {
-            return mType;
-        }
-    }
-    return nullptr;
-}
-
 void TaskMeasure::createTypeInfo(const std::string& type)
 {
-    typeInfo.reset();
+    if (type == "DISTANCE" || type == "DISTANCEFREE") {
+        typeInfo = std::make_unique<TaskMeasureDistanceInfo>(*formLayout, [this]() {
+            return _mMeasureObject;
+        });
+    }
+    else {
+        typeInfo.reset();
+    }
 }
 
 
-TaskMeasureTypeInfo::TaskMeasureTypeInfo(QFormLayout& parentFormLayout)
+TaskMeasureTypeInfo::TaskMeasureTypeInfo(
+    QFormLayout& parentFormLayout,
+    MeasureObjectGetter measureObjectGetter
+)
     : _parentFormLayout(parentFormLayout)
     , _container(new QWidget())
+    , _measureObjectGetter(std::move(measureObjectGetter))
 {
     _parentFormLayout.addRow(_container);
 }
@@ -841,4 +793,128 @@ TaskMeasureTypeInfo::TaskMeasureTypeInfo(QFormLayout& parentFormLayout)
 TaskMeasureTypeInfo::~TaskMeasureTypeInfo()
 {
     _parentFormLayout.removeRow(_container);
+}
+
+Measure::MeasureBase* TaskMeasureTypeInfo::getMeasureObject() const
+{
+    return _measureObjectGetter();
+}
+
+TaskMeasureDistanceInfo::TaskMeasureDistanceInfo(
+    QFormLayout& formLayout,
+    MeasureObjectGetter measureObjectGetter
+)
+    : TaskMeasureTypeInfo(formLayout, std::move(measureObjectGetter))
+{
+    QSettings settings;
+    settings.beginGroup(QLatin1String(taskMeasureSettingsGroup));
+    _delta = settings.value(QLatin1String(taskMeasureShowDeltaSettingsName), _delta).toBool();
+    settings.endGroup();
+
+    _showDelta = new QCheckBox();
+    _showDelta->setChecked(_delta);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    connect(_showDelta, &QCheckBox::checkStateChanged, this, &TaskMeasureDistanceInfo::showDeltaChanged);
+#else
+    connect(_showDelta, &QCheckBox::stateChanged, this, &TaskMeasureDistanceInfo::showDeltaChanged);
+#endif
+
+    auto* showDeltaLayout = new QHBoxLayout();
+    showDeltaLayout->setContentsMargins(0, 0, 0, 0);
+    showDeltaLayout->setSpacing(8);
+    showDeltaLayout->addWidget(_showDelta, 0, Qt::AlignVCenter | Qt::AlignLeft);
+    showDeltaLayout->addWidget(new QLabel(tr("Show Delta")), 0, Qt::AlignVCenter | Qt::AlignLeft);
+    showDeltaLayout->addStretch(1);
+
+    _deltaXResult = new QLineEdit();
+    _deltaYResult = new QLineEdit();
+    _deltaZResult = new QLineEdit();
+    _deltaXResult->setReadOnly(true);
+    _deltaYResult->setReadOnly(true);
+    _deltaZResult->setReadOnly(true);
+
+    _deltaResult = new QWidget();
+    auto* deltaLayout = new QFormLayout(_deltaResult);
+    deltaLayout->addRow(QStringLiteral("Δx"), _deltaXResult);
+    deltaLayout->addRow(QStringLiteral("Δy"), _deltaYResult);
+    deltaLayout->addRow(QStringLiteral("Δz"), _deltaZResult);
+
+    auto* containerLayout = new QFormLayout(_container);
+    containerLayout->addRow(showDeltaLayout);
+    containerLayout->addRow(_deltaResult);
+
+    _deltaResult->setVisible(_delta);
+}
+
+void TaskMeasureDistanceInfo::resetUIState()
+{
+    _deltaXResult->setText(QLatin1String("-"));
+    _deltaYResult->setText(QLatin1String("-"));
+    _deltaZResult->setText(QLatin1String("-"));
+}
+
+void TaskMeasureDistanceInfo::update()
+{
+    auto* measureObject = getMeasureObject();
+    if (!measureObject) {
+        return;
+    }
+
+    const Gui::Document* guiDoc = Gui::Application::Instance->activeDocument();
+    if (!guiDoc) {
+        return;
+    }
+
+    Gui::ViewProvider* viewObject = guiDoc->getViewProvider(measureObject);
+    if (!viewObject) {
+        return;
+    }
+
+    auto* showDeltaProp = viewObject->getPropertyByName<App::PropertyBool>("ShowDelta");
+    if (showDeltaProp) {
+        showDeltaProp->setValue(_delta);
+        viewObject->update(showDeltaProp);
+    }
+
+    if (!_delta) {
+        return;
+    }
+
+    const auto* deltaXProp = measureObject->getPropertyByName<App::PropertyDistance>("DistanceX");
+    const auto* deltaYProp = measureObject->getPropertyByName<App::PropertyDistance>("DistanceY");
+    const auto* deltaZProp = measureObject->getPropertyByName<App::PropertyDistance>("DistanceZ");
+    if (!deltaXProp || !deltaYProp || !deltaZProp) {
+        Base::Console().error(
+            "TaskMeasureDistanceInfo: measure type '%s' must define DistanceX, DistanceY, and "
+            "DistanceZ properties\n",
+            measureObject->getTypeId().getName()
+        );
+        return;
+    }
+
+    auto getDeltaText = [measureObject](const App::PropertyDistance* deltaValue) {
+        return QString::fromStdString(
+            Base::UnitsApi::toUnicodeSuperscript(
+                (measureObject->formatQuantity(deltaValue->getQuantityValue()))
+            )
+        );
+    };
+
+    _deltaXResult->setText(getDeltaText(deltaXProp));
+    _deltaYResult->setText(getDeltaText(deltaYProp));
+    _deltaZResult->setText(getDeltaText(deltaZProp));
+}
+
+void TaskMeasureDistanceInfo::showDeltaChanged(int checkState)
+{
+    _delta = checkState == Qt::CheckState::Checked;
+
+    QSettings settings;
+    settings.beginGroup(QLatin1String(taskMeasureSettingsGroup));
+    settings.setValue(QLatin1String(taskMeasureShowDeltaSettingsName), _delta);
+    settings.endGroup();
+    settings.sync();  // immediate write to the settings file
+
+    _deltaResult->setVisible(_delta);
+    update();
 }

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -32,6 +32,7 @@
 #include <App/DocumentObjectGroup.h>
 #include <App/Link.h>
 #include <Mod/Measure/App/MeasureDistance.h>
+#include <Mod/Measure/App/Preferences.h>
 #include <App/PropertyStandard.h>
 #include <Gui/MainWindow.h>
 #include <Gui/Application.h>
@@ -44,7 +45,6 @@ using enum Gui::InputHint::UserInput;
 
 #include <QVBoxLayout>
 #include <QPushButton>
-#include <QSettings>
 #include <QAction>
 #include <QMenu>
 #include <QShortcut>
@@ -142,11 +142,9 @@ TaskMeasure::TaskMeasure()
 
     setupShortcuts(taskbox);
 
-    QSettings settings;
-    settings.beginGroup(taskMeasureSettingsGroup);
-    mAutoSave = settings.value(taskMeasureAutoSaveSettingsName, mAutoSave).toBool();
-    mGreedySelection = settings.value(taskMeasureGreedySelection, false).toBool();
-    settings.endGroup();
+    auto preferences = Measure::Preferences::getPreferenceGroup(taskMeasureSettingsGroup);
+    mAutoSave = preferences->GetBool(taskMeasureAutoSaveSettingsName, false);
+    mGreedySelection = preferences->GetBool(taskMeasureGreedySelection, false);
 
     autoSaveAction = new QAction(tr("Auto Save"));
     autoSaveAction->setCheckable(true);
@@ -159,9 +157,7 @@ TaskMeasure::TaskMeasure()
 
     newMeasurementBehaviourAction = new QAction(tr("Additive Selection"));
     newMeasurementBehaviourAction->setCheckable(true);
-    newMeasurementBehaviourAction->setChecked(
-        Gui::Selection().getSelectionStyle() == SelectionStyle::GreedySelection
-    );
+    newMeasurementBehaviourAction->setChecked(mGreedySelection);
     newMeasurementBehaviourAction->setToolTip(
         tr("If checked, new selection will be added to the measurement. If unchecked, the Ctrl key "
            "must be "
@@ -718,21 +714,16 @@ void TaskMeasure::autoSaveChanged(bool checked)
 {
     mAutoSave = checked;
 
-    QSettings settings;
-    settings.beginGroup(QLatin1String(taskMeasureSettingsGroup));
-    settings.setValue(QLatin1String(taskMeasureAutoSaveSettingsName), mAutoSave);
-    settings.endGroup();
+    Measure::Preferences::getPreferenceGroup(taskMeasureSettingsGroup)
+        ->SetBool(taskMeasureAutoSaveSettingsName, mAutoSave);
 }
 
 void TaskMeasure::newMeasurementBehaviourChanged(bool checked)
 {
-    QSettings settings;
-    settings.beginGroup(QLatin1String(taskMeasureSettingsGroup));
-    settings.setValue(QLatin1String(taskMeasureGreedySelection), true);
     mGreedySelection = checked;
+    Measure::Preferences::getPreferenceGroup(taskMeasureSettingsGroup)
+        ->SetBool(taskMeasureGreedySelection, mGreedySelection);
     updateSelectionType();
-
-    settings.endGroup();
 }
 void TaskMeasure::updateSelectionType()
 {
@@ -810,13 +801,11 @@ TaskMeasureDistanceInfo::TaskMeasureDistanceInfo(
 )
     : TaskMeasureTypeInfo(formLayout, std::move(measureObjectGetter))
 {
-    QSettings settings;
-    settings.beginGroup(taskMeasureSettingsGroup);
-    _delta = settings.value(taskMeasureShowDeltaSettingsName, _delta).toBool();
-    settings.endGroup();
-
     _showDelta = new QCheckBox();
-    _showDelta->setChecked(_delta);
+    _showDelta->setChecked(
+        Measure::Preferences::getPreferenceGroup(taskMeasureSettingsGroup)
+            ->GetBool(taskMeasureShowDeltaSettingsName, true)
+    );
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
     connect(_showDelta, &QCheckBox::checkStateChanged, this, &TaskMeasureDistanceInfo::showDeltaChanged);
 #else
@@ -848,7 +837,7 @@ TaskMeasureDistanceInfo::TaskMeasureDistanceInfo(
     containerLayout->addRow(showDeltaLayout);
     containerLayout->addRow(_deltaResult);
 
-    _deltaResult->setVisible(_delta);
+    _deltaResult->setVisible(_showDelta->isChecked());
 }
 
 void TaskMeasureDistanceInfo::resetUIState()
@@ -877,11 +866,11 @@ void TaskMeasureDistanceInfo::update()
 
     auto* showDeltaProp = viewObject->getPropertyByName<App::PropertyBool>("ShowDelta");
     if (showDeltaProp) {
-        showDeltaProp->setValue(_delta);
+        showDeltaProp->setValue(_showDelta->isChecked());
         viewObject->update(showDeltaProp);
     }
 
-    if (!_delta) {
+    if (!_showDelta->isChecked()) {
         return;
     }
 
@@ -912,14 +901,11 @@ void TaskMeasureDistanceInfo::update()
 
 void TaskMeasureDistanceInfo::showDeltaChanged(int checkState)
 {
-    _delta = checkState == Qt::CheckState::Checked;
+    const bool showDelta = checkState == Qt::CheckState::Checked;
 
-    QSettings settings;
-    settings.beginGroup(taskMeasureSettingsGroup);
-    settings.setValue(taskMeasureShowDeltaSettingsName, _delta);
-    settings.endGroup();
-    settings.sync();  // immediate write to the settings file
+    Measure::Preferences::getPreferenceGroup(taskMeasureSettingsGroup)
+        ->SetBool(taskMeasureShowDeltaSettingsName, showDelta);
 
-    _deltaResult->setVisible(_delta);
+    _deltaResult->setVisible(showDelta);
     update();
 }

--- a/src/Mod/Measure/Gui/TaskMeasure.h
+++ b/src/Mod/Measure/Gui/TaskMeasure.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include <QColumnView>
 #include <QString>
 #include <QComboBox>
@@ -93,8 +95,6 @@ private:
     QLineEdit* valueResult {nullptr};
     QComboBox* modeSwitch {nullptr};
     QComboBox* unitSwitch {nullptr};
-    QCheckBox* showDelta {nullptr};
-    QLabel* showDeltaLabel {nullptr};
     QAction* autoSaveAction {nullptr};
     QAction* newMeasurementBehaviourAction {nullptr};
     QToolButton* mSettings {nullptr};
@@ -106,26 +106,22 @@ private:
     void removeObject();
     void onModeChanged(int index);
     void onUnitChanged(int index);
-    void showDeltaChanged(int checkState);
     void autoSaveChanged(bool checked);
     void newMeasurementBehaviourChanged(bool checked);
     void updateSelectionType();
     void setModeSilent(App::MeasureType* mode);
-    App::MeasureType* getMeasureType();
     void enableAnnotateButton(bool state);
     void createObject(const App::MeasureType* measureType);
     void ensureGroup(Measure::MeasureBase* measurement);
-    void setDeltaPossible(bool possible);
-    void initViewObject(Measure::MeasureBase* measure);
     void syncDisplayUnit();
     void refreshResult();
+    void updateAnnotation();
     void createTypeInfo(const std::string& type);
 
     // Stores if the mode is explicitly set by the user or implicitly through the selection
     bool explicitMode = false;
 
     // Stores if delta measures shall be shown
-    bool delta = true;
     bool mAutoSave = false;
     bool mGreedySelection = false;
     Gui::Document* mTargetDoc;
@@ -136,15 +132,43 @@ class TaskMeasureTypeInfo: public QObject
 {
     Q_OBJECT
 public:
-    explicit TaskMeasureTypeInfo(QFormLayout& parentFormLayout);
-    virtual ~TaskMeasureTypeInfo();
+    using MeasureObjectGetter = std::function<Measure::MeasureBase*()>;
+
+    explicit TaskMeasureTypeInfo(QFormLayout& parentFormLayout, MeasureObjectGetter measureObjectGetter);
+    ~TaskMeasureTypeInfo() override;
     virtual void resetUIState() = 0;
-    virtual void update(Measure::MeasureBase& measureObject) = 0;
+    virtual void update() = 0;
 
 protected:
+    Measure::MeasureBase* getMeasureObject() const;
+
     QFormLayout& _parentFormLayout;
     // Every Qt object created by derived classes must have _container as a parent
     QWidget* _container {nullptr};
+
+private:
+    MeasureObjectGetter _measureObjectGetter;
+};
+
+class TaskMeasureDistanceInfo: public TaskMeasureTypeInfo
+{
+    Q_OBJECT
+public:
+    explicit TaskMeasureDistanceInfo(QFormLayout& formLayout, MeasureObjectGetter measureObjectGetter);
+    void resetUIState() override;
+    void update() override;
+
+private:
+    void showDeltaChanged(int checkState);
+
+private:
+    QCheckBox* _showDelta {nullptr};
+    QLineEdit* _deltaXResult {nullptr};
+    QLineEdit* _deltaYResult {nullptr};
+    QLineEdit* _deltaZResult {nullptr};
+    QWidget* _deltaResult {nullptr};
+
+    static inline bool _delta {true};
 };
 
 }  // namespace MeasureGui

--- a/src/Mod/Measure/Gui/TaskMeasure.h
+++ b/src/Mod/Measure/Gui/TaskMeasure.h
@@ -2,6 +2,7 @@
 
 /***************************************************************************
  *   Copyright (c) 2023 David Friedli <david[at]friedli-be.ch>             *
+ *   Copyright (c) 2026 Loke S. Haugsnes <lokesh[at]live.no>               *
  *                                                                         *
  *   This file is part of FreeCAD.                                         *
  *                                                                         *
@@ -29,6 +30,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QCheckBox>
+#include <QFormLayout>
 
 #include <App/Application.h>
 #include <App/Document.h>
@@ -47,6 +49,7 @@
 
 namespace MeasureGui
 {
+class TaskMeasureTypeInfo;
 
 class TaskMeasure: public Gui::TaskView::TaskDialog, public Gui::SelectionObserver
 {
@@ -86,6 +89,7 @@ private:
 
     Measure::MeasureBase* _mMeasureObject = nullptr;
 
+    QFormLayout* formLayout {nullptr};
     QLineEdit* valueResult {nullptr};
     QComboBox* modeSwitch {nullptr};
     QComboBox* unitSwitch {nullptr};
@@ -94,6 +98,8 @@ private:
     QAction* autoSaveAction {nullptr};
     QAction* newMeasurementBehaviourAction {nullptr};
     QToolButton* mSettings {nullptr};
+
+    std::unique_ptr<TaskMeasureTypeInfo> typeInfo;
 
     fastsignals::connection m_deletedConnection;
 
@@ -113,6 +119,7 @@ private:
     void initViewObject(Measure::MeasureBase* measure);
     void syncDisplayUnit();
     void refreshResult();
+    void createTypeInfo(const std::string& type);
 
     // Stores if the mode is explicitly set by the user or implicitly through the selection
     bool explicitMode = false;
@@ -122,6 +129,22 @@ private:
     bool mAutoSave = false;
     bool mGreedySelection = false;
     Gui::Document* mTargetDoc;
+};
+
+// When creating a new TaskMeasureTypeInfo, remember to add it to TaskMeasure::createTypeInfo
+class TaskMeasureTypeInfo: public QObject
+{
+    Q_OBJECT
+public:
+    explicit TaskMeasureTypeInfo(QFormLayout& parentFormLayout);
+    virtual ~TaskMeasureTypeInfo();
+    virtual void resetUIState() = 0;
+    virtual void update(Measure::MeasureBase& measureObject) = 0;
+
+protected:
+    QFormLayout& _parentFormLayout;
+    // Every Qt object created by derived classes must have _container as a parent
+    QWidget* _container {nullptr};
 };
 
 }  // namespace MeasureGui

--- a/src/Mod/Measure/Gui/TaskMeasure.h
+++ b/src/Mod/Measure/Gui/TaskMeasure.h
@@ -168,8 +168,6 @@ private:
     QLineEdit* _deltaYResult {nullptr};
     QLineEdit* _deltaZResult {nullptr};
     QWidget* _deltaResult {nullptr};
-
-    static inline bool _delta {true};
 };
 
 }  // namespace MeasureGui

--- a/src/Mod/Measure/Gui/TaskMeasure.h
+++ b/src/Mod/Measure/Gui/TaskMeasure.h
@@ -55,6 +55,7 @@ class TaskMeasureTypeInfo;
 
 class TaskMeasure: public Gui::TaskView::TaskDialog, public Gui::SelectionObserver
 {
+    Q_OBJECT
 
 public:
     TaskMeasure();


### PR DESCRIPTION
Adds delta measurement's in the task panel.

The deltas respect the unit and the desimal count.

I can make it look closer to the way it does in the issue(one delta per line) if this is desired.
Also when turning off deltas the hole box has a jerk to it, if someone with more QT experience know how to fix this it would be great.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: Claude Haiku 4.5

## Issues
Adds: https://github.com/FreeCAD/FreeCAD/issues/27509
And I will just mention: https://github.com/FreeCAD/FreeCAD/issues/19440

## Video

https://github.com/user-attachments/assets/2346a8bd-b604-4ee8-a6a3-9a20fcdaa3f6

