### PR TITLE
Gui: Fix B-rep selection overlay colors and depth testing

### DIFF
--- a/src/Gui/Selection/SoFCUnifiedSelection.cpp
+++ b/src/Gui/Selection/SoFCUnifiedSelection.cpp
@@ -1728,7 +1728,7 @@ bool SoFCSelectionRoot::_renderPrivate(SoGLRenderAction* action, bool inPath)
             style = SoFCSelectionRoot::Box;
         }
         else {
-            renderBBox(action, this, ctx->hlAll ? ctx->hlColor : ctx->selColor);
+            renderBBox(action, this, (ctx->hlAll && !ctx->selAll) ? ctx->hlColor : ctx->selColor);
             return true;
         }
     }
@@ -2252,7 +2252,7 @@ void SoFCPathAnnotation::GLRenderBelowPath(SoGLRenderAction* action)
                 SbColor selColor, hlColor;
                 SoFCSelectionRoot::checkSelection(sel, selColor, hl, hlColor);
                 if (sel || hl) {
-                    SoFCSelectionRoot::renderBBox(action, this, hl ? hlColor : selColor);
+                    SoFCSelectionRoot::renderBBox(action, this, (hl && !sel) ? hlColor : selColor);
                 }
                 else {
                     inherited::GLRenderInPath(action);

--- a/src/Gui/View3DInventorSelection.cpp
+++ b/src/Gui/View3DInventorSelection.cpp
@@ -211,7 +211,7 @@ void View3DInventorSelection::checkGroupOnTop(const SelectionChanges& Reason)
             return;
         }
         SoSelectionElementAction action(SoSelectionElementAction::All);
-        action.setColor(selectionRoot->colorHighlight.getValue());
+        action.setColor(selectionRoot->colorSelection.getValue());
         action.apply(pcGroupOnTopSel);
     }
     if (onTop == 2 || onTop == 3) {

--- a/src/Mod/Part/Gui/SoBrepEdgeSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepEdgeSet.cpp
@@ -60,6 +60,15 @@ struct SoBrepEdgeSet::SelContext: Gui::SoFCSelectionContextEx
     std::vector<int32_t> hl, sl;
 };
 
+/// Controls how B-rep overlay primitives interact with the scene depth buffer.
+enum class OverlayDepthMode
+{
+    /// Keep normal occlusion so committed selection does not expose hidden geometry.
+    RespectDepth,
+    /// Render above model geometry for hover and preselection feedback.
+    DrawOnTop,
+};
+
 static void applyOverlayPrimitiveState(SoState* state, SoNode* node)
 {
     if (!state || !node) {
@@ -72,12 +81,37 @@ static void applyOverlayPrimitiveState(SoState* state, SoNode* node)
     SoOverrideElement::setMaterialBindingOverride(state, node, true);
 }
 
+static void applyOverlayDepthState(SoState* state, OverlayDepthMode depthMode)
+{
+    switch (depthMode) {
+        case OverlayDepthMode::DrawOnTop:
+            SoDepthBufferElement::set(
+                state,
+                FALSE,
+                FALSE,
+                SoDepthBufferElement::ALWAYS,
+                SbVec2f(0.0f, 1.0f)
+            );
+            return;
+        case OverlayDepthMode::RespectDepth:
+            SoDepthBufferElement::set(
+                state,
+                TRUE,
+                FALSE,
+                SoDepthBufferElement::LEQUAL,
+                SbVec2f(0.0f, 1.0f)
+            );
+            return;
+    }
+}
+
 static void renderOverlayLines(
     SoGLRenderAction* action,
     SoIndexedLineSet* lineSet,
     const int32_t* indices,
     int numIndices,
-    const Base::Color& color
+    const Base::Color& color,
+    OverlayDepthMode depthMode
 )
 {
     if (!action || !lineSet || !indices || numIndices <= 0) {
@@ -111,7 +145,7 @@ static void renderOverlayLines(
     state->push();
 
     applyOverlayPrimitiveState(state, lineSet);
-    SoDepthBufferElement::set(state, FALSE, FALSE, SoDepthBufferElement::ALWAYS, SbVec2f(0.0f, 1.0f));
+    applyOverlayDepthState(state, depthMode);
 
     const SbColor sbColor(color.r, color.g, color.b);
     const float transparency = std::max(0.0f, 1.0f - color.a);
@@ -142,7 +176,8 @@ static void renderOverlayLines(
     SoIndexedLineSet* lineSet,
     const int32_t* indices,
     int numIndices,
-    const SbColor& color
+    const SbColor& color,
+    OverlayDepthMode depthMode
 )
 {
     renderOverlayLines(
@@ -150,7 +185,8 @@ static void renderOverlayLines(
         lineSet,
         indices,
         numIndices,
-        Base::Color(color[0], color[1], color[2], 1.0f)
+        Base::Color(color[0], color[1], color[2], 1.0f),
+        depthMode
     );
 }
 
@@ -213,7 +249,8 @@ static void renderColorOverrides(
             lineSet,
             group.indices.data(),
             static_cast<int>(group.indices.size()),
-            group.color
+            group.color,
+            OverlayDepthMode::DrawOnTop
         );
     }
 }
@@ -395,7 +432,8 @@ void SoBrepEdgeSet::GLRender(SoGLRenderAction* action)
             overlayLineSet,
             highlightCoordIndex.getValues(0),
             hlNum,
-            highlightColor.getValue()
+            highlightColor.getValue(),
+            OverlayDepthMode::DrawOnTop
         );
     }
     const int selNum = selectionCoordIndex.getNum();
@@ -405,7 +443,8 @@ void SoBrepEdgeSet::GLRender(SoGLRenderAction* action)
             overlayLineSet,
             selectionCoordIndex.getValues(0),
             selNum,
-            selectionColor.getValue()
+            selectionColor.getValue(),
+            OverlayDepthMode::DrawOnTop
         );
     }
 }
