### PR TITLE
TechDraw: add broken-out complex sections

### DIFF
--- a/src/Mod/TechDraw/App/DrawComplexSection.cpp
+++ b/src/Mod/TechDraw/App/DrawComplexSection.cpp
@@ -64,6 +64,7 @@
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepBuilderAPI_Transform.hxx>
+#include <BRepClass3d_SolidClassifier.hxx>
 #include <BRepGProp.hxx>
 #include <BRepLProp_SLProps.hxx>
 #include <BRepLib.hxx>
@@ -101,6 +102,7 @@
 #include <BRepBuilderAPI_MakeVertex.hxx>
 #include <GeomLib_IsPlanarSurface.hxx>
 
+#include <algorithm>
 #include <cmath>
 
 #include <sstream>
@@ -128,6 +130,26 @@ using namespace TechDraw;
 using namespace std;
 using DU = DrawUtil;
 
+namespace
+{
+constexpr long StrategyOffset = 0;
+constexpr long StrategyAligned = 1;
+constexpr long StrategyBrokenOut = 3;
+constexpr double BrokenOutToolOffsetFactor = 1.0e-7;
+
+bool directionsAreParallel(Base::Vector3d first, Base::Vector3d second)
+{
+    if (first.Length() <= Precision::Confusion() ||
+        second.Length() <= Precision::Confusion()) {
+        return false;
+    }
+
+    first.Normalize();
+    second.Normalize();
+    return DU::fpCompare(std::fabs(first.Dot(second)), 1.0, EWTOLERANCE);
+}
+}
+
 //===========================================================================
 // DrawComplexSection
 //===========================================================================
@@ -135,7 +157,7 @@ using DU = DrawUtil;
 //NOLINTBEGIN
 PROPERTY_SOURCE(TechDraw::DrawComplexSection, TechDraw::DrawViewSection)
 
