### PR TITLE
TechDraw: Fix view frame appearing when hovering protruding children

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -524,6 +524,10 @@ void QGIView::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 {
     QGraphicsItemGroup::hoverEnterEvent(event);
 
+    if (!isInsideViewFrame(event->pos())) {
+        return;
+    }
+
     m_isHovered = true;
 
     if (isSelected()) {
@@ -548,6 +552,56 @@ void QGIView::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 
     if (isSelected()) {
         m_colCurrent = getSelectColor();
+        m_lock->setVisible(getViewObject()->isLocked() && getViewObject()->showLock());
+    } else {
+        m_colCurrent = PreferencesGui::getAccessibleQColor(PreferencesGui::normalQColor());
+        m_lock->hide();
+    }
+
+    updateFrameVisibility();
+    drawBorder();
+}
+
+bool QGIView::isInsideViewFrame(const QPointF& pos) const
+{
+    auto feat = getViewObject();
+    if (!feat) {
+        return false;
+    }
+
+    if (m_border->rect().contains(pos)) {
+        return true;
+    }
+
+    QRectF labelAtPos = m_label->boundingRect().translated(m_label->pos());
+    if (labelAtPos.contains(pos)) {
+        return true;
+    }
+
+    QRectF captionAtPos = m_caption->boundingRect().translated(m_caption->pos());
+    if (captionAtPos.contains(pos)) {
+        return true;
+    }
+
+    return false;
+}
+
+void QGIView::hoverMoveEvent(QGraphicsSceneHoverEvent *event)
+{
+    QGraphicsItemGroup::hoverMoveEvent(event);
+
+    bool inside = isInsideViewFrame(event->pos());
+    if (inside == m_isHovered) {
+        return;
+    }
+
+    m_isHovered = inside;
+
+    if (isSelected()) {
+        m_colCurrent = getSelectColor();
+        m_lock->setVisible(getViewObject()->isLocked() && getViewObject()->showLock());
+    } else if (m_isHovered) {
+        m_colCurrent = getPreColor();
         m_lock->setVisible(getViewObject()->isLocked() && getViewObject()->showLock());
     } else {
         m_colCurrent = PreferencesGui::getAccessibleQColor(PreferencesGui::normalQColor());
@@ -836,7 +890,7 @@ QRectF QGIView::customChildrenBoundingRect() const
 
 QRectF QGIView::boundingRect() const
 {
-    QRectF totalRect = customChildrenBoundingRect();
+    QRectF totalRect = frameRect();
     totalRect = totalRect.united(m_border->rect());
     totalRect = totalRect.united(m_label->boundingRect().translated(m_label->pos()));
     totalRect = totalRect.united(m_caption->boundingRect().translated(m_caption->pos()));

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -176,6 +176,7 @@ public:
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
+    void hoverMoveEvent(QGraphicsSceneHoverEvent *event) override;
 
     template <typename T>
     std::vector<T> getObjects(std::vector<int> indexes);
@@ -245,6 +246,7 @@ private:
                        QPointF& outLockPos) const;
 
     bool m_inhibitSnapOnPosChange{false};
+    bool isInsideViewFrame(const QPointF& pos) const;
 };
 
 } // namespace


### PR DESCRIPTION
In TechDraw, when hovering near a view with protruding children, its selection bounds would be extended to include the total rect of these children. This PR makes the view frame ONLY appear when the mouse is hovered within the bounds of the view, caption and label.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
None

## Before Video

https://github.com/user-attachments/assets/2144384a-07e2-433b-a4bd-bbf81ff3a76d

## After Video

https://github.com/user-attachments/assets/a0c18d43-760b-4339-af74-cbd747e24e59

