### PR TITLE
TechDraw: Improve hover and selection of balloons

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
@@ -113,12 +113,12 @@ void QGIPrimPath::setPrettyNormal() {
 
 void QGIPrimPath::setPrettyPre() {
     m_pen.setColor(getPreColor());
-    m_brush.setColor(getPreColor());
+    m_brush.setColor(m_highlightFill ? getPreColor() : m_colNormalFill);
 }
 
 void QGIPrimPath::setPrettySel() {
     m_pen.setColor(getSelectColor());
-    m_brush.setColor(getSelectColor());
+    m_brush.setColor(m_highlightFill ? getSelectColor() : m_colNormalFill);
 }
 
 //wf: why would a face use its parent's normal colour?

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.h
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.h
@@ -73,6 +73,8 @@ public:
     void setFillColor(QColor c);
     QColor getFillColor() { return getDefaultFillColor(); }
 
+    void setHighlightFill(bool on) { m_highlightFill = on; }
+
 protected:
     void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
     void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
@@ -107,6 +109,7 @@ protected:
     Qt::BrushStyle m_fillNormal;               //current Normal fill style
 
     double m_edgeFuzz;
+    bool m_highlightFill = true;
 };
 
 } // namespace MDIViewPageGui

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -1029,4 +1029,26 @@ void QGIViewBalloon::updatePositionFromFeatureXY()
     //      QGIViewBalloon::placeBalloon(), QGSPage::createBalloon(), etc.
 }
 
+QPainterPath QGIViewBalloon::shape() const
+{
+    QPainterPath path;
+
+    if (balloonShape) {
+        QPainterPath p = mapFromItem(balloonShape, balloonShape->path());
+        p.setFillRule(Qt::WindingFill);
+        path.addPath(p);   // use the raw path (closed bubble) so the interior counts
+    }
+    if (balloonLines) {
+        path.addPath(mapFromItem(balloonLines, balloonLines->shape()));
+    }
+    if (balloonLabel) {
+        path.addPath(mapFromItem(balloonLabel, balloonLabel->shape()));
+    }
+    if (arrow && arrow->isVisible()) {
+        path.addPath(mapFromItem(arrow, arrow->shape()));
+    }
+
+    return path;
+}
+
 #include <Mod/TechDraw/Gui/moc_QGIViewBalloon.cpp>

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -356,6 +356,9 @@ void QGIViewBalloon::select(bool state)
 
 void QGIViewBalloon::hover(bool state)
 {
+    if (hasHover == state) {
+        return;
+    }
     hasHover = state;
     draw();
 }

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -65,6 +65,32 @@ using namespace TechDrawGui;
 using DU = DrawUtil;
 using DGU = DrawGuiUtil;
 
