### PR TITLE
Part: Fix face colors after restore and topology changes

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -146,6 +146,7 @@
 #include "PropertyExpressionEngine.h"
 #include "PropertyFile.h"
 #include "PropertyLinks.h"
+#include "PropertyLinkSubValueMap.h"
 #include "PropertyPythonObject.h"
 #include "StringHasherPy.h"
 #include "StringIDPy.h"
@@ -2190,6 +2191,11 @@ void Application::initTypes()
     App::PropertyLinkSubListChild   ::init();
     App::PropertyLinkSubListGlobal  ::init();
     App::PropertyLinkSubListHidden  ::init();
+    App::PropertyLinkSubValueMapBase     ::init();
+    App::PropertyLinkSubColorMap         ::init();
+    App::PropertyLinkSubColorMapHidden   ::init();
+    App::PropertyLinkSubMaterialMap      ::init();
+    App::PropertyLinkSubMaterialMapHidden::init();
     App::PropertyXLink              ::init();
     App::PropertyXLinkSub           ::init();
     App::PropertyXLinkSubHidden     ::init();

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -261,7 +261,10 @@ SET(Properties_CPP_SRCS
     PropertyFile.cpp
     PropertyGeo.cpp
     PropertyLinks.cpp
+    PropertyLinkSubReferenceStore.cpp
+    PropertyLinkSubValueMap.cpp
     PropertyPythonObject.cpp
+    PropertySerialization.cpp
     PropertyStandard.cpp
     PropertyUnits.cpp
     PropertyExpressionEngine.cpp
@@ -274,7 +277,9 @@ SET(Properties_HPP_SRCS
     PropertyFile.h
     PropertyGeo.h
     PropertyLinks.h
+    PropertyLinkSubValueMap.h
     PropertyPythonObject.h
+    PropertySerialization.h
     PropertyStandard.h
     PropertyUnits.h
     PropertyExpressionEngine.h

--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -68,6 +68,11 @@ unsigned int PropertyContainer::getMemSize () const
     return size;
 }
 
+App::DocumentObject* PropertyContainer::getPropertyLinkOwner() const
+{
+    return nullptr;
+}
+
 App::Property* PropertyContainer::addDynamicProperty(
     std::string_view type,
     const char* name,
@@ -653,4 +658,3 @@ void PropertyData::visitProperties(OffsetBase offsetBase,
         visitor(reinterpret_cast<Property*>(spec.Offset + offset));
     };
 }
-

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -322,6 +322,17 @@ public:
   virtual std::string getFullName() const {return {};}
 
   /**
+   * @brief Return the document object that owns link-like properties in this container.
+   *
+   * Most property containers are not document objects and therefore cannot own
+   * links.  Containers that proxy document-object properties, such as view
+   * providers, can override this hook to return the associated document object.
+   *
+   * @return The owning document object, or `nullptr` when this container has no link owner.
+   */
+  virtual App::DocumentObject* getPropertyLinkOwner() const;
+
+  /**
    * @brief Find a property by its name.
    *
    * @param[in] name The name of the property to find.

--- a/src/App/PropertyLinkSubReferenceStore.cpp
+++ b/src/App/PropertyLinkSubReferenceStore.cpp
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 The FreeCAD Project Association AISBL
+// SPDX-FileNotice: Part of the FreeCAD project.
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "PropertyLinks.h"
+
+#include <Base/Exception.h>
+
+#include "DocumentObject.h"
+#include "ElementNamingUtils.h"
+
+using namespace App;
+
+std::size_t PropertyLinkSubReferenceStore::size() const
+{
+    return _references.size();
+}
+
+bool PropertyLinkSubReferenceStore::empty() const
+{
+    return _references.empty();
+}
+
+PropertyLinkSubReferenceStore::iterator PropertyLinkSubReferenceStore::begin()
+{
+    return _references.begin();
+}
+
+PropertyLinkSubReferenceStore::iterator PropertyLinkSubReferenceStore::end()
+{
+    return _references.end();
+}
+
+PropertyLinkSubReferenceStore::const_iterator PropertyLinkSubReferenceStore::begin() const
+{
+    return _references.begin();
+}
+
+PropertyLinkSubReferenceStore::const_iterator PropertyLinkSubReferenceStore::end() const
+{
+    return _references.end();
+}
+
+PropertyLinkSubReferenceStore::Reference&
+PropertyLinkSubReferenceStore::operator[](std::size_t index)
+{
+    return _references[index];
+}
+
+const PropertyLinkSubReferenceStore::Reference&
+PropertyLinkSubReferenceStore::operator[](std::size_t index) const
+{
+    return _references[index];
+}
+
+const std::vector<PropertyLinkSubReferenceStore::Reference>&
+PropertyLinkSubReferenceStore::references() const
+{
+    return _references;
+}
+
+void PropertyLinkSubReferenceStore::set(std::vector<Reference>&& references)
+{
+    _references = std::move(references);
+}
+
+void PropertyLinkSubReferenceStore::set(std::vector<App::DocumentObject*> objects,
+                                        std::vector<std::string> subNames,
+                                        std::vector<PropertyLinkBase::ShadowSub> shadows)
+{
+    if (objects.size() != subNames.size()) {
+        throw Base::ValueError("PropertyLinkSubReferenceStore: object and subelement counts differ");
+    }
+
+    if (shadows.size() != objects.size()) {
+        shadows.clear();
+        shadows.resize(objects.size());
+    }
+
+    _references.clear();
+    _references.reserve(objects.size());
+    for (std::size_t i = 0; i < objects.size(); ++i) {
+        _references.push_back({objects[i], std::move(subNames[i]), std::move(shadows[i])});
+    }
+}
+
+std::vector<App::DocumentObject*> PropertyLinkSubReferenceStore::objects() const
+{
+    std::vector<App::DocumentObject*> objects;
+    objects.reserve(_references.size());
+    for (const auto& reference : _references) {
+        objects.push_back(reference.object);
+    }
+    return objects;
+}
+
+std::vector<std::string> PropertyLinkSubReferenceStore::subNames() const
+{
+    std::vector<std::string> subNames;
+    subNames.reserve(_references.size());
+    for (const auto& reference : _references) {
+        subNames.push_back(reference.subName);
+    }
+    return subNames;
+}
+
+std::vector<std::string> PropertyLinkSubReferenceStore::subNames(bool newStyle) const
+{
+    std::vector<std::string> result;
+    result.reserve(_references.size());
+    std::string tmp;
+    for (const auto& reference : _references) {
+        result.push_back(getSubNameWithStyle(reference.subName, reference.shadow, newStyle, tmp));
+    }
+    return result;
+}
+
+std::vector<PropertyLinkBase::ShadowSub> PropertyLinkSubReferenceStore::shadows() const
+{
+    std::vector<PropertyLinkBase::ShadowSub> shadows;
+    shadows.reserve(_references.size());
+    for (const auto& reference : _references) {
+        shadows.push_back(reference.shadow);
+    }
+    return shadows;
+}
+
+std::vector<PropertyLinkSubReferenceStore::Reference>
+PropertyLinkSubReferenceStore::references(bool newStyle) const
+{
+    std::vector<Reference> result;
+    result.reserve(_references.size());
+    std::string tmp;
+    for (const auto& reference : _references) {
+        result.push_back({reference.object,
+                          getSubNameWithStyle(reference.subName, reference.shadow, newStyle, tmp),
+                          reference.shadow});
+    }
+    return result;
+}
+
+void PropertyLinkSubReferenceStore::clearShadows()
+{
+    for (auto& reference : _references) {
+        reference.shadow = {};
+    }
+}
+
+std::vector<std::size_t> PropertyLinkSubReferenceStore::attachedEntryIndices() const
+{
+    std::vector<std::size_t> indices;
+    indices.reserve(_references.size());
+    for (std::size_t i = 0; i < _references.size(); ++i) {
+        if (auto* obj = _references[i].object; obj && obj->isAttachedToDocument()) {
+            indices.push_back(i);
+        }
+    }
+    return indices;
+}
+
+unsigned int PropertyLinkSubReferenceStore::getMemSize() const
+{
+    unsigned int size =
+        static_cast<unsigned int>(_references.size() * sizeof(App::DocumentObject*));
+    for (const auto& reference : _references) {
+        size += static_cast<unsigned int>(reference.subName.size());
+    }
+    return size;
+}
+
+const std::string& PropertyLinkSubReferenceStore::getSubNameWithStyle(
+    const std::string& subName,
+    const PropertyLinkBase::ShadowSub& shadow,
+    bool newStyle,
+    std::string& tmp)
+{
+    if (!newStyle) {
+        if (!shadow.oldName.empty()) {
+            return shadow.oldName;
+        }
+    }
+    else if (!shadow.newName.empty()) {
+        if (Data::hasMissingElement(shadow.oldName.c_str())) {
+            auto pos = shadow.newName.rfind('.');
+            if (pos != std::string::npos) {
+                tmp = shadow.newName.substr(0, pos + 1);
+                tmp += shadow.oldName;
+                return tmp;
+            }
+        }
+        return shadow.newName;
+    }
+    return subName;
+}

--- a/src/App/PropertyLinkSubValueMap.cpp
+++ b/src/App/PropertyLinkSubValueMap.cpp
@@ -1,0 +1,1447 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 The FreeCAD Project Association AISBL
+// SPDX-FileNotice: Part of the FreeCAD project.
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "PropertyLinkSubValueMap.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <utility>
+
+#include <CXX/Objects.hxx>
+
+#include <Base/Console.h>
+#include <Base/Exception.h>
+#include <Base/Reader.h>
+#include <Base/Stream.h>
+#include <Base/Writer.h>
+
+#include "ComplexGeoData.h"
+#include "Document.h"
+#include "DocumentObject.h"
+#include "DocumentObjectPy.h"
+#include "DocumentObserver.h"
+#include "ElementNamingUtils.h"
+#include "GeoFeature.h"
+#include "IndexedName.h"
+#include "MaterialPy.h"
+#include "ObjectIdentifier.h"
+#include "PropertySerialization.h"
+#include "PropertyStandard.h"
+
+using namespace App;
+
+namespace
+{
+
+constexpr int MapFormatVersion = 1;
+constexpr const char* LinkElementName = "Link";
+constexpr const char* ShadowedAttribute = "shadowed";
+constexpr const char* ShadowAttribute = "shadow";
+constexpr const char* MappedAttribute = "mapped";
+constexpr const char* ValueFileAttribute = "file";
+constexpr const char* MapVersionAttribute = "version";
+constexpr const char* ValueVersionAttribute = "valueVersion";
+
+struct GeometryCacheElement
+{
+    std::string name;
+    std::size_t replacementOffset {};
+};
+
+const std::string& activeReferenceSubName(
+    const App::PropertyLinkSubReferenceStore::Reference& reference)
+{
+    if (!reference.shadow.newName.empty()) {
+        return reference.shadow.newName;
+    }
+    if (!reference.shadow.oldName.empty()) {
+        return reference.shadow.oldName;
+    }
+    return reference.subName;
+}
+
+// The Python facade accepts both full multi-object entries and the shorthand
+// `(object, {subname: value, ...})`. Keep that parsing local to avoid making
+// these property-specific assignment rules look like general App API.
+App::DocumentObject* getDocumentObject(PyObject* value, const char* errorMessage)
+{
+    if (!PyObject_TypeCheck(value, &(DocumentObjectPy::Type))) {
+        throw Base::TypeError(errorMessage);
+    }
+    return static_cast<DocumentObjectPy*>(value)->getDocumentObjectPtr();
+}
+
+std::string getSubName(PyObject* value)
+{
+    PropertyString stringProp;
+    stringProp.setPyObject(value);
+    return stringProp.getValue();
+}
+
+template<class TraitsT>
+void appendPyEntry(std::vector<App::DocumentObject*>& objects,
+                   std::vector<std::string>& subNames,
+                   std::vector<typename TraitsT::Value>& values,
+                   App::DocumentObject* object,
+                   PyObject* pySubName,
+                   PyObject* pyValue)
+{
+    objects.push_back(object);
+    subNames.push_back(getSubName(pySubName));
+    values.push_back(TraitsT::fromPyObject(pyValue));
+}
+
+template<class TraitsT>
+void appendPyObjectEntries(std::vector<App::DocumentObject*>& objects,
+                           std::vector<std::string>& subNames,
+                           std::vector<typename TraitsT::Value>& values,
+                           PyObject* pyEntries,
+                           const char* errorMessage)
+{
+    Py::Sequence entries(pyEntries);
+    for (Py::Sequence::size_type i = 0; i < entries.size(); ++i) {
+        Py::Object entry = entries[i];
+        if (!PyTuple_Check(entry.ptr()) && !PyList_Check(entry.ptr())) {
+            throw Base::TypeError(errorMessage);
+        }
+
+        Py::Sequence entrySequence(entry);
+        if (entrySequence.size() != 3) {
+            throw Base::ValueError("map entries must contain object, subname, and value");
+        }
+
+        auto* object = getDocumentObject(entrySequence[0].ptr(), errorMessage);
+        appendPyEntry<TraitsT>(
+            objects, subNames, values, object, entrySequence[1].ptr(), entrySequence[2].ptr());
+    }
+}
+
+template<class TraitsT>
+void appendPySingleObjectEntries(std::vector<App::DocumentObject*>& objects,
+                                 std::vector<std::string>& subNames,
+                                 std::vector<typename TraitsT::Value>& values,
+                                 App::DocumentObject* object,
+                                 PyObject* pyMapping,
+                                 const char* errorMessage)
+{
+    if (PyDict_Check(pyMapping)) {
+        PyObject* key {};
+        PyObject* item {};
+        Py_ssize_t pos {};
+        while (PyDict_Next(pyMapping, &pos, &key, &item)) {
+            appendPyEntry<TraitsT>(objects, subNames, values, object, key, item);
+        }
+        return;
+    }
+
+    if (!PyTuple_Check(pyMapping) && !PyList_Check(pyMapping)) {
+        throw Base::TypeError(errorMessage);
+    }
+
+    Py::Sequence entries(pyMapping);
+    for (Py::Sequence::size_type i = 0; i < entries.size(); ++i) {
+        Py::Object entry = entries[i];
+        if (!PyTuple_Check(entry.ptr()) && !PyList_Check(entry.ptr())) {
+            throw Base::TypeError(errorMessage);
+        }
+
+        Py::Sequence entrySequence(entry);
+        if (entrySequence.size() != 2) {
+            throw Base::ValueError("single-object map entries must contain subname and value");
+        }
+        appendPyEntry<TraitsT>(
+            objects, subNames, values, object, entrySequence[0].ptr(), entrySequence[1].ptr());
+    }
+}
+
+GeometryCacheElement indexedElementNameForGeometryCache(
+    const App::PropertyLinkSubReferenceStore::Reference& reference)
+{
+    const std::string& subName = activeReferenceSubName(reference);
+    const char* element = Data::findElementName(subName.c_str());
+    if (!element || !element[0] || Data::hasMissingElement(element)) {
+        return {};
+    }
+
+    const auto replacementOffset = static_cast<std::size_t>(element - subName.c_str());
+    if (!Data::isMappedElement(element)) {
+        return {element, replacementOffset};
+    }
+
+    const char* suffix = std::strrchr(element, '.');
+    if (!suffix || !suffix[1]) {
+        return {};
+    }
+    ++suffix;
+
+    const Data::IndexedName index(suffix);
+    if (!index) {
+        return {};
+    }
+
+    return {suffix, replacementOffset};
+}
+
+std::string indexedFallbackSubName(
+    const App::PropertyLinkSubReferenceStore::Reference& reference)
+{
+    const std::string& subName = activeReferenceSubName(reference);
+    const char* element = Data::findElementName(subName.c_str());
+    if (!element || !element[0] || Data::hasMissingElement(element)
+        || !Data::isMappedElement(element)) {
+        return {};
+    }
+
+    const char* suffix = std::strrchr(element, '.');
+    if (!suffix || !suffix[1]) {
+        return {};
+    }
+    ++suffix;
+
+    const Data::IndexedName index(suffix);
+    if (!index) {
+        return {};
+    }
+
+    std::string result(subName, 0, static_cast<std::size_t>(element - subName.c_str()));
+    result += suffix;
+    return result;
+}
+
+std::string subNameFromCachedElement(
+    const App::PropertyLinkSubReferenceStore::Reference& reference,
+    const GeometryCacheElement& cachedElement,
+    const std::string& replacementElement)
+{
+    const std::string& subName = activeReferenceSubName(reference);
+    if (cachedElement.replacementOffset > subName.size()) {
+        return {};
+    }
+
+    std::string result(subName, 0, cachedElement.replacementOffset);
+    result += replacementElement;
+    return result;
+}
+
+bool isMissingReference(const std::string& subName, const App::PropertyLinkBase::ShadowSub& shadow)
+{
+    return Data::hasMissingElement(subName.c_str())
+        || Data::hasMissingElement(shadow.oldName.c_str())
+        || Data::hasMissingElement(shadow.newName.c_str());
+}
+
+std::string findCachedSubName(App::DocumentObject* feature,
+                              const App::PropertyLinkSubReferenceStore::Reference& reference)
+{
+    // An indexed subelement can still exist after recompute while naming different geometry.
+    // Prefer the feature's pre-change geometry snapshot when this map references that feature
+    // directly; fall back to the generic topo-name updater when the cache has no match.
+    if (!feature || feature != reference.object) {
+        return {};
+    }
+
+    auto* geo = freecad_cast<App::GeoFeature*>(feature);
+    if (!geo) {
+        return {};
+    }
+
+    const GeometryCacheElement cachedElement = indexedElementNameForGeometryCache(reference);
+    if (cachedElement.name.empty()) {
+        return {};
+    }
+
+    auto names = geo->searchElementCache(cachedElement.name, Data::SearchOption::CheckGeometry);
+    if (names.empty()) {
+        names = geo->searchElementCache(cachedElement.name, Data::SearchOptions());
+    }
+    if (names.empty()) {
+        return {};
+    }
+
+    return subNameFromCachedElement(reference, cachedElement, names.front());
+}
+
+}  // namespace
+
+namespace App
+{
+
+struct PropertyLinkSubColorMapTraits
+{
+    using Value = Base::Color;
+
+    static const char* xmlName()
+    {
+        return "LinkSubColorMap";
+    }
+
+    static int valueFormatVersion()
+    {
+        return 1;
+    }
+
+    static Py::Tuple toPyObject(const Base::Color& value)
+    {
+        Py::Tuple rgba(4);
+        rgba[0] = Py::Float(value.r);
+        rgba[1] = Py::Float(value.g);
+        rgba[2] = Py::Float(value.b);
+        rgba[3] = Py::Float(value.a);
+        return rgba;
+    }
+
+    static Base::Color fromPyObject(PyObject* value)
+    {
+        PropertyColor color;
+        color.setPyObject(value);
+        return color.getValue();
+    }
+
+    static void saveValues(Base::OutputStream& stream,
+                           const std::vector<Base::Color>& values,
+                           const std::vector<std::size_t>& indices)
+    {
+        stream << static_cast<uint32_t>(indices.size());
+        for (auto index : indices) {
+            stream << values[index].getPackedValue();
+        }
+    }
+
+    static std::vector<Base::Color>
+    restoreValues(Base::InputStream& stream, int restoredValueFormat)
+    {
+        if (restoredValueFormat != valueFormatVersion()) {
+            throw Base::RuntimeError("Unsupported color map value format");
+        }
+
+        uint32_t count {};
+        stream >> count;
+
+        std::vector<Base::Color> values(count);
+        uint32_t packed {};
+        for (auto& value : values) {
+            stream >> packed;
+            value.setPackedValue(packed);
+        }
+        return values;
+    }
+
+    static unsigned int valueMemSize(const std::vector<Base::Color>& values)
+    {
+        return static_cast<unsigned int>(values.size() * sizeof(Base::Color));
+    }
+};
+
+struct PropertyLinkSubMaterialMapTraits
+{
+    using Value = App::Material;
+
+    static const char* xmlName()
+    {
+        return "LinkSubMaterialMap";
+    }
+
+    static int valueFormatVersion()
+    {
+        return 3;
+    }
+
+    static Py::Object toPyObject(const App::Material& value)
+    {
+        return Py::asObject(new MaterialPy(new Material(value)));
+    }
+
+    static App::Material fromPyObject(PyObject* value)
+    {
+        if (!PyObject_TypeCheck(value, &(MaterialPy::Type))) {
+            std::string error = "type must be 'Material', not ";
+            error += value->ob_type->tp_name;
+            throw Base::TypeError(error);
+        }
+        return *static_cast<MaterialPy*>(value)->getMaterialPtr();
+    }
+
+    static void saveValues(Base::OutputStream& stream,
+                           const std::vector<App::Material>& values,
+                           const std::vector<std::size_t>& indices)
+    {
+        stream << static_cast<uint32_t>(indices.size());
+        for (auto index : indices) {
+            const auto& material = values[index];
+            stream << material.ambientColor.getPackedValue();
+            stream << material.diffuseColor.getPackedValue();
+            stream << material.specularColor.getPackedValue();
+            stream << material.emissiveColor.getPackedValue();
+            stream << material.shininess;
+            stream << material.transparency;
+        }
+
+        for (auto index : indices) {
+            const auto& material = values[index];
+            PropertySerialization::writeBinaryString(stream, material.image);
+            PropertySerialization::writeBinaryString(stream, material.imagePath);
+            PropertySerialization::writeBinaryString(stream, material.uuid);
+        }
+    }
+
+    static std::vector<App::Material>
+    restoreValues(Base::InputStream& stream, int restoredValueFormat)
+    {
+        if (restoredValueFormat != valueFormatVersion()) {
+            throw Base::RuntimeError("Unsupported material map value format");
+        }
+
+        uint32_t count {};
+        stream >> count;
+
+        std::vector<App::Material> values(count);
+        uint32_t packed {};
+        float value {};
+        for (auto& material : values) {
+            stream >> packed;
+            material.ambientColor.setPackedValue(packed);
+            stream >> packed;
+            material.diffuseColor.setPackedValue(packed);
+            stream >> packed;
+            material.specularColor.setPackedValue(packed);
+            stream >> packed;
+            material.emissiveColor.setPackedValue(packed);
+            stream >> value;
+            material.shininess = value;
+            stream >> value;
+            material.transparency = value;
+        }
+
+        for (auto& material : values) {
+            PropertySerialization::readBinaryString(stream, material.image);
+            PropertySerialization::readBinaryString(stream, material.imagePath);
+            PropertySerialization::readBinaryString(stream, material.uuid);
+        }
+
+        return values;
+    }
+
+    static unsigned int valueMemSize(const std::vector<App::Material>& values)
+    {
+        return static_cast<unsigned int>(values.size() * sizeof(App::Material));
+    }
+};
+
+}  // namespace App
+
+TYPESYSTEM_SOURCE_ABSTRACT(App::PropertyLinkSubValueMapBase, App::PropertyLinkBase)
+TYPESYSTEM_SOURCE(App::PropertyLinkSubColorMap, App::PropertyLinkSubValueMapBase)
+TYPESYSTEM_SOURCE(App::PropertyLinkSubColorMapHidden, App::PropertyLinkSubColorMap)
+TYPESYSTEM_SOURCE(App::PropertyLinkSubMaterialMap, App::PropertyLinkSubValueMapBase)
+TYPESYSTEM_SOURCE(App::PropertyLinkSubMaterialMapHidden, App::PropertyLinkSubMaterialMap)
+
+PropertyLinkSubValueMapBase::PropertyLinkSubValueMapBase() = default;
+
+PropertyLinkSubValueMapBase::~PropertyLinkSubValueMapBase()
+{
+    // Dynamic properties can be deleted while their owner remains alive.  Keep
+    // the owning object's backlink set in sync in that case.
+    maintainBackLinks({});
+}
+
+void PropertyLinkSubValueMapBase::afterRestore()
+{
+    if (!testFlag(LinkRestoreLabel)) {
+        return;
+    }
+
+    setFlag(LinkRestoreLabel, false);
+    for (auto& reference : _references) {
+        restoreLabelReference(reference.object, reference.subName, &reference.shadow);
+    }
+}
+
+void PropertyLinkSubValueMapBase::onContainerRestored()
+{
+    unregisterElementReference();
+    for (auto& reference : _references) {
+        _registerElementReference(reference.object, reference.subName, reference.shadow);
+    }
+}
+
+int PropertyLinkSubValueMapBase::getSize() const
+{
+    return static_cast<int>(_references.size());
+}
+
+std::vector<App::DocumentObject*> PropertyLinkSubValueMapBase::getObjects() const
+{
+    return _references.objects();
+}
+
+std::vector<std::string> PropertyLinkSubValueMapBase::getSubValues() const
+{
+    return _references.subNames();
+}
+
+std::vector<std::string> PropertyLinkSubValueMapBase::getSubValues(bool newStyle) const
+{
+    return _references.subNames(newStyle);
+}
+
+std::vector<PropertyLinkBase::ShadowSub> PropertyLinkSubValueMapBase::getShadowSubs() const
+{
+    return _references.shadows();
+}
+
+std::vector<PropertyLinkSubValueMapBase::Reference>
+PropertyLinkSubValueMapBase::getReferences(bool newStyle) const
+{
+    return _references.references(newStyle);
+}
+
+App::DocumentObject* PropertyLinkSubValueMapBase::getLinkOwner() const
+{
+    auto* container = getContainer();
+    if (auto* owner = freecad_cast<App::DocumentObject*>(container)) {
+        return owner;
+    }
+    return container ? container->getPropertyLinkOwner() : nullptr;
+}
+
+App::Document* PropertyLinkSubValueMapBase::getOwnerDocument() const
+{
+    auto* owner = getLinkOwner();
+    return owner ? owner->getDocument() : nullptr;
+}
+
+void PropertyLinkSubValueMapBase::verifyObject(App::DocumentObject* obj,
+                                               App::DocumentObject* owner) const
+{
+    if (!obj) {
+        throw Base::ValueError("PropertyLinkSubValueMap does not accept null document objects");
+    }
+    if (!obj->isAttachedToDocument()) {
+        throw Base::ValueError("PropertyLinkSubValueMap: invalid document object");
+    }
+    if (!testFlag(LinkAllowExternal) && owner && owner->getDocument() != obj->getDocument()) {
+        throw Base::ValueError("PropertyLinkSubValueMap does not support external object");
+    }
+}
+
+void PropertyLinkSubValueMapBase::maintainBackLinks(
+    const std::vector<App::DocumentObject*>& objects)
+{
+    auto* owner = getLinkOwner();
+    if (!owner || owner->testStatus(ObjectStatus::Destroy) || _pcScope == LinkScope::Hidden) {
+        return;
+    }
+
+    for (auto& reference : _references) {
+        if (reference.object) {
+            reference.object->_removeBackLink(owner);
+        }
+    }
+
+    for (auto* obj : objects) {
+        if (obj) {
+            obj->_addBackLink(owner);
+        }
+    }
+}
+
+void PropertyLinkSubValueMapBase::setReferences(std::vector<App::DocumentObject*>&& objects,
+                                                std::vector<std::string>&& subNames,
+                                                std::vector<ShadowSub>&& shadowSubs)
+{
+    const bool hasShadowSubs = shadowSubs.size() == objects.size();
+    _references.set(std::move(objects), std::move(subNames), std::move(shadowSubs));
+
+    if (hasShadowSubs) {
+        onContainerRestored();
+    }
+    else {
+        updateElementReference(nullptr);
+    }
+
+    checkLabelReferences(getSubValues());
+}
+
+void PropertyLinkSubValueMapBase::saveReferences(Base::Writer& writer,
+                                                 const char* elementName) const
+{
+    auto* owner = getLinkOwner();
+    const bool exporting = owner && owner->isExporting();
+
+    for (auto index : getPersistedEntryIndices()) {
+        const auto& reference = _references[index];
+        auto* obj = reference.object;
+        const auto& shadow = reference.shadow;
+        const auto& sub = shadow.oldName.empty() ? reference.subName : shadow.oldName;
+
+        // Store the original reference plus optional topology-shadow state. A
+        // shadowed entry keeps the currently mapped subname, while mapped marks
+        // exported references that should adopt their remapped name after load.
+        writer.Stream() << writer.ind() << "<" << elementName << " obj=\""
+                        << obj->getExportName() << "\" sub=\"";
+        if (exporting) {
+            std::string exportName;
+            writer.Stream() << encodeAttribute(exportSubName(exportName, obj, sub.c_str()));
+            if (!shadow.oldName.empty() && reference.subName == shadow.newName) {
+                writer.Stream() << "\" " << MappedAttribute << "=\"1";
+            }
+        }
+        else {
+            writer.Stream() << encodeAttribute(sub);
+            if (!reference.subName.empty()) {
+                if (sub != reference.subName) {
+                    writer.Stream() << "\" " << ShadowedAttribute << "=\""
+                                    << encodeAttribute(reference.subName);
+                }
+                else if (!shadow.newName.empty()) {
+                    writer.Stream() << "\" " << ShadowAttribute << "=\""
+                                    << encodeAttribute(shadow.newName);
+                }
+            }
+        }
+        writer.Stream() << "\"/>\n";
+    }
+}
+
+void PropertyLinkSubValueMapBase::restoreReferences(
+    Base::XMLReader& reader,
+    const char* elementName,
+    int count,
+    std::vector<std::size_t>& restoredValueIndices)
+{
+    std::vector<Reference> references;
+    std::vector<App::DocumentObject*> backlinkObjects;
+    std::vector<int> mapped;
+    // XML stores references, while typed values live in the side file. If a
+    // referenced object is missing during restore, skip that reference and keep
+    // the original XML position so RestoreDocFile() can replay only surviving
+    // value payloads.
+    references.reserve(count);
+    backlinkObjects.reserve(count);
+    restoredValueIndices.clear();
+    restoredValueIndices.reserve(count);
+
+    auto* document = getOwnerDocument();
+    bool restoreLabel = false;
+
+    for (int i = 0; i < count; ++i) {
+        reader.readElement(LinkElementName);
+        std::string name = reader.getName(reader.getAttribute<const char*>("obj"));
+        auto* child = document ? document->getObject(name.c_str()) : nullptr;
+        if (child) {
+            Reference reference;
+            reference.object = child;
+            reference.shadow.oldName =
+                importSubName(reader, reader.getAttribute<const char*>("sub"), restoreLabel);
+            if (reader.hasAttribute(ShadowedAttribute)) {
+                reference.shadow.newName =
+                    importSubName(reader, reader.getAttribute<const char*>(ShadowedAttribute), restoreLabel);
+                reference.subName = reference.shadow.newName;
+            }
+            else {
+                reference.subName = reference.shadow.oldName;
+                if (reader.hasAttribute(ShadowAttribute)) {
+                    reference.shadow.newName =
+                        importSubName(reader, reader.getAttribute<const char*>(ShadowAttribute), restoreLabel);
+                }
+            }
+            if (reader.hasAttribute(MappedAttribute)) {
+                mapped.push_back(static_cast<int>(references.size()));
+            }
+            restoredValueIndices.push_back(static_cast<std::size_t>(i));
+            backlinkObjects.push_back(child);
+            references.push_back(std::move(reference));
+        }
+        else if (reader.isVerbose()) {
+            Base::Console().warning("Lost link to '%s' while loading, maybe "
+                                    "an object was not loaded correctly\n",
+                                    name.c_str());
+        }
+    }
+
+    reader.readEndElement(elementName);
+
+    setFlag(LinkRestoreLabel, restoreLabel);
+    maintainBackLinks(backlinkObjects);
+    _references.set(std::move(references));
+    onContainerRestored();
+    checkLabelReferences(getSubValues());
+    _mapped = std::move(mapped);
+}
+
+std::vector<std::size_t> PropertyLinkSubValueMapBase::getPersistedEntryIndices() const
+{
+    return _references.attachedEntryIndices();
+}
+
+void PropertyLinkSubValueMapBase::updateElementReference(DocumentObject* feature,
+                                                         bool reverse,
+                                                         bool notify)
+{
+    if (!feature) {
+        _references.clearShadows();
+        unregisterElementReference();
+    }
+
+    auto* owner = getLinkOwner();
+    if (owner && owner->isRestoring()) {
+        return;
+    }
+
+    bool touched = false;
+    for (auto& reference : _references) {
+        auto storeRecoveredSubName = [&](const std::string& subName) {
+            if (subName == reference.subName && reference.shadow.oldName.empty()
+                && reference.shadow.newName.empty()) {
+                return false;
+            }
+            if (notify && !touched) {
+                aboutToSetValue();
+            }
+            reference.subName = subName;
+            reference.shadow = {};
+            touched = true;
+            return true;
+        };
+
+        if (!reverse) {
+            const std::string cachedSubName = findCachedSubName(feature, reference);
+            if (!cachedSubName.empty()) {
+                auto subName = cachedSubName;
+                ShadowSub shadow;
+                if (_updateElementReference(feature,
+                                            reference.object,
+                                            subName,
+                                            shadow,
+                                            reverse,
+                                            notify && !touched)) {
+                    reference.subName = std::move(subName);
+                    reference.shadow = std::move(shadow);
+                    touched = true;
+                    continue;
+                }
+                if (storeRecoveredSubName(cachedSubName)) {
+                    continue;
+                }
+            }
+        }
+
+        // Stale generated names from older stored maps can become missing even
+        // though they still carry a usable indexed `.FaceN` tail. Let normal
+        // TNP remapping try first; only fall back to that indexed tail after
+        // the reference is explicitly reported as missing.
+        const std::string fallbackSubName = reverse ? std::string() : indexedFallbackSubName(reference);
+        if (_updateElementReference(feature,
+                                    reference.object,
+                                    reference.subName,
+                                    reference.shadow,
+                                    reverse,
+                                    notify && !touched,
+                                    fallbackSubName.empty())) {
+            if (!fallbackSubName.empty()
+                && isMissingReference(reference.subName, reference.shadow)
+                && storeRecoveredSubName(fallbackSubName)) {
+                continue;
+            }
+            touched = true;
+        }
+    }
+
+    if (!touched) {
+        return;
+    }
+
+    std::vector<int> mapped;
+    mapped.reserve(_mapped.size());
+    for (int index : _mapped) {
+        if (index < static_cast<int>(_references.size())) {
+            // `_mapped` entries have received topology-shadow updates but have
+            // not yet been materialized into the stored subname. Once the new
+            // name is known, make it the visible reference and drop the entry
+            // from the pending mapped list.
+            if (!_references[index].shadow.newName.empty()) {
+                _references[index].subName = _references[index].shadow.newName;
+            }
+            else {
+                mapped.push_back(index);
+            }
+        }
+    }
+    _mapped.swap(mapped);
+
+    if (owner && feature) {
+        owner->onUpdateElementReference(this);
+    }
+    if (notify) {
+        hasSetValue();
+    }
+}
+
+bool PropertyLinkSubValueMapBase::referenceChanged() const
+{
+    return !_mapped.empty();
+}
+
+void PropertyLinkSubValueMapBase::getLinks(std::vector<App::DocumentObject*>& objs,
+                                           bool all,
+                                           std::vector<std::string>* subs,
+                                           bool newStyle) const
+{
+    if (!all && _pcScope == LinkScope::Hidden) {
+        return;
+    }
+
+    objs.reserve(objs.size() + _references.size());
+    for (const auto& reference : _references) {
+        if (reference.object && reference.object->isAttachedToDocument()) {
+            objs.push_back(reference.object);
+        }
+    }
+
+    if (subs) {
+        auto subNames = getSubValues(newStyle);
+        subs->reserve(subs->size() + subNames.size());
+        std::move(subNames.begin(), subNames.end(), std::back_inserter(*subs));
+    }
+}
+
+void PropertyLinkSubValueMapBase::getLinksTo(std::vector<App::ObjectIdentifier>& identifiers,
+                                             App::DocumentObject* obj,
+                                             const char* subname,
+                                             bool all) const
+{
+    if (!obj || (!all && _pcScope == LinkScope::Hidden)) {
+        return;
+    }
+
+    App::SubObjectT objT(obj, subname);
+    auto subObject = objT.getSubObject();
+    auto subElement = objT.getOldElementName();
+
+    for (std::size_t i = 0; i < _references.size(); ++i) {
+        const auto& reference = _references[i];
+        if (reference.object != obj) {
+            continue;
+        }
+
+        if (!subname || reference.subName == subname) {
+            identifiers.emplace_back(*this, static_cast<int>(i));
+            continue;
+        }
+
+        if (!subObject) {
+            continue;
+        }
+
+        App::SubObjectT stored(obj, reference.subName.c_str());
+        if (stored.getSubObject() == subObject && stored.getOldElementName() == subElement) {
+            identifiers.emplace_back(*this);
+            continue;
+        }
+
+        const auto& shadow = reference.shadow;
+        App::SubObjectT shadowed(
+            obj,
+            shadow.newName.empty() ? shadow.oldName.c_str() : shadow.newName.c_str()
+        );
+        if (shadowed.getSubObject() == subObject && shadowed.getOldElementName() == subElement) {
+            identifiers.emplace_back(*this);
+        }
+    }
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::PropertyLinkSubValueMapT()
+    : _valueFormatVersion(TraitsT::valueFormatVersion())
+{
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::~PropertyLinkSubValueMapT() = default;
+
+template<class ValueT, class TraitsT, class DerivedT>
+void PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::clear()
+{
+    setEntries({}, {}, {}, {}, false);
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+void PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::setValue()
+{
+    clear();
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+void PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::setValue(App::DocumentObject* object,
+                                                                   const char* subName,
+                                                                   const Value& value)
+{
+    std::vector<App::DocumentObject*> objects = getObjects();
+    std::vector<std::string> subNames = getSubValues();
+    std::vector<Value> values = _values;
+    std::vector<ShadowSub> shadowSubs = getShadowSubs();
+
+    const std::string sub = subName ? subName : "";
+    for (std::size_t i = 0; i < objects.size(); ++i) {
+        if (objects[i] == object && subNames[i] == sub) {
+            objects.erase(objects.begin() + static_cast<std::ptrdiff_t>(i));
+            subNames.erase(subNames.begin() + static_cast<std::ptrdiff_t>(i));
+            values.erase(values.begin() + static_cast<std::ptrdiff_t>(i));
+            shadowSubs.erase(shadowSubs.begin() + static_cast<std::ptrdiff_t>(i));
+            break;
+        }
+    }
+
+    objects.push_back(object);
+    subNames.push_back(sub);
+    values.push_back(value);
+    shadowSubs.emplace_back();
+    setEntries(std::move(objects), std::move(subNames), std::move(values), std::move(shadowSubs), false);
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+void PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::setValues(
+    std::vector<App::DocumentObject*> objects,
+    std::vector<std::string> subNames,
+    std::vector<Value> values,
+    std::vector<ShadowSub>&& shadowSubs)
+{
+    setEntries(std::move(objects), std::move(subNames), std::move(values), std::move(shadowSubs), true);
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+bool PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::getValue(App::DocumentObject* object,
+                                                                  const char* subName,
+                                                                  Value& value,
+                                                                  bool newStyle) const
+{
+    const std::string sub = subName ? subName : "";
+    auto subNames = getSubValues(newStyle);
+    for (std::size_t i = 0; i < _references.size(); ++i) {
+        if (_references[i].object == object && subNames[i] == sub) {
+            value = _values[i];
+            return true;
+        }
+    }
+    return false;
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+std::vector<typename PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::Entry>
+PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::getEntries(bool newStyle) const
+{
+    std::vector<Entry> entries;
+    entries.reserve(_references.size());
+
+    auto subNames = getSubValues(newStyle);
+    for (std::size_t i = 0; i < _references.size(); ++i) {
+        entries.push_back({_references[i].object, std::move(subNames[i]), _values[i]});
+    }
+
+    return entries;
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+std::map<std::string, ValueT>
+PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::getValuesForObject(App::DocumentObject* object,
+                                                                        bool newStyle) const
+{
+    std::map<std::string, Value> values;
+    auto subNames = getSubValues(newStyle);
+    for (std::size_t i = 0; i < _references.size(); ++i) {
+        if (_references[i].object == object) {
+            values[subNames[i]] = _values[i];
+        }
+    }
+    return values;
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+PyObject* PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::getPyObject()
+{
+    Py::List list(_references.size());
+    auto subNames = getSubValues(true);
+
+    for (std::size_t i = 0; i < _references.size(); ++i) {
+        Py::Tuple item(3);
+        auto* object = _references[i].object;
+        item[0] = object ? Py::asObject(object->getPyObject()) : Py::None();
+        item[1] = Py::String(subNames[i]);
+        item[2] = TraitsT::toPyObject(_values[i]);
+        list.setItem(static_cast<int>(i), item);
+    }
+
+    return Py::new_reference_to(list);
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+void PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::setPyObject(PyObject* value)
+{
+    static const char* errorMessage =
+        "expected None, [(object, subname, value), ...], "
+        "or (object, {subname: value, ...})";
+
+    if (value == Py_None) {
+        clear();
+        return;
+    }
+    if (!PyTuple_Check(value) && !PyList_Check(value)) {
+        throw Base::TypeError(errorMessage);
+    }
+
+    std::vector<App::DocumentObject*> objects;
+    std::vector<std::string> subNames;
+    std::vector<Value> values;
+
+    Py::Sequence sequence(value);
+    if (sequence.size() == 0) {
+        clear();
+        return;
+    }
+
+    if (sequence.size() == 2 && PyObject_TypeCheck(sequence[0].ptr(), &(DocumentObjectPy::Type))) {
+        auto* object = static_cast<DocumentObjectPy*>(sequence[0].ptr())->getDocumentObjectPtr();
+        Py::Object mapping = sequence[1];
+        appendPySingleObjectEntries<TraitsT>(objects, subNames, values, object, mapping.ptr(), errorMessage);
+        setValues(std::move(objects), std::move(subNames), std::move(values));
+        return;
+    }
+
+    appendPyObjectEntries<TraitsT>(objects, subNames, values, value, errorMessage);
+    setValues(std::move(objects), std::move(subNames), std::move(values));
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+void PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::Save(Base::Writer& writer) const
+{
+    if (writer.isForceXML()) {
+        // Values are stored in a side file, like PropertyColorList and
+        // PropertyMaterialList. In force-XML mode there is no value payload to
+        // pair with these references, so omit the property entirely.
+        return;
+    }
+
+    const auto indices = getPersistedEntryIndices();
+    writer.Stream() << writer.ind() << "<" << TraitsT::xmlName() << " count=\""
+                    << indices.size() << "\" " << ValueFileAttribute << "=\""
+                    << (indices.empty() ? "" : writer.addFile(getName(), this))
+                    << "\" " << MapVersionAttribute << "=\"" << MapFormatVersion << "\" "
+                    << ValueVersionAttribute << "=\"" << TraitsT::valueFormatVersion() << "\">"
+                    << "\n";
+    writer.incInd();
+    saveReferences(writer, LinkElementName);
+    writer.decInd();
+    writer.Stream() << writer.ind() << "</" << TraitsT::xmlName() << ">\n";
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+void PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::Restore(Base::XMLReader& reader)
+{
+    reader.readElement(TraitsT::xmlName());
+    const int count = reader.getAttribute<long>("count");
+    const int mapFormatVersion = reader.hasAttribute(MapVersionAttribute)
+        ? static_cast<int>(reader.getAttribute<long>(MapVersionAttribute))
+        : MapFormatVersion;
+    if (mapFormatVersion > MapFormatVersion) {
+        throw Base::RuntimeError("Unsupported link sub value map format");
+    }
+
+    _valueFormatVersion = reader.hasAttribute(ValueVersionAttribute)
+        ? static_cast<int>(reader.getAttribute<long>(ValueVersionAttribute))
+        : TraitsT::valueFormatVersion();
+
+    std::string file;
+    if (reader.hasAttribute(ValueFileAttribute)) {
+        file = reader.getAttribute<const char*>(ValueFileAttribute);
+    }
+
+    restoreReferences(reader, TraitsT::xmlName(), count, _restoreValueIndices);
+    _values.assign(_references.size(), Value {});
+
+    if (!file.empty()) {
+        reader.addFile(file.c_str(), this);
+    }
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+void PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::SaveDocFile(Base::Writer& writer) const
+{
+    Base::OutputStream stream(writer.Stream());
+    TraitsT::saveValues(stream, _values, getPersistedEntryIndices());
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+void PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::RestoreDocFile(Base::Reader& reader)
+{
+    Base::InputStream stream(reader);
+    auto restoredValues = TraitsT::restoreValues(stream, _valueFormatVersion);
+
+    std::vector<Value> values;
+    values.reserve(_restoreValueIndices.size());
+    // References whose target object was lost during XML restore are skipped,
+    // so replay only the side-file values that still have a surviving entry.
+    for (auto index : _restoreValueIndices) {
+        if (index < restoredValues.size()) {
+            values.push_back(restoredValues[index]);
+        }
+    }
+
+    if (values.size() != _references.size()) {
+        values.resize(_references.size());
+    }
+
+    aboutToSetValue();
+    _values = std::move(values);
+    hasSetValue();
+    _restoreValueIndices.clear();
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+Property* PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::Copy() const
+{
+    auto* copy = new DerivedT();
+    copy->_references = _references;
+    copy->_mapped = _mapped;
+    copy->_values = _values;
+    return copy;
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+void PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::Paste(const Property& from)
+{
+    if (!from.isDerivedFrom<DerivedT>()) {
+        throw Base::TypeError("Incompatible property to paste to");
+    }
+
+    const auto& map = static_cast<const PropertyLinkSubValueMapT&>(from);
+    setEntries(map.getObjects(),
+               map.getSubValues(),
+               std::vector<Value>(map._values),
+               map.getShadowSubs(),
+               false);
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+Property* PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::CopyOnImportExternal(
+    const std::map<std::string, std::string>& nameMap) const
+{
+    auto* owner = getLinkOwner();
+    if (!owner || !owner->getDocument()) {
+        return nullptr;
+    }
+
+    bool changed = false;
+    std::vector<App::DocumentObject*> objects;
+    std::vector<std::string> subNames;
+    std::vector<Value> values;
+    objects.reserve(_references.size());
+    subNames.reserve(_references.size());
+    values.reserve(_values.size());
+
+    for (std::size_t i = 0; i < _references.size(); ++i) {
+        const auto& reference = _references[i];
+        auto* object = tryImport(owner->getDocument(), reference.object, nameMap);
+        auto subName =
+            tryImportSubName(reference.object, reference.subName.c_str(), owner->getDocument(), nameMap);
+        if (!subName.empty()) {
+            changed = true;
+        }
+        else {
+            subName = reference.subName;
+        }
+        changed = changed || object != reference.object;
+        objects.push_back(object);
+        subNames.push_back(std::move(subName));
+        values.push_back(_values[i]);
+    }
+
+    if (!changed) {
+        return nullptr;
+    }
+
+    auto* copy = new DerivedT();
+    copy->setEntries(std::move(objects), std::move(subNames), std::move(values), {}, true);
+    return copy;
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+Property* PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::CopyOnLabelChange(
+    App::DocumentObject* obj,
+    const std::string& ref,
+    const char* newLabel) const
+{
+    auto* owner = getLinkOwner();
+    if (!owner || !owner->getDocument()) {
+        return nullptr;
+    }
+
+    bool changed = false;
+    std::vector<std::string> subNames;
+    subNames.reserve(_references.size());
+    for (const auto& reference : _references) {
+        auto subName =
+            updateLabelReference(reference.object, reference.subName.c_str(), obj, ref, newLabel);
+        if (!subName.empty()) {
+            changed = true;
+            subNames.push_back(std::move(subName));
+        }
+        else {
+            subNames.push_back(reference.subName);
+        }
+    }
+
+    if (!changed) {
+        return nullptr;
+    }
+
+    auto* copy = new DerivedT();
+    copy->setEntries(getObjects(),
+                     std::move(subNames),
+                     std::vector<Value>(_values),
+                     {},
+                     true);
+    return copy;
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+Property* PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::CopyOnLinkReplace(
+    const App::DocumentObject* parent,
+    App::DocumentObject* oldObj,
+    App::DocumentObject* newObj) const
+{
+    bool changed = false;
+    std::vector<App::DocumentObject*> objects;
+    std::vector<std::string> subNames;
+    std::vector<Value> values;
+    objects.reserve(_references.size());
+    subNames.reserve(_references.size());
+    values.reserve(_values.size());
+
+    for (std::size_t i = 0; i < _references.size(); ++i) {
+        auto* object = _references[i].object;
+        auto subName = _references[i].subName;
+        auto replacement =
+            tryReplaceLink(getContainer(), object, parent, oldObj, newObj, subName.c_str());
+        if (replacement.first) {
+            object = replacement.first;
+            subName = std::move(replacement.second);
+            changed = true;
+        }
+        objects.push_back(object);
+        subNames.push_back(std::move(subName));
+        values.push_back(_values[i]);
+    }
+
+    if (!changed) {
+        return nullptr;
+    }
+
+    auto* copy = new DerivedT();
+    copy->setEntries(std::move(objects), std::move(subNames), std::move(values), {}, true);
+    return copy;
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+void PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::breakLink(App::DocumentObject* obj,
+                                                                    bool clearLinks)
+{
+    if (clearLinks && getLinkOwner() == obj) {
+        this->clear();
+        return;
+    }
+
+    std::vector<App::DocumentObject*> objects;
+    std::vector<std::string> subNames;
+    std::vector<Value> values;
+    objects.reserve(_references.size());
+    subNames.reserve(_references.size());
+    values.reserve(_values.size());
+
+    for (std::size_t i = 0; i < _references.size(); ++i) {
+        if (_references[i].object == obj) {
+            continue;
+        }
+        objects.push_back(_references[i].object);
+        subNames.push_back(_references[i].subName);
+        values.push_back(_values[i]);
+    }
+
+    if (objects.size() != _references.size()) {
+        setEntries(std::move(objects), std::move(subNames), std::move(values), {}, false);
+    }
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+bool PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::adjustLink(
+    const std::set<App::DocumentObject*>& inList)
+{
+    if (_pcScope == LinkScope::Hidden) {
+        return false;
+    }
+
+    auto objects = getObjects();
+    auto subNames = getSubValues();
+    bool touched = false;
+
+    for (std::size_t i = 0; i < subNames.size(); ++i) {
+        auto*& object = objects[i];
+        auto& subName = subNames[i];
+        if (!object || !object->isAttachedToDocument() || !inList.contains(object)) {
+            continue;
+        }
+
+        touched = true;
+        auto pos = subName.find('.');
+        for (; pos != std::string::npos; pos = subName.find('.', pos + 1)) {
+            auto* subObject = object->getSubObject(subName.substr(0, pos + 1).c_str());
+            if (!subObject || subObject->getDocument() != object->getDocument()) {
+                pos = std::string::npos;
+                break;
+            }
+            if (!inList.contains(subObject)) {
+                object = subObject;
+                subName = subName.substr(pos + 1);
+                break;
+            }
+        }
+        if (pos == std::string::npos) {
+            return false;
+        }
+    }
+
+    if (touched) {
+        setEntries(std::move(objects), std::move(subNames), std::vector<Value>(_values), {}, true);
+    }
+    return touched;
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+unsigned int PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::getMemSize() const
+{
+    unsigned int size = _references.getMemSize();
+    size += TraitsT::valueMemSize(_values);
+    return size;
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+bool PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::isSame(const Property& other) const
+{
+    if (&other == this) {
+        return true;
+    }
+    if (getTypeId() != other.getTypeId()) {
+        return false;
+    }
+
+    const auto& map = static_cast<const PropertyLinkSubValueMapT&>(other);
+    if (getScope() != map.getScope() || _references.size() != map._references.size()
+        || _values != map._values) {
+        return false;
+    }
+
+    for (std::size_t i = 0; i < _references.size(); ++i) {
+        if (_references[i].object != map._references[i].object
+            || _references[i].subName != map._references[i].subName) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+template<class ValueT, class TraitsT, class DerivedT>
+void PropertyLinkSubValueMapT<ValueT, TraitsT, DerivedT>::setEntries(
+    std::vector<App::DocumentObject*> objects,
+    std::vector<std::string> subNames,
+    std::vector<Value> values,
+    std::vector<ShadowSub>&& shadowSubs,
+    bool canonicalize)
+{
+    if (objects.size() != subNames.size() || objects.size() != values.size()) {
+        throw Base::ValueError("PropertyLinkSubValueMap: object, subelement, and value counts differ");
+    }
+
+    auto* owner = getLinkOwner();
+    for (auto* object : objects) {
+        verifyObject(object, owner);
+    }
+
+    if (shadowSubs.size() != objects.size()) {
+        shadowSubs.clear();
+        shadowSubs.resize(objects.size());
+    }
+
+    if (canonicalize) {
+        // Duplicate keys follow Python dict-style last-write-wins semantics,
+        // while preserving the relative order of surviving entries.
+        std::map<std::pair<App::DocumentObject*, std::string>, std::size_t> lastIndexByKey;
+        for (std::size_t i = 0; i < objects.size(); ++i) {
+            lastIndexByKey[{objects[i], subNames[i]}] = i;
+        }
+
+        std::vector<App::DocumentObject*> canonicalObjects;
+        std::vector<std::string> canonicalSubNames;
+        std::vector<Value> canonicalValues;
+        std::vector<ShadowSub> canonicalShadowSubs;
+        canonicalObjects.reserve(lastIndexByKey.size());
+        canonicalSubNames.reserve(lastIndexByKey.size());
+        canonicalValues.reserve(lastIndexByKey.size());
+        canonicalShadowSubs.reserve(lastIndexByKey.size());
+
+        for (std::size_t i = 0; i < objects.size(); ++i) {
+            const auto key = std::make_pair(objects[i], subNames[i]);
+            const auto last = lastIndexByKey.find(key);
+            if (last == lastIndexByKey.end() || last->second != i) {
+                continue;
+            }
+
+            canonicalObjects.push_back(objects[i]);
+            canonicalSubNames.push_back(std::move(subNames[i]));
+            canonicalValues.push_back(std::move(values[i]));
+            canonicalShadowSubs.push_back(std::move(shadowSubs[i]));
+        }
+
+        objects = std::move(canonicalObjects);
+        subNames = std::move(canonicalSubNames);
+        values = std::move(canonicalValues);
+        shadowSubs = std::move(canonicalShadowSubs);
+    }
+
+    maintainBackLinks(objects);
+
+    aboutToSetValue();
+    _values = std::move(values);
+    setReferences(std::move(objects), std::move(subNames), std::move(shadowSubs));
+    hasSetValue();
+}
+
+namespace App
+{
+
+template class PropertyLinkSubValueMapT<Base::Color,
+                                        PropertyLinkSubColorMapTraits,
+                                        PropertyLinkSubColorMap>;
+template class PropertyLinkSubValueMapT<App::Material,
+                                        PropertyLinkSubMaterialMapTraits,
+                                        PropertyLinkSubMaterialMap>;
+
+}  // namespace App

--- a/src/App/PropertyLinkSubValueMap.h
+++ b/src/App/PropertyLinkSubValueMap.h
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 The FreeCAD Project Association AISBL
+// SPDX-FileNotice: Part of the FreeCAD project.
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <Base/Color.h>
+
+#include "Material.h"
+#include "PropertyLinks.h"
+
+namespace App
+{
+
+class PropertyLinkSubColorMap;
+class PropertyLinkSubMaterialMap;
+struct PropertyLinkSubColorMapTraits;
+struct PropertyLinkSubMaterialMapTraits;
+
+/**
+ * @brief Base class for topology-aware subelement value maps.
+ *
+ * The class stores the document-object/subelement-reference side of the map and
+ * implements the `PropertyLinkBase` integration shared by all value types:
+ * dependency scope, label reference registration, topology element remapping,
+ * link replacement, and backlink maintenance. Concrete subclasses add typed
+ * value storage and persistence.
+ *
+ * References are intentionally multi-object capable. A map may contain
+ * `(object, subelement)` entries for one object, for several objects, or for a
+ * higher-level linked subname path.
+ */
+class AppExport PropertyLinkSubValueMapBase: public PropertyLinkBase
+{
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();
+
+public:
+    /**
+     * @brief Stored reference for one map entry.
+     */
+    using Reference = PropertyLinkSubReferenceStore::Reference;
+
+    PropertyLinkSubValueMapBase();
+    ~PropertyLinkSubValueMapBase() override;
+
+    void afterRestore() override;
+    void onContainerRestored() override;
+
+    /**
+     * @brief Return the number of map entries.
+     */
+    int getSize() const;
+
+    /**
+     * @brief Return the linked document objects in entry order.
+     */
+    std::vector<App::DocumentObject*> getObjects() const;
+
+    /**
+     * @brief Return the stored subelement names in entry order.
+     */
+    std::vector<std::string> getSubValues() const;
+
+    /**
+     * @brief Return subelement names using old or new style topology names.
+     *
+     * @param newStyle If true, prefer mapped/new style names. If false, prefer
+     * old style names.
+     */
+    std::vector<std::string> getSubValues(bool newStyle) const;
+
+    /**
+     * @brief Return the topology shadow references in entry order.
+     */
+    std::vector<ShadowSub> getShadowSubs() const;
+
+    /**
+     * @brief Return all references in entry order.
+     *
+     * @param newStyle If true, each returned subelement name prefers the mapped
+     * topology name.
+     */
+    std::vector<Reference> getReferences(bool newStyle = true) const;
+
+    void updateElementReference(DocumentObject* feature,
+                                bool reverse = false,
+                                bool notify = false) override;
+    bool referenceChanged() const override;
+
+    void getLinks(std::vector<App::DocumentObject*>& objs,
+                  bool all = false,
+                  std::vector<std::string>* subs = nullptr,
+                  bool newStyle = true) const override;
+
+    void getLinksTo(std::vector<App::ObjectIdentifier>& identifiers,
+                    App::DocumentObject* obj,
+                    const char* subname = nullptr,
+                    bool all = false) const override;
+
+protected:
+    /**
+     * @brief Return the document object that owns this property's link state.
+     */
+    App::DocumentObject* getLinkOwner() const;
+
+    /**
+     * @brief Return the document used to resolve object names during restore.
+     */
+    App::Document* getOwnerDocument() const;
+
+    /**
+     * @brief Check whether a candidate linked object is valid for this map.
+     */
+    void verifyObject(App::DocumentObject* obj, App::DocumentObject* owner) const;
+
+    /**
+     * @brief Maintain backlinks from linked objects to the owning document object.
+     */
+    void maintainBackLinks(const std::vector<App::DocumentObject*>& objects);
+
+    /**
+     * @brief Replace the stored references after typed values have been updated.
+     */
+    void setReferences(std::vector<App::DocumentObject*>&& objects,
+                       std::vector<std::string>&& subNames,
+                       std::vector<ShadowSub>&& shadowSubs = {});
+
+    /**
+     * @brief Write the reference XML elements common to all typed maps.
+     */
+    void saveReferences(Base::Writer& writer, const char* elementName) const;
+
+    /**
+     * @brief Restore the reference XML elements common to all typed maps.
+     */
+    void restoreReferences(Base::XMLReader& reader,
+                           const char* elementName,
+                           int count,
+                           std::vector<std::size_t>& restoredValueIndices);
+
+    /**
+     * @brief Return indices that will be written to a document side file.
+     */
+    std::vector<std::size_t> getPersistedEntryIndices() const;
+
+    /**
+     * @brief Stored link references in value order.
+     *
+     * The shared store keeps linked objects, subelement names, and topology
+     * shadows together so reference updates cannot desynchronize parallel
+     * containers.
+     */
+    PropertyLinkSubReferenceStore _references;
+    std::vector<int> _mapped;
+};
+
+/**
+ * @brief Typed topology-aware map from subelement references to values.
+ *
+ * @tparam ValueT Stored C++ value type.
+ * @tparam TraitsT Value conversion and serialization policy.
+ * @tparam DerivedT Registered concrete FreeCAD property type.
+ */
+template<class ValueT, class TraitsT, class DerivedT>
+class AppExport PropertyLinkSubValueMapT: public PropertyLinkSubValueMapBase
+{
+public:
+    using Value = ValueT;
+
+    /**
+     * @brief Full typed entry returned by `getEntries()`.
+     */
+    struct Entry
+    {
+        App::DocumentObject* object {nullptr}; /**< Linked document object. */
+        std::string subName;                   /**< Subelement name. */
+        Value value {};                        /**< Value assigned to the subelement. */
+    };
+
+    PropertyLinkSubValueMapT();
+    ~PropertyLinkSubValueMapT() override;
+
+    /**
+     * @brief Clear all entries.
+     */
+    void clear();
+
+    /**
+     * @brief Clear all entries.
+     *
+     * This overload matches the default-initialization convention used by
+     * FreeCAD's static property registration macros.
+     */
+    void setValue();
+
+    /**
+     * @brief Set one map entry, replacing any existing entry with the same key.
+     */
+    void setValue(App::DocumentObject* object, const char* subName, const Value& value);
+
+    /**
+     * @brief Replace all map entries.
+     *
+     * Duplicate `(object, subName)` keys are canonicalized with last-write-wins
+     * semantics.
+     */
+    void setValues(std::vector<App::DocumentObject*> objects,
+                   std::vector<std::string> subNames,
+                   std::vector<Value> values,
+                   std::vector<ShadowSub>&& shadowSubs = {});
+
+    /**
+     * @brief Return all stored values in entry order.
+     */
+    const std::vector<Value>& getValues() const
+    {
+        return _values;
+    }
+
+    /**
+     * @brief Return the value for one `(object, subName)` key.
+     *
+     * @param object Linked document object.
+     * @param subName Subelement name to query.
+     * @param value Receives the stored value when the method returns true.
+     * @param newStyle If true, compare against mapped/new style subelement
+     * names. If false, compare against old style names.
+     */
+    bool getValue(App::DocumentObject* object,
+                  const char* subName,
+                  Value& value,
+                  bool newStyle = true) const;
+
+    /**
+     * @brief Return all entries in entry order.
+     */
+    std::vector<Entry> getEntries(bool newStyle = true) const;
+
+    /**
+     * @brief Return entries belonging to one object keyed by subelement name.
+     */
+    std::map<std::string, Value>
+    getValuesForObject(App::DocumentObject* object, bool newStyle = true) const;
+
+    PyObject* getPyObject() override;
+    void setPyObject(PyObject* value) override;
+
+    void Save(Base::Writer& writer) const override;
+    void Restore(Base::XMLReader& reader) override;
+    void SaveDocFile(Base::Writer& writer) const override;
+    void RestoreDocFile(Base::Reader& reader) override;
+
+    Property* Copy() const override;
+    void Paste(const Property& from) override;
+
+    Property*
+    CopyOnImportExternal(const std::map<std::string, std::string>& nameMap) const override;
+
+    Property* CopyOnLabelChange(App::DocumentObject* obj,
+                                const std::string& ref,
+                                const char* newLabel) const override;
+
+    Property* CopyOnLinkReplace(const App::DocumentObject* parent,
+                                App::DocumentObject* oldObj,
+                                App::DocumentObject* newObj) const override;
+
+    void breakLink(App::DocumentObject* obj, bool clear) override;
+    bool adjustLink(const std::set<App::DocumentObject*>& inList) override;
+
+    unsigned int getMemSize() const override;
+    bool isSame(const Property& other) const override;
+
+protected:
+    void setEntries(std::vector<App::DocumentObject*> objects,
+                    std::vector<std::string> subNames,
+                    std::vector<Value> values,
+                    std::vector<ShadowSub>&& shadowSubs,
+                    bool canonicalize);
+
+private:
+    std::vector<Value> _values;
+    std::vector<std::size_t> _restoreValueIndices;
+    int _valueFormatVersion {0};
+};
+
+/**
+ * @brief Topology-aware map from subelement references to colors.
+ */
+class AppExport PropertyLinkSubColorMap
+    : public PropertyLinkSubValueMapT<Base::Color,
+                                      PropertyLinkSubColorMapTraits,
+                                      PropertyLinkSubColorMap>
+{
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();
+};
+
+/**
+ * @brief Hidden topology-aware map from subelement references to colors.
+ */
+class AppExport PropertyLinkSubColorMapHidden: public PropertyLinkSubColorMap
+{
+    TYPESYSTEM_HEADER();
+
+public:
+    PropertyLinkSubColorMapHidden()
+    {
+        _pcScope = LinkScope::Hidden;
+    }
+};
+
+/**
+ * @brief Topology-aware map from subelement references to materials.
+ */
+class AppExport PropertyLinkSubMaterialMap
+    : public PropertyLinkSubValueMapT<App::Material,
+                                      PropertyLinkSubMaterialMapTraits,
+                                      PropertyLinkSubMaterialMap>
+{
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();
+};
+
+/**
+ * @brief Hidden topology-aware map from subelement references to materials.
+ */
+class AppExport PropertyLinkSubMaterialMapHidden: public PropertyLinkSubMaterialMap
+{
+    TYPESYSTEM_HEADER();
+
+public:
+    PropertyLinkSubMaterialMapHidden()
+    {
+        _pcScope = LinkScope::Hidden;
+    }
+};
+
+}  // namespace App

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -420,7 +420,8 @@ bool PropertyLinkBase::_updateElementReference(DocumentObject* feature,
                                                std::string& sub,
                                                ShadowSub& shadow,
                                                bool reverse,
-                                               bool notify)
+                                               bool notify,
+                                               bool warnMissing)
 {
     if (!obj || !obj->getNameInDocument()) {
         return false;
@@ -513,9 +514,11 @@ bool PropertyLinkBase::_updateElementReference(DocumentObject* feature,
     };
 
     if (missing) {
-        FC_WARN(propertyName(this)
-                << " missing element reference " << ret->getFullName() << " "
-                << (elementName.newName.size() ? elementName.newName : elementName.oldName));
+        if (warnMissing) {
+            FC_WARN(propertyName(this)
+                    << " missing element reference " << ret->getFullName() << " "
+                    << (elementName.newName.size() ? elementName.newName : elementName.oldName));
+        }
         shadow.oldName.swap(elementName.oldName);
     }
     else {
@@ -1398,23 +1401,7 @@ static inline const std::string& getSubNameWithStyle(const std::string& subName,
                                                      bool newStyle,
                                                      std::string& tmp)
 {
-    if (!newStyle) {
-        if (!shadow.oldName.empty()) {
-            return shadow.oldName;
-        }
-    }
-    else if (!shadow.newName.empty()) {
-        if (Data::hasMissingElement(shadow.oldName.c_str())) {
-            auto pos = shadow.newName.rfind('.');
-            if (pos != std::string::npos) {
-                tmp = shadow.newName.substr(0, pos + 1);
-                tmp += shadow.oldName;
-                return tmp;
-            }
-        }
-        return shadow.newName;
-    }
-    return subName;
+    return PropertyLinkSubReferenceStore::getSubNameWithStyle(subName, shadow, newStyle, tmp);
 }
 
 std::vector<std::string> PropertyLinkSub::getSubValues(bool newStyle) const

--- a/src/App/PropertyLinks.h
+++ b/src/App/PropertyLinks.h
@@ -417,13 +417,15 @@ public:
      * update. If false, then the other way around.
      *
      * @param[in] notify: if true, call aboutToSetValue() before change
+     * @param[in] warnMissing: if true, warn when the resolved reference is missing
      */
     bool _updateElementReference(App::DocumentObject* feature,
                                  App::DocumentObject* obj,
                                  std::string& sub,
                                  ShadowSub& shadow,
                                  bool reverse,
-                                 bool notify = false);
+                                 bool notify = false,
+                                 bool warnMissing = true);
 
     /** Helper function to register geometry element reference
      *
@@ -653,6 +655,119 @@ protected:
 private:
     std::set<std::string> _LabelRefs;
     std::set<App::DocumentObject*> _ElementRefs;
+};
+
+/**
+ * @brief Row-based storage for document-object subelement references.
+ *
+ * The store keeps the linked object, stored subelement name, and topology shadow
+ * data together for each entry. It is intentionally limited to reference data:
+ * owning properties remain responsible for validation, backlinks, persistence
+ * envelopes, and property change notifications.
+ */
+class AppExport PropertyLinkSubReferenceStore
+{
+public:
+    /**
+     * @brief Stored reference for one subelement entry.
+     */
+    struct Reference
+    {
+        App::DocumentObject* object {nullptr}; /**< Linked document object. */
+        std::string subName;                   /**< Stored subelement reference. */
+        PropertyLinkBase::ShadowSub shadow;    /**< Old/new style topology reference pair. */
+    };
+
+    using iterator = std::vector<Reference>::iterator;
+    using const_iterator = std::vector<Reference>::const_iterator;
+
+    /**
+     * @brief Return the number of stored references.
+     */
+    std::size_t size() const;
+
+    /**
+     * @brief Return true when no references are stored.
+     */
+    bool empty() const;
+
+    iterator begin();
+    iterator end();
+    const_iterator begin() const;
+    const_iterator end() const;
+
+    Reference& operator[](std::size_t index);
+    const Reference& operator[](std::size_t index) const;
+
+    /**
+     * @brief Return all references in stored order.
+     */
+    const std::vector<Reference>& references() const;
+
+    /**
+     * @brief Replace the stored references.
+     */
+    void set(std::vector<Reference>&& references);
+
+    /**
+     * @brief Replace the stored references from parallel legacy vectors.
+     *
+     * @throws Base::ValueError if the object and subelement counts differ.
+     */
+    void set(std::vector<App::DocumentObject*> objects,
+             std::vector<std::string> subNames,
+             std::vector<PropertyLinkBase::ShadowSub> shadows = {});
+
+    /**
+     * @brief Return linked objects in reference order.
+     */
+    std::vector<App::DocumentObject*> objects() const;
+
+    /**
+     * @brief Return stored subelement names in reference order.
+     */
+    std::vector<std::string> subNames() const;
+
+    /**
+     * @brief Return subelement names using old or new style topology names.
+     */
+    std::vector<std::string> subNames(bool newStyle) const;
+
+    /**
+     * @brief Return topology shadows in reference order.
+     */
+    std::vector<PropertyLinkBase::ShadowSub> shadows() const;
+
+    /**
+     * @brief Return references using old or new style topology names.
+     */
+    std::vector<Reference> references(bool newStyle) const;
+
+    /**
+     * @brief Clear topology shadows without removing references.
+     */
+    void clearShadows();
+
+    /**
+     * @brief Return indices whose linked object is still attached to a document.
+     */
+    std::vector<std::size_t> attachedEntryIndices() const;
+
+    /**
+     * @brief Return the stored-size estimate for linked objects and subnames.
+     */
+    unsigned int getMemSize() const;
+
+    /**
+     * @brief Return \p subName in old or new topology-reference style.
+     */
+    static const std::string& getSubNameWithStyle(const std::string& subName,
+                                                  const PropertyLinkBase::ShadowSub& shadow,
+                                                  bool newStyle,
+                                                  std::string& tmp);
+
+private:
+    std::vector<Reference> _references;
 };
 
 /** The general Link Property

--- a/src/App/PropertySerialization.cpp
+++ b/src/App/PropertySerialization.cpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 The FreeCAD Project Association AISBL
+// SPDX-FileNotice: Part of the FreeCAD project.
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "PropertySerialization.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include <Base/Exception.h>
+#include <Base/Stream.h>
+
+namespace
+{
+
+int toStreamSize(std::size_t size)
+{
+    if (size > static_cast<std::size_t>(std::numeric_limits<uint32_t>::max())
+        || size > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+        throw Base::RuntimeError("String is too large to store in a property stream");
+    }
+    return static_cast<int>(size);
+}
+
+}  // namespace
+
+void App::PropertySerialization::writeBinaryString(Base::OutputStream& stream,
+                                                   const std::string& value)
+{
+    const auto streamSize = toStreamSize(value.size());
+    const auto size = static_cast<uint32_t>(value.size());
+    stream << size;
+    stream.write(value.c_str(), streamSize);
+}
+
+void App::PropertySerialization::readBinaryString(Base::InputStream& stream,
+                                                  std::string& value)
+{
+    uint32_t size {};
+    stream >> size;
+    if (size == 0) {
+        value.clear();
+        return;
+    }
+
+    const auto streamSize = toStreamSize(size);
+    std::vector<char> buffer(static_cast<std::size_t>(size));
+    stream.read(buffer.data(), streamSize);
+    value.assign(buffer.data(), buffer.size());
+}

--- a/src/App/PropertySerialization.h
+++ b/src/App/PropertySerialization.h
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 The FreeCAD Project Association AISBL
+// SPDX-FileNotice: Part of the FreeCAD project.
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+#include <string>
+
+namespace Base
+{
+class InputStream;
+class OutputStream;
+}  // namespace Base
+
+namespace App::PropertySerialization
+{
+
+/**
+ * @brief Write a length-prefixed string to a property side-file stream.
+ *
+ * The payload is written as a 32-bit byte count followed by the raw string
+ * bytes. This helper is intended for FreeCAD property side files, not XML
+ * attribute encoding.
+ */
+void writeBinaryString(Base::OutputStream& stream, const std::string& value);
+
+/**
+ * @brief Read a length-prefixed string from a property side-file stream.
+ *
+ * The format matches `writeBinaryString()`: a 32-bit byte count followed by raw
+ * string bytes.
+ */
+void readBinaryString(Base::InputStream& stream, std::string& value);
+
+}  // namespace App::PropertySerialization

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -51,6 +51,7 @@
 #include "DocumentObject.h"
 #include "MaterialPy.h"
 #include "ObjectIdentifier.h"
+#include "PropertySerialization.h"
 
 
 using namespace App;
@@ -3444,17 +3445,10 @@ void PropertyMaterialList::SaveDocFile(Base::Writer& writer) const
 
     // Apply the latest changes last for backwards compatibility
     for (const auto& it : _lValueList) {
-        writeString(str, it.image);
-        writeString(str, it.imagePath);
-        writeString(str, it.uuid);
+        PropertySerialization::writeBinaryString(str, it.image);
+        PropertySerialization::writeBinaryString(str, it.imagePath);
+        PropertySerialization::writeBinaryString(str, it.uuid);
     }
-}
-
-void PropertyMaterialList::writeString(Base::OutputStream& str, const std::string& value) const
-{
-    uint32_t uCt = (uint32_t)value.size();
-    str << uCt;
-    str.write(value.c_str(), uCt);
 }
 
 void PropertyMaterialList::RestoreDocFile(Base::Reader& reader)
