### PR TITLE
Mesh: Keep colors after recompute

### DIFF
--- a/src/Mod/Mesh/Gui/ViewProviderMeshFaceSet.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderMeshFaceSet.cpp
@@ -140,6 +140,9 @@ void ViewProviderMeshFaceSet::updateData(const App::Property* prop)
         else {
             highlightSelection();
         }
+        if (Coloring.getValue()) {
+            Coloring.touch();
+        }
     }
 }
 

--- a/src/Mod/MeshPart/Gui/Tessellation.cpp
+++ b/src/Mod/MeshPart/Gui/Tessellation.cpp
@@ -397,6 +397,7 @@ void Tessellation::setFaceColors(int method, App::Document* doc, App::DocumentOb
 
                 vpmesh->highlightSegments(diff_col);
                 addFaceColors(vpmesh->getObject<Mesh::Feature>(), diff_col);
+                vpmesh->Coloring.setValue(true);
             }
         }
     }
@@ -424,6 +425,7 @@ void Tessellation::addFaceColors(Mesh::Feature* mesh, const std::vector<Base::Co
             prop->setValues(colorPerFace);
         }
     }
+    mesh->purgeTouched();
 }
 
 std::vector<Base::Color> Tessellation::getUniqueColors(const std::vector<Base::Color>& colors) const


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Cherry-pick https://codeberg.org/xwzCAD/FreeCAD/pulls/228/

This PR fixes two things:

- After its creation the mesh is not touched any more
- Colors survive a recompute. Select the mesh and from the context-menu run the command to recompute it
