### PR TITLE
 BIM/Draft: keep BIM grid defaults for BIM documents

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -980,6 +980,11 @@ Document::Document(const char* documentName)
         GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Units");
     UnitSystem.setValue(hGrpu->GetInt("UserSchema", 0));
     ADD_PROPERTY_TYPE(Comment, (""), 0, Prop_None, "Additional tag to save a comment");
+    ADD_PROPERTY_TYPE(Context,
+                      (""),
+                      0,
+                      Prop_None,
+                      "Primary workflow context of the document");
     ADD_PROPERTY_TYPE(Meta, (), 0, Prop_None, "Map with additional meta information");
     ADD_PROPERTY_TYPE(Material, (), 0, Prop_None, "Map with material properties");
     // create the uuid for the document
@@ -1032,6 +1037,26 @@ Document::Document(const char* documentName)
                       PropertyType(Prop_Hidden | Prop_ReadOnly),
                       "Link of the tip object of the document");
     Uid.touch();
+}
+
+std::size_t Document::getUnitSchema() const
+{
+    const auto schema = UnitSystem.getValue();
+
+    if (schema < 0 || static_cast<std::size_t>(schema) >= Base::UnitsApi::count()) {
+        return Base::UnitsApi::getDefSchemaNum();
+    }
+
+    return static_cast<std::size_t>(schema);
+}
+
+void Document::setUnitSchema(std::size_t schema)
+{
+    if (schema >= Base::UnitsApi::count()) {
+        throw Base::ValueError("Invalid document unit schema");
+    }
+
+    UnitSystem.setValue(static_cast<long>(schema));
 }
 
 Document::~Document()

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -42,6 +42,7 @@
 #include <vector>
 #include <utility>
 #include <list>
+#include <cstddef>
 #include <string>
 #include <string_view>
 
@@ -168,6 +169,13 @@ public:
     PropertyString Company;
     /// The Unit System for this document.
     PropertyEnumeration UnitSystem;
+
+    /// Return the numeric unit-schema identifier represented by UnitSystem.
+    std::size_t getUnitSchema() const;
+
+    /// Set the numeric unit-schema identifier represented by UnitSystem.
+    void setUnitSchema(std::size_t schema);
+
     /// A long comment or description (utf-8 with line breaks).
     PropertyString Comment;
     /// The Id, e.g. a Part number.
@@ -178,6 +186,8 @@ public:
     PropertyString License;
     /// The URL to the license description or contract.
     PropertyString LicenseURL;
+    /// Primary workflow context of the document, for example "BIM".
+    PropertyString Context;
     /// Meta descriptions.
     PropertyMap Meta;
     /// Material descriptions, used and defined in the Material module.

--- a/src/App/Document.pyi
+++ b/src/App/Document.pyi
@@ -56,6 +56,9 @@ class Document(PropertyContainer):
     Name: Final[str] = ""
     """The internal name of the document"""
 
+    UnitSchema: int = 0
+    """Numeric unit-schema identifier represented by the document's UnitSystem."""
+
     RecomputesFrozen: bool = False
     """Returns or sets if automatic recomputes for this document are disabled."""
 

--- a/src/App/DocumentPyImp.cpp
+++ b/src/App/DocumentPyImp.cpp
@@ -1039,6 +1039,21 @@ Py::String DocumentPy::getName() const
     return {getDocumentPtr()->getName()};
 }
 
+Py::Long DocumentPy::getUnitSchema() const
+{
+    return Py::Long(static_cast<long>(getDocumentPtr()->getUnitSchema()));
+}
+
+void DocumentPy::setUnitSchema(Py::Long arg)
+{
+    const auto value = arg.as_long();
+    if (value < 0) {
+        throw Base::ValueError("Invalid document unit schema");
+    }
+
+    getDocumentPtr()->setUnitSchema(static_cast<std::size_t>(value));
+}
+
 Py::Boolean DocumentPy::getRecomputesFrozen() const
 {
     return {getDocumentPtr()->testStatus(Document::Status::SkipRecompute)};

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -653,6 +653,14 @@ class Scheme(IntEnum):
 
 App.Units.Scheme = Scheme
 
+class MeasurementSystem(IntEnum):
+    Other = -1
+    Internal = 0
+    Metric = 1
+    Imperial = 2
+
+App.Units.MeasurementSystem = MeasurementSystem
+
 class NumberFormat(IntEnum):
     Default = 0
     Fixed = 1

--- a/src/Base/FreeCAD.Units.module.pyi
+++ b/src/Base/FreeCAD.Units.module.pyi
@@ -8,12 +8,31 @@ small helper aliases and module data members those signatures need.
 
 from __future__ import annotations
 
+from enum import IntEnum
 from typing import Literal, TypeAlias, overload
 
 from FreeCAD.Base import Quantity
 
 _NumberFormat: TypeAlias = Literal["g", "f", "e"]
 Radian: Quantity
+
+class Scheme(IntEnum):
+    Internal = 0
+    MKS = 1
+    Imperial = 2
+    ImperialDecimal = 3
+    Centimeter = 4
+    ImperialBuilding = 5
+    MmMin = 6
+    ImperialCivil = 7
+    FEM = 8
+    MeterDecimal = 9
+
+class MeasurementSystem(IntEnum):
+    Other = -1
+    Internal = 0
+    Metric = 1
+    Imperial = 2
 
 # Schema helpers
 @overload
@@ -47,6 +66,16 @@ def getSchema() -> int:
 
 def setSchema(index: int, /) -> None:
     """Set the active unit-schema index."""
+    ...
+
+@overload
+def getMeasurementSystem() -> MeasurementSystem:
+    """Return the measurement-system classification for the active schema."""
+    ...
+
+@overload
+def getMeasurementSystem(index: int, /) -> MeasurementSystem:
+    """Return the measurement-system classification for one schema index."""
     ...
 
 def schemaTranslate(quantity: Quantity, schema: int, /) -> tuple[str, float, str]:

--- a/src/Base/UnitsApi.cpp
+++ b/src/Base/UnitsApi.cpp
@@ -40,6 +40,27 @@ std::unique_ptr<UnitsSchemas> UnitsApi::schemas = std::make_unique<UnitsSchemas>
     UnitsSchemasData::unitSchemasDataPack
 );
 
