### PR TITLE
Sketcher: Add Option to include axes in Trimming Operation

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -481,7 +481,7 @@ public:
     );
 
     /// trim a curve
-    int trim(int geoId, const Base::Vector3d& point);
+    int trim(int geoId, const Base::Vector3d& point, bool includeSketchAxes);
     /// extend a curve
     int extend(int geoId, double increment, PointPos endPoint);
     /// Once smaller pieces have been created from a larger curve (by split or trim, say), derive
@@ -940,6 +940,7 @@ public:
     bool seekTrimPoints(
         int GeoId,
         const Base::Vector3d& point,
+        bool includeSketchAxes,
         int& GeoId1,
         Base::Vector3d& intersect1,
         int& GeoId2,

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -481,7 +481,7 @@ public:
     );
 
     /// trim a curve
-    int trim(int geoId, const Base::Vector3d& point, bool includeSketchAxes);
+    int trim(int geoId, const Base::Vector3d& point, bool includeSketchAxes = false);
     /// extend a curve
     int extend(int geoId, double increment, PointPos endPoint);
     /// Once smaller pieces have been created from a larger curve (by split or trim, say), derive

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -408,6 +408,7 @@ int SketchObject::extend(int GeoId, double increment, PointPos endpoint)
 bool SketchObject::seekTrimPoints(
     int GeoId,
     const Base::Vector3d& point,
+    bool includeSketchAxes,
     int& GeoId1,
     Base::Vector3d& intersect1,
     int& GeoId2,
@@ -418,9 +419,23 @@ bool SketchObject::seekTrimPoints(
         return false;
     }
 
-    auto geos = getCompleteGeometry();  // this includes the axes too
+    auto geos = getCompleteGeometry();  // this includes the axes as GeomBoundedCurve
 
-    geos.resize(geos.size() - 2);  // remove the axes to avoid intersections with the axes
+    // remove the axes since they aren't infinite lines and not all intersections will count
+    geos.resize(geos.size() - 2);
+
+    Part::GeomLine hAxis, vAxis;
+    int hAxisIndex, vAxisIndex = -1;
+    if (includeSketchAxes) {
+        // re-add the axes as infinite lines
+        hAxisIndex = geos.size();
+        hAxis.setLine(Base::Vector3d(0, 0, 0), Base::Vector3d(1, 0, 0));
+        geos.push_back(&hAxis);
+
+        vAxisIndex = geos.size();
+        vAxis.setLine(Base::Vector3d(0, 0, 0), Base::Vector3d(0, 1, 0));
+        geos.push_back(&vAxis);
+    }
 
     int localindex1, localindex2;
 
@@ -433,8 +448,18 @@ bool SketchObject::seekTrimPoints(
     }
 
     // invalid complete geometry indices are mapped to GeoUndef
-    GeoId1 = getGeoIdFromCompleteGeometryIndex(localindex1);
-    GeoId2 = getGeoIdFromCompleteGeometryIndex(localindex2);
+    auto getGeoIdForIndex = [&](int index) {
+        if (includeSketchAxes && index == hAxisIndex) {
+            return Part::Part2DObject::H_Axis;
+        }
+        if (includeSketchAxes && index == vAxisIndex) {
+            return Part::Part2DObject::V_Axis;
+        }
+        return getGeoIdFromCompleteGeometryIndex(index);
+    };
+
+    GeoId1 = getGeoIdForIndex(localindex1);
+    GeoId2 = getGeoIdForIndex(localindex2);
 
     return true;
 }
@@ -747,7 +772,7 @@ void createNewConstraintsForTrim(
     }
 }
 
