### PR TITLE
TechDraw: improve GD&T balloon workaround

### DIFF
--- a/src/Mod/TechDraw/CMakeLists.txt
+++ b/src/Mod/TechDraw/CMakeLists.txt
@@ -185,6 +185,7 @@ SET(TDTest_SRCS
     TDTest/DrawViewPartTest.py
     TDTest/DrawViewSectionTest.py
     TDTest/DrawViewBalloonTest.py
+    TDTest/DrawViewBalloonGuiTest.py
     TDTest/DrawViewDetailTest.py
     TDTest/TechDrawTestUtilities.py
 )

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -21,7 +21,9 @@
  *                                                                         *
  ***************************************************************************/
 
+# include <algorithm>
 # include <cmath>
+# include <numeric>
 # include <string>
 
 # include <QGuiApplication>
@@ -30,7 +32,10 @@
 # include <QPaintDevice>
 # include <QPainter>
 # include <QPainterPath>
+# include <QStringList>
 # include <QSvgGenerator>
+# include <QTextDocument>
+# include <QTextOption>
 
 #include <App/Application.h>
 #include <Base/Parameter.h>
@@ -65,6 +70,92 @@ using namespace TechDrawGui;
 using DU = DrawUtil;
 using DGU = DrawGuiUtil;
 
+namespace
+{
+struct BalloonTableText
+{
+    QString text;
+    QString html;
+    std::vector<double> separators;
+    int rowCount = 1;
+    double width = 0.0;
+};
+
+BalloonTableText makeBalloonTableText(const QString& source, const QFont& font)
+{
+    BalloonTableText result;
+    result.text = source;
+
+    if (!source.contains(QLatin1Char('|'))) {
+        return result;
+    }
+
+    const QFontMetrics fm(font);
+    const QStringList lines = source.split(QLatin1Char('\n'), Qt::KeepEmptyParts);
+    std::vector<QStringList> rows;
+    rows.reserve(lines.size());
+
+    qsizetype columnCount = 0;
+    for (const QString& line : lines) {
+        rows.push_back(line.split(QLatin1Char('|'), Qt::KeepEmptyParts));
+        columnCount = std::max(columnCount, rows.back().size());
+    }
+
+    if (columnCount <= 1) {
+        return result;
+    }
+
+    std::vector<double> widths(static_cast<std::size_t>(columnCount), 0.0);
+    const double symbolCellPadding = Gui::QtTools::horizontalAdvance(fm, QStringLiteral(" "));
+    const double valueCellPadding = Gui::QtTools::horizontalAdvance(fm, QStringLiteral("    "));
+    for (const auto& row : rows) {
+        for (qsizetype column = 0; column < columnCount; ++column) {
+            const QString cell = column < row.size() ? row.at(column).trimmed() : QString();
+            const double padding = column == 0 ? symbolCellPadding : valueCellPadding;
+            widths[static_cast<std::size_t>(column)] = std::max(
+                widths[static_cast<std::size_t>(column)],
+                static_cast<double>(Gui::QtTools::horizontalAdvance(fm, cell)) + padding);
+        }
+    }
+
+    // GD&T/ISO-GPS feature control frames conventionally use a square symbol cell.
+    widths.front() = std::max(widths.front(), static_cast<double>(fm.lineSpacing()));
+
+    result.text.clear();
+    QString html = QStringLiteral("<table border=\"0\" cellspacing=\"0\" cellpadding=\"0\">");
+    for (std::size_t rowIndex = 0; rowIndex < rows.size(); ++rowIndex) {
+        const auto& row = rows[rowIndex];
+        QString displayRow;
+        html += QStringLiteral("<tr>");
+        for (qsizetype column = 0; column < columnCount; ++column) {
+            const QString cell = column < row.size() ? row.at(column).trimmed() : QString();
+            displayRow += cell;
+            html += QStringLiteral("<td width=\"%1\" align=\"center\" valign=\"middle\">%2</td>")
+                    .arg(std::ceil(widths[static_cast<std::size_t>(column)]))
+                    .arg(cell.toHtmlEscaped());
+        }
+        html += QStringLiteral("</tr>");
+        if (rowIndex + 1 < rows.size()) {
+            displayRow += QLatin1Char('\n');
+        }
+        result.text += displayRow;
+    }
+    html += QStringLiteral("</table>");
+
+    result.html = html;
+    result.rowCount = static_cast<int>(std::max<qsizetype>(1, rows.size()));
+    result.width = std::accumulate(widths.begin(), widths.end(), 0.0);
+
+    double separator = 0.0;
+    for (qsizetype column = 0; column < columnCount - 1; ++column) {
+        separator += widths[static_cast<std::size_t>(column)];
+        result.separators.push_back(separator);
+    }
+
+    return result;
+}
+}
+
 QGIBalloonLabel::QGIBalloonLabel()
 {
     m_originDrag = false;
@@ -78,9 +169,15 @@ QGIBalloonLabel::QGIBalloonLabel()
 
     m_labelText = new QGCustomText();
     m_labelText->setTightBounding(true);
+    m_labelText->document()->setDocumentMargin(0.0);
+    QTextOption textOption = m_labelText->document()->defaultTextOption();
+    textOption.setAlignment(Qt::AlignCenter);
+    m_labelText->document()->setDefaultTextOption(textOption);
     m_labelText->setParentItem(this);
 
     verticalSep = false;
+    rowCount = 1;
+    tableWidth = 0.0;
     hasHover = false;
     parent = nullptr;
 }
