### PR TITLE
Sketcher: Esc should not cancel sketch edit

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
@@ -43,6 +43,7 @@ TaskDlgEditSketch::TaskDlgEditSketch(ViewProviderSketch* sketchView)
     , sketchView(sketchView)
 {
     assert(sketchView);
+    roleOnEscape = QDialogButtonBox::ButtonRole::AcceptRole;
 
     ToolSettings = new TaskSketcherTool(sketchView);
     Constraints = new TaskSketcherConstraints(sketchView);


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/pull/29337#issuecomment-4691294377
Fix : https://github.com/AstoCAD/FreeCAD/issues/146

Pressing esc should not cancel changes.
