### PR TITLE
CAM: Add support for fractional percentages for adaptive stepover and UI elements for stepover distance

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathAdaptive.py
+++ b/src/Mod/CAM/CAMTests/TestPathAdaptive.py
@@ -478,7 +478,7 @@ class TestPathAdaptive(PathTestBase):
         adaptive.FinishingProfile = False
         adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
-        adaptive.StepOver = 75
+        adaptive.StepOverPercent = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
         # Have to set expression to None before numerical value assignment
@@ -510,7 +510,7 @@ class TestPathAdaptive(PathTestBase):
         adaptive.FinishingProfile = False
         adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
-        adaptive.StepOver = 75
+        adaptive.StepOverPercent = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
         # Have to set expression to None before numerical value assignment
@@ -536,7 +536,7 @@ class TestPathAdaptive(PathTestBase):
         adaptive.FinishingProfile = False
         adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
-        adaptive.StepOver = 75
+        adaptive.StepOverPercent = 75
         adaptive.UseOutline = True
         adaptive.setExpression("StepDown", None)
         # Have to set expression to None before numerical value assignment
@@ -575,7 +575,7 @@ class TestPathAdaptive(PathTestBase):
         adaptive.FinishingProfile = False
         adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
-        adaptive.StepOver = 75
+        adaptive.StepOverPercent = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
         # Have to set expression to None before numerical value assignment
@@ -616,7 +616,7 @@ class TestPathAdaptive(PathTestBase):
         adaptive.FinishingProfile = False
         adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
-        adaptive.StepOver = 75
+        adaptive.StepOverPercent = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
         # Have to set expression to None before numerical value assignment
@@ -657,7 +657,7 @@ class TestPathAdaptive(PathTestBase):
         adaptive.FinishingProfile = False
         adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
-        adaptive.StepOver = 75
+        adaptive.StepOverPercent = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
         # Have to set expression to None before numerical value assignment
@@ -698,7 +698,7 @@ class TestPathAdaptive(PathTestBase):
         adaptive.FinishingProfile = False
         adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
-        adaptive.StepOver = 75
+        adaptive.StepOverPercent = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
         # Have to set expression to None before numerical value assignment
@@ -757,7 +757,7 @@ class TestPathAdaptive(PathTestBase):
         adaptive.FinishingProfile = False
         adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
-        adaptive.StepOver = 75
+        adaptive.StepOverPercent = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
         adaptive.ModelAwareExperiment = True
@@ -821,7 +821,7 @@ class TestPathAdaptive(PathTestBase):
         adaptive.FinishingProfile = False
         adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
-        adaptive.StepOver = 75
+        adaptive.StepOverPercent = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
         # Have to set expression to None before numerical value assignment
@@ -881,7 +881,7 @@ class TestPathAdaptive(PathTestBase):
         adaptive.FinishingProfile = False
         adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
-        adaptive.StepOver = 75
+        adaptive.StepOverPercent = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
         adaptive.ModelAwareExperiment = True
@@ -957,7 +957,7 @@ class TestPathAdaptive(PathTestBase):
         adaptive.FinishingProfile = False
         adaptive.HelixMaxRampAngle = 75.0
         adaptive.LiftDistance.Value = 1.0
-        adaptive.StepOver = 75
+        adaptive.StepOverPercent = 75
         adaptive.UseOutline = False
         adaptive.setExpression("StepDown", None)
         adaptive.ModelAwareExperiment = True

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
@@ -150,7 +150,7 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="4" column="1">
        <widget class="QDoubleSpinBox" name="stepOver">
         <property name="toolTip">
