### PR TITLE
Assembly: Fix joint creation preselection not working properly

### DIFF
--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -2229,13 +2229,6 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
     def addSelection(self, doc_name, obj_name, sub_name, mousePos):
         rootObj = App.getDocument(doc_name).getObject(obj_name)
 
-        # We do not need the full TNP string like :"Part.Body.Pad.;#a:1;:G0;XTR;:Hc94:8,F.Face6"
-        # instead we need : "Part.Body.Pad.Face6"
-        resolved = rootObj.resolveSubElement(sub_name, True)
-        sub_name = resolved[2]
-
-        sub_name = UtilsAssembly.fixBodyExtraFeatureInSub(doc_name, sub_name)
-
         comp, new_sub = UtilsAssembly.getComponentReference(self.assembly, rootObj, sub_name)
         if not comp:
             # Selection was not valid (not inside assembly or logic failed)
@@ -2285,12 +2278,6 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
 
         rootObj = App.getDocument(doc_name).getObject(obj_name)
 
-        # Apply the same processing as in addSelection to ensure consistent comparison
-        resolved = rootObj.resolveSubElement(sub_name, True)
-        sub_name = resolved[2]
-
-        sub_name = UtilsAssembly.fixBodyExtraFeatureInSub(doc_name, sub_name)
-
         comp, new_sub = UtilsAssembly.getComponentReference(self.assembly, rootObj, sub_name)
         if not comp:
             return
@@ -2312,8 +2299,6 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
         if not sub_name:
             self.presel_ref = None
             return
-
-        sub_name = UtilsAssembly.fixBodyExtraFeatureInSub(doc_name, sub_name)
 
         rootObj = App.getDocument(doc_name).getObject(obj_name)
 

--- a/src/Mod/Assembly/UtilsAssembly.py
+++ b/src/Mod/Assembly/UtilsAssembly.py
@@ -1224,7 +1224,7 @@ def getComponentReference(assembly, root_obj, sub_string):
         return None, ""
 
     doc = assembly.Document
-    
+
     # We do not need the full TNP string like :"Part.Body.Pad.;#a:1;:G0;XTR;:Hc94:8,F.Face6"
     # instead we need : "Part.Body.Pad.Face6"
     resolved = root_obj.resolveSubElement(sub_string, True)

--- a/src/Mod/Assembly/UtilsAssembly.py
+++ b/src/Mod/Assembly/UtilsAssembly.py
@@ -1224,6 +1224,12 @@ def getComponentReference(assembly, root_obj, sub_string):
         return None, ""
 
     doc = assembly.Document
+    
+    # We do not need the full TNP string like :"Part.Body.Pad.;#a:1;:G0;XTR;:Hc94:8,F.Face6"
+    # instead we need : "Part.Body.Pad.Face6"
+    resolved = root_obj.resolveSubElement(sub_string, True)
+    sub_string = resolved[2]
+    sub_string = fixBodyExtraFeatureInSub(doc.Name, sub_string)
 
     # 1. Reconstruct full path
     # e.g. ['Part', 'Assembly', 'Cylinder', 'Face1']


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/30662

The bug happened because in the preselection workflow of the create joint tool, we were not removing the TNP and feature name from the subname.

This PR fixes this by moving the cleaning of the subname to `getComponentReference`