### PR TITLE
TechDraw: Add auxiliary view

### DIFF
--- a/src/Mod/TechDraw/App/AppTechDraw.cpp
+++ b/src/Mod/TechDraw/App/AppTechDraw.cpp
@@ -40,6 +40,7 @@
 #include "DrawTileWeld.h"
 #include "DrawViewAnnotation.h"
 #include "DrawViewArch.h"
+#include "DrawAuxiliaryViewPy.h"
 #include "DrawViewBalloon.h"
 #include "DrawViewClip.h"
 #include "DrawViewCollection.h"
@@ -117,6 +118,7 @@ PyMOD_INIT_FUNC(TechDraw)
     TechDraw::DrawTileWeld        ::init();
     TechDraw::DrawWeldSymbol      ::init();
     TechDraw::DrawBrokenView      ::init();
+    TechDraw::DrawAuxiliaryView   ::init();
 
     TechDraw::PropertyGeomFormatList::init();
     TechDraw::GeomFormat            ::init();
@@ -147,6 +149,7 @@ PyMOD_INIT_FUNC(TechDraw)
     TechDraw::DrawTileWeldPython  ::init();
     TechDraw::DrawWeldSymbolPython::init();
     TechDraw::DrawBrokenViewPython::init();
+    TechDraw::DrawAuxiliaryViewPython::init();
 
     TechDraw::LineFormat::initCurrentLineFormat();
 

--- a/src/Mod/TechDraw/App/CMakeLists.txt
+++ b/src/Mod/TechDraw/App/CMakeLists.txt
@@ -42,6 +42,7 @@ generate_from_py(DrawTileWeld)
 generate_from_py(DrawWeldSymbol)
 generate_from_py(CosmeticExtension)
 generate_from_py(DrawBrokenView)
+generate_from_py(DrawAuxiliaryView)
 
 SET(Draw_SRCS
     DrawPage.cpp
@@ -118,6 +119,8 @@ SET(Draw_SRCS
     FeatureProjection.h
     DrawBrokenView.cpp
     DrawBrokenView.h
+    DrawAuxiliaryView.cpp
+    DrawAuxiliaryView.h
 )
 
 SET(TechDraw_SRCS
@@ -244,6 +247,8 @@ SET(Python_SRCS
     CosmeticExtensionPyImp.cpp
     DrawBrokenView.pyi
     DrawBrokenViewPyImp.cpp
+    DrawAuxiliaryView.pyi
+    DrawAuxiliaryViewPyImp.cpp
 )
 
 SOURCE_GROUP("Mod" FILES ${TechDraw_SRCS})

--- a/src/Mod/TechDraw/App/DrawAuxiliaryView.cpp
+++ b/src/Mod/TechDraw/App/DrawAuxiliaryView.cpp
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 meaqua9420                                        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <algorithm>
+
+#include <TopoDS_Shape.hxx>
+#include <gp_Ax2.hxx>
+
+#include <Base/Console.h>
+#include <Base/Converter.h>
+#include <Base/Tools.h>
+
+#include "DrawAuxiliaryView.h"
+#include "DrawProjGroup.h"
+#include "DrawAuxiliaryViewPy.h"
+#include "DrawProjGroupItem.h"
+#include "DrawUtil.h"
+#include "Preferences.h"
+
+
+using namespace TechDraw;
+
+
+PROPERTY_SOURCE(TechDraw::DrawAuxiliaryView, TechDraw::DrawViewPart)
+
+const char* DrawAuxiliaryView::AuxiliaryOrientationEnums[] = {"Along", "Across", nullptr};
+
+DrawAuxiliaryView::DrawAuxiliaryView()
+{
+    static const char* group = "Auxiliary view";
+
+    ADD_PROPERTY_TYPE(BaseView, (nullptr), group, App::Prop_None,
+                      "2D base view this auxiliary view relates to");
+    BaseView.setScope(App::LinkScope::Global);
+    ADD_PROPERTY_TYPE(AuxiliaryDirection, (1.0, 0.0, 0.0), group, App::Prop_None,
+                      "Projection direction in the BaseView local coordinate system");
+    AuxiliaryOrientation.setEnums(AuxiliaryOrientationEnums);
+    ADD_PROPERTY_TYPE(AuxiliaryOrientation, ((long)0), group, App::Prop_None,
+                      "Use the reference direction as-is or perpendicular to it");
+    ADD_PROPERTY_TYPE(ReferenceLabel, ("A"), group, App::Prop_None,
+                      "Reference label shown on both the base and auxiliary views");
+    ADD_PROPERTY_TYPE(ReferenceStart, (0.0, 0.0, 0.0), group, App::Prop_None,
+                      "Start point for the reference marker in BaseView coordinates");
+    ADD_PROPERTY_TYPE(ReferenceEnd, (1.0, 0.0, 0.0), group, App::Prop_None,
+                      "End point for the reference marker in BaseView coordinates");
+    ADD_PROPERTY_TYPE(ReverseDirection, (false), group, App::Prop_None,
+                      "Reverse the auxiliary projection direction");
+    ADD_PROPERTY_TYPE(KeepAligned, (true), group, App::Prop_None,
+                      "Keep the auxiliary view aligned to the base view");
+
+    ScaleType.setValue("Custom");
+    Direction.setStatus(App::Property::ReadOnly, true);
+    XDirection.setStatus(App::Property::ReadOnly, true);
+}
+
+short DrawAuxiliaryView::mustExecute() const
+{
+    if (isRestoring()) {
+        return TechDraw::DrawView::mustExecute();
+    }
+
+    if (BaseView.isTouched() || AuxiliaryDirection.isTouched()
+        || AuxiliaryOrientation.isTouched()
+        || ReverseDirection.isTouched()
+        || KeepAligned.isTouched()) {
+        return 1;
+    }
+
+    return TechDraw::DrawViewPart::mustExecute();
+}
+
+void DrawAuxiliaryView::onChanged(const App::Property* prop)
+{
+    if (isRestoring()) {
+        DrawViewPart::onChanged(prop);
+        return;
+    }
+
+    if (prop == &ReferenceLabel) {
+        std::string lblText = "Auxiliary " + std::string(ReferenceLabel.getValue());
+        Label.setValue(lblText);
+    }
+
+    if (prop == &BaseView || prop == &AuxiliaryDirection || prop == &AuxiliaryOrientation
+        || prop == &ReferenceLabel
+        || prop == &ReferenceStart || prop == &ReferenceEnd || prop == &ReverseDirection
+        || prop == &KeepAligned) {
+        requestBasePaint();
+    }
+
+    DrawViewPart::onChanged(prop);
+}
+
+App::DocumentObjectExecReturn* DrawAuxiliaryView::execute()
+{
+    if (!keepUpdated()) {
+        return DrawView::execute();
+    }
+
+    if (!isBaseValid()) {
+        return new App::DocumentObjectExecReturn(
+            "BaseView must be a TechDraw::DrawViewPart or DrawProjGroupItem");
+    }
+
+    if (waitingForHlr()) {
+        return DrawView::execute();
+    }
+
+    auto* base = getBaseDVP();
+    TopoDS_Shape shape = base->getSourceShape();
+    if (shape.IsNull()) {
+        Base::Console().message("DAV::execute - %s - BaseView source shape is Null.\n",
+                                getNameInDocument());
+        return DrawView::execute();
+    }
+
+    updateProjectionFromBase();
+    partExec(shape);
+    requestBasePaint();
+
+    return DrawView::execute();
+}
+
+void DrawAuxiliaryView::postHlrTasks()
+{
+    DrawViewPart::postHlrTasks();
+    autoPosition();
+}
+
+void DrawAuxiliaryView::unsetupObject()
+{
+    requestBasePaint();
+    DrawViewPart::unsetupObject();
+}
+
+DrawViewPart* DrawAuxiliaryView::getBaseDVP() const
+{
+    App::DocumentObject* base = BaseView.getValue();
+    if (!base || !base->isDerivedFrom<TechDraw::DrawViewPart>()) {
+        return nullptr;
+    }
+    return static_cast<TechDraw::DrawViewPart*>(base);
+}
+
+bool DrawAuxiliaryView::isBaseValid() const
+{
+    return canUseAsBaseView(getBaseDVP());
+}
+
+bool DrawAuxiliaryView::canUseAsBaseView(const DrawViewPart* base)
+{
+    return base && (base->getTypeId() == TechDraw::DrawViewPart::getClassTypeId()
+                    || base->isDerivedFrom<TechDraw::DrawProjGroupItem>());
+}
+
+Base::Vector3d DrawAuxiliaryView::getEffectiveAuxiliaryDirection() const
+{
+    Base::Vector3d localDirection = AuxiliaryDirection.getValue();
+    localDirection.z = 0.0;
+
+    if (AuxiliaryOrientation.isValue("Across")) {
+        localDirection = Base::Vector3d(-localDirection.y, localDirection.x, 0.0);
+    }
+
+    if (DrawUtil::fpCompare(localDirection.Length(), 0.0)) {
+        localDirection = Base::Vector3d(1.0, 0.0, 0.0);
+    }
+
+    localDirection.Normalize();
+    if (ReverseDirection.getValue()) {
+        localDirection *= -1.0;
+    }
+
+    return localDirection;
+}
+
+void DrawAuxiliaryView::updateProjectionFromBase()
+{
+    auto* base = getBaseDVP();
+    if (!base) {
+        return;
+    }
+
+    gp_Ax2 auxCS = base->localVectorToCS(getEffectiveAuxiliaryDirection());
+    Base::Vector3d newDirection(auxCS.Direction().X(),
+                                auxCS.Direction().Y(),
+                                auxCS.Direction().Z());
+    Base::Vector3d newXDirection(auxCS.XDirection().X(),
+                                 auxCS.XDirection().Y(),
+                                 auxCS.XDirection().Z());
+
+    Direction.setValue(newDirection);
+    Direction.purgeTouched();
+    XDirection.setValue(newXDirection);
+    XDirection.purgeTouched();
+}
+
+void DrawAuxiliaryView::autoPosition()
+{
+    if (!KeepAligned.getValue() || LockPosition.getValue()) {
+        return;
+    }
+
+    auto* base = getBaseDVP();
+    if (!base || !base->hasGeometry() || !hasGeometry()) {
+        return;
+    }
+
+    Base::Vector3d localAlignment = getEffectiveAuxiliaryDirection();
+    Base::Vector3d pageAlignment = localAlignment;
+    pageAlignment.RotateZ(Base::toRadians(base->Rotation.getValue()));
+    pageAlignment.z = 0.0;
+    if (DrawUtil::fpCompare(pageAlignment.Length(), 0.0)) {
+        return;
+    }
+    pageAlignment.Normalize();
+
+    Base::Vector3d basePosition(base->X.getValue(), base->Y.getValue(), 0.0);
+    if (DrawView::isProjGroupItem(base)) {
+        auto* item = static_cast<DrawProjGroupItem*>(base);
+        auto* group = item->getPGroup();
+        if (group) {
+            basePosition.x += group->X.getValue();
+            basePosition.y += group->Y.getValue();
+        }
+    }
+
+    const double baseSize = base->getSizeAlongVector(localAlignment) * base->getScale();
+    const double auxiliarySize = getSizeAlongVector(Base::Vector3d(1.0, 0.0, 0.0)) * getScale();
+    const double spacing = std::max(Preferences::groupSpaceX(), Preferences::groupSpaceY());
+    const double distance = (baseSize + auxiliarySize) / 2.0 + spacing;
+
+    Base::Vector3d newPosition = basePosition + pageAlignment * distance;
+    const double tolerance = 0.001;
+    bool changed = false;
+
+    if (!DrawUtil::fpCompare(X.getValue(), newPosition.x, tolerance)) {
+        X.setValue(newPosition.x);
+        changed = true;
+    }
+    if (!DrawUtil::fpCompare(Y.getValue(), newPosition.y, tolerance)) {
+        Y.setValue(newPosition.y);
+        changed = true;
+    }
+
+    if (changed) {
+        requestPaint();
+        purgeTouched();
+    }
+}
+
+void DrawAuxiliaryView::requestBasePaint() const
+{
+    auto* base = getBaseDVP();
+    if (base) {
+        base->requestPaint();
+    }
+}
+
+PyObject* DrawAuxiliaryView::getPyObject()
+{
+    if (PythonObject.is(Py::_None())) {
+        PythonObject = Py::Object(new DrawAuxiliaryViewPy(this), true);
+    }
+    return Py::new_reference_to(PythonObject);
+}
+
+// Python Drawing feature ---------------------------------------------------------
+
+namespace App
+{
+/// @cond DOXERR
+PROPERTY_SOURCE_TEMPLATE(TechDraw::DrawAuxiliaryViewPython, TechDraw::DrawAuxiliaryView)
+template<> const char* TechDraw::DrawAuxiliaryViewPython::getViewProviderName() const
+{
+    return "TechDrawGui::ViewProviderViewPart";
+}
+/// @endcond
+
+// explicit template instantiation
+template class TechDrawExport FeaturePythonT<TechDraw::DrawAuxiliaryView>;
+}  // namespace App

--- a/src/Mod/TechDraw/App/DrawAuxiliaryView.h
+++ b/src/Mod/TechDraw/App/DrawAuxiliaryView.h
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 meaqua9420                                        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include <App/FeaturePython.h>
+#include <App/PropertyLinks.h>
+#include <App/PropertyStandard.h>
+#include <Mod/TechDraw/TechDrawGlobal.h>
+
+#include "DrawViewPart.h"
+
+
+namespace TechDraw
+{
+
+class TechDrawExport DrawAuxiliaryView : public DrawViewPart
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(TechDraw::DrawAuxiliaryView);
+
+public:
+    static const char* AuxiliaryOrientationEnums[];
+
+    DrawAuxiliaryView();
+    ~DrawAuxiliaryView() override = default;
+
+    App::PropertyLink BaseView;
+    App::PropertyVector AuxiliaryDirection;
+    App::PropertyEnumeration AuxiliaryOrientation;
+    App::PropertyString ReferenceLabel;
+    App::PropertyVector ReferenceStart;
+    App::PropertyVector ReferenceEnd;
+    App::PropertyBool ReverseDirection;
+    App::PropertyBool KeepAligned;
+
+    short mustExecute() const override;
+    App::DocumentObjectExecReturn* execute() override;
+    void postHlrTasks() override;
+    void onChanged(const App::Property* prop) override;
+    void unsetupObject() override;
+    PyObject* getPyObject() override;
+    const char* getViewProviderName() const override
+    {
+        return "TechDrawGui::ViewProviderViewPart";
+    }
+
+    static bool canUseAsBaseView(const DrawViewPart* base);
+
+    DrawViewPart* getBaseDVP() const;
+    bool isBaseValid() const;
+    Base::Vector3d getEffectiveAuxiliaryDirection() const;
+    void updateProjectionFromBase();
+    void autoPosition();
+
+private:
+    void requestBasePaint() const;
+};
+
+using DrawAuxiliaryViewPython = App::FeaturePythonT<DrawAuxiliaryView>;
+
+}  // namespace TechDraw

--- a/src/Mod/TechDraw/App/DrawAuxiliaryView.pyi
+++ b/src/Mod/TechDraw/App/DrawAuxiliaryView.pyi
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+from Base.Metadata import export
+from TechDraw.DrawViewPart import DrawViewPart
+
+
+@export(
+    Include="Mod/TechDraw/App/DrawAuxiliaryView.h",
+    Namespace="TechDraw",
+    FatherInclude="Mod/TechDraw/App/DrawViewPartPy.h",
+)
+class DrawAuxiliaryView(DrawViewPart):
+    """
+    Feature for creating and manipulating Technical Drawing auxiliary views
+
+    License: LGPL-2.1-or-later
+    """
+
+    pass

--- a/src/Mod/TechDraw/App/DrawAuxiliaryViewPyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawAuxiliaryViewPyImp.cpp
@@ -1,0 +1,46 @@
+/***************************************************************************
+ *   Copyright (c) 2026 meaqua9420                                        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "DrawAuxiliaryView.h"
+
+// inclusion of the generated files
+#include <Mod/TechDraw/App/DrawViewPartPy.h>
+#include <Mod/TechDraw/App/DrawAuxiliaryViewPy.h>
+#include <Mod/TechDraw/App/DrawAuxiliaryViewPy.cpp>
+
+
+using namespace TechDraw;
+
+std::string DrawAuxiliaryViewPy::representation() const
+{
+    return std::string("<DrawAuxiliaryView object>");
+}
+
+PyObject* DrawAuxiliaryViewPy::getCustomAttributes(const char* /*attr*/) const
+{
+    return nullptr;
+}
+
+int DrawAuxiliaryViewPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
+{
+    return 0;
+}

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -73,6 +73,7 @@
 
 #include "Cosmetic.h"
 #include "CenterLine.h"
