### PR TITLE
BIM: add bSDD classification integration

### DIFF
--- a/src/Mod/BIM/BimBsdd.py
+++ b/src/Mod/BIM/BimBsdd.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 # ***************************************************************************
-# *                                                                         * 
+# *                                                                         *
 # *   This file is part of FreeCAD.                                         *
 # *                                                                         *
 # *   FreeCAD is free software: you can redistribute it and/or modify it    *
@@ -25,7 +25,6 @@ import json
 
 import FreeCAD
 from PySide import QtCore, QtNetwork
-
 
 BSDD_API_BASE_URL = "https://api.bsdd.buildingsmart.org"
 BSDD_PREFERENCES_PATH = "User parameter:BaseApp/Preferences/Mod/BIM"

--- a/src/Mod/BIM/BimBsdd.py
+++ b/src/Mod/BIM/BimBsdd.py
@@ -1,16 +1,30 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *                                                                         * 
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
 """Asynchronous bSDD network core with preference-backed filtering."""
 
 import json
 
 import FreeCAD
-
-try:
-    from PySide import QtCore, QtNetwork
-except ImportError:
-    try:
-        from PySide6 import QtCore, QtNetwork
-    except ImportError:
-        from PySide2 import QtCore, QtNetwork
+from PySide import QtCore, QtNetwork
 
 
 BSDD_API_BASE_URL = "https://api.bsdd.buildingsmart.org"

--- a/src/Mod/BIM/BimBsdd.py
+++ b/src/Mod/BIM/BimBsdd.py
@@ -1,0 +1,273 @@
+"""Asynchronous bSDD network core with preference-backed filtering."""
+
+import json
+
+import FreeCAD
+
+try:
+    from PySide import QtCore, QtNetwork
+except ImportError:
+    try:
+        from PySide6 import QtCore, QtNetwork
+    except ImportError:
+        from PySide2 import QtCore, QtNetwork
+
+
+BSDD_API_BASE_URL = "https://api.bsdd.buildingsmart.org"
+BSDD_PREFERENCES_PATH = "User parameter:BaseApp/Preferences/Mod/BIM"
+BSDD_PREVIEW_KEY = "BsddLoadPreviewDomains"
+BSDD_TEST_KEY = "BsddLoadTestDomains"
+BSDD_INACTIVE_KEY = "BsddLoadInactiveDomains"
+BSDD_API_URL_KEY = "BsddApiBaseUrl"
+BSDD_IFC_DICTIONARY_URI = "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/latest"
+_DOMAIN_CACHE_KEY = "__domains__"
+_BSDD_CLIENT = None
+
+
+class BsddSettings:
+    """Stores the bSDD settings synchronized from FreeCAD parameters."""
+
+    def __init__(self):
+        self.include_preview = False
+        self.include_test = False
+        self.include_inactive = False
+        self.api_base_url = BSDD_API_BASE_URL
+
+
+class BsddNetworkClient(QtCore.QObject):
+    """Background-only asynchronous bSDD client with in-memory caches."""
+
+    dictionariesReady = QtCore.Signal(object)
+    searchReady = QtCore.Signal(object, object)
+    conceptReady = QtCore.Signal(str, object)
+    requestFailed = QtCore.Signal(str, str, object)
+
+    def __init__(self, network_manager=None, parent=None):
+        super().__init__(parent)
+        self._parameter_group = FreeCAD.ParamGet(BSDD_PREFERENCES_PATH)
+        self.settings = BsddSettings()
+        self.domain_cache = {}
+        self.search_cache = {}
+        self.concept_cache = {}
+        self._pending_concept_payloads = {}
+        self._network_manager = network_manager or QtNetwork.QNetworkAccessManager(self)
+        self.refresh_settings()
+
+    def refresh_settings(self):
+        """Synchronizes the cached settings with the central parameter store."""
+        self.settings.include_preview = self._parameter_group.GetBool(BSDD_PREVIEW_KEY, False)
+        self.settings.include_test = self._parameter_group.GetBool(BSDD_TEST_KEY, False)
+        self.settings.include_inactive = self._parameter_group.GetBool(BSDD_INACTIVE_KEY, False)
+        self.settings.api_base_url = self._parameter_group.GetString(
+            BSDD_API_URL_KEY, BSDD_API_BASE_URL
+        ).rstrip("/")
+        return self.settings
+
+    def clear_caches(self):
+        """Clears all in-memory bSDD caches."""
+        self.domain_cache.clear()
+        self.search_cache.clear()
+        self.concept_cache.clear()
+
+    def fetch_dictionaries(self, force_refresh=False):
+        """Retrieves the dictionary registry payload."""
+        self.refresh_settings()
+        cache_key = self._dictionary_cache_key()
+        if (not force_refresh) and (cache_key in self.domain_cache):
+            self.dictionariesReady.emit(self.domain_cache[cache_key])
+            return
+        self._submit_json_request(
+            request_kind="dictionary",
+            cache_key=cache_key,
+            endpoint="/api/Dictionary/v1",
+            query_items=self._status_query_items(),
+        )
+
+    def search_concepts(self, query_text, active_dictionaries=None, related_ifc_entity=""):
+        """Retrieves filtered search results."""
+        self.refresh_settings()
+        active_dictionaries = tuple(sorted(active_dictionaries or ()))
+        search_key = self._search_cache_key(query_text, active_dictionaries, related_ifc_entity)
+        if search_key in self.search_cache:
+            self.searchReady.emit(search_key, self.search_cache[search_key])
+            return search_key
+        query_items = self._status_query_items()
+        query_items.append(("SearchText", query_text))
+        for dictionary_uri in active_dictionaries:
+            query_items.append(("DictionaryUris", dictionary_uri))
+        if related_ifc_entity:
+            query_items.append(("RelatedIfcEntities", related_ifc_entity))
+        self._submit_json_request(
+            request_kind="search",
+            cache_key=search_key,
+            endpoint="/api/Class/Search/v1",
+            query_items=query_items,
+        )
+        return search_key
+
+    def fetch_concept(self, concept_uri):
+        """Retrieves a full concept payload."""
+        self.refresh_settings()
+        cache_key = self._concept_cache_key(concept_uri)
+        if cache_key in self.concept_cache:
+            self.conceptReady.emit(concept_uri, self.concept_cache[cache_key])
+            return
+        self._pending_concept_payloads[cache_key] = {"base": None, "properties": None}
+        query_items = self._status_query_items()
+        query_items.append(("Uri", concept_uri))
+        self._submit_json_request(
+            request_kind="concept_base",
+            cache_key=cache_key,
+            endpoint="/api/Class/v1",
+            query_items=query_items,
+        )
+        property_query_items = self._status_query_items()
+        property_query_items.append(("ClassUri", concept_uri))
+        self._submit_json_request(
+            request_kind="concept_properties",
+            cache_key=cache_key,
+            endpoint="/api/Class/Properties/v1",
+            query_items=property_query_items,
+        )
+
+    def _status_query_items(self):
+        return [
+            ("IncludePreview", self._bool_string(self.settings.include_preview)),
+            ("IncludeTestDictionaries", self._bool_string(self.settings.include_test)),
+            ("IncludeInactive", self._bool_string(self.settings.include_inactive)),
+        ]
+
+    def _submit_json_request(self, request_kind, cache_key, endpoint, query_items):
+        request = self._build_request(endpoint, query_items)
+        reply = self._network_manager.get(request)
+        reply.finished.connect(
+            lambda rk=request_kind, ck=cache_key, rp=reply: self._process_reply(rk, ck, rp)
+        )
+
+    def _build_request(self, endpoint, query_items):
+        url = QtCore.QUrl(self.settings.api_base_url + endpoint)
+        url_query = QtCore.QUrlQuery()
+        for key, value in query_items:
+            url_query.addQueryItem(key, value)
+        url.setQuery(url_query)
+        request = QtNetwork.QNetworkRequest(url)
+        request.setRawHeader(b"Accept", b"application/json")
+        user_agent = self._user_agent().encode("utf-8")
+        request.setRawHeader(b"User-Agent", user_agent)
+        request.setRawHeader(b"X-User-Agent", user_agent)
+        return request
+
+    def _process_reply(self, request_kind, cache_key, reply):
+        try:
+            if reply.error() != QtNetwork.QNetworkReply.NoError:
+                if request_kind in ["concept_base", "concept_properties"]:
+                    self._pending_concept_payloads.pop(cache_key, None)
+                self.requestFailed.emit(request_kind, reply.errorString(), cache_key)
+                return
+            payload = bytes(reply.readAll())
+            parsed_payload = json.loads(payload.decode("utf-8")) if payload else None
+            if request_kind == "dictionary":
+                self.domain_cache[cache_key] = parsed_payload
+                self.dictionariesReady.emit(parsed_payload)
+            elif request_kind == "search":
+                self.search_cache[cache_key] = parsed_payload
+                self.searchReady.emit(cache_key, parsed_payload)
+            elif request_kind == "concept_base":
+                self._collect_concept_payload(cache_key, "base", parsed_payload)
+            elif request_kind == "concept_properties":
+                self._collect_concept_payload(cache_key, "properties", parsed_payload)
+        except Exception as err:
+            if request_kind in ["concept_base", "concept_properties"]:
+                self._pending_concept_payloads.pop(cache_key, None)
+            self.requestFailed.emit(request_kind, str(err), cache_key)
+        finally:
+            reply.deleteLater()
+
+    def _collect_concept_payload(self, concept_uri, payload_kind, payload):
+        if (
+            isinstance(concept_uri, tuple)
+            and len(concept_uri) == 2
+            and isinstance(concept_uri[1], tuple)
+        ):
+            cache_key = concept_uri
+            concept_uri = concept_uri[0]
+        else:
+            cache_key = self._concept_cache_key(concept_uri)
+        pending = self._pending_concept_payloads.setdefault(
+            cache_key, {"base": None, "properties": None}
+        )
+        if payload_kind == "base":
+            pending["base"] = payload or {}
+        elif payload_kind == "properties":
+            pending["properties"] = self._normalize_concept_properties_payload(payload)
+        if pending["base"] is None or pending["properties"] is None:
+            return
+        merged_payload = self._merge_concept_payloads(pending["base"], pending["properties"])
+        self.concept_cache[cache_key] = merged_payload
+        self._pending_concept_payloads.pop(cache_key, None)
+        self.conceptReady.emit(concept_uri, merged_payload)
+
+    def _settings_cache_signature(self):
+        return (
+            self.settings.api_base_url,
+            bool(self.settings.include_preview),
+            bool(self.settings.include_test),
+            bool(self.settings.include_inactive),
+        )
+
+    def _dictionary_cache_key(self):
+        return (_DOMAIN_CACHE_KEY, self._settings_cache_signature())
+
+    def _search_cache_key(self, query_text, active_dictionaries, related_ifc_entity):
+        return (
+            query_text,
+            tuple(active_dictionaries or ()),
+            related_ifc_entity or "",
+            self._settings_cache_signature(),
+        )
+
+    def _concept_cache_key(self, concept_uri):
+        return (concept_uri, self._settings_cache_signature())
+
+    @staticmethod
+    def _normalize_concept_properties_payload(payload):
+        if not isinstance(payload, dict):
+            return {"classProperties": payload or []}
+        if payload.get("classProperties") is not None:
+            return payload
+        if payload.get("properties") is not None:
+            normalized = dict(payload)
+            normalized["classProperties"] = payload.get("properties") or []
+            return normalized
+        return payload
+
+    @staticmethod
+    def _merge_concept_payloads(base_payload, properties_payload):
+        merged = {}
+        if isinstance(base_payload, dict):
+            merged.update(base_payload)
+        if isinstance(properties_payload, dict):
+            merged.update(properties_payload)
+            if properties_payload.get("classProperties") is not None:
+                merged["classProperties"] = properties_payload.get("classProperties") or []
+        return merged
+
+    @staticmethod
+    def _bool_string(value):
+        return "true" if value else "false"
+
+    @staticmethod
+    def _user_agent():
+        try:
+            version = ".".join(FreeCAD.Version()[:3])
+        except Exception:
+            version = "unknown"
+        return f"FreeCAD-BIM/{version}"
+
+
+def get_bsdd_network_client():
+    """Returns a lazily-instantiated shared bSDD client."""
+    global _BSDD_CLIENT
+    if _BSDD_CLIENT is None:
+        _BSDD_CLIENT = BsddNetworkClient()
+    return _BSDD_CLIENT

--- a/src/Mod/BIM/BimBsddClient.py
+++ b/src/Mod/BIM/BimBsddClient.py
@@ -1,0 +1,3 @@
+"""Compatibility shim for the bSDD network client module."""
+
+from BimBsdd import *  # noqa: F401,F403

--- a/src/Mod/BIM/BimBsddClient.py
+++ b/src/Mod/BIM/BimBsddClient.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 # ***************************************************************************
-# *                                                                         * 
+# *                                                                         *
 # *   This file is part of FreeCAD.                                         *
 # *                                                                         *
 # *   FreeCAD is free software: you can redistribute it and/or modify it    *

--- a/src/Mod/BIM/BimBsddClient.py
+++ b/src/Mod/BIM/BimBsddClient.py
@@ -1,3 +1,24 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *                                                                         * 
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
 """Compatibility shim for the bSDD network client module."""
 
 from BimBsdd import (

--- a/src/Mod/BIM/BimBsddClient.py
+++ b/src/Mod/BIM/BimBsddClient.py
@@ -1,3 +1,27 @@
 """Compatibility shim for the bSDD network client module."""
 
-from BimBsdd import *  # noqa: F401,F403
+from BimBsdd import (
+    BSDD_API_BASE_URL,
+    BSDD_API_URL_KEY,
+    BSDD_IFC_DICTIONARY_URI,
+    BSDD_INACTIVE_KEY,
+    BSDD_PREFERENCES_PATH,
+    BSDD_PREVIEW_KEY,
+    BSDD_TEST_KEY,
+    BsddNetworkClient,
+    BsddSettings,
+    get_bsdd_network_client,
+)
+
+__all__ = [
+    "BSDD_API_BASE_URL",
+    "BSDD_API_URL_KEY",
+    "BSDD_IFC_DICTIONARY_URI",
+    "BSDD_INACTIVE_KEY",
+    "BSDD_PREFERENCES_PATH",
+    "BSDD_PREVIEW_KEY",
+    "BSDD_TEST_KEY",
+    "BsddNetworkClient",
+    "BsddSettings",
+    "get_bsdd_network_client",
+]

--- a/src/Mod/BIM/BimBsddContract.py
+++ b/src/Mod/BIM/BimBsddContract.py
@@ -1,0 +1,167 @@
+"""Canonical bSDD contract and validation helpers."""
+
+
+def _as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [v for v in value if v not in [None, ""]]
+    return [value]
+
+
+def _first_non_empty(*values):
+    for value in values:
+        if value not in [None, ""]:
+            return value
+    return ""
+
+
+def _extract_active_ifc_type(obj):
+    if not obj:
+        return ""
+    for attr_name in ["IfcClass", "IfcType", "IfcRole"]:
+        value = getattr(obj, attr_name, "")
+        if value:
+            return str(value)
+    return ""
+
+
+def _extract_applicable_ifc_types(payload):
+    values = []
+    for key in ["relatedIfcEntities", "relatedIfcEntity", "applicableIfcClasses"]:
+        values.extend(_as_list(payload.get(key)))
+    return [str(value) for value in values if value]
+
+
+def _extract_dictionary_metadata(payload):
+    return {
+        "name": _first_non_empty(
+            payload.get("dictionaryName"),
+            payload.get("classificationName"),
+            payload.get("source"),
+        ),
+        "namespace_uri": _first_non_empty(
+            payload.get("dictionaryUri"),
+            payload.get("namespaceUri"),
+            payload.get("dictionaryNamespaceUri"),
+        ),
+        "version": _first_non_empty(
+            payload.get("dictionaryVersion"),
+            payload.get("version"),
+            payload.get("versionDate"),
+        ),
+    }
+
+
+def _extract_class_metadata(payload):
+    return {
+        "reference_code": _first_non_empty(
+            payload.get("referenceCode"),
+            payload.get("identification"),
+            payload.get("code"),
+        ),
+        "name": _first_non_empty(
+            payload.get("name"),
+            payload.get("description"),
+            payload.get("referenceCode"),
+        ),
+        "description": _first_non_empty(
+            payload.get("description"),
+            payload.get("definition"),
+            payload.get("name"),
+        ),
+        "uri": _first_non_empty(
+            payload.get("uri"),
+            payload.get("conceptUri"),
+            payload.get("location"),
+        ),
+    }
+
+
+def _extract_property_value(prop):
+    for key in [
+        "predefinedValue",
+        "defaultValue",
+        "value",
+        "valueExpression",
+        "exampleValue",
+    ]:
+        if prop.get(key) not in [None, ""]:
+            return prop.get(key)
+    return None
+
+
+def _extract_extended_properties(payload):
+    results = []
+    for prop in payload.get("classProperties", []) or []:
+        results.append(
+            {
+                "property_set": _first_non_empty(
+                    prop.get("propertySet"),
+                    prop.get("propertySetName"),
+                    prop.get("pset"),
+                ),
+                "name": _first_non_empty(prop.get("name"), prop.get("code")),
+                "data_type": _first_non_empty(
+                    prop.get("dataType"),
+                    prop.get("propertyDomainName"),
+                    prop.get("type"),
+                ),
+                "value": _extract_property_value(prop),
+                "allowed_values": prop.get("allowedValues") or prop.get("values") or [],
+                "uri": _first_non_empty(prop.get("uri"), prop.get("propertyUri")),
+            }
+        )
+    return results
+
+
+def merge_payloads(base_payload, detail_payload):
+    merged = {}
+    if isinstance(base_payload, dict):
+        merged.update(base_payload)
+    if isinstance(detail_payload, dict):
+        merged.update(detail_payload)
+        base_props = (base_payload or {}).get("classProperties") or []
+        detail_props = detail_payload.get("classProperties") or []
+        merged["classProperties"] = detail_props or base_props
+    return merged
+
+
+def build_canonical_contract(base_payload, detail_payload=None, active_object=None):
+    payload = merge_payloads(base_payload, detail_payload)
+    active_ifc_type = _extract_active_ifc_type(active_object)
+    applicable_ifc_types = _extract_applicable_ifc_types(payload)
+    is_applicable = (not applicable_ifc_types) or (active_ifc_type in applicable_ifc_types)
+    return {
+        "dictionary_metadata": _extract_dictionary_metadata(payload),
+        "class_metadata": _extract_class_metadata(payload),
+        "validation_filters": {
+            "applicable_ifc_types": applicable_ifc_types,
+            "active_ifc_type": active_ifc_type,
+            "is_applicable": is_applicable,
+        },
+        "extended_properties": _extract_extended_properties(payload),
+    }
+
+
+def refresh_contract_validation(contract, active_object=None):
+    refreshed = dict(contract or {})
+    validation = dict(refreshed.get("validation_filters", {}) or {})
+    applicable_ifc_types = list(validation.get("applicable_ifc_types") or [])
+    active_ifc_type = _extract_active_ifc_type(active_object)
+    validation["active_ifc_type"] = active_ifc_type
+    validation["is_applicable"] = (not applicable_ifc_types) or (
+        active_ifc_type in applicable_ifc_types
+    )
+    refreshed["validation_filters"] = validation
+    return refreshed
+
+
+def build_legacy_classification_string(contract):
+    dictionary_name = contract.get("dictionary_metadata", {}).get("name", "")
+    reference_code = contract.get("class_metadata", {}).get("reference_code", "")
+    name = contract.get("class_metadata", {}).get("name", "")
+    code = reference_code or name
+    if dictionary_name and code:
+        return "{} {}".format(dictionary_name, code)
+    return code or dictionary_name

--- a/src/Mod/BIM/BimBsddContract.py
+++ b/src/Mod/BIM/BimBsddContract.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 # ***************************************************************************
-# *                                                                         * 
+# *                                                                         *
 # *   This file is part of FreeCAD.                                         *
 # *                                                                         *
 # *   FreeCAD is free software: you can redistribute it and/or modify it    *

--- a/src/Mod/BIM/BimBsddContract.py
+++ b/src/Mod/BIM/BimBsddContract.py
@@ -1,3 +1,25 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *                                                                         * 
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
 """Canonical bSDD contract and validation helpers."""
 
 

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -59,6 +59,9 @@ SET(Arch_SRCS
     ArchSketchObject.py
     BimSelect.py
     BimStatus.py
+    BimBsdd.py
+    BimBsddClient.py
+    BimBsddContract.py
     TestArch.py
     TestArchGui.py
     ArchReport.py
@@ -264,6 +267,8 @@ SET(bimtests_SRCS
     bimtests/TestArchStairsGui.py
     bimtests/TestArchReport.py
     bimtests/TestArchReportGui.py
+    bimtests/TestBsdd.py
+    bimtests/TestBsddContract.py
 )
 
 set(bimtests_FIXTURES

--- a/src/Mod/BIM/TestArch.py
+++ b/src/Mod/BIM/TestArch.py
@@ -50,5 +50,5 @@ from bimtests.TestArchComponent import TestArchComponent
 from bimtests.TestWebGLExport import TestWebGLExport
 from bimtests.TestArchReport import TestArchReport
 from bimtests.TestArchCovering import TestArchCovering
-from bimtests.TestBsdd import TestBsdd  # noqa: F401
-from bimtests.TestBsddContract import TestBsddContract  # noqa: F401
+from bimtests.TestBsdd import TestBsdd 
+from bimtests.TestBsddContract import TestBsddContract  

--- a/src/Mod/BIM/TestArch.py
+++ b/src/Mod/BIM/TestArch.py
@@ -50,3 +50,5 @@ from bimtests.TestArchComponent import TestArchComponent
 from bimtests.TestWebGLExport import TestWebGLExport
 from bimtests.TestArchReport import TestArchReport
 from bimtests.TestArchCovering import TestArchCovering
+from bimtests.TestBsdd import TestBsdd
+from bimtests.TestBsddContract import TestBsddContract

--- a/src/Mod/BIM/TestArch.py
+++ b/src/Mod/BIM/TestArch.py
@@ -50,5 +50,5 @@ from bimtests.TestArchComponent import TestArchComponent
 from bimtests.TestWebGLExport import TestWebGLExport
 from bimtests.TestArchReport import TestArchReport
 from bimtests.TestArchCovering import TestArchCovering
-from bimtests.TestBsdd import TestBsdd
-from bimtests.TestBsddContract import TestBsddContract
+from bimtests.TestBsdd import TestBsdd  # noqa: F401
+from bimtests.TestBsddContract import TestBsddContract  # noqa: F401

--- a/src/Mod/BIM/TestArch.py
+++ b/src/Mod/BIM/TestArch.py
@@ -50,5 +50,5 @@ from bimtests.TestArchComponent import TestArchComponent
 from bimtests.TestWebGLExport import TestWebGLExport
 from bimtests.TestArchReport import TestArchReport
 from bimtests.TestArchCovering import TestArchCovering
-from bimtests.TestBsdd import TestBsdd 
-from bimtests.TestBsddContract import TestBsddContract  
+from bimtests.TestBsdd import TestBsdd
+from bimtests.TestBsddContract import TestBsddContract

--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -49,8 +49,6 @@ BSDD_DICTIONARY_META_PRESENT_KEY = "BIM_BsddActiveDictionariesPresent"
 BSDD_CONTRACT_ROLE = 33
 
 
-
-
 class BIM_Classification:
 
     def GetResources(self):
@@ -323,7 +321,9 @@ class BIM_Classification:
             ) = self._load_bsdd_dictionary_state()
             self._apply_provider_visibility()
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_setup_bsdd_ui", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_setup_bsdd_ui", err)
+            )
 
     def _connect_bsdd_signals(self):
         try:
