### PR TITLE
Gui: rotate view by dragging NaviCube

### DIFF
--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -62,6 +62,7 @@
 #include "Action.h"
 #include "MainWindow.h"
 #include "Navigation/NavigationAnimation.h"
+#include "Navigation/NavigationStyle.h"
 #include "Inventor/SoNaviCube.h"
 #include "View3DInventorViewer.h"
 #include "View3DInventor.h"
@@ -109,8 +110,10 @@ private:
     bool mousePressed(short x, short y);
     bool mouseReleased(short x, short y);
     bool mouseMoved(short x, short y);
+    bool hasDraggedPastThreshold(short x, short y) const;
+    void startCameraRotationDrag();
+    void updateCameraRotationDrag(short x, short y);
     PickId pickFace(short x, short y);
-    bool inDragZone(short x, short y);
 
     void prepare();
     void handleResize(const SbVec2s& viewSize);
@@ -163,14 +166,23 @@ public:
     SbVec2s viewSize = SbVec2s(0, 0);
 
 private:
+    enum class MouseDragMode
+    {
+        None,
+        MoveNaviCube,
+        RotateCamera
+    };
+
     bool mouseDown = false;
-    bool dragging = false;
-    bool mightDrag = false;
+    bool dragStarted = false;
     bool hovering = false;
     QElapsedTimer clickTimer;
     PickId lastClickPickId = PickId::None;
     PickId pendingHiliteId = PickId::None;
     int pendingHiliteCount = 0;
+    MouseDragMode dragMode = MouseDragMode::None;
+    SbVec2s pressPos = SbVec2s(0, 0);
+    SbVec2s lastDragPos = SbVec2s(0, 0);
 
     SbVec2f relPos = SbVec2f(1.0f, 1.0f);
     SbVec2s posAreaBase = SbVec2s(0, 0);
@@ -906,11 +918,26 @@ PickId NaviCubeImplementation::pickFace(short x, short y)
 
 bool NaviCubeImplementation::mousePressed(short x, short y)
 {
-    mouseDown = true;
-    mightDrag = inDragZone(x, y);
     PickId pick = pickFace(x, y);
     setHilite(pick);
-    return pick != PickId::None;
+    if (pick == PickId::None) {
+        mouseDown = false;
+        dragStarted = false;
+        dragMode = MouseDragMode::None;
+        return false;
+    }
+
+    mouseDown = true;
+    dragStarted = false;
+    pressPos = SbVec2s(x, y);
+    lastDragPos = pressPos;
+
+    const FaceType faceType = getFaceType(pick);
+    const bool dragAllowed = faceType == FaceType::Main || faceType == FaceType::Edge
+        || faceType == FaceType::Corner;
+    dragMode = dragAllowed ? (draggable ? MouseDragMode::MoveNaviCube : MouseDragMode::RotateCamera)
+                           : MouseDragMode::None;
+    return true;
 }
 
 void NaviCubeImplementation::handleMenu()
@@ -1026,11 +1053,23 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
 {
     static const float pi = boost::math::constants::pi<float>();
 
-    mouseDown = false;
+    setHilite(PickId::None);
+    if (!mouseDown) {
+        return false;
+    }
 
-    if (dragging) {
-        dragging = false;
-        setHilite(PickId::None);
+    const bool wasDragging = dragStarted;
+    const MouseDragMode releasedDragMode = dragMode;
+    mouseDown = false;
+    dragStarted = false;
+    dragMode = MouseDragMode::None;
+
+    if (wasDragging) {
+        if (releasedDragMode == MouseDragMode::RotateCamera) {
+            if (auto* navigation = viewer->navigationStyle()) {
+                navigation->endOrbitDrag();
+            }
+        }
         resetClickState();
     }
     else {
@@ -1106,7 +1145,7 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
         else {
             setHilite(PickId::None);
             resetClickState();
-            return false;
+            return true;
         }
     }
     return true;
@@ -1123,25 +1162,73 @@ void NaviCubeImplementation::setHilite(PickId hilite)
     }
 }
 