-         <string>The sideways distance* the cutting tool moves between successive passes (*a percentage of the tool's diameter).</string>
+         <string>The sideways distance the cutting tool moves between successive passes, as percentage of the tool's diameter.</string>
         </property>
         <property name="suffix">
          <string>%</string>
@@ -175,7 +175,24 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="4" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Step over</string>
+         <string>Step over (percent)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="Gui::QuantitySpinBox" name="stepOverDistance" native="true">
+        <property name="toolTip">
+         <string>The sideways distance the cutting tool moves between successive passes.</string>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true"/>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_stepOverDistance">
+        <property name="text">
+         <string>Step over (distance)</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
@@ -148,24 +148,27 @@ Larger values (further to the right) will calculate faster; smaller values (furt
        </widget>
       </item>
       <item row="4" column="1">
-       <widget class="QSpinBox" name="stepOver">
+       <widget class="QDoubleSpinBox" name="stepOver">
         <property name="toolTip">
          <string>The sideways distance* the cutting tool moves between successive passes (*a percentage of the tool's diameter).</string>
         </property>
         <property name="suffix">
          <string>%</string>
         </property>
+        <property name="decimals">
+         <number>2</number>
+        </property>
         <property name="minimum">
-         <number>1</number>
+         <double>0.1</double>
         </property>
         <property name="maximum">
-         <number>100</number>
+         <double>100.0</double>
         </property>
         <property name="singleStep">
-         <number>5</number>
+         <double>5.0</double>
         </property>
         <property name="value">
-         <number>20</number>
+         <double>20.0</double>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -257,7 +257,7 @@ def GenerateGCode(op, obj, adaptiveResults):
                     spiralArgs = {
                         "center": centerBottom,
                         "outer_radius": r,
-                        "step": op.tool.Diameter.Value * obj.StepOver / 100,
+                        "step": op.tool.Diameter.Value * obj.StepOverPercent / 100,
                         "inner_radius": r_bottom,
                         "direction": "CCW",
                         "startAt": "Inside",
@@ -409,7 +409,7 @@ def Execute(op, obj):
             "geometry": path2d,
             "clearedArea": clearedArea,
             "stockGeometry": stockPath2d,
-            "stepover": float(obj.StepOver),
+            "stepover": float(obj.StepOverPercent),
             "effectiveHelixDiameter": float(helixDiameter),
             "helixMinDiameter": float(helixMinDiameter),
             "operationType": obj.OperationType,
@@ -441,7 +441,7 @@ def Execute(op, obj):
 
         if inputStateChanged or adaptiveResults is None:
             a2d = area.Adaptive2d()
-            a2d.stepOverFactor = 0.01 * obj.StepOver
+            a2d.stepOverFactor = 0.01 * obj.StepOverPercent
             a2d.toolDiameter = float(op.tool.Diameter)
             a2d.helixRampTargetDiameter = helixDiameter
             a2d.helixRampMinDiameter = helixMinDiameter
@@ -539,7 +539,6 @@ def ExecuteModelAware(op, obj):
     try:
         obj.HelixMinDiameterPercent = max(obj.HelixMinDiameterPercent, 10)
         obj.HelixMaxDiameterPercent = max(obj.HelixMaxDiameterPercent, obj.HelixMinDiameterPercent)
-        obj.StepOver = max(obj.StepOver, 1)
 
         helixDiameter = obj.HelixMaxDiameterPercent / 100 * op.tool.Diameter.Value
         helixMinDiameter = obj.HelixMinDiameterPercent / 100 * op.tool.Diameter.Value
@@ -621,7 +620,7 @@ def ExecuteModelAware(op, obj):
                 if k["opType"] in [outsideClearing, outsideProfiling]
             ],
             "stockGeometry": stockPaths,
-            "stepover": obj.StepOver,
+            "stepover": obj.StepOverPercent,
             "effectiveHelixDiameter": helixDiameter,
             "helixMinDiameter": helixMinDiameter,
             "operationType": "Clearing",
@@ -643,7 +642,7 @@ def ExecuteModelAware(op, obj):
                 if k["opType"] in [insideClearing, insideProfiling]
             ],
             "stockGeometry": stockPaths,
-            "stepover": obj.StepOver,
+            "stepover": obj.StepOverPercent,
             "effectiveHelixDiameter": helixDiameter,
             "helixMinDiameter": helixMinDiameter,
             "operationType": "Clearing",
@@ -699,7 +698,7 @@ def ExecuteModelAware(op, obj):
                 opType = rdict["opType"]
 
                 a2d = area.Adaptive2d()
-                a2d.stepOverFactor = 0.01 * obj.StepOver
+                a2d.stepOverFactor = 0.01 * obj.StepOverPercent
                 a2d.toolDiameter = op.tool.Diameter.Value
                 a2d.helixRampTargetDiameter = helixDiameter
                 a2d.helixRampMinDiameter = helixMinDiameter
@@ -1563,8 +1562,8 @@ class PathAdaptive(PathOp.ObjectOp):
             ),
         )
         obj.addProperty(
-            "App::PropertyPercent",
-            "StepOver",
+            "App::PropertyFloat",
+            "StepOverPercent",
             "Adaptive",
             QT_TRANSLATE_NOOP(
                 "App::Property",
@@ -1765,7 +1764,7 @@ class PathAdaptive(PathOp.ObjectOp):
         obj.Side = "Inside"
         obj.OperationType = "Clearing"
         obj.Tolerance = 0.1
-        obj.StepOver = 20
+        obj.StepOverPercent = 20
         obj.LiftDistance = 0
         # obj.ProcessHoles = True
         obj.ForceInsideOut = False
@@ -1791,6 +1790,12 @@ class PathAdaptive(PathOp.ObjectOp):
         """opExecute(obj) ... called whenever the receiver needs to be recalculated.
         See documentation of execute() for a list of base functionality provided.
         Should be overwritten by subclasses."""
+
+        # Enforce StepOverPercent constraints
+        if obj.StepOverPercent > 100.0:
+            obj.StepOverPercent = 100.0
+        if obj.StepOverPercent < 0.1:
+            obj.StepOverPercent = 0.1
 
         obj.setEditorMode("OrderCutsByRegion", 0 if obj.ModelAwareExperiment else 2)
         obj.setEditorMode("ZStockToLeave", 0 if obj.ModelAwareExperiment else 2)
@@ -1930,6 +1935,27 @@ class PathAdaptive(PathOp.ObjectOp):
             if obj.getGroupOfProperty(prop) != "AdaptiveHelixEntry":
                 obj.setGroupOfProperty(prop, "AdaptiveHelixEntry")
 
+        # Migrate StepOver to StepOverPercent
+        if not hasattr(obj, "StepOverPercent"):
+            # Get value from old StepOver property or use default
+            if hasattr(obj, "StepOver"):
+                oldValue = obj.StepOver
+                obj.removeProperty("StepOver")
+            else:
+                oldValue = 20
+
+            # Create new StepOverPercent property
+            obj.addProperty(
+                "App::PropertyFloat",
+                "StepOverPercent",
+                "Adaptive",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Percent of cutter diameter to step over on each pass",
+                ),
+            )
+            obj.StepOverPercent = float(oldValue)
+
         FeatureExtensions.initialize_properties(obj)
 
 
@@ -1938,7 +1964,7 @@ def SetupProperties():
         "Side",
         "OperationType",
         "Tolerance",
-        "StepOver",
+        "StepOverPercent",
         "LiftDistance",
         "KeepToolDownRatio",
         "StockToLeave",

--- a/src/Mod/CAM/Path/Op/Gui/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Gui/Adaptive.py
@@ -50,6 +50,18 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.LiftDistance.setProperty("unit", obj.LiftDistance.getUserPreferred()[2])
         self.form.KeepToolDownRatio.setProperty("unit", obj.KeepToolDownRatio.getUserPreferred()[2])
         self.form.StockToLeave.setProperty("unit", obj.StockToLeave.getUserPreferred()[2])
+        # Use user's preferred length unit
+        self.form.stepOverDistance.setProperty(
+            "unit", FreeCAD.Units.Quantity("1 mm").getUserPreferred()[2]
+        )
+
+        # Connect controls to keep step over percent and distance in sync
+        self.form.stepOver.valueChanged.connect(lambda: self.updateStepOverDistance(obj))
+        self.form.stepOverDistance.valueChanged.connect(lambda: self.updateStepOverPercent(obj))
+        self.form.stepOverDistance.editingFinished.connect(lambda: self.updateStepOverDistance(obj))
+        self.form.toolController.currentIndexChanged.connect(
+            lambda: self.updateStepOverDistance(obj)
+        )
 
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
@@ -81,10 +93,36 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.StopButton.toggled)
         return signals
 