+namespace
+{
+UnitsApi::MeasurementSystem getMeasurementSystemForSchemaName(const std::string& name)
+{
+    if (name == "Imperial" || name == "ImperialDecimal" || name == "ImperialBuilding"
+        || name == "ImperialCivil") {
+        return UnitsApi::MeasurementSystem::Imperial;
+    }
+
+    if (name == "MKS" || name == "Centimeter" || name == "MmMin" || name == "MeterDecimal") {
+        return UnitsApi::MeasurementSystem::Metric;
+    }
+
+    if (name == "Internal" || name == "FEM") {
+        return UnitsApi::MeasurementSystem::Internal;
+    }
+
+    return UnitsApi::MeasurementSystem::Other;
+}
+}  // namespace
+
 std::vector<std::string> UnitsApi::getDescriptions()
 {
     return schemas->descriptions();
@@ -63,6 +84,16 @@ bool UnitsApi::isMultiUnitAngle()
 bool UnitsApi::isMultiUnitLength()
 {
     return schemas->currentSchema()->isMultiUnitLength();
+}
+
+UnitsApi::MeasurementSystem UnitsApi::getMeasurementSystem()
+{
+    return getMeasurementSystemForSchemaName(schemas->currentSchema()->getName());
+}
+
+UnitsApi::MeasurementSystem UnitsApi::getMeasurementSystem(const std::size_t num)
+{
+    return getMeasurementSystemForSchemaName(schemas->spec(num).name);
 }
 
 std::string UnitsApi::getBasicLengthUnit()

--- a/src/Base/UnitsApi.h
+++ b/src/Base/UnitsApi.h
@@ -38,6 +38,14 @@ class UnitsSchemas;
 class BaseExport UnitsApi
 {
 public:
+    enum class MeasurementSystem
+    {
+        Other = -1,
+        Internal = 0,
+        Metric = 1,
+        Imperial = 2
+    };
+
     static std::unique_ptr<UnitsSchema> createSchema(std::size_t num);
     static void setSchema(const std::string& name);
     static void setSchema(std::size_t num);
@@ -63,6 +71,8 @@ public:
 
     static bool isMultiUnitAngle();
     static bool isMultiUnitLength();
+    static MeasurementSystem getMeasurementSystem();
+    static MeasurementSystem getMeasurementSystem(std::size_t num);
     static std::string getBasicLengthUnit();
 
     static std::size_t getDefSchemaNum();
@@ -79,6 +89,7 @@ protected:
     static PyObject* sListSchemas(PyObject* self, PyObject* args);
     static PyObject* sGetSchema(PyObject* self, PyObject* args);
     static PyObject* sSetSchema(PyObject* self, PyObject* args);
+    static PyObject* sGetMeasurementSystem(PyObject* self, PyObject* args);
     static PyObject* sSchemaTranslate(PyObject* self, PyObject* args);
     static PyObject* sToNumber(PyObject* self, PyObject* args);
 };

--- a/src/Base/UnitsApiPy.cpp
+++ b/src/Base/UnitsApiPy.cpp
@@ -34,6 +34,21 @@
 
 using namespace Base;
 
+namespace
+{
+PyObject* measurementSystemToPyObject(PyObject* module, UnitsApi::MeasurementSystem system)
+{
+    PyObject* enumType = PyObject_GetAttrString(module, "MeasurementSystem");
+    if (enumType == nullptr) {
+        return nullptr;
+    }
+
+    PyObject* value = PyObject_CallFunction(enumType, "i", static_cast<int>(system));
+    Py_DECREF(enumType);
+    return value;
+}
+}  // namespace
+
 //**************************************************************************
 // Python stuff of UnitsApi
 
@@ -62,6 +77,12 @@ PyMethodDef UnitsApi::Methods[] = {
      METH_VARARGS,
      "setSchema(int) -> None\n\n"
      "Sets the current schema to the given number, if possible"},
+    {"getMeasurementSystem",
+     sGetMeasurementSystem,
+     METH_VARARGS,
+     "getMeasurementSystem() -> MeasurementSystem\n\n"
+     "getMeasurementSystem(int) -> MeasurementSystem\n\n"
+     "Returns the measurement-system classification for the current or given schema"},
     {"schemaTranslate",
      sSchemaTranslate,
      METH_VARARGS,
@@ -150,6 +171,27 @@ PyObject* UnitsApi::sSetSchema(PyObject* /*self*/, PyObject* args)
         schemas->select(index);
     }
     Py_Return;
+}
+
+PyObject* UnitsApi::sGetMeasurementSystem(PyObject* self, PyObject* args)
+{
+    if (PyArg_ParseTuple(args, "")) {
+        return measurementSystemToPyObject(self, UnitsApi::getMeasurementSystem());
+    }
+
+    PyErr_Clear();
+    int index {};
+    if (PyArg_ParseTuple(args, "i", &index)) {
+        if (index < 0 || index >= static_cast<int>(count())) {
+            PyErr_SetString(PyExc_ValueError, "invalid schema value");
+            return nullptr;
+        }
+
+        return measurementSystemToPyObject(self, UnitsApi::getMeasurementSystem(index));
+    }
+
+    PyErr_SetString(PyExc_TypeError, "int or empty argument list expected");
+    return nullptr;
 }
 
 PyObject* UnitsApi::sSchemaTranslate(PyObject* /*self*/, PyObject* args)

--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -63,6 +63,111 @@ if FreeCAD.GuiUp:
 QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
 translate = FreeCAD.Qt.translate
 