@@ -343,7 +343,9 @@ class BIM_Classification:
             self._bsdd_client.requestFailed.connect(self._on_bsdd_request_failed)
             self._bsdd_signals_connected = True
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_connect_bsdd_signals", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_connect_bsdd_signals", err)
+            )
 
     def _disconnect_bsdd_signals(self):
         try:
@@ -356,7 +358,9 @@ class BIM_Classification:
         except (RuntimeError, TypeError):
             return
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_disconnect_bsdd_signals", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_disconnect_bsdd_signals", err)
+            )
         finally:
             self._bsdd_signals_connected = False
 
@@ -365,7 +369,9 @@ class BIM_Classification:
             FreeCADGui.Selection.addObserver(self)
             self._selection_observer_installed = True
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_install_selection_observer", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_install_selection_observer", err)
+            )
 
     def _remove_selection_observer(self):
         try:
@@ -373,13 +379,17 @@ class BIM_Classification:
                 FreeCADGui.Selection.removeObserver(self)
                 self._selection_observer_installed = False
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_remove_selection_observer", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_remove_selection_observer", err)
+            )
 
     def _request_bsdd_dictionaries(self):
         try:
             self._bsdd_client.fetch_dictionaries()
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_request_bsdd_dictionaries", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_request_bsdd_dictionaries", err)
+            )
 
     def _on_provider_changed(self, *_args):
         try:
@@ -390,7 +400,9 @@ class BIM_Classification:
                 self._request_bsdd_dictionaries()
                 self._schedule_bsdd_search()
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_provider_changed", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_on_provider_changed", err)
+            )
 
     def _apply_provider_visibility(self):
         try:
@@ -410,7 +422,9 @@ class BIM_Classification:
             )
             self.form.groupClasses.setTitle(title)
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_apply_provider_visibility", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_apply_provider_visibility", err)
+            )
 
     def _is_bsdd_provider_active(self):
         try:
@@ -419,14 +433,18 @@ class BIM_Classification:
                 and self.form.comboProvider.currentText() == "bSDD"
             )
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_is_bsdd_provider_active", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_is_bsdd_provider_active", err)
+            )
             return False
 
     def _on_bsdd_search_text_changed(self, *_args):
         try:
             self._schedule_bsdd_search()
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_search_text_changed", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_search_text_changed", err)
+            )
 
     def _schedule_bsdd_search(self):
         try:
@@ -436,7 +454,9 @@ class BIM_Classification:
                 self._search_timer.stop()
             self._search_timer.start()
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_schedule_bsdd_search", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_schedule_bsdd_search", err)
+            )
 
     def _normalize_bsdd_context_query(self, related_ifc_entity):
         try:
@@ -448,7 +468,9 @@ class BIM_Classification:
             normalized = re.sub(r"(?<!^)(?=[A-Z])", " ", normalized).strip()
             return normalized or str(related_ifc_entity)
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_normalize_bsdd_context_query", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_normalize_bsdd_context_query", err)
+            )
             return related_ifc_entity or ""
 
     def _set_bsdd_results_placeholder(self, message):
@@ -462,7 +484,9 @@ class BIM_Classification:
                 self.form.bsddResultsModel.appendRow(item)
             self._populate_bsdd_properties(None)
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_set_bsdd_results_placeholder", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_set_bsdd_results_placeholder", err)
+            )
 
     def _get_bsdd_search_inputs(self):
         try:
@@ -471,7 +495,9 @@ class BIM_Classification:
             related_ifc_entity = self._bsdd_context_ifc_class or ""
             return query_text, active_dictionaries, related_ifc_entity
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_get_bsdd_search_inputs", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_get_bsdd_search_inputs", err)
+            )
             return "", [], ""
 
     def _build_bsdd_search_candidates(self, query_text, active_dictionaries, related_ifc_entity):
@@ -496,7 +522,9 @@ class BIM_Classification:
                         candidates.append(candidate)
             return candidates
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_build_bsdd_search_candidates", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_build_bsdd_search_candidates", err)
+            )
             return []
 
     def _dispatch_bsdd_search_candidate(self, dictionary_uri):
@@ -522,7 +550,9 @@ class BIM_Classification:
                     dictionary_uri,
                 )
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_dispatch_bsdd_search_candidate", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_dispatch_bsdd_search_candidate", err)
+            )
 
     def _initialize_bsdd_result_tree(self, active_dictionaries):
         try:
@@ -543,7 +573,9 @@ class BIM_Classification:
                 self._bsdd_dictionary_nodes[dictionary_uri] = dict_item
             self.form.bsddResultsTree.expandAll()
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_initialize_bsdd_result_tree", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_initialize_bsdd_result_tree", err)
+            )
 
     def _clear_bsdd_dictionary_branch(self, dictionary_uri):
         try:
@@ -551,7 +583,9 @@ class BIM_Classification:
             if node is not None:
                 node.removeRows(0, node.rowCount())
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_clear_bsdd_dictionary_branch", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_clear_bsdd_dictionary_branch", err)
+            )
 
     def _append_bsdd_dictionary_results(self, dictionary_uri, concepts):
         try:
@@ -572,7 +606,9 @@ class BIM_Classification:
                 if node.rowCount() and not self.form.bsddResultsTree.currentIndex().isValid():
                     self.form.bsddResultsTree.setCurrentIndex(node.child(0).index())
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_append_bsdd_dictionary_results", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_append_bsdd_dictionary_results", err)
+            )
 
     def _finalize_bsdd_dictionary_branch(self, dictionary_uri, message=None):
         try:
@@ -589,7 +625,9 @@ class BIM_Classification:
             placeholder.setSelectable(False)
             node.appendRow(placeholder)
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_finalize_bsdd_dictionary_branch", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_finalize_bsdd_dictionary_branch", err)
+            )
 
     def _finalize_bsdd_search_batch_if_empty(self):
         try:
@@ -600,7 +638,11 @@ class BIM_Classification:
             for dictionary_uri in self._bsdd_dictionary_nodes.keys():
                 self._finalize_bsdd_dictionary_branch(dictionary_uri)
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_finalize_bsdd_search_batch_if_empty", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format(
+                    "_finalize_bsdd_search_batch_if_empty", err
+                )
+            )
 
     def _perform_bsdd_search(self):
         try:
@@ -641,7 +683,9 @@ class BIM_Classification:
                     )
                 )
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_perform_bsdd_search", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_perform_bsdd_search", err)
+            )
 
     def _on_bsdd_dictionary_toggle(self, checked):
         try:
@@ -650,7 +694,9 @@ class BIM_Classification:
                 QtCore.Qt.DownArrow if checked else QtCore.Qt.RightArrow
             )
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_dictionary_toggle", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_dictionary_toggle", err)
+            )
 
     def _get_active_bsdd_dictionaries(self):
         active = []
@@ -662,7 +708,9 @@ class BIM_Classification:
                     if uri:
                         active.append(uri)
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_get_active_bsdd_dictionaries", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_get_active_bsdd_dictionaries", err)
+            )
         return active
 
     def _on_bsdd_dictionary_item_changed(self, *_args):
@@ -672,7 +720,9 @@ class BIM_Classification:
             self._save_bsdd_dictionary_state()
             self._schedule_bsdd_search()
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_dictionary_item_changed", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_dictionary_item_changed", err)
+            )
 
     def _on_bsdd_dictionaries_ready(self, payload):
         try:
@@ -710,8 +760,14 @@ class BIM_Classification:
             try:
                 self.form.bsddDictionaryList.blockSignals(False)
             except Exception as block_err:
-                FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_dictionaries_ready.blockSignals", block_err))
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_dictionaries_ready", err))
+                FreeCAD.Console.PrintWarning(
+                    "BIM bSDD UI warning in {}: {}\n".format(
+                        "_on_bsdd_dictionaries_ready.blockSignals", block_err
+                    )
+                )
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_dictionaries_ready", err)
+            )
 
     def _on_bsdd_search_ready(self, search_key, payload):
         try:
@@ -736,7 +792,9 @@ class BIM_Classification:
                 return
             self._append_bsdd_dictionary_results(dictionary_uri, classes)
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_search_ready", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_search_ready", err)
+            )
 
     def _on_bsdd_result_changed(self, current, _previous):
         try:
@@ -754,7 +812,9 @@ class BIM_Classification:
             if concept_uri:
                 self._bsdd_client.fetch_concept(concept_uri)
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_result_changed", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_result_changed", err)
+            )
 
     def _on_bsdd_concept_ready(self, concept_uri, payload):
         try:
@@ -766,7 +826,9 @@ class BIM_Classification:
                 self._update_bsdd_contract()
                 self._populate_bsdd_properties(payload)
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_concept_ready", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_concept_ready", err)
+            )
 
     def _on_bsdd_request_failed(self, request_kind, message, cache_key):
         try:
@@ -787,7 +849,9 @@ class BIM_Classification:
                 "bSDD request failed [{}] {} ({})\n".format(request_kind, message, cache_key)
             )
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_request_failed", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_request_failed", err)
+            )
 
     def _populate_bsdd_properties(self, payload):
         try:
@@ -821,7 +885,9 @@ class BIM_Classification:
                 self.form.bsddPropertyTable.setItem(row, 1, QtWidgets.QTableWidgetItem(str(value)))
             self.form.bsddPropertyTable.resizeColumnsToContents()
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_populate_bsdd_properties", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_populate_bsdd_properties", err)
+            )
 
     def _refresh_bsdd_context(self):
         try:
@@ -832,7 +898,9 @@ class BIM_Classification:
                     translate("BIM", "Current IFC context: {}").format(context_text)
                 )
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_refresh_bsdd_context", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_refresh_bsdd_context", err)
+            )
 
     def _get_active_ifc_context(self):
         try:
@@ -850,14 +918,18 @@ class BIM_Classification:
                     if token.startswith("Ifc"):
                         return token
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_get_active_ifc_context", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_get_active_ifc_context", err)
+            )
         return ""
 
     def _serialize_bsdd_dictionary_state(self):
         try:
             return "|".join(self._get_active_bsdd_dictionaries())
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_serialize_bsdd_dictionary_state", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_serialize_bsdd_dictionary_state", err)
+            )
             return ""
 
     def _save_bsdd_dictionary_state(self):
@@ -870,7 +942,9 @@ class BIM_Classification:
             FreeCAD.ActiveDocument.Meta = meta
             self._has_saved_bsdd_dictionary_state = True
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_save_bsdd_dictionary_state", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_save_bsdd_dictionary_state", err)
+            )
 
     def _load_bsdd_dictionary_state(self):
         try:
@@ -883,7 +957,9 @@ class BIM_Classification:
                 return has_saved, set()
             return has_saved, {entry for entry in value.split("|") if entry}
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_load_bsdd_dictionary_state", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_load_bsdd_dictionary_state", err)
+            )
             return False, set()
 
     def _get_selected_bsdd_concept(self):
@@ -891,7 +967,9 @@ class BIM_Classification:
             index = self.form.bsddResultsTree.currentIndex()
             return index.data(QtCore.Qt.UserRole)
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_get_selected_bsdd_concept", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_get_selected_bsdd_concept", err)
+            )
             return None
 
     def _update_bsdd_contract(self):
@@ -913,7 +991,9 @@ class BIM_Classification:
             self._bsdd_contract = contract
         except Exception as err:
             self._bsdd_contract = None
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_update_bsdd_contract", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_update_bsdd_contract", err)
+            )
 
     def _get_current_bsdd_contract(self):
         try:
@@ -921,7 +1001,9 @@ class BIM_Classification:
                 self._update_bsdd_contract()
             return self._bsdd_contract
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_get_current_bsdd_contract", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_get_current_bsdd_contract", err)
+            )
             return None
 
     def _store_bsdd_contract_for_item(self, tree_item, contract):
@@ -933,7 +1015,9 @@ class BIM_Classification:
             elif object_name:
                 self._bsdd_object_contracts.pop(object_name, None)
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_store_bsdd_contract_for_item", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_store_bsdd_contract_for_item", err)
+            )
 
     def _get_stored_bsdd_contract_for_item(self, tree_item):
         try:
@@ -945,7 +1029,9 @@ class BIM_Classification:
                 return self._bsdd_object_contracts.get(object_name)
             return None
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_get_stored_bsdd_contract_for_item", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_get_stored_bsdd_contract_for_item", err)
+            )
             return None
 
     def _restore_bsdd_contract_for_item(self, tree_item, object_name):
@@ -956,7 +1042,9 @@ class BIM_Classification:
             if contract:
                 self._store_bsdd_contract_for_item(tree_item, contract)
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_restore_bsdd_contract_for_item", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_restore_bsdd_contract_for_item", err)
+            )
 
     def _apply_bsdd_contract_to_object(self, obj, contract):
         try:
@@ -996,7 +1084,9 @@ class BIM_Classification:
             prefix = self.form.comboSystem.currentText()
             return code, label, prefix
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_get_selected_class_values", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("_get_selected_class_values", err)
+            )
             return None, None, None
 
     def addSelection(self, document, object, element, position):
@@ -1006,7 +1096,9 @@ class BIM_Classification:
             if self._is_bsdd_provider_active():
                 self._schedule_bsdd_search()
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("addSelection", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("addSelection", err)
+            )
 
     def removeSelection(self, document, object, element, position=None):
         try:
@@ -1015,7 +1107,9 @@ class BIM_Classification:
             if self._is_bsdd_provider_active():
                 self._schedule_bsdd_search()
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("removeSelection", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("removeSelection", err)
+            )
 
     def setSelection(self, document):
         try:
@@ -1024,7 +1118,9 @@ class BIM_Classification:
             if self._is_bsdd_provider_active():
                 self._schedule_bsdd_search()
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("setSelection", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("setSelection", err)
+            )
 
     def clearSelection(self, document):
         try:
@@ -1033,7 +1129,9 @@ class BIM_Classification:
             if self._is_bsdd_provider_active():
                 self._schedule_bsdd_search()
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("clearSelection", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("clearSelection", err)
+            )
 
     def updateObjects(self, idx=None):
         # store current state of tree into self.objectslist before redrawing
@@ -1490,7 +1588,11 @@ class BIM_Classification:
                         try:
                             FreeCAD.ActiveDocument.abortTransaction()
                         except Exception as err:
-                            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("accept.abortTransaction", err))
+                            FreeCAD.Console.PrintWarning(
+                                "BIM bSDD UI warning in {}: {}\n".format(
+                                    "accept.abortTransaction", err
+                                )
+                            )
                         return self.reject()
                 if self.form.checkPrefix.isChecked() and prefix:
                     code = prefix + " " + code
