### PR TITLE
TaskImage: Allow snapping image rotation by calibration line

### DIFF
--- a/src/Gui/TaskView/TaskImage.cpp
+++ b/src/Gui/TaskView/TaskImage.cpp
@@ -239,6 +239,9 @@ void TaskImage::startScale()
         ui->groupBoxCalibration->show();
         ui->pushButtonApply->setEnabled(false);
 
+        ui->spinBoxWidth->setEnabled(false);
+        ui->spinBoxHeight->setEnabled(false);
+
         showToolHints();
     }
 }
@@ -304,6 +307,9 @@ void TaskImage::rejectScale()
         scale->deactivate();
         ui->pushButtonScale->show();
         ui->groupBoxCalibration->hide();
+
+        ui->spinBoxWidth->setEnabled(true);
+        ui->spinBoxHeight->setEnabled(true);
 
         showToolHints();
     }
@@ -583,6 +589,8 @@ void InteractiveScale::activate()
         viewer->addEventCallback(SoButtonEvent::getClassTypeId(), InteractiveScale::soEventFilter, this);
         viewer->setSelectionEnabled(false);
         viewer->getWidget()->setCursor(QCursor(Qt::CrossCursor));
+        // Focus the 3D view so our keybinds won't appear to be broken
+        viewer->setFocus();
         active = true;
     }
 }

--- a/src/Gui/TaskView/TaskImage.cpp
+++ b/src/Gui/TaskView/TaskImage.cpp
@@ -42,6 +42,8 @@
 #include <Gui/Camera.h>
 #include <Gui/Document.h>
 #include <Gui/EditableDatumLabel.h>
+#include <Gui/InputHint.h>
+#include <Gui/MainWindow.h>
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
 #include <Gui/ViewProviderDocumentObject.h>
@@ -205,6 +207,30 @@ void TaskImage::scaleImage(double factor)
     }
 }
 
+void TaskImage::showToolHints() const
+{
+    using enum Gui::InputHint::UserInput;
+    InteractiveScaleState state = scale->getState();
+
+    InputHint snap = {tr("%1 snap angle"), {ModifierCtrl}};
+    InputHint toggleCenter = {tr("%1 toggle centering"), {KeyC}};
+    InputHint toggleRotation = {tr("%1 toggle rotating to line"), {KeyR}};
+
+    std::list<Gui::InputHint> hints = Gui::lookupHints<InteractiveScaleState>(
+        state,
+        {
+            {.state = InteractiveScaleState::PickingFirst,
+             .hints = {{tr("%1 pick first point"), {MouseLeft}}, toggleCenter, toggleRotation}},
+            {.state = InteractiveScaleState::PickingSecond,
+             .hints = {snap, {tr("%1 pick second point"), {MouseLeft}}, toggleCenter, toggleRotation}},
+            {.state = InteractiveScaleState::Pending, .hints = {toggleCenter, toggleRotation}},
+        }
+    );
+
+    Gui::getMainWindow()->showHints(hints);
+}
+
+
 void TaskImage::startScale()
 {
     if (scale) {
@@ -212,15 +238,29 @@ void TaskImage::startScale()
         ui->pushButtonScale->hide();
         ui->groupBoxCalibration->show();
         ui->pushButtonApply->setEnabled(false);
+
+        showToolHints();
     }
 }
 
 void TaskImage::acceptScale()
 {
     if (scale) {
+        bool update = false;
+        if (ui->checkBoxCenterMidpoint->isChecked()) {
+            SbVec3f midpoint = scale->getMidPoint();
+            ui->spinBoxX->setValue(-midpoint[0]);
+            ui->spinBoxY->setValue(-midpoint[1]);
+            update = true;
+        }
         if (ui->checkBoxOrient->isChecked()) {
             applyOrientation();
+            update = true;
         }
+        if (update) {
+            updatePlacement();
+        }
+
         scaleImage(scale->getScaleFactor());
         rejectScale();
     }
@@ -241,12 +281,21 @@ void TaskImage::applyOrientation()
     float newAngle = placementAngle + adjustment;
 
     ui->spinBoxRotation->setValue(newAngle);
-    updatePlacement();
 }
 
 void TaskImage::enableApplyBtn()
 {
     ui->pushButtonApply->setEnabled(true);
+}
+
+void TaskImage::toggleRotation()
+{
+    ui->checkBoxOrient->toggle();
+}
+
+void TaskImage::toggleCentering()
+{
+    ui->checkBoxCenterMidpoint->toggle();
 }
 
 void TaskImage::rejectScale()
