### PR TITLE
Fix regression with 3mf thumbnail

### DIFF
--- a/src/Gui/SoFCOffscreenRenderer.cpp
+++ b/src/Gui/SoFCOffscreenRenderer.cpp
@@ -637,7 +637,13 @@ SbBool SoQtOffscreenRenderer::renderFromBase(SoBase* base)
 {
     const SbVec2s fullsize = this->viewport.getViewportSizePixels();
 
-    QSurfaceFormat format;
+    // Start from the application-wide default format so the offscreen context inherits the OpenGL
+    // compatibility profile requested in Application::runApplication(). A freshly constructed
+    // QSurfaceFormat requests a NoProfile/2.0 context, which on Wayland with proprietary drivers
+    // resolves to a core/ES context lacking the legacy GL entry points (glBegin/glEnd, etc.) that
+    // Coin uses to draw geometry. In that case glClear still paints the background but no geometry
+    // is rendered, producing an empty image.
+    QSurfaceFormat format = QSurfaceFormat::defaultFormat();
     format.setSamples(PRIVATE(this)->numSamples);
     QOpenGLContext context;
     context.setFormat(format);

--- a/src/Mod/Mesh/Gui/ThumbnailExtension.cpp
+++ b/src/Mod/Mesh/Gui/ThumbnailExtension.cpp
@@ -24,14 +24,17 @@
 
 #include <QBuffer>
 #include <QByteArray>
+#include <QOpenGLFramebufferObjectFormat>
 
 #include <Inventor/SbRotation.h>
 #include <Inventor/SbViewportRegion.h>
 #include <Inventor/nodes/SoCoordinate3.h>
 #include <Inventor/nodes/SoDirectionalLight.h>
 #include <Inventor/nodes/SoIndexedFaceSet.h>
+#include <Inventor/nodes/SoMaterial.h>
 #include <Inventor/nodes/SoOrthographicCamera.h>
 #include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoShapeHints.h>
 
 #include <Gui/SoFCOffscreenRenderer.h>
 
@@ -47,21 +50,48 @@ Mesh::Extension3MF::Resource ThumbnailExtension3MF::addMesh(const Mesh::MeshObje
     SoIndexedFaceSet* faces = new SoIndexedFaceSet();
 
     SoOrthographicCamera* cam = new SoOrthographicCamera();
+
+    // The mesh geometry carries no normals or material. Without a SoShapeHints the face set is not
+    // shaded (it renders as a flat, single-color silhouette); without a SoMaterial it falls back to
+    // Coin's default near-white color. Either way the result blends into the white background and is
+    // then erased by the transparent-background pass (which turns every white pixel transparent),
+    // leaving an empty image. Give it shading and a distinct color so it survives and is visible.
+    SoShapeHints* hints = new SoShapeHints();
+    hints->vertexOrdering = SoShapeHints::COUNTERCLOCKWISE;
+    hints->shapeType = SoShapeHints::UNKNOWN_SHAPE_TYPE;
+    hints->creaseAngle = 0.5F;
+
+    SoMaterial* material = new SoMaterial();
+    material->diffuseColor.setValue(0.6F, 0.6F, 0.65F);
+
+    SbRotation rot(-0.35355F, -0.14644F, -0.35355F, -0.85355F);
+
+    // Light the faces the camera sees by aligning the light with the camera view direction.
+    SoDirectionalLight* light = new SoDirectionalLight();
+    SbVec3f lightDir(0.0F, 0.0F, -1.0F);
+    rot.multVec(lightDir, lightDir);
+    light->direction.setValue(lightDir);
+
     SoSeparator* root = new SoSeparator();
     root->ref();
     root->addChild(cam);
-    root->addChild(new SoDirectionalLight);
+    root->addChild(light);
+    root->addChild(hints);
+    root->addChild(material);
     root->addChild(coord);
     root->addChild(faces);
 
     ViewProviderMeshBuilder().createMesh(mesh.getKernel(), coord, faces);
 
-    SbRotation rot(-0.35355F, -0.14644F, -0.35355F, -0.85355F);
     cam->orientation.setValue(rot);
     SbViewportRegion vpr(256, 256);
     cam->viewAll(root, vpr);
 
     Gui::SoQtOffscreenRenderer renderer(vpr);
+    // The renderer defaults to a 32-bit float internal texture format (GL_RGB32F_ARB). Reading
+    // that framebuffer back into an 8-bit QImage yields a corrupted (magenta) image on some
+    // drivers, so request a standard 8-bit format like the regular screenshot path does.
+    renderer.setInternalTextureFormat(QOpenGLFramebufferObjectFormat().internalTextureFormat());
     renderer.setBackgroundColor(SbColor4f(1.0F, 1.0F, 1.0F, 0.0F));
     QImage img;
     renderer.render(root);


### PR DESCRIPTION
PR #23768 (commit b3e8ed7814a, "request OpenGL compatibility profile"). To fix blank 3D views on Wayland/NVIDIA, it forced an OpenGL compatibility profile in two places — the app-wide default format and QuarterWidget — because Coin needs legacy GL entry points to draw geometry. It missed the third context-creation site, SoQtOffscreenRenderer::renderFromBase, which kept building a bare NoProfile context.

So after that commit the on-screen view rendered but the offscreen thumbnail context lacked the legacy functions and drew no geometry. Three fixes:

src/Gui/SoFCOffscreenRenderer.cpp — SoQtOffscreenRenderer::renderFromBase built its GL context from a fresh QSurfaceFormat (NoProfile/2.0). On Wayland/proprietary drivers that yields a core context lacking the legacy entry points Coin uses, so the background cleared but no geometry drew → blank image.
Now starts from QSurfaceFormat::defaultFormat() so the offscreen context inherits the app-wide compatibility profile (the third site #23768 missed).

src/Mod/Mesh/Gui/ThumbnailExtension.cpp — two fixes:
- Set an 8-bit internal texture format (QOpenGLFramebufferObjectFormat().internalTextureFormat()) instead of inheriting the renderer's float default (GL_RGB32F_ARB), which read back as a corrupted magenta image.
- Added SoShapeHints + SoMaterial (blue-grey) + a camera-aligned headlight to the thumbnail scene, so the mesh is shaded and a non-white color — otherwise it rendered near-white and was erased by the transparent-background pass.


