### PR TITLE
Gui: improve Navicube rendering and home navigation

### DIFF
--- a/src/Gui/Camera.cpp
+++ b/src/Gui/Camera.cpp
@@ -24,6 +24,10 @@
 #include "Camera.h"
 #include "Utilities.h"
 
+#include <App/Application.h>
+
+#include <cmath>
+
 using namespace Gui;
 
 
@@ -113,6 +117,80 @@ SbRotation Camera::rotation(Camera::Orientation view)
         default:
             return top();
     }
+}
+
+SbRotation Camera::rotation(const std::string& view, Camera::Orientation fallback)
+{
+    if (view == "Top") {
+        return rotation(Top);
+    }
+    if (view == "Bottom") {
+        return rotation(Bottom);
+    }
+    if (view == "Front") {
+        return rotation(Front);
+    }
+    if (view == "Rear") {
+        return rotation(Rear);
+    }
+    if (view == "Left") {
+        return rotation(Left);
+    }
+    if (view == "Right") {
+        return rotation(Right);
+    }
+    if (view == "Isometric") {
+        return rotation(Isometric);
+    }
+    if (view == "Dimetric") {
+        return rotation(Dimetric);
+    }
+    if (view == "Trimetric") {
+        return rotation(Trimetric);
+    }
+    if (view == "Custom") {
+        auto hGrp = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/View/Custom"
+        );
+        SbRotation rot;
+        rot.setValue(
+            static_cast<float>(hGrp->GetFloat("Q0", 0)),
+            static_cast<float>(hGrp->GetFloat("Q1", 0)),
+            static_cast<float>(hGrp->GetFloat("Q2", 0)),
+            static_cast<float>(hGrp->GetFloat("Q3", 1))
+        );
+        return rot;
+    }
+
+    return rotation(fallback);
+}
+
+SbRotation Camera::defaultOrientation(const char* fallbackView)
+{
+    auto hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/View"
+    );
+    return rotation(hGrp->GetASCII("NewDocumentCameraOrientation", fallbackView), Top);
+}
+
+bool Camera::rotationsMatch(const SbRotation& lhs, const SbRotation& rhs, float squaredTolerance)
+{
+    float l0 {};
+    float l1 {};
+    float l2 {};
+    float l3 {};
+    float r0 {};
+    float r1 {};
+    float r2 {};
+    float r3 {};
+    lhs.getValue(l0, l1, l2, l3);
+    rhs.getValue(r0, r1, r2, r3);
+    const float dot = l0 * r0 + l1 * r1 + l2 * r2 + l3 * r3;
+    const float absDot = std::fabs(dot);
+    // For unit quaternions, q and -q encode the same rotation, so compare
+    // against the closer sign.
+    const float squaredDistance = 2.0F * (1.0F - absDot);
+    return squaredDistance <= squaredTolerance;
 }
 
 Base::Rotation Camera::convert(Camera::Orientation view)

--- a/src/Gui/Camera.h
+++ b/src/Gui/Camera.h
@@ -27,6 +27,8 @@
 #include <Base/Rotation.h>
 #include <FCGlobal.h>
 
+#include <string>
+
 namespace Gui
 {
 
@@ -57,6 +59,15 @@ public:
     static SbRotation trimetric();
 
     static SbRotation rotation(Orientation view);
+    /// Return a named orientation, or the fallback orientation when the name is unknown.
+    static SbRotation rotation(const std::string& view, Orientation fallback = Top);
+    /// Return the configured new-document orientation, or fallbackView when no preference is set.
+    static SbRotation defaultOrientation(const char* fallbackView = "Trimetric");
+    static bool rotationsMatch(
+        const SbRotation& lhs,
+        const SbRotation& rhs,
+        float squaredTolerance = 1e-6F
+    );
     static Base::Rotation convert(Orientation view);
     static Base::Rotation convert(const SbRotation&);
     static SbRotation convert(const Base::Rotation&);

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -1423,17 +1423,7 @@ StdCmdViewHome::StdCmdViewHome()
 void StdCmdViewHome::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-
-    auto hGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/View"
-    );
-    std::string default_view = hGrp->GetASCII("NewDocumentCameraOrientation", "Top");
-    doCommand(
-        Command::Gui,
-        "Gui.activeDocument().activeView().viewDefaultOrientation('%s',0)",
-        default_view.c_str()
-    );
-    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"ViewFit\")");
+    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"ViewHome\")");
 }
 
 //===========================================================================

