### PR TITLE
TechDraw: fix handling of empty template fields

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -84,8 +84,7 @@ namespace sp = std::placeholders;
 TYPESYSTEM_SOURCE_ABSTRACT(TechDrawGui::MDIViewPage, Gui::MDIView)
 
 MDIViewPage::MDIViewPage(ViewProviderPage* pageVp, Gui::Document* doc, QWidget* parent)
-    : Gui::MDIView(doc, parent), m_vpPage(pageVp),
-      m_previewState(false)
+    : Gui::MDIView(doc, parent), m_vpPage(pageVp)
 {
     setMouseTracking(true);
 
@@ -394,9 +393,7 @@ void MDIViewPage::printPreview()
 
     QPrintPreviewDialog dlg(&printer, this);
     connect(&dlg, &QPrintPreviewDialog::paintRequested, this, qOverload<QPrinter*>(&MDIViewPage::print));
-    m_previewState = true;
     dlg.exec();
-    m_previewState = false;
 }
 
 
@@ -445,7 +442,7 @@ void MDIViewPage::print(QPrinter* printer)
         }
     }
 
-    PagePrinter::print(getViewProviderPage(), printer, m_previewState);
+    PagePrinter::print(getViewProviderPage(), printer);
 }
 
 // static routine to print all pages in a document.  Used by PrintAll command in Command.cpp

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -167,7 +167,6 @@ private:
 
     QString defaultFileName();
 
-    bool m_previewState{false};
 };
 
 class MDIViewPagePy : public Py::PythonExtension<MDIViewPagePy>

--- a/src/Mod/TechDraw/Gui/PagePrinter.cpp
+++ b/src/Mod/TechDraw/Gui/PagePrinter.cpp
@@ -170,10 +170,16 @@ void PagePrinter::printAll(QPrinter* printer, App::Document* doc)
             printer->newPage();
         }
         firstTime = false;
+
+        QGISVGTemplate* ourTemplate{nullptr};
+        QGSPage* ourScene{nullptr};
+        preRenderSetUp(vpp, ourScene, ourTemplate);
+
         QRectF sourceRect(0.0, Rez::guiX(-height), Rez::guiX(width), Rez::guiX(height));
         QRect targetRect = printer->pageLayout().fullRectPixels(printer->resolution());
         renderPage(vpp, painter, sourceRect, targetRect);
-        dPage->redrawCommand();
+
+        postRenderCleanUp(ourScene, dPage, ourTemplate);
     }
 
     ourDoc->setModified(docModifiedState);
@@ -236,8 +242,9 @@ void PagePrinter::printAllPdf(QPrinter* printer, App::Document* doc)
             continue;// can't print this one
         }
 
-        auto ourScene = vpp->getQGSPage();
-        ourScene->setExportingPdf(true);
+        QGISVGTemplate* ourTemplate{nullptr};
+        QGSPage* ourScene{nullptr};
+        preRenderSetUp(vpp, ourScene, ourTemplate);
 
         auto dPage = static_cast<TechDraw::DrawPage*>(obj);
         double width{0};
@@ -253,9 +260,8 @@ void PagePrinter::printAllPdf(QPrinter* printer, App::Document* doc)
         QRectF sourceRect(0.0, Rez::guiX(-height), Rez::guiX(width), Rez::guiX(height));
         QRect targetRect(0, 0, width * dpmm, height * dpmm);
         renderPage(vpp, painter, sourceRect, targetRect);
-        dPage->redrawCommand();
 
-        ourScene->setExportingPdf(false);
+        postRenderCleanUp(ourScene, dPage, ourTemplate);
     }
 
     ourDoc->setModified(docModifiedState);