@@ -3535,9 +3529,9 @@ void PropertyMaterialList::RestoreDocFileV3(Base::Reader& reader)
         it.transparency = valueF;
     }
     for (auto& it : values) {
-        readString(str, it.image);
-        readString(str, it.imagePath);
-        readString(str, it.uuid);
+        PropertySerialization::readBinaryString(str, it.image);
+        PropertySerialization::readBinaryString(str, it.imagePath);
+        PropertySerialization::readBinaryString(str, it.uuid);
     }
     convertAlpha(values);
     setValues(values);
@@ -3548,16 +3542,6 @@ void PropertyMaterialList::convertAlpha(std::vector<App::Material>& materials) c
     if (requiresAlphaConversion) {
         std::ranges::for_each(materials, convertAlphaInMaterial);
     }
-}
-
-void PropertyMaterialList::readString(Base::InputStream& str, std::string& value)
-{
-    uint32_t uCt {};
-    str >> uCt;
-
-    std::vector<char> temp(uCt);
-    str.read(temp.data(), uCt);
-    value.assign(temp.data(), temp.size());
 }
 
 const char* PropertyMaterialList::getEditorName() const

--- a/src/App/PropertyStandard.h
+++ b/src/App/PropertyStandard.h
@@ -39,8 +39,6 @@
 
 namespace Base
 {
-class InputStream;
-class OutputStream;
 class Writer;
 }  // namespace Base
 
