### PR TITLE
CAM: Use current file path as default for file selection dialog

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/ZCorrect.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/ZCorrect.py
@@ -310,11 +310,16 @@ class TaskPanel:
         self.form.SetProbePointFileName.clicked.connect(self.SetProbePointFileName)
 
     def SetProbePointFileName(self):
+        path = self.form.ProbePointFileName.text().strip()
+        if not os.path.exists(path):
+            path = os.path.dirname(path)
+        if not os.path.exists(path):
+            path = os.path.dirname(FreeCAD.activeDocument().FileName)
         filename = QtGui.QFileDialog.getOpenFileName(
             self.form,
             translate("CAM_Probe", "Select Probe Point File"),
-            None,
-            translate("CAM_Probe", "All Files (*.*)"),
+            path,
+            translate("CAM_Probe", "All Files (*)"),
         )
         if filename and filename[0]:
             self.obj.probefile = str(filename[0])

--- a/src/Mod/CAM/Path/Dressup/Gui/ZCorrect.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/ZCorrect.py
@@ -320,11 +320,16 @@ class TaskPanel:
         self.form.SetProbePointFileName.clicked.connect(self.SetProbePointFileName)
 
     def SetProbePointFileName(self):
+        path = self.form.ProbePointFileName.text().strip()
+        if not os.path.exists(path):
+            path = os.path.dirname(path)
+        if not os.path.exists(path):
+            path = os.path.dirname(FreeCAD.activeDocument().FileName)
         filename = QtGui.QFileDialog.getOpenFileName(
             self.form,
             translate("CAM_Probe", "Select Probe Point File"),
-            None,
-            translate("CAM_Probe", "All Files (*.*)"),
+            path,
+            translate("CAM_Probe", "All Files (*)"),
         )
         if filename and filename[0]:
             self.obj.probefile = str(filename[0])

--- a/src/Mod/CAM/Path/Main/Gui/Camotics.py
+++ b/src/Mod/CAM/Path/Main/Gui/Camotics.py
@@ -34,6 +34,7 @@ import Path.Post.Command as PathPost
 import camotics
 import io
 import json
+import os
 import queue
 import subprocess
 
@@ -82,7 +83,7 @@ class CAMoticsUI:
         filename = QtGui.QFileDialog.getSaveFileName(
             self.form,
             translate("Path", "Save Project As"),
-            "",
+            os.path.dirname(FreeCAD.activeDocument().FileName),
             translate("Path", "CAMotics Project (*.camotics)"),
         )[0]
         if filename:

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -42,6 +42,7 @@ from Path.Tool.toolbit.ui.selector import ToolBitSelector
 from Machine.models import MachineFactory
 from Machine.ui.editor import MachineEditorDialog
 import math
+import os
 import traceback
 from PySide import QtWidgets
 
@@ -1134,11 +1135,16 @@ class TaskPanel:
         self.populateMachineCombo()
 
     def setPostProcessorOutputFile(self):
+        generator = Path.Post.Utils.FilenameGenerator(job=self.vobj.Object)
+        gen_filenames = generator.generate_filenames()
+        resolved_path = next(gen_filenames)
+        if not os.path.exists(resolved_path) and not os.path.exists(os.path.dirname(resolved_path)):
+            resolved_path = os.path.dirname(FreeCAD.activeDocument().FileName)
         filename = QtGui.QFileDialog.getSaveFileName(
             self.form,
             translate("CAM_Job", "Select Output File"),
-            None,
-            translate("CAM_Job", "All Files (*.*)"),
+            resolved_path,
+            translate("CAM_Job", "All Files (*)"),
         )
         if filename and filename[0]:
             self.obj.PostProcessorOutputFile = str(filename[0])

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -1135,7 +1135,9 @@ class TaskPanel:
         self.populateMachineCombo()
 
     def setPostProcessorOutputFile(self):
-        generator = Path.Post.Utils.FilenameGenerator(job=self.vobj.Object)
+        from Path.Post.Utils import FilenameGenerator
+
+        generator = FilenameGenerator(job=self.vobj.Object)
         gen_filenames = generator.generate_filenames()
         resolved_path = next(gen_filenames)
         if not os.path.exists(resolved_path) and not os.path.exists(os.path.dirname(resolved_path)):
@@ -1147,8 +1149,17 @@ class TaskPanel:
             translate("CAM_Job", "All Files (*)"),
         )
         if filename and filename[0]:
-            self.obj.PostProcessorOutputFile = str(filename[0])
-            self.setFields()
+            msgBox = QtGui.QMessageBox()
+            msgBox.setWindowTitle("Warning")
+            msgBox.setText("<p align='center'>This will replace filename template</p>")
+            msgBox.setInformativeText("<p align='center'>Are you sure?</p>")
+            msgBox.findChild(QtGui.QGridLayout).setColumnMinimumWidth(1, 250)
+            btn1 = msgBox.addButton("Ok", QtGui.QMessageBox.ButtonRole.YesRole)
+            btn2 = msgBox.addButton("Cancel", QtGui.QMessageBox.ButtonRole.RejectRole)
+            msgBox.exec()
+            if msgBox.clickedButton() == btn1:
+                self.obj.PostProcessorOutputFile = str(filename[0])
+                self.setFields()
 
     def operationSelect(self):
         if self.form.operationsList.selectedItems():

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -33,6 +33,7 @@ import FreeCADGui
 import Path
 import Path.Preferences as PathPref
 from PySide import QtCore, QtGui
