### PR TITLE
PartDesign: FeatureMultiTransform prevent double recompute

### DIFF
--- a/src/Mod/PartDesign/App/FeatureMultiTransform.cpp
+++ b/src/Mod/PartDesign/App/FeatureMultiTransform.cpp
@@ -57,13 +57,14 @@ void MultiTransform::positionBySupport()
             throw Base::TypeError("Transformation features must be subclasses of Transformed");
         }
 
-        transFeature->Placement.setValue(this->Placement.getValue());
-
-        // To avoid that a linked transform feature stays touched after a recompute
-        // we have to purge the touched state
-        if (this->isRecomputing()) {
-            transFeature->purgeTouched();
+        const auto& placement = this->Placement.getValue();
+        if (transFeature->Placement.getValue() != placement) {
+            transFeature->Placement.setValue(placement);
         }
+
+        // These objects only store transformation parameters. Their execution is handled by this
+        // MultiTransform, so synchronizing their placement must not schedule another document pass.
+        transFeature->purgeTouched();
     }
 }
 
@@ -104,6 +105,10 @@ const std::list<gp_Trsf> MultiTransform::getTransformations(
         }
 
         std::list<gp_Trsf> newTransformations = transFeature->getTransformations(originals);
+        // Computing transformations can update derived helper properties such as Spacings and
+        // Offset. The helper is not executed independently, so do not let those updates schedule
+        // the parent MultiTransform for a second document recompute pass.
+        transFeature->purgeTouched();
         if (result.empty()) {
             // First transformation Feature
             result = newTransformations;


### PR DESCRIPTION
Fix partially the performance issue of pattern tools : https://github.com/FreeCAD/FreeCAD/issues/18205

What this PR does is that it prevents the recompute of multitransform to run twice.

MultiTransform helper features update derived properties while calculating their transformations. For example, PolarPattern updates Spacings, while LinearPattern updates Spacings and Offset. These property changes leave the helper features touched after MultiTransform has executed, causing the document to schedule a second recompute pass and execute the expensive MultiTransform Boolean twice.  
The fix purges the touched state after transformation calculation because these helper features are parameter containers; their geometry is computed exclusively by the parent MultiTransform.

Tested on the file provided in https://forum.freecad.org/viewtopic.php?t=104008 it halves the recompute time: 
Before it took me 40 seconds if I change polar pattern to 23 occurences.
Now it takes me 20 seconds