### PR TITLE
TechDraw: Add auxiliary view

### DIFF
--- a/src/Mod/TechDraw/App/AppTechDraw.cpp
+++ b/src/Mod/TechDraw/App/AppTechDraw.cpp
@@ -26,6 +26,7 @@
 #include "CenterLine.h"
 #include "CosmeticExtension.h"
 #include "Cosmetic.h"
+#include "DrawAuxiliaryView.h"
 #include "DrawComplexSection.h"
 #include "DrawGeomHatch.h"
 #include "DrawHatch.h"
@@ -92,6 +93,7 @@ PyMOD_INIT_FUNC(TechDraw)
     TechDraw::DrawViewSpreadsheet ::init();
 
     TechDraw::DrawViewSection     ::init();
+    TechDraw::DrawAuxiliaryView   ::init();
     TechDraw::DrawComplexSection     ::init();
     TechDraw::DrawViewDimension   ::init();
     TechDraw::DrawViewDimExtent   ::init();
@@ -138,6 +140,7 @@ PyMOD_INIT_FUNC(TechDraw)
     TechDraw::DrawViewPython      ::init();
     TechDraw::DrawViewPartPython  ::init();
     TechDraw::DrawViewSectionPython::init();
+    TechDraw::DrawAuxiliaryViewPython::init();
     TechDraw::DrawComplexSectionPython ::init();
     TechDraw::DrawTemplatePython  ::init();
     TechDraw::DrawViewSymbolPython::init();