+    def updateStepOverDistance(self, obj):
+        """Update step over distance from percent"""
+        if hasattr(obj, "ToolController") and obj.ToolController:
+            toolDiameter = obj.ToolController.Tool.Diameter.Value
+            percent = self.form.stepOver.value()
+            distance = toolDiameter * percent / 100.0
+            self.form.stepOverDistance.blockSignals(True)
+            self.form.stepOverDistance.setProperty("rawValue", distance)
+            self.form.stepOverDistance.blockSignals(False)
+
+    def updateStepOverPercent(self, obj):
+        """Update step over percent when distance changes"""
+        if hasattr(obj, "ToolController") and obj.ToolController:
+            toolDiameter = obj.ToolController.Tool.Diameter.Value
+            if toolDiameter > 0:
+                distance = self.form.stepOverDistance.property("rawValue")
+                percent = (distance / toolDiameter) * 100.0
+                percent = max(0.1, min(100.0, percent))
+
+                self.form.stepOver.blockSignals(True)
+                self.form.stepOver.setValue(percent)
+                self.form.stepOver.blockSignals(False)
+                self.getFields(obj)
+
     def setFields(self, obj):
         self.selectInComboBox(obj.Side, self.form.Side)
         self.selectInComboBox(obj.OperationType, self.form.OperationType)
         self.form.stepOver.setValue(obj.StepOverPercent)