@@ -332,21 +338,19 @@ void PagePrinter::print(ViewProviderPage* vpPage, QPrinter* printer, bool isPrev
 
     QPainter painter(printer);
 
-    auto ourScene = vpPage->getQGSPage();
-    if (!printer->outputFileName().isEmpty() ||
-        isPreview) {
-        ourScene->setExportingPdf(true);
-    }
     auto ourDoc = Gui::Application::Instance->getDocument(dPage->getDocument());
     auto docModifiedState = ourDoc->isModified();
+
+    QGISVGTemplate* ourTemplate{nullptr};
+    QGSPage* ourScene{nullptr};
+    preRenderSetUp(vpPage, ourScene, ourTemplate);
 
     QRect targetRect = printer->pageLayout().fullRectPixels(printer->resolution());
     QRectF sourceRect(0.0, Rez::guiX(-height), Rez::guiX(width), Rez::guiX(height));
     renderPage(vpPage, painter, sourceRect, targetRect);
 
-    ourScene->setExportingPdf(false);  // doesn't hurt if not pdf
+    postRenderCleanUp(ourScene, dPage, ourTemplate);
     ourDoc->setModified(docModifiedState);
-    dPage->redrawCommand();
 }
 
 
@@ -390,10 +394,12 @@ void PagePrinter::printPdf(ViewProviderPage* vpPage, const std::string& file)
     // pdfWriter layout is established.
     QPainter painter(&pdfWriter);
 
-    auto ourScene = vpPage->getQGSPage();
-    ourScene->setExportingPdf(true);
     auto ourDoc = Gui::Application::Instance->getDocument(dPage->getDocument());
     auto docModifiedState = ourDoc->isModified();
+
+    QGISVGTemplate* ourTemplate{nullptr};
+    QGSPage* ourScene{nullptr};
+    preRenderSetUp(vpPage, ourScene, ourTemplate);
 
     // render the page
     QRectF sourceRect(0.0, Rez::guiX(-height), Rez::guiX(width), Rez::guiX(height));
@@ -403,9 +409,35 @@ void PagePrinter::printPdf(ViewProviderPage* vpPage, const std::string& file)
     QRect targetRect(0, 0, twide, thigh);
     renderPage(vpPage, painter, sourceRect, targetRect);
 
-    ourScene->setExportingPdf(false);
+    postRenderCleanUp(ourScene, dPage, ourTemplate);
     ourDoc->setModified(docModifiedState);
+}
+
+void PagePrinter::preRenderSetUp(TechDrawGui::ViewProviderPage* vpp,
+                                 QGSPage*& ourScene,
+                                 QGISVGTemplate*& ourTemplate)
+{
+    if (!vpp) {
+        return;
+    }
+    ourScene = vpp->getQGSPage();
+    // setExportingPdf does not hurt anything here and protects against Windows
+    // Pdf writer not asking for file name until after rendering.
+    ourScene->setExportingPdf(true);
+    ourTemplate = static_cast<QGISVGTemplate*>(vpp->getQTemplate());
+    ourTemplate->updateView(true);
+}
+
+void PagePrinter::postRenderCleanUp(QGSPage* ourScene,
+                                    TechDraw::DrawPage* dPage,
+                                    QGISVGTemplate* ourTemplate)
+{
+    if (!ourScene) {
+        return;
+    }
+    ourScene->setExportingPdf(false);
     dPage->redrawCommand();
+    ourTemplate->updateView(true);
 }
 
 