+_BIM_VIEW_CONTEXT = "BIM"
+_BIM_VIEW_POLICY_OWNER = "BIM"
+_BIM_DOCUMENT_OBSERVER = None
+
+
+def get_default_bim_grid_settings(schema=None, document=None):
+    """Return the default BIM grid preset for a schema or document."""
+    if document is not None:
+        schema = document.UnitSchema
+    elif schema is None:
+        schema = FreeCAD.Units.getSchema()
+
+    system = FreeCAD.Units.getMeasurementSystem(schema)
+    if system == FreeCAD.Units.MeasurementSystem.Imperial:
+        return {"spacing": "1in", "mainlines": 12}
+    if schema == FreeCAD.Units.Scheme.Centimeter:
+        return {"spacing": "10cm", "mainlines": 10}
+    return {"spacing": "0.1m", "mainlines": 10}
+
+
+def get_bim_view_policy(document=None):
+    from draftguitools.gui_viewpolicy import DraftViewPolicy
+    from draftguitools.gui_viewpolicy import GridVisibility
+
+    settings = get_default_bim_grid_settings(document=document)
+    spacing = FreeCAD.Units.Quantity(settings["spacing"]).Value
+
+    return DraftViewPolicy(
+        spacing=spacing,
+        mainlines=settings["mainlines"],
+        size=200,
+        visibility=GridVisibility.ALWAYS,
+    )
+
+
+def mark_bim_document(document):
+    if document is None:
+        return
+    if getattr(document, "Context", "") != _BIM_VIEW_CONTEXT:
+        document.Context = _BIM_VIEW_CONTEXT
+
+
+def is_bim_document(document):
+    return getattr(document, "Context", "") == _BIM_VIEW_CONTEXT
+
+
+def is_legacy_bim_document(document):
+    if document is None:
+        return False
+
+    if hasattr(document, "IfcFilePath"):
+        return True
+
+    for obj in getattr(document, "Objects", []):
+        if getattr(obj, "IfcType", None) == "Project":
+            return True
+        if getattr(getattr(obj, "Proxy", None), "Type", None) == "Project":
+            return True
+
+    return False
+
+
+def migrate_legacy_bim_document(document=None):
+    if document is None:
+        document = FreeCAD.ActiveDocument
+    if is_bim_document(document):
+        return False
+    if is_legacy_bim_document(document):
+        mark_bim_document(document)
+        return True
+    return False
+
+
+def ensure_bim_view_policy(document=None):
+    migrate_legacy_bim_document(document)
+    if not FreeCAD.GuiUp:
+        return False
+
+    from draftguitools import gui_viewpolicy
+
+    gui_viewpolicy.registry.register_context_policy(
+        _BIM_VIEW_CONTEXT, _BIM_VIEW_POLICY_OWNER, get_bim_view_policy
+    )
+    _ensure_bim_document_observer()
+    return True
+
+
+class _BimDocumentObserver:
+    """Promotes legacy BIM documents to the explicit BIM context on activation."""
+
+    def slotActivateDocument(self, document):
+        migrate_legacy_bim_document(document)
+
+
+def _ensure_bim_document_observer():
+    global _BIM_DOCUMENT_OBSERVER
+    if _BIM_DOCUMENT_OBSERVER is not None:
+        return
+    _BIM_DOCUMENT_OBSERVER = _BimDocumentObserver()
+    FreeCAD.addDocumentObserver(_BIM_DOCUMENT_OBSERVER)
+
+
+if FreeCAD.GuiUp:
+    ensure_bim_view_policy()
+
 
 # Importing all members from these modules enables us to use them directly by
 # simply importing the Arch module, as if they were part of this module.
@@ -914,6 +1019,8 @@ def makeProject(sites=None, name=None):
         internalName="Project",
         defaultLabel=name if name else translate("Arch", "Project"),
     )
+
+    mark_bim_document(project.Document)
 
     # Initialize all relevant properties
     if sites:

--- a/src/Mod/BIM/InitGui.py
+++ b/src/Mod/BIM/InitGui.py
@@ -620,6 +620,21 @@ class BIMWorkbench(Workbench):
             self.BimSelectObserver = BimSelect.Setup()
             FreeCADGui.addDocumentObserver(self.BimSelectObserver)
 
+    def _get_bim_view_policy(self, document=None):
+        import Arch
+
+        return Arch.get_bim_view_policy(document)
+
+    def _set_bim_view_policy(self, enabled):
+        owner = "BIMWorkbench"
+        snapper = getattr(FreeCADGui, "Snapper", None)
+        if snapper is None:
+            return
+        if enabled:
+            snapper.pushViewPolicy(owner, self._get_bim_view_policy)
+        else:
+            snapper.popViewPolicy(owner)
+
     def Activated(self):
 
         import WorkingPlane
@@ -634,6 +649,7 @@ class BIMWorkbench(Workbench):
             FreeCADGui.draftToolBar.Activated()
         if hasattr(FreeCADGui, "Snapper"):
             FreeCADGui.Snapper.show()
+            self._set_bim_view_policy(True)
         if hasattr(WorkingPlane, "_view_observer_start"):
             WorkingPlane._view_observer_start()
         else:
@@ -648,7 +664,6 @@ class BIMWorkbench(Workbench):
                 "Improper loading of grid_observer code. "
                 "The BIM Workbench will not work correctly.\n"
             )
-
         if PARAMS.GetBool("FirstTime", True) and (not hasattr(FreeCAD, "TestEnvironment")):
             todo.ToDo.delay(FreeCADGui.runCommand, "BIM_Welcome")
         todo.ToDo.delay(BimStatus.setStatusIcons, True)
@@ -732,6 +747,7 @@ class BIMWorkbench(Workbench):
         if hasattr(FreeCADGui, "draftToolBar"):
             FreeCADGui.draftToolBar.Deactivated()
         if hasattr(FreeCADGui, "Snapper"):
+            self._set_bim_view_policy(False)
             FreeCADGui.Snapper.hide()
         if hasattr(WorkingPlane, "_view_observer_stop"):
             WorkingPlane._view_observer_stop()

--- a/src/Mod/BIM/bimcommands/BimProjectManager.py
+++ b/src/Mod/BIM/bimcommands/BimProjectManager.py
@@ -203,6 +203,7 @@ class BIM_ProjectManager:
                     doc.Label = self.form.projectName.text()
         if doc:
             FreeCAD.setActiveDocument(doc.Name)