+        self.updateStepOverDistance(obj)
+
         self.form.Tolerance.setValue(int(obj.Tolerance * 100))
 
         self.form.HelixMaxRampAngle.setText(

--- a/src/Mod/CAM/Path/Op/Gui/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Gui/Adaptive.py
@@ -84,7 +84,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     def setFields(self, obj):
         self.selectInComboBox(obj.Side, self.form.Side)
         self.selectInComboBox(obj.OperationType, self.form.OperationType)
-        self.form.stepOver.setValue(obj.StepOver)
+        self.form.stepOver.setValue(obj.StepOverPercent)
         self.form.Tolerance.setValue(int(obj.Tolerance * 100))
 
         self.form.HelixMaxRampAngle.setText(
@@ -128,8 +128,8 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         if obj.OperationType != str(self.form.OperationType.currentData()):
             obj.OperationType = str(self.form.OperationType.currentData())
 
-        if obj.StepOver != self.form.stepOver.value():
-            obj.StepOver = self.form.stepOver.value()
+        if obj.StepOverPercent != self.form.stepOver.value():
+            obj.StepOverPercent = self.form.stepOver.value()
 
         if obj.HelixMaxDiameterPercent != self.form.HelixMaxDiameterPercent.value():
             obj.HelixMaxDiameterPercent = self.form.HelixMaxDiameterPercent.value()


### PR DESCRIPTION
From a conversation on discord with DamnGoodDan in the CAM channel. I asked him to make an issue for this but then just went ahead and wrote the PR without it.

Changes:

- migrate the StepOver property to the better named StepOverPercent and convert the type to float to allow fractional values
- update the task ui panel to display the step over as a distance as well as a percent. The user may edit either, and the other updates. Step over is still only ever stored as a percent
- updated the minimum legal value of StepOverPercent to 0.1% (i.e. 6um on a 6mm tool; I'm happy to set this to some other value but this seems reasonable to me). I tested it (6mm/0.1%/6um) on a sample model and it took an unreasonably long time but did complete eventually

<img width="523" height="216" alt="20260617_14h54m34s_grim" src="https://github.com/user-attachments/assets/d4da3d54-fc08-490d-b6d2-f1a612a5703c" />


https://github.com/user-attachments/assets/5317bfd5-8bd2-4dec-904e-f563f5545f1e