@@ -255,6 +304,8 @@ void TaskImage::rejectScale()
         scale->deactivate();
         ui->pushButtonScale->show();
         ui->groupBoxCalibration->hide();
+
+        showToolHints();
     }
 }
 
@@ -268,6 +319,9 @@ void TaskImage::onInteractiveScale()
             connect(scale, &InteractiveScale::scaleRequired, this, &TaskImage::acceptScale);
             connect(scale, &InteractiveScale::scaleCanceled, this, &TaskImage::rejectScale);
             connect(scale, &InteractiveScale::enableApplyBtn, this, &TaskImage::enableApplyBtn);
+            connect(scale, &InteractiveScale::showToolHints, this, &TaskImage::showToolHints);
+            connect(scale, &InteractiveScale::toggleRotation, this, &TaskImage::toggleRotation);
+            connect(scale, &InteractiveScale::toggleCentering, this, &TaskImage::toggleCentering);
         }
     }
 
@@ -500,6 +554,23 @@ InteractiveScale::~InteractiveScale()
     delete measureLabel;
 }
 
+InteractiveScaleState InteractiveScale::getState() const
+{
+    if (!active) {
+        return InteractiveScaleState::Inactive;
+    }
+    else if (points.size() == 0) {
+        return InteractiveScaleState::PickingFirst;
+    }
+    else if (points.size() == 1) {
+        return InteractiveScaleState::PickingSecond;
+    }
+    else {
+        return InteractiveScaleState::Pending;
+    }
+}
+
+
 void InteractiveScale::activate()
 {
     if (viewer) {
@@ -554,7 +625,16 @@ double InteractiveScale::getAngleDegrees() const
     }
 
     SbVec3f delta = points[1] - points[0];
-    return std::atan2(delta[1], delta[0]) * 180.0 / M_PI;
+    return Base::toDegrees(std::atan2(delta[1], delta[0]));
+}
+
+SbVec3f InteractiveScale::getMidPoint() const
+{
+    if (points.size() < 2) {
+        return {0.0F, 0.0F, 0.0F};
+    }
+
+    return (points[0] + points[1]) / 2;
 }
 
 double InteractiveScale::getDistance(const SbVec3f& pt) const
@@ -564,6 +644,23 @@ double InteractiveScale::getDistance(const SbVec3f& pt) const
     }
 
     return (points[0] - pt).length();
+}
+
+SbVec3f InteractiveScale::snapAtAngle(const SbVec3f& pt) const
+{
+    if (points.size() < 1) {
+        return pt;
+    }
+    const SbVec3f& first = points[0];
+    SbVec3f delta = pt - first;
+
+    float angle = std::atan2(delta[1], delta[0]);
+    // Snap in radians, since we'll use them for the vector
+    const float snapSize = Base::toRadians(5.0);
+    angle = snapSize * round(angle / snapSize);
+
+    SbVec3f snapPos = first + delta.length() * SbVec3f {cos(angle), sin(angle), 0.0F};
+    return snapPos;
 }
 
 void InteractiveScale::setDistance(const SbVec3f& pos3d)
@@ -601,14 +698,21 @@ void InteractiveScale::collectPoint(const SbVec3f& pos3d)
 
         measureLabel->label->setPoints(planePoint, planePoint);
         measureLabel->activate();
