### PR TITLE
Gui: Fall back to PySide widget type names

### DIFF
--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -330,13 +330,14 @@ static bool loadPySideModule(const std::string& moduleName, PyTypeObject**& type
 }
 
 #if defined(HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
-template<typename qttype>
 # if defined(HAVE_SHIBOKEN2)
-SbkObjectType*
+using ShibokenTypeObject = SbkObjectType;
 # else
-PyTypeObject*
+using ShibokenTypeObject = PyTypeObject;
 # endif
-getPyTypeObjectForTypeName()
+
+template<typename qttype>
+static ShibokenTypeObject* getPyTypeObjectForTypeName()
 {
 # if defined(HAVE_SHIBOKEN_TYPE_FOR_TYPENAME)
 #  if defined(HAVE_SHIBOKEN2)
@@ -351,6 +352,15 @@ getPyTypeObjectForTypeName()
 #  else
     return Shiboken::SbkType<qttype>();
 #  endif
+# endif
+}
+
+static ShibokenTypeObject* getPyTypeObjectForPySideTypeName(const char* typeName)
+{
+# if defined(HAVE_SHIBOKEN2)
+    return reinterpret_cast<SbkObjectType*>(Shiboken::Conversions::getPythonTypeObject(typeName));
+# else
+    return Shiboken::Conversions::getPythonTypeObject(typeName);
 # endif
 }
 
@@ -837,8 +847,18 @@ Py::Object PythonWrapper::fromQWidget(QWidget* widget, const char* className)
 #if defined(HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
     // Access shiboken/PySide via C++
     auto type = getPyTypeObjectForTypeName<QWidget>();
+    const char* wrapperName = typeName;
+    if (!type) {
+        // Some Shiboken builds do not resolve Qt widget classes via typeid().name().
+        // Caller-provided class names and getWrapperName() use PySide type names instead.
+        type = getPyTypeObjectForPySideTypeName(wrapperName);
+    }
+    if (!type) {
+        wrapperName = getWrapperName(widget);
+        type = getPyTypeObjectForPySideTypeName(wrapperName);
+    }
     if (type) {
-        PyObject* pyobj = Shiboken::Object::newObject(type, widget, false, false, typeName);
+        PyObject* pyobj = Shiboken::Object::newObject(type, widget, false, false, wrapperName);
         WrapperManager::instance().addQObject(widget, pyobj);
         return Py::asObject(pyobj);
     }

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -23,6 +23,7 @@ SET(Test_SRCS
     TestPythonSyntax.py
     TestPerf.py
     TestTreeSelection.py
+    TestGraphicsViewWrapping.py
     TestRubberbandSelection.py
     TestCoinNodeSnapshots.py
     TestCoinSelectionVisual.py

--- a/src/Mod/Test/InitGui.py
+++ b/src/Mod/Test/InitGui.py
@@ -98,6 +98,7 @@ FreeCAD.__unit_test__ += [
     "Menu.MenuDeleteCases",
     "Menu.MenuCreateCases",
     "GuiDocument",
+    "TestGraphicsViewWrapping",
     "TestRubberbandSelection",
     "TestCoinSelectionVisual",
     "TestCoinNodeSnapshots",

--- a/src/Mod/Test/TestGraphicsViewWrapping.py
+++ b/src/Mod/Test/TestGraphicsViewWrapping.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 FreeCAD contributors
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+"""GUI regression tests for wrapping 3D views as PySide widgets.
+
+To run tests:
+    FreeCAD -t TestGraphicsViewWrapping.TestGraphicsViewWrapping
+"""
+
+import unittest
+
+import FreeCAD
+import FreeCADGui
+from PySide6 import QtWidgets
+
+
+class TestGraphicsViewWrapping(unittest.TestCase):
+    def setUp(self):
+        self.doc = FreeCAD.newDocument("TestGraphicsViewWrapping")
+        FreeCADGui.ActiveDocument = FreeCADGui.getDocument(self.doc.Name)
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.doc.Name)
+
+    def test_active_view_wraps_as_qgraphics_view(self):
+        view = FreeCADGui.ActiveDocument.ActiveView
+
+        # graphicsView() wraps a C++ QGraphicsView through Shiboken. Some
+        # Shiboken builds do not resolve Qt widget RTTI names, so this used to
+        # raise "RuntimeError: Failed to wrap widget" instead of falling back to
+        # PySide's public type names.
+        graphics_view = view.graphicsView()
+
+        self.assertIsInstance(graphics_view, QtWidgets.QGraphicsView)
+        self.assertIsNotNone(graphics_view.viewport())


### PR DESCRIPTION
This fixes a narrow QWidget wrapping failure seen when `ActiveView.graphicsView()` exposes the 3D view graphics widget to Python. On some PySide/Shiboken builds, resolving Qt widget classes from C++ RTTI names can return no Python type even though the corresponding PySide type name, such as `QGraphicsView`, is available.

The existing RTTI-based lookup remains the first path. The new fallback only runs when that lookup fails, and it resolves the same widget through PySide's public type names before creating the Shiboken object wrapper.

- fall back to PySide type-name lookup when Shiboken cannot resolve Qt widget RTTI names
- preserve the existing QWidget wrapping path when it works
- add a GUI regression test for `ActiveView.graphicsView()` returning `QGraphicsView`
