### PR TITLE
Gui: added shortcut and button to go back and forth between workbenches

### DIFF
--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -32,6 +32,10 @@
 #include <QAbstractButton>
 #include <QTimer>
 #include <QProcess>
+#include <QMenu>
+#include <QAction>
+#include <QToolButton>
+#include <QToolBar>
 
 #include <App/Document.h>
 #include <Base/Exception.h>
@@ -62,7 +66,22 @@ using Base::Sequencer;
 using namespace Gui;
 namespace sp = std::placeholders;
 
+namespace {
+    class DelayedPopupAction : public Gui::Action {
+    public:
+        DelayedPopupAction(Gui::Command* cmd, QObject* parent) : Gui::Action(cmd, parent) {}
 
+        void addTo(QWidget* widget) override {
+            Gui::Action::addTo(widget);
+            if (QToolBar* toolBar = qobject_cast<QToolBar*>(widget)) {
+                if (QToolButton* toolButton = qobject_cast<QToolButton*>(toolBar->widgetForAction(this->action()))) {
+                    toolButton->setPopupMode(QToolButton::DelayedPopup);
+                    toolButton->setStyleSheet("QToolButton::menu-indicator { image: none; width: 0px; padding: 0px; }");
+                }
+            }
+        }
+    };
+}
 //===========================================================================
 // Std_Workbench
 //===========================================================================
@@ -93,6 +112,7 @@ void StdCmdWorkbench::activated(int i)
                 return;
             }
         }
+        WorkbenchManager::instance()->cleanNextWorkbenches();
         doCommand(Gui, "Gui.activateWorkbench(\"%s\")", switch_to.c_str());
     }
     catch (const Base::PyException& e) {
@@ -131,6 +151,182 @@ Action* StdCmdWorkbench::createAction()
         pcAction->setIcon(Gui::BitmapFactory().iconFromTheme(getPixmap()));
     }
 