+import os
 
 translate = FreeCAD.Qt.translate
 
@@ -153,6 +154,7 @@ class PostProcessDialog:
         self._populate_fixtures()
         self._populate_job_details()
         self._populate_operations()
+        self._populate_output()
         self._populate_warnings()  # must be last — updates tab badge
 
     def _populate_title(self):
@@ -577,6 +579,19 @@ class PostProcessDialog:
         tree.resizeColumnToContents(0)
         tree.blockSignals(False)
         self._update_ops_tab_label()
+
+    def _populate_output(self):
+        """Set fields of Output tab while init dialog"""
+
+        # set Output folder
+        generator = Path.Post.Utils.FilenameGenerator(job=self.job)
+        gen_filenames = generator.generate_filenames()
+        resolved_dir = os.path.dirname(next(gen_filenames))
+        self.dialog.lineEditOutputLocation.setText(resolved_dir)
+
+        # set Filename template
+        default_template = getattr(self.job, "PostProcessorOutputFile", "") or ""
+        self.dialog.lineEditFilenameTemplate.setText(default_template)
 
     def _get_dialog_overrides(self):
         """Collect current dialog widget values as an overrides dict.
@@ -1266,7 +1281,9 @@ class PostProcessDialog:
 
     def _browse_output_location(self):
         dlg = self.dialog
-        current = dlg.lineEditOutputLocation.text().strip() or ""
+        current = dlg.lineEditOutputLocation.text().strip()
+        if not os.path.exists(os.path.dirname(current)) and not os.path.exists(current):
+            current = os.path.dirname(FreeCAD.activeDocument().FileName)
         folder = QtGui.QFileDialog.getExistingDirectory(
             dlg,
             translate("CAM_Post", "Select Output Folder"),

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -592,15 +592,17 @@ class PostProcessDialog:
 
     def _populate_output(self):
         """Set fields of Output tab while init dialog"""
+        from Path.Post.Utils import FilenameGenerator
 
         # set Output folder
-        generator = Path.Post.Utils.FilenameGenerator(job=self.job)
+        generator = FilenameGenerator(job=self.job)
         gen_filenames = generator.generate_filenames()
         resolved_dir = os.path.dirname(next(gen_filenames))
         self.dialog.lineEditOutputLocation.setText(resolved_dir)
 
         # set Filename template
-        default_template = getattr(self.job, "PostProcessorOutputFile", "") or ""
+        jobPostProcessorOutputFile = getattr(self.job, "PostProcessorOutputFile", "") or ""
+        default_template = os.path.basename(jobPostProcessorOutputFile)
         self.dialog.lineEditFilenameTemplate.setText(default_template)
 
     def _get_dialog_overrides(self):

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -34,6 +34,7 @@ import Path
 import Path.Preferences as PathPref
 from Path.Main.Gui.Editor import CodeEditor
 from PySide import QtCore, QtGui
+import os
 
 translate = FreeCAD.Qt.translate
 
@@ -160,6 +161,7 @@ class PostProcessDialog:
         self._populate_fixtures()
         self._populate_job_details()
         self._populate_operations()
+        self._populate_output()
         self._populate_warnings()  # must be last — updates tab badge
 
     def _populate_title(self):
@@ -587,6 +589,19 @@ class PostProcessDialog:
         tree.resizeColumnToContents(0)
         tree.blockSignals(False)
         self._update_ops_tab_label()
+
+    def _populate_output(self):
+        """Set fields of Output tab while init dialog"""
+
+        # set Output folder
+        generator = Path.Post.Utils.FilenameGenerator(job=self.job)
+        gen_filenames = generator.generate_filenames()
+        resolved_dir = os.path.dirname(next(gen_filenames))
+        self.dialog.lineEditOutputLocation.setText(resolved_dir)
+
+        # set Filename template
+        default_template = getattr(self.job, "PostProcessorOutputFile", "") or ""
+        self.dialog.lineEditFilenameTemplate.setText(default_template)
 
     def _get_dialog_overrides(self):
         """Collect current dialog widget values as an overrides dict.
@@ -1276,7 +1291,9 @@ class PostProcessDialog:
 
     def _browse_output_location(self):
         dlg = self.dialog
-        current = dlg.lineEditOutputLocation.text().strip() or ""
+        current = dlg.lineEditOutputLocation.text().strip()
+        if not os.path.exists(os.path.dirname(current)) and not os.path.exists(current):
+            current = os.path.dirname(FreeCAD.activeDocument().FileName)
         folder = QtGui.QFileDialog.getExistingDirectory(
             dlg,
             translate("CAM_Post", "Select Output Folder"),


### PR DESCRIPTION
Touched:
- ZCorrectDressup: selection probe file
- Job: selection output file
- Machine based post-process: selection output file
- Camotics

<img width="497" height="227" alt="Screenshot_20260607_100411_lossy" src="https://github.com/user-attachments/assets/c0bb63de-e49b-4aba-a0ce-6ead3da96a71" />
<img width="497" height="335" alt="Screenshot_20260607_100510_lossy" src="https://github.com/user-attachments/assets/35716ea2-b86b-475d-8aab-27d0e9de94e3" />
<img width="749" height="207" alt="Screenshot_20260607_100551_lossy" src="https://github.com/user-attachments/assets/05584396-66df-4eae-9ca5-bc7cf4c3ea72" />
