### PR TITLE
App: Link: Do not claim child if property say not to

### DIFF
--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2629,8 +2629,8 @@ std::vector<App::DocumentObject*> ViewProviderLink::claimChildren() const
     if (ext && !ext->_getShowElementValue() && ext->_getElementCountValue()) {
         // in array mode without element objects, we'd better not show the
         // linked object's children to avoid inconsistent behavior on selection.
-        // We claim the linked object instead
-        if (ext) {
+        // Claim the linked object only if requested.
+        if (ext->getLinkClaimChildValue()) {
             auto obj = ext->getLinkedObjectValue();
             if (obj) {
                 ret.push_back(obj);


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/30693

Currently if `elementCount >0` the LinkClaimChild property is ignored.

After this PR, if LinkClaimChild is false, then the link do not claim the linked as a child, even in the case of elementCount >0