### PR TITLE
Change version number to 26.3.0-dev per FEP-0003

### DIFF
--- a/package/fedora/freecad.spec
+++ b/package/fedora/freecad.spec
@@ -16,7 +16,7 @@
 
 Name:           freecad
 Epoch:          1
-Version:        1.2.0~dev
+Version:        26.3.0~dev
 Release:        1%{?dist}
 
 Summary:        A general purpose 3D CAD modeler

--- a/package/rattler-build/pixi.lock
+++ b/package/rattler-build/pixi.lock
@@ -4285,7 +4285,7 @@ packages:
   timestamp: 1765632825351
 - conda: .
   name: freecad
-  version: 1.2.0dev
+  version: 26.3.0dev
   build: h3c70cbc_0
   subdir: win-64
   variants:
@@ -4347,7 +4347,7 @@ packages:
   - tbb >=2022.3.0
 - conda: .
   name: freecad
-  version: 1.2.0dev
+  version: 26.3.0dev
   build: h6d4d2f9_0
   subdir: linux-aarch64
   variants:
@@ -4410,7 +4410,7 @@ packages:
   - libzlib >=1.3.1,<2.0a0
 - conda: .
   name: freecad
-  version: 1.2.0dev
+  version: 26.3.0dev
   build: h81b34b9_0
   subdir: linux-64
   variants:
@@ -4474,7 +4474,7 @@ packages:
   - libzlib >=1.3.1,<2.0a0
 - conda: .
   name: freecad
-  version: 1.2.0dev
+  version: 26.3.0dev
   build: hc347f7b_0
   subdir: osx-64
   variants:
@@ -4535,7 +4535,7 @@ packages:
   - libzlib >=1.3.1,<2.0a0
 - conda: .
   name: freecad
-  version: 1.2.0dev
+  version: 26.3.0dev
   build: he8ea13f_0
   subdir: osx-arm64
   variants:

--- a/package/rattler-build/pixi.toml
+++ b/package/rattler-build/pixi.toml
@@ -8,7 +8,7 @@ preview = ["pixi-build"]
 
 [package]
 name = "freecad"
-version = "1.2.0dev"
+version = "26.3.0dev"
 homepage = "https://freecad.org"
 repository = "https://github.com/FreeCAD/FreeCAD"
 description = "FreeCAD"

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "1.2.0dev"
+  version: "26.3.0dev"
 
 package:
   name: freecad

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "FreeCAD"
-version = "1.2.0"
+version = "26.3.0"
 description = "pixi instructions for FreeCAD"
 authors = ["looooo <sppedflyer@gmail.com>"]
 channels = ["conda-forge"]

--- a/src/Tools/tests/test_sync_version.py
+++ b/src/Tools/tests/test_sync_version.py
@@ -73,6 +73,13 @@ class TestVersionInfo(unittest.TestCase):
         version = make_version(suffix="RC1")
         self.assertEqual(version.conda, "1.2.0RC1")
 
+    def test_calver_dev_version(self):
+        version = make_version(major=26, minor=3, patch=0, suffix="dev")
+        self.assertEqual(version.simple, "26.3.0")
+        self.assertEqual(version.complete, "26.3.0-dev")
+        self.assertEqual(version.rpm, "26.3.0~dev")
+        self.assertEqual(version.conda, "26.3.0dev")
+
     def test_lowercase_name(self):
         version = make_version(name="FreeCAD")
         self.assertEqual(version.lowercase_name, "freecad")

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "name": "FreeCAD",
-  "version_major": 1,
-  "version_minor": 2,
+  "version_major": 26,
+  "version_minor": 3,
   "version_patch": 0,
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "dev",


### PR DESCRIPTION
Change version number to 26.3.0-dev based on the accepted [FEP-0003](https://github.com/FreeCAD/FreeCAD-Enhancement-Proposals/blob/master/FEPs/FEP-0003-release-schedule/README.md)