-bool NaviCubeImplementation::inDragZone(short x, short y)
+bool NaviCubeImplementation::hasDraggedPastThreshold(short x, short y) const
 {
-    qreal physicalCubeWidgetSize = getPhysicalCubeWidgetSize();
-    int limit = physicalCubeWidgetSize / 4;
-    return std::abs(x) < limit && std::abs(y) < limit;
+    const long dx = x - pressPos[0];
+    const long dy = y - pressPos[1];
+    constexpr long minimumDragThreshold = 3;
+    const long threshold
+        = std::max(minimumDragThreshold, static_cast<long>(std::lround(3.0 * devicePixelRatio)));
+    return dx * dx + dy * dy >= threshold * threshold;
+}
+
+void NaviCubeImplementation::startCameraRotationDrag()
+{
+    constexpr float minCameraDistanceFactor = 1.05F;
+    constexpr float clippingRadiusFactor = 1.0F;
+    constexpr float dragSensitivity = 0.45F;
+
+    dragStarted = true;
+    setHilite(PickId::None);
+
+    if (auto* navigation = viewer->navigationStyle()) {
+        NavigationStyle::OrbitDragOptions options;
+        options.centerMode = NavigationStyle::OrbitDragOptions::CenterMode::SceneBoundingSphere;
+        options.minDistanceFactor = minCameraDistanceFactor;
+        options.clippingRadiusFactor = clippingRadiusFactor;
+        options.sensitivity = dragSensitivity;
+        navigation->beginOrbitDrag(options);
+    }
+}
+
+void NaviCubeImplementation::updateCameraRotationDrag(short x, short y)
+{
+    const int dx = x - lastDragPos[0];
+    const int dy = y - lastDragPos[1];
+    if (dx == 0 && dy == 0) {
+        return;
+    }
+
+    auto* navigation = viewer->navigationStyle();
+    const qreal physicalCubeWidgetSize = getPhysicalCubeWidgetSize();
+    if (!navigation || physicalCubeWidgetSize <= 0) {
+        lastDragPos = SbVec2s(x, y);
+        return;
+    }
+
+    const auto toProjectorPos = [physicalCubeWidgetSize](short value) {
+        return 0.5F + static_cast<float>(value) / static_cast<float>(physicalCubeWidgetSize);
+    };
+    const SbVec2f curpos(toProjectorPos(x), toProjectorPos(y));
+    const SbVec2f prevpos(toProjectorPos(lastDragPos[0]), toProjectorPos(lastDragPos[1]));
+    navigation->updateOrbitDrag(curpos, prevpos);
+
+    lastDragPos = SbVec2s(x, y);
+    requestRedraw(false);
 }
 
 bool NaviCubeImplementation::mouseMoved(short x, short y)
 {
     qreal physicalCubeWidgetSize = getPhysicalCubeWidgetSize();
-    bool hovering = std::abs(x) <= physicalCubeWidgetSize / 2
-        && std::abs(y) <= physicalCubeWidgetSize / 2;
+    bool hovering = mouseDown
+        || (std::abs(x) <= physicalCubeWidgetSize / 2 && std::abs(y) <= physicalCubeWidgetSize / 2);
 
     if (hovering != this->hovering) {
         this->hovering = hovering;
         viewer->getSoRenderManager()->scheduleRedraw();
     }
 
-    if (!dragging) {
+    if (!dragStarted) {
         PickId pick = pickFace(x, y);
         if (!mouseDown) {
             setHiliteWithHysteresis(pick);
@@ -1151,22 +1238,36 @@ bool NaviCubeImplementation::mouseMoved(short x, short y)
         }
     }
 
-    if (mouseDown && draggable) {
-        if (mightDrag && !dragging) {
-            dragging = true;
+    if (mouseDown && dragMode == MouseDragMode::MoveNaviCube) {
+        const int dx = x - pressPos[0];
+        const int dy = y - pressPos[1];
+        if (!dragStarted && hasDraggedPastThreshold(x, y)) {
+            dragStarted = true;
             setHilite(PickId::None);
         }
-        if (dragging && (std::abs(x) || std::abs(y))) {
-            float newX = relPos[0] + (float)(x) / posAreaSize[0];
-            float newY = relPos[1] + (float)(y) / posAreaSize[1];
+        if (dragStarted && (dx != 0 || dy != 0)) {
+            float newX = relPos[0] + static_cast<float>(dx) / posAreaSize[0];
+            float newY = relPos[1] + static_cast<float>(dy) / posAreaSize[1];
             relPos[0] = std::min(std::max(newX, 0.0f), 1.0f);
             relPos[1] = std::min(std::max(newY, 0.0f), 1.0f);
 
             viewer->getSoRenderManager()->scheduleRedraw();
-            return true;
         }
+        return true;
     }
-    return false;
+
+    if (mouseDown && dragMode == MouseDragMode::RotateCamera) {
+        if (!dragStarted && hasDraggedPastThreshold(x, y)) {
+            startCameraRotationDrag();
+        }
+        if (dragStarted) {
+            updateCameraRotationDrag(x, y);
+        }
+        return true;
+    }
+
+    // Button controls do not start drags, but NaviCube still owns the mouse sequence until release.
+    return mouseDown;
 }
 
 void NaviCubeImplementation::setHiliteWithHysteresis(PickId hilite)

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -40,6 +40,7 @@
 #include <QMenu>
 
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 
@@ -1251,7 +1252,73 @@ void NavigationStyle::spin_simplified(SbVec2f curpos, SbVec2f prevpos)
     hasDragged = true;
 }
 
+void NavigationStyle::beginOrbitDrag(const OrbitDragOptions& options)
+{
+    stopAnimating();
+
+    OrbitDragState state;
+    state.center = viewer->getFocalPoint();
+    state.sensitivity = std::max(0.0F, options.sensitivity);
+
+    SbSphere sceneSphere;
+    if (options.centerMode == OrbitDragOptions::CenterMode::SceneBoundingSphere
+        && getObjectBoundingSphere(sceneSphere)) {
+        state.center = sceneSphere.getCenter();
+        state.minDistance = std::max(0.0F, options.minDistanceFactor) * sceneSphere.getRadius();
+        state.clippingRadius = std::max(0.0F, options.clippingRadiusFactor) * sceneSphere.getRadius();
+    }
+
+    orbitDrag = state;
+    applyOrbitDragCameraConstraints(*orbitDrag);
+}
+
+void NavigationStyle::updateOrbitDrag(SbVec2f curpos, SbVec2f prevpos)
+{
+    if (!isRotationEnabled()) {
+        return;
+    }
+
+    if (!orbitDrag) {
+        return;
+    }
+
+    assert(this->spinprojector);
+
+    const float dragSensitivity = orbitDrag->sensitivity;
+    const auto scalePosition = [dragSensitivity](SbVec2f position) {
+        return SbVec2f(
+            0.5F + dragSensitivity * (position[0] - 0.5F),
+            0.5F + dragSensitivity * (position[1] - 0.5F)
+        );
+    };
+
+    curpos = scalePosition(curpos);
+    prevpos = scalePosition(prevpos);
+
+    if (getOrbitStyle() == FreeTurntable) {
+        SbVec2f midpos(prevpos[0], curpos[1]);
+        spinSimplifiedInternal(curpos, midpos, &orbitDrag->center);
+        spinSimplifiedInternal(midpos, prevpos, &orbitDrag->center);
+    }
+    else {
+        spinSimplifiedInternal(curpos, prevpos, &orbitDrag->center);
+    }
+
+    applyOrbitDragCameraConstraints(*orbitDrag);
+    hasDragged = true;
+}
+
+void NavigationStyle::endOrbitDrag()
+{
+    orbitDrag.reset();
+}
+
 void NavigationStyle::spinSimplifiedInternal(SbVec2f curpos, SbVec2f prevpos)
+{
+    spinSimplifiedInternal(curpos, prevpos, nullptr);
+}
+
+void NavigationStyle::spinSimplifiedInternal(SbVec2f curpos, SbVec2f prevpos, const SbVec3f* center)
 {
     // 0000333: Turntable camera rotation
     SbMatrix mat;
@@ -1271,7 +1338,10 @@ void NavigationStyle::spinSimplifiedInternal(SbVec2f curpos, SbVec2f prevpos)
     }
     r.invert();
 
-    if (this->rotationCenterMode && this->rotationCenterFound) {
+    if (center) {
+        this->reorientCamera(viewer->getSoRenderManager()->getCamera(), r, *center);
+    }
+    else if (this->rotationCenterMode && this->rotationCenterFound) {
         this->reorientCamera(viewer->getSoRenderManager()->getCamera(), r, rotationCenter);
     }
     else {
@@ -1279,13 +1349,13 @@ void NavigationStyle::spinSimplifiedInternal(SbVec2f curpos, SbVec2f prevpos)
     }
 }
 
-bool NavigationStyle::getObjectBoundingBoxCenter(SbVec3f& center) const
+bool NavigationStyle::getObjectBoundingSphere(SbSphere& sphere) const
 {
     if (!viewer->objectGroup) {
         return false;
     }
 
-    // Get the bounding box center of the physical object group
+    // Get the bounding sphere of the physical object group.
     SoGetBoundingBoxAction action(viewer->getSoRenderManager()->getViewportRegion());
     action.apply(viewer->objectGroup);
     const SbBox3f boundingBox = action.getBoundingBox();
@@ -1293,8 +1363,55 @@ bool NavigationStyle::getObjectBoundingBoxCenter(SbVec3f& center) const
         return false;
     }
 
-    center = boundingBox.getCenter();
+    sphere.circumscribe(boundingBox);
     return true;
+}
+
+bool NavigationStyle::getObjectBoundingBoxCenter(SbVec3f& center) const
+{
+    SbSphere sphere;
+    if (!getObjectBoundingSphere(sphere)) {
+        return false;
+    }
+
+    center = sphere.getCenter();
+    return true;
+}
+
+void NavigationStyle::applyOrbitDragCameraConstraints(const OrbitDragState& state)
+{
+    SoCamera* camera = viewer->getSoRenderManager()->getCamera();
+    if (!camera) {
+        return;
+    }
+
+    SbVec3f direction;
+    camera->orientation.getValue().multVec(SbVec3f(0, 0, -1), direction);
+
+    SbVec3f cameraPosition = camera->position.getValue();
+    float centerDepth = (state.center - cameraPosition).dot(direction);
+    if (state.minDistance > 0.0F && centerDepth < state.minDistance) {
+        cameraPosition -= (state.minDistance - centerDepth) * direction;
+        camera->position = cameraPosition;
+        centerDepth = state.minDistance;
+    }
+
+    if (centerDepth > 0.0F) {
+        camera->focalDistance = centerDepth;
+    }
+
+    if (state.clippingRadius <= 0.0F || centerDepth <= 0.0F) {
+        return;
+    }
+
+    const float minNearDistance = camera->isOfType(SoPerspectiveCamera::getClassTypeId())
+        ? std::max(state.clippingRadius * 1.0e-4F, 1.0e-5F)
+        : 0.0F;
+    const float minClipSpan = std::max(state.clippingRadius * 1.0e-3F, 1.0e-4F);
+    const float nearDistance = std::max(minNearDistance, centerDepth - state.clippingRadius);
+    const float farDistance = std::max(centerDepth + state.clippingRadius, nearDistance + minClipSpan);
+    camera->nearDistance = nearDistance;
+    camera->farDistance = farDistance;
 }
 
 SbBool NavigationStyle::doSpin()

--- a/src/Gui/Navigation/NavigationStyle.h
+++ b/src/Gui/Navigation/NavigationStyle.h
@@ -139,6 +139,27 @@ public:
         Programmatic
     };
 
+    /** Options for an explicit mouse-drag orbit sequence. */
+    struct OrbitDragOptions
+    {
+        enum class CenterMode
+        {
+            FocalPoint,         /**< Orbit around the current viewer focal point. */
+            SceneBoundingSphere /**< Orbit around the scene bounding sphere center. */
+        };
+
+        /** Center used for the constrained orbit drag. */
+        CenterMode centerMode = CenterMode::FocalPoint;
+        /** Minimum camera depth as a multiple of the scene bounding sphere radius. Values <= 0
+         * disable it. */
+        float minDistanceFactor = 0.0F;
+        /** Near/far clipping half range as a multiple of the scene bounding sphere radius. Values
+         * <= 0 leave clipping unchanged. */
+        float clippingRadiusFactor = 0.0F;
+        /** Multiplier applied to the drag distance before updating the orbit. */
+        float sensitivity = 1.0F;
+    };
+
 public:
     NavigationStyle();
     ~NavigationStyle() override;
@@ -245,6 +266,12 @@ public:
 
     void setOrbitStyle(OrbitStyle style);
     OrbitStyle getOrbitStyle() const;
+    /** Starts an explicit orbit drag with optional camera and clipping constraints. */
+    void beginOrbitDrag(const OrbitDragOptions& options);
+    /** Applies one incremental orbit drag update using normalized projector positions. */
+    void updateOrbitDrag(SbVec2f curpos, SbVec2f prevpos);
+    /** Ends the active explicit orbit drag and clears its constraints. */
+    void endOrbitDrag();
 
     SbBool isViewing() const;
     void setViewing(SbBool);
@@ -301,9 +328,24 @@ protected:
     virtual void openPopupMenu(const SbVec2s& position);
 
 private:
+    struct OrbitDragState
+    {
+        SbVec3f center;
+        float minDistance = 0.0F;
+        float clippingRadius = 0.0F;
+        float sensitivity = 1.0F;
+    };
+
     void spinInternal(const SbVec2f& pointerpos, const SbVec2f& lastpos);
     void spinSimplifiedInternal(const SbVec2f curpos, const SbVec2f prevpos);
+    void spinSimplifiedInternal(
+        const SbVec2f curpos,
+        const SbVec2f prevpos,
+        const SbVec3f* rotationCenter
+    );
+    bool getObjectBoundingSphere(SbSphere& sphere) const;
     bool getObjectBoundingBoxCenter(SbVec3f& center) const;
+    void applyOrbitDragCameraConstraints(const OrbitDragState& state);
 
 protected:
     void clearLog();
@@ -389,6 +431,7 @@ private:
     SbBool rotationCenterFound;
     SbBool rotationCenterIsScenePointAtCursor;
     NavigationStyle::RotationCenterModes rotationCenterMode;
+    std::optional<OrbitDragState> orbitDrag;
     float sensitivity;
     SbBool resetcursorpos;
 


### PR DESCRIPTION
This PR makes the NaviCube support direct press-and-drag camera rotation when the existing movable NaviCube mode is disabled. The drag is routed through the navigation style orbit code with scene-bounds constraints, so the feature behaves like normal view orbiting while keeping the existing movable-cube mode intact.

- Add constrained orbit-drag support to `NavigationStyle`, including scene bounding-sphere centering, minimum camera distance enforcement, and clipping-plane adjustment around the scene.
- Use that constrained orbit path from the NaviCube when dragging a cube face with movable NaviCube mode disabled.
- Preserve the existing movable NaviCube behavior through its explicit drag mode.
- Keep the NaviCube drag handling readable with separate drag modes, threshold handling, and camera-drag update helpers.

**Demo:**

https://github.com/user-attachments/assets/e6e98132-9779-496f-9654-125411a57d99