@@ -1541,7 +1643,9 @@ class BIM_Classification:
                 if self.form.treeClass.itemBelow(i):
                     self.form.treeClass.setCurrentItem(self.form.treeClass.itemBelow(i))
         except Exception as err:
-            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("onDownArrow", err))
+            FreeCAD.Console.PrintWarning(
+                "BIM bSDD UI warning in {}: {}\n".format("onDownArrow", err)
+            )
 
     def onVisible(self, index):
         PARAMS.SetInt("BimClassificationVisibleState", getattr(index, "value", index))
@@ -1569,4 +1673,3 @@ class BIM_Classification:
 
 
 FreeCADGui.addCommand("BIM_Classification", BIM_Classification())
-

--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -381,7 +381,7 @@ class BIM_Classification:
             self._bsdd_client.conceptReady.disconnect(self._on_bsdd_concept_ready)
             self._bsdd_client.requestFailed.disconnect(self._on_bsdd_request_failed)
         except (RuntimeError, TypeError):
-            pass
+            return
         except Exception as err:
             _print_ui_error("_disconnect_bsdd_signals", err)
         finally:
@@ -745,8 +745,8 @@ class BIM_Classification:
             self._updating_bsdd_dictionaries = False
             try:
                 self.form.bsddDictionaryList.blockSignals(False)
-            except Exception:
-                pass
+            except Exception as block_err:
+                _print_ui_error("_on_bsdd_dictionaries_ready.blockSignals", block_err)
             _print_ui_error("_on_bsdd_dictionaries_ready", err)
 
     def _on_bsdd_search_ready(self, search_key, payload):
@@ -1530,8 +1530,8 @@ class BIM_Classification:
                     ):
                         try:
                             FreeCAD.ActiveDocument.abortTransaction()
-                        except Exception:
-                            pass
+                        except Exception as err:
+                            _print_ui_error("accept.abortTransaction", err)
                         return self.reject()
                 if self.form.checkPrefix.isChecked() and prefix:
                     code = prefix + " " + code

--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -25,6 +25,7 @@
 """The BIM Classification command"""
 
 import os
+import re
 
 import FreeCAD
 import FreeCADGui
@@ -33,6 +34,44 @@ QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
 translate = FreeCAD.Qt.translate
 
 PARAMS = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM")
+BSDD_PROVIDER_MODE_KEY = "BimClassificationProvider"
+BSDD_DICTIONARY_META_KEY = "BIM_BsddActiveDictionaries"
+BSDD_DICTIONARY_META_PRESENT_KEY = "BIM_BsddActiveDictionariesPresent"
+BSDD_CONTRACT_ROLE = 33
+
+
+def _get_qt_modules():
+    try:
+        from PySide import QtCore, QtGui
+
+        try:
+            from PySide import QtWidgets
+        except ImportError:
+            QtWidgets = QtGui
+    except ImportError:
+        try:
+            from PySide6 import QtCore, QtGui, QtWidgets
+        except ImportError:
+            from PySide2 import QtCore, QtGui, QtWidgets
+    return QtCore, QtGui, QtWidgets
+
+
+def _load_bsdd_module():
+    try:
+        import BimBsddClient as BsddModule
+    except ImportError:
+        import BimBsdd as BsddModule
+    return BsddModule
+
+
+def _load_bsdd_contract_module():
+    import BimBsddContract
+
+    return BimBsddContract
+
+
+def _print_ui_error(context, err):
+    FreeCAD.Console.PrintError("BIM bSDD UI error in {}: {}\n".format(context, err))
 
 
 class BIM_Classification:
@@ -59,8 +98,11 @@ class BIM_Classification:
             return
 
         import Draft
-        from PySide import QtCore, QtGui
         from bimcommands import BimMaterial
+
+        QtCore, QtGui, QtWidgets = _get_qt_modules()
+        BsddModule = _load_bsdd_module()
+        BsddContractModule = _load_bsdd_contract_module()
 
         # init checks
         if not hasattr(self, "Classes"):
@@ -91,6 +133,32 @@ class BIM_Classification:
         searchBox.setToolTip(translate("BIM", "Searches classes"))
         self.form.search = searchBox
         self.form.horizontalLayout_2.addWidget(searchBox)
+        self._bsdd_module = BsddModule
+        self._bsdd_contract_module = BsddContractModule
+        self._bsdd_client = BsddModule.get_bsdd_network_client()
+        self._bsdd_context_ifc_class = ""
+        self._bsdd_selected_concept = None
+        self._restored_bsdd_dictionary_uris = set()
+        self._has_saved_bsdd_dictionary_state = False
+        self._bsdd_dictionary_uris = []
+        self._bsdd_search_batch_id = 0
+        self._bsdd_dictionary_labels = {}
+        self._bsdd_dictionary_nodes = {}
+        self._bsdd_pending_requests = {}
+        self._bsdd_dictionary_candidates = {}
+        self._bsdd_dictionary_has_results = set()
+        self._bsdd_contract = None
+        self._bsdd_contract_detail_payload = None
+        self._bsdd_object_contracts = {}
+        self._search_timer = QtCore.QTimer(self.form)
+        self._search_timer.setSingleShot(True)
+        self._search_timer.setInterval(300)
+        self._selection_observer_installed = False
+        self._updating_bsdd_dictionaries = False
+        self._bsdd_signals_connected = False
+        self._setup_bsdd_ui(QtCore, QtGui, QtWidgets)
+        self._connect_bsdd_signals()
+        self._install_selection_observer()
 
         # set help line
         self.form.labelDownload.setText(
@@ -177,6 +245,8 @@ class BIM_Classification:
         )
 
         self.updateClasses()
+        self._refresh_bsdd_context()
+        self._request_bsdd_dictionaries()
 
         # select current classification
         if current:
@@ -194,6 +264,821 @@ class BIM_Classification:
 
         self.form.search.setFocus()
 
