### PR TITLE
TechDraw: Add context-aware context menus

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -47,6 +47,7 @@
 #include <Base/Console.h>
 #include <Base/Stream.h>
 #include <Gui/Application.h>
+#include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>
 #include <Gui/Document.h>
 #include <Gui/FileDialog.h>
@@ -59,6 +60,13 @@
 #include <Mod/TechDraw/App/DrawPage.h>
 #include <Mod/TechDraw/App/DrawPagePy.h>
 #include <Mod/TechDraw/App/DrawTemplate.h>
+#include <Mod/TechDraw/App/DrawUtil.h>
+#include <Mod/TechDraw/App/DrawViewDimension.h>
+#include <Mod/TechDraw/App/DrawViewBalloon.h>
+#include <Mod/TechDraw/App/DrawLeaderLine.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
+#include <Mod/TechDraw/App/DrawViewSection.h>
+#include <Mod/TechDraw/App/Geometry.h>
 #include <Mod/TechDraw/App/Preferences.h>
 
 #include "MDIViewPage.h"
@@ -113,6 +121,15 @@ MDIViewPage::MDIViewPage(ViewProviderPage* pageVp, Gui::Document* doc, QWidget* 
     m_printAllAction = new QAction(tr("Print All Pages"), this);
 
     connect(m_printAllAction, &QAction::triggered, this, qOverload<>(&MDIViewPage::printAllPages));
+
+    m_exportSVGAction->setIcon(
+        Gui::BitmapFactory().iconFromTheme("actions/TechDraw_ExportPageSVG"));
+    m_exportDXFAction->setIcon(
+        Gui::BitmapFactory().iconFromTheme("actions/TechDraw_ExportPageDXF"));
+    m_exportPDFAction->setIcon(
+        Gui::BitmapFactory().iconFromTheme("Std_PrintPdf"));
+    m_printAllAction->setIcon(
+        Gui::BitmapFactory().iconFromTheme("actions/TechDraw_PrintAll"));
 
     isSelectionBlocked = false;
     isContextualMenuEnabled = true;
@@ -466,22 +483,227 @@ PyObject* MDIViewPage::getPyObject()
 
 void MDIViewPage::contextMenuEvent(QContextMenuEvent* event)
 {
-    if (isContextualMenuEnabled) {
-        QMenu menu;
-        menu.addAction(m_toggleGridAction);
-        menu.addAction(m_toggleFrameAction);
-        menu.addAction(m_toggleKeepUpdatedAction);
-        menu.addAction(m_exportSVGAction);
-        menu.addAction(m_exportDXFAction);
-        menu.addAction(m_exportPDFAction);
-        menu.addAction(m_printAllAction);
-        if (PreferencesGui::getViewFrameMode() == ViewFrameMode::Manual) {
-            m_toggleFrameAction->setEnabled(true);
-        } else {
-            m_toggleFrameAction->setEnabled(false);
-        }
-        menu.exec(event->globalPos());
+    if (!isContextualMenuEnabled) {
+        return;
     }
+
+    QMenu menu;
+
+    if (!addSelectionGroups(menu)) {
+        addPageGroup(menu);
+    }
+    menu.exec(event->globalPos());
+}
+
+static bool hasWholeViewPartSelected()
+{
+    for (auto& sel : Gui::Selection().getSelectionEx()) {
+        auto* obj = sel.getObject();
+        if (obj
+            && obj->isDerivedFrom<TechDraw::DrawViewPart>()
+            && sel.getSubNames().empty()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool hasWholeDrawViewSelected()
+{
+    for (auto& sel : Gui::Selection().getSelectionEx()) {
+        auto* obj = sel.getObject();
+        if (obj
+            && obj->isDerivedFrom<TechDraw::DrawView>()
+            && sel.getSubNames().empty()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool MDIViewPage::addSelectionGroups(QMenu& menu)
+{
+    bool added = false;
+    auto ctx = getSelectionContext();
+
+    if (!Gui::Selection().getObjectsOfType(
+            TechDraw::DrawViewDimension::getClassTypeId()).empty()) {
+        addCommandsByName(menu, {
+            "TechDraw_ExtensionIncreaseDecimal",
+            "TechDraw_ExtensionDecreaseDecimal",
+        });
+        menu.addSeparator();
+        addCommandsByName(menu, {
+            "TechDraw_ExtensionCustomizeFormat",
+            "TechDraw_ExtensionInsertDiameter",
+            "TechDraw_ExtensionInsertSquare",
+            "TechDraw_ExtensionInsertRepetition",
+            "TechDraw_ExtensionRemovePrefixChar",
+        });
+        menu.addSeparator();
+        addCommandsByName(menu, {
+            "TechDraw_DimensionRepair",
+        });
+        menu.addSeparator();
+        added = true;
+    }
+
+    if (!Gui::Selection().getObjectsOfType(
+            TechDraw::DrawViewBalloon::getClassTypeId()).empty()) {
+        if (addCommandsByName(menu, {
+                "TechDraw_ExtensionCustomizeFormat",
+            }) > 0) {
+            menu.addSeparator();
+            added = true;
+        }
+    }
+
+    if (!Gui::Selection().getObjectsOfType(
+            TechDraw::DrawLeaderLine::getClassTypeId()).empty()) {
+        if (addCommandsByName(menu, {
+                "TechDraw_WeldSymbol",
+            }) > 0) {
+            menu.addSeparator();
+            added = true;
+        }
+    }
+
+    if (ctx.hasFace) {
+        if (addCommandsByName(menu, {
+                "TechDraw_AreaDimension",
+                "TechDraw_Hatch",
+                "TechDraw_GeometricHatch",
+            }) > 0) {
+            menu.addSeparator();
+            added = true;
+        }
+    }
+
+    if (ctx.hasCircleEdge) {
+        if (addCommandsByName(menu, {
+                "TechDraw_ExtensionCircleCenterLines",
+            }) > 0) {
+            menu.addSeparator();
+            added = true;
+        }
+    }
+
+    if (ctx.hasGeomEdge || ctx.hasCosmeticEdge) {
+        addCommandsByName(menu, { "TechDraw_DecorateLine" });
+        menu.addSeparator();
+        added = true;
+    }
+
+    if (ctx.hasCosmeticEdge) {
+        addCommandsByName(menu, {
+            "TechDraw_ExtensionExtendLine",
+            "TechDraw_ExtensionShortenLine",
+        });
+        menu.addSeparator();
+        added = true;
+    }
+
+    if (hasWholeViewPartSelected()) {
+        if (!Gui::Selection().getObjectsOfType(
+                TechDraw::DrawViewSection::getClassTypeId()).empty()) {
+            if (addCommandsByName(menu, {
+                    "TechDraw_ExtensionPositionSectionView",
+                }) > 0) {
+                menu.addSeparator();
+                added = true;
+            }
+        }
+        if (addCommandsByName(menu, {
+                "TechDraw_ShowAll",
+                "TechDraw_ExtensionLockUnlockView",
+            }) > 0) {
+            menu.addSeparator();
+            added = true;
+        }
+    }
+
+    if (hasWholeDrawViewSelected()) {
+        if (addCommandsByName(menu, {
+                "TechDraw_StackTop",
+                "TechDraw_StackBottom",
+                "TechDraw_StackUp",
+                "TechDraw_StackDown",
+            }) > 0) {
+            menu.addSeparator();
+            added = true;
+        }
+    }
+
+    return added;
+}
+
+void MDIViewPage::addPageGroup(QMenu& menu)
+{
+    menu.addAction(m_toggleGridAction);
+    menu.addAction(m_toggleFrameAction);
+    menu.addAction(m_toggleKeepUpdatedAction);
+    menu.addSeparator();
+    menu.addAction(m_exportSVGAction);
+    menu.addAction(m_exportDXFAction);
+    menu.addAction(m_exportPDFAction);
+    menu.addSeparator();
+    menu.addAction(m_printAllAction);
+
+    m_toggleGridAction->setCheckable(true);
+    m_toggleGridAction->setChecked(m_vpPage->ShowGrid.getValue());
+
+    m_toggleFrameAction->setCheckable(true);
+    m_toggleFrameAction->setChecked(m_vpPage->getFrameState());
+    m_toggleFrameAction->setEnabled(
+        PreferencesGui::getViewFrameMode() == ViewFrameMode::Manual);
+
+    m_toggleKeepUpdatedAction->setCheckable(true);
+    m_toggleKeepUpdatedAction->setChecked(
+        m_vpPage->getDrawPage()->KeepUpdated.getValue());
+}
+
+int MDIViewPage::addCommandsByName(QMenu& menu,
+                                   std::initializer_list<const char*> names)
+{
+    int count = 0;
+    auto& mgr = Gui::Application::Instance->commandManager();
+    for (const char* name : names) {
+        if (Gui::Command* c = mgr.getCommandByName(name)) {
+            c->addTo(&menu);
+            ++count;
+        }
+    }
+    return count;
+}
+
+MDIViewPage::SelectionContext MDIViewPage::getSelectionContext()
+{
+    SelectionContext ctx;
+    for (auto& sel : Gui::Selection().getSelectionEx()) {
+        auto* dvp = dynamic_cast<TechDraw::DrawViewPart*>(sel.getObject());
+        for (auto& sub : sel.getSubNames()) {
+            std::string geomType = TechDraw::DrawUtil::getGeomTypeFromName(sub);
+            if (geomType == "Face") {
+                ctx.hasFace = true;
+            }
+            else if (geomType == "Edge") {
+                if (dvp && dvp->isCosmeticEdge(sub)) {
+                    ctx.hasCosmeticEdge = true;
+                } else {
+                    ctx.hasGeomEdge = true;
+                    if (dvp) {
+                        int idx = TechDraw::DrawUtil::getIndexFromName(sub);
+                        TechDraw::BaseGeomPtr geom = dvp->getGeomByIndex(idx);
+                        if (geom && (geom->getGeomType() == TechDraw::GeomType::CIRCLE
+                                  || geom->getGeomType() == TechDraw::GeomType::ARCOFCIRCLE)) {
+                            ctx.hasCircleEdge = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return ctx;
 }
 
 void MDIViewPage::toggleFrame() { m_vpPage->toggleFrameState(); }
@@ -819,6 +1041,27 @@ void MDIViewPage::sceneSelectionManager()
         }
     }
     m_orderedSceneSelection = m_new;
+}
+
+// for context menus. Right click can add to selection, but not remove from selection.
+// this is the same as Sketcher WB
+void MDIViewPage::selectOnRightPress(QGraphicsItem* item)
+{
+    while (item
+           && !dynamic_cast<QGIView*>(item)
+           && !dynamic_cast<QGIEdge*>(item)
+           && !dynamic_cast<QGIVertex*>(item)
+           && !dynamic_cast<QGIFace*>(item)
+           && !dynamic_cast<QGIDatumLabel*>(item)
+           && !dynamic_cast<QGMText*>(item)) {
+        item = item->parentItem();
+    }
+    if (!item) {
+        return;
+    }
+    blockSceneSelection(true);
+    addSceneItemToTreeSel(item, Gui::Selection().getSelectionEx());
+    blockSceneSelection(false);
 }
 
 //! update Tree Selection from QGraphicsScene selection. on exit, the tree

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -97,13 +97,13 @@ MDIViewPage::MDIViewPage(ViewProviderPage* pageVp, Gui::Document* doc, QWidget* 
 {
     setMouseTracking(true);
 
-    m_toggleKeepUpdatedAction = new QAction(tr("Toggle &Keep Updated"), this);
+    m_toggleKeepUpdatedAction = new QAction(tr("&Keep Updated"), this);
     connect(m_toggleKeepUpdatedAction, &QAction::triggered, this, &MDIViewPage::toggleKeepUpdated);
 
-    m_toggleFrameAction = new QAction(tr("Toggle &Frames"), this);
+    m_toggleFrameAction = new QAction(tr("Show &Frames"), this);
     connect(m_toggleFrameAction, &QAction::triggered, this, &MDIViewPage::toggleFrame);
 
-    m_toggleGridAction = new QAction(tr("Toggle &Grid"), this);
+    m_toggleGridAction = new QAction(tr("Show &Grid"), this);
     connect(m_toggleGridAction, &QAction::triggered, this, &MDIViewPage::toggleGrid);
 
     m_exportSVGAction = new QAction(tr("&Export SVG"), this);

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -495,12 +495,13 @@ void MDIViewPage::contextMenuEvent(QContextMenuEvent* event)
     menu.exec(event->globalPos());
 }
 
-static bool hasWholeViewPartSelected()
+template<typename T>
+static bool hasWholeSelectionOf()
 {
     for (auto& sel : Gui::Selection().getSelectionEx()) {
         auto* obj = sel.getObject();
         if (obj
-            && obj->isDerivedFrom<TechDraw::DrawViewPart>()
+            && obj->isDerivedFrom<T>()
             && sel.getSubNames().empty()) {
             return true;
         }
@@ -508,17 +509,10 @@ static bool hasWholeViewPartSelected()
     return false;
 }
 
-static bool hasWholeDrawViewSelected()
+template<typename T>
+static bool hasSelectionOfType()
 {
-    for (auto& sel : Gui::Selection().getSelectionEx()) {
-        auto* obj = sel.getObject();
-        if (obj
-            && obj->isDerivedFrom<TechDraw::DrawView>()
-            && sel.getSubNames().empty()) {
-            return true;
-        }
-    }
-    return false;
+    return !Gui::Selection().getObjectsOfType(T::getClassTypeId()).empty();
 }
 
 bool MDIViewPage::addSelectionGroups(QMenu& menu)
@@ -526,8 +520,7 @@ bool MDIViewPage::addSelectionGroups(QMenu& menu)
     bool added = false;
     auto ctx = getSelectionContext();
 
-    if (!Gui::Selection().getObjectsOfType(
-            TechDraw::DrawViewDimension::getClassTypeId()).empty()) {
+    if (hasSelectionOfType<TechDraw::DrawViewDimension>()) {
         addCommandsByName(menu, {
             "TechDraw_ExtensionIncreaseDecimal",
             "TechDraw_ExtensionDecreaseDecimal",
@@ -548,8 +541,7 @@ bool MDIViewPage::addSelectionGroups(QMenu& menu)
         added = true;
     }
 
-    if (!Gui::Selection().getObjectsOfType(
-            TechDraw::DrawViewBalloon::getClassTypeId()).empty()) {
+    if (hasSelectionOfType<TechDraw::DrawViewBalloon>()) {
         if (addCommandsByName(menu, {
                 "TechDraw_ExtensionCustomizeFormat",
             }) > 0) {
@@ -558,8 +550,7 @@ bool MDIViewPage::addSelectionGroups(QMenu& menu)
         }
     }
 
-    if (!Gui::Selection().getObjectsOfType(
-            TechDraw::DrawLeaderLine::getClassTypeId()).empty()) {
+    if (hasSelectionOfType<TechDraw::DrawLeaderLine>()) {
         if (addCommandsByName(menu, {
                 "TechDraw_WeldSymbol",
             }) > 0) {
@@ -603,9 +594,8 @@ bool MDIViewPage::addSelectionGroups(QMenu& menu)
         added = true;
     }
 
-    if (hasWholeViewPartSelected()) {
-        if (!Gui::Selection().getObjectsOfType(
-                TechDraw::DrawViewSection::getClassTypeId()).empty()) {
+    if (hasWholeSelectionOf<TechDraw::DrawViewPart>()) {
+        if (hasSelectionOfType<TechDraw::DrawViewSection>()) {
             if (addCommandsByName(menu, {
                     "TechDraw_ExtensionPositionSectionView",
                 }) > 0) {
@@ -622,7 +612,7 @@ bool MDIViewPage::addSelectionGroups(QMenu& menu)
         }
     }
 
-    if (hasWholeDrawViewSelected()) {
+    if (hasWholeSelectionOf<TechDraw::DrawView>()) {
         if (addCommandsByName(menu, {
                 "TechDraw_StackTop",
                 "TechDraw_StackBottom",
@@ -679,6 +669,27 @@ int MDIViewPage::addCommandsByName(QMenu& menu,
 MDIViewPage::SelectionContext MDIViewPage::getSelectionContext()
 {
     SelectionContext ctx;
+
+    auto fillContextForEdge = [&ctx](TechDraw::DrawViewPart* dvp, const std::string& sub) {
+        if (dvp && dvp->isCosmeticEdge(sub)) {
+            ctx.hasCosmeticEdge = true;
+            return;
+        }
+
+        ctx.hasGeomEdge = true;
+        if (!dvp) {
+            return;
+        }
+
+        int idx = TechDraw::DrawUtil::getIndexFromName(sub);
+        TechDraw::BaseGeomPtr geom = dvp->getGeomByIndex(idx);
+        if (geom
+            && (geom->getGeomType() == TechDraw::GeomType::CIRCLE
+                || geom->getGeomType() == TechDraw::GeomType::ARCOFCIRCLE)) {
+            ctx.hasCircleEdge = true;
+        }
+    };
+
     for (auto& sel : Gui::Selection().getSelectionEx()) {
         auto* dvp = dynamic_cast<TechDraw::DrawViewPart*>(sel.getObject());
         for (auto& sub : sel.getSubNames()) {
@@ -687,22 +698,11 @@ MDIViewPage::SelectionContext MDIViewPage::getSelectionContext()
                 ctx.hasFace = true;
             }
             else if (geomType == "Edge") {
-                if (dvp && dvp->isCosmeticEdge(sub)) {
-                    ctx.hasCosmeticEdge = true;
-                } else {
-                    ctx.hasGeomEdge = true;
-                    if (dvp) {
-                        int idx = TechDraw::DrawUtil::getIndexFromName(sub);
-                        TechDraw::BaseGeomPtr geom = dvp->getGeomByIndex(idx);
-                        if (geom && (geom->getGeomType() == TechDraw::GeomType::CIRCLE
-                                  || geom->getGeomType() == TechDraw::GeomType::ARCOFCIRCLE)) {
-                            ctx.hasCircleEdge = true;
-                        }
-                    }
-                }
+                fillContextForEdge(dvp, sub);
             }
         }
     }
+
     return ctx;
 }
 

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -71,6 +71,7 @@ public:
     void selectQGIView(App::DocumentObject *obj, bool isSelected, const std::vector<std::string> &subNames);
     void clearSceneSelection();
     void blockSceneSelection(bool isBlocked);
+    void selectOnRightPress(QGraphicsItem* item);
 
     bool onMsg(const char* pMsg) override;
     bool onHasMsg(const char* pMsg) const override;
@@ -143,6 +144,19 @@ protected:
     void sceneSelectionManager();
 
 private:
+    struct SelectionContext {
+        bool hasFace = false;
+        bool hasGeomEdge = false;
+        bool hasCosmeticEdge = false;
+        bool hasCircleEdge = false;
+    };
+
+    static SelectionContext getSelectionContext();
+
+    bool addSelectionGroups(QMenu& menu);
+    void addPageGroup(QMenu& menu);
+    int addCommandsByName(QMenu& menu, std::initializer_list<const char*> names);
+
     using Connection = fastsignals::connection;
     Connection connectDeletedObject;
 

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -476,6 +476,15 @@ void QGVPage::mousePressEvent(QMouseEvent* event)
         toolHandler->mousePressEvent(event);
     }
     else {
+        if (event->button() == Qt::RightButton && m_parentMDI) {
+            if (QGraphicsItem* item = itemAt(event->pos())) {
+                m_parentMDI->selectOnRightPress(item);
+            }
+            m_navStyle->handleMousePressEvent(event);
+            // do not call base class because it would clear the 
+            // selection on right click
+            return;
+        }
         m_navStyle->handleMousePressEvent(event);
     }
     QGraphicsView::mousePressEvent(event);


### PR DESCRIPTION
TechDraw workbench currently does not have contextually aware context menus.

This PR:
- Adds context-aware context menus
- Adds icons and checkboxes to existing commands in the context menu
- Changes right clicking logic such that it adds to the selection, but never removes from selection (same as Sketcher WB).
- ~~Removes the following from the toolbar:~~
   - ~~Dimension Repair~~
   - ~~Lock/Unlock View~~
   - ~~Position Section View~~
   - ~~Increase/Decrease Decimals~~
   - ~~Show All Edges~~
   - ~~Stack Group~~

Notes:
1) Commands only appear in the context menu when they are applicable to the current selection.
2) If uses has both a balloon and a dimension in current selection, then right clicks, commands for both balloons and dimension will be shown. It is up to the commands themselves to grab what they need from selection.
3) Context menus focus on modifiing existing objects, not creating new ones. Open for discussion whether we want dimensions to be an exception (I already have **Area Annotation** as a command for the face context menu).

---

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: Claude Sonnet 4.6

## Issues
Fixes https://github.com/FreeCAD/FreeCAD/issues/21306 in `QGVPage.cpp`
I couldn't find any other existing issues.

## Demo Video
https://youtu.be/ye-y2Ql6Rxw

## Context Menu Commands

| Selection | Commands |
|-----------|----------|
| **Dimension** | Increase Decimal Places, Decrease Decimal Places, Customize Format, Insert Ø Prefix, Insert □ Prefix, Insert n× Prefix, Remove Prefix, Dimension Repair |
| **Balloon** | Customize Format |
| **Leader Line** | Add Weld Symbol |
| **Face** | Area Dimension, Hatch, Geometric Hatch |
| **Circular Edge** | Circle Center Lines |
| **Any Edge** | Decorate Line |
| **Cosmetic Edge** | Extend Line, Shorten Line |
| **View** (section only) | Position Section View |
| **View** | Show All, Lock/Unlock View |
| **Any View** | Stack Top, Stack Bottom, Stack Up, Stack Down |
| **Empty page** | Toggle Grid, Toggle Frames, Toggle Keep Updated, Export SVG, Export DXF, Export PDF, Print All |