+#include "DrawAuxiliaryView.h"
 #include "DrawGeomHatch.h"
 #include "DrawHatch.h"
 #include "DrawPage.h"
@@ -288,6 +289,13 @@ void DrawViewPart::onChanged(const App::Property* prop)
     }
 
     DrawView::onChanged(prop);
+
+    if (!isRestoring() &&
+        (prop == &X || prop == &Y || prop == &Scale || prop == &Rotation)) {
+        for (auto* auxView : getAuxiliaryRefs()) {
+            auxView->autoPosition();
+        }
+    }
 }
 
 void DrawViewPart::partExec(TopoDS_Shape& shape)
@@ -1210,6 +1218,25 @@ std::vector<DrawViewDetail*> DrawViewPart::getDetailRefs() const
                 result.push_back(detail);
             }
 
+        }
+    }
+    return result;
+}
+
+std::vector<DrawAuxiliaryView*> DrawViewPart::getAuxiliaryRefs() const
+{
+    std::vector<DrawAuxiliaryView*> result;
+    std::vector<App::DocumentObject*> inObjs = getInList();
+    for (auto& o : inObjs) {
+        if (o->isDerivedFrom<DrawAuxiliaryView>() &&
+            !o->isRemoving()) {
+            // expressions can add extra links to this DVP so we keep only
+            // objects that are BaseViews
+            auto auxView = static_cast<TechDraw::DrawAuxiliaryView*>(o);
+            auto base = auxView->BaseView.getValue();
+            if (base == this) {
+                result.push_back(auxView);
+            }
         }
     }
     return result;

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -67,6 +67,7 @@ class DrawViewDimension;
 class DrawProjectSplit;
 class DrawViewSection;
 class DrawViewDetail;
+class DrawAuxiliaryView;
 class DrawViewBalloon;
 class CosmeticVertex;
 class CosmeticEdge;
@@ -150,6 +151,7 @@ public:
     std::vector<TechDraw::DrawViewBalloon*> getBalloons() const;
     virtual std::vector<DrawViewSection*> getSectionRefs() const;
     virtual std::vector<DrawViewDetail*> getDetailRefs() const;
+    virtual std::vector<DrawAuxiliaryView*> getAuxiliaryRefs() const;
 
     const std::vector<TechDraw::VertexPtr> getVertexGeometry() const;
     const BaseGeomPtrVector getEdgeGeometry() const;

--- a/src/Mod/TechDraw/CMakeLists.txt
+++ b/src/Mod/TechDraw/CMakeLists.txt
@@ -186,6 +186,7 @@ SET(TDTest_SRCS
     TDTest/DrawViewSectionTest.py
     TDTest/DrawViewBalloonTest.py
     TDTest/DrawViewDetailTest.py
+    TDTest/DrawAuxiliaryViewTest.py
     TDTest/TechDrawTestUtilities.py
 )
 

--- a/src/Mod/TechDraw/Gui/CMakeLists.txt
+++ b/src/Mod/TechDraw/Gui/CMakeLists.txt
@@ -45,6 +45,7 @@ set(TechDrawGui_UIC_SRCS
     TaskCosVertex.ui
     TaskCenterLine.ui
     TaskDetail.ui
+    TaskAuxiliaryView.ui
     TaskDimension.ui
     TaskGeomHatch.ui
     TaskHatch.ui
@@ -189,6 +190,9 @@ SET(TechDrawGui_SRCS
     TaskDetail.ui
     TaskDetail.cpp
     TaskDetail.h
+    TaskAuxiliaryView.ui
+    TaskAuxiliaryView.cpp
+    TaskAuxiliaryView.h
     PreferencesGui.cpp
     PreferencesGui.h
     TaskCosmeticLine.cpp
@@ -296,6 +300,8 @@ SET(TechDrawGuiView_SRCS
     QGIDimLines.h
     QGISectionLine.cpp
     QGISectionLine.h
+    QGIAuxiliaryMarker.cpp
+    QGIAuxiliaryMarker.h
     QGIDecoration.cpp
     QGIDecoration.h
     QGICenterLine.cpp
@@ -426,6 +432,7 @@ SET(TechDrawGuiTaskDlgs_SRCS
     SymbolChooser.ui
     TaskActiveView.ui
     TaskDetail.ui
+    TaskAuxiliaryView.ui
     TaskCosmeticLine.ui
     TaskSelectLineAttributes.ui
     TaskCustomizeFormat.ui

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -50,6 +50,7 @@
 #include <Mod/Spreadsheet/App/Sheet.h>
 
 #include <Mod/TechDraw/App/DrawComplexSection.h>
+#include <Mod/TechDraw/App/DrawAuxiliaryView.h>
 #include <Mod/TechDraw/App/DrawPage.h>
 #include <Mod/TechDraw/App/DrawProjGroup.h>
 #include <Mod/TechDraw/App/DrawUtil.h>
@@ -60,6 +61,7 @@
 #include <Mod/TechDraw/App/DrawViewDraft.h>
 #include <Mod/TechDraw/App/DrawViewPart.h>
 #include <Mod/TechDraw/App/DrawViewSymbol.h>
+#include <Mod/TechDraw/App/Geometry.h>
 #include <Mod/TechDraw/App/Preferences.h>
 #include <Mod/TechDraw/App/DrawBrokenView.h>
 
@@ -72,6 +74,7 @@
 #include "TaskActiveView.h"
 #include "TaskComplexSection.h"
 #include "TaskDetail.h"
+#include "TaskAuxiliaryView.h"
 #include "TaskProjGroup.h"
 #include "TaskProjection.h"
 #include "TaskSectionView.h"
@@ -81,6 +84,10 @@
 
 void execSimpleSection(Gui::Command* cmd);
 void execComplexSection(Gui::Command* cmd);
+bool getAuxiliarySelection(Gui::Command* cmd,
+                           TechDraw::DrawViewPart*& baseView,
+                           Base::Vector3d& referenceStart,
+                           Base::Vector3d& referenceEnd);
 void getSelectedShapes(Gui::Command* cmd,
                       std::vector<App::DocumentObject*>& shapes,
                       std::vector<App::DocumentObject*>& xShapes,
@@ -1050,6 +1057,63 @@ bool CmdTechDrawDetailView::isActive()
 }
 
 //===========================================================================
+// TechDraw_AuxiliaryView
+//===========================================================================
+
+DEF_STD_CMD_A(CmdTechDrawAuxiliaryView)
+
+CmdTechDrawAuxiliaryView::CmdTechDrawAuxiliaryView()
+    : Command("TechDraw_AuxiliaryView")
+{
+    sAppModule = "TechDraw";
+    sGroup = QT_TR_NOOP("TechDraw");
+    sMenuText = QT_TR_NOOP("Auxiliary View");
+    sToolTipText =
+        QT_TR_NOOP("Inserts a new auxiliary view based on the selected straight edge or two vertices");
+    sWhatsThis = "TechDraw_AuxiliaryView";
+    sStatusTip = sToolTipText;
+    sPixmap = "actions/TechDraw_AuxiliaryView";
+}
+
+void CmdTechDrawAuxiliaryView::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+
+    Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
+    if (dlg) {
+        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Task in progress"),
+                             QObject::tr("Close active task dialog and try again"));
+        return;
+    }
+
+    TechDraw::DrawViewPart* baseView = nullptr;
+    Base::Vector3d referenceStart;
+    Base::Vector3d referenceEnd;
+    if (!getAuxiliarySelection(this, baseView, referenceStart, referenceEnd)) {
+        return;
+    }
+
+    if (!baseView->findParentPage()) {
+        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+                             QObject::tr("The selected base view is not on a TechDraw page"));
+        return;
+    }
+
+    Gui::Control().showDialog(new TaskDlgAuxiliaryView(baseView, referenceStart, referenceEnd));
+}
+
+bool CmdTechDrawAuxiliaryView::isActive()
+{
+    bool havePage = DrawGuiUtil::needPage(this);
+    bool haveView = DrawGuiUtil::needView(this);
+    bool taskInProgress = false;
+    if (havePage) {
+        taskInProgress = Gui::Control().activeDialog();
+    }
+    return (havePage && haveView && !taskInProgress);
+}
+
+//===========================================================================
 // TechDraw_ProjectionGroup
 //===========================================================================
 
@@ -1962,6 +2026,7 @@ void CreateTechDrawCommands()
     rcCmdMgr.addCommand(new CmdTechDrawSectionView());
     rcCmdMgr.addCommand(new CmdTechDrawComplexSection());
     rcCmdMgr.addCommand(new CmdTechDrawDetailView());
+    rcCmdMgr.addCommand(new CmdTechDrawAuxiliaryView());
     rcCmdMgr.addCommand(new CmdTechDrawProjectionGroup());
     rcCmdMgr.addCommand(new CmdTechDrawClipGroup());
     rcCmdMgr.addCommand(new CmdTechDrawClipGroupAdd());
@@ -1979,6 +2044,106 @@ void CreateTechDrawCommands()
 }
 
 //****************************************
+
+bool getAuxiliarySelection(Gui::Command* cmd,
+                           TechDraw::DrawViewPart*& baseView,
+                           Base::Vector3d& referenceStart,
+                           Base::Vector3d& referenceEnd)
+{
+    baseView = nullptr;
+    std::vector<std::string> edgeNames;
+    std::vector<std::string> vertexNames;
+
+    auto selection = cmd->getSelection().getSelectionEx();
+    for (auto& sel : selection) {
+        auto* obj = sel.getObject();
+        if (!obj || !obj->isDerivedFrom<TechDraw::DrawViewPart>()) {
+            continue;
+        }
+
+        auto* candidate = static_cast<TechDraw::DrawViewPart*>(obj);
+        if (!TechDraw::DrawAuxiliaryView::canUseAsBaseView(candidate)) {
+            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+                                 QObject::tr(
+                                     "Select a base DrawViewPart or projection group item, "
+                                     "not a dependent view"));
+            return false;
+        }
+
+        if (baseView && baseView != candidate) {
+            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+                                 QObject::tr("Select references from a single base view"));
+            return false;
+        }
+        baseView = candidate;
+
+        for (const auto& subName : sel.getSubNames()) {
+            std::string subType = TechDraw::DrawUtil::getGeomTypeFromName(subName);
+            if (subType == "Edge") {
+                edgeNames.push_back(subName);
+            }
+            else if (subType == "Vertex") {
+                vertexNames.push_back(subName);
+            }
+        }
+    }
+
+    if (!baseView) {
+        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+                             QObject::tr("Select a TechDraw view first"));
+        return false;
+    }
+
+    if (edgeNames.size() == 1 && vertexNames.empty()) {
+        TechDraw::BaseGeomPtr edge = baseView->getEdge(edgeNames.front());
+        if (!edge || edge->getGeomType() != TechDraw::GeomType::GENERIC) {
+            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+                                 QObject::tr("Select one straight edge or two vertices"));
+            return false;
+        }
+
+        referenceStart = edge->getStartPoint();
+        referenceEnd = edge->getEndPoint();
+    }
+    else if (edgeNames.empty() && vertexNames.size() == 2) {
+        TechDraw::VertexPtr vertex0 = baseView->getVertex(vertexNames.front());
+        TechDraw::VertexPtr vertex1 = baseView->getVertex(vertexNames.back());
+        if (!vertex0 || !vertex1) {
+            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+                                 QObject::tr("The selected vertices could not be read"));
+            return false;
+        }
+
+        referenceStart = vertex0->point();
+        referenceEnd = vertex1->point();
+    }
+    else {
+        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+                             QObject::tr("Select one straight edge or exactly two vertices"));
+        return false;
+    }
+
+    if ((referenceEnd - referenceStart).Length() < 1.0e-7) {
+        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+                             QObject::tr("The auxiliary reference direction is zero length"));
+        return false;
+    }
+
+    double scale = baseView->getScale();
+    if (!TechDraw::DrawUtil::fpCompare(scale, 0.0)) {
+        referenceStart /= scale;
+        referenceEnd /= scale;
+    }
+
+    double rotation = baseView->Rotation.getValue();
+    if (!TechDraw::DrawUtil::fpCompare(rotation, 0.0)) {
+        double rotationRad = Base::toRadians(rotation);
+        referenceStart.RotateZ(-rotationRad);
+        referenceEnd.RotateZ(-rotationRad);
+    }
+
+    return true;
+}
 
 
 //! extract the selected shapes and xShapes and determine if a face has been
