### PR TITLE
Sketcher: Prefer geometry over constraint datum labels

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -1363,28 +1363,49 @@ bool EditModeCoinManager::detectAxisPreselection(
     return false;
 }
 
+EditModeCoinManager::PreselectionCandidates EditModeCoinManager::collectPreselectionCandidates(
+    const SoPickedPointList& points,
+    const SbVec2s& cursorPos,
+    int hoveredPointIndex
+)
+{
+    PreselectionCandidates candidates;
+
+    candidates.Constraint = detectConstraintPreselection(points, cursorPos);
+    detectGeometryPreselection(points, cursorPos, hoveredPointIndex, candidates.Geometry);
+    detectAxisPreselection(points, candidates.Axis);
+
+    return candidates;
+}
+
+EditModeCoinManager::PreselectionResult EditModeCoinManager::resolvePreselectionCandidates(
+    const PreselectionCandidates& candidates
+) const
+{
+    if (candidates.Constraint.hasWinner()) {
+        return candidates.Constraint;
+    }
+
+    if (candidates.Geometry.hasWinner()) {
+        return candidates.Geometry;
+    }
+
+    if (candidates.Axis.hasWinner()) {
+        return candidates.Axis;
+    }
+
+    return {};
+}
+
 EditModeCoinManager::PreselectionResult EditModeCoinManager::detectPreselection(
     const SoPickedPointList& points,
     const SbVec2s& cursorPos,
     int hoveredPointIndex
 )
 {
-    PreselectionResult result;
-
-    result = detectConstraintPreselection(points, cursorPos);
-    if (result.hasWinner()) {
-        return result;
-    }
-
-    if (detectGeometryPreselection(points, cursorPos, hoveredPointIndex, result)) {
-        return result;
-    }
-
-    if (detectAxisPreselection(points, result)) {
-        return result;
-    }
-
-    return result;
+    return resolvePreselectionCandidates(
+        collectPreselectionCandidates(points, cursorPos, hoveredPointIndex)
+    );
 }
 
 SoGroup* EditModeCoinManager::getSelectedConstraints()

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -27,6 +27,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <ranges>
 
 #include <Inventor/SbVec3f.h>
 #include <Inventor/SoPickedPoint.h>
@@ -76,6 +77,43 @@ struct ScreenPreselectionPolicy
     static constexpr float PointHoverHysteresisPx = 2.0F;
     static constexpr float EdgeHitPaddingPx = 2.0F;
 };
