### PR TITLE
Measure: MassProperties Improvements

### DIFF
--- a/src/Mod/Measure/Gui/Command.cpp
+++ b/src/Mod/Measure/Gui/Command.cpp
@@ -113,10 +113,16 @@ void StdCmdMassProperties::activated(int iMsg)
 bool StdCmdMassProperties::isActive()
 {
     App::Document* doc = App::GetApplication().getActiveDocument();
-    if (!doc) {
+    if (!doc || doc->countObjectsOfType<App::GeoFeature>() == 0) {
         return false;
     }
-    return Gui::Control().activeDialog() == nullptr;
+
+    Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
+    if (view && view->isDerivedFrom<Gui::View3DInventor>()) {
+        Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
+        return !viewer->isEditing();
+    }
+    return false;
 }
 
 void CreateMassPropertiesCommands()

--- a/src/Mod/Measure/Gui/TaskMassProperties.cpp
+++ b/src/Mod/Measure/Gui/TaskMassProperties.cpp
@@ -306,49 +306,58 @@ bool TaskMassProperties::eventFilter(QObject* watched, QEvent* event)
 
     if (event->type() == QEvent::ShortcutOverride || event->type() == QEvent::KeyPress) {
         auto* keyEvent = static_cast<QKeyEvent*>(event);
-        if (keyEvent->key() == Qt::Key_Delete) {
-            if (event->type() == QEvent::ShortcutOverride) {
-                event->accept();
-                return true;
-            }
-
-            if (panel->ui.objectList->hasFocus()) {
-                QList<QListWidgetItem*> selectedItems = panel->ui.objectList->selectedItems();
-                if (selectedItems.empty()) {
-                    event->accept();
-                    return true;
-                }
-
-                std::vector<QString> toRemove;
-                for (auto* item : selectedItems) {
-                    toRemove.push_back(item->data(Qt::UserRole).toString());
-                }
-
-                if (toRemove.size() == static_cast<std::size_t>(panel->ui.objectList->count())) {
-                    Gui::Selection().clearSelection();
-                }
-
-                for (const auto& userData : toRemove) {
-                    QStringList parts = userData.split(QStringLiteral("|"));
-                    if (parts.size() == 3) {
-                        std::string docName = parts[0].toStdString();
-                        std::string objName = parts[1].toStdString();
-                        std::string subName = parts[2].toStdString();
-                        Gui::Selection().rmvSelection(
-                            docName.empty() ? nullptr : docName.c_str(),
-                            objName.empty() ? nullptr : objName.c_str(),
-                            subName.empty() ? nullptr : subName.c_str()
-                        );
-                    }
-                }
-
-                event->accept();
-                return true;
-            }
-
+        if (keyEvent->key() != Qt::Key_Delete && keyEvent->key() != Qt::Key_Backspace) {
             event->accept();
             return true;
         }
+        if (event->type() == QEvent::ShortcutOverride) {
+            event->accept();
+            return true;
+        }
+    }
+    else if (event->type() == QEvent::MouseButtonRelease) {
+        auto* mouseEvent = static_cast<QMouseEvent*>(event);
+        if (mouseEvent->button() != Qt::RightButton) {
+            return Gui::TaskView::TaskDialog::eventFilter(watched, event);
+        }
+    }
+    else {
+        return Gui::TaskView::TaskDialog::eventFilter(watched, event);
+    }
+
+
+    if (panel->ui.objectList->hasFocus()) {
+        QList<QListWidgetItem*> selectedItems = panel->ui.objectList->selectedItems();
+        if (selectedItems.empty()) {
+            event->accept();
+            return true;
+        }
+
+        std::vector<QString> toRemove;
+        for (auto* item : selectedItems) {
+            toRemove.push_back(item->data(Qt::UserRole).toString());
+        }
+
+        if (toRemove.size() == static_cast<std::size_t>(panel->ui.objectList->count())) {
+            Gui::Selection().clearSelection();
+        }
+
+        for (const auto& userData : toRemove) {
+            QStringList parts = userData.split(QStringLiteral("|"));
+            if (parts.size() == 3) {
+                std::string docName = parts[0].toStdString();
+                std::string objName = parts[1].toStdString();
+                std::string subName = parts[2].toStdString();
+                Gui::Selection().rmvSelection(
+                    docName.empty() ? nullptr : docName.c_str(),
+                    objName.empty() ? nullptr : objName.c_str(),
+                    subName.empty() ? nullptr : subName.c_str()
+                );
+            }
+        }
+
+        event->accept();
+        return true;
     }
 
     return Gui::TaskView::TaskDialog::eventFilter(watched, event);
@@ -411,20 +420,14 @@ void TaskMassProperties::escape()
 void TaskMassProperties::removeTemporaryObjects()
 {
     App::Document* doc = App::GetApplication().getActiveDocument();
-    if (!doc) {
+    if (!doc || !doc->getObject("MassPropertiesPreview")) {
         return;
     }
 
-    if (!doc->getObject("MassPropertiesPreview")) {
-        return;
-    }
-
-    doc->openTransaction("Remove temporary mass properties object");
-    if (doc->getObject("MassPropertiesPreview")) {
-        doc->removeObject("MassPropertiesPreview");
-    }
-
-    doc->commitTransaction();
+    int savedMode = doc->getUndoMode();
+    doc->setUndoMode(0);
+    doc->removeObject("MassPropertiesPreview");
+    doc->setUndoMode(savedMode);
 }
 
 
@@ -1056,7 +1059,8 @@ void TaskMassProperties::tryUpdate()
         hasCurrentDatumPlacement ? &currentDatumPlacement : nullptr
     );
 
-    if (info.volume.getValue() == 0.0 && info.mass.getValue() == 0.0) {
+    if (info.volume.getValue() == 0.0 && info.mass.getValue() == 0.0
+        && info.surfaceArea.getValue() == 0.0) {
         this->clearUiFields();
         this->removeTemporaryObjects();
         objectsToMeasure.clear();
@@ -1118,72 +1122,82 @@ void TaskMassProperties::tryUpdate()
 
     const QString densitySuffix = objectsToMeasure.size() > 1 ? tr(" (Average)") : QString();
 
-    setText(panel->ui.volumeEdit, info.volume);
-    setText(panel->ui.massEdit, info.mass);
+    if (info.mass.getValue() + info.volume.getValue() != 0.0) {
+        setText(panel->ui.volumeEdit, info.volume);
+        setText(panel->ui.massEdit, info.mass);
+        setText(panel->ui.densityEdit, info.density, densitySuffix);
+    }
+
     setText(panel->ui.surfaceAreaEdit, info.surfaceArea);
-    setText(panel->ui.densityEdit, info.density, densitySuffix);
 
-    setText(panel->ui.cogXText, Base::Quantity(info.cog.x, Base::Unit::Length));
-    setText(panel->ui.cogYText, Base::Quantity(info.cog.y, Base::Unit::Length));
-    setText(panel->ui.cogZText, Base::Quantity(info.cog.z, Base::Unit::Length));
-    setText(panel->ui.covXText, Base::Quantity(info.cov.x, Base::Unit::Length));
-    setText(panel->ui.covYText, Base::Quantity(info.cov.y, Base::Unit::Length));
-    setText(panel->ui.covZText, Base::Quantity(info.cov.z, Base::Unit::Length));
 
-    setText(panel->ui.inertiaJoxText, Base::Quantity(info.inertiaJo.x, Base::Unit::Inertia));
-    setText(panel->ui.inertiaJoyText, Base::Quantity(info.inertiaJo.y, Base::Unit::Inertia));
-    setText(panel->ui.inertiaJozText, Base::Quantity(info.inertiaJo.z, Base::Unit::Inertia));
-    setText(panel->ui.inertiaJxyText, Base::Quantity(info.inertiaJCross.x, Base::Unit::Inertia));
-    setText(panel->ui.inertiaJzxText, Base::Quantity(info.inertiaJCross.y, Base::Unit::Inertia));
-    setText(panel->ui.inertiaJzyText, Base::Quantity(info.inertiaJCross.z, Base::Unit::Inertia));
+    if (info.mass.getValue() != 0.0) {
+        setText(panel->ui.cogXText, Base::Quantity(info.cog.x, Base::Unit::Length));
+        setText(panel->ui.cogYText, Base::Quantity(info.cog.y, Base::Unit::Length));
+        setText(panel->ui.cogZText, Base::Quantity(info.cog.z, Base::Unit::Length));
+        setText(panel->ui.covXText, Base::Quantity(info.cov.x, Base::Unit::Length));
+        setText(panel->ui.covYText, Base::Quantity(info.cov.y, Base::Unit::Length));
+        setText(panel->ui.covZText, Base::Quantity(info.cov.z, Base::Unit::Length));
+        setText(panel->ui.inertiaJoxText, Base::Quantity(info.inertiaJo.x, Base::Unit::Inertia));
+        setText(panel->ui.inertiaJoyText, Base::Quantity(info.inertiaJo.y, Base::Unit::Inertia));
+        setText(panel->ui.inertiaJozText, Base::Quantity(info.inertiaJo.z, Base::Unit::Inertia));
+        setText(panel->ui.inertiaJxyText, Base::Quantity(info.inertiaJCross.x, Base::Unit::Inertia));
+        setText(panel->ui.inertiaJzxText, Base::Quantity(info.inertiaJCross.y, Base::Unit::Inertia));
+        setText(panel->ui.inertiaJzyText, Base::Quantity(info.inertiaJCross.z, Base::Unit::Inertia));
 
-    setText(panel->ui.inertiaJxText, Base::Quantity(info.inertiaJ.x, Base::Unit::Inertia));
-    setText(panel->ui.inertiaJyText, Base::Quantity(info.inertiaJ.y, Base::Unit::Inertia));
-    setText(panel->ui.inertiaJzText, Base::Quantity(info.inertiaJ.z, Base::Unit::Inertia));
-    setText(panel->ui.axisInertiaText, Base::Quantity(info.axisInertia, Base::Unit::Inertia));
+        setText(panel->ui.inertiaJxText, Base::Quantity(info.inertiaJ.x, Base::Unit::Inertia));
+        setText(panel->ui.inertiaJyText, Base::Quantity(info.inertiaJ.y, Base::Unit::Inertia));
+        setText(panel->ui.inertiaJzText, Base::Quantity(info.inertiaJ.z, Base::Unit::Inertia));
+        setText(panel->ui.axisInertiaText, Base::Quantity(info.axisInertia, Base::Unit::Inertia));
+    }
 
     const bool hasAxisSelection = currentMode == MassPropertiesMode::Custom && referenceDatum
         && referenceDatum->isDerivedFrom<App::Line>();
 
     const auto infoSnapshot = currentInfo;
-    QTimer::singleShot(0, this, [infoSnapshot, hasAxisSelection]() {
-        App::Document* doc = App::GetApplication().getActiveDocument();
-        if (!doc) {
-            return;
-        }
+    if (info.mass.getValue() != 0.0) {
+        QTimer::singleShot(0, this, [infoSnapshot, hasAxisSelection]() {
+            App::Document* doc = App::GetApplication().getActiveDocument();
+            if (!doc) {
+                return;
+            }
 
-        App::DocumentObject* obj = doc->getObject("MassPropertiesPreview");
-        if (!obj) {
-            obj = doc->addObject("Measure::Result", "MassPropertiesPreview");
-        }
 
-        obj->Visibility.setValue(true);
+            int savedMode = doc->getUndoMode();
+            doc->setUndoMode(0);
 
-        auto* guiDoc = Gui::Application::Instance->activeDocument();
-        if (!guiDoc) {
-            return;
-        }
+            App::DocumentObject* obj = doc->getObject("MassPropertiesPreview");
+            if (!obj) {
+                obj = doc->addObject("Measure::Result", "MassPropertiesPreview");
+            }
 
-        auto* view = dynamic_cast<Gui::ViewProviderDocumentObject*>(guiDoc->getViewProvider(obj));
-        if (!view) {
-            return;
-        }
+            obj->Visibility.setValue(true);
 
-        if (auto* resultView = dynamic_cast<ViewProviderMassPropertiesResult*>(view)) {
-            resultView->setCenters(infoSnapshot.cog, infoSnapshot.cov);
-            resultView->setPrincipalAxes(
-                infoSnapshot.cog,
-                infoSnapshot.principalAxis1,
-                infoSnapshot.principalAxis2,
-                infoSnapshot.principalAxis3,
-                !hasAxisSelection
-            );
-        }
+            auto* guiDoc = Gui::Application::Instance->activeDocument();
+            if (guiDoc) {
+                auto* view = dynamic_cast<Gui::ViewProviderDocumentObject*>(
+                    guiDoc->getViewProvider(obj)
+                );
+                if (view) {
+                    if (auto* resultView = dynamic_cast<ViewProviderMassPropertiesResult*>(view)) {
+                        resultView->setCenters(infoSnapshot.cog, infoSnapshot.cov);
+                        resultView->setPrincipalAxes(
+                            infoSnapshot.cog,
+                            infoSnapshot.principalAxis1,
+                            infoSnapshot.principalAxis2,
+                            infoSnapshot.principalAxis3,
+                            !hasAxisSelection
+                        );
+                    }
+                    view->setShowable(true);
+                    view->ShowInTree.setValue(false);
+                    view->show();
+                }
+            }
 
-        view->setShowable(true);
-        view->ShowInTree.setValue(false);
-        view->show();
-    });
+            doc->setUndoMode(savedMode);
+        });
+    }
 }
 
 void TaskMassProperties::updateInertiaVisibility()

--- a/src/Mod/Measure/Gui/TaskMassProperties.cpp
+++ b/src/Mod/Measure/Gui/TaskMassProperties.cpp
@@ -424,10 +424,7 @@ void TaskMassProperties::removeTemporaryObjects()
         return;
     }
 
-    int savedMode = doc->getUndoMode();
-    doc->setUndoMode(0);
     doc->removeObject("MassPropertiesPreview");
-    doc->setUndoMode(savedMode);
 }
 
 
@@ -1163,9 +1160,6 @@ void TaskMassProperties::tryUpdate()
             }
 
 