--- a/src/Gui/Inventor/SoNaviCube.cpp
+++ b/src/Gui/Inventor/SoNaviCube.cpp
@@ -382,6 +382,10 @@ constexpr float OVERLAY_ORTHO_EXTENT = 2.1F;
 constexpr float OVERLAY_FOV_SCALE = 1.1F;
 constexpr float OVERLAY_CUBE_Z = -5.1F;
 constexpr float OVERLAY_BUTTON_Z = -4.0F;  // in front of the cube (cube is centered at z≈-5.1)
+constexpr float BACKSIDE_HIT_LEFT = 0.79F;
+constexpr float BACKSIDE_HIT_TOP = 0.0F;
+constexpr float BACKSIDE_HIT_RIGHT = 1.0F;
+constexpr float BACKSIDE_HIT_BOTTOM = 0.16F;
 
 }  // namespace
 
@@ -1388,6 +1392,18 @@ SoNaviCube::PickId SoNaviCube::pickAt(const SbVec2s& point) const
         return PickId::None;
     }
 
+    const SbVec2f overlayPoint(
+        (static_cast<float>(localPoint[0]) + 0.5F) / viewportWidth,
+        1.0F - ((static_cast<float>(localPoint[1]) + 0.5F) / viewportHeight)
+    );
+    for (PickId pickId : kButtonPickIds) {
+        const ButtonHitRect& rect = buttonHitRects[pickIndex(pickId)];
+        if (rect.active && overlayPoint[0] >= rect.left && overlayPoint[0] <= rect.right
+            && overlayPoint[1] >= rect.top && overlayPoint[1] <= rect.bottom) {
+            return pickId;
+        }
+    }
+
     const SbViewportRegion vp(static_cast<int>(viewportWidth), static_cast<int>(viewportHeight));
     SoRayPickAction pick(vp);
     pick.setPoint(localPoint);
@@ -1704,6 +1720,9 @@ void SoNaviCube::rebuildButtonFaces() const
     for (auto& outline : buttonOutlineIndices) {
         outline.clear();
     }
+    for (auto& rect : buttonHitRects) {
+        rect = {};
+    }
     addButtonFace(PickId::ArrowNorth);
     addButtonFace(PickId::ArrowSouth);
     addButtonFace(PickId::ArrowEast);
@@ -1720,9 +1739,11 @@ void SoNaviCube::addButtonFace(PickId pickId) const
     auto& verts = buttonOverlayVerts[pickIndex(pickId)];
     auto& outline = buttonOutlineIndices[pickIndex(pickId)];
     auto& tris = buttonTriangleIndices[pickIndex(pickId)];
+    auto& hitRect = buttonHitRects[pickIndex(pickId)];
     verts.clear();
     outline.clear();
     tris.clear();
+    hitRect = {};
     float scale = 0.005F;
     float offx = 0.5F;
     float offy = 0.5F;
