### PR TITLE
Escape strings when passing to interpreter

### DIFF
--- a/src/Base/Tools.cpp
+++ b/src/Base/Tools.cpp
@@ -238,6 +238,12 @@ std::string Base::Tools::escapeEncodeString(const std::string& s)
             case '\'':
                 result += "\\\'";
                 break;
+            case '\n':
+                result += "\\n";
+                break;
+            case '\r':
+                result += "\\r";
+                break;
             default:
                 result += s.at(i);
                 break;

--- a/src/Mod/MeshPart/Gui/Tessellation.cpp
+++ b/src/Mod/MeshPart/Gui/Tessellation.cpp
@@ -334,7 +334,8 @@ void Tessellation::process(int method, App::Document* doc, const std::list<App::
                 continue;
             }
 
-            QString label = QString::fromUtf8(sobj->Label.getValue());
+            std::string label = sobj->Label.getValue();
+            label = Base::Tools::escapeEncodeString(label);
 
             QString param = getMeshingParameters(method, sobj);
 
@@ -347,7 +348,13 @@ void Tessellation::process(int method, App::Document* doc, const std::list<App::
                               "__mesh__.Label=\"%5 (Meshed)\"\n"
                               "del __doc__, __mesh__, __part__, __shape__\n"
             )
-                              .arg(QString::fromUtf8(doc->getName()), objname, subname, param, label);
+                              .arg(
+                                  QString::fromUtf8(doc->getName()),
+                                  objname,
+                                  subname,
+                                  param,
+                                  QString::fromUtf8(label.c_str())
+                              );
 
             Gui::Command::runCommand(Gui::Command::Doc, cmd.toUtf8());
 

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1256,7 +1256,8 @@ void CmdPartMakeSolid::activated(int iMsg)
         nullptr,
         Gui::ResolveMode::FollowLink
     );