-const char* DrawComplexSection::ProjectionStrategyEnums[] = {"Offset", "Aligned", "NoParallel",
+const char* DrawComplexSection::ProjectionStrategyEnums[] = {"Offset", "Aligned", "NoParallel", "BrokenOut",
                                                              nullptr};
 //NOLINTEND
 
@@ -151,11 +173,33 @@ DrawComplexSection::DrawComplexSection() :
     ProjectionStrategy.setEnums(ProjectionStrategyEnums);
     ADD_PROPERTY_TYPE(ProjectionStrategy, ((long)0), fgroup, App::Prop_None,
                       "Make a single cut, or use the profile in pieces");
+    ADD_PROPERTY_TYPE(BrokenOutDepth, (10.0), fgroup, App::Prop_None,
+                      "Depth for broken-out section cuts");
 //NOLINTEND
+}
+
+short DrawComplexSection::mustExecute() const
+{
+    if (isRestoring()) {
+        return DrawViewSection::mustExecute();
+    }
+
+    if (CuttingToolWireObject.isTouched()
+        || ProjectionStrategy.isTouched()) {
+        return 1;
+    }
+
+    if (ProjectionStrategy.getValue() == StrategyBrokenOut && BrokenOutDepth.isTouched()) {
+        return 1;
+    }
+
+    return DrawViewSection::mustExecute();
 }
 
 TopoDS_Shape DrawComplexSection::makeCuttingTool(double dMax)
 {
+    m_toolFaceShape = {};
+
     TopoDS_Wire profileWire = makeProfileWire();
     if (profileWire.IsNull()) {
         throw Base::RuntimeError("Can not make wire from cutting tool (1)");
@@ -166,7 +210,7 @@ TopoDS_Shape DrawComplexSection::makeCuttingTool(double dMax)
     }
 
     // use "canBuild(profile, sectionnormal)" or validateProfileDirection?
-    if (ProjectionStrategy.getValue() == 0) {
+    if (ProjectionStrategy.getValue() == StrategyOffset) {
         // Offset. Warn if profile is not quite aligned with section normal. if
         // the profile and normal are misaligned, the check below for empty "solids"
         // will not be correct.
@@ -184,7 +228,16 @@ TopoDS_Shape DrawComplexSection::makeCuttingTool(double dMax)
     }
 
     if (BRep_Tool::IsClosed(profileWire)) {
+        if (ProjectionStrategy.getValue() == StrategyBrokenOut) {
+            return makeBrokenOutCuttingTool(profileWire, dMax);
+        }
         return makeCuttingToolFromClosedProfile(profileWire, dMax);
+    }
+
+    if (ProjectionStrategy.getValue() == StrategyBrokenOut) {
+        Base::Console().warning("%s requires a closed profile for broken-out section\n",
+                                Label.getValue());
+        return {};
     }
 
     TopoDS_Shape cuttingTool = cuttingToolFromProfile(profileWire, dMax);
@@ -214,8 +267,9 @@ TopoDS_Shape DrawComplexSection::makeCuttingTool(double dMax)
 
 TopoDS_Shape DrawComplexSection::getShapeToPrepare() const
 {
-    if (ProjectionStrategy.getValue() == 0) {
-        //Offset. Use regular section behaviour
+    if (ProjectionStrategy.getValue() == StrategyOffset ||
+        ProjectionStrategy.getValue() == StrategyBrokenOut) {
+        // Offset and BrokenOut use regular section behaviour.
         return DrawViewSection::getShapeToPrepare();
     }
     //Aligned (or NoParallel) strategy
@@ -225,9 +279,41 @@ TopoDS_Shape DrawComplexSection::getShapeToPrepare() const
 //get the shape ready for projection and cut surface finding
 TopoDS_Shape DrawComplexSection::prepareShape(const TopoDS_Shape& cutShape, double shapeSize)
 {
-    if (ProjectionStrategy.getValue() == 0) {
-        //Offset. Use regular section behaviour
+    if (ProjectionStrategy.getValue() == StrategyOffset) {
+        // Offset uses regular section behaviour.
         return DrawViewSection::prepareShape(cutShape, shapeSize);
+    }
+    if (ProjectionStrategy.getValue() == StrategyBrokenOut) {
+        (void)shapeSize;
+        TopoDS_Shape preparedShape;
+        try {
+            Base::Vector3d origin(0.0, 0.0, 0.0);
+            m_projectionCS = getProjectionCS(origin);
+
+            gp_Pnt inputCenter = ShapeUtils::findCentroid(m_saveShape, m_projectionCS);
+            Base::Vector3d centroid(inputCenter.X(), inputCenter.Y(), inputCenter.Z());
+
+            m_cutShapeRaw = cutShape;
+            preparedShape = ShapeUtils::moveShape(cutShape, centroid * -1.0);
+            m_cutShape = preparedShape;
+            m_saveCentroid = centroid;
+
+            preparedShape = ShapeUtils::scaleShape(preparedShape, getScale());
+
+            if (!DrawUtil::fpCompare(Rotation.getValue(), 0.0)) {
+                preparedShape =
+                    ShapeUtils::rotateShape(preparedShape, m_projectionCS, Rotation.getValue());
+            }
+            if (debugSection()) {
+                BRepTools::Write(m_cutShape, "DCSBrokenOutCutShape.brep");
+            }
+        }
+        catch (Standard_Failure& e1) {
+            Base::Console().warning("DCS::prepareShape - failed to build broken-out shape %s - %s **\n",
+                                    getNameInDocument(),
+                                    e1.GetMessageString());
+        }
+        return preparedShape;
     }
 
     //"Aligned" projection (Aligned Section)
@@ -253,8 +339,17 @@ TopoDS_Shape DrawComplexSection::prepareShape(const TopoDS_Shape& cutShape, doub
 
 void DrawComplexSection::makeSectionCut(const TopoDS_Shape& baseShape)
 {
-    if (ProjectionStrategy.getValue() == 0) {
-        //Offset. Use regular section behaviour
+    if (ProjectionStrategy.getValue() == StrategyOffset ||
+        ProjectionStrategy.getValue() == StrategyBrokenOut) {
+        if (ProjectionStrategy.getValue() == StrategyBrokenOut && m_cuttingTool.IsNull()) {
+            BRep_Builder builder;
+            TopoDS_Compound emptyCut;
+            builder.MakeCompound(emptyCut);
+            m_cutPieces = emptyCut;
+            waitingForCut(false);
+            return;
+        }
+        // Offset and BrokenOut use regular section behaviour.
         return DrawViewSection::makeSectionCut(baseShape);
     }
 
@@ -282,6 +377,33 @@ void DrawComplexSection::makeSectionCut(const TopoDS_Shape& baseShape)
 
 void DrawComplexSection::onSectionCutFinished()
 {
+    if (ProjectionStrategy.getValue() == StrategyBrokenOut && m_cuttingTool.IsNull()) {
+        if (DU::isGuiUp()) {
+            QObject::disconnect(connectCutWatcher);
+            showProgressMessage(getNameInDocument(), "has finished making section cut");
+        }
+
+        geometryObject = std::make_shared<TechDraw::GeometryObject>(getNameInDocument(), this);
+        m_tempGeometryObject = nullptr;
+        m_preparedShape = {};
+        m_cutShape = {};
+        m_cutShapeRaw = {};
+
+        BRep_Builder builder;
+        builder.MakeCompound(m_sectionTopoDSFaces);
+        m_tdSectionFaces.clear();
+
+        waitingForCut(false);
+        waitingForHlr(false);
+
+        auto* dvp = dynamic_cast<TechDraw::DrawViewPart*>(BaseView.getValue());
+        if (dvp) {
+            dvp->requestPaint();
+        }
+        requestPaint();
+        return;
+    }
+
     if (m_cutFuture.isRunning() ||  //waitingForCut()
         m_alignFuture.isRunning()) {//waitingForAlign()
         //can not continue yet.  return until the other thread ends
@@ -465,7 +587,8 @@ DrawComplexSection::findSectionPlaneIntersections(const TopoDS_Shape& shapeToInt
                                 getNameInDocument());
         return {};
     }
-    if (ProjectionStrategy.getValue() == 0) {//Offset
+    if (ProjectionStrategy.getValue() == StrategyOffset ||
+        ProjectionStrategy.getValue() == StrategyBrokenOut) {
         return singleToolIntersections(shapeToIntersect);
     }
 
@@ -542,8 +665,9 @@ TopoDS_Compound DrawComplexSection::alignedToolIntersections(const TopoDS_Shape&
 
 TopoDS_Compound DrawComplexSection::alignSectionFaces(const TopoDS_Shape& faceIntersections)
 {
-    if (ProjectionStrategy.getValue() == 0) {
-        //Offset. Use regular section behaviour
+    if (ProjectionStrategy.getValue() == StrategyOffset ||
+        ProjectionStrategy.getValue() == StrategyBrokenOut) {
+        // Offset and BrokenOut use regular section behaviour.
         return DrawViewSection::alignSectionFaces(faceIntersections);
     }
 
@@ -552,7 +676,8 @@ TopoDS_Compound DrawComplexSection::alignSectionFaces(const TopoDS_Shape& faceIn
 
 TopoDS_Shape DrawComplexSection::getShapeToIntersect()
 {
-    if (ProjectionStrategy.getValue() == 0) {//Offset
+    if (ProjectionStrategy.getValue() == StrategyOffset ||
+        ProjectionStrategy.getValue() == StrategyBrokenOut) {
         return DrawViewSection::getShapeToIntersect();
     }
     //Aligned
@@ -561,7 +686,8 @@ TopoDS_Shape DrawComplexSection::getShapeToIntersect()
 
 TopoDS_Shape DrawComplexSection::getShapeForDetail() const
 {
-    if (ProjectionStrategy.getValue() == 0) {//Offset
+    if (ProjectionStrategy.getValue() == StrategyOffset ||
+        ProjectionStrategy.getValue() == StrategyBrokenOut) {
         return DrawViewSection::getShapeForDetail();
     }
     //Aligned
@@ -858,8 +984,9 @@ std::pair<Base::Vector3d, Base::Vector3d>
 //the regular sectionPlane for Offset.
 gp_Pln DrawComplexSection::getSectionPlane() const
 {
-    if (ProjectionStrategy.getValue() == 0) {
-        //Offset. Use regular section behaviour
+    if (ProjectionStrategy.getValue() == StrategyOffset ||
+        ProjectionStrategy.getValue() == StrategyBrokenOut) {
+        // Offset and BrokenOut use regular section behaviour.
         return DrawViewSection::getSectionPlane();
     }
 
@@ -935,8 +1062,10 @@ bool DrawComplexSection::validateProfilePosition(const TopoDS_Wire& profileWire,
 
 bool DrawComplexSection::showSegment(gp_Dir segmentNormal) const
 {
-    if (ProjectionStrategy.getValue() < 2) {
-        //Offset or Aligned are always true
+    if (ProjectionStrategy.getValue() == StrategyOffset ||
+        ProjectionStrategy.getValue() == StrategyAligned ||
+        ProjectionStrategy.getValue() == StrategyBrokenOut) {
+        // Offset, Aligned, and BrokenOut are always true.
         return true;
     }
 
@@ -1611,10 +1740,152 @@ TopoDS_Shape DrawComplexSection::makeCuttingToolFromClosedProfile(const TopoDS_W
     return prism;
 }
 
+TopoDS_Shape DrawComplexSection::makeBrokenOutCuttingTool(const TopoDS_Wire& profileWire, double dMax)
+{
+    TopoDS_Face toolFace;
+    try {
+        BRepBuilderAPI_MakeFace mkFace(profileWire);
+        toolFace = mkFace.Face();
+        if (toolFace.IsNull()) {
+            return {};
+        }
+    }
+    catch (...) {
+        Base::Console().error("%s could not make broken-out tool from closed profile\n",
+                              Label.getValue());
+        return {};
+    }
+
+    double cutDepth = BrokenOutDepth.getValue();
+    if (cutDepth <= Precision::Confusion()) {
+        Base::Console().warning("%s broken-out depth should be positive\n",
+                                Label.getValue());
+        return {};
+    }
+    cutDepth = std::min(cutDepth, dMax);
+
+    const double toolOffset = std::max(Precision::Confusion(), dMax * BrokenOutToolOffsetFactor);
+    auto makePrism = [&](Base::Vector3d direction) {
+        direction.Normalize();
+        TopoDS_Shape startFace = ShapeUtils::moveShape(toolFace, direction * -toolOffset);
+        gp_Vec prismVector = Base::convertTo<gp_Vec>(direction * (cutDepth + toolOffset));
+        return BRepPrimAPI_MakePrism(startFace, prismVector).Shape();
+    };
+
+    Base::Vector3d faceNormal = Base::convertTo<Base::Vector3d>(getFaceNormal(toolFace));
+    faceNormal.Normalize();
+
+    auto* baseDvp = getBaseDVP();
+    if (baseDvp) {
+        Base::Vector3d baseDirection = baseDvp->Direction.getValue();
+        if (baseDirection.Length() > Precision::Confusion()) {
+            baseDirection.Normalize();
+            if (!directionsAreParallel(Direction.getValue(), baseDirection) ||
+                !directionsAreParallel(SectionNormal.getValue(), baseDirection)) {
+                Base::Console().warning("%s broken-out view direction should match the base view direction\n",
+                                        Label.getValue());
+                return {};
+            }
+
+            double alignment = std::fabs(faceNormal.Dot(baseDirection));
+            if (!DU::fpCompare(alignment, 1.0, EWTOLERANCE)) {
+                Base::Console().warning("%s broken-out profile should be parallel to the base view plane\n",
+                                        Label.getValue());
+                return {};
+            }
+        }
+    }
+
+    Base::Vector3d oppositeNormal = faceNormal * -1.0;
+    TopoDS_Shape prismAlongNormal = makePrism(faceNormal);
+    TopoDS_Shape prismOppositeNormal = makePrism(oppositeNormal);
+
+    auto intersectionVolume = [&](const TopoDS_Shape& prism) {
+        if (m_saveShape.IsNull() || prism.IsNull()) {
+            return 0.0;
+        }
+        TopoDS_Shape common = shapeShapeIntersect(m_saveShape, prism);
+        if (common.IsNull()) {
+            return 0.0;
+        }
+        GProp_GProps props;
+        BRepGProp::VolumeProperties(common, props);
+        return props.Mass();
+    };
+
+    double volumeAlongNormal = intersectionVolume(prismAlongNormal);
+    double volumeOppositeNormal = intersectionVolume(prismOppositeNormal);
+
+    Base::Vector3d cutDirection = faceNormal;
+    TopoDS_Shape prism = prismAlongNormal;
+    if (volumeOppositeNormal > volumeAlongNormal + EWTOLERANCE) {
+        cutDirection = oppositeNormal;
+        prism = prismOppositeNormal;
+    }
+    else if (std::fabs(volumeAlongNormal - volumeOppositeNormal) <= EWTOLERANCE && baseDvp) {
+        Base::Vector3d inwardDirection = baseDvp->Direction.getValue() * -1.0;
+        if (inwardDirection.Length() > Precision::Confusion()) {
+            inwardDirection.Normalize();
+            if (oppositeNormal.Dot(inwardDirection) > faceNormal.Dot(inwardDirection)) {
+                cutDirection = oppositeNormal;
+                prism = prismOppositeNormal;
+            }
+        }
+    }
+
+    if (!m_saveShape.IsNull()) {
+        const double pointOffset = std::max(Precision::Confusion() * 10.0,
+                                            dMax * BrokenOutToolOffsetFactor);
+        BRepClass3d_SolidClassifier classifier(m_saveShape);
+        bool allVerticesStartOnSurface = true;
+        for (TopExp_Explorer exp(profileWire, TopAbs_VERTEX); exp.More(); exp.Next()) {
+            const TopoDS_Vertex vertex = TopoDS::Vertex(exp.Current());
+            const gp_Pnt point = BRep_Tool::Pnt(vertex);
+            classifier.Perform(point, pointOffset);
+            const TopAbs_State pointState = classifier.State();
+
+            if (pointState == TopAbs_IN) {
+                allVerticesStartOnSurface = false;
+                break;
+            }
+
+            gp_Pnt pointInward = point.Translated(
+                Base::convertTo<gp_Vec>(cutDirection * pointOffset));
+            gp_Pnt pointOutward = point.Translated(
+                Base::convertTo<gp_Vec>(cutDirection * -pointOffset));
+
+            classifier.Perform(pointInward, pointOffset);
+            const TopAbs_State inwardState = classifier.State();
+            classifier.Perform(pointOutward, pointOffset);
+            const TopAbs_State outwardState = classifier.State();
+
+            const bool hasSolidInward = inwardState == TopAbs_IN || inwardState == TopAbs_ON;
+            const bool hasAirOutward = outwardState == TopAbs_OUT || outwardState == TopAbs_ON;
+            if (pointState != TopAbs_ON && !(hasSolidInward && hasAirOutward)) {
+                allVerticesStartOnSurface = false;
+                break;
+            }
+        }
+
+        if (!allVerticesStartOnSurface) {
+            Base::Console().warning("%s broken-out profile should lie on the source surface\n",
+                                    Label.getValue());
+            return {};
+        }
+    }
+
+    m_toolFaceShape = ShapeUtils::moveShape(toolFace, cutDirection * cutDepth);
+    if (debugSection()) {
+        BRepTools::Write(m_toolFaceShape, "DCSBrokenOutDepthFace.brep");
+    }
+
+    return prism;
+}
+
 bool DrawComplexSection::validateProfileAlignment(const TopoDS_Wire& profileWire) const
 {
     // use "canBuild(profile, sectionnormal)"?
-    if (ProjectionStrategy.getValue() == 0) {
+    if (ProjectionStrategy.getValue() == StrategyOffset) {
         // Offset. Warn if profile is not quite aligned with section normal. if
         // the profile and normal are misaligned, the check below for empty "solids"
         // will not be correct.

--- a/src/Mod/TechDraw/App/DrawComplexSection.h
+++ b/src/Mod/TechDraw/App/DrawComplexSection.h
@@ -61,13 +61,16 @@ public:
 //NOLINTBEGIN
     App::PropertyLink CuttingToolWireObject;
     App::PropertyEnumeration ProjectionStrategy;//Offset or Aligned
+    App::PropertyLength BrokenOutDepth;
 //NOLINTEND
 
+    short mustExecute() const override;
     TopoDS_Shape makeCuttingTool(double dMax) override;
     void makeSectionCut(const TopoDS_Shape& baseShape) override;
     TopoDS_Wire closeProfileForCut(const TopoDS_Wire& profileWire,
                                    double dMax) const;
     TopoDS_Shape makeCuttingToolFromClosedProfile(const TopoDS_Wire& profileWire, double dMax);
+    TopoDS_Shape makeBrokenOutCuttingTool(const TopoDS_Wire& profileWire, double dMax);
     TopoDS_Shape cuttingToolFromProfile(const TopoDS_Wire& inProfileWire,
                                         double dMax) const;
     TopoDS_Wire closeSingleEdgeProfile(const TopoDS_Edge& singleEdge,

--- a/src/Mod/TechDraw/CMakeLists.txt
+++ b/src/Mod/TechDraw/CMakeLists.txt
@@ -184,6 +184,8 @@ SET(TDTest_SRCS
     TDTest/DrawViewDimensionTest.py
     TDTest/DrawViewPartTest.py
     TDTest/DrawViewSectionTest.py
+    TDTest/DrawComplexSectionTest.py
+    TDTest/DrawComplexSectionGuiTest.py
     TDTest/DrawViewBalloonTest.py
     TDTest/DrawViewDetailTest.py
     TDTest/TechDrawTestUtilities.py

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -828,6 +828,10 @@ void QGIViewPart::drawComplexSectionLine(TechDraw::DrawViewSection* viewSection,
     }
 
     auto dcs = static_cast<DrawComplexSection*>(viewSection);
+    if (dcs->ProjectionStrategy.isValue("BrokenOut")) {
+        return;
+    }
+
     std::pair<Base::Vector3d, Base::Vector3d> ends = dcs->sectionLineEnds();
     Base::Vector3d vStart = Rez::guiX(ends.first);//already scaled by dcs
     Base::Vector3d vEnd = Rez::guiX(ends.second);
@@ -1505,5 +1509,4 @@ void QGIViewPart::setMovableFlagProjGroupItem()
     // not locked, not autoDistribute
     setFlag(QGraphicsItem::ItemIsMovable, true);
 }
-
 

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
@@ -32,6 +32,7 @@
 #include <Gui/Command.h>
 #include <Gui/Control.h>
 #include <Gui/MainWindow.h>
+#include <Gui/QuantitySpinBox.h>
 #include <Gui/Selection/Selection.h>
 #include <Gui/WaitCursor.h>
 
@@ -52,6 +53,11 @@ using namespace Gui;
 using namespace TechDraw;
 using namespace TechDrawGui;
 using DU = DrawUtil;
+
+namespace
+{
+constexpr int BrokenOutStrategyIndex = 3;
+}
 
 //ctor for creation
 TaskComplexSection::TaskComplexSection(TechDraw::DrawPage* page, TechDraw::DrawViewPart* baseView,
@@ -143,6 +149,7 @@ void TaskComplexSection::setUiPrimary()
         ui->cmbScaleType->setCurrentIndex(Preferences::scaleType());
     }
     ui->cmbStrategy->setCurrentIndex(0);
+    ui->sbBrokenOutDepth->setValue(10.0);
 
     setUiCommon();
 
@@ -180,6 +187,7 @@ void TaskComplexSection::setUiEdit()
         ui->leBaseView->setText(QString::fromStdString(m_baseView->getNameInDocument()));
     }
     ui->cmbStrategy->setCurrentIndex(m_section->ProjectionStrategy.getValue());
+    ui->sbBrokenOutDepth->setValue(m_section->BrokenOutDepth.getValue());
     ui->leSymbol->setText(QString::fromStdString(m_section->SectionSymbol.getValue()));
     ui->sbScale->setValue(m_section->Scale.getValue());
     ui->cmbScaleType->setCurrentIndex(m_section->getScaleType());
@@ -206,6 +214,7 @@ void TaskComplexSection::setUiCommon()
     ui->leProfileObject->setText(QString::fromStdString(m_profileObject->getNameInDocument())
                                  + QStringLiteral(" / ")
                                  + QString::fromStdString(m_profileObject->Label.getValue()));
+    ui->sbBrokenOutDepth->setUnit(Base::Unit::Length);
 
     m_compass = new CompassWidget(this);
     auto layout = ui->compassLayout;
@@ -227,6 +236,10 @@ void TaskComplexSection::setUiCommon()
 
     connect(ui->pbUpdateNow, &QPushButton::clicked, this, &TaskComplexSection::updateNowClicked);
     connect(ui->cbLiveUpdate, &QCheckBox::clicked, this, &TaskComplexSection::liveUpdateClicked);
+    connect(ui->cmbStrategy, qOverload<int>(&QComboBox::currentIndexChanged), this,
+            &TaskComplexSection::onStrategyChanged);
+    connect(ui->sbBrokenOutDepth, qOverload<double>(&QuantitySpinBox::valueChanged), this,
+            &TaskComplexSection::onBrokenOutDepthChanged);
 
     connect(ui->pbSectionObjects, &QPushButton::clicked, this,
             &TaskComplexSection::onSectionObjectsUseSelectionClicked);
@@ -235,6 +248,7 @@ void TaskComplexSection::setUiCommon()
 
     connect(m_viewDirectionWidget, &VectorEditWidget::valueChanged, this,
             &TaskComplexSection::slotViewDirectionChanged);
+    updateUi();
 }
 
 //save the start conditions
@@ -249,6 +263,8 @@ void TaskComplexSection::saveSectionState()
         m_saveXDir = m_section->XDirection.getValue();
         m_saveOrigin = m_section->SectionOrigin.getValue();
         m_saveDirName = m_section->SectionDirection.getValueAsString();
+        m_saveProjectionStrategy = m_section->ProjectionStrategy.getValue();
+        m_saveBrokenOutDepth = m_section->BrokenOutDepth.getValue();
         m_saved = true;
     }
     if (m_baseView) {
@@ -272,6 +288,8 @@ void TaskComplexSection::restoreSectionState()
     m_section->XDirection.setValue(m_saveXDir);
     m_section->SectionOrigin.setValue(m_saveOrigin);
     m_section->SectionDirection.setValue(m_saveDirName.c_str());
+    m_section->ProjectionStrategy.setValue(m_saveProjectionStrategy);
+    m_section->BrokenOutDepth.setValue(m_saveBrokenOutDepth);
 }
 
 void TaskComplexSection::onSectionObjectsUseSelectionClicked()
@@ -364,6 +382,34 @@ void TaskComplexSection::onScaleChanged()
     m_scaleEdited = true;
     checkAll(false);
     apply();
+}
+
+void TaskComplexSection::onStrategyChanged()
+{
+    updateUi();
+    checkAll(false);
+    apply();
+}
+
+void TaskComplexSection::onBrokenOutDepthChanged()
+{
+    checkAll(false);
+    apply();
+}
+
+void TaskComplexSection::updateUi()
+{
+    const bool showBrokenOutDepth = ui->cmbStrategy->currentIndex() == BrokenOutStrategyIndex;
+    ui->labelBrokenOutDepth->setVisible(showBrokenOutDepth);
+    ui->sbBrokenOutDepth->setVisible(showBrokenOutDepth);
+    ui->sbBrokenOutDepth->setEnabled(showBrokenOutDepth);
+
+    ui->pbUp->setEnabled(!showBrokenOutDepth);
+    ui->pbDown->setEnabled(!showBrokenOutDepth);
+    ui->pbLeft->setEnabled(!showBrokenOutDepth);
+    ui->pbRight->setEnabled(!showBrokenOutDepth);
+    m_compass->setEnabled(!showBrokenOutDepth);
+    m_viewDirectionWidget->setEnabled(!showBrokenOutDepth);
 }
 
 void TaskComplexSection::onProfileObjectsUseSelectionClicked()
@@ -480,9 +526,12 @@ bool TaskComplexSection::apply(bool forceUpdate)
     }
 
     Base::Vector3d localUnit = m_viewDirectionWidget->value();
+    const bool isBrokenOut = ui->cmbStrategy->currentIndex() == BrokenOutStrategyIndex;
     if (m_baseView) {
-        if (!DrawComplexSection::canBuild(m_baseView->localVectorToCS(localUnit),
-                                          m_profileObject)) {
+        gp_Ax2 sectionCS = isBrokenOut ?
+            m_baseView->getProjectionCS() :
+            m_baseView->localVectorToCS(localUnit);
+        if (!DrawComplexSection::canBuild(sectionCS, m_profileObject)) {
             Base::Console().error(
                 "Cannot build complex section with this profile and direction (1)\n");
             return false;
@@ -584,6 +633,10 @@ void TaskComplexSection::createComplexSection()
         int projectionStrategy = ui->cmbStrategy->currentIndex();
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.ProjectionStrategy = %d",
                            m_sectionName.c_str(), projectionStrategy);
+        if (projectionStrategy == BrokenOutStrategyIndex) {
+            Command::doCommand(Command::Doc, "App.ActiveDocument.%s.BrokenOutDepth = %0.7f",
+                               m_sectionName.c_str(), ui->sbBrokenOutDepth->value().getValue());
+        }
 
         Command::doCommand(Command::Doc,
                            "App.activeDocument().%s.SectionOrigin = FreeCAD.Vector(0.0, 0.0, 0.0)",
@@ -603,7 +656,14 @@ void TaskComplexSection::createComplexSection()
             Command::doCommand(Command::Doc,
                                "App.ActiveDocument.%s.BaseView = App.ActiveDocument.%s",
                                m_sectionName.c_str(), m_baseView->getNameInDocument());
-            m_section->setCSFromBase(localUnit * -1.0);
+            if (projectionStrategy == BrokenOutStrategyIndex) {
+                m_section->SectionNormal.setValue(m_baseView->Direction.getValue());
+                m_section->Direction.setValue(m_baseView->Direction.getValue());
+                m_section->XDirection.setValue(m_baseView->getXDirection());
+            }
+            else {
+                m_section->setCSFromBase(localUnit * -1.0);
+            }
             m_section->Source.setValues(m_baseView->Source.getValues());
             m_section->XSource.setValues(m_baseView->XSource.getValues());
         }
@@ -628,8 +688,11 @@ void TaskComplexSection::createComplexSection()
         m_section->XSource.setValues(m_xShapes);
 
         //auto orientation of view relative to base view
-        double viewDirectionAngle = m_compass->positiveValue();
-        double rotation = requiredRotation(viewDirectionAngle);
+        double rotation = 0.0;
+        if (projectionStrategy != BrokenOutStrategyIndex) {
+            double viewDirectionAngle = m_compass->positiveValue();
+            rotation = requiredRotation(viewDirectionAngle);
+        }
         //NOLINTNEXTLINE
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.Rotation = %.6f",
                            m_sectionName.c_str(), rotation);
@@ -668,6 +731,10 @@ void TaskComplexSection::updateComplexSection()
         int projectionStrategy = ui->cmbStrategy->currentIndex();
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.ProjectionStrategy = %d",
                            m_sectionName.c_str(), projectionStrategy);
+        if (projectionStrategy == BrokenOutStrategyIndex) {
+            Command::doCommand(Command::Doc, "App.ActiveDocument.%s.BrokenOutDepth = %0.7f",
+                               m_sectionName.c_str(), ui->sbBrokenOutDepth->value().getValue());
+        }
         Command::doCommand(Command::Doc, "App.activeDocument().%s.SectionDirection = 'Aligned'",
                            m_sectionName.c_str());
         //NOLINTEND
@@ -675,8 +742,15 @@ void TaskComplexSection::updateComplexSection()
         m_section->CuttingToolWireObject.setValue(m_profileObject);
         m_section->SectionDirection.setValue("Aligned");
         Base::Vector3d localUnit = m_viewDirectionWidget->value();
-        m_section->setCSFromBase(localUnit * -1.0);
         if (m_baseView) {
+            if (projectionStrategy == BrokenOutStrategyIndex) {
+                m_section->SectionNormal.setValue(m_baseView->Direction.getValue());
+                m_section->Direction.setValue(m_baseView->Direction.getValue());
+                m_section->XDirection.setValue(m_baseView->getXDirection());
+            }
+            else {
+                m_section->setCSFromBase(localUnit * -1.0);
+            }
             m_section->Source.setValues(m_baseView->Source.getValues());
             m_section->XSource.setValues(m_baseView->XSource.getValues());
         }
@@ -687,8 +761,11 @@ void TaskComplexSection::updateComplexSection()
         }
 
         //auto orientation of view relative to base view
-        double viewDirectionAngle = m_compass->positiveValue();
-        double rotation = requiredRotation(viewDirectionAngle);
+        double rotation = 0.0;
+        if (projectionStrategy != BrokenOutStrategyIndex) {
+            double viewDirectionAngle = m_compass->positiveValue();
+            rotation = requiredRotation(viewDirectionAngle);
+        }
 
         //NOLINTNEXTLINE
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.Rotation = %.6f",

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.h
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.h
@@ -98,6 +98,8 @@ protected Q_SLOTS:
     void onRightClicked();
     void onIdentifierChanged();
     void onScaleChanged();
+    void onStrategyChanged();
+    void onBrokenOutDepthChanged();
     void scaleTypeChanged(int index);
     void liveUpdateClicked();
     void updateNowClicked();
@@ -130,6 +132,8 @@ private:
     std::string m_savePageName;
     std::string m_saveSymbol;
     std::string m_saveDirName;
+    long m_saveProjectionStrategy;
+    double m_saveBrokenOutDepth;
     Base::Vector3d m_saveDirection;
     Base::Vector3d m_saveOrigin;
     double m_saveScale;

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.ui
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.ui
@@ -204,6 +204,40 @@
             <string>No parallel</string>
            </property>
           </item>
+          <item>
+           <property name="text">
+            <string>Broken out</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="labelBrokenOutDepth">
+          <property name="text">
+           <string>Broken-out depth</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="Gui::QuantitySpinBox" name="sbBrokenOutDepth">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>26</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Depth for broken-out section cuts</string>
+          </property>
+          <property name="keyboardTracking">
+           <bool>false</bool>
+          </property>
+          <property name="minimum" stdset="0">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true"/>
+          </property>
          </widget>
         </item>
         <item row="2" column="0">
@@ -423,6 +457,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="Resources/TechDraw.qrc"/>
  </resources>

--- a/src/Mod/TechDraw/TDTest/DrawComplexSectionGuiTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawComplexSectionGuiTest.py
@@ -1,0 +1,111 @@
+import FreeCAD
+import Part
+import unittest
+from .TechDrawTestUtilities import createPageWithSVGTemplate
+from PySide import QtCore, QtWidgets
+
+try:
+    import shiboken6 as shiboken
+except ImportError:
+    import shiboken2 as shiboken
+
+
+class DrawComplexSectionGuiTest(unittest.TestCase):
+    def setUp(self):
+        FreeCAD.newDocument("TDComplexSectionGui")
+        FreeCAD.setActiveDocument("TDComplexSectionGui")
+        FreeCAD.ActiveDocument = FreeCAD.getDocument("TDComplexSectionGui")
+
+        self.box = FreeCAD.ActiveDocument.addObject("Part::Box", "Box")
+        self.box.Length = 10.0
+        self.box.Width = 10.0
+        self.box.Height = 10.0
+
+        self.closedProfile = FreeCAD.ActiveDocument.addObject(
+            "Part::Feature", "ClosedProfile"
+        )
+        self.closedProfile.Shape = Part.makePolygon(
+            [
+                FreeCAD.Vector(1.0, 1.0, 10.0),
+                FreeCAD.Vector(4.0, 1.0, 10.0),
+                FreeCAD.Vector(4.0, 4.0, 10.0),
+                FreeCAD.Vector(1.0, 4.0, 10.0),
+                FreeCAD.Vector(1.0, 1.0, 10.0),
+            ]
+        )
+
+        self.page = createPageWithSVGTemplate()
+        self.page.Scale = 5.0
+
+        self.view = FreeCAD.ActiveDocument.addObject("TechDraw::DrawViewPart", "View")
+        self.page.addView(self.view)
+        self.view.Source = [self.box]
+        self.view.Direction = (0.0, 0.0, 1.0)
+        self.view.Rotation = 0.0
+        self.view.X = 30.0
+        self.view.Y = 150.0
+
+    def tearDown(self):
+        FreeCAD.closeDocument("TDComplexSectionGui")
+
+    def waitForGui(self, milliseconds=2000):
+        loop = QtCore.QEventLoop()
+        timer = QtCore.QTimer()
+        timer.setSingleShot(True)
+        timer.timeout.connect(loop.quit)
+        timer.start(milliseconds)
+        loop.exec_()
+
+    def testBrokenOutSectionDrawsSectionFaceAndPatternHatch(self):
+        import TechDrawGui
+
+        section = FreeCAD.ActiveDocument.addObject(
+            "TechDraw::DrawComplexSection", "BrokenOutSection"
+        )
+        self.page.addView(section)
+        section.Source = [self.box]
+        section.BaseView = self.view
+        section.CuttingToolWireObject = self.closedProfile
+        section.Direction = (0.0, 0.0, 1.0)
+        section.SectionNormal = (0.0, 0.0, 1.0)
+        section.SectionOrigin = (5.0, 5.0, 10.0)
+        section.ProjectionStrategy = "BrokenOut"
+        section.BrokenOutDepth = 4.0
+        section.CutSurfaceDisplay = "PatHatch"
+        section.HatchScale = 1.0
+
+        FreeCAD.ActiveDocument.recompute()
+        self.page.ViewObject.show()
+        self.page.requestPaint()
+        self.waitForGui()
+
+        sceneObject = TechDrawGui.getSceneForPage(self.page)
+        sceneAddress = shiboken.getCppPointer(sceneObject)[0]
+        scene = shiboken.wrapInstance(sceneAddress, QtWidgets.QGraphicsScene)
+        sectionFaces = [
+            item
+            for item in scene.items()
+            if item.type() == 65556 and abs(item.zValue() - 40.0) < 0.1
+        ]
+
+        self.assertGreaterEqual(
+            len(sectionFaces),
+            1,
+            "Broken-out section should draw at least one section-face item",
+        )
+        self.assertTrue(
+            any(face.path().boundingRect().width() > 0 for face in sectionFaces),
+            "Broken-out section faces should have a non-empty drawn path",
+        )
+        self.assertTrue(
+            any(
+                child.type() == 2 and not child.path().isEmpty()
+                for face in sectionFaces
+                for child in face.childItems()
+            ),
+            "Broken-out section faces should draw PAT hatch child paths",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/TechDraw/TDTest/DrawComplexSectionTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawComplexSectionTest.py
@@ -1,0 +1,327 @@
+import FreeCAD
+import Part
+import unittest
+from .TechDrawTestUtilities import createPageWithSVGTemplate
+
+
+class DrawComplexSectionTest(unittest.TestCase):
+    def setUp(self):
+        FreeCAD.newDocument("TDComplexSection")
+        FreeCAD.setActiveDocument("TDComplexSection")
+        FreeCAD.ActiveDocument = FreeCAD.getDocument("TDComplexSection")
+
+        self.box = FreeCAD.ActiveDocument.addObject("Part::Box", "Box")
+        self.box.Length = 10.0
+        self.box.Width = 10.0
+        self.box.Height = 10.0
+
+        self.cavityPart = FreeCAD.ActiveDocument.addObject(
+            "Part::Feature", "BlindInternalCavity"
+        )
+        self.cavityPart.Shape = Part.makeBox(10.0, 10.0, 10.0).cut(
+            Part.makeCylinder(
+                1.0,
+                5.0,
+                FreeCAD.Vector(5.0, 5.0, 0.0),
+                FreeCAD.Vector(0.0, 0.0, 1.0),
+            )
+        )
+
+        self.openProfile = FreeCAD.ActiveDocument.addObject("Part::Feature", "OpenProfile")
+        self.openProfile.Shape = Part.makeLine(
+            FreeCAD.Vector(1.0, 1.0, 10.0),
+            FreeCAD.Vector(4.0, 1.0, 10.0),
+        )
+
+        self.closedProfile = FreeCAD.ActiveDocument.addObject(
+            "Part::Feature", "ClosedProfile"
+        )
+        self.closedProfile.Shape = Part.makePolygon(
+            [
+                FreeCAD.Vector(1.0, 1.0, 10.0),
+                FreeCAD.Vector(4.0, 1.0, 10.0),
+                FreeCAD.Vector(4.0, 4.0, 10.0),
+                FreeCAD.Vector(1.0, 4.0, 10.0),
+                FreeCAD.Vector(1.0, 1.0, 10.0),
+            ]
+        )
+
+        self.wideClosedProfile = FreeCAD.ActiveDocument.addObject(
+            "Part::Feature", "WideClosedProfile"
+        )
+        self.wideClosedProfile.Shape = Part.makePolygon(
+            [
+                FreeCAD.Vector(2.0, 2.0, 10.0),
+                FreeCAD.Vector(8.0, 2.0, 10.0),
+                FreeCAD.Vector(8.0, 8.0, 10.0),
+                FreeCAD.Vector(2.0, 8.0, 10.0),
+                FreeCAD.Vector(2.0, 2.0, 10.0),
+            ]
+        )
+
+        self.misalignedClosedProfile = FreeCAD.ActiveDocument.addObject(
+            "Part::Feature", "MisalignedClosedProfile"
+        )
+        self.misalignedClosedProfile.Shape = Part.makePolygon(
+            [
+                FreeCAD.Vector(3.0, 0.0, 3.0),
+                FreeCAD.Vector(7.0, 0.0, 3.0),
+                FreeCAD.Vector(7.0, 0.0, 7.0),
+                FreeCAD.Vector(3.0, 0.0, 7.0),
+                FreeCAD.Vector(3.0, 0.0, 3.0),
+            ]
+        )
+
+        self.internalClosedProfile = FreeCAD.ActiveDocument.addObject(
+            "Part::Feature", "InternalClosedProfile"
+        )
+        self.internalClosedProfile.Shape = Part.makePolygon(
+            [
+                FreeCAD.Vector(1.0, 1.0, 5.0),
+                FreeCAD.Vector(4.0, 1.0, 5.0),
+                FreeCAD.Vector(4.0, 4.0, 5.0),
+                FreeCAD.Vector(1.0, 4.0, 5.0),
+                FreeCAD.Vector(1.0, 1.0, 5.0),
+            ]
+        )
+
+        self.page = createPageWithSVGTemplate()
+        self.page.Scale = 5.0
+
+        self.view = FreeCAD.ActiveDocument.addObject("TechDraw::DrawViewPart", "View")
+        self.page.addView(self.view)
+        self.view.Source = [self.box]
+        self.view.Direction = (0.0, 0.0, 1.0)
+        self.view.Rotation = 0.0
+        self.view.X = 30.0
+        self.view.Y = 150.0
+
+        self.cavityView = FreeCAD.ActiveDocument.addObject(
+            "TechDraw::DrawViewPart", "CavityView"
+        )
+        self.page.addView(self.cavityView)
+        self.cavityView.Source = [self.cavityPart]
+        self.cavityView.Direction = (0.0, 0.0, 1.0)
+        self.cavityView.Rotation = 0.0
+        self.cavityView.X = 90.0
+        self.cavityView.Y = 150.0
+
+        FreeCAD.ActiveDocument.recompute()
+
+    def tearDown(self):
+        FreeCAD.closeDocument("TDComplexSection")
+
+    def makeComplexSection(
+        self,
+        profile=None,
+        strategy="BrokenOut",
+        depth=4.0,
+        direction=(0.0, 0.0, 1.0),
+        source=None,
+        baseView=None,
+    ):
+        section = FreeCAD.ActiveDocument.addObject(
+            "TechDraw::DrawComplexSection", "ComplexSection"
+        )
+        source = source if source else self.box
+        baseView = baseView if baseView else self.view
+        self.page.addView(section)
+        section.Source = [source]
+        section.BaseView = baseView
+        section.CuttingToolWireObject = profile if profile else self.closedProfile
+        section.Direction = direction
+        section.SectionNormal = direction
+        section.SectionOrigin = (5.0, 5.0, 10.0)
+        section.ProjectionStrategy = strategy
+        section.BrokenOutDepth = depth
+        FreeCAD.ActiveDocument.recompute()
+        return section
+
+    def visibleBounds(self, section):
+        xs = []
+        ys = []
+        for edge in section.getVisibleEdges():
+            for vertex in edge.Vertexes:
+                xs.append(vertex.Point.x)
+                ys.append(vertex.Point.y)
+        return (min(xs), max(xs), min(ys), max(ys))
+
+    def assertBoundsAlmostEqual(self, bounds, expected):
+        for actual, target in zip(bounds, expected):
+            self.assertAlmostEqual(actual, target, places=6)
+
+    def scaledBounds(self, bounds):
+        scale = self.page.Scale
+        return tuple(value * scale for value in bounds)
+
+    def edgeBounds(self, edge):
+        xs = []
+        ys = []
+        for vertex in edge.Vertexes:
+            xs.append(vertex.Point.x)
+            ys.append(vertex.Point.y)
+        return (min(xs), max(xs), min(ys), max(ys))
+
+    def innerBoundaryBounds(self, section):
+        outer = self.scaledBounds((-5.0, 5.0, -5.0, 5.0))
+
+        def touchesOuter(edge_bounds):
+            return any(
+                abs(actual - target) < 1e-6
+                for actual in edge_bounds
+                for target in outer
+            )
+
+        inner_edges = []
+        for edge in section.getVisibleEdges():
+            bounds = self.edgeBounds(edge)
+            if not touchesOuter(bounds):
+                inner_edges.append(edge)
+
+        self.assertEqual(
+            len(inner_edges),
+            4,
+            "Broken-out section should include four local boundary edges",
+        )
+
+        xs = []
+        ys = []
+        for edge in inner_edges:
+            for vertex in edge.Vertexes:
+                xs.append(vertex.Point.x)
+                ys.append(vertex.Point.y)
+        return (min(xs), max(xs), min(ys), max(ys))
+
+    def assertUpToDate(self, section):
+        self.assertTrue("Up-to-date" in section.State)
+
+    def assertBlankSection(self, section, message):
+        self.assertEqual(len(section.getVisibleEdges()), 0, message)
+        self.assertEqual(len(section.getHiddenEdges()), 0, message)
+        self.assertUpToDate(section)
+
+    def testBrokenOutClosedProfileProducesGeometry(self):
+        section = self.makeComplexSection()
+
+        self.assertEqual(
+            len(section.getVisibleEdges()),
+            8,
+            "Broken-out section should show base outline plus the local broken-out boundary",
+        )
+        self.assertEqual(len(section.getHiddenEdges()), 0)
+        self.assertBoundsAlmostEqual(
+            self.visibleBounds(section), self.scaledBounds((-5.0, 5.0, -5.0, 5.0))
+        )
+        self.assertBoundsAlmostEqual(
+            self.innerBoundaryBounds(section), self.scaledBounds((-4.0, -1.0, 1.0, 4.0))
+        )
+        self.assertUpToDate(section)
+
+    def testBrokenOutDepthChangeInvalidatesAndRecomputes(self):
+        section = self.makeComplexSection(depth=3.0)
+        self.assertFalse(section.MustExecute)
+
+        section.BrokenOutDepth = 6.0
+        self.assertTrue(section.MustExecute)
+
+        FreeCAD.ActiveDocument.recompute()
+        self.assertFalse(section.MustExecute)
+        self.assertEqual(len(section.getVisibleEdges()), 8)
+        self.assertBoundsAlmostEqual(
+            self.visibleBounds(section), self.scaledBounds((-5.0, 5.0, -5.0, 5.0))
+        )
+        self.assertBoundsAlmostEqual(
+            self.innerBoundaryBounds(section), self.scaledBounds((-4.0, -1.0, 1.0, 4.0))
+        )
+        self.assertUpToDate(section)
+
+    def testBrokenOutDepthRevealsInternalGeometry(self):
+        shallow = self.makeComplexSection(
+            self.wideClosedProfile,
+            depth=3.0,
+            source=self.cavityPart,
+            baseView=self.cavityView,
+        )
+        deep = self.makeComplexSection(
+            self.wideClosedProfile,
+            depth=7.0,
+            source=self.cavityPart,
+            baseView=self.cavityView,
+        )
+
+        self.assertEqual(len(shallow.getVisibleEdges()), 8)
+        self.assertGreater(
+            len(deep.getVisibleEdges()),
+            len(shallow.getVisibleEdges()),
+            "Deeper broken-out cuts should reveal internal geometry",
+        )
+        self.assertEqual(len(shallow.getHiddenEdges()), 0)
+        self.assertEqual(len(deep.getHiddenEdges()), 0)
+        self.assertUpToDate(shallow)
+        self.assertUpToDate(deep)
+
+    def testBrokenOutRequiresClosedProfile(self):
+        section = self.makeComplexSection(self.openProfile)
+
+        self.assertBlankSection(
+            section,
+            "Broken-out section with an open profile should stay blank without crashing",
+        )
+
+    def testBrokenOutRequiresProfileOnBaseViewPlane(self):
+        section = self.makeComplexSection(self.misalignedClosedProfile)
+
+        self.assertBlankSection(
+            section,
+            "Broken-out section with a profile off the base view plane should stay blank",
+        )
+
+    def testBrokenOutRequiresProfileOnSourceSurface(self):
+        section = self.makeComplexSection(self.internalClosedProfile)
+
+        self.assertBlankSection(
+            section,
+            "Broken-out section with a profile inside the source solid should stay blank",
+        )
+
+    def testBrokenOutRequiresBaseViewDirection(self):
+        section = self.makeComplexSection(direction=(0.0, 1.0, 0.0))
+
+        self.assertBlankSection(
+            section,
+            "Broken-out section should use the base view projection direction",
+        )
+
+    def testBrokenOutRequiresPositiveDepth(self):
+        section = self.makeComplexSection(depth=0.0)
+
+        self.assertBlankSection(
+            section,
+            "Broken-out section with zero depth should stay blank",
+        )
+
+    def testBrokenOutClearsStaleGeometry(self):
+        section = self.makeComplexSection()
+        self.assertGreater(len(section.getVisibleEdges()), 0)
+
+        section.CuttingToolWireObject = self.openProfile
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertBlankSection(
+            section,
+            "Broken-out section should clear stale edges when the profile becomes invalid",
+        )
+
+    def testOffsetComplexSectionStillProducesGeometry(self):
+        section = self.makeComplexSection(self.openProfile, "Offset")
+
+        self.assertGreater(
+            len(section.getVisibleEdges()),
+            0,
+            "Existing offset complex sections should continue to produce geometry",
+        )
+        self.assertUpToDate(section)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/TechDraw/TestTechDrawApp.py
+++ b/src/Mod/TechDraw/TestTechDrawApp.py
@@ -27,4 +27,5 @@ from TDTest.DrawViewBalloonTest import DrawViewBalloonTest  # noqa: F401
 from TDTest.DrawViewImageTest import DrawViewImageTest  # noqa: F401
 from TDTest.DrawViewSymbolTest import DrawViewSymbolTest  # noqa: F401
 from TDTest.DrawProjectionGroupTest import DrawProjectionGroupTest  # noqa: F401
+from TDTest.DrawComplexSectionTest import DrawComplexSectionTest  # noqa: F401
 

--- a/src/Mod/TechDraw/TestTechDrawGui.py
+++ b/src/Mod/TechDraw/TestTechDrawGui.py
@@ -26,4 +26,5 @@ from TDTest.DrawViewSectionTest import DrawViewSectionTest  # noqa: F401
 from TDTest.DrawViewPartTest import DrawViewPartTest  # noqa: F401
 from TDTest.DrawViewDetailTest import DrawViewDetailTest  # noqa: F401
 from TDTest.DrawViewDimensionTest import DrawViewDimensionTest  # noqa: F401
+from TDTest.DrawComplexSectionGuiTest import DrawComplexSectionGuiTest  # noqa: F401
 


### PR DESCRIPTION
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Summary

This adds an initial implementation of TechDraw broken-out section views through the existing Complex Section tool.

The new `BrokenOut` projection strategy:

- uses a closed profile as the local broken-out boundary
- adds a `BrokenOutDepth` length property
- adds a task-panel depth control for the `Broken out` strategy
- builds a bounded local cutting prism from the closed profile and depth
- validates the profile direction/placement for base-view-local broken-out sections
- clears stale generated geometry when the broken-out profile becomes invalid
- suppresses the normal complex-section source-view line/arrows for broken-out views
- keeps the existing Offset/Aligned/NoParallel strategies on their previous paths

## Issues

Fixes #8075.

## Before and After Images

Public validation artifacts:

![Broken-out section TechDraw validation preview](https://raw.githubusercontent.com/adityawrk/FreeCAD/pr-artifacts/freecad-td-demos/pr-artifacts/30688-broken-out-section/td_broken_out_views.png)

- PNG preview: https://raw.githubusercontent.com/adityawrk/FreeCAD/pr-artifacts/freecad-td-demos/pr-artifacts/30688-broken-out-section/td_broken_out_views.png
- SVG: https://raw.githubusercontent.com/adityawrk/FreeCAD/pr-artifacts/freecad-td-demos/pr-artifacts/30688-broken-out-section/td_broken_out_views.svg

The generated evidence covers:

- a basic broken-out section with the outer projected outline plus the local broken-out boundary
- a shallow broken-out cut where a blind internal cavity remains hidden
- a deeper broken-out cut where the same blind internal cavity becomes visible

## Tests

```bash
pixi run cmake --build build/debug --target TechDraw_Data TDTestTarget TechDrawGui -j 8
pixi run build/debug/bin/FreeCADCmd -t TDTest.DrawComplexSectionTest.DrawComplexSectionTest
pixi run build/debug/bin/FreeCADCmd -t TestTechDrawApp
pixi run build/debug/bin/FreeCAD --hidden -t TDTest.DrawComplexSectionGuiTest.DrawComplexSectionGuiTest
pixi run build/debug/bin/FreeCAD --hidden -t TestTechDrawGui
git -c core.whitespace=cr-at-eol diff --check
```

Latest local results:

- focused broken-out app test: 10 tests OK
- broader `TestTechDrawApp`: 17 tests OK
- focused GUI section-face/hatch test: 1 test OK
- broader `TestTechDrawGui`: 6 tests OK
- CRLF-aware whitespace check: clean

## AI Assistance Disclosure

I used OpenAI Codex (GPT-5) as an assistive coding tool while reviewing the TechDraw code paths, preparing the implementation, and writing tests. I reviewed and tested the resulting changes locally.
