### PR TITLE
Add per sketch GeometryCreationMode state

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
+++ b/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
@@ -56,26 +56,28 @@ bool isAlterGeoActive(Gui::Document* doc)
 
 void slotActiveDocument(const Gui::Document& doc, GeometryCreationMode lastActiveMode)
 {
-    // Get the construction status and invoke ToggleConstruction if needed to ensure correct contruction indicators
+    // Get the construction status and invoke ToggleConstruction if needed to ensure correct
+    // contruction indicators
     auto vp = dynamic_cast<SketcherGui::ViewProviderSketch*>(doc.getInEdit());
     if (vp) {
         GeometryCreationMode currentDocumentMode = vp->getGeometryCreationMode();
-        if (lastActiveMode != currentDocumentMode) 
-        {
+        if (lastActiveMode != currentDocumentMode) {
             // Notify for icon update
             Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
             rcCmdMgr.updateCommands("ToggleConstruction", static_cast<int>(currentDocumentMode));
         }
-    } else {
+    }
+    else {
         // Init to Normal when ViewProviderSketch isn't yet available
         Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
         rcCmdMgr.updateCommands("ToggleConstruction", static_cast<int>(GeometryCreationMode::Normal));
-    }  
+    }
 }
 
 namespace SketcherGui
 {
-// Tracks the rendered state of the construction geometry, allowing update as needed when document activation occurs
+// Tracks the rendered state of the construction geometry, allowing update as needed when document
+// activation occurs
 GeometryCreationMode renderedCreationMode = GeometryCreationMode::Normal;
 
 /* Constrain commands =======================================================*/
@@ -98,12 +100,13 @@ CmdSketcherToggleConstruction::CmdSketcherToggleConstruction()
         slotActiveDocument(doc, renderedCreationMode);
     });
 
