### PR TITLE
Sketcher: Fix fillet not working if AutoRecompute is ON

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1140,6 +1140,13 @@ private:
 
                 obj->fillet(geoId1, geoId2, refPnt1, refPnt2, radius, true, true);
 
+                if (!obj->noRecomputes) {
+                    // obj->fillet calls obj->solve() at the end only if obj->noRecomputes
+                    // See cause an issue, we need the solve even if !obj->noRecomputes
+                    // See https://github.com/FreeCAD/FreeCAD/issues/30625
+                    obj->solve();
+                }
+
                 if (isConstructionMode()) {
                     int filletGeoId = geoId + 1;
                     Gui::cmdAppObjectArgs(obj, "toggleConstruction(%d) ", filletGeoId);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1141,8 +1141,8 @@ private:
                 obj->fillet(geoId1, geoId2, refPnt1, refPnt2, radius, true, true);
 
                 if (!obj->noRecomputes) {
-                    // obj->fillet calls obj->solve() at the end only if obj->noRecomputes
-                    // See cause an issue, we need the solve even if !obj->noRecomputes
+                    // obj->fillet() solves at the end only when obj->noRecomputes is set, but we
+                    // need the solve even when AutoRecompute is on or the fillet won't appear.
                     // See https://github.com/FreeCAD/FreeCAD/issues/30625
                     obj->solve();
                 }


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/30625

At the end of `obj->fillet` there is 

```
    if (noRecomputes) {
        solve();
    }
```

Turns out that we need that solve or it causes the bug. So we just make sure we also solve in the case where AutoRecompute is ON.