-            int savedMode = doc->getUndoMode();
-            doc->setUndoMode(0);
-
             App::DocumentObject* obj = doc->getObject("MassPropertiesPreview");
             if (!obj) {
                 obj = doc->addObject("Measure::Result", "MassPropertiesPreview");
@@ -1174,28 +1168,28 @@ void TaskMassProperties::tryUpdate()
             obj->Visibility.setValue(true);
 
             auto* guiDoc = Gui::Application::Instance->activeDocument();
-            if (guiDoc) {
-                auto* view = dynamic_cast<Gui::ViewProviderDocumentObject*>(
-                    guiDoc->getViewProvider(obj)
-                );
-                if (view) {
-                    if (auto* resultView = dynamic_cast<ViewProviderMassPropertiesResult*>(view)) {
-                        resultView->setCenters(infoSnapshot.cog, infoSnapshot.cov);
-                        resultView->setPrincipalAxes(
-                            infoSnapshot.cog,
-                            infoSnapshot.principalAxis1,
-                            infoSnapshot.principalAxis2,
-                            infoSnapshot.principalAxis3,
-                            !hasAxisSelection
-                        );
-                    }
-                    view->setShowable(true);
-                    view->ShowInTree.setValue(false);
-                    view->show();
-                }
+            if (!guiDoc) {
+                return;
             }
 
-            doc->setUndoMode(savedMode);
+            auto* view = dynamic_cast<Gui::ViewProviderDocumentObject*>(guiDoc->getViewProvider(obj));
+            if (!view) {
+                return;
+            }
+
+            if (auto* resultView = dynamic_cast<ViewProviderMassPropertiesResult*>(view)) {
+                resultView->setCenters(infoSnapshot.cog, infoSnapshot.cov);
+                resultView->setPrincipalAxes(
+                    infoSnapshot.cog,
+                    infoSnapshot.principalAxis1,
+                    infoSnapshot.principalAxis2,
+                    infoSnapshot.principalAxis3,
+                    !hasAxisSelection
+                );
+            }
+            view->setShowable(true);
+            view->ShowInTree.setValue(false);
+            view->show();
         });
     }
 }


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This PR has a bunch of small improvements for the Mass Properties tool:

1. Added the Qt::Key_Backspace which is one of the delete keys on Mac. This makes sure that the user under no circumstance can by mistake delete their pats or assembly
2. Changed the isActve function to not be active when things like techdraw is active
3. Removed an if else statement that prevented the measurement of surfaces
4. Changed so the COM and COV does not show up if the Mass or Volume is 0
5. Made sure the preview viewprovider does not get added to the list under the undo buttons
6. Changed so that the right mouse button click removes parts from the list



- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
closes #30802 
