### PR TITLE
TechDraw: derive side thread depth from Hole data

### DIFF
--- a/src/Mod/TechDraw/CMakeLists.txt
+++ b/src/Mod/TechDraw/CMakeLists.txt
@@ -186,6 +186,7 @@ SET(TDTest_SRCS
     TDTest/DrawViewSectionTest.py
     TDTest/DrawViewBalloonTest.py
     TDTest/DrawViewDetailTest.py
+    TDTest/DrawThreadExtensionTest.py
     TDTest/TechDrawTestUtilities.py
 )
 
@@ -211,4 +212,3 @@ fc_copy_sources(TDTestTarget "${CMAKE_BINARY_DIR}/Mod/TechDraw" ${TDAllTest})
 # install Python packages (for make install)
 INSTALL(FILES ${TDTest_SRCS} DESTINATION Mod/TechDraw/TDTest)
 INSTALL(FILES ${TDTestFile_SRCS} DESTINATION Mod/TechDraw/TDTest)
-

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -27,9 +27,15 @@
 #include <BRepAdaptor_Curve.hxx>
 #include <GCPnts_AbscissaPoint.hxx>
 
+#include <algorithm>
+#include <cmath>
+#include <optional>
+#include <set>
+
 
 #include <App/Document.h>
 #include <App/DocumentObject.h>
+#include <App/PropertyStandard.h>
 #include <Base/Console.h>
 #include <Base/Type.h>
 #include <Gui/Action.h>
@@ -82,6 +88,16 @@ Base::Vector3d _circleCenter(Base::Vector3d p1, Base::Vector3d p2, Base::Vector3
 void _createThreadCircle(const std::string Name, TechDraw::DrawViewPart* objFeat, double factor);
 void _createThreadLines(const std::vector<std::string>& SubNames, TechDraw::DrawViewPart* objFeat,
                         double factor, bool endLine);
+std::optional<Base::Vector3d> _getThreadDepthReference(const std::vector<std::string>& subNames,
+                                                       TechDraw::DrawViewPart* objFeat);
+std::optional<double> _getThreadDepthFraction(const Base::Vector3d& start,
+                                              const Base::Vector3d& end,
+                                              const std::optional<Base::Vector3d>& depthReference);
+std::optional<double> _getThreadDepthFractionFromSources(const std::vector<std::string>& subNames,
+                                                         TechDraw::DrawViewPart* objFeat,
+                                                         double selectedDepth);
+std::optional<double> _getThreadDepthFractionFromObject(App::DocumentObject* source,
+                                                        double selectedDepth);
 void _setLineAttributes(TechDraw::CosmeticEdge* cosEdge);
 void _setLineAttributes(TechDraw::CenterLine* cosEdge);
 void _setLineAttributes(TechDraw::CosmeticEdge* cosEdge, int style, float weight, Base::Color color);
@@ -403,7 +419,8 @@ CmdTechDrawExtensionThreadHoleSide::CmdTechDrawExtensionThreadHoleSide()
     sAppModule = "TechDraw";
     sGroup = QT_TR_NOOP("TechDraw");
     sMenuText = QT_TR_NOOP("Cosmetic Thread Hole Side View");
-    sToolTipText = QT_TR_NOOP("Adds a cosmetic thread to the side view of a hole or circle");
+    sToolTipText = QT_TR_NOOP("Adds a cosmetic thread to the side view of a hole or circle. "
+                              "Select a third edge or vertex to limit thread depth.");
     sWhatsThis = "TechDraw_ExtensionThreadHoleSide";
     sStatusTip = sMenuText;
     sPixmap = "TechDraw_ExtensionThreadHoleSide";
@@ -455,7 +472,8 @@ CmdTechDrawExtensionThreadBoltSide::CmdTechDrawExtensionThreadBoltSide()
     sGroup = QT_TR_NOOP("TechDraw");
     sMenuText = QT_TR_NOOP("Cosmetic Thread Bolt Side View");
     sToolTipText = QT_TR_NOOP("Adds a cosmetic thread to the side view of a "
-            "bolt/screw/rod between two selected parallel lines");
+            "bolt/screw/rod between two selected parallel lines. "
+            "Select a third edge or vertex to limit thread depth.");
     sWhatsThis = "TechDraw_ExtensionThreadBoltSide";
     sStatusTip = sMenuText;
     sPixmap = "TechDraw_ExtensionThreadBoltSide";