@@ -1300,9 +1298,6 @@ private:
 
     void RestoreDocFileV0(uint32_t count, Base::Reader& reader);
     void RestoreDocFileV3(Base::Reader& reader);
-
-    void writeString(Base::OutputStream& str, const std::string& value) const;
-    void readString(Base::InputStream& str, std::string& value);
 
     void verifyIndex(int index) const;
     void setMinimumSizeOne();

--- a/src/Gui/ViewProviderDocumentObject.h
+++ b/src/Gui/ViewProviderDocumentObject.h
@@ -99,6 +99,11 @@ public:
     {
         return pcObject;
     }
+    /// Get the App object as the owner of link-like properties on this view provider.
+    App::DocumentObject* getPropertyLinkOwner() const override
+    {
+        return getObject();
+    }
     /// Get the object of this ViewProvider object as specified type
     template<class T>
     T* getObject() const

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -37,6 +37,7 @@
 # include <BRepAdaptor_HCompCurve.hxx>
 #endif
 
+#include <BRepGProp.hxx>
 #include <BRepBndLib.hxx>
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepCheck_Analyzer.hxx>
@@ -73,6 +74,7 @@
 #include <GeomConvert.hxx>
 #include <GeomFill_BezierCurves.hxx>
 #include <GeomFill_BSplineCurves.hxx>
