### PR TITLE
CAM: SelectLoop - recompute

### DIFF
--- a/src/Mod/CAM/PathCommands.py
+++ b/src/Mod/CAM/PathCommands.py
@@ -80,6 +80,7 @@ class _CommandSelectLoop:
         newSelection = []
         for sel in selection:
             obj = sel.Object
+            obj.recompute()  # need in some cases to get identical hash codes
             subs = sel.SubObjects
             edges = None
             names = None


### PR DESCRIPTION
[hash_code.zip](https://github.com/user-attachments/files/29206272/hash_code.zip)

The model in attached project give different hash codes for the same shapes
This breaks logic of **SelectLoop** tool

To solve the issue need to recompute the object

Thanks help from [forum](https://forum.freecad.org/viewtopic.php?t=106022)

<img width="734" height="254" alt="Screenshot_20260620_154709_lossy" src="https://github.com/user-attachments/assets/5ba8d21d-ec27-4ffe-873e-f1f892c135c5" />