--- a/src/Mod/TechDraw/Gui/PagePrinter.cpp
+++ b/src/Mod/TechDraw/Gui/PagePrinter.cpp
@@ -326,7 +326,7 @@ void PagePrinter::renderPage(ViewProviderPage* vpp, QPainter& painter, QRectF& s
 
 
 /// print the Page associated with the view provider
-void PagePrinter::print(ViewProviderPage* vpPage, QPrinter* printer, bool isPreview)
+void PagePrinter::print(ViewProviderPage* vpPage, QPrinter* printer)
 {
     QPageLayout pageLayout = printer->pageLayout();
 

--- a/src/Mod/TechDraw/Gui/PagePrinter.h
+++ b/src/Mod/TechDraw/Gui/PagePrinter.h
@@ -105,7 +105,7 @@ public:
     static PaperAttributes getPaperAttributes(TechDraw::DrawPage* pageObject);
     static PaperAttributes getPaperAttributes(ViewProviderPage* vpPage);
 
-    static void print(ViewProviderPage* vpPage, QPrinter* printer, bool isPreview = false);
+    static void print(ViewProviderPage* vpPage, QPrinter* printer);
     static void printPdf(ViewProviderPage* vpPage, const std::string& file);
     static void printAll(QPrinter* printer, App::Document* doc);
     static void printAllPdf(QPrinter* printer, App::Document* doc);

--- a/src/Mod/TechDraw/Gui/PagePrinter.h
+++ b/src/Mod/TechDraw/Gui/PagePrinter.h
@@ -28,6 +28,7 @@
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
 #include "ViewProviderPage.h"
+#include "QGISVGTemplate.h"
 
 QT_BEGIN_NAMESPACE
 class QGraphicsScene;
@@ -112,6 +113,13 @@ public:
     static void saveSVG(ViewProviderPage* vpPage, const std::string& file);
     static void saveDXF(ViewProviderPage* vpPage, const std::string& file);
     static void savePDF(ViewProviderPage* vpPage, const std::string& file);
+
+    static void postRenderCleanUp(QGSPage* ourScene,
+                                    TechDraw::DrawPage* dPage,
+                                    QGISVGTemplate* ourTemplate);
+    static void preRenderSetUp(TechDrawGui::ViewProviderPage* vpp,
+                               QGSPage*& ourScene,
+                               QGISVGTemplate*& ourTemplate);
 };
 
 }  // namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
@@ -387,8 +387,6 @@ void QGISVGTemplate::createClickHandles()
             // For more details please see https://qt-project.atlassian.net/browse/QTBUG-32405
             if (isShortText) {
                 textRect = fm.boundingRect(QStringLiteral("_"));
-                // textRect is now valid, so we don't need to run the shortText code
-                isShortText = false;
             }
             else {
                 textRect = fm.boundingRect(content);
@@ -421,7 +419,6 @@ void QGISVGTemplate::createClickHandles()
             textRect.setTop(textRect.bottom() - MinRectHeight);
             textRect.setRight(textRect.left() + MinRectWidth);
         }
-
 
         // Get tight bounding box of text
         double factor = textRect.height() / fm.height();  // Correcting font metrics and SVG text due to different font sizes

