### PR TITLE
Draft: persist grid settings in documents

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -62,6 +62,7 @@ SET(Draft_tests
     drafttests/test_draftgeomutils.py
     drafttests/test_dwg.py
     drafttests/test_dxf.py
+    drafttests/test_grid_settings.py
     drafttests/test_import.py
     drafttests/test_import_gui.py
     drafttests/test_import_tools.py

--- a/src/Mod/Draft/TestDraft.py
+++ b/src/Mod/Draft/TestDraft.py
@@ -114,6 +114,7 @@ from drafttests.test_dxf import DraftDXF as DraftTest06
 # from drafttests.test_oca import DraftOCA as DraftTest08
 # from drafttests.test_airfoildat import DraftAirfoilDAT as DraftTest09
 from drafttests.test_array import DraftArray as DraftTest10
+from drafttests.test_grid_settings import DraftGridSettings as DraftTest11
 
 # Use the modules so that code checkers don't complain (flake8)
 True if DraftTest01 else False
@@ -126,3 +127,4 @@ True if DraftTest06 else False
 # True if DraftTest08 else False
 # True if DraftTest09 else False
 True if DraftTest10 else False
+True if DraftTest11 else False

--- a/src/Mod/Draft/draftguitools/gui_selectplane.py
+++ b/src/Mod/Draft/draftguitools/gui_selectplane.py
@@ -92,6 +92,7 @@ class Draft_SelectPlane:
         if hasattr(Gui, "Snapper"):
             Gui.Snapper.setTrackers()
             self.grid = Gui.Snapper.grid
+        self.doc_name = App.ActiveDocument.Name if App.ActiveDocument is not None else None
         self.offset = 0
         self.center = params.get_param("CenterPlaneOnView")
 
@@ -104,12 +105,12 @@ class Draft_SelectPlane:
         form.fieldOffset.setText(Units.Quantity(self.offset, Units.Length).UserString)
         form.checkCenter.setChecked(self.center)
         try:
-            q = Units.Quantity(params.get_param("gridSpacing"))
+            q = Units.Quantity(params.get_grid_param("gridSpacing", self.doc_name))
         except ValueError:
             q = Units.Quantity("1 mm")
         form.fieldGridSpacing.setText(q.UserString)
-        form.fieldGridMainLine.setValue(params.get_param("gridEvery"))
-        form.fieldGridExtension.setValue(params.get_param("gridSize"))
+        form.fieldGridMainLine.setValue(params.get_grid_param("gridEvery", self.doc_name))
+        form.fieldGridExtension.setValue(params.get_grid_param("gridSize", self.doc_name))
         form.fieldSnapRadius.setValue(params.get_param("snapRange"))
 
         # Set icons
@@ -269,33 +270,30 @@ class Draft_SelectPlane:
         self.center = bool(getattr(val, "value", val))
         params.set_param("CenterPlaneOnView", self.center)
 
+    def _update_grid(self):
+        params.refresh_grid(self.doc_name)
+        if self.grid is not None:
+            self.grid.show_during_command = True
+            self.grid.on()
+
     def on_set_grid_size(self, text):
         try:
             q = Units.Quantity(text)
-        except Exception:
+        except (TypeError, ValueError):
             pass
         else:
-            params.set_param("gridSpacing", q.UserString)
-            # ParamObserver handles grid changes. See params.py.
-            if self.grid is not None:
-                self.grid.show_during_command = True
-                self.grid.on()
+            if params.set_grid_param("gridSpacing", q.UserString, self.doc_name):
+                self._update_grid()
 
     def on_set_main_line(self, i):
         if i > 1:
-            params.set_param("gridEvery", i)
-            # ParamObserver handles grid changes. See params.py.
-            if self.grid is not None:
-                self.grid.show_during_command = True
-                self.grid.on()
+            if params.set_grid_param("gridEvery", i, self.doc_name):
+                self._update_grid()
 
     def on_set_extension(self, i):
         if i > 1:
-            params.set_param("gridSize", i)
-            # ParamObserver handles grid changes. See params.py.
-            if self.grid is not None:
-                self.grid.show_during_command = True
-                self.grid.on()
+            if params.set_grid_param("gridSize", i, self.doc_name):
+                self._update_grid()
 
     def on_set_snap_radius(self, i):
         params.set_param("snapRange", i)

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -1735,7 +1735,8 @@ class Snapper:
                 self.extLine2 = self.trackers[8][i]
                 self.holdTracker = self.trackers[9][i]
             else:
-                self.grid = trackers.gridTracker()
+                doc_name = App.ActiveDocument.Name if App.ActiveDocument is not None else None
+                self.grid = trackers.gridTracker(doc_name)
                 if params.get_param("alwaysShowGrid"):
                     self.grid.show_always = True
                 if params.get_param("grid"):

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -1145,8 +1145,8 @@ class wireTracker(Tracker):
 class gridTracker(Tracker):
     """A grid tracker."""
 
-    def __init__(self):
-
+    def __init__(self, doc_name=None):
+        self.doc_name = doc_name
         col, red, green, blue, gtrans = self.getGridColors()
         pick = coin.SoPickStyle()
         pick.style.setValue(coin.SoPickStyle.UNPICKABLE)
@@ -1501,11 +1501,13 @@ class gridTracker(Tracker):
     def reset(self):
         """Reset the grid according to preferences settings."""
         try:
-            self.space = FreeCAD.Units.Quantity(params.get_param("gridSpacing")).Value
+            self.space = FreeCAD.Units.Quantity(
+                params.get_grid_param("gridSpacing", self.doc_name)
+            ).Value
         except ValueError:
             self.space = 1
-        self.mainlines = params.get_param("gridEvery")
-        self.numlines = params.get_param("gridSize")
+        self.mainlines = params.get_grid_param("gridEvery", self.doc_name)
+        self.numlines = params.get_grid_param("gridSize", self.doc_name)
         self.update()
 
     def set(self):

--- a/src/Mod/Draft/drafttests/test_grid_settings.py
+++ b/src/Mod/Draft/drafttests/test_grid_settings.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2026 FreeCAD Project Association                        *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+import unittest
+
+import FreeCAD as App
+from draftutils import params
+
+
+class DraftGridSettings(unittest.TestCase):
+    """Tests for document-backed Draft grid settings."""
+
+    def setUp(self):
+        self.doc = App.newDocument(self.id().split(".")[-1])
+        self._param_group = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+        self._saved_string_params = {
+            "gridSpacing": (
+                "gridSpacing" in self._param_group.GetStrings(),
+                self._param_group.GetString("gridSpacing", ""),
+            ),
+        }
+        self._saved_int_params = {
+            entry: (
+                entry in self._param_group.GetInts(),
+                self._param_group.GetInt(entry, 0),
+            )
+            for entry in ("gridEvery", "gridSize")
+        }
+        self._param_group.SetString("gridSpacing", "2 mm")
+        self._param_group.SetInt("gridEvery", 8)
+        self._param_group.SetInt("gridSize", 20)
+
+    def tearDown(self):
+        try:
+            self._restore_preferences()
+        finally:
+            App.closeDocument(self.doc.Name)
+
+    def _restore_preferences(self):
+        for entry, (exists, value) in self._saved_string_params.items():
+            if exists:
+                self._param_group.SetString(entry, value)
+            else:
+                self._param_group.RemString(entry)
+        for entry, (exists, value) in self._saved_int_params.items():
+            if exists:
+                self._param_group.SetInt(entry, value)
+            else:
+                self._param_group.RemInt(entry)
+
+    def assertQuantityEqual(self, actual, expected):
+        self.assertAlmostEqual(
+            App.Units.Quantity(actual).Value,
+            App.Units.Quantity(expected).Value,
+        )
+
+    def test_document_grid_settings_override_preferences(self):
+        self.doc.Meta = {
+            "Draft.GridSpacing": "7 mm",
+            "Draft.GridMainlines": "12",
+            "Draft.GridSize": "24",
+        }
+
+        self.assertQuantityEqual(params.get_grid_param("gridSpacing", self.doc), "7 mm")
+        self.assertEqual(params.get_grid_param("gridEvery", self.doc), 12)
+        self.assertEqual(params.get_grid_param("gridSize", self.doc), 24)
+
+    def test_invalid_document_grid_settings_fall_back_to_preferences(self):
+        self.doc.Meta = {
+            "Draft.GridSpacing": "0 mm",
+            "Draft.GridMainlines": "1",
+            "Draft.GridSize": "0",
+        }
+
+        self.assertQuantityEqual(params.get_grid_param("gridSpacing", self.doc), "2 mm")
+        self.assertEqual(params.get_grid_param("gridEvery", self.doc), 8)
+        self.assertEqual(params.get_grid_param("gridSize", self.doc), 20)
+
+        self.doc.Meta = {"Draft.GridSpacing": "invalid"}
+        self.assertQuantityEqual(params.get_grid_param("gridSpacing", self.doc), "2 mm")
+
+    def test_set_grid_param_preserves_unrelated_metadata_and_preferences(self):
+        self.doc.Meta = {
+            "BIM.GridSpacing": "1 m",
+            "Draft.Other": "keep",
+        }
+
+        self.assertTrue(params.set_grid_param("gridSpacing", "5 mm", self.doc))
+        self.assertTrue(params.set_grid_param("gridEvery", 14, self.doc))
+        self.assertTrue(params.set_grid_param("gridSize", 30, self.doc))
+
+        self.assertQuantityEqual(self.doc.Meta["Draft.GridSpacing"], "5 mm")
+        self.assertEqual(self.doc.Meta["Draft.GridMainlines"], "14")
+        self.assertEqual(self.doc.Meta["Draft.GridSize"], "30")
+        self.assertEqual(self.doc.Meta["BIM.GridSpacing"], "1 m")
+        self.assertEqual(self.doc.Meta["Draft.Other"], "keep")
+        self.assertQuantityEqual(params.get_param("gridSpacing"), "2 mm")
+        self.assertEqual(params.get_param("gridEvery"), 8)
+        self.assertEqual(params.get_param("gridSize"), 20)
+
+    def test_set_grid_param_rejects_invalid_document_values(self):
+        self.assertFalse(params.set_grid_param("gridSpacing", "0 mm", self.doc))
+        self.assertFalse(params.set_grid_param("gridSpacing", "-5 mm", self.doc))
+        self.assertFalse(params.set_grid_param("gridEvery", 1, self.doc))
+        self.assertEqual(self.doc.Meta, {})
+
+    def test_explicit_missing_document_does_not_write_preferences(self):
+        self.assertFalse(params.set_grid_param("gridSize", 40, "MissingDocument"))
+
+        self.assertEqual(params.get_param("gridSize"), 20)

--- a/src/Mod/Draft/draftutils/params.py
+++ b/src/Mod/Draft/draftutils/params.py
@@ -121,7 +121,28 @@ def _param_observer_callback_scalemultiplier(value):
         scale_widget.scaleLabel.setText(scale_label)
 
 
-def _param_observer_callback_grid():
+def _document_name(doc):
+    if doc is None:
+        return None
+    if isinstance(doc, str):
+        return doc
+    return doc.Name
+
+
+def _resolve_document(doc):
+    if doc is None:
+        return App.ActiveDocument
+    if isinstance(doc, str):
+        if doc in App.listDocuments():
+            return App.getDocument(doc)
+        return None
+    return doc
+
+
+def refresh_grid(doc=None):
+    if not App.GuiUp:
+        return
+    document_name = _document_name(doc)
     if hasattr(App, "draft_working_planes") and hasattr(Gui, "Snapper"):
         try:
             trackers = Gui.Snapper.trackers
@@ -130,12 +151,22 @@ def _param_observer_callback_grid():
                 if view in trackers[0]:
                     i = trackers[0].index(view)
                     grid = trackers[1][i]
+                    grid_doc_name = grid.doc_name
+                    if document_name is not None and grid_doc_name not in (
+                        None,
+                        document_name,
+                    ):
+                        continue
                     grid.pts = []
                     grid.reset()
                     grid.displayHumanFigure(wp)
                     grid.setAxesColor(wp)
         except Exception:
             pass
+
+
+def _param_observer_callback_grid():
+    refresh_grid()
 
 
 def _param_observer_callback_snapbar(value):
@@ -771,6 +802,102 @@ def _get_param_dictionary():
 
 
 PARAM_DICT = _get_param_dictionary()
+
+_GRID_DOCUMENT_NAMESPACE = "Draft"
+_GRID_DOCUMENT_SETTINGS = {
+    "gridSpacing": "GridSpacing",
+    "gridEvery": "GridMainlines",
+    "gridSize": "GridSize",
+}
+
+
+def _is_valid_grid_spacing(value):
+    try:
+        quantity = App.Units.Quantity(value)
+    except (TypeError, ValueError):
+        return False
+    return quantity.Value > 0
+
+
+def _grid_param_default(entry):
+    value = get_param(entry)
+    if entry == "gridSpacing":
+        if _is_valid_grid_spacing(value):
+            return value
+        default = get_param(entry, ret_default=True)
+        if _is_valid_grid_spacing(default):
+            return default
+        return "1 mm"
+
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        value = 0
+    if value > 1:
+        return value
+
+    try:
+        default = int(get_param(entry, ret_default=True))
+    except (TypeError, ValueError):
+        default = 2
+    return default if default > 1 else 2
+
+
+def get_grid_param(entry, doc=None):
+    """Return a grid parameter with document settings overriding preferences."""
+    document_key = _GRID_DOCUMENT_SETTINGS.get(entry)
+    if document_key is None:
+        return get_param(entry)
+
+    default = _grid_param_default(entry)
+    doc = _resolve_document(doc)
+    if doc is None:
+        return default
+
+    settings = doc.settings(_GRID_DOCUMENT_NAMESPACE)
+    if entry == "gridSpacing":
+        value = settings.getString(document_key, default)
+        return value if _is_valid_grid_spacing(value) else default
+
+    value = settings.getInt(document_key, default)
+    return value if value > 1 else default
+
+
+def set_grid_param(entry, value, doc=None):
+    """Store a grid parameter in document settings, or preferences if no document exists."""
+    document_key = _GRID_DOCUMENT_SETTINGS.get(entry)
+    if document_key is None:
+        return set_param(entry, value)
+
+    if entry == "gridSpacing":
+        try:
+            quantity = App.Units.Quantity(value)
+        except (TypeError, ValueError):
+            return False
+        if quantity.Value <= 0:
+            return False
+        value = quantity.UserString
+    else:
+        try:
+            value = int(value)
+        except (TypeError, ValueError):
+            return False
+        if value <= 1:
+            return False
+
+    source_doc = doc
+    doc = _resolve_document(doc)
+    if doc is None:
+        if source_doc is not None:
+            return False
+        return set_param(entry, value)
+
+    settings = doc.settings(_GRID_DOCUMENT_NAMESPACE)
+    if entry == "gridSpacing":
+        settings.setString(document_key, value)
+    else:
+        settings.setInt(document_key, value)
+    return True
 
 
 def get_param(entry, path="Mod/Draft", ret_default=False, silent=False):


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on top of #30692, which adds the core namespaced document settings API.


## Motivation

Draft grid spacing, mainline frequency, and grid size are currently stored as global Draft preferences. That makes grid geometry user-local instead of document-local: reopening or sharing a document can lose the intended Draft grid context.

This builds on the namespaced document settings API so Draft can persist document-specific grid geometry in `Document.Meta` through a small, typed, inspectable API instead of adding more ad hoc metadata access.

## Summary

- Store Draft grid geometry in document settings:
  - `Draft.GridSpacing`
  - `Draft.GridMainlines`
  - `Draft.GridSize`
- Keep existing Draft preferences as fallbacks when the document has no valid value.
- Keep grid visibility, color, transparency, and other UI preferences as global preferences.
- Update the Select Plane task panel to read/write document grid settings.
- Refresh matching grid trackers after document setting writes.
- Keep grid trackers tied to a document name instead of retaining a document object.
- Add focused headless tests for document overrides, invalid fallback, metadata preservation, and invalid writes.

Refs FreeCAD/FreeCAD#20457