### PR TITLE
BIM: remove BIM_Views shortcut

### DIFF
--- a/src/Mod/BIM/BimStatus.py
+++ b/src/Mod/BIM/BimStatus.py
@@ -117,7 +117,7 @@ def setStatusIcons(show=True):
 
                 bimviewsbutton.setText("")
                 bimviewsbutton.setToolTip(
-                    translate("BIM", "Toggles the BIM Views Manager on/off (Ctrl+9)")
+                    translate("BIM", "Toggles the BIM Views Manager on/off")
                 )
                 bimviewsbutton.setCheckable(True)
                 if BimViews.findWidget():

--- a/src/Mod/BIM/BimStatus.py
+++ b/src/Mod/BIM/BimStatus.py
@@ -116,9 +116,7 @@ def setStatusIcons(show=True):
                 bimviewsbutton.setIcon(QtGui.QIcon(":/icons/BIM_Views.svg"))
 
                 bimviewsbutton.setText("")
-                bimviewsbutton.setToolTip(
-                    translate("BIM", "Toggles the BIM Views Manager on/off")
-                )
+                bimviewsbutton.setToolTip(translate("BIM", "Toggles the BIM Views Manager on/off"))
                 bimviewsbutton.setCheckable(True)
                 if BimViews.findWidget():
                     bimviewsbutton.setChecked(True)

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -43,7 +43,6 @@ class BIM_Views:
             "Pixmap": "BIM_Views",
             "MenuText": QT_TRANSLATE_NOOP("BIM_Views", "Views Manager"),
             "ToolTip": QT_TRANSLATE_NOOP("BIM_Views", "Shows or hides the views manager"),
-            "Accel": "Ctrl+9",
         }
 
     def Activated(self):


### PR DESCRIPTION
Fixes: #28908.

The shortcut for BIM_Views did not work because the command does not occur in a toolbar or menu. Adding it to a menu would be possible, but since it is already available in the Status Bar, would be superfluous. This PR therefore removes the shortcut.