@@ -1802,6 +1823,9 @@ void SoNaviCube::addButtonFace(PickId pickId) const
         case PickId::Backside: {
             offx = 0.80F;
             offy = 0.0F;
+            // The icon has two disconnected arrow loops; keep the center gap clickable.
+            hitRect
+                = {true, BACKSIDE_HIT_LEFT, BACKSIDE_HIT_TOP, BACKSIDE_HIT_RIGHT, BACKSIDE_HIT_BOTTOM};
             const auto loop1 = appendLoop(
                 {24.0F, 21.5F, 17.0F, 29.1F, 16.7F, 25.6F, 12.0F, 25.3F, 8.2F,  24.0F, 4.0F,
                  22.0F, 1.2F,  19.0F, 0.0F,  15.0F, 0.0F,  10.0F, 1.5F,  8.1F,  4.4F,  6.1F,

--- a/src/Gui/Inventor/SoNaviCube.cpp
+++ b/src/Gui/Inventor/SoNaviCube.cpp
@@ -1784,6 +1784,12 @@ void SoNaviCube::addButtonFace(PickId pickId) const
         }
     };
 
+    const auto addPoint = [&](float x, float y) {
+        const auto index = static_cast<std::int32_t>(verts.size());
+        verts.push_back(transform(x, y));
+        return index;
+    };
+
     switch (pickId) {
         default:
             break;
@@ -1816,8 +1822,29 @@ void SoNaviCube::addButtonFace(PickId pickId) const
             const auto base = appendLoop({0.0F,   -18.0F, 18.0F,  -6.0F, 12.0F,  -6.0F, 12.0F, 8.0F,
                                           4.0F,   8.0F,   4.0F,   0.0F,  -4.0F,  0.0F,  -4.0F, 8.0F,
                                           -12.0F, 8.0F,   -12.0F, -6.0F, -18.0F, -6.0F});
-            appendTriangles(base, {10, 1, 0, 9, 2, 1, 9, 3, 2, 9, 8, 3,
-                                   8,  7, 3, 7, 4, 3, 7, 6, 5, 7, 5, 4});
+            const int roofTop = 0;
+            const int roofRight = 1;
+            const int rightWallTop = 2;
+            const int rightWallBottom = 3;
+            const int doorRightBottom = 4;
+            const int doorRightTop = 5;
+            const int doorLeftTop = 6;
+            const int doorLeftBottom = 7;
+            const int leftWallBottom = 8;
+            const int leftWallTop = 9;
+            const int roofLeft = 10;
+            const int doorRightLintel = addPoint(4.0F, -6.0F) - base;
+            const int doorLeftLintel = addPoint(-4.0F, -6.0F) - base;
+
+            // Keep the door as a true cutout: fill the roof, side walls, and lintel separately
+            // instead of drawing triangles through the opening.
+            appendTriangles(base, {roofLeft,        roofRight,       roofTop,
+                                   doorRightLintel, rightWallBottom, rightWallTop,
+                                   doorRightLintel, doorRightBottom, rightWallBottom,
+                                   leftWallTop,     doorLeftBottom,  doorLeftLintel,
+                                   leftWallTop,     leftWallBottom,  doorLeftBottom,
+                                   doorLeftLintel,  doorRightTop,    doorRightLintel,
+                                   doorLeftLintel,  doorLeftTop,     doorRightTop});
             break;
         }
         case PickId::Backside: {

--- a/src/Gui/Inventor/SoNaviCube.cpp
+++ b/src/Gui/Inventor/SoNaviCube.cpp
@@ -1751,6 +1751,7 @@ void SoNaviCube::addButtonFace(PickId pickId) const
             verts.push_back(transform(pts[i * 2], pts[i * 2 + 1]));
             outline.push_back(base + i);
         }
+        outline.push_back(base);
         outline.push_back(-1);
         return base;
     };
@@ -1835,10 +1836,11 @@ void SoNaviCube::addButtonFace(PickId pickId) const
     }
 
     if (outline.empty() && !verts.empty()) {
-        outline.reserve(verts.size() + 1);
+        outline.reserve(verts.size() + 2);
         for (std::int32_t i = 0; i < static_cast<std::int32_t>(verts.size()); ++i) {
             outline.push_back(i);
         }
+        outline.push_back(0);
         outline.push_back(-1);
     }
 