@@ -473,7 +512,8 @@ void SoBrepEdgeSet::renderHighlight(SoGLRenderAction* action, SelContextPtr ctx)
                 overlayLineSet,
                 this->coordIndex.getValues(0),
                 this->coordIndex.getNum(),
-                ctx->highlightColor
+                ctx->highlightColor,
+                OverlayDepthMode::DrawOnTop
             );
         }
         else {
@@ -484,7 +524,14 @@ void SoBrepEdgeSet::renderHighlight(SoGLRenderAction* action, SelContextPtr ctx)
                 );
             }
             else {
-                renderOverlayLines(action, overlayLineSet, ctx->hl.data(), num, ctx->highlightColor);
+                renderOverlayLines(
+                    action,
+                    overlayLineSet,
+                    ctx->hl.data(),
+                    num,
+                    ctx->highlightColor,
+                    OverlayDepthMode::DrawOnTop
+                );
             }
         }
     }
@@ -509,7 +556,8 @@ void SoBrepEdgeSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx,
                 overlayLineSet,
                 this->coordIndex.getValues(0),
                 this->coordIndex.getNum(),
-                ctx->selectionColor
+                ctx->selectionColor,
+                OverlayDepthMode::RespectDepth
             );
         }
         else {
@@ -520,7 +568,14 @@ void SoBrepEdgeSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx,
                 );
             }
             else {
-                renderOverlayLines(action, overlayLineSet, ctx->sl.data(), num, ctx->selectionColor);
+                renderOverlayLines(
+                    action,
+                    overlayLineSet,
+                    ctx->sl.data(),
+                    num,
+                    ctx->selectionColor,
+                    OverlayDepthMode::RespectDepth
+                );
             }
         }
     }

--- a/src/Mod/Part/Gui/SoBrepEdgeSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepEdgeSet.cpp
@@ -298,8 +298,8 @@ void SoBrepEdgeSet::GLRender(SoGLRenderAction* action)
 
     bool hasColorOverride = (ctx2 && !ctx2->colors.empty());
 
