### PR TITLE
TechDraw: add Removed and Rotated complex sections

### DIFF
--- a/src/Mod/TechDraw/App/DrawComplexSection.cpp
+++ b/src/Mod/TechDraw/App/DrawComplexSection.cpp
@@ -102,6 +102,7 @@
 #include <GeomLib_IsPlanarSurface.hxx>
 
 #include <cmath>
+#include <memory>
 
 #include <sstream>
 
@@ -135,8 +136,14 @@ using DU = DrawUtil;
 //NOLINTBEGIN
 PROPERTY_SOURCE(TechDraw::DrawComplexSection, TechDraw::DrawViewSection)
 
-const char* DrawComplexSection::ProjectionStrategyEnums[] = {"Offset", "Aligned", "NoParallel",
-                                                             nullptr};
+const char* DrawComplexSection::ProjectionStrategyEnums[] = {
+    "Offset",
+    "Aligned",
+    "NoParallel",
+    "Removed",
+    "Rotated",
+    nullptr
+};
 //NOLINTEND
 
 DrawComplexSection::DrawComplexSection() :
@@ -150,12 +157,43 @@ DrawComplexSection::DrawComplexSection() :
     CuttingToolWireObject.setScope(App::LinkScope::Global);
     ProjectionStrategy.setEnums(ProjectionStrategyEnums);
     ADD_PROPERTY_TYPE(ProjectionStrategy, ((long)0), fgroup, App::Prop_None,
-                      "Make a single cut, or use the profile in pieces");
+                      "Make a single cut, use the profile in pieces, or show only the cut face");
 //NOLINTEND
