### PR TITLE
[codex] Fix TechDraw tolerance units and precision

### DIFF
--- a/src/Mod/TechDraw/App/DimensionFormatter.cpp
+++ b/src/Mod/TechDraw/App/DimensionFormatter.cpp
@@ -103,7 +103,8 @@ std::string DimensionFormatter::formatValue(const qreal value,
 
     double factor{1.0};
     std::string unitText{""};
-    asQuantity.getUserString(factor, unitText);
+    Base::Quantity unitQuantity {isDim ? value : m_dimension->getDimValue(), unit};
+    unitQuantity.getUserString(factor, unitText);
     std::string squareTag{"^2"};
 
     if (unitText.empty()) {

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -103,9 +103,9 @@ const char* DrawViewDimension::TypeEnums[] = {"Distance",
 
 const char* DrawViewDimension::MeasureTypeEnums[] = {"True", "Projected", nullptr};
 
-// constraint to set the step size to 0.1
+// constraint to set the step size to 0.01
 static const App::PropertyQuantityConstraint::Constraints ToleranceConstraint = {
-    -std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), 0.1};
+    -std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), 0.01};
 // constraint to force positive values
 static const App::PropertyQuantityConstraint::Constraints PositiveConstraint = {
     0.0, std::numeric_limits<double>::max(), 0.1};

--- a/src/Mod/TechDraw/Gui/TaskDimension.ui
+++ b/src/Mod/TechDraw/Gui/TaskDimension.ui
@@ -168,7 +168,7 @@ If 'Equal tolerance' is checked this is also
 the negated value for 'Undertolerance'.</string>
           </property>
           <property name="singleStep" stdset="0">
-           <double>0.100000000000000</double>
+           <double>0.010000000000000</double>
           </property>
           <property name="value" stdset="0">
            <double>0.000000000000000</double>
@@ -196,7 +196,7 @@ If 'Equal tolerance' is checked it will be replaced
 by negative value of 'Overtolerance'.</string>
           </property>
           <property name="singleStep" stdset="0">
-           <double>0.100000000000000</double>
+           <double>0.010000000000000</double>
           </property>
           <property name="value" stdset="0">
            <double>0.000000000000000</double>

--- a/tests/src/Mod/TechDraw/App/CMakeLists.txt
+++ b/tests/src/Mod/TechDraw/App/CMakeLists.txt
@@ -2,4 +2,5 @@
 
 add_executable(TechDraw_tests_run
         LineFormat.cpp
+        TestDimensionFormatter.cpp
 )

--- a/tests/src/Mod/TechDraw/App/TestDimensionFormatter.cpp
+++ b/tests/src/Mod/TechDraw/App/TestDimensionFormatter.cpp
@@ -53,16 +53,15 @@ TEST_F(TestDimensionFormatter, TolerancesUseDimensionDisplayUnit)
     dimension->UnderTolerance.setValue(-0.55);
 
     const auto tolerances = dimension->getFormattedToleranceValues(
-        TechDraw::DimensionFormatter::Format::FORMATTED);
+        TechDraw::DimensionFormatter::Format::FORMATTED
+    );
 
     bool parsed = false;
-    const double underTolerance =
-        QLocale().toDouble(QString::fromStdString(tolerances.first), &parsed);
+    const double underTolerance = QLocale().toDouble(QString::fromStdString(tolerances.first), &parsed);
     ASSERT_TRUE(parsed);
     EXPECT_NEAR(underTolerance, -0.55, 1e-6);
 
-    const double overTolerance =
-        QLocale().toDouble(QString::fromStdString(tolerances.second), &parsed);
+    const double overTolerance = QLocale().toDouble(QString::fromStdString(tolerances.second), &parsed);
     ASSERT_TRUE(parsed);
     EXPECT_NEAR(overTolerance, 0.05, 1e-6);
 
@@ -71,12 +70,14 @@ TEST_F(TestDimensionFormatter, TolerancesUseDimensionDisplayUnit)
         dimension->getDimValue(),
         QStringLiteral("%.2f"),
         TechDraw::DimensionFormatter::Format::UNIT,
