### PR TITLE
TechDraw: Fix Balloon task panel column stretch

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskBalloon.ui
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.ui
@@ -231,7 +231,7 @@
      <property name="checkable">
       <bool>true</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,0" columnminimumwidth="0,0">
+     <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,1" columnminimumwidth="0,0">
       <property name="verticalSpacing">
        <number>12</number>
       </property>


### PR DESCRIPTION
Fixed column stretch ratio in the Leader Line groupbox of the balloon task panel in TechDraw.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

No AI was used in the making of this PR.



## Issues
None. Follow up to PR #29807

## Before

<img width="432" height="245" alt="20260613_12h04m17s_grim" src="https://github.com/user-attachments/assets/3be06cf2-e711-43f1-8555-e33decda2aa5" />



## After

<img width="429" height="216" alt="20260613_12h05m27s_grim" src="https://github.com/user-attachments/assets/212b62bb-1a72-4375-a6a7-58150ac04935" />

