### PR TITLE
CAM: get object by name

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/Array.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Array.py
@@ -76,7 +76,8 @@ class CommandPathDressupArray:
         # everything ok!
         FreeCAD.ActiveDocument.openTransaction("Create Path Array Dress-up")
         FreeCADGui.addModule("Path.Dressup.Gui.Array")
-        FreeCADGui.doCommand("Path.Dressup.Gui.Array.Create(App.ActiveDocument.%s)" % op.Name)
+        FreeCADGui.doCommand(f"base = FreeCAD.ActiveDocument.getObject('{op.Name}')")
+        FreeCADGui.doCommand("Path.Dressup.Gui.Array.Create(base)")
         # FreeCAD.ActiveDocument.commitTransaction()  # Final `commitTransaction()` called via TaskPanel.accept()
         FreeCAD.ActiveDocument.recompute()
 

--- a/src/Mod/CAM/Path/Dressup/Gui/AxisMap.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/AxisMap.py
@@ -280,7 +280,7 @@ class CommandPathDressup:
             'obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", "AxisMapDressup")'
         )
         FreeCADGui.doCommand("Path.Dressup.Gui.AxisMap.ObjectDressup(obj)")
-        FreeCADGui.doCommand("base = FreeCAD.ActiveDocument." + op.Name)
+        FreeCADGui.doCommand(f"base = FreeCAD.ActiveDocument.getObject('{op.Name}')")
         FreeCADGui.doCommand("job = PathScripts.PathUtils.findParentJob(base)")
         FreeCADGui.doCommand("obj.Base = base")
         FreeCADGui.doCommand("job.Proxy.addOperation(obj, base)")

--- a/src/Mod/CAM/Path/Dressup/Gui/Boundary.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Boundary.py
@@ -292,7 +292,8 @@ class CommandPathDressupPathBoundary:
         # everything ok!
         FreeCAD.ActiveDocument.openTransaction("Create Path Boundary Dress-up")
         FreeCADGui.addModule("Path.Dressup.Gui.Boundary")
-        FreeCADGui.doCommand("Path.Dressup.Gui.Boundary.Create(App.ActiveDocument.%s)" % op.Name)
+        FreeCADGui.doCommand(f"base = FreeCAD.ActiveDocument.getObject('{op.Name}')")
+        FreeCADGui.doCommand("Path.Dressup.Gui.Boundary.Create(base)")
         # FreeCAD.ActiveDocument.commitTransaction()  # Final `commitTransaction()` called via TaskPanel.accept()
         FreeCAD.ActiveDocument.recompute()
 

--- a/src/Mod/CAM/Path/Dressup/Gui/DogboneII.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/DogboneII.py
@@ -249,7 +249,8 @@ class SelObserver(object):
         PST.clear()
 
     def addSelection(self, doc, obj, sub, pnt):
-        FreeCADGui.doCommand("Gui.Selection.addSelection(FreeCAD.ActiveDocument." + obj + ")")
+        FreeCADGui.doCommand(f"obj = FreeCAD.ActiveDocument.getObject('{obj}')")
+        FreeCADGui.doCommand("Gui.Selection.addSelection(obj)")
         FreeCADGui.updateGui()
 
 
@@ -347,9 +348,8 @@ class CommandDressupDogboneII(object):
         # everything ok!
         FreeCAD.ActiveDocument.openTransaction("Create Dogbone Dress-up")
         FreeCADGui.addModule("Path.Dressup.Gui.DogboneII")
-        FreeCADGui.doCommand(
-            "Path.Dressup.Gui.DogboneII.Create(FreeCAD.ActiveDocument.%s)" % op.Name
-        )
+        FreeCADGui.doCommand(f"base = FreeCAD.ActiveDocument.getObject('{op.Name}')")
+        FreeCADGui.doCommand("Path.Dressup.Gui.DogboneII.Create(base)")
         # FreeCAD.ActiveDocument.commitTransaction()  # Final `commitTransaction()` called via TaskPanel.accept()
         FreeCAD.ActiveDocument.recompute()
 

--- a/src/Mod/CAM/Path/Dressup/Gui/Dragknife.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Dragknife.py
@@ -613,14 +613,14 @@ class CommandDressupDragknife:
             'obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython","DragknifeDressup")'
         )
         FreeCADGui.doCommand("Path.Dressup.Gui.Dragknife.ObjectDressup(obj)")
-        FreeCADGui.doCommand("base = FreeCAD.ActiveDocument." + op.Name)
+        FreeCADGui.doCommand(f"base = FreeCAD.ActiveDocument.getObject('{op.Name}')")
         FreeCADGui.doCommand("job = PathScripts.PathUtils.findParentJob(base)")
         FreeCADGui.doCommand("obj.Base = base")
         FreeCADGui.doCommand("job.Proxy.addOperation(obj, base)")
         FreeCADGui.doCommand(
             "obj.ViewObject.Proxy = Path.Dressup.Gui.Dragknife.ViewProviderDressup(obj.ViewObject)"
         )