+    def _setup_bsdd_ui(self, QtCore, QtGui, QtWidgets):
+        try:
+            providerLayout = QtWidgets.QHBoxLayout()
+            providerLabel = QtWidgets.QLabel(translate("BIM", "Provider"))
+            self.form.comboProvider = QtWidgets.QComboBox(self.form.groupClasses)
+            self.form.comboProvider.addItem("Legacy")
+            self.form.comboProvider.addItem("bSDD")
+            providerLayout.addWidget(providerLabel)
+            providerLayout.addWidget(self.form.comboProvider, 1)
+            self.form.verticalLayout_3.insertLayout(0, providerLayout)
+
+            self.form.bsddPanel = QtWidgets.QWidget(self.form.groupClasses)
+            self.form.bsddPanelLayout = QtWidgets.QVBoxLayout(self.form.bsddPanel)
+            self.form.bsddPanelLayout.setContentsMargins(0, 0, 0, 0)
+
+            self.form.bsddContextLabel = QtWidgets.QLabel(self.form.bsddPanel)
+            self.form.bsddContextLabel.setWordWrap(True)
+            self.form.bsddPanelLayout.addWidget(self.form.bsddContextLabel)
+
+            self.form.bsddSearch = QtWidgets.QLineEdit(self.form.bsddPanel)
+            self.form.bsddSearch.setPlaceholderText(translate("BIM", "Search bSDD concepts..."))
+            self.form.bsddPanelLayout.addWidget(self.form.bsddSearch)
+
+            self.form.bsddDictionaryToggle = QtWidgets.QToolButton(self.form.bsddPanel)
+            self.form.bsddDictionaryToggle.setText(translate("BIM", "Active dictionaries"))
+            self.form.bsddDictionaryToggle.setCheckable(True)
+            self.form.bsddDictionaryToggle.setChecked(False)
+            self.form.bsddDictionaryToggle.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
+            self.form.bsddDictionaryToggle.setArrowType(QtCore.Qt.RightArrow)
+            self.form.bsddPanelLayout.addWidget(self.form.bsddDictionaryToggle)
+
+            self.form.bsddDictionaryContainer = QtWidgets.QWidget(self.form.bsddPanel)
+            self.form.bsddDictionaryContainerLayout = QtWidgets.QVBoxLayout(
+                self.form.bsddDictionaryContainer
+            )
+            self.form.bsddDictionaryContainerLayout.setContentsMargins(0, 0, 0, 0)
+
+            self.form.bsddDictionaryList = QtWidgets.QListWidget(self.form.bsddDictionaryContainer)
+            self.form.bsddDictionaryList.setSelectionMode(
+                QtWidgets.QAbstractItemView.NoSelection
+            )
+            self.form.bsddDictionaryList.setMinimumHeight(110)
+            self.form.bsddDictionaryContainerLayout.addWidget(self.form.bsddDictionaryList)
+            self.form.bsddPanelLayout.addWidget(self.form.bsddDictionaryContainer)
+            self.form.bsddDictionaryContainer.setVisible(False)
+
+            self.form.bsddSplitter = QtWidgets.QSplitter(QtCore.Qt.Vertical, self.form.bsddPanel)
+            self.form.bsddResultsTree = QtWidgets.QTreeView(self.form.bsddSplitter)
+            self.form.bsddResultsTree.setEditTriggers(
+                QtWidgets.QAbstractItemView.NoEditTriggers
+            )
+            self.form.bsddResultsTree.setAlternatingRowColors(True)
+            self.form.bsddResultsTree.setSelectionBehavior(
+                QtWidgets.QAbstractItemView.SelectRows
+            )
+            self.form.bsddResultsTree.setUniformRowHeights(True)
+
+            self.form.bsddPropertyTable = QtWidgets.QTableWidget(self.form.bsddSplitter)
+            self.form.bsddPropertyTable.setColumnCount(2)
+            self.form.bsddPropertyTable.setHorizontalHeaderLabels(
+                [translate("BIM", "Property"), translate("BIM", "Value")]
+            )
+            self.form.bsddPropertyTable.setEditTriggers(
+                QtWidgets.QAbstractItemView.NoEditTriggers
+            )
+            self.form.bsddPropertyTable.setSelectionBehavior(
+                QtWidgets.QAbstractItemView.SelectRows
+            )
+            self.form.bsddPropertyTable.setWordWrap(True)
+            self.form.bsddPropertyTable.verticalHeader().setVisible(False)
+            self.form.bsddPropertyTable.horizontalHeader().setStretchLastSection(True)
+            self.form.bsddPanelLayout.addWidget(self.form.bsddSplitter, 1)
+
+            self.form.bsddResultsModel = QtGui.QStandardItemModel(self.form.bsddResultsTree)
+            self.form.bsddResultsModel.setHorizontalHeaderLabels(
+                [translate("BIM", "bSDD Concepts")]
+            )
+            self.form.bsddResultsTree.setModel(self.form.bsddResultsModel)
+            self.form.bsddResultsTree.header().setStretchLastSection(True)
+
+            insertIndex = self.form.verticalLayout_3.indexOf(self.form.treeClass)
+            if insertIndex < 0:
+                insertIndex = 3
+            self.form.verticalLayout_3.insertWidget(insertIndex, self.form.bsddPanel)
+            self.form.bsddPanel.hide()
+
+            provider = PARAMS.GetString(BSDD_PROVIDER_MODE_KEY, "Legacy")
+            self.form.comboProvider.setCurrentText(provider if provider in ["Legacy", "bSDD"] else "Legacy")
+            (
+                self._has_saved_bsdd_dictionary_state,
+                self._restored_bsdd_dictionary_uris,
+            ) = self._load_bsdd_dictionary_state()
+            self._apply_provider_visibility()
+        except Exception as err:
+            _print_ui_error("_setup_bsdd_ui", err)
+
+    def _connect_bsdd_signals(self):
+        try:
+            if getattr(self, "_bsdd_signals_connected", False):
+                return
+            self.form.comboProvider.currentIndexChanged.connect(self._on_provider_changed)
+            self.form.bsddSearch.textChanged.connect(self._on_bsdd_search_text_changed)
+            self._search_timer.timeout.connect(self._perform_bsdd_search)
+            self.form.bsddDictionaryToggle.toggled.connect(self._on_bsdd_dictionary_toggle)
+            self.form.bsddDictionaryList.itemChanged.connect(self._on_bsdd_dictionary_item_changed)
+            self.form.bsddResultsTree.selectionModel().currentChanged.connect(
+                self._on_bsdd_result_changed
+            )
+            self._bsdd_client.dictionariesReady.connect(self._on_bsdd_dictionaries_ready)
+            self._bsdd_client.searchReady.connect(self._on_bsdd_search_ready)
+            self._bsdd_client.conceptReady.connect(self._on_bsdd_concept_ready)
+            self._bsdd_client.requestFailed.connect(self._on_bsdd_request_failed)
+            self._bsdd_signals_connected = True
+        except Exception as err:
+            _print_ui_error("_connect_bsdd_signals", err)
+
+    def _disconnect_bsdd_signals(self):
+        try:
+            if not getattr(self, "_bsdd_signals_connected", False):
+                return
+            self._bsdd_client.dictionariesReady.disconnect(self._on_bsdd_dictionaries_ready)
+            self._bsdd_client.searchReady.disconnect(self._on_bsdd_search_ready)
+            self._bsdd_client.conceptReady.disconnect(self._on_bsdd_concept_ready)
+            self._bsdd_client.requestFailed.disconnect(self._on_bsdd_request_failed)
+        except (RuntimeError, TypeError):
+            pass
+        except Exception as err:
+            _print_ui_error("_disconnect_bsdd_signals", err)
+        finally:
+            self._bsdd_signals_connected = False
+
+    def _install_selection_observer(self):
+        try:
+            FreeCADGui.Selection.addObserver(self)
+            self._selection_observer_installed = True
+        except Exception as err:
+            _print_ui_error("_install_selection_observer", err)
+
+    def _remove_selection_observer(self):
+        try:
+            if getattr(self, "_selection_observer_installed", False):
+                FreeCADGui.Selection.removeObserver(self)
+                self._selection_observer_installed = False
+        except Exception as err:
+            _print_ui_error("_remove_selection_observer", err)
+
+    def _request_bsdd_dictionaries(self):
+        try:
+            self._bsdd_client.fetch_dictionaries()
+        except Exception as err:
+            _print_ui_error("_request_bsdd_dictionaries", err)
+
+    def _on_provider_changed(self, *_args):
+        try:
+            PARAMS.SetString(BSDD_PROVIDER_MODE_KEY, self.form.comboProvider.currentText())
+            self._apply_provider_visibility()
+            self._refresh_bsdd_context()
+            if self._is_bsdd_provider_active():
+                self._request_bsdd_dictionaries()
+                self._schedule_bsdd_search()
+        except Exception as err:
+            _print_ui_error("_on_provider_changed", err)
+
+    def _apply_provider_visibility(self):
+        try:
+            legacy_visible = not self._is_bsdd_provider_active()
+            self.form.comboSystem.setVisible(legacy_visible)
+            self.form.search.setVisible(legacy_visible)
+            self.form.treeClass.setVisible(legacy_visible)
+            self.form.buttonApply.setVisible(True)
+            self.form.buttonRename.setVisible(True)
+            self.form.checkPrefix.setVisible(True)
+            self.form.bsddPanel.setVisible(not legacy_visible)
+            self.form.labelDownload.setVisible(legacy_visible)
+            title = (
+                translate("BIM", "Available classification systems")
+                if legacy_visible
+                else translate("BIM", "buildingSMART Data Dictionary")
+            )
+            self.form.groupClasses.setTitle(title)
+        except Exception as err:
+            _print_ui_error("_apply_provider_visibility", err)
+
+    def _is_bsdd_provider_active(self):
+        try:
+            return (
+                hasattr(self.form, "comboProvider")
+                and self.form.comboProvider.currentText() == "bSDD"
+            )
+        except Exception as err:
+            _print_ui_error("_is_bsdd_provider_active", err)
+            return False
+
+    def _on_bsdd_search_text_changed(self, *_args):
+        try:
+            self._schedule_bsdd_search()
+        except Exception as err:
+            _print_ui_error("_on_bsdd_search_text_changed", err)
+
+    def _schedule_bsdd_search(self):
+        try:
+            if not self._is_bsdd_provider_active():
+                return
+            if self._search_timer.isActive():
+                self._search_timer.stop()
+            self._search_timer.start()
+        except Exception as err:
+            _print_ui_error("_schedule_bsdd_search", err)
+
+    def _normalize_bsdd_context_query(self, related_ifc_entity):
+        try:
+            if not related_ifc_entity:
+                return ""
+            normalized = str(related_ifc_entity)
+            if normalized.startswith("Ifc") and len(normalized) > 3:
+                normalized = normalized[3:]
+            normalized = re.sub(r"(?<!^)(?=[A-Z])", " ", normalized).strip()
+            return normalized or str(related_ifc_entity)
+        except Exception as err:
+            _print_ui_error("_normalize_bsdd_context_query", err)
+            return related_ifc_entity or ""
+
+    def _set_bsdd_results_placeholder(self, message):
+        try:
+            QtCore, QtGui, _QtWidgets = _get_qt_modules()
+            self.form.bsddResultsModel.removeRows(0, self.form.bsddResultsModel.rowCount())
+            if message:
+                item = QtGui.QStandardItem(message)
+                item.setEditable(False)
+                item.setSelectable(False)
+                item.setData(None, QtCore.Qt.UserRole)
+                self.form.bsddResultsModel.appendRow(item)
+            self._populate_bsdd_properties(None)
+        except Exception as err:
+            _print_ui_error("_set_bsdd_results_placeholder", err)
+
+    def _get_bsdd_search_inputs(self):
+        try:
+            query_text = self.form.bsddSearch.text().strip()
+            active_dictionaries = self._get_active_bsdd_dictionaries()
+            related_ifc_entity = self._bsdd_context_ifc_class or ""
+            return query_text, active_dictionaries, related_ifc_entity
+        except Exception as err:
+            _print_ui_error("_get_bsdd_search_inputs", err)
+            return "", [], ""
+
+    def _build_bsdd_search_candidates(self, query_text, active_dictionaries, related_ifc_entity):
+        try:
+            candidates = []
+            normalized_context_query = self._normalize_bsdd_context_query(related_ifc_entity)
+
+            if query_text:
+                candidates.append((query_text, ""))
+                return candidates
+
+            if related_ifc_entity:
+                fallback_pairs = [
+                    (normalized_context_query, related_ifc_entity),
+                    (normalized_context_query, ""),
+                    (related_ifc_entity, ""),
+                ]
+                for candidate_query, candidate_context in fallback_pairs:
+                    candidate_query = (candidate_query or "").strip()
+                    candidate = (candidate_query, candidate_context)
+                    if candidate_query and candidate not in candidates:
+                        candidates.append(candidate)
+            return candidates
+        except Exception as err:
+            _print_ui_error("_build_bsdd_search_candidates", err)
+            return []
+
+    def _dispatch_bsdd_search_candidate(self, dictionary_uri):
+        try:
+            candidates = self._bsdd_dictionary_candidates.get(dictionary_uri, [])
+            if not candidates:
+                self._finalize_bsdd_dictionary_branch(dictionary_uri)
+                return
+            query_text, related_ifc_entity = candidates.pop(0)
+            search_key = self._bsdd_client._search_cache_key(
+                query_text, (dictionary_uri,), related_ifc_entity
+            )
+            self._bsdd_pending_requests[search_key] = (self._bsdd_search_batch_id, dictionary_uri)
+            returned_search_key = self._bsdd_client.search_concepts(
+                query_text,
+                active_dictionaries=[dictionary_uri],
+                related_ifc_entity=related_ifc_entity,
+            )
+            if returned_search_key != search_key:
+                self._bsdd_pending_requests.pop(search_key, None)
+                self._bsdd_pending_requests[returned_search_key] = (
+                    self._bsdd_search_batch_id,
+                    dictionary_uri,
+                )
+        except Exception as err:
+            _print_ui_error("_dispatch_bsdd_search_candidate", err)
+
+    def _initialize_bsdd_result_tree(self, active_dictionaries):
+        try:
+            QtCore, QtGui, _QtWidgets = _get_qt_modules()
+            self.form.bsddResultsModel.removeRows(0, self.form.bsddResultsModel.rowCount())
+            self._populate_bsdd_properties(None)
+            self._bsdd_dictionary_nodes = {}
+            for dictionary_uri in active_dictionaries:
+                label = self._bsdd_dictionary_labels.get(dictionary_uri, dictionary_uri)
+                dict_item = QtGui.QStandardItem(label)
+                dict_item.setEditable(False)
+                dict_item.setSelectable(False)
+                dict_item.setData(dictionary_uri, QtCore.Qt.UserRole)
+                loading_item = QtGui.QStandardItem(translate("BIM", "Searching..."))
+                loading_item.setEditable(False)
+                loading_item.setSelectable(False)
+                dict_item.appendRow(loading_item)
+                self.form.bsddResultsModel.appendRow(dict_item)
+                self._bsdd_dictionary_nodes[dictionary_uri] = dict_item
+            self.form.bsddResultsTree.expandAll()
+        except Exception as err:
+            _print_ui_error("_initialize_bsdd_result_tree", err)
+
+    def _clear_bsdd_dictionary_branch(self, dictionary_uri):
+        try:
+            node = self._bsdd_dictionary_nodes.get(dictionary_uri)
+            if node is not None:
+                node.removeRows(0, node.rowCount())
+        except Exception as err:
+            _print_ui_error("_clear_bsdd_dictionary_branch", err)
+
+    def _append_bsdd_dictionary_results(self, dictionary_uri, concepts):
+        try:
+            QtCore, QtGui, _QtWidgets = _get_qt_modules()
+            node = self._bsdd_dictionary_nodes.get(dictionary_uri)
+            if node is None:
+                return
+            self._clear_bsdd_dictionary_branch(dictionary_uri)
+            for concept in concepts:
+                name = concept.get("name") or concept.get("referenceCode") or "<unnamed>"
+                concept_item = QtGui.QStandardItem(name)
+                concept_item.setEditable(False)
+                concept_item.setData(concept, QtCore.Qt.UserRole)
+                node.appendRow(concept_item)
+            self._bsdd_dictionary_has_results.add(dictionary_uri)
+            index = node.index()
+            if index.isValid():
+                self.form.bsddResultsTree.setExpanded(index, True)
+                if node.rowCount() and not self.form.bsddResultsTree.currentIndex().isValid():
+                    self.form.bsddResultsTree.setCurrentIndex(node.child(0).index())
+        except Exception as err:
+            _print_ui_error("_append_bsdd_dictionary_results", err)
+
+    def _finalize_bsdd_dictionary_branch(self, dictionary_uri, message=None):
+        try:
+            QtCore, QtGui, _QtWidgets = _get_qt_modules()
+            del QtCore
+            node = self._bsdd_dictionary_nodes.get(dictionary_uri)
+            if node is None:
+                return
+            if dictionary_uri in self._bsdd_dictionary_has_results:
+                return
+            self._clear_bsdd_dictionary_branch(dictionary_uri)
+            placeholder = QtGui.QStandardItem(
+                message or translate("BIM", "No matches in this dictionary.")
+            )
+            placeholder.setEditable(False)
+            placeholder.setSelectable(False)
+            node.appendRow(placeholder)
+        except Exception as err:
+            _print_ui_error("_finalize_bsdd_dictionary_branch", err)
+
+    def _finalize_bsdd_search_batch_if_empty(self):
+        try:
+            if self._bsdd_dictionary_has_results:
+                return
+            if self._bsdd_pending_requests:
+                return
+            for dictionary_uri in self._bsdd_dictionary_nodes.keys():
+                self._finalize_bsdd_dictionary_branch(dictionary_uri)
+        except Exception as err:
+            _print_ui_error("_finalize_bsdd_search_batch_if_empty", err)
+
+    def _perform_bsdd_search(self):
+        try:
+            if not self._is_bsdd_provider_active():
+                return
+            self._refresh_bsdd_context()
+            query_text, active_dictionaries, related_ifc_entity = self._get_bsdd_search_inputs()
+            text_search_active = bool(query_text)
+            self._bsdd_search_batch_id += 1
+            self._bsdd_pending_requests = {}
+            self._bsdd_dictionary_candidates = {}
+            self._bsdd_dictionary_has_results = set()
+            if not active_dictionaries:
+                self._set_bsdd_results_placeholder(
+                    translate("BIM", "Select at least one bSDD dictionary to search.")
+                )
+                if hasattr(self.form, "bsddDictionaryToggle") and (
+                    not self.form.bsddDictionaryToggle.isChecked()
+                ):
+                    self.form.bsddDictionaryToggle.setChecked(True)
+                return
+            candidates = self._build_bsdd_search_candidates(
+                query_text, active_dictionaries, related_ifc_entity
+            )
+            if not candidates:
+                self._set_bsdd_results_placeholder(
+                    translate("BIM", "Select an IFC object or enter search text.")
+                )
+                return
+            self._initialize_bsdd_result_tree(active_dictionaries)
+            for dictionary_uri in active_dictionaries:
+                self._bsdd_dictionary_candidates[dictionary_uri] = list(candidates)
+                self._dispatch_bsdd_search_candidate(dictionary_uri)
+            if text_search_active:
+                FreeCAD.Console.PrintMessage(
+                    "bSDD text search across {} selected dictionaries for '{}'\n".format(
+                        len(active_dictionaries), query_text
+                    )
+                )
+        except Exception as err:
+            _print_ui_error("_perform_bsdd_search", err)
+
+    def _on_bsdd_dictionary_toggle(self, checked):
+        try:
+            QtCore, _QtGui, _QtWidgets = _get_qt_modules()
+            self.form.bsddDictionaryContainer.setVisible(bool(checked))
+            self.form.bsddDictionaryToggle.setArrowType(
+                QtCore.Qt.DownArrow if checked else QtCore.Qt.RightArrow
+            )
+        except Exception as err:
+            _print_ui_error("_on_bsdd_dictionary_toggle", err)
+
+    def _get_active_bsdd_dictionaries(self):
+        active = []
+        try:
+            QtCore, _QtGui, _QtWidgets = _get_qt_modules()
+            for row in range(self.form.bsddDictionaryList.count()):
+                item = self.form.bsddDictionaryList.item(row)
+                if item.checkState() == QtCore.Qt.Checked:
+                    uri = item.data(QtCore.Qt.UserRole)
+                    if uri:
+                        active.append(uri)
+        except Exception as err:
+            _print_ui_error("_get_active_bsdd_dictionaries", err)
+        return active
+
+    def _on_bsdd_dictionary_item_changed(self, *_args):
+        try:
+            if getattr(self, "_updating_bsdd_dictionaries", False):
+                return
+            self._save_bsdd_dictionary_state()
+            self._schedule_bsdd_search()
+        except Exception as err:
+            _print_ui_error("_on_bsdd_dictionary_item_changed", err)
+
+    def _on_bsdd_dictionaries_ready(self, payload):
+        try:
+            if isinstance(payload, dict):
+                dictionaries = payload.get("dictionaries") or payload.get("results") or []
+            else:
+                dictionaries = payload or []
+            QtCore, QtGui, QtWidgets = _get_qt_modules()
+            del QtGui
+            self._updating_bsdd_dictionaries = True
+            self.form.bsddDictionaryList.blockSignals(True)
+            self.form.bsddDictionaryList.clear()
+            restored = set(self._restored_bsdd_dictionary_uris or [])
+            self._bsdd_dictionary_uris = []
+            for dictionary in dictionaries:
+                name = dictionary.get("name", "<unnamed>")
+                uri = dictionary.get("uri", "")
+                status = dictionary.get("status", "")
+                text = name if not status else "{} ({})".format(name, status)
+                self._bsdd_dictionary_labels[uri] = name
+                item = QtWidgets.QListWidgetItem(text)
+                item.setFlags(item.flags() | QtCore.Qt.ItemIsUserCheckable)
+                item.setData(QtCore.Qt.UserRole, uri)
+                item.setToolTip(uri)
+                is_checked = uri in restored if self._has_saved_bsdd_dictionary_state else False
+                item.setCheckState(QtCore.Qt.Checked if is_checked else QtCore.Qt.Unchecked)
+                self.form.bsddDictionaryList.addItem(item)
+                self._bsdd_dictionary_uris.append(uri)
+            self.form.bsddDictionaryList.blockSignals(False)
+            self._updating_bsdd_dictionaries = False
+            if self._has_saved_bsdd_dictionary_state:
+                self._save_bsdd_dictionary_state()
+            if self._is_bsdd_provider_active():
+                self._schedule_bsdd_search()
+        except Exception as err:
+            self._updating_bsdd_dictionaries = False
+            try:
+                self.form.bsddDictionaryList.blockSignals(False)
+            except Exception:
+                pass
+            _print_ui_error("_on_bsdd_dictionaries_ready", err)
+
+    def _on_bsdd_search_ready(self, search_key, payload):
+        try:
+            if not self._is_bsdd_provider_active():
+                return
+            request_info = self._bsdd_pending_requests.pop(tuple(search_key), None)
+            if not request_info:
+                return
+            batch_id, dictionary_uri = request_info
+            if batch_id != self._bsdd_search_batch_id:
+                return
+            if isinstance(payload, dict):
+                classes = payload.get("classes") or payload.get("results") or []
+            else:
+                classes = payload or []
+            if (not classes) and self._bsdd_dictionary_candidates.get(dictionary_uri):
+                self._dispatch_bsdd_search_candidate(dictionary_uri)
+                return
+            if not classes:
+                self._finalize_bsdd_dictionary_branch(dictionary_uri)
+                self._finalize_bsdd_search_batch_if_empty()
+                return
+            self._append_bsdd_dictionary_results(dictionary_uri, classes)
+        except Exception as err:
+            _print_ui_error("_on_bsdd_search_ready", err)
+
+    def _on_bsdd_result_changed(self, current, _previous):
+        try:
+            QtCore, _QtGui, _QtWidgets = _get_qt_modules()
+            self._bsdd_selected_concept = None
+            self._bsdd_contract_detail_payload = None
+            self._bsdd_contract = None
+            concept = current.data(QtCore.Qt.UserRole)
+            if not concept:
+                self._populate_bsdd_properties(None)
+                return
+            self._bsdd_selected_concept = concept
+            self._update_bsdd_contract()
+            self._populate_bsdd_properties(concept)
+            concept_uri = concept.get("uri", "")
+            if concept_uri:
+                self._bsdd_client.fetch_concept(concept_uri)
+        except Exception as err:
+            _print_ui_error("_on_bsdd_result_changed", err)
+
+    def _on_bsdd_concept_ready(self, concept_uri, payload):
+        try:
+            if not self._is_bsdd_provider_active():
+                return
+            current = self._get_selected_bsdd_concept()
+            if current and current.get("uri") == concept_uri:
+                self._bsdd_contract_detail_payload = payload
+                self._update_bsdd_contract()
+                self._populate_bsdd_properties(payload)
+        except Exception as err:
+            _print_ui_error("_on_bsdd_concept_ready", err)
+
+    def _on_bsdd_request_failed(self, request_kind, message, cache_key):
+        try:
+            cache_key = tuple(cache_key) if isinstance(cache_key, (list, tuple)) else cache_key
+            request_info = self._bsdd_pending_requests.pop(cache_key, None)
+            if request_info:
+                batch_id, dictionary_uri = request_info
+                if batch_id == self._bsdd_search_batch_id:
+                    if self._bsdd_dictionary_candidates.get(dictionary_uri):
+                        self._dispatch_bsdd_search_candidate(dictionary_uri)
+                    else:
+                        self._finalize_bsdd_dictionary_branch(
+                            dictionary_uri,
+                            translate("BIM", "Request failed for this dictionary."),
+                        )
+                        self._finalize_bsdd_search_batch_if_empty()
+            FreeCAD.Console.PrintError(
+                "bSDD request failed [{}] {} ({})\n".format(request_kind, message, cache_key)
+            )
+        except Exception as err:
+            _print_ui_error("_on_bsdd_request_failed", err)
+
+    def _populate_bsdd_properties(self, payload):
+        try:
+            _QtCore, _QtGui, QtWidgets = _get_qt_modules()
+            self.form.bsddPropertyTable.setRowCount(0)
+            if not payload:
+                return
+            rows = []
+            for key in ["name", "referenceCode", "dictionaryName", "classType", "uri", "description"]:
+                value = payload.get(key)
+                if value:
+                    rows.append((key, value))
+            for relation_key in ["relatedIfcEntity", "relatedIfcEntities"]:
+                value = payload.get(relation_key)
+                if value:
+                    rows.append((relation_key, value))
+            for property_item in payload.get("classProperties", []):
+                label = property_item.get("name", "property")
+                pset = property_item.get("propertySet", "")
+                value = pset if pset else property_item.get("dataType", "")
+                rows.append((label, value))
+            self.form.bsddPropertyTable.setRowCount(len(rows))
+            for row, (key, value) in enumerate(rows):
+                self.form.bsddPropertyTable.setItem(row, 0, QtWidgets.QTableWidgetItem(str(key)))
+                self.form.bsddPropertyTable.setItem(row, 1, QtWidgets.QTableWidgetItem(str(value)))
+            self.form.bsddPropertyTable.resizeColumnsToContents()
+        except Exception as err:
+            _print_ui_error("_populate_bsdd_properties", err)
+
+    def _refresh_bsdd_context(self):
+        try:
+            self._bsdd_context_ifc_class = self._get_active_ifc_context()
+            context_text = self._bsdd_context_ifc_class or translate("BIM", "No IFC context")
+            if hasattr(self.form, "bsddContextLabel"):
+                self.form.bsddContextLabel.setText(
+                    translate("BIM", "Current IFC context: {}").format(context_text)
+                )
+        except Exception as err:
+            _print_ui_error("_refresh_bsdd_context", err)
+
+    def _get_active_ifc_context(self):
+        try:
+            selection = FreeCADGui.Selection.getSelection()
+            if not selection:
+                return ""
+            obj = selection[0]
+            for attr_name in ["IfcClass", "IfcType", "IfcRole"]:
+                value = getattr(obj, attr_name, "")
+                if value and str(value).startswith("Ifc"):
+                    return str(value)
+            classification = getattr(obj, "Classification", "")
+            if classification:
+                for token in str(classification).split():
+                    if token.startswith("Ifc"):
+                        return token
+        except Exception as err:
+            _print_ui_error("_get_active_ifc_context", err)
+        return ""
+
+    def _serialize_bsdd_dictionary_state(self):
+        try:
+            return "|".join(self._get_active_bsdd_dictionaries())
+        except Exception as err:
+            _print_ui_error("_serialize_bsdd_dictionary_state", err)
+            return ""
+
+    def _save_bsdd_dictionary_state(self):
+        try:
+            if not FreeCAD.ActiveDocument:
+                return
+            meta = FreeCAD.ActiveDocument.Meta
+            meta[BSDD_DICTIONARY_META_KEY] = self._serialize_bsdd_dictionary_state()
+            meta[BSDD_DICTIONARY_META_PRESENT_KEY] = "1"
+            FreeCAD.ActiveDocument.Meta = meta
+            self._has_saved_bsdd_dictionary_state = True
+        except Exception as err:
+            _print_ui_error("_save_bsdd_dictionary_state", err)
+
+    def _load_bsdd_dictionary_state(self):
+        try:
+            if not FreeCAD.ActiveDocument:
+                return False, set()
+            meta = FreeCAD.ActiveDocument.Meta
+            has_saved = (
+                BSDD_DICTIONARY_META_PRESENT_KEY in meta or BSDD_DICTIONARY_META_KEY in meta
+            )
+            value = meta.get(BSDD_DICTIONARY_META_KEY, "")
+            if not value:
+                return has_saved, set()
+            return has_saved, {entry for entry in value.split("|") if entry}
+        except Exception as err:
+            _print_ui_error("_load_bsdd_dictionary_state", err)
+            return False, set()
+
+    def _get_selected_bsdd_concept(self):
+        try:
+            QtCore, _QtGui, _QtWidgets = _get_qt_modules()
+            index = self.form.bsddResultsTree.currentIndex()
+            return index.data(QtCore.Qt.UserRole)
+        except Exception as err:
+            _print_ui_error("_get_selected_bsdd_concept", err)
+            return None
+
+    def _update_bsdd_contract(self):
+        try:
+            concept = self._bsdd_selected_concept
+            if not concept:
+                self._bsdd_contract = None
+                return
+            active_object = None
+            selection = FreeCADGui.Selection.getSelection()
+            if selection:
+                active_object = selection[0]
+            contract = self._bsdd_contract_module.build_canonical_contract(
+                concept, self._bsdd_contract_detail_payload, active_object
+            )
+            contract["legacy_string"] = self._bsdd_contract_module.build_legacy_classification_string(
+                contract
+            )
+            self._bsdd_contract = contract
+        except Exception as err:
+            self._bsdd_contract = None
+            _print_ui_error("_update_bsdd_contract", err)
+
+    def _get_current_bsdd_contract(self):
+        try:
+            if not self._bsdd_contract:
+                self._update_bsdd_contract()
+            return self._bsdd_contract
+        except Exception as err:
+            _print_ui_error("_get_current_bsdd_contract", err)
+            return None
+
+    def _store_bsdd_contract_for_item(self, tree_item, contract):
+        try:
+            QtCore, _QtGui, _QtWidgets = _get_qt_modules()
+            tree_item.setData(0, QtCore.Qt.UserRole + BSDD_CONTRACT_ROLE, contract)
+            object_name = tree_item.toolTip(0)
+            if object_name and contract:
+                self._bsdd_object_contracts[object_name] = contract
+            elif object_name:
+                self._bsdd_object_contracts.pop(object_name, None)
+        except Exception as err:
+            _print_ui_error("_store_bsdd_contract_for_item", err)
+
+    def _get_stored_bsdd_contract_for_item(self, tree_item):
+        try:
+            QtCore, _QtGui, _QtWidgets = _get_qt_modules()
+            contract = tree_item.data(0, QtCore.Qt.UserRole + BSDD_CONTRACT_ROLE)
+            if contract:
+                return contract
+            object_name = tree_item.toolTip(0)
+            if object_name:
+                return self._bsdd_object_contracts.get(object_name)
+            return None
+        except Exception as err:
+            _print_ui_error("_get_stored_bsdd_contract_for_item", err)
+            return None
+
+    def _restore_bsdd_contract_for_item(self, tree_item, object_name):
+        try:
+            if not object_name:
+                return
+            contract = self._bsdd_object_contracts.get(object_name)
+            if contract:
+                self._store_bsdd_contract_for_item(tree_item, contract)
+        except Exception as err:
+            _print_ui_error("_restore_bsdd_contract_for_item", err)
+
+    def _apply_bsdd_contract_to_object(self, obj, contract):
+        try:
+            if not contract:
+                return False
+            from nativeifc import ifc_classification, ifc_tools
+
+            if self._bsdd_contract_module:
+                contract = self._bsdd_contract_module.refresh_contract_validation(contract, obj)
+            if not ifc_tools.get_ifcfile(obj) or not ifc_tools.get_ifc_element(obj):
+                return True
+            ifc_classification.apply_canonical_contract(obj, contract)
+            return True
+        except Exception as err:
+            FreeCAD.Console.PrintError(
+                "BIM bSDD semantic mapping error for {}: {}\n".format(obj.Label, err)
+            )
+            return False
+
+    def _get_selected_class_values(self):
+        try:
+            if self._is_bsdd_provider_active():
+                contract = self._get_current_bsdd_contract()
+                if not contract:
+                    return None, None, None
+                class_metadata = contract.get("class_metadata", {})
+                dictionary_metadata = contract.get("dictionary_metadata", {})
+                code = class_metadata.get("reference_code") or class_metadata.get("name")
+                label = class_metadata.get("name") or code
+                prefix = dictionary_metadata.get("name") or "bSDD"
+                return code, label, prefix
+            if len(self.form.treeClass.selectedItems()) != 1:
+                return None, None, None
+            item = self.form.treeClass.selectedItems()[0]
+            code = item.text(0)
+            label = item.toolTip(0) or item.text(0)
+            prefix = self.form.comboSystem.currentText()
+            return code, label, prefix
+        except Exception as err:
+            _print_ui_error("_get_selected_class_values", err)
+            return None, None, None
+
+    def addSelection(self, document, object, element, position):
+        try:
+            del document, object, element, position
+            self._refresh_bsdd_context()
+            if self._is_bsdd_provider_active():
+                self._schedule_bsdd_search()
+        except Exception as err:
+            _print_ui_error("addSelection", err)
+
+    def removeSelection(self, document, object, element, position=None):
+        try:
+            del document, object, element, position
+            self._refresh_bsdd_context()
+            if self._is_bsdd_provider_active():
+                self._schedule_bsdd_search()
+        except Exception as err:
+            _print_ui_error("removeSelection", err)
+
+    def setSelection(self, document):
+        try:
+            del document
+            self._refresh_bsdd_context()
+            if self._is_bsdd_provider_active():
+                self._schedule_bsdd_search()
+        except Exception as err:
+            _print_ui_error("setSelection", err)
+
+    def clearSelection(self, document):
+        try:
+            del document
+            self._refresh_bsdd_context()
+            if self._is_bsdd_provider_active():
+                self._schedule_bsdd_search()
+        except Exception as err:
+            _print_ui_error("clearSelection", err)
+
     def updateObjects(self, idx=None):
         # store current state of tree into self.objectslist before redrawing
 