@@ -2107,4 +2272,3 @@ Base::Vector3d checkDirectionVsBasis(Base::Vector3d dir)
     return dir;
 
 }
-

--- a/src/Mod/TechDraw/Gui/QGIAuxiliaryMarker.cpp
+++ b/src/Mod/TechDraw/Gui/QGIAuxiliaryMarker.cpp
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 meaqua9420                                        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QPainterPath>
+
+#include <Mod/TechDraw/App/ArrowPropEnum.h>
+
+#include "QGIAuxiliaryMarker.h"
+#include "QGIArrow.h"
+#include "QGCustomText.h"
+#include "QGIView.h"
+#include "Rez.h"
+
+
+using namespace TechDrawGui;
+
+QGIAuxiliaryMarker::QGIAuxiliaryMarker()
+    : m_line(new QGraphicsPathItem())
+    , m_arrow(new QGIArrow())
+    , m_label(new QGCustomText())
+    , m_start(0.0, 0.0)
+    , m_end(0.0, 0.0)
+    , m_direction(1.0, 0.0, 0.0)
+    , m_fontSize(0.0)
+    , m_arrowSize(QGIArrow::getPrefArrowSize())
+{
+    addToGroup(m_line);
+    addToGroup(m_arrow);
+    addToGroup(m_label);
+
+    m_linePen.setWidthF(Rez::guiX(0.35));
+    m_linePen.setColor(getColor());
+    m_linePen.setStyle(Qt::SolidLine);
+    m_linePen.setCapStyle(Qt::FlatCap);
+}
+
+void QGIAuxiliaryMarker::setEnds(Base::Vector3d start, Base::Vector3d end)
+{
+    m_start = QPointF(start.x, start.y);
+    m_end = QPointF(end.x, end.y);
+}
+
+void QGIAuxiliaryMarker::setDirection(Base::Vector3d direction)
+{
+    if (direction.Length() < 1.0e-7) {
+        direction = Base::Vector3d(1.0, 0.0, 0.0);
+    }
+
+    direction.z = 0.0;
+    direction.Normalize();
+    m_direction = direction;
+}
+
+void QGIAuxiliaryMarker::setLabel(const char* label)
+{
+    m_labelText = label ? label : "";
+}
+
+void QGIAuxiliaryMarker::setFont(QFont font, double size)
+{
+    m_font = font;
+    m_fontSize = size;
+}
+
+void QGIAuxiliaryMarker::setArrowSize(double arrowSize)
+{
+    m_arrowSize = arrowSize;
+}
+
+void QGIAuxiliaryMarker::setLinePen(const QPen& linePen)
+{
+    m_linePen = linePen;
+}
+
+void QGIAuxiliaryMarker::draw()
+{
+    prepareGeometryChange();
+
+    QPainterPath path;
+    path.moveTo(m_start);
+    path.lineTo(m_end);
+    m_line->setPen(m_linePen);
+    m_line->setPath(path);
+
+    QPointF arrowPos = (m_start + m_end) / 2.0;
+    m_arrow->setStyle(TechDraw::ArrowType::FILLED_ARROW);
+    m_arrow->setSize(m_arrowSize);
+    m_arrow->setDirMode(true);
+    m_arrow->setDirection(m_direction);
+    m_arrow->setPos(arrowPos);
+    m_arrow->draw();
+
+    if (m_fontSize >= 0.0) {
+        m_font.setPixelSize(QGIView::exactFontSize(m_font.family().toStdString(), m_fontSize));
+    }
+    m_label->setFont(m_font);
+    m_label->setPlainText(QString::fromUtf8(m_labelText.c_str()));
+    m_label->setColor(m_linePen.color());
+
+    QRectF labelRect = m_label->boundingRect();
+    double labelGap = Rez::guiX(m_arrowSize) + 0.5 * labelRect.height();
+    QPointF labelMotion(m_direction.x, m_direction.y);
+    QPointF labelPos = arrowPos + labelMotion * labelGap;
+    m_label->centerAt(labelPos);
+
+    update();
+}