--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
@@ -210,7 +210,6 @@ QGISVGTemplate::QGISVGTemplate(QGSPage* scene) : QGITemplate(scene),
 {
     m_pageRectangle->setZValue(ZVALUE::BACKGROUND);
 
-
     m_svgItem->setSharedRenderer(m_svgRender);
 
     m_svgItem->setFlags(QGraphicsItem::ItemClipsToShape);
@@ -343,6 +342,12 @@ void QGISVGTemplate::clearClickHandles()
 
 void QGISVGTemplate::createClickHandles()
 {
+    auto* qgsp = static_cast<QGSPage*>(scene());
+    if (qgsp->getExportingAny()) {
+        // no click handles on export
+        return;
+    }
+
     prepareGeometryChange();
     TechDraw::DrawSVGTemplate* svgTemplate = getSVGTemplate();
     if (svgTemplate->isRestoring()) {
@@ -364,16 +369,35 @@ void QGISVGTemplate::createClickHandles()
 
     TechDraw::XMLQuery query(templateDocument);
 
-
     std::vector<QDomElement> textElements = getFCElements(templateDocument);
     for(QDomElement& textElement : textElements) {
-        // Get tight bounding box of text
-        QFont font = getFont(textElement);
-        QFontMetricsF fm(font);
-
         // Get elements bounding box of text
         QString id = textElement.attribute(QStringLiteral("id"));
         QRectF textRect = m_svgRender->boundsOnElement(id);
+        QString name = textElement.attribute(QStringLiteral(FREECAD_ATTR_EDITABLE));
+        QString content = QString::fromStdString(textMap[name.toStdString()]);
+
+        QDomElement tspan = textElement.firstChildElement();
+        QFont font = getFont(tspan);
+        QFontMetricsF fm(font);
+
+        // deal with empty text
+        bool isShortText{false};
+        if (content.isEmpty()) {
+            // if there is no content, the bounding rect will be oversized and the rect may obscure other
+            // fields and make them unselectable. The calculated box is slightly out of position, but
+            // will correct itself once the content is no longer empty.
+            constexpr double MinRectHeight{3.25};   // roughly 3.5px in the svg
+            constexpr double MinRectWidth{2.381};   // roughly width of '_' character @ 3.5px
+            constexpr double UpwardRectShift{1.75}; // magic. Eliminates some dead space in br of empty text.
+            textRect.setBottom(textRect.bottom() - UpwardRectShift);
+            textRect.setTop(textRect.bottom() - MinRectHeight);
+            textRect.setRight(textRect.left() + MinRectWidth);
+            isShortText = true;
+        }
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 2, 0)
+        // from PR 27117
         if (!textRect.isValid()) {
             // This is a Qt5 workaround for boundsOnElement() issue fixed in Qt6.2.0
             // Once Qt6 is mandatory, this code may be safely removed.
@@ -395,26 +419,12 @@ void QGISVGTemplate::createClickHandles()
                 }
             }
         }
+#endif
 
+        // Get tight bounding box of text
         double factor = textRect.height() / fm.height();  // Correcting font metrics and SVG text due to different font sizes
         QRectF tightTextRect = textRect.adjusted(0.0, 0.0, 0.0, -fm.descent() * factor);
-        tightTextRect.setTop(tightTextRect.bottom() - fm.capHeight() * factor);
-
-        // Ensure min size; if no text content, tightTextRect will have no size
-        // and factor will also be incorrect
-
-        // Default font size guess. Getting attribute seems complicated, as it can have different units
-        // and both be in style attribute and native attribute
-        font.setPointSizeF(1.5);
-        fm = QFontMetricsF(font);
-
-        if (tightTextRect.height() < fm.capHeight()) {
-            tightTextRect.setTop(tightTextRect.bottom() - fm.capHeight());
-        }
-        double charWidth = fm.horizontalAdvance(QLatin1Char(' '));
-        if(tightTextRect.width() < charWidth) {
-            tightTextRect.setWidth(charWidth);
-        }
+        tightTextRect.setTop(tightTextRect.bottom() - (fm.capHeight() * factor));
 
         // Transform tight bounding box of text
         QPolygonF tightTextPoly(tightTextRect);  // Polygon because rect cannot be rotated
@@ -425,7 +435,6 @@ void QGISVGTemplate::createClickHandles()
         templateTransform.scale(Rez::getRezFactor(), Rez::getRezFactor());
         tightTextPoly = templateTransform.map(tightTextPoly);
 
-        QString name = textElement.attribute(QStringLiteral(FREECAD_ATTR_EDITABLE));
         auto item(new TemplateTextField(this, svgTemplate, name.toStdString()));
         item->setAutofillId(textElement.attribute(QStringLiteral(FREECAD_ATTR_AUTOFILL)).toStdString());
 
@@ -446,8 +455,13 @@ void QGISVGTemplate::createClickHandles()
         QPointF bottomRight = clickpoly.at(2);
         item->setLine(bottomLeft, bottomRight);
         item->setLineColor(PreferencesGui::templateClickBoxColor());
-        item->hideLine();
         item->setZValue(ZVALUE::SVGTEMPLATE + 1);
+
+        if (isShortText) {
+            item->showLine();
+        } else {
+            item->hideLine();
+        }
 
         addToGroup(item);
     }

--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
@@ -365,36 +365,19 @@ void QGISVGTemplate::createClickHandles()
 
     //TODO: Find location of special fields (first/third angle) and make graphics items for them
 
