### PR TITLE
Gui: fix annotation label drag handling and frame rendering

### DIFF
--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -456,6 +456,7 @@ void NavigationStyle::initialize()
     this->button1down = false;
     this->button2down = false;
     this->button3down = false;
+    clearClickCandidateState();
     this->ctrldown = false;
     this->shiftdown = false;
     this->altdown = false;
@@ -1958,11 +1959,16 @@ void NavigationStyle::clearSelectionStartPosition()
     selectionStartPosition.reset();
 }
 
-void NavigationStyle::clearPendingClickEvent()
+void NavigationStyle::recordClickCandidate(const SoMouseButtonEvent* event)
 {
-    mouseDownConsumedEvent.setButton(SoMouseButtonEvent::ANY);
-    // A cleared event must not remain a click candidate for the next double-click check.
-    mouseDownConsumedEvent.setTime(SbTime::zero());
+    clearDeferredMouseDownEvent();
+    lastClickCandidateTime = event->getTime();
+}
+
+void NavigationStyle::clearClickCandidateState()
+{
+    clearDeferredMouseDownEvent();
+    lastClickCandidateTime = SbTime::zero();
 }
 
 int NavigationStyle::selectionMoveThreshold() const
@@ -2029,7 +2035,8 @@ bool NavigationStyle::tryStartBoxSelection(
     }
 
     Gui::Selection().rmvPreselect();
-    clearPendingClickEvent();
+    // A drag is not a click candidate for the next double-click check.
+    clearClickCandidateState();
 
     auto* selection = new BoxSelectSelection(additiveSelection, selectElement);
     selection->setAnchor(startPosition, current);
@@ -2473,30 +2480,54 @@ SbBool NavigationStyle::processClickEvent(const SoMouseButtonEvent* const event)
     SbBool processed = false;
     const SbBool press = event->getState() == SoButtonEvent::DOWN ? true : false;
     if (press) {
-        SbTime tmp = (event->getTime() - mouseDownConsumedEvent.getTime());
-        float dci = (float)QApplication::doubleClickInterval() / 1000.0f;
-        // a double-click?
-        if (tmp.getValue() < dci) {
-            mouseDownConsumedEvent = *event;
-            mouseDownConsumedEvent.setTime(event->getTime());
+        if (isDoubleClickCandidate(event)) {
+            deferMouseDownEvent(event);
             processed = true;
         }
         else {
-            mouseDownConsumedEvent.setTime(event->getTime());
-            // 'ANY' is used to mark that we don't know yet if it will
-            // be a double-click event.
-            mouseDownConsumedEvent.setButton(SoMouseButtonEvent::ANY);
+            recordClickCandidate(event);
         }
     }
     else if (!press) {
-        if (mouseDownConsumedEvent.getButton() == SoMouseButtonEvent::BUTTON1) {
-            // now handle the postponed event
-            NavigationStyle::processSoEvent(&mouseDownConsumedEvent);
-            mouseDownConsumedEvent.setButton(SoMouseButtonEvent::ANY);
-        }
+        replayDeferredMouseDownEvent();
     }
 
     return processed;
+}
+
+bool NavigationStyle::isDoubleClickCandidate(const SoMouseButtonEvent* event) const
+{
+    if (lastClickCandidateTime == SbTime::zero()) {
+        return false;
+    }
+
+    const SbTime elapsed = event->getTime() - lastClickCandidateTime;
+    const auto doubleClickInterval = static_cast<float>(QApplication::doubleClickInterval())
+        / 1000.0F;
+    return elapsed.getValue() < doubleClickInterval;
+}
+
+void NavigationStyle::deferMouseDownEvent(const SoMouseButtonEvent* event)
+{
+    deferredMouseDownEvent = *event;
+    deferredMouseDownEvent.setTime(event->getTime());
+    hasDeferredMouseDownEvent = true;
+    lastClickCandidateTime = event->getTime();
+}
+
+void NavigationStyle::clearDeferredMouseDownEvent()
+{
+    hasDeferredMouseDownEvent = false;
+}
+
+void NavigationStyle::replayDeferredMouseDownEvent()
+{
+    if (!hasDeferredMouseDownEvent) {
+        return;
+    }
+
+    NavigationStyle::processSoEvent(&deferredMouseDownEvent);
+    clearDeferredMouseDownEvent();
 }
 
 SbBool NavigationStyle::processWheelEvent(const SoMouseWheelEvent* const event)

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -23,10 +23,15 @@
 
 
 #include <Inventor/SbViewportRegion.h>