+            Arch.mark_bim_document(doc)
 
         # Project creation
         if self.form.groupNewProject.isChecked():

--- a/src/Mod/BIM/bimcommands/BimSetup.py
+++ b/src/Mod/BIM/bimcommands/BimSetup.py
@@ -374,6 +374,7 @@ class BIM_Setup:
         del self.form
 
     def setPreset(self, preset=None):
+        import Arch
         from PySide import QtGui
 
         unit = None
@@ -407,10 +408,11 @@ class BIM_Setup:
 
         elif preset == 1:
             # centimeters
+            grid_settings = Arch.get_default_bim_grid_settings(FreeCAD.Units.Scheme.Centimeter)
             unit = 1
             decimals = 2
-            grid = "10cm"
-            squares = 10
+            grid = grid_settings["spacing"]
+            squares = grid_settings["mainlines"]
             tsize = "20cm"
             linewidth = 1
             dimstyle = 0
@@ -422,10 +424,11 @@ class BIM_Setup:
 
         elif preset == 2:
             # meters
+            grid_settings = Arch.get_default_bim_grid_settings(FreeCAD.Units.Scheme.MKS)
             unit = 2
             decimals = 2
-            grid = "0.1m"
-            squares = 10
+            grid = grid_settings["spacing"]
+            squares = grid_settings["mainlines"]
             tsize = "0.2m"
             linewidth = 1
             dimstyle = 0
@@ -437,10 +440,13 @@ class BIM_Setup:
 
         elif preset == 3:
             # US
+            grid_settings = Arch.get_default_bim_grid_settings(
+                FreeCAD.Units.Scheme.ImperialBuilding
+            )
             unit = 5
             decimals = 2
-            grid = "1in"
-            squares = 12
+            grid = grid_settings["spacing"]
+            squares = grid_settings["mainlines"]
             tsize = "8in"
             linewidth = 1
             dimstyle = 3

--- a/src/Mod/BIM/bimtests/TestArchGrid.py
+++ b/src/Mod/BIM/bimtests/TestArchGrid.py
@@ -39,3 +39,19 @@ class TestArchGrid(TestArchBase.TestArchBase):
         grid = Arch.makeGrid(name="TestGrid")
         self.assertIsNotNone(grid, "makeGrid failed to create a grid object.")
         self.assertEqual(grid.Label, "TestGrid", "Grid label is incorrect.")
