### PR TITLE
[codex] Fix material transparency unit conversion

### DIFF
--- a/src/Mod/Material/App/Materials.cpp
+++ b/src/Mod/Material/App/Materials.cpp
@@ -1650,7 +1650,7 @@ Material& Material::operator=(const App::Material& other)
     getAppearanceProperty(QStringLiteral("SpecularColor"))->setColor(other.specularColor);
     getAppearanceProperty(QStringLiteral("EmissiveColor"))->setColor(other.emissiveColor);
     getAppearanceProperty(QStringLiteral("Shininess"))->setFloat(other.shininess);
-    getAppearanceProperty(QStringLiteral("Transparency"))->setFloat(other.transparency);
+    getAppearanceProperty(QStringLiteral("Transparency"))->setFloat(other.transparency * 100.0F);
 
     if (!other.image.empty() || !other.imagePath.empty()) {
         if (!hasAppearanceModel(ModelUUIDs::ModelUUID_Rendering_Texture)) {
@@ -1770,7 +1770,8 @@ App::Material Material::getMaterialAppearance() const
         custom = true;
     }
     if (hasAppearanceProperty(QStringLiteral("Transparency"))) {
-        material.transparency = getAppearanceProperty(QStringLiteral("Transparency"))->getFloat();
+        material.transparency =
+            getAppearanceProperty(QStringLiteral("Transparency"))->getFloat() / 100.0F;
         custom = true;
     }
     if (hasAppearanceProperty(QStringLiteral("TextureImage"))) {

--- a/src/Mod/Material/Gui/MaterialsEditor.cpp
+++ b/src/Mod/Material/Gui/MaterialsEditor.cpp
@@ -1030,7 +1030,7 @@ bool MaterialsEditor::updateMaterialPreview() const
     }
     if (_material->hasAppearanceProperty(QStringLiteral("Transparency"))) {
         double value = _material->getAppearanceValue(QStringLiteral("Transparency")).toDouble();
-        _rendered->setTransparency(value);
+        _rendered->setTransparency(value / 100.0);
     }
     else {
         _rendered->resetTransparency();

--- a/tests/src/Mod/Material/App/TestMaterials.cpp
+++ b/tests/src/Mod/Material/App/TestMaterials.cpp
@@ -345,6 +345,20 @@ TEST_F(TestMaterial, TestCalculiXSteel)
     EXPECT_EQ(steel->getPhysicalQuantity(QStringLiteral("ThermalExpansionCoefficient")).getUserString(), parseQuantity("12.00 µm/m/K").toStdString());
 }
 
+TEST_F(TestMaterial, TestTransparencyUnits)
+{
+    Materials::Material material;
+    material.addAppearance(Materials::ModelUUIDs::ModelUUID_Rendering_Basic);
+    material.getAppearanceProperty(QStringLiteral("Transparency"))->setFloat(80.0);
+
+    auto appearance = material.getMaterialAppearance();
+    EXPECT_NEAR(appearance.transparency, 0.8F, 1e-6);
+
+    appearance.transparency = 0.35F;
+    material = appearance;
+    EXPECT_NEAR(material.getAppearanceValue(QStringLiteral("Transparency")).toDouble(), 35.0, 1e-6);
+}
+
 TEST_F(TestMaterial, TestColumns)
 {
     // Start with an empty material


### PR DESCRIPTION
## Summary

- convert material-card transparency percentages to the 0–1 range used by `App::Material`
- convert `App::Material` transparency back to percentage values when writing material data
- use the same conversion in the material appearance preview
- add a regression test for both conversion directions

## Root cause

Material cards persist transparency as a percentage, while `App::Material` and Coin rendering use a normalized value between 0 and 1. The material path passed the stored value through unchanged, so a card value of `80` became `80` internally and was displayed as `8000` by the percentage-based property editor.

## Impact

Applying a material with 80% transparency now produces an object transparency value of 80 and a normalized rendering value of 0.8. Saving an `App::Material` value of 0.35 writes 35 to the material model.

## Validation

- added `TestTransparencyUnits` for the 80% → 0.8 and 0.35 → 35 conversions
- verified the remote diff contains only the three intended files
- full FreeCAD build/tests were not available locally; CI is expected to run the C++ test suite

Fixes #21271