--- a/src/Mod/TechDraw/Gui/QGIAuxiliaryMarker.h
+++ b/src/Mod/TechDraw/Gui/QGIAuxiliaryMarker.h
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 meaqua9420                                        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include <string>
+
+#include <QFont>
+#include <QGraphicsPathItem>
+#include <QPen>
+
+#include <Base/Vector3D.h>
+#include <Mod/TechDraw/TechDrawGlobal.h>
+
+#include "QGIDecoration.h"
+#include "QGIUserTypes.h"
+
+
+namespace TechDrawGui
+{
+
+class QGIArrow;
+class QGCustomText;
+
+class TechDrawGuiExport QGIAuxiliaryMarker : public QGIDecoration
+{
+public:
+    explicit QGIAuxiliaryMarker();
+    ~QGIAuxiliaryMarker() override = default;
+
+    enum {Type = UserType::QGIAuxiliaryMarker};
+    int type() const override { return Type; }
+
+    void setEnds(Base::Vector3d start, Base::Vector3d end);
+    void setDirection(Base::Vector3d direction);
+    void setLabel(const char* label);
+    void setFont(QFont font, double size);
+    void setArrowSize(double arrowSize);
+    void setLinePen(const QPen& linePen);
+    void draw() override;
+
+private:
+    QGraphicsPathItem* m_line;
+    QGIArrow* m_arrow;
+    QGCustomText* m_label;
+    QPointF m_start;
+    QPointF m_end;
+    Base::Vector3d m_direction;
+    std::string m_labelText;
+    QFont m_font;
+    double m_fontSize;
+    double m_arrowSize;
+    QPen m_linePen;
+};
+
+}  // namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGIUserTypes.h
+++ b/src/Mod/TechDraw/Gui/QGIUserTypes.h
@@ -44,6 +44,7 @@ enum : int {
     QGDisplayArea,
     QGEPath,
     QGIArrow,
+    QGIAuxiliaryMarker,
     QGIBalloonLabel,
     QGIBreakLine,
     QGICaption,

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -41,6 +41,7 @@
 #include <Gui/Selection/Selection.h>
 #include <Gui/Tools.h>
 #include <Gui/ViewProvider.h>
+#include <Mod/TechDraw/App/DrawAuxiliaryView.h>
 #include <Mod/TechDraw/App/DrawPage.h>
 #include <Mod/TechDraw/App/DrawProjGroup.h>
 #include <Mod/TechDraw/App/DrawProjGroupItem.h>
@@ -256,6 +257,13 @@ void QGIView::dragFinished()
     Gui::ViewProvider *vp = getViewProvider(viewObj);
     if (vp && !vp->isRestoring()) {
         snapping = true; // avoid triggering updateView by the VP updateData
+        if (auto* auxiliaryView = dynamic_cast<TechDraw::DrawAuxiliaryView*>(viewObj)) {
+            if (auxiliaryView->KeepAligned.getValue()) {
+                Gui::Command::doCommand(Gui::Command::Doc,
+                                        "App.ActiveDocument.%s.KeepAligned = False",
+                                        viewObj->getNameInDocument());
+            }
+        }
         if (setX) {
             Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.X = %f",
                                 viewObj->getNameInDocument(), candidateX);

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -35,6 +35,7 @@
 #include <Gui/Selection/Selection.h>
 #include <Mod/TechDraw/App/CenterLine.h>
 #include <Mod/TechDraw/App/Cosmetic.h>
+#include <Mod/TechDraw/App/DrawAuxiliaryView.h>
 #include <Mod/TechDraw/App/DrawComplexSection.h>
 #include <Mod/TechDraw/App/DrawGeomHatch.h>
 #include <Mod/TechDraw/App/DrawHatch.h>
@@ -51,6 +52,7 @@
 #include "MDIViewPage.h"
 #include "PreferencesGui.h"
 #include "QGIArrow.h"
+#include "QGIAuxiliaryMarker.h"
 #include "QGICMark.h"
 #include "QGICenterLine.h"
 #include "QGIEdge.h"
@@ -279,6 +281,7 @@ void QGIViewPart::draw()
     //this is old C/L
     drawCenterLines(true);//have to draw centerlines after border to get size correct.
     drawAllSectionLines();//same for section lines
+    drawAllAuxiliaryMarkers();
 
     prepareGeometryChange();
 }
@@ -710,6 +713,67 @@ void QGIViewPart::drawAllSectionLines()
             }
         }
     }
+}
+
+void QGIViewPart::drawAllAuxiliaryMarkers()
+{
+    auto* viewPart = static_cast<TechDraw::DrawViewPart*>(getViewObject());
+    if (!viewPart) {
+        return;
+    }
+
+    auto vp = static_cast<ViewProviderViewPart*>(getViewProvider(getViewObject()));
+    if (!vp || !vp->ShowSectionLine.getValue()) {
+        return;
+    }
+
+    auto refs = viewPart->getAuxiliaryRefs();
+    for (auto& r : refs) {
+        drawAuxiliaryMarker(r, true);
+    }
+}
+
+void QGIViewPart::drawAuxiliaryMarker(TechDraw::DrawAuxiliaryView* auxiliaryView, bool b)
+{
+    Q_UNUSED(b);
+
+    auto* viewPart = static_cast<TechDraw::DrawViewPart*>(getViewObject());
+    if (!viewPart || !auxiliaryView) {
+        return;
+    }
+
+    auto vp = static_cast<ViewProviderViewPart*>(getViewProvider(viewPart));
+    if (!vp) {
+        return;
+    }
+
+    double scale = viewPart->getScale();
+    Base::Vector3d start = Rez::guiX(auxiliaryView->ReferenceStart.getValue()) * scale;
+    Base::Vector3d end = Rez::guiX(auxiliaryView->ReferenceEnd.getValue()) * scale;
+    if (start.IsEqual(end, EWTOLERANCE)) {
+        return;
+    }
+
+    auto* marker = new QGIAuxiliaryMarker();
+    addToGroupWithoutUpdate(marker);
+    marker->setEnds(start, end);
+
+    Base::Vector3d arrowDir = viewPart->projectPoint(auxiliaryView->Direction.getValue());
+    marker->setDirection(Base::Vector3d(arrowDir.x, -arrowDir.y, 0.0));
+
+    Base::Color color = Preferences::getAccessibleColor(vp->SectionLineColor.getValue());
+    QPen markerPen = m_dashedLineGenerator->getLinePen(
+        (size_t)vp->SectionLineStyle.getValue(), vp->HiddenWidth.getValue());
+    markerPen.setColor(color.asValue<QColor>());
+    markerPen.setWidthF(Rez::guiX(vp->HiddenWidth.getValue()));
+    marker->setLinePen(markerPen);
+
+    marker->setLabel(auxiliaryView->ReferenceLabel.getValue());
+    marker->setFont(getFont(), Preferences::labelFontSizeMM());
+    marker->setArrowSize(QGIArrow::getPrefArrowSize());
+    marker->setZValue(ZVALUE::SECTIONLINE);
+    marker->setRotation(-viewPart->Rotation.getValue());
+    marker->draw();
 }
 
 void QGIViewPart::drawSectionLine(TechDraw::DrawViewSection* viewSection, bool b)