@@ -589,7 +607,8 @@ CmdTechDrawExtensionThreadsGroup::CmdTechDrawExtensionThreadsGroup()
     sAppModule = "TechDraw";
     sGroup = QT_TR_NOOP("TechDraw");
     sMenuText = QT_TR_NOOP("Cosmetic Thread Hole Side View");
-    sToolTipText = QT_TR_NOOP("Adds a cosmetic thread to the side view of a selected hole between two selected parallel lines");
+    sToolTipText = QT_TR_NOOP("Adds a cosmetic thread to the side view of a selected hole between two selected parallel lines. "
+                              "Select a third edge or vertex to limit thread depth.");
     sWhatsThis = "TechDraw_ExtensionThreadsGroup";
     sStatusTip = sMenuText;
 }
@@ -672,7 +691,8 @@ void CmdTechDrawExtensionThreadsGroup::languageChange()
                                           "Cosmetic Thread Hole Side View"));
     arc1->setToolTip(QApplication::translate("CmdTechDrawExtensionThreadHoleSide",
                                              "Adds a cosmetic thread to the side view of a "
-                                             "selected hole between two selected parallel lines"));
+                                             "selected hole between two selected parallel lines. "
+                                             "Select a third edge or vertex to limit thread depth."));
     arc1->setStatusTip(arc1->text());
     QAction* arc2 = action[1];
     arc2->setText(QApplication::translate("CmdTechDrawExtensionThreadHoleBottom",
@@ -687,7 +707,8 @@ void CmdTechDrawExtensionThreadsGroup::languageChange()
     arc3->setToolTip(
         QApplication::translate("CmdTechDrawExtensionThreadBoltSide",
                                 "Adds a cosmetic thread to the side view of a bolt/screw/rod "
-                                "between two selected parallel lines"));
+                                "between two selected parallel lines. "
+                                "Select a third edge or vertex to limit thread depth."));
     arc3->setStatusTip(arc3->text());
     QAction* arc4 = action[3];
     arc4->setText(QApplication::translate("CmdTechDrawExtensionThreadBoltBottom",
@@ -2252,6 +2273,34 @@ void _createThreadLines(const std::vector<std::string>& SubNames, TechDraw::Draw
             start1 = help2;
             end1 = help1;
         }
+        const Base::Vector3d depthStart = (start0 + start1) / 2.0;
+        const Base::Vector3d depthEnd = (end0 + end1) / 2.0;
+        const std::optional<Base::Vector3d> depthReference = _getThreadDepthReference(SubNames, objFeat);
+        std::optional<double> depthFraction =
+            _getThreadDepthFraction(depthStart, depthEnd, depthReference);
+        const bool depthFractionFromSelectedReference = depthFraction.has_value();
+        if (!depthFraction && endLine) {
+            const double selectedDepth = (depthEnd - depthStart).Length();
+            depthFraction = _getThreadDepthFractionFromSources(SubNames, objFeat, selectedDepth);
+        }
+        if (depthFraction) {
+            const Base::Vector3d reference0 = start0 + (end0 - start0) * *depthFraction;
+            const Base::Vector3d reference1 = start1 + (end1 - start1) * *depthFraction;
+            // A selected reference is a point on the drawing, so keep the shorter side adjacent
+            // to that reference. A source ThreadDepth is already a length fraction and must not
+            // be mirrored, otherwise valid depths over half the selected side become too short.
+            if (!depthFractionFromSelectedReference || *depthFraction <= 0.5) {
+                end0 = reference0;
+                end1 = reference1;
+            }
+            else {
+                start0 = end0;
+                start1 = end1;
+                end0 = reference0;
+                end1 = reference1;
+            }
+        }
+
         float kernelDiam = (start1 - start0).Length();
         float kernelFactor = (kernelDiam * factor - kernelDiam) / 2;
         Base::Vector3d delta = (start1 - start0).Normalize() * kernelFactor;
@@ -2272,8 +2321,159 @@ void _createThreadLines(const std::vector<std::string>& SubNames, TechDraw::Draw
                 objFeat->addCosmeticEdge(end0 - delta, end1 + delta);
             TechDraw::CosmeticEdge* cosTag3 = objFeat->getCosmeticEdge(line3Tag);
             _setLineAttributes(cosTag3, solidStyle, graphicWeight, threadColor);
+
+            std::string centerLineTag = objFeat->addCenterLine(depthStart, depthEnd);
+            TechDraw::CenterLine* centerLine = objFeat->getCenterLine(centerLineTag);
+            if (centerLine) {
+                _setLineAttributes(centerLine,
+                                   Preferences::CenterLineStyle(),
+                                   thinWeight,
+                                   threadColor);
+            }
         }
     }
+}
+
+std::optional<Base::Vector3d> _getThreadDepthReference(const std::vector<std::string>& subNames,
+                                                       TechDraw::DrawViewPart* objFeat)
+{
+    if (subNames.size() < 3) {
+        return std::nullopt;
+    }
+
+    const std::string& depthName = subNames[2];
+    std::string depthType = TechDraw::DrawUtil::getGeomTypeFromName(depthName);
+    int depthId = TechDraw::DrawUtil::getIndexFromName(depthName);
+
+    if (depthType == "Vertex") {
+        TechDraw::VertexPtr vertex = objFeat->getProjVertexByIndex(depthId);
+        if (vertex) {
+            return CosmeticVertex::makeCanonicalPointInverted(objFeat, vertex->point());
+        }
+        return std::nullopt;
+    }
+
+    if (depthType != "Edge") {
+        return std::nullopt;
+    }
+
+    TechDraw::BaseGeomPtr geom = objFeat->getGeomByIndex(depthId);
+    if (!geom) {
+        return std::nullopt;
+    }
+
+    if (geom->getGeomType() == GeomType::GENERIC) {
+        TechDraw::GenericPtr line = std::static_pointer_cast<TechDraw::Generic>(geom);
+        Base::Vector3d start = CosmeticVertex::makeCanonicalPointInverted(objFeat,
+                                                                          line->getStartPoint());
+        Base::Vector3d end = CosmeticVertex::makeCanonicalPointInverted(objFeat,
+                                                                        line->getEndPoint());
+        return (start + end) / 2.0;
+    }
+
+    if (geom->getGeomType() == GeomType::CIRCLE || geom->getGeomType() == GeomType::ARCOFCIRCLE) {
+        TechDraw::CirclePtr circle = std::static_pointer_cast<TechDraw::Circle>(geom);
+        return CosmeticVertex::makeCanonicalPointInverted(objFeat, circle->center);
+    }
+
+    return std::nullopt;
+}
+
+std::optional<double> _getThreadDepthFraction(const Base::Vector3d& start,
+                                              const Base::Vector3d& end,
+                                              const std::optional<Base::Vector3d>& depthReference)
+{
+    if (!depthReference) {
+        return std::nullopt;
+    }
+
+    Base::Vector3d axis = end - start;
+    const double axisLengthSquared = axis.Dot(axis);
+    if (axisLengthSquared <= Precision::Confusion()) {
+        return std::nullopt;
+    }
+
+    const double rawFraction = ((*depthReference - start).Dot(axis)) / axisLengthSquared;
+    const double clampedFraction = std::clamp(rawFraction, 0.0, 1.0);
+    if (clampedFraction <= Precision::Confusion()
+        || clampedFraction >= 1.0 - Precision::Confusion()) {
+        return std::nullopt;
+    }
+
+    return clampedFraction;
+}
+
+std::optional<double> _getThreadDepthFractionFromSources(const std::vector<std::string>& subNames,
+                                                         TechDraw::DrawViewPart* objFeat,
+                                                         double selectedDepth)
+{
+    if (subNames.size() != 2 || selectedDepth <= Precision::Confusion()) {
+        return std::nullopt;
+    }
+
+    std::optional<double> matchedFraction;
+    std::set<App::DocumentObject*> visited;
+    for (App::DocumentObject* source : objFeat->getAllSources()) {
+        if (!source) {
+            continue;
+        }
+
+        std::vector<App::DocumentObject*> candidates{source};
+        const std::vector<App::DocumentObject*> sourceChildren = source->getOutListRecursive();
+        candidates.insert(candidates.end(), sourceChildren.begin(), sourceChildren.end());
+
+        for (App::DocumentObject* candidate : candidates) {
+            if (!candidate || !visited.insert(candidate).second) {
+                continue;
+            }
+
+            std::optional<double> candidateFraction =
+                _getThreadDepthFractionFromObject(candidate, selectedDepth);
+            if (!candidateFraction) {
+                continue;
+            }
+
+            if (matchedFraction) {
+                return std::nullopt;
+            }
+            matchedFraction = candidateFraction;
+        }
+    }
+
+    return matchedFraction;
+}
+
+std::optional<double> _getThreadDepthFractionFromObject(App::DocumentObject* source,
+                                                        double selectedDepth)
+{
+    auto* threaded = dynamic_cast<App::PropertyBool*>(source->getPropertyByName("Threaded"));
+    auto* depth = dynamic_cast<App::PropertyLength*>(source->getPropertyByName("Depth"));
+    auto* threadDepth =
+        dynamic_cast<App::PropertyLength*>(source->getPropertyByName("ThreadDepth"));
+    if (!threaded || !depth || !threadDepth || !threaded->getValue()) {
+        return std::nullopt;
+    }
+
+    const double sourceDepth = depth->getValue();
+    const double sourceThreadDepth = threadDepth->getValue();
+    if (sourceDepth <= Precision::Confusion()
+        || sourceThreadDepth <= Precision::Confusion()
+        || sourceThreadDepth >= sourceDepth - Precision::Confusion()) {
+        return std::nullopt;
+    }
+
+    const double depthTolerance = std::max(Precision::Confusion(), sourceDepth * 0.02);
+    if (std::abs(sourceDepth - selectedDepth) > depthTolerance) {
+        return std::nullopt;
+    }
+
+    const double fraction = sourceThreadDepth / sourceDepth;
+    if (fraction <= Precision::Confusion()
+        || fraction >= 1.0 - Precision::Confusion()) {
+        return std::nullopt;
+    }
+
+    return std::clamp(fraction, 0.0, 1.0);
 }
 
 void _setLineAttributes(TechDraw::CosmeticEdge* cosEdge)