+    return pcAction;
+}
+
+//===========================================================================
+// Std_PreviousWorkbench
+//===========================================================================
+
+DEF_STD_CMD_AC(StdCmdPreviousWorkbench)
+
+StdCmdPreviousWorkbench::StdCmdPreviousWorkbench()
+    : Command("Std_PreviousWorkbench")
+{
+    sGroup = "View";
+    sMenuText = QT_TR_NOOP("Previous Workbench");
+    sToolTipText = QT_TR_NOOP("Switches to the previous workbench");
+    sWhatsThis = "Std_PreviousWorkbench";
+    sStatusTip = sToolTipText;
+    sPixmap = "button_left";
+    sAccel = "Alt+Left";
+    eType = 0;
+}
+
+void StdCmdPreviousWorkbench::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    try {
+        Workbench* w = WorkbenchManager::instance()->getPreviousWorkbench();
+        if (!w) {
+            return;
+        }
+        WorkbenchManager::instance()->goToPreviousWorkbench();
+        doCommand(Gui, "Gui.activateWorkbench(\"%s\")", w->name().c_str());
+    }
+    catch (const Base::PyException& e) {
+        QString msg(QLatin1String(e.what()));
+        // ignore '<type 'exceptions.*Error'>' prefixes
+        QRegularExpression rx;
+        rx.setPattern(QLatin1String(R"(^\s*<type 'exceptions.\w*'>:\s*)"));
+        auto match = rx.match(msg);
+        if (match.hasMatch()) {
+            msg = msg.mid(match.capturedLength());
+        }
+        QMessageBox::critical(getMainWindow(), QObject::tr("Cannot load workbench"), msg);
+    }
+    catch (...) {
+        QMessageBox::critical(
+            getMainWindow(),
+            QObject::tr("Cannot Load Workbench"),
+            QObject::tr("A general error occurred while loading the workbench")
+        );
+    }
+}
+
+bool StdCmdPreviousWorkbench::isActive()
+{
+    return true;
+}
+
+Action* StdCmdPreviousWorkbench::createAction()
+{
+    Gui::Action* pcAction = new DelayedPopupAction(this, getMainWindow());
+    pcAction->setShortcut(QString::fromLatin1(getAccel()));
+    applyCommandData(this->className(), pcAction);
+    if (getPixmap()) {
+        pcAction->setIcon(Gui::BitmapFactory().iconFromTheme(getPixmap()));
+    }
+
+    QMenu* historyMenu = new QMenu(getMainWindow());
+    pcAction->action()->setMenu(historyMenu);
+    QObject::connect(pcAction->action(), &QObject::destroyed, historyMenu, &QObject::deleteLater);
+    QObject::connect(historyMenu, &QMenu::aboutToShow, [historyMenu]() {
+        historyMenu->clear();
+        auto historyList = WorkbenchManager::instance()->getPreviousWorkbenchList();
+        if (historyList.empty()) {
+            QAction* emptyAction = historyMenu->addAction(QObject::tr("No History"));
+            emptyAction->setEnabled(false);
+            return;
+        }
+        for (Workbench* wb : historyList) {
+            QString wbName = QString::fromStdString(wb->name());
+            QAction* itemAction = historyMenu->addAction(wbName);
+
+            QObject::connect(itemAction, &QAction::triggered, [wbName]() {
+                WorkbenchManager::instance()->jumpInHistory(wbName.toStdString(), "backwards");
+                Gui::Command::doCommand(Gui::Command::Gui, "Gui.activateWorkbench(\"%s\")", wbName.toUtf8().constData());
+            });
+        }
+    });
+    return pcAction;
+}
+
+//===========================================================================
+// Std_NextWorkbench
+//===========================================================================
+
+DEF_STD_CMD_AC(StdCmdNextWorkbench)
+
+StdCmdNextWorkbench::StdCmdNextWorkbench()
+    : Command("Std_NextWorkbench")
+{
+    sGroup = "View";
+    sMenuText = QT_TR_NOOP("Next Workbench");
+    sToolTipText = QT_TR_NOOP("Switches to the next workbench");
+    sWhatsThis = "Std_NextWorkbench";
+    sStatusTip = sToolTipText;
+    sPixmap = "button_right";
+    sAccel = "Alt+Right";
+    eType = 0;
+}
+
+void StdCmdNextWorkbench::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    try {
+        Workbench* w = WorkbenchManager::instance()->getNextWorkbench();
+        if (!w) {
+            return;
+        }
+        WorkbenchManager::instance()->goToNextWorkbench();
+        doCommand(Gui, "Gui.activateWorkbench(\"%s\")", w->name().c_str());
+    }
+    catch (const Base::PyException& e) {
+        QString msg(QLatin1String(e.what()));
+        // ignore '<type 'exceptions.*Error'>' prefixes
+        QRegularExpression rx;
+        rx.setPattern(QLatin1String(R"(^\s*<type 'exceptions.\w*'>:\s*)"));
+        auto match = rx.match(msg);
+        if (match.hasMatch()) {
+            msg = msg.mid(match.capturedLength());
+        }
+        QMessageBox::critical(getMainWindow(), QObject::tr("Cannot load workbench"), msg);
+    }
+    catch (...) {
+        QMessageBox::critical(
+            getMainWindow(),
+            QObject::tr("Cannot Load Workbench"),
+            QObject::tr("A general error occurred while loading the workbench")
+        );
+    }
+}
+
+bool StdCmdNextWorkbench::isActive()
+{
+    return true;
+}
+
+Action* StdCmdNextWorkbench::createAction()
+{
+    Gui::Action* pcAction = new DelayedPopupAction(this, getMainWindow());
+    pcAction->setShortcut(QString::fromLatin1(getAccel()));
+    applyCommandData(this->className(), pcAction);
+    if (getPixmap()) {
+        pcAction->setIcon(Gui::BitmapFactory().iconFromTheme(getPixmap()));
+    }
+
+    QMenu* historyMenu = new QMenu(getMainWindow());
+    pcAction->action()->setMenu(historyMenu);
+    QObject::connect(pcAction->action(), &QObject::destroyed, historyMenu, &QObject::deleteLater);
+    QObject::connect(historyMenu, &QMenu::aboutToShow, [historyMenu]() {
+        historyMenu->clear();
+        auto historyList = WorkbenchManager::instance()->getNextWorkbenchList();
+        if (historyList.empty()) {
+            QAction* emptyAction = historyMenu->addAction(QObject::tr("No History"));
+            emptyAction->setEnabled(false);
+            return;
+        }
+        for (Workbench* wb : historyList) {
+            QString wbName = QString::fromStdString(wb->name());
+            QAction* itemAction = historyMenu->addAction(wbName);
+
+            QObject::connect(itemAction, &QAction::triggered, [wbName]() {
+                WorkbenchManager::instance()->jumpInHistory(wbName.toStdString(), "forward");
+                Gui::Command::doCommand(Gui::Command::Gui, "Gui.activateWorkbench(\"%s\")", wbName.toUtf8().constData());
+            });
+        }
+    });
     return pcAction;
 }
 
@@ -1061,6 +1257,8 @@ void CreateStdCommands()
     rcCmdMgr.addCommand(new StdCmdDlgCustomize());
     rcCmdMgr.addCommand(new StdCmdCommandLine());
     rcCmdMgr.addCommand(new StdCmdWorkbench());
+    rcCmdMgr.addCommand(new StdCmdPreviousWorkbench());
+    rcCmdMgr.addCommand(new StdCmdNextWorkbench());
     rcCmdMgr.addCommand(new StdCmdRecentFiles());
     rcCmdMgr.addCommand(new StdCmdRecentMacros());
     rcCmdMgr.addCommand(new StdCmdWhatsThis());

