### PR TITLE
Sketcher: Harden against flip with flipped h_sd parameter

### DIFF
--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -2359,7 +2359,7 @@ int System::solve_DL(SubSystem* subsys, bool isRedundantsolving)
 
         // get the steepest descent direction
         alpha = g.squaredNorm() / (Jx * g).squaredNorm();
-        h_sd = alpha * g;
+        h_sd = -alpha * g;
 
         // get the gauss-newton step
         // https://forum.freecad.org/viewtopic.php?f=10&t=12769&start=50#p106220


### PR DESCRIPTION

Following [Methods for Non-Linear Least Squares Problems (2nd ed.)](https://www2.imm.dtu.dk/pubdb/edoc/imm3215.pdf)

the sign of `h_sd` has been flipped

it seems to behave better, but there seems to be a performance penalty (see the butterfly example).
I think there are optimization opportunities left in the solver, but I don't know if they should be in a follow up PR or in this one. In either case, help would be appreciated since this is not something I have much experience in

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
Fix #29909
Fix #28141

## Before and After Images

L flipping before

https://github.com/user-attachments/assets/c69cb61f-2fcc-4ab9-a9a8-e27231e52eec



L not flipping after

https://github.com/user-attachments/assets/49366df0-cb2c-47fa-bde3-60f00c44f339

Rounded rectangle becoming a butterfly before


https://github.com/user-attachments/assets/a36f36b5-f11f-400f-8748-3c5612e9c945



Rounded rectangle staying a rounded rectangle after


https://github.com/user-attachments/assets/47982310-5a85-4ae7-86bb-878a76e02e5b


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