@@ -1381,7 +1445,7 @@ void QGIViewPart::updateFrameVisibility()
     QGIView::updateFrameVisibility();
 
     bool showDecorations = shouldShowFrame();
-    
+
     for (auto& child : childItems()) {
         if (child->type() == UserType::QGIVertex) {
             child->setVisible(showDecorations || child->isSelected());
@@ -1505,5 +1569,3 @@ void QGIViewPart::setMovableFlagProjGroupItem()
     // not locked, not autoDistribute
     setFlag(QGraphicsItem::ItemIsMovable, true);
 }
-
-

--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -45,6 +45,7 @@ class DrawViewSection;
 class DrawHatch;
 class DrawGeomHatch;
 class DrawViewDetail;
+class DrawAuxiliaryView;
 class DrawView;
 class LineGenerator;
 }
@@ -86,6 +87,8 @@ public:
     virtual void drawAllSectionLines();
     virtual void drawSectionLine(TechDraw::DrawViewSection* s, bool b);
     virtual void drawComplexSectionLine(TechDraw::DrawViewSection* viewSection, bool b);
+    virtual void drawAllAuxiliaryMarkers();
+    virtual void drawAuxiliaryMarker(TechDraw::DrawAuxiliaryView* auxiliaryView, bool b);
     virtual void drawCenterLines(bool b);
     virtual void drawAllHighlights();
     virtual void drawHighlight(TechDraw::DrawViewDetail* viewDetail, bool b);

--- a/src/Mod/TechDraw/Gui/Resources/TechDraw.qrc
+++ b/src/Mod/TechDraw/Gui/Resources/TechDraw.qrc
@@ -9,6 +9,7 @@
         <file>icons/actions/TechDraw_ActiveView.svg</file>
         <file>icons/actions/TechDraw_Annotation.svg</file>
         <file>icons/actions/TechDraw_ArchView.svg</file>
+        <file>icons/actions/TechDraw_AuxiliaryView.svg</file>
         <file>icons/actions/TechDraw_ClipGroup.svg</file>
         <file>icons/actions/TechDraw_ClipGroupAdd.svg</file>
         <file>icons/actions/TechDraw_ClipGroupRemove.svg</file>

--- a/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_AuxiliaryView.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_AuxiliaryView.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64"
+   xmlns="http://www.w3.org/2000/svg">
+  <g
+     fill="none"
+     stroke-linecap="round"
+     stroke-linejoin="round">
+    <path
+       d="M 10,48 H 38 V 18 H 10 Z"
+       style="stroke:#042a2a;stroke-width:8" />
+    <path
+       d="M 10,48 H 38 V 18 H 10 Z"
+       style="stroke:#16d0d2;stroke-width:4" />
+    <path
+       d="M 10,48 H 38 V 18 H 10 Z"
+       style="stroke:#34e0e2;stroke-width:2" />
+    <path
+       d="M 16,40 H 33"
+       style="stroke:#042a2a;stroke-width:7" />
+    <path
+       d="M 16,40 H 33"
+       style="stroke:#eeeeec;stroke-width:3" />
+    <path
+       d="M 33,40 L 49,24"
+       style="stroke:#042a2a;stroke-width:7" />
+    <path
+       d="M 33,40 L 49,24"
+       style="stroke:#16d0d2;stroke-width:3" />
+    <path
+       d="M 48,15 L 56,16 L 55,24 Z"
+       style="fill:#16d0d2;stroke:#042a2a;stroke-width:2" />
+    <path
+       d="M 45,20 H 55 V 31"
+       style="stroke:#042a2a;stroke-width:4" />
+    <path
+       d="M 45,20 H 55 V 31"
+       style="stroke:#eeeeec;stroke-width:1.5" />
+  </g>
+</svg>