@@ -205,6 +1090,9 @@ class BIM_Classification:
                 elif child.toolTip(0) in self.matlist:
                     self.matlist[child.toolTip(0)] = child.text(1)
                 self.labellist[child.toolTip(0)] = child.text(0)
+                contract = self._get_stored_bsdd_contract_for_item(child)
+                if contract:
+                    self._bsdd_object_contracts[child.toolTip(0)] = contract
             for childrow in range(child.childCount()):
                 grandchild = child.child(childrow)
                 if grandchild.toolTip(0):
@@ -213,6 +1101,9 @@ class BIM_Classification:
                     elif grandchild.toolTip(0) in self.matlist:
                         self.matlist[grandchild.toolTip(0)] = grandchild.text(1)
                     self.labellist[grandchild.toolTip(0)] = grandchild.text(0)
+                    contract = self._get_stored_bsdd_contract_for_item(grandchild)
+                    if contract:
+                        self._bsdd_object_contracts[grandchild.toolTip(0)] = contract
 
         self.form.treeObjects.clear()
 
@@ -264,6 +1155,7 @@ class BIM_Classification:
                         it = QtGui.QTreeWidgetItem([self.labellist[name], d[name]])
                         it.setIcon(0, self.getIcon(obj))
                         it.setToolTip(0, name)
+                        self._restore_bsdd_contract_for_item(it, name)
                         mit.addChild(it)
             mit.sortChildren(0, QtCore.Qt.AscendingOrder)
         self.form.treeObjects.expandAll()
@@ -298,6 +1190,7 @@ class BIM_Classification:
                         it = QtGui.QTreeWidgetItem([self.labellist[name], self.objectslist[name]])
                         it.setIcon(0, self.getIcon(obj))
                         it.setToolTip(0, name)
+                        self._restore_bsdd_contract_for_item(it, name)
                         mit.addChild(it)
             mit.sortChildren(0, QtCore.Qt.AscendingOrder)
         self.form.treeObjects.expandAll()
@@ -344,6 +1237,7 @@ class BIM_Classification:
                 it = QtGui.QTreeWidgetItem([self.labellist[name], code])
                 it.setIcon(0, self.getIcon(obj))
                 it.setToolTip(0, name)
+                self._restore_bsdd_contract_for_item(it, name)
                 mit.addChild(it)
         # objects next
         for obj in rel:
@@ -352,6 +1246,7 @@ class BIM_Classification:
                 it = QtGui.QTreeWidgetItem([self.labellist[obj.Name], code])
                 it.setIcon(0, self.getIcon(obj))
                 it.setToolTip(0, name)
+                self._restore_bsdd_contract_for_item(it, obj.Name)
                 ok = False
                 for par in obj.InListRecursive:
                     if par.Name in done:
@@ -382,6 +1277,7 @@ class BIM_Classification:
                     it = QtGui.QTreeWidgetItem([self.labellist[name], code])
                     it.setIcon(0, self.getIcon(obj))
                     it.setToolTip(0, name)
+                    self._restore_bsdd_contract_for_item(it, name)
                     self.form.treeObjects.addTopLevelItem(it)
                     if obj in FreeCADGui.Selection.getSelection():
                         self.form.treeObjects.setCurrentItem(it)
@@ -544,20 +1440,33 @@ class BIM_Classification:
         return [item.ID, item.Name, [self.listize(it) for it in item.children]]
 
     def apply(self, item=None, col=None):
-        if self.form.treeObjects.selectedItems() and len(self.form.treeClass.selectedItems()) == 1:
-            c = self.form.treeClass.selectedItems()[0].text(0)
-            if self.form.checkPrefix.isChecked():
-                c = self.form.comboSystem.currentText() + " " + c
-            for m in self.form.treeObjects.selectedItems():
-                if m.toolTip(0):
-                    m.setText(1, c)
+        try:
+            del item, col
+            if self.form.treeObjects.selectedItems():
+                code, _label, prefix = self._get_selected_class_values()
+                if not code:
+                    return
+                if self.form.checkPrefix.isChecked() and prefix:
+                    code = prefix + " " + code
+                contract = self._get_current_bsdd_contract() if self._is_bsdd_provider_active() else None
+                for m in self.form.treeObjects.selectedItems():
+                    if m.toolTip(0):
+                        m.setText(1, code)
+                        self._store_bsdd_contract_for_item(m, contract)
+        except Exception as err:
+            _print_ui_error("apply", err)
 
     def rename(self):
-        if self.form.treeObjects.selectedItems() and len(self.form.treeClass.selectedItems()) == 1:
-            c = self.form.treeClass.selectedItems()[0].toolTip(0)
-            for m in self.form.treeObjects.selectedItems():
-                if m.toolTip(0):
-                    m.setText(0, c)
+        try:
+            if self.form.treeObjects.selectedItems():
+                _code, label, _prefix = self._get_selected_class_values()
+                if not label:
+                    return
+                for m in self.form.treeObjects.selectedItems():
+                    if m.toolTip(0):
+                        m.setText(0, label)
+        except Exception as err:
+            _print_ui_error("rename", err)
 
     def accept(self):
         if not self.isEditing:
@@ -572,6 +1481,13 @@ class BIM_Classification:
                     if item.toolTip(0):
                         obj = FreeCAD.ActiveDocument.getObject(item.toolTip(0))
                         if obj:
+                            contract = self._get_stored_bsdd_contract_for_item(item)
+                            if contract:
+                                if not changed:
+                                    FreeCAD.ActiveDocument.openTransaction("Change standard codes")
+                                    changed = True
+                                if not self._apply_bsdd_contract_to_object(obj, contract):
+                                    continue
                             if hasattr(obj, "StandardCode"):
                                 if code != obj.StandardCode:
                                     if not changed:
@@ -603,15 +1519,23 @@ class BIM_Classification:
         else:
             # Close the form if user has pressed Enter and did not
             # select anything
-            if len(self.form.treeClass.selectedItems()) < 1:
+            code, _label, prefix = self._get_selected_class_values()
+            if not code:
                 return self.reject()
-
-            code = self.form.treeClass.selectedItems()[0].text(0)
             pl = self.isEditing.PropertiesList
             if ("StandardCode" in pl) or ("IfcClass" in pl):
                 FreeCAD.ActiveDocument.openTransaction("Change standard codes")
-                if self.form.checkPrefix.isChecked():
-                    code = self.form.comboSystem.currentText() + " " + code
+                if self._is_bsdd_provider_active():
+                    if not self._apply_bsdd_contract_to_object(
+                        self.isEditing, self._get_current_bsdd_contract()
+                    ):
+                        try:
+                            FreeCAD.ActiveDocument.abortTransaction()
+                        except Exception:
+                            pass
+                        return self.reject()
+                if self.form.checkPrefix.isChecked() and prefix:
+                    code = prefix + " " + code
                 if "StandardCode" in pl:
                     self.isEditing.StandardCode = code
                 else:
@@ -632,21 +1556,34 @@ class BIM_Classification:
         return self.reject()
 
     def reject(self):
+        try:
+            if hasattr(self, "_search_timer") and self._search_timer.isActive():
+                self._search_timer.stop()
+            self._disconnect_bsdd_signals()
+            self._remove_selection_observer()
+        except Exception as err:
+            _print_ui_error("reject", err)
         self.form.hide()
         del self.form
         return True
 
     def onUpArrow(self):
-        if self.form:
-            i = self.form.treeClass.currentItem()
-            if self.form.treeClass.itemAbove(i):
-                self.form.treeClass.setCurrentItem(self.form.treeClass.itemAbove(i))
+        try:
+            if self.form and (not self._is_bsdd_provider_active()):
+                i = self.form.treeClass.currentItem()
+                if self.form.treeClass.itemAbove(i):
+                    self.form.treeClass.setCurrentItem(self.form.treeClass.itemAbove(i))
+        except Exception as err:
+            _print_ui_error("onUpArrow", err)
 
     def onDownArrow(self):
-        if self.form:
-            i = self.form.treeClass.currentItem()
-            if self.form.treeClass.itemBelow(i):
-                self.form.treeClass.setCurrentItem(self.form.treeClass.itemBelow(i))
+        try:
+            if self.form and (not self._is_bsdd_provider_active()):
+                i = self.form.treeClass.currentItem()
+                if self.form.treeClass.itemBelow(i):
+                    self.form.treeClass.setCurrentItem(self.form.treeClass.itemBelow(i))
+        except Exception as err:
+            _print_ui_error("onDownArrow", err)
 
     def onVisible(self, index):
         PARAMS.SetInt("BimClassificationVisibleState", getattr(index, "value", index))

--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -29,6 +29,15 @@ import re
 
 import FreeCAD
 import FreeCADGui
+from PySide import QtCore, QtGui
+
+try:
+    from PySide import QtWidgets
+except ImportError:
+    QtWidgets = QtGui
+
+import BimBsdd
+import BimBsddContract
 
 QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
 translate = FreeCAD.Qt.translate
@@ -40,38 +49,6 @@ BSDD_DICTIONARY_META_PRESENT_KEY = "BIM_BsddActiveDictionariesPresent"
 BSDD_CONTRACT_ROLE = 33
 
 
-def _get_qt_modules():
-    try:
-        from PySide import QtCore, QtGui
-
-        try:
-            from PySide import QtWidgets
-        except ImportError:
-            QtWidgets = QtGui
-    except ImportError:
-        try:
-            from PySide6 import QtCore, QtGui, QtWidgets
-        except ImportError:
-            from PySide2 import QtCore, QtGui, QtWidgets
-    return QtCore, QtGui, QtWidgets
-
-
-def _load_bsdd_module():
-    try:
-        import BimBsddClient as BsddModule
-    except ImportError:
-        import BimBsdd as BsddModule
-    return BsddModule
-
-
-def _load_bsdd_contract_module():
-    import BimBsddContract
-
-    return BimBsddContract
-
-
-def _print_ui_error(context, err):
-    FreeCAD.Console.PrintError("BIM bSDD UI error in {}: {}\n".format(context, err))
 
 
 class BIM_Classification:
@@ -99,10 +76,6 @@ class BIM_Classification:
 
         import Draft
         from bimcommands import BimMaterial
-
-        QtCore, QtGui, QtWidgets = _get_qt_modules()
-        BsddModule = _load_bsdd_module()
-        BsddContractModule = _load_bsdd_contract_module()
 
         # init checks
         if not hasattr(self, "Classes"):
@@ -133,9 +106,9 @@ class BIM_Classification:
         searchBox.setToolTip(translate("BIM", "Searches classes"))
         self.form.search = searchBox
         self.form.horizontalLayout_2.addWidget(searchBox)
-        self._bsdd_module = BsddModule
-        self._bsdd_contract_module = BsddContractModule
-        self._bsdd_client = BsddModule.get_bsdd_network_client()
+        self._bsdd_module = BimBsdd
+        self._bsdd_contract_module = BimBsddContract
+        self._bsdd_client = BimBsdd.get_bsdd_network_client()
         self._bsdd_context_ifc_class = ""
         self._bsdd_selected_concept = None
         self._restored_bsdd_dictionary_uris = set()
@@ -350,7 +323,7 @@ class BIM_Classification:
             ) = self._load_bsdd_dictionary_state()
             self._apply_provider_visibility()
         except Exception as err:
