### PR TITLE
TechDraw: reopen view task panels on double-click in page

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -530,7 +530,7 @@ void QGIView::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 
     // a projection group item should edit its parent group, not itself
     App::DocumentObject* target = feature;
-    if (auto* dpgi = dynamic_cast<TechDraw::DrawProjGroupItem*>(feature)) {
+    if (auto* dpgi = freecad_cast<TechDraw::DrawProjGroupItem*>(feature)) {
         if (auto* group = dpgi->getPGroup()) {
             target = group;
         }

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -520,6 +520,32 @@ void QGIView::mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
     event->setModifiers(originalModifiers);
 }
 
+void QGIView::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
+{
+    auto* feature = getViewObject();
+    if (!feature) {
+        QGraphicsItemGroup::mouseDoubleClickEvent(event);
+        return;
+    }
+
+    // a projection group item should edit its parent group, not itself
+    App::DocumentObject* target = feature;
+    if (auto* dpgi = dynamic_cast<TechDraw::DrawProjGroupItem*>(feature)) {
+        if (auto* group = dpgi->getPGroup()) {
+            target = group;
+        }
+    }
+
+    auto* vp = getViewProvider(target);
+    if (vp && vp->doubleClicked()) {
+        event->accept();
+        return;
+    }
+
+    QGraphicsItemGroup::mouseDoubleClickEvent(event);
+}
+
+
 void QGIView::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 {
     QGraphicsItemGroup::hoverEnterEvent(event);

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -176,6 +176,7 @@ public:
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
+    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
 
     template <typename T>
     std::vector<T> getObjects(std::vector<int> indexes);


### PR DESCRIPTION
In TechDraw, a user must double click on the tree view item for a `View` or `Projection Group` to open the corresponding task panel to edit the view. This PR introduces functionality such that double clicking on the view on the page has the same effect. Ever since I started using TechDraw, this is intuitively what I felt was natural. 

The `mouseDoubleClickEvent()` override for `QGIView` resolves the view that was double-clicked (`feature`) to its parent projection group if it is in one, and gets the view provider for it, calling the existing `doubleClicked()` on that view provider so we dont duplicate the panel opening logic.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by Claude Opus 4.8

## Issues
I don't think there is an existing issue.

## Demo Video

https://github.com/user-attachments/assets/08825a41-f8b9-4655-af49-b9011361143e

