### PR TITLE
Draft: don't launch Move after aborting Clone with no-shape objects

### DIFF
--- a/src/Mod/BIM/bimcommands/BimClone.py
+++ b/src/Mod/BIM/bimcommands/BimClone.py
@@ -35,7 +35,10 @@ class BIM_Clone(DraftTools.Draft_Clone):
 
     def __init__(self):
         DraftTools.Draft_Clone.__init__(self)
+
+    def Activated(self):
         self.moveAfterCloning = True
+        super().Activated()
 
     def GetResources(self):
         return {

--- a/src/Mod/Draft/draftguitools/gui_clone.py
+++ b/src/Mod/Draft/draftguitools/gui_clone.py
@@ -92,6 +92,7 @@ class Clone(gui_base_original.Modifier):
         """Proceed with the command if objects were selected."""
         objs = Gui.Selection.getSelection()
         if not objs:
+            self.moveAfterCloning = False
             self.finish()
             return
         objs_shape = [obj for obj in objs if hasattr(obj, "Shape")]

--- a/src/Mod/Draft/draftguitools/gui_clone.py
+++ b/src/Mod/Draft/draftguitools/gui_clone.py
@@ -97,6 +97,7 @@ class Clone(gui_base_original.Modifier):
         objs_shape = [obj for obj in objs if hasattr(obj, "Shape")]
         if not objs_shape:
             _wrn(translate("draft", "Cannot clone objects without a shape, aborting"))
+            self.moveAfterCloning = False
             self.finish()
             return
         elif len(objs_shape) < len(objs):


### PR DESCRIPTION
Fixes #30700.

When `BIM_Clone` aborts because the selected objects have no shape, it called `self.finish()` while `moveAfterCloning` was still `True`, which caused `Draft_Move` to open unexpectedly.

Set `moveAfterCloning = False` in the abort path before calling `finish()`.