--- a/src/Gui/Inventor/SoNaviCube.h
+++ b/src/Gui/Inventor/SoNaviCube.h
@@ -146,6 +146,15 @@ private:
         ::SoTexture2* texture {nullptr};
     };
 
+    struct ButtonHitRect
+    {
+        bool active {false};
+        float left {0.0F};
+        float top {0.0F};
+        float right {0.0F};
+        float bottom {0.0F};
+    };
+
     void renderCoin(SoGLRenderAction* action);
     void ensureSceneGraph() const;
     void rebuildSceneGraph() const;
@@ -271,6 +280,7 @@ private:
     mutable std::array<std::vector<SbVec3f>, kPickIdCount> buttonOverlayVerts;
     mutable std::array<std::vector<int>, kPickIdCount> buttonTriangleIndices;
     mutable std::array<std::vector<std::int32_t>, kPickIdCount> buttonOutlineIndices;
+    mutable std::array<ButtonHitRect, kPickIdCount> buttonHitRects;
     mutable std::vector<SbVec3f> cubeCoordsData;
     mutable std::vector<std::int32_t> cubeCoordIndexData;
     mutable std::vector<SbVec3f> edgeCoordsData;

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1026,11 +1026,11 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
 {
     static const float pi = boost::math::constants::pi<float>();
 
-    setHilite(PickId::None);
     mouseDown = false;
 
     if (dragging) {
         dragging = false;
+        setHilite(PickId::None);
         resetClickState();
     }
     else {
@@ -1062,17 +1062,20 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
                 lastClickPickId = pickId;
                 clickTimer.start();
             }
+            setHilite(PickId::None);
         }
         else if (faceType == FaceType::Button) {
             // Handle the menu
             if (pickId == PickId::ViewMenu) {
                 resetClickState();
+                setHilite(PickId::None);
                 handleMenu();
                 return true;
             }
             else if (pickId == PickId::Home) {
                 resetClickState();
                 viewer->viewHome();
+                setHilite(pickId);
                 return true;
             }
 
@@ -1098,8 +1101,10 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
             }
 
             flatButtonAnimation = viewer->setCameraOrientation(flatButtonTargetOrientation);
+            setHilite(pickId);
         }
         else {
+            setHilite(PickId::None);
             resetClickState();
             return false;
         }

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1071,9 +1071,8 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
                 return true;
             }
             else if (pickId == PickId::Home) {
-                CommandManager& rcCmdMgr = Application::Instance->commandManager();
-                rcCmdMgr.runCommandByName("Std_ViewHome");
-
+                resetClickState();
+                viewer->viewHome();
                 return true;
             }
 

--- a/src/Gui/Navigation/NavigationAnimation.cpp
+++ b/src/Gui/Navigation/NavigationAnimation.cpp
@@ -31,7 +31,12 @@ using namespace Gui;
 
 NavigationAnimation::NavigationAnimation(NavigationStyle* navigation)
     : navigation(navigation)
