### PR TITLE
Draft: update label text on custom text change

### DIFF
--- a/src/Mod/Draft/draftobjects/label.py
+++ b/src/Mod/Draft/draftobjects/label.py
@@ -250,6 +250,8 @@ class Label(DraftAnnotation):
     def onChanged(self, obj, prop):
         """Execute when a property is changed."""
         self.show_and_hide(obj, prop)
+        if prop in ("CustomText", "LabelType", "Target"):
+            self.update_text(obj)
 
     def show_and_hide(self, obj, prop):
         """Show and hide the properties depending on the touched property."""
@@ -290,9 +292,16 @@ class Label(DraftAnnotation):
             # will be overwritten
             pass
 
+        self.update_text(obj)
+
+    def update_text(self, obj):
+        """Update the text displayed by this label."""
+        properties = obj.PropertiesList
+        if "Text" not in properties or "LabelType" not in properties:
+            return
+
         if obj.LabelType == "Custom":
-            if obj.CustomText:
-                obj.Text = obj.CustomText
+            obj.Text = obj.CustomText if obj.CustomText else []
 
         elif obj.Target and obj.Target[0]:
             target = obj.Target[0]

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -326,6 +326,17 @@ class DraftCreation(test_base.DraftTestCaseDoc):
         self.doc.recompute()
         self.assertTrue(obj, "'{}' failed".format(operation))
 
+    def test_label_custom_text_updates_text_immediately(self):
+        """Change label custom text without waiting for recompute."""
+        operation = "Draft Label custom text update"
+        _msg("  Test '{}'".format(operation))
+        obj = Draft.make_label(custom_text="Original")
+        self.doc.recompute()
+        self.assertEqual(list(obj.Text), ["Original"], "'{}' setup failed".format(operation))
+
+        obj.CustomText = ["Foo"]
+        self.assertEqual(list(obj.Text), ["Foo"], "'{}' failed".format(operation))
+
     def test_layer(self):
         """Create a layer, and add a rectangle to it."""
         operation = "Draft Layer"


### PR DESCRIPTION
## Summary
- Refresh Draft Label derived Text immediately when Custom Text changes
- Reuse the same text update path from recompute/execute
- Add a regression test for changing Custom Text without a recompute

Fixes #30701
