### PR TITLE
Gui: marshal view messages from Python worker threads

### DIFF
--- a/src/App/MainThreadSignal.h
+++ b/src/App/MainThreadSignal.h
@@ -24,13 +24,14 @@
 
 #include <Base/Interpreter.h>
 #include <fastsignals/signal.h>
+#include <exception>
 #include <functional>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <tuple>
 #include <type_traits>
 #include <utility>
-#include <variant>
 
 namespace App
 {
@@ -73,6 +74,59 @@ public:
         }
         else {
             fn();  // no hooks, run inline
+        }
+    }
+
+    // Invoke synchronously on the main thread, return its value, and transport
+    // exceptions back to the calling thread. This deliberately does not manage
+    // the Python GIL; Python-facing callers must release it before blocking.
+    template<class Function>
+    static auto invokeBlocking(Function&& function) -> std::invoke_result_t<Function&&>
+    {
+        using Result = std::invoke_result_t<Function&&>;
+        static_assert(
+            !std::is_reference_v<Result>,
+            "Blocking main-thread calls must return by value"
+        );
+
+        if (isMainThread()) {
+            return std::invoke(std::forward<Function>(function));
+        }
+
+        using StoredResult =
+            std::conditional_t<std::is_void_v<Result>, bool, std::remove_cv_t<Result>>;
+        std::optional<StoredResult> result;
+        bool completed = false;
+        std::exception_ptr exception;
+
+        invoke(
+            [&]() {
+                try {
+                    if constexpr (std::is_void_v<Result>) {
+                        std::invoke(std::forward<Function>(function));
+                        result.emplace(true);
+                    }
+                    else {
+                        result.emplace(std::invoke(std::forward<Function>(function)));
+                    }
+                }
+                catch (...) {
+                    exception = std::current_exception();
+                }
+                completed = true;
+            },
+            true
+        );
+
+        if (!completed) {
+            throw std::runtime_error("Blocking main-thread invocation did not execute");
+        }
+        if (exception) {
+            std::rethrow_exception(exception);
+        }
+
+        if constexpr (!std::is_void_v<Result>) {
+            return std::move(*result);
         }
     }
 
@@ -132,8 +186,6 @@ auto captureSignalArg(PDecl&& x)
     }
 }
 
-template<class T>
-using non_void_t = std::conditional_t<std::is_void_v<T>, std::monostate, T>;
 }  // namespace detail
 
 // Wrapper that mirrors fastsignals::signal but executes slots on GUI thread.
@@ -240,26 +292,11 @@ private:
             detail::captureSignalArg<typename ::fastsignals::signal_arg_t<Arguments>>(args)...
         );
 
-        if constexpr (std::is_void_v<result_type>) {
-            MainThreadSignalConfig::invoke(
-                [self, caps = std::move(caps)]() mutable {
-                    std::apply([self](auto&... c) { self->sig_(c.get()...); }, caps);
-                },
-                /*blocking=*/true
-            );
-        }
-        else {
-            std::optional<detail::non_void_t<result_type>> result;
-            MainThreadSignalConfig::invoke(
-                [self, caps = std::move(caps), &result]() mutable {
-                    result.emplace(
-                        std::apply([self](auto&... c) { return self->sig_(c.get()...); }, caps)
-                    );
-                },
-                /*blocking=*/true
-            );
-            return std::move(*result);
-        }
+        return MainThreadSignalConfig::invokeBlocking(
+            [self, caps = std::move(caps)]() mutable {
+                return std::apply([self](auto&... c) { return self->sig_(c.get()...); }, caps);
+            }
+        );
     }
 
     mutable base_sig sig_;

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -26,6 +26,7 @@
 #include <QPrinter>
 #include <QFileInfo>
 #include <map>
+#include <string>
 #include <Inventor/SoInput.h>
 #include <Inventor/SoPath.h>
 #include <Inventor/actions/SoGetPrimitiveCountAction.h>
@@ -37,6 +38,7 @@
 
 #include <App/DocumentObjectPy.h>
 #include <App/DocumentPy.h>
+#include <App/MainThreadSignal.h>
 #include <App/PropertyFile.h>
 #include <Base/Exception.h>
 #include <Base/Interpreter.h>
@@ -87,6 +89,18 @@ void requirePythonMainThread(const char* api)
     catch (const Base::Exception& exception) {
         throw Py::RuntimeError(exception.what());
     }
+}
+
+template<typename SendMessage>
+bool sendViewMessageOnMainThread(const SendMessage& sendMessage)
+{
+    if (App::MainThreadSignalConfig::isMainThread()) {
+        return sendMessage();
+    }
+
+    // View handlers may run Python on the GUI thread, so do not hold the worker's GIL.
+    Base::PyGILStateRelease release;
+    return App::MainThreadSignalConfig::invokeBlocking(sendMessage);
 }
 
 struct CoinActionTarget
