### PR TITLE
[TD]fix Balloon positioning

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewBalloon.h
+++ b/src/Mod/TechDraw/App/DrawViewBalloon.h
@@ -83,6 +83,8 @@ public:
 
     App::PropertyLink *getOwnerProperty() override { return &SourceView; }
 
+    bool snapsToPosition() const override { return false; }
+
 protected:
     void onChanged(const App::Property* prop) override;
     void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName,

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -131,7 +131,7 @@ public:
     bool isInnerView() const { return m_innerView; }
     void isInnerView(bool state) { m_innerView = state; }
     QGIViewClip* getClipGroup();
-    void updatePositionFromFeatureXY();
+    virtual void updatePositionFromFeatureXY();
 
     bool isSnapping() { return snapping; }
     void snapPosition(QPointF& position);

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -330,7 +330,6 @@ bool QGIViewBalloon::getGroupSelection()
 //Set selection state for this and its children
 void QGIViewBalloon::setGroupSelection(bool isSelected)
 {
-    //    Base::Console().message("QGIVB::setGroupSelection(%d)\n", b);
     setSelected(isSelected);
     balloonLabel->setSelected(isSelected);
     balloonLines->setSelected(isSelected);
@@ -340,7 +339,6 @@ void QGIViewBalloon::setGroupSelection(bool isSelected)
 
 void QGIViewBalloon::select(bool state)
 {
-    //    Base::Console().message("QGIVBall::select(%d)\n", state);
     setSelected(state);
     draw();
 }
@@ -353,7 +351,6 @@ void QGIViewBalloon::hover(bool state)
 
 void QGIViewBalloon::setViewPartFeature(TechDraw::DrawViewBalloon* balloonFeat)
 {
-    //    Base::Console().message("QGIVB::setViewPartFeature()\n");
     if (!balloonFeat) {
         return;
     }
@@ -447,9 +444,14 @@ void QGIViewBalloon::updateBalloon(bool obtuse)
     }
 
     balloonLabel->setDimString(labelText, Rez::guiX(balloon->TextWrapLen.getValue()));
-    float x = Rez::guiX(balloon->X.getValue() * refObj->getScale());
-    float y = Rez::guiX(balloon->Y.getValue() * refObj->getScale());
-    balloonLabel->setPosFromCenter(x, -y);
+
+    if (balloon->X.isTouched() || balloon->Y.isTouched()) {
+        float x = Rez::guiX(balloon->X.getValue() * refObj->getScale());
+        float y = Rez::guiX(balloon->Y.getValue() * refObj->getScale());
+        balloonLabel->setPosFromCenter(x, -y);
+    }
+
+
 }
 
 void QGIViewBalloon::balloonLabelDragged(bool originDrag)
@@ -541,8 +543,6 @@ void QGIViewBalloon::balloonLabelDragFinished()
 //from QGVP::mouseReleaseEvent - pos = eventPos in scene coords?
 void QGIViewBalloon::placeBalloon(QPointF pos)
 {
-    //    Base::Console().message("QGIVB::placeBalloon(%s)\n",
-    //                            DrawUtil::formatVector(pos).c_str());
     auto balloon(dynamic_cast<TechDraw::DrawViewBalloon*>(getViewObject()));
     if (!balloon) {
         return;
@@ -1017,6 +1017,16 @@ void QGIViewBalloon::getBalloonPoints(TechDraw::DrawViewBalloon* balloon, DrawVi
     }
     labelPos = Base::Vector3d(x, y, 0.0);
     arrowPos = arrowTipPosInParent;
+}
+
+//! get the X&Y position from the feature in parent coords, convert to Qt coords and update
+//! this graphic item's scene position.
+// Since balloon positioning is different from shape views, we don't want to use
+// QGIView::updatePositionFromFeatureXY here.
+void QGIViewBalloon::updatePositionFromFeatureXY()
+{
+    //TODO: opportunity to use this method to centralize positioning logic from
+    //      QGIViewBalloon::placeBalloon(), QGSPage::createBalloon(), etc.
 }
 
 #include <Mod/TechDraw/Gui/moc_QGIViewBalloon.cpp>

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.h
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.h
@@ -201,6 +201,8 @@ public:
     TechDraw::ArrowType prefDefaultArrow() const;
     bool prefOrthoPyramid() const;
 
+    void updatePositionFromFeatureXY() override;
+
     TechDraw::DrawViewBalloon* getBalloonFeat()
     {
         return dvBalloon;


### PR DESCRIPTION
This PR implements a fix for issue #30734. The issue was introduced by PR #30154 which neglected to special case the handling of Balloons. 

Balloons are positioned within a parent view, while other views are positioned on the page. The fix overrides the default view position setting logic in QGIView which does not apply to balloons.

Note that Leader Lines also require special positioning and may require a similar change in a separate PR.

before change:
<img width="592" height="658" alt="BalloonShifts_before" src="https://github.com/user-attachments/assets/4bfa1250-3aca-4c0a-b264-6d2e9dc5c626" />

after change:
<img width="783" height="757" alt="BalloonShifts_after" src="https://github.com/user-attachments/assets/9051069a-38e4-4ced-b28e-f67b5ca9594a" />