--- a/src/Mod/TechDraw/App/CMakeLists.txt
+++ b/src/Mod/TechDraw/App/CMakeLists.txt
@@ -46,6 +46,8 @@ generate_from_py(DrawBrokenView)
 SET(Draw_SRCS
     DrawPage.cpp
     DrawPage.h
+    DrawAuxiliaryView.cpp
+    DrawAuxiliaryView.h
     DrawComplexSection.cpp
     DrawComplexSection.h
     DrawView.cpp

--- a/src/Mod/TechDraw/App/DrawAuxiliaryView.cpp
+++ b/src/Mod/TechDraw/App/DrawAuxiliaryView.cpp
@@ -1,0 +1,353 @@
+/***************************************************************************
+ *   Copyright (c) 2026 FreeCAD contributors                               *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <Base/Console.h>
+#include <Base/Converter.h>
+#include <Base/Tools.h>
+
+#include "DrawAuxiliaryView.h"
+#include "DrawUtil.h"
+
+using namespace TechDraw;
+
+// NOLINTBEGIN
+PROPERTY_SOURCE(TechDraw::DrawAuxiliaryView, TechDraw::DrawViewPart)
+
+const char* DrawAuxiliaryView::ProjectionModeEnums[] = {"Across", "Along", nullptr};
+// NOLINTEND
+
+DrawAuxiliaryView::DrawAuxiliaryView()
+{
+    static const char* agroup = "Auxiliary";
+
+    ADD_PROPERTY_TYPE(BaseView,
+                      (nullptr),
+                      agroup,
+                      App::Prop_None,
+                      "The base view used to calculate this auxiliary view");
+    BaseView.setScope(App::LinkScope::Global);
+
+    ADD_PROPERTY_TYPE(AuxiliaryDirection,
+                      (1.0, 0.0, 0.0),
+                      agroup,
+                      App::Prop_None,
+                      "Reference line direction in the base view coordinate system");
+
+    ADD_PROPERTY_TYPE(ReferenceStart,
+                      (0.0, 0.0, 0.0),
+                      agroup,
+                      App::Prop_None,
+                      "Start point of the reference marker in base view coordinates");
+    ADD_PROPERTY_TYPE(ReferenceEnd,
+                      (1.0, 0.0, 0.0),
+                      agroup,
+                      App::Prop_None,
+                      "End point of the reference marker in base view coordinates");
+
+    ProjectionMode.setEnums(ProjectionModeEnums);
+    ADD_PROPERTY_TYPE(ProjectionMode,
+                      ((long)0),
+                      agroup,
+                      App::Prop_None,
+                      "Use a view direction across or along the reference line");
+
+    ADD_PROPERTY_TYPE(ReverseDirection,
+                      (false),
+                      agroup,
+                      App::Prop_None,
+                      "Reverse the auxiliary view direction");
+    ADD_PROPERTY_TYPE(KeepAligned,
+                      (true),
+                      agroup,
+                      App::Prop_None,
+                      "Keep the auxiliary view aligned with its base reference marker");
+
+    ADD_PROPERTY_TYPE(AlignmentOffset,
+                      (0.0, 0.0, 0.0),
+                      agroup,
+                      App::Prop_Hidden,
+                      "Page offset from the base view used when KeepAligned is true");
+    ADD_PROPERTY_TYPE(AlignmentOffsetInitialized,
+                      (false),
+                      agroup,
+                      App::Prop_Hidden,
+                      "Whether AlignmentOffset has been captured for the current base view");
+
+    ADD_PROPERTY_TYPE(ReferenceLabel,
+                      ("A"),
+                      agroup,
+                      App::Prop_None,
+                      "Reference label shown on the base and auxiliary views");
+}
+
+App::DocumentObjectExecReturn* DrawAuxiliaryView::execute()
+{
+    if (!getBaseDVP()) {
+        clearBaseSources();
+        return new App::DocumentObjectExecReturn("BaseView object not found");
+    }
+
+    updateProjectionFromBase();
+    updateAlignmentFromBase();
+    return DrawViewPart::execute();
+}
+
+short DrawAuxiliaryView::mustExecute() const
+{
+    if (isRestoring()) {
+        return DrawViewPart::mustExecute();
+    }
+
+    if (BaseView.isTouched()
+        || AuxiliaryDirection.isTouched()
+        || ProjectionMode.isTouched()
+        || ReverseDirection.isTouched()
+        || KeepAligned.isTouched()
+        || ReferenceStart.isTouched()
+        || ReferenceEnd.isTouched()
+        || AlignmentOffset.isTouched()
+        || AlignmentOffsetInitialized.isTouched()) {
+        return 1;
+    }
+
+    return DrawViewPart::mustExecute();
+}
+
+void DrawAuxiliaryView::onChanged(const App::Property* prop)
+{
+    if (isRestoring()) {
+        DrawViewPart::onChanged(prop);
+        return;
+    }
+
+    if (prop == &BaseView) {
+        AlignmentOffsetInitialized.setValue(false);
+        if (!getBaseDVP()) {
+            clearBaseSources();
+        }
+    }
+
+    if (prop == &ReferenceStart || prop == &ReferenceEnd) {
+        syncDirectionFromReference();
+    }
+
+    if (prop == &BaseView
+        || prop == &AuxiliaryDirection
+        || prop == &ProjectionMode
+        || prop == &ReverseDirection) {
+        updateProjectionFromBase();
+    }
+
+    if (prop == &KeepAligned && KeepAligned.getValue()) {
+        captureAlignmentOffset();
+        updateAlignmentFromBase();
+    }
+
+    if ((prop == &X || prop == &Y) && KeepAligned.getValue()) {
+        captureAlignmentOffset();
+    }
+
+    if (prop == &BaseView
+        || prop == &ReferenceStart
+        || prop == &ReferenceEnd
+        || prop == &ReferenceLabel
+        || prop == &AuxiliaryDirection
+        || prop == &ProjectionMode
+        || prop == &ReverseDirection) {
+        auto base = getBaseDVP();
+        if (base) {
+            base->requestPaint();
+        }
+    }
+
+    DrawViewPart::onChanged(prop);
+}
+
+void DrawAuxiliaryView::unsetupObject()
+{
+    auto base = getBaseDVP();
+    if (base) {
+        base->requestPaint();
+    }
+    DrawViewPart::unsetupObject();
+}
+
+TechDraw::DrawViewPart* DrawAuxiliaryView::getBaseDVP() const
+{
+    return dynamic_cast<TechDraw::DrawViewPart*>(BaseView.getValue());
+}
+
+Base::Vector3d DrawAuxiliaryView::getSafeReferenceDirection() const
+{
+    Base::Vector3d reference = AuxiliaryDirection.getValue();
+    reference.z = 0.0;
+    if (DrawUtil::fpCompare(reference.Length(), 0.0)) {
+        return Base::Vector3d(1.0, 0.0, 0.0);
+    }
+
+    reference.Normalize();
+    return reference;
+}
+
+Base::Vector3d DrawAuxiliaryView::getAuxiliaryLocalDirection() const
+{
+    const Base::Vector3d reference = getSafeReferenceDirection();
+    Base::Vector3d localDirection = reference;
+    if (ProjectionMode.isValue("Across")) {
+        localDirection = Base::Vector3d(-reference.y, reference.x, 0.0);
+    }
+
+    if (ReverseDirection.getValue()) {
+        localDirection = localDirection * -1.0;
+    }
+
+    if (DrawUtil::fpCompare(localDirection.Length(), 0.0)) {
+        return Base::Vector3d(0.0, 1.0, 0.0);
+    }
+
+    localDirection.Normalize();
+    return localDirection;
+}
+
+Base::Vector3d DrawAuxiliaryView::getAuxiliaryDirection() const
+{
+    TechDraw::DrawViewPart* base = getBaseDVP();
+    if (!base) {
+        return Direction.getValue();
+    }
+
+    return base->localVectorToDirection(getAuxiliaryLocalDirection());
+}
+
+Base::Vector3d DrawAuxiliaryView::getAuxiliaryXDirection() const
+{
+    TechDraw::DrawViewPart* base = getBaseDVP();
+    if (!base) {
+        return getXDirection();
+    }
+
+    gp_Ax2 auxiliaryCS = base->localVectorToCS(getAuxiliaryLocalDirection());
+    return Base::convertTo<Base::Vector3d>(auxiliaryCS.XDirection());
+}
+
+void DrawAuxiliaryView::captureAlignmentOffset()
+{
+    TechDraw::DrawViewPart* base = getBaseDVP();
+    if (!base) {
+        AlignmentOffsetInitialized.setValue(false);
+        return;
+    }
+
+    Base::Vector3d offset = getPosition() - base->getPosition();
+    offset.z = 0.0;
+    AlignmentOffset.setValue(offset);
+    AlignmentOffsetInitialized.setValue(true);
+}
+
+void DrawAuxiliaryView::clearBaseSources()
+{
+    std::vector<App::DocumentObject*> emptySources;
+    if (!Source.getValues().empty()) {
+        Source.setValues(emptySources);
+    }
+    if (!XSource.getValues().empty()) {
+        XSource.setValues(emptySources);
+    }
+}
+
+void DrawAuxiliaryView::mirrorSourcesFromBase(TechDraw::DrawViewPart* base)
+{
+    if (!base) {
+        clearBaseSources();
+        return;
+    }
+
+    auto baseSources = base->Source.getValues();
+    if (Source.getValues() != baseSources) {
+        Source.setValues(baseSources);
+    }
+
+    auto baseXSources = base->XSource.getValues();
+    if (XSource.getValues() != baseXSources) {
+        XSource.setValues(baseXSources);
+    }
+}
+
+void DrawAuxiliaryView::syncDirectionFromReference()
+{
+    Base::Vector3d reference = ReferenceEnd.getValue() - ReferenceStart.getValue();
+    reference.z = 0.0;
+    AuxiliaryDirection.setValue(reference);
+}
+
+void DrawAuxiliaryView::updateAlignmentFromBase()
+{
+    if (!KeepAligned.getValue()) {
+        return;
+    }
+
+    TechDraw::DrawViewPart* base = getBaseDVP();
+    if (!base) {
+        return;
+    }
+
+    if (!AlignmentOffsetInitialized.getValue()) {
+        captureAlignmentOffset();
+        if (!AlignmentOffsetInitialized.getValue()) {
+            return;
+        }
+    }
+
+    Base::Vector3d offset = AlignmentOffset.getValue();
+    offset.z = 0.0;
+    const Base::Vector3d position = base->getPosition() + offset;
+    setPosition(position.x, position.y, true);
+}
+
+void DrawAuxiliaryView::updateProjectionFromBase()
+{
+    TechDraw::DrawViewPart* base = getBaseDVP();
+    if (!base) {
+        clearBaseSources();
+        return;
+    }
+
+    mirrorSourcesFromBase(base);
+
+    Direction.setValue(getAuxiliaryDirection());
+    XDirection.setValue(getAuxiliaryXDirection());
+}
+
+namespace App
+{
+/// @cond DOXERR
+PROPERTY_SOURCE_TEMPLATE(TechDraw::DrawAuxiliaryViewPython, TechDraw::DrawAuxiliaryView)
+template<>
+const char* TechDraw::DrawAuxiliaryViewPython::getViewProviderName() const
+{
+    return "TechDrawGui::ViewProviderViewPart";
+}
+/// @endcond
+
+// explicit template instantiation
+template class TechDrawExport FeaturePythonT<TechDraw::DrawAuxiliaryView>;
+}// namespace App

--- a/src/Mod/TechDraw/App/DrawAuxiliaryView.h
+++ b/src/Mod/TechDraw/App/DrawAuxiliaryView.h
@@ -1,0 +1,82 @@
+/***************************************************************************
+ *   Copyright (c) 2026 FreeCAD contributors                               *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include <Mod/TechDraw/TechDrawGlobal.h>
+
+#include "DrawViewPart.h"
+
+namespace TechDraw
+{
+
+// NOLINTBEGIN
+class TechDrawExport DrawAuxiliaryView: public TechDraw::DrawViewPart
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(TechDraw::DrawAuxiliaryView);
+
+public:
+    DrawAuxiliaryView();
+    ~DrawAuxiliaryView() override = default;
+
+    App::PropertyLink BaseView;
+    App::PropertyVector AuxiliaryDirection;
+    App::PropertyVector ReferenceStart;
+    App::PropertyVector ReferenceEnd;
+    App::PropertyEnumeration ProjectionMode;
+    App::PropertyBool ReverseDirection;
+    App::PropertyBool KeepAligned;
+    App::PropertyVector AlignmentOffset;
+    App::PropertyBool AlignmentOffsetInitialized;
+    App::PropertyString ReferenceLabel;
+// NOLINTEND
+
+    App::DocumentObjectExecReturn* execute() override;
+    short mustExecute() const override;
+    void onChanged(const App::Property* prop) override;
+    void unsetupObject() override;
+
+    const char* getViewProviderName() const override
+    {
+        return "TechDrawGui::ViewProviderViewPart";
+    }
+
+    TechDraw::DrawViewPart* getBaseDVP() const;
+    Base::Vector3d getAuxiliaryLocalDirection() const;
+    Base::Vector3d getAuxiliaryDirection() const;
+    Base::Vector3d getAuxiliaryXDirection() const;
+    void captureAlignmentOffset();
+    void clearBaseSources();
+    void mirrorSourcesFromBase(TechDraw::DrawViewPart* base);
+    void syncDirectionFromReference();
+    void updateAlignmentFromBase();
+    void updateProjectionFromBase();
+
+    static const char* ProjectionModeEnums[];
+
+private:
+    Base::Vector3d getSafeReferenceDirection() const;
+};
+
+using DrawAuxiliaryViewPython = App::FeaturePythonT<DrawAuxiliaryView>;
+
+}// namespace TechDraw

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -73,6 +73,7 @@
 
 #include "Cosmetic.h"
 #include "CenterLine.h"
+#include "DrawAuxiliaryView.h"
 #include "DrawGeomHatch.h"
 #include "DrawHatch.h"
 #include "DrawPage.h"
@@ -288,6 +289,13 @@ void DrawViewPart::onChanged(const App::Property* prop)
     }
 
     DrawView::onChanged(prop);
+
+    if (prop == &X || prop == &Y) {
+        auto auxiliaryRefs = getAuxiliaryRefs();
+        for (auto& auxiliaryView : auxiliaryRefs) {
+            auxiliaryView->updateAlignmentFromBase();
+        }
+    }
 }
 
 void DrawViewPart::partExec(TopoDS_Shape& shape)
@@ -1189,6 +1197,25 @@ std::vector<DrawViewSection*> DrawViewPart::getSectionRefs() const
             auto base = section->BaseView.getValue();
             if (base == this) {
                 result.push_back(section);
+            }
+        }
+    }
+    return result;
+}
+
+std::vector<DrawAuxiliaryView*> DrawViewPart::getAuxiliaryRefs() const
+{
+    std::vector<DrawAuxiliaryView*> result;
+    std::vector<App::DocumentObject*> inObjs = getInList();
+    for (auto& o : inObjs) {
+        if (o->isDerivedFrom<DrawAuxiliaryView>() &&
+            !o->isRemoving()) {
+            // expressions can add extra links to this DVP so we keep only
+            // objects that are BaseViews
+            auto auxiliary = static_cast<TechDraw::DrawAuxiliaryView*>(o);
+            auto base = auxiliary->BaseView.getValue();
+            if (base == this) {
+                result.push_back(auxiliary);
             }
         }
     }

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -65,6 +65,7 @@ class DrawHatch;
 class DrawGeomHatch;
 class DrawViewDimension;
 class DrawProjectSplit;
+class DrawAuxiliaryView;
 class DrawViewSection;
 class DrawViewDetail;
 class DrawViewBalloon;
@@ -148,6 +149,7 @@ public:
     std::vector<TechDraw::DrawGeomHatch*> getGeomHatches() const;
     std::vector<TechDraw::DrawViewDimension*> getDimensions() const;
     std::vector<TechDraw::DrawViewBalloon*> getBalloons() const;
+    virtual std::vector<DrawAuxiliaryView*> getAuxiliaryRefs() const;
     virtual std::vector<DrawViewSection*> getSectionRefs() const;
     virtual std::vector<DrawViewDetail*> getDetailRefs() const;
 

--- a/src/Mod/TechDraw/CMakeLists.txt
+++ b/src/Mod/TechDraw/CMakeLists.txt
@@ -176,6 +176,8 @@ endif(BUILD_GUI)
 #unit test files
 SET(TDTest_SRCS
     TDTest/__init__.py
+    TDTest/DrawAuxiliaryViewGuiTest.py
+    TDTest/DrawAuxiliaryViewTest.py
     TDTest/DrawHatchTest.py
     TDTest/DrawProjectionGroupTest.py
     TDTest/DrawViewAnnotationTest.py
@@ -211,4 +213,3 @@ fc_copy_sources(TDTestTarget "${CMAKE_BINARY_DIR}/Mod/TechDraw" ${TDAllTest})
 # install Python packages (for make install)
 INSTALL(FILES ${TDTest_SRCS} DESTINATION Mod/TechDraw/TDTest)
 INSTALL(FILES ${TDTestFile_SRCS} DESTINATION Mod/TechDraw/TDTest)
-

--- a/src/Mod/TechDraw/Gui/CMakeLists.txt
+++ b/src/Mod/TechDraw/Gui/CMakeLists.txt
@@ -189,6 +189,8 @@ SET(TechDrawGui_SRCS
     TaskDetail.ui
     TaskDetail.cpp
     TaskDetail.h
+    TaskAuxiliaryView.cpp
+    TaskAuxiliaryView.h
     PreferencesGui.cpp
     PreferencesGui.h
     TaskCosmeticLine.cpp
@@ -250,6 +252,8 @@ SET(TechDrawGuiView_SRCS
     QGIView.h
     QGIArrow.cpp
     QGIArrow.h
+    QGIAuxiliaryMarker.cpp
+    QGIAuxiliaryMarker.h
     QGIDatumLabel.cpp
     QGIDatumLabel.h
     QGIEdge.cpp

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -24,6 +24,7 @@
 #include <QMessageBox>
 #include <QCheckBox>
 #include <QPushButton>
+#include <set>
 #include <vector>
 
 
@@ -49,6 +50,8 @@
 
 #include <Mod/Spreadsheet/App/Sheet.h>
 
+#include <Mod/TechDraw/App/CosmeticVertex.h>
+#include <Mod/TechDraw/App/DrawAuxiliaryView.h>
 #include <Mod/TechDraw/App/DrawComplexSection.h>
 #include <Mod/TechDraw/App/DrawPage.h>
 #include <Mod/TechDraw/App/DrawProjGroup.h>
@@ -60,6 +63,7 @@
 #include <Mod/TechDraw/App/DrawViewDraft.h>
 #include <Mod/TechDraw/App/DrawViewPart.h>
 #include <Mod/TechDraw/App/DrawViewSymbol.h>
+#include <Mod/TechDraw/App/Geometry.h>
 #include <Mod/TechDraw/App/Preferences.h>
 #include <Mod/TechDraw/App/DrawBrokenView.h>
 
@@ -81,6 +85,7 @@
 
 void execSimpleSection(Gui::Command* cmd);
 void execComplexSection(Gui::Command* cmd);
+void execAuxiliaryView(Gui::Command* cmd);
 void getSelectedShapes(Gui::Command* cmd,
                       std::vector<App::DocumentObject*>& shapes,
                       std::vector<App::DocumentObject*>& xShapes,
@@ -88,6 +93,167 @@ void getSelectedShapes(Gui::Command* cmd,
                       std::string& faceName);
 
 std::pair<App::DocumentObject*, std::string> faceFromSelection();
+
+namespace
+{
+
+struct AuxiliaryReference
+{
+    TechDraw::DrawViewPart* baseView = nullptr;
+    Base::Vector3d start;
+    Base::Vector3d end;
+    Base::Vector3d direction;
+};
+
+void showWrongAuxiliarySelection(const QString& message)
+{
+    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong Selection"), message);
+}
+
+std::string nextAuxiliaryLabel(TechDraw::DrawViewPart* baseView)
+{
+    if (!baseView) {
+        return "A";
+    }
+
+    std::set<std::string> usedLabels;
+    const auto refs = baseView->getAuxiliaryRefs();
+    for (auto* ref : refs) {
+        if (ref) {
+            usedLabels.insert(ref->ReferenceLabel.getValue());
+        }
+    }
+
+    for (char label = 'A'; label <= 'Z'; ++label) {
+        std::string candidate(1, label);
+        if (usedLabels.find(candidate) == usedLabels.end()) {
+            return candidate;
+        }
+    }
+
+    std::size_t index = refs.size() + 1;
+    while (true) {
+        std::string candidate = std::string("A") + std::to_string(index);
+        if (usedLabels.find(candidate) == usedLabels.end()) {
+            return candidate;
+        }
+        ++index;
+    }
+}
+
+bool getCanonicalPointFromVertexName(TechDraw::DrawViewPart* baseView,
+                                     const std::string& vertexName,
+                                     Base::Vector3d& point)
+{
+    const int index = TechDraw::DrawUtil::getIndexFromName(vertexName);
+    TechDraw::VertexPtr vertex = baseView->getProjVertexByIndex(index);
+    if (!vertex) {
+        return false;
+    }
+
+    point = TechDraw::CosmeticVertex::makeCanonicalPointInverted(baseView, vertex->point());
+    point.z = 0.0;
+    return true;
+}
+
+bool collectAuxiliaryReference(Gui::Command* cmd, AuxiliaryReference& reference)
+{
+    std::vector<Gui::SelectionObject> selection = cmd->getSelection().getSelectionEx();
+    if (selection.empty()) {
+        showWrongAuxiliarySelection(QObject::tr("Select one straight edge or two vertices in a base view."));
+        return false;
+    }
+
+    std::vector<std::string> edgeNames;
+    std::vector<std::string> vertexNames;
+
+    for (auto& selected : selection) {
+        App::DocumentObject* obj = selected.getObject();
+        if (!obj || !obj->isDerivedFrom<TechDraw::DrawViewPart>()) {
+            continue;
+        }
+
+        if (obj->isDerivedFrom<TechDraw::DrawAuxiliaryView>()) {
+            showWrongAuxiliarySelection(QObject::tr("Select geometry from a base view, not an auxiliary view."));
+            return false;
+        }
+
+        auto* candidateBase = static_cast<TechDraw::DrawViewPart*>(obj);
+        if (reference.baseView && reference.baseView != candidateBase) {
+            showWrongAuxiliarySelection(QObject::tr("Select reference geometry from only one base view."));
+            return false;
+        }
+        reference.baseView = candidateBase;
+
+        for (const auto& subName : selected.getSubNames()) {
+            const std::string geomType = TechDraw::DrawUtil::getGeomTypeFromName(subName);
+            if (geomType == "Edge") {
+                edgeNames.push_back(subName);
+            }
+            else if (geomType == "Vertex") {
+                vertexNames.push_back(subName);
+            }
+            else {
+                showWrongAuxiliarySelection(QObject::tr("Select only straight edges or vertices."));
+                return false;
+            }
+        }
+    }
+
+    if (!reference.baseView) {
+        showWrongAuxiliarySelection(QObject::tr("Select geometry from a TechDraw view."));
+        return false;
+    }
+
+    if (edgeNames.size() == 1 && vertexNames.empty()) {
+        const int index = TechDraw::DrawUtil::getIndexFromName(edgeNames.front());
+        TechDraw::BaseGeomPtr geom = reference.baseView->getGeomByIndex(index);
+        if (!geom || geom->getGeomType() != TechDraw::GeomType::GENERIC) {
+            showWrongAuxiliarySelection(QObject::tr("Select a straight edge for the auxiliary reference."));
+            return false;
+        }
+
+        reference.start =
+            TechDraw::CosmeticVertex::makeCanonicalPointInverted(reference.baseView, geom->getStartPoint());
+        reference.end =
+            TechDraw::CosmeticVertex::makeCanonicalPointInverted(reference.baseView, geom->getEndPoint());
+    }
+    else if (vertexNames.size() == 2 && edgeNames.empty()) {
+        if (!getCanonicalPointFromVertexName(reference.baseView, vertexNames.front(), reference.start)
+            || !getCanonicalPointFromVertexName(reference.baseView, vertexNames.back(), reference.end)) {
+            showWrongAuxiliarySelection(QObject::tr("Could not resolve the selected vertices."));
+            return false;
+        }
+    }
+    else {
+        showWrongAuxiliarySelection(QObject::tr("Select exactly one straight edge or exactly two vertices."));
+        return false;
+    }
+
+    reference.start.z = 0.0;
+    reference.end.z = 0.0;
+    reference.direction = reference.end - reference.start;
+    reference.direction.z = 0.0;
+    if (reference.direction.Length() < 1.0e-7) {
+        showWrongAuxiliarySelection(QObject::tr("The auxiliary reference direction is zero length."));
+        return false;
+    }
+
+    return true;
+}
+
+Base::Vector3d defaultAuxiliaryPlacementDirection(const Base::Vector3d& referenceDirection)
+{
+    Base::Vector3d result(-referenceDirection.y, referenceDirection.x, 0.0);
+    if (result.Length() < 1.0e-7) {
+        return Base::Vector3d(1.0, 0.0, 0.0);
+    }
+    result.Normalize();
+    return result;
+}
+
+}  // namespace
+
 std::pair<Base::Vector3d, Base::Vector3d> viewDirection();
 Base::Vector3d checkDirectionVsBasis(Base::Vector3d dir);
 
@@ -1003,6 +1169,144 @@ void execComplexSection(Gui::Command* cmd)
 
     Gui::Control().showDialog(
         new TaskDlgComplexSection(page, baseView, shapes, xShapes, profileObject, profileSubs));
+}
+
+//===========================================================================
+// TechDraw_AuxiliaryView
+//===========================================================================
+
+DEF_STD_CMD_A(CmdTechDrawAuxiliaryView)
+
+CmdTechDrawAuxiliaryView::CmdTechDrawAuxiliaryView() : Command("TechDraw_AuxiliaryView")
+{
+    sAppModule = "TechDraw";
+    sGroup = QT_TR_NOOP("TechDraw");
+    sMenuText = QT_TR_NOOP("Auxiliary View");
+    sToolTipText = QT_TR_NOOP("Inserts an auxiliary view from a selected straight edge or two vertices");
+    sWhatsThis = "TechDraw_AuxiliaryView";
+    sStatusTip = sToolTipText;
+    sPixmap = "actions/TechDraw_View";
+}
+
+void CmdTechDrawAuxiliaryView::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
+    if (dlg) {
+        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Task in progress"),
+                             QObject::tr("Close active task dialog and try again"));
+        return;
+    }
+
+    execAuxiliaryView(this);
+}
+
+bool CmdTechDrawAuxiliaryView::isActive()
+{
+    bool havePage = DrawGuiUtil::needPage(this);
+    bool haveView = DrawGuiUtil::needView(this);
+    bool taskInProgress = false;
+    if (havePage) {
+        taskInProgress = Gui::Control().activeDialog();
+    }
+    return (havePage && haveView && !taskInProgress);
+}
+
+void execAuxiliaryView(Gui::Command* cmd)
+{
+    AuxiliaryReference reference;
+    if (!collectAuxiliaryReference(cmd, reference)) {
+        return;
+    }
+
+    TechDraw::DrawPage* page = reference.baseView->findParentPage();
+    if (!page) {
+        page = DrawGuiUtil::findPage(cmd);
+    }
+    if (!page) {
+        return;
+    }
+
+    Base::Vector3d placementDirection = defaultAuxiliaryPlacementDirection(reference.direction);
+    const double placementOffset =
+        std::max(reference.baseView->getBoxX(), reference.baseView->getBoxY()) * 1.25 + 20.0;
+    const double newX = reference.baseView->X.getValue() + placementDirection.x * placementOffset;
+    const double newY = reference.baseView->Y.getValue() + placementDirection.y * placementOffset;
+
+    const std::string auxiliaryName = cmd->getUniqueObjectName("AuxiliaryView");
+    const std::string pageName = page->getNameInDocument();
+    const std::string baseName = reference.baseView->getNameInDocument();
+    const std::string referenceLabel = nextAuxiliaryLabel(reference.baseView);
+
+    cmd->openCommand(QT_TRANSLATE_NOOP("Command", "Create Auxiliary View"));
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().addObject('TechDraw::DrawAuxiliaryView', '%s')",
+                   auxiliaryName.c_str());
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().%s.addView(App.activeDocument().%s)",
+                   pageName.c_str(),
+                   auxiliaryName.c_str());
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().%s.BaseView = App.activeDocument().%s",
+                   auxiliaryName.c_str(),
+                   baseName.c_str());
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().%s.Source = App.activeDocument().%s.Source",
+                   auxiliaryName.c_str(),
+                   baseName.c_str());
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().%s.XSource = App.activeDocument().%s.XSource",
+                   auxiliaryName.c_str(),
+                   baseName.c_str());
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().%s.ReferenceStart = FreeCAD.Vector(%.6f, %.6f, %.6f)",
+                   auxiliaryName.c_str(),
+                   reference.start.x,
+                   reference.start.y,
+                   reference.start.z);
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().%s.ReferenceEnd = FreeCAD.Vector(%.6f, %.6f, %.6f)",
+                   auxiliaryName.c_str(),
+                   reference.end.x,
+                   reference.end.y,
+                   reference.end.z);
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().%s.AuxiliaryDirection = FreeCAD.Vector(%.6f, %.6f, %.6f)",
+                   auxiliaryName.c_str(),
+                   reference.direction.x,
+                   reference.direction.y,
+                   reference.direction.z);
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().%s.ReferenceLabel = '%s'",
+                   auxiliaryName.c_str(),
+                   referenceLabel.c_str());
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().%s.ProjectionMode = 'Across'",
+                   auxiliaryName.c_str());
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().%s.Scale = App.activeDocument().%s.Scale",
+                   auxiliaryName.c_str(),
+                   baseName.c_str());
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().%s.ScaleType = %d",
+                   auxiliaryName.c_str(),
+                   static_cast<int>(reference.baseView->ScaleType.getValue()));
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().%s.X = %.6f",
+                   auxiliaryName.c_str(),
+                   newX);
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().%s.Y = %.6f",
+                   auxiliaryName.c_str(),
+                   newY);
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().%s.recompute()",
+                   auxiliaryName.c_str());
+
+    reference.baseView->requestPaint();
+    cmd->getSelection().clearSelection();
+    cmd->updateActive();
+    cmd->commitCommand();
 }
 
 //===========================================================================
@@ -1961,6 +2265,7 @@ void CreateTechDrawCommands()
     rcCmdMgr.addCommand(new CmdTechDrawSectionGroup());
     rcCmdMgr.addCommand(new CmdTechDrawSectionView());
     rcCmdMgr.addCommand(new CmdTechDrawComplexSection());
+    rcCmdMgr.addCommand(new CmdTechDrawAuxiliaryView());
     rcCmdMgr.addCommand(new CmdTechDrawDetailView());
     rcCmdMgr.addCommand(new CmdTechDrawProjectionGroup());
     rcCmdMgr.addCommand(new CmdTechDrawClipGroup());
@@ -2107,4 +2412,3 @@ Base::Vector3d checkDirectionVsBasis(Base::Vector3d dir)
     return dir;
 
 }
-

--- a/src/Mod/TechDraw/Gui/QGIAuxiliaryMarker.cpp
+++ b/src/Mod/TechDraw/Gui/QGIAuxiliaryMarker.cpp
@@ -1,0 +1,162 @@
+/***************************************************************************
+ *   Copyright (c) 2026 FreeCAD contributors                               *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <algorithm>
+
+#include <QPainterPath>
+
+#include "PreferencesGui.h"
+#include "QGCustomText.h"
+#include "QGIAuxiliaryMarker.h"
+#include "QGIArrow.h"
+#include "Rez.h"
+#include "ZVALUE.h"
+
+using namespace TechDrawGui;
+
+QGIAuxiliaryMarker::QGIAuxiliaryMarker()
+    : m_line(new QGraphicsPathItem())
+    , m_arrow1(new QGIArrow())
+    , m_arrow2(new QGIArrow())
+    , m_label1(new QGCustomText())
+    , m_label2(new QGCustomText())
+    , m_start(0.0, 0.0)
+    , m_end(0.0, 0.0)
+    , m_direction(1.0, 0.0, 0.0)
+    , m_labelText(QStringLiteral("A"))
+    , m_font(PreferencesGui::labelFontQFont())
+    , m_arrowSize(QGIArrow::getPrefArrowSize())
+    , m_color(PreferencesGui::normalQColor())
+{
+    addToGroup(m_line);
+    addToGroup(m_arrow1);
+    addToGroup(m_arrow2);
+    addToGroup(m_label1);
+    addToGroup(m_label2);
+
+    m_font.setPixelSize(std::max(1, PreferencesGui::labelFontSizePX()));
+    setWidth(Rez::guiX(0.35));
+    setColor(m_color);
+}
+
+void QGIAuxiliaryMarker::setEnds(const Base::Vector3d& start, const Base::Vector3d& end)
+{
+    m_start = QPointF(start.x, start.y);
+    m_end = QPointF(end.x, end.y);
+}
+
+void QGIAuxiliaryMarker::setDirection(const Base::Vector3d& direction)
+{
+    Base::Vector3d qtDirection(direction.x, -direction.y, 0.0);
+    if (qtDirection.Length() < 1.0e-12) {
+        qtDirection = Base::Vector3d(1.0, 0.0, 0.0);
+    }
+    qtDirection.Normalize();
+    m_direction = qtDirection;
+}
+
+void QGIAuxiliaryMarker::setLabel(const QString& label)
+{
+    m_labelText = label;
+}
+
+void QGIAuxiliaryMarker::setFont(const QFont& font)
+{
+    m_font = font;
+}
+
+void QGIAuxiliaryMarker::setArrowSize(double arrowSize)
+{
+    m_arrowSize = arrowSize;
+}
+
+void QGIAuxiliaryMarker::setLinePen(const QPen& pen)
+{
+    m_pen = pen;
+}
+
+void QGIAuxiliaryMarker::setMarkerColor(const QColor& color)
+{
+    m_color = color;
+    setColor(color);
+}
+
+void QGIAuxiliaryMarker::draw()
+{
+    prepareGeometryChange();
+    drawReferenceLine();
+    drawArrow(m_arrow1, m_start);
+    drawArrow(m_arrow2, m_end);
+    drawLabel(m_label1, labelPosition(m_start));
+    drawLabel(m_label2, labelPosition(m_end));
+    update();
+}
+
+void QGIAuxiliaryMarker::drawReferenceLine()
+{
+    QPainterPath path;
+    path.moveTo(m_start);
+    path.lineTo(m_end);
+
+    m_line->setPath(path);
+    m_line->setPen(m_pen);
+    m_line->setZValue(ZVALUE::SECTIONLINE);
+}
+
+void QGIAuxiliaryMarker::drawArrow(QGIArrow* arrow, const QPointF& position)
+{
+    if (!arrow) {
+        return;
+    }
+
+    arrow->setStyle(TechDraw::ArrowType::FILLED_ARROW);
+    arrow->setDirMode(true);
+    arrow->setDirection(m_direction);
+    arrow->setSize(m_arrowSize);
+    arrow->setNormalColor(m_color);
+    arrow->setFillColor(m_color);
+    arrow->setPos(position);
+    arrow->setZValue(ZVALUE::SECTIONLINE + 1);
+    arrow->draw();
+}
+
+void QGIAuxiliaryMarker::drawLabel(QGCustomText* label, const QPointF& position)
+{
+    if (!label) {
+        return;
+    }
+
+    label->setFont(m_font);
+    label->setPlainText(m_labelText);
+    label->setColor(m_color);
+    label->centerAt(position);
+    label->setTransformOriginPoint(label->mapFromParent(position));
+    label->setRotation(360.0 - rotation());
+    label->setZValue(ZVALUE::SECTIONLINE + 2);
+}
+
+QPointF QGIAuxiliaryMarker::labelPosition(const QPointF& reference) const
+{
+    const double fontGap = std::max(1, m_font.pixelSize());
+    const double gap = std::max(fontGap, Rez::guiX(m_arrowSize));
+    return reference + QPointF(m_direction.x * gap, m_direction.y * gap);
+}

--- a/src/Mod/TechDraw/Gui/QGIAuxiliaryMarker.h
+++ b/src/Mod/TechDraw/Gui/QGIAuxiliaryMarker.h
@@ -1,0 +1,89 @@
+/***************************************************************************
+ *   Copyright (c) 2026 FreeCAD contributors                               *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include <Mod/TechDraw/TechDrawGlobal.h>
+
+#include <QColor>
+#include <QFont>
+#include <QGraphicsPathItem>
+#include <QPen>
+#include <QPointF>
+#include <QString>
+
+#include <Base/Vector3D.h>
+
+#include "QGIDecoration.h"
+#include "QGIUserTypes.h"
+
+namespace TechDrawGui
+{
+
+class QGIArrow;
+class QGCustomText;
+
+class TechDrawGuiExport QGIAuxiliaryMarker: public QGIDecoration
+{
+public:
+    explicit QGIAuxiliaryMarker();
+    ~QGIAuxiliaryMarker() override = default;
+
+    enum
+    {
+        Type = UserType::QGIAuxiliaryMarker
+    };
+    int type() const override
+    {
+        return Type;
+    }
+
+    void setEnds(const Base::Vector3d& start, const Base::Vector3d& end);
+    void setDirection(const Base::Vector3d& direction);
+    void setLabel(const QString& label);
+    void setFont(const QFont& font);
+    void setArrowSize(double arrowSize);
+    void setLinePen(const QPen& pen);
+    void setMarkerColor(const QColor& color);
+    void draw() override;
+
+private:
+    void drawReferenceLine();
+    void drawArrow(QGIArrow* arrow, const QPointF& position);
+    void drawLabel(QGCustomText* label, const QPointF& position);
+    QPointF labelPosition(const QPointF& reference) const;
+
+    QGraphicsPathItem* m_line;
+    QGIArrow* m_arrow1;
+    QGIArrow* m_arrow2;
+    QGCustomText* m_label1;
+    QGCustomText* m_label2;
+    QPointF m_start;
+    QPointF m_end;
+    Base::Vector3d m_direction;
+    QString m_labelText;
+    QFont m_font;
+    double m_arrowSize;
+    QColor m_color;
+};
+
+}  // namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGIUserTypes.h
+++ b/src/Mod/TechDraw/Gui/QGIUserTypes.h
@@ -83,7 +83,8 @@ enum : int {
     QGMarker,
     QGMText,
     QGTracker,
-    TemplateTextField
+    TemplateTextField,
+    QGIAuxiliaryMarker
 };
 };
 }

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -35,6 +35,7 @@
 #include <Gui/Selection/Selection.h>
 #include <Mod/TechDraw/App/CenterLine.h>
 #include <Mod/TechDraw/App/Cosmetic.h>
+#include <Mod/TechDraw/App/DrawAuxiliaryView.h>
 #include <Mod/TechDraw/App/DrawComplexSection.h>
 #include <Mod/TechDraw/App/DrawGeomHatch.h>
 #include <Mod/TechDraw/App/DrawHatch.h>
@@ -51,6 +52,7 @@
 #include "MDIViewPage.h"
 #include "PreferencesGui.h"
 #include "QGIArrow.h"
+#include "QGIAuxiliaryMarker.h"
 #include "QGICMark.h"
 #include "QGICenterLine.h"
 #include "QGIEdge.h"
@@ -279,6 +281,7 @@ void QGIViewPart::draw()
     //this is old C/L
     drawCenterLines(true);//have to draw centerlines after border to get size correct.
     drawAllSectionLines();//same for section lines
+    drawAllAuxiliaryMarkers();
 
     prepareGeometryChange();
 }
@@ -899,6 +902,75 @@ void QGIViewPart::drawComplexSectionLine(TechDraw::DrawViewSection* viewSection,
     sectionLine->draw();
 }
 
+void QGIViewPart::drawAllAuxiliaryMarkers()
+{
+    TechDraw::DrawViewPart* viewPart = static_cast<TechDraw::DrawViewPart*>(getViewObject());
+    if (!viewPart) {
+        return;
+    }
+
+    auto vp = static_cast<ViewProviderViewPart*>(getViewProvider(viewPart));
+    if (!vp) {
+        return;
+    }
+
+    if (!vp->ShowSectionLine.getValue()) {
+        return;
+    }
+
+    auto refs = viewPart->getAuxiliaryRefs();
+    for (auto& auxiliaryView : refs) {
+        drawAuxiliaryMarker(auxiliaryView, true);
+    }
+}
+
+void QGIViewPart::drawAuxiliaryMarker(TechDraw::DrawAuxiliaryView* auxiliaryView, bool b)
+{
+    Q_UNUSED(b);
+
+    TechDraw::DrawViewPart* viewPart = static_cast<TechDraw::DrawViewPart*>(getViewObject());
+    if (!viewPart || !auxiliaryView) {
+        return;
+    }
+
+    auto vp = static_cast<ViewProviderViewPart*>(getViewProvider(viewPart));
+    if (!vp) {
+        return;
+    }
+
+    const double scale = viewPart->getScale();
+    Base::Vector3d start = Rez::guiX(auxiliaryView->ReferenceStart.getValue()) * scale;
+    Base::Vector3d end = Rez::guiX(auxiliaryView->ReferenceEnd.getValue()) * scale;
+    if (start.IsEqual(end, EWTOLERANCE)) {
+        Base::Console().message("QGIVP::drawAuxiliaryMarker - marker endpoints are equal. No marker created.\n");
+        return;
+    }
+
+    auto marker = new QGIAuxiliaryMarker();
+    addToGroupWithoutUpdate(marker);
+    marker->setPos(0.0, 0.0);
+    marker->setEnds(start, end);
+    marker->setDirection(auxiliaryView->getAuxiliaryLocalDirection());
+    marker->setLabel(QString::fromUtf8(auxiliaryView->ReferenceLabel.getValue()));
+
+    Base::Color color = Preferences::getAccessibleColor(vp->SectionLineColor.getValue());
+    QPen markerPen = m_dashedLineGenerator->getLinePen((size_t)vp->SectionLineStyle.getValue(),
+                                                       vp->HiddenWidth.getValue());
+    markerPen.setColor(color.asValue<QColor>());
+    markerPen.setWidthF(Rez::guiX(vp->HiddenWidth.getValue()));
+    marker->setLinePen(markerPen);
+    marker->setMarkerColor(color.asValue<QColor>());
+
+    QFont markerFont = PreferencesGui::labelFontQFont();
+    markerFont.setPixelSize(
+        exactFontSize(Preferences::labelFont(), std::max(1.0, Preferences::labelFontSizeMM())));
+    marker->setFont(markerFont);
+    marker->setArrowSize(QGIArrow::getPrefArrowSize());
+    marker->setZValue(ZVALUE::SECTIONLINE);
+    marker->setRotation(-viewPart->Rotation.getValue());
+    marker->draw();
+}
+
 //TODO: use Cosmetic::CenterLine object for this to make it usable for dims.
 // these are the view center lines (ie x,y axes)
 void QGIViewPart::drawCenterLines(bool b)
@@ -1505,5 +1577,3 @@ void QGIViewPart::setMovableFlagProjGroupItem()
     // not locked, not autoDistribute
     setFlag(QGraphicsItem::ItemIsMovable, true);
 }
-
-

--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -40,6 +40,7 @@ class Color;
 }
 
 namespace TechDraw {
+class DrawAuxiliaryView;
 class DrawViewPart;
 class DrawViewSection;
 class DrawHatch;
@@ -86,6 +87,8 @@ public:
     virtual void drawAllSectionLines();
     virtual void drawSectionLine(TechDraw::DrawViewSection* s, bool b);
     virtual void drawComplexSectionLine(TechDraw::DrawViewSection* viewSection, bool b);
+    virtual void drawAllAuxiliaryMarkers();
+    virtual void drawAuxiliaryMarker(TechDraw::DrawAuxiliaryView* auxiliaryView, bool b);
     virtual void drawCenterLines(bool b);
     virtual void drawAllHighlights();
     virtual void drawHighlight(TechDraw::DrawViewDetail* viewDetail, bool b);

--- a/src/Mod/TechDraw/Gui/TaskAuxiliaryView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskAuxiliaryView.cpp
@@ -1,0 +1,189 @@
+/***************************************************************************
+ *   Copyright (c) 2026 FreeCAD contributors                               *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QEvent>
+#include <QFormLayout>
+#include <QLineEdit>
+
+#include <Base/Tools.h>
+#include <Gui/BitmapFactory.h>
+#include <Gui/Command.h>
+#include <Mod/TechDraw/App/DrawAuxiliaryView.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
+
+#include "TaskAuxiliaryView.h"
+
+using namespace TechDrawGui;
+
+TaskAuxiliaryView::TaskAuxiliaryView(TechDraw::DrawAuxiliaryView* auxiliaryView)
+    : m_auxiliaryView(auxiliaryView)
+    , m_baseViewEdit(new QLineEdit(this))
+    , m_referenceLabelEdit(new QLineEdit(this))
+    , m_projectionModeCombo(new QComboBox(this))
+    , m_reverseDirectionCheck(new QCheckBox(this))
+    , m_keepAlignedCheck(new QCheckBox(this))
+{
+    initUi();
+}
+
+void TaskAuxiliaryView::initUi()
+{
+    auto* form = new QFormLayout(this);
+    form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
+
+    m_baseViewEdit->setReadOnly(true);
+    if (auto baseView = getBaseView()) {
+        m_baseViewEdit->setText(QString::fromUtf8(baseView->getNameInDocument()));
+    }
+
+    m_projectionModeCombo->addItem(tr("Across"), QStringLiteral("Across"));
+    m_projectionModeCombo->addItem(tr("Along"), QStringLiteral("Along"));
+
+    if (m_auxiliaryView) {
+        m_referenceLabelEdit->setText(QString::fromUtf8(m_auxiliaryView->ReferenceLabel.getValue()));
+        m_projectionModeCombo->setCurrentIndex(m_auxiliaryView->ProjectionMode.isValue("Along") ? 1 : 0);
+        m_reverseDirectionCheck->setChecked(m_auxiliaryView->ReverseDirection.getValue());
+        m_keepAlignedCheck->setChecked(m_auxiliaryView->KeepAligned.getValue());
+    }
+
+    form->addRow(tr("Base view"), m_baseViewEdit);
+    form->addRow(tr("Reference label"), m_referenceLabelEdit);
+    form->addRow(tr("Projection mode"), m_projectionModeCombo);
+    form->addRow(tr("Reverse direction"), m_reverseDirectionCheck);
+    form->addRow(tr("Keep aligned"), m_keepAlignedCheck);
+
+    setLayout(form);
+    setWindowTitle(tr("Auxiliary View"));
+}
+
+bool TaskAuxiliaryView::accept()
+{
+    if (!m_auxiliaryView) {
+        return false;
+    }
+
+    const std::string auxiliaryName = m_auxiliaryView->getNameInDocument();
+    const std::string label =
+        Base::Tools::escapeEncodeString(m_referenceLabelEdit->text().toStdString());
+    const std::string mode = m_projectionModeCombo->currentData().toString().toStdString();
+    const char* reverse = m_reverseDirectionCheck->isChecked() ? "True" : "False";
+    const char* keepAligned = m_keepAlignedCheck->isChecked() ? "True" : "False";
+
+    int transaction =
+        Gui::Command::openActiveDocumentCommand(QT_TRANSLATE_NOOP("Command", "Edit Auxiliary View"));
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            "App.ActiveDocument.%s.ReferenceLabel = '%s'",
+                            auxiliaryName.c_str(),
+                            label.c_str());
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            "App.ActiveDocument.%s.ProjectionMode = '%s'",
+                            auxiliaryName.c_str(),
+                            mode.c_str());
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            "App.ActiveDocument.%s.ReverseDirection = %s",
+                            auxiliaryName.c_str(),
+                            reverse);
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            "App.ActiveDocument.%s.KeepAligned = %s",
+                            auxiliaryName.c_str(),
+                            keepAligned);
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            "App.ActiveDocument.%s.recompute()",
+                            auxiliaryName.c_str());
+    Gui::Command::updateActive();
+    Gui::Command::commitCommand(transaction);
+
+    if (auto baseView = getBaseView()) {
+        baseView->requestPaint();
+    }
+    m_auxiliaryView->requestPaint();
+
+    return true;
+}
+
+bool TaskAuxiliaryView::reject()
+{
+    return true;
+}
+
+std::string TaskAuxiliaryView::getAuxiliaryName() const
+{
+    if (!m_auxiliaryView) {
+        return {};
+    }
+
+    return m_auxiliaryView->getNameInDocument();
+}
+
+void TaskAuxiliaryView::changeEvent(QEvent* event)
+{
+    if (event->type() == QEvent::LanguageChange) {
+        setWindowTitle(tr("Auxiliary View"));
+    }
+    QWidget::changeEvent(event);
+}
+
+TechDraw::DrawViewPart* TaskAuxiliaryView::getBaseView() const
+{
+    if (!m_auxiliaryView) {
+        return nullptr;
+    }
+
+    return m_auxiliaryView->getBaseDVP();
+}
+
+TaskDlgAuxiliaryView::TaskDlgAuxiliaryView(TechDraw::DrawAuxiliaryView* auxiliaryView)
+    : TaskDialog()
+    , widget(new TaskAuxiliaryView(auxiliaryView))
+    , taskbox(new Gui::TaskView::TaskBox(Gui::BitmapFactory().pixmap("actions/TechDraw_View"),
+                                         widget->windowTitle(),
+                                         true,
+                                         nullptr))
+{
+    taskbox->groupLayout()->addWidget(widget);
+    Content.push_back(taskbox);
+}
+
+void TaskDlgAuxiliaryView::open()
+{}
+
+void TaskDlgAuxiliaryView::clicked(int)
+{}
+
+bool TaskDlgAuxiliaryView::accept()
+{
+    return widget->accept();
+}
+
+bool TaskDlgAuxiliaryView::reject()
+{
+    return widget->reject();
+}
+
+std::string TaskDlgAuxiliaryView::getAuxiliaryName() const
+{
+    return widget->getAuxiliaryName();
+}
+
+#include <Mod/TechDraw/Gui/moc_TaskAuxiliaryView.cpp>

--- a/src/Mod/TechDraw/Gui/TaskAuxiliaryView.h
+++ b/src/Mod/TechDraw/Gui/TaskAuxiliaryView.h
@@ -1,0 +1,95 @@
+/***************************************************************************
+ *   Copyright (c) 2026 FreeCAD contributors                               *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include <string>
+
+#include <Gui/TaskView/TaskDialog.h>
+#include <Gui/TaskView/TaskView.h>
+#include <Mod/TechDraw/TechDrawGlobal.h>
+
+class QCheckBox;
+class QComboBox;
+class QLineEdit;
+
+namespace TechDraw
+{
+class DrawAuxiliaryView;
+class DrawViewPart;
+}
+
+namespace TechDrawGui
+{
+
+class TaskAuxiliaryView: public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit TaskAuxiliaryView(TechDraw::DrawAuxiliaryView* auxiliaryView);
+    ~TaskAuxiliaryView() override = default;
+
+    bool accept();
+    bool reject();
+    std::string getAuxiliaryName() const;
+
+protected:
+    void changeEvent(QEvent* event) override;
+
+private:
+    void initUi();
+    TechDraw::DrawViewPart* getBaseView() const;
+
+    TechDraw::DrawAuxiliaryView* m_auxiliaryView;
+    QLineEdit* m_baseViewEdit;
+    QLineEdit* m_referenceLabelEdit;
+    QComboBox* m_projectionModeCombo;
+    QCheckBox* m_reverseDirectionCheck;
+    QCheckBox* m_keepAlignedCheck;
+};
+
+class TaskDlgAuxiliaryView: public Gui::TaskView::TaskDialog
+{
+    Q_OBJECT
+
+public:
+    explicit TaskDlgAuxiliaryView(TechDraw::DrawAuxiliaryView* auxiliaryView);
+    ~TaskDlgAuxiliaryView() override = default;
+
+    void open() override;
+    void clicked(int) override;
+    bool accept() override;
+    bool reject() override;
+    void helpRequested() override {}
+    bool isAllowedAlterDocument() const override
+    {
+        return false;
+    }
+    std::string getAuxiliaryName() const;
+
+private:
+    TaskAuxiliaryView* widget;
+    Gui::TaskView::TaskBox* taskbox;
+};
+
+}  // namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/ViewProviderProjGroupItem.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderProjGroupItem.cpp
@@ -143,6 +143,7 @@ bool ViewProviderProjGroupItem::onDelete(const std::vector<std::string> &)
     // get child views
     auto viewSection = dpgi->getSectionRefs();
     auto viewDetail = dpgi->getDetailRefs();
+    auto viewAuxiliary = dpgi->getAuxiliaryRefs();
     auto viewLeader = dpgi->getLeaders();
 
    if (isAnchor)
@@ -167,6 +168,14 @@ bool ViewProviderProjGroupItem::onDelete(const std::vector<std::string> &)
    else if (!viewDetail.empty()) {
        bodyMessageStream << qApp->translate("Std_Delete",
            "You cannot delete this view because it has a detail view that would become broken.");
+       QMessageBox::warning(Gui::getMainWindow(),
+           qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,
+           QMessageBox::Ok);
+       return false;
+   }
+   else if (!viewAuxiliary.empty()) {
+       bodyMessageStream << qApp->translate("Std_Delete",
+           "You cannot delete this view because it has an auxiliary view that would become broken.");
        QMessageBox::warning(Gui::getMainWindow(),
            qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,
            QMessageBox::Ok);

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -39,6 +39,7 @@
 
 #include <Mod/TechDraw/App/DrawGeomHatch.h>
 #include <Mod/TechDraw/App/DrawHatch.h>
+#include <Mod/TechDraw/App/DrawAuxiliaryView.h>
 #include <Mod/TechDraw/App/DrawLeaderLine.h>
 #include <Mod/TechDraw/App/DrawRichAnno.h>
 #include <Mod/TechDraw/App/DrawViewBalloon.h>
@@ -56,6 +57,7 @@
 #include "PreferencesGui.h"
 #include "QGIView.h"
 #include "TaskDetail.h"
+#include "TaskAuxiliaryView.h"
 #include "TaskProjGroup.h"
 #include "ViewProviderViewPart.h"
 #include "ViewProviderPage.h"
@@ -294,6 +296,17 @@ bool ViewProviderViewPart::setEdit(int ModNum)
         }
         return setDetailEdit(ModNum, dvd);
     }
+    auto* dav = dynamic_cast<TechDraw::DrawAuxiliaryView*>(dvp);
+    if (dav) {
+        if (!dav->BaseView.getValue()) {
+            Base::Console().error("DrawAuxiliaryView - %s - has no BaseView!\n", dav->getNameInDocument());
+            return false;
+        }
+        Gui::Control().showDialog(new TaskDlgAuxiliaryView(dav));
+        Gui::Selection().clearSelection();
+        Gui::Selection().addSelection(dav->getDocument()->getName(), dav->getNameInDocument());
+        return true;
+    }
     auto* view = getObject<TechDraw::DrawView>();
     Gui::Control().showDialog(new TaskDlgProjGroup(view, false));
 
@@ -384,12 +397,26 @@ bool ViewProviderViewPart::onDelete(const std::vector<std::string> & subNames)
             return false;
         }
     }
+    auto* dlgAuxiliary = dynamic_cast<TaskDlgAuxiliaryView*>(dlg);
+    if (dlgAuxiliary) {
+        std::string dlgAuxiliaryTarget = dlgAuxiliary->getAuxiliaryName();
+        if (getViewObject()->getNameInDocument() == dlgAuxiliaryTarget) {
+            bodyMessageStream << qApp->translate("Std_Delete",
+            "Close open dialog before deleting auxiliary view object");
+            bodyMessage = bodyMessageStream.readLine();
+            QMessageBox::warning(Gui::getMainWindow(),
+            qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,
+            QMessageBox::Ok);
+            return false;
+        }
+    }
 
     // get child views
     auto viewSection = getViewObject()->getSectionRefs();
     auto viewDetail = getViewObject()->getDetailRefs();
+    auto viewAuxiliary = getViewObject()->getAuxiliaryRefs();
 
-    if (!viewSection.empty() || !viewDetail.empty()) {
+    if (!viewSection.empty() || !viewDetail.empty() || !viewAuxiliary.empty()) {
         bodyMessageStream << qApp->translate("Std_Delete",
             "You cannot delete this view because it has one or more dependent views that would become broken.");
         bodyMessage = bodyMessageStream.readLine();

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -213,6 +213,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     *views << "TechDraw_BrokenView";
     *views << "TechDraw_SectionView";
     *views << "TechDraw_ComplexSection";
+    *views << "TechDraw_AuxiliaryView";
     *views << "TechDraw_DetailView";
     *views << "TechDraw_ProjectionGroup";
     *views << "TechDraw_ClipGroup";
@@ -301,6 +302,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *views << "TechDraw_BrokenView";
     *views << "TechDraw_ActiveView";
     *views << "TechDraw_SectionGroup";
+    *views << "TechDraw_AuxiliaryView";
     *views << "TechDraw_DetailView";
     *views << "TechDraw_DraftView";
     *views << "TechDraw_ClipGroup";
@@ -417,6 +419,7 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *views << "TechDraw_View";
     *views << "TechDraw_ActiveView";
     *views << "TechDraw_SectionGroup";
+    *views << "TechDraw_AuxiliaryView";
     *views << "TechDraw_DetailView";
     *views << "TechDraw_DraftView";
     *views << "TechDraw_ClipGroup";

--- a/src/Mod/TechDraw/TDTest/DrawAuxiliaryViewGuiTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawAuxiliaryViewGuiTest.py
@@ -1,0 +1,87 @@
+import os
+import re
+import tempfile
+import unittest
+
+import FreeCAD
+import TechDrawGui
+
+from .TechDrawTestUtilities import createPageWithSVGTemplate
+
+
+class DrawAuxiliaryViewGuiTest(unittest.TestCase):
+    def setUp(self):
+        FreeCAD.newDocument("TDAuxiliaryGui")
+        FreeCAD.setActiveDocument("TDAuxiliaryGui")
+        FreeCAD.ActiveDocument = FreeCAD.getDocument("TDAuxiliaryGui")
+
+        self.box = FreeCAD.ActiveDocument.addObject("Part::Box", "Box")
+        self.page = createPageWithSVGTemplate()
+
+        self.base = FreeCAD.ActiveDocument.addObject("TechDraw::DrawViewPart", "BaseView")
+        self.page.addView(self.base)
+        self.base.Source = [self.box]
+        self.base.Direction = (0.0, -1.0, 0.0)
+        self.base.XDirection = (1.0, 0.0, 0.0)
+        self.base.Scale = 1.0
+
+    def tearDown(self):
+        FreeCAD.closeDocument("TDAuxiliaryGui")
+
+    def makeAuxiliaryView(self):
+        auxiliary = FreeCAD.ActiveDocument.addObject("TechDraw::DrawAuxiliaryView", "Auxiliary")
+        self.page.addView(auxiliary)
+        auxiliary.BaseView = self.base
+        auxiliary.ReferenceStart = FreeCAD.Vector(0.0, 0.0, 0.0)
+        auxiliary.ReferenceEnd = FreeCAD.Vector(10.0, 0.0, 0.0)
+        auxiliary.AuxiliaryDirection = FreeCAD.Vector(10.0, 0.0, 0.0)
+        auxiliary.ReferenceLabel = "AUX"
+        auxiliary.Scale = 1.0
+        return auxiliary
+
+    def assertAuxiliaryLabelsAreOnPage(self, svg):
+        view_box_match = re.search(r"<svg[^>]*viewBox=\"([^\"]+)\"", svg)
+        self.assertIsNotNone(view_box_match)
+        min_x, min_y, width, height = [float(value) for value in view_box_match.group(1).split()]
+        max_x = min_x + width
+        max_y = min_y + height
+
+        label_positions = re.findall(
+            r"<g[^>]*transform=\"matrix\([^,]+,[^,]+,[^,]+,[^,]+,([-.0-9]+),([-.0-9]+)\)\"[^>]*>\s*"
+            r"<text[^>]*>AUX</text>",
+            svg,
+        )
+        self.assertEqual(len(label_positions), 2)
+        for label_x, label_y in label_positions:
+            self.assertGreaterEqual(float(label_x), min_x)
+            self.assertLessEqual(float(label_x), max_x)
+            self.assertGreaterEqual(float(label_y), min_y)
+            self.assertLessEqual(float(label_y), max_y)
+
+    def testAuxiliaryMarkerIsExportedWithBaseView(self):
+        auxiliary = self.makeAuxiliaryView()
+        FreeCAD.ActiveDocument.recompute()
+
+        with tempfile.TemporaryDirectory() as directory:
+            svg_path = os.path.join(directory, "auxiliary_marker.svg")
+            TechDrawGui.exportPageAsSvg(self.page, svg_path)
+            with open(svg_path, encoding="utf-8") as svg_file:
+                svg = svg_file.read()
+
+        self.assertEqual(svg.count(">AUX<"), 2)
+        self.assertAuxiliaryLabelsAreOnPage(svg)
+
+        FreeCAD.ActiveDocument.removeObject(auxiliary.Name)
+        FreeCAD.ActiveDocument.recompute()
+
+        with tempfile.TemporaryDirectory() as directory:
+            svg_path = os.path.join(directory, "auxiliary_marker_removed.svg")
+            TechDrawGui.exportPageAsSvg(self.page, svg_path)
+            with open(svg_path, encoding="utf-8") as svg_file:
+                svg = svg_file.read()
+
+        self.assertEqual(svg.count(">AUX<"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/TechDraw/TDTest/DrawAuxiliaryViewTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawAuxiliaryViewTest.py
@@ -1,0 +1,182 @@
+import FreeCAD
+import unittest
+
+from .TechDrawTestUtilities import createPageWithSVGTemplate
+
+
+class DrawAuxiliaryViewTest(unittest.TestCase):
+    def setUp(self):
+        FreeCAD.newDocument("TDAuxiliary")
+        FreeCAD.setActiveDocument("TDAuxiliary")
+        FreeCAD.ActiveDocument = FreeCAD.getDocument("TDAuxiliary")
+
+        self.box = FreeCAD.ActiveDocument.addObject("Part::Box", "Box")
+        self.page = createPageWithSVGTemplate()
+
+        self.base = FreeCAD.ActiveDocument.addObject("TechDraw::DrawViewPart", "BaseView")
+        self.page.addView(self.base)
+        self.base.Source = [self.box]
+        self.base.Direction = (0.0, -1.0, 0.0)
+        self.base.XDirection = (1.0, 0.0, 0.0)
+        self.base.Scale = 1.0
+        FreeCAD.ActiveDocument.recompute()
+
+    def tearDown(self):
+        FreeCAD.closeDocument("TDAuxiliary")
+
+    def makeAuxiliaryView(self):
+        auxiliary = FreeCAD.ActiveDocument.addObject("TechDraw::DrawAuxiliaryView", "Auxiliary")
+        self.page.addView(auxiliary)
+        auxiliary.BaseView = self.base
+        auxiliary.Scale = 1.0
+        return auxiliary
+
+    def setReference(self, auxiliary, start, end):
+        auxiliary.ReferenceStart = start
+        auxiliary.ReferenceEnd = end
+        auxiliary.AuxiliaryDirection = end - start
+
+    def assertVectorAlmostEqual(self, actual, expected):
+        self.assertAlmostEqual(actual.x, expected.x, places=3)
+        self.assertAlmostEqual(actual.y, expected.y, places=3)
+        self.assertAlmostEqual(actual.z, expected.z, places=3)
+
+    def testAuxiliaryViewAcrossReferenceDirection(self):
+        auxiliary = self.makeAuxiliaryView()
+        self.setReference(
+            auxiliary,
+            FreeCAD.Vector(0.0, 0.0, 0.0),
+            FreeCAD.Vector(1.0, 0.0, 0.0),
+        )
+        auxiliary.ProjectionMode = "Across"
+
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertVectorAlmostEqual(auxiliary.Direction, FreeCAD.Vector(0.0, 0.0, 1.0))
+        self.assertVectorAlmostEqual(auxiliary.XDirection, FreeCAD.Vector(1.0, 0.0, 0.0))
+        self.assertEqual(auxiliary.Source, self.base.Source)
+
+    def testAuxiliaryViewCanReverseDirection(self):
+        auxiliary = self.makeAuxiliaryView()
+        self.setReference(
+            auxiliary,
+            FreeCAD.Vector(0.0, 0.0, 0.0),
+            FreeCAD.Vector(1.0, 0.0, 0.0),
+        )
+        auxiliary.ProjectionMode = "Across"
+        auxiliary.ReverseDirection = True
+
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertVectorAlmostEqual(auxiliary.Direction, FreeCAD.Vector(0.0, 0.0, -1.0))
+        self.assertVectorAlmostEqual(auxiliary.XDirection, FreeCAD.Vector(1.0, 0.0, 0.0))
+
+    def testAuxiliaryViewCanProjectAlongReferenceDirection(self):
+        auxiliary = self.makeAuxiliaryView()
+        self.setReference(
+            auxiliary,
+            FreeCAD.Vector(0.0, 0.0, 0.0),
+            FreeCAD.Vector(1.0, 0.0, 0.0),
+        )
+        auxiliary.ProjectionMode = "Along"
+
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertVectorAlmostEqual(auxiliary.Direction, FreeCAD.Vector(1.0, 0.0, 0.0))
+        self.assertVectorAlmostEqual(auxiliary.XDirection, FreeCAD.Vector(0.0, 0.0, 1.0))
+
+    def testAuxiliaryViewUsesDefaultReferenceWhenReferenceDirectionIsZero(self):
+        auxiliary = self.makeAuxiliaryView()
+        auxiliary.AuxiliaryDirection = FreeCAD.Vector(0.0, 0.0, 0.0)
+        auxiliary.ProjectionMode = "Across"
+
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertVectorAlmostEqual(auxiliary.AuxiliaryDirection, FreeCAD.Vector(0.0, 0.0, 0.0))
+        self.assertVectorAlmostEqual(auxiliary.Direction, FreeCAD.Vector(0.0, 0.0, 1.0))
+
+    def testAuxiliaryViewStoresReferenceMarkerEndpoints(self):
+        auxiliary = self.makeAuxiliaryView()
+        self.setReference(
+            auxiliary,
+            FreeCAD.Vector(2.0, 3.0, 0.0),
+            FreeCAD.Vector(8.0, 3.0, 0.0),
+        )
+
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertVectorAlmostEqual(auxiliary.ReferenceStart, FreeCAD.Vector(2.0, 3.0, 0.0))
+        self.assertVectorAlmostEqual(auxiliary.ReferenceEnd, FreeCAD.Vector(8.0, 3.0, 0.0))
+        self.assertTrue(auxiliary.KeepAligned)
+
+    def testAuxiliaryViewKeepsPageOffsetFromBaseView(self):
+        auxiliary = self.makeAuxiliaryView()
+        self.base.X = 20.0
+        self.base.Y = 30.0
+        auxiliary.X = 65.0
+        auxiliary.Y = 10.0
+        FreeCAD.ActiveDocument.recompute()
+
+        self.base.X = 40.0
+        self.base.Y = 50.0
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertAlmostEqual(auxiliary.X.Value, 85.0, places=3)
+        self.assertAlmostEqual(auxiliary.Y.Value, 30.0, places=3)
+
+        auxiliary.KeepAligned = False
+        self.base.X = 60.0
+        self.base.Y = 70.0
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertAlmostEqual(auxiliary.X.Value, 85.0, places=3)
+        self.assertAlmostEqual(auxiliary.Y.Value, 30.0, places=3)
+
+    def testAuxiliaryViewKeepsZeroPageOffsetFromBaseView(self):
+        self.base.X = 20.0
+        self.base.Y = 30.0
+        auxiliary = self.makeAuxiliaryView()
+        auxiliary.X = 20.0
+        auxiliary.Y = 30.0
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertVectorAlmostEqual(auxiliary.AlignmentOffset, FreeCAD.Vector(0.0, 0.0, 0.0))
+
+        self.base.X = 40.0
+        self.base.Y = 50.0
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertAlmostEqual(auxiliary.X.Value, 40.0, places=3)
+        self.assertAlmostEqual(auxiliary.Y.Value, 50.0, places=3)
+
+    def testAuxiliaryViewMirrorsBaseSources(self):
+        auxiliary = self.makeAuxiliaryView()
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertEqual(auxiliary.Source, [self.box])
+
+        replacement = FreeCAD.ActiveDocument.addObject("Part::Box", "ReplacementBox")
+        self.base.Source = [replacement]
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertEqual(auxiliary.Source, [replacement])
+
+        auxiliary.BaseView = None
+
+        self.assertEqual(auxiliary.Source, [])
+        self.assertEqual(auxiliary.XSource, [])
+
+    def testReferenceEndpointChangesUpdateProjectionDirection(self):
+        auxiliary = self.makeAuxiliaryView()
+        auxiliary.ReferenceStart = FreeCAD.Vector(0.0, 0.0, 0.0)
+        auxiliary.ReferenceEnd = FreeCAD.Vector(0.0, 1.0, 0.0)
+        auxiliary.ProjectionMode = "Across"
+
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertVectorAlmostEqual(auxiliary.AuxiliaryDirection, FreeCAD.Vector(0.0, 1.0, 0.0))
+        self.assertVectorAlmostEqual(auxiliary.Direction, FreeCAD.Vector(-1.0, 0.0, 0.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/TechDraw/TestTechDrawApp.py
+++ b/src/Mod/TechDraw/TestTechDrawApp.py
@@ -21,6 +21,7 @@
 # **************************************************************************
 
 #tests that do not require Gui
+from TDTest.DrawAuxiliaryViewTest import DrawAuxiliaryViewTest  # noqa: F401
 from TDTest.DrawHatchTest import DrawHatchTest  # noqa: F401
 from TDTest.DrawViewAnnotationTest import DrawViewAnnotationTest  # noqa: F401
 from TDTest.DrawViewBalloonTest import DrawViewBalloonTest  # noqa: F401

--- a/src/Mod/TechDraw/TestTechDrawGui.py
+++ b/src/Mod/TechDraw/TestTechDrawGui.py
@@ -26,4 +26,5 @@ from TDTest.DrawViewSectionTest import DrawViewSectionTest  # noqa: F401
 from TDTest.DrawViewPartTest import DrawViewPartTest  # noqa: F401
 from TDTest.DrawViewDetailTest import DrawViewDetailTest  # noqa: F401
 from TDTest.DrawViewDimensionTest import DrawViewDimensionTest  # noqa: F401
+from TDTest.DrawAuxiliaryViewGuiTest import DrawAuxiliaryViewGuiTest  # noqa: F401
 


### PR DESCRIPTION
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Summary

This adds a native TechDraw auxiliary-view workflow:

- new `TechDraw::DrawAuxiliaryView` object derived from `DrawViewPart`
- base-view link plus reference start/end, reference label, projection mode, reverse direction, and keep-aligned properties
- projection direction derived from a selected straight edge or two selected vertices in the base view
- `TechDraw_AuxiliaryView` command with workbench menu/toolbar/command-bar wiring
- base-view marker drawing with a dashed reference line, arrows, and labels
- edit task dialog for label, projection mode, reverse direction, and keep-aligned behavior
- base deletion guard so a base view cannot be removed while auxiliary views depend on it
- focused app and GUI tests for projection math, source mirroring, alignment, marker export, and marker removal

The auxiliary view treats `BaseView` as authoritative: it mirrors `Source` / `XSource`, updates when reference endpoints change, and can keep its page offset while the base view moves.

## Issues

Fixes #5810

## Before and After Images

Before: TechDraw did not have a native auxiliary-view command; users had to create normal projected views or manual workarounds.

After: selecting a straight edge in a base view creates a linked auxiliary view, shows the reference marker on the base view, and exports the marker to SVG.

Public validation artifacts:

![TechDraw auxiliary view validation preview](https://raw.githubusercontent.com/adityawrk/FreeCAD/pr-artifacts/freecad-td-demos/pr-artifacts/30698-auxiliary-view/td5810_auxiliary_view.png)

- PNG preview: https://raw.githubusercontent.com/adityawrk/FreeCAD/pr-artifacts/freecad-td-demos/pr-artifacts/30698-auxiliary-view/td5810_auxiliary_view.png
- SVG: https://raw.githubusercontent.com/adityawrk/FreeCAD/pr-artifacts/freecad-td-demos/pr-artifacts/30698-auxiliary-view/td5810_auxiliary_view.svg

The smoke export includes two `AUX` labels and an on-page dashed reference marker.

## Tests

```bash
pixi run cmake --build build/debug --target TechDraw_Data TDTestTarget TechDrawGui -j 8
pixi run python -m py_compile src/Mod/TechDraw/TDTest/DrawAuxiliaryViewTest.py src/Mod/TechDraw/TDTest/DrawAuxiliaryViewGuiTest.py
pixi run build/debug/bin/FreeCADCmd -t TDTest.DrawAuxiliaryViewTest.DrawAuxiliaryViewTest
pixi run build/debug/bin/FreeCAD --hidden -t TDTest.DrawAuxiliaryViewGuiTest.DrawAuxiliaryViewGuiTest
pixi run build/debug/bin/FreeCADCmd -t TestTechDrawApp
pixi run build/debug/bin/FreeCAD --hidden -t TestTechDrawGui
pixi run build/debug/bin/FreeCAD --hidden ../freecad-auxiliary-view-5810-smoke.py
git -c core.whitespace=cr-at-eol diff --check
```

Latest local results:

- focused app test: 9 tests OK
- focused GUI test: 1 test OK
- broader TechDraw app suite: 16 tests OK
- broader TechDraw GUI suite: 6 tests OK
- command-path smoke test passed and exported FCStd/SVG/PNG artifacts

## AI Assistance Disclosure

I used OpenAI Codex (GPT-5) as coding assistance while implementing, reviewing, and testing this PR. I reviewed the changes, ran the tests listed above, and take responsibility for the submission.

## Notes

This PR keeps the command icon on the existing generic TechDraw view icon so the feature behavior can be reviewed first. Dedicated documentation/wiki updates can follow after the UX and naming are accepted.
