### PR TITLE
[codex] Stop restoring previous BIM container on deactivation

### DIFF
--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -1197,7 +1197,7 @@ class ViewProviderBuildingPart:
         vobj = self.Object.ViewObject
 
         if (not hasattr(vobj, "DoubleClickActivates")) or vobj.DoubleClickActivates:
-            if toggle_working_plane(self.Object, action, restore=True):
+            if toggle_working_plane(self.Object, action):
                 print("Setting active working plane to: ", self.Object.Label)
             else:
                 print("Deactivating working plane from: ", self.Object.Label)

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -526,7 +526,7 @@ class BIM_Views:
                 item = vm.tree.selectedItems()[-1]
                 obj = FreeCAD.ActiveDocument.getObject(item.toolTip(0))
                 if obj:
-                    toggle_working_plane(obj, None, restore=True, dialog=dialog)
+                    toggle_working_plane(obj, None, dialog=dialog)
                     FreeCADGui.Selection.clearSelection()
 
     def editObject(self, item, column):

--- a/src/Mod/BIM/bimtests/TestArchBuildingPartGui.py
+++ b/src/Mod/BIM/bimtests/TestArchBuildingPartGui.py
@@ -1,13 +1,38 @@
+from unittest import mock
+
 import FreeCAD as App
 import FreeCADGui
 import Arch
 import Draft
 import Part
 import Sketcher
+
 from bimtests.TestArchBaseGui import TestArchBaseGui
 
 
 class TestArchBuildingPartGui(TestArchBaseGui):
+
+    def testDeactivationDoesNotRestorePreviousContainer(self):
+        first = Arch.makeBuildingPart(name="First")
+        second = Arch.makeBuildingPart(name="Second")
+        third = Arch.makeBuildingPart(name="Third")
+        active_view = FreeCADGui.ActiveDocument.ActiveView
+
+        def restore_second(restore=False):
+            if restore:
+                active_view.setActiveObject("Arch", second)
+
+        with (
+            mock.patch.object(first.ViewObject.Proxy, "setWorkingPlane"),
+            mock.patch.object(second.ViewObject.Proxy, "setWorkingPlane"),
+            mock.patch.object(third.ViewObject.Proxy, "setWorkingPlane", side_effect=restore_second),
+        ):
+            first.ViewObject.Proxy.activate()
+            second.ViewObject.Proxy.activate()
+            third.ViewObject.Proxy.activate()
+            third.ViewObject.Proxy.activate()
+
+        self.assertIsNone(active_view.getActiveObject("Arch"))
 
     def testBuildingPart(self):
         """Create a BuildingPart from a wall with a window and check its shape."""

--- a/src/Mod/BIM/bimtests/TestArchBuildingPartGui.py
+++ b/src/Mod/BIM/bimtests/TestArchBuildingPartGui.py
@@ -25,7 +25,9 @@ class TestArchBuildingPartGui(TestArchBaseGui):
         with (
             mock.patch.object(first.ViewObject.Proxy, "setWorkingPlane"),
             mock.patch.object(second.ViewObject.Proxy, "setWorkingPlane"),
-            mock.patch.object(third.ViewObject.Proxy, "setWorkingPlane", side_effect=restore_second),
+            mock.patch.object(
+                third.ViewObject.Proxy, "setWorkingPlane", side_effect=restore_second
+            ),
         ):
             first.ViewObject.Proxy.activate()
             second.ViewObject.Proxy.activate()

--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -1042,7 +1042,7 @@ def toggle_working_plane(obj, action=None, restore=False, dialog=None):
         if is_active_ifc:
             Gui.ActiveDocument.ActiveView.setActiveObject("NativeIFC", None)
 
-        if (
+        if restore and (
             hasattr(obj, "ViewObject")
             and hasattr(obj.ViewObject, "Proxy")
             and hasattr(obj.ViewObject.Proxy, "setWorkingPlane")


### PR DESCRIPTION
## Summary

- stop reactivating the previously active BIM container when a BuildingPart is deactivated
- make the existing `restore` option in the shared working-plane toggle control whether restoration actually runs
- keep BuildingPart context-menu and BIM Views behavior consistent
- add a GUI regression test covering three consecutively activated containers

## Root cause

The shared toggle accepted a `restore` argument but ignored it during deactivation and always called `setWorkingPlane(restore=True)`. BuildingPart and BIM Views also explicitly requested restoration, so deactivating the latest level popped the working-plane history and made the previous level active again.

## Impact

Deactivating a Building, Level, or Drawing container now leaves no BIM container active and does not change the current working plane, matching the explicit activation model used by Part Design bodies.

## Validation

- added `testDeactivationDoesNotRestorePreviousContainer` with three BuildingParts
- compiled all four changed Python files successfully
- verified the patch is limited to four files (`+28/-3`)
- full FreeCAD GUI tests were unavailable locally; CI is expected to run `TestArchGui`

Fixes #30702