-        FreeCADGui.doCommand("Gui.ActiveDocument.getObject(base.Name).Visibility = False")
+        FreeCADGui.doCommand("base.Visibility = False")
         FreeCADGui.doCommand("obj.filterAngle = 20")
         FreeCADGui.doCommand("obj.offset = 2")
         FreeCADGui.doCommand("obj.pivotheight = 4")

--- a/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
@@ -1743,7 +1743,8 @@ class CommandPathDressup:
         # everything ok!
         App.ActiveDocument.openTransaction("Create LeadInOut Dressup")
         FreeCADGui.addModule("Path.Dressup.Gui.LeadInOut")
-        FreeCADGui.doCommand("Path.Dressup.Gui.LeadInOut.Create(App.ActiveDocument.%s)" % op.Name)
+        FreeCADGui.doCommand(f"base = FreeCAD.ActiveDocument.getObject('{op.Name}')")
+        FreeCADGui.doCommand("Path.Dressup.Gui.LeadInOut.Create(base)")
         # FreeCAD.ActiveDocument.commitTransaction()  # Final `commitTransaction()` called via TaskPanel.accept()
         App.ActiveDocument.recompute()
 

--- a/src/Mod/CAM/Path/Dressup/Gui/Mirror.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Mirror.py
@@ -285,7 +285,7 @@ class CommandPathDressup:
             'obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", "MirrorDressup")'
         )
         FreeCADGui.doCommand("Path.Dressup.Gui.Mirror.ObjectDressup(obj)")
-        FreeCADGui.doCommand("baseOp = FreeCAD.ActiveDocument." + op.Name)
+        FreeCADGui.doCommand(f"baseOp = FreeCAD.ActiveDocument.getObject('{op.Name}')")
         FreeCADGui.doCommand("job = PathScripts.PathUtils.findParentJob(baseOp)")
         FreeCADGui.doCommand("obj.Base = baseOp")
         FreeCADGui.doCommand("job.Proxy.addOperation(obj, baseOp)")

--- a/src/Mod/CAM/Path/Dressup/Gui/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Tags.py
@@ -594,7 +594,8 @@ class CommandPathDressupTag:
         # everything ok!
         FreeCAD.ActiveDocument.openTransaction("Create Tag Dress-up")
         FreeCADGui.addModule("Path.Dressup.Gui.Tags")
-        FreeCADGui.doCommand("Path.Dressup.Gui.Tags.Create(App.ActiveDocument.%s)" % op.Name)
+        FreeCADGui.doCommand(f"base = FreeCAD.ActiveDocument.getObject('{op.Name}')")
+        FreeCADGui.doCommand("Path.Dressup.Gui.Tags.Create(base)")
         # FreeCAD.ActiveDocument.commitTransaction()  # Final `commitTransaction()` called via TaskPanel.accept()
         FreeCAD.ActiveDocument.recompute()
 

--- a/src/Mod/CAM/Path/Dressup/Gui/ZCorrect.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/ZCorrect.py
@@ -399,10 +399,10 @@ class CommandPathDressup:
             'obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", "ZCorrectDressup")'
         )
         FreeCADGui.doCommand("Path.Dressup.Gui.ZCorrect.ObjectDressup(obj)")
-        FreeCADGui.doCommand("obj.Base = FreeCAD.ActiveDocument." + op.Name)
+        FreeCADGui.doCommand(f"obj.Base = FreeCAD.ActiveDocument.getObject('{op.Name}')")
         FreeCADGui.doCommand("Path.Dressup.Gui.ZCorrect.ViewProviderDressup(obj.ViewObject)")
         FreeCADGui.doCommand("PathScripts.PathUtils.addToJob(obj)")
-        FreeCADGui.doCommand("Gui.ActiveDocument.getObject(obj.Base.Name).Visibility = False")
+        FreeCADGui.doCommand("obj.Base.Visibility = False")
         FreeCADGui.doCommand("obj.ViewObject.Document.setEdit(obj.ViewObject, 0)")
         # FreeCAD.ActiveDocument.commitTransaction()  # Final `commitTransaction()` called via TaskPanel.accept()
         FreeCAD.ActiveDocument.recompute()

--- a/src/Mod/CAM/Path/Main/Gui/Inspect.py
+++ b/src/Mod/CAM/Path/Main/Gui/Inspect.py
@@ -285,9 +285,8 @@ class CommandPathInspect:
 
         # if everything is ok, execute
         FreeCADGui.addModule("Path.Main.Gui.Inspect")
-        FreeCADGui.doCommand(
-            "Path.Main.Gui.Inspect.show(FreeCAD.ActiveDocument." + selection[0].Name + ")"
-        )
+        FreeCADGui.doCommand(f"obj = FreeCAD.ActiveDocument.getObject('{selection[0].Name}')")
+        FreeCADGui.doCommand("Path.Main.Gui.Inspect.show(obj)")
 
 
 if FreeCAD.GuiUp:


### PR DESCRIPTION
### Description

**Inspect** window will not open if op name is the same as one of the property name of `FreeCAD.ActiveDocument`

E.g. op **Comment**
`FreeCAD.ActiveDocument` also contains property `Comment`


### Changes

Instead of `FreeCAD.ActiveDocument.Comment`
use `FreeCAD.ActiveDocument.getObject("Comment")`