+#include <GProp_GProps.hxx>
 #include <Precision.hxx>
 #include <ShapeAnalysis_FreeBounds.hxx>
 #include <ShapeBuild_ReShape.hxx>
@@ -137,6 +139,38 @@ static void expandCompound(const TopoShape& shape, std::vector<TopoShape>& res)
     for (auto& s : shape.getSubTopoShapes()) {
         expandCompound(s, res);
     }
+}
+
+static bool isSamePlanarFaceWithDifferentBoundary(
+    const TopoShape& face,
+    const TopoShape& candidate,
+    double tol
+)
+{
+    // A sketch edit can split an edge of an otherwise unchanged planar cap. In that case the
+    // boundary topology differs, but the face plane, area, and center still identify the cap.
+    if (face.shapeType() != TopAbs_FACE || candidate.shapeType() != TopAbs_FACE) {
+        return false;
+    }
+    if (!face.isCoplanar(candidate, tol)) {
+        return false;
+    }
+
+    GProp_GProps faceProps;
+    GProp_GProps candidateProps;
+    BRepGProp::SurfaceProperties(face.getShape(), faceProps);
+    BRepGProp::SurfaceProperties(candidate.getShape(), candidateProps);
+
+    const double faceArea = faceProps.Mass();
+    const double candidateArea = candidateProps.Mass();
+    const double areaTolerance = std::max(tol, std::max(faceArea, candidateArea) * 1e-9);
+    if (std::abs(faceArea - candidateArea) > areaTolerance) {
+        return false;
+    }
+
+    const double centerTolerance = std::max(tol, Precision::Confusion());
+    return faceProps.CentreOfMass().SquareDistance(candidateProps.CentreOfMass())
+        <= centerTolerance * centerTolerance;
 }
 
 void TopoShape::initCache(int reset) const