-            _print_ui_error("_setup_bsdd_ui", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_setup_bsdd_ui", err))
 
     def _connect_bsdd_signals(self):
         try:
@@ -370,7 +343,7 @@ class BIM_Classification:
             self._bsdd_client.requestFailed.connect(self._on_bsdd_request_failed)
             self._bsdd_signals_connected = True
         except Exception as err:
-            _print_ui_error("_connect_bsdd_signals", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_connect_bsdd_signals", err))
 
     def _disconnect_bsdd_signals(self):
         try:
@@ -383,7 +356,7 @@ class BIM_Classification:
         except (RuntimeError, TypeError):
             return
         except Exception as err:
-            _print_ui_error("_disconnect_bsdd_signals", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_disconnect_bsdd_signals", err))
         finally:
             self._bsdd_signals_connected = False
 
@@ -392,7 +365,7 @@ class BIM_Classification:
             FreeCADGui.Selection.addObserver(self)
             self._selection_observer_installed = True
         except Exception as err:
-            _print_ui_error("_install_selection_observer", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_install_selection_observer", err))
 
     def _remove_selection_observer(self):
         try:
@@ -400,13 +373,13 @@ class BIM_Classification:
                 FreeCADGui.Selection.removeObserver(self)
                 self._selection_observer_installed = False
         except Exception as err:
-            _print_ui_error("_remove_selection_observer", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_remove_selection_observer", err))
 
     def _request_bsdd_dictionaries(self):
         try:
             self._bsdd_client.fetch_dictionaries()
         except Exception as err:
-            _print_ui_error("_request_bsdd_dictionaries", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_request_bsdd_dictionaries", err))
 
     def _on_provider_changed(self, *_args):
         try:
@@ -417,7 +390,7 @@ class BIM_Classification:
                 self._request_bsdd_dictionaries()
                 self._schedule_bsdd_search()
         except Exception as err:
-            _print_ui_error("_on_provider_changed", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_provider_changed", err))
 
     def _apply_provider_visibility(self):
         try:
@@ -437,7 +410,7 @@ class BIM_Classification:
             )
             self.form.groupClasses.setTitle(title)
         except Exception as err:
-            _print_ui_error("_apply_provider_visibility", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_apply_provider_visibility", err))
 
     def _is_bsdd_provider_active(self):
         try:
@@ -446,14 +419,14 @@ class BIM_Classification:
                 and self.form.comboProvider.currentText() == "bSDD"
             )
         except Exception as err:
-            _print_ui_error("_is_bsdd_provider_active", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_is_bsdd_provider_active", err))
             return False
 
     def _on_bsdd_search_text_changed(self, *_args):
         try:
             self._schedule_bsdd_search()
         except Exception as err:
-            _print_ui_error("_on_bsdd_search_text_changed", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_search_text_changed", err))
 
     def _schedule_bsdd_search(self):
         try:
@@ -463,7 +436,7 @@ class BIM_Classification:
                 self._search_timer.stop()
             self._search_timer.start()
         except Exception as err:
-            _print_ui_error("_schedule_bsdd_search", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_schedule_bsdd_search", err))
 
     def _normalize_bsdd_context_query(self, related_ifc_entity):
         try:
@@ -475,12 +448,11 @@ class BIM_Classification:
             normalized = re.sub(r"(?<!^)(?=[A-Z])", " ", normalized).strip()
             return normalized or str(related_ifc_entity)
         except Exception as err:
-            _print_ui_error("_normalize_bsdd_context_query", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_normalize_bsdd_context_query", err))
             return related_ifc_entity or ""
 
     def _set_bsdd_results_placeholder(self, message):
         try:
-            QtCore, QtGui, _QtWidgets = _get_qt_modules()
             self.form.bsddResultsModel.removeRows(0, self.form.bsddResultsModel.rowCount())
             if message:
                 item = QtGui.QStandardItem(message)
@@ -490,7 +462,7 @@ class BIM_Classification:
                 self.form.bsddResultsModel.appendRow(item)
             self._populate_bsdd_properties(None)
         except Exception as err:
-            _print_ui_error("_set_bsdd_results_placeholder", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_set_bsdd_results_placeholder", err))
 
     def _get_bsdd_search_inputs(self):
         try:
@@ -499,7 +471,7 @@ class BIM_Classification:
             related_ifc_entity = self._bsdd_context_ifc_class or ""
             return query_text, active_dictionaries, related_ifc_entity
         except Exception as err:
-            _print_ui_error("_get_bsdd_search_inputs", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_get_bsdd_search_inputs", err))
             return "", [], ""
 
     def _build_bsdd_search_candidates(self, query_text, active_dictionaries, related_ifc_entity):
@@ -524,7 +496,7 @@ class BIM_Classification:
                         candidates.append(candidate)
             return candidates
         except Exception as err:
-            _print_ui_error("_build_bsdd_search_candidates", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_build_bsdd_search_candidates", err))
             return []
 
     def _dispatch_bsdd_search_candidate(self, dictionary_uri):
@@ -550,11 +522,10 @@ class BIM_Classification:
                     dictionary_uri,
                 )
         except Exception as err:
-            _print_ui_error("_dispatch_bsdd_search_candidate", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_dispatch_bsdd_search_candidate", err))
 
     def _initialize_bsdd_result_tree(self, active_dictionaries):
         try:
-            QtCore, QtGui, _QtWidgets = _get_qt_modules()
             self.form.bsddResultsModel.removeRows(0, self.form.bsddResultsModel.rowCount())
             self._populate_bsdd_properties(None)
             self._bsdd_dictionary_nodes = {}
@@ -572,7 +543,7 @@ class BIM_Classification:
                 self._bsdd_dictionary_nodes[dictionary_uri] = dict_item
             self.form.bsddResultsTree.expandAll()
         except Exception as err:
-            _print_ui_error("_initialize_bsdd_result_tree", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_initialize_bsdd_result_tree", err))
 
     def _clear_bsdd_dictionary_branch(self, dictionary_uri):
         try:
@@ -580,11 +551,10 @@ class BIM_Classification:
             if node is not None:
                 node.removeRows(0, node.rowCount())
         except Exception as err:
-            _print_ui_error("_clear_bsdd_dictionary_branch", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_clear_bsdd_dictionary_branch", err))
 
     def _append_bsdd_dictionary_results(self, dictionary_uri, concepts):
         try:
-            QtCore, QtGui, _QtWidgets = _get_qt_modules()
             node = self._bsdd_dictionary_nodes.get(dictionary_uri)
             if node is None:
                 return
@@ -602,12 +572,10 @@ class BIM_Classification:
                 if node.rowCount() and not self.form.bsddResultsTree.currentIndex().isValid():
                     self.form.bsddResultsTree.setCurrentIndex(node.child(0).index())
         except Exception as err:
-            _print_ui_error("_append_bsdd_dictionary_results", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_append_bsdd_dictionary_results", err))
 
     def _finalize_bsdd_dictionary_branch(self, dictionary_uri, message=None):
         try:
-            QtCore, QtGui, _QtWidgets = _get_qt_modules()
-            del QtCore
             node = self._bsdd_dictionary_nodes.get(dictionary_uri)
             if node is None:
                 return
@@ -621,7 +589,7 @@ class BIM_Classification:
             placeholder.setSelectable(False)
             node.appendRow(placeholder)
         except Exception as err:
-            _print_ui_error("_finalize_bsdd_dictionary_branch", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_finalize_bsdd_dictionary_branch", err))
 
     def _finalize_bsdd_search_batch_if_empty(self):
         try:
@@ -632,7 +600,7 @@ class BIM_Classification:
             for dictionary_uri in self._bsdd_dictionary_nodes.keys():
                 self._finalize_bsdd_dictionary_branch(dictionary_uri)
         except Exception as err:
-            _print_ui_error("_finalize_bsdd_search_batch_if_empty", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_finalize_bsdd_search_batch_if_empty", err))
 
     def _perform_bsdd_search(self):
         try:
@@ -673,22 +641,20 @@ class BIM_Classification:
                     )
                 )
         except Exception as err:
-            _print_ui_error("_perform_bsdd_search", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_perform_bsdd_search", err))
 
     def _on_bsdd_dictionary_toggle(self, checked):
         try:
-            QtCore, _QtGui, _QtWidgets = _get_qt_modules()
             self.form.bsddDictionaryContainer.setVisible(bool(checked))
             self.form.bsddDictionaryToggle.setArrowType(
                 QtCore.Qt.DownArrow if checked else QtCore.Qt.RightArrow
             )
         except Exception as err:
-            _print_ui_error("_on_bsdd_dictionary_toggle", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_dictionary_toggle", err))
 
     def _get_active_bsdd_dictionaries(self):
         active = []
         try:
-            QtCore, _QtGui, _QtWidgets = _get_qt_modules()
             for row in range(self.form.bsddDictionaryList.count()):
                 item = self.form.bsddDictionaryList.item(row)
                 if item.checkState() == QtCore.Qt.Checked:
@@ -696,7 +662,7 @@ class BIM_Classification:
                     if uri:
                         active.append(uri)
         except Exception as err:
-            _print_ui_error("_get_active_bsdd_dictionaries", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_get_active_bsdd_dictionaries", err))
         return active
 
     def _on_bsdd_dictionary_item_changed(self, *_args):
@@ -706,7 +672,7 @@ class BIM_Classification:
             self._save_bsdd_dictionary_state()
             self._schedule_bsdd_search()
         except Exception as err:
-            _print_ui_error("_on_bsdd_dictionary_item_changed", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_dictionary_item_changed", err))
 
     def _on_bsdd_dictionaries_ready(self, payload):
         try:
@@ -714,8 +680,6 @@ class BIM_Classification:
                 dictionaries = payload.get("dictionaries") or payload.get("results") or []
             else:
                 dictionaries = payload or []
-            QtCore, QtGui, QtWidgets = _get_qt_modules()
-            del QtGui
             self._updating_bsdd_dictionaries = True
             self.form.bsddDictionaryList.blockSignals(True)
             self.form.bsddDictionaryList.clear()
@@ -746,8 +710,8 @@ class BIM_Classification:
             try:
                 self.form.bsddDictionaryList.blockSignals(False)
             except Exception as block_err:
-                _print_ui_error("_on_bsdd_dictionaries_ready.blockSignals", block_err)
-            _print_ui_error("_on_bsdd_dictionaries_ready", err)
+                FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_dictionaries_ready.blockSignals", block_err))
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_dictionaries_ready", err))
 
     def _on_bsdd_search_ready(self, search_key, payload):
         try:
@@ -772,11 +736,10 @@ class BIM_Classification:
                 return
             self._append_bsdd_dictionary_results(dictionary_uri, classes)
         except Exception as err:
-            _print_ui_error("_on_bsdd_search_ready", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_search_ready", err))
 
     def _on_bsdd_result_changed(self, current, _previous):
         try:
-            QtCore, _QtGui, _QtWidgets = _get_qt_modules()
             self._bsdd_selected_concept = None
             self._bsdd_contract_detail_payload = None
             self._bsdd_contract = None
@@ -791,7 +754,7 @@ class BIM_Classification:
             if concept_uri:
                 self._bsdd_client.fetch_concept(concept_uri)
         except Exception as err:
-            _print_ui_error("_on_bsdd_result_changed", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_result_changed", err))
 
     def _on_bsdd_concept_ready(self, concept_uri, payload):
         try:
@@ -803,7 +766,7 @@ class BIM_Classification:
                 self._update_bsdd_contract()
                 self._populate_bsdd_properties(payload)
         except Exception as err:
-            _print_ui_error("_on_bsdd_concept_ready", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_concept_ready", err))
 
     def _on_bsdd_request_failed(self, request_kind, message, cache_key):
         try:
@@ -824,11 +787,10 @@ class BIM_Classification:
                 "bSDD request failed [{}] {} ({})\n".format(request_kind, message, cache_key)
             )
         except Exception as err:
-            _print_ui_error("_on_bsdd_request_failed", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_on_bsdd_request_failed", err))
 
     def _populate_bsdd_properties(self, payload):
         try:
-            _QtCore, _QtGui, QtWidgets = _get_qt_modules()
             self.form.bsddPropertyTable.setRowCount(0)
             if not payload:
                 return
@@ -859,7 +821,7 @@ class BIM_Classification:
                 self.form.bsddPropertyTable.setItem(row, 1, QtWidgets.QTableWidgetItem(str(value)))
             self.form.bsddPropertyTable.resizeColumnsToContents()
         except Exception as err:
-            _print_ui_error("_populate_bsdd_properties", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_populate_bsdd_properties", err))
 
     def _refresh_bsdd_context(self):
         try:
@@ -870,7 +832,7 @@ class BIM_Classification:
                     translate("BIM", "Current IFC context: {}").format(context_text)
                 )
         except Exception as err:
-            _print_ui_error("_refresh_bsdd_context", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_refresh_bsdd_context", err))
 
     def _get_active_ifc_context(self):
         try:
@@ -888,14 +850,14 @@ class BIM_Classification:
                     if token.startswith("Ifc"):
                         return token
         except Exception as err:
-            _print_ui_error("_get_active_ifc_context", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_get_active_ifc_context", err))
         return ""
 
     def _serialize_bsdd_dictionary_state(self):
         try:
             return "|".join(self._get_active_bsdd_dictionaries())
         except Exception as err:
-            _print_ui_error("_serialize_bsdd_dictionary_state", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_serialize_bsdd_dictionary_state", err))
             return ""
 
     def _save_bsdd_dictionary_state(self):
@@ -908,7 +870,7 @@ class BIM_Classification:
             FreeCAD.ActiveDocument.Meta = meta
             self._has_saved_bsdd_dictionary_state = True
         except Exception as err:
-            _print_ui_error("_save_bsdd_dictionary_state", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_save_bsdd_dictionary_state", err))
 
     def _load_bsdd_dictionary_state(self):
         try:
@@ -921,16 +883,15 @@ class BIM_Classification:
                 return has_saved, set()
             return has_saved, {entry for entry in value.split("|") if entry}
         except Exception as err:
-            _print_ui_error("_load_bsdd_dictionary_state", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_load_bsdd_dictionary_state", err))
             return False, set()
 
     def _get_selected_bsdd_concept(self):
         try:
-            QtCore, _QtGui, _QtWidgets = _get_qt_modules()
             index = self.form.bsddResultsTree.currentIndex()
             return index.data(QtCore.Qt.UserRole)
         except Exception as err:
-            _print_ui_error("_get_selected_bsdd_concept", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_get_selected_bsdd_concept", err))
             return None
 
     def _update_bsdd_contract(self):
@@ -952,7 +913,7 @@ class BIM_Classification:
             self._bsdd_contract = contract
         except Exception as err:
             self._bsdd_contract = None
-            _print_ui_error("_update_bsdd_contract", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_update_bsdd_contract", err))
 
     def _get_current_bsdd_contract(self):
         try:
@@ -960,12 +921,11 @@ class BIM_Classification:
                 self._update_bsdd_contract()
             return self._bsdd_contract
         except Exception as err:
-            _print_ui_error("_get_current_bsdd_contract", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_get_current_bsdd_contract", err))
             return None
 
     def _store_bsdd_contract_for_item(self, tree_item, contract):
         try:
-            QtCore, _QtGui, _QtWidgets = _get_qt_modules()
             tree_item.setData(0, QtCore.Qt.UserRole + BSDD_CONTRACT_ROLE, contract)
             object_name = tree_item.toolTip(0)
             if object_name and contract:
@@ -973,11 +933,10 @@ class BIM_Classification:
             elif object_name:
                 self._bsdd_object_contracts.pop(object_name, None)
         except Exception as err:
-            _print_ui_error("_store_bsdd_contract_for_item", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_store_bsdd_contract_for_item", err))
 
     def _get_stored_bsdd_contract_for_item(self, tree_item):
         try:
-            QtCore, _QtGui, _QtWidgets = _get_qt_modules()
             contract = tree_item.data(0, QtCore.Qt.UserRole + BSDD_CONTRACT_ROLE)
             if contract:
                 return contract
@@ -986,7 +945,7 @@ class BIM_Classification:
                 return self._bsdd_object_contracts.get(object_name)
             return None
         except Exception as err:
-            _print_ui_error("_get_stored_bsdd_contract_for_item", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_get_stored_bsdd_contract_for_item", err))
             return None
 
     def _restore_bsdd_contract_for_item(self, tree_item, object_name):
@@ -997,7 +956,7 @@ class BIM_Classification:
             if contract:
                 self._store_bsdd_contract_for_item(tree_item, contract)
         except Exception as err:
-            _print_ui_error("_restore_bsdd_contract_for_item", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_restore_bsdd_contract_for_item", err))
 
     def _apply_bsdd_contract_to_object(self, obj, contract):
         try:
@@ -1037,7 +996,7 @@ class BIM_Classification:
             prefix = self.form.comboSystem.currentText()
             return code, label, prefix
         except Exception as err:
-            _print_ui_error("_get_selected_class_values", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("_get_selected_class_values", err))
             return None, None, None
 
     def addSelection(self, document, object, element, position):
@@ -1047,7 +1006,7 @@ class BIM_Classification:
             if self._is_bsdd_provider_active():
                 self._schedule_bsdd_search()
         except Exception as err:
-            _print_ui_error("addSelection", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("addSelection", err))
 
     def removeSelection(self, document, object, element, position=None):
         try:
@@ -1056,7 +1015,7 @@ class BIM_Classification:
             if self._is_bsdd_provider_active():
                 self._schedule_bsdd_search()
         except Exception as err:
-            _print_ui_error("removeSelection", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("removeSelection", err))
 
     def setSelection(self, document):
         try:
@@ -1065,7 +1024,7 @@ class BIM_Classification:
             if self._is_bsdd_provider_active():
                 self._schedule_bsdd_search()
         except Exception as err:
-            _print_ui_error("setSelection", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("setSelection", err))
 
     def clearSelection(self, document):
         try:
@@ -1074,7 +1033,7 @@ class BIM_Classification:
             if self._is_bsdd_provider_active():
                 self._schedule_bsdd_search()
         except Exception as err:
-            _print_ui_error("clearSelection", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("clearSelection", err))
 
     def updateObjects(self, idx=None):
         # store current state of tree into self.objectslist before redrawing
@@ -1453,7 +1412,7 @@ class BIM_Classification:
                         m.setText(1, code)
                         self._store_bsdd_contract_for_item(m, contract)
         except Exception as err:
-            _print_ui_error("apply", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("apply", err))
 
     def rename(self):
         try:
@@ -1465,7 +1424,7 @@ class BIM_Classification:
                     if m.toolTip(0):
                         m.setText(0, label)
         except Exception as err:
-            _print_ui_error("rename", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("rename", err))
 
     def accept(self):
         if not self.isEditing:
@@ -1531,7 +1490,7 @@ class BIM_Classification:
                         try:
                             FreeCAD.ActiveDocument.abortTransaction()
                         except Exception as err:
-                            _print_ui_error("accept.abortTransaction", err)
+                            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("accept.abortTransaction", err))
                         return self.reject()
                 if self.form.checkPrefix.isChecked() and prefix:
                     code = prefix + " " + code
@@ -1561,7 +1520,7 @@ class BIM_Classification:
             self._disconnect_bsdd_signals()
             self._remove_selection_observer()
         except Exception as err:
-            _print_ui_error("reject", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("reject", err))
         self.form.hide()
         del self.form
         return True
@@ -1573,7 +1532,7 @@ class BIM_Classification:
                 if self.form.treeClass.itemAbove(i):
                     self.form.treeClass.setCurrentItem(self.form.treeClass.itemAbove(i))
         except Exception as err:
-            _print_ui_error("onUpArrow", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("onUpArrow", err))
 
     def onDownArrow(self):
         try:
@@ -1582,7 +1541,7 @@ class BIM_Classification:
                 if self.form.treeClass.itemBelow(i):
                     self.form.treeClass.setCurrentItem(self.form.treeClass.itemBelow(i))
         except Exception as err:
-            _print_ui_error("onDownArrow", err)
+            FreeCAD.Console.PrintWarning("BIM bSDD UI warning in {}: {}\n".format("onDownArrow", err))
 
     def onVisible(self, index):
         PARAMS.SetInt("BimClassificationVisibleState", getattr(index, "value", index))
@@ -1610,3 +1569,4 @@ class BIM_Classification:
 
 
 FreeCADGui.addCommand("BIM_Classification", BIM_Classification())
+

--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -302,9 +302,7 @@ class BIM_Classification:
             self.form.bsddDictionaryContainerLayout.setContentsMargins(0, 0, 0, 0)
 
             self.form.bsddDictionaryList = QtWidgets.QListWidget(self.form.bsddDictionaryContainer)
-            self.form.bsddDictionaryList.setSelectionMode(
-                QtWidgets.QAbstractItemView.NoSelection
-            )
+            self.form.bsddDictionaryList.setSelectionMode(QtWidgets.QAbstractItemView.NoSelection)
             self.form.bsddDictionaryList.setMinimumHeight(110)
             self.form.bsddDictionaryContainerLayout.addWidget(self.form.bsddDictionaryList)
             self.form.bsddPanelLayout.addWidget(self.form.bsddDictionaryContainer)
@@ -312,13 +310,9 @@ class BIM_Classification:
 
             self.form.bsddSplitter = QtWidgets.QSplitter(QtCore.Qt.Vertical, self.form.bsddPanel)
             self.form.bsddResultsTree = QtWidgets.QTreeView(self.form.bsddSplitter)
-            self.form.bsddResultsTree.setEditTriggers(
-                QtWidgets.QAbstractItemView.NoEditTriggers
-            )
+            self.form.bsddResultsTree.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
             self.form.bsddResultsTree.setAlternatingRowColors(True)
-            self.form.bsddResultsTree.setSelectionBehavior(
-                QtWidgets.QAbstractItemView.SelectRows
-            )
+            self.form.bsddResultsTree.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
             self.form.bsddResultsTree.setUniformRowHeights(True)
 
             self.form.bsddPropertyTable = QtWidgets.QTableWidget(self.form.bsddSplitter)
@@ -326,12 +320,8 @@ class BIM_Classification:
             self.form.bsddPropertyTable.setHorizontalHeaderLabels(
                 [translate("BIM", "Property"), translate("BIM", "Value")]
             )
-            self.form.bsddPropertyTable.setEditTriggers(
-                QtWidgets.QAbstractItemView.NoEditTriggers
-            )
-            self.form.bsddPropertyTable.setSelectionBehavior(
-                QtWidgets.QAbstractItemView.SelectRows
-            )
+            self.form.bsddPropertyTable.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+            self.form.bsddPropertyTable.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
             self.form.bsddPropertyTable.setWordWrap(True)
             self.form.bsddPropertyTable.verticalHeader().setVisible(False)
             self.form.bsddPropertyTable.horizontalHeader().setStretchLastSection(True)
@@ -351,7 +341,9 @@ class BIM_Classification:
             self.form.bsddPanel.hide()
 
             provider = PARAMS.GetString(BSDD_PROVIDER_MODE_KEY, "Legacy")
-            self.form.comboProvider.setCurrentText(provider if provider in ["Legacy", "bSDD"] else "Legacy")
+            self.form.comboProvider.setCurrentText(
+                provider if provider in ["Legacy", "bSDD"] else "Legacy"
+            )
             (
                 self._has_saved_bsdd_dictionary_state,
                 self._restored_bsdd_dictionary_uris,
@@ -841,7 +833,14 @@ class BIM_Classification:
             if not payload:
                 return
             rows = []
-            for key in ["name", "referenceCode", "dictionaryName", "classType", "uri", "description"]:
+            for key in [
+                "name",
+                "referenceCode",
+                "dictionaryName",
+                "classType",
+                "uri",
+                "description",
+            ]:
                 value = payload.get(key)
                 if value:
                     rows.append((key, value))
@@ -916,9 +915,7 @@ class BIM_Classification:
             if not FreeCAD.ActiveDocument:
                 return False, set()
             meta = FreeCAD.ActiveDocument.Meta
-            has_saved = (
-                BSDD_DICTIONARY_META_PRESENT_KEY in meta or BSDD_DICTIONARY_META_KEY in meta
-            )
+            has_saved = BSDD_DICTIONARY_META_PRESENT_KEY in meta or BSDD_DICTIONARY_META_KEY in meta
             value = meta.get(BSDD_DICTIONARY_META_KEY, "")
             if not value:
                 return has_saved, set()
@@ -949,8 +946,8 @@ class BIM_Classification:
             contract = self._bsdd_contract_module.build_canonical_contract(
                 concept, self._bsdd_contract_detail_payload, active_object
             )
-            contract["legacy_string"] = self._bsdd_contract_module.build_legacy_classification_string(
-                contract
+            contract["legacy_string"] = (
+                self._bsdd_contract_module.build_legacy_classification_string(contract)
             )
             self._bsdd_contract = contract
         except Exception as err:
@@ -1448,7 +1445,9 @@ class BIM_Classification:
                     return
                 if self.form.checkPrefix.isChecked() and prefix:
                     code = prefix + " " + code
-                contract = self._get_current_bsdd_contract() if self._is_bsdd_provider_active() else None
+                contract = (
+                    self._get_current_bsdd_contract() if self._is_bsdd_provider_active() else None
+                )
                 for m in self.form.treeObjects.selectedItems():
                     if m.toolTip(0):
                         m.setText(1, code)

--- a/src/Mod/BIM/bimtests/TestBsdd.py
+++ b/src/Mod/BIM/bimtests/TestBsdd.py
@@ -1,0 +1,295 @@
+import os
+import json
+import os
+import unittest
+
+import FreeCAD
+
+import BimBsdd
+
+try:
+    from PySide import QtCore, QtNetwork
+except ImportError:
+    try:
+        from PySide6 import QtCore, QtNetwork
+    except ImportError:
+        from PySide2 import QtCore, QtNetwork
+
+
+class _FakeReply(QtCore.QObject):
+    finished = QtCore.Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+
+class _FakeNetworkManager:
+    def __init__(self):
+        self.requests = []
+
+    def get(self, request):
+        self.requests.append(request)
+        return _FakeReply()
+
+
+class TestBsdd(unittest.TestCase):
+
+    def setUp(self):
+        self.params = FreeCAD.ParamGet(BimBsdd.BSDD_PREFERENCES_PATH)
+        self.params.SetBool(BimBsdd.BSDD_PREVIEW_KEY, True)
+        self.params.SetBool(BimBsdd.BSDD_TEST_KEY, False)
+        self.params.SetBool(BimBsdd.BSDD_INACTIVE_KEY, True)
+        self.params.SetString(BimBsdd.BSDD_API_URL_KEY, BimBsdd.BSDD_API_BASE_URL)
+
+    def test_syncs_preferences_on_initialization(self):
+        client = BimBsdd.BsddNetworkClient(network_manager=_FakeNetworkManager())
+        self.assertTrue(client.settings.include_preview)
+        self.assertFalse(client.settings.include_test)
+        self.assertTrue(client.settings.include_inactive)
+
+    def test_dictionary_cache_short_circuits_network(self):
+        manager = _FakeNetworkManager()
+        client = BimBsdd.BsddNetworkClient(network_manager=manager)
+        cached_payload = [{"name": "IFC"}]
+        received_payloads = []
+        client.domain_cache[client._dictionary_cache_key()] = cached_payload
+        client.dictionariesReady.connect(received_payloads.append)
+        client.fetch_dictionaries()
+        self.assertEqual(received_payloads, [cached_payload])
+        self.assertEqual(len(manager.requests), 0)
+
+    def test_search_request_includes_status_and_context_filters(self):
+        manager = _FakeNetworkManager()
+        client = BimBsdd.BsddNetworkClient(network_manager=manager)
+        client.search_concepts(
+            "wall",
+            active_dictionaries=["dict-b", "dict-a"],
+            related_ifc_entity="IfcWall",
+        )
+        self.assertEqual(len(manager.requests), 1)
+        query = manager.requests[0].url().query()
+        self.assertIn("IncludePreview=true", query)
+        self.assertIn("IncludeTestDictionaries=false", query)
+        self.assertIn("IncludeInactive=true", query)
+        self.assertIn("SearchText=wall", query)
+        self.assertIn("DictionaryUris=dict-a", query)
+        self.assertIn("DictionaryUris=dict-b", query)
+        self.assertIn("RelatedIfcEntities=IfcWall", query)
+
+    def test_settings_change_invalidates_dictionary_and_search_cache_keys(self):
+        manager = _FakeNetworkManager()
+        client = BimBsdd.BsddNetworkClient(network_manager=manager)
+
+        first_dictionary_key = client._dictionary_cache_key()
+        first_search_key = client.search_concepts(
+            "wall",
+            active_dictionaries=["dict-a"],
+            related_ifc_entity="IfcWall",
+        )
+
+        self.params.SetBool(BimBsdd.BSDD_TEST_KEY, True)
+        client.refresh_settings()
+
+        second_dictionary_key = client._dictionary_cache_key()
+        second_search_key = client._search_cache_key("wall", ("dict-a",), "IfcWall")
+
+        self.assertNotEqual(first_dictionary_key, second_dictionary_key)
+        self.assertNotEqual(first_search_key, second_search_key)
+
+    def test_fetch_concept_requests_class_and_properties_and_merges_payloads(self):
+        manager = _FakeNetworkManager()
+        client = BimBsdd.BsddNetworkClient(network_manager=manager)
+        received = []
+        client.conceptReady.connect(lambda concept_uri, payload: received.append((concept_uri, payload)))
+
+        concept_uri = "https://example.org/class/IfcWall"
+        client.fetch_concept(concept_uri)
+
+        self.assertEqual(len(manager.requests), 2)
+        request_urls = [request.url().toString() for request in manager.requests]
+        self.assertTrue(any("/api/Class/v1" in url and "Uri=" in url for url in request_urls))
+        self.assertTrue(
+            any("/api/Class/Properties/v1" in url and "ClassUri=" in url for url in request_urls)
+        )
+
+        client._collect_concept_payload(
+            concept_uri,
+            "base",
+            {"referenceCode": "IfcWall", "name": "Wall", "classType": "Class"},
+        )
+        self.assertEqual(received, [])
+        client._collect_concept_payload(
+            concept_uri,
+            "properties",
+            {"classProperties": [{"name": "IsExternal", "propertySet": "Pset_WallCommon"}]},
+        )
+
+        self.assertEqual(len(received), 1)
+        merged_payload = received[0][1]
+        self.assertEqual(received[0][0], concept_uri)
+        self.assertEqual(merged_payload.get("referenceCode"), "IfcWall")
+        self.assertEqual(merged_payload.get("name"), "Wall")
+        self.assertEqual(merged_payload.get("classType"), "Class")
+        self.assertTrue(merged_payload.get("classProperties"))
+        self.assertEqual(merged_payload["classProperties"][0]["name"], "IsExternal")
+
+    def _run_live_json_request(self, url):
+        app = QtCore.QCoreApplication.instance()
+        if app is None:
+            app = QtCore.QCoreApplication([])
+
+        network_manager = QtNetwork.QNetworkAccessManager()
+        request = QtNetwork.QNetworkRequest(QtCore.QUrl(url))
+        request.setRawHeader(b"Accept", b"application/json")
+        request.setRawHeader(b"User-Agent", b"FreeCAD-BIM-Test")
+        request.setRawHeader(b"X-User-Agent", b"FreeCAD-BIM-Test")
+
+        state = {"payload": None, "error": None}
+        event_loop = QtCore.QEventLoop()
+        timeout = QtCore.QTimer()
+        timeout.setSingleShot(True)
+        timeout.timeout.connect(lambda: (state.__setitem__("error", "request timeout"), event_loop.quit()))
+
+        reply = network_manager.get(request)
+
+        def finish():
+            try:
+                if reply.error() != QtNetwork.QNetworkReply.NoError:
+                    state["error"] = reply.errorString()
+                else:
+                    state["payload"] = json.loads(bytes(reply.readAll()).decode("utf-8"))
+            except Exception as err:
+                state["error"] = str(err)
+            finally:
+                reply.deleteLater()
+                event_loop.quit()
+
+        reply.finished.connect(finish)
+        timeout.start(30000)
+        event_loop.exec_()
+        timeout.stop()
+        self.assertIsNone(state["error"], state["error"])
+        return state["payload"]
+
+    @unittest.skipUnless(
+        os.environ.get("FREECAD_RUN_LIVE_BSDD_TESTS") == "1",
+        "Set FREECAD_RUN_LIVE_BSDD_TESTS=1 to run live bSDD integration tests.",
+    )
+    def test_live_dictionary_loading_returns_ifc_dictionary(self):
+        payload = self._run_live_json_request(
+            "https://api.bsdd.buildingsmart.org/api/Dictionary/v1"
+        )
+        dictionaries = payload.get("dictionaries") or payload.get("results") or payload
+        self.assertTrue(dictionaries, "Live bSDD dictionary load returned no dictionaries.")
+
+        ifc_dictionary = None
+        for item in dictionaries:
+            if item.get("name") == "IFC" or "identifier.buildingsmart.org/uri/buildingsmart/ifc" in item.get("uri", ""):
+                ifc_dictionary = item
+                break
+
+        self.assertIsNotNone(ifc_dictionary, "IFC dictionary not found in live bSDD dictionary response.")
+        self.assertEqual(ifc_dictionary.get("name"), "IFC")
+        self.assertIn("identifier.buildingsmart.org/uri/buildingsmart/ifc", ifc_dictionary.get("uri", ""))
+
+    @unittest.skipUnless(
+        os.environ.get("FREECAD_RUN_LIVE_BSDD_TESTS") == "1",
+        "Set FREECAD_RUN_LIVE_BSDD_TESTS=1 to run live bSDD integration tests.",
+    )
+    def test_live_wall_search_returns_ifc_wall_data(self):
+        app = QtCore.QCoreApplication.instance()
+        if app is None:
+            app = QtCore.QCoreApplication([])
+
+        client = BimBsdd.BsddNetworkClient()
+        received = {}
+        failures = []
+        event_loop = QtCore.QEventLoop()
+
+        def on_search_ready(search_key, payload):
+            received["search_key"] = search_key
+            received["payload"] = payload
+            items = payload.get("classes") or payload.get("results") or []
+            wall_item = None
+            for item in items:
+                reference_code = item.get("referenceCode", "")
+                name = item.get("name", "")
+                uri = item.get("uri", "")
+                if (
+                    reference_code == "IfcWall"
+                    or name == "IfcWall"
+                    or uri.endswith("/class/IfcWall")
+                ):
+                    wall_item = item
+                    break
+            if wall_item is None:
+                failures.append("bSDD search did not return an IfcWall entry")
+                event_loop.quit()
+                return
+            received["wall_item"] = wall_item
+            client.fetch_concept(wall_item["uri"])
+
+        def on_concept_ready(concept_uri, payload):
+            received["concept_uri"] = concept_uri
+            received["concept_payload"] = payload
+            event_loop.quit()
+
+        def on_failure(request_kind, message, cache_key):
+            failures.append(f"{request_kind}: {message} ({cache_key})")
+            event_loop.quit()
+
+        timeout = QtCore.QTimer()
+        timeout.setSingleShot(True)
+        timeout.timeout.connect(
+            lambda: (failures.append("Timed out waiting for live bSDD response"), event_loop.quit())
+        )
+
+        client.searchReady.connect(on_search_ready)
+        client.conceptReady.connect(on_concept_ready)
+        client.requestFailed.connect(on_failure)
+
+        timeout.start(30000)
+        client.search_concepts(
+            "wall",
+            active_dictionaries=[BimBsdd.BSDD_IFC_DICTIONARY_URI],
+            related_ifc_entity="IfcWall",
+        )
+        event_loop.exec_()
+        timeout.stop()
+
+        if failures:
+            self.fail("; ".join(failures))
+
+        search_payload = received["payload"]
+        search_items = search_payload.get("classes") or search_payload.get("results") or []
+        self.assertTrue(search_items, "Live bSDD search returned no classes.")
+        self.assertEqual(received["wall_item"]["referenceCode"], "IfcWall")
+
+        concept_payload = received["concept_payload"]
+        self.assertEqual(concept_payload.get("referenceCode"), "IfcWall")
+        self.assertEqual(concept_payload.get("name"), "Wall")
+        self.assertEqual(concept_payload.get("classType"), "Class")
+
+    @unittest.skipUnless(
+        os.environ.get("FREECAD_RUN_LIVE_BSDD_TESTS") == "1",
+        "Set FREECAD_RUN_LIVE_BSDD_TESTS=1 to run live bSDD integration tests.",
+    )
+    def test_live_ifc_wall_properties_returns_property_data(self):
+        payload = self._run_live_json_request(
+            "https://api.bsdd.buildingsmart.org/api/Class/Properties/v1"
+            "?ClassUri=https%3A%2F%2Fidentifier.buildingsmart.org%2Furi%2Fbuildingsmart%2Fifc%2Flatest%2Fclass%2FIfcWall"
+        )
+        class_properties = payload.get("classProperties") or payload.get("properties") or []
+        self.assertTrue(class_properties, "Live bSDD properties response returned no properties for IfcWall.")
+
+        property_names = {item.get("name") for item in class_properties}
+        self.assertIn("IsExternal", property_names)
+
+        wall_common_property = None
+        for item in class_properties:
+            if item.get("name") == "IsExternal":
+                wall_common_property = item
+                break
+
+        self.assertIsNotNone(wall_common_property, "IfcWall properties did not include IsExternal.")
+        self.assertEqual(wall_common_property.get("propertySet"), "Pset_WallCommon")

--- a/src/Mod/BIM/bimtests/TestBsdd.py
+++ b/src/Mod/BIM/bimtests/TestBsdd.py
@@ -100,7 +100,9 @@ class TestBsdd(unittest.TestCase):
         manager = _FakeNetworkManager()
         client = BimBsdd.BsddNetworkClient(network_manager=manager)
         received = []
-        client.conceptReady.connect(lambda concept_uri, payload: received.append((concept_uri, payload)))
+        client.conceptReady.connect(
+            lambda concept_uri, payload: received.append((concept_uri, payload))
+        )
 
         concept_uri = "https://example.org/class/IfcWall"
         client.fetch_concept(concept_uri)
@@ -148,7 +150,9 @@ class TestBsdd(unittest.TestCase):
         event_loop = QtCore.QEventLoop()
         timeout = QtCore.QTimer()
         timeout.setSingleShot(True)
-        timeout.timeout.connect(lambda: (state.__setitem__("error", "request timeout"), event_loop.quit()))
+        timeout.timeout.connect(
+            lambda: (state.__setitem__("error", "request timeout"), event_loop.quit())
+        )
 
         reply = network_manager.get(request)
 
@@ -184,13 +188,21 @@ class TestBsdd(unittest.TestCase):
 
         ifc_dictionary = None
         for item in dictionaries:
-            if item.get("name") == "IFC" or "identifier.buildingsmart.org/uri/buildingsmart/ifc" in item.get("uri", ""):
+            if item.get(
+                "name"
+            ) == "IFC" or "identifier.buildingsmart.org/uri/buildingsmart/ifc" in item.get(
+                "uri", ""
+            ):
                 ifc_dictionary = item
                 break
 
-        self.assertIsNotNone(ifc_dictionary, "IFC dictionary not found in live bSDD dictionary response.")
+        self.assertIsNotNone(
+            ifc_dictionary, "IFC dictionary not found in live bSDD dictionary response."
+        )
         self.assertEqual(ifc_dictionary.get("name"), "IFC")
-        self.assertIn("identifier.buildingsmart.org/uri/buildingsmart/ifc", ifc_dictionary.get("uri", ""))
+        self.assertIn(
+            "identifier.buildingsmart.org/uri/buildingsmart/ifc", ifc_dictionary.get("uri", "")
+        )
 
     @unittest.skipUnless(
         os.environ.get("FREECAD_RUN_LIVE_BSDD_TESTS") == "1",
@@ -280,7 +292,9 @@ class TestBsdd(unittest.TestCase):
             "?ClassUri=https%3A%2F%2Fidentifier.buildingsmart.org%2Furi%2Fbuildingsmart%2Fifc%2Flatest%2Fclass%2FIfcWall"
         )
         class_properties = payload.get("classProperties") or payload.get("properties") or []
-        self.assertTrue(class_properties, "Live bSDD properties response returned no properties for IfcWall.")
+        self.assertTrue(
+            class_properties, "Live bSDD properties response returned no properties for IfcWall."
+        )
 
         property_names = {item.get("name") for item in class_properties}
         self.assertIn("IsExternal", property_names)

--- a/src/Mod/BIM/bimtests/TestBsdd.py
+++ b/src/Mod/BIM/bimtests/TestBsdd.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 # ***************************************************************************
-# *                                                                         * 
+# *                                                                         *
 # *   This file is part of FreeCAD.                                         *
 # *                                                                         *
 # *   FreeCAD is free software: you can redistribute it and/or modify it    *

--- a/src/Mod/BIM/bimtests/TestBsdd.py
+++ b/src/Mod/BIM/bimtests/TestBsdd.py
@@ -136,9 +136,8 @@ class TestBsdd(unittest.TestCase):
         self.assertEqual(merged_payload["classProperties"][0]["name"], "IsExternal")
 
     def _run_live_json_request(self, url):
-        app = QtCore.QCoreApplication.instance()
-        if app is None:
-            app = QtCore.QCoreApplication([])
+        if QtCore.QCoreApplication.instance() is None:
+            QtCore.QCoreApplication([])
 
         network_manager = QtNetwork.QNetworkAccessManager()
         request = QtNetwork.QNetworkRequest(QtCore.QUrl(url))
@@ -209,9 +208,8 @@ class TestBsdd(unittest.TestCase):
         "Set FREECAD_RUN_LIVE_BSDD_TESTS=1 to run live bSDD integration tests.",
     )
     def test_live_wall_search_returns_ifc_wall_data(self):
-        app = QtCore.QCoreApplication.instance()
-        if app is None:
-            app = QtCore.QCoreApplication([])
+        if QtCore.QCoreApplication.instance() is None:
+            QtCore.QCoreApplication([])
 
         client = BimBsdd.BsddNetworkClient()
         received = {}

--- a/src/Mod/BIM/bimtests/TestBsdd.py
+++ b/src/Mod/BIM/bimtests/TestBsdd.py
@@ -1,3 +1,24 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *                                                                         * 
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
 import os
 import json
 import os

--- a/src/Mod/BIM/bimtests/TestBsddContract.py
+++ b/src/Mod/BIM/bimtests/TestBsddContract.py
@@ -1,3 +1,24 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *                                                                         * 
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
 import unittest
 
 import BimBsddContract

--- a/src/Mod/BIM/bimtests/TestBsddContract.py
+++ b/src/Mod/BIM/bimtests/TestBsddContract.py
@@ -1,0 +1,128 @@
+import unittest
+
+import BimBsddContract
+from nativeifc import ifc_classification
+
+
+class _MockObject:
+    IfcClass = "IfcWall"
+
+
+class TestBsddContract(unittest.TestCase):
+
+    def test_builds_canonical_contract(self):
+        payload = {
+            "dictionaryName": "IFC",
+            "dictionaryUri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/latest",
+            "dictionaryVersion": "4.3",
+            "referenceCode": "IfcWall",
+            "name": "Wall",
+            "description": "A wall element.",
+            "uri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/latest/class/IfcWall",
+            "relatedIfcEntities": ["IfcWall"],
+            "classProperties": [
+                {
+                    "propertySet": "Pset_WallCommon",
+                    "name": "IsExternal",
+                    "dataType": "Boolean",
+                    "predefinedValue": "TRUE",
+                }
+            ],
+        }
+        contract = BimBsddContract.build_canonical_contract(payload, active_object=_MockObject())
+        self.assertEqual(contract["dictionary_metadata"]["name"], "IFC")
+        self.assertEqual(contract["class_metadata"]["reference_code"], "IfcWall")
+        self.assertTrue(contract["validation_filters"]["is_applicable"])
+        self.assertEqual(contract["extended_properties"][0]["property_set"], "Pset_WallCommon")
+
+    def test_builds_legacy_classification_string(self):
+        contract = {
+            "dictionary_metadata": {"name": "IFC"},
+            "class_metadata": {"reference_code": "IfcWall", "name": "Wall"},
+        }
+        self.assertEqual(
+            BimBsddContract.build_legacy_classification_string(contract), "IFC IfcWall"
+        )
+
+    def test_refreshes_validation_for_target_object(self):
+        class SlabObject:
+            IfcClass = "IfcSlab"
+
+        payload = {
+            "referenceCode": "IfcWall",
+            "name": "Wall",
+            "relatedIfcEntities": ["IfcWall"],
+        }
+        contract = BimBsddContract.build_canonical_contract(payload, active_object=_MockObject())
+        self.assertTrue(contract["validation_filters"]["is_applicable"])
+
+        refreshed = BimBsddContract.refresh_contract_validation(contract, SlabObject())
+        self.assertEqual(refreshed["validation_filters"]["active_ifc_type"], "IfcSlab")
+        self.assertFalse(refreshed["validation_filters"]["is_applicable"])
+        self.assertTrue(contract["validation_filters"]["is_applicable"])
+
+    def test_classification_match_requires_namespace_not_name_alone(self):
+        class ExistingClassification:
+            Name = "IFC"
+            Source = "https://example.org/uri/ifc/older"
+            Location = ""
+            Edition = "4.0"
+
+        metadata = {
+            "name": "IFC",
+            "namespace_uri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/latest",
+            "version": "4.3",
+        }
+
+        self.assertFalse(
+            ifc_classification._classification_matches_dictionary(
+                ExistingClassification(), metadata
+            )
+        )
+
+    def test_classification_match_allows_name_only_reuse_without_namespace(self):
+        class ExistingClassification:
+            Name = "Uniclass"
+            Source = ""
+            Location = ""
+            Edition = "2015"
+
+        metadata = {
+            "name": "Uniclass",
+            "version": "2015",
+        }
+
+        self.assertTrue(
+            ifc_classification._classification_matches_dictionary(
+                ExistingClassification(), metadata
+            )
+        )
+
+    def test_missing_property_value_does_not_fall_back_to_allowed_enum(self):
+        self.assertIsNone(
+            ifc_classification._coerce_contract_value(
+                None, "String", [{"value": "ENUM_A"}, {"value": "ENUM_B"}]
+            )
+        )
+        self.assertIsNone(
+            ifc_classification._coerce_contract_value(
+                "", "String", [{"value": "ENUM_A"}, {"value": "ENUM_B"}]
+            )
+        )
+
+    def test_contract_does_not_invent_value_from_allowed_enum(self):
+        payload = {
+            "referenceCode": "IfcWall",
+            "name": "Wall",
+            "classProperties": [
+                {
+                    "propertySet": "Pset_WallCommon",
+                    "name": "Status",
+                    "dataType": "String",
+                    "allowedValues": [{"value": "NEW"}, {"value": "EXISTING"}],
+                }
+            ],
+        }
+        contract = BimBsddContract.build_canonical_contract(payload, active_object=_MockObject())
+        self.assertEqual(contract["extended_properties"][0]["name"], "Status")
+        self.assertIsNone(contract["extended_properties"][0]["value"])

--- a/src/Mod/BIM/bimtests/TestBsddContract.py
+++ b/src/Mod/BIM/bimtests/TestBsddContract.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 # ***************************************************************************
-# *                                                                         * 
+# *                                                                         *
 # *   This file is part of FreeCAD.                                         *
 # *                                                                         *
 # *   FreeCAD is free software: you can redistribute it and/or modify it    *

--- a/src/Mod/BIM/nativeifc/ifc_classification.py
+++ b/src/Mod/BIM/nativeifc/ifc_classification.py
@@ -23,6 +23,7 @@
 # ***************************************************************************
 
 
+from . import ifc_psets  # lazy import
 from . import ifc_tools  # lazy import
 
 
@@ -109,3 +110,290 @@ def show_classification(obj):
                     cname = ref.Name or ref.Identification
                     obj.Classification = sname + " " + cname
                     break
+
+
+def _first_non_empty(*values):
+    for value in values:
+        if value not in [None, ""]:
+            return value
+    return ""
+
+
+def _get_object_ifc_type(obj):
+    for attr_name in ["IfcClass", "IfcType", "IfcRole"]:
+        value = getattr(obj, attr_name, "")
+        if value:
+            return str(value)
+    return ""
+
+
+def _coerce_contract_value(value, data_type="", allowed_values=None):
+    if isinstance(value, dict):
+        value = _first_non_empty(value.get("value"), value.get("code"), value.get("name"))
+    if isinstance(value, str):
+        upper_value = value.strip().upper()
+        if upper_value in ["TRUE", ".T.", "YES"]:
+            return True
+        if upper_value in ["FALSE", ".F.", "NO"]:
+            return False
+        if upper_value in ["UNKNOWN", "UNDEFINED", "NOTDEFINED", "N/A"]:
+            return ""
+        lowered_type = (data_type or "").lower()
+        if "int" in lowered_type:
+            try:
+                return int(value)
+            except Exception:
+                pass
+        if any(token in lowered_type for token in ["real", "float", "number", "numeric"]):
+            try:
+                return float(value)
+            except Exception:
+                pass
+        try:
+            if "." in value:
+                return float(value)
+            return int(value)
+        except Exception:
+            return value
+    if value in [None, ""]:
+        return None
+    return value
+
+
+def _get_project_element(ifcfile):
+    projects = ifcfile.by_type("IfcProject")
+    return projects[0] if projects else None
+
+
+def _get_classification_namespace(classification):
+    for attr_name in ["Source", "Location"]:
+        value = getattr(classification, attr_name, "")
+        if value:
+            return value
+    return ""
+
+
+def _classification_matches_dictionary(classification, dictionary_metadata):
+    target_name = dictionary_metadata.get("name", "")
+    target_namespace = dictionary_metadata.get("namespace_uri", "")
+    target_version = dictionary_metadata.get("version", "")
+    classification_name = getattr(classification, "Name", "") or ""
+    classification_namespace = _get_classification_namespace(classification)
+    classification_version = getattr(classification, "Edition", "") or ""
+
+    if target_namespace:
+        if classification_namespace != target_namespace:
+            return False
+        if target_version and classification_version and classification_version != target_version:
+            return False
+        return True
+
+    if classification_namespace:
+        return False
+    if target_name and classification_name != target_name:
+        return False
+    if target_version and classification_version and classification_version != target_version:
+        return False
+    return bool(target_name)
+
+
+def _ensure_project_classification_relation(ifcfile, classification):
+    project = _get_project_element(ifcfile)
+    if not project:
+        return
+    for rel in ifcfile.by_type("IfcRelAssociatesClassification"):
+        if rel.RelatingClassification == classification and project in rel.RelatedObjects:
+            return
+    owner_history = None
+    try:
+        owner_history = ifc_tools.ifcopenshell.api.owner.create_owner_history(ifcfile)
+    except Exception:
+        pass
+    ifcfile.create_entity(
+        "IfcRelAssociatesClassification",
+        GlobalId=ifc_tools.ifcopenshell.guid.new(),
+        OwnerHistory=owner_history,
+        RelatedObjects=[project],
+        RelatingClassification=classification,
+    )
+
+
+def _find_classification_root(ifcfile, dictionary_metadata):
+    for classification in ifcfile.by_type("IfcClassification"):
+        if _classification_matches_dictionary(classification, dictionary_metadata):
+            return classification
+    return None
+
+
+def _upsert_classification_root(ifcfile, dictionary_metadata):
+    classification = _find_classification_root(ifcfile, dictionary_metadata)
+    if not classification:
+        classification = ifc_tools.api_run(
+            "classification.add_classification",
+            ifcfile,
+            classification=dictionary_metadata.get("name", "bSDD"),
+        )
+    attrs = {}
+    if dictionary_metadata.get("name"):
+        attrs["Name"] = dictionary_metadata["name"]
+    if dictionary_metadata.get("namespace_uri") and hasattr(classification, "Source"):
+        attrs["Source"] = dictionary_metadata["namespace_uri"]
+    if dictionary_metadata.get("namespace_uri") and hasattr(classification, "Location"):
+        attrs["Location"] = dictionary_metadata["namespace_uri"]
+    if dictionary_metadata.get("version") and hasattr(classification, "Edition"):
+        attrs["Edition"] = dictionary_metadata["version"]
+    if attrs:
+        ifc_tools.api_run(
+            "classification.edit_classification",
+            ifcfile,
+            classification=classification,
+            attributes=attrs,
+        )
+    _ensure_project_classification_relation(ifcfile, classification)
+    return classification
+
+
+def _get_reference_identification(reference):
+    identification = getattr(reference, "Identification", None)
+    if not identification:
+        identification = getattr(reference, "ItemReference", None)
+    return identification
+
+
+def _find_classification_reference(ifcfile, classification, class_metadata):
+    reference_code = class_metadata.get("reference_code", "")
+    concept_uri = class_metadata.get("uri", "")
+    for reference in ifcfile.by_type("IfcClassificationReference"):
+        if getattr(reference, "ReferencedSource", None) != classification:
+            continue
+        if reference_code and _get_reference_identification(reference) == reference_code:
+            return reference
+        if concept_uri and getattr(reference, "Location", "") == concept_uri:
+            return reference
+    return None
+
+
+def _upsert_classification_reference(ifcfile, classification, class_metadata):
+    reference = _find_classification_reference(ifcfile, classification, class_metadata)
+    if not reference:
+        reference = ifcfile.createIfcClassificationReference(
+            Name=class_metadata.get("name", ""),
+            ReferencedSource=classification,
+        )
+    attrs = {"Name": class_metadata.get("name", "")}
+    if class_metadata.get("description") and hasattr(reference, "Description"):
+        attrs["Description"] = class_metadata["description"]
+    if class_metadata.get("uri") and hasattr(reference, "Location"):
+        attrs["Location"] = class_metadata["uri"]
+    identification_attr = (
+        "ItemReference" if hasattr(reference, "ItemReference") else "Identification"
+    )
+    if class_metadata.get("reference_code"):
+        attrs[identification_attr] = class_metadata["reference_code"]
+    ifc_tools.api_run(
+        "classification.edit_reference",
+        ifcfile,
+        reference=reference,
+        attributes=attrs,
+    )
+    return reference
+
+
+def _find_reference_relation(ifcfile, reference):
+    for rel in ifcfile.by_type("IfcRelAssociatesClassification"):
+        if rel.RelatingClassification == reference:
+            return rel
+    return None
+
+
+def _ensure_reference_relation(ifcfile, reference, element):
+    rel = _find_reference_relation(ifcfile, reference)
+    if rel:
+        related_objects = set(rel.RelatedObjects)
+        if element in related_objects:
+            return False
+        related_objects.add(element)
+        rel.RelatedObjects = list(related_objects)
+        try:
+            ifc_tools.ifcopenshell.api.owner.update_owner_history(ifcfile, element=rel)
+        except Exception:
+            pass
+        return True
+    owner_history = None
+    try:
+        owner_history = ifc_tools.ifcopenshell.api.owner.create_owner_history(ifcfile)
+    except Exception:
+        pass
+    ifcfile.create_entity(
+        "IfcRelAssociatesClassification",
+        GlobalId=ifc_tools.ifcopenshell.guid.new(),
+        OwnerHistory=owner_history,
+        RelatedObjects=[element],
+        RelatingClassification=reference,
+    )
+    return True
+
+
+def _upsert_extended_properties(obj, contract, ifcfile, element):
+    for prop in contract.get("extended_properties", []):
+        pset_name = prop.get("property_set", "")
+        prop_name = prop.get("name", "")
+        if not pset_name or not prop_name:
+            continue
+        coerced_value = _coerce_contract_value(
+            prop.get("value"), prop.get("data_type", ""), prop.get("allowed_values", [])
+        )
+        if coerced_value in [None, ""]:
+            continue
+        pset = ifc_psets.get_pset(pset_name, element)
+        if not pset:
+            pset = ifc_tools.api_run("pset.add_pset", ifcfile, product=element, name=pset_name)
+        ifc_tools.api_run(
+            "pset.edit_pset",
+            ifcfile,
+            pset=pset,
+            properties={prop_name: coerced_value},
+        )
+    try:
+        ifc_psets.show_psets(obj)
+    except Exception:
+        pass
+
+
+def apply_canonical_contract(obj, contract):
+    """Applies a canonical bSDD contract to a native IFC object."""
+
+    validation = contract.get("validation_filters", {})
+    applicable_ifc_types = validation.get("applicable_ifc_types") or []
+    active_ifc_type = _get_object_ifc_type(obj)
+    is_applicable = (not applicable_ifc_types) or (active_ifc_type in applicable_ifc_types)
+    if applicable_ifc_types and not is_applicable:
+        raise ValueError(
+            "Classification is not applicable to IFC type {}".format(
+                active_ifc_type or validation.get("active_ifc_type", "")
+            )
+        )
+    ifcfile = ifc_tools.get_ifcfile(obj)
+    element = ifc_tools.get_ifc_element(obj, ifcfile)
+    if not ifcfile or not element:
+        return False
+
+    classification = _upsert_classification_root(
+        ifcfile, contract.get("dictionary_metadata", {})
+    )
+    reference = _upsert_classification_reference(
+        ifcfile, classification, contract.get("class_metadata", {})
+    )
+    _ensure_reference_relation(ifcfile, reference, element)
+    _upsert_extended_properties(obj, contract, ifcfile, element)
+
+    legacy_string = _first_non_empty(
+        contract.get("legacy_string"),
+        "{} {}".format(
+            contract.get("dictionary_metadata", {}).get("name", ""),
+            contract.get("class_metadata", {}).get("reference_code", ""),
+        ).strip(),
+    )
+    if hasattr(obj, "StandardCode") and legacy_string:
+        obj.StandardCode = legacy_string
+    return True

--- a/src/Mod/BIM/nativeifc/ifc_classification.py
+++ b/src/Mod/BIM/nativeifc/ifc_classification.py
@@ -378,9 +378,7 @@ def apply_canonical_contract(obj, contract):
     if not ifcfile or not element:
         return False
 
-    classification = _upsert_classification_root(
-        ifcfile, contract.get("dictionary_metadata", {})
-    )
+    classification = _upsert_classification_root(ifcfile, contract.get("dictionary_metadata", {}))
     reference = _upsert_classification_reference(
         ifcfile, classification, contract.get("class_metadata", {})
     )

--- a/src/Mod/BIM/nativeifc/ifc_classification.py
+++ b/src/Mod/BIM/nativeifc/ifc_classification.py
@@ -22,8 +22,8 @@
 # *                                                                         *
 # ***************************************************************************
 
+import FreeCAD
 
-from . import ifc_psets  # lazy import
 from . import ifc_tools  # lazy import
 
 
@@ -207,8 +207,10 @@ def _ensure_project_classification_relation(ifcfile, classification):
     owner_history = None
     try:
         owner_history = ifc_tools.ifcopenshell.api.owner.create_owner_history(ifcfile)
-    except Exception:
-        pass
+    except Exception as err:
+        FreeCAD.Console.PrintLog(
+            "IFC classification: proceeding without project owner history: {}\n".format(err)
+        )
     ifcfile.create_entity(
         "IfcRelAssociatesClassification",
         GlobalId=ifc_tools.ifcopenshell.guid.new(),
@@ -322,8 +324,10 @@ def _ensure_reference_relation(ifcfile, reference, element):
     owner_history = None
     try:
         owner_history = ifc_tools.ifcopenshell.api.owner.create_owner_history(ifcfile)
-    except Exception:
-        pass
+    except Exception as err:
+        FreeCAD.Console.PrintLog(
+            "IFC classification: proceeding without reference owner history: {}\n".format(err)
+        )
     ifcfile.create_entity(
         "IfcRelAssociatesClassification",
         GlobalId=ifc_tools.ifcopenshell.guid.new(),
@@ -335,6 +339,8 @@ def _ensure_reference_relation(ifcfile, reference, element):
 
 
 def _upsert_extended_properties(obj, contract, ifcfile, element):
+    from . import ifc_psets  # lazy import
+
     for prop in contract.get("extended_properties", []):
         pset_name = prop.get("property_set", "")
         prop_name = prop.get("name", "")
@@ -356,8 +362,12 @@ def _upsert_extended_properties(obj, contract, ifcfile, element):
         )
     try:
         ifc_psets.show_psets(obj)
-    except Exception:
-        pass
+    except Exception as err:
+        FreeCAD.Console.PrintLog(
+            "IFC classification: failed to refresh psets UI for {}: {}\n".format(
+                getattr(obj, "Label", "<unnamed>"), err
+            )
+        )
 
 
 def apply_canonical_contract(obj, contract):


### PR DESCRIPTION
Fixes : #5607

  The main goal is to let users search bSDD concepts from the existing classification dialog, apply them to objects, and preserve the result both as legacy text classification and, when possible, as semantic IFC classification data for native IFC objects.

  - Changes

  1. adds a bSDD-backed provider to the existing BIM_Classification dialog
  2. adds dictionary selection and concept search against the bSDD service
  3. normalizes bSDD responses into an internal contract used by the UI and IFC mapping code
  4. applies semantic IFC classification references and applicable property sets for native IFC objects
  5. keeps legacy StandardCode / Classification behavior for backward compatibility
  6. falls back cleanly for non-native BIM objects that do not have an IFC element behind them
  7. adds tests for the bSDD client layer and contract-building logic
  8. wires the new runtime modules and tests into the BIM build/test manifests

  - implementation

  The implementation is split into separate layers on purpose:

   `BimBsdd.py` handles bSDD requests, caching, and concept/property payload merging
   `BimBsddContract.py` builds a stable internal representation from raw bSDD data
   `BimClassification.py` integrates the new provider into the existing BIM classification UI
   `ifc_classification.py` maps the selected contract into IFC classification relations and property sets

  This keeps the network logic, UI logic, and IFC mapping logic separate and easier to maintain.

  - Behavior

  - For native IFC objects, selected bSDD concepts can be written as IFC classification references and property sets.
  - For non-native objects, the workflow still works, but it falls back to the legacy text-based classification path.
  - Existing legacy classification workflows remain intact.


https://github.com/user-attachments/assets/ff03d02c-8bf3-4a13-82b8-5a7469b359f1

