### PR TITLE
[codex] Avoid double offset when attaching TechDraw balloons

### DIFF
--- a/src/Mod/TechDraw/CMakeLists.txt
+++ b/src/Mod/TechDraw/CMakeLists.txt
@@ -185,6 +185,7 @@ SET(TDTest_SRCS
     TDTest/DrawViewPartTest.py
     TDTest/DrawViewSectionTest.py
     TDTest/DrawViewBalloonTest.py
+    TDTest/BalloonPositionTest.py
     TDTest/DrawViewDetailTest.py
     TDTest/TechDrawTestUtilities.py
 )
@@ -211,4 +212,3 @@ fc_copy_sources(TDTestTarget "${CMAKE_BINARY_DIR}/Mod/TechDraw" ${TDAllTest})
 # install Python packages (for make install)
 INSTALL(FILES ${TDTest_SRCS} DESTINATION Mod/TechDraw/TDTest)
 INSTALL(FILES ${TDTestFile_SRCS} DESTINATION Mod/TechDraw/TDTest)
-

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -411,7 +411,9 @@ bool QGSPage::attachView(App::DocumentObject* obj)
         return true;
     }
 
-    if (qview) {
+    // Balloons position their label and leader relative to the source view.
+    // Moving the graphics container as well would apply their X/Y offset twice.
+    if (qview && !dynamic_cast<QGIViewBalloon*>(qview)) {
         qview->updatePositionFromFeatureXY();
     }
 

--- a/src/Mod/TechDraw/TDTest/BalloonPositionTest.py
+++ b/src/Mod/TechDraw/TDTest/BalloonPositionTest.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+import FreeCAD
+import TechDrawGui
+from PySide import QtCore
+
+from .TechDrawTestUtilities import createPageWithSVGTemplate
+
+
+class BalloonPositionTest(unittest.TestCase):
+    def setUp(self):
+        FreeCAD.newDocument("TDBalloonPosition")
+        self.doc = FreeCAD.ActiveDocument
+        self.doc.addObject("Part::Box", "Box")
+        self.page = createPageWithSVGTemplate()
+        self.page.ViewObject.show()
+
+        self.view = self.doc.addObject("TechDraw::DrawViewPart", "View")
+        self.page.addView(self.view)
+        self.view.Source = [self.doc.Box]
+        self.view.X = 80
+        self.view.Y = 70
+        self.doc.recompute()
+        QtCore.QCoreApplication.processEvents()
+
+    def tearDown(self):
+        FreeCAD.closeDocument("TDBalloonPosition")
+
+    def graphicsItem(self, view):
+        scene = TechDrawGui.getSceneForPage(self.page)
+        for item in scene.items():
+            if item.data(1) == view.Name:
+                return item
+        self.fail(f"Graphics item for {view.Name} was not found")
+
+    def testBalloonOffsetAppliedOnce(self):
+        balloon = self.doc.addObject("TechDraw::DrawViewBalloon", "Balloon")
+        balloon.SourceView = self.view
+        balloon.OriginX = 10
+        balloon.OriginY = 15
+        balloon.X = 30
+        balloon.Y = 40
+        balloon.Text = "1"
+        self.page.addView(balloon)
+
+        self.doc.recompute()
+        QtCore.QCoreApplication.processEvents()
+
+        item = self.graphicsItem(balloon)
+        self.assertIsNotNone(item.parentItem())
+        self.assertEqual(item.pos(), QtCore.QPointF(0, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/TechDraw/TestTechDrawGui.py
+++ b/src/Mod/TechDraw/TestTechDrawGui.py
@@ -26,4 +26,5 @@ from TDTest.DrawViewSectionTest import DrawViewSectionTest  # noqa: F401
 from TDTest.DrawViewPartTest import DrawViewPartTest  # noqa: F401
 from TDTest.DrawViewDetailTest import DrawViewDetailTest  # noqa: F401
 from TDTest.DrawViewDimensionTest import DrawViewDimensionTest  # noqa: F401
+from TDTest.BalloonPositionTest import BalloonPositionTest  # noqa: F401
 


### PR DESCRIPTION
## Summary

- keep a newly attached TechDraw balloon container at its source-view origin
- avoid applying the balloon X/Y offset both to the container and its internal label
- add a GUI regression test that verifies the balloon container remains at local `(0, 0)`

## Root cause

`QGIViewBalloon` already uses the feature X/Y values to position its label relative to the source view. The generic post-attach position sync then moved the entire graphics container by the same values, doubling the intended offset and shifting the arrow away from the selected feature.

## Validation

- added `BalloonPositionTest`, which creates a parent view and balloon with non-zero coordinates and checks the attached balloon container stays at its parent origin
- Python syntax validation passed
- full FreeCAD GUI tests were unavailable locally; CI is expected to run `TestTechDrawGui`

Fixes #30734