### PR TITLE
Fix crash in DlgExpressionInput

### DIFF
--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -684,13 +684,18 @@ void DlgExpressionInput::acceptWithVarSet()
 
 void DlgExpressionInput::accept()
 {
-    if (varSetsVisible) {
-        if (needReportOnVarSet()) {
-            return;
+    try {
+        if (varSetsVisible) {
+            if (needReportOnVarSet()) {
+                return;
+            }
+            acceptWithVarSet();
         }
-        acceptWithVarSet();
+        QDialog::accept();
     }
-    QDialog::accept();
+    catch (const Base::Exception& e) {
+        e.ReportException();
+    }
 }
 
 static App::Document* getPreselectedDocument()

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -639,7 +639,12 @@ void DlgExpressionInput::acceptWithVarSet()
     if (const NumberExpression* ne = toNumberExpr(expr)) {
         // the value is a number: directly assign it to the property instead of
         // making it an expression in the variable set
-        Gui::cmdAppObjectArgs(obj, "%s = %f", prop->getName(), ne->getValue());
+        if (prop->isDerivedFrom<App::PropertyInteger>()) {
+            Gui::cmdAppObjectArgs(obj, "%s = %d", prop->getName(), std::lround(ne->getValue()));
+        }
+        else {
+            Gui::cmdAppObjectArgs(obj, "%s = %f", prop->getName(), ne->getValue());
+        }
     }
     else if (const StringExpression* se = toStringExpr(expr)) {
         // the value is a string: directly assign it to the property.

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -680,7 +680,7 @@ void DlgExpressionInput::accept()
         QDialog::accept();
     }
     catch (const Base::Exception& e) {
-        e.ReportException();
+        e.reportException();
     }
 }
 

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -44,7 +44,7 @@
 #include "Dialogs/DlgExpressionInput.h"
 #include "ui_DlgExpressionInput.h"
 #include "Application.h"
-#include "Command.h"
+#include "CommandT.h"
 #include "Tools.h"
 #include "ExpressionBinding.h"
 #include "BitmapFactory.h"
@@ -639,36 +639,17 @@ void DlgExpressionInput::acceptWithVarSet()
     if (const NumberExpression* ne = toNumberExpr(expr)) {
         // the value is a number: directly assign it to the property instead of
         // making it an expression in the variable set
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            "App.getDocument('%s').getObject('%s').%s = %f",
-            obj->getDocument()->getName(),
-            obj->getNameInDocument(),
-            prop->getName(),
-            ne->getValue()
-        );
+        Gui::cmdAppObjectArgs(obj, "%s = %f", prop->getName(), ne->getValue());
     }
     else if (const StringExpression* se = toStringExpr(expr)) {
         // the value is a string: directly assign it to the property.
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            "App.getDocument('%s').getObject('%s').%s = \"%s\"",
-            obj->getDocument()->getName(),
-            obj->getNameInDocument(),
-            prop->getName(),
-            se->getText().c_str()
-        );
+        std::string text = Base::Tools::quoted(se->getText());
+        Gui::cmdAppObjectArgs(obj, "%s = %s", prop->getName(), text);
     }
     else if (const OperatorExpression* une = toUnitNumberExpr(expr)) {
         // the value is a unit number: directly assign it to the property.
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            "App.getDocument('%s').getObject('%s').%s = \"%s\"",
-            obj->getDocument()->getName(),
-            obj->getNameInDocument(),
-            prop->getName(),
-            une->toString().c_str()
-        );
+        std::string text = Base::Tools::quoted(une->toString());
+        Gui::cmdAppObjectArgs(obj, "%s = %s", prop->getName(), text);
     }
     else {
         // the value is an expression: make an expression binding in the VarSet


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Cherry-pick https://codeberg.org/xwzCAD/FreeCAD/pulls/224/commits

When a property of type PropertyInteger is added then convert double to
long.

This fixes https://github.com/FreeCAD/FreeCAD/issues/30674