+}
+
+short DrawComplexSection::mustExecute() const
+{
+    if (isRestoring()) {
+        return DrawViewSection::mustExecute();
+    }
+
+    if (ProjectionStrategy.isTouched() || CuttingToolWireObject.isTouched()) {
+        return 1;
+    }
+
+    return DrawViewSection::mustExecute();
+}
+
+bool DrawComplexSection::isOffsetStrategy() const
+{
+    return ProjectionStrategy.getValue() == StrategyOffset;
+}
+
+bool DrawComplexSection::isNoParallelStrategy() const
+{
+    return ProjectionStrategy.getValue() == StrategyNoParallel;
+}
+
+bool DrawComplexSection::isFaceOnlyStrategy() const
+{
+    return ProjectionStrategy.getValue() == StrategyRemoved
+        || ProjectionStrategy.getValue() == StrategyRotated;
 }
 
 TopoDS_Shape DrawComplexSection::makeCuttingTool(double dMax)
 {
+    m_toolFaceShape.Nullify();
+
     TopoDS_Wire profileWire = makeProfileWire();
     if (profileWire.IsNull()) {
         throw Base::RuntimeError("Can not make wire from cutting tool (1)");
@@ -166,9 +204,9 @@ TopoDS_Shape DrawComplexSection::makeCuttingTool(double dMax)
     }
 
     // use "canBuild(profile, sectionnormal)" or validateProfileDirection?
-    if (ProjectionStrategy.getValue() == 0) {
-        // Offset. Warn if profile is not quite aligned with section normal. if
-        // the profile and normal are misaligned, the check below for empty "solids"
+    if (isOffsetStrategy() || isFaceOnlyStrategy()) {
+        // These strategies use the complete profile as a single cutting tool.
+        // If the profile and normal are misaligned, the empty-solid checks below
         // will not be correct.
         constexpr double AngleThresholdDeg{5.0};
         // bool isOK =
@@ -214,7 +252,7 @@ TopoDS_Shape DrawComplexSection::makeCuttingTool(double dMax)
 
 TopoDS_Shape DrawComplexSection::getShapeToPrepare() const
 {
-    if (ProjectionStrategy.getValue() == 0) {
+    if (isOffsetStrategy() || isFaceOnlyStrategy()) {
         //Offset. Use regular section behaviour
         return DrawViewSection::getShapeToPrepare();
     }
@@ -225,9 +263,55 @@ TopoDS_Shape DrawComplexSection::getShapeToPrepare() const
 //get the shape ready for projection and cut surface finding
 TopoDS_Shape DrawComplexSection::prepareShape(const TopoDS_Shape& cutShape, double shapeSize)
 {
-    if (ProjectionStrategy.getValue() == 0) {
+    if (isOffsetStrategy()) {
         //Offset. Use regular section behaviour
         return DrawViewSection::prepareShape(cutShape, shapeSize);
+    }
+
+    if (isFaceOnlyStrategy()) {
+        TopoDS_Shape preparedShape;
+        try {
+            TopoDS_Compound faceIntersections = toolFaceIntersections(m_saveShape);
+            if (isTrulyEmpty(faceIntersections)) {
+                m_cutShape.Nullify();
+                m_cutShapeRaw.Nullify();
+                m_preparedShape.Nullify();
+                return {};
+            }
+
+            Base::Vector3d origin(0.0, 0.0, 0.0);
+            m_projectionCS = getProjectionCS(origin);
+            gp_Pnt inputCenter = ShapeUtils::findCentroid(faceIntersections, m_projectionCS);
+            Base::Vector3d centroid(inputCenter.X(), inputCenter.Y(), inputCenter.Z());
+
+            m_cutShapeRaw = faceIntersections;
+            preparedShape = ShapeUtils::moveShape(faceIntersections, centroid * -1.0);
+            m_cutShape = preparedShape;
+            m_saveCentroid = centroid;
+
+            preparedShape = ShapeUtils::scaleShape(preparedShape, getScale());
+
+            if (!DrawUtil::fpCompare(Rotation.getValue(), 0.0)) {
+                preparedShape =
+                    ShapeUtils::rotateShape(preparedShape, m_projectionCS, Rotation.getValue());
+            }
+        }
+        catch (Standard_Failure& e1) {
+            Base::Console().warning("DCS::prepareShape - failed to build face-only shape %s - %s **\n",
+                                    getNameInDocument(),
+                                    e1.GetMessageString());
+        }
+        catch (Base::Exception& e1) {
+            Base::Console().warning("DCS::prepareShape - failed to build face-only shape %s - %s **\n",
+                                    getNameInDocument(),
+                                    e1.what());
+        }
+
+        m_preparedShape = preparedShape;
+        if (debugSection()) {
+            BRepTools::Write(m_preparedShape, "DCSprepareShape_faceOnlyPreparedShape.brep");
+        }
+        return m_preparedShape;
     }
 
     //"Aligned" projection (Aligned Section)
@@ -253,9 +337,18 @@ TopoDS_Shape DrawComplexSection::prepareShape(const TopoDS_Shape& cutShape, doub
 
 void DrawComplexSection::makeSectionCut(const TopoDS_Shape& baseShape)
 {
-    if (ProjectionStrategy.getValue() == 0) {
-        //Offset. Use regular section behaviour
+    if (isOffsetStrategy()) {
+        // Offset uses regular section behaviour.
         return DrawViewSection::makeSectionCut(baseShape);
+    }
+
+    if (isFaceOnlyStrategy()) {
+        showProgressMessage(getNameInDocument(), "is preparing face-only section");
+        BRepBuilderAPI_Copy BuilderCopy(baseShape);
+        m_saveShape = BuilderCopy.Shape();
+        m_cutPieces = m_saveShape;
+        waitingForCut(false);
+        return;
     }
 
     try {
@@ -282,6 +375,43 @@ void DrawComplexSection::makeSectionCut(const TopoDS_Shape& baseShape)
 
 void DrawComplexSection::onSectionCutFinished()
 {
+    if (isFaceOnlyStrategy()) {
+        if (DU::isGuiUp()) {
+            QObject::disconnect(connectCutWatcher);
+            showProgressMessage(getNameInDocument(), "has finished preparing face-only section");
+        }
+        waitingForCut(false);
+
+        m_preparedShape = prepareShape(getShapeToPrepare(), m_shapeSize);
+        if (debugSection()) {
+            BRepTools::Write(m_preparedShape, "DCSPreparedFaceOnlyShape.brep");
+        }
+
+        if (m_preparedShape.IsNull()) {
+            geometryObject = std::make_shared<TechDraw::GeometryObject>(getNameInDocument(), this);
+            m_tempGeometryObject = nullptr;
+            m_sectionTopoDSFaces.Nullify();
+            m_tdSectionFaces.clear();
+            postSectionCutTasks();
+            bbox = geometryObject->calcBoundingBox();
+            waitingForHlr(false);
+            DrawViewPart::postHlrTasks();
+            if (auto* dvp = getBaseDVP()) {
+                dvp->requestPaint();
+            }
+            requestPaint();
+            return;
+        }
+
+        postSectionCutTasks();
+
+        m_tempGeometryObject = buildGeometryObject(m_preparedShape, getProjectionCS());
+        if (!DU::isGuiUp()) {
+            onHlrFinished();
+        }
+        return;
+    }
+
     if (m_cutFuture.isRunning() ||  //waitingForCut()
         m_alignFuture.isRunning()) {//waitingForAlign()
         //can not continue yet.  return until the other thread ends
@@ -465,11 +595,61 @@ DrawComplexSection::findSectionPlaneIntersections(const TopoDS_Shape& shapeToInt
                                 getNameInDocument());
         return {};
     }
-    if (ProjectionStrategy.getValue() == 0) {//Offset
+    if (isOffsetStrategy()) {
         return singleToolIntersections(shapeToIntersect);
+    }
+    if (isFaceOnlyStrategy()) {
+        return toolFaceIntersections(m_saveShape);
     }
 
     return alignedToolIntersections(shapeToIntersect);
+}
+
+//Intersect the cutting tool face with the uncut source shape to produce the face-only view.
+TopoDS_Compound DrawComplexSection::toolFaceIntersections(const TopoDS_Shape& shapeToIntersect)
+{
+    TopoDS_Compound result;
+
+    if (m_toolFaceShape.IsNull() || shapeToIntersect.IsNull()) {
+        return result;
+    }
+
+    TopoDS_Shape intersect = shapeShapeIntersect(m_toolFaceShape, shapeToIntersect);
+    if (intersect.IsNull()) {
+        return result;
+    }
+
+    BRep_Builder builder;
+    builder.MakeCompound(result);
+    TopTools_IndexedMapOfShape faceEdges;
+    bool hasFaces = false;
+    TopExp_Explorer expFaces(intersect, TopAbs_FACE);
+    for (; expFaces.More(); expFaces.Next()) {
+        TopoDS_Face face = TopoDS::Face(expFaces.Current());
+        TopExp::MapShapes(face, TopAbs_EDGE, faceEdges);
+        builder.Add(result, face);
+        hasFaces = true;
+    }
+
+    TopExp_Explorer expEdges(intersect, TopAbs_EDGE);
+    for (; expEdges.More(); expEdges.Next()) {
+        TopoDS_Edge edge = TopoDS::Edge(expEdges.Current());
+        bool edgeBelongsToFace = false;
+        for (int iEdge = 1; iEdge <= faceEdges.Extent(); ++iEdge) {
+            if (edge.IsSame(faceEdges.FindKey(iEdge))) {
+                edgeBelongsToFace = true;
+                break;
+            }
+        }
+        if (edgeBelongsToFace) {
+            continue;
+        }
+        builder.Add(result, edge);
+    }
+    // Edge-only commons are tangent contacts, not actual section faces.  Keep
+    // loose edges only as supplements to real cut faces, for cases such as
+    // cylindrical holes whose axes lie in the section plane.
+    return hasFaces ? result : TopoDS_Compound();
 }
 
 //Intersect cutShape with each segment of the cutting tool
@@ -542,8 +722,8 @@ TopoDS_Compound DrawComplexSection::alignedToolIntersections(const TopoDS_Shape&
 
 TopoDS_Compound DrawComplexSection::alignSectionFaces(const TopoDS_Shape& faceIntersections)
 {
-    if (ProjectionStrategy.getValue() == 0) {
-        //Offset. Use regular section behaviour
+    if (isOffsetStrategy() || isFaceOnlyStrategy()) {
+        // Offset, Removed and Rotated use regular section-face placement.
         return DrawViewSection::alignSectionFaces(faceIntersections);
     }
 
@@ -552,7 +732,7 @@ TopoDS_Compound DrawComplexSection::alignSectionFaces(const TopoDS_Shape& faceIn
 
 TopoDS_Shape DrawComplexSection::getShapeToIntersect()
 {
-    if (ProjectionStrategy.getValue() == 0) {//Offset
+    if (isOffsetStrategy() || isFaceOnlyStrategy()) {
         return DrawViewSection::getShapeToIntersect();
     }
     //Aligned
@@ -561,10 +741,9 @@ TopoDS_Shape DrawComplexSection::getShapeToIntersect()
 
 TopoDS_Shape DrawComplexSection::getShapeForDetail() const
 {
-    if (ProjectionStrategy.getValue() == 0) {//Offset
+    if (isOffsetStrategy()) {
         return DrawViewSection::getShapeForDetail();
     }
-    //Aligned
     return m_preparedShape;
 }
 
@@ -858,7 +1037,7 @@ std::pair<Base::Vector3d, Base::Vector3d>
 //the regular sectionPlane for Offset.
 gp_Pln DrawComplexSection::getSectionPlane() const
 {
-    if (ProjectionStrategy.getValue() == 0) {
+    if (isOffsetStrategy() || isFaceOnlyStrategy()) {
         //Offset. Use regular section behaviour
         return DrawViewSection::getSectionPlane();
     }
@@ -935,8 +1114,7 @@ bool DrawComplexSection::validateProfilePosition(const TopoDS_Wire& profileWire,
 
 bool DrawComplexSection::showSegment(gp_Dir segmentNormal) const
 {
-    if (ProjectionStrategy.getValue() < 2) {
-        //Offset or Aligned are always true
+    if (!isNoParallelStrategy()) {
         return true;
     }
 
@@ -1008,20 +1186,32 @@ bool DrawComplexSection::boxesIntersect(TopoDS_Face& face, TopoDS_Shape& shape)
 TopoDS_Shape DrawComplexSection::shapeShapeIntersect(const TopoDS_Shape& shape0,
                                                      const TopoDS_Shape& shape1)
 {
-    FCBRepAlgoAPI_Common anOp;
-    anOp.SetFuzzyValue(EWTOLERANCE);
-    TopTools_ListOfShape anArg1;
-    TopTools_ListOfShape anArg2;
-    anArg1.Append(shape0);
-    anArg2.Append(shape1);
-    anOp.SetArguments(anArg1);
-    anOp.SetTools(anArg2);
-    anOp.Build();
-    TopoDS_Shape result = anOp.Shape();//always a compound
-    if (isTrulyEmpty(result)) {
-        return {};
+    try {
+        FCBRepAlgoAPI_Common anOp;
+        anOp.SetFuzzyValue(EWTOLERANCE);
+        TopTools_ListOfShape anArg1;
+        TopTools_ListOfShape anArg2;
+        anArg1.Append(shape0);
+        anArg2.Append(shape1);
+        anOp.SetArguments(anArg1);
+        anOp.SetTools(anArg2);
+        anOp.Build();
+        if (!anOp.IsDone()) {
+            return {};
+        }
+
+        TopoDS_Shape result = anOp.Shape();//always a compound
+        if (isTrulyEmpty(result)) {
+            return {};
+        }
+        return result;
     }
-    return result;
+    catch (Standard_Failure& e1) {
+        Base::Console().warning("DCS::shapeShapeIntersect - common failed in %s - %s **\n",
+                                getNameInDocument(),
+                                e1.GetMessageString());
+    }
+    return {};
 }
 
 //find all the intersecting regions of face and shape
@@ -1604,6 +1794,7 @@ TopoDS_Shape DrawComplexSection::makeCuttingToolFromClosedProfile(const TopoDS_W
         Base::Console().error("%s could not make tool from closed profile\n", Label.getValue());
         return {};
     }
+    m_toolFaceShape = toolFace;
     gp_Dir gpNormal = getFaceNormal(toolFace);
     auto extrudeDir = 2 * dMax * gpNormal;
     TopoDS_Shape prism = BRepPrimAPI_MakePrism(toolFace, extrudeDir).Shape();
@@ -1614,9 +1805,9 @@ TopoDS_Shape DrawComplexSection::makeCuttingToolFromClosedProfile(const TopoDS_W
 bool DrawComplexSection::validateProfileAlignment(const TopoDS_Wire& profileWire) const
 {
     // use "canBuild(profile, sectionnormal)"?
-    if (ProjectionStrategy.getValue() == 0) {
-        // Offset. Warn if profile is not quite aligned with section normal. if
-        // the profile and normal are misaligned, the check below for empty "solids"
+    if (isOffsetStrategy() || isFaceOnlyStrategy()) {
+        // These strategies use the complete profile as a single cutting tool.
+        // If the profile and normal are misaligned, the empty-solid checks below
         // will not be correct.
         // just a warning here, so don't fail on this
         constexpr double AngleThresholdDeg{5.0};
@@ -1744,7 +1935,7 @@ TopoDS_Wire DrawComplexSection::closeSingleEdgeProfile(const TopoDS_Edge& single
 {
     std::pair<Base::Vector3d, Base::Vector3d> edgeEnds = getSegmentEnds(singleEdge);
 
-    Base::Vector3d midEdgePoint = (edgeEnds.first + edgeEnds.second / 2);
+    Base::Vector3d midEdgePoint = (edgeEnds.first + edgeEnds.second) / 2;
     Base::Vector3d SNPoint = SectionNormal.getValue() * dMax;
     Base::Vector3d awayDirection = SNPoint - midEdgePoint;   // from midpoint to snpoint
     awayDirection.Normalize();

--- a/src/Mod/TechDraw/App/DrawComplexSection.h
+++ b/src/Mod/TechDraw/App/DrawComplexSection.h
@@ -58,9 +58,18 @@ public:
     DrawComplexSection();
     ~DrawComplexSection() override = default;
 
+    enum ProjectionStrategyType : long
+    {
+        StrategyOffset = 0,
+        StrategyAligned = 1,
+        StrategyNoParallel = 2,
+        StrategyRemoved = 3,
+        StrategyRotated = 4,
+    };
+
 //NOLINTBEGIN
     App::PropertyLink CuttingToolWireObject;
-    App::PropertyEnumeration ProjectionStrategy;//Offset or Aligned
+    App::PropertyEnumeration ProjectionStrategy;
 //NOLINTEND
 
     TopoDS_Shape makeCuttingTool(double dMax) override;
@@ -106,6 +115,7 @@ public:
     ChangePointVector getChangePointsFromSectionLine() override;
 
     bool isBaseValid() const override;
+    short mustExecute() const override;
     bool validateProfilePosition(const TopoDS_Wire& profileWire, const gp_Ax2& sectionCS) const;
     bool validateSketchNormal(App::DocumentObject* sketchObject) const;
     bool validateProfileAlignment(const TopoDS_Wire& profileWire) const;
@@ -137,6 +147,10 @@ public Q_SLOTS:
     void onSectionCutFinished() override;
 
 private:
+    bool isOffsetStrategy() const;
+    bool isNoParallelStrategy() const;
+    bool isFaceOnlyStrategy() const;
+
     bool validateOffsetProfile(const TopoDS_Wire& profile,
                                Base::Vector3d direction,
                                double angleThresholdDeg) const;
@@ -167,6 +181,7 @@ private:
     std::vector<std::pair<int, Base::Vector3d> >
                     getSegmentViewDirections(const TopoDS_Wire& profileWire,
                                            Base::Vector3d sectionNormal) const;
+    TopoDS_Compound toolFaceIntersections(const TopoDS_Shape& shapeToIntersect);
     static gp_Dir getFaceNormal(TopoDS_Face& face);
     static bool faceContainsEndpoints(const TopoDS_Edge& edgeToMatch,
                                       const TopoDS_Face& faceToSearch);

--- a/src/Mod/TechDraw/CMakeLists.txt
+++ b/src/Mod/TechDraw/CMakeLists.txt
@@ -184,6 +184,7 @@ SET(TDTest_SRCS
     TDTest/DrawViewDimensionTest.py
     TDTest/DrawViewPartTest.py
     TDTest/DrawViewSectionTest.py
+    TDTest/DrawComplexSectionTest.py
     TDTest/DrawViewBalloonTest.py
     TDTest/DrawViewDetailTest.py
     TDTest/TechDrawTestUtilities.py
@@ -211,4 +212,3 @@ fc_copy_sources(TDTestTarget "${CMAKE_BINARY_DIR}/Mod/TechDraw" ${TDAllTest})
 # install Python packages (for make install)
 INSTALL(FILES ${TDTest_SRCS} DESTINATION Mod/TechDraw/TDTest)
 INSTALL(FILES ${TDTestFile_SRCS} DESTINATION Mod/TechDraw/TDTest)
-

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
@@ -21,7 +21,13 @@
  ***************************************************************************/
 
 #include <QMessageBox>
+#include <BRepBndLib.hxx>
+#include <Bnd_Box.hxx>
 #include <gp_Pnt.hxx>
+#include <TopoDS_Wire.hxx>
+
+#include <algorithm>
+#include <cmath>
 
 #include <App/Document.h>
 #include <App/Link.h>
@@ -39,6 +45,7 @@
 #include "Widgets/VectorEditWidget.h"
 #include <Mod/TechDraw/App/DrawComplexSection.h>
 #include <Mod/TechDraw/App/DrawPage.h>
+#include <Mod/TechDraw/App/ShapeUtils.h>
 #include <Mod/TechDraw/App/DrawUtil.h>
 #include <Mod/TechDraw/App/DrawViewPart.h>
 #include <Mod/TechDraw/App/Preferences.h>
@@ -72,6 +79,7 @@ TaskComplexSection::TaskComplexSection(TechDraw::DrawPage* page, TechDraw::DrawV
     m_applyDeferred(0),
     m_angle(0.0),
     m_directionIsSet(false),
+    m_directionEdited(false),
     m_modelIsDirty(false),
     m_scaleEdited(false)
 {
@@ -106,6 +114,7 @@ TaskComplexSection::TaskComplexSection(TechDraw::DrawComplexSection* complexSect
     m_applyDeferred(0),
     m_angle(0.0),
     m_directionIsSet(true),
+    m_directionEdited(false),
     m_modelIsDirty(false),
     m_scaleEdited(false)
 {
@@ -249,6 +258,10 @@ void TaskComplexSection::saveSectionState()
         m_saveXDir = m_section->XDirection.getValue();
         m_saveOrigin = m_section->SectionOrigin.getValue();
         m_saveDirName = m_section->SectionDirection.getValueAsString();
+        m_saveProjectionStrategy = m_section->ProjectionStrategy.getValue();
+        m_saveX = m_section->X.getValue();
+        m_saveY = m_section->Y.getValue();
+        m_saveRotation = m_section->Rotation.getValue();
         m_saved = true;
     }
     if (m_baseView) {
@@ -272,6 +285,10 @@ void TaskComplexSection::restoreSectionState()
     m_section->XDirection.setValue(m_saveXDir);
     m_section->SectionOrigin.setValue(m_saveOrigin);
     m_section->SectionDirection.setValue(m_saveDirName.c_str());
+    m_section->ProjectionStrategy.setValue(m_saveProjectionStrategy);
+    m_section->X.setValue(m_saveX);
+    m_section->Y.setValue(m_saveY);
+    m_section->Rotation.setValue(m_saveRotation);
 }
 
 void TaskComplexSection::onSectionObjectsUseSelectionClicked()
@@ -304,6 +321,7 @@ void TaskComplexSection::slotViewDirectionChanged(Base::Vector3d newDirection)
     projectedViewDirection.Normalize();
     double viewAngle = atan2(projectedViewDirection.y, projectedViewDirection.x);
     m_compass->setDialAngle(Base::toDegrees(viewAngle));
+    m_directionEdited = true;
     checkAll(false);
     applyAligned();
 }
@@ -317,6 +335,7 @@ void TaskComplexSection::slotChangeAngle(double newAngle)
     double unitY = sin(angleRadians);
     Base::Vector3d localUnit(unitX, unitY, 0.0);
     m_viewDirectionWidget->setValueNoNotify(localUnit);
+    m_directionEdited = true;
     checkAll(false);
     applyAligned();
 }
@@ -326,6 +345,7 @@ void TaskComplexSection::onUpClicked()
     checkAll(false);
     m_compass->setToNorth();
     m_viewDirectionWidget->setValueNoNotify(Base::Vector3d(0.0, 1.0, 0.0));
+    m_directionEdited = true;
     applyAligned();
 }
 
@@ -334,6 +354,7 @@ void TaskComplexSection::onDownClicked()
     checkAll(false);
     m_compass->setToSouth();
     m_viewDirectionWidget->setValueNoNotify(Base::Vector3d(0.0, -1.0, 0.0));
+    m_directionEdited = true;
     applyAligned();
 }
 
@@ -342,6 +363,7 @@ void TaskComplexSection::onLeftClicked()
     checkAll(false);
     m_compass->setToWest();
     m_viewDirectionWidget->setValueNoNotify(Base::Vector3d(-1.0, 0.0, 0.0));
+    m_directionEdited = true;
     applyAligned();
 }
 
@@ -350,6 +372,7 @@ void TaskComplexSection::onRightClicked()
     checkAll(false);
     m_compass->setToEast();
     m_viewDirectionWidget->setValueNoNotify(Base::Vector3d(1.0, 0.0, 0.0));
+    m_directionEdited = true;
     applyAligned();
 }
 
@@ -531,6 +554,8 @@ bool TaskComplexSection::apply(bool forceUpdate)
 
     wc.restoreCursor();
     m_applyDeferred = 0;
+    m_directionEdited = false;
+    m_scaleEdited = false;
     ui->lPendingUpdates->setText(QString());
     return true;
 }
@@ -633,6 +658,7 @@ void TaskComplexSection::createComplexSection()
         //NOLINTNEXTLINE
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.Rotation = %.6f",
                            m_sectionName.c_str(), rotation);
+        positionFaceOnlySection(projectionStrategy);
 
     }
     Gui::Command::commitCommand(tid);
@@ -666,12 +692,14 @@ void TaskComplexSection::updateComplexSection()
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.ScaleType = %d",
                            m_sectionName.c_str(), scaleType);
         int projectionStrategy = ui->cmbStrategy->currentIndex();
+        int previousProjectionStrategy = m_section->ProjectionStrategy.getValue();
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.ProjectionStrategy = %d",
                            m_sectionName.c_str(), projectionStrategy);
         Command::doCommand(Command::Doc, "App.activeDocument().%s.SectionDirection = 'Aligned'",
                            m_sectionName.c_str());
         //NOLINTEND
 
+        App::DocumentObject* previousProfileObject = m_section->CuttingToolWireObject.getValue();
         m_section->CuttingToolWireObject.setValue(m_profileObject);
         m_section->SectionDirection.setValue("Aligned");
         Base::Vector3d localUnit = m_viewDirectionWidget->value();
@@ -693,6 +721,14 @@ void TaskComplexSection::updateComplexSection()
         //NOLINTNEXTLINE
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.Rotation = %.6f",
                            m_sectionName.c_str(), rotation);
+
+        if (isFaceOnlyStrategy(projectionStrategy)
+            && (projectionStrategy != previousProjectionStrategy
+                || m_profileObject != previousProfileObject
+                || m_directionEdited
+                || m_scaleEdited)) {
+            positionFaceOnlySection(projectionStrategy);
+        }
     }
     Gui::Command::commitCommand(tid);
 }
@@ -704,6 +740,138 @@ std::string TaskComplexSection::makeSectionLabel(const QString& symbol)
     std::string uniqueLabel = "Section" + uniqueSuffix;
     std::string temp = symbol.toStdString();
     return ( uniqueLabel + " " + temp + " - " + temp );
+}
+
+bool TaskComplexSection::isFaceOnlyStrategy(int strategy) const
+{
+    return strategy == TechDraw::DrawComplexSection::StrategyRemoved
+        || strategy == TechDraw::DrawComplexSection::StrategyRotated;
+}
+
+void TaskComplexSection::positionFaceOnlySection(int strategy)
+{
+    if (!m_section || !m_baseView || !isFaceOnlyStrategy(strategy)) {
+        return;
+    }
+
+    Base::Vector3d sectionLineCenter;
+    Base::Vector3d sectionLineSize;
+    if (!sectionLineBoundsOnBase(sectionLineCenter, sectionLineSize)) {
+        std::pair<Base::Vector3d, Base::Vector3d> lineEnds = m_section->sectionLineEnds();
+        sectionLineCenter = (lineEnds.first + lineEnds.second) / 2.0;
+        Base::Vector3d lineDelta = lineEnds.second - lineEnds.first;
+        sectionLineSize = Base::Vector3d(std::abs(lineDelta.x), std::abs(lineDelta.y), 0.0);
+    }
+    Base::Vector3d sectionPosition(m_baseView->X.getValue(), m_baseView->Y.getValue(), 0.0);
+    sectionPosition += sectionLineCenter;
+
+    if (strategy == TechDraw::DrawComplexSection::StrategyRemoved) {
+        Base::Vector3d removeDirection = m_section->SectionNormal.getValue() * -1.0;
+        Base::Vector3d removeDirectionOnBase = m_baseView->projectPoint(removeDirection, false);
+        if (removeDirectionOnBase.Length() > 0.000001) {
+            removeDirectionOnBase.Normalize();
+            constexpr double RemovedSectionGap = 10.0;
+            double baseHalfSize =
+                m_baseView->getSizeAlongVector(removeDirectionOnBase) * m_baseView->getScale() / 2.0;
+            double sectionHalfSize =
+                (std::abs(removeDirectionOnBase.x) * sectionLineSize.x
+                 + std::abs(removeDirectionOnBase.y) * sectionLineSize.y) / 2.0;
+            Base::Vector3d sectionViewSize;
+            if (sectionViewBounds(sectionViewSize)) {
+                double sectionViewHalfSize =
+                    (std::abs(removeDirectionOnBase.x) * sectionViewSize.x
+                     + std::abs(removeDirectionOnBase.y) * sectionViewSize.y) / 2.0;
+                sectionHalfSize = std::max(sectionHalfSize, sectionViewHalfSize);
+            }
+            sectionPosition +=
+                removeDirectionOnBase * (baseHalfSize + sectionHalfSize + RemovedSectionGap);
+        }
+    }
+
+    Command::doCommand(Command::Doc, "App.ActiveDocument.%s.X = %.6f",
+                       m_sectionName.c_str(), sectionPosition.x);
+    Command::doCommand(Command::Doc, "App.ActiveDocument.%s.Y = %.6f",
+                       m_sectionName.c_str(), sectionPosition.y);
+}
+
+bool TaskComplexSection::sectionLineBoundsOnBase(Base::Vector3d& center, Base::Vector3d& size) const
+{
+    TopoDS_Wire lineWire = m_section->makeSectionLineWire();
+    if (!lineWire.IsNull()) {
+        TopoDS_Shape projectedWire =
+            GeometryObject::projectSimpleShape(lineWire, m_baseView->getProjectionCS());
+        if (!projectedWire.IsNull()) {
+            Bnd_Box lineBox;
+            lineBox.SetGap(0.0);
+            BRepBndLib::Add(projectedWire, lineBox);
+            if (!lineBox.IsVoid()) {
+                double xMin = 0.0;
+                double yMin = 0.0;
+                double zMin = 0.0;
+                double xMax = 0.0;
+                double yMax = 0.0;
+                double zMax = 0.0;
+                lineBox.Get(xMin, yMin, zMin, xMax, yMax, zMax);
+                center = Base::Vector3d((xMin + xMax) / 2.0, (yMin + yMax) / 2.0, 0.0);
+                size = Base::Vector3d(xMax - xMin, yMax - yMin, 0.0);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool TaskComplexSection::sectionViewBounds(Base::Vector3d& size) const
+{
+    if (!m_section) {
+        return false;
+    }
+
+    try {
+        TopoDS_Shape sourceShape = m_section->getShapeToCut();
+        if (sourceShape.IsNull()) {
+            return false;
+        }
+
+        gp_Ax2 projectionCS = m_section->getProjectionCS();
+        gp_Pnt inputCenter = ShapeUtils::findCentroid(sourceShape, projectionCS);
+        Base::Vector3d centroid(inputCenter.X(), inputCenter.Y(), inputCenter.Z());
+
+        TopoDS_Shape preparedShape = ShapeUtils::moveShape(sourceShape, centroid * -1.0);
+        preparedShape = ShapeUtils::scaleShape(preparedShape, m_section->getScale());
+        if (!DrawUtil::fpCompare(m_section->Rotation.getValue(), 0.0)) {
+            preparedShape =
+                ShapeUtils::rotateShape(preparedShape, projectionCS, m_section->Rotation.getValue());
+        }
+
+        TopoDS_Shape projectedShape =
+            GeometryObject::projectSimpleShape(preparedShape, projectionCS);
+        if (projectedShape.IsNull()) {
+            return false;
+        }
+
+        Bnd_Box sectionBox;
+        sectionBox.SetGap(0.0);
+        BRepBndLib::Add(projectedShape, sectionBox);
+        if (sectionBox.IsVoid()) {
+            return false;
+        }
+
+        double xMin = 0.0;
+        double yMin = 0.0;
+        double zMin = 0.0;
+        double xMax = 0.0;
+        double yMax = 0.0;
+        double zMax = 0.0;
+        sectionBox.Get(xMin, yMin, zMin, xMax, yMax, zMax);
+        size = Base::Vector3d(xMax - xMin, yMax - yMin, 0.0);
+        constexpr double MinimumSectionSize = 0.000001;
+        return size.x > MinimumSectionSize || size.y > MinimumSectionSize;
+    }
+    catch (...) {
+        Base::Console().warning("TaskComplexSection - could not estimate section view bounds\n");
+        return false;
+    }
 }
 
 void TaskComplexSection::failNoObject()

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.h
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.h
@@ -110,6 +110,10 @@ private:
 
     void createComplexSection();
     void updateComplexSection();
+    bool isFaceOnlyStrategy(int strategy) const;
+    void positionFaceOnlySection(int strategy);
+    bool sectionLineBoundsOnBase(Base::Vector3d& center, Base::Vector3d& size) const;
+    bool sectionViewBounds(Base::Vector3d& size) const;
 
     QString sourcesToString();
     std::unique_ptr<Ui_TaskComplexSection> ui;
@@ -133,7 +137,11 @@ private:
     Base::Vector3d m_saveDirection;
     Base::Vector3d m_saveOrigin;
     double m_saveScale;
+    double m_saveX;
+    double m_saveY;
+    double m_saveRotation;
     int m_saveScaleType;
+    int m_saveProjectionStrategy;
     bool m_saved;
     bool m_createMode;
     Base::Vector3d m_normal;
@@ -143,6 +151,7 @@ private:
     double m_angle;
     VectorEditWidget* m_viewDirectionWidget;
     bool m_directionIsSet;
+    bool m_directionEdited;
     bool m_modelIsDirty;
 
     bool m_scaleEdited;

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.ui
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.ui
@@ -204,6 +204,16 @@
             <string>No parallel</string>
            </property>
           </item>
+          <item>
+           <property name="text">
+            <string>Removed</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Rotated</string>
+           </property>
+          </item>
          </widget>
         </item>
         <item row="2" column="0">

--- a/src/Mod/TechDraw/TDTest/DrawComplexSectionTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawComplexSectionTest.py
@@ -1,0 +1,240 @@
+import FreeCAD
+import Part
+import unittest
+from .TechDrawTestUtilities import createPageWithSVGTemplate
+
+
+class DrawComplexSectionTest(unittest.TestCase):
+    def setUp(self):
+        FreeCAD.newDocument("TDComplexSection")
+        FreeCAD.setActiveDocument("TDComplexSection")
+        FreeCAD.ActiveDocument = FreeCAD.getDocument("TDComplexSection")
+
+        self.box = FreeCAD.ActiveDocument.addObject("Part::Box", "Box")
+        self.box.Length = 10.0
+        self.box.Width = 10.0
+        self.box.Height = 10.0
+
+        self.profile = FreeCAD.ActiveDocument.addObject("Part::Feature", "SectionProfile")
+        self.profile.Shape = Part.makeLine(
+            FreeCAD.Vector(2.0, 5.0, 5.0),
+            FreeCAD.Vector(8.0, 5.0, 5.0),
+        )
+
+        self.closedProfile = FreeCAD.ActiveDocument.addObject(
+            "Part::Feature", "ClosedSectionProfile"
+        )
+        self.closedProfile.Shape = Part.makePolygon(
+            [
+                FreeCAD.Vector(2.0, 5.0, 2.0),
+                FreeCAD.Vector(8.0, 5.0, 2.0),
+                FreeCAD.Vector(8.0, 5.0, 8.0),
+                FreeCAD.Vector(2.0, 5.0, 8.0),
+                FreeCAD.Vector(2.0, 5.0, 2.0),
+            ]
+        )
+
+        self.outsideProfile = FreeCAD.ActiveDocument.addObject(
+            "Part::Feature", "OutsideSectionProfile"
+        )
+        self.outsideProfile.Shape = Part.makeLine(
+            FreeCAD.Vector(2.0, 20.0, 5.0),
+            FreeCAD.Vector(8.0, 20.0, 5.0),
+        )
+
+        self.holedBar = FreeCAD.ActiveDocument.addObject("Part::Feature", "HoledBar")
+        holeBox = Part.makeBox(12.0, 8.0, 8.0)
+        throughHole = Part.makeCylinder(
+            1.5,
+            14.0,
+            FreeCAD.Vector(-1.0, 4.0, 4.0),
+            FreeCAD.Vector(1.0, 0.0, 0.0),
+        )
+        self.holedBar.Shape = holeBox.cut(throughHole)
+
+        self.holeProfile = FreeCAD.ActiveDocument.addObject(
+            "Part::Feature", "HoleSectionProfile"
+        )
+        self.holeProfile.Shape = Part.makeLine(
+            FreeCAD.Vector(1.0, 4.0, 4.0),
+            FreeCAD.Vector(11.0, 4.0, 4.0),
+        )
+
+        self.tangentCylinder = FreeCAD.ActiveDocument.addObject(
+            "Part::Feature", "TangentCylinder"
+        )
+        self.tangentCylinder.Shape = Part.makeCylinder(
+            2.0,
+            10.0,
+            FreeCAD.Vector(0.0, 5.0, 5.0),
+            FreeCAD.Vector(1.0, 0.0, 0.0),
+        )
+
+        self.tangentProfile = FreeCAD.ActiveDocument.addObject(
+            "Part::Feature", "TangentSectionProfile"
+        )
+        self.tangentProfile.Shape = Part.makeLine(
+            FreeCAD.Vector(0.0, 7.0, 5.0),
+            FreeCAD.Vector(10.0, 7.0, 5.0),
+        )
+
+        self.page = createPageWithSVGTemplate()
+        self.page.Scale = 5.0
+
+        self.view = FreeCAD.ActiveDocument.addObject("TechDraw::DrawViewPart", "View")
+        self.page.addView(self.view)
+        self.view.Source = [self.box]
+        self.view.Direction = (0.0, 0.0, 1.0)
+        self.view.Rotation = 0.0
+        self.view.X = 30.0
+        self.view.Y = 150.0
+        FreeCAD.ActiveDocument.recompute()
+
+    def tearDown(self):
+        FreeCAD.closeDocument("TDComplexSection")
+
+    def makePartView(self, source, name):
+        view = FreeCAD.ActiveDocument.addObject("TechDraw::DrawViewPart", name)
+        self.page.addView(view)
+        view.Source = [source]
+        view.Direction = (0.0, 0.0, 1.0)
+        view.Rotation = 0.0
+        view.X = 30.0
+        view.Y = 150.0
+        FreeCAD.ActiveDocument.recompute()
+        return view
+
+    def makeComplexSection(self, strategy, profile=None, source=None, baseView=None, origin=None):
+        if source is None:
+            source = self.box
+        if baseView is None:
+            baseView = self.view
+        if origin is None:
+            origin = (5.0, 5.0, 5.0)
+
+        section = FreeCAD.ActiveDocument.addObject(
+            "TechDraw::DrawComplexSection", "ComplexSection"
+        )
+        self.page.addView(section)
+        section.Source = [source]
+        section.BaseView = baseView
+        section.CuttingToolWireObject = profile if profile else self.profile
+        section.Direction = (0.0, 1.0, 0.0)
+        section.SectionNormal = (0.0, 1.0, 0.0)
+        section.SectionOrigin = origin
+        section.ProjectionStrategy = strategy
+        FreeCAD.ActiveDocument.recompute()
+        return section
+
+    def assertFaceOnlyBoxSection(self, section, message):
+        self.assertEqual(len(section.getVisibleEdges()), 4, message)
+        self.assertEqual(
+            len(section.getHiddenEdges()),
+            0,
+            "Face-only complex section should not include outlines behind the section plane",
+        )
+        self.assertTrue("Up-to-date" in section.State)
+
+    def assertBlankSection(self, section, message):
+        self.assertEqual(len(section.getVisibleEdges()), 0, message)
+        self.assertEqual(len(section.getHiddenEdges()), 0, message)
+        self.assertTrue("Up-to-date" in section.State)
+
+    def testRemovedComplexSectionShowsOnlyCutFace(self):
+        section = self.makeComplexSection("Removed")
+
+        self.assertFaceOnlyBoxSection(
+            section,
+            "Removed complex section should show only the cut face",
+        )
+
+    def testRotatedComplexSectionShowsOnlyCutFace(self):
+        section = self.makeComplexSection("Rotated")
+
+        self.assertFaceOnlyBoxSection(
+            section,
+            "Rotated complex section should show only the cut face",
+        )
+
+    def testFaceOnlyComplexSectionSupportsClosedProfiles(self):
+        section = self.makeComplexSection("Removed", self.closedProfile)
+
+        edges = section.getVisibleEdges()
+        self.assertTrue(edges, "Closed profile section should not produce a blank view")
+        self.assertTrue("Up-to-date" in section.State)
+
+    def testFaceOnlyComplexSectionPreservesThroughHoleEdges(self):
+        holeView = self.makePartView(self.holedBar, "HoleView")
+        section = self.makeComplexSection(
+            "Removed",
+            self.holeProfile,
+            self.holedBar,
+            holeView,
+            (6.0, 4.0, 4.0),
+        )
+
+        self.assertEqual(
+            len(section.getVisibleEdges()),
+            8,
+            "Through-hole section should include the cut face and hole edges",
+        )
+        self.assertEqual(len(section.getHiddenEdges()), 0)
+        self.assertTrue("Up-to-date" in section.State)
+
+    def testFaceOnlyComplexSectionIgnoresTangentEdgeContacts(self):
+        tangentView = self.makePartView(self.tangentCylinder, "TangentView")
+        section = self.makeComplexSection(
+            "Removed",
+            self.tangentProfile,
+            self.tangentCylinder,
+            tangentView,
+            (5.0, 7.0, 5.0),
+        )
+
+        self.assertBlankSection(
+            section,
+            "Tangent contact should not create a face-only section",
+        )
+
+    def testFaceOnlyComplexSectionCanRecomputeFromStrategyChange(self):
+        section = self.makeComplexSection("Offset")
+        self.assertNotEqual(
+            len(section.getVisibleEdges()),
+            4,
+            "Offset complex section should include more than the cut face",
+        )
+
+        section.ProjectionStrategy = "Removed"
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertFaceOnlyBoxSection(
+            section,
+            "Strategy change should recompute face-only geometry",
+        )
+
+    def testFaceOnlyComplexSectionWithoutIntersectionStaysUpToDate(self):
+        section = self.makeComplexSection("Removed", self.outsideProfile)
+        section.SectionOrigin = (5.0, 20.0, 5.0)
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertBlankSection(
+            section,
+            "Non-intersecting face-only section should be blank",
+        )
+
+    def testFaceOnlyComplexSectionClearsStaleGeometry(self):
+        section = self.makeComplexSection("Removed")
+        self.assertEqual(len(section.getVisibleEdges()), 4)
+
+        section.CuttingToolWireObject = self.outsideProfile
+        section.SectionOrigin = (5.0, 20.0, 5.0)
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertBlankSection(
+            section,
+            "Blank face-only recompute should clear old edges",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/TechDraw/TestTechDrawApp.py
+++ b/src/Mod/TechDraw/TestTechDrawApp.py
@@ -27,4 +27,5 @@ from TDTest.DrawViewBalloonTest import DrawViewBalloonTest  # noqa: F401
 from TDTest.DrawViewImageTest import DrawViewImageTest  # noqa: F401
 from TDTest.DrawViewSymbolTest import DrawViewSymbolTest  # noqa: F401
 from TDTest.DrawProjectionGroupTest import DrawProjectionGroupTest  # noqa: F401
+from TDTest.DrawComplexSectionTest import DrawComplexSectionTest  # noqa: F401
 


### PR DESCRIPTION
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Summary

Adds TechDraw support for `Removed` and `Rotated` complex section views.

The implementation keeps the existing projection strategies unchanged and appends the new strategies after them. Removed and Rotated sections use a face-only section path so the resulting view shows the sectioned face geometry instead of the projected background outline of the source solid. Through-hole section faces still keep their hole edge supplements, while tangent edge-only contacts are treated as blank sections rather than fake section results.

The task panel now exposes the two new strategies and persists/restores the strategy, X/Y offset, and rotation values.

AI assistance disclosure: I used OpenAI Codex (GPT-5) as an assistive development and review tool while working on this patch. I reviewed and tested the changes locally and take responsibility for the contribution and the PR communication.

## Issues

Fixes #8076.

## Before and After Images

This change affects TechDraw section-view output and the complex-section task panel.

Public validation artifacts:

![Removed and rotated TechDraw section validation preview](https://raw.githubusercontent.com/adityawrk/FreeCAD/pr-artifacts/freecad-td-demos/pr-artifacts/30689-removed-rotated-sections/td_removed_rotated_views.png)

- PNG preview: https://raw.githubusercontent.com/adityawrk/FreeCAD/pr-artifacts/freecad-td-demos/pr-artifacts/30689-removed-rotated-sections/td_removed_rotated_views.png
- SVG: https://raw.githubusercontent.com/adityawrk/FreeCAD/pr-artifacts/freecad-td-demos/pr-artifacts/30689-removed-rotated-sections/td_removed_rotated_views.svg

The generated evidence covers:

- `RemovedSection`: `Removed`, visible edges = 4, hidden edges = 0
- `RotatedSection`: `Rotated`, visible edges = 4, hidden edges = 0
- `OffsetControl`: `Offset`, visible edges = 10, hidden edges = 0
- `HoleRemovedSection`: `Removed`, visible edges = 8, hidden edges = 0

I could generate and inspect app-side SVG/PNG evidence in this environment. A live FreeCAD GUI screenshot was not reliable here because the debug executable did not expose a normal macOS app-window target for screenshot capture.

## Testing

```bash
pixi run cmake --build build/debug --target TechDraw TDTestTarget -j 8
pixi run build/debug/bin/FreeCADCmd -t TestTechDrawApp
git -c core.whitespace=cr-at-eol diff --check
```

Results:

- Build passed.
- `TestTechDrawApp` passed: 15 tests OK.
- CRLF-aware whitespace check passed.

Plain `git diff --check` reports CRLF noise in existing CRLF files touched by the patch (`TaskComplexSection.ui` and `TestTechDrawApp.py`), so I used the CRLF-aware check above.
