### PR TITLE
Fix various typos

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -388,7 +388,7 @@ class MaterialDialog(QtWidgets.QDialog):
             try:
                 self.materialTreeWidget.UUID = current_uuid
             except Exception as e:
-                Path.Log.debug("Could not pre-select material %s: %s" % (current_uuid, e))
+                Path.Log.debug("Could not preselect material %s: %s" % (current_uuid, e))
 
         # Create OK and Cancel buttons
         self.okButton = QtWidgets.QPushButton("OK")

--- a/src/Mod/CAM/libarea/Adaptive.cpp
+++ b/src/Mod/CAM/libarea/Adaptive.cpp
@@ -1824,15 +1824,15 @@ std::list<AdaptiveOutput> Adaptive2d::Execute(
             for (const Path& path : currentTBP) {
                 bool orientation = Orientation(path);
                 int direction = (getPathNestingLevel(path, toolBounds) % 2 == 1) ? 1 : -1;
-                bool finshing = false;
+                bool finishing = false;
                 for (const IntPoint& p : path) {
                     if (p.Z == 1) {
-                        finshing = true;
+                        finishing = true;
                         break;
                     }
                 }
 
-                if (finshing) {
+                if (finishing) {
                     Paths out;
                     clipof.Clear();
                     clipof.AddPath(path, JoinType::jtRound, EndType::etClosedPolygon);

--- a/src/Mod/Fem/femmesh/gmshtools.py
+++ b/src/Mod/Fem/femmesh/gmshtools.py
@@ -2008,7 +2008,7 @@ class GmshPreviewTools(GmshTools):
         # size fields
         self.write_size_fields(geo)
 
-        # estimate good max mesh size values for coarse visualizaion mesh
+        # estimate good max mesh size values for coarse visualization mesh
         area = self.part_obj.Shape.Area
         factor = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Fem/Gmsh").GetInt(
             "previewMeshFactor", 5
@@ -2029,7 +2029,7 @@ class GmshPreviewTools(GmshTools):
         geo.write("Plugin(MeshSizeFieldView).Run;\n")
         geo.write("\n")
 
-        # save view msh for later data extraction (we have addiotional views for result size field)
+        # save view msh for later data extraction (we have additional views for result size field)
         geo.write(f"Save View[{len(self.result_view_settings)}] 'preview_data.msh';\n")
 
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1318,7 +1318,7 @@ private:
                 PointPos prevPos = geoEltIds.back().Pos;
                 obj->moveGeometry(prevGeoId, prevPos, toVector3d(points.back()));
 
-                // Then transfert back the constraints
+                // Then transfer back the constraints
                 if (pointWasCreated) {
                     int pointGeoId = getHighestCurveIndex();
                     // We must first remove the point on object constraint.
@@ -2041,7 +2041,7 @@ void DSHPolyLineController::doConstructionMethodChanged()
         }
     }
 
-    // Since line has 4 OVP but arc has 5, and because we are not reseting the whole tool,
+    // Since line has 4 OVP but arc has 5, and because we are not resetting the whole tool,
     // we need to reset the OVP to have the correct number.
     resetOnViewParameters();
 


### PR DESCRIPTION
Found via codespell

Note: could not fix the following typos because github/vscode immediately auto-fixes the ^M line end  
```
./src/App/Application.h:326: unsuccesful ==> unsuccessful
./src/App/Application.h:791: exectuable ==> executable
```