### PR TITLE
Gui: Avoid startup warnings from desktop portal and Qt font DB

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2296,6 +2296,12 @@ void setCategoryFilterRules()
     stream.flush();
     QLoggingCategory::setFilterRules(filter);
 }
+
+bool isSuppressedQtWarning(const QMessageLogContext& context, const QString& msg)
+{
+    return context.category && strcmp(context.category, "qt.text.font.db") == 0
+        && msg.startsWith(QStringLiteral("OpenType support missing for "));
+}
 }  // namespace
 
 using _qt_msg_handler_old = void (*)(QtMsgType, const QMessageLogContext&, const QString&);
@@ -2303,6 +2309,10 @@ _qt_msg_handler_old old_qtmsg_handler = nullptr;
 
 void messageHandler(QtMsgType type, const QMessageLogContext& context, const QString& msg)
 {
+    if (type == QtWarningMsg && isSuppressedQtWarning(context, msg)) {
+        return;
+    }
+
     QByteArray output;
     if (context.category && strcmp(context.category, "default") != 0) {
         output.append('(');

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -42,6 +42,7 @@
 #include <QApplication>
 #include <QLocale>
 #include <QMessageBox>
+#include <QStandardPaths>
 
 // FreeCAD header
 #include <App/Application.h>
@@ -103,6 +104,19 @@ static bool inGuiMode()
     return App::Application::Config()["RunMode"] == "Gui"
         || App::Application::Config()["RunMode"] == "Internal";
 }
+
+#if defined(FC_OS_LINUX) || defined(FC_OS_BSD)
+static bool desktopFileIsAvailable(const QString& desktopFileName)
+{
+    const QString desktopFile = desktopFileName + QStringLiteral(".desktop");
+    return !QStandardPaths::locate(QStandardPaths::ApplicationsLocation, desktopFile).isEmpty();
+}
+#else
+static bool desktopFileIsAvailable(const QString&)
+{
+    return true;
+}
+#endif
 
 static void displayInfo(const std::string& msg, bool preformatted = true)
 {
@@ -230,10 +244,14 @@ int main(int argc, char** argv)
 #else
         App::Application::init(argc, argv);
 #endif
-        // to set window icon on wayland, the desktop file has to be available to the compositor
-        QGuiApplication::setDesktopFileName(
-            QString::fromStdString(App::Application::Config()["DesktopFileName"])
+        // To set the window icon on Wayland, the desktop file has to be available to the
+        // compositor. Qt also uses the desktop file name to register with the portal registry.
+        const QString desktopFileName = QString::fromStdString(
+            App::Application::Config()["DesktopFileName"]
         );
+        if (desktopFileIsAvailable(desktopFileName)) {
+            QGuiApplication::setDesktopFileName(desktopFileName);
+        }
 
 #if defined(_MSC_VER)
         // create a dump file when the application crashes


### PR DESCRIPTION
- Guard desktop file registration so build-tree/source launches only advertise `org.freecad.FreeCAD` when the matching desktop file is available through XDG application paths.
- Filter Qt's known `qt.text.font.db` OpenType support warning by category and exact message prefix.

Prevents the following warnings on a default development build:

<img width="1023" height="687" alt="qt-warnings" src="https://github.com/user-attachments/assets/213c3719-4f80-4c40-9945-6d978ee9236d" />