--- a/src/Mod/TechDraw/Gui/TaskAuxiliaryView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskAuxiliaryView.cpp
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 meaqua9420                                        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QLineEdit>
+#include <QPushButton>
+
+#include <App/Document.h>
+#include <Base/Console.h>
+#include <Gui/BitmapFactory.h>
+#include <Gui/Command.h>
+
+#include <Mod/TechDraw/App/DrawAuxiliaryView.h>
+#include <Mod/TechDraw/App/DrawPage.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
+
+#include "TaskAuxiliaryView.h"
+#include "ui_TaskAuxiliaryView.h"
+
+
+using namespace TechDrawGui;
+
+TaskAuxiliaryView::TaskAuxiliaryView(TechDraw::DrawViewPart* baseFeat,
+                                     Base::Vector3d referenceStart,
+                                     Base::Vector3d referenceEnd)
+    : ui(new Ui_TaskAuxiliaryView)
+    , m_auxiliaryFeat(nullptr)
+    , m_baseFeat(baseFeat)
+    , m_basePage(baseFeat ? baseFeat->findParentPage() : nullptr)
+    , m_doc(baseFeat ? baseFeat->getDocument() : nullptr)
+    , m_referenceStart(referenceStart)
+    , m_referenceEnd(referenceEnd)
+    , m_saveReverse(false)
+    , m_editMode(false)
+{
+    ui->setupUi(this);
+
+    if (!m_baseFeat || !m_basePage || !m_doc) {
+        Base::Console().error("TaskAuxiliaryView - bad base view. Cannot proceed.\n");
+        return;
+    }
+
+    m_baseName = m_baseFeat->getNameInDocument();
+    m_pageName = m_basePage->getNameInDocument();
+    ui->leBaseView->setText(QString::fromStdString(m_baseName));
+    ui->leAuxiliaryView->setText(QObject::tr("New auxiliary view"));
+    ui->cbOrientation->setCurrentIndex(1);
+}
+
+TaskAuxiliaryView::TaskAuxiliaryView(TechDraw::DrawAuxiliaryView* auxiliaryFeat)
+    : ui(new Ui_TaskAuxiliaryView)
+    , m_auxiliaryFeat(auxiliaryFeat)
+    , m_baseFeat(auxiliaryFeat ? auxiliaryFeat->getBaseDVP() : nullptr)
+    , m_basePage(m_baseFeat ? m_baseFeat->findParentPage() : nullptr)
+    , m_doc(auxiliaryFeat ? auxiliaryFeat->getDocument() : nullptr)
+    , m_referenceStart(auxiliaryFeat ? auxiliaryFeat->ReferenceStart.getValue()
+                                     : Base::Vector3d(0.0, 0.0, 0.0))
+    , m_referenceEnd(auxiliaryFeat ? auxiliaryFeat->ReferenceEnd.getValue()
+                                   : Base::Vector3d(1.0, 0.0, 0.0))
+    , m_saveReverse(false)
+    , m_editMode(true)
+{
+    ui->setupUi(this);
+
+    if (!m_auxiliaryFeat || !m_baseFeat || !m_basePage || !m_doc) {
+        Base::Console().error("TaskAuxiliaryView - bad auxiliary view. Cannot proceed.\n");
+        return;
+    }
+
+    m_auxiliaryName = m_auxiliaryFeat->getNameInDocument();
+    m_baseName = m_baseFeat->getNameInDocument();
+    m_pageName = m_basePage->getNameInDocument();
+
+    saveAuxiliaryState();
+    setUiFromFeat();
+}
+
+TaskAuxiliaryView::~TaskAuxiliaryView() = default;
+
+void TaskAuxiliaryView::setUiFromFeat()
+{
+    ui->leBaseView->setText(QString::fromStdString(m_baseName));
+
+    if (!m_auxiliaryFeat) {
+        return;
+    }
+
+    ui->leAuxiliaryView->setText(QString::fromStdString(m_auxiliaryName));
+    ui->leReferenceLabel->setText(QString::fromUtf8(m_auxiliaryFeat->ReferenceLabel.getValue()));
+    std::string orientation = m_auxiliaryFeat->AuxiliaryOrientation.getValueAsString();
+    ui->cbOrientation->setCurrentIndex(orientation == "Across" ? 1 : 0);
+    ui->cbReverse->setChecked(m_auxiliaryFeat->ReverseDirection.getValue());
+}
+
+Base::Vector3d TaskAuxiliaryView::referenceDirection() const
+{
+    Base::Vector3d direction = m_referenceEnd - m_referenceStart;
+    direction.z = 0.0;
+    if (direction.Length() < 1.0e-7) {
+        direction = Base::Vector3d(1.0, 0.0, 0.0);
+    }
+    direction.Normalize();
+    return direction;
+}
+
+void TaskAuxiliaryView::createAuxiliaryView()
+{
+    if (!m_baseFeat || !m_basePage || !m_doc) {
+        return;
+    }
+
+    int tid = Gui::Command::openActiveDocumentCommand(
+        QT_TRANSLATE_NOOP("Command", "Create Auxiliary View"));
+
+    const std::string objectName{"Auxiliary"};
+    m_auxiliaryName = m_doc->getUniqueObjectName(objectName.c_str());
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            "App.activeDocument().addObject('TechDraw::DrawAuxiliaryView', '%s')",
+                            m_auxiliaryName.c_str());
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            "App.activeDocument().%s.translateLabel('DrawAuxiliaryView', 'Auxiliary', '%s')",
+                            m_auxiliaryName.c_str(),
+                            m_auxiliaryName.c_str());
+
+    App::DocumentObject* docObj = m_doc->getObject(m_auxiliaryName.c_str());
+    m_auxiliaryFeat = dynamic_cast<TechDraw::DrawAuxiliaryView*>(docObj);
+    if (!m_auxiliaryFeat) {
+        Base::Console().error("TaskAuxiliaryView - new auxiliary view not found.\n");
+        Gui::Command::abortCommand(tid);
+        return;
+    }
+
+    m_auxiliaryFeat->Source.setValues(m_baseFeat->Source.getValues());
+    m_auxiliaryFeat->XSource.setValues(m_baseFeat->XSource.getValues());
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            "App.activeDocument().%s.BaseView = App.activeDocument().%s",
+                            m_auxiliaryName.c_str(),
+                            m_baseName.c_str());
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            "App.activeDocument().%s.Scale = App.activeDocument().%s.Scale",
+                            m_auxiliaryName.c_str(),
+                            m_baseName.c_str());
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            "App.activeDocument().%s.ScaleType = 2",
+                            m_auxiliaryName.c_str());
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            "App.activeDocument().%s.addView(App.activeDocument().%s)",
+                            m_pageName.c_str(),
+                            m_auxiliaryName.c_str());
+
+    updateAuxiliaryView();
+
+    Gui::Command::updateActive();
+    Gui::Command::commitCommand(tid);
+
+    m_auxiliaryFeat->recomputeFeature();
+    m_baseFeat->requestPaint();
+}
+
+void TaskAuxiliaryView::updateAuxiliaryView()
+{
+    auto* auxiliaryFeat = getAuxiliaryFeat();
+    if (!auxiliaryFeat) {
+        return;
+    }
+
+    QString ref = ui->leReferenceLabel->text();
+    auxiliaryFeat->AuxiliaryDirection.setValue(referenceDirection());
+    auxiliaryFeat->AuxiliaryOrientation.setValue(ui->cbOrientation->currentIndex());
+    auxiliaryFeat->ReferenceLabel.setValue(ref.toStdString());
+    auxiliaryFeat->ReferenceStart.setValue(m_referenceStart);
+    auxiliaryFeat->ReferenceEnd.setValue(m_referenceEnd);
+    auxiliaryFeat->ReverseDirection.setValue(ui->cbReverse->isChecked());
+
+    if (m_baseFeat) {
+        m_baseFeat->requestPaint();
+    }
+}
+
+bool TaskAuxiliaryView::accept()
+{
+    if (!m_editMode) {
+        createAuxiliaryView();
+        return true;
+    }
+
+    int tid = Gui::Command::openActiveDocumentCommand(
+        QT_TRANSLATE_NOOP("Command", "Update Auxiliary View"));
+    updateAuxiliaryView();
+    Gui::Command::updateActive();
+    Gui::Command::commitCommand(tid);
+
+    if (m_auxiliaryFeat) {
+        m_auxiliaryFeat->recomputeFeature();
+    }
+    Gui::Command::doCommand(Gui::Command::Gui, "Gui.ActiveDocument.resetEdit()");
+    return true;
+}
+
+bool TaskAuxiliaryView::reject()
+{
+    if (m_editMode) {
+        restoreAuxiliaryState();
+        Gui::Command::doCommand(Gui::Command::Gui, "Gui.ActiveDocument.resetEdit()");
+    }
+    return true;
+}
+
+TechDraw::DrawAuxiliaryView* TaskAuxiliaryView::getAuxiliaryFeat()
+{
+    if (m_auxiliaryFeat) {
+        return m_auxiliaryFeat;
+    }
+    if (!m_doc || m_auxiliaryName.empty()) {
+        return nullptr;
+    }
+    return dynamic_cast<TechDraw::DrawAuxiliaryView*>(m_doc->getObject(m_auxiliaryName.c_str()));
+}
+
+void TaskAuxiliaryView::saveAuxiliaryState()
+{
+    if (!m_auxiliaryFeat) {
+        return;
+    }
+
+    m_saveReferenceStart = m_auxiliaryFeat->ReferenceStart.getValue();
+    m_saveReferenceEnd = m_auxiliaryFeat->ReferenceEnd.getValue();
+    m_saveDirection = m_auxiliaryFeat->AuxiliaryDirection.getValue();
+    m_saveLabel = m_auxiliaryFeat->ReferenceLabel.getValue();
+    m_saveOrientation = m_auxiliaryFeat->AuxiliaryOrientation.getValueAsString();
+    m_saveReverse = m_auxiliaryFeat->ReverseDirection.getValue();
+}
+
+void TaskAuxiliaryView::restoreAuxiliaryState()
+{
+    if (!m_auxiliaryFeat) {
+        return;
+    }
+
+    m_auxiliaryFeat->ReferenceStart.setValue(m_saveReferenceStart);
+    m_auxiliaryFeat->ReferenceEnd.setValue(m_saveReferenceEnd);
+    m_auxiliaryFeat->AuxiliaryDirection.setValue(m_saveDirection);
+    m_auxiliaryFeat->ReferenceLabel.setValue(m_saveLabel);
+    m_auxiliaryFeat->AuxiliaryOrientation.setValue(m_saveOrientation.c_str());
+    m_auxiliaryFeat->ReverseDirection.setValue(m_saveReverse);
+    m_auxiliaryFeat->recomputeFeature();
+    if (m_baseFeat) {
+        m_baseFeat->requestPaint();
+    }
+}
+
+void TaskAuxiliaryView::changeEvent(QEvent* event)
+{
+    QWidget::changeEvent(event);
+    if (event->type() == QEvent::LanguageChange) {
+        ui->retranslateUi(this);
+    }
+}
+
+TaskDlgAuxiliaryView::TaskDlgAuxiliaryView(TechDraw::DrawViewPart* baseFeat,
+                                           Base::Vector3d referenceStart,
+                                           Base::Vector3d referenceEnd)
+    : TaskDialog()
+{
+    widget = new TaskAuxiliaryView(baseFeat, referenceStart, referenceEnd);
+    taskbox = new Gui::TaskView::TaskBox(
+        Gui::BitmapFactory().pixmap("actions/TechDraw_AuxiliaryView"),
+        widget->windowTitle(),
+        true,
+        nullptr);
+    taskbox->groupLayout()->addWidget(widget);
+    Content.push_back(taskbox);
+}
+
+TaskDlgAuxiliaryView::TaskDlgAuxiliaryView(TechDraw::DrawAuxiliaryView* auxiliaryFeat)
+    : TaskDialog()
+{
+    widget = new TaskAuxiliaryView(auxiliaryFeat);
+    taskbox = new Gui::TaskView::TaskBox(
+        Gui::BitmapFactory().pixmap("actions/TechDraw_AuxiliaryView"),
+        widget->windowTitle(),
+        true,
+        nullptr);
+    taskbox->groupLayout()->addWidget(widget);
+    Content.push_back(taskbox);
+}
+
+TaskDlgAuxiliaryView::~TaskDlgAuxiliaryView() = default;
+
+void TaskDlgAuxiliaryView::open()
+{}
+
+bool TaskDlgAuxiliaryView::accept()
+{
+    widget->accept();
+    return true;
+}
+
+bool TaskDlgAuxiliaryView::reject()
+{
+    widget->reject();
+    return true;
+}
+
+void TaskDlgAuxiliaryView::modifyStandardButtons(QDialogButtonBox* box)
+{
+    Q_UNUSED(box);
+}
+
+std::string TaskDlgAuxiliaryView::getAuxiliaryName() const
+{
+    auto* auxiliaryObj = widget->getAuxiliaryFeat();
+    if (!auxiliaryObj) {
+        return {"not found"};
+    }
+
+    return auxiliaryObj->getNameInDocument();
+}
+
+#include <Mod/TechDraw/Gui/moc_TaskAuxiliaryView.cpp>