-    runCommand(Doc, "import Part");
+    addModule(Doc, "Part");
+    openCommand("Make solid");
     for (auto it : objs) {
         const TopoDS_Shape& shape = Part::Feature::getShape(
             it,
@@ -1265,6 +1266,9 @@ void CmdPartMakeSolid::activated(int iMsg)
         if (!shape.IsNull()) {
             TopAbs_ShapeEnum type = shape.ShapeType();
             QString str;
+            QString name = QString::fromLatin1(it->getNameInDocument());
+            std::string label = it->Label.getValue();
+            label = Base::Tools::escapeEncodeString(label);
             if (type == TopAbs_SOLID) {
                 Base::Console().message(
                     "%s is ignored because it is already a solid.\n",
@@ -1280,10 +1284,7 @@ void CmdPartMakeSolid::activated(int iMsg)
                           "__o__.Shape=__s__\n"
                           "del __s__, __o__"
                 )
-                          .arg(
-                              QLatin1String(it->getNameInDocument()),
-                              QLatin1String(it->Label.getValue())
-                          );
+                          .arg(name, QString::fromUtf8(label.c_str()));
             }
             else if (type == TopAbs_SHELL) {
                 str = QStringLiteral(
@@ -1294,10 +1295,7 @@ void CmdPartMakeSolid::activated(int iMsg)
                           "__o__.Shape=__s__\n"
                           "del __s__, __o__"
                 )
-                          .arg(
-                              QLatin1String(it->getNameInDocument()),
-                              QLatin1String(it->Label.getValue())
-                          );
+                          .arg(name, QString::fromUtf8(label.c_str()));
             }
             else {
                 Base::Console().message(
@@ -1308,7 +1306,7 @@ void CmdPartMakeSolid::activated(int iMsg)
 
             try {
                 if (!str.isEmpty()) {
-                    runCommand(Doc, str.toLatin1());
+                    runCommand(Doc, str.toUtf8());
                 }
             }
             catch (const Base::Exception& e) {
@@ -1316,6 +1314,8 @@ void CmdPartMakeSolid::activated(int iMsg)
             }
         }
     }
+
+    commitCommand();
 }
 
 bool CmdPartMakeSolid::isActive()
@@ -1358,6 +1358,8 @@ void CmdPartReverseShape::activated(int iMsg)
             name += "_rev";
             name = getUniqueObjectName(name.c_str());
 
+            std::string label = it->Label.getValue();
+            label = Base::Tools::escapeEncodeString(label);
             QString str = QStringLiteral(
                               "__o__=App.ActiveDocument.addObject(\"Part::Reverse\",\"%1\")\n"
                               "__o__.Source=App.ActiveDocument.%2\n"
@@ -1367,11 +1369,11 @@ void CmdPartReverseShape::activated(int iMsg)
                               .arg(
                                   QString::fromLatin1(name.c_str()),
                                   QString::fromLatin1(it->getNameInDocument()),
-                                  QString::fromLatin1(it->Label.getValue())
+                                  QString::fromUtf8(label.c_str())
                               );
 
             try {
-                runCommand(Doc, str.toLatin1());
+                runCommand(Doc, str.toUtf8());
                 copyVisual(name.c_str(), "ShapeAppearance", it->getNameInDocument());
                 copyVisual(name.c_str(), "LineColor", it->getNameInDocument());
                 copyVisual(name.c_str(), "PointColor", it->getNameInDocument());

--- a/src/Mod/Part/Gui/CommandParametric.cpp
+++ b/src/Mod/Part/Gui/CommandParametric.cpp
@@ -82,7 +82,7 @@ void CmdPartCylinder::activated(int iMsg)
     Q_UNUSED(iMsg);
     std::string name = qApp->translate("CmdPartCylinder", "Cylinder").toUtf8().toStdString();
     name = Base::Tools::escapeEncodeString(name);
-    openCommand(name.c_str());
+    openCommand(name);
 
     runCommand(Doc, "App.ActiveDocument.addObject(\"Part::Cylinder\",\"Cylinder\")");
     QString cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
@@ -126,7 +126,7 @@ void CmdPartBox::activated(int iMsg)
     Q_UNUSED(iMsg);
     std::string name = qApp->translate("CmdPartBox", "Cube").toUtf8().toStdString();
     name = Base::Tools::escapeEncodeString(name);
-    openCommand(name.c_str());
+    openCommand(name);
 
     runCommand(Doc, "App.ActiveDocument.addObject(\"Part::Box\",\"Box\")");
     QString cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
@@ -170,7 +170,7 @@ void CmdPartSphere::activated(int iMsg)
     Q_UNUSED(iMsg);
     std::string name = qApp->translate("CmdPartSphere", "Sphere").toUtf8().toStdString();
     name = Base::Tools::escapeEncodeString(name);
-    openCommand(name.c_str());
+    openCommand(name);
 
     runCommand(Doc, "App.ActiveDocument.addObject(\"Part::Sphere\",\"Sphere\")");
     QString cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
@@ -214,7 +214,7 @@ void CmdPartCone::activated(int iMsg)
     Q_UNUSED(iMsg);
     std::string name = qApp->translate("CmdPartCone", "Cone").toUtf8().toStdString();
     name = Base::Tools::escapeEncodeString(name);
-    openCommand(name.c_str());
+    openCommand(name);
 
     runCommand(Doc, "App.ActiveDocument.addObject(\"Part::Cone\",\"Cone\")");
     QString cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
@@ -258,7 +258,7 @@ void CmdPartTorus::activated(int iMsg)
     Q_UNUSED(iMsg);
     std::string name = qApp->translate("CmdPartTorus", "Torus").toUtf8().toStdString();
     name = Base::Tools::escapeEncodeString(name);
-    openCommand(name.c_str());
+    openCommand(name);
 
     runCommand(Doc, "App.ActiveDocument.addObject(\"Part::Torus\",\"Torus\")");
     QString cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")

--- a/src/Mod/Part/Gui/CommandParametric.cpp
+++ b/src/Mod/Part/Gui/CommandParametric.cpp
@@ -23,10 +23,13 @@
  ***************************************************************************/
 
 
+#include <string>
+
 #include <QApplication>
 
 
 #include <App/Part.h>
+#include <Base/Tools.h>
 #include <Gui/Application.h>
 #include <Gui/Command.h>
 #include <Gui/Document.h>
@@ -77,13 +80,13 @@ CmdPartCylinder::CmdPartCylinder()
 void CmdPartCylinder::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QString cmd;
-    cmd = qApp->translate("CmdPartCylinder", "Cylinder");
-    openCommand((const char*)cmd.toUtf8());
+    std::string name = qApp->translate("CmdPartCylinder", "Cylinder").toUtf8().toStdString();
+    name = Base::Tools::escapeEncodeString(name);
+    openCommand(name.c_str());
 
     runCommand(Doc, "App.ActiveDocument.addObject(\"Part::Cylinder\",\"Cylinder\")");
-    cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
-              .arg(qApp->translate("CmdPartCylinder", "Cylinder"));
+    QString cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
+                      .arg(QString::fromUtf8(name.c_str()));
     runCommand(Doc, cmd.toUtf8());
     runCommand(Doc, getAutoGroupCommandStr().toUtf8());
     commitCommand();
@@ -121,13 +124,13 @@ CmdPartBox::CmdPartBox()
 void CmdPartBox::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QString cmd;
-    cmd = qApp->translate("CmdPartBox", "Cube");
-    openCommand((const char*)cmd.toUtf8());
+    std::string name = qApp->translate("CmdPartBox", "Cube").toUtf8().toStdString();
+    name = Base::Tools::escapeEncodeString(name);
+    openCommand(name.c_str());
 
     runCommand(Doc, "App.ActiveDocument.addObject(\"Part::Box\",\"Box\")");
-    cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
-              .arg(qApp->translate("CmdPartBox", "Cube"));
+    QString cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
+                      .arg(QString::fromUtf8(name.c_str()));
     runCommand(Doc, cmd.toUtf8());
     runCommand(Doc, getAutoGroupCommandStr().toUtf8());
     commitCommand();
@@ -165,13 +168,13 @@ CmdPartSphere::CmdPartSphere()
 void CmdPartSphere::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QString cmd;
-    cmd = qApp->translate("CmdPartSphere", "Sphere");
-    openCommand((const char*)cmd.toUtf8());
+    std::string name = qApp->translate("CmdPartSphere", "Sphere").toUtf8().toStdString();
+    name = Base::Tools::escapeEncodeString(name);
+    openCommand(name.c_str());
 
     runCommand(Doc, "App.ActiveDocument.addObject(\"Part::Sphere\",\"Sphere\")");
-    cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
-              .arg(qApp->translate("CmdPartSphere", "Sphere"));
+    QString cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
+                      .arg(QString::fromUtf8(name.c_str()));
     runCommand(Doc, cmd.toUtf8());
     runCommand(Doc, getAutoGroupCommandStr().toUtf8());
     commitCommand();
@@ -209,13 +212,13 @@ CmdPartCone::CmdPartCone()
 void CmdPartCone::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QString cmd;
-    cmd = qApp->translate("CmdPartCone", "Cone");
-    openCommand((const char*)cmd.toUtf8());
+    std::string name = qApp->translate("CmdPartCone", "Cone").toUtf8().toStdString();
+    name = Base::Tools::escapeEncodeString(name);
+    openCommand(name.c_str());
 
     runCommand(Doc, "App.ActiveDocument.addObject(\"Part::Cone\",\"Cone\")");
-    cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
-              .arg(qApp->translate("CmdPartCone", "Cone"));
+    QString cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
+                      .arg(QString::fromUtf8(name.c_str()));
     runCommand(Doc, cmd.toUtf8());
     runCommand(Doc, getAutoGroupCommandStr().toUtf8());
     commitCommand();
@@ -253,13 +256,13 @@ CmdPartTorus::CmdPartTorus()
 void CmdPartTorus::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QString cmd;
-    cmd = qApp->translate("CmdPartTorus", "Torus");
-    openCommand((const char*)cmd.toUtf8());
+    std::string name = qApp->translate("CmdPartTorus", "Torus").toUtf8().toStdString();
+    name = Base::Tools::escapeEncodeString(name);
+    openCommand(name.c_str());
 
     runCommand(Doc, "App.ActiveDocument.addObject(\"Part::Torus\",\"Torus\")");
-    cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
-              .arg(qApp->translate("CmdPartTorus", "Torus"));
+    QString cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
+                      .arg(QString::fromUtf8(name.c_str()));
     runCommand(Doc, cmd.toUtf8());
     runCommand(Doc, getAutoGroupCommandStr().toUtf8());
     commitCommand();

--- a/src/Mod/Part/Gui/Mirroring.cpp
+++ b/src/Mod/Part/Gui/Mirroring.cpp
@@ -364,6 +364,8 @@ bool Mirroring::accept()
             label = label.left(pos);
         }
         label.append(QStringLiteral(" (Mirror #%1)").arg(++count));
+        std::string escapedLabel = Base::Tools::escapeEncodeString(label.toUtf8().toStdString());
+        label = QString::fromUtf8(escapedLabel.c_str());
 
         QString code = QStringLiteral(
                            "__doc__=FreeCAD.getDocument(\"%1\")\n"
@@ -416,7 +418,13 @@ TaskMirroring::TaskMirroring()
 
 bool TaskMirroring::accept()
 {
-    return widget->accept();
+    try {
+        return widget->accept();
+    }
+    catch (const Base::Exception& e) {
+        e.reportException();
+        return false;
+    }
 }
 
 bool TaskMirroring::reject()

--- a/src/Mod/Part/Gui/Mirroring.cpp
+++ b/src/Mod/Part/Gui/Mirroring.cpp
@@ -354,8 +354,7 @@ bool Mirroring::accept()
     double basez = ui->baseZ->value().getValue();
     for (auto item : items) {
         shape = item->data(0, Qt::UserRole).toString();
-        std::string escapedstr = Base::Tools::escapedUnicodeFromUtf8(item->text(0).toUtf8());
-        label = QString::fromStdString(escapedstr);
+        label = item->text(0);
         selectionString = QString::fromStdString(selection);
 
         // if we already have the suffix " (Mirror #<number>)" remove it

--- a/src/Mod/Part/TestPartGui.py
+++ b/src/Mod/Part/TestPartGui.py
@@ -171,6 +171,10 @@ class PartMirrorGuiTestCases(unittest.TestCase):
         label = 'a");print("Erasing your hard drive, please stand by....")'
         self.assertEqual(f"{label} (Mirror #1)", self.mirrorBoxWithLabel(label))
 
+    def testMirrorLabelWithNewlinesIsNotMangled(self):
+        label = "a\nb\nc"
+        self.assertEqual(f"{label} (Mirror #1)", self.mirrorBoxWithLabel(label))
+
 
 class SectionCutTestCases(unittest.TestCase):
     def setUp(self):

--- a/src/Mod/Part/TestPartGui.py
+++ b/src/Mod/Part/TestPartGui.py
@@ -134,6 +134,44 @@ class ProjectionOnSurfaceTestCases(unittest.TestCase):
         FreeCAD.closeDocument("ProjectionOnSurface")
 
 
+class PartMirrorGuiTestCases(unittest.TestCase):
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("PartMirrorGuiTest")
+
+    def tearDown(self):
+        if FreeCADGui.Control.activeDialog():
+            FreeCADGui.Control.closeDialog()
+        FreeCADGui.Selection.clearSelection()
+        FreeCAD.closeDocument(self.Doc.Name)
+
+    def mirrorBoxWithLabel(self, label):
+        if not FreeCAD.GuiUp:
+            self.skipTest("This test requires a graphical user interface (GUI).")
+
+        box = self.Doc.addObject("Part::Box", "Box")
+        box.Label = label
+        self.Doc.recompute()
+
+        FreeCADGui.Selection.clearSelection()
+        FreeCADGui.Selection.addSelection(self.Doc.Name, box.Name)
+        FreeCADGui.runCommand("Part_Mirror")
+        self.assertTrue(FreeCADGui.Control.activeDialog(), "Part Mirror task dialog did not open.")
+
+        FreeCADGui.Control.activeTaskDialog().accept()
+        QtWidgets.QApplication.processEvents()
+
+        mirrors = [obj for obj in self.Doc.Objects if obj.isDerivedFrom("Part::Mirroring")]
+        self.assertEqual(1, len(mirrors))
+        return mirrors[0].Label
+
+    def testMirrorLabelWithUnicodeIsNotDoubleEscaped(self):
+        self.assertEqual("caf\u00e9 (Mirror #1)", self.mirrorBoxWithLabel("caf\u00e9"))
+
+    def testMirrorLabelEscapesQuotesBeforePythonCommand(self):
+        label = 'a");print("Erasing your hard drive, please stand by....")'
+        self.assertEqual(f"{label} (Mirror #1)", self.mirrorBoxWithLabel(label))
+
+
 class SectionCutTestCases(unittest.TestCase):
     def setUp(self):
         self.Doc = FreeCAD.newDocument("SectionCut")

--- a/tests/src/Base/Tools.cpp
+++ b/tests/src/Base/Tools.cpp
@@ -120,6 +120,8 @@ TEST(BaseToolsSuite, TestEscapeEncodeString)
     EXPECT_EQ(Base::Tools::escapeEncodeString("a\\b"), "a\\\\b");
     EXPECT_EQ(Base::Tools::escapeEncodeString("a\"b"), "a\\\"b");
     EXPECT_EQ(Base::Tools::escapeEncodeString("a'b"), "a\\\'b");
+    EXPECT_EQ(Base::Tools::escapeEncodeString("a\nb"), "a\\nb");
+    EXPECT_EQ(Base::Tools::escapeEncodeString("a\rb"), "a\\rb");
     EXPECT_EQ(Base::Tools::escapeEncodeString("plain"), "plain");
 }
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Cherry-picked from https://codeberg.org/xwzCAD/FreeCAD/pulls/225

- To avoid a hard crash on some systems (e.g. macOS) handle exceptions in TaskMirroring::accept()
- To fix the actual exception escape the string
- Escape string in Tessellation::process()
- Escape string in several Part commands




<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes #30687

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