+
+    def test_bim_grid_policy_uses_document_unit_schema(self):
+        """BIM grid defaults must resolve from each document's unit schema."""
+        Arch.mark_bim_document(self.document)
+
+        self.document.UnitSchema = App.Units.Scheme.ImperialBuilding
+        imperial_settings = Arch.get_default_bim_grid_settings(document=self.document)
+        self.assertEqual(imperial_settings, {"spacing": "1in", "mainlines": 12})
+
+        self.document.UnitSchema = App.Units.Scheme.Centimeter
+        centimeter_settings = Arch.get_default_bim_grid_settings(document=self.document)
+        self.assertEqual(centimeter_settings, {"spacing": "10cm", "mainlines": 10})
+
+        self.document.UnitSchema = App.Units.Scheme.MKS
+        metric_settings = Arch.get_default_bim_grid_settings(document=self.document)
+        self.assertEqual(metric_settings, {"spacing": "0.1m", "mainlines": 10})

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -102,6 +102,7 @@ def create_document_object(document, filename=None, shapemode=0, strategy=0, sil
     """
 
     obj = add_object(document, otype="project")
+    Arch.mark_bim_document(document)
     ifcfile, project, full = setup_project(obj, filename, shapemode, silent)
     # populate according to strategy
     if strategy == 0:
@@ -135,6 +136,7 @@ def convert_document(document, filename=None, shapemode=0, strategy=0, silent=Fa
         document.addProperty("App::PropertyPythonObject", "Proxy", locked=True)
     document.setPropertyStatus("Proxy", "Transient")
     document.Proxy = ifc_objects.document_object()
+    Arch.mark_bim_document(document)
     ifcfile, project, full = setup_project(document, filename, shapemode, silent)
     if strategy == 0:
         create_children(document, ifcfile, recursive=False)

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -67,6 +67,7 @@ SET(Draft_tests
     drafttests/test_dwg.py
     drafttests/test_dxf.py
     drafttests/test_grid_settings.py
+    drafttests/test_view_policy_gui.py
     drafttests/test_import.py
     drafttests/test_import_gui.py
     drafttests/test_import_tools.py
@@ -271,6 +272,7 @@ SET(Draft_GUI_tools
     draftguitools/gui_selectplane.py
     draftguitools/gui_snaps.py
     draftguitools/gui_snapper.py
+    draftguitools/gui_viewpolicy.py
     draftguitools/gui_trackers.py
     draftguitools/gui_edit_base_object.py
     draftguitools/gui_edit_draft_objects.py

--- a/src/Mod/Draft/TestDraft.py
+++ b/src/Mod/Draft/TestDraft.py
@@ -116,15 +116,14 @@ from drafttests.test_dxf import DraftDXF as DraftTest06
 from drafttests.test_array import DraftArray as DraftTest10
 from drafttests.test_grid_settings import DraftGridSettings as DraftTest11
 
-# Use the modules so that code checkers don't complain (flake8)
-True if DraftTest01 else False
-True if DraftTest02 else False
-True if DraftTest03 else False
-True if DraftTest04 else False
-True if DraftTest05 else False
-True if DraftTest06 else False
-# True if DraftTest07 else False
-# True if DraftTest08 else False
-# True if DraftTest09 else False
-True if DraftTest10 else False
-True if DraftTest11 else False
+# Keep imported test classes referenced for static analysis.
+DRAFT_TEST_CLASSES = (
+    DraftTest01,
+    DraftTest02,
+    DraftTest03,
+    DraftTest04,
+    DraftTest05,
+    DraftTest06,
+    DraftTest10,
+    DraftTest11,
+)

--- a/src/Mod/Draft/TestDraftGui.py
+++ b/src/Mod/Draft/TestDraftGui.py
@@ -103,11 +103,15 @@ from drafttests.test_pivy import DraftPivy as DraftTestGui03
 from drafttests.test_dimension_gui import DraftGuiDimension as DraftTestGui04
 from drafttests.test_manual_input_gui import DraftGuiManualInput as DraftTestGui05
 from drafttests.test_lines_gui import DraftGuiLines as DraftTestGui06
+from drafttests.test_view_policy_gui import DraftViewPolicyGui as DraftTestGui07
 
-# Use the modules so that code checkers don't complain (flake8)
-True if DraftTestGui01 else False
-True if DraftTestGui02 else False
-True if DraftTestGui03 else False
-True if DraftTestGui04 else False
-True if DraftTestGui05 else False
-True if DraftTestGui06 else False
+# Keep imported test classes referenced for static analysis.
+DRAFT_GUI_TEST_CLASSES = (
+    DraftTestGui01,
+    DraftTestGui02,
+    DraftTestGui03,
+    DraftTestGui04,
+    DraftTestGui05,
+    DraftTestGui06,
+    DraftTestGui07,
+)

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -56,6 +56,7 @@ from draftgeoutils import general as geo_general
 from draftgeoutils import geometry as geo_geometry
 from draftgeoutils import intersections as geo_intersections
 from draftguitools import gui_trackers as trackers
+from draftguitools import gui_viewpolicy as view_policy
 from draftutils import gui_utils
 from draftutils import params
 from draftutils import utils
@@ -68,6 +69,28 @@ __author__ = "Yorik van Havre"
 __url__ = "https://www.freecad.org"
 
 UNSNAPPABLES = ("Image::ImagePlane",)
+
+
+class GridDocumentObserver:
+    """Refreshes Draft grid policy when a document or its context changes."""
+
+    def __init__(self, snapper):
+        self.snapper = snapper
+
+    def slotActivateDocument(self, doc):
+        self.snapper._syncActiveViewDocument()
+        self.snapper._applyGridProfiles()
+
+    def slotChangedDocument(self, doc, prop):
+        if prop in (
+            view_policy.DOCUMENT_CONTEXT_PROPERTY,
+            view_policy.DOCUMENT_UNIT_SYSTEM_PROPERTY,
+        ):
+            self.snapper._applyGridProfiles()
+
+    def slotDeletedDocument(self, doc):
+        self.snapper._clearViewDocuments(doc)
+        self.snapper._applyGridProfiles()
 
 
 class Snapper:
@@ -130,6 +153,9 @@ class Snapper:
         self.running = False
         self.callbackClick = None
         self.callbackMove = None
+        self._viewDocuments = {}
+        self._gridDocumentObserver = GridDocumentObserver(self)
+        App.addDocumentObserver(self._gridDocumentObserver)
         self.snapObjectIndex = 0
         self.pointConstraintProvider = None
 
@@ -1637,6 +1663,83 @@ class Snapper:
         """Toggle FreeCAD Draft Grid."""
         Gui.runCommand("Draft_ToggleGrid")
 
+    def _getGridProfile(self, document):
+        return view_policy.registry.resolve(document)
+
+    def _setViewDocument(self, view, document):
+        if view is not None:
+            self._viewDocuments[id(view)] = document
+
+    def _getViewDocument(self, view):
+        if view is None:
+            return None
+        return self._viewDocuments.get(id(view))
+
+    def _clearViewDocuments(self, document):
+        stale_views = [
+            view_id for view_id, existing in self._viewDocuments.items() if existing == document
+        ]
+        for view_id in stale_views:
+            del self._viewDocuments[view_id]
+
+    def _syncActiveViewDocument(self):
+        view = gui_utils.get_3d_view()
+        if view is not None:
+            self._setViewDocument(view, App.ActiveDocument)
+            self.setTrackers(update_grid=False)
+
+    def _applyGridProfile(self, grid, document=None):
+        if document is None:
+            document = App.ActiveDocument
+        profile = self._getGridProfile(document)
+        if profile is None:
+            grid.clearRuntimeConfig()
+            grid.restoreDefaultVisibility()
+            return
+
+        grid.setRuntimeConfig(profile.as_overrides())
+        grid.restoreDefaultVisibility()
+        if profile.visibility == view_policy.GridVisibility.HIDDEN:
+            grid.show_always = False
+            grid.show_during_command = False
+        elif profile.visibility == view_policy.GridVisibility.DURING_COMMAND:
+            grid.show_always = False
+            grid.show_during_command = True
+        elif profile.visibility == view_policy.GridVisibility.ALWAYS:
+            grid.show_always = True
+            grid.show_during_command = False
+
+    def _applyGridProfiles(self):
+        for view, grid in zip(self.trackers[0], self.trackers[1]):
+            self._applyGridProfile(grid, self._getViewDocument(view))
+            self._syncGridProfile(grid)
+
+    def _syncGridProfile(self, grid):
+        if grid.show_always or (
+            grid.show_during_command
+            and hasattr(App, "activeDraftCommand")
+            and App.activeDraftCommand
+        ):
+            grid.set()
+        elif grid.Visible:
+            grid.off()
+
+    def pushViewPolicy(self, owner, policy):
+        view_policy.registry.push_policy(owner, policy)
+        self._applyGridProfiles()
+
+    def popViewPolicy(self, owner):
+        view_policy.registry.pop_policy(owner)
+        self._applyGridProfiles()
+
+    def setContextViewPolicy(self, context, owner, policy):
+        view_policy.registry.register_context_policy(context, owner, policy)
+        self._applyGridProfiles()
+
+    def clearContextViewPolicy(self, context, owner):
+        view_policy.registry.clear_context_policy(context, owner)
+        self._applyGridProfiles()
+
     def showradius(self):
         """Show the snap radius indicator."""
         self.radius = self.getScreenDist(params.get_param("snapRange"), (400, 300))
@@ -1743,10 +1846,11 @@ class Snapper:
             else:
                 doc_name = App.ActiveDocument.Name if App.ActiveDocument is not None else None
                 self.grid = trackers.gridTracker(doc_name)
-                if params.get_param("alwaysShowGrid"):
-                    self.grid.show_always = True
-                if params.get_param("grid"):
-                    self.grid.show_during_command = True
+                self.grid.setVisibilityDefaults(
+                    show_always=params.get_param("alwaysShowGrid"),
+                    show_during_command=params.get_param("grid"),
+                )
+                self._applyGridProfile(self.grid, App.ActiveDocument)
                 self.tracker = trackers.snapTracker()
                 self.trackLine = trackers.lineTracker()
                 self.extLine = trackers.lineTracker(dotted=True)
@@ -1768,6 +1872,8 @@ class Snapper:
                 self.trackers[8].append(self.extLine2)
                 self.trackers[9].append(self.holdTracker)
             self.activeview = v
+            self._setViewDocument(v, App.ActiveDocument)
+            self._applyGridProfile(self.grid, App.ActiveDocument)
 
         self.hideRadius()
 

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -1225,6 +1225,9 @@ class gridTracker(Tracker):
         s.addChild(texts)
 
         super().__init__(children=[s], name="gridTracker")
+        self.runtime_config = {}
+        self.default_show_always = False
+        self.default_show_during_command = False
         self.show_during_command = False
         self.show_always = False
         self.reset()
@@ -1498,16 +1501,47 @@ class gridTracker(Tracker):
         self.mainlines = ml
         self.update()
 
-    def reset(self):
-        """Reset the grid according to preferences settings."""
+    def setVisibilityDefaults(self, show_always=False, show_during_command=False):
+        self.default_show_always = bool(show_always)
+        self.default_show_during_command = bool(show_during_command)
+        self.restoreDefaultVisibility()
+
+    def restoreDefaultVisibility(self):
+        self.show_always = self.default_show_always
+        self.show_during_command = self.default_show_during_command
+
+    def setRuntimeConfig(self, config=None):
+        self.runtime_config = dict(config or {})
+
+    def clearRuntimeConfig(self):
+        self.runtime_config = {}
+
+    def _getPreferenceConfig(self):
         try:
-            self.space = FreeCAD.Units.Quantity(
+            spacing = FreeCAD.Units.Quantity(
                 params.get_grid_param("gridSpacing", self.doc_name)
             ).Value
         except ValueError:
-            self.space = 1
-        self.mainlines = params.get_grid_param("gridEvery", self.doc_name)
-        self.numlines = params.get_grid_param("gridSize", self.doc_name)
+            spacing = 1
+        return {
+            "space": spacing,
+            "mainlines": params.get_grid_param("gridEvery", self.doc_name),
+            "numlines": params.get_grid_param("gridSize", self.doc_name),
+        }
+
+    def _getResolvedConfig(self):
+        config = self._getPreferenceConfig()
+        for key, value in self.runtime_config.items():
+            if value is not None:
+                config[key] = value
+        return config
+
+    def reset(self):
+        """Reset the grid according to preferences settings."""
+        config = self._getResolvedConfig()
+        self.space = config["space"]
+        self.mainlines = config["mainlines"]
+        self.numlines = config["numlines"]
         self.update()
 
     def set(self):

--- a/src/Mod/Draft/draftguitools/gui_viewpolicy.py
+++ b/src/Mod/Draft/draftguitools/gui_viewpolicy.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Runtime Draft view-policy registry and resolution helpers."""
+
+import collections as coll
+from dataclasses import dataclass
+
+DOCUMENT_CONTEXT_PROPERTY = "Context"
+DOCUMENT_UNIT_SYSTEM_PROPERTY = "UnitSystem"
+
+
+class GridVisibility:
+    """Visibility modes that one Draft view policy can request for the grid."""
+
+    HIDDEN = "hidden"
+    DURING_COMMAND = "during_command"
+    ALWAYS = "always"
+
+
+@dataclass(slots=True)
+class DraftViewPolicy:
+    """Runtime grid policy overrides resolved from document and workbench state."""
+
+    spacing: float | None = None
+    mainlines: int | None = None
+    size: int | None = None
+    visibility: str | None = None
+
+    def as_overrides(self):
+        return {
+            "space": self.spacing,
+            "mainlines": self.mainlines,
+            "numlines": self.size,
+        }
+
+    def overlay(self, other):
+        for attr in ("spacing", "mainlines", "size", "visibility"):
+            value = getattr(other, attr)
+            if value is not None:
+                setattr(self, attr, value)
+        return self
+
+
+def get_document_view_context(document):
+    if document is None:
+        return ""
+    return getattr(document, DOCUMENT_CONTEXT_PROPERTY, "")
+
+
+class DraftViewPolicyRegistry:
+    """Stores and resolves Draft view policies for context and tool scopes.
+
+    Policies may be concrete ``DraftViewPolicy`` instances or callables that
+    receive the document being resolved.
+    """
+
+    def __init__(self):
+        self._context_policies = {}
+        self._active_policies = coll.OrderedDict()
+
+    def resolve(self, document):
+        profile = self._get_context_policy(document)
+        if not self._active_policies:
+            return profile
+        if profile is None:
+            profile = DraftViewPolicy()
+        for active_policy in self._active_policies.values():
+            active_policy = self._resolve_policy(active_policy, document)
+            if active_policy is not None:
+                profile.overlay(active_policy)
+        return profile
+
+    def register_context_policy(self, context, owner, policy):
+        policies = self._get_context_policies(context, create=True)
+        policies[owner] = policy
+        policies.move_to_end(owner)
+
+    def clear_context_policy(self, context, owner):
+        policies = self._get_context_policies(context)
+        if not policies or owner not in policies:
+            return
+        del policies[owner]
+        if not policies:
+            self._context_policies.pop(context, None)
+
+    def push_policy(self, owner, policy):
+        self._active_policies[owner] = policy
+        self._active_policies.move_to_end(owner)
+
+    def pop_policy(self, owner):
+        self._active_policies.pop(owner, None)
+
+    def _get_context_policies(self, context, create=False):
+        if not context:
+            return None
+        if create:
+            return self._context_policies.setdefault(context, coll.OrderedDict())
+        return self._context_policies.get(context)
+
+    def _get_context_policy(self, document):
+        policies = self._get_context_policies(get_document_view_context(document))
+        if not policies:
+            return None
+        profile = DraftViewPolicy()
+        for active_policy in policies.values():
+            active_policy = self._resolve_policy(active_policy, document)
+            if active_policy is not None:
+                profile.overlay(active_policy)
+        return profile
+
+    @staticmethod
+    def _resolve_policy(policy, document):
+        return policy(document) if callable(policy) else policy
+
+
+registry = DraftViewPolicyRegistry()

--- a/src/Mod/Draft/drafttests/test_grid_settings.py
+++ b/src/Mod/Draft/drafttests/test_grid_settings.py
@@ -22,8 +22,10 @@
 # ***************************************************************************
 
 import unittest
+from types import SimpleNamespace
 
 import FreeCAD as App
+from draftguitools import gui_viewpolicy
 from draftutils import params
 
 
@@ -128,3 +130,26 @@ class DraftGridSettings(unittest.TestCase):
         self.assertFalse(params.set_grid_param("gridSize", 40, "MissingDocument"))
 
         self.assertEqual(params.get_param("gridSize"), 20)
+
+    def test_context_policy_factory_resolves_per_document(self):
+        registry = gui_viewpolicy.DraftViewPolicyRegistry()
+        metric_document = SimpleNamespace(Context="BIM", UnitSystem=App.Units.Scheme.MKS)
+        imperial_document = SimpleNamespace(
+            Context="BIM", UnitSystem=App.Units.Scheme.ImperialBuilding
+        )
+
+        def factory(document):
+            spacing = 100 if document.UnitSystem == App.Units.Scheme.MKS else 25.4
+            return gui_viewpolicy.DraftViewPolicy(spacing=spacing)
+
+        registry.register_context_policy("BIM", "test", factory)
+
+        self.assertEqual(registry.resolve(metric_document).spacing, 100)
+        self.assertEqual(registry.resolve(imperial_document).spacing, 25.4)
+
+    def test_measurement_system_returns_enum(self):
+        self.assertIsInstance(App.Units.getMeasurementSystem(), App.Units.MeasurementSystem)
+        self.assertIsInstance(
+            App.Units.getMeasurementSystem(App.Units.Scheme.ImperialBuilding),
+            App.Units.MeasurementSystem,
+        )

--- a/src/Mod/Draft/drafttests/test_view_policy_gui.py
+++ b/src/Mod/Draft/drafttests/test_view_policy_gui.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2026 FreeCAD Project Association                       *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it   *
+# *   under the terms of the GNU Lesser General Public License as published *
+# *   by the Free Software Foundation, either version 2 of the             *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# ***************************************************************************
+
+from types import SimpleNamespace
+import unittest
+
+import FreeCAD as App
+from draftguitools import gui_snapper
+from draftguitools import gui_viewpolicy
+
+
+class _FakeGrid:
+    def __init__(self):
+        self.runtime_config = {}
+        self.default_show_always = False
+        self.default_show_during_command = False
+        self.show_always = False
+        self.show_during_command = False
+        self.Visible = False
+        self.set_count = 0
+        self.off_count = 0
+
+    def setRuntimeConfig(self, config=None):
+        self.runtime_config = dict(config or {})
+
+    def clearRuntimeConfig(self):
+        self.runtime_config = {}
+
+    def restoreDefaultVisibility(self):
+        self.show_always = self.default_show_always
+        self.show_during_command = self.default_show_during_command
+
+    def set(self):
+        self.set_count += 1
+        self.Visible = True
+
+    def off(self):
+        self.off_count += 1
+        self.Visible = False
+
+
+class DraftViewPolicyGui(unittest.TestCase):
+    def test_all_tracked_grids_are_resolved_and_synchronized(self):
+        registry = gui_viewpolicy.DraftViewPolicyRegistry()
+        metric_document = SimpleNamespace(Context="BIM", UnitSystem=App.Units.Scheme.MKS)
+        imperial_document = SimpleNamespace(
+            Context="BIM", UnitSystem=App.Units.Scheme.ImperialBuilding
+        )
+        registry.register_context_policy(
+            "BIM",
+            "test",
+            lambda document: gui_viewpolicy.DraftViewPolicy(
+                spacing=(100 if document.UnitSystem == App.Units.Scheme.MKS else 25.4),
+                visibility=gui_viewpolicy.GridVisibility.ALWAYS,
+            ),
+        )
+
+        view_metric = object()
+        view_imperial = object()
+        grid_metric = _FakeGrid()
+        grid_imperial = _FakeGrid()
+        snapper = object.__new__(gui_snapper.Snapper)
+        snapper.trackers = [[view_metric, view_imperial], [grid_metric, grid_imperial]]
+        snapper._viewDocuments = {
+            id(view_metric): metric_document,
+            id(view_imperial): imperial_document,
+        }
+
+        old_registry = gui_snapper.view_policy.registry
+        gui_snapper.view_policy.registry = registry
+        try:
+            observer = gui_snapper.GridDocumentObserver(snapper)
+            snapper._applyGridProfiles()
+            self.assertEqual(grid_metric.runtime_config["space"], 100)
+            self.assertEqual(grid_imperial.runtime_config["space"], 25.4)
+            self.assertEqual(grid_metric.set_count, 1)
+            self.assertEqual(grid_imperial.set_count, 1)
+
+            imperial_document.UnitSystem = App.Units.Scheme.MKS
+            observer.slotChangedDocument(imperial_document, "UnitSystem")
+            self.assertEqual(grid_imperial.runtime_config["space"], 100)
+            self.assertEqual(grid_imperial.set_count, 2)
+
+            metric_document.Context = ""
+            observer.slotChangedDocument(metric_document, "Context")
+            self.assertEqual(grid_metric.runtime_config, {})
+            self.assertEqual(grid_metric.off_count, 1)
+        finally:
+            gui_snapper.view_policy.registry = old_registry

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -45,6 +45,7 @@
 #include "NewFileButton.h"
 #include <App/DocumentObject.h>
 #include <App/Application.h>
+#include <App/Document.h>
 #include <Base/Interpreter.h>
 #include <Base/Tools.h>
 #include <Gui/Action.h>
@@ -348,6 +349,9 @@ void StartView::newDraftFile()
 void StartView::newArchFile()
 {
     Gui::Application::Instance->commandManager().runCommandByName("Std_New");
+    if (auto* doc = App::GetApplication().getActiveDocument()) {
+        doc->Context.setValue("BIM");
+    }
     try {
         Gui::Application::Instance->activateWorkbench("BIMWorkbench");
     }

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -698,6 +698,34 @@ class DocumentBasicCases(unittest.TestCase):
         FreeCAD.closeDocument("CreateTest")
 
 
+class DocumentUnitSchemaCases(unittest.TestCase):
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("UnitSchemaTest")
+        self.Schemas = self.Doc.getEnumerationsOfProperty("UnitSystem")
+
+    def tearDown(self):
+        FreeCAD.closeDocument("UnitSchemaTest")
+
+    def testUnitSchemaAccessors(self):
+        imperial = int(FreeCAD.Units.Scheme.ImperialBuilding)
+        self.Doc.UnitSchema = FreeCAD.Units.Scheme.ImperialBuilding
+
+        self.assertIsInstance(self.Doc.UnitSchema, int)
+        self.assertEqual(self.Doc.UnitSchema, imperial)
+        self.assertEqual(self.Doc.UnitSystem, self.Schemas[imperial])
+
+        metric = int(FreeCAD.Units.Scheme.MKS)
+        self.Doc.UnitSystem = self.Schemas[metric]
+        self.assertEqual(self.Doc.UnitSchema, metric)
+
+    def testUnitSchemaRejectsInvalidValues(self):
+        with self.assertRaises(ValueError):
+            self.Doc.UnitSchema = -1
+
+        with self.assertRaises(ValueError):
+            self.Doc.UnitSchema = len(self.Schemas)
+
+
 class DocumentDuplicateLabelCases(unittest.TestCase):
     """Tests for the DuplicateLabels document preference (issue #25519)."""
 

--- a/src/Tools/typing/smoke/smoke.py
+++ b/src/Tools/typing/smoke/smoke.py
@@ -101,6 +101,9 @@ def exercise(
     document = FreeCAD.activeDocument()
     active_document = FreeCAD.ActiveDocument
     documents = FreeCAD.listDocuments()
+    cast(FreeCAD.Document, object()).UnitSchema = FreeCAD.Units.Scheme.MKS
+    document_schema: int = cast(FreeCAD.Document, object()).UnitSchema
+    assert_type(document_schema, int)
     part_feature = cast(FreeCAD.Document, object()).addObject("Part::Feature", "Shape")
     copied_object = cast(FreeCAD.Document, object()).copyObject(obj, True)
     transaction = FreeCAD.getActiveTransaction()
@@ -111,6 +114,8 @@ def exercise(
     schema = Units.getSchema()
     schema_names = Units.listSchemas()
     schema_description = Units.listSchemas(schema)
+    measurement_system = Units.getMeasurementSystem()
+    building_us_measurement_system = Units.getMeasurementSystem(Units.Scheme.ImperialBuilding)
     schema_translation = Units.schemaTranslate(parsed_quantity, schema)
     quantity_number = Units.toNumber(parsed_quantity)
     fixed_number = Units.toNumber(1.0, "f", 2)
@@ -371,6 +376,8 @@ def exercise(
     assert_type(schema, int)
     assert_type(schema_names, tuple[str, ...])
     assert_type(schema_description, str)
+    assert_type(measurement_system, Units.MeasurementSystem)
+    assert_type(building_us_measurement_system, Units.MeasurementSystem)
     assert_type(schema_translation, tuple[str, float, str])
     assert_type(quantity_number, str)
     assert_type(fixed_number, str)


### PR DESCRIPTION
Add document-aware BIM grid defaults while preserving normal Draft behavior.

## Problem

BIM documents currently inherit the active Draft grid state, which can produce unsuitable spacing and inconsistent behavior when switching workbenches or documents.

## Changes

### Core API

- Add `App::Document::Context` for document workflow context.
- Add derived read/write `Document.UnitSchema`, backed by the existing `UnitSystem` property.
- Add `FreeCAD.Units.MeasurementSystem`.
- Add `FreeCAD.Units.getMeasurementSystem([schema])`.

`Document.UnitSchema` is exposed as an `int`; no second stored document property is introduced.

### Draft

- Add a runtime Draft view-policy registry.
- Resolve policies per document rather than snapshotting global unit settings.
- Re-resolve policies when document `Context` or `UnitSystem` changes.
- Apply resolved grid geometry and visibility to every tracked 3D view.
- Preserve normal Draft behavior for non-BIM documents.

### BIM

- Mark BIM documents with `Context = "BIM"`.
- Register BIM grid policies for BIM-context documents.
- Keep BIM grid behavior when switching between BIM and Draft.
- Mark explicit BIM document creation paths as BIM.
- Preserve the existing degraded behavior when `FreeCADGui.Snapper` is unavailable.

### BIM grid defaults

- Centimeter schema: `10 cm`, major every `10`
- Imperial schemas: `1 in`, major every `12`
- Other metric schemas: `0.1 m`, major every `10`

## Result

- BIM documents receive stable, document-specific grid defaults.
- Metric and imperial BIM documents can remain open simultaneously with independent policies.
- Changing a document’s unit system updates its BIM grid spacing.
- Multiple 3D views remain synchronized.
- Draft preferences are not rewritten when switching workbenches.