--- a/src/Mod/TechDraw/Gui/TaskAuxiliaryView.h
+++ b/src/Mod/TechDraw/Gui/TaskAuxiliaryView.h
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 meaqua9420                                        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <Base/Vector3D.h>
+#include <Gui/TaskView/TaskDialog.h>
+#include <Gui/TaskView/TaskView.h>
+#include <Mod/TechDraw/TechDrawGlobal.h>
+
+class QPushButton;
+class QDialogButtonBox;
+
+namespace App
+{
+class Document;
+}
+
+namespace TechDraw
+{
+class DrawAuxiliaryView;
+class DrawPage;
+class DrawViewPart;
+}
+
+namespace TechDrawGui
+{
+
+class Ui_TaskAuxiliaryView;
+
+class TaskAuxiliaryView : public QWidget
+{
+    Q_OBJECT
+
+public:
+    TaskAuxiliaryView(TechDraw::DrawViewPart* baseFeat,
+                      Base::Vector3d referenceStart,
+                      Base::Vector3d referenceEnd);
+    explicit TaskAuxiliaryView(TechDraw::DrawAuxiliaryView* auxiliaryFeat);
+    ~TaskAuxiliaryView() override;
+
+    bool accept();
+    bool reject();
+
+    TechDraw::DrawAuxiliaryView* getAuxiliaryFeat();
+
+protected:
+    void changeEvent(QEvent* event) override;
+
+private:
+    void setUiFromFeat();
+    void createAuxiliaryView();
+    void updateAuxiliaryView();
+    void saveAuxiliaryState();
+    void restoreAuxiliaryState();
+    Base::Vector3d referenceDirection() const;
+
+    std::unique_ptr<Ui_TaskAuxiliaryView> ui;
+    TechDraw::DrawAuxiliaryView* m_auxiliaryFeat;
+    TechDraw::DrawViewPart* m_baseFeat;
+    TechDraw::DrawPage* m_basePage;
+    App::Document* m_doc;
+    std::string m_auxiliaryName;
+    std::string m_baseName;
+    std::string m_pageName;
+    Base::Vector3d m_referenceStart;
+    Base::Vector3d m_referenceEnd;
+    Base::Vector3d m_saveReferenceStart;
+    Base::Vector3d m_saveReferenceEnd;
+    Base::Vector3d m_saveDirection;
+    std::string m_saveLabel;
+    std::string m_saveOrientation;
+    bool m_saveReverse;
+    bool m_editMode;
+};
+
+class TaskDlgAuxiliaryView : public Gui::TaskView::TaskDialog
+{
+    Q_OBJECT
+
+public:
+    TaskDlgAuxiliaryView(TechDraw::DrawViewPart* baseFeat,
+                         Base::Vector3d referenceStart,
+                         Base::Vector3d referenceEnd);
+    explicit TaskDlgAuxiliaryView(TechDraw::DrawAuxiliaryView* auxiliaryFeat);
+    ~TaskDlgAuxiliaryView() override;
+
+    void open() override;
+    bool accept() override;
+    bool reject() override;
+    bool isAllowedAlterDocument() const override
+    {
+        return false;
+    }
+    void modifyStandardButtons(QDialogButtonBox* box) override;
+
+    std::string getAuxiliaryName() const;
+
+private:
+    TaskAuxiliaryView* widget;
+    Gui::TaskView::TaskBox* taskbox;
+};
+
+}  // namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/TaskAuxiliaryView.ui
+++ b/src/Mod/TechDraw/Gui/TaskAuxiliaryView.ui
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TechDrawGui::TaskAuxiliaryView</class>
+ <widget class="QWidget" name="TechDrawGui::TaskAuxiliaryView">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>360</width>
+    <height>180</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Auxiliary View</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="Resources/TechDraw.qrc">
+    <normaloff>:/icons/actions/TechDraw_AuxiliaryView.svg</normaloff>:/icons/actions/TechDraw_AuxiliaryView.svg</iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="lblBaseView">
+       <property name="text">
+        <string>Base view</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="leBaseView">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="lblAuxiliaryView">
+       <property name="text">
+        <string>Auxiliary view</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="leAuxiliaryView">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="lblReferenceLabel">
+       <property name="text">
+        <string>Reference label</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="leReferenceLabel">
+       <property name="text">
+        <string>A</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="lblOrientation">
+       <property name="text">
+        <string>Orientation</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="cbOrientation">
+       <item>
+        <property name="text">
+         <string>Along</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Across</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QCheckBox" name="cbReverse">
+       <property name="text">
+        <string>Reverse direction</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="Resources/TechDraw.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -40,6 +40,7 @@
 #include <Mod/TechDraw/App/DrawGeomHatch.h>
 #include <Mod/TechDraw/App/DrawHatch.h>
 #include <Mod/TechDraw/App/DrawLeaderLine.h>
+#include <Mod/TechDraw/App/DrawAuxiliaryView.h>
 #include <Mod/TechDraw/App/DrawRichAnno.h>
 #include <Mod/TechDraw/App/DrawViewBalloon.h>
 #include <Mod/TechDraw/App/DrawViewDetail.h>
@@ -55,6 +56,7 @@
 
 #include "PreferencesGui.h"
 #include "QGIView.h"
+#include "TaskAuxiliaryView.h"
 #include "TaskDetail.h"
 #include "TaskProjGroup.h"
 #include "ViewProviderViewPart.h"
@@ -214,10 +216,13 @@ void ViewProviderViewPart::attach(App::DocumentObject *pcFeat)
 //    Base::Console().message("VPVP::attach(%s)\n", pcFeat->getNameInDocument());
     auto* dvm = dynamic_cast<TechDraw::DrawViewMulti*>(pcFeat);
     auto* dvd = dynamic_cast<TechDraw::DrawViewDetail*>(pcFeat);
+    auto* dva = dynamic_cast<TechDraw::DrawAuxiliaryView*>(pcFeat);
     if (dvm) {
         sPixmap = "TechDraw_TreeMulti";
     } else if (dvd) {
         sPixmap = "actions/TechDraw_DetailView";
+    } else if (dva) {
+        sPixmap = "actions/TechDraw_AuxiliaryView";
     }
 
     ViewProviderDrawingView::attach(pcFeat);
@@ -287,12 +292,24 @@ bool ViewProviderViewPart::setEdit(int ModNum)
 
     TechDraw::DrawViewPart* dvp = getViewObject();
     auto* dvd = dynamic_cast<TechDraw::DrawViewDetail*>(dvp);
+    auto* dva = dynamic_cast<TechDraw::DrawAuxiliaryView*>(dvp);
     if (dvd) {
         if (!dvd->BaseView.getValue()) {
             Base::Console().error("DrawViewDetail - %s - has no BaseView!\n", dvd->getNameInDocument());
             return false;
         }
         return setDetailEdit(ModNum, dvd);
+    }
+    if (dva) {
+        if (!dva->BaseView.getValue()) {
+            Base::Console().error("DrawAuxiliaryView - %s - has no BaseView!\n",
+                                  dva->getNameInDocument());
+            return false;
+        }
+        Gui::Control().showDialog(new TaskDlgAuxiliaryView(dva));
+        Gui::Selection().clearSelection();
+        Gui::Selection().addSelection(dva->getDocument()->getName(), dva->getNameInDocument());
+        return true;
     }
     auto* view = getObject<TechDraw::DrawView>();
     Gui::Control().showDialog(new TaskDlgProjGroup(view, false));
@@ -372,6 +389,7 @@ bool ViewProviderViewPart::onDelete(const std::vector<std::string> & subNames)
     // with a derived class here in the parent
     Gui::TaskView::TaskDialog *dlg = Gui::Control().activeDialog();
     auto* dlgDetail = dynamic_cast<TaskDlgDetail*>(dlg);
+    auto* dlgAuxiliary = dynamic_cast<TaskDlgAuxiliaryView*>(dlg);
     if (dlgDetail) {
         std::string dlgDetailTarget = dlgDetail->getDetailName();   //new method
         if (getViewObject()->getNameInDocument() == dlgDetailTarget) {
@@ -384,12 +402,25 @@ bool ViewProviderViewPart::onDelete(const std::vector<std::string> & subNames)
             return false;
         }
     }
+    if (dlgAuxiliary) {
+        std::string dlgAuxiliaryTarget = dlgAuxiliary->getAuxiliaryName();
+        if (getViewObject()->getNameInDocument() == dlgAuxiliaryTarget) {
+            bodyMessageStream << qApp->translate("Std_Delete",
+            "Close open dialog before deleting auxiliary view object");
+            bodyMessage = bodyMessageStream.readLine();
+            QMessageBox::warning(Gui::getMainWindow(),
+            qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,
+            QMessageBox::Ok);
+            return false;
+        }
+    }
 
     // get child views
     auto viewSection = getViewObject()->getSectionRefs();
     auto viewDetail = getViewObject()->getDetailRefs();
+    auto viewAuxiliary = getViewObject()->getAuxiliaryRefs();
 