+#include <Inventor/SoEventManager.h>
 #include <Inventor/SoPickedPoint.h>
 #include <Inventor/actions/SoGetBoundingBoxAction.h>
+#include <Inventor/actions/SoHandleEventAction.h>
+#include <Inventor/actions/SoRayPickAction.h>
+#include <Inventor/details/SoNodeKitDetail.h>
 #include <Inventor/draggers/SoDragger.h>
 #include <Inventor/errors/SoDebugError.h>
+#include <Inventor/lists/SoPickedPointList.h>
 #include <Inventor/nodes/SoSeparator.h>
 #include <Inventor/nodes/SoCamera.h>
 #include <Inventor/nodes/SoOrthographicCamera.h>
@@ -64,6 +69,84 @@
 #include "ViewParams.h"
 
 using namespace Gui;
+
+namespace
+{
+
+bool pickedPathContainsDragger(const SoPickedPoint* pick)
+{
+    if (!pick->getPath()) {
+        return false;
+    }
+
+    const auto fullpath = Gui::toFullPath(pick->getPath());
+    for (int i = 0; i < fullpath->getLength(); ++i) {
+        const auto* node = fullpath->getNode(i);
+        if (node->isOfType(SoDragger::getClassTypeId())) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool nodeKitDetailReferencesDragger(const SoDetail* detail)
+{
+    if (!detail || !detail->isOfType(SoNodeKitDetail::getClassTypeId())) {
+        return false;
+    }
+
+    const auto* nodeKitDetail = static_cast<const SoNodeKitDetail*>(detail);
+    const auto* nodeKit = nodeKitDetail->getNodeKit();
+    return nodeKit && nodeKit->isOfType(SoDragger::getClassTypeId());
+}
+
+bool pickedNodeKitOwnerIsDragger(const SoPickedPoint* pick)
+{
+    if (nodeKitDetailReferencesDragger(pick->getDetail())) {
+        return true;
+    }
+
+    if (!pick->getPath()) {
+        return false;
+    }
+
+    const auto fullpath = Gui::toFullPath(pick->getPath());
+    for (int i = 0; i < fullpath->getLength(); ++i) {
+        if (nodeKitDetailReferencesDragger(pick->getDetail(fullpath->getNode(i)))) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool pickedPointBelongsToDragger(const SoPickedPoint* pick)
+{
+    return pick && (pickedPathContainsDragger(pick) || pickedNodeKitOwnerIsDragger(pick));
+}
+
+bool sceneGraphHasEventGrabber(View3DInventorViewer* viewer)
+{
+    if (!viewer) {
+        return false;
+    }
+
+    auto* manager = viewer->getSoEventManager();
+    if (!manager) {
+        return false;
+    }
+
+    auto* action = manager->getHandleEventAction();
+    return action && action->getGrabber();
+}
+
+bool isLeftButtonPress(const SoEvent* const ev)
+{
+    return SoMouseButtonEvent::isButtonPressEvent(ev, SoMouseButtonEvent::BUTTON1);
+}
+
+}  // namespace
 
 class FCSphereSheetProjector: public SbSphereSheetProjector
 {
@@ -1875,6 +1958,13 @@ void NavigationStyle::clearSelectionStartPosition()
     selectionStartPosition.reset();
 }
 
+void NavigationStyle::clearPendingClickEvent()
+{
+    mouseDownConsumedEvent.setButton(SoMouseButtonEvent::ANY);
+    // A cleared event must not remain a click candidate for the next double-click check.
+    mouseDownConsumedEvent.setTime(SbTime::zero());
+}
+
 int NavigationStyle::selectionMoveThreshold() const
 {
     return QApplication::startDragDistance();
@@ -1923,6 +2013,10 @@ bool NavigationStyle::tryStartBoxSelection(
     if (viewer->isEditing() || viewer->isEditingViewProvider()) {
         return false;
     }
+    // An active grabber means an Inventor node already owns this drag stream.
+    if (sceneGraphHasEventGrabber(viewer)) {
+        return false;
+    }
 
     const SbVec2s current = ev->getPosition();
     const SbVec2f movedBy(current - startPosition);
@@ -1935,8 +2029,7 @@ bool NavigationStyle::tryStartBoxSelection(
     }
 
     Gui::Selection().rmvPreselect();
-    mouseDownConsumedEvent.setButton(SoMouseButtonEvent::ANY);
-    mouseDownConsumedEvent.setTime(ev->getTime());
+    clearPendingClickEvent();
 
     auto* selection = new BoxSelectSelection(additiveSelection, selectElement);
     selection->setAnchor(startPosition, current);
@@ -1954,14 +2047,16 @@ bool NavigationStyle::isDraggerUnderCursor(const SbVec2s pos) const
     SoRayPickAction rp(this->viewer->getSoRenderManager()->getViewportRegion());
     rp.setRadius(viewer->getPickRadius());
     rp.setPoint(pos);
+    rp.setPickAll(true);
     rp.apply(sceneGraph);
-    SoPickedPoint* pick = rp.getPickedPoint();
-    if (pick) {
-        const auto fullpath = Gui::toFullPath(pick->getPath());
-        for (int i = 0; i < fullpath->getLength(); ++i) {
-            if (fullpath->getNode(i)->isOfType(SoDragger::getClassTypeId())) {
-                return true;
-            }
+
+    // Dragger surrogate parts can be arbitrary scene paths set via setPartAsPath().
+    // In that case the picked path need not contain the dragger, but Coin keeps the
+    // owning nodekit in SoNodeKitDetail.
+    const SoPickedPointList& picks = rp.getPickedPointList();
+    for (int i = 0; i < picks.getLength(); ++i) {
+        if (pickedPointBelongsToDragger(picks[i])) {
+            return true;
         }
     }
 
@@ -2180,6 +2275,11 @@ SbBool NavigationStyle::processSoEvent(const SoEvent* const ev)
 
     if (!processed && !offeredtoViewerEventBase) {
         processed = viewer->processSoEventBase(ev);
+    }
+    if (processed && isLeftButtonPress(ev) && currentmode == NavigationStyle::SELECTION) {
+        // A handled press gives the scene graph ownership of this pointer stream.
+        clearSelectionStartPosition();
+        setViewingMode(NavigationStyle::INTERACT);
     }
 
     return processed;

--- a/src/Gui/Navigation/NavigationStyle.h
+++ b/src/Gui/Navigation/NavigationStyle.h
@@ -356,6 +356,7 @@ protected:
     void updateSelectionStartPosition(SbBool press, const SbVec2s& position);
     void setSelectionStartPosition(const SbVec2s& position);
     void clearSelectionStartPosition();
+    void clearPendingClickEvent();
     bool handleSelectionDragMotion(
         const SoLocation2Event* const ev,
         ViewerMode& newmode,

--- a/src/Gui/Navigation/NavigationStyle.h
+++ b/src/Gui/Navigation/NavigationStyle.h
@@ -346,6 +346,12 @@ private:
     bool getObjectBoundingSphere(SbSphere& sphere) const;
     bool getObjectBoundingBoxCenter(SbVec3f& center) const;
     void applyOrbitDragCameraConstraints(const OrbitDragState& state);
+    bool isDoubleClickCandidate(const SoMouseButtonEvent* event) const;
+    void deferMouseDownEvent(const SoMouseButtonEvent* event);
+    void clearDeferredMouseDownEvent();
+    void replayDeferredMouseDownEvent();
+    void recordClickCandidate(const SoMouseButtonEvent* event);
+    void clearClickCandidateState();
 
 protected:
     void clearLog();
@@ -356,7 +362,6 @@ protected:
     void updateSelectionStartPosition(SbBool press, const SbVec2s& position);
     void setSelectionStartPosition(const SbVec2s& position);
     void clearSelectionStartPosition();
-    void clearPendingClickEvent();
     bool handleSelectionDragMotion(
         const SoLocation2Event* const ev,
         ViewerMode& newmode,
@@ -384,7 +389,9 @@ protected:
     NavigationAnimator* animator;
     SbBool animationEnabled;
     ViewerMode currentmode;
-    SoMouseButtonEvent mouseDownConsumedEvent;
+    SoMouseButtonEvent deferredMouseDownEvent;
+    bool hasDeferredMouseDownEvent {false};
+    SbTime lastClickCandidateTime;
     SbVec2f lastmouseposition;
     SbVec2s globalPos;
     SbVec2s localPos;

--- a/src/Gui/Navigation/TinkerCADNavigationStyle.cpp
+++ b/src/Gui/Navigation/TinkerCADNavigationStyle.cpp
@@ -134,10 +134,6 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent* const ev)
                 // If we are in edit mode then simply ignore the RMB events
                 // to pass the event to the base class.
                 this->button2down = press;
-                if (press) {
-                    mouseDownConsumedEvent = *event;
-                    mouseDownConsumedEvent.setTime(ev->getTime());
-                }
 
                 // About to start rotating
                 if (press && (curmode == NavigationStyle::IDLE)) {

--- a/src/Gui/ViewProviderAnnotation.cpp
+++ b/src/Gui/ViewProviderAnnotation.cpp
@@ -41,6 +41,7 @@
 #include <Inventor/nodes/SoPickStyle.h>
 #include <Inventor/nodes/SoPointSet.h>
 #include <Inventor/nodes/SoRotationXYZ.h>
+#include <Inventor/nodes/SoSeparator.h>
 #include <Inventor/nodes/SoText2.h>
 #include <Inventor/nodes/SoTranslation.h>
 
@@ -64,6 +65,31 @@
 
 
 using namespace Gui;
+
+namespace
+{
+
+SoSeparator* createLabelDragHandle(SoImage* image, SoImage* hitProxy)
+{
+    auto* handle = new SoSeparator();
+    auto* pickStyle = new SoPickStyle();
+    pickStyle->style = SoPickStyle::BOUNDING_BOX_ON_TOP;
+    handle->addChild(pickStyle);
+    handle->addChild(hitProxy);
+
+    // Let the transparent proxy own picking for the full label bounds.
+    // The rendered image is visual-only so it cannot compete with the dragger path.
+    auto* visual = new SoSeparator();
+    auto* visualPickStyle = new SoPickStyle();
+    visualPickStyle->style = SoPickStyle::UNPICKABLE;
+    visual->addChild(visualPickStyle);
+    visual->addChild(image);
+    handle->addChild(visual);
+
+    return handle;
+}
+
+}  // namespace
 
 const char* ViewProviderAnnotation::JustificationEnums[] = {"Left", "Right", "Center", nullptr};
 const char* ViewProviderAnnotation::RotationAxisEnums[] = {"X", "Y", "Z", nullptr};
@@ -292,6 +318,8 @@ ViewProviderAnnotationLabel::ViewProviderAnnotationLabel()
     pCoords->ref();
     pImage = new SoImage();
     pImage->ref();
+    pImageHitProxy = new SoImage();
+    pImageHitProxy->ref();
 
     BackgroundColor.touch();
 
@@ -305,6 +333,7 @@ ViewProviderAnnotationLabel::~ViewProviderAnnotationLabel()
     pTextTranslation->unref();
     pCoords->unref();
     pImage->unref();
+    pImageHitProxy->unref();
 }
 
 void ViewProviderAnnotationLabel::onChanged(const App::Property* prop)
@@ -358,7 +387,7 @@ void ViewProviderAnnotationLabel::attach(App::DocumentObject* f)
     pickStyleObj->style = SoPickStyle::SHAPE_ON_TOP;
     textsep->addChild(pickStyleObj);
     textsep->addChild(pBaseTranslation);
-    textsep->addChild(pImage);
+    textsep->addChild(createLabelDragHandle(pImage, pImageHitProxy));
 
     // image with line
     SoSeparator* linesep = new SoAnnotation();
@@ -366,24 +395,32 @@ void ViewProviderAnnotationLabel::attach(App::DocumentObject* f)
     pickStyleLine->style = SoPickStyle::SHAPE_ON_TOP;
     linesep->addChild(pickStyleLine);
     linesep->addChild(pBaseTranslation);
-    linesep->addChild(pColor);
-    linesep->addChild(pCoords);
-    linesep->addChild(new SoLineSet());
+
+    // Keep the leader as visual-only so it cannot steal label-corner drags.
+    auto lineVisual = new SoSeparator();
+    auto linePickStyle = new SoPickStyle();
+    linePickStyle->style = SoPickStyle::UNPICKABLE;
+    lineVisual->addChild(linePickStyle);
+    lineVisual->addChild(pColor);
+    lineVisual->addChild(pCoords);
+    lineVisual->addChild(new SoLineSet());
     auto ds = new SoDrawStyle();
     ds->pointSize.setValue(3.0f);
-    linesep->addChild(ds);
-    linesep->addChild(new SoPointSet());
+    lineVisual->addChild(ds);
+    lineVisual->addChild(new SoPointSet());
+    linesep->addChild(lineVisual);
+
     linesep->addChild(pTextTranslation);
-    linesep->addChild(pImage);
+    linesep->addChild(createLabelDragHandle(pImage, pImageHitProxy));
 
     addDisplayMaskMode(linesep, "Line");
     addDisplayMaskMode(textsep, "Object");
 
-    // Use the image node as the transform handle
+    // Use the image bounds as the transform handle
     SoSearchAction sa;
     sa.setInterest(SoSearchAction::FIRST);
     sa.setSearchingAll(true);
-    sa.setNode(this->pImage);
+    sa.setNode(this->pImageHitProxy);
     sa.apply(pcRoot);
     SoPath* imagePath = sa.getPath();
     if (imagePath) {
@@ -471,6 +508,7 @@ void ViewProviderAnnotationLabel::drawImage(const std::vector<std::string>& s)
 {
     if (s.empty()) {
         pImage->image = SoSFImage();
+        pImageHitProxy->image = SoSFImage();
         this->hide();
         return;
     }
@@ -526,4 +564,11 @@ void ViewProviderAnnotationLabel::drawImage(const std::vector<std::string>& s)
     SoSFImage sfimage;
     Gui::BitmapFactory().convert(image, sfimage);
     pImage->image = sfimage;
+
+    QImage hitProxy(image.size(), QImage::Format_ARGB32_Premultiplied);
+    hitProxy.fill(Qt::transparent);
+
+    SoSFImage sfHitProxy;
+    Gui::BitmapFactory().convert(hitProxy, sfHitProxy);
+    pImageHitProxy->image = sfHitProxy;
 }

--- a/src/Gui/ViewProviderAnnotation.cpp
+++ b/src/Gui/ViewProviderAnnotation.cpp
@@ -89,6 +89,32 @@ SoSeparator* createLabelDragHandle(SoImage* image, SoImage* hitProxy)
     return handle;
 }
 
+bool projectPointerToPlane(
+    SoDragger& drag,
+    const Base::Vector3d& planePoint,
+    const Base::Vector3d& planeNormal,
+    Base::Vector3d& intersection
+)
+{
+    const SoEvent* event = drag.getEvent();
+    if (!event) {
+        return false;
+    }
+
+    SbViewVolume viewVolume = drag.getViewVolume();
+    SbLine pointerLine;
+    viewVolume.projectPointToLine(event->getNormalizedPosition(drag.getViewportRegion()), pointerLine);
+
+    SbVec3f point;
+    const SbPlane dragPlane(Base::convertTo<SbVec3f>(planeNormal), Base::convertTo<SbVec3f>(planePoint));
+    if (!dragPlane.intersect(pointerLine, point)) {
+        return false;
+    }
+
+    intersection = Base::convertTo<Base::Vector3d>(point);
+    return true;
+}
+
 }  // namespace
 
 const char* ViewProviderAnnotation::JustificationEnums[] = {"Left", "Right", "Center", nullptr};
@@ -457,16 +483,44 @@ void ViewProviderAnnotationLabel::updateData(const App::Property* prop)
 }
 
 
-void ViewProviderAnnotationLabel::dragStartCallback(void*, SoDragger*)
+void ViewProviderAnnotationLabel::dragStartCallback(void* data, SoDragger* drag)
 {
+    auto that = static_cast<ViewProviderAnnotationLabel*>(data);
+    that->dragState.reset();
+    if (auto* obj = that->getObject<App::AnnotationLabel>()) {
+        const Base::Vector3d basePosition = obj->BasePosition.getValue();
+        const Base::Vector3d startTextPosition = obj->TextPosition.getValue();
+        const Base::Vector3d pickedPoint = Base::convertTo<Base::Vector3d>(
+            drag->getWorldStartingPoint()
+        );
+
+        DragState state;
+        state.basePosition = basePosition;
+        state.currentTextPosition = startTextPosition;
+        state.pickOffset = pickedPoint - (basePosition + startTextPosition);
+        state.planePoint = pickedPoint;
+        state.planeNormal = Base::convertTo<Base::Vector3d>(
+            drag->getViewVolume().getProjectionDirection()
+        );
+        that->dragState = state;
+    }
+
     // This is called when a manipulator is about to manipulating
     Gui::Application::Instance->activeDocument()->openCommand(
         QT_TRANSLATE_NOOP("Command", "Transform")
     );
 }
 
-void ViewProviderAnnotationLabel::dragFinishCallback(void*, SoDragger*)
+void ViewProviderAnnotationLabel::dragFinishCallback(void* data, SoDragger*)
 {
+    auto that = static_cast<ViewProviderAnnotationLabel*>(data);
+    if (that->dragState) {
+        if (auto* obj = that->getObject<App::AnnotationLabel>()) {
+            obj->TextPosition.setValue(that->dragState->currentTextPosition);
+        }
+        that->dragState.reset();
+    }
+
     // This is called when a manipulator has done manipulating
     Gui::Application::Instance->activeDocument()->commitCommand();
 }
@@ -474,34 +528,22 @@ void ViewProviderAnnotationLabel::dragFinishCallback(void*, SoDragger*)
 void ViewProviderAnnotationLabel::dragMotionCallback(void* data, SoDragger* drag)
 {
     auto that = static_cast<ViewProviderAnnotationLabel*>(data);
-    if (auto* obj = that->getObject<App::AnnotationLabel>()) {
-        Base::Vector3d basepos = obj->BasePosition.getValue();
-        Base::Vector3d textpos = obj->TextPosition.getValue();
-
-        auto globalText = Base::convertTo<SbVec3f>(basepos + textpos);
-        SbVec3f pnt = drag->getWorldStartingPoint();
-        // difference between the label's origin and the picked point
-        SbVec3f move = pnt - globalText;
-
-        SbViewVolume vv = drag->getViewVolume();
-        SbVec3f normal = vv.getProjectionDirection();
-
-        SbPlane plane(normal, pnt);
-
-        const SoEvent* ev = drag->getEvent();
-        const SbViewportRegion& vpr = drag->getViewportRegion();
-
-        SbLine line;
-        vv.projectPointToLine(ev->getNormalizedPosition(vpr), line);
-
-        SbVec3f intersect;
-        plane.intersect(line, intersect);
-        drag->setStartingPoint(intersect);
-
-        auto text = Base::convertTo<Base::Vector3d>(intersect - move);
-        text = text - basepos;
-        obj->TextPosition.setValue(text);
+    if (!that->dragState) {
+        return;
     }
+
+    DragState& state = *that->dragState;
+    Base::Vector3d pointerPosition;
+    if (projectPointerToPlane(*drag, state.planePoint, state.planeNormal, pointerPosition)) {
+        that->previewTextPosition(state, pointerPosition - state.pickOffset - state.basePosition);
+    }
+}
+
+void ViewProviderAnnotationLabel::previewTextPosition(DragState& state, const Base::Vector3d& textPosition)
+{
+    state.currentTextPosition = textPosition;
+    pCoords->point.set1Value(1, SbVec3f(textPosition.x, textPosition.y, textPosition.z));
+    pTextTranslation->translation.setValue(textPosition.x, textPosition.y, textPosition.z);
 }
 
 void ViewProviderAnnotationLabel::drawImage(const std::vector<std::string>& s)

--- a/src/Gui/ViewProviderAnnotation.cpp
+++ b/src/Gui/ViewProviderAnnotation.cpp
@@ -573,17 +573,23 @@ void ViewProviderAnnotationLabel::drawImage(const std::vector<std::string>& s)
         lines << line;
     }
 
-    QImage image(w + 10, h + 10, QImage::Format_ARGB32_Premultiplied);
+    constexpr int textPadding = 5;
+    constexpr qreal frameWidth = 2.0;
+    constexpr qreal cornerRadius = 5.0;
+
+    QImage image(w + 2 * textPadding, h + 2 * textPadding, QImage::Format_ARGB32_Premultiplied);
     image.fill(0x00000000);
     QPainter painter(&image);
     painter.setRenderHint(QPainter::Antialiasing);
 
     bool drawFrame = this->Frame.getValue();
     if (drawFrame) {
-        painter.setPen(QPen(QColor(0, 0, 127), 2, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+        painter.setPen(QPen(QColor(0, 0, 127), frameWidth, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
         painter.setBrush(QBrush(brush, Qt::SolidPattern));
-        QRectF rectangle(0.0, 0.0, w + 10, h + 10);
-        painter.drawRoundedRect(rectangle, 5, 5);
+        const QRectF rectangle
+            = QRectF(image.rect())
+                  .adjusted(frameWidth / 2.0, frameWidth / 2.0, -frameWidth / 2.0, -frameWidth / 2.0);
+        painter.drawRoundedRect(rectangle, cornerRadius, cornerRadius);
     }
 
     painter.setPen(front);
@@ -600,7 +606,7 @@ void ViewProviderAnnotationLabel::drawImage(const std::vector<std::string>& s)
     }
     QString text = lines.join(QLatin1String("\n"));
     painter.setFont(font);
-    painter.drawText(5, 5, w, h, align, text);
+    painter.drawText(textPadding, textPadding, w, h, align, text);
     painter.end();
 
     SoSFImage sfimage;

--- a/src/Gui/ViewProviderAnnotation.h
+++ b/src/Gui/ViewProviderAnnotation.h
@@ -25,6 +25,8 @@
 
 #include "ViewProviderDocumentObject.h"
 #include <App/PropertyUnits.h>
+#include <Base/Vector3D.h>
+#include <optional>
 #include "SoTextLabel.h"
 
 class SoFont;
@@ -116,12 +118,25 @@ private:
     static void dragMotionCallback(void* data, SoDragger* d);
 
 private:
+    struct DragState
+    {
+        Base::Vector3d basePosition;
+        Base::Vector3d currentTextPosition;
+        Base::Vector3d pickOffset;
+        Base::Vector3d planePoint;
+        Base::Vector3d planeNormal;
+    };
+
+    void previewTextPosition(DragState& state, const Base::Vector3d& textPosition);
+
+private:
     SoCoordinate3* pCoords;
     SoImage* pImage;
     SoImage* pImageHitProxy;
     SoBaseColor* pColor;
     SoTranslation* pBaseTranslation;
     TranslateManip* pTextTranslation;
+    std::optional<DragState> dragState;
 
     static const char* JustificationEnums[];
 };

--- a/src/Gui/ViewProviderAnnotation.h
+++ b/src/Gui/ViewProviderAnnotation.h
@@ -118,6 +118,7 @@ private:
 private:
     SoCoordinate3* pCoords;
     SoImage* pImage;
+    SoImage* pImageHitProxy;
     SoBaseColor* pColor;
     SoTranslation* pBaseTranslation;
     TranslateManip* pTextTranslation;

--- a/src/Mod/Test/TestRubberbandSelection.py
+++ b/src/Mod/Test/TestRubberbandSelection.py
@@ -299,6 +299,35 @@ class TestRubberbandSelection(unittest.TestCase):
                     "A fast drag after box selection must still deliver its press to the viewer",
                 )
 
+    def test_annotation_label_corner_drag_reaches_dragger(self):
+        self._ensure_selection_objects()
+        FreeCADGui.Selection.clearSelection()
+        self.view.setNavigationType("Gui::CADNavigationStyle")
+
+        label = self.doc.addObject("App::AnnotationLabel", "DragLabel")
+        label.LabelText = ["Drag me"]
+        label.BasePosition = FreeCAD.Vector(0, 0, 0)
+        label.TextPosition = FreeCAD.Vector(0, 0, 0)
+        self.doc.recompute()
+        label.ViewObject.DisplayMode = "Line"
+        label.ViewObject.FontSize = 18
+        label.ViewObject.Frame = True
+        label.ViewObject.BackgroundColor = (1.0, 1.0, 0.25, 0.0)
+        label.ViewObject.TextColor = (0.0, 0.0, 0.0, 0.0)
+        self._refresh_view()
+
+        bounds = self._annotation_label_bounds()
+        start = QtCore.QPoint(bounds.left() + 4, bounds.bottom() - 4)
+        end = start + QtCore.QPoint(80, -30)
+
+        self._drag_path(start, end)
+
+        self.assertNotEqual(
+            label.TextPosition,
+            FreeCAD.Vector(0, 0, 0),
+            "Dragging from the annotation label corner should move the annotation",
+        )
+
     def test_cubic_bezier_drag_release_is_not_stolen_when_selection_is_disabled(self):
         try:
             from draftguitools import gui_beziers
@@ -394,6 +423,38 @@ class TestRubberbandSelection(unittest.TestCase):
 
     def _selection_rect(self, obj):
         return self._object_rect(obj, pad=18)
+
+    def _annotation_label_bounds(self):
+        self._process_events()
+        image = self.viewer.grabFramebuffer()
+        min_x = image.width()
+        min_y = image.height()
+        max_x = -1
+        max_y = -1
+
+        for y in range(image.height()):
+            for x in range(image.width()):
+                color = image.pixelColor(x, y)
+                if color.red() > 190 and color.green() > 190 and color.blue() < 140:
+                    min_x = min(min_x, x)
+                    min_y = min(min_y, y)
+                    max_x = max(max_x, x)
+                    max_y = max(max_y, y)
+
+        if max_x < 0:
+            self.fail("Could not find the rendered annotation label")
+
+        image_to_widget_x = self.viewport.width() / image.width()
+        image_to_widget_y = self.viewport.height() / image.height()
+        top_left = QtCore.QPoint(
+            round(min_x * image_to_widget_x),
+            round(min_y * image_to_widget_y),
+        )
+        bottom_right = QtCore.QPoint(
+            round(max_x * image_to_widget_x),
+            round(max_y * image_to_widget_y),
+        )
+        return QtCore.QRect(top_left, bottom_right)
 
     def _ensure_selection_objects(self):
         if self.left_box and self.right_box:

--- a/src/Mod/Test/TestRubberbandSelection.py
+++ b/src/Mod/Test/TestRubberbandSelection.py
@@ -216,6 +216,89 @@ class TestRubberbandSelection(unittest.TestCase):
                     "Viewer callbacks should receive drag motion before box selection starts",
                 )
 
+    def test_scene_graph_handled_press_keeps_release(self):
+        for label, style in self.VIEWER_HANDOFF_STYLES:
+            with self.subTest(style=label):
+                FreeCADGui.Selection.clearSelection()
+                self.view.setNavigationType(style)
+                self._refresh_view()
+
+                state = {"presses": 0, "releases": 0}
+
+                def on_button(event_callback):
+                    event = event_callback.getEvent()
+                    if event.getButton() != coin.SoMouseButtonEvent.BUTTON1:
+                        return
+                    if event.getState() == coin.SoButtonEvent.DOWN:
+                        state["presses"] += 1
+                    else:
+                        state["releases"] += 1
+                    event_callback.setHandled()
+
+                button_callback = self.view.addEventCallbackPivy(
+                    coin.SoMouseButtonEvent.getClassTypeId(),
+                    on_button,
+                )
+
+                try:
+                    start = self.viewport.rect().center() + QtCore.QPoint(-60, 0)
+                    end = start + QtCore.QPoint(90, 0)
+                    self._drag_path(start, end)
+                finally:
+                    self.view.removeEventCallbackPivy(
+                        coin.SoMouseButtonEvent.getClassTypeId(),
+                        button_callback,
+                    )
+
+                self.assertEqual(state["presses"], 1)
+                self.assertEqual(
+                    state["releases"],
+                    1,
+                    "Box selection must not steal release after the scene graph handles press",
+                )
+
+    def test_box_select_does_not_swallow_next_viewer_press(self):
+        for label, style in self.VIEWER_HANDOFF_STYLES:
+            with self.subTest(style=label):
+                FreeCADGui.Selection.clearSelection()
+                self.view.setNavigationType(style)
+                self._refresh_view()
+
+                first_start = self.viewport.rect().center() + QtCore.QPoint(-120, 0)
+                first_end = first_start + QtCore.QPoint(90, 0)
+                self._drag_path(first_start, first_end)
+
+                state = {"presses": 0}
+
+                def on_button(event_callback):
+                    event = event_callback.getEvent()
+                    if event.getButton() != coin.SoMouseButtonEvent.BUTTON1:
+                        return
+                    if event.getState() == coin.SoButtonEvent.DOWN:
+                        state["presses"] += 1
+                    event_callback.setHandled()
+
+                button_callback = self.view.addEventCallbackPivy(
+                    coin.SoMouseButtonEvent.getClassTypeId(),
+                    on_button,
+                )
+
+                try:
+                    second_start = self.viewport.rect().center() + QtCore.QPoint(-20, 0)
+                    second_end = second_start + QtCore.QPoint(90, 0)
+                    self._drag_path(second_start, second_end)
+                finally:
+                    self.view.removeEventCallbackPivy(
+                        coin.SoMouseButtonEvent.getClassTypeId(),
+                        button_callback,
+                    )
+
+                self.assertEqual(
+                    state["presses"],
+                    1,
+                    "A fast drag after box selection must still deliver its press to the viewer",
+                )
+
     def test_cubic_bezier_drag_release_is_not_stolen_when_selection_is_disabled(self):
         try:
             from draftguitools import gui_beziers


### PR DESCRIPTION
This fixes two related annotation label issues observed while testing box selection and annotation dragging.

**1.**
Annotation labels could still trigger erroneous box selection when dragging from parts of the label, especially the lower-left corner. In Line display mode that corner can overlap the leader line or endpoint, so picking could resolve to the leader geometry instead of the label dragger. When that happened, the scene graph did not own the drag stream and rubber-band selection could start.

The fix changes the handoff between box selection and interactive scene objects. If a drag starts on something that can already handle the drag, such as an annotation label dragger, box selection now stays out of the way.

For annotation labels specifically, the whole label rectangle is now the drag target. The rendered label and its leader line are still visible, but they no longer compete with the dragger for mouse presses. This prevents the leader line or endpoint from accidentally turning a label drag into a box selection.

The click tracking was also cleaned up so a completed box selection does not confuse the next quick click-drag as part of a double-click sequence.

**2.**
This also fixes a separate label rendering artifact. The rounded label frame was painted directly on the texture edge with a 2 px pen, which clipped half of the antialiased stroke. Insetting the frame by half the pen width keeps the full border inside the texture and prevents the background fill from appearing outside the rounded corner.

https://github.com/user-attachments/assets/93740734-2356-4dec-8e32-438bf5e2f806