-    Gui::Application::Instance->signalNewDocument.connect([](const Gui::Document& doc, bool) { 
-        Gui::Application::Instance->commandManager()
-            .updateCommands("ToggleConstruction", static_cast<int>(GeometryCreationMode::Normal));
-
+    Gui::Application::Instance->signalNewDocument.connect([](const Gui::Document& doc, bool) {
+        Gui::Application::Instance->commandManager().updateCommands(
+            "ToggleConstruction",
+            static_cast<int>(GeometryCreationMode::Normal)
+        );
     });
-    
+
     // list of toggle construction commands
     Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CreateLine");
@@ -174,7 +177,8 @@ GeometryCreationMode toggleCreationMode(GeometryCreationMode currentMode)
 {
     if (currentMode == GeometryCreationMode::Normal) {
         return GeometryCreationMode::Construction;
-    } else {
+    }
+    else {
         return GeometryCreationMode::Normal;
     }
 }
@@ -185,11 +189,9 @@ void CmdSketcherToggleConstruction::activated(int iMsg)
     // Option A: nothing is selected change creation mode from/to construction
     if (Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() == 0) {
         auto doc = getActiveGuiDocument();
-        if (doc)
-        {
+        if (doc) {
             auto vp = dynamic_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-            if (vp)
-            {
+            if (vp) {
                 GeometryCreationMode newMode = toggleCreationMode(vp->getGeometryCreationMode());
                 vp->setGeometryCreationMode(newMode);
 

--- a/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
+++ b/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
@@ -31,6 +31,7 @@
 #include <Gui/Notifications.h>
 #include <Gui/Selection/Selection.h>
 #include <Gui/Selection/SelectionObject.h>
+#include <Gui/ViewProviderDocumentObject.h>
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "GeometryCreationMode.h"
@@ -41,7 +42,6 @@
 using namespace std;
 using namespace SketcherGui;
 using namespace Sketcher;
-namespace sp = std::placeholders;
 
 bool isAlterGeoActive(Gui::Document* doc)
 {
@@ -54,32 +54,44 @@ bool isAlterGeoActive(Gui::Document* doc)
     return false;
 }
 
-void slotActiveDocument(const Gui::Document& doc, GeometryCreationMode lastActiveMode)
+namespace
 {
-    // Get the construction status and invoke ToggleConstruction if needed to ensure correct
-    // contruction indicators
-    auto vp = dynamic_cast<SketcherGui::ViewProviderSketch*>(doc.getInEdit());
-    if (vp) {
-        GeometryCreationMode currentDocumentMode = vp->getGeometryCreationMode();
-        if (lastActiveMode != currentDocumentMode) {
-            // Notify for icon update
-            Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
-            rcCmdMgr.updateCommands("ToggleConstruction", static_cast<int>(currentDocumentMode));
-        }
+
+void updateToggleConstructionCommands(GeometryCreationMode mode)
+{
+    Gui::Application::Instance->commandManager().updateCommands(
+        "ToggleConstruction",
+        static_cast<int>(mode)
+    );
+}
+
+GeometryCreationMode geometryCreationModeFromViewProvider(const Gui::ViewProviderDocumentObject& vp)
+{
+    auto sketchVp = dynamic_cast<const SketcherGui::ViewProviderSketch*>(&vp);
+    if (sketchVp) {
+        return sketchVp->getGeometryCreationMode();
     }
-    else {
-        // Init to Normal when ViewProviderSketch isn't yet available
-        Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
-        rcCmdMgr.updateCommands("ToggleConstruction", static_cast<int>(GeometryCreationMode::Normal));
+
+    return GeometryCreationMode::Normal;
+}
+
+void updateToggleConstructionCommands(const Gui::Document& doc)
+{
+    auto vp = dynamic_cast<SketcherGui::ViewProviderSketch*>(doc.getInEdit());
+    updateToggleConstructionCommands(vp ? vp->getGeometryCreationMode() : GeometryCreationMode::Normal);
+}
+
+void resetToggleConstructionCommandsForDocument(const Gui::ViewProviderDocumentObject& vp)
+{
+    if (vp.getDocument() == Gui::Application::Instance->activeDocument()) {
+        updateToggleConstructionCommands(GeometryCreationMode::Normal);
     }
 }
 
+}  // namespace
+
 namespace SketcherGui
 {
-// Tracks the rendered state of the construction geometry, allowing update as needed when document
-// activation occurs
-GeometryCreationMode renderedCreationMode = GeometryCreationMode::Normal;
-
 /* Constrain commands =======================================================*/
 DEF_STD_CMD_AU(CmdSketcherToggleConstruction)
 
@@ -96,15 +108,22 @@ CmdSketcherToggleConstruction::CmdSketcherToggleConstruction()
     sAccel = "G, N";
     eType = ForEdit;
 
-    Gui::Application::Instance->signalActiveDocument.connect([this](const Gui::Document& doc) {
-        slotActiveDocument(doc, renderedCreationMode);
+    auto app = Gui::Application::Instance;
+
+    app->signalActiveDocument.connect([](const Gui::Document& doc) {
+        updateToggleConstructionCommands(doc);
     });
 
-    Gui::Application::Instance->signalNewDocument.connect([](const Gui::Document& doc, bool) {
-        Gui::Application::Instance->commandManager().updateCommands(
-            "ToggleConstruction",
-            static_cast<int>(GeometryCreationMode::Normal)
-        );
+    app->signalNewDocument.connect([](const Gui::Document&, bool) {
+        updateToggleConstructionCommands(GeometryCreationMode::Normal);
+    });
+
+    app->signalInEdit.connect([](const Gui::ViewProviderDocumentObject& vp) {
+        updateToggleConstructionCommands(geometryCreationModeFromViewProvider(vp));
+    });
+
+    app->signalResetEdit.connect([](const Gui::ViewProviderDocumentObject& vp) {
+        resetToggleConstructionCommandsForDocument(vp);
     });
 
     // list of toggle construction commands
@@ -157,9 +176,6 @@ void CmdSketcherToggleConstruction::updateAction(int mode)
     if (act) {
 
         GeometryCreationMode creationMode = static_cast<GeometryCreationMode>(mode);
-
-        // Store
-        renderedCreationMode = creationMode;
 
         // Apply
         switch (creationMode) {

--- a/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
+++ b/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
@@ -41,6 +41,7 @@
 using namespace std;
 using namespace SketcherGui;
 using namespace Sketcher;
+namespace sp = std::placeholders;
 
 bool isAlterGeoActive(Gui::Document* doc)
 {
@@ -53,10 +54,29 @@ bool isAlterGeoActive(Gui::Document* doc)
     return false;
 }
 
+void slotActiveDocument(const Gui::Document& doc, GeometryCreationMode lastActiveMode)
+{
+    // Get the construction status and invoke ToggleConstruction if needed to ensure correct contruction indicators
+    auto vp = dynamic_cast<SketcherGui::ViewProviderSketch*>(doc.getInEdit());
+    if (vp) {
+        GeometryCreationMode currentDocumentMode = vp->getGeometryCreationMode();
+        if (lastActiveMode != currentDocumentMode) 
+        {
+            // Notify for icon update
+            Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
+            rcCmdMgr.updateCommands("ToggleConstruction", static_cast<int>(currentDocumentMode));
+        }
+    } else {
+        // Init to Normal when ViewProviderSketch isn't yet available
+        Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
+        rcCmdMgr.updateCommands("ToggleConstruction", static_cast<int>(GeometryCreationMode::Normal));
+    }  
+}
+
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;
+// Tracks the rendered state of the construction geometry, allowing update as needed when document activation occurs
+GeometryCreationMode renderedCreationMode = GeometryCreationMode::Normal;
 
 /* Constrain commands =======================================================*/
 DEF_STD_CMD_AU(CmdSketcherToggleConstruction)
@@ -74,6 +94,16 @@ CmdSketcherToggleConstruction::CmdSketcherToggleConstruction()
     sAccel = "G, N";
     eType = ForEdit;
 
+    Gui::Application::Instance->signalActiveDocument.connect([this](const Gui::Document& doc) {
+        slotActiveDocument(doc, renderedCreationMode);
+    });
+
+    Gui::Application::Instance->signalNewDocument.connect([](const Gui::Document& doc, bool) { 
+        Gui::Application::Instance->commandManager()
+            .updateCommands("ToggleConstruction", static_cast<int>(GeometryCreationMode::Normal));
+
+    });
+    
     // list of toggle construction commands
     Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CreateLine");
@@ -122,7 +152,14 @@ void CmdSketcherToggleConstruction::updateAction(int mode)
 {
     auto act = getAction();
     if (act) {
-        switch (static_cast<GeometryCreationMode>(mode)) {
+
+        GeometryCreationMode creationMode = static_cast<GeometryCreationMode>(mode);
+
+        // Store
+        renderedCreationMode = creationMode;
+
+        // Apply
+        switch (creationMode) {
             case GeometryCreationMode::Normal:
                 act->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_ToggleConstruction"));
                 break;
@@ -133,22 +170,33 @@ void CmdSketcherToggleConstruction::updateAction(int mode)
     }
 }
 
+GeometryCreationMode toggleCreationMode(GeometryCreationMode currentMode)
+{
+    if (currentMode == GeometryCreationMode::Normal) {
+        return GeometryCreationMode::Construction;
+    } else {
+        return GeometryCreationMode::Normal;
+    }
+}
+
 void CmdSketcherToggleConstruction::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     // Option A: nothing is selected change creation mode from/to construction
     if (Gui::Selection().countObjectsOfType<Sketcher::SketchObject>() == 0) {
+        auto doc = getActiveGuiDocument();
+        if (doc)
+        {
+            auto vp = dynamic_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
+            if (vp)
+            {
+                GeometryCreationMode newMode = toggleCreationMode(vp->getGeometryCreationMode());
+                vp->setGeometryCreationMode(newMode);
 
-        Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
-
-        if (geometryCreationMode == GeometryCreationMode::Construction) {
-            geometryCreationMode = GeometryCreationMode::Normal;
+                Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
+                rcCmdMgr.updateCommands("ToggleConstruction", static_cast<int>(newMode));
+            }
         }
-        else {
-            geometryCreationMode = GeometryCreationMode::Construction;
-        }
-
-        rcCmdMgr.updateCommands("ToggleConstruction", static_cast<int>(geometryCreationMode));
     }
     else  // there was a selection, so operate in toggle mode.
     {

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -45,7 +45,6 @@
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "CircleEllipseConstructionMethod.h"
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 
@@ -95,10 +94,6 @@ using namespace SketcherGui;
         } \
     }
 
-namespace SketcherGui
-{
-GeometryCreationMode geometryCreationMode = GeometryCreationMode::Normal;
-}
 
 /* Sketch commands =======================================================*/
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -316,6 +316,15 @@ bool DrawSketchHandler::isWidgetVisible() const
     return false;
 };
 
+bool DrawSketchHandler::isConstructionMode() const {
+    return sketchgui->geometryCreationMode == GeometryCreationMode::Construction;
+}
+
+const char* DrawSketchHandler::constructionModeAsBooleanText()
+{
+    return sketchgui->geometryCreationMode == GeometryCreationMode::Construction ? "True" : "False";
+}
+
 QPixmap DrawSketchHandler::getToolIcon() const
 {
     return QPixmap();

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -316,7 +316,8 @@ bool DrawSketchHandler::isWidgetVisible() const
     return false;
 };
 
-bool DrawSketchHandler::isConstructionMode() const {
+bool DrawSketchHandler::isConstructionMode() const
+{
     return sketchgui->isConstructionMode();
 }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -317,12 +317,12 @@ bool DrawSketchHandler::isWidgetVisible() const
 };
 
 bool DrawSketchHandler::isConstructionMode() const {
-    return sketchgui->geometryCreationMode == GeometryCreationMode::Construction;
+    return sketchgui->isConstructionMode();
 }
 
 const char* DrawSketchHandler::constructionModeAsBooleanText()
 {
-    return sketchgui->geometryCreationMode == GeometryCreationMode::Construction ? "True" : "False";
+    return sketchgui->isConstructionMode() ? "True" : "False";
 }
 
 QPixmap DrawSketchHandler::getToolIcon() const

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -295,6 +295,8 @@ protected:
     void setAxisPickStyle(bool on);
     void moveCursorToSketchPoint(Base::Vector2d point);
     void ensureFocus();
+    bool isConstructionMode() const;
+    const char* constructionModeAsBooleanText();
     void preselectAtPoint(Base::Vector2d point);
 
     void drawPositionAtCursor(const Base::Vector2d& position);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -37,7 +37,6 @@
 
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 
@@ -50,8 +49,6 @@ using namespace std;
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class DrawSketchHandlerArc;
 
@@ -268,7 +265,6 @@ private:
 
     void executeCommands() override
     {
-
         if (constructionMethod() == ConstructionMethod::Center) {
             if (arcAngle > 0) {
                 endAngle = startAngle + arcAngle;
@@ -578,7 +574,7 @@ void DSHArcController::configureToolWidget()
         };
         toolWidget->setComboboxElements(WCombobox::FirstCombo, names);
 
-        if (isConstructionMode()) {
+        if (handler->isConstructionMode()) {
             toolWidget->setComboboxItemIcon(
                 WCombobox::FirstCombo,
                 0,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -33,7 +33,6 @@
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "DrawSketchHandler.h"
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 #include "SnapManager.h"
@@ -56,8 +55,6 @@
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class DrawSketchHandlerArcOfEllipse;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -33,7 +33,6 @@
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "DrawSketchHandler.h"
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 #include "SnapManager.h"
@@ -60,8 +59,6 @@
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class DrawSketchHandlerArcOfHyperbola;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
@@ -33,7 +33,6 @@
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "DrawSketchHandler.h"
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 #include "SnapManager.h"
@@ -56,8 +55,6 @@
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class DrawSketchHandlerArcOfParabola;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcSlot.h
@@ -38,13 +38,10 @@
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
 
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class DrawSketchHandlerArcSlot;
 
@@ -615,7 +612,7 @@ void DSHArcSlotController::configureToolWidget()
         };
         toolWidget->setComboboxElements(WCombobox::FirstCombo, names);
 
-        if (isConstructionMode()) {
+        if (handler->isConstructionMode()) {
             toolWidget->setComboboxItemIcon(
                 WCombobox::FirstCombo,
                 0,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -36,14 +36,11 @@
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
 
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class DrawSketchHandlerBSpline;
 
@@ -959,7 +956,7 @@ void DSHBSplineController::configureToolWidget()
         );
         syncCheckboxToHandler(WCheckbox::FirstBox, handler->periodic);
 
-        if (isConstructionMode()) {
+        if (handler->isConstructionMode()) {
             toolWidget->setComboboxItemIcon(
                 WCombobox::FirstCombo,
                 0,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
@@ -37,7 +37,6 @@
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "DrawSketchHandler.h"
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 #include "SnapManager.h"
@@ -45,8 +44,6 @@
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class CarbonCopySelection: public Gui::SelectionFilterGate
 {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -37,15 +37,12 @@
 
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 
 #include "CircleEllipseConstructionMethod.h"
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class DrawSketchHandlerCircle;
 
@@ -420,7 +417,7 @@ void DSHCircleController::configureToolWidget()
         };
         toolWidget->setComboboxElements(WCombobox::FirstCombo, names);
 
-        if (isConstructionMode()) {
+        if (handler->isConstructionMode()) {
             toolWidget->setComboboxItemIcon(
                 WCombobox::FirstCombo,
                 0,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
@@ -39,7 +39,6 @@
 #include <Mod/Sketcher/App/SketchObject.h>
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 
@@ -47,8 +46,6 @@
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 /* Ellipse ==============================================================================*/
 class DrawSketchHandlerEllipse;
@@ -503,7 +500,7 @@ void DSHEllipseController::configureToolWidget()
         };
         toolWidget->setComboboxElements(WCombobox::FirstCombo, names);
 
-        if (isConstructionMode()) {
+        if (handler->isConstructionMode()) {
             toolWidget->setComboboxItemIcon(
                 WCombobox::FirstCombo,
                 0,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
@@ -32,7 +32,6 @@
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "DrawSketchHandler.h"
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 #include "SnapManager.h"
@@ -40,8 +39,6 @@
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class ExtendSelection: public Gui::SelectionFilterGate
 {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
@@ -38,7 +38,6 @@
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "DrawSketchHandler.h"
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 #include <Mod/Part/App/Datums.h>
@@ -47,8 +46,6 @@
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class ExternalSelection: public Gui::SelectionFilterGate
 {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
@@ -32,7 +32,6 @@
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "DrawSketchHandler.h"
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 
@@ -40,8 +39,6 @@ using namespace Sketcher;
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class FilletSelection: public Gui::SelectionFilterGate
 {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -36,7 +36,6 @@
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
 
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 
 #include <vector>
@@ -44,8 +43,6 @@
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class DrawSketchHandlerLine;
 
@@ -362,7 +359,7 @@ void DSHLineController::configureToolWidget()
         };
         toolWidget->setComboboxElements(WCombobox::FirstCombo, names);
 
-        if (isConstructionMode()) {
+        if (handler->isConstructionMode()) {
             toolWidget->setComboboxItemIcon(
                 WCombobox::FirstCombo,
                 0,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -41,7 +41,6 @@
 #include "DrawSketchControllableHandler.h"
 
 #include "DrawSketchHandler.h"
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 #include "SnapManager.h"
@@ -50,8 +49,6 @@ using namespace Sketcher;
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class DrawSketchHandlerLineSet: public DrawSketchHandler
 {
@@ -1736,7 +1733,7 @@ void DSHPolyLineController::configureToolWidget()
         );
         syncCheckboxToHandler(WCheckbox::FirstBox, handler->fillet);
 
-        if (isConstructionMode()) {
+        if (handler->isConstructionMode()) {
             toolWidget->setComboboxItemIcon(
                 WCombobox::FirstCombo,
                 0,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
@@ -60,7 +60,6 @@
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
 
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 
 
@@ -68,8 +67,6 @@ using namespace Sketcher;
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class DrawSketchHandlerOffset;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -32,7 +32,6 @@
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
-#include "GeometryCreationMode.h"
 
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
@@ -42,8 +41,6 @@
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class DrawSketchHandlerPoint;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
@@ -35,7 +35,6 @@
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 
 #include "DrawSketchDefaultWidgetController.h"
@@ -45,8 +44,6 @@
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class DrawSketchHandlerPolygon;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -37,13 +37,10 @@
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
 
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class DrawSketchHandlerRectangle;
 
@@ -2114,7 +2111,7 @@ void DSHRectangleController::configureToolWidget()
         );
         syncCheckboxToHandler(WCheckbox::SecondBox, handler->makeFrame);
 
-        if (isConstructionMode()) {
+        if (handler->isConstructionMode()) {
             toolWidget->setComboboxItemIcon(
                 WCombobox::FirstCombo,
                 0,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
@@ -36,7 +36,6 @@
 #include "DrawSketchControllableHandler.h"
 #include "SketcherTransformationExpressionHelper.h"
 
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 
 using namespace Sketcher;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
@@ -39,7 +39,6 @@
 #include "DrawSketchControllableHandler.h"
 #include "SketcherTransformationExpressionHelper.h"
 
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 
 #include <memory>
@@ -48,8 +47,6 @@ using namespace Sketcher;
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class DrawSketchHandlerScale;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
@@ -38,16 +38,12 @@
 
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
-
 
 class DrawSketchHandlerSlot;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -32,7 +32,6 @@
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "DrawSketchHandler.h"
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 #include "SnapManager.h"
@@ -40,9 +39,6 @@
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
-
 
 class SplittingSelection: public Gui::SelectionFilterGate
 {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSymmetry.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSymmetry.h
@@ -38,15 +38,12 @@
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
 
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 
 using namespace Sketcher;
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class DrawSketchHandlerSymmetry;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerText.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerText.h
@@ -38,7 +38,6 @@
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
 
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "CommandConstraints.h"
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
@@ -42,7 +42,6 @@
 #include "DrawSketchControllableHandler.h"
 #include "SketcherTransformationExpressionHelper.h"
 
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
@@ -35,7 +35,6 @@
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "DrawSketchHandler.h"
-#include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 #include "SnapManager.h"
@@ -43,8 +42,6 @@
 
 namespace SketcherGui
 {
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
 class TrimmingSelection: public Gui::SelectionFilterGate
 {

--- a/src/Mod/Sketcher/Gui/Utils.h
+++ b/src/Mod/Sketcher/Gui/Utils.h
@@ -34,7 +34,6 @@
 
 #include "AutoConstraint.h"
 #include "ViewProviderSketchGeometryExtension.h"
-#include "GeometryCreationMode.h"
 
 namespace App
 {
@@ -168,23 +167,6 @@ inline bool isVertex(int GeoId, Sketcher::PointPos PosId)
 inline bool isEdge(int GeoId, Sketcher::PointPos PosId)
 {
     return (GeoId != Sketcher::GeoEnum::GeoUndef && PosId == Sketcher::PointPos::none);
-}
-
-extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
-
-inline GeometryCreationMode currentGeometryCreationMode()
-{
-    return geometryCreationMode;
-}
-
-inline bool isConstructionMode()
-{
-    return geometryCreationMode == GeometryCreationMode::Construction;
-}
-
-inline const char* constructionModeAsBooleanText()
-{
-    return geometryCreationMode == GeometryCreationMode::Construction ? "True" : "False";
 }
 
 /* helper functions ======================================================*/

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3191,6 +3191,16 @@ void ViewProviderSketch::doBoxSelection(const SbVec2s& startPos, const SbVec2s& 
     updateColor();
 }
 
+void ViewProviderSketch::setGeometryCreationMode(GeometryCreationMode newMode)
+{
+    geometryCreationMode = newMode;
+}
+
+GeometryCreationMode ViewProviderSketch::getGeometryCreationMode()
+{
+    return geometryCreationMode;
+}
+
 void ViewProviderSketch::updateColor()
 {
     assert(isInEditMode());
@@ -3587,12 +3597,12 @@ bool ViewProviderSketch::getIsShownVirtualSpace() const
 
 void ViewProviderSketch::drawEdit(const std::vector<Base::Vector2d>& EditCurve)
 {
-    editCoinManager->drawEdit(EditCurve, currentGeometryCreationMode());
+    editCoinManager->drawEdit(EditCurve, geometryCreationMode);
 }
 
 void ViewProviderSketch::drawEdit(const std::list<std::vector<Base::Vector2d>>& list)
 {
-    editCoinManager->drawEdit(list, currentGeometryCreationMode());
+    editCoinManager->drawEdit(list, geometryCreationMode);
 }
 
 void ViewProviderSketch::drawLineExtensionAutoConstraintHint(

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3191,12 +3191,17 @@ void ViewProviderSketch::doBoxSelection(const SbVec2s& startPos, const SbVec2s& 
     updateColor();
 }
 
+bool ViewProviderSketch::isConstructionMode() const
+{
+    return geometryCreationMode == GeometryCreationMode::Construction;
+}
+
 void ViewProviderSketch::setGeometryCreationMode(GeometryCreationMode newMode)
 {
     geometryCreationMode = newMode;
 }
 
-GeometryCreationMode ViewProviderSketch::getGeometryCreationMode()
+GeometryCreationMode ViewProviderSketch::getGeometryCreationMode() const
 {
     return geometryCreationMode;
 }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -559,14 +559,13 @@ public:
     void purgeHandler();
     //@}
 
-    // the active sketch GeometryCreationMode
-    GeometryCreationMode geometryCreationMode = GeometryCreationMode::Normal;
+    bool isConstructionMode() const;
 
     // set the current GeometryCreationMode mode
     void setGeometryCreationMode(GeometryCreationMode geometryCreationMode);
 
     // gets the GeometryCreationMode
-    GeometryCreationMode getGeometryCreationMode();
+    GeometryCreationMode getGeometryCreationMode() const;
 
     // TODO: SketchMode should be refactored. DrawSketchHandler, its inheritance and free functions
     // should access this mode via the DrawSketchHandler Attorney. I will not refactor this at this
@@ -881,6 +880,9 @@ private:
     void commitDragMove(double x, double y);
 
     //@}
+
+    // the active sketch GeometryCreationMode
+    GeometryCreationMode geometryCreationMode = GeometryCreationMode::Normal;
 
     /** @name Selection functions */
     //@{

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -559,6 +559,14 @@ public:
     void purgeHandler();
     //@}
 
+    // the active sketch GeometryCreationMode
+    GeometryCreationMode geometryCreationMode = GeometryCreationMode::Normal;
+
+    // set the current GeometryCreationMode mode
+    void setGeometryCreationMode(GeometryCreationMode geometryCreationMode);
+
+    // gets the GeometryCreationMode
+    GeometryCreationMode getGeometryCreationMode();
 
     // TODO: SketchMode should be refactored. DrawSketchHandler, its inheritance and free functions
     // should access this mode via the DrawSketchHandler Attorney. I will not refactor this at this


### PR DESCRIPTION
This PR is driven by #13979, which describes how the current construction mode button acts as a single global toggle. Once clicked, it remains active after a sketch is closed and affects all other open documents. Initially, a small fix to exit out of construction mode when closing a sketch was produced but after further discussion it evolved into this larger solution to eliminate the global nature and move state into individual documents.

**Briefly**
- Observes document lifecycle events (`signalActiveDocument`) to toggle state as needed and refresh UI elements when switching documents
- Moves construction-mode(`GeometryCreationMode`) state into `ViewProviderSketch` for per document storage
- Removes GeometryCreationMode functions from utils.h
- Removes GeometryCreationMode bindings in each DrawSketchHandler implementation, replacing the utils.h implementations, like `isConstructionMode` with in-scope calls in the `DrawSketchHandler` base.
- Public members were added to `ViewProviderSketch` over the attorney pattern, due to the non-private nature of the data

As this is one of my first FreeCAD contributions, I look forward to a code review and hope someone with more FreeCAD and C++ experience can confirm the choices made or recommend alternative techniques and patterns where applicable.

## AI Use
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: claude-sonnet-4-6
Assisted-by: devin (deepwiki.com)

Although AI assistance is indicated, almost the entirety of this revision comes from personal analysis and efforts. This entailed evaluating existing implementations and numerous iterations adapting those to achieve alternative behavior. AI use encompassed discussions to better understand FreeCAD architecture and to troubleshoot roadblocks due to limited experience with the system and language. AI use did not involve agent mode at any stage.

## Issues
In response to #13979

## Before and After
**Before UX**
As described in #13979, toggling on construction mode survives Sketcher close and switching documents reveals the mode has switched for all.

**Revised UX**
The revised behavior depicted below shows the state resets to normal when sketches are opened and is correctly retained across document instances. Note the toolbar icons and actions behave as expected for each document:
https://github.com/FreeCAD/FreeCAD/compare/main...jlewin:FreeCAD:sketch-construction-toggle
<img width="1026" height="770" alt="Image" src="https://github.com/user-attachments/assets/18211e8e-ec27-46be-ab28-2dd2556eb712" />