-    if (ctx && ctx->highlightIndex == std::numeric_limits<int>::max()) {
-        if (ctx->selectionIndex.empty() || ctx->isSelectAll()) {
+    if (ctx && ctx->highlightIndex == std::numeric_limits<int>::max() && !ctx->isSelectAll()) {
+        if (ctx->selectionIndex.empty()) {
             if (ctx2) {
                 ctx2->selectionColor = ctx->highlightColor;
                 renderSelection(action, ctx2);

--- a/src/Mod/Part/Gui/SoBrepFaceSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepFaceSet.cpp
@@ -513,7 +513,7 @@ bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction* action, SelContext
 
     uint32_t diffuseColor = diffuse[0].getPackedValue(trans0);
     int singleColor = 0;
-    if (ctx && ctx->isHighlightAll()) {
+    if (ctx && ctx->isHighlightAll() && !ctx->isSelectAll()) {
         singleColor = 1;
         diffuseColor = ctx->highlightColor.getPackedValue(trans0);
     }

--- a/src/Mod/Part/Gui/SoBrepPointSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepPointSet.cpp
@@ -182,8 +182,8 @@ void SoBrepPointSet::GLRender(SoGLRenderAction* action)
         return;
     }
 
-    if (ctx && ctx->highlightIndex == std::numeric_limits<int>::max()) {
-        if (ctx->selectionIndex.empty() || ctx->isSelectAll()) {
+    if (ctx && ctx->highlightIndex == std::numeric_limits<int>::max() && !ctx->isSelectAll()) {
+        if (ctx->selectionIndex.empty()) {
             if (ctx2) {
                 ctx2->selectionColor = ctx->highlightColor;
                 renderSelection(action, ctx2);

--- a/src/Mod/Part/Gui/SoBrepPointSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepPointSet.cpp
@@ -50,6 +50,15 @@ using namespace PartGui;
 
 SO_NODE_SOURCE(SoBrepPointSet)
 
+/// Controls how B-rep overlay primitives interact with the scene depth buffer.
+enum class OverlayDepthMode
+{
+    /// Keep normal occlusion so committed selection does not expose hidden geometry.
+    RespectDepth,
+    /// Render above model geometry for hover and preselection feedback.
+    DrawOnTop,
+};
+
 static void applyOverlayPrimitiveState(SoState* state, SoNode* node)
 {
     if (!state || !node) {
@@ -62,12 +71,37 @@ static void applyOverlayPrimitiveState(SoState* state, SoNode* node)
     SoOverrideElement::setMaterialBindingOverride(state, node, true);
 }
 
+static void applyOverlayDepthState(SoState* state, OverlayDepthMode depthMode)
+{
+    switch (depthMode) {
+        case OverlayDepthMode::DrawOnTop:
+            SoDepthBufferElement::set(
+                state,
+                FALSE,
+                FALSE,
+                SoDepthBufferElement::ALWAYS,
+                SbVec2f(0.0f, 1.0f)
+            );
+            return;
+        case OverlayDepthMode::RespectDepth:
+            SoDepthBufferElement::set(
+                state,
+                TRUE,
+                FALSE,
+                SoDepthBufferElement::LEQUAL,
+                SbVec2f(0.0f, 1.0f)
+            );
+            return;
+    }
+}
+
 static void renderOverlayPoints(
     SoGLRenderAction* action,
     SoIndexedPointSet* pointSet,
     const int32_t* indices,
     int numIndices,
-    const SbColor& color
+    const SbColor& color,
+    OverlayDepthMode depthMode
 )
 {
     if (!action || !pointSet || !indices || numIndices <= 0) {
@@ -93,7 +127,7 @@ static void renderOverlayPoints(
     state->push();
 
     applyOverlayPrimitiveState(state, pointSet);
-    SoDepthBufferElement::set(state, FALSE, FALSE, SoDepthBufferElement::ALWAYS, SbVec2f(0.0f, 1.0f));
+    applyOverlayDepthState(state, depthMode);
 
     SoLazyElement::setEmissive(state, &color);
     uint32_t packedColor = color.getPackedValue(0.0);
@@ -265,7 +299,8 @@ void SoBrepPointSet::GLRender(SoGLRenderAction* action)
             overlayPointSet,
             highlightCoordIndex.getValues(0),
             hlNum,
-            highlightColor.getValue()
+            highlightColor.getValue(),
+            OverlayDepthMode::DrawOnTop
         );
     }
     const int selNum = selectionCoordIndex.getNum();
@@ -275,7 +310,8 @@ void SoBrepPointSet::GLRender(SoGLRenderAction* action)
             overlayPointSet,
             selectionCoordIndex.getValues(0),
             selNum,
-            selectionColor.getValue()
+            selectionColor.getValue(),
+            OverlayDepthMode::DrawOnTop
         );
     }
 }
@@ -339,7 +375,8 @@ void SoBrepPointSet::renderHighlight(SoGLRenderAction* action, SelContextPtr ctx
             overlayPointSet,
             pointIndices.data(),
             static_cast<int>(pointIndices.size()),
-            ctx->highlightColor
+            ctx->highlightColor,
+            OverlayDepthMode::DrawOnTop
         );
         return;
     }
@@ -349,7 +386,14 @@ void SoBrepPointSet::renderHighlight(SoGLRenderAction* action, SelContextPtr ctx
     }
 
     const int32_t pointIndices[1] = {static_cast<int32_t>(id)};
-    renderOverlayPoints(action, overlayPointSet, pointIndices, 1, ctx->highlightColor);
+    renderOverlayPoints(
+        action,
+        overlayPointSet,
+        pointIndices,
+        1,
+        ctx->highlightColor,
+        OverlayDepthMode::DrawOnTop
+    );
 }
 
 void SoBrepPointSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx, bool /*push*/)
@@ -375,7 +419,8 @@ void SoBrepPointSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx
             overlayPointSet,
             pointIndices.data(),
             static_cast<int>(pointIndices.size()),
-            ctx->selectionColor
+            ctx->selectionColor,
+            OverlayDepthMode::RespectDepth
         );
     }
     else {
@@ -397,7 +442,8 @@ void SoBrepPointSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx
             overlayPointSet,
             pointIndices.data(),
             static_cast<int>(pointIndices.size()),
-            ctx->selectionColor
+            ctx->selectionColor,
+            OverlayDepthMode::RespectDepth
         );
 
         if (warn) {


### PR DESCRIPTION
This follows a regression report in Discord by kinghat for whole body selection.

This fixes a regression where selecting a PartDesign Body could render with highlight/preselection behavior instead of committed selection behavior.

The change makes committed selection take priority when selection and highlight states overlap, and keeps BREP selection overlays depth-tested so hidden/internal edges are not drawn through the selected solid. Preselection/highlight overlays still draw on top as before.

**Before:**

https://github.com/user-attachments/assets/34069abc-e62e-4541-a358-87ccc0e3d906

**After:**

https://github.com/user-attachments/assets/7b79c350-a82b-4f7d-906c-4d988178f5c9

Asissted-by: GPT-5.5-xhigh