-int SketchObject::trim(int GeoId, const Base::Vector3d& point)
+int SketchObject::trim(int GeoId, const Base::Vector3d& point, bool includeSketchAxes)
 {
     if (!isGeoIdAllowedForTrim(this, GeoId)) {
         return -1;
@@ -784,6 +809,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
     if (!SketchObject::seekTrimPoints(
             GeoId,
             point,
+            includeSketchAxes,
             cuttingGeoIds[0],
             cutPoints[0],
             cuttingGeoIds[1],

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -424,15 +424,17 @@ bool SketchObject::seekTrimPoints(
     // remove the axes since they aren't infinite lines and not all intersections will count
     geos.resize(geos.size() - 2);
 
-    Part::GeomLine hAxis, vAxis;
-    int hAxisIndex, vAxisIndex = -1;
+    Part::GeomLine hAxis;
+    Part::GeomLine vAxis;
+    int hAxisIndex = -1;
+    int vAxisIndex = -1;
     if (includeSketchAxes) {
         // re-add the axes as infinite lines
-        hAxisIndex = geos.size();
+        hAxisIndex = static_cast<int>(geos.size());
         hAxis.setLine(Base::Vector3d(0, 0, 0), Base::Vector3d(1, 0, 0));
         geos.push_back(&hAxis);
 
-        vAxisIndex = geos.size();
+        vAxisIndex = static_cast<int>(geos.size());
         vAxis.setLine(Base::Vector3d(0, 0, 0), Base::Vector3d(0, 1, 0));
         geos.push_back(&vAxis);
     }

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -1583,14 +1583,17 @@ PyObject* SketchObjectPy::trim(PyObject* args)
 {
     PyObject* pcObj;
     int GeoId;
+    PyObject* includeAxes = Py_False;
 
-    if (!PyArg_ParseTuple(args, "iO!", &GeoId, &(Base::VectorPy::Type), &pcObj)) {
+    if (
+        !PyArg_ParseTuple(args, "iO!|O!", &GeoId, &(Base::VectorPy::Type), &pcObj, &PyBool_Type, &includeAxes)
+    ) {
         return nullptr;
     }
 
     Base::Vector3d v1 = static_cast<Base::VectorPy*>(pcObj)->value();
 
-    if (this->getSketchObjectPtr()->trim(GeoId, v1)) {
+    if (this->getSketchObjectPtr()->trim(GeoId, v1, Base::asBoolean(includeAxes))) {
         std::stringstream str;
         str << "Not able to trim curve with the given index: " << GeoId;
         PyErr_SetString(PyExc_ValueError, str.str().c_str());

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
@@ -242,10 +242,15 @@ private:
 public:
     std::list<Gui::InputHint> getToolHints() const override
     {
-        return {
-            {tr("%1 pick edge to trim", "Sketcher Trimming: hint"),
-             {Gui::InputHint::UserInput::MouseLeft}},
-        };
+        using enum Gui::InputHint::UserInput;
+
+        return Gui::lookupHints<SelectMode>(
+            state(),
+            {{.state = SelectMode::SeekFirst,
+              .hints
+              = {{tr("%1 pick edge to trim", "Sketcher Trimming: hint"), {MouseLeft}},
+                 {tr("%1 toggle include axes as trim boundaries"), {KeyU}}}}}
+        );
     }
 };
 
@@ -255,7 +260,7 @@ void DSHTrimmingController::configureToolWidget()
     if (!init) {  // Code to be executed only upon initialisation
         toolWidget->setCheckboxLabel(
             WCheckbox::FirstBox,
-            QApplication::translate("TaskSketcherTool_c1_trimming", "Include axes")
+            QApplication::translate("TaskSketcherTool_c1_trimming", "Include axes (U)")
         );
         toolWidget->setCheckboxToolTip(
             WCheckbox::FirstBox,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
@@ -78,28 +78,43 @@ public:
     }
 };
 
-class DrawSketchHandlerTrimming: public DrawSketchHandler
+class DrawSketchHandlerTrimming;
+
+using DSHTrimmingController = DrawSketchDefaultWidgetController<
+    DrawSketchHandlerTrimming,
+    StateMachines::OneSeekEnd,
+    /*PAutoConstraintSize=*/0,
+    /*OnViewParametersT=*/OnViewParameters<0, 0>,
+    /*WidgetParametersT=*/WidgetParameters<0, 0>,
+    /*WidgetCheckboxesT=*/WidgetCheckboxes<1, 1>,
+    /*WidgetComboboxesT=*/WidgetComboboxes<0, 0>,
+    /*WidgetLineEditsT=*/WidgetLineEdits<0, 0>>;
+
+using DSHTrimmingControllerBase = DSHTrimmingController::ControllerBase;
+using DrawSketchHandlerTrimmingBase = DrawSketchControllableHandler<DSHTrimmingController>;
+
+class DrawSketchHandlerTrimming: public DrawSketchHandlerTrimmingBase
 {
     Q_DECLARE_TR_FUNCTIONS(SketcherGui::DrawSketchHandlerTrimming)
 
+    friend DSHTrimmingController;
+    friend DSHTrimmingControllerBase;
+
 public:
-    DrawSketchHandlerTrimming() = default;
+    DrawSketchHandlerTrimming()
+        : DrawSketchHandlerTrimmingBase()
+    {}
     ~DrawSketchHandlerTrimming() override
     {
         Gui::Selection().rmvSelectionGate();
     }
 
-    void mouseMove(SnapManager::SnapHandle snapHandle) override
+    void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
-        Base::Vector2d onSketchPos = snapHandle.compute();
-        if (mousePressed) {
-            executeCommands(onSketchPos);
-            return;
-        }
+        trimPos = onSketchPos;
+        geoIdToTrim = getPreselectCurve();
 
-        int GeoId = getPreselectCurve();
-
-        if (GeoId < 0) {
+        if (geoIdToTrim < 0) {
             EditMarkers.resize(0);
             drawEditMarkers(EditMarkers, 2);
         }
@@ -108,8 +123,9 @@ public:
         int GeoId1, GeoId2;
         Base::Vector3d intersect1, intersect2;
         if (!sk->seekTrimPoints(
-                GeoId,
+                geoIdToTrim,
                 Base::Vector3d(onSketchPos.x, onSketchPos.y, 0),
+                includeAxes,
                 GeoId1,
                 intersect1,
                 GeoId2,
@@ -124,7 +140,7 @@ public:
             EditMarkers.emplace_back(intersect1.x, intersect1.y);
         }
         else {
-            auto start = sk->getPoint(GeoId, Sketcher::PointPos::start);
+            auto start = sk->getPoint(geoIdToTrim, Sketcher::PointPos::start);
             EditMarkers.emplace_back(start.x, start.y);
         }
 
@@ -132,7 +148,7 @@ public:
             EditMarkers.emplace_back(intersect2.x, intersect2.y);
         }
         else {
-            auto end = sk->getPoint(GeoId, Sketcher::PointPos::end);
+            auto end = sk->getPoint(geoIdToTrim, Sketcher::PointPos::end);
             EditMarkers.emplace_back(end.x, end.y);
         }
 
@@ -140,30 +156,19 @@ public:
         drawEditMarkers(EditMarkers, 2);
     }
 
-    bool pressButton(Base::Vector2d onSketchPos) override
+    bool canGoToNextMode() override
     {
-        Q_UNUSED(onSketchPos);
-        mousePressed = true;
-
-        EditMarkers.resize(0);
-        drawEditMarkers(EditMarkers);
-
-        return true;
+        if (geoIdToTrim < 0) {
+            return false;
+        }
+        const Part::Geometry* geo = sketchgui->getSketchObject()->getGeometry(geoIdToTrim);
+        return geo->isDerivedFrom<Part::GeomTrimmedCurve>() || geo->is<Part::GeomCircle>()
+            || geo->is<Part::GeomEllipse>() || geo->is<Part::GeomBSplineCurve>();
     }
 
-    bool releaseButton(Base::Vector2d onSketchPos) override
+    void executeCommands() override
     {
-        mousePressed = false;
-
-        executeCommands(onSketchPos);
-
-        return true;
-    }
-
-    void executeCommands(Base::Vector2d onSketchPos)
-    {
-        int GeoId = getPreselectCurve();
-        if (GeoId < 0) {
+        if (geoIdToTrim < 0) {
             return;
         }
 
@@ -172,49 +177,67 @@ public:
         // resulting in another edge being deleted.
         Gui::Selection().rmvPreselect();
 
-        const Part::Geometry* geo = sketchgui->getSketchObject()->getGeometry(GeoId);
-        if (geo->isDerivedFrom<Part::GeomTrimmedCurve>() || geo->is<Part::GeomCircle>()
-            || geo->is<Part::GeomEllipse>() || geo->is<Part::GeomBSplineCurve>()) {
-            try {
-                openCommand(QT_TRANSLATE_NOOP("Command", "Trim edge"));
-                Gui::cmdAppObjectArgs(
-                    sketchgui->getObject(),
-                    "trim(%d,App.Vector(%f,%f,0))",
-                    GeoId,
-                    onSketchPos.x,
-                    onSketchPos.y
-                );
-                commitCommand();
-                tryAutoRecompute(sketchgui->getObject<Sketcher::SketchObject>());
-            }
-            catch (const Base::Exception&) {
-                Gui::NotifyError(
-                    sketchgui,
-                    QT_TRANSLATE_NOOP("Notifications", "Error"),
-                    QT_TRANSLATE_NOOP("Notifications", "Failed to trim edge")
-                );
-
-                abortCommand();
-            }
+        try {
+            openCommand(QT_TRANSLATE_NOOP("Command", "Trim edge"));
+            Gui::cmdAppObjectArgs(
+                sketchgui->getObject(),
+                "trim(%d,App.Vector(%f,%f,0),%s)",
+                geoIdToTrim,
+                trimPos.x,
+                trimPos.y,
+                includeAxes ? "True" : "False"
+            );
+            commitCommand();
+            tryAutoRecompute(sketchgui->getObject<Sketcher::SketchObject>());
+        }
+        catch (const Base::Exception&) {
+            Gui::NotifyError(
+                sketchgui,
+                QT_TRANSLATE_NOOP("Notifications", "Error"),
+                QT_TRANSLATE_NOOP("Notifications", "Failed to trim edge")
+            );
+            abortCommand();
         }
     }
 
 private:
-    void activated() override
+    std::string getToolName() const override
     {
-        Gui::Selection().clearSelection();
-        Gui::Selection().rmvSelectionGate();
-        Gui::Selection().addSelectionGate(new TrimmingSelection(sketchgui->getObject()));
+        return "DSH_Trimming";
     }
 
     QString getCrosshairCursorSVGName() const override
     {
+        Gui::Selection().rmvSelectionGate();
+        Gui::Selection().addSelectionGate(new TrimmingSelection(sketchgui->getObject()));
         return QStringLiteral("Sketcher_Pointer_Trimming");
+    }
+
+    std::unique_ptr<QWidget> createWidget() const override
+    {
+        return std::make_unique<SketcherToolDefaultWidget>();
+    }
+
+    bool isWidgetVisible() const override
+    {
+        return true;
+    };
+
+    QPixmap getToolIcon() const override
+    {
+        return Gui::BitmapFactory().pixmap("Sketcher_Trimming");
+    }
+
+    QString getToolWidgetText() const override
+    {
+        return QString(tr("Trimming Parameters"));
     }
 
 private:
     std::vector<Base::Vector2d> EditMarkers;
-    bool mousePressed = false;
+    Base::Vector2d trimPos;
+    int geoIdToTrim = Sketcher::GeoEnum::GeoUndef;
+    bool includeAxes = false;
 
 public:
     std::list<Gui::InputHint> getToolHints() const override
@@ -226,4 +249,28 @@ public:
     }
 };
 
+template<>
+void DSHTrimmingController::configureToolWidget()
+{
+    if (!init) {  // Code to be executed only upon initialisation
+        toolWidget->setCheckboxLabel(
+            WCheckbox::FirstBox,
+            QApplication::translate("TaskSketcherTool_c1_trimming", "Include axes")
+        );
+        toolWidget->setCheckboxToolTip(
+            WCheckbox::FirstBox,
+            QApplication::translate("TaskSketcherTool_c1_trimming", "Include axes as trim boundaries")
+        );
+    }
+    syncCheckboxToHandler(WCheckbox::FirstBox, handler->includeAxes);
+}
+
+template<>
+void DSHTrimmingController::adaptDrawingToCheckboxChange(int checkboxindex, bool value)
+{
+    if (checkboxindex == WCheckbox::FirstBox) {
+        handler->includeAxes = value;
+    }
+    handler->updateCursor();
+}
 }  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
@@ -109,10 +109,28 @@ public:
         Gui::Selection().rmvSelectionGate();
     }
 
+    bool pressButton(Base::Vector2d onSketchPos) override
+    {
+        mousePressed = true;
+        return DrawSketchControllableHandler::pressButton(onSketchPos);
+    }
+
+    bool releaseButton(Base::Vector2d onSketchPos) override
+    {
+        mousePressed = false;
+        return DrawSketchControllableHandler::releaseButton(onSketchPos);
+    }
+
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
         trimPos = onSketchPos;
         geoIdToTrim = getPreselectCurve();
+
+        // Hold-and-drag trim
+        if (mousePressed) {
+            executeCommands();
+            return;
+        }
 
         if (geoIdToTrim < 0) {
             EditMarkers.resize(0);
@@ -235,6 +253,7 @@ private:
 
 private:
     std::vector<Base::Vector2d> EditMarkers;
+    bool mousePressed = false;
     Base::Vector2d trimPos;
     int geoIdToTrim = Sketcher::GeoEnum::GeoUndef;
     bool includeAxes = false;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
@@ -34,10 +34,10 @@
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
-#include "DrawSketchHandler.h"
+#include "DrawSketchControllableHandler.h"
+#include "DrawSketchDefaultWidgetController.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
-#include "SnapManager.h"
 
 
 namespace SketcherGui

--- a/tests/src/Mod/Sketcher/App/SketchObjectChanges.cpp
+++ b/tests/src/Mod/Sketcher/App/SketchObjectChanges.cpp
@@ -310,7 +310,7 @@ TEST_F(SketchObjectTest, testTrimWithoutIntersection)
     Base::Vector3d trimPoint(2.0, 3.1, 0.0);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -335,7 +335,7 @@ TEST_F(SketchObjectTest, testTrimLineSegmentEnd)
     int geoId = getObject()->addGeometry(&lineSeg);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -370,7 +370,7 @@ TEST_F(SketchObjectTest, testTrimLineSegmentMid)
     int geoId = getObject()->addGeometry(&lineSeg);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -399,7 +399,7 @@ TEST_F(SketchObjectTest, testTrimCircleEnd)
     int geoId = getObject()->addGeometry(&circle);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -431,7 +431,7 @@ TEST_F(SketchObjectTest, testTrimCircleMid)
     int geoId = getObject()->addGeometry(&circle);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -463,7 +463,7 @@ TEST_F(SketchObjectTest, testTrimArcOfCircleEnd)
     int geoId = getObject()->addGeometry(&arcOfCircle);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -497,7 +497,7 @@ TEST_F(SketchObjectTest, testTrimArcOfCircleMid)
     int geoId = getObject()->addGeometry(&arcOfCircle);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -527,7 +527,7 @@ TEST_F(SketchObjectTest, testTrimEllipseEnd)
     int geoId = getObject()->addGeometry(&ellipse);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
     // remove all internal geometry
     for (int iterGeoId = 0; iterGeoId < getObject()->getHighestCurveIndex(); ++iterGeoId) {
         getObject()->deleteUnusedInternalGeometryAndUpdateGeoId(iterGeoId);
@@ -566,7 +566,7 @@ TEST_F(SketchObjectTest, testTrimEllipseMid)
     getObject()->deleteUnusedInternalGeometry(geoId);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
     // remove all internal geometry
     for (int iterGeoId = 0; iterGeoId < getObject()->getHighestCurveIndex(); ++iterGeoId) {
         getObject()->deleteUnusedInternalGeometryAndUpdateGeoId(iterGeoId);
@@ -602,7 +602,7 @@ TEST_F(SketchObjectTest, testTrimPeriodicBSplineEnd)
     int geoId = getObject()->addGeometry(periodicBSpline.get());
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -637,7 +637,7 @@ TEST_F(SketchObjectTest, testTrimPeriodicBSplineMid)
     int geoId = getObject()->addGeometry(periodicBSpline.get());
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
     // remove all internal geometry
     for (int iterGeoId = 0; iterGeoId < getObject()->getHighestCurveIndex(); ++iterGeoId) {
         getObject()->deleteUnusedInternalGeometryAndUpdateGeoId(iterGeoId);
@@ -673,7 +673,7 @@ TEST_F(SketchObjectTest, testTrimNonPeriodicBSplineEnd)
     int geoId = getObject()->addGeometry(nonPeriodicBSpline.get());
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
     // remove all internal geometry
     for (int iterGeoId = 0; iterGeoId < getObject()->getHighestCurveIndex(); ++iterGeoId) {
         getObject()->deleteUnusedInternalGeometryAndUpdateGeoId(iterGeoId);
@@ -712,7 +712,7 @@ TEST_F(SketchObjectTest, testTrimNonPeriodicBSplineMid)
     int geoId = getObject()->addGeometry(nonPeriodicBSpline.get());
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
     // remove all internal geometry
     for (int i = 0; i < getObject()->getHighestCurveIndex(); ++i) {
         if (getObject()->getGeometry(i)->is<Part::GeomBSplineCurve>()) {
@@ -760,7 +760,7 @@ TEST_F(SketchObjectTest, testTrimEffectOnConstruction)
     int geoId = getObject()->addGeometry(&circle, true);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -800,7 +800,7 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnFullLengthConstraints)
     EXPECT_EQ(countConstraintsOfType(getObject(), Sketcher::ConstraintType::Distance), 1);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -836,7 +836,7 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnSymmetricConstraints)
     EXPECT_EQ(countConstraintsOfType(getObject(), Sketcher::ConstraintType::Symmetric), 1);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -871,7 +871,7 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnUnrelatedTangent)
     EXPECT_EQ(countConstraintsOfType(getObject(), Sketcher::ConstraintType::Tangent), 1);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    int result = getObject()->trim(geoId, trimPoint, false);
 
     // Assert
     EXPECT_EQ(result, 0);

--- a/tests/src/Mod/Sketcher/App/SketchObjectChanges.cpp
+++ b/tests/src/Mod/Sketcher/App/SketchObjectChanges.cpp
@@ -310,7 +310,7 @@ TEST_F(SketchObjectTest, testTrimWithoutIntersection)
     Base::Vector3d trimPoint(2.0, 3.1, 0.0);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -335,7 +335,7 @@ TEST_F(SketchObjectTest, testTrimLineSegmentEnd)
     int geoId = getObject()->addGeometry(&lineSeg);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -370,7 +370,7 @@ TEST_F(SketchObjectTest, testTrimLineSegmentMid)
     int geoId = getObject()->addGeometry(&lineSeg);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -399,7 +399,7 @@ TEST_F(SketchObjectTest, testTrimCircleEnd)
     int geoId = getObject()->addGeometry(&circle);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -431,7 +431,7 @@ TEST_F(SketchObjectTest, testTrimCircleMid)
     int geoId = getObject()->addGeometry(&circle);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -463,7 +463,7 @@ TEST_F(SketchObjectTest, testTrimArcOfCircleEnd)
     int geoId = getObject()->addGeometry(&arcOfCircle);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -497,7 +497,7 @@ TEST_F(SketchObjectTest, testTrimArcOfCircleMid)
     int geoId = getObject()->addGeometry(&arcOfCircle);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -527,7 +527,7 @@ TEST_F(SketchObjectTest, testTrimEllipseEnd)
     int geoId = getObject()->addGeometry(&ellipse);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
     // remove all internal geometry
     for (int iterGeoId = 0; iterGeoId < getObject()->getHighestCurveIndex(); ++iterGeoId) {
         getObject()->deleteUnusedInternalGeometryAndUpdateGeoId(iterGeoId);
@@ -566,7 +566,7 @@ TEST_F(SketchObjectTest, testTrimEllipseMid)
     getObject()->deleteUnusedInternalGeometry(geoId);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
     // remove all internal geometry
     for (int iterGeoId = 0; iterGeoId < getObject()->getHighestCurveIndex(); ++iterGeoId) {
         getObject()->deleteUnusedInternalGeometryAndUpdateGeoId(iterGeoId);
@@ -602,7 +602,7 @@ TEST_F(SketchObjectTest, testTrimPeriodicBSplineEnd)
     int geoId = getObject()->addGeometry(periodicBSpline.get());
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -637,7 +637,7 @@ TEST_F(SketchObjectTest, testTrimPeriodicBSplineMid)
     int geoId = getObject()->addGeometry(periodicBSpline.get());
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
     // remove all internal geometry
     for (int iterGeoId = 0; iterGeoId < getObject()->getHighestCurveIndex(); ++iterGeoId) {
         getObject()->deleteUnusedInternalGeometryAndUpdateGeoId(iterGeoId);
@@ -673,7 +673,7 @@ TEST_F(SketchObjectTest, testTrimNonPeriodicBSplineEnd)
     int geoId = getObject()->addGeometry(nonPeriodicBSpline.get());
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
     // remove all internal geometry
     for (int iterGeoId = 0; iterGeoId < getObject()->getHighestCurveIndex(); ++iterGeoId) {
         getObject()->deleteUnusedInternalGeometryAndUpdateGeoId(iterGeoId);
@@ -712,7 +712,7 @@ TEST_F(SketchObjectTest, testTrimNonPeriodicBSplineMid)
     int geoId = getObject()->addGeometry(nonPeriodicBSpline.get());
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
     // remove all internal geometry
     for (int i = 0; i < getObject()->getHighestCurveIndex(); ++i) {
         if (getObject()->getGeometry(i)->is<Part::GeomBSplineCurve>()) {
@@ -760,7 +760,7 @@ TEST_F(SketchObjectTest, testTrimEffectOnConstruction)
     int geoId = getObject()->addGeometry(&circle, true);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -800,7 +800,7 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnFullLengthConstraints)
     EXPECT_EQ(countConstraintsOfType(getObject(), Sketcher::ConstraintType::Distance), 1);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -836,7 +836,7 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnSymmetricConstraints)
     EXPECT_EQ(countConstraintsOfType(getObject(), Sketcher::ConstraintType::Symmetric), 1);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
 
     // Assert
     EXPECT_EQ(result, 0);
@@ -871,7 +871,7 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnUnrelatedTangent)
     EXPECT_EQ(countConstraintsOfType(getObject(), Sketcher::ConstraintType::Tangent), 1);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint, false);
+    int result = getObject()->trim(geoId, trimPoint);
 
     // Assert
     EXPECT_EQ(result, 0);


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This PR provides an option to include the vertical and horizontal axis as trimming boundary.
You can enable or disable the option in the task widget, where I included a new option for trimming.
The param in the python command is implemented as optional, so old python commands should not break. They use the trimming operation without taking the axes into account (same handling as before).

Open questions from my side:
* Should I make this option persistant?
  * Currently you have to activate this option every time you start the trimming operation.
* Should this option have a hotkey? If so, which one? 

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->
Assisted-by Claude Opus 4.8 for refactoring the trimming drawsketchhandler


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
fixes #30337 

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

https://github.com/user-attachments/assets/8e94f9d7-cef9-4c54-8092-8f500beba24f

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
