### PR TITLE
Sketcher: Copy: fix crash when external selected

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -248,6 +248,13 @@ bool copySelectionToClipboard(Sketcher::SketchObject* obj)
         Sketcher::PythonConverter::Mode::OmitInternalGeometry);
 
     // Export constraints of selected geos.
+    // Map each original geo id once; remapping in-place can cascade when new ids overlap old ids.
+    std::unordered_map<int, int> copiedGeoIds;
+    copiedGeoIds.reserve(listOfGeoId.size());
+    for (size_t j = 0; j < listOfGeoId.size(); j++) {
+        copiedGeoIds.emplace(listOfGeoId[j], static_cast<int>(j));
+    }
+
     std::vector<std::unique_ptr<Sketcher::Constraint>> shapeConstraints;
     for (auto constr : obj->Constraints.getValues()) {
 
@@ -274,12 +281,10 @@ bool copySelectionToClipboard(Sketcher::SketchObject* obj)
         }
 
         std::unique_ptr<Constraint> temp(constr->copy());
-        for (size_t j = 0; j < listOfGeoId.size(); j++) {
-            for (int i = 0; temp->hasElement(i); ++i) {
-                int geoid = temp->getGeoId(i);
-                if (geoid != GeoEnum::GeoUndef && geoid == listOfGeoId[j]) {
-                    temp->setGeoId(i, j);
-                }
+        for (int i = 0; temp->hasElement(i); ++i) {
+            const auto mappedGeoId = copiedGeoIds.find(temp->getGeoId(i));
+            if (mappedGeoId != copiedGeoIds.end()) {
+                temp->setGeoId(i, mappedGeoId->second);
             }
         }
         shapeConstraints.push_back(std::move(temp));


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/26622

The copy command was remapping constraint geo ids in-place. When selected geometry includes real external edges, the sorted copy list starts with negative ids, so a source id can be remapped to a new id that later also appears as an original id. That cascades. In the repro, source constraint 9 effectively became geoId1=81, pos=mid, geoId2=-2; -2 then maps to solver geo 82, matching the ASAN trace. Since geo 81 is a line, PointPos::mid is invalid and the solver falls over.

superseed part of https://github.com/FreeCAD/FreeCAD/pull/30749.