### PR TITLE
Fix 30706: Allow Macro dirs as sources of PropertyPythonObject - Alt

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -1494,6 +1494,7 @@ class InitPipeline:
             sys_path=PathPriority.FallbackLast,
         )
         self.search_paths.commit()
+        App.__MacroDirs__ = list({str(user_macro), str(user_macro_default), str(std_macro)})
 
     def post(self) -> None:
         """

--- a/src/App/PropertyPythonObject.cpp
+++ b/src/App/PropertyPythonObject.cpp
@@ -151,14 +151,16 @@ bool isAllowedModule(const std::string& moduleName)
     // This is populated during startup by FreeCADInit.py and includes built-in workbenches,
     // user addons, and any additional configured module paths.
     Py::Module freecad(PyImport_ImportModule("FreeCAD"), true);
-    if (!freecad.hasAttr("__ModDirs__")) {
-        throw Py::RuntimeError("FreeCAD.__ModDirs__ not set -- FreeCADInit.py has not run yet");
+    if (!freecad.hasAttr("__ModDirs__") or !freecad.hasAttr("__MacroDirs__")) {
+        throw Py::RuntimeError("FreeCAD.__ModDirs__ or FreeCAD.__MacroDirs__ not set -- FreeCADInit.py has not run yet");
     }
-    Py::List modDirs(freecad.getAttr("__ModDirs__"));
+    Py::List allowedDirs(freecad.getAttr("__ModDirs__"));
+    allowedDirs.extend(freecad.getAttr("__MacroDirs__"));
+    const int allowedDirsSize = static_cast<int>(allowedDirs.size());
 
     auto isUnderFreeCAD = [&](const std::string& path) {
-        for (int i = 0; i < static_cast<int>(modDirs.size()); ++i) {
-            if (isUnderDirectory(path, Py::String(modDirs[i]).as_std_string())) {
+        for (int i = 0; i < allowedDirsSize; ++i) {
+            if (isUnderDirectory(path, Py::String(allowedDirs[i]).as_std_string())) {
                 return true;
             }
         }


### PR DESCRIPTION
https://github.com/FreeCAD/FreeCAD/pull/28756 introduced a regression reported in https://github.com/FreeCAD/FreeCAD/issues/30706

There is a c++ based PR here: https://github.com/FreeCAD/FreeCAD/pull/30736
This is an **Alternative** solution using the python based Init scripts.

There is a functional difference: In this PR, changes to user defined macro directory requires freecad restart bacause the allowed directory list is set at bootstrap. In the other PR (https://github.com/FreeCAD/FreeCAD/pull/30736) the user preferences is queried each time.