### PR TITLE
BIM: Label 2D drawings from selected section

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -257,8 +257,17 @@ def make2DDrawing(objectslist=None, baseobj=None, name=None):
     App::GeometryPython
         The created 2D drawing object.
     """
+    default_label = translate("Arch", "Drawing")
+    if name:
+        label = name
+    elif baseobj:
+        base_label = baseobj.Label or baseobj.Name
+        label = f"{base_label} - {default_label}"
+    else:
+        label = default_label
+
     obj = makeBuildingPart(objectslist)
-    obj.Label = name if name else translate("Arch", "Drawing")
+    obj.Label = label
     obj.IfcType = "Annotation"
     obj.ObjectType = "DRAWING"
     obj.setEditorMode("Area", 2)

--- a/src/Mod/BIM/bimcommands/BimDrawingView.py
+++ b/src/Mod/BIM/bimcommands/BimDrawingView.py
@@ -66,26 +66,27 @@ class BIM_DrawingView:
         FreeCADGui.addModule("Arch")
         FreeCADGui.addModule("Draft")
         FreeCADGui.addModule("WorkingPlane")
-        FreeCADGui.doCommand("obj = Arch.make2DDrawing()")
-        FreeCADGui.doCommand("Draft.autogroup(obj)")
         s = FreeCADGui.Selection.getSelection()
-        if len(s) == 1:
-            s = s[0]
-            if Draft.getType(s) == "SectionPlane":
-                FreeCADGui.doCommand(
-                    "vobj = Draft.make_shape2dview(FreeCAD.ActiveDocument." + s.Name + ")"
-                )
-                FreeCADGui.doCommand("vobj.Label = " + repr(translate("BIM", "Viewed lines")))
-                FreeCADGui.doCommand("vobj.InPlace = False")
-                FreeCADGui.doCommand("obj.addObject(vobj)")
-                FreeCADGui.doCommand(
-                    "cobj = Draft.make_shape2dview(FreeCAD.ActiveDocument." + s.Name + ")"
-                )
-                FreeCADGui.doCommand("cobj.Label = " + repr(translate("BIM", "Cut lines")))
-                FreeCADGui.doCommand("cobj.InPlace = False")
-                FreeCADGui.doCommand('cobj.ProjectionMode = "Cutfaces"')
-                FreeCADGui.doCommand("cobj.ViewObject.LineWidth = " + str(cut_lines_width))
-                FreeCADGui.doCommand("obj.addObject(cobj)")
+        section = None
+        if len(s) == 1 and Draft.getType(s[0]) == "SectionPlane":
+            section = s[0]
+        if section:
+            section_object = "FreeCAD.ActiveDocument.getObject(" + repr(section.Name) + ")"
+            FreeCADGui.doCommand("obj = Arch.make2DDrawing(baseobj=" + section_object + ")")
+        else:
+            FreeCADGui.doCommand("obj = Arch.make2DDrawing()")
+        FreeCADGui.doCommand("Draft.autogroup(obj)")
+        if section:
+            FreeCADGui.doCommand("vobj = Draft.make_shape2dview(" + section_object + ")")
+            FreeCADGui.doCommand("vobj.Label = " + repr(translate("BIM", "Viewed lines")))
+            FreeCADGui.doCommand("vobj.InPlace = False")
+            FreeCADGui.doCommand("obj.addObject(vobj)")
+            FreeCADGui.doCommand("cobj = Draft.make_shape2dview(" + section_object + ")")
+            FreeCADGui.doCommand("cobj.Label = " + repr(translate("BIM", "Cut lines")))
+            FreeCADGui.doCommand("cobj.InPlace = False")
+            FreeCADGui.doCommand('cobj.ProjectionMode = "Cutfaces"')
+            FreeCADGui.doCommand("cobj.ViewObject.LineWidth = " + str(cut_lines_width))
+            FreeCADGui.doCommand("obj.addObject(cobj)")
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()
 

--- a/src/Mod/BIM/bimtests/TestArchBuildingPart.py
+++ b/src/Mod/BIM/bimtests/TestArchBuildingPart.py
@@ -111,3 +111,50 @@ class TestArchBuildingPart(TestArchBase.TestArchBase):
         obj = Arch.make2DDrawing()
         self.assertIsNotNone(obj, "make2DDrawing failed to create an object")
         self.assertEqual(obj.Label, "Drawing", "Incorrect default label for 2D Drawing")
+
+    def test_make2DDrawing_uses_base_object_label(self):
+        """Test make2DDrawing default label from a base object."""
+        operation = "Testing make2DDrawing label with base object..."
+        self.printTestMessage(operation)
+
+        section = Arch.makeSectionPlane(name="Floor Plan Level 01")
+        obj = Arch.make2DDrawing(baseobj=section)
+
+        self.assertIsNotNone(obj, "make2DDrawing failed to create an object")
+        self.assertEqual(
+            obj.Label,
+            "Floor Plan Level 01 - Drawing",
+            "2D Drawing label should include the base object label",
+        )
+
+    def test_make2DDrawing_uses_base_object_name_without_label(self):
+        """Test make2DDrawing label fallback when base label is unavailable."""
+        operation = "Testing make2DDrawing label fallback..."
+        self.printTestMessage(operation)
+
+        base = App.ActiveDocument.addObject("App::DocumentObject", "BaseSection")
+        base.Label = ""
+        obj = Arch.make2DDrawing(baseobj=base)
+
+        self.assertIsNotNone(obj, "make2DDrawing failed to create an object")
+        self.assertEqual(
+            obj.Label,
+            "BaseSection - Drawing",
+            "2D Drawing label should fall back to the base object name",
+        )
+
+    def test_make2DDrawing_name_overrides_base_object_label(self):
+        """Test explicit make2DDrawing name takes precedence."""
+        operation = "Testing make2DDrawing explicit name..."
+        self.printTestMessage(operation)
+
+        base = App.ActiveDocument.addObject("App::DocumentObject", "BaseSection")
+        base.Label = "Floor Plan Level 01"
+        obj = Arch.make2DDrawing(baseobj=base, name="Custom Drawing")
+
+        self.assertIsNotNone(obj, "make2DDrawing failed to create an object")
+        self.assertEqual(
+            obj.Label,
+            "Custom Drawing",
+            "Explicit 2D Drawing label should override the base object label",
+        )


### PR DESCRIPTION
This updates the BIM 2D Drawing command so drawings created from a selected section plane inherit useful context from that section. Instead of creating another generic `Drawing`, the generated container is labeled with the selected section label as a suffix-style drawing name, for example `Floor Plan Level 01 - Drawing`, while preserving the existing `Drawing` default when no section is selected.

- Use the selected section plane label when creating a BIM 2D Drawing from it
- Format generated labels as `<section label> - Drawing`
- Keep the default `Drawing` label when no base object is provided and preserve explicit `name=` overrides

Closes #30715
