### PR TITLE
Sketcher: support B-splines in the Offset tool

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -2466,14 +2466,15 @@ void CmdSketcherOffset::activated(int iMsg)
 
             const Part::Geometry* geo = Obj->getGeometry(geoId);
             if (!isPoint(*geo)
-                && !isBSplineCurve(*geo)
                 && !isEllipse(*geo)
                 && !isArcOfEllipse(*geo)
                 && !isArcOfHyperbola(*geo)
                 && !isArcOfParabola(*geo)
                 && !GeometryFacade::isInternalAligned(geo)) {
-                // Currently ellipse/parabola/hyperbola/bspline are not handled correctly.
+                // Currently ellipse/parabola/hyperbola are not handled correctly.
                 // Occ engine gives offset of those as set of lines and arcs and does not seem to work consistently.
+                // B-splines are supported: their offset comes back as a B-spline edge (see
+                // DrawSketchHandlerOffset::curveToBSpline).
                 listOfGeoIds.push_back(geoId);
             }
         }
@@ -2486,7 +2487,7 @@ void CmdSketcherOffset::activated(int iMsg)
         getSelection().clearSelection();
         Gui::NotifyUserError(Obj,
             QT_TRANSLATE_NOOP("Notifications", "Invalid selection"),
-            QT_TRANSLATE_NOOP("Notifications", "Selection has no valid geometries. B-splines and points are not supported yet."));
+            QT_TRANSLATE_NOOP("Notifications", "Selection has no valid geometries. Points, ellipses, and hyperbola/parabola arcs are not supported yet."));
     }
 }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
@@ -42,6 +42,9 @@
 #include <BRepBuilderAPI_MakeVertex.hxx>
 #include <BRepBuilderAPI.hxx>
 #include <BRepExtrema_DistShapeShape.hxx>
+#include <GeomConvert.hxx>
+#include <Geom_BSplineCurve.hxx>
+#include <Geom_TrimmedCurve.hxx>
 #include <TopoDS.hxx>
 #include <TopExp_Explorer.hxx>
 #include <gp_Pln.hxx>
@@ -369,6 +372,39 @@ private:
         }
     }
 
+    Part::Geometry* curveToBSpline(const TopoDS_Edge& edge)
+    {
+        // Offsetting a B-spline yields non-analytic edges: OCC represents them as OffsetCurve
+        // segments (most common), or as B-spline/Bezier curves. Convert any of these to a
+        // Part::GeomBSplineCurve, honoring the edge trimming and placement.
+        TopLoc_Location loc;
+        double first = 0.0;
+        double last = 0.0;
+        Handle(Geom_Curve) hCurve = BRep_Tool::Curve(edge, loc, first, last);
+        if (hCurve.IsNull()) {
+            return nullptr;
+        }
+        if (!loc.IsIdentity()) {
+            hCurve = Handle(Geom_Curve)::DownCast(hCurve->Transformed(loc.Transformation()));
+        }
+
+        Handle(Geom_BSplineCurve) hBSpline;
+        try {
+            Handle(Geom_TrimmedCurve) tCurve = new Geom_TrimmedCurve(hCurve, first, last);
+            hBSpline = GeomConvert::CurveToBSplineCurve(tCurve);
+        }
+        catch (const Standard_Failure&) {
+            return nullptr;
+        }
+        if (hBSpline.IsNull()) {
+            return nullptr;
+        }
+
+        auto* bSpline = new Part::GeomBSplineCurve(hBSpline);
+        GeometryFacade::setConstruction(bSpline, false);
+        return bSpline;
+    }
+
     void getOffsetGeos(std::vector<Part::Geometry*>& geometriesToAdd, std::vector<int>& listOfOffsetGeoIds)
     {
         TopoDS_Shape offsetShape = makeOffsetShape();
@@ -377,23 +413,36 @@ private:
         }
 
         TopExp_Explorer expl(offsetShape, TopAbs_EDGE);
-        int geoIdToAdd = firstCurveCreated;
-        for (; expl.More(); expl.Next(), geoIdToAdd++) {
+        for (; expl.More(); expl.Next()) {
             const TopoDS_Edge& edge = TopoDS::Edge(expl.Current());
             BRepAdaptor_Curve curve(edge);
+
+            Part::Geometry* geo = nullptr;
             if (curve.GetType() == GeomAbs_Line) {
-                geometriesToAdd.push_back(curveToLine(curve));
-                listOfOffsetGeoIds.push_back(geoIdToAdd);
+                geo = curveToLine(curve);
             }
             else if (curve.GetType() == GeomAbs_Circle) {
-                geometriesToAdd.push_back(curveToCircleOrArc(curve, edge));
-                listOfOffsetGeoIds.push_back(geoIdToAdd);
+                geo = curveToCircleOrArc(curve, edge);
             }
             else if (curve.GetType() == GeomAbs_Ellipse) {
-                geometriesToAdd.push_back(curveToEllipseOrArc(curve, edge));
-                listOfOffsetGeoIds.push_back(geoIdToAdd);
+                geo = curveToEllipseOrArc(curve, edge);
             }
-            // TODO Bspline support
+            else {
+                // Offsetting a B-spline produces non-analytic edges (OffsetCurve, BSpline or
+                // Bezier). Convert any such edge to a B-spline so the B-spline section is not
+                // dropped from the result.
+                geo = curveToBSpline(edge);
+            }
+
+            if (geo) {
+                // addGeometry() assigns sequential ids from firstCurveCreated, so an offset
+                // geometry's id equals its position in geometriesToAdd. Deriving it this way
+                // (not from the edge index) keeps ids aligned when an edge type is skipped.
+                listOfOffsetGeoIds.push_back(
+                    firstCurveCreated + static_cast<int>(geometriesToAdd.size())
+                );
+                geometriesToAdd.push_back(geo);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

The **Offset** tool did not work on geometry containing a B-spline.

- B-splines were filtered out of the selection in `CmdSketcherOffset::activated()`. Selecting only a B-spline reported *"B-splines and points are not supported yet"*, and offsetting a contour that mixed lines/arcs **with** a B-spline silently dropped the B-spline from the source wire.
- Even when a B-spline reached the offset, the result was discarded. OCC returns the offset of a B-spline as a series of `OffsetCurve` segments (joined by arcs), but `getOffsetGeos()` only converted `Line`/`Circle`/`Ellipse` edges and skipped everything else — so the offset of the B-spline section was missing from the output.

## Changes

- Allow B-spline edges through the Offset selection filter.
- Convert any non-analytic offset edge (`OffsetCurve` / `BSpline` / `Bezier`) to a `Part::GeomBSplineCurve` via `GeomConvert::CurveToBSplineCurve`, honoring the edge's trimming and placement.
- Derive the new geometry ids from their position in the add-list instead of the edge index. Previously the id counter advanced per edge while `addGeometry()` assigns ids only to the geometries actually added, so any skipped edge type misaligned the ids used to build the joining coincidence/tangent constraints.

## Notes

- The default **Arc** join mode works for B-splines. OCC's **Intersection** mode can still fail for some open B-splines (`BRepOffsetAPI_MakeOffset` returns a null shape); in that case the tool reports that the offset could not be created, as before.
- OCC splits the spline's offset at its knots, so the offset of one B-spline comes back as several B-spline pieces joined by coincidence constraints — geometrically complete, just not a single curve.

## Testing

- Builds cleanly (`/W4 /WX`).
- Verified that offsetting a B-spline (and a line→B-spline→line contour) now produces the B-spline section instead of dropping it; every resulting edge converts to a valid B-spline.