--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -66,22 +66,30 @@ using Base::Sequencer;
 using namespace Gui;
 namespace sp = std::placeholders;
 
-namespace {
-    class DelayedPopupAction : public Gui::Action {
-    public:
-        DelayedPopupAction(Gui::Command* cmd, QObject* parent) : Gui::Action(cmd, parent) {}
+namespace
+{
+class DelayedPopupAction: public Gui::Action
+{
+public:
+    DelayedPopupAction(Gui::Command* cmd, QObject* parent)
+        : Gui::Action(cmd, parent)
+    {}
 
-        void addTo(QWidget* widget) override {
-            Gui::Action::addTo(widget);
-            if (QToolBar* toolBar = qobject_cast<QToolBar*>(widget)) {
-                if (QToolButton* toolButton = qobject_cast<QToolButton*>(toolBar->widgetForAction(this->action()))) {
-                    toolButton->setPopupMode(QToolButton::DelayedPopup);
-                    toolButton->setStyleSheet("QToolButton::menu-indicator { image: none; width: 0px; padding: 0px; }");
-                }
+    void addTo(QWidget* widget) override
+    {
+        Gui::Action::addTo(widget);
+        if (QToolBar* toolBar = qobject_cast<QToolBar*>(widget)) {
+            if (QToolButton* toolButton
+                = qobject_cast<QToolButton*>(toolBar->widgetForAction(this->action()))) {
+                toolButton->setPopupMode(QToolButton::DelayedPopup);
+                toolButton->setStyleSheet(
+                    "QToolButton::menu-indicator { image: none; width: 0px; padding: 0px; }"
+                );
             }
         }
-    };
-}
+    }
+};
+}  // namespace
 //===========================================================================
 // Std_Workbench
 //===========================================================================
@@ -235,7 +243,11 @@ Action* StdCmdPreviousWorkbench::createAction()
 
             QObject::connect(itemAction, &QAction::triggered, [wbName]() {
                 WorkbenchManager::instance()->jumpInHistory(wbName.toStdString(), "backwards");
-                Gui::Command::doCommand(Gui::Command::Gui, "Gui.activateWorkbench(\"%s\")", wbName.toUtf8().constData());
+                Gui::Command::doCommand(
+                    Gui::Command::Gui,
+                    "Gui.activateWorkbench(\"%s\")",
+                    wbName.toUtf8().constData()
+                );
             });
         }
     });
@@ -323,7 +335,11 @@ Action* StdCmdNextWorkbench::createAction()
 
             QObject::connect(itemAction, &QAction::triggered, [wbName]() {
                 WorkbenchManager::instance()->jumpInHistory(wbName.toStdString(), "forward");
-                Gui::Command::doCommand(Gui::Command::Gui, "Gui.activateWorkbench(\"%s\")", wbName.toUtf8().constData());
+                Gui::Command::doCommand(
+                    Gui::Command::Gui,
+                    "Gui.activateWorkbench(\"%s\")",
+                    wbName.toUtf8().constData()
+                );
             });
         }
     });

--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -214,7 +214,7 @@ void StdCmdPreviousWorkbench::activated(int iMsg)
 
 bool StdCmdPreviousWorkbench::isActive()
 {
-    return true;
+    return (WorkbenchManager::instance()->getPreviousWorkbenchList().size() != 0);
 }
 
 Action* StdCmdPreviousWorkbench::createAction()
@@ -306,7 +306,7 @@ void StdCmdNextWorkbench::activated(int iMsg)
 
 bool StdCmdNextWorkbench::isActive()
 {
-    return true;
+    return (WorkbenchManager::instance()->getNextWorkbenchList().size() != 0);
 }
 
 Action* StdCmdNextWorkbench::createAction()

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -754,6 +754,8 @@ MenuItem* StdWorkbench::setupMenuBar() const
           << "Std_ToggleTransparency"
           << "Separator"
           << "Std_Workbench"
