### PR TITLE
Sketcher/Tests: Make sure the frame is ready before checking for hover

### DIFF
--- a/src/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py
+++ b/src/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py
@@ -221,13 +221,31 @@ class TestExternalFacePreselection(SketcherGuiTestCase):
         view.fitAll()
         self.pump(300)
 
+        face_center_3d = FreeCAD.Vector(0, -20, 10)
+
+        def face_center_is_framed():
+            width, height = view.getSize()
+            if width <= 0 or height <= 0:
+                return False
+            screen_x, screen_y = view.getPointOnScreen(face_center_3d)
+            margin_x = width * 0.1
+            margin_y = height * 0.1
+            return (
+                margin_x < screen_x < width - margin_x and margin_y < screen_y < height - margin_y
+            )
+
+        self.assertTrue(
+            self.wait_until(face_center_is_framed, timeout_ms=5000, step_ms=100),
+            "Camera never framed the Pad face; getPointOnScreen stayed at the "
+            "viewport edge, so no valid interior hover point could be computed.",
+        )
+
         # Activate External Geometry tool
         FreeCADGui.runCommand("Sketcher_Projection", 0)
         self.pump(300)
 
         # Simulate mouse hover over the front face center
         viewport = view.graphicsView().viewport()
-        face_center_3d = FreeCAD.Vector(0, -20, 10)
         screen_pt = view.getPointOnScreen(face_center_3d)
         hover_pos = self.viewport_to_qpoint(view, viewport, screen_pt)
         presel = self.hover_for_preselection(viewport, hover_pos)


### PR DESCRIPTION
We currently have a fragile GUI test that's failing CI intermittently because it's got a hardcoded 300ms wait for the 3D view to finish framing, rather than actually checking to see if it's done. This PR adds a short check to actually wait up to five second for the `view.getPointOnScreen(face_center_3d)` to start returning valid-looking results before actually running the hover test.

See failure here, for example:
https://github.com/FreeCAD/FreeCAD/actions/runs/27893108529/job/82539999899

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.