### PR TITLE
TechDraw: restore locked view positions from X/Y changes

### DIFF
--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -259,8 +259,7 @@ void ViewProviderDrawingView::updateData(const App::Property* prop)
     if (prop == &obj->X ||
         prop == &obj->Y) {
 
-        if (qgiv->isSnapping() ||
-            obj->LockPosition.getValue()) {
+        if (qgiv->isSnapping()) {
             Gui::ViewProviderDocumentObject::updateData(prop);
             return;
         }


### PR DESCRIPTION
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

This fixes a restore-time placement regression for locked TechDraw views.

`ViewProviderDrawingView::updateData()` currently ignores `X` / `Y` updates when `LockPosition` is true. That prevents locked views from being dragged, but it also prevents the graphics item from being synchronized when saved nonzero `X` / `Y` properties are replayed while opening a document. The result is that the model values remain correct while the page item can stay at the initial scene origin.

This keeps the existing `qgiv->isSnapping()` guard, but allows locked views to receive model-to-view position synchronization. Locking is still enforced by the movable flag and by the app-side position-setting logic; it should not block restoring an already-saved position.

AI assistance was used during investigation and drafting. I reviewed, tested, and take responsibility for the final patch.

## Issues

Fixes #30723

## Before and After Images

No screenshots attached. The affected issue includes a sample document and before/after screenshots.

## Validation

- Built `TechDrawGui` locally:
  - `pixi run cmake --build build/debug --target TechDrawGui --config RelWithDebInfo --parallel 4`
- Built `FreeCADCmd.exe` locally:
  - `pixi run cmake --build build/debug --target FreeCADCmd.exe --config RelWithDebInfo --parallel 4`
- Checked the issue sample archive directly: the two locked views have saved nonzero positions:
  - `DraftView`: `X=149.91824`, `Y=193.639995`, `LockPosition=true`
  - `View`: `X=149.91824`, `Y=34.033448`, `LockPosition=true`

I could not complete a local GUI/runtime confirmation in this Windows command build: opening the full issue sample through `FreeCADCmd` and running `TestTechDrawGui` both stayed CPU-bound until I stopped them. The code path is GUI-side, so a normal GUI run or CI should still verify:

- opening the #30723 sample restores both locked views at their saved nonzero page positions, not `[0,0]`
- locked views still cannot be dragged
- unlocked drag still updates `X` / `Y`
- snapping remains guarded while `qgiv->isSnapping()` is true