+
+struct PreselectionPriority
+{
+    static constexpr int None = 0;
+    static constexpr int ConstraintDatumLabel = 100;
+    static constexpr int Axis = 300;
+    static constexpr int ConstraintFallback = 350;
+    static constexpr int Edge = 400;
+    static constexpr int ConstraintIcon = 450;
+    static constexpr int Point = 500;
+};
+
+int preselectionPriority(const EditModeCoinManager::PreselectionResult& result)
+{
+    using Result = EditModeCoinManager::PreselectionResult;
+
+    switch (result.Kind) {
+        case Result::HitKind::Point:
+            return PreselectionPriority::Point;
+        case Result::HitKind::Constraint:
+            if (result.ConstraintKind == Result::ConstraintHitKind::Icon) {
+                return PreselectionPriority::ConstraintIcon;
+            }
+            if (result.ConstraintKind == Result::ConstraintHitKind::DatumLabel) {
+                return PreselectionPriority::ConstraintDatumLabel;
+            }
+            return PreselectionPriority::ConstraintFallback;
+        case Result::HitKind::Edge:
+            return PreselectionPriority::Edge;
+        case Result::HitKind::Axis:
+            return PreselectionPriority::Axis;
+        case Result::HitKind::None:
+            return PreselectionPriority::None;
+    }
+
+    return PreselectionPriority::None;
+}
 
 float distanceSquaredToSegment(const SbVec2f& point, const SbVec2f& segmentStart, const SbVec2f& segmentEnd)
 {
@@ -1093,13 +1131,29 @@ EditModeCoinManager::PreselectionResult EditModeCoinManager::detectConstraintPre
 )
 {
     PreselectionResult result;
-    Base::Vector3d pickedPoint;
+    auto toPreselectionResult = [](const auto& hit, PreselectionResult& target) {
+        using ConstraintResult = EditModeConstraintCoinManager::ConstraintPreselectionResult;
 
-    result.ConstrIndices
-        = pEditModeConstraintCoinManager->detectPreselectionConstr(cursorPos, &pickedPoint);
-    if (!result.ConstrIndices.empty()) {
-        result.Kind = PreselectionResult::HitKind::Constraint;
-        result.setPickedPoint(pickedPoint);
+        target.Kind = PreselectionResult::HitKind::Constraint;
+        target.ConstrIndices = hit.ConstrIndices;
+        target.setPickedPoint(hit.PickedPoint);
+
+        switch (hit.Kind) {
+            case ConstraintResult::HitKind::Icon:
+                target.ConstraintKind = PreselectionResult::ConstraintHitKind::Icon;
+                break;
+            case ConstraintResult::HitKind::DatumLabel:
+                target.ConstraintKind = PreselectionResult::ConstraintHitKind::DatumLabel;
+                break;
+            case ConstraintResult::HitKind::None:
+                target.ConstraintKind = PreselectionResult::ConstraintHitKind::None;
+                break;
+        }
+    };
+
+    auto constraintHit = pEditModeConstraintCoinManager->detectPreselectionConstr(cursorPos);
+    if (constraintHit.hasHit()) {
+        toPreselectionResult(constraintHit, result);
         return result;
     }
 
@@ -1109,14 +1163,12 @@ EditModeCoinManager::PreselectionResult EditModeCoinManager::detectConstraintPre
             continue;
         }
 
-        result.ConstrIndices
-            = pEditModeConstraintCoinManager->detectPreselectionConstr(point, cursorPos);
-        if (result.ConstrIndices.empty()) {
+        constraintHit = pEditModeConstraintCoinManager->detectPreselectionConstr(point, cursorPos);
+        if (!constraintHit.hasHit()) {
             continue;
         }
 
-        result.Kind = PreselectionResult::HitKind::Constraint;
-        result.setPickedPoint(point);
+        toPreselectionResult(constraintHit, result);
         return result;
     }
 
@@ -1370,10 +1422,21 @@ EditModeCoinManager::PreselectionCandidates EditModeCoinManager::collectPreselec
 )
 {
     PreselectionCandidates candidates;
+    auto addCandidate = [&candidates](const PreselectionResult& result) {
+        if (result.hasWinner()) {
+            candidates.Items.push_back(result);
+        }
+    };
 
-    candidates.Constraint = detectConstraintPreselection(points, cursorPos);
-    detectGeometryPreselection(points, cursorPos, hoveredPointIndex, candidates.Geometry);
-    detectAxisPreselection(points, candidates.Axis);
+    addCandidate(detectConstraintPreselection(points, cursorPos));
+
+    PreselectionResult geometry;
+    detectGeometryPreselection(points, cursorPos, hoveredPointIndex, geometry);
+    addCandidate(geometry);
+
+    PreselectionResult axis;
+    detectAxisPreselection(points, axis);
+    addCandidate(axis);
 
     return candidates;
 }
@@ -1382,19 +1445,16 @@ EditModeCoinManager::PreselectionResult EditModeCoinManager::resolvePreselection
     const PreselectionCandidates& candidates
 ) const
 {
-    if (candidates.Constraint.hasWinner()) {
-        return candidates.Constraint;
+    if (candidates.Items.empty()) {
+        return {};
     }
 
-    if (candidates.Geometry.hasWinner()) {
-        return candidates.Geometry;
-    }
-
-    if (candidates.Axis.hasWinner()) {
-        return candidates.Axis;
-    }
-
-    return {};
+    return *std::ranges::max_element(
+        candidates.Items,
+        [](const PreselectionResult& lhs, const PreselectionResult& rhs) {
+            return preselectionPriority(lhs) < preselectionPriority(rhs);
+        }
+    );
 }
 
 EditModeCoinManager::PreselectionResult EditModeCoinManager::detectPreselection(

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <optional>
 #include <vector>
@@ -178,13 +179,20 @@ public:
      */
     struct PreselectionResult
     {
-        enum class HitKind
+        enum class HitKind : std::int8_t
         {
             None = -1,
             Point = 0,
             Edge = 1,
             Axis = 2,
             Constraint = 3
+        };
+
+        enum class ConstraintHitKind : std::uint8_t
+        {
+            None,
+            Icon,
+            DatumLabel
         };
 
         enum SpecialValues
@@ -208,6 +216,7 @@ public:
                                       // -3,-4,-5,... for external geometry
         Axes Cross = Axes::None;
         std::set<int> ConstrIndices;
+        ConstraintHitKind ConstraintKind = ConstraintHitKind::None;
         std::optional<Base::Vector3d> PickedPoint;
 
         [[nodiscard]] inline bool hasWinner() const
@@ -235,15 +244,14 @@ public:
             GeoIndex = InvalidCurve;
             Cross = Axes::None;
             ConstrIndices.clear();
+            ConstraintKind = ConstraintHitKind::None;
             PickedPoint.reset();
         }
     };
 
     struct PreselectionCandidates
     {
-        PreselectionResult Constraint;
-        PreselectionResult Geometry;
-        PreselectionResult Axis;
+        std::vector<PreselectionResult> Items;
     };
 
 public:

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -239,6 +239,13 @@ public:
         }
     };
 
