### PR TITLE
CAM: Path.Op.Base - Allow add only shapes

### DIFF
--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -877,8 +877,6 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
         for sel in selection:
             if not hasattr(sel.Object, "Shape"):
                 continue
-            if not getattr(sel.Object.ViewObject, "Selectable", False):
-                continue
             # check each selection
             if self.selectionSupportedAsBaseGeometry(sel, False):
                 added = True

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -875,6 +875,10 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
         Path.Log.track(selection)
         added = False
         for sel in selection:
+            if not hasattr(sel.Object, "Shape"):
+                continue
+            if not getattr(sel.Object.ViewObject, "Selectable", False):
+                continue
             # check each selection
             if self.selectionSupportedAsBaseGeometry(sel, False):
                 added = True

--- a/src/Mod/CAM/PathScripts/PathUtilsGui.py
+++ b/src/Mod/CAM/PathScripts/PathUtilsGui.py
@@ -25,6 +25,7 @@ import FreeCADGui
 import FreeCAD
 import Path
 import Path.Main.Gui.JobCmd as PathJobCmd
+import Path.Main.Job as PathJob
 import Path.Tool.Controller as PathToolController
 import PathScripts.PathUtils as PathUtils
 from PySide import QtGui
@@ -63,6 +64,15 @@ class PathUtilsUserInput(object):
     def chooseJob(self, jobs):
         job = None
         selected = FreeCADGui.Selection.getSelection()
+
+        jbs = [
+            sel
+            for sel in selected
+            if hasattr(sel, "Proxy") and isinstance(sel.Proxy, PathJob.ObjectJob)
+        ]
+        if len(jbs) == 1:
+            return jbs[0]
+
         if 1 == len(selected):
             found = PathUtils.findParentJob(selected[0])
             if found:

--- a/src/Mod/CAM/PathScripts/PathUtilsGui.py
+++ b/src/Mod/CAM/PathScripts/PathUtilsGui.py
@@ -28,7 +28,7 @@ import Path.Main.Gui.JobCmd as PathJobCmd
 import Path.Main.Job as PathJob
 import Path.Tool.Controller as PathToolController
 import PathScripts.PathUtils as PathUtils
-from PySide import QtGui
+from PySide.QtGui import QInputDialog
 
 if False:
     Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
@@ -62,7 +62,6 @@ class PathUtilsUserInput(object):
         return [i for i in controllers if i.Label == form.uiToolController.currentText()][0]
 
     def chooseJob(self, jobs):
-        job = None
         selected = FreeCADGui.Selection.getSelection()
 
         jbs = [
@@ -70,42 +69,30 @@ class PathUtilsUserInput(object):
             for sel in selected
             if hasattr(sel, "Proxy") and isinstance(sel.Proxy, PathJob.ObjectJob)
         ]
-        if len(jbs) == 1:
+        if len(jbs) == 1:  # selection contains one Job object
             return jbs[0]
 
-        if 1 == len(selected):
+        if len(selected) == 1:  # selection contains only one object
             found = PathUtils.findParentJob(selected[0])
             if found:
                 return found
 
-        modelSelected = []
-        for job in jobs:
-            if all([o in job.Model.Group for o in selected]):
-                modelSelected.append(job)
-        if 1 == len(modelSelected):
-            job = modelSelected[0]
-        else:
-            modelObjectSelected = []
-            for job in jobs:
-                if all([o in job.Proxy.baseObjects(job) for o in selected]):
-                    modelObjectSelected.append(job)
-            if 1 == len(modelObjectSelected):
-                job = modelObjectSelected[0]
-            else:
-                if modelObjectSelected:
-                    mylist = [j.Label for j in modelObjectSelected]
-                else:
-                    mylist = [j.Label for j in jobs]
+        jbs = [j for j in jobs if all(o in j.Model.Group for o in selected)]
+        if len(jbs) == 1:  # all selected objects inside Model group of one Job
+            return jbs[0]
 
-                jobname, result = QtGui.QInputDialog.getItem(
-                    None, translate("Path", "Choose a CAM Job"), None, mylist
-                )
+        jbs = [j for j in jobs if all(o in j.Proxy.baseObjects(j) for o in selected)]
+        if len(jbs) == 1:  # all selected objects has a clone inside one Job
+            return jobs[0]
 
-                if result is False:
-                    return None
-                else:
-                    job = [j for j in jobs if j.Label == jobname][0]
-        return job
+        jobs = jbs or jobs
+        labels = [j.Label for j in jobs]
+        label, ok = QInputDialog.getItem(None, translate("Path", "Choose a CAM Job"), None, labels)
+        if ok:  # return Job selected in dialog
+            index = labels.index(label)
+            return jobs[index]
+
+        return None
 
     def createJob(self):
         return PathJobCmd.CommandJobCreate().Activated()


### PR DESCRIPTION
### Changes:

- `Base.TaskPanelBaseGeometryPage`: Do not add objects, which not contains shape
- `PathUtilsUserInput.chooseJob()`:
   - Refactor
   - If selection contains one `Job` object, do not show job selection dialog