+          << "Std_PreviousWorkbench"
+          << "Std_NextWorkbench"
           << "Std_ToolBarMenu"
           << "Std_DockViewMenu";
     if (DockWindowManager::instance()->isOverlayActivated()) {
@@ -851,7 +853,7 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     // Workbench switcher
     auto wb = new ToolBarItem(root);
     wb->setCommand("Workbench");
-    *wb << "Std_Workbench";
+    *wb << "Std_Workbench" << "Separator" << "Std_PreviousWorkbench" << "Std_NextWorkbench";
 
     // Macro
     auto macro = new ToolBarItem(root, ToolBarItem::DefaultVisibility::Hidden);
@@ -1021,7 +1023,7 @@ MenuItem* NoneWorkbench::setupMenuBar() const
     // View
     auto view = new MenuItem(menuBar);
     view->setCommand("&View");
-    *view << "Std_Workbench";
+    *view << "Std_Workbench" << "Std_NextWorkbench";
 
     // Separator
     auto sep = new MenuItem(menuBar);

--- a/src/Gui/WorkbenchManager.cpp
+++ b/src/Gui/WorkbenchManager.cpp
@@ -115,6 +115,14 @@ bool WorkbenchManager::activate(const std::string& name, std::string_view classN
 {
     Workbench* wb = createWorkbench(name, className);
     if (wb) {
+
+        if (_activeWorkbench && !_isGoingToPreviousWorkbench && _activeWorkbench->name() != "NoneWorkbench") {
+            _previousWorkbenches.push_front(_activeWorkbench);
+        }
+        _isGoingToPreviousWorkbench = false;
+
+        removeFromPreviousWorkbenches(wb);
+        
         _activeWorkbench = wb;
         wb->activate();
         return true;
@@ -144,4 +152,108 @@ std::list<std::string> WorkbenchManager::workbenches() const
         wb.push_back(it.first);
     }
     return wb;
+}
+
+Workbench* WorkbenchManager::getPreviousWorkbench() const
+{
+    if (_previousWorkbenches.empty() || _previousWorkbenches.front()->name() == "NoneWorkbench") {
+        return nullptr;
+    }
+    return _previousWorkbenches.front();
+}
+
+std::list<Workbench*> WorkbenchManager::getPreviousWorkbenchList() const
+{
+    return _previousWorkbenches;
+}
+
+Workbench* WorkbenchManager::getNextWorkbench() const
+{
+    if (_nextWorkbenches.empty()) {
+        return nullptr;
+    }
+    return _nextWorkbenches.front();
+}
+
+std::list<Workbench*> WorkbenchManager::getNextWorkbenchList() const
+{
+    return _nextWorkbenches;
+}
+
+void WorkbenchManager::goToPreviousWorkbench()
+{
+    _previousWorkbenches.pop_front();
+    _nextWorkbenches.push_front(_activeWorkbench);
+    _isGoingToPreviousWorkbench = true;
+}
+
+void WorkbenchManager::goToNextWorkbench()
+{
+    _nextWorkbenches.pop_front();
+}
+
+void WorkbenchManager::cleanNextWorkbenches()
+{
+    while (!_nextWorkbenches.empty()) {
+        _nextWorkbenches.pop_back();
+    }
+}
+
+void WorkbenchManager::removeFromPreviousWorkbenches(Workbench* wb)
+{
+    auto it = std::find(_previousWorkbenches.begin(), _previousWorkbenches.end(), wb);
+    if (it != _previousWorkbenches.end()) {
+        _previousWorkbenches.erase(it);
+    }
+}
+
+void WorkbenchManager::jumpInHistory(const std::string& name, const std::string& direction)
+{
+    if (!_activeWorkbench || _activeWorkbench->name() == name) {
+        return;
+    }
+    Workbench* tempActive = _activeWorkbench;
+    if (direction == "backwards" || direction == "Past" || direction == "past") {
+        
+        bool found = false;
+        for (Workbench* wb : _previousWorkbenches) {
+            if (wb->name() == name) { found = true; break; }
+        }
+        if (!found) return;
+
+        while (!_previousWorkbenches.empty()) {
+            Workbench* targetWb = _previousWorkbenches.front();
+            _previousWorkbenches.pop_front();
+            
+            _nextWorkbenches.push_front(tempActive);
+            tempActive = targetWb;
+            
+            if (tempActive->name() == name) {
+                break;
+            }
+        }
+    } 
+    else if (direction == "forward" || direction == "Future" || direction == "future") {
+        
+        bool found = false;
+        for (Workbench* wb : _nextWorkbenches) {
+            if (wb->name() == name) { found = true; break; }
+        }
+        if (!found) return;
+
+        while (!_nextWorkbenches.empty()) {
+            Workbench* targetWb = _nextWorkbenches.front();
+            _nextWorkbenches.pop_front();
+            
+            _previousWorkbenches.push_front(tempActive);
+            tempActive = targetWb;
+            
+            if (tempActive->name() == name) {
+                break;
+            }
+        }
+    }
+    _nextWorkbenches.remove(tempActive);
+    _previousWorkbenches.remove(tempActive);
+    _isGoingToPreviousWorkbench = true;
 }

--- a/src/Gui/WorkbenchManager.cpp
+++ b/src/Gui/WorkbenchManager.cpp
@@ -116,13 +116,14 @@ bool WorkbenchManager::activate(const std::string& name, std::string_view classN
     Workbench* wb = createWorkbench(name, className);
     if (wb) {
 
-        if (_activeWorkbench && !_isGoingToPreviousWorkbench && _activeWorkbench->name() != "NoneWorkbench") {
+        if (_activeWorkbench && !_isGoingToPreviousWorkbench
+            && _activeWorkbench->name() != "NoneWorkbench") {
             _previousWorkbenches.push_front(_activeWorkbench);
         }
         _isGoingToPreviousWorkbench = false;
 
         removeFromPreviousWorkbenches(wb);
-        
+
         _activeWorkbench = wb;
         wb->activate();
         return true;
@@ -214,40 +215,50 @@ void WorkbenchManager::jumpInHistory(const std::string& name, const std::string&
     }
     Workbench* tempActive = _activeWorkbench;
     if (direction == "backwards" || direction == "Past" || direction == "past") {
-        
+
         bool found = false;
         for (Workbench* wb : _previousWorkbenches) {
-            if (wb->name() == name) { found = true; break; }
+            if (wb->name() == name) {
+                found = true;
+                break;
+            }
         }
-        if (!found) return;
+        if (!found) {
+            return;
+        }
 
         while (!_previousWorkbenches.empty()) {
             Workbench* targetWb = _previousWorkbenches.front();
             _previousWorkbenches.pop_front();
-            
+
             _nextWorkbenches.push_front(tempActive);
             tempActive = targetWb;
-            
+
             if (tempActive->name() == name) {
                 break;
             }
         }
-    } 
+    }
     else if (direction == "forward" || direction == "Future" || direction == "future") {
-        
+
         bool found = false;
         for (Workbench* wb : _nextWorkbenches) {
-            if (wb->name() == name) { found = true; break; }
+            if (wb->name() == name) {
+                found = true;
+                break;
+            }
         }
-        if (!found) return;
+        if (!found) {
+            return;
+        }
 
         while (!_nextWorkbenches.empty()) {
             Workbench* targetWb = _nextWorkbenches.front();
             _nextWorkbenches.pop_front();
-            
+
             _previousWorkbenches.push_front(tempActive);
             tempActive = targetWb;
-            
+
             if (tempActive->name() == name) {
                 break;
             }

--- a/src/Gui/WorkbenchManager.h
+++ b/src/Gui/WorkbenchManager.h
@@ -65,6 +65,24 @@ public:
     std::string activeName() const;
     /** Returns a list of all created workbench objects. */
     std::list<std::string> workbenches() const;
+    /** Returns the previously active workbench. */
+    Workbench* getPreviousWorkbench() const;
+    /** Returns the next active workbench. */
+    Workbench* getNextWorkbench() const;
+    /** Returns a list of all previously active workbenches. */
+    std::list<Workbench*> getPreviousWorkbenchList() const;
+    /** Returns a list of all next active workbenches. */
+    std::list<Workbench*> getNextWorkbenchList() const;
+    /** Handles switching to the previous workbench. */
+    void goToPreviousWorkbench();
+    /** Handles switching to the next workbench. */
+    void goToNextWorkbench();
+    /** Empties the list of next workbenches. */
+    void cleanNextWorkbenches();
+    /** Removes a workbench from the list of previous workbenches. */
+    void removeFromPreviousWorkbenches(Workbench* wb);
+    /** Jumps to a workbench in the history list. */
+    void jumpInHistory(const std::string& name, const std::string& direction);
 
 protected:
     WorkbenchManager();
@@ -74,6 +92,9 @@ private:
     static WorkbenchManager* _instance;
     Workbench* _activeWorkbench {nullptr};
     std::map<std::string, Workbench*> _workbenches;
+    std::list<Workbench*> _previousWorkbenches;
+    std::list<Workbench*> _nextWorkbenches;
+    bool _isGoingToPreviousWorkbench {false};
 };
 
 }  // namespace Gui

--- a/tests/src/Gui/WorkbenchManagerHistory.cpp
+++ b/tests/src/Gui/WorkbenchManagerHistory.cpp
@@ -1,0 +1,145 @@
+#include <gtest/gtest.h>
+#include "WorkbenchManager.h"
+
+using namespace Gui;
+
+// ============================================================================
+// Test Case 1: The Initial State (Empty History)
+// Goal: Verify the app doesn't crash when history is empty.
+// ============================================================================
+TEST(WorkbenchManagerTest, TestCase1_InitialState) {
+    WorkbenchManager manager;
+    
+    // Result: The previous and next lists must be completely empty.
+    EXPECT_TRUE(manager.getPreviousWorkbenchList().empty());
+    EXPECT_TRUE(manager.getNextWorkbenchList().empty());
+    EXPECT_EQ(manager.getPreviousWorkbench(), nullptr);
+    EXPECT_EQ(manager.getNextWorkbench(), nullptr);
+}
+
+// ============================================================================
+// Test Case 2 Linear Walk
+// Goal: Verify basic LIFO stack movement.
+// ============================================================================
+TEST(WorkbenchManagerTest, TestCase2_LinearWalk) {
+    WorkbenchManager manager;
+    
+    // Action: Change workbenches in order: Part -> Draft -> Sketcher -> TechDraw.
+    manager.activate("Part", "Part");
+    manager.activate("Draft", "Draft");
+    manager.activate("Sketcher", "Sketcher");
+    manager.activate("TechDraw", "TechDraw");
+
+    // Action: Click the "Previous" button 3 times.
+    manager.goToPreviousWorkbench(); manager.activate("Sketcher", "Sketcher");
+    manager.goToPreviousWorkbench(); manager.activate("Draft", "Draft");
+    manager.goToPreviousWorkbench(); manager.activate("Part", "Part");
+
+    // Result: You should be back on Part.
+    EXPECT_EQ(manager.activeName(), "Part");
+
+    // Result: "Next" list should have Draft, Sketcher, and TechDraw (Size 3).
+    EXPECT_EQ(manager.getNextWorkbenchList().size(), 3);
+}
+
+// ============================================================================
+// Test Case 3
+// Goal: Verify the "Forward" stack is cleared when navigating to a new branch.
+// ============================================================================
+TEST(WorkbenchManagerTest, TestCase3_TheBranch) {
+    WorkbenchManager manager;
+    
+    // Setup: We are on Part, and Next list has Draft.
+    manager.activate("Part", "Part");
+    manager.activate("Draft", "Draft");
+    manager.goToPreviousWorkbench(); manager.activate("Part", "Part");
+    
+    // Verify setup is correct
+    ASSERT_FALSE(manager.getNextWorkbenchList().empty());
+
+    // Action: Select BIM (a brand new branch)
+    manager.activate("BIM", "BIM");
+
+    // Result: Active is BIM
+    EXPECT_EQ(manager.activeName(), "BIM");
+    
+    // Result: CRITICAL - The "Next" history must be completely empty.
+    EXPECT_TRUE(manager.getNextWorkbenchList().empty());
+}
+
+// ============================================================================
+// Test Case 4:Over-clicking bounds
+// Goal: Verify pointer safety when hitting the end of the lists.
+// ============================================================================
+TEST(WorkbenchManagerTest, TestCase4_TheWall) {
+    WorkbenchManager manager;
+    manager.activate("Part", "Part");
+
+    // Action: Try to go back when at the first workbench.
+    // Result: getPreviousWorkbench returns nullptr. No crash.
+    EXPECT_EQ(manager.getPreviousWorkbench(), nullptr);
+
+    // Action: Try to go forward when at the most recent workbench.
+    // Result: getNextWorkbench returns nullptr. No crash.
+    EXPECT_EQ(manager.getNextWorkbench(), nullptr);
+}
+
+// ============================================================================
+// Test Cases 5: Dropdown Jump Logic
+// Goal: Verify jumpInHistory correctly moves multiple items between stacks.
+// ============================================================================
+TEST(WorkbenchManagerTest, TestCase5_JumpsAndBranches) {
+    WorkbenchManager manager;
+    
+    // Setup: Build history PartDesign -> Sketcher -> Draft -> TechDraw
+    manager.activate("PartDesign", "PartDesign");
+    manager.activate("Sketcher", "Sketcher");
+    manager.activate("Draft", "Draft");
+    manager.activate("TechDraw", "TechDraw");
+
+    // Action: Jump to PartDesign (bottom of history)
+    manager.jumpInHistory("PartDesign", "backwards");
+    manager.activate("PartDesign", "PartDesign");
+    
+    EXPECT_EQ(manager.activeName(), "PartDesign");
+    EXPECT_EQ(manager.getNextWorkbenchList().size(), 3); // Sketcher, Draft, TechDraw are in the future
+
+    // Action: Jump forward to TechDraw (top of Next stack)
+    manager.jumpInHistory("TechDraw", "forward");
+    manager.activate("TechDraw", "TechDraw");
+    
+    EXPECT_EQ(manager.activeName(), "TechDraw");
+    EXPECT_TRUE(manager.getNextWorkbenchList().empty()); // No more future
+    EXPECT_EQ(manager.getPreviousWorkbenchList().size(), 3); // Past is restored
+
+    // Action: Jump backwards by only 1 to Draft
+    manager.jumpInHistory("Draft", "backwards");
+    manager.activate("Draft", "Draft");
+    
+    EXPECT_EQ(manager.activeName(), "Draft");
+    EXPECT_EQ(manager.getNextWorkbenchList().size(), 1); // Only TechDraw is in the future
+
+    // Action: User is on Draft, but activates BIM instead of going forward.
+    manager.activate("BIM", "BIM");
+    
+    EXPECT_EQ(manager.activeName(), "BIM");
+    EXPECT_TRUE(manager.getNextWorkbenchList().empty()); 
+}
+
+// ============================================================================
+// Test Case 6: Duplicate Self-Navigation
+// Goal: Ensure navigating to the same workbench doesn't create broken loops.
+// ============================================================================
+TEST(WorkbenchManagerTest, TestCase6_DuplicateSelfNavigation) {
+    WorkbenchManager manager;
+    
+    // Setup: Activate Sketcher
+    manager.activate("Sketcher", "Sketcher");
+    size_t historySize = manager.getPreviousWorkbenchList().size();
+    
+    // Action: Activate Sketcher AGAIN
+    manager.activate("Sketcher", "Sketcher");
+    
+    // Result: History size should NOT grow (no duplicate push)
+    EXPECT_EQ(manager.getPreviousWorkbenchList().size(), historySize);
+}

--- a/tests/src/Gui/WorkbenchManagerHistory.cpp
+++ b/tests/src/Gui/WorkbenchManagerHistory.cpp
@@ -7,9 +7,10 @@ using namespace Gui;
 // Test Case 1: The Initial State (Empty History)
 // Goal: Verify the app doesn't crash when history is empty.
 // ============================================================================
-TEST(WorkbenchManagerTest, TestCase1_InitialState) {
+TEST(WorkbenchManagerTest, TestCase1_InitialState)
+{
     WorkbenchManager manager;
-    
+
     // Result: The previous and next lists must be completely empty.
     EXPECT_TRUE(manager.getPreviousWorkbenchList().empty());
     EXPECT_TRUE(manager.getNextWorkbenchList().empty());
@@ -21,9 +22,10 @@ TEST(WorkbenchManagerTest, TestCase1_InitialState) {
 // Test Case 2 Linear Walk
 // Goal: Verify basic LIFO stack movement.
 // ============================================================================
-TEST(WorkbenchManagerTest, TestCase2_LinearWalk) {
+TEST(WorkbenchManagerTest, TestCase2_LinearWalk)
+{
     WorkbenchManager manager;
-    
+
     // Action: Change workbenches in order: Part -> Draft -> Sketcher -> TechDraw.
     manager.activate("Part", "Part");
     manager.activate("Draft", "Draft");
@@ -31,9 +33,12 @@ TEST(WorkbenchManagerTest, TestCase2_LinearWalk) {
     manager.activate("TechDraw", "TechDraw");
 
     // Action: Click the "Previous" button 3 times.
-    manager.goToPreviousWorkbench(); manager.activate("Sketcher", "Sketcher");
-    manager.goToPreviousWorkbench(); manager.activate("Draft", "Draft");
-    manager.goToPreviousWorkbench(); manager.activate("Part", "Part");
+    manager.goToPreviousWorkbench();
+    manager.activate("Sketcher", "Sketcher");
+    manager.goToPreviousWorkbench();
+    manager.activate("Draft", "Draft");
+    manager.goToPreviousWorkbench();
+    manager.activate("Part", "Part");
 
     // Result: You should be back on Part.
     EXPECT_EQ(manager.activeName(), "Part");
@@ -46,14 +51,16 @@ TEST(WorkbenchManagerTest, TestCase2_LinearWalk) {
 // Test Case 3
 // Goal: Verify the "Forward" stack is cleared when navigating to a new branch.
 // ============================================================================
-TEST(WorkbenchManagerTest, TestCase3_TheBranch) {
+TEST(WorkbenchManagerTest, TestCase3_TheBranch)
+{
     WorkbenchManager manager;
-    
+
     // Setup: We are on Part, and Next list has Draft.
     manager.activate("Part", "Part");
     manager.activate("Draft", "Draft");
-    manager.goToPreviousWorkbench(); manager.activate("Part", "Part");
-    
+    manager.goToPreviousWorkbench();
+    manager.activate("Part", "Part");
+
     // Verify setup is correct
     ASSERT_FALSE(manager.getNextWorkbenchList().empty());
 
@@ -62,7 +69,7 @@ TEST(WorkbenchManagerTest, TestCase3_TheBranch) {
 
     // Result: Active is BIM
     EXPECT_EQ(manager.activeName(), "BIM");
-    
+
     // Result: CRITICAL - The "Next" history must be completely empty.
     EXPECT_TRUE(manager.getNextWorkbenchList().empty());
 }
@@ -71,7 +78,8 @@ TEST(WorkbenchManagerTest, TestCase3_TheBranch) {
 // Test Case 4:Over-clicking bounds
 // Goal: Verify pointer safety when hitting the end of the lists.
 // ============================================================================
-TEST(WorkbenchManagerTest, TestCase4_TheWall) {
+TEST(WorkbenchManagerTest, TestCase4_TheWall)
+{
     WorkbenchManager manager;
     manager.activate("Part", "Part");
 
@@ -88,9 +96,10 @@ TEST(WorkbenchManagerTest, TestCase4_TheWall) {
 // Test Cases 5: Dropdown Jump Logic
 // Goal: Verify jumpInHistory correctly moves multiple items between stacks.
 // ============================================================================
-TEST(WorkbenchManagerTest, TestCase5_JumpsAndBranches) {
+TEST(WorkbenchManagerTest, TestCase5_JumpsAndBranches)
+{
     WorkbenchManager manager;
-    
+
     // Setup: Build history PartDesign -> Sketcher -> Draft -> TechDraw
     manager.activate("PartDesign", "PartDesign");
     manager.activate("Sketcher", "Sketcher");
@@ -100,46 +109,47 @@ TEST(WorkbenchManagerTest, TestCase5_JumpsAndBranches) {
     // Action: Jump to PartDesign (bottom of history)
     manager.jumpInHistory("PartDesign", "backwards");
     manager.activate("PartDesign", "PartDesign");
-    
+
     EXPECT_EQ(manager.activeName(), "PartDesign");
-    EXPECT_EQ(manager.getNextWorkbenchList().size(), 3); // Sketcher, Draft, TechDraw are in the future
+    EXPECT_EQ(manager.getNextWorkbenchList().size(), 3);  // Sketcher, Draft, TechDraw are in the future
 
     // Action: Jump forward to TechDraw (top of Next stack)
     manager.jumpInHistory("TechDraw", "forward");
     manager.activate("TechDraw", "TechDraw");
-    
+
     EXPECT_EQ(manager.activeName(), "TechDraw");
-    EXPECT_TRUE(manager.getNextWorkbenchList().empty()); // No more future
-    EXPECT_EQ(manager.getPreviousWorkbenchList().size(), 3); // Past is restored
+    EXPECT_TRUE(manager.getNextWorkbenchList().empty());      // No more future
+    EXPECT_EQ(manager.getPreviousWorkbenchList().size(), 3);  // Past is restored
 
     // Action: Jump backwards by only 1 to Draft
     manager.jumpInHistory("Draft", "backwards");
     manager.activate("Draft", "Draft");
-    
+
     EXPECT_EQ(manager.activeName(), "Draft");
-    EXPECT_EQ(manager.getNextWorkbenchList().size(), 1); // Only TechDraw is in the future
+    EXPECT_EQ(manager.getNextWorkbenchList().size(), 1);  // Only TechDraw is in the future
 
     // Action: User is on Draft, but activates BIM instead of going forward.
     manager.activate("BIM", "BIM");
-    
+
     EXPECT_EQ(manager.activeName(), "BIM");
-    EXPECT_TRUE(manager.getNextWorkbenchList().empty()); 
+    EXPECT_TRUE(manager.getNextWorkbenchList().empty());
 }
 
 // ============================================================================
 // Test Case 6: Duplicate Self-Navigation
 // Goal: Ensure navigating to the same workbench doesn't create broken loops.
 // ============================================================================
-TEST(WorkbenchManagerTest, TestCase6_DuplicateSelfNavigation) {
+TEST(WorkbenchManagerTest, TestCase6_DuplicateSelfNavigation)
+{
     WorkbenchManager manager;
-    
+
     // Setup: Activate Sketcher
     manager.activate("Sketcher", "Sketcher");
     size_t historySize = manager.getPreviousWorkbenchList().size();
-    
+
     // Action: Activate Sketcher AGAIN
     manager.activate("Sketcher", "Sketcher");
-    
+
     // Result: History size should NOT grow (no duplicate push)
     EXPECT_EQ(manager.getPreviousWorkbenchList().size(), historySize);
 }


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

Added two buttons to go back and forth between previously used workbenches
These buttons show the history when held, letting the user go multiple steps back or forward, without having to cross every workbench to get there
Also added two shortcuts for each respective button, Alt + Left Arrow to go back and Alt + Right Arrow to go forth
This work was assisted by the models Gemini 3.1 pro and Claude Sonnet 4.6, for help in correcting bugs and for further knowledge of c++ libraries.

The code includes tests, and although we are unsure how helpful these are, as the new feature is very straightforward, we decided to create them anyways, but we can alter these accordingly if you find them unhelpful.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: Gemini 3.1 pro
Assisted-by: Claude Sonnet 4.6

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
This pull request is in relation to (and should close) the issue #29403 

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
Before:
<img width="441" height="223" alt="WhatsApp Image 2026-06-08 at 11 27 06" src="https://github.com/user-attachments/assets/ed2a7937-30f3-44d2-aa9d-03fa7451aa41" />
After (showing the effect of holding down the respective buttons):
<img width="441" height="223" alt="WhatsApp Image 2026-06-08 at 11 25 42" src="https://github.com/user-attachments/assets/65da139f-42e3-476d-8125-65fc628a862f" />
<img width="441" height="223" alt="WhatsApp Image 2026-06-08 at 11 24 57" src="https://github.com/user-attachments/assets/b0d1c7f1-97ec-422d-b93d-79de11459b47" />



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->