### PR TITLE
[codex] Restore locked TechDraw view positions

### DIFF
--- a/src/Mod/TechDraw/CMakeLists.txt
+++ b/src/Mod/TechDraw/CMakeLists.txt
@@ -186,6 +186,7 @@ SET(TDTest_SRCS
     TDTest/DrawViewSectionTest.py
     TDTest/DrawViewBalloonTest.py
     TDTest/DrawViewDetailTest.py
+    TDTest/LockedViewPositionTest.py
     TDTest/TechDrawTestUtilities.py
 )
 
@@ -211,4 +212,3 @@ fc_copy_sources(TDTestTarget "${CMAKE_BINARY_DIR}/Mod/TechDraw" ${TDAllTest})
 # install Python packages (for make install)
 INSTALL(FILES ${TDTest_SRCS} DESTINATION Mod/TechDraw/TDTest)
 INSTALL(FILES ${TDTestFile_SRCS} DESTINATION Mod/TechDraw/TDTest)
-

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -259,8 +259,7 @@ void ViewProviderDrawingView::updateData(const App::Property* prop)
     if (prop == &obj->X ||
         prop == &obj->Y) {
 
-        if (qgiv->isSnapping() ||
-            obj->LockPosition.getValue()) {
+        if (qgiv->isSnapping()) {
             Gui::ViewProviderDocumentObject::updateData(prop);
             return;
         }

--- a/src/Mod/TechDraw/TDTest/LockedViewPositionTest.py
+++ b/src/Mod/TechDraw/TDTest/LockedViewPositionTest.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+import FreeCAD
+import TechDrawGui
+from PySide import QtCore
+
+from .TechDrawTestUtilities import createPageWithSVGTemplate
+
+
+class LockedViewPositionTest(unittest.TestCase):
+    def setUp(self):
+        FreeCAD.newDocument("TDLockedPosition")
+        self.doc = FreeCAD.ActiveDocument
+        self.doc.addObject("Part::Box", "Box")
+        self.page = createPageWithSVGTemplate()
+        self.page.ViewObject.show()
+
+    def tearDown(self):
+        FreeCAD.closeDocument("TDLockedPosition")
+
+    def graphicsItem(self, view):
+        scene = TechDrawGui.getSceneForPage(self.page)
+        for item in scene.items():
+            if item.data(1) == view.Name:
+                return item
+        self.fail(f"Graphics item for {view.Name} was not found")
+
+    def testLockedViewTracksFeaturePosition(self):
+        unlocked = self.doc.addObject("TechDraw::DrawViewPart", "UnlockedView")
+        locked = self.doc.addObject("TechDraw::DrawViewPart", "LockedView")
+        self.page.addView(unlocked)
+        self.page.addView(locked)
+        unlocked.Source = [self.doc.Box]
+        locked.Source = [self.doc.Box]
+        locked.LockPosition = True
+
+        for view in (unlocked, locked):
+            view.X = 42
+            view.Y = 73
+
+        self.doc.recompute()
+        QtCore.QCoreApplication.processEvents()
+
+        self.assertEqual(self.graphicsItem(locked).pos(), self.graphicsItem(unlocked).pos())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/TechDraw/TestTechDrawGui.py
+++ b/src/Mod/TechDraw/TestTechDrawGui.py
@@ -26,4 +26,4 @@ from TDTest.DrawViewSectionTest import DrawViewSectionTest  # noqa: F401
 from TDTest.DrawViewPartTest import DrawViewPartTest  # noqa: F401
 from TDTest.DrawViewDetailTest import DrawViewDetailTest  # noqa: F401
 from TDTest.DrawViewDimensionTest import DrawViewDimensionTest  # noqa: F401
-
+from TDTest.LockedViewPositionTest import LockedViewPositionTest  # noqa: F401


### PR DESCRIPTION
## Summary

- allow X/Y property updates to reposition locked TechDraw graphics items
- keep `LockPosition` responsible for user dragging, without blocking model-to-GUI synchronization
- add a GUI regression test comparing locked and unlocked views with identical feature coordinates

## Root cause

During document loading, a graphics item can be attached while its X/Y properties still have their default values. The saved X/Y values are restored afterward, but `ViewProviderDrawingView::updateData()` returned early whenever `LockPosition` was true. Unlocked views therefore moved to their saved coordinates while locked views stayed at the graphics item's initial `(0,0)` position.

## Impact

Locked `TechDraw_View` and `TechDraw_DraftView` objects now recover their saved page positions when a document opens. Locking still prevents interactive dragging through the existing movable-flag logic.

## Validation

- added `LockedViewPositionTest`, which gives locked and unlocked views identical X/Y values and verifies their graphics positions match
- verified the issue attachment stores non-zero locked positions (`149.91824, 193.639995` and `149.91824, 34.033448`)
- compiled the new Python test successfully
- verified the patch is limited to four files (`+53/-4`)
- full FreeCAD GUI tests were unavailable locally; CI is expected to run `TestTechDrawGui`

Fixes #30723