### PR TITLE
Draft: Draft_Edit: 'Set Point as First' option for wire and B-spline

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
@@ -115,8 +115,10 @@ class DraftWireGuiTools(GuiTools):
             return menu
         else:
             return menu + [
-                (translate("draft", "Set Point as First"),
-                lambda: self.set_first_point(obj, node_idx)),
+                (
+                    translate("draft", "Set Point as First"),
+                    lambda: self.set_first_point(obj, node_idx),
+                ),
             ]
 
     def get_edit_obj_context_menu(self, edit_command, obj, position):

--- a/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
@@ -108,9 +108,16 @@ class DraftWireGuiTools(GuiTools):
         obj.Points = pts
 
     def get_edit_point_context_menu(self, edit_command, obj, node_idx):
-        return [
+        menu = [
             (translate("draft", "Delete Point"), lambda: self.delete_point(obj, node_idx)),
         ]
+        if node_idx == 0 or not obj.Closed:
+            return menu
+        else:
+            return menu + [
+                (translate("draft", "Set Point as First"),
+                lambda: self.set_first_point(obj, node_idx)),
+            ]
 
     def get_edit_obj_context_menu(self, edit_command, obj, position):
         return [
@@ -188,6 +195,11 @@ class DraftWireGuiTools(GuiTools):
 
     def reverse_wire(self, obj):
         obj.Points = reversed(obj.Points)
+        obj.recompute()
+
+    def set_first_point(self, obj, node_idx):
+        pts = obj.Points
+        obj.Points = pts[node_idx:] + pts[0:node_idx]
         obj.recompute()
 
 


### PR DESCRIPTION
Closes #25007.

The option is only offered if the wire or B-spline is closed and the point under the cursor is not the 1st point of the curve. Note that shifting the 1st point of a B-spline will change its shape.

<img width="285" height="132" alt="afbeelding" src="https://github.com/user-attachments/assets/84d34efc-cb1d-404f-b4c8-ede0e26a46d3" />