-        true);
+        true
+    );
     const auto toleranceUnit = dimension->formatValue(
         dimension->OverTolerance.getValue(),
         QStringLiteral("%+.2f"),
         TechDraw::DimensionFormatter::Format::UNIT,
-        false);
+        false
+    );
     EXPECT_EQ(toleranceUnit, dimensionUnit);
 }
 

--- a/tests/src/Mod/TechDraw/App/TestDimensionFormatter.cpp
+++ b/tests/src/Mod/TechDraw/App/TestDimensionFormatter.cpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include <QLocale>
+#include <QString>
+
+#include <App/Application.h>
+#include <Mod/TechDraw/App/DimensionFormatter.h>
+#include <Mod/TechDraw/App/DrawViewDimension.h>
+#include <src/App/InitApplication.h>
+
+namespace
+{
+
+class TestDrawViewDimension: public TechDraw::DrawViewDimension
+{
+public:
+    double getDimValue() override
+    {
+        return 20.2;
+    }
+};
+
+class TestDimensionFormatter: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        if (App::Application::GetARGC() == 0) {
+            tests::initApplication();
+        }
+    }
+
+    void SetUp() override
+    {
+        dimension = std::make_unique<TestDrawViewDimension>();
+        dimension->Type.setValue("Distance");
+        dimension->EqualTolerance.setValue(false);
+        dimension->ShowUnits.setValue(false);
+        dimension->FormatSpecOverTolerance.setValue("%+.2f");
+        dimension->FormatSpecUnderTolerance.setValue("%+.2f");
+    }
+
+    std::unique_ptr<TestDrawViewDimension> dimension;
+};
+
+TEST_F(TestDimensionFormatter, TolerancesUseDimensionDisplayUnit)
+{
+    dimension->OverTolerance.setValue(0.05);
+    dimension->UnderTolerance.setValue(-0.55);
+
+    const auto tolerances = dimension->getFormattedToleranceValues(
+        TechDraw::DimensionFormatter::Format::FORMATTED);
+
+    bool parsed = false;
+    const double underTolerance =
+        QLocale().toDouble(QString::fromStdString(tolerances.first), &parsed);
+    ASSERT_TRUE(parsed);
+    EXPECT_NEAR(underTolerance, -0.55, 1e-6);
+
+    const double overTolerance =
+        QLocale().toDouble(QString::fromStdString(tolerances.second), &parsed);
+    ASSERT_TRUE(parsed);
+    EXPECT_NEAR(overTolerance, 0.05, 1e-6);
+
+    dimension->ShowUnits.setValue(true);
+    const auto dimensionUnit = dimension->formatValue(
+        dimension->getDimValue(),
+        QStringLiteral("%.2f"),
+        TechDraw::DimensionFormatter::Format::UNIT,
+        true);
+    const auto toleranceUnit = dimension->formatValue(
+        dimension->OverTolerance.getValue(),
+        QStringLiteral("%+.2f"),
+        TechDraw::DimensionFormatter::Format::UNIT,
+        false);
+    EXPECT_EQ(toleranceUnit, dimensionUnit);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

- format tolerance values using the same display unit and scale factor as the parent dimension
- reduce the tolerance property and task-panel step size from 0.1 to 0.01
- add a TechDraw regression test for asymmetric `+0.05` / `-0.55` tolerances and unit consistency

## Root cause

Tolerance quantities selected their display unit independently from the dimension. For a millimetre dimension, a tolerance of `0.05 mm` could therefore normalize to `50 µm`. When units were hidden the drawing showed `50`; when units were enabled it showed the tolerance unit (`µm`) instead of the dimension unit.

The tolerance controls also used a hard-coded step of `0.1`, which made hundredth-level adjustments unnecessarily difficult.

## Impact

Tolerance values now retain their intended magnitude and sign while using the dimension's display unit. A `20.2 mm` dimension can display `+0.05` and `-0.55` tolerances, and enabling units keeps all three values in the same unit.

## Validation

- added `TolerancesUseDimensionDisplayUnit` to verify both signed values and unit equality
- verified the remote diff contains only the five intended files
- full FreeCAD build/tests were not available locally; CI is expected to run `TechDraw_tests_run`

Fixes #30743