--- a/src/Mod/TechDraw/TDTest/DrawThreadExtensionTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawThreadExtensionTest.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
+import FreeCAD
+import FreeCADGui
+import math
+import Part
+import Sketcher
+import unittest
+import _PartDesign
+
+from .TechDrawTestUtilities import createPageWithSVGTemplate
+from PySide import QtCore
+
+
+class DrawThreadExtensionTest(unittest.TestCase):
+    def setUp(self):
+        FreeCAD.newDocument("TDThreadExtension")
+        FreeCAD.setActiveDocument("TDThreadExtension")
+        FreeCAD.ActiveDocument = FreeCAD.getDocument("TDThreadExtension")
+
+        self.page = createPageWithSVGTemplate()
+
+    def tearDown(self):
+        FreeCAD.closeDocument("TDThreadExtension")
+
+    def waitForGui(self):
+        loop = QtCore.QEventLoop()
+        timer = QtCore.QTimer()
+        timer.setSingleShot(True)
+        timer.timeout.connect(loop.quit)
+        timer.start(1000)
+        loop.exec_()
+        FreeCADGui.updateGui()
+
+    def selectViewEdges(self, view, subnames):
+        FreeCADGui.Selection.clearSelection()
+        for subname in subnames:
+            FreeCADGui.Selection.addSelection(FreeCAD.ActiveDocument.Name, view.Name, subname)
+
+    def makeThreadDepthView(self,
+                            side0Start=FreeCAD.Vector(0, 0, 0),
+                            side0End=FreeCAD.Vector(0, 20, 0),
+                            side1Start=FreeCAD.Vector(10, 0, 0),
+                            side1End=FreeCAD.Vector(10, 20, 0),
+                            depthStart=FreeCAD.Vector(0, 8, 0),
+                            depthEnd=FreeCAD.Vector(10, 8, 0)):
+        fixture_shape = Part.makeCompound(
+            [
+                Part.makeLine(side0Start, side0End),
+                Part.makeLine(side1Start, side1End),
+                Part.makeLine(depthStart, depthEnd),
+            ]
+        )
+        fixture = FreeCAD.ActiveDocument.addObject("Part::Feature", "ThreadDepthFixture")
+        fixture.Shape = fixture_shape
+
+        view = FreeCAD.ActiveDocument.addObject("TechDraw::DrawViewPart", "View")
+        self.page.addView(view)
+        view.Source = [fixture]
+        view.Direction = (0, 0, 1)
+        view.Scale = 1.0
+        FreeCAD.ActiveDocument.recompute()
+        self.waitForGui()
+        self.assertEqual(len(view.getVisibleEdges()), 3)
+        return view
+
+    def makePartDesignThreadedHoleView(self, threaded=True, threadDepth=4):
+        body = FreeCAD.ActiveDocument.addObject("PartDesign::Body", "Body")
+        box = FreeCAD.ActiveDocument.addObject("PartDesign::AdditiveBox", "Box")
+        box.Length = 10
+        box.Width = 10
+        box.Height = 10
+        body.addObject(box)
+        FreeCAD.ActiveDocument.recompute()
+
+        sketch = FreeCAD.ActiveDocument.addObject("Sketcher::SketchObject", "SketchHole")
+        sketch.AttachmentSupport = (FreeCAD.ActiveDocument.XY_Plane, [""])
+        sketch.MapMode = "FlatFace"
+        sketch.MapReversed = True
+        body.addObject(sketch)
+        sketch.addGeometry(Part.Circle(FreeCAD.Vector(-5, 5, 0), FreeCAD.Vector(0, 0, 1), 1), False)
+        sketch.addConstraint(Sketcher.Constraint("Radius", 0, 1))
+        sketch.addConstraint(Sketcher.Constraint("DistanceX", 0, 3, -5))
+        sketch.addConstraint(Sketcher.Constraint("DistanceY", 0, 3, 5))
+        FreeCAD.ActiveDocument.recompute()
+
+        hole = FreeCAD.ActiveDocument.addObject("PartDesign::Hole", "Hole")
+        hole.Profile = sketch
+        body.addObject(hole)
+        hole.Depth = 10
+        hole.ThreadType = 1
+        hole.ThreadSize = 0
+        hole.Threaded = threaded
+        hole.ThreadDepthType = 1
+        hole.ThreadDepth = threadDepth
+        hole.DepthType = 0
+        hole.DrillPoint = 0
+        FreeCAD.ActiveDocument.recompute()
+
+        view = FreeCAD.ActiveDocument.addObject("TechDraw::DrawViewPart", "HoleView")
+        self.page.addView(view)
+        view.Source = [body]
+        view.Direction = (0, 1, 0)
+        view.Scale = 1.0
+        view.HardHidden = True
+        view.SmoothHidden = True
+        FreeCAD.ActiveDocument.recompute()
+        self.waitForGui()
+        self.assertGreaterEqual(len(view.getHiddenEdges()), 2)
+        return view
+
+    def findHiddenHoleSideEdgeNames(self, view):
+        visibleCount = len(view.getVisibleEdges())
+        candidates = []
+        for index, edge in enumerate(view.getHiddenEdges()):
+            vertices = edge.Vertexes
+            if len(vertices) != 2:
+                continue
+
+            start = vertices[0].Point
+            end = vertices[1].Point
+            if abs(start.x - end.x) > 1e-3:
+                continue
+
+            candidates.append((abs((start.x + end.x) / 2.0), visibleCount + index))
+
+        self.assertGreaterEqual(len(candidates), 2)
+        return [f"Edge{index}" for _, index in sorted(candidates)[:2]]
+
+    def runThreadCommand(self, view, subnames, command):
+        self.selectViewEdges(view, subnames)
+        FreeCADGui.runCommand(command)
+        self.waitForGui()
+
+    def cosmeticLineLengths(self, view):
+        return [
+            math.hypot(edge.End.x - edge.Start.x, edge.End.y - edge.Start.y)
+            for edge in view.CosmeticEdges[:2]
+        ]
+
+    def assertThreadLineLengths(self, view, expectedLength, expectedEdges):
+        self.assertEqual(len(view.CosmeticEdges), expectedEdges)
+        for length in self.cosmeticLineLengths(view):
+            self.assertAlmostEqual(length, expectedLength, places=3)
+
+    def pointsAlmostEqual(self, first, second):
+        return (
+            abs(first.x - second.x) < 1e-3
+            and abs(first.y - second.y) < 1e-3
+            and abs(first.z - second.z) < 1e-3
+        )
+
+    def assertHoleThreadEndLineConnectsThreadEdges(self, view):
+        endLine = view.CosmeticEdges[2]
+        firstThread = view.CosmeticEdges[0]
+        secondThread = view.CosmeticEdges[1]
+        endpointPairs = [
+            (firstThread.Start, secondThread.Start),
+            (firstThread.Start, secondThread.End),
+            (firstThread.End, secondThread.Start),
+            (firstThread.End, secondThread.End),
+        ]
+        for first, second in endpointPairs:
+            if (self.pointsAlmostEqual(endLine.Start, first)
+                    and self.pointsAlmostEqual(endLine.End, second)):
+                return
+            if (self.pointsAlmostEqual(endLine.Start, second)
+                    and self.pointsAlmostEqual(endLine.End, first)):
+                return
+        self.fail("Thread end line is not connected to the generated thread line endpoints")
+
+    def testThreadHoleSideUsesFullSelectedEdgeLengthByDefault(self):
+        view = self.makeThreadDepthView()
+
+        self.runThreadCommand(view, ["Edge0", "Edge1"], "TechDraw_ExtensionThreadHoleSide")
+
+        self.assertThreadLineLengths(view, 20.0, 3)
+
+    def testThreadHoleSideCanUseSelectedDepthReference(self):
+        view = self.makeThreadDepthView()
+
+        self.runThreadCommand(view, ["Edge0", "Edge1", "Edge2"], "TechDraw_ExtensionThreadHoleSide")
+
+        self.assertThreadLineLengths(view, 8.0, 3)
+        self.assertHoleThreadEndLineConnectsThreadEdges(view)
+
+    def testThreadHoleSideUsesPartDesignHoleThreadDepth(self):
+        view = self.makePartDesignThreadedHoleView()
+        sideEdges = self.findHiddenHoleSideEdgeNames(view)
+
+        self.runThreadCommand(view, sideEdges, "TechDraw_ExtensionThreadHoleSide")
+
+        self.assertThreadLineLengths(view, 4.0, 3)
+        self.assertEqual(len(view.CenterLines), 1)
+        self.assertHoleThreadEndLineConnectsThreadEdges(view)
+
+    def testThreadHoleSideUsesPartDesignHoleThreadDepthOverHalfDepth(self):
+        view = self.makePartDesignThreadedHoleView(threadDepth=8)
+        sideEdges = self.findHiddenHoleSideEdgeNames(view)
+
+        self.runThreadCommand(view, sideEdges, "TechDraw_ExtensionThreadHoleSide")
+
+        self.assertThreadLineLengths(view, 8.0, 3)
+        self.assertEqual(len(view.CenterLines), 1)
+        self.assertHoleThreadEndLineConnectsThreadEdges(view)
+
+    def testThreadHoleSideIgnoresUnthreadedPartDesignHole(self):
+        view = self.makePartDesignThreadedHoleView(threaded=False, threadDepth=4)
+        sideEdges = self.findHiddenHoleSideEdgeNames(view)
+
+        self.runThreadCommand(view, sideEdges, "TechDraw_ExtensionThreadHoleSide")
+
+        self.assertThreadLineLengths(view, 10.0, 3)
+        self.assertEqual(len(view.CenterLines), 1)
+
+    def testThreadHoleSideDepthReferenceHandlesReversedSideEdges(self):
+        view = self.makeThreadDepthView(
+            side0Start=FreeCAD.Vector(0, 20, 0),
+            side0End=FreeCAD.Vector(0, 0, 0),
+            side1Start=FreeCAD.Vector(10, 20, 0),
+            side1End=FreeCAD.Vector(10, 0, 0),
+        )
+
+        self.runThreadCommand(view, ["Edge0", "Edge1", "Edge2"], "TechDraw_ExtensionThreadHoleSide")
+
+        self.assertThreadLineLengths(view, 8.0, 3)
+        self.assertHoleThreadEndLineConnectsThreadEdges(view)
+
+    def testThreadHoleSideDepthReferenceHandlesMixedSideEdgeOrientation(self):
+        view = self.makeThreadDepthView(
+            side0Start=FreeCAD.Vector(0, 0, 0),
+            side0End=FreeCAD.Vector(0, 20, 0),
+            side1Start=FreeCAD.Vector(10, 20, 0),
+            side1End=FreeCAD.Vector(10, 0, 0),
+        )
+
+        self.runThreadCommand(view, ["Edge0", "Edge1", "Edge2"], "TechDraw_ExtensionThreadHoleSide")
+
+        self.assertThreadLineLengths(view, 8.0, 3)
+        self.assertHoleThreadEndLineConnectsThreadEdges(view)
+
+    def testThreadHoleSideDepthReferenceHandlesSwappedSelectionOrder(self):
+        view = self.makeThreadDepthView()
+
+        self.runThreadCommand(view, ["Edge1", "Edge0", "Edge2"], "TechDraw_ExtensionThreadHoleSide")
+
+        self.assertThreadLineLengths(view, 8.0, 3)
+        self.assertHoleThreadEndLineConnectsThreadEdges(view)
+
+    def testThreadBoltSideCanUseSelectedDepthReference(self):
+        view = self.makeThreadDepthView()
+
+        self.runThreadCommand(view, ["Edge0", "Edge1", "Edge2"], "TechDraw_ExtensionThreadBoltSide")
+
+        self.assertThreadLineLengths(view, 8.0, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/TechDraw/TestTechDrawGui.py
+++ b/src/Mod/TechDraw/TestTechDrawGui.py
@@ -26,4 +26,5 @@ from TDTest.DrawViewSectionTest import DrawViewSectionTest  # noqa: F401
 from TDTest.DrawViewPartTest import DrawViewPartTest  # noqa: F401
 from TDTest.DrawViewDetailTest import DrawViewDetailTest  # noqa: F401
 from TDTest.DrawViewDimensionTest import DrawViewDimensionTest  # noqa: F401
+from TDTest.DrawThreadExtensionTest import DrawThreadExtensionTest  # noqa: F401
 


### PR DESCRIPTION
Refs https://github.com/FreeCAD/FreeCAD/issues/6127

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Summary

- keeps the existing full-length side-thread behavior when no reliable thread-depth input is available
- lets side cosmetic thread commands use an optional third selected projected edge or vertex as a thread-depth reference
- lets hole-side thread cosmetics derive `ThreadDepth / Depth` from an unambiguous threaded source object under the current `DrawViewPart` sources, including PartDesign Body children
- adds a centerline for hole-side cosmetic thread representation
- keeps ambiguous, missing, non-threaded, full-depth, or depth-mismatched source candidates falling back to the previous behavior rather than guessing

## Notes

This is intentionally framed as a follow-up improvement for side-view thread depth and centerline behavior, not as a full claim that every ISO 6410-1 thread presentation convention is complete.

This work was assisted by OpenAI Codex (GPT-5).

The automatic source-derived path is conservative:

- it only runs for `TechDraw_ExtensionThreadHoleSide` when exactly two side edges are selected
- it only scans the current view sources and their recursive children
- it requires `Threaded = true`, `Depth`, and `ThreadDepth`
- it requires `ThreadDepth < Depth`
- it requires the source `Depth` to match the selected projected side-edge depth within tolerance
- it refuses ambiguous matches

Users can still select a third projected edge or vertex when automatic source lookup is not appropriate.

## Tests

```bash
pixi run cmake --build build/debug --target TechDrawGui TDTestTarget -j 8
pixi run build/debug/bin/FreeCAD --hidden -t TDTest.DrawThreadExtensionTest.DrawThreadExtensionTest
pixi run build/debug/bin/FreeCADCmd -t TestTechDrawApp
pixi run build/debug/bin/FreeCAD --hidden -t TestTechDrawGui
git -c core.whitespace=cr-at-eol diff --check
pixi run python -m py_compile src/Mod/TechDraw/TDTest/DrawThreadExtensionTest.py
```

Focused `DrawThreadExtensionTest` coverage includes:

- default two-edge full-length side threads
- third selected reference edge depth limiting
- reversed, mixed, and swapped side-edge orientation
- bolt-side behavior through the shared thread-line helper
- real `PartDesign::Hole` source metadata with `Depth = 10` and `ThreadDepth = 4`
- source-derived `ThreadDepth` over half the hole depth, covering `Depth = 10` and `ThreadDepth = 8`
- unthreaded PartDesign Hole fallback to full selected side-edge length

Assisted-by: OpenAI Codex (GPT-5)