-    auto textMap = svgTemplate->EditableTexts.getValues();
-
-    TechDraw::XMLQuery query(templateDocument);
-
     std::vector<QDomElement> textElements = getFCElements(templateDocument);
     for(QDomElement& textElement : textElements) {
         // Get elements bounding box of text
         QString id = textElement.attribute(QStringLiteral("id"));
         QRectF textRect = m_svgRender->boundsOnElement(id);
         QString name = textElement.attribute(QStringLiteral(FREECAD_ATTR_EDITABLE));
-        QString content = QString::fromStdString(textMap[name.toStdString()]);
-
         QDomElement tspan = textElement.firstChildElement();
-        QFont font = getFont(tspan);
+        QFont font = getFont(tspan.isNull() ? textElement : tspan);
         QFontMetricsF fm(font);
 
         // deal with empty text
-        bool isShortText{false};
-        if (content.isEmpty()) {
-            // if there is no content, the bounding rect will be oversized and the rect may obscure other
-            // fields and make them unselectable. The calculated box is slightly out of position, but
-            // will correct itself once the content is no longer empty.
-            constexpr double MinRectHeight{3.25};   // roughly 3.5px in the svg
-            constexpr double MinRectWidth{2.381};   // roughly width of '_' character @ 3.5px
-            constexpr double UpwardRectShift{1.75}; // magic. Eliminates some dead space in br of empty text.
-            textRect.setBottom(textRect.bottom() - UpwardRectShift);
-            textRect.setTop(textRect.bottom() - MinRectHeight);
-            textRect.setRight(textRect.left() + MinRectWidth);
-            isShortText = true;
-        }
+        QString content = QString::fromStdString(svgTemplate->EditableTexts.getValue(name.toStdString()));
+        bool isShortText = content.isEmpty();
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 2, 0)
         // from PR 27117
@@ -402,7 +385,14 @@ void QGISVGTemplate::createClickHandles()
             // This is a Qt5 workaround for boundsOnElement() issue fixed in Qt6.2.0
             // Once Qt6 is mandatory, this code may be safely removed.
             // For more details please see https://qt-project.atlassian.net/browse/QTBUG-32405
-            textRect = fm.boundingRect(textElement.text());
+            if (isShortText) {
+                textRect = fm.boundingRect(QStringLiteral("_"));
+                // textRect is now valid, so we don't need to run the shortText code
+                isShortText = false;
+            }
+            else {
+                textRect = fm.boundingRect(content);
+            }
             if (textRect.isValid()) {
                 textRect = m_svgRender->transformForElement(id).mapRect(textRect);
                 textRect.translate(textElement.attribute(QStringLiteral("x")).toDouble(),
@@ -410,7 +400,6 @@ void QGISVGTemplate::createClickHandles()
 
                 QMap<QString, QString> styleMap = parseStyle(textElement.attribute(QStringLiteral("style")));
                 QString textAnchor = styleMap[QStringLiteral("text-anchor")];
-
                 if (textAnchor.compare(QStringLiteral("middle")) == 0) {
                     textRect.translate(-textRect.width()/2.0, 0.0);
                 }
@@ -420,6 +409,19 @@ void QGISVGTemplate::createClickHandles()
             }
         }
 #endif
+
+        if (isShortText) {
+            // if there is no content, the bounding rect will be oversized and the rect may obscure other
+            // fields and make them unselectable. The calculated box is slightly out of position, but
+            // will correct itself once the content is no longer empty.
+            constexpr double MinRectHeight{3.25};   // roughly 3.5px in the svg
+            constexpr double MinRectWidth{2.381};   // roughly width of '_' character @ 3.5px
+            constexpr double UpwardRectShift{1.75}; // magic. Eliminates some dead space in br of empty text.
+            textRect.setBottom(textRect.bottom() - UpwardRectShift);
+            textRect.setTop(textRect.bottom() - MinRectHeight);
+            textRect.setRight(textRect.left() + MinRectWidth);
+        }
+
 
         // Get tight bounding box of text
         double factor = textRect.height() / fm.height();  // Correcting font metrics and SVG text due to different font sizes

--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
@@ -234,8 +234,6 @@ void QGISVGTemplate::load(QByteArray svgCode)
     QSize size = m_svgRender->defaultSize();
     m_svgItem->setSharedRenderer(m_svgRender);
 