@@ -227,6 +324,13 @@ void QGIBalloonLabel::setDimString(QString text, qreal maxWidth)
     prepareGeometryChange();
     m_labelText->setPlainText(text);
     m_labelText->setTextWidth(maxWidth);
+}
+
+void QGIBalloonLabel::setDimHtml(QString html)
+{
+    prepareGeometryChange();
+    m_labelText->setTextWidth(-1);
+    m_labelText->setHtml(html);
 }
 
 void QGIBalloonLabel::setPrettySel() { m_labelText->setPrettySel(); }
@@ -431,22 +535,30 @@ void QGIViewBalloon::updateBalloon(bool obtuse)
     balloonLabel->setFont(font);
 
     QString labelText = QString::fromUtf8(balloon->Text.getStrValue().data());
+    QString labelHtml;
     balloonLabel->setVerticalSep(false);
-    balloonLabel->setSeps(std::vector<int>());
+    balloonLabel->setSeps(std::vector<double>());
+    balloonLabel->setRowCount(1);
+    balloonLabel->setTableWidth(0.0);
 
     if (strcmp(balloon->BubbleShape.getValueAsString(), "Rectangle") == 0) {
-        std::vector<int> newSeps;
-        while (labelText.contains(QStringLiteral("|"))) {
-            int pos = labelText.indexOf(QStringLiteral("|"));
-            labelText.replace(pos, 1, QStringLiteral("   "));
-            QFontMetrics fm(balloonLabel->getFont());
-            newSeps.push_back(Gui::QtTools::horizontalAdvance(fm, labelText.left(pos + 2)));
+        const auto tableText = makeBalloonTableText(labelText, balloonLabel->getFont());
+        if (!tableText.separators.empty()) {
+            labelText = tableText.text;
+            labelHtml = tableText.html;
             balloonLabel->setVerticalSep(true);
+            balloonLabel->setSeps(tableText.separators);
+            balloonLabel->setRowCount(tableText.rowCount);
+            balloonLabel->setTableWidth(tableText.width);
         }
-        balloonLabel->setSeps(newSeps);
     }
 
-    balloonLabel->setDimString(labelText, Rez::guiX(balloon->TextWrapLen.getValue()));
+    if (labelHtml.isEmpty()) {
+        balloonLabel->setDimString(labelText, Rez::guiX(balloon->TextWrapLen.getValue()));
+    }
+    else {
+        balloonLabel->setDimHtml(labelHtml);
+    }
     float x = Rez::guiX(balloon->X.getValue() * refObj->getScale());
     float y = Rez::guiX(balloon->Y.getValue() * refObj->getScale());
     balloonLabel->setPosFromCenter(x, -y);
@@ -664,6 +776,11 @@ void QGIViewBalloon::drawBalloon(bool originDrag)
     float scale = balloon->ShapeScale.getValue();
     double offsetLR = 0;
     double offsetUD = 0;
+    bool useRectAnchor = false;
+    bool useCircleAnchor = false;
+    double anchorHalfWidth = 0.0;
+    double anchorHalfHeight = 0.0;
+    double anchorRadius = 0.0;
     QPainterPath balloonPath;
 
     if (strcmp(balloonType, "Circular") == 0) {
@@ -673,27 +790,45 @@ void QGIViewBalloon::drawBalloon(bool originDrag)
         balloonPath.addEllipse(lblCenter.x - balloonRadius, lblCenter.y - balloonRadius,
                                balloonRadius * 2, balloonRadius * 2);
         offsetLR = balloonRadius;
+        useCircleAnchor = true;
+        anchorRadius = balloonRadius;
     }
     else if (strcmp(balloonType, "None") == 0) {
         balloonPath = QPainterPath();
         offsetLR = (textWidth / 2.0) + Rez::guiX(2.0);
+        useRectAnchor = true;
+        anchorHalfWidth = offsetLR;
+        anchorHalfHeight = (textHeight / 2.0) + Rez::guiX(1.0);
     }
     else if (strcmp(balloonType, "Rectangle") == 0) {
         //Add some room
         textHeight = (textHeight * scale) + Rez::guiX(1.0);
-        // we add some textWidth later because we first need to handle the text separators
+        const double tableWidth = balloonLabel->getTableWidth() * scale;
+        const double frameWidth = std::max((textWidth * scale) + Rez::guiX(2.0),
+                                           tableWidth + Rez::guiX(2.0));
         if (balloonLabel->getVerticalSep()) {
-            for (auto& sep : balloonLabel->getSeps()) {
-                balloonPath.moveTo(lblCenter.x - (textWidth / 2.0) + sep,
-                                   lblCenter.y - (textHeight / 2.0));
-                balloonPath.lineTo(lblCenter.x - (textWidth / 2.0) + sep,
-                                   lblCenter.y + (textHeight / 2.0));
+            const double frameLeft = lblCenter.x - (frameWidth / 2.0);
+            const double frameTop = lblCenter.y - (textHeight / 2.0);
+            const double tableOffset = (frameWidth - tableWidth) / 2.0;
+            for (const auto sep : balloonLabel->getSeps()) {
+                const double sepX = frameLeft + tableOffset + (sep * scale);
+                balloonPath.moveTo(sepX, frameTop);
+                balloonPath.lineTo(sepX, frameTop + textHeight);
+            }
+            const int rowCount = balloonLabel->getRowCount();
+            for (int row = 1; row < rowCount; ++row) {
+                const double sepY = frameTop + (textHeight * row / rowCount);
+                balloonPath.moveTo(frameLeft, sepY);
+                balloonPath.lineTo(frameLeft + frameWidth, sepY);
             }
         }
-        textWidth = (textWidth * scale) + Rez::guiX(2.0);
+        textWidth = frameWidth;
         balloonPath.addRect(lblCenter.x - (textWidth / 2.0), lblCenter.y - (textHeight / 2.0),
                             textWidth, textHeight);
         offsetLR = (textWidth / 2.0);
+        useRectAnchor = true;
+        anchorHalfWidth = textWidth / 2.0;
+        anchorHalfHeight = textHeight / 2.0;
     }
     else if (strcmp(balloonType, "Triangle") == 0) {
         double radius = sqrt(pow((textHeight / 2.0), 2) + pow((textWidth / 2.0), 2));
@@ -725,6 +860,9 @@ void QGIViewBalloon::drawBalloon(bool originDrag)
         balloonPath.arcTo(textBoxCorner.x() - (textHeight / 2), textBoxCorner.y(), textHeight,
                           textHeight, -90, -180);
         offsetLR = (textWidth / 2.0) + (textHeight / 2.0);
+        useRectAnchor = true;
+        anchorHalfWidth = offsetLR;
+        anchorHalfHeight = textHeight / 2.0;
     }
     else if (strcmp(balloonType, "Square") == 0) {
         //Add some room
@@ -733,6 +871,9 @@ void QGIViewBalloon::drawBalloon(bool originDrag)
         double max = std::max(textWidth, textHeight);
         balloonPath.addRect(lblCenter.x - (max / 2.0), lblCenter.y - (max / 2.0), max, max);
         offsetLR = (max / 2.0);
+        useRectAnchor = true;
+        anchorHalfWidth = max / 2.0;
+        anchorHalfHeight = max / 2.0;
     }
     else if (strcmp(balloonType, "Hexagon") == 0) {
         double radius = sqrt(pow((textHeight / 2.0), 2) + pow((textWidth / 2.0), 2));
@@ -769,6 +910,29 @@ void QGIViewBalloon::drawBalloon(bool originDrag)
     // avoid starting the line inside the balloon
     dLineStart.y = lblCenter.y + offsetUD;
     dLineStart.x = lblCenter.x + offsetLR;
+    Base::Vector3d centerToArrow = arrowTipPosInParent - lblCenter;
+    if (useCircleAnchor) {
+        double length = centerToArrow.Length();
+        if (!DrawUtil::fpCompare(length, 0.0)) {
+            dLineStart = lblCenter + (centerToArrow / length * anchorRadius);
+        }
+    }
+    else if (useRectAnchor) {
+        const double dx = centerToArrow.x;
+        const double dy = centerToArrow.y;
+        if (!DrawUtil::fpCompare(dx, 0.0) || !DrawUtil::fpCompare(dy, 0.0)) {
+            if (std::abs(dx) * anchorHalfHeight > std::abs(dy) * anchorHalfWidth) {
+                const double side = (dx >= 0.0) ? anchorHalfWidth : -anchorHalfWidth;
+                dLineStart.x = lblCenter.x + side;
+                dLineStart.y = lblCenter.y + dy * std::abs(side / dx);
+            }
+            else {
+                const double side = (dy >= 0.0) ? anchorHalfHeight : -anchorHalfHeight;
+                dLineStart.x = lblCenter.x + dx * std::abs(side / dy);
+                dLineStart.y = lblCenter.y + side;
+            }
+        }
+    }
 
     if (DrawUtil::fpCompare(kinkLength, 0.0)
         && strcmp(balloonType,

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.h
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.h
@@ -95,6 +95,7 @@ public:
     }
     void setDimString(QString text);
     void setDimString(QString text, qreal maxWidth);
+    void setDimHtml(QString html);
     void setPrettySel();
     void setPrettyPre();
     void setPrettyNormal();
@@ -124,13 +125,29 @@ public:
     {
         verticalSep = sep;
     }
-    std::vector<int> getSeps() const
+    std::vector<double> getSeps() const
     {
         return seps;
     }
-    void setSeps(std::vector<int> newSeps)
+    void setSeps(std::vector<double> newSeps)
     {
         seps = newSeps;
+    }
+    int getRowCount() const
+    {
+        return rowCount;
+    }
+    void setRowCount(int rows)
+    {
+        rowCount = rows;
+    }
+    double getTableWidth() const
+    {
+        return tableWidth;
+    }
+    void setTableWidth(double width)
+    {
+        tableWidth = width;
     }
     QGCustomText* m_labelText;
 
@@ -152,7 +169,9 @@ private:
 
     QGIViewBalloon* parent;
     bool verticalSep;
-    std::vector<int> seps;
+    std::vector<double> seps;
+    int rowCount;
+    double tableWidth;
 
     QColor m_colNormal;
 

--- a/src/Mod/TechDraw/Gui/TaskBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.cpp
@@ -29,6 +29,10 @@
 #include <Gui/Command.h>
 #include <Gui/Document.h>
 #include <Gui/Control.h>
+#include <QComboBox>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QTextCursor>
 
 #include "TaskBalloon.h"
 #include "ui_TaskBalloon.h"
@@ -61,10 +65,33 @@ TaskBalloon::TaskBalloon(QGIViewBalloon *parent, ViewProviderBalloon *balloonVP)
 
     std::string value = parent->getBalloonFeat()->Text.getValue();
     QString qs = QString::fromUtf8(value.data(), value.size());
-    ui->leText->setText(qs);
+    ui->leText->setPlainText(qs);
     ui->leText->selectAll();
-    connect(ui->leText, &QLineEdit::textChanged, this, &TaskBalloon::onTextChanged);
-    QTimer::singleShot(0, ui->leText, qOverload<>(&QLineEdit::setFocus));
+    connect(ui->leText, &QPlainTextEdit::textChanged, this, &TaskBalloon::onTextChanged);
+    QTimer::singleShot(0, ui->leText, [this]() {
+        ui->leText->setFocus();
+    });
+
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("⏤ Straightness"), QString::fromUtf8("⏤"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("⏥ Flatness"), QString::fromUtf8("⏥"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("○ Circularity"), QString::fromUtf8("○"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("⌭ Cylindricity"), QString::fromUtf8("⌭"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("⌒ Profile of a line"), QString::fromUtf8("⌒"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("⌓ Profile of a surface"), QString::fromUtf8("⌓"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("∥ Parallelism"), QString::fromUtf8("∥"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("⟂ Perpendicularity"), QString::fromUtf8("⟂"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("∠ Angularity"), QString::fromUtf8("∠"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("⌖ Position"), QString::fromUtf8("⌖"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("◎ Concentricity/coaxiality"), QString::fromUtf8("◎"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("⌯ Symmetry"), QString::fromUtf8("⌯"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("↗ Circular run-out"), QString::fromUtf8("↗"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("⌰ Total run-out"), QString::fromUtf8("⌰"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("Ⓜ Maximum material condition"), QString::fromUtf8("Ⓜ"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("Ⓛ Least material condition"), QString::fromUtf8("Ⓛ"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("Ⓢ Regardless of feature size"), QString::fromUtf8("Ⓢ"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("Ⓟ Projected tolerance zone"), QString::fromUtf8("Ⓟ"));
+    ui->comboIsoGpsSymbol->addItem(QString::fromUtf8("Ⓔ Envelope requirement"), QString::fromUtf8("Ⓔ"));
+    connect(ui->buttonInsertSymbol, &QPushButton::clicked, this, &TaskBalloon::onInsertSymbolClicked);
 
     DrawGuiUtil::loadArrowBox(ui->comboEndSymbol);
     i = parent->getBalloonFeat()->EndType.getValue();
@@ -162,8 +189,21 @@ void TaskBalloon::recomputeFeature()
 
 void TaskBalloon::onTextChanged()
 {
-    m_parent->getBalloonFeat()->Text.setValue(ui->leText->text().toUtf8().constData());
+    m_parent->getBalloonFeat()->Text.setValue(ui->leText->toPlainText().toUtf8().constData());
     recomputeFeature();
+}
+
+void TaskBalloon::onInsertSymbolClicked()
+{
+    const QString symbol = ui->comboIsoGpsSymbol->currentData().toString();
+    if (symbol.isEmpty()) {
+        return;
+    }
+
+    QTextCursor cursor = ui->leText->textCursor();
+    cursor.insertText(symbol);
+    ui->leText->setTextCursor(cursor);
+    ui->leText->setFocus();
 }
 
 void TaskBalloon::onColorChanged()

--- a/src/Mod/TechDraw/Gui/TaskBalloon.h
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.h
@@ -57,6 +57,7 @@ public:
 
 private Q_SLOTS:
     void onTextChanged();
+    void onInsertSymbolClicked();
     void onColorChanged();
     void onFontsizeChanged();
     void onBubbleShapeChanged();

--- a/src/Mod/TechDraw/Gui/TaskBalloon.ui
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.ui
@@ -31,20 +31,54 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QLineEdit" name="leText">
+       <widget class="QPlainTextEdit" name="leText">
         <property name="toolTip">
          <string>Text to be displayed</string>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>64</height>
+         </size>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
+       <widget class="QLabel" name="lIsoGpsSymbol">
+        <property name="text">
+         <string>ISO GPS symbol</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="symbolLayout">
+        <item>
+         <widget class="QComboBox" name="comboIsoGpsSymbol">
+          <property name="toolTip">
+           <string>Geometric tolerance and modifier symbols to insert into the balloon text</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="buttonInsertSymbol">
+          <property name="toolTip">
+           <string>Insert the selected ISO GPS symbol at the cursor</string>
+          </property>
+          <property name="text">
+           <string>Insert</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="0">
        <widget class="QLabel" name="lColor">
         <property name="text">
          <string>Text color</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="Gui::ColorButton" name="textColor">
         <property name="toolTip">
          <string>Color for text</string>
@@ -58,14 +92,14 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="lFSize">
         <property name="text">
          <string>Font size</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="Gui::QuantitySpinBox" name="qsbFontSize" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">

--- a/src/Mod/TechDraw/TDTest/DrawViewBalloonGuiTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawViewBalloonGuiTest.py
@@ -1,0 +1,87 @@
+import os
+import re
+import tempfile
+import unittest
+
+import FreeCAD
+import TechDrawGui
+
+from .TechDrawTestUtilities import createPageWithSVGTemplate
+
+
+class DrawViewBalloonGuiTest(unittest.TestCase):
+    def setUp(self):
+        FreeCAD.newDocument("TDBalloonGui")
+        FreeCAD.setActiveDocument("TDBalloonGui")
+        FreeCAD.ActiveDocument = FreeCAD.getDocument("TDBalloonGui")
+        self.document = FreeCAD.ActiveDocument
+
+        self.document.addObject("Part::Box", "Box")
+
+        self.page = createPageWithSVGTemplate(self.document)
+        self.page.Scale = 5.0
+
+        self.view = self.document.addObject("TechDraw::DrawViewPart", "View")
+        self.page.addView(self.view)
+        self.view.Source = [self.document.Box]
+        self.view.X = 80
+        self.view.Y = 120
+
+        self.balloon = self.document.addObject("TechDraw::DrawViewBalloon", "Balloon")
+        self.page.addView(self.balloon)
+        self.balloon.SourceView = self.view
+        self.balloon.BubbleShape = "Rectangle"
+        self.balloon.Text = "⌖|0.05|A\n⌯|0.10|B"
+        self.balloon.OriginX = 5
+        self.balloon.OriginY = 5
+        self.balloon.X = 45
+        self.balloon.Y = 45
+
+        self.document.recompute()
+
+    def tearDown(self):
+        FreeCAD.closeDocument("TDBalloonGui")
+
+    def _export_svg(self):
+        handle, path = tempfile.mkstemp(suffix=".svg")
+        os.close(handle)
+        TechDrawGui.exportPageAsSvg(self.page, path)
+        with open(path, "r", encoding="utf-8") as svg_file:
+            svg = svg_file.read()
+        os.remove(path)
+        return svg
+
+    def testMultilineRectangleBalloonSvgExport(self):
+        svg = self._export_svg()
+
+        self.assertNotIn("nan", svg.lower())
+        self.assertNotIn("inf", svg.lower())
+        self.assertNotIn("|", svg)
+        for token in ("⌖", "0.05", "A", "⌯", "0.10", "B"):
+            self.assertIn(token, svg)
+
+        paths = re.findall(r'<path d="([^"]+)"', svg)
+        frame_path = max(paths, key=lambda path: path.count("M"))
+        self.assertGreaterEqual(frame_path.count("M"), 4)
+
+        coordinates = [
+            (float(x), float(y))
+            for x, y in re.findall(r"(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?)", frame_path)
+        ]
+        xs = sorted({round(x, 3) for x, _y in coordinates})
+        ys = sorted({round(y, 3) for _x, y in coordinates})
+        self.assertGreaterEqual(len(xs), 4)
+        self.assertGreaterEqual(len(ys), 3)
+
+        left = xs[0]
+        first_separator = xs[1]
+        top = ys[0]
+        row_separator = ys[1]
+
+        first_cell_width = first_separator - left
+        row_height = row_separator - top
+        self.assertLess(abs(first_cell_width - row_height), max(2.0, row_height * 0.20))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/TechDraw/TestTechDrawGui.py
+++ b/src/Mod/TechDraw/TestTechDrawGui.py
@@ -26,4 +26,5 @@ from TDTest.DrawViewSectionTest import DrawViewSectionTest  # noqa: F401
 from TDTest.DrawViewPartTest import DrawViewPartTest  # noqa: F401
 from TDTest.DrawViewDetailTest import DrawViewDetailTest  # noqa: F401
 from TDTest.DrawViewDimensionTest import DrawViewDimensionTest  # noqa: F401
+from TDTest.DrawViewBalloonGuiTest import DrawViewBalloonGuiTest  # noqa: F401
 


### PR DESCRIPTION
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Summary

Improves TechDraw rectangular balloons so they can be used as a practical 2D GD&T / ISO GPS feature-control-frame workaround.

This keeps the existing `DrawViewBalloon` object and text syntax, but makes the rectangular `|` separator mode table-aware:

- the balloon task panel now accepts multi-line text
- rectangular balloon text uses zero document margin and centered text layout
- `|`-separated rectangular balloon text is laid out as centered table cells
- multi-line rectangular `|` text draws consistent column separators plus row separators
- the first cell is kept square-sized for GD&T/ISO GPS characteristic symbols
- leader lines for rectangular balloons start on the frame boundary instead of inside the balloon
- the task panel includes an ISO GPS symbol picker for common geometric characteristic/modifier symbols

This does not add a new native GD&T object or data model. It enhances the existing balloon text workflow: for rectangular balloons, `|` creates cells and newlines create rows.

The ISO GPS entries are Unicode text inserted into the balloon string, so the exact glyph appearance depends on the selected TechDraw font's symbol coverage.

## Issues

Fixes #11112.

## Before and After Images

Before: users could hack GD&T into rectangular balloons, but multiline frame text/separators required manual SVG cleanup and leaders could start inside the balloon.

After: `⌖|0.05|A\n⌯|0.10|B` exports as a two-row feature-control-frame-like rectangular balloon with centered cells, square-ish symbol cells, row/column separators, and a connected leader.

Public validation artifacts:

![TechDraw GD&T balloon validation preview](https://raw.githubusercontent.com/adityawrk/FreeCAD/pr-artifacts/freecad-td-demos/pr-artifacts/11112-gdt-balloon/td11112_gdt_balloon.png)

- PNG preview: https://raw.githubusercontent.com/adityawrk/FreeCAD/pr-artifacts/freecad-td-demos/pr-artifacts/11112-gdt-balloon/td11112_gdt_balloon.png
- SVG: https://raw.githubusercontent.com/adityawrk/FreeCAD/pr-artifacts/freecad-td-demos/pr-artifacts/11112-gdt-balloon/td11112_gdt_balloon.svg

## Tests

```bash
.pixi/envs/default/bin/ninja -C build/debug TechDrawGui TechDraw_Data TDTestTarget -j2
build/debug/bin/FreeCADCmd -t TDTest.DrawViewBalloonTest.DrawViewBalloonTest
build/debug/bin/FreeCAD --hidden -t TDTest.DrawViewBalloonGuiTest.DrawViewBalloonGuiTest
build/debug/bin/FreeCADCmd -t TestTechDrawApp
build/debug/bin/FreeCAD --hidden -t TestTechDrawGui
build/debug/bin/FreeCAD --hidden ../freecad-gdt-balloon-11112-smoke.py
git -c core.whitespace=cr-at-eol diff --check
```

Latest local results:

- build passed
- existing focused app balloon test passed: 1 test OK
- new focused GUI/SVG export test passed: 1 test OK
- broader `TestTechDrawApp` passed: 7 tests OK
- broader `TestTechDrawGui` passed: 6 tests OK
- smoke export passed and generated FCStd/SVG/PNG evidence
- CRLF-aware whitespace check passed

## AI Assistance Disclosure

I used OpenAI Codex (GPT-5) as coding assistance while implementing, reviewing, and testing this PR. I reviewed the changes, ran the tests listed above, and take responsibility for the submission.