@@ -565,12 +599,28 @@ std::vector<TopoShape> TopoShape::findSubShapesWithSharedVertex(
                     if (!shapeSet.insert(shape).second) {
                         continue;
                     }
+                    auto addPlanarFaceMatch = [&]() {
+                        if (shapeType != TopAbs_FACE) {
+                            return false;
+                        }
+                        if (!isSamePlanarFaceWithDifferentBoundary(subshape, shape, tol)) {
+                            return false;
+                        }
+                        if (names) {
+                            names->push_back(shapeName(shapeType) + std::to_string(idx));
+                        }
+                        res.push_back(shape);
+                        return true;
+                    };
                     TopoShape otherWire;
                     std::vector<TopoDS_Shape> otherVertices;
                     if (shapeType == TopAbs_FACE) {
                         otherWire = shape.splitWires();
                         if (wire.countSubShapes(TopAbs_EDGE)
                             != otherWire.countSubShapes(TopAbs_EDGE)) {
+                            if (addPlanarFaceMatch() && singleSearch) {
+                                return res;
+                            }
                             continue;
                         }
                         otherVertices = otherWire.getSubShapes(TopAbs_VERTEX);
@@ -579,6 +629,9 @@ std::vector<TopoShape> TopoShape::findSubShapesWithSharedVertex(
                         otherVertices = shape.getSubShapes(TopAbs_VERTEX);
                     }
                     if (otherVertices.size() != vertices.size()) {
+                        if (addPlanarFaceMatch() && singleSearch) {
+                            return res;
+                        }
                         continue;
                     }
                     if (checkGeometry && !compareGeometry(shape, false)) {
@@ -3784,6 +3837,54 @@ struct MapperPrism: MapperMaker
     }
 };
 
+struct MapperFinitePrism: MapperMaker
+{
+    BRepPrimAPI_MakePrism& prism;
+
+    explicit MapperFinitePrism(BRepPrimAPI_MakePrism& maker)
+        : MapperMaker(maker)
+        , prism(maker)
+    {}
+
+    const std::vector<TopoDS_Shape>& generated(const TopoDS_Shape& s) const override
+    {
+        MapperMaker::generated(s);
+        if (!_res.empty()) {
+            return _res;
+        }
+
+        try {
+            // BRepPrimAPI_MakePrism exposes cap history separately from Generated().
+            // Include it so finite extrusions name top and bottom profiles directly.
+            appendGenerated(prism.FirstShape(s));
+            appendGenerated(prism.LastShape(s));
+        }
+        catch (const Standard_Failure& e) {
+            if (FC_LOG_INSTANCE.isEnabled(FC_LOGLEVEL_LOG)) {
+                FC_WARN("Exception on prism shape mapper: " << e.GetMessageString());
+            }
+        }
+
+        return _res;
+    }
+
+private:
+    void appendGenerated(const TopoDS_Shape& shape) const
+    {
+        if (shape.IsNull()) {
+            return;
+        }
+
+        for (const auto& existing : _res) {
+            if (existing.IsSame(shape)) {
+                return;
+            }
+        }
+
+        _res.push_back(shape);
+    }
+};
+
 TopoShape& TopoShape::makeElementFilledFace(
     const std::vector<TopoShape>& _shapes,
     const BRepFillingParams& params,
@@ -4596,7 +4697,7 @@ TopoShape& TopoShape::makeElementPrism(const TopoShape& base, const gp_Vec& vec,
         FC_THROWM(NullShapeException, "Null shape");
     }
     BRepPrimAPI_MakePrism mkPrism(base.getShape(), vec);
-    return makeElementShape(mkPrism, base, op);
+    return makeShapeWithElementMap(mkPrism.Shape(), MapperFinitePrism(mkPrism), {base}, op);
 }
 
 TopoShape& TopoShape::makeElementPrismUntil(

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -100,6 +100,32 @@ using namespace PartGui;
 
 PROPERTY_SOURCE(PartGui::ViewProviderPartExt, Gui::ViewProviderGeometryObject)
 
+namespace
+{
+
+enum class FaceMaterialMode
+{
+    Unchanged,
+    Overall,
+    PerPart,
+};
+
+FaceMaterialMode getFaceMaterialMode(int materialCount, int faceCount)
+{
+    if (materialCount <= 0) {
+        return FaceMaterialMode::Unchanged;
+    }
+
+    // Per-face binding is valid only when every rendered face can map to a material.
+    if (materialCount > 1 && faceCount > 0 && materialCount >= faceCount) {
+        return FaceMaterialMode::PerPart;
+    }
+
+    return FaceMaterialMode::Overall;
+}
+
+}  // namespace
+
 
 //**************************************************************************
 // Construction/Destruction
@@ -680,17 +706,19 @@ void ViewProviderPartExt::setHighlightedFaces(const std::vector<App::Material>& 
     Gui::SoUpdateVBOAction action;
     action.apply(this->faceset);
 
-    int size = static_cast<int>(materials.size());
-    if (size > 1 && size == this->faceset->partIndex.getNum()) {
+    const int materialCount = static_cast<int>(materials.size());
+    const int faceCount = this->faceset->partIndex.getNum();
+    const auto mode = getFaceMaterialMode(materialCount, faceCount);
+    if (mode == FaceMaterialMode::PerPart) {
         pcFaceBind->value = SoMaterialBinding::PER_PART;
         texture.activateMaterial();
 
-        pcShapeMaterial->diffuseColor.setNum(size);
-        pcShapeMaterial->ambientColor.setNum(size);
-        pcShapeMaterial->specularColor.setNum(size);
-        pcShapeMaterial->emissiveColor.setNum(size);
-        pcShapeMaterial->shininess.setNum(size);
-        pcShapeMaterial->transparency.setNum(size);
+        pcShapeMaterial->diffuseColor.setNum(materialCount);
+        pcShapeMaterial->ambientColor.setNum(materialCount);
+        pcShapeMaterial->specularColor.setNum(materialCount);
+        pcShapeMaterial->emissiveColor.setNum(materialCount);
+        pcShapeMaterial->shininess.setNum(materialCount);
+        pcShapeMaterial->transparency.setNum(materialCount);
 
         SbColor* dc = pcShapeMaterial->diffuseColor.startEditing();
         SbColor* ac = pcShapeMaterial->ambientColor.startEditing();
@@ -699,7 +727,7 @@ void ViewProviderPartExt::setHighlightedFaces(const std::vector<App::Material>& 
         float* sh = pcShapeMaterial->shininess.startEditing();
         float* tr = pcShapeMaterial->transparency.startEditing();
 
-        for (int i = 0; i < size; i++) {
+        for (int i = 0; i < materialCount; i++) {
             dc[i].setValue(
                 materials[i].diffuseColor.r,
                 materials[i].diffuseColor.g,
@@ -731,7 +759,7 @@ void ViewProviderPartExt::setHighlightedFaces(const std::vector<App::Material>& 
         pcShapeMaterial->shininess.finishEditing();
         pcShapeMaterial->transparency.finishEditing();
     }
-    else if (size == 1) {
+    else if (mode == FaceMaterialMode::Overall) {
         pcFaceBind->value = SoMaterialBinding::OVERALL;
         setCoinAppearance(materials[0]);
     }
@@ -962,7 +990,10 @@ void ViewProviderPartExt::updateData(const App::Property* prop)
         }
 
         if (!VisualTouched) {
-            if (this->faceset->partIndex.getNum() > this->pcShapeMaterial->diffuseColor.getNum()) {
+            const int materialCount = this->pcShapeMaterial->diffuseColor.getNum();
+            const int faceCount = this->faceset->partIndex.getNum();
+            const auto mode = getFaceMaterialMode(materialCount, faceCount);
+            if (mode == FaceMaterialMode::Overall) {
                 this->pcFaceBind->value = SoMaterialBinding::OVERALL;
             }
         }

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -50,6 +50,7 @@
 
 #include <QAction>
 #include <QMenu>
+#include <cstring>
 #include <sstream>
 
 #include <Inventor/SoPickedPoint.h>
@@ -71,6 +72,7 @@
 
 #include <App/Application.h>
 #include <App/Document.h>
+#include <App/ElementNamingUtils.h>
 #include <Base/Console.h>
 #include <Base/Parameter.h>
 #include <Base/TimeInfo.h>
@@ -107,7 +109,7 @@ enum class FaceMaterialMode
 {
     Unchanged,
     Overall,
-    PerPart,
+    PerFace,
 };
 
 FaceMaterialMode getFaceMaterialMode(int materialCount, int faceCount)
@@ -118,10 +120,36 @@ FaceMaterialMode getFaceMaterialMode(int materialCount, int faceCount)
 
     // Per-face binding is valid only when every rendered face can map to a material.
     if (materialCount > 1 && faceCount > 0 && materialCount >= faceCount) {
-        return FaceMaterialMode::PerPart;
+        return FaceMaterialMode::PerFace;
     }
 
     return FaceMaterialMode::Overall;
+}
+
+Base::Color materialDiffuseColor(const App::Material& material)
+{
+    auto color = material.diffuseColor;
+    color.setTransparency(material.transparency);
+    return color;
+}
+
+Data::IndexedName faceIndexedNameFromSubName(const std::string& subName)
+{
+    const char* element = Data::findElementName(subName.c_str());
+    if (!element) {
+        return Data::IndexedName();
+    }
+
+    Data::IndexedName index(element);
+    if (index && std::strcmp(index.getType(), "Face") == 0) {
+        return index;
+    }
+
+    if (const char* dot = std::strrchr(element, '.')) {
+        return Data::IndexedName(dot + 1);
+    }
+
+    return Data::IndexedName();
 }
 
 }  // namespace
@@ -195,6 +223,20 @@ ViewProviderPartExt::ViewProviderPartExt()
 
     ADD_PROPERTY_TYPE(LineMaterial, (lmat), osgroup, App::Prop_None, "Object line material.");
     ADD_PROPERTY_TYPE(PointMaterial, (vmat), osgroup, App::Prop_None, "Object point material.");
+    ADD_PROPERTY_TYPE(
+        FaceAppearanceMaterials,
+        (),
+        osgroup,
+        App::Prop_Hidden,
+        "Tracked face appearances by topological face reference."
+    );
+    ADD_PROPERTY_TYPE(
+        FaceAppearanceDefaultMaterial,
+        (ShapeAppearance[0]),
+        osgroup,
+        App::Prop_Hidden,
+        "Default face appearance used when a face has no topological material match."
+    );
     ADD_PROPERTY_TYPE(LineColor, (lmat.diffuseColor), osgroup, App::Prop_None, "Set object line color.");
     ADD_PROPERTY_TYPE(PointColor, (vmat.diffuseColor), osgroup, App::Prop_None, "Set object point color");
     ADD_PROPERTY_TYPE(
@@ -414,8 +456,14 @@ void ViewProviderPartExt::onChanged(const App::Property* prop)
     else if (prop == &LineColorArray) {
         setHighlightedEdges(LineColorArray.getValues());
     }
+    else if (prop == &FaceAppearanceMaterials) {
+        if (!syncingFaceAppearanceMap) {
+            ensureCurrentFaceAppearances();
+        }
+    }
     else if (prop == &_diffuseColor) {
         // Used to load the old DiffuseColor values asynchronously
+        syncFaceAppearanceDefaultMaterial();
         std::vector<Base::Color> colors = _diffuseColor.getValues();
         std::vector<float> transparencies;
         transparencies.resize(static_cast<int>(colors.size()));
@@ -427,7 +475,11 @@ void ViewProviderPartExt::onChanged(const App::Property* prop)
         ShapeAppearance.setTransparencies(transparencies);
     }
     else if (prop == &ShapeAppearance) {
-        setHighlightedFaces(ShapeAppearance);
+        if (!syncingFaceAppearanceMap) {
+            syncFaceAppearanceDefaultMaterial();
+            syncFaceAppearanceMap(FaceAppearanceSyncMode::Reset);
+        }
+        setHighlightedFaces(getResolvedFaceAppearances());
         ViewProviderGeometryObject::onChanged(prop);
     }
     else if (prop == &Transparency) {
@@ -435,6 +487,7 @@ void ViewProviderPartExt::onChanged(const App::Property* prop)
         long value = Base::toPercent(Mat.transparency);
         if (value != Transparency.getValue()) {
             float trans = Base::fromPercent(Transparency.getValue());
+            FaceAppearanceDefaultMaterial.setTransparency(trans);
             ShapeAppearance.setTransparency(trans);
         }
     }
@@ -709,7 +762,7 @@ void ViewProviderPartExt::setHighlightedFaces(const std::vector<App::Material>& 
     const int materialCount = static_cast<int>(materials.size());
     const int faceCount = this->faceset->partIndex.getNum();
     const auto mode = getFaceMaterialMode(materialCount, faceCount);
-    if (mode == FaceMaterialMode::PerPart) {
+    if (mode == FaceMaterialMode::PerFace) {
         pcFaceBind->value = SoMaterialBinding::PER_PART;
         texture.activateMaterial();
 
@@ -770,6 +823,142 @@ void ViewProviderPartExt::setHighlightedFaces(const App::PropertyMaterialList& a
     setHighlightedFaces(appearance.getValues());
 }
 
+int ViewProviderPartExt::getCurrentFaceCount() const
+{
+    if (const auto* feature = freecad_cast<const Part::Feature*>(getObject())) {
+        const int shapeFaceCount = static_cast<int>(
+            feature->Shape.getShape().countSubShapes(TopAbs_FACE)
+        );
+        if (shapeFaceCount > 0) {
+            return shapeFaceCount;
+        }
+    }
+
+    try {
+        const int shapeFaceCount = static_cast<int>(getRenderedShape().countSubShapes(TopAbs_FACE));
+        if (shapeFaceCount > 0) {
+            return shapeFaceCount;
+        }
+    }
+    catch (...) {
+        // Fall back to the last rendered scene graph when the shape is not available.
+    }
+
+    return this->faceset->partIndex.getNum();
+}
+
+void ViewProviderPartExt::syncFaceAppearanceMap(FaceAppearanceSyncMode mode)
+{
+    if (syncingFaceAppearanceMap || isRestoring()) {
+        return;
+    }
+
+    const int faceCount = getCurrentFaceCount();
+    auto materials = ShapeAppearance.getValues();
+    if (faceCount <= 0 || static_cast<int>(materials.size()) != faceCount) {
+        if (mode == FaceAppearanceSyncMode::Reset && FaceAppearanceMaterials.getSize() > 0) {
+            Base::FlagToggler<> guard(syncingFaceAppearanceMap);
+            FaceAppearanceMaterials.clear();
+        }
+        return;
+    }
+
+    const bool reset = mode == FaceAppearanceSyncMode::Reset;
+    if (!reset && FaceAppearanceMaterials.getSize() > 0) {
+        return;
+    }
+    if (mode == FaceAppearanceSyncMode::ExistingOnly && FaceAppearanceMaterials.getSize() == 0) {
+        return;
+    }
+
+    auto* object = getObject();
+    if (!object) {
+        return;
+    }
+
+    std::vector<App::DocumentObject*> objects;
+    std::vector<std::string> elements;
+    objects.reserve(materials.size());
+    elements.reserve(materials.size());
+    for (int i = 0; i < faceCount; ++i) {
+        objects.push_back(object);
+        elements.push_back("Face" + std::to_string(i + 1));
+    }
+
+    Base::FlagToggler<> guard(syncingFaceAppearanceMap);
+    FaceAppearanceMaterials.setValues(std::move(objects), std::move(elements), std::move(materials));
+}
+
+void ViewProviderPartExt::syncFaceAppearanceDefaultMaterial()
+{
+    if (ShapeAppearance.getSize() == 1) {
+        FaceAppearanceDefaultMaterial.setValue(ShapeAppearance[0]);
+    }
+}
+
+std::vector<App::Material> ViewProviderPartExt::getResolvedFaceAppearances() const
+{
+    const int faceCount = getCurrentFaceCount();
+    if (faceCount <= 0) {
+        return ShapeAppearance.getValues();
+    }
+
+    const auto entries = FaceAppearanceMaterials.getEntries();
+    if (entries.empty()) {
+        return ShapeAppearance.getValues();
+    }
+
+    const App::Material defaultMaterial = FaceAppearanceDefaultMaterial.getValue();
+    std::vector<App::Material> resolved(static_cast<size_t>(faceCount), defaultMaterial);
+    std::vector<bool> assigned(static_cast<size_t>(faceCount), false);
+    bool hasResolvedFace = false;
+
+    auto assignFace = [&](const Data::IndexedName& index, const App::Material& material) {
+        if (!index || std::strcmp(index.getType(), "Face") != 0) {
+            return;
+        }
+
+        const int faceIndex = index.getIndex() - 1;
+        if (faceIndex < 0 || faceIndex >= faceCount) {
+            return;
+        }
+
+        const auto pos = static_cast<size_t>(faceIndex);
+        if (!assigned[pos]) {
+            resolved[pos] = material;
+            assigned[pos] = true;
+            hasResolvedFace = true;
+        }
+    };
+
+    auto* object = getObject();
+    for (const auto& entry : entries) {
+        if (entry.object != object || Data::hasMissingElement(entry.subName.c_str())) {
+            // Leave unresolved old faces at the default material.
+            continue;
+        }
+
+        assignFace(faceIndexedNameFromSubName(entry.subName), entry.value);
+    }
+
+    if (!hasResolvedFace) {
+        return ShapeAppearance.getValues();
+    }
+
+    return resolved;
+}
+
+void ViewProviderPartExt::ensureCurrentFaceAppearances()
+{
+    auto appearances = getResolvedFaceAppearances();
+    if (ShapeAppearance.getValues() != appearances) {
+        Base::FlagToggler<> guard(syncingFaceAppearanceMap);
+        ShapeAppearance.setValues(appearances);
+    }
+
+    setHighlightedFaces(appearances);
+}
+
 std::map<std::string, Base::Color> ViewProviderPartExt::getElementColors(const char* element) const
 {
     std::map<std::string, Base::Color> ret;
@@ -784,22 +973,21 @@ std::map<std::string, Base::Color> ViewProviderPartExt::getElementColors(const c
     }
 
     if (boost::starts_with(element, "Face")) {
-        auto size = ShapeAppearance.getSize();
+        const auto appearances = getResolvedFaceAppearances();
+        const auto size = static_cast<int>(appearances.size());
         if (element[4] == '*') {
             auto color = ShapeAppearance.getDiffuseColor();
             color.setTransparency(Base::fromPercent(Transparency.getValue()));
             bool singleColor = true;
             for (int i = 0; i < size; ++i) {
-                auto color_i = ShapeAppearance.getDiffuseColor(i);
-                color_i.setTransparency(ShapeAppearance.getTransparency(i));
+                const auto color_i = materialDiffuseColor(appearances[i]);
                 if (color_i != color) {
                     ret[std::string(element, 4) + std::to_string(i + 1)] = color_i;
                 }
                 singleColor = singleColor && color == color_i;
             }
             if (size > 0 && singleColor) {
-                color = ShapeAppearance.getDiffuseColor(0);
-                color.setTransparency(ShapeAppearance.getTransparency());
+                color = materialDiffuseColor(appearances.front());
                 ret.clear();
             }
             ret["Face"] = color;
@@ -807,9 +995,7 @@ std::map<std::string, Base::Color> ViewProviderPartExt::getElementColors(const c
         else {
             int idx = atoi(element + 4);
             if (idx > 0 && idx <= size) {
-                auto color_i = ShapeAppearance.getDiffuseColor(idx - 1);
-                color_i.setTransparency(ShapeAppearance.getTransparency(idx - 1));
-                ret[element] = color_i;
+                ret[element] = materialDiffuseColor(appearances[static_cast<size_t>(idx - 1)]);
             }
             else {
                 auto color_i = ShapeAppearance.getDiffuseColor();
@@ -979,6 +1165,7 @@ void ViewProviderPartExt::reload()
 
 void ViewProviderPartExt::updateData(const App::Property* prop)
 {
+    bool applyFaceAppearances = false;
     const char* propName = prop->getName();
     if (propName && (strcmp(propName, "Shape") == 0 || strstr(propName, "Touched"))) {
         // calculate the visual only if visible
@@ -996,9 +1183,13 @@ void ViewProviderPartExt::updateData(const App::Property* prop)
             if (mode == FaceMaterialMode::Overall) {
                 this->pcFaceBind->value = SoMaterialBinding::OVERALL;
             }
+            applyFaceAppearances = true;
         }
     }
     Gui::ViewProviderGeometryObject::updateData(prop);
+    if (applyFaceAppearances) {
+        ensureCurrentFaceAppearances();
+    }
 }
 
 void ViewProviderPartExt::startRestoring()
@@ -1015,6 +1206,8 @@ void ViewProviderPartExt::finishRestoring()
     if (_diffuseColor.getSize() > 1) {
         onChanged(&_diffuseColor);
     }
+    syncFaceAppearanceMap(FaceAppearanceSyncMode::CreateIfMissing);
+    ensureCurrentFaceAppearances();
     Gui::ViewProviderGeometryObject::finishRestoring();
 }
 
@@ -1497,7 +1690,8 @@ void ViewProviderPartExt::updateVisual()
         haction.apply(this->faceset);
         haction.apply(this->lineset);
         haction.apply(this->nodeset);
-        setHighlightedFaces(ShapeAppearance.getValues());
+        syncFaceAppearanceMap(FaceAppearanceSyncMode::CreateIfMissing);
+        ensureCurrentFaceAppearances();
         setHighlightedEdges(LineColorArray.getValues());
         setHighlightedPoints(PointColorArray.getValue());
         return;
@@ -1546,7 +1740,8 @@ void ViewProviderPartExt::updateVisual()
     }
 
     // The material has to be checked again
-    setHighlightedFaces(ShapeAppearance.getValues());
+    syncFaceAppearanceMap(FaceAppearanceSyncMode::CreateIfMissing);
+    ensureCurrentFaceAppearances();
     setHighlightedEdges(LineColorArray.getValues());
     setHighlightedPoints(PointColorArray.getValue());
 }

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -29,6 +29,7 @@
 
 #include <map>
 
+#include <App/PropertyLinkSubValueMap.h>
 #include <App/PropertyUnits.h>
 #include <Gui/ViewProviderGeometryObject.h>
 #include <Gui/ViewProviderTextureExtension.h>
@@ -91,6 +92,8 @@ public:
     App::PropertyColor LineColor;
     App::PropertyMaterial LineMaterial;
     App::PropertyColorList LineColorArray;
+    App::PropertyLinkSubMaterialMapHidden FaceAppearanceMaterials;
+    App::PropertyMaterial FaceAppearanceDefaultMaterial;
 
     void attach(App::DocumentObject*) override;
     void setDisplayMode(const char* ModeName) override;
@@ -153,6 +156,13 @@ public:
      */
     //@{
     std::map<std::string, Base::Color> getElementColors(const char* element = nullptr) const override;
+    /// Synchronize legacy face-appearance state with topology-aware face references.
+    ///
+    /// Rebuilds ShapeAppearance and the rendered face material binding from
+    /// FaceAppearanceMaterials when topology remapping has changed the current face indices.
+    /// This is idempotent and exists for legacy/rendering entry points that still consume
+    /// positional face-appearance arrays.
+    void ensureCurrentFaceAppearances();
     //@}
 
     bool isUpdateForced() const override
@@ -206,9 +216,24 @@ protected:
     //@}
 
 protected:
+    enum class FaceAppearanceSyncMode
+    {
+        /// Update only when tracked face appearances already exist.
+        ExistingOnly,
+        /// Create tracked face appearances from the legacy positional list.
+        CreateIfMissing,
+        /// Replace tracked face appearances after an explicit legacy edit.
+        Reset,
+    };
+
     /// get called by the container whenever a property has been changed
     void onChanged(const App::Property* prop) override;
     bool loadParameter();
+    int getCurrentFaceCount() const;
+    std::vector<App::Material> getResolvedFaceAppearances() const;
+    /// Update the unmapped-face fallback when ShapeAppearance represents one overall material.
+    void syncFaceAppearanceDefaultMaterial();
+    void syncFaceAppearanceMap(FaceAppearanceSyncMode mode = FaceAppearanceSyncMode::ExistingOnly);
     void updateVisual();
     void handleChangedPropertyName(
         Base::XMLReader& reader,
@@ -236,6 +261,7 @@ protected:
     bool VisualTouched;
     bool NormalsFromUV;
     bool faceHighlightActive = false;
+    bool syncingFaceAppearanceMap = false;
 
 private:
     Gui::ViewProviderFaceTexture texture;

--- a/src/Mod/Part/Gui/ViewProviderPartExtPyImp.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPartExtPyImp.cpp
@@ -47,6 +47,10 @@ PyObject* ViewProviderPartExtPy::getCustomAttributes(const char* attr) const
 {
     ViewProviderPartExt* vp = getViewProviderPartExtPtr();
     if (strcmp(attr, "DiffuseColor") == 0) {
+        // DiffuseColor is the legacy Python facade for face colors. Synchronize
+        // pending topological remaps before exposing the positional list.
+        vp->ensureCurrentFaceAppearances();
+
         // Get the color properties
         App::PropertyColorList prop;
 

--- a/src/Mod/Part/parttests/ColorPerFaceTest.py
+++ b/src/Mod/Part/parttests/ColorPerFaceTest.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-# test to check color per face when after restore
+"""Tests for Part per-face color persistence and topology updates."""
 
+from collections import Counter
 import FreeCAD as App
 import Part
+import Sketcher
 import os
 import tempfile
 import unittest
@@ -12,15 +14,119 @@ from pivy import coin
 
 
 class ColorPerFaceTest(unittest.TestCase):
+    """Exercise per-face color behavior across recompute and restore."""
+
     def setUp(self):
+        """Create a temporary document for each test."""
         TempPath = tempfile.gettempdir()
         self.fileName = TempPath + os.sep + "ColorPerFaceTest.FCStd"
         self.doc = App.newDocument()
 
     def tearDown(self):
+        """Close the temporary document after each test."""
         App.closeDocument(self.doc.Name)
 
+    def makeClosedSketch(self, name, points):
+        """Create a closed sketch from ordered 2D point tuples."""
+        sketch = self.doc.addObject("Sketcher::SketchObject", name)
+        geometry = []
+        for start, end in zip(points, points[1:] + points[:1]):
+            geometry.append(
+                Part.LineSegment(
+                    App.Vector(start[0], start[1], 0),
+                    App.Vector(end[0], end[1], 0),
+                )
+            )
+        sketch.addGeometry(geometry, False)
+        constraints = []
+        for index in range(len(points)):
+            constraints.append(
+                Sketcher.Constraint("Coincident", index, 2, (index + 1) % len(points), 1)
+            )
+        sketch.addConstraint(constraints)
+        return sketch
+
+    def makeSketchWithSplitFirstEdge(self, sketch):
+        """Copy a sketch and split its first edge into two collinear edges."""
+        sketch001 = self.doc.copyObject(sketch, False)
+        sketch001.Label = "Sketch001"
+        sketch001.delGeometry(0)
+        first = sketch001.addGeometry(
+            Part.LineSegment(App.Vector(0, 0, 0), App.Vector(5, 0, 0)),
+            False,
+        )
+        second = sketch001.addGeometry(
+            Part.LineSegment(App.Vector(5, 0, 0), App.Vector(10, 0, 0)),
+            False,
+        )
+        sketch001.addConstraint(Sketcher.Constraint("Coincident", first, 2, second, 1))
+        return sketch001
+
+    def makeSolidExtrusion(self, sketch):
+        """Create a solid extrusion from a sketch."""
+        extrude = self.doc.addObject("Part::Extrusion", "Extrude")
+        extrude.Base = sketch
+        extrude.Dir = App.Vector(0, 0, 10)
+        extrude.Solid = True
+        self.doc.recompute()
+        return extrude
+
+    def assertFaceMaterialCount(self, obj, expected):
+        """Assert that the scene graph has one material per rendered face."""
+        sa = coin.SoSearchAction()
+        sa.setType(coin.SoMaterialBinding.getClassTypeId())
+        sa.setInterest(coin.SoSearchAction.ALL)
+        sa.apply(obj.ViewObject.RootNode)
+        paths = sa.getPaths()
+
+        bind = paths.get(1).getTail()
+        self.assertEqual(bind.value.getValue(), bind.PER_PART)
+
+        sa = coin.SoSearchAction()
+        sa.setType(coin.SoMaterial.getClassTypeId())
+        sa.setInterest(coin.SoSearchAction.ALL)
+        sa.apply(obj.ViewObject.RootNode)
+        paths = sa.getPaths()
+
+        mat = paths.get(1).getTail()
+        self.assertEqual(mat.diffuseColor.getNum(), expected)
+
+    def colorTuple(self, color):
+        """Convert a color sequence into a rounded tuple."""
+        return tuple(round(float(value), 4) for value in color)
+
+    def faceColorCounts(self, obj):
+        """Return rounded DiffuseColor counts for an object."""
+        return Counter(self.colorTuple(color) for color in obj.ViewObject.DiffuseColor)
+
+    def faceColorsMatching(self, obj, predicate):
+        """Return colors of faces whose center normal satisfies predicate."""
+        matches = []
+        for face, color in zip(obj.Shape.Faces, obj.ViewObject.DiffuseColor):
+            u0, u1, v0, v1 = face.ParameterRange
+            normal = face.normalAt((u0 + u1) / 2, (v0 + v1) / 2)
+            if predicate(normal):
+                matches.append(self.colorTuple(color))
+        return matches
+
+    def assertSingleMatchingFaceColor(self, obj, predicate, expected):
+        """Assert that exactly one matching face has the expected color."""
+        matches = self.faceColorsMatching(obj, predicate)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0], self.colorTuple(expected))
+
+    def assertMatchingFaceColors(self, obj, predicate, expected):
+        """Assert that matching faces have the expected color multiset."""
+        expectedColors = Counter(self.colorTuple(color) for color in expected)
+        self.assertEqual(Counter(self.faceColorsMatching(obj, predicate)), expectedColors)
+
+    def assertHasBlueFace(self, obj):
+        """Assert that an object still has at least one blue face color."""
+        colors = obj.ViewObject.getElementColors("Face*")
+        self.assertIn((0.0, 0.0, 1.0, 1.0), [self.colorTuple(color) for color in colors.values()])
+
     def testBox(self):
+        """Restore a box with a complete per-face color list."""
         box = self.doc.addObject("Part::Box", "Box")
         self.doc.recompute()
 
@@ -55,6 +161,7 @@ class ColorPerFaceTest(unittest.TestCase):
         self.assertEqual(mat.diffuseColor.getNum(), 6)
 
     def testBoxAndLink(self):
+        """Restore linked box colors without losing per-face materials."""
         box = self.doc.addObject("Part::Box", "Box")
         self.doc.recompute()
 
@@ -169,6 +276,104 @@ class ColorPerFaceTest(unittest.TestCase):
         self.assertEqual(mat.diffuseColor.getNum(), 1)
         self.assertEqual(mat.diffuseColor[0].getValue(), (1.0, 0.0, 0.0))
 
+    def testFaceColorsTrackStableFacesAfterTopologyChange(self):
+        """Keep stable face colors after a topology-changing sketch edit."""
+        sketch = self.makeClosedSketch("Sketch", [(0, 0), (10, 0), (10, 10), (0, 10)])
+        sketch001 = self.makeSketchWithSplitFirstEdge(sketch)
+        extrude = self.makeSolidExtrusion(sketch)
+
+        defaultFaceColor = (0.0, 1.0, 0.0, 1.0)
+        red = (1.0, 0.0, 0.0, 1.0)
+        blue = (0.0, 0.0, 1.0, 1.0)
+        yellow = (1.0, 1.0, 0.0, 1.0)
+
+        extrude.ViewObject.ShapeColor = defaultFaceColor
+        extrude.ViewObject.DiffuseColor = [
+            red,
+            blue,
+            red,
+            blue,
+            yellow,
+            yellow,
+        ]
+        self.assertEqual(len(extrude.Shape.Faces), 6)
+        self.assertFaceMaterialCount(extrude, 6)
+
+        extrude.Base = sketch001
+        self.doc.recompute()
+
+        self.assertEqual(len(extrude.Shape.Faces), 7)
+        self.assertFaceMaterialCount(extrude, 7)
+        self.assertHasBlueFace(extrude)
+        self.assertEqual(len(extrude.ViewObject.DiffuseColor), 7)
+        counts = self.faceColorCounts(extrude)
+        self.assertGreater(counts[red], 0, counts)
+        self.assertGreater(counts[blue], 0, counts)
+        self.assertEqual(counts[red] + counts[blue], 3, counts)
+        self.assertEqual(counts[yellow], 2, counts)
+        self.assertEqual(counts[defaultFaceColor], 2, counts)
+        self.assertSingleMatchingFaceColor(extrude, lambda normal: normal.z > 0.9, yellow)
+        self.assertSingleMatchingFaceColor(extrude, lambda normal: normal.z < -0.9, yellow)
+        self.assertMatchingFaceColors(
+            extrude, lambda normal: normal.y < -0.9, [defaultFaceColor, defaultFaceColor]
+        )
+
+        self.doc.saveAs(self.fileName)
+        App.closeDocument(self.doc.Name)
+
+        self.doc = App.openDocument(self.fileName)
+        extrude = self.doc.Extrude
+        self.assertEqual(len(extrude.Shape.Faces), 7)
+        self.assertFaceMaterialCount(extrude, 7)
+        self.assertHasBlueFace(extrude)
+        self.assertEqual(len(extrude.ViewObject.DiffuseColor), 7)
+        counts = self.faceColorCounts(extrude)
+        self.assertGreater(counts[red], 0, counts)
+        self.assertGreater(counts[blue], 0, counts)
+        self.assertEqual(counts[red] + counts[blue], 3, counts)
+        self.assertEqual(counts[yellow], 2, counts)
+        self.assertEqual(counts[defaultFaceColor], 2, counts)
+        self.assertSingleMatchingFaceColor(extrude, lambda normal: normal.z > 0.9, yellow)
+        self.assertSingleMatchingFaceColor(extrude, lambda normal: normal.z < -0.9, yellow)
+        self.assertMatchingFaceColors(
+            extrude, lambda normal: normal.y < -0.9, [defaultFaceColor, defaultFaceColor]
+        )
+
+    def testFaceColorsRecoverStaleMappedNamesAfterTopologyChange(self):
+        """Keep usable colors when old generated face names can only fall back to FaceN."""
+        sketch = self.makeClosedSketch("Sketch", [(0, 0), (10, 0), (10, 10), (0, 10)])
+        sketch001 = self.makeSketchWithSplitFirstEdge(sketch)
+        extrude = self.makeSolidExtrusion(sketch)
+
+        defaultFaceColor = (0.0, 1.0, 0.0, 1.0)
+        red = (1.0, 0.0, 0.0, 1.0)
+        blue = (0.0, 0.0, 1.0, 1.0)
+        yellow = (1.0, 1.0, 0.0, 1.0)
+
+        extrude.ViewObject.ShapeColor = defaultFaceColor
+        extrude.ViewObject.DiffuseColor = [
+            red,
+            blue,
+            red,
+            blue,
+            yellow,
+            yellow,
+        ]
+        staleEntries = extrude.ViewObject.FaceAppearanceMaterials
+        self.assertTrue(any(".Face" in entry[1] for entry in staleEntries))
+        extrude.ViewObject.FaceAppearanceMaterials = staleEntries
+
+        extrude.Base = sketch001
+        self.doc.recompute()
+
+        self.assertEqual(len(extrude.Shape.Faces), 7)
+        self.assertFaceMaterialCount(extrude, 7)
+        counts = self.faceColorCounts(extrude)
+        self.assertEqual(counts[red], 2, counts)
+        self.assertEqual(counts[blue], 1, counts)
+        self.assertEqual(counts[yellow], 2, counts)
+        self.assertEqual(counts[defaultFaceColor], 2, counts)
+
     def testMultiFuse(self):
         """
         Both input objects are red. So, it's expected that the output object is red, too.
@@ -210,6 +415,7 @@ class ColorPerFaceTest(unittest.TestCase):
         self.assertEqual(fuse.ViewObject.DiffuseColor[0], (1.0, 0.0, 0.0, 1.0))
 
     def testMultiFuseSaveRestore(self):
+        """Restore generated multi-fuse per-face colors."""
         box = self.doc.addObject("Part::Box", "Box")
         cyl = self.doc.addObject("Part::Cylinder", "Cylinder")
         box.ViewObject.ShapeColor = (1.0, 0.0, 0.0, 1.0)

--- a/src/Mod/Part/parttests/ColorPerFaceTest.py
+++ b/src/Mod/Part/parttests/ColorPerFaceTest.py
@@ -129,6 +129,46 @@ class ColorPerFaceTest(unittest.TestCase):
         mat = paths.get(1).getTail()
         self.assertEqual(mat.diffuseColor.getNum(), 6)
 
+    def testTooFewFaceColorsSaveRestore(self):
+        """
+        If the shape has more faces than stored colors then restore must use
+        the first stored color, matching the live recompute fallback.
+        """
+        box = self.doc.addObject("Part::Box", "Box")
+        self.doc.recompute()
+
+        box.ViewObject.DiffuseColor = [
+            (1.0, 0.0, 0.0, 1.0),
+            (0.0, 0.0, 1.0, 1.0),
+        ]
+
+        self.doc.saveAs(self.fileName)
+        App.closeDocument(self.doc.Name)
+
+        self.doc = App.openDocument(self.fileName)
+        box = self.doc.Box
+        self.assertEqual(len(box.Shape.Faces), 6)
+        self.assertEqual(len(box.ViewObject.DiffuseColor), 2)
+
+        sa = coin.SoSearchAction()
+        sa.setType(coin.SoMaterialBinding.getClassTypeId())
+        sa.setInterest(coin.SoSearchAction.ALL)
+        sa.apply(box.ViewObject.RootNode)
+        paths = sa.getPaths()
+
+        bind = paths.get(1).getTail()
+        self.assertEqual(bind.value.getValue(), bind.OVERALL)
+
+        sa = coin.SoSearchAction()
+        sa.setType(coin.SoMaterial.getClassTypeId())
+        sa.setInterest(coin.SoSearchAction.ALL)
+        sa.apply(box.ViewObject.RootNode)
+        paths = sa.getPaths()
+
+        mat = paths.get(1).getTail()
+        self.assertEqual(mat.diffuseColor.getNum(), 1)
+        self.assertEqual(mat.diffuseColor[0].getValue(), (1.0, 0.0, 0.0))
+
     def testMultiFuse(self):
         """
         Both input objects are red. So, it's expected that the output object is red, too.

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -1578,6 +1578,59 @@ class DocumentPlatformCases(unittest.TestCase):
         self.assertTrue(abs(self.Doc.Test.ColourList[1][2] - 1.0) < 0.01)
         self.assertTrue(abs(self.Doc.Test.ColourList[1][3] - 1.0) < 0.01)
 
+    def testLinkSubColorMap(self):
+        source = self.Doc.addObject("App::FeatureTest", "Source")
+        self.Doc.Test.addProperty("App::PropertyLinkSubColorMap", "SubColors", "Test")
+
+        self.Doc.Test.SubColors = [
+            (source, "Face1", (1.0, 0.0, 0.0, 1.0)),
+            (source, "Face1", (0.0, 1.0, 0.0, 0.25)),
+            (source, "Edge1", (0.0, 0.0, 1.0, 1.0)),
+        ]
+
+        colors = self.Doc.Test.SubColors
+        self.assertEqual(len(colors), 2)
+        self.assertEqual(colors[0][0], source)
+        self.assertEqual(colors[0][1], "Face1")
+        self.assertLess(abs(colors[0][2][1] - 1.0), 0.01)
+
+        # saving and restoring
+        self.Doc.saveAs(self.DocName)
+        FreeCAD.closeDocument("PlatformTests")
+        self.Doc = FreeCAD.open(self.DocName)
+
+        colors = self.Doc.Test.SubColors
+        self.assertEqual(len(colors), 2)
+        self.assertEqual(colors[0][0], self.Doc.Source)
+        self.assertEqual(colors[0][1], "Face1")
+        self.assertLess(abs(colors[0][2][1] - 1.0), 0.01)
+        self.assertLess(abs(colors[0][2][3] - 0.25), 0.01)
+        self.assertEqual(colors[1][1], "Edge1")
+        self.assertLess(abs(colors[1][2][2] - 1.0), 0.01)
+
+    def testLinkSubMaterialMap(self):
+        source = self.Doc.addObject("App::FeatureTest", "Source")
+        material = self.Doc.Test.Material
+        material.DiffuseColor = (0.2, 0.4, 0.6)
+        material.Transparency = 0.3
+
+        self.Doc.Test.addProperty("App::PropertyLinkSubMaterialMap", "SubMaterials", "Test")
+        self.Doc.Test.SubMaterials = (source, {"Face1": material})
+
+        # saving and restoring
+        self.Doc.saveAs(self.DocName)
+        FreeCAD.closeDocument("PlatformTests")
+        self.Doc = FreeCAD.open(self.DocName)
+
+        materials = self.Doc.Test.SubMaterials
+        self.assertEqual(len(materials), 1)
+        self.assertEqual(materials[0][0], self.Doc.Source)
+        self.assertEqual(materials[0][1], "Face1")
+        self.assertLess(abs(materials[0][2].DiffuseColor[0] - 0.2), 0.01)
+        self.assertLess(abs(materials[0][2].DiffuseColor[1] - 0.4), 0.01)
+        self.assertLess(abs(materials[0][2].DiffuseColor[2] - 0.6), 0.01)
+        self.assertLess(abs(materials[0][2].Transparency - 0.3), 0.01)
+
     def testVectorList(self):
         self.Doc.Test.VectorList = [(-0.05, 2.5, 5.2), (-0.05, 2.5, 5.2)]
 

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -2872,6 +2872,11 @@ TEST_F(TopoShapeExpansionTest, makeElementPrism)
     EXPECT_TRUE(PartTestHelpers::boxesMatch(bb, Base::BoundBox3d(0.0, 0.0, 0.0, 0.75, 1.0, 1.0)));
     EXPECT_FLOAT_EQ(getVolume(result.getShape()), 0.75);
     // Assert elementMap is correct
+    // Finite prisms keep the standard Generated() history names when OCCT
+    // provides them. FirstShape/LastShape are only a fallback for missing cap
+    // history, so existing stable face names are preserved.
+    // Keep the opaque topology names one-per-line so changes remain reviewable.
+    // clang-format off
     EXPECT_TRUE(elementsMatch(
         result,
         {
@@ -2902,6 +2907,7 @@ TEST_F(TopoShapeExpansionTest, makeElementPrism)
             "Vertex4;:H2,V",
         }
     ));
+    // clang-format on
 }
 
 TEST_F(TopoShapeExpansionTest, makeElementPrismUntil)


### PR DESCRIPTION
This fixes the Part per-face color inconsistency from #8016 and extends face-color storage so stable faces can keep their colors across supported topology remaps.

Previously, if a Part object had a stored per-face color list that no longer matched the current number of rendered faces, live recompute and save/reopen could produce different scene graph state. In the reported case, recompute displayed the object using the first stored color as an overall fallback, but reopening the saved file restored the object with the default grey material.

The first change centralizes the face-material binding decision in the Part view provider. Per-face binding is now used only when every rendered face can map to a stored material. If the stored material list is non-empty but too short for the current face count, the view provider applies the first stored material as the overall color instead of leaving the material node unchanged.

The second change adds reusable App-level infrastructure for values keyed by linked subelements, then uses it in `ViewProviderPartExt` to track face appearances by topological face reference. The legacy positional `ShapeAppearance` / `DiffuseColor` list remains the rendering and Python compatibility surface, but it is rebuilt from the topology-aware material map after recompute and document restore.

For the sketch/extrude case from the issue, the Part topology mapping is also improved. Finite prism history now includes cap shapes exposed by `BRepPrimAPI_MakePrism::FirstShape()` / `LastShape()`, and planar face matching can recognize an unchanged cap even when a sketch edit splits one boundary edge into multiple collinear edges. Stable cap faces therefore keep their assigned colors, while genuinely new or split faces fall back to the default face material.

Regression coverage now includes saving and reopening incomplete face-color lists, generic topology-aware subelement color/material maps, finite prism element-map history, topology-changing recompute of per-face colors, save/reopen of remapped face appearances, and the Coin material binding used for rendering.

Fixes #8016

Assisted-by: GPT-5.5-xhigh
