### PR TITLE
Fem: Add option to set mpiexec binary path for run Elmer solver

### DIFF
--- a/src/Mod/Fem/Gui/DlgSettingsFemElmer.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemElmer.ui
@@ -132,6 +132,56 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="l_mpi_binary_path">
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>MPI path</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::PrefFileChooser" name="fc_mpi_binary_path" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="sizeIncrement">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="baseSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Leave blank to use default MPI binary file</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>mpiBinaryPath</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Fem/Elmer</cstring>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/DlgSettingsFemElmerImp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemElmerImp.cpp
@@ -49,6 +49,12 @@ DlgSettingsFemElmerImp::DlgSettingsFemElmerImp(QWidget* parent)
         this,
         &DlgSettingsFemElmerImp::onfileNameSelected
     );
+    connect(
+        ui->fc_mpi_binary_path,
+        &Gui::PrefFileChooser::fileNameSelected,
+        this,
+        &DlgSettingsFemElmerImp::onfileNameSelected
+    );
 }
 
 DlgSettingsFemElmerImp::~DlgSettingsFemElmerImp() = default;
@@ -57,6 +63,7 @@ void DlgSettingsFemElmerImp::saveSettings()
 {
     ui->fc_elmer_binary_path->onSave();
     ui->fc_grid_binary_path->onSave();
+    ui->fc_mpi_binary_path->onSave();
 
     ui->sb_log_verbosity->onSave();
     ui->sb_num_tasks->onSave();
@@ -70,6 +77,7 @@ void DlgSettingsFemElmerImp::loadSettings()
 {
     ui->fc_elmer_binary_path->onRestore();
     ui->fc_grid_binary_path->onRestore();
+    ui->fc_mpi_binary_path->onRestore();
 
     ui->sb_log_verbosity->onRestore();
     ui->sb_num_tasks->onRestore();

--- a/src/Mod/Fem/femsolver/elmer/elmertools.py
+++ b/src/Mod/Fem/femsolver/elmer/elmertools.py
@@ -29,7 +29,6 @@ __url__ = "https://www.freecad.org"
 from PySide.QtCore import QProcess, QProcessEnvironment
 import os
 import re
-import shutil
 
 import FreeCAD
 
@@ -90,10 +89,10 @@ class ElmerTools(ObjectTools):
 
         if num_proc > 1:
             # MPI parallel computing version
-            mpi = shutil.which("mpiexec")
+            mpi_bin = settings.get_binary("MPIElmer")
             self._result_format = ".pvtu"
             command_list = ["-n", str(num_proc), elmer_bin]
-            self.process.start(mpi, command_list)
+            self.process.start(mpi_bin, command_list)
         else:
             self._result_format = ".vtu"
             command_list = []

--- a/src/Mod/Fem/femsolver/settings.py
+++ b/src/Mod/Fem/femsolver/settings.py
@@ -271,6 +271,11 @@ _SOLVER_PARAM = {
         param_path=_PARAM_PATH + "Elmer",
         custom_path="gridBinaryPath",
     ),
+    "MPIElmer": _SolverDlg(
+        default="mpiexec",
+        param_path=_PARAM_PATH + "Elmer",
+        custom_path="mpiBinaryPath",
+    ),
     "Mystran": _SolverDlg(
         default="mystran",
         param_path=_PARAM_PATH + "Mystran",


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Add user preference option to set custom path to mpiexec/mpirun binary used by Elmer solver.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes #30572
## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
<img width="702" height="192" alt="image" src="https://github.com/user-attachments/assets/1e3ddf62-d7cb-4228-ba32-e2160e815dcf" />



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
