### PR TITLE
Gui: fit view when `GuiDocument.xml` is missing

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -90,6 +90,7 @@ struct DocumentP
     bool _isModified;
     bool _isTransacting;
     bool _isActive;
+    bool _restoredGuiDocument;
     bool _changeViewTouchDocument;
     bool _editWantsRestore;
     bool _editWantsRestorePrevious;
@@ -436,6 +437,7 @@ Document::Document(App::Document* pcDocument, Application* app)
     d->_isModified = false;
     d->_isTransacting = false;
     d->_isActive = false;
+    d->_restoredGuiDocument = false;
     d->_pcAppWnd = app;
     d->_pcDocument = pcDocument;
     d->_editViewProvider = nullptr;
@@ -1915,6 +1917,7 @@ void Document::Save(Base::Writer& writer) const
  */
 void Document::Restore(Base::XMLReader& reader)
 {
+    d->_restoredGuiDocument = false;
     reader.addFile("GuiDocument.xml", this);
 
     // hide all elements to avoid to update the 3d view when loading data files
@@ -1931,6 +1934,8 @@ void Document::Restore(Base::XMLReader& reader)
  */
 void Document::RestoreDocFile(Base::Reader& reader)
 {
+    d->_restoredGuiDocument = true;
+
     // We must create an XML parser to read from the input stream
     std::shared_ptr<Base::XMLReader> localreader
         = std::make_shared<Base::XMLReader>("GuiDocument.xml", reader);
@@ -2051,6 +2056,15 @@ void Document::slotFinishRestoreDocument(const App::Document& doc)
         ViewProvider* viewProvider = getViewProvider(act);
         if (viewProvider && viewProvider->isDerivedFrom<ViewProviderDocumentObject>()) {
             signalActivatedObject(*(static_cast<ViewProviderDocumentObject*>(viewProvider)));
+        }
+    }
+
+    if (!d->_restoredGuiDocument) {
+        for (auto* mdiView : getMDIViews()) {
+            if (auto* view3D = freecad_cast<View3DInventor*>(mdiView)) {
+                view3D->viewAll();
+                break;
+            }
         }
     }
 

--- a/src/Mod/Test/GuiDocument.py
+++ b/src/Mod/Test/GuiDocument.py
@@ -22,6 +22,7 @@
 ***************************************************************************/"""
 
 import os
+import tempfile
 import threading
 import time
 import unittest
@@ -43,7 +44,8 @@ class TestGuiDocument(unittest.TestCase):
 
     def tearDown(self):
         # Close the document
-        FreeCAD.closeDocument("TestDoc")
+        if self.doc is not None and self.doc.Name in FreeCAD.listDocuments():
+            FreeCAD.closeDocument(self.doc.Name)
 
     def _findAutoSaver(self):
         app = QtWidgets.QApplication.instance()
@@ -94,6 +96,22 @@ class TestGuiDocument(unittest.TestCase):
             if expected_label is not None:
                 document_xml = recovery.read("Document.xml").decode("utf-8", errors="replace")
                 self.assertIn(expected_label, document_xml)
+
+    def _writeArchiveWithoutGuiDocument(self, source_path, target_path):
+        with zipfile.ZipFile(source_path, "r") as source:
+            self.assertIn("Document.xml", source.namelist())
+            self.assertIn("GuiDocument.xml", source.namelist())
+
+            with zipfile.ZipFile(target_path, "w") as target:
+                for item in source.infolist():
+                    if item.filename == "GuiDocument.xml":
+                        continue
+
+                    target.writestr(item, source.read(item.filename))
+
+        with zipfile.ZipFile(target_path, "r") as target:
+            self.assertIn("Document.xml", target.namelist())
+            self.assertNotIn("GuiDocument.xml", target.namelist())
 
     def testGetTreeRootObject(self):
         # Create objects at the root level
@@ -197,6 +215,67 @@ class TestGuiDocument(unittest.TestCase):
         self.assertTrue(FreeCAD.writeRecoverySnapshotToTransientDir(self.doc))
 
         self._assertRecoveryArchiveContains()
+
+    def testRestoreWithoutGuiDocumentFitsViewAndRestoresVisibility(self):
+        try:
+            from pivy import coin  # noqa: F401
+        except ImportError as exc:
+            raise unittest.SkipTest(f"Coin bindings are unavailable: {exc}") from exc
+
+        try:
+            import Part  # noqa: F401
+        except ImportError as exc:
+            raise unittest.SkipTest(f"Part workbench objects are unavailable: {exc}") from exc
+
+        visible_box = self.doc.addObject("Part::Box", "VisibleBox")
+        hidden_cylinder = self.doc.addObject("Part::Cylinder", "HiddenCylinder")
+
+        visible_box.Length = 25
+        visible_box.Width = 20
+        visible_box.Height = 15
+        visible_box.Placement.Base = FreeCAD.Vector(80, 35, 45)
+        visible_box.Visibility = True
+        visible_box.ViewObject.Visibility = True
+
+        hidden_cylinder.Radius = 5
+        hidden_cylinder.Height = 20
+        hidden_cylinder.Placement.Base = FreeCAD.Vector(120, 50, 55)
+        hidden_cylinder.Visibility = False
+        hidden_cylinder.ViewObject.Visibility = False
+
+        self.doc.recompute()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_path = os.path.join(temp_dir, "with_gui_document.FCStd")
+            target_path = os.path.join(temp_dir, "without_gui_document.FCStd")
+
+            self.doc.saveAs(source_path)
+            self._writeArchiveWithoutGuiDocument(source_path, target_path)
+
+            FreeCAD.closeDocument(self.doc.Name)
+            self.doc = None
+
+            restored_doc = FreeCAD.openDocument(target_path)
+            self.doc = restored_doc
+            try:
+                FreeCAD.setActiveDocument(restored_doc.Name)
+
+                view = FreeCADGui.getDocument(restored_doc.Name).ActiveView
+                self.assertIsNotNone(view)
+
+                self.assertTrue(restored_doc.VisibleBox.ViewObject.Visibility)
+                self.assertFalse(restored_doc.HiddenCylinder.Visibility)
+                self.assertFalse(restored_doc.HiddenCylinder.ViewObject.Visibility)
+
+                def cameraIsFitted():
+                    position = view.getCameraNode().position.getValue().getValue()
+                    return sum(abs(component) for component in position) > 10.0
+
+                self.assertTrue(self._processEventsUntil(cameraIsFitted), view.getCamera())
+            finally:
+                if self.doc is not None and self.doc.Name in FreeCAD.listDocuments():
+                    FreeCAD.closeDocument(self.doc.Name)
+                self.doc = None
 
     def testAutoSaverFlushWritesRecoverySnapshot(self):
         obj = self.doc.addObject("App::FeaturePython", "AutoSaveGuiObject")


### PR DESCRIPTION
Fixes #28714.

## Problem

Some `.FCStd` files are created by headless or CLI workflows and contain `Document.xml` without `GuiDocument.xml`. When those files are opened in the GUI, object visibility can be restored from the application document state, but there is no saved GUI camera state to restore. The result is a document whose visible geometry is present but may remain outside the default 3D view until the user manually runs a fit-view command.

## Fix

This change tracks whether `GuiDocument.xml` was actually restored during GUI document loading. If restore finishes without a GUI document, FreeCAD schedules a `viewAll()` on the first 3D view.

The delayed call lets document restore and view-provider synchronization finish first, then frames the loaded geometry. Normal documents that include `GuiDocument.xml` continue to use their saved GUI state and are not refit.

## Test

Added a GUI regression test that creates a normal `.FCStd`, strips only `GuiDocument.xml`, reopens it, and verifies that:

- visible geometry remains visible
- hidden geometry remains hidden
- the 3D camera is moved from the default framing