+    struct PreselectionCandidates
+    {
+        PreselectionResult Constraint;
+        PreselectionResult Geometry;
+        PreselectionResult Axis;
+    };
+
 public:
     explicit EditModeCoinManager(ViewProviderSketch& vp);
     ~EditModeCoinManager();
@@ -322,6 +329,12 @@ private:
     bool detectPointPreselection(const SoPickedPoint* point, int layerIndex, PreselectionResult& result);
     bool detectCurvePreselection(const SoPickedPoint* point, int layerIndex, PreselectionResult& result);
     bool detectAxisPreselection(const SoPickedPoint* point, PreselectionResult& result);
+    PreselectionCandidates collectPreselectionCandidates(
+        const SoPickedPointList& points,
+        const SbVec2s& cursorPos,
+        int hoveredPointIndex
+    );
+    PreselectionResult resolvePreselectionCandidates(const PreselectionCandidates& candidates) const;
 
     // This function populates the coin nodes with the information of the current geometry
     void processGeometry(const GeoListFacade& geolistfacade);

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2181,18 +2181,18 @@ QString EditModeConstraintCoinManager::getPresentationString(
     return fixedValueStr;
 }
 
-std::set<int> EditModeConstraintCoinManager::detectPreselectionConstr(
+EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCoinManager::detectPreselectionConstr(
     const SoPickedPoint* Point,
     const SbVec2s& cursorScreenPos
 )
 {
-    std::set<int> constrIndices;
+    ConstraintPreselectionResult result;
     SoPath* path = Point->getPath();
 
     // The picked node must be a child of the main constraint group.
     SoNode* tailFather2 = path->getNode(path->getLength() - 3);
     if (tailFather2 != editModeScenegraphNodes.constrGroup) {
-        return constrIndices;
+        return result;
     }
 
     SoNode* tail = path->getTail();  // This is the SoImage or SoDatumLabel node that was picked.
@@ -2208,21 +2208,23 @@ std::set<int> EditModeConstraintCoinManager::detectPreselectionConstr(
     if (dynamic_cast<SoDatumLabel*>(tail)) {
         for (int i = 0; i < editModeScenegraphNodes.constrGroup->getNumChildren(); ++i) {
             if (editModeScenegraphNodes.constrGroup->getChild(i) == sep) {
-                constrIndices.insert(i);
+                result.Kind = ConstraintPreselectionResult::HitKind::DatumLabel;
+                result.ConstrIndices.insert(i);
+                result.PickedPoint = Base::convertTo<Base::Vector3d>(Point->getPoint());
                 break;
             }
         }
     }
 
-    return constrIndices;
+    return result;
 }
 
-std::set<int> EditModeConstraintCoinManager::detectPreselectionConstr(
+EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCoinManager::detectPreselectionConstr(
     const SbVec2s& cursorScreenPos,
     Base::Vector3d* pickedPoint
 )
 {
-    std::set<int> constrIndices;
+    ConstraintPreselectionResult result;
 
     for (int i = 0; i < editModeScenegraphNodes.constrGroup->getNumChildren(); ++i) {
         auto* sep = dynamic_cast<SoSeparator*>(editModeScenegraphNodes.constrGroup->getChild(i));
@@ -2234,10 +2236,9 @@ std::set<int> EditModeConstraintCoinManager::detectPreselectionConstr(
             iconIndex < sep->getNumChildren()) {
             auto* iconNode = dynamic_cast<SoImage*>(sep->getChild(iconIndex));
             if (iconNode) {
-                constrIndices
-                    = detectPreselectionIcon(sep, iconNode, iconIndex, cursorScreenPos, pickedPoint);
-                if (!constrIndices.empty()) {
-                    return constrIndices;
+                result = detectPreselectionIcon(sep, iconNode, iconIndex, cursorScreenPos, pickedPoint);
+                if (result.hasHit()) {
+                    return result;
                 }
             }
         }
@@ -2246,16 +2247,15 @@ std::set<int> EditModeConstraintCoinManager::detectPreselectionConstr(
             iconIndex < sep->getNumChildren()) {
             auto* iconNode = dynamic_cast<SoImage*>(sep->getChild(iconIndex));
             if (iconNode) {
-                constrIndices
-                    = detectPreselectionIcon(sep, iconNode, iconIndex, cursorScreenPos, pickedPoint);
-                if (!constrIndices.empty()) {
-                    return constrIndices;
+                result = detectPreselectionIcon(sep, iconNode, iconIndex, cursorScreenPos, pickedPoint);
+                if (result.hasHit()) {
+                    return result;
                 }
             }
         }
     }
 
-    return constrIndices;
+    return result;
 }
 
 std::set<int> EditModeConstraintCoinManager::parseConstraintIds(const QString& constrIdsStr) const
@@ -2326,7 +2326,7 @@ bool EditModeConstraintCoinManager::resolveIconScreenGeometry(
     return true;
 }
 
-std::set<int> EditModeConstraintCoinManager::detectPreselectionIcon(
+EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCoinManager::detectPreselectionIcon(
     SoSeparator* sep,
     SoImage* iconNode,
     int iconIndex,
@@ -2334,7 +2334,7 @@ std::set<int> EditModeConstraintCoinManager::detectPreselectionIcon(
     Base::Vector3d* pickedPoint
 ) const
 {
-    std::set<int> constrIndices;
+    ConstraintPreselectionResult result;
     SbVec2f iconScreenCenter;
     SbVec3s iconSize;
     QString constrIdsStr;
@@ -2344,7 +2344,7 @@ std::set<int> EditModeConstraintCoinManager::detectPreselectionIcon(
     if (
         !resolveIconScreenGeometry(sep, iconNode, iconIndex, iconScreenCenter, iconSize, constrIdsStr, resultPoint)
     ) {
-        return constrIndices;
+        return result;
     }
 
     int relativeX = static_cast<int>(cursorScreenPos[0] - iconScreenCenter[0] + iconSize[0] / 2.0f);
@@ -2359,18 +2359,25 @@ std::set<int> EditModeConstraintCoinManager::detectPreselectionIcon(
     if (combinedConstrBoxes.count(constrIdsStr)) {
         for (const auto& boxInfo : combinedConstrBoxes.at(constrIdsStr)) {
             if (boxInfo.first.marginsAdded(iconHitPadding).contains(relativeX, relativeY)) {
-                constrIndices.insert(boxInfo.second.begin(), boxInfo.second.end());
+                result.ConstrIndices.insert(boxInfo.second.begin(), boxInfo.second.end());
             }
         }
-        return constrIndices;
+        if (!result.ConstrIndices.empty()) {
+            result.Kind = ConstraintPreselectionResult::HitKind::Icon;
+            result.PickedPoint = *resultPoint;
+        }
+        return result;
     }
 
     QRect iconBounds(0, 0, iconSize[0], iconSize[1]);
     if (iconBounds.marginsAdded(iconHitPadding).contains(relativeX, relativeY)) {
-        return parseConstraintIds(constrIdsStr);
+        result.Kind = ConstraintPreselectionResult::HitKind::Icon;
+        result.ConstrIndices = parseConstraintIds(constrIdsStr);
+        result.PickedPoint = *resultPoint;
+        return result;
     }
 
-    return constrIndices;
+    return result;
 }
 
 SbVec3s EditModeConstraintCoinManager::getDisplayedSize(const SoImage* iconPtr) const

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
@@ -24,12 +24,15 @@
 
 #pragma once
 
+#include <cstdint>
+#include <set>
 #include <vector>
 
 #include <QColor>
 #include <QImage>
 #include <QRect>
 
+#include <Base/Vector3D.h>
 #include <Inventor/nodes/SoImage.h>
 #include <Inventor/nodes/SoInfo.h>
 
@@ -95,6 +98,25 @@ private:
     };
 
 public:
+    struct ConstraintPreselectionResult
+    {
+        enum class HitKind : std::uint8_t
+        {
+            None,
+            Icon,
+            DatumLabel
+        };
+
+        HitKind Kind = HitKind::None;
+        std::set<int> ConstrIndices;
+        Base::Vector3d PickedPoint;
+
+        [[nodiscard]] bool hasHit() const
+        {
+            return Kind != HitKind::None && !ConstrIndices.empty();
+        }
+    };
+
     explicit EditModeConstraintCoinManager(
         ViewProviderSketch& vp,
         DrawingParameters& drawingParams,
@@ -134,8 +156,11 @@ public:
     void setConstraintSelectability(bool enabled = true);
     //@}
 
-    std::set<int> detectPreselectionConstr(const SoPickedPoint* Point, const SbVec2s& cursorScreenPos);
-    std::set<int> detectPreselectionConstr(
+    ConstraintPreselectionResult detectPreselectionConstr(
+        const SoPickedPoint* Point,
+        const SbVec2s& cursorScreenPos
+    );
+    ConstraintPreselectionResult detectPreselectionConstr(
         const SbVec2s& cursorScreenPos,
         Base::Vector3d* pickedPoint = nullptr
     );
@@ -172,7 +197,7 @@ private:
         QString& constrIdsStr,
         Base::Vector3d* pickedPoint = nullptr
     ) const;
-    std::set<int> detectPreselectionIcon(
+    ConstraintPreselectionResult detectPreselectionIcon(
         SoSeparator* sep,
         SoImage* iconNode,
         int iconIndex,

--- a/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import math
 import time
 import unittest
 
@@ -149,8 +150,6 @@ class SketcherGuiTestCases(unittest.TestCase):
     def setUp(self):
         self.doc = FreeCAD.newDocument("SketchGuiTest")
         self.sketch = self.doc.addObject("Sketcher::SketchObject", "Sketch")
-        constraint_id, self.probe_point = self.build_issue_25840_sketch(self.sketch)
-        self.expected_constraint_name = f"Constraint{constraint_id + 1}"
         self.doc.recompute()
 
         FreeCADGui.getMainWindow().show()
@@ -174,6 +173,11 @@ class SketcherGuiTestCases(unittest.TestCase):
             self.pump_gui_events(4, 0.01)
 
     def testPointOnObjectPreselectionMatchesTiltedHitArea(self):
+        constraint_id, self.probe_point = self.build_issue_25840_sketch(self.sketch)
+        self.expected_constraint_name = f"Constraint{constraint_id + 1}"
+        self.doc.recompute()
+        self.pump_gui_events(6)
+
         tilt_y = FreeCAD.Rotation(FreeCAD.Vector(0, 1, 0), 2.0)
 
         counts_by_state = {}
@@ -216,3 +220,119 @@ class SketcherGuiTestCases(unittest.TestCase):
             0.20,
             detail,
         )
+
+    def testPointMarkerWinsOverOverlappingConstraintLabel(self):
+        start_point = FreeCAD.Vector(80.0, 100.0, 0.0)
+        end_point = FreeCAD.Vector(120.0, 140.0, 0.0)
+        marker_point = FreeCAD.Vector(92.0, 88.0, 0.0)
+
+        line_id = self.sketch.addGeometry(
+            Part.LineSegment(start_point, end_point),
+            False,
+        )
+        self.sketch.addGeometry(Part.Point(marker_point), False)
+        self.doc.recompute()
+        self.pump_gui_events(6)
+
+        self.configure_view_state(self.view)
+        self.pump_gui_events(8)
+
+        marker_coin = tuple(int(value) for value in self.view.getPointOnViewport(marker_point))
+
+        vertex_offsets = []
+        for dy in range(-12, 13, 2):
+            for dx in range(-12, 13, 2):
+                probe_coin = (marker_coin[0] + dx, marker_coin[1] + dy)
+                probe_info = SketcherGui.getActiveSketchPreselection(probe_coin)
+                probe_kind = self.classify_preselection(probe_info, "Constraint0")
+                if probe_kind == "vertex":
+                    vertex_offsets.append((dx, dy))
+
+        constraint_id = self.sketch.addConstraint(
+            Sketcher.Constraint("Distance", line_id, 1, line_id, 2, 40.0)
+        )
+        self.sketch.setLabelDistance(constraint_id, -12.0 * math.sqrt(2.0))
+        self.sketch.setLabelPosition(constraint_id, 0.0)
+        self.expected_constraint_name = f"Constraint{constraint_id + 1}"
+        self.doc.recompute()
+        self.pump_gui_events(12)
+
+        marker_info = SketcherGui.getActiveSketchPreselection(marker_coin)
+        marker_kind = self.classify_preselection(marker_info, self.expected_constraint_name)
+
+        probe_results = []
+        for dx, dy in vertex_offsets:
+            probe_coin = (marker_coin[0] + dx, marker_coin[1] + dy)
+            probe_info = SketcherGui.getActiveSketchPreselection(probe_coin)
+            probe_kind = self.classify_preselection(probe_info, self.expected_constraint_name)
+            probe_results.append((dx, dy, probe_kind, probe_info))
+
+        unexpected_probe_results = [result for result in probe_results if result[2] != "vertex"]
+
+        detail = (
+            f"marker_info={marker_info}, vertex_offsets={vertex_offsets}, "
+            f"probe_results={probe_results}, marker_coin={marker_coin}"
+        )
+
+        self.assertGreater(len(vertex_offsets), 0, detail)
+        self.assertEqual(marker_kind, "vertex", detail)
+        self.assertEqual(unexpected_probe_results, [], detail)
+
+    def testCurveWinsOverOverlappingDistanceDimensionLine(self):
+        start_point = FreeCAD.Vector(80.0, 100.0, 0.0)
+        end_point = FreeCAD.Vector(130.0, 100.0, 0.0)
+        midpoint = FreeCAD.Vector(105.0, 100.0, 0.0)
+
+        line_id = self.sketch.addGeometry(
+            Part.LineSegment(start_point, end_point),
+            False,
+        )
+        self.doc.recompute()
+        self.pump_gui_events(6)
+
+        self.configure_view_state(self.view)
+        self.pump_gui_events(8)
+
+        midpoint_coin = tuple(int(value) for value in self.view.getPointOnViewport(midpoint))
+
+        edge_offsets = []
+        for dy in range(-10, 11, 2):
+            for dx in range(-16, 17, 2):
+                probe_coin = (midpoint_coin[0] + dx, midpoint_coin[1] + dy)
+                probe_info = SketcherGui.getActiveSketchPreselection(probe_coin)
+                probe_kind = self.classify_preselection(probe_info, "Constraint0")
+                if probe_kind == "edge":
+                    edge_offsets.append((dx, dy))
+
+        constraint_id = self.sketch.addConstraint(
+            Sketcher.Constraint(
+                "Distance",
+                line_id,
+                1,
+                line_id,
+                2,
+                start_point.distanceToPoint(end_point),
+            )
+        )
+        self.sketch.setLabelDistance(constraint_id, 0.0)
+        self.sketch.setLabelPosition(constraint_id, 0.0)
+        self.expected_constraint_name = f"Constraint{constraint_id + 1}"
+        self.doc.recompute()
+        self.pump_gui_events(12)
+
+        probe_results = []
+        for dx, dy in edge_offsets:
+            probe_coin = (midpoint_coin[0] + dx, midpoint_coin[1] + dy)
+            probe_info = SketcherGui.getActiveSketchPreselection(probe_coin)
+            probe_kind = self.classify_preselection(probe_info, self.expected_constraint_name)
+            probe_results.append((dx, dy, probe_kind, probe_info))
+
+        unexpected_probe_results = [result for result in probe_results if result[2] != "edge"]
+
+        detail = (
+            f"edge_offsets={edge_offsets}, probe_results={probe_results}, "
+            f"midpoint_coin={midpoint_coin}"
+        )
+
+        self.assertGreater(len(edge_offsets), 0, detail)
+        self.assertEqual(unexpected_probe_results, [], detail)


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/30341#issuecomment-4670952394
Fixes https://github.com/FreeCAD/FreeCAD/issues/30864

This fixes Sketcher preselection conflicts where constraint datum labels or dimension presentation lines could take precedence over overlapping sketch geometry, making points, curves, or axes difficult to select.

- Collect Sketcher preselection candidates before resolving the final hit
- Classify constraint hits as icons or datum labels
- Keep constraint icons preferred while letting sketch geometry win over overlapping datum labels
- Add GUI regression tests for overlapping point markers and dimension lines

## Rationale
When sketch geometry and constraint presentation graphics overlap in edit mode, the old traversal-order based resolution could select the constraint label/datum presentation instead of the intended geometry. Resolving all collected candidates through an explicit priority model makes the behavior predictable: constraint icons remain easy to target, while datum labels no longer mask points, curves, or axes.

Assisted-by: GPT-5.5-xhigh
