### PR TITLE
CAM: setFromGCode - Fix scientific notation

### DIFF
--- a/src/Mod/CAM/App/Command.cpp
+++ b/src/Mod/CAM/App/Command.cpp
@@ -191,7 +191,8 @@ void Command::setFromGCode(const std::string& str)
     std::string key;
     std::string value;
     for (unsigned int i = 0; i < gcode_part.size(); i++) {
-        if ((isdigit(gcode_part[i])) || (gcode_part[i] == '-') || (gcode_part[i] == '.')) {
+        if ((isdigit(gcode_part[i])) || (gcode_part[i] == '-') || (gcode_part[i] == '.')
+            || ((gcode_part[i] == 'e') && (i > 0) && (isdigit(gcode_part[i - 1])))) {
             value += gcode_part[i];
         }
         else if (isalpha(gcode_part[i])) {

--- a/src/Mod/CAM/CAMTests/TestPathCore.py
+++ b/src/Mod/CAM/CAMTests/TestPathCore.py
@@ -84,6 +84,10 @@ class TestPathCore(PathTestBase):
         c3.setFromGCode("G1X1Y0")
         self.assertEqual(str(c3), "Command G1 [ X:1 Y:0 ]")
 
+        # set from gcode with scientific notation
+        c3.setFromGCode("G1X1Y-1.2345e-06Z10")
+        self.assertEqual(str(c3), "Command G1 [ X:1 Y:-1.2345e-06 Z:10 ]")
+
     def test10(self):
         """Test Path Object core functionality"""
 


### PR DESCRIPTION
### Changes:
- Fixed scientific notation in `Path.Command.setFromGCode()`
- Added test

---

### Description

`Path.Command.setFromGCode()` incorrect process scientific notation

```
cmd = "G2 F10 I-1.2846656005649493e-07 J2.0 K0.0 X-2.0 Y-55.0 Z7.0"
Path.Command(cmd)
Path.Command(cmd).toGCode()
```

**Before**
```
Command G2 [ E:-7 F:10 I:-1.2847 J:2 K:0 X:-2 Y:-55 Z:7 ]
G2 E-7.000000 F10.000000 I-1.284666 J2.000000 K0.000000 X-2.000000 Y-55.000000 Z7.000000
```

**After**
```
Command G2 [ F:10 I:-1.2847e-07 J:2 K:0 X:-2 Y:-55 Z:7 ]
G2 F10.000000 I-0.000000 J2.000000 K0.000000 X-2.000000 Y-55.000000 Z7.000000
```

