### PR TITLE
Sketcher: Fix geometry dragging for past geometries

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -684,233 +684,6 @@ protected:
         See documentation of the functions above*/
     //@{
 
-    // TODO: Figure out and explain what it actually returns
-    bool generateOneAutoConstraintFromSuggestion(
-        const AutoConstraint& ac,
-        int geoId1,
-        Sketcher::PointPos posId1
-    )
-    {
-        int geoId2 = ac.GeoId;
-        Sketcher::PointPos posId2 = ac.PosId;
-
-        static const auto isStartOrEnd = [](const Sketcher::PointPos posId) {
-            return posId == Sketcher::PointPos::start || posId == Sketcher::PointPos::end;
-        };
-
-
-        switch (ac.Type) {
-            case Sketcher::Coincident: {
-                if (posId1 == Sketcher::PointPos::none) {
-                    return true;
-                }
-
-                // find if there is already a matching tangency
-                auto itOfTangentConstraint = AutoConstraints.end();
-                if (isStartOrEnd(posId1) && isStartOrEnd(posId2)) {
-                    itOfTangentConstraint = std::ranges::find(
-                        AutoConstraints,
-                        std::tuple {Sketcher::Tangent, geoId1, geoId2},
-                        [](const auto& ace) {
-                            return std::tuple {ace->Type, ace->First, ace->Second};
-                        }
-                    );
-                }
-
-                if (itOfTangentConstraint != AutoConstraints.end()) {
-                    // modify tangency to endpoint-to-endpoint
-                    (*itOfTangentConstraint)->FirstPos = posId1;
-                    (*itOfTangentConstraint)->SecondPos = posId2;
-                }
-                else {
-                    auto c = std::make_unique<Sketcher::Constraint>();
-                    c->Type = Sketcher::Coincident;
-                    c->First = geoId1;
-                    c->FirstPos = posId1;
-                    c->Second = geoId2;
-                    c->SecondPos = posId2;
-                    AutoConstraints.push_back(std::move(c));
-                }
-            } break;
-            case Sketcher::PointOnObject: {
-                if (posId1 == Sketcher::PointPos::none) {
-                    // Auto constraining an edge so swap parameters
-                    std::swap(geoId1, geoId2);
-                    std::swap(posId1, posId2);
-                }
-
-                auto itOfTangentConstraint = AutoConstraints.end();
-                if (isStartOrEnd(posId1)) {
-                    itOfTangentConstraint = std::ranges::find_if(AutoConstraints, [&](const auto& ace) {
-                        return ace->Type == Sketcher::Tangent && ace->involvesGeoId(geoId1)
-                            && ace->involvesGeoId(geoId2);
-                    });
-                }
-
-                // if tangency, convert to point-to-edge tangency
-                if (itOfTangentConstraint != AutoConstraints.end()) {
-                    if ((*itOfTangentConstraint)->First != geoId1) {
-                        std::swap((*itOfTangentConstraint)->Second, (*itOfTangentConstraint)->First);
-                    }
-
-                    (*itOfTangentConstraint)->FirstPos = posId1;
-                }
-                else {
-                    auto c = std::make_unique<Sketcher::Constraint>();
-                    c->Type = Sketcher::PointOnObject;
-                    c->First = geoId1;
-                    c->FirstPos = posId1;
-                    c->Second = geoId2;
-                    AutoConstraints.push_back(std::move(c));
-                }
-            } break;
-            case Sketcher::Symmetric: {
-                auto c = std::make_unique<Sketcher::Constraint>();
-                c->Type = Sketcher::Symmetric;
-                c->First = geoId2;
-                c->FirstPos = Sketcher::PointPos::start;
-                c->Second = geoId2;
-                c->SecondPos = Sketcher::PointPos::end;
-                c->Third = geoId1;
-                c->ThirdPos = posId1;
-                AutoConstraints.push_back(std::move(c));
-            } break;
-            // In special case of Horizontal/Vertical constraint, geoId2 is normally
-            // unused and should be 'Constraint::GeoUndef' However it can be used as a
-            // way to require the function to apply these constraints on another
-            // geometry In this case the caller as to set geoId2, then it will be used
-            // as target instead of geoId2
-            case Sketcher::Horizontal:
-            case Sketcher::Vertical: {
-                auto c = std::make_unique<Sketcher::Constraint>();
-                c->Type = ac.Type;
-                c->First = (geoId2 != Sketcher::GeoEnum::GeoUndef ? geoId2 : geoId1);
-                AutoConstraints.push_back(std::move(c));
-            } break;
-            case Sketcher::Perpendicular: {
-                auto c = std::make_unique<Sketcher::Constraint>();
-                c->Type = Sketcher::Perpendicular;
-                c->First = geoId1;
-                c->Second = geoId2;
-                AutoConstraints.push_back(std::move(c));
-            } break;
-            case Sketcher::Parallel: {
-                auto c = std::make_unique<Sketcher::Constraint>();
-                c->Type = Sketcher::Parallel;
-                c->First = geoId1;
-                c->Second = geoId2;
-                AutoConstraints.push_back(std::move(c));
-            } break;
-            case Sketcher::Tangent: {
-                Sketcher::SketchObject* Obj = sketchgui->getObject<Sketcher::SketchObject>();
-
-                const Part::Geometry* geom1 = Obj->getGeometry(geoId1);
-                const Part::Geometry* geom2 = Obj->getGeometry(geoId2);
-                if (!geom1 || !geom2) {
-                    return false;
-                }
-
-                // 2026.01.16: Do not use swap as it did before or it breaks resultCoincident.
-                // NOTE: Temporarily deactivated : ellipse tangency support using construction elements
-                if (geom1->is<Part::GeomEllipse>()
-                    && (geom2->is<Part::GeomConic>() || geom2->is<Part::GeomArcOfConic>())) {
-                    // makeTangentToEllipseviaNewPoint(
-                    //     Obj,
-                    //     static_cast<const Part::GeomEllipse*>(geom1),
-                    //     geom2,
-                    //     geoId1,
-                    //     geoId2);
-                    return false;
-                }
-                else if (
-                    geom2->is<Part::GeomEllipse>()
-                    && (geom1->is<Part::GeomConic>() || geom1->is<Part::GeomArcOfConic>())
-                ) {
-                    // makeTangentToEllipseviaNewPoint(
-                    //     Obj,
-                    //     static_cast<const Part::GeomEllipse*>(geom2),
-                    //     geom1,
-                    //     geoId2,
-                    //     geoId1);
-                    return false;
-                }
-                else if (
-                    geom1->is<Part::GeomArcOfEllipse>()
-                    && (geom2->is<Part::GeomConic>() || geom2->is<Part::GeomArcOfConic>())
-                ) {
-                    // makeTangentToArcOfEllipseviaNewPoint(
-                    //     Obj,
-                    //     static_cast<const Part::GeomArcOfEllipse*>(geom1),
-                    //     geom2,
-                    //     geoId1,
-                    //     geoId2);
-                    return false;
-                }
-                else if (
-                    geom2->is<Part::GeomArcOfEllipse>()
-                    && (geom1->is<Part::GeomConic>() || geom1->is<Part::GeomArcOfConic>())
-                ) {
-                    // makeTangentToArcOfEllipseviaNewPoint(
-                    //     Obj,
-                    //     static_cast<const Part::GeomArcOfEllipse*>(geom2),
-                    //     geom1,
-                    //     geoId2,
-                    //     geoId1);
-                    return false;
-                }
-
-                auto resultCoincident = std::ranges::find_if(AutoConstraints, [&](const auto& ace) {
-                    return ace->Type == Sketcher::Coincident && ace->First == geoId1
-                        && ace->Second == geoId2;
-                });
-
-                auto resultPointOnObject = std::ranges::find_if(AutoConstraints, [&](const auto& ace) {
-                    return ace->Type == Sketcher::PointOnObject && ace->involvesGeoId(geoId1)
-                        && ace->involvesGeoId(geoId2);
-                });
-
-                if (resultCoincident != AutoConstraints.end()
-                    && isStartOrEnd((*resultCoincident)->FirstPos)
-                    && isStartOrEnd((*resultCoincident)->SecondPos)) {
-                    // endpoint-to-endpoint tangency
-                    (*resultCoincident)->Type = Sketcher::Tangent;
-                }
-                else if (
-                    resultPointOnObject != AutoConstraints.end()
-                    && isStartOrEnd((*resultPointOnObject)->FirstPos)
-                ) {
-                    // endpoint-to-edge tangency
-                    (*resultPointOnObject)->Type = Sketcher::Tangent;
-                }
-                else if (
-                    resultCoincident != AutoConstraints.end()
-                    && (*resultCoincident)->FirstPos == Sketcher::PointPos::mid
-                    && (*resultCoincident)->SecondPos == Sketcher::PointPos::mid && geom1 && geom2
-                    && (geom1->is<Part::GeomCircle>() || geom1->is<Part::GeomArcOfCircle>())
-                    && (geom2->is<Part::GeomCircle>() || geom2->is<Part::GeomArcOfCircle>())
-                ) {
-                    // equality
-                    auto c = std::make_unique<Sketcher::Constraint>();
-                    c->Type = Sketcher::Equal;
-                    c->First = geoId1;
-                    c->Second = geoId2;
-                    AutoConstraints.push_back(std::move(c));
-                }
-                else {  // regular edge to edge tangency
-                    auto c = std::make_unique<Sketcher::Constraint>();
-                    c->Type = Sketcher::Tangent;
-                    c->First = geoId1;
-                    c->Second = geoId2;
-                    AutoConstraints.push_back(std::move(c));
-                }
-            } break;
-            default:
-                break;
-        }
-
-        return true;
-    }
-
     /** @brief Convenience function to automatically generate and add to the AutoConstraints vector
      *  the suggested constraints.
      *
@@ -927,7 +700,7 @@ protected:
         }
 
         for (auto& ac : autoConstrs) {
-            if (!generateOneAutoConstraintFromSuggestion(ac, geoId1, posId1)) {
+            if (!generateOneAutoConstraintFromSuggestion(ac, geoId1, posId1, AutoConstraints)) {
                 return;
             }
         }
@@ -960,16 +733,7 @@ protected:
      * all the constraints stored in the AutoConstraints vector. */
     void tryAddAutoConstraints()
     {
-        auto autoConstraints = toPointerVector(AutoConstraints);
-
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            Sketcher::PythonConverter::convert(
-                Gui::Command::getObjectCmd(sketchgui->getObject()),
-                autoConstraints
-            )
-                .c_str()
-        );
+        addGeneratedAutoConstraints(AutoConstraints);
     }
 
     /** @brief Convenience function to remove redundant autoconstraints from the AutoConstraints
@@ -986,69 +750,19 @@ protected:
      */
     void removeRedundantAutoConstraints()
     {
-
-        if (AutoConstraints.empty()) {
-            return;
-        }
-
-        auto sketchobject = getSketchObject();
-
-        auto autoConstraints = toPointerVector(AutoConstraints);
-
-        // Allows a diagnose with the new autoconstraints as if they were part of the sketchobject,
-        // but WITHOUT adding them to the sketchobject..
-        sketchobject->diagnoseAdditionalConstraints(autoConstraints);
-
-        if (sketchobject->getLastHasRedundancies()) {
-            Base::Console().message(
-                sketchobject->getFullLabel(),
-                QT_TRANSLATE_NOOP("Notifications", "Autoconstraints cause redundancy. Removing them") "\n"
+        if (!filterRedundantAutoConstraints(AutoConstraints)) {
+            // This exception stops the procedure here, which means that:
+            // 1) Geometry (and constraints of the geometry in case of a multicurve shape)
+            // are created 2) No autoconstrains are actually added 3) No widget mandated
+            // constraints are added
+            THROWM(
+                Base::RuntimeError,
+                QT_TRANSLATE_NOOP(
+                    "Notifications",
+                    "Redundant constraint is not an autoconstraint. No autoconstraints "
+                    "or additional constraints were added. Please report!"
+                ) "\n"
             );
-
-            auto lastsketchconstraintindex = sketchobject->Constraints.getSize() - 1;
-
-            auto redundants = sketchobject->getLastRedundant();  // redundants is always sorted
-
-            for (int index = redundants.size() - 1; index >= 0; index--) {
-                int redundantconstraintindex = redundants[index] - 1;
-                if (redundantconstraintindex > lastsketchconstraintindex) {
-                    int removeindex = redundantconstraintindex - lastsketchconstraintindex - 1;
-                    AutoConstraints.erase(std::next(AutoConstraints.begin(), removeindex));
-                }
-                else {
-                    // This exception stops the procedure here, which means that:
-                    // 1) Geometry (and constraints of the geometry in case of a multicurve shape)
-                    // are created 2) No autoconstrains are actually added 3) No widget mandated
-                    // constraints are added
-                    THROWM(
-                        Base::RuntimeError,
-                        QT_TRANSLATE_NOOP(
-                            "Notifications",
-                            "Redundant constraint is not an autoconstraint. No autoconstraints "
-                            "or additional constraints were added. Please report!"
-                        ) "\n"
-                    );
-                }
-            }
-
-            // NOTE: If we removed all redundants in the list, then at this moment there are no
-            // redundants anymore
-        }
-
-        // This can happen if OVP generated constraints and autoconstraints are conflicting
-        // For instance : https://github.com/FreeCAD/FreeCAD/issues/17722
-        if (sketchobject->getLastHasConflicts()) {
-            auto lastsketchconstraintindex = sketchobject->Constraints.getSize() - 1;
-
-            auto conflicting = sketchobject->getLastConflicting();
-
-            for (int index = conflicting.size() - 1; index >= 0; index--) {
-                int conflictingIndex = conflicting[index] - 1;
-                if (conflictingIndex > lastsketchconstraintindex) {
-                    int removeindex = conflictingIndex - lastsketchconstraintindex - 1;
-                    AutoConstraints.erase(std::next(AutoConstraints.begin(), removeindex));
-                }
-            }
         }
     }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -22,7 +22,12 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <algorithm>
 #include <cmath>
+#include <iterator>
+#include <ranges>
+#include <tuple>
+#include <utility>
 
 #include <QGuiApplication>
 #include <QPainter>
@@ -37,6 +42,7 @@
 #include <Gui/MainWindow.h>
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
+#include <Mod/Sketcher/App/PythonConverter.h>
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "CommandConstraints.h"
@@ -1093,6 +1099,304 @@ int DrawSketchHandler::seekAutoConstraint(
     }
 
     return suggestedConstraints.size();
+}
+
+// TODO: Figure out and explain what it actually returns
+bool DrawSketchHandler::generateOneAutoConstraintFromSuggestion(
+    const AutoConstraint& ac,
+    int geoId1,
+    Sketcher::PointPos posId1,
+    std::vector<std::unique_ptr<Sketcher::Constraint>>& autoConstraints
+)
+{
+    int geoId2 = ac.GeoId;
+    Sketcher::PointPos posId2 = ac.PosId;
+
+    static const auto isStartOrEnd = [](const Sketcher::PointPos posId) {
+        return posId == Sketcher::PointPos::start || posId == Sketcher::PointPos::end;
+    };
+
+    switch (ac.Type) {
+        case Sketcher::Coincident: {
+            if (posId1 == Sketcher::PointPos::none) {
+                return true;
+            }
+
+            // find if there is already a matching tangency
+            auto itOfTangentConstraint = autoConstraints.end();
+            if (isStartOrEnd(posId1) && isStartOrEnd(posId2)) {
+                itOfTangentConstraint = std::ranges::find(
+                    autoConstraints,
+                    std::tuple {Sketcher::Tangent, geoId1, geoId2},
+                    [](const auto& ace) { return std::tuple {ace->Type, ace->First, ace->Second}; }
+                );
+            }
+
+            if (itOfTangentConstraint != autoConstraints.end()) {
+                // modify tangency to endpoint-to-endpoint
+                (*itOfTangentConstraint)->FirstPos = posId1;
+                (*itOfTangentConstraint)->SecondPos = posId2;
+            }
+            else {
+                auto c = std::make_unique<Sketcher::Constraint>();
+                c->Type = Sketcher::Coincident;
+                c->First = geoId1;
+                c->FirstPos = posId1;
+                c->Second = geoId2;
+                c->SecondPos = posId2;
+                autoConstraints.push_back(std::move(c));
+            }
+        } break;
+        case Sketcher::PointOnObject: {
+            if (posId1 == Sketcher::PointPos::none) {
+                // Auto constraining an edge so swap parameters
+                std::swap(geoId1, geoId2);
+                std::swap(posId1, posId2);
+            }
+
+            auto itOfTangentConstraint = autoConstraints.end();
+            if (isStartOrEnd(posId1)) {
+                itOfTangentConstraint = std::ranges::find_if(autoConstraints, [&](const auto& ace) {
+                    return ace->Type == Sketcher::Tangent && ace->involvesGeoId(geoId1)
+                        && ace->involvesGeoId(geoId2);
+                });
+            }
+
+            // if tangency, convert to point-to-edge tangency
+            if (itOfTangentConstraint != autoConstraints.end()) {
+                if ((*itOfTangentConstraint)->First != geoId1) {
+                    std::swap((*itOfTangentConstraint)->Second, (*itOfTangentConstraint)->First);
+                }
+
+                (*itOfTangentConstraint)->FirstPos = posId1;
+            }
+            else {
+                auto c = std::make_unique<Sketcher::Constraint>();
+                c->Type = Sketcher::PointOnObject;
+                c->First = geoId1;
+                c->FirstPos = posId1;
+                c->Second = geoId2;
+                autoConstraints.push_back(std::move(c));
+            }
+        } break;
+        case Sketcher::Symmetric: {
+            auto c = std::make_unique<Sketcher::Constraint>();
+            c->Type = Sketcher::Symmetric;
+            c->First = geoId2;
+            c->FirstPos = Sketcher::PointPos::start;
+            c->Second = geoId2;
+            c->SecondPos = Sketcher::PointPos::end;
+            c->Third = geoId1;
+            c->ThirdPos = posId1;
+            autoConstraints.push_back(std::move(c));
+        } break;
+        // In special case of Horizontal/Vertical constraint, geoId2 is normally
+        // unused and should be 'Constraint::GeoUndef' However it can be used as a
+        // way to require the function to apply these constraints on another
+        // geometry In this case the caller as to set geoId2, then it will be used
+        // as target instead of geoId2
+        case Sketcher::Horizontal:
+        case Sketcher::Vertical: {
+            auto c = std::make_unique<Sketcher::Constraint>();
+            c->Type = ac.Type;
+            c->First = (geoId2 != Sketcher::GeoEnum::GeoUndef ? geoId2 : geoId1);
+            autoConstraints.push_back(std::move(c));
+        } break;
+        case Sketcher::Perpendicular: {
+            auto c = std::make_unique<Sketcher::Constraint>();
+            c->Type = Sketcher::Perpendicular;
+            c->First = geoId1;
+            c->Second = geoId2;
+            autoConstraints.push_back(std::move(c));
+        } break;
+        case Sketcher::Parallel: {
+            auto c = std::make_unique<Sketcher::Constraint>();
+            c->Type = Sketcher::Parallel;
+            c->First = geoId1;
+            c->Second = geoId2;
+            autoConstraints.push_back(std::move(c));
+        } break;
+        case Sketcher::Tangent: {
+            Sketcher::SketchObject* Obj = sketchgui->getObject<Sketcher::SketchObject>();
+
+            const Part::Geometry* geom1 = Obj->getGeometry(geoId1);
+            const Part::Geometry* geom2 = Obj->getGeometry(geoId2);
+            if (!geom1 || !geom2) {
+                return false;
+            }
+
+            // 2026.01.16: Do not use swap as it did before or it breaks resultCoincident.
+            // NOTE: Temporarily deactivated : ellipse tangency support using construction elements
+            if (geom1->is<Part::GeomEllipse>()
+                && (geom2->is<Part::GeomConic>() || geom2->is<Part::GeomArcOfConic>())) {
+                // makeTangentToEllipseviaNewPoint(
+                //     Obj,
+                //     static_cast<const Part::GeomEllipse*>(geom1),
+                //     geom2,
+                //     geoId1,
+                //     geoId2);
+                return false;
+            }
+            else if (
+                geom2->is<Part::GeomEllipse>()
+                && (geom1->is<Part::GeomConic>() || geom1->is<Part::GeomArcOfConic>())
+            ) {
+                // makeTangentToEllipseviaNewPoint(
+                //     Obj,
+                //     static_cast<const Part::GeomEllipse*>(geom2),
+                //     geom1,
+                //     geoId2,
+                //     geoId1);
+                return false;
+            }
+            else if (
+                geom1->is<Part::GeomArcOfEllipse>()
+                && (geom2->is<Part::GeomConic>() || geom2->is<Part::GeomArcOfConic>())
+            ) {
+                // makeTangentToArcOfEllipseviaNewPoint(
+                //     Obj,
+                //     static_cast<const Part::GeomArcOfEllipse*>(geom1),
+                //     geom2,
+                //     geoId1,
+                //     geoId2);
+                return false;
+            }
+            else if (
+                geom2->is<Part::GeomArcOfEllipse>()
+                && (geom1->is<Part::GeomConic>() || geom1->is<Part::GeomArcOfConic>())
+            ) {
+                // makeTangentToArcOfEllipseviaNewPoint(
+                //     Obj,
+                //     static_cast<const Part::GeomArcOfEllipse*>(geom2),
+                //     geom1,
+                //     geoId2,
+                //     geoId1);
+                return false;
+            }
+
+            auto resultCoincident = std::ranges::find_if(autoConstraints, [&](const auto& ace) {
+                return ace->Type == Sketcher::Coincident && ace->First == geoId1
+                    && ace->Second == geoId2;
+            });
+
+            auto resultPointOnObject = std::ranges::find_if(autoConstraints, [&](const auto& ace) {
+                return ace->Type == Sketcher::PointOnObject && ace->involvesGeoId(geoId1)
+                    && ace->involvesGeoId(geoId2);
+            });
+
+            if (resultCoincident != autoConstraints.end()
+                && isStartOrEnd((*resultCoincident)->FirstPos)
+                && isStartOrEnd((*resultCoincident)->SecondPos)) {
+                // endpoint-to-endpoint tangency
+                (*resultCoincident)->Type = Sketcher::Tangent;
+            }
+            else if (
+                resultPointOnObject != autoConstraints.end()
+                && isStartOrEnd((*resultPointOnObject)->FirstPos)
+            ) {
+                // endpoint-to-edge tangency
+                (*resultPointOnObject)->Type = Sketcher::Tangent;
+            }
+            else if (
+                resultCoincident != autoConstraints.end()
+                && (*resultCoincident)->FirstPos == Sketcher::PointPos::mid
+                && (*resultCoincident)->SecondPos == Sketcher::PointPos::mid && geom1 && geom2
+                && (geom1->is<Part::GeomCircle>() || geom1->is<Part::GeomArcOfCircle>())
+                && (geom2->is<Part::GeomCircle>() || geom2->is<Part::GeomArcOfCircle>())
+            ) {
+                // equality
+                auto c = std::make_unique<Sketcher::Constraint>();
+                c->Type = Sketcher::Equal;
+                c->First = geoId1;
+                c->Second = geoId2;
+                autoConstraints.push_back(std::move(c));
+            }
+            else {  // regular edge to edge tangency
+                auto c = std::make_unique<Sketcher::Constraint>();
+                c->Type = Sketcher::Tangent;
+                c->First = geoId1;
+                c->Second = geoId2;
+                autoConstraints.push_back(std::move(c));
+            }
+        } break;
+        default:
+            break;
+    }
+
+    return true;
+}
+
+bool DrawSketchHandler::filterRedundantAutoConstraints(
+    std::vector<std::unique_ptr<Sketcher::Constraint>>& autoConstraints
+)
+{
+    if (autoConstraints.empty()) {
+        return true;
+    }
+
+    auto sketchobject = getSketchObject();
+
+    auto constraints = toPointerVector(autoConstraints);
+
+    // Allows a diagnose with the new autoconstraints as if they were part of the sketchobject,
+    // but WITHOUT adding them to the sketchobject..
+    sketchobject->diagnoseAdditionalConstraints(constraints);
+
+    if (sketchobject->getLastHasRedundancies()) {
+        Base::Console().message(
+            sketchobject->getFullLabel(),
+            QT_TRANSLATE_NOOP("Notifications", "Autoconstraints cause redundancy. Removing them") "\n"
+        );
+
+        auto lastsketchconstraintindex = sketchobject->Constraints.getSize() - 1;
+
+        auto redundants = sketchobject->getLastRedundant();  // redundants is always sorted
+
+        for (int index = redundants.size() - 1; index >= 0; index--) {
+            int redundantconstraintindex = redundants[index] - 1;
+            if (redundantconstraintindex > lastsketchconstraintindex) {
+                int removeindex = redundantconstraintindex - lastsketchconstraintindex - 1;
+                autoConstraints.erase(std::next(autoConstraints.begin(), removeindex));
+            }
+            else {
+                return false;
+            }
+        }
+
+        // NOTE: If we removed all redundants in the list, then at this moment there are no
+        // redundants anymore
+    }
+
+    // This can happen if OVP generated constraints and autoconstraints are conflicting
+    // For instance : https://github.com/FreeCAD/FreeCAD/issues/17722
+    if (sketchobject->getLastHasConflicts()) {
+        auto lastsketchconstraintindex = sketchobject->Constraints.getSize() - 1;
+
+        auto conflicting = sketchobject->getLastConflicting();
+
+        for (int index = conflicting.size() - 1; index >= 0; index--) {
+            int conflictingIndex = conflicting[index] - 1;
+            if (conflictingIndex > lastsketchconstraintindex) {
+                int removeindex = conflictingIndex - lastsketchconstraintindex - 1;
+                autoConstraints.erase(std::next(autoConstraints.begin(), removeindex));
+            }
+        }
+    }
+
+    return true;
+}
+
+void DrawSketchHandler::addGeneratedAutoConstraints(
+    const std::vector<std::unique_ptr<Sketcher::Constraint>>& autoConstraints
+)
+{
+    auto constraints = toPointerVector(autoConstraints);
+
+    Gui::Command::doCommand(
+        Gui::Command::Doc,
+        Sketcher::PythonConverter::convert(Gui::Command::getObjectCmd(sketchgui->getObject()), constraints)
+            .c_str()
+    );
 }
 
 void DrawSketchHandler::createAutoConstraints(

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -314,6 +314,19 @@ protected:
 
     Sketcher::SketchObject* getSketchObject();
 
+    bool generateOneAutoConstraintFromSuggestion(
+        const AutoConstraint& autoConstraint,
+        int geoId,
+        Sketcher::PointPos pointPos,
+        std::vector<std::unique_ptr<Sketcher::Constraint>>& autoConstraints
+    );
+    bool filterRedundantAutoConstraints(
+        std::vector<std::unique_ptr<Sketcher::Constraint>>& autoConstraints
+    );
+    void addGeneratedAutoConstraints(
+        const std::vector<std::unique_ptr<Sketcher::Constraint>>& autoConstraints
+    );
+
     void setAngleSnapping(bool enable, Base::Vector2d referencePoint = Base::Vector2d(0., 0.));
 
     void moveConstraint(int constNum, const Base::Vector2d& toPos, OffsetMode offset = NoOffset);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <memory>
 #include <numbers>
 
 #include <QWidget>
@@ -32,6 +33,7 @@
 #include <Precision.hxx>
 #include <Base/Vector3D.h>
 #include <Mod/Part/App/Geometry.h>
+#include <Mod/Sketcher/App/Sketch.h>
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "DrawSketchHandlerDragAutoConstraint.h"
@@ -89,29 +91,14 @@ bool DrawSketchHandlerDragAutoConstraint::hasMoved(const Base::Vector2d& actualP
     return (actualPos - startPos).Sqr() > Precision::SquareConfusion();
 }
 
-Base::Vector2d DrawSketchHandlerDragAutoConstraint::getDirection(
-    const GeoElementId& dragged,
-    const Base::Vector2d& pos
-) const
+Base::Vector2d DrawSketchHandlerDragAutoConstraint::getDirection(const Part::Geometry* geometry) const
 {
-    const Part::Geometry* geo = sketchgui->getSketchObject()->getGeometry(dragged.GeoId);
-    if (!geo || !geo->isDerivedFrom<Part::GeomLineSegment>()) {
+    if (!geometry || !geometry->isDerivedFrom<Part::GeomLineSegment>()) {
         return Base::Vector2d(0.0, 0.0);
     }
 
-    const auto* line = static_cast<const Part::GeomLineSegment*>(geo);
-
-    Base::Vector2d startPoint = toVector2d(line->getStartPoint());
-    Base::Vector2d endPoint = toVector2d(line->getEndPoint());
-
-    if (dragged.Pos == PointPos::start) {
-        startPoint = pos;
-    }
-    else if (dragged.Pos == PointPos::end) {
-        endPoint = pos;
-    }
-
-    return endPoint - startPoint;
+    const auto* line = static_cast<const Part::GeomLineSegment*>(geometry);
+    return toVector2d(line->getEndPoint()) - toVector2d(line->getStartPoint());
 }
 
 bool DrawSketchHandlerDragAutoConstraint::isExistingConstraint(
@@ -220,9 +207,21 @@ void DrawSketchHandlerDragAutoConstraint::update(
     }
 
     const auto& dragged = draggedElements.front();
-    const Base::Vector2d actualPos = toVector2d(
-        sketchgui->getSolvedSketch().getPoint(dragged.GeoId, dragged.Pos)
-    );
+    const Sketch& solvedSketch = sketchgui->getSolvedSketch();
+
+    std::vector<std::unique_ptr<Part::Geometry>> solvedGeometry;
+    for (Part::Geometry* geometry : solvedSketch.extractGeometry(true, false)) {
+        solvedGeometry.emplace_back(geometry);
+    }
+
+    auto getSolvedGeometry = [&solvedGeometry](int geoId) -> const Part::Geometry* {
+        if (geoId < 0 || static_cast<std::size_t>(geoId) >= solvedGeometry.size()) {
+            return nullptr;
+        }
+        return solvedGeometry[geoId].get();
+    };
+
+    const Base::Vector2d actualPos = toVector2d(solvedSketch.getPoint(dragged.GeoId, dragged.Pos));
 
     if (!hasMoved(actualPos)) {
         unsetCursor();
@@ -252,7 +251,7 @@ void DrawSketchHandlerDragAutoConstraint::update(
             continue;
         }
 
-        const double dist = (actualPos - toVector2d(obj->getPoint(geoId, posId))).Length();
+        const double dist = (actualPos - toVector2d(solvedSketch.getPoint(geoId, posId))).Length();
         if (dist < bestPointDist) {
             bestPointDist = dist;
             bestPointGeoId = geoId;
@@ -287,7 +286,7 @@ void DrawSketchHandlerDragAutoConstraint::update(
         };
 
         for (int geoId = 0; geoId <= obj->getHighestCurveIndex(); ++geoId) {
-            const Part::Geometry* geo = obj->getGeometry(geoId);
+            const Part::Geometry* geo = getSolvedGeometry(geoId);
             if (!geo) {
                 continue;
             }
@@ -309,7 +308,9 @@ void DrawSketchHandlerDragAutoConstraint::update(
 
                 const Base::Vector2d projection = a + ab * t;
                 const double distance = (actualPos - projection).Length();
-                considerCurve(geoId, distance, isLineCenterAutoConstraint(geoId, actualPos));
+                const Base::Vector2d midpoint = (a + b) / 2.0;
+                const bool lineCenter = (actualPos - midpoint).Length() < ab.Length() * 0.05;
+                considerCurve(geoId, distance, lineCenter);
             }
             else if (geo->is<Part::GeomCircle>()) {
                 const auto* circle = static_cast<const Part::GeomCircle*>(geo);
@@ -332,7 +333,7 @@ void DrawSketchHandlerDragAutoConstraint::update(
         }
     }
 
-    const Base::Vector2d dir = getDirection(dragged, actualPos);
+    const Base::Vector2d dir = getDirection(getSolvedGeometry(dragged.GeoId));
     if (dir.Sqr() > Precision::SquareConfusion()) {
         using std::numbers::pi;
         constexpr double angleDevRad = Base::toRadians<double>(2);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.cpp
@@ -372,5 +372,30 @@ void DrawSketchHandlerDragAutoConstraint::create(const std::vector<GeoElementId>
         return;
     }
 
-    createAutoConstraints(suggestedConstraints, dragged.front().GeoId, dragged.front().Pos, false);
+    SketchObject* obj = getSketchObject();
+    if (!obj) {
+        return;
+    }
+
+    std::vector<std::unique_ptr<Constraint>> autoConstraints;
+
+    for (const AutoConstraint& suggestion : suggestedConstraints) {
+        if (!generateOneAutoConstraintFromSuggestion(
+                suggestion,
+                dragged.front().GeoId,
+                dragged.front().Pos,
+                autoConstraints
+            )) {
+            break;
+        }
+    }
+
+    const bool valid = filterRedundantAutoConstraints(autoConstraints);
+    obj->solve(false);
+
+    if (!valid) {
+        return;
+    }
+
+    addGeneratedAutoConstraints(autoConstraints);
 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.h
@@ -30,6 +30,11 @@
 
 #include "DrawSketchHandler.h"
 
+namespace Part
+{
+class Geometry;
+}
+
 namespace SketcherGui
 {
 
@@ -70,7 +75,7 @@ private:
         Sketcher::PointPos posId = Sketcher::PointPos::none
     );
     bool hasMoved(const Base::Vector2d& actualPos) const;
-    Base::Vector2d getDirection(const Sketcher::GeoElementId& dragged, const Base::Vector2d& pos) const;
+    Base::Vector2d getDirection(const Part::Geometry* geometry) const;
     bool isExistingConstraint(
         const Sketcher::GeoElementId& dragged,
         const AutoConstraint& constraint


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Here, `solved` was used for the point to indicate drag, but I hadn't considered that the point's movements could change the geometry associated with it. Therefore, I used `sketch` for the geometry, which wasn't updated according to the position during drag. With this PR, the constraints during drag are determined according to the `solved` position. Actually, I made most of the changes myself, but when I asked ChatGPT 5.5, they said there might be memory-related issues, so I corrected them accordingly.

I have shared the redundant auto constrain workflow in src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h, so it works the same way when drawing and dragging. I didn't realize that this system was in this file before, in fact, it shouldn't be. It was necessary to carry it somehow in order to use it jointly. I did a complete migration and made the auto constrain function common, but ChatGpt 5.5 told me that it might be good to drop a wraper, so I dropped a wraper and made the name of the function I moved different.

Don't look at it as a huge code change, it's a complete one-to-one move, so it's an existing code, not one I wrote.

I'm trying to be honest about AI, but I guess it's better to say less. However, I would like to point out that I have never used an AI-supported tool, I only use AI as a chat.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
fix #30874
## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