+        Q_EMIT showToolHints();
     }
     else if (points.size() == 1) {
+        // Snap when Ctrl is held
+        if (QApplication::keyboardModifiers() == Qt::ControlModifier) {
+            planePoint = snapAtAngle(planePoint);
+        }
+
         double distance = getDistance(planePoint);
         if (distance > Base::Precision::Confusion()) {
             points.push_back(planePoint);
 
             measureLabel->startEdit(distance, this, true);
 
+            Q_EMIT showToolHints();
             Q_EMIT enableApplyBtn();
         }
         else {
@@ -632,6 +736,12 @@ void InteractiveScale::getMousePosition(void* ud, SoEventCallback* ecb)
         std::unique_ptr<SoPickedPoint> pp(view->getPointOnRay(l2e->getPosition(), scale->viewProv));
         if (pp) {
             SbVec3f pos3d = scale->getCoordsOnImagePlane(pp->getPoint());
+
+            // Snap when Ctrl is held
+            if (QApplication::keyboardModifiers() == Qt::ControlModifier) {
+                pos3d = scale->snapAtAngle(pos3d);
+            }
+
             scale->setDistance(pos3d);
         }
     }
@@ -643,12 +753,31 @@ void InteractiveScale::soEventFilter(void* ud, SoEventCallback* ecb)
 
     const SoEvent* soEvent = ecb->getEvent();
     if (soEvent->isOfType(SoKeyboardEvent::getClassTypeId())) {
-        /* If user presses escape, then we cancel the tool.*/
         const auto kbe = static_cast<const SoKeyboardEvent*>(soEvent);  // NOLINT
 
-        if (kbe->getKey() == SoKeyboardEvent::ESCAPE && kbe->getState() == SoButtonEvent::UP) {
-            ecb->setHandled();
-            Q_EMIT scale->scaleCanceled();
+        // We only care about release events
+        if (kbe->getState() != SoButtonEvent::UP) {
+            return;
+        }
+
+        switch (kbe->getKey()) {
+            case SoKeyboardEvent::ESCAPE:
+                // Cancel the tool
+                ecb->setHandled();
+                Q_EMIT scale->scaleCanceled();
+                break;
+            case SoKeyboardEvent::R:
+                // Toggle rotating the image by the line
+                ecb->setHandled();
+                Q_EMIT scale->toggleRotation();
+                break;
+            case SoKeyboardEvent::C:
+                // Toggle centering the image on midpoint
+                ecb->setHandled();
+                Q_EMIT scale->toggleCentering();
+                break;
+            default:
+                break;
         }
     }
     else if (soEvent->isOfType(SoMouseButtonEvent::getClassTypeId())) {

--- a/src/Gui/TaskView/TaskImage.cpp
+++ b/src/Gui/TaskView/TaskImage.cpp
@@ -251,7 +251,7 @@ void TaskImage::acceptScale()
     if (scale) {
         bool update = false;
         if (ui->checkBoxCenterMidpoint->isChecked()) {
-            SbVec3f midpoint = scale->getMidPoint();
+            SbVec3f midpoint = scale->getMidPoint() * scale->getScaleFactor();
             ui->spinBoxX->setValue(-midpoint[0]);
             ui->spinBoxY->setValue(-midpoint[1]);
             update = true;

--- a/src/Gui/TaskView/TaskImage.cpp
+++ b/src/Gui/TaskView/TaskImage.cpp
@@ -218,9 +218,30 @@ void TaskImage::startScale()
 void TaskImage::acceptScale()
 {
     if (scale) {
+        if (ui->checkBoxOrient->isChecked()) {
+            applyOrientation();
+        }
         scaleImage(scale->getScaleFactor());
         rejectScale();
     }
+}
+
+void TaskImage::applyOrientation()
+{
+    // Get the display angle we'll use as the snap base
+    double placementAngle = ui->spinBoxRotation->value().getValue();
+    float lineAngle = scale->getAngleDegrees();
+    float displayAngle = placementAngle + lineAngle;
+
+    // Figure out where to snap the measured angle and the adjustment we'll apply
+    const float snapSize = 45.0;
+    float snapTarget = snapSize * std::round(displayAngle / snapSize);
+    float adjustment = snapTarget - displayAngle;
+
+    float newAngle = placementAngle + adjustment;
+
+    ui->spinBoxRotation->setValue(newAngle);
+    updatePlacement();
 }
 
 void TaskImage::enableApplyBtn()
@@ -469,7 +490,6 @@ InteractiveScale::InteractiveScale(
     , placement(plc)
     , viewer(view)
     , viewProv(vp)
-    , midPoint(SbVec3f(0, 0, 0))
 {
     measureLabel = new EditableDatumLabel(viewer, placement);  // NOLINT
     measureLabel->setActivatedColor();
@@ -527,6 +547,16 @@ double InteractiveScale::getScaleFactor() const
     return measureLabel->getValue() / (points[0] - points[1]).length();
 }
 
+double InteractiveScale::getAngleDegrees() const
+{
+    if (points.size() < 2) {
+        return 0.0;
+    }
+
+    SbVec3f delta = points[1] - points[0];
+    return std::atan2(delta[1], delta[0]) * 180.0 / M_PI;
+}
+
 double InteractiveScale::getDistance(const SbVec3f& pt) const
 {
     if (points.empty()) {
@@ -548,7 +578,7 @@ void InteractiveScale::setDistance(const SbVec3f& pos3d)
     std::string valueStr;
     valueStr = quantity.getUserString(factor, unitStr);
     measureLabel->label->string = SbString(valueStr.c_str());
-    measureLabel->label->setPoints(getCoordsOnImagePlane(points[0]), getCoordsOnImagePlane(pos3d));
+    measureLabel->label->setPoints(points[0], pos3d);
 }
 
 void InteractiveScale::findPointOnImagePlane(SoEventCallback* ecb)
@@ -565,20 +595,19 @@ void InteractiveScale::findPointOnImagePlane(SoEventCallback* ecb)
 
 void InteractiveScale::collectPoint(const SbVec3f& pos3d)
 {
+    SbVec3f planePoint = getCoordsOnImagePlane(pos3d);
     if (points.empty()) {
-        points.push_back(pos3d);
+        points.push_back(planePoint);
 
-        measureLabel->label->setPoints(getCoordsOnImagePlane(pos3d), getCoordsOnImagePlane(pos3d));
+        measureLabel->label->setPoints(planePoint, planePoint);
         measureLabel->activate();
     }
     else if (points.size() == 1) {
-        double distance = getDistance(pos3d);
+        double distance = getDistance(planePoint);
         if (distance > Base::Precision::Confusion()) {
-            points.push_back(pos3d);
+            points.push_back(planePoint);
 
-            midPoint = (points[0] + points[1]) / 2;
-
-            measureLabel->startEdit(getDistance(points[1]), this, true);
+            measureLabel->startEdit(distance, this, true);
 
             Q_EMIT enableApplyBtn();
         }
@@ -602,7 +631,7 @@ void InteractiveScale::getMousePosition(void* ud, SoEventCallback* ecb)
 
         std::unique_ptr<SoPickedPoint> pp(view->getPointOnRay(l2e->getPosition(), scale->viewProv));
         if (pp) {
-            SbVec3f pos3d = pp->getPoint();
+            SbVec3f pos3d = scale->getCoordsOnImagePlane(pp->getPoint());
             scale->setDistance(pos3d);
         }
     }
@@ -664,7 +693,7 @@ void InteractiveScale::setPlacement(const Base::Placement& plc)
     measureLabel->setPlacement(plc);
 }
 
-SbVec3f InteractiveScale::getCoordsOnImagePlane(const SbVec3f& point)
+SbVec3f InteractiveScale::getCoordsOnImagePlane(const SbVec3f& point) const
 {
     // Plane form
     Base::Vector3d RX(1, 0, 0);

--- a/src/Gui/TaskView/TaskImage.h
+++ b/src/Gui/TaskView/TaskImage.h
@@ -38,6 +38,14 @@ class EditableDatumLabel;
 namespace Gui
 {
 
+enum class InteractiveScaleState
+{
+    Inactive,
+    PickingFirst,
+    PickingSecond,
+    Pending
+};
+
 class View3DInventorViewer;
 class ViewProvider;
 class InteractiveScale: public QObject
@@ -58,9 +66,11 @@ public:
     }
     double getScaleFactor() const;
     double getAngleDegrees() const;
+    SbVec3f getMidPoint() const;
     // Point is expected to be in image plane coordinates
     double getDistance(const SbVec3f&) const;
     void setPlacement(const Base::Placement& plc);
+    InteractiveScaleState getState() const;
 
 private:
     static void soEventFilter(void* ud, SoEventCallback* ecb);
@@ -69,6 +79,8 @@ private:
     void collectPoint(const SbVec3f&);
     // Point is expected to be in image plane coordinates
     void setDistance(const SbVec3f&);
+    // Point is expected to be in image plane coordinates
+    SbVec3f snapAtAngle(const SbVec3f&) const;
 
     /// Convert a world-space point into the image plane coordinate system
     SbVec3f getCoordsOnImagePlane(const SbVec3f& point) const;
@@ -77,6 +89,9 @@ Q_SIGNALS:
     void scaleRequired();
     void scaleCanceled();
     void enableApplyBtn();
+    void showToolHints();
+    void toggleRotation();
+    void toggleCentering();
 
 private:
     bool active;
@@ -114,6 +129,10 @@ private:
     void applyOrientation();
     void rejectScale();
     void enableApplyBtn();
+    void showToolHints() const;
+    void toggleRotation();
+    void toggleCentering();
+
 
     void restore(const Base::Placement&);
     void restoreAngles(const Base::Rotation&);

--- a/src/Gui/TaskView/TaskImage.h
+++ b/src/Gui/TaskView/TaskImage.h
@@ -57,6 +57,8 @@ public:
         return active;
     }
     double getScaleFactor() const;
+    double getAngleDegrees() const;
+    // Point is expected to be in image plane coordinates
     double getDistance(const SbVec3f&) const;
     void setPlacement(const Base::Placement& plc);
 
@@ -65,10 +67,11 @@ private:
     static void getMousePosition(void* ud, SoEventCallback* ecb);
     void findPointOnImagePlane(SoEventCallback* ecb);
     void collectPoint(const SbVec3f&);
+    // Point is expected to be in image plane coordinates
     void setDistance(const SbVec3f&);
 
-    /// give the coordinates of a line on the image plane in imagePlane (2D) coordinates
-    SbVec3f getCoordsOnImagePlane(const SbVec3f& point);
+    /// Convert a world-space point into the image plane coordinate system
+    SbVec3f getCoordsOnImagePlane(const SbVec3f& point) const;
 
 Q_SIGNALS:
     void scaleRequired();
@@ -81,8 +84,8 @@ private:
     EditableDatumLabel* measureLabel;
     QPointer<Gui::View3DInventorViewer> viewer;
     ViewProvider* viewProv;
+    // 2D coordinates on the image plane, in its coordinate system
     std::vector<SbVec3f> points;
-    SbVec3f midPoint;
 };
 
 class Ui_TaskImage;
@@ -108,6 +111,7 @@ private:
     void scaleImage(double);
     void startScale();
     void acceptScale();
+    void applyOrientation();
     void rejectScale();
     void enableApplyBtn();
 

--- a/src/Gui/TaskView/TaskImage.ui
+++ b/src/Gui/TaskView/TaskImage.ui
@@ -238,7 +238,7 @@
         </property>
        </widget>
       </item>
-	  <item row="3" column="0" colspan="2">
+      <item row="3" column="0" colspan="2">
        <widget class="QPushButton" name="pushButtonScale">
         <property name="toolTip">
          <string>Scales the image interactively by setting a length between two points of the image</string>
@@ -248,25 +248,42 @@
         </property>
        </widget>
       </item>
-	  <item row="4" column="0" colspan="2">
-	   <widget class="QGroupBox" name="groupBoxCalibration">
+      <item row="4" column="0" colspan="2">
+       <widget class="QGroupBox" name="groupBoxCalibration">
         <property name="title">
          <string>Calibration</string>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout">
+        <layout class="QVBoxLayout" name="calibrationLayout">
          <item>
-          <widget class="QPushButton" name="pushButtonApply">
+          <widget class="QCheckBox" name="checkBoxOrient">
            <property name="text">
-            <string>Apply</string>
+            <string>Snap rotation to line</string>
+           </property>
+           <property name="toolTip">
+            <string>Rotate the image to align the drawn line to the nearest 45 degree angle</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="pushButtonCancel">
-           <property name="text">
-            <string>Cancel</string>
-           </property>
-          </widget>
+          <layout class="QHBoxLayout" name="buttonLayout">
+           <item>
+            <widget class="QPushButton" name="pushButtonApply">
+             <property name="text">
+              <string>Apply</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pushButtonCancel">
+             <property name="text">
+              <string>Cancel</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </widget>

--- a/src/Gui/TaskView/TaskImage.ui
+++ b/src/Gui/TaskView/TaskImage.ui
@@ -257,10 +257,23 @@
          <item>
           <widget class="QCheckBox" name="checkBoxOrient">
            <property name="text">
-            <string>Snap rotation to line</string>
+            <string>Snap rotation to line (R)</string>
            </property>
            <property name="toolTip">
             <string>Rotate the image to align the drawn line to the nearest 45 degree angle</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="checkBoxCenterMidpoint">
+           <property name="text">
+            <string>Center on midpoint (C)</string>
+           </property>
+           <property name="toolTip">
+            <string>Center the image on the midpoint of the drawn line</string>
            </property>
            <property name="checked">
             <bool>false</bool>


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
This commit adds a new QoL feature to the image calibration feature, allowing to rotate the image to align the calibration line to the nearest 45 degree angle (horizontal, vertical, diagonal). Implemented as a checkbox near the Apply/Cancel buttons.

There was some tidying up; the calibration points are now stored as image plane coordinates to ease their use (and fixing a niche bug when rotating the image after starting drawing the calibration line), and the unused `midPoint` was removed.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
I didn't scan the issues thoroughly (and only after implementation), but noticed some.  
Fixes #10072, partially fixes #24144 (rotation).

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
**Old** calibration buttons:
<img width="328" height="104" alt="image" src="https://github.com/user-attachments/assets/6373cd2b-2175-4bbd-bfa2-26e41d93a1de" />

The **new** checkbox and tooltip, open for bikeshedding:
<img width="694" height="584" alt="image" src="https://github.com/user-attachments/assets/0553f1cf-8501-4ec0-96a8-7270bce7da4f" />

**New** feature in use:

https://github.com/user-attachments/assets/9fc042ea-c435-4db0-8f00-1ca9e071e0f2

Also fixed is this bug (recorded from 1.2.0dev.20260512) I ran into while implementing the feature, where rotating the image during calibration causes issues:

https://github.com/user-attachments/assets/2c84758c-8f49-4a85-ba16-046a635ec666

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
