### PR TITLE
PartDesign: Fix pattern failing with primitive

### DIFF
--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -253,8 +253,8 @@ App::DocumentObjectExecReturn* Transformed::recomputePreview()
             if (auto* feature = freecad_cast<FeatureAddSub*>(original)) {
                 auto shape = feature->AddSubShape.getShape();
 
-                gp_Trsf trsf = feature->getLocation().Transformation().Multiplied(
-                    supportTransform.Inverted()
+                gp_Trsf trsf = supportTransform.Inverted().Multiplied(
+                    feature->getLocation().Transformation()
                 );
 
                 if (shape.isNull()) {
@@ -405,7 +405,7 @@ App::DocumentObjectExecReturn* Transformed::execute()
                         QT_TRANSLATE_NOOP("Exception", "Shape of additive/subtractive feature is empty")
                     );
                 }
-                gp_Trsf trsf = feature->getLocation().Transformation().Multiplied(trsfInv);
+                gp_Trsf trsf = trsfInv.Multiplied(feature->getLocation().Transformation());
                 if (!fuseShape.isNull()) {
                     fuseShape = fuseShape.makeElementTransform(trsf);
                 }


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/6238

Fix PartDesign transformed feature placement for primitives

PartDesign transformed features were converting an original feature's local `AddSubShape` into the support coordinate system with the transform order reversed. This happened to work when original and support placements were the same or identity, but failed for mapped primitives whose local frames differ, placing patterned cuts in the wrong position.

Use `support^-1 * original` for the frame conversion in both preview and execute paths.