### PR TITLE
Assembly: Fix subassembly rigid change joint bug

### DIFF
--- a/src/Mod/Assembly/App/AssemblyLink.cpp
+++ b/src/Mod/Assembly/App/AssemblyLink.cpp
@@ -220,6 +220,7 @@ void AssemblyLink::onChanged(const App::Property* prop)
                 propPlc->setValue(movePlc);
             }
         }
+        updateParentJoints();
         return;
     }
     App::Part::onChanged(prop);


### PR DESCRIPTION
PR https://github.com/FreeCAD/FreeCAD/pull/27172 added a function `updateParentJoints`, but this function is actually unused! So that PR was fixing nothing. It happens that when I pulled I forgot one part of the fix.

Fix https://github.com/FreeCAD/FreeCAD/issues/28096
Fix https://github.com/FreeCAD/FreeCAD/issues/28782
Fix #27140