+// Bubble outline needs a filled hit region so its interior is hoverable
+namespace {
+class QGIBalloonBubble : public QGIDimLines {
+public:
+    explicit QGIBalloonBubble(QGIViewBalloon* b) : m_balloon(b) {
+        setAcceptHoverEvents(true);
+    }
+    QPainterPath shape() const override {
+        QPainterPath p = path();
+        p.setFillRule(Qt::WindingFill);
+        return p;
+    }
+protected:
+    void hoverEnterEvent(QGraphicsSceneHoverEvent* e) override {
+        if (m_balloon) m_balloon->hover(true);
+        e->accept();
+    }
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent* e) override {
+        if (m_balloon) m_balloon->hover(false);
+        e->accept();
+    }
+private:
+    QGIViewBalloon* m_balloon;
+};
+}
+
 QGIBalloonLabel::QGIBalloonLabel()
 {
     m_originDrag = false;
@@ -163,29 +189,13 @@ void QGIBalloonLabel::hoverEnterEvent(QGraphicsSceneHoverEvent* event)
 {
     Q_EMIT hover(true);
     hasHover = true;
-    if (!isSelected()) {
-        setPrettyPre();
-    }
-    else {
-        setPrettySel();
-    }
     QGraphicsItem::hoverEnterEvent(event);
 }
 
 void QGIBalloonLabel::hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
 {
-    QGIView* view = dynamic_cast<QGIView*>(parentItem());
-    assert(view);
-    Q_UNUSED(view);
-
     Q_EMIT hover(false);
     hasHover = false;
-    if (!isSelected()) {
-        setPrettyNormal();
-    }
-    else {
-        setPrettySel();
-    }
     QGraphicsItem::hoverLeaveEvent(event);
 }
 
@@ -262,8 +272,9 @@ QGIViewBalloon::QGIViewBalloon()
     balloonLines->setNormalColor(prefNormalColor());
     balloonLines->setPrettyNormal();
 
-    balloonShape = new QGIDimLines();
+    balloonShape = new QGIBalloonBubble(this);
     addToGroup(balloonShape);
+    balloonShape->setHighlightFill(false);
     balloonShape->setNormalColor(prefNormalColor());
     balloonShape->setFill(Qt::transparent, Qt::SolidPattern);
     balloonShape->setPrettyNormal();
@@ -668,8 +679,8 @@ void QGIViewBalloon::drawBalloon(bool originDrag)
 
     if (strcmp(balloonType, "Circular") == 0) {
         double balloonRadius = sqrt(pow((textHeight / 2.0), 2) + pow((textWidth / 2.0), 2));
-        balloonRadius = balloonRadius * scale;
         balloonPath.moveTo(lblCenter.x, lblCenter.y);
+        balloonRadius = balloonRadius * scale;
         balloonPath.addEllipse(lblCenter.x - balloonRadius, lblCenter.y - balloonRadius,
                                balloonRadius * 2, balloonRadius * 2);
         offsetLR = balloonRadius;
@@ -867,25 +878,24 @@ void QGIViewBalloon::setPrettyPre(void)
     arrow->setPrettyPre();
     balloonShape->setPrettyPre();
     balloonLines->setPrettyPre();
+    balloonLabel->setPrettyPre();
 }
 
 void QGIViewBalloon::setPrettySel(void)
 {
-    //    Base::Console().message("QGIVBal::setPrettySel()\n");
     arrow->setPrettySel();
-    //    balloonShape->setFill(Qt::white, Qt::NoBrush);
     balloonShape->setPrettySel();
     balloonLines->setPrettySel();
+    balloonLabel->setPrettySel();
 }
 
 void QGIViewBalloon::setPrettyNormal(void)
 {
     arrow->setPrettyNormal();
-    //    balloonShape->setFill(Qt::white, Qt::SolidPattern);
     balloonShape->setPrettyNormal();
     balloonLines->setPrettyNormal();
+    balloonLabel->setPrettyNormal();
 }
-
 
 void QGIViewBalloon::drawBorder(void)
 {
@@ -1036,7 +1046,7 @@ QPainterPath QGIViewBalloon::shape() const
     if (balloonShape) {
         QPainterPath p = mapFromItem(balloonShape, balloonShape->path());
         p.setFillRule(Qt::WindingFill);
-        path.addPath(p);   // use the raw path (closed bubble) so the interior counts
+        path.addPath(p);
     }
     if (balloonLines) {
         path.addPath(mapFromItem(balloonLines, balloonLines->shape()));
@@ -1049,6 +1059,18 @@ QPainterPath QGIViewBalloon::shape() const
     }
 
     return path;
+}
+
+void QGIViewBalloon::hoverEnterEvent(QGraphicsSceneHoverEvent* event)
+{
+    hover(true);
+    QGIView::hoverEnterEvent(event);
+}
+
+void QGIViewBalloon::hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
+{
+    hover(false);
+    QGIView::hoverLeaveEvent(event);
 }
 
 #include <Mod/TechDraw/Gui/moc_QGIViewBalloon.cpp>

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.h
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.h
@@ -183,6 +183,8 @@ public:
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
                QWidget* widget = nullptr) override;
 
+    QPainterPath shape() const override;
+
     QString getLabelText();
     void placeBalloon(QPointF pos);
     void setPrettyPre();

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.h
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.h
@@ -235,6 +235,8 @@ protected:
                           bool isDragging,
                           Base::Vector3d& labelPos,
                           Base::Vector3d& arrowPos);
+    void hoverEnterEvent(QGraphicsSceneHoverEvent* event) override;
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) override;
 
 
 private:


### PR DESCRIPTION
In TechDraw, Balloons suffered from multiple selection and hover problems:
1) The balloon's selectable region was its entire bounding rectangle, which spanned the empty space between the bubble and the arrow tip. Clicking anywhere in that box selected the balloon and blocked selection of items behind it.

<img width="332" height="441" alt="20260616_23h09m31s_grim" src="https://github.com/user-attachments/assets/0f532a38-4f5d-4019-b45f-82b57b9bef3b" />

2) The leader line was not highlighted on hover.
3) Hover/selection highlighting filled the bubble with the highlight colour, making the balloon number unreadable.

This PR solves each point.
- The first commit fixes the selection bounds of the balloon so that it is not rectangular, but rather follows bubble, leader, and arrow
- The second commit fixes the hover highlighting (so the bubble interior, leader, arrow, and number all respond consistently) and stops the bubble interior from being filled with the highlight colour. This includes a small addition to `QGIPrimPath` (`setHighlightFill`) used by the balloon. Ive preserved the default existing behaviour for all other items.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by Claude Opus 4.8

## Issues
None

## Before Video 

https://github.com/user-attachments/assets/fcf61510-c4f6-4210-923f-9e3fc363640e

## After Video

https://github.com/user-attachments/assets/2a4dc047-b280-4b2b-8ff4-f290d96891e5