-    createClickHandles();
-
     //convert from pixels or mm or inches in svg file to mm page size
     TechDraw::DrawSVGTemplate* tmplte = getSVGTemplate();
     double xaspect = tmplte->getWidth() / static_cast<double>(size.width());
@@ -280,6 +278,9 @@ void QGISVGTemplate::draw()
 
     QString templateSvg = tmplte->processTemplate();
     load(templateSvg.toUtf8());
+
+    clearClickHandles();
+    createClickHandles();
 }
 
 void QGISVGTemplate::drawPageRectangle()
@@ -307,10 +308,7 @@ void QGISVGTemplate::drawPageRectangle()
 
 void QGISVGTemplate::updateView(bool update)
 {
-    if (update) {
-        clearClickHandles();
-        createClickHandles();
-    }
+    Q_UNUSED(update);
     draw();
 }
 
@@ -456,6 +454,7 @@ void QGISVGTemplate::createClickHandles()
         item->setLineColor(PreferencesGui::templateClickBoxColor());
         item->setZValue(ZVALUE::SVGTEMPLATE + 1);
 
+        item->setShortText(isShortText);
         if (isShortText) {
             item->showLine();
         } else {

--- a/src/Mod/TechDraw/Gui/TemplateTextField.cpp
+++ b/src/Mod/TechDraw/Gui/TemplateTextField.cpp
@@ -46,7 +46,8 @@ TemplateTextField::TemplateTextField(QGraphicsItem *parent,
       tmplte(myTmplte),
       fieldName(myFieldName),
       m_rect(new QGraphicsRectItem()),
-      m_line(new QGraphicsPathItem())
+      m_line(new QGraphicsPathItem()),
+      m_isShortText(false)
 {
     setFlag(QGraphicsItem::ItemIsFocusable, true);
     setAcceptHoverEvents(true);
@@ -133,6 +134,21 @@ void TemplateTextField::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 {
     hideLine();
     QGraphicsItemGroup::hoverLeaveEvent(event);
+}
+
+
+void TemplateTextField::hideLine()
+{
+    if (!tmplte) {
+        return;
+    }
+
+    // like template's isShort
+    if (isShortText()) {
+        return;
+    }
+
+    m_line->hide();
 }
 
 

--- a/src/Mod/TechDraw/Gui/TemplateTextField.h
+++ b/src/Mod/TechDraw/Gui/TemplateTextField.h
@@ -62,8 +62,10 @@ class TechDrawGuiExport TemplateTextField : public QGraphicsItemGroup
         void setRectangle(QRectF rect);
         void setLine(QPointF from, QPointF to);
         void setLineColor(QColor color);
-        void hideLine() { m_line->hide(); }
+        void hideLine();
         void showLine() { m_line->show(); }
+        void setShortText(bool newState) { m_isShortText = newState;}
+        bool isShortText() const { return m_isShortText; }
 
     protected:
         /// Need this to properly handle mouse release
@@ -82,5 +84,8 @@ class TechDrawGuiExport TemplateTextField : public QGraphicsItemGroup
 
         QGraphicsRectItem* m_rect;
         QGraphicsPathItem* m_line;
+
+        bool m_isShortText;
 };
 }   // namespace TechDrawGui
+


### PR DESCRIPTION
This PR implements a fix for issue #30471.  If a template text field was empty,  QSvgRenderer::boundsOnElement() reports a bounding rectangle that has zero width, but an extremely large height.  The zero width creates a click area that is virtually unclickable, and the large height overlaps adjacent fields.  

The fix implements a minimum size click box, and shows the click boxunderline when the field is empty.

Before:
<img width="880" height="305" alt="ShortTemplateText_preFix" src="https://github.com/user-attachments/assets/87795fca-a36b-4995-9469-3eab60f1f3e8" />

After:
<img width="1217" height="502" alt="ShortTemplateText_postFix" src="https://github.com/user-attachments/assets/fd2ef9ac-2ecc-44c0-9cd8-99bcf4750a60" />
