### PR TITLE
CAM: Expressions in Custom operation

### DIFF
--- a/src/Mod/CAM/Path/Op/Custom.py
+++ b/src/Mod/CAM/Path/Op/Custom.py
@@ -22,7 +22,7 @@
 # ***************************************************************************
 
 import FreeCAD
-import FreeCADGui
+import re
 import os
 import Path
 import Path.Op.Base as PathOp
@@ -140,9 +140,6 @@ class ObjectCustom(PathOp.ObjectOp):
         for n in self.propertyEnumerations():
             setattr(obj, n[0], n[1])
 
-    def onDocumentRestore(self, obj):
-        self.setEditorModes(self, obj)
-
     def setEditorModes(self, obj, features=None):
         if not hasattr(obj, "Source"):
             return
@@ -165,22 +162,37 @@ class ObjectCustom(PathOp.ObjectOp):
         if os.path.exists(prospective_path):
             return prospective_path
 
+    def parseExpressions(self, obj, line, index):
+        pattern = r"\{\{(.+?)\}\}"
+        while match := re.search(pattern, line):
+            expr = match.group(1)
+            try:
+                value = obj.evalExpression(expr)
+            except Exception:
+                Path.Log.warning(
+                    translate("PathCustom", "Can not parse expression from line %s: %s")
+                    % (index, line)
+                )
+                obj.Path = Path.Path()
+                raise Exception("Can not parse expression!")
+            line = re.sub(pattern, str(value), line, count=1)
+        return line
+
     def opExecute(self, obj):
         self.commandlist.append(Path.Command("(Begin Custom)"))
         errorNumLines = []
         errorLines = []
-        counter = 0
 
         if obj.Source == "Text" and obj.Gcode:
-            for l in obj.Gcode:
-                counter += 1
+            for i, line in enumerate(obj.Gcode):
+                line = self.parseExpressions(obj, line, i)
                 try:
-                    newcommand = Path.Command(str(l))
+                    newcommand = Path.Command(str(line))
                     self.commandlist.append(newcommand)
                 except ValueError:
-                    errorNumLines.append(counter)
+                    errorNumLines.append(i)
                     if len(errorLines) < 7:
-                        errorLines.append(f"{counter}: {str(l).strip()}")
+                        errorLines.append(f"{i}: {str(line).strip()}")
             if errorLines:
                 Path.Log.warning(
                     translate("PathCustom", "Total invalid lines in Custom Text G-code: %s")
@@ -197,18 +209,18 @@ class ObjectCustom(PathOp.ObjectOp):
                 )
             else:
                 with open(gcode_file) as fd:
-                    for l in fd.readlines():
-                        l = l.strip()
-                        counter += 1
+                    for i, line in enumerate(fd.readlines()):
+                        line = line.strip()
+                        line = self.parseExpressions(obj, line, i)
                         try:
-                            newcommand = Path.Command(str(l))
+                            newcommand = Path.Command(str(line))
                             self.commandlist.append(newcommand)
                         except ValueError:
-                            errorNumLines.append(counter)
+                            errorNumLines.append(i)
                             if len(errorLines) < 7:
-                                errorLines.append(f"{counter}: {str(l).strip()}")
+                                errorLines.append(f"{i}: {str(line).strip()}")
                 if errorLines:
-                    Path.Log.warning(f'"{gcode_file}"')
+                    Path.Log.warning(gcode_file)
                     Path.Log.warning(
                         translate("PathCustom", "Total invalid lines in Custom File G-code: %s")
                         % len(errorNumLines)

--- a/src/Mod/CAM/Path/Op/Gui/Custom.py
+++ b/src/Mod/CAM/Path/Op/Gui/Custom.py
@@ -54,6 +54,14 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
         # add editor with lines enumeration
         self.editor = CodeEditor()
+        toolTip = (
+            "Form to enter G-code"
+            "\n\nTo add an expression, surround string with characters '{{expression}}'"
+            "\nExample:"
+            "\nG0 Z{{VarSet.HeightZ.Value+5}}"
+            "\nG0 X{{Profile.Path.Commands[3].x}} Y{{Profile.Path.Commands[3].y}}"
+        )
+        self.editor.setToolTip(toolTip)
         form.txtGCodeBox.layout().removeWidget(form.txtGCode)
         form.txtGCode.deleteLater()
         form.txtGCodeBox.layout().addWidget(self.editor)


### PR DESCRIPTION
### Description

Calculate [expressions](https://wiki.freecad.org/Expressions) inside **Custom** raw-gcode

Expression should starts from `@` and ends by `@`
`@ expr @`

Line can contains several expressions

Example:
`G0 X@10+5@` will be translated to `G0 X15`

---
 
<img width="1065" height="334" alt="Screenshot_20260612_213740_hor" src="https://github.com/user-attachments/assets/af5caee8-8306-4a6b-b19e-ecdb1fbedaec" />