@@ -1138,15 +1152,20 @@ PyObject* ApplicationPy::sSendActiveView(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
-    requirePythonMainThread("FreeCADGui.SendMsgToActiveView");
-
-    if (!Application::Instance->sendMsgToActiveView(psCommandStr)) {
-        if (!Base::asBoolean(suppress)) {
-            Base::Console().warning("Unknown view command: %s\n", psCommandStr);
+    PY_TRY
+    {
+        const std::string command(psCommandStr);
+        if (!sendViewMessageOnMainThread([&command]() {
+                return Application::Instance->sendMsgToActiveView(command.c_str());
+            })) {
+            if (!Base::asBoolean(suppress)) {
+                Base::Console().warning("Unknown view command: %s\n", command.c_str());
+            }
         }
-    }
 
-    Py_Return;
+        Py_Return;
+    }
+    PY_CATCH;
 }
 
 PyObject* ApplicationPy::sSendFocusView(PyObject* /*self*/, PyObject* args)
@@ -1158,15 +1177,20 @@ PyObject* ApplicationPy::sSendFocusView(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
-    requirePythonMainThread("FreeCADGui.SendMsgToFocusView");
-
-    if (!Application::Instance->sendMsgToFocusView(psCommandStr)) {
-        if (!Base::asBoolean(suppress)) {
-            Base::Console().warning("Unknown view command: %s\n", psCommandStr);
+    PY_TRY
+    {
+        const std::string command(psCommandStr);
+        if (!sendViewMessageOnMainThread([&command]() {
+                return Application::Instance->sendMsgToFocusView(command.c_str());
+            })) {
+            if (!Base::asBoolean(suppress)) {
+                Base::Console().warning("Unknown view command: %s\n", command.c_str());
+            }
         }
-    }
 
-    Py_Return;
+        Py_Return;
+    }
+    PY_CATCH;
 }
 
 PyObject* ApplicationPy::sGetMainWindow(PyObject* /*self*/, PyObject* args)

--- a/src/Mod/Test/GuiDocument.py
+++ b/src/Mod/Test/GuiDocument.py
@@ -83,6 +83,66 @@ class TestGuiDocument(unittest.TestCase):
 
         return predicate()
 
+    def _runWorkerWithGuiEvents(self, target, timeout=3.0):
+        exceptions = []
+
+        def run():
+            try:
+                target()
+            except Exception as exc:  # pragma: no cover - exercised through assertion below
+                exceptions.append(exc)
+
+        worker = threading.Thread(target=run, daemon=True)
+        worker.start()
+
+        self.assertTrue(
+            self._processEventsUntil(lambda: not worker.is_alive(), timeout),
+            "worker thread did not finish while the GUI event loop was being serviced",
+        )
+        worker.join()
+
+        if exceptions:
+            raise exceptions[0]
+
+    def _activeViewWidget(self):
+        main_window = FreeCADGui.getMainWindow()
+        mdi_area = main_window.findChild(QtWidgets.QMdiArea)
+        self.assertIsNotNone(mdi_area)
+
+        sub_window = mdi_area.activeSubWindow()
+        self.assertIsNotNone(sub_window)
+
+        view_widget = sub_window.widget()
+        self.assertIsNotNone(view_widget)
+        return view_widget
+
+    @staticmethod
+    def _focusIsWithin(widget):
+        focus = QtWidgets.QApplication.focusWidget()
+        while focus is not None:
+            if focus is widget:
+                return True
+            focus = focus.parentWidget()
+        return False
+
+    def _assertWorkerViewMessageChangesDirection(self, send_message):
+        view = FreeCADGui.getDocument(self.doc.Name).ActiveView
+        self.assertIsNotNone(view)
+
+        animation_enabled = view.isAnimationEnabled()
+        view.setAnimationEnabled(False)
+        try:
+            view.viewTop()
+            expected = view.getViewDirection()
+            view.viewAxonometric()
+            self.assertFalse(view.getViewDirection().isEqual(expected, 1e-12))
+
+            self._runWorkerWithGuiEvents(lambda: send_message("ViewTop", True))
+
+            self.assertTrue(view.getViewDirection().isEqual(expected, 1e-12))
+        finally:
+            view.setAnimationEnabled(animation_enabled)
+
     def _assertRecoveryArchiveContains(self, expected_label=None):
         archive = self._recoveryArchive()
         self.assertTrue(os.path.isfile(archive))
@@ -161,6 +221,21 @@ class TestGuiDocument(unittest.TestCase):
         self.assertIn("exception", result)
         self.assertIsInstance(result["exception"], RuntimeError)
         self.assertIn("main thread", str(result["exception"]).lower())
+
+    def testSendMsgToActiveViewFromWorkerThread(self):
+        self._assertWorkerViewMessageChangesDirection(FreeCADGui.SendMsgToActiveView)
+
+    def testSendMsgToFocusViewFromWorkerThread(self):
+        view_widget = self._activeViewWidget()
+        view_widget.activateWindow()
+        view_widget.setFocus(QtCore.Qt.FocusReason.OtherFocusReason)
+
+        self.assertTrue(
+            self._processEventsUntil(lambda: self._focusIsWithin(view_widget)),
+            "active MDI view did not receive focus",
+        )
+
+        self._assertWorkerViewMessageChangesDirection(FreeCADGui.sendMsgToFocusView)
 
     def testRefreshFallsBackToSyncForFeaturePython(self):
         params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Document")


### PR DESCRIPTION
This restores compatibility for legacy Python callers that send view messages from worker threads, such as addon code fitting the active view after background work. The GUI main-thread guard remains in place for general GUI API access, but `SendMsgToActiveView` and `SendMsgToFocusView` now marshal their narrow view-message operation to the GUI thread and release the GIL while waiting.

Fixes #30113.
