### PR TITLE
Pin build_release.yml Windows image to VS2022

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -118,7 +118,7 @@ jobs:
           - { target: osx-64, os: macos-15-intel, deploy_target: "10.13" }
           - { target: osx-arm64, os: macos-latest, deploy_target: "11.0" }
           - { target: osx-arm64, os: macos-latest, deploy_target: "15.0" }
-          - { target: win-64, os: windows-latest }
+          - { target: win-64, os: windows-2022 }
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Should fix the Windows weekly build, as reported on Discord