### PR TITLE
Gui: Selection : getObjectsOfType : reverse the change of order

### DIFF
--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -727,7 +727,7 @@ vector<App::DocumentObject*> SelectionSingleton::getObjectsOfType(
 
     std::vector<App::DocumentObject*> temp;
     std::set<App::DocumentObject*> objs;
-    
+
     for (auto& sel : context.info->selList) {
         if (App::DocumentObject* pObject = getObjectOfType(sel, typeId, resolve)) {
             auto ret = objs.insert(pObject);
@@ -736,7 +736,7 @@ vector<App::DocumentObject*> SelectionSingleton::getObjectsOfType(
             }
         }
     }
-    
+
     return temp;
 }
 

--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -725,14 +725,19 @@ vector<App::DocumentObject*> SelectionSingleton::getObjectsOfType(
         return {};
     }
 
+    std::vector<App::DocumentObject*> temp;
     std::set<App::DocumentObject*> objs;
+    
     for (auto& sel : context.info->selList) {
         if (App::DocumentObject* pObject = getObjectOfType(sel, typeId, resolve)) {
-            objs.insert(pObject);
+            auto ret = objs.insert(pObject);
+            if (ret.second) {
+                temp.push_back(pObject);
+            }
         }
     }
-
-    return std::vector<App::DocumentObject*>(objs.begin(), objs.end());
+    
+    return temp;
 }
 
 std::vector<App::DocumentObject*> SelectionSingleton::getObjectsOfType(


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/30545

https://github.com/FreeCAD/FreeCAD/commit/3076ce66be3 changed the code of `SelectionSingleton::getObjectsOfType` and by doing so it changed the order in which it returned the values.

Before that commit, `getObjectsOfType()` iterated the selection list and pushed unique objects into a vector, preserving selection order. After that commit, it collects objects into:

```
std::set<App::DocumentObject*> objs;
...
return std::vector<App::DocumentObject*>(objs.begin(), objs.end());
```
That means callers now get pointer-sorted order, not selection order. In practice this can look like object creation order.

I think this was done just to refactor the function to make it look nicer. @theo-vt can you please confirm?

This PR revert this.

@Roy-043 please confirm if it fix the bug for you