### PR TITLE
TechDraw: add broken-out complex sections

### DIFF
--- a/src/Mod/TechDraw/App/DrawComplexSection.cpp
+++ b/src/Mod/TechDraw/App/DrawComplexSection.cpp
@@ -128,6 +128,14 @@ using namespace TechDraw;
 using namespace std;
 using DU = DrawUtil;
 
+namespace
+{
+constexpr long StrategyOffset = 0;
+constexpr long StrategyNoParallel = 2;
+constexpr long StrategyBrokenOut = 3;
+constexpr double DefaultBrokenOutDepth = 1.0;
+}
+
 //===========================================================================
 // DrawComplexSection
 //===========================================================================
@@ -136,7 +144,7 @@ using DU = DrawUtil;
 PROPERTY_SOURCE(TechDraw::DrawComplexSection, TechDraw::DrawViewSection)
 
 const char* DrawComplexSection::ProjectionStrategyEnums[] = {"Offset", "Aligned", "NoParallel",
-                                                             nullptr};
+                                                             "BrokenOut", nullptr};
 //NOLINTEND
 
 DrawComplexSection::DrawComplexSection() :
@@ -151,7 +159,19 @@ DrawComplexSection::DrawComplexSection() :
     ProjectionStrategy.setEnums(ProjectionStrategyEnums);
     ADD_PROPERTY_TYPE(ProjectionStrategy, ((long)0), fgroup, App::Prop_None,
                       "Make a single cut, or use the profile in pieces");
+    ADD_PROPERTY_TYPE(BrokenOutDepth, (DefaultBrokenOutDepth), fgroup, App::Prop_None,
+                      "Depth of the local broken-out section cut");
 //NOLINTEND
+}
+
+short DrawComplexSection::mustExecute() const
+{
+    if (ProjectionStrategy.isTouched() || CuttingToolWireObject.isTouched()
+        || BrokenOutDepth.isTouched()) {
+        return 1;
+    }
+
+    return DrawViewSection::mustExecute();
 }
 
 TopoDS_Shape DrawComplexSection::makeCuttingTool(double dMax)
@@ -166,7 +186,7 @@ TopoDS_Shape DrawComplexSection::makeCuttingTool(double dMax)
     }
 
     // use "canBuild(profile, sectionnormal)" or validateProfileDirection?
