### PR TITLE
BIM: Fit section planes using local bounds

### DIFF
--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -65,6 +65,50 @@ else:
 ISRENDERING = False  # flag to prevent concurrent runs of the coin renderer
 
 
+def getSectionPlaneLocalBoundBox(objects, placement):
+    """Return object bounds expressed in section plane local coordinates."""
+
+    if not objects:
+        return FreeCAD.BoundBox()
+
+    inverse_matrix = placement.inverse().Matrix
+    local_boundbox = None
+    for obj in Draft.get_group_contents(objects):
+        if not hasattr(obj, "Shape") or not hasattr(obj.Shape, "BoundBox"):
+            continue
+        boundbox = obj.Shape.BoundBox
+        if not boundbox.isValid():
+            continue
+        transformed_boundbox = boundbox.transformed(inverse_matrix)
+        local_boundbox = (
+            transformed_boundbox
+            if local_boundbox is None
+            else local_boundbox.united(transformed_boundbox)
+        )
+    return local_boundbox or FreeCAD.BoundBox()
+
+
+def getSectionPlaneFit(objects, placement):
+    """Return display length and height needed to cover objects from a placement."""
+
+    local_boundbox = getSectionPlaneLocalBoundBox(objects, placement)
+    if not local_boundbox.isValid():
+        return None
+
+    margin = local_boundbox.XLength * 0.1
+    return local_boundbox.XLength + margin, local_boundbox.YLength + margin
+
+
+def getSectionPlaneCenter(objects, placement):
+    """Return the world-space center of object bounds for a section placement."""
+
+    local_boundbox = getSectionPlaneLocalBoundBox(objects, placement)
+    if not local_boundbox.isValid():
+        return None
+
+    return placement.multVec(local_boundbox.Center)
+
+
 def getSectionData(source):
     """Returns some common data from section planes and building parts"""
 
@@ -1716,39 +1760,19 @@ class SectionPlaneTaskPanel:
     def rotateZ(self):
         self.rotate(FreeCAD.Vector(0, 0, 1))
 
-    def getBB(self):
-        bb = FreeCAD.BoundBox()
-        if self.obj:
-            for o in Draft.get_group_contents(self.obj.Objects):
-                if hasattr(o, "Shape") and hasattr(o.Shape, "BoundBox"):
-                    bb.add(o.Shape.BoundBox)
-        return bb
-
     def resize(self):
         if self.obj and self.obj.ViewObject:
-            bb = self.getBB()
-            n = self.obj.Proxy.getNormal(self.obj)
-            margin = bb.XLength * 0.1
-            if (n.getAngle(FreeCAD.Vector(1, 0, 0)) < 0.1) or (
-                n.getAngle(FreeCAD.Vector(-1, 0, 0)) < 0.1
-            ):
-                self.obj.ViewObject.DisplayLength = bb.YLength + margin
-                self.obj.ViewObject.DisplayHeight = bb.ZLength + margin
-            elif (n.getAngle(FreeCAD.Vector(0, 1, 0)) < 0.1) or (
-                n.getAngle(FreeCAD.Vector(0, -1, 0)) < 0.1
-            ):
-                self.obj.ViewObject.DisplayLength = bb.XLength + margin
-                self.obj.ViewObject.DisplayHeight = bb.ZLength + margin
-            elif (n.getAngle(FreeCAD.Vector(0, 0, 1)) < 0.1) or (
-                n.getAngle(FreeCAD.Vector(0, 0, -1)) < 0.1
-            ):
-                self.obj.ViewObject.DisplayLength = bb.XLength + margin
-                self.obj.ViewObject.DisplayHeight = bb.YLength + margin
-            self.obj.Proxy.execute(self.obj)
+            fit = getSectionPlaneFit(self.obj.Objects, self.obj.Placement)
+            if fit is not None:
+                self.obj.ViewObject.DisplayLength = fit[0]
+                self.obj.ViewObject.DisplayHeight = fit[1]
+                self.obj.Proxy.execute(self.obj)
 
     def recenter(self):
         if self.obj:
-            self.obj.Placement.Base = self.getBB().Center
+            center = getSectionPlaneCenter(self.obj.Objects, self.obj.Placement)
+            if center is not None:
+                self.obj.Placement.Base = center
 
     def onTreeClick(self):
         if self.tree.selectedItems():

--- a/src/Mod/BIM/bimtests/TestArchSectionPlane.py
+++ b/src/Mod/BIM/bimtests/TestArchSectionPlane.py
@@ -23,6 +23,7 @@
 # ***************************************************************************
 
 import Arch
+import ArchSectionPlane
 import Draft
 import os
 import FreeCAD as App
@@ -30,6 +31,14 @@ from bimtests import TestArchBase
 
 
 class TestArchSectionPlane(TestArchBase.TestArchBase):
+
+    def _makeBox(self, length=1000, width=2000, height=3000):
+        box = self.document.addObject("Part::Box", "SectionPlaneFitBox")
+        box.Length = length
+        box.Width = width
+        box.Height = height
+        self.document.recompute()
+        return box
 
     def test_makeSectionPlane(self):
         """Test the makeSectionPlane function."""
@@ -43,6 +52,55 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         self.assertEqual(
             section_plane.Label, "TestSectionPlane", "Section plane label is incorrect."
         )
+
+    def testSectionPlaneFitUsesLocalAxesAfterRotateY(self):
+        """Resize-to-fit dimensions follow the rotated section plane axes."""
+
+        box = self._makeBox()
+        placement = App.Placement(App.Vector(0, 0, 0), App.Rotation(App.Vector(0, 1, 0), 90))
+
+        length, height = ArchSectionPlane.getSectionPlaneFit([box], placement)
+
+        self.assertAlmostEqual(length, 3300)
+        self.assertAlmostEqual(height, 2300)
+
+    def testSectionPlaneFitCombinesMultipleObjects(self):
+        """Resize-to-fit covers the combined bounds of all objects."""
+
+        box = self._makeBox()
+        second_box = self._makeBox()
+        second_box.Placement.Base = App.Vector(2000, 500, -100)
+        self.document.recompute()
+
+        length, height = ArchSectionPlane.getSectionPlaneFit([box, second_box], App.Placement())
+
+        self.assertAlmostEqual(length, 3300)
+        self.assertAlmostEqual(height, 2800)
+
+    def testSectionPlaneFitUsesLocalAxesAfterRotateZ(self):
+        """Resize-to-fit handles in-plane rotations without swapping axes."""
+
+        box = self._makeBox()
+        placement = App.Placement(App.Vector(0, 0, 0), App.Rotation(App.Vector(0, 0, 1), 90))
+
+        length, height = ArchSectionPlane.getSectionPlaneFit([box], placement)
+
+        self.assertAlmostEqual(length, 2200)
+        self.assertAlmostEqual(height, 1200)
+
+    def testSectionPlaneCenterRecentersLocalBounds(self):
+        """Recenter moves the placement base to the local bound-box center."""
+
+        box = self._makeBox()
+        placement = App.Placement(App.Vector(500, -250, 125), App.Rotation(App.Vector(0, 1, 0), 90))
+        center = ArchSectionPlane.getSectionPlaneCenter([box], placement)
+        recentered = App.Placement(center, placement.Rotation)
+
+        local_boundbox = ArchSectionPlane.getSectionPlaneLocalBoundBox([box], recentered)
+
+        self.assertAlmostEqual(local_boundbox.Center.x, 0)
+        self.assertAlmostEqual(local_boundbox.Center.y, 0)
+        self.assertAlmostEqual(local_boundbox.Center.z, 0)
 
     def testTechDrawViewGeneration(self):
         """Tests the whole TD view generation workflow"""


### PR DESCRIPTION
This fixes `Resize to Fit` and `Recenter Plane` for BIM section planes after rotation.

The previous implementation inferred the fitting dimensions from the section plane normal and the global object bounding-box axes. That works for the default orientation, but after rotations such as `Rotate Y`, the section plane’s local display axes no longer map cleanly to those world axes, so the fitted plane can be too small.

This change projects the scoped object bounds into the section plane’s local coordinate frame before computing `DisplayLength`, `DisplayHeight`, and the recenter point.

Fixes #30714.
