### PR TITLE
Sketcher: Removed unused OVP for arcs in new Polyline tool

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1670,7 +1670,6 @@ auto DSHPolyLineControllerBase::getState(int labelindex) const
             break;
         case OnViewParameter::Third:
         case OnViewParameter::Fourth:
-        case OnViewParameter::Fifth:
             return SelectMode::SeekSecond;
             break;
         default:
@@ -1764,13 +1763,6 @@ void DSHPolyLineController::configureToolWidget()
         Gui::EditableDatumLabel::Function::Dimensioning
     );
 
-    if (handler->constructionMethod() == ConstructionMethod::Arc) {
-        onViewParameters[OnViewParameter::Fifth]->setLabelType(
-            Gui::SoDatumLabel::ANGLE,
-            Gui::EditableDatumLabel::Function::Dimensioning
-        );
-    }
-
     toolWidget->setCheckboxChecked(WCheckbox::FirstBox, handler->fillet);
 }
 
@@ -1807,9 +1799,6 @@ void DSHPolyLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSke
                 handler->resetSeekSecond = false;
                 unsetOnViewParameter(thirdParam.get());
                 unsetOnViewParameter(fourthParam.get());
-                if (handler->constructionMethod() == ConstructionMethod::Arc) {
-                    unsetOnViewParameter(onViewParameters[OnViewParameter::Fifth].get());
-                }
                 setFocusToOnViewParameter(OnViewParameter::Third);
                 return;
             }
@@ -1889,15 +1878,6 @@ void DSHPolyLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSke
                     dir.Rotate(angle);
                     onSketchPos = center + dir * radius;
                 }
-                if (onViewParameters[OnViewParameter::Fifth]->isSet) {
-                    double angle = Base::toRadians(
-                        onViewParameters[OnViewParameter::Fifth]->getValue()
-                    );
-
-                    if (handler->angleToPrevious != angle) {
-                        handler->angleToPrevious = angle;
-                    }
-                }
             }
         } break;
         default:
@@ -1962,8 +1942,6 @@ void DSHPolyLineController::adaptParameters(Base::Vector2d onSketchPos)
                 fourthParam->setLabelRange(handler->dirChangeAngle);
             }
             else {
-                auto& fifthParam = onViewParameters[OnViewParameter::Fifth];
-
                 Base::Vector3d start = toVector3d(handler->center);
                 Base::Vector3d end = toVector3d(onSketchPos);
                 Base::Vector3d vec = end - start;
@@ -1977,19 +1955,10 @@ void DSHPolyLineController::adaptParameters(Base::Vector2d onSketchPos)
                     setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Unit::Angle);
                 }
 
-                if (!fifthParam->isSet) {
-                    double angle = Base::toDegrees(handler->angleToPrevious);
-                    setOnViewParameterValue(OnViewParameter::Fifth, angle, Base::Unit::Angle);
-                }
-
                 thirdParam->setPoints(start, end);
                 fourthParam->setPoints(start, Base::Vector3d());
                 fourthParam->setLabelStartAngle(handler->startAngle);
                 fourthParam->setLabelRange(handler->range);
-
-                fifthParam->setPoints(toVector3d(prevPoint), Base::Vector3d());
-                fifthParam->setLabelStartAngle(handler->previousDirectionAngle);
-                fifthParam->setLabelRange(handler->angleToPrevious);
             }
         } break;
         default:
@@ -2020,9 +1989,6 @@ void DSHPolyLineController::computeNextDrawSketchHandlerMode()
 
                 unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
                 unsetOnViewParameter(onViewParameters[OnViewParameter::Fourth].get());
-                if (handler->constructionMethod() == ConstructionMethod::Arc) {
-                    unsetOnViewParameter(onViewParameters[OnViewParameter::Fifth].get());
-                }
             }
         } break;
         default:


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->

This PR removes the unused OVP in the new Polyline tool for the angle in arc mode between the last and the current line segment.
Currently it is possible to do right angle or tangent arcs in the polyline tool. So this OVP for the angle is currently unused and not necessary.


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
fixes #30627

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
n/a


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
