### PR TITLE
Gui: Clear all document selection contexts

### DIFF
--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -73,6 +73,14 @@ namespace sp = std::placeholders;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
+namespace
+{
+bool isAllDocumentSelection(const char* pDocName)
+{
+    return !pDocName || !pDocName[0] || strcmp(pDocName, "*") == 0;
+}
+}  // namespace
+
 SelectionObserver::SelectionObserver(bool attach, ResolveMode resolve)
     : resolve(resolve)
     , blockedSelection(false)
@@ -2002,8 +2010,8 @@ void SelectionSingleton::clearSelection(const char* pDocName, bool clearPreSelec
     // Because the introduction of external editing, it is best to make
     // clearSelection(0) behave as clearCompleteSelection(), which is the same
     // behavior of python Selection.clearSelection(None)
-    if (!pDocName || !pDocName[0] || strcmp(pDocName, "*") == 0) {
-        clearCompleteSelection(pDocName, clearPreSelect);
+    if (isAllDocumentSelection(pDocName)) {
+        clearCompleteSelection(nullptr, clearPreSelect);
         return;
     }
 
@@ -2053,54 +2061,113 @@ void SelectionSingleton::clearSelection(const char* pDocName, bool clearPreSelec
 
 void SelectionSingleton::clearCompleteSelection(const char* pDocName, bool clearPreSelect)
 {
-    auto context = getSelectionContext(pDocName);
-    if (!context.info) {
-        return;
-    }
+    const bool clearAllDocuments = isAllDocumentSelection(pDocName);
+    auto docNames = getCompleteSelectionDocumentNames(pDocName);
 
-    if (!context.info->pickedList.empty()) {
-        context.info->pickedList.clear();
-        notify(SelectionChanges(SelectionChanges::PickedListChanged, context.docName.c_str()));
-    }
-
-    if (clearPreSelect) {
+    if (clearPreSelect && (clearAllDocuments || !docNames.empty())) {
         rmvPreselect();
     }
 
-    if (context.info->selList.empty()) {
+    if (docNames.empty()) {
         return;
     }
 
-    if (!logDisabled) {
-        Application::Instance->macroManager()->addLine(
-            MacroManager::Cmt,
-            clearPreSelect ? "Gui.Selection.clearSelection()" : "Gui.Selection.clearSelection(False)"
-        );
+    bool selectionChanged = false;
+    bool macroLogged = false;
+    for (const auto& docName : docNames) {
+        auto result = clearCompleteSelectionForDocument(docName);
+        if (result.docName.empty()) {
+            continue;
+        }
+
+        if (result.selectionChanged) {
+            selectionChanged = true;
+            if (!macroLogged) {
+                if (!logDisabled) {
+                    Application::Instance->macroManager()->addLine(
+                        MacroManager::Cmt,
+                        clearPreSelect ? "Gui.Selection.clearSelection()"
+                                       : "Gui.Selection.clearSelection(False)"
+                    );
+                }
+                macroLogged = true;
+            }
+        }
+
+        if (result.pickedListChanged) {
+            notify(SelectionChanges(SelectionChanges::PickedListChanged, result.docName.c_str()));
+        }
+        if (result.selectionChanged) {
+            notify(SelectionChanges(SelectionChanges::ClrSelection, result.docName.c_str()));
+        }
     }
 
-    // Send the clear selection notification to all view providers associated with the
-    // objects being deselected.
+    if (selectionChanged) {
+        getMainWindow()->updateActions();
+    }
+}
+
+std::vector<std::string> SelectionSingleton::getCompleteSelectionDocumentNames(const char* pDocName) const
+{
+    if (!isAllDocumentSelection(pDocName)) {
+        auto doc = getDocument(pDocName);
+        if (!doc) {
+            return {};
+        }
+        return {doc->getName()};
+    }
+
+    // Work from document names so selection notifications cannot leave us with stale context
+    // pointers if an observer closes a document while the global clear is in progress.
+    std::vector<std::string> docNames;
+    docNames.reserve(docSelectionContext.size());
+    for (const auto& contextEntry : docSelectionContext) {
+        auto doc = contextEntry.first;
+        if (doc) {
+            docNames.emplace_back(doc->getName());
+        }
+    }
+
+    return docNames;
+}
+
+SelectionSingleton::CompleteSelectionClearResult SelectionSingleton::clearCompleteSelectionForDocument(
+    const std::string& docName
+)
+{
+    auto context = getSelectionContext(docName.c_str());
+    if (!context.info) {
+        return {};
+    }
+
+    CompleteSelectionClearResult result {.docName = context.docName};
+    result.pickedListChanged = !context.info->pickedList.empty();
+    if (result.pickedListChanged) {
+        context.info->pickedList.clear();
+    }
+
+    if (context.info->selList.empty()) {
+        return result;
+    }
 
     std::set<ViewProvider*> viewProviders;
-    for (SelectionDescription& sel : context.info->selList) {
+    for (const auto& sel : context.info->selList) {
         if (auto vp = Application::Instance->getViewProvider(sel.pObject)) {
             viewProviders.insert(vp);
         }
     }
 
     for (auto& vp : viewProviders) {
-        SelectionChanges Chng(SelectionChanges::ClrSelection, pDocName);
+        SelectionChanges Chng(SelectionChanges::ClrSelection, result.docName.c_str());
         vp->onSelectionChanged(Chng);
     }
 
     context.info->selList.clear();
-
-    SelectionChanges Chng(SelectionChanges::ClrSelection, context.docName.c_str());
+    result.selectionChanged = true;
 
     FC_LOG("Clear selection");
 
-    notify(std::move(Chng));
-    getMainWindow()->updateActions();
+    return result;
 }
 
 bool SelectionSingleton::isSelected(

--- a/src/Gui/Selection/Selection.h
+++ b/src/Gui/Selection/Selection.h
@@ -381,7 +381,7 @@ public:
     /// Set the selection for a document
     void setSelection(const char* pDocName, const std::vector<App::DocumentObject*>&);
     /// Clear the selection of document \a pDocName. If the document name is not given the selection
-    /// of the active document is cleared.
+    /// of all documents is cleared.
     void clearSelection(const char* pDocName = nullptr, bool clearPreSelect = true);
     /// Clear the selection of all documents
     void clearCompleteSelection(const char* pDocName = nullptr, bool clearPreSelect = true);
@@ -868,10 +868,18 @@ protected:
         const SelectionInfo* info;
         std::string docName;
     };
+    struct CompleteSelectionClearResult
+    {
+        std::string docName;
+        bool selectionChanged {false};
+        bool pickedListChanged {false};
+    };
 
     // Returns a selection context or nullptr if the document is not found
     SelectionContext getSelectionContext(const char* pDocName);
     SelectionConstContext getSelectionContext(const char* pDocName) const;
+    std::vector<std::string> getCompleteSelectionDocumentNames(const char* pDocName) const;
+    CompleteSelectionClearResult clearCompleteSelectionForDocument(const std::string& docName);
 
     static SelectionSingleton* _pcSingleton;
 

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -23,6 +23,7 @@ SET(Test_SRCS
     TestPythonSyntax.py
     TestPerf.py
     TestTreeSelection.py
+    TestMultiDocumentSelection.py
     TestRubberbandSelection.py
     TestCoinNodeSnapshots.py
     TestCoinSelectionVisual.py

--- a/src/Mod/Test/InitGui.py
+++ b/src/Mod/Test/InitGui.py
@@ -98,6 +98,7 @@ FreeCAD.__unit_test__ += [
     "Menu.MenuDeleteCases",
     "Menu.MenuCreateCases",
     "GuiDocument",
+    "TestMultiDocumentSelection",
     "TestRubberbandSelection",
     "TestCoinSelectionVisual",
     "TestCoinNodeSnapshots",

--- a/src/Mod/Test/TestMultiDocumentSelection.py
+++ b/src/Mod/Test/TestMultiDocumentSelection.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 FreeCAD contributors
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+"""GUI regression tests for selection across multiple documents.
+
+To run tests:
+    FreeCAD -t TestMultiDocumentSelection.TestMultiDocumentSelection
+"""
+
+import time
+import unittest
+
+import FreeCAD
+import FreeCADGui
+from PySide6 import QtCore, QtGui, QtWidgets
+
+
+class TestMultiDocumentSelection(unittest.TestCase):
+    def setUp(self):
+        self.docs = []
+
+    def tearDown(self):
+        FreeCADGui.Selection.clearSelection()
+        for doc in reversed(self.docs):
+            if doc.Name in FreeCAD.listDocuments():
+                FreeCAD.closeDocument(doc.Name)
+
+    def test_global_clear_selection_clears_inactive_document_contexts(self):
+        doc_a, obj_a = self._new_document_with_object("Issue30778_A")
+        FreeCADGui.Selection.addSelection(doc_a.Name, obj_a.Name)
+
+        doc_b, obj_b = self._new_document_with_object("Issue30778_B")
+        FreeCADGui.Selection.addSelection(doc_b.Name, obj_b.Name)
+
+        self.assertEqual(self._selected_names(doc_a), [obj_a.Name])
+        self.assertEqual(self._selected_names(doc_b), [obj_b.Name])
+
+        self._activate_document(doc_b)
+        FreeCADGui.Selection.clearSelection()
+
+        self.assertEqual(FreeCAD.ActiveDocument.Name, doc_b.Name)
+        self.assertEqual(FreeCADGui.ActiveDocument.Document.Name, doc_b.Name)
+        self.assertEqual(self._selected_names(doc_a), [])
+        self.assertEqual(self._selected_names(doc_b), [])
+
+    def test_empty_viewport_click_clears_inactive_document_contexts(self):
+        doc_a, obj_a = self._new_document_with_object("Issue30778_Click_A")
+        FreeCADGui.Selection.addSelection(doc_a.Name, obj_a.Name)
+
+        doc_b, _ = self._new_document_with_object("Issue30778_Click_B")
+        self._activate_document(doc_b)
+        viewport = self._prepare_active_view()
+
+        self.assertEqual(self._selected_names(doc_a), [obj_a.Name])
+
+        self._click_viewport(viewport, viewport.rect().center())
+
+        self.assertEqual(FreeCAD.ActiveDocument.Name, doc_b.Name)
+        self.assertEqual(FreeCADGui.ActiveDocument.Document.Name, doc_b.Name)
+        self.assertEqual(self._selected_names(doc_a), [])
+        self.assertEqual(self._selected_names(doc_b), [])
+
+    def _new_document_with_object(self, name):
+        doc = FreeCAD.newDocument(name)
+        self.docs.append(doc)
+        self._activate_document(doc)
+        obj = doc.addObject("App::DocumentObjectGroup", "Rectangle")
+        doc.recompute()
+        return doc, obj
+
+    def _activate_document(self, doc):
+        FreeCAD.setActiveDocument(doc.Name)
+        FreeCADGui.ActiveDocument = FreeCADGui.getDocument(doc.Name)
+        FreeCADGui.updateGui()
+
+    def _selected_names(self, doc):
+        return [obj.Name for obj in FreeCADGui.Selection.getSelection(doc.Name)]
+
+    def _prepare_active_view(self):
+        view = FreeCADGui.ActiveDocument.ActiveView
+        view.getViewer().setEnabledNaviCube(False)
+        view.setAxisCross(False)
+        view.viewIsometric()
+        view.fitAll()
+
+        graphics_view = view.graphicsView()
+        viewport = graphics_view.viewport()
+        viewport.setFocus(QtCore.Qt.FocusReason.OtherFocusReason)
+        self._process_events()
+        self._process_events()
+        return viewport
+
+    def _click_viewport(self, viewport, pos):
+        self._send_mouse_event(
+            viewport,
+            QtCore.QEvent.Type.MouseMove,
+            pos,
+            QtCore.Qt.MouseButton.NoButton,
+            QtCore.Qt.MouseButton.NoButton,
+        )
+        self._process_events(10)
+        self._send_mouse_event(
+            viewport,
+            QtCore.QEvent.Type.MouseButtonPress,
+            pos,
+            QtCore.Qt.MouseButton.LeftButton,
+            QtCore.Qt.MouseButton.LeftButton,
+        )
+        self._process_events(10)
+        self._send_mouse_event(
+            viewport,
+            QtCore.QEvent.Type.MouseButtonRelease,
+            pos,
+            QtCore.Qt.MouseButton.LeftButton,
+            QtCore.Qt.MouseButton.NoButton,
+        )
+        self._process_events()
+
+    def _send_mouse_event(self, viewport, event_type, pos, button, buttons):
+        app = QtWidgets.QApplication.instance()
+        global_pos = viewport.mapToGlobal(pos)
+        QtGui.QCursor.setPos(global_pos)
+        event = QtGui.QMouseEvent(
+            event_type,
+            QtCore.QPointF(pos),
+            QtCore.QPointF(global_pos),
+            button,
+            buttons,
+            QtCore.Qt.KeyboardModifier.NoModifier,
+        )
+        app.sendEvent(viewport, event)
+
+    def _process_events(self, wait_ms=50):
+        FreeCADGui.updateGui()
+        app = QtWidgets.QApplication.instance()
+        app.processEvents()
+        time.sleep(wait_ms / 1000.0)
+        app.processEvents()


### PR DESCRIPTION
This fixes a stale multi-document selection state where a global clear could leave selections behind in inactive document contexts. When a later 3D viewport click cleared selection without a document name, only the active document context was cleared, allowing an older selection from another document to remain and unexpectedly affect document activation. 

The change makes global clears consistently clear every document selection context and emit notifications using the correct document name for each cleared context.

- clear every document selection context for global selection clears (`None`, empty, or `*`)
- notify view providers and selection observers with each cleared context's document name
- add a GUI regression test for clearing selections across multiple document contexts

Fixes #30778