-{}
+{
+    auto* animation = static_cast<QVariantAnimation*>(this);
+    QObject::connect(animation, &QVariantAnimation::finished, animation, [this]() {
+        Q_EMIT completed();
+    });
+}
 
 void NavigationAnimation::updateCurrentValue(const QVariant& value)
 {

--- a/src/Gui/Navigation/NavigationAnimation.h
+++ b/src/Gui/Navigation/NavigationAnimation.h
@@ -39,6 +39,8 @@ public:
     using QVariantAnimation::state;
 
 Q_SIGNALS:
+    // QVariantAnimation::finished is intentionally hidden by protected inheritance.
+    void completed();
     void interrupted();
 
 protected:

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -49,6 +49,7 @@
 #include "Navigation/NavigationStyle.h"
 #include "Navigation/NavigationStylePy.h"
 #include "Application.h"
+#include "Camera.h"
 #include "Command.h"
 #include "Action.h"
 #include "Inventor/SoMouseWheelEvent.h"
@@ -61,23 +62,6 @@
 #include "View3DInventorViewer.h"
 
 using namespace Gui;
-
-namespace
-{
-bool rotationsMatch(const SbRotation& lhs, const SbRotation& rhs, float squaredTolerance = 1e-6F)
-{
-    float l0, l1, l2, l3;
-    float r0, r1, r2, r3;
-    lhs.getValue(l0, l1, l2, l3);
-    rhs.getValue(r0, r1, r2, r3);
-    const float dot = l0 * r0 + l1 * r1 + l2 * r2 + l3 * r3;
-    const float absDot = std::fabs(dot);
-    // For unit quaternions, ||a - b||^2 = 2 - 2 * dot(a, b). Since q and -q
-    // encode the same rotation, use abs(dot) to compare against the closer sign.
-    const float squaredDistance = 2.0F * (1.0F - absDot);
-    return squaredDistance <= squaredTolerance;
-}
-}  // namespace
 
 class FCSphereSheetProjector: public SbSphereSheetProjector
 {
@@ -1550,7 +1534,7 @@ SbBool NavigationStyle::canChangeCameraOrientation(
     const OrientationChangeSource source
 ) const
 {
-    if (rotationsMatch(current, target)) {
+    if (Camera::rotationsMatch(current, target)) {
         return true;
     }
     if (isOrientationLocked()) {

--- a/src/Gui/SplitView3DInventor.cpp
+++ b/src/Gui/SplitView3DInventor.cpp
@@ -147,6 +147,12 @@ bool AbstractSplitView::onMsg(const char* pMsg)
         viewAll();
         return true;
     }
+    else if (strcmp("ViewHome", pMsg) == 0) {
+        for (auto* view : _viewer) {
+            view->viewHome();
+        }
+        return true;
+    }
     else if (strcmp("ViewBottom", pMsg) == 0) {
         SbRotation rot(Camera::rotation(Camera::Bottom));
         for (std::vector<View3DInventorViewer*>::iterator it = _viewer.begin(); it != _viewer.end();
@@ -227,6 +233,9 @@ bool AbstractSplitView::onHasMsg(const char* pMsg) const
         return true;
     }
     else if (strcmp("ViewFit", pMsg) == 0) {
+        return true;
+    }
+    else if (strcmp("ViewHome", pMsg) == 0) {
         return true;
     }
     else if (strcmp("ViewBottom", pMsg) == 0) {

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -364,6 +364,10 @@ bool View3DInventor::onMsg(const char* pMsg)
         _viewer->viewAll();
         return true;
     }
+    else if (strcmp("ViewHome", pMsg) == 0) {
+        _viewer->viewHome();
+        return true;
+    }
     else if (strcmp("ViewVR", pMsg) == 0) {
         // call the VR portion of the viewer
         _viewer->viewVR();
@@ -506,6 +510,9 @@ bool View3DInventor::onHasMsg(const char* pMsg) const
         return true;
     }
     else if (strcmp("ViewFit", pMsg) == 0) {
+        return true;
+    }
+    else if (strcmp("ViewHome", pMsg) == 0) {
         return true;
     }
     else if (strcmp("ViewVR", pMsg) == 0) {

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -119,6 +119,7 @@
 
 #include "View3DInventorViewer.h"
 #include "Application.h"
+#include "Camera.h"
 #include "Command.h"
 #include "Document.h"
 #include "GLPainter.h"
@@ -4219,6 +4220,35 @@ SbBox3f View3DInventorViewer::getBoundingBox() const
     SoGetBoundingBoxAction action(vp);
     action.apply(this->getSoRenderManager()->getSceneGraph());
     return action.getBoundingBox();
+}
+
+void View3DInventorViewer::viewHome()
+{
+    SoCamera* camera = getCamera();
+    if (!camera) {
+        return;
+    }
+
+    const SbRotation orientation = Camera::defaultOrientation("Top");
+    if (Camera::rotationsMatch(camera->orientation.getValue(), orientation)) {
+        viewAll();
+        return;
+    }
+
+    auto animation = setCameraOrientation(orientation, true);
+    if (animation && animation->state() == QAbstractAnimation::Running) {
+        QObject::connect(
+            animation.get(),
+            &NavigationAnimation::completed,
+            this,
+            [this]() { viewAll(); },
+            // Let NavigationAnimator finish its cleanup before fitting the scene.
+            Qt::QueuedConnection
+        );
+        return;
+    }
+
+    viewAll();
 }
 
 void View3DInventorViewer::viewAll()

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -485,6 +485,10 @@ public:
      */
     void scale(float factor);
     /**
+     * Move the camera to the configured home orientation and fit the scene.
+     */
+    void viewHome();
+    /**
      * Reposition the current camera so we can see the complete scene.
      */
     void viewAll() override;

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -696,54 +696,12 @@ Py::Object View3DInventorPy::viewDefaultOrientation(const Py::Tuple& args)
     }
 
     try {
-        std::string newDocView;
-        SbRotation rot(0, 0, 0, 1);
+        SbRotation rot;
         if (view) {
-            newDocView = view;
+            rot = Camera::rotation(view, Camera::Top);
         }
         else {
-            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-                "User parameter:BaseApp/Preferences/View"
-            );
-            newDocView = hGrp->GetASCII("NewDocumentCameraOrientation", "Trimetric");
-        }
-
-        if (newDocView == "Top") {
-            rot = Camera::rotation(Camera::Top);
-        }
-        else if (newDocView == "Bottom") {
-            rot = Camera::rotation(Camera::Bottom);
-        }
-        else if (newDocView == "Front") {
-            rot = Camera::rotation(Camera::Front);
-        }
-        else if (newDocView == "Rear") {
-            rot = Camera::rotation(Camera::Rear);
-        }
-        else if (newDocView == "Left") {
-            rot = Camera::rotation(Camera::Left);
-        }
-        else if (newDocView == "Right") {
-            rot = Camera::rotation(Camera::Right);
-        }
-        else if (newDocView == "Isometric") {
-            rot = Camera::rotation(Camera::Isometric);
-        }
-        else if (newDocView == "Dimetric") {
-            rot = Camera::rotation(Camera::Dimetric);
-        }
-        else if (newDocView == "Trimetric") {
-            rot = Camera::rotation(Camera::Trimetric);
-        }
-        else if (newDocView == "Custom") {
-            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-                "User parameter:BaseApp/Preferences/View/Custom"
-            );
-            auto q0 = static_cast<float>(hGrp->GetFloat("Q0", 0));
-            auto q1 = static_cast<float>(hGrp->GetFloat("Q1", 0));
-            auto q2 = static_cast<float>(hGrp->GetFloat("Q2", 0));
-            auto q3 = static_cast<float>(hGrp->GetFloat("Q3", 1));
-            rot.setValue(q0, q1, q2, q3);
+            rot = Camera::defaultOrientation("Trimetric");
         }
 
         auto* viewer = getView3DInventorPtr()->getViewer();


### PR DESCRIPTION
Fixes an issue with the rendering of NaviCube button borders, caused when rebasing https://github.com/FreeCAD/FreeCAD/pull/29030. 

- close the Navicube button outline geometry so button borders render cleanly

I also noticed another issue related to handling of home button, I don't think it was caused by my changes but still worth fixing, please check the videos.

- route Navicube Home and Std_ViewHome through a shared viewer-level Home implementation
- animate to the configured home orientation before fitting the scene, avoiding the abrupt view jump
- support the new ViewHome message in split 3D views

**Before:**

https://github.com/user-attachments/assets/0f824fd7-3bb9-4e3c-8e30-740a29750b1a

**After:**

https://github.com/user-attachments/assets/013c15ac-fd6f-4d68-a491-d46ddafcf281

Want to review this one @PaddleStroke?
