### PR TITLE
BIM: better menu texts for IFC Diff tools

### DIFF
--- a/src/Mod/BIM/bimcommands/BimDiff.py
+++ b/src/Mod/BIM/bimcommands/BimDiff.py
@@ -35,7 +35,7 @@ class BIM_Diff:
     def GetResources(self):
         return {
             "Pixmap": "BIM_Diff",
-            "MenuText": QT_TRANSLATE_NOOP("BIM_Diff", "IFC Diff"),
+            "MenuText": QT_TRANSLATE_NOOP("BIM_Diff", "IFC Shape Diff"),
             "ToolTip": QT_TRANSLATE_NOOP(
                 "BIM_Diff", "Shows the difference between two IFC-based documents"
             ),

--- a/src/Mod/BIM/nativeifc/ifc_commands.py
+++ b/src/Mod/BIM/nativeifc/ifc_commands.py
@@ -51,7 +51,7 @@ class IFC_Diff:
         tt = QT_TRANSLATE_NOOP("IFC_Diff", "Shows the current unsaved changes in the IFC file")
         return {
             "Pixmap": "IFC",
-            "MenuText": QT_TRANSLATE_NOOP("IFC_Diff", "IFC Diff"),
+            "MenuText": QT_TRANSLATE_NOOP("IFC_Diff", "IFC File Diff"),
             "ToolTip": tt,
             "Accel": "I, D",
         }


### PR DESCRIPTION
Closes: #24662.

Both diff tools currently use the same menu text: "IFC Diff"

New menu texts:
BIM_Diff: "IFC Shape Diff"
IFC_Diff: "IFC File Diff"