-    if (ProjectionStrategy.getValue() == 0) {
+    if (ProjectionStrategy.getValue() == StrategyOffset) {
         // Offset. Warn if profile is not quite aligned with section normal. if
         // the profile and normal are misaligned, the check below for empty "solids"
         // will not be correct.
@@ -181,6 +201,13 @@ TopoDS_Shape DrawComplexSection::makeCuttingTool(double dMax)
         if (!validateSketchNormal(CuttingToolWireObject.getValue())) {
             Base::Console().warning("cutting object not aligned with section normal in %s\n", Label.getValue());
         }
+    }
+
+    if (isBrokenOut()) {
+        if (!BRep_Tool::IsClosed(profileWire)) {
+            throw Base::RuntimeError("Broken-out sections require a closed profile");
+        }
+        return makeBrokenOutCuttingTool(profileWire);
     }
 
     if (BRep_Tool::IsClosed(profileWire)) {
@@ -214,7 +241,7 @@ TopoDS_Shape DrawComplexSection::makeCuttingTool(double dMax)
 
 TopoDS_Shape DrawComplexSection::getShapeToPrepare() const
 {
-    if (ProjectionStrategy.getValue() == 0) {
+    if (ProjectionStrategy.getValue() == StrategyOffset || isBrokenOut()) {
         //Offset. Use regular section behaviour
         return DrawViewSection::getShapeToPrepare();
     }
@@ -225,7 +252,7 @@ TopoDS_Shape DrawComplexSection::getShapeToPrepare() const
 //get the shape ready for projection and cut surface finding
 TopoDS_Shape DrawComplexSection::prepareShape(const TopoDS_Shape& cutShape, double shapeSize)
 {
-    if (ProjectionStrategy.getValue() == 0) {
+    if (ProjectionStrategy.getValue() == StrategyOffset || isBrokenOut()) {
         //Offset. Use regular section behaviour
         return DrawViewSection::prepareShape(cutShape, shapeSize);
     }
@@ -253,7 +280,7 @@ TopoDS_Shape DrawComplexSection::prepareShape(const TopoDS_Shape& cutShape, doub
 
 void DrawComplexSection::makeSectionCut(const TopoDS_Shape& baseShape)
 {
-    if (ProjectionStrategy.getValue() == 0) {
+    if (ProjectionStrategy.getValue() == StrategyOffset || isBrokenOut()) {
         //Offset. Use regular section behaviour
         return DrawViewSection::makeSectionCut(baseShape);
     }
@@ -465,7 +492,7 @@ DrawComplexSection::findSectionPlaneIntersections(const TopoDS_Shape& shapeToInt
                                 getNameInDocument());
         return {};
     }
-    if (ProjectionStrategy.getValue() == 0) {//Offset
+    if (ProjectionStrategy.getValue() == StrategyOffset || isBrokenOut()) {
         return singleToolIntersections(shapeToIntersect);
     }
 
@@ -542,7 +569,7 @@ TopoDS_Compound DrawComplexSection::alignedToolIntersections(const TopoDS_Shape&
 
 TopoDS_Compound DrawComplexSection::alignSectionFaces(const TopoDS_Shape& faceIntersections)
 {
-    if (ProjectionStrategy.getValue() == 0) {
+    if (ProjectionStrategy.getValue() == StrategyOffset || isBrokenOut()) {
         //Offset. Use regular section behaviour
         return DrawViewSection::alignSectionFaces(faceIntersections);
     }
@@ -552,7 +579,7 @@ TopoDS_Compound DrawComplexSection::alignSectionFaces(const TopoDS_Shape& faceIn
 
 TopoDS_Shape DrawComplexSection::getShapeToIntersect()
 {
-    if (ProjectionStrategy.getValue() == 0) {//Offset
+    if (ProjectionStrategy.getValue() == StrategyOffset || isBrokenOut()) {
         return DrawViewSection::getShapeToIntersect();
     }
     //Aligned
@@ -561,7 +588,7 @@ TopoDS_Shape DrawComplexSection::getShapeToIntersect()
 
 TopoDS_Shape DrawComplexSection::getShapeForDetail() const
 {
-    if (ProjectionStrategy.getValue() == 0) {//Offset
+    if (ProjectionStrategy.getValue() == StrategyOffset || isBrokenOut()) {
         return DrawViewSection::getShapeForDetail();
     }
     //Aligned
@@ -858,7 +885,7 @@ std::pair<Base::Vector3d, Base::Vector3d>
 //the regular sectionPlane for Offset.
 gp_Pln DrawComplexSection::getSectionPlane() const
 {
-    if (ProjectionStrategy.getValue() == 0) {
+    if (ProjectionStrategy.getValue() == StrategyOffset || isBrokenOut()) {
         //Offset. Use regular section behaviour
         return DrawViewSection::getSectionPlane();
     }
@@ -935,8 +962,8 @@ bool DrawComplexSection::validateProfilePosition(const TopoDS_Wire& profileWire,
 
 bool DrawComplexSection::showSegment(gp_Dir segmentNormal) const
 {
-    if (ProjectionStrategy.getValue() < 2) {
-        //Offset or Aligned are always true
+    if (ProjectionStrategy.getValue() != StrategyNoParallel) {
+        //Offset, Aligned, and BrokenOut are always true
         return true;
     }
 
@@ -1611,10 +1638,49 @@ TopoDS_Shape DrawComplexSection::makeCuttingToolFromClosedProfile(const TopoDS_W
     return prism;
 }
 
+TopoDS_Shape DrawComplexSection::makeBrokenOutCuttingTool(const TopoDS_Wire& profileWire)
+{
+    const double cutDepth = BrokenOutDepth.getValue();
+    if (cutDepth <= Precision::Confusion()) {
+        throw Base::RuntimeError("Broken-out section depth must be greater than zero");
+    }
+
+    TopoDS_Face profileFace;
+    try {
+        BRepBuilderAPI_MakeFace mkFace(profileWire);
+        profileFace = mkFace.Face();
+        if (profileFace.IsNull()) {
+            return {};
+        }
+    }
+    catch (...) {
+        Base::Console().error("%s could not make broken-out profile face\n", Label.getValue());
+        return {};
+    }
+
+    auto* baseDvp = getBaseDVP();
+    Base::Vector3d viewDirection = baseDvp ? baseDvp->Direction.getValue() : Direction.getValue();
+    if (DrawUtil::fpCompare(viewDirection.Length(), 0.0)) {
+        viewDirection = SectionNormal.getValue();
+    }
+    viewDirection.Normalize();
+
+    Base::Vector3d cutDirection = viewDirection * -1.0;
+    gp_Vec cutVector = Base::convertTo<gp_Vec>(cutDirection * cutDepth);
+    TopoDS_Shape prism = BRepPrimAPI_MakePrism(profileFace, cutVector).Shape();
+
+    m_toolFaceShape = ShapeUtils::moveShape(profileFace, cutDirection * cutDepth);
+    if (debugSection()) {
+        BRepTools::Write(m_toolFaceShape, "DCSmakeBrokenOutCuttingTool_m_toolFaceShape.brep");
+    }
+
+    return prism;
+}
+
 bool DrawComplexSection::validateProfileAlignment(const TopoDS_Wire& profileWire) const
 {
     // use "canBuild(profile, sectionnormal)"?
-    if (ProjectionStrategy.getValue() == 0) {
+    if (ProjectionStrategy.getValue() == StrategyOffset) {
         // Offset. Warn if profile is not quite aligned with section normal. if
         // the profile and normal are misaligned, the check below for empty "solids"
         // will not be correct.
@@ -1635,6 +1701,11 @@ bool DrawComplexSection::validateProfileAlignment(const TopoDS_Wire& profileWire
     }
 
     return true;
+}
+
+bool DrawComplexSection::isBrokenOut() const
+{
+    return ProjectionStrategy.getValue() == StrategyBrokenOut;
 }
 
 

--- a/src/Mod/TechDraw/App/DrawComplexSection.h
+++ b/src/Mod/TechDraw/App/DrawComplexSection.h
@@ -61,13 +61,16 @@ public:
 //NOLINTBEGIN
     App::PropertyLink CuttingToolWireObject;
     App::PropertyEnumeration ProjectionStrategy;//Offset or Aligned
+    App::PropertyLength BrokenOutDepth;
 //NOLINTEND
 
+    short mustExecute() const override;
     TopoDS_Shape makeCuttingTool(double dMax) override;
     void makeSectionCut(const TopoDS_Shape& baseShape) override;
     TopoDS_Wire closeProfileForCut(const TopoDS_Wire& profileWire,
                                    double dMax) const;
     TopoDS_Shape makeCuttingToolFromClosedProfile(const TopoDS_Wire& profileWire, double dMax);
+    TopoDS_Shape makeBrokenOutCuttingTool(const TopoDS_Wire& profileWire);
     TopoDS_Shape cuttingToolFromProfile(const TopoDS_Wire& inProfileWire,
                                         double dMax) const;
     TopoDS_Wire closeSingleEdgeProfile(const TopoDS_Edge& singleEdge,
@@ -117,6 +120,7 @@ public:
 
     bool showSegment(gp_Dir segmentNormal) const;
     bool showSegment(const Base::Vector3d& segmentNormal) const;
+    bool isBrokenOut() const;
     void waitingForAlign(bool s) { m_waitingForAlign = s; }
     bool waitingForAlign() const { return m_waitingForAlign; }
 

--- a/src/Mod/TechDraw/CMakeLists.txt
+++ b/src/Mod/TechDraw/CMakeLists.txt
@@ -184,6 +184,7 @@ SET(TDTest_SRCS
     TDTest/DrawViewDimensionTest.py
     TDTest/DrawViewPartTest.py
     TDTest/DrawViewSectionTest.py
+    TDTest/DrawComplexSectionTest.py
     TDTest/DrawViewBalloonTest.py
     TDTest/DrawViewDetailTest.py
     TDTest/TechDrawTestUtilities.py
@@ -211,4 +212,3 @@ fc_copy_sources(TDTestTarget "${CMAKE_BINARY_DIR}/Mod/TechDraw" ${TDAllTest})
 # install Python packages (for make install)
 INSTALL(FILES ${TDTest_SRCS} DESTINATION Mod/TechDraw/TDTest)
 INSTALL(FILES ${TDTestFile_SRCS} DESTINATION Mod/TechDraw/TDTest)
-

--- a/src/Mod/TechDraw/Gui/QGISectionLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.cpp
@@ -80,19 +80,34 @@ QGISectionLine::QGISectionLine() :
 void QGISectionLine::draw()
 {
     prepareGeometryChange();
-    int format = Preferences::sectionLineConvention();
-    if (format == ANSISTANDARD) {                           //"ASME"/"ANSI"
-        extensionEndsTrad();
-    } else {
-        extensionEndsISO();
-    }
 
     if (!pathMode()) {
         makeSectionLine();
     }
-    makeExtensionLine();
-    makeArrows();
-    makeSymbols();
+    if (m_showAnnotations) {
+        m_arrow1->show();
+        m_arrow2->show();
+        m_symbol1->show();
+        m_symbol2->show();
+
+        int format = Preferences::sectionLineConvention();
+        if (format == ANSISTANDARD) {                           //"ASME"/"ANSI"
+            extensionEndsTrad();
+        } else {
+            extensionEndsISO();
+        }
+        makeExtensionLine();
+        makeArrows();
+        makeSymbols();
+    }
+    else {
+        QPainterPath emptyPath;
+        m_extend->setPath(emptyPath);
+        m_arrow1->hide();
+        m_arrow2->hide();
+        m_symbol1->hide();
+        m_symbol2->hide();
+    }
     makeChangePointMarks();
     update();
 }

--- a/src/Mod/TechDraw/Gui/QGISectionLine.h
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.h
@@ -67,6 +67,7 @@ public:
     void setSectionColor(QColor c);
     void setPathMode(bool mode) { m_pathMode = mode; }
     void setShowLine(bool state) { m_showLine = state; }
+    void setShowAnnotations(bool state) { m_showAnnotations = state; }
     bool pathMode() { return m_pathMode; }
     void setChangePoints(TechDraw::ChangePointVector changePoints);
     void clearChangePoints();
@@ -128,6 +129,7 @@ private:
     TechDraw::ChangePointVector m_changePointData;
 
     bool m_showLine{true};
+    bool m_showAnnotations{true};
 };
 
 }

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -828,16 +828,11 @@ void QGIViewPart::drawComplexSectionLine(TechDraw::DrawViewSection* viewSection,
     }
 
     auto dcs = static_cast<DrawComplexSection*>(viewSection);
-    std::pair<Base::Vector3d, Base::Vector3d> ends = dcs->sectionLineEnds();
-    Base::Vector3d vStart = Rez::guiX(ends.first);//already scaled by dcs
-    Base::Vector3d vEnd = Rez::guiX(ends.second);
-    if (vStart.IsEqual(vEnd, EWTOLERANCE) ) {
-        Base::Console().message("QGIVP::drawComplexSectionLine - line endpoints are equal. No section line created.\n");
+    BaseGeomPtrVector edges = dcs->makeSectionLineGeometry();
+    if (edges.empty()) {
         return;
     }
 
-
-    BaseGeomPtrVector edges = dcs->makeSectionLineGeometry();
     QPainterPath wirePath;
     QPainterPath firstSeg = drawPainterPath(edges.front());
     wirePath.connectPath(firstSeg);
@@ -851,6 +846,29 @@ void QGIViewPart::drawComplexSectionLine(TechDraw::DrawViewSection* viewSection,
         wirePath.connectPath(edgePath);
     }
 
+    Base::Vector3d vStart;
+    Base::Vector3d vEnd;
+    if (dcs->isBrokenOut()) {
+        QRectF pathBounds = wirePath.boundingRect();
+        if (pathBounds.isEmpty()) {
+            return;
+        }
+        QPointF left = pathBounds.center();
+        left.setX(pathBounds.left());
+        QPointF right = pathBounds.center();
+        right.setX(pathBounds.right());
+        vStart = Base::Vector3d(left.x(), left.y(), 0.0);
+        vEnd = Base::Vector3d(right.x(), right.y(), 0.0);
+    }
+    else {
+        std::pair<Base::Vector3d, Base::Vector3d> ends = dcs->sectionLineEnds();
+        vStart = Rez::guiX(ends.first);//already scaled by dcs
+        vEnd = Rez::guiX(ends.second);
+    }
+    if (vStart.IsEqual(vEnd, EWTOLERANCE) ) {
+        Base::Console().message("QGIVP::drawComplexSectionLine - line endpoints are equal. No section line created.\n");
+        return;
+    }
 
     QGISectionLine* sectionLine = new QGISectionLine();
     addToGroupWithoutUpdate(sectionLine);
@@ -860,15 +878,20 @@ void QGIViewPart::drawComplexSectionLine(TechDraw::DrawViewSection* viewSection,
     sectionLine->setPathMode(true);
     sectionLine->setPath(wirePath);
     sectionLine->setEnds(vStart, vEnd);
-    if (vp->SectionLineMarks.getValue()) {
+    if (vp->SectionLineMarks.getValue() && !dcs->isBrokenOut()) {
         sectionLine->setChangePoints(dcs->getChangePointsFromSectionLine());
     }
     else {
         sectionLine->clearChangePoints();
     }
 
-    std::pair<Base::Vector3d, Base::Vector3d> dirsDCS = dcs->sectionLineArrowDirsMapped();
-    sectionLine->setArrowDirections(dirsDCS.first, dirsDCS.second);
+    if (dcs->isBrokenOut()) {
+        sectionLine->setShowAnnotations(false);
+    }
+    else {
+        std::pair<Base::Vector3d, Base::Vector3d> dirsDCS = dcs->sectionLineArrowDirsMapped();
+        sectionLine->setArrowDirections(dirsDCS.first, dirsDCS.second);
+    }
 
     //set the general parameters
     sectionLine->setPos(0.0, 0.0);
@@ -1505,5 +1528,4 @@ void QGIViewPart::setMovableFlagProjGroupItem()
     // not locked, not autoDistribute
     setFlag(QGraphicsItem::ItemIsMovable, true);
 }
-
 

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
@@ -180,6 +180,7 @@ void TaskComplexSection::setUiEdit()
         ui->leBaseView->setText(QString::fromStdString(m_baseView->getNameInDocument()));
     }
     ui->cmbStrategy->setCurrentIndex(m_section->ProjectionStrategy.getValue());
+    ui->sbBrokenOutDepth->setValue(m_section->BrokenOutDepth.getValue());
     ui->leSymbol->setText(QString::fromStdString(m_section->SectionSymbol.getValue()));
     ui->sbScale->setValue(m_section->Scale.getValue());
     ui->cmbScaleType->setCurrentIndex(m_section->getScaleType());
@@ -584,6 +585,8 @@ void TaskComplexSection::createComplexSection()
         int projectionStrategy = ui->cmbStrategy->currentIndex();
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.ProjectionStrategy = %d",
                            m_sectionName.c_str(), projectionStrategy);
+        Command::doCommand(Command::Doc, "App.ActiveDocument.%s.BrokenOutDepth = %0.7f",
+                           m_sectionName.c_str(), ui->sbBrokenOutDepth->value());
 
         Command::doCommand(Command::Doc,
                            "App.activeDocument().%s.SectionOrigin = FreeCAD.Vector(0.0, 0.0, 0.0)",
@@ -668,6 +671,8 @@ void TaskComplexSection::updateComplexSection()
         int projectionStrategy = ui->cmbStrategy->currentIndex();
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.ProjectionStrategy = %d",
                            m_sectionName.c_str(), projectionStrategy);
+        Command::doCommand(Command::Doc, "App.ActiveDocument.%s.BrokenOutDepth = %0.7f",
+                           m_sectionName.c_str(), ui->sbBrokenOutDepth->value());
         Command::doCommand(Command::Doc, "App.activeDocument().%s.SectionDirection = 'Aligned'",
                            m_sectionName.c_str());
         //NOLINTEND

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.ui
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.ui
@@ -204,6 +204,43 @@
             <string>No parallel</string>
            </property>
           </item>
+          <item>
+           <property name="text">
+            <string>Broken out</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="labelBrokenOutDepth">
+          <property name="text">
+           <string>Broken-out depth</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QDoubleSpinBox" name="sbBrokenOutDepth">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>26</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Depth of the local broken-out section cut</string>
+          </property>
+          <property name="decimals">
+           <number>6</number>
+          </property>
+          <property name="minimum">
+           <double>0.001000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>999999.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
          </widget>
         </item>
         <item row="2" column="0">

--- a/src/Mod/TechDraw/TDTest/DrawComplexSectionTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawComplexSectionTest.py
@@ -1,0 +1,79 @@
+import FreeCAD
+import Part
+import unittest
+from .TechDrawTestUtilities import createPageWithSVGTemplate
+from PySide import QtCore
+
+
+class DrawComplexSectionTest(unittest.TestCase):
+    def setUp(self):
+        FreeCAD.newDocument("TDComplexSection")
+        FreeCAD.setActiveDocument("TDComplexSection")
+        FreeCAD.ActiveDocument = FreeCAD.getDocument("TDComplexSection")
+
+        self.box = FreeCAD.ActiveDocument.addObject("Part::Box", "Box")
+        self.box.Length = 10.0
+        self.box.Width = 10.0
+        self.box.Height = 10.0
+
+        self.page = createPageWithSVGTemplate()
+        self.page.Scale = 5.0
+
+        self.view = FreeCAD.ActiveDocument.addObject("TechDraw::DrawViewPart", "View")
+        self.page.addView(self.view)
+        self.view.Source = [self.box]
+        self.view.Direction = (0.0, 0.0, 1.0)
+        self.view.XDirection = (1.0, 0.0, 0.0)
+        self.view.Rotation = 0.0
+        self.view.X = 30.0
+        self.view.Y = 150.0
+        FreeCAD.ActiveDocument.recompute()
+        self._waitForThreads()
+
+    def tearDown(self):
+        FreeCAD.closeDocument("TDComplexSection")
+
+    def _waitForThreads(self):
+        loop = QtCore.QEventLoop()
+        timer = QtCore.QTimer()
+        timer.setSingleShot(True)
+        timer.timeout.connect(loop.quit)
+        timer.start(2000)
+        loop.exec_()
+
+    def testMakeBrokenOutComplexSection(self):
+        profile = FreeCAD.ActiveDocument.addObject("Part::Feature", "BrokenOutProfile")
+        profile.Shape = Part.makePolygon([
+            FreeCAD.Vector(2.0, 2.0, 10.0),
+            FreeCAD.Vector(8.0, 2.0, 10.0),
+            FreeCAD.Vector(8.0, 8.0, 10.0),
+            FreeCAD.Vector(2.0, 8.0, 10.0),
+            FreeCAD.Vector(2.0, 2.0, 10.0),
+        ])
+
+        section = FreeCAD.ActiveDocument.addObject(
+            "TechDraw::DrawComplexSection", "BrokenOutSection"
+        )
+        self.page.addView(section)
+        section.Source = [self.box]
+        section.BaseView = self.view
+        section.CuttingToolWireObject = profile
+        section.ProjectionStrategy = "BrokenOut"
+        section.BrokenOutDepth = 3.0
+        section.Direction = self.view.Direction
+        section.SectionNormal = self.view.Direction
+        section.XDirection = self.view.XDirection
+        section.SectionOrigin = (0.0, 0.0, 0.0)
+        section.SectionDirection = "Aligned"
+
+        FreeCAD.ActiveDocument.recompute()
+        self._waitForThreads()
+
+        self.assertEqual(section.ProjectionStrategy, "BrokenOut")
+        self.assertEqual(section.BrokenOutDepth, 3.0)
+        self.assertGreater(len(section.getVisibleEdges()), 0)
+        self.assertTrue("Up-to-date" in section.State)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/TechDraw/TestTechDrawGui.py
+++ b/src/Mod/TechDraw/TestTechDrawGui.py
@@ -23,6 +23,7 @@
 #these tests require QApplication in order to process events while waiting for 
 #threads to complete
 from TDTest.DrawViewSectionTest import DrawViewSectionTest  # noqa: F401
+from TDTest.DrawComplexSectionTest import DrawComplexSectionTest  # noqa: F401
 from TDTest.DrawViewPartTest import DrawViewPartTest  # noqa: F401
 from TDTest.DrawViewDetailTest import DrawViewDetailTest  # noqa: F401
 from TDTest.DrawViewDimensionTest import DrawViewDimensionTest  # noqa: F401


### PR DESCRIPTION
## Summary

Adds a `BrokenOut` strategy for TechDraw complex section views so a closed profile can create a local broken-out pocket with an explicit depth.

## Linked Issue / Bounty

Fixes #8075.

Reward context: https://github.com/FreeCAD/FreeCAD/issues/8075#issuecomment-2840137107

## Problem

`DrawComplexSection` supports existing complex-section strategies, but the open issue asks for a local broken-out section that keeps the surrounding view intact while cutting only inside the selected closed boundary.

## Fix

- Add a `BrokenOut` projection strategy and `BrokenOutDepth` property.
- Build a bounded local cutting prism from the closed section profile along the inverse base-view direction.
- Render the closed broken-out boundary without section arrows or symbol extensions.
- Expose the strategy/depth in the TechDraw complex-section task panel.
- Register a focused TechDraw GUI regression test for the new strategy.

## Validation

- `pixi run configure-debug`
- `pixi run cmake --build build/debug --target TechDraw_Data TDTestTarget TechDrawGui -j 8`
- Helper targets `FreeCAD`, `Material*`, and `PartGui`
- `pixi run build/debug/bin/FreeCAD --hidden -t TDTest.DrawComplexSectionTest.DrawComplexSectionTest` - 1 test OK
- `pixi run build/debug/bin/FreeCAD --hidden -t TestTechDrawGui` - 6 tests OK
- Semantic broken-out probe for a top-view closed profile at z=10, `BrokenOutDepth=3`, cut vector `(0,0,-3)`, expected interval z=10 to z=7, visible edge count 8, state `['Up-to-date']`

## Risk Notes / Maintainer Attention

- No fresh pre-fix reproduction was run because the branch was already on the fix commit; validation relies on the added regression test and semantic probe.
- The test runtime emitted missing qss icon warnings and a non-fatal `AttachmentEditor` import traceback before successful OK/PASS summaries.
- This implements explicit depth control only; selecting target geometry as the depth stop is not included.
- UI change: adds a `BrokenOut` strategy option and depth field in the complex-section task panel. No before/after screenshots are attached.
- AI assistance disclosure: this patch was assisted by GPT-5 (Codex), also disclosed with the commit trailer `Assisted-by: GPT-5 (Codex)`.