-    if (!viewSection.empty() || !viewDetail.empty()) {
+    if (!viewSection.empty() || !viewDetail.empty() || !viewAuxiliary.empty()) {
         bodyMessageStream << qApp->translate("Std_Delete",
             "You cannot delete this view because it has one or more dependent views that would become broken.");
         bodyMessage = bodyMessageStream.readLine();

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -213,6 +213,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     *views << "TechDraw_BrokenView";
     *views << "TechDraw_SectionView";
     *views << "TechDraw_ComplexSection";
+    *views << "TechDraw_AuxiliaryView";
     *views << "TechDraw_DetailView";
     *views << "TechDraw_ProjectionGroup";
     *views << "TechDraw_ClipGroup";
@@ -301,6 +302,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *views << "TechDraw_BrokenView";
     *views << "TechDraw_ActiveView";
     *views << "TechDraw_SectionGroup";
+    *views << "TechDraw_AuxiliaryView";
     *views << "TechDraw_DetailView";
     *views << "TechDraw_DraftView";
     *views << "TechDraw_ClipGroup";
@@ -417,6 +419,7 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *views << "TechDraw_View";
     *views << "TechDraw_ActiveView";
     *views << "TechDraw_SectionGroup";
+    *views << "TechDraw_AuxiliaryView";
     *views << "TechDraw_DetailView";
     *views << "TechDraw_DraftView";
     *views << "TechDraw_ClipGroup";

--- a/src/Mod/TechDraw/TDTest/DrawAuxiliaryViewTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawAuxiliaryViewTest.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+
+# test script for DrawAuxiliaryView
+# creates a page, a base view and an auxiliary view
+
+
+import FreeCAD
+import unittest
+from .TechDrawTestUtilities import createPageWithSVGTemplate
+from PySide import QtCore
+
+
+def wait_for_projection():
+    loop = QtCore.QEventLoop()
+    timer = QtCore.QTimer()
+    timer.setSingleShot(True)
+    timer.timeout.connect(loop.quit)
+    timer.start(2000)
+    loop.exec_()
+
+
+class DrawAuxiliaryViewTest(unittest.TestCase):
+    def setUp(self):
+        """Creates a page and a base view"""
+        FreeCAD.newDocument("TDAuxiliary")
+        FreeCAD.setActiveDocument("TDAuxiliary")
+        FreeCAD.ActiveDocument = FreeCAD.getDocument("TDAuxiliary")
+
+        self.box = FreeCAD.ActiveDocument.addObject("Part::Box", "Box")
+        self.box.Length = 10.0
+        self.box.Width = 6.0
+        self.box.Height = 3.0
+
+        self.page = createPageWithSVGTemplate()
+        self.page.Scale = 5.0
+        print("DrawAuxiliaryView test: page created")
+
+        self.view = FreeCAD.ActiveDocument.addObject("TechDraw::DrawViewPart", "View")
+        self.page.addView(self.view)
+        self.view.Source = [self.box]
+        self.view.Direction = (0.0, 0.0, 1.0)
+        self.view.XDirection = (1.0, 0.0, 0.0)
+        self.view.Rotation = 0.0
+        FreeCAD.ActiveDocument.recompute()
+        wait_for_projection()
+        print("DrawAuxiliaryView test: base view created")
+
+    def tearDown(self):
+        print("DrawAuxiliaryView test finished")
+        FreeCAD.closeDocument("TDAuxiliary")
+
+    def testMakeDrawAuxiliaryView(self):
+        """Tests if an auxiliary view can be added to a page"""
+        auxiliary = FreeCAD.ActiveDocument.addObject(
+            "TechDraw::DrawAuxiliaryView", "Auxiliary"
+        )
+        self.page.addView(auxiliary)
+        auxiliary.BaseView = self.view
+        auxiliary.AuxiliaryDirection = (1.0, 0.0, 0.0)
+        auxiliary.AuxiliaryOrientation = "Along"
+        auxiliary.ReferenceLabel = "A"
+        auxiliary.ReferenceStart = (0.0, 0.0, 0.0)
+        auxiliary.ReferenceEnd = (10.0, 0.0, 0.0)
+
+        FreeCAD.ActiveDocument.recompute()
+        wait_for_projection()
+        print("DrawAuxiliaryView test: auxiliary view created")
+
+        edges = auxiliary.getVisibleEdges()
+        self.assertGreater(len(edges), 0, "DrawAuxiliaryView has no visible edges")
+        self.assertTrue(
+            "Up-to-date" in auxiliary.State,
+            "DrawAuxiliaryView is not Up-to-date",
+        )
+        self.assertEqual(auxiliary.BaseView, self.view)
+        self.assertAlmostEqual(auxiliary.Direction.x, 1.0)
+        self.assertAlmostEqual(auxiliary.XDirection.y, 1.0)
+        self.assertTrue(auxiliary.KeepAligned)
+        self.assertGreater(auxiliary.X, self.view.X)
+        self.assertAlmostEqual(auxiliary.Y, self.view.Y)
+
+        aligned_offset = auxiliary.X - self.view.X
+        self.view.X = self.view.X + 10.0
+        self.assertAlmostEqual(auxiliary.X - self.view.X, aligned_offset)
+        self.assertAlmostEqual(auxiliary.Y, self.view.Y)
+
+        auxiliary.KeepAligned = False
+        auxiliary.X = 12.0
+        auxiliary.Y = 34.0
+        self.view.X = self.view.X + 10.0
+        FreeCAD.ActiveDocument.recompute()
+        wait_for_projection()
+
+        self.assertAlmostEqual(auxiliary.X, 12.0)
+        self.assertAlmostEqual(auxiliary.Y, 34.0)
+
+        auxiliary.ReverseDirection = True
+        FreeCAD.ActiveDocument.recompute()
+        wait_for_projection()
+
+        self.assertTrue(
+            "Up-to-date" in auxiliary.State,
+            "DrawAuxiliaryView is not Up-to-date after reversing direction",
+        )
+        self.assertAlmostEqual(auxiliary.Direction.x, -1.0)
+
+        auxiliary.ReverseDirection = False
+        auxiliary.AuxiliaryOrientation = "Across"
+        FreeCAD.ActiveDocument.recompute()
+        wait_for_projection()
+
+        self.assertAlmostEqual(auxiliary.Direction.y, 1.0)
+
+    def testProjectionGroupItemCanBeBaseView(self):
+        """Tests if an auxiliary view can use a projection group item as base"""
+        group = FreeCAD.ActiveDocument.addObject("TechDraw::DrawProjGroup", "ProjGroup")
+        self.page.addView(group)
+        group.Source = [self.box]
+        group.addProjection("Front")
+        group.Anchor.Direction = (0.0, 0.0, 1.0)
+        group.Anchor.RotationVector = (1.0, 0.0, 0.0)
+
+        FreeCAD.ActiveDocument.recompute()
+        wait_for_projection()
+
+        base_item = group.Anchor
+        self.assertIsNotNone(base_item, "Projection group did not create an anchor item")
+        self.assertGreater(
+            len(base_item.getVisibleEdges()),
+            0,
+            "Projection group anchor has no visible edges",
+        )
+
+        auxiliary = FreeCAD.ActiveDocument.addObject(
+            "TechDraw::DrawAuxiliaryView", "AuxiliaryFromProjection"
+        )
+        self.page.addView(auxiliary)
+        auxiliary.BaseView = base_item
+        auxiliary.AuxiliaryDirection = (1.0, 0.0, 0.0)
+        auxiliary.AuxiliaryOrientation = "Along"
+        auxiliary.ReferenceLabel = "B"
+        auxiliary.ReferenceStart = (0.0, 0.0, 0.0)
+        auxiliary.ReferenceEnd = (10.0, 0.0, 0.0)
+
+        FreeCAD.ActiveDocument.recompute()
+        wait_for_projection()
+        print("DrawAuxiliaryView test: projection group auxiliary view created")
+
+        edges = auxiliary.getVisibleEdges()
+        self.assertGreater(
+            len(edges),
+            0,
+            "DrawAuxiliaryView from projection group item has no visible edges",
+        )
+        self.assertTrue(
+            "Up-to-date" in auxiliary.State,
+            "DrawAuxiliaryView from projection group item is not Up-to-date",
+        )
+        self.assertEqual(auxiliary.BaseView, base_item)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/TechDraw/TechDrawTools/TDToolsMovers.py
+++ b/src/Mod/TechDraw/TechDrawTools/TDToolsMovers.py
@@ -65,7 +65,9 @@ def projGroupMove(view, fromPage, toPage, copy):
 def moveView(view, fromPage, toPage, copy=False):
     if view.isDerivedFrom("TechDraw::DrawProjGroup"):
         projGroupMove(view, fromPage, toPage, copy)
-    elif view.isDerivedFrom("TechDraw::DrawViewSection") or view.isDerivedFrom("TechDraw::DrawViewDetail"):
+    elif (view.isDerivedFrom("TechDraw::DrawViewSection")
+          or view.isDerivedFrom("TechDraw::DrawViewDetail")
+          or view.isDerivedFrom("TechDraw::DrawAuxiliaryView")):
         sectionViewMove(view, fromPage, toPage, copy)
     elif view.isDerivedFrom("TechDraw::DrawView"):
         simpleViewMove(view, fromPage, toPage, copy)

--- a/src/Mod/TechDraw/TestTechDrawGui.py
+++ b/src/Mod/TechDraw/TestTechDrawGui.py
@@ -25,5 +25,6 @@
 from TDTest.DrawViewSectionTest import DrawViewSectionTest  # noqa: F401
 from TDTest.DrawViewPartTest import DrawViewPartTest  # noqa: F401
 from TDTest.DrawViewDetailTest import DrawViewDetailTest  # noqa: F401
+from TDTest.DrawAuxiliaryViewTest import DrawAuxiliaryViewTest  # noqa: F401
 from TDTest.DrawViewDimensionTest import DrawViewDimensionTest  # noqa: F401
 


### PR DESCRIPTION
## Summary

- Adds `TechDraw::DrawAuxiliaryView`, derived from `DrawViewPart`.
- Adds the `TechDraw_AuxiliaryView` command for one selected straight edge or exactly two selected vertices on a base view or projection group item.
- Adds a small task panel for the reference label, along/across orientation, and reverse direction.
- Draws a reference marker and label on the base view.
- Keeps auxiliary views aligned to their base view until the auxiliary view is dragged manually.
- Adds TechDraw regression coverage for the native auxiliary view and projection-group-item base views.

## Issues

Fixes #5810

## Before and After Images

Before: TechDraw did not have a native auxiliary view command.

After: the TechDraw Views toolbar/menu includes an Auxiliary View command. With one straight edge or exactly two vertices selected on a base view, the command opens a task panel where the user can set the reference label, choose along/across orientation, and reverse the direction before creating the view.

![Auxiliary View task panel](https://raw.githubusercontent.com/meaqua9420/FreeCAD/pr-30645-screenshots/freecad-auxiliary-view-task-panel.png)

After accepting the task panel, FreeCAD creates a linked `Auxiliary` view on the same page. The new view follows the base view while `KeepAligned` is enabled, and dragging the auxiliary view manually breaks that alignment.

![Created Auxiliary View](https://raw.githubusercontent.com/meaqua9420/FreeCAD/pr-30645-screenshots/freecad-auxiliary-view-created.png)

## AI Assistance

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

I used Codex as an assistive tool for code review, test planning, and investigating a local macOS GUI automation teardown crash. I reviewed the resulting code and validated it with the commands listed below.

## Validation

- `pixi run cmake --build build/debug --target TechDrawGui --parallel 8`
- `pixi run ./build/debug/bin/FreeCAD -t TDTest.DrawAuxiliaryViewTest.DrawAuxiliaryViewTest`
- `pixi run ./build/debug/bin/FreeCAD -t TestTechDrawGui`
- `pixi run ./build/debug/bin/FreeCADCmd -t TestTechDrawApp`
- `pixi run ./build/debug/bin/FreeCADCmd -t 0`
- `git diff --check origin/main...HEAD`

The local macOS GUI automation teardown crash was investigated separately from the feature path. The crash stack was in forced application teardown, and the same forced-quit pattern was reproducible with an existing TechDraw Detail View command smoke. A no-quit Auxiliary View command smoke stayed running after OK and produced an up-to-date auxiliary view.
