### PR TITLE
Sketcher: Fix task panel expansion persistence when hidden

### DIFF
--- a/src/Gui/QSint/actionpanel/actiongroup.cpp
+++ b/src/Gui/QSint/actionpanel/actiongroup.cpp
@@ -111,7 +111,10 @@ void ActionGroup::showHide()
 {
     if (m_foldStep || !myHeader->expandable()) return;
 
-    if (myGroup->isVisible())
+    const bool expand = !m_expanded;
+    setExpandedState(expand);
+
+    if (!expand)
     {
         m_foldPixmap = myGroup->transparentRender();
         m_tempHeight = m_fullHeight = myGroup->height();
@@ -137,6 +140,10 @@ void ActionGroup::showHide()
 
 void ActionGroup::processHide()
 {
+    if (m_foldStep <= 0) {
+        return;
+    }
+
     if (--m_foldStep == 0)
     {
         myDummy->hide();
@@ -155,6 +162,10 @@ void ActionGroup::processHide()
 
 void ActionGroup::processShow()
 {
+    if (m_foldStep <= 0) {
+        return;
+    }
+
     if (--m_foldStep == 0)
     {
         myDummy->hide();
@@ -213,6 +224,47 @@ bool ActionGroup::isExpandable() const
 void ActionGroup::setExpandable(bool expandable)
 {
     myHeader->setExpandable(expandable);
+}
+
+bool ActionGroup::isExpanded() const
+{
+    return m_expanded;
+}
+
+void ActionGroup::setExpanded(bool expanded)
+{
+    m_foldStep = 0;
+    m_foldDirection = expanded ? 1 : -1;
+    m_foldPixmap = QPixmap();
+
+    setExpandedState(expanded);
+
+    myDummy->setFixedHeight(0);
+    myDummy->hide();
+    myHeader->setFold(expanded);
+
+    if (expanded) {
+        myGroup->show();
+        setMinimumHeight(0);
+        setMaximumHeight(QWIDGETSIZE_MAX);
+    }
+    else {
+        myGroup->hide();
+        setFixedHeight(myHeader->height() + separatorHeight);
+    }
+
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    updateGeometry();
+}
+
+void ActionGroup::setExpandedState(bool expanded)
+{
+    if (m_expanded == expanded) {
+        return;
+    }
+
+    m_expanded = expanded;
+    Q_EMIT expandedChanged();
 }
 
 bool ActionGroup::hasHeader() const

--- a/src/Gui/QSint/actionpanel/actiongroup.h
+++ b/src/Gui/QSint/actionpanel/actiongroup.h
@@ -31,11 +31,13 @@ class QSINT_EXPORT ActionGroup : public QWidget
     Q_OBJECT
 
     Q_PROPERTY(bool expandable READ isExpandable WRITE setExpandable NOTIFY expandableChanged)
+    Q_PROPERTY(bool expanded READ isExpanded WRITE setExpanded NOTIFY expandedChanged)
     Q_PROPERTY(bool header READ hasHeader WRITE setHeader NOTIFY headerChanged)
     Q_PROPERTY(QString headerText READ headerText WRITE setHeaderText NOTIFY headerTextChanged)
 
 Q_SIGNALS:
     void expandableChanged();
+    void expandedChanged();
     void headerChanged();
     void headerTextChanged();
 
@@ -120,6 +122,18 @@ public:
     void setExpandable(bool expandable);
 
     /**
+     * @brief Checks if the group is expanded.
+     * @return `true` if the group is expanded, `false` if collapsed.
+     */
+    bool isExpanded() const;
+
+    /**
+     * @brief Sets whether the group is expanded.
+     * @param expanded If `true`, the group contents are shown.
+     */
+    void setExpanded(bool expanded);
+
+    /**
      * @brief Checks if the group has a header.
      * @return `true` if the group has a header, `false` otherwise.
      */
@@ -185,11 +199,18 @@ protected:
      */
     void init(bool hasHeader);
 
+    /**
+     * @brief Sets the logical expansion state.
+     * @param expanded If `true`, the group is considered expanded.
+     */
+    void setExpandedState(bool expanded);
+
     double m_foldStep = 0;      ///< Current folding animation step.
     double m_foldDelta = 0;     ///< Change in height per animation step.
     double m_fullHeight = 0;    ///< Full (expanded) height of the group.
     double m_tempHeight = 0;    ///< Temporary height during animation.
     int m_foldDirection = 0;    ///< Direction of folding animation.
+    bool m_expanded = true;     ///< Logical expansion state.
 
     QPixmap m_foldPixmap;       ///< Pixmap for the fold/unfold icon.
 

--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -188,6 +188,7 @@ void TaskBox::hideGroupBox()
     m_foldStep = 0.0;
     m_foldDirection = -1;
 
+    setExpandedState(false);
     myHeader->setFold(false);
 
     myDummy->setFixedHeight(0);
@@ -197,11 +198,6 @@ void TaskBox::hideGroupBox()
     m_foldPixmap = QPixmap();
     setFixedHeight(myHeader->height());
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
-}
-
-bool TaskBox::isGroupVisible() const
-{
-    return myGroup->isVisible();
 }
 
 void TaskBox::actionEvent(QActionEvent* e)

--- a/src/Gui/TaskView/TaskView.h
+++ b/src/Gui/TaskView/TaskView.h
@@ -110,7 +110,6 @@ public:
 
     ~TaskBox() override;
     void hideGroupBox();
-    bool isGroupVisible() const;
 
 protected:
     void showEvent(QShowEvent*) override;

--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
@@ -150,10 +150,10 @@ void TaskDlgEditSketch::saveDialogState() const
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Sketcher"
     );
-    hGrp->SetBool("ExpandedMessagesWidget", Messages->isGroupVisible());
-    hGrp->SetBool("ExpandedSolverAdvancedWidget", SolverAdvanced->isGroupVisible());
-    hGrp->SetBool("ExpandedConstraintsWidget", Constraints->isGroupVisible());
-    hGrp->SetBool("ExpandedElementsWidget", Elements->isGroupVisible());
+    hGrp->SetBool("ExpandedMessagesWidget", Messages->isExpanded());
+    hGrp->SetBool("ExpandedSolverAdvancedWidget", SolverAdvanced->isExpanded());
+    hGrp->SetBool("ExpandedConstraintsWidget", Constraints->isExpanded());
+    hGrp->SetBool("ExpandedElementsWidget", Elements->isExpanded());
 }
 
 QDialogButtonBox::StandardButtons TaskDlgEditSketch::getStandardButtons() const

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(Gui_tests_run
 )
 
 # Qt tests
-setup_qt_test(QuantitySpinBox)
+setup_qt_test(QuantitySpinBox TaskBox)
 
 target_link_libraries(Gui_tests_run PRIVATE
     GTest::gtest_main

--- a/tests/src/Gui/TaskBox.cpp
+++ b/tests/src/Gui/TaskBox.cpp
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <QCoreApplication>
+#include <QWidget>
+#include <QtTest/QTest>
+
+#include "Gui/TaskView/TaskView.h"
+#include <src/App/InitApplication.h>
+
+class testTaskBox: public QObject
+{
+    Q_OBJECT
+
+public:
+    testTaskBox()
+    {
+        tests::initApplication();
+    }
+
+private Q_SLOTS:
+    void test_expansionStateSurvivesHiddenParent()  // NOLINT
+    {
+        QWidget parent;
+        parent.resize(200, 100);
+
+        Gui::TaskView::TaskBox taskBox(QStringLiteral("Group"), true, &parent);
+        taskBox.resize(200, 100);
+        taskBox.show();
+        parent.show();
+        QCoreApplication::processEvents();
+
+        QVERIFY(taskBox.isVisible());
+        QVERIFY(taskBox.isExpanded());
+
+        parent.hide();
+        QCoreApplication::processEvents();
+
+        QVERIFY(!taskBox.isVisible());
+        QVERIFY(taskBox.isExpanded());
+    }
+
+    void test_showHideUsesExpansionStateWhenParentIsHidden()  // NOLINT
+    {
+        QWidget parent;
+        parent.resize(200, 100);
+
+        Gui::TaskView::TaskBox taskBox(QStringLiteral("Group"), true, &parent);
+        auto content = new QWidget();
+        content->setMinimumSize(20, 20);
+        QVERIFY(taskBox.addWidget(content));
+
+        taskBox.show();
+        parent.show();
+        QCoreApplication::processEvents();
+
+        QVERIFY(taskBox.isExpanded());
+
+        parent.hide();
+        QCoreApplication::processEvents();
+
+        QVERIFY(!taskBox.isVisible());
+        QVERIFY(taskBox.isExpanded());
+
+        taskBox.showHide();
+        QTest::qWait(400);
+
+        QVERIFY(!taskBox.isExpanded());
+
+        parent.show();
+        QCoreApplication::processEvents();
+
+        QVERIFY(taskBox.isVisible());
+        QVERIFY(!content->isVisible());
+    }
+
+    void test_hideGroupBoxUpdatesExpansionState()  // NOLINT
+    {
+        Gui::TaskView::TaskBox taskBox(QStringLiteral("Group"), true);
+
+        QVERIFY(taskBox.isExpanded());
+
+        taskBox.hideGroupBox();
+
+        QVERIFY(!taskBox.isExpanded());
+    }
+
+    void test_setExpandedUpdatesStateAndContents()  // NOLINT
+    {
+        QWidget parent;
+        parent.resize(200, 100);
+
+        Gui::TaskView::TaskBox taskBox(QStringLiteral("Group"), true, &parent);
+        auto content = new QWidget();
+        content->setMinimumSize(20, 20);
+        QVERIFY(taskBox.addWidget(content));
+
+        taskBox.show();
+        parent.show();
+        QCoreApplication::processEvents();
+
+        QVERIFY(taskBox.isExpanded());
+        QVERIFY(content->isVisible());
+
+        taskBox.setExpanded(false);
+        QCoreApplication::processEvents();
+
+        QVERIFY(!taskBox.isExpanded());
+        QVERIFY(!content->isVisible());
+
+        taskBox.setExpanded(true);
+        QCoreApplication::processEvents();
+
+        QVERIFY(taskBox.isExpanded());
+        QVERIFY(content->isVisible());
+    }
+
+    void test_setExpandedCancelsPendingFoldTimers()  // NOLINT
+    {
+        QWidget parent;
+        parent.resize(200, 100);
+
+        Gui::TaskView::TaskBox taskBox(QStringLiteral("Group"), true, &parent);
+        auto content = new QWidget();
+        content->setMinimumSize(20, 20);
+        QVERIFY(taskBox.addWidget(content));
+
+        taskBox.show();
+        parent.show();
+        QCoreApplication::processEvents();
+
+        QVERIFY(taskBox.isExpanded());
+
+        taskBox.showHide();
+        taskBox.setExpanded(true);
+
+        QTest::qWait(400);
+
+        QVERIFY(taskBox.isExpanded());
+        QVERIFY(content->isVisible());
+        QCOMPARE(taskBox.maximumHeight(), QWIDGETSIZE_MAX);
+    }
+};
+
+QTEST_MAIN(testTaskBox)
+
+#include "TaskBox.moc"


### PR DESCRIPTION
Task panel group expansion state was read from `QWidget::isVisible()` when Sketcher persisted its task panel preferences. That worked while the task view was visible, but it broke with overlay/autohide or otherwise hidden parents: child widgets reported not visible because an ancestor was hidden, even though the group itself was logically expanded. Closing Sketcher in that state stored expanded sections as collapsed, so the next edit opened with collapsed sections.

This fixes that by adding an explicit expanded property/state to `QSint::ActionGroup`. User toggles and programmatic `hideGroupBox()` calls update that logical state, and Sketcher now persists task panel sections through `isExpanded()` instead of effective QWidget visibility. The old visibility-derived `TaskBox::isGroupVisible()` API was removed.

Focused Qt regression coverage checks `TaskBox` expansion state independently from effective widget visibility, `showHide()` while an ancestor is hidden, direct `setExpanded()` behavior, `hideGroupBox()` programmatic collapse, and cancellation of stale fold-animation timers.

Fixes #30865