### PR TITLE
Assembly : Handle deletion of body gracefully when clicking on the view

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1509,14 +1509,17 @@ std::vector<SelectionObject> getDeleteSelection()
     std::vector<std::pair<App::DocumentObject*, std::vector<std::string>>> redirected;
 
     auto redirect = [&redirected](App::DocumentObject* root, const char* selectedSubName) {
-        auto* obj = findDeleteTarget(root, selectedSubName);
+        App::ElementNamePair elementName;
+        auto* obj = root;
         std::string subName;
-        if (!obj) {
-            obj = root;
-            if (selectedSubName && selectedSubName[0]) {
-                App::ElementNamePair elementName;
-                obj = App::GeoFeature::resolveElement(root, selectedSubName, elementName);
-                subName = elementName.oldName;
+        if (selectedSubName && selectedSubName[0]) {
+            obj = App::GeoFeature::resolveElement(root, selectedSubName, elementName);
+            subName = elementName.oldName;
+        }
+        if (!subName.empty()) {
+            if (auto* target = findDeleteTarget(root, selectedSubName)) {
+                obj = target;
+                subName.clear();
             }
         }
         if (!obj) {

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1477,6 +1477,90 @@ bool StdCmdSelectAll::isActive()
 //===========================================================================
 // Std_Delete
 //===========================================================================
+namespace
+{
+
+App::DocumentObject* findDeleteTarget(App::DocumentObject* root, const char* subName)
+{
+    if (!root) {
+        return nullptr;
+    }
+
+    for (auto* context : root->getSubObjectList(subName)) {
+        auto* obj = context ? context->getLinkedObject(true) : nullptr;
+        auto* vp = obj ? Application::Instance->getViewProvider(obj) : nullptr;
+        if (vp) {
+            if (auto* target = vp->getDeleteTarget(context)) {
+                return target;
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+std::vector<SelectionObject> getDeleteSelection()
+{
+    auto selections = Selection().getSelectionEx(
+        nullptr,
+        App::DocumentObject::getClassTypeId(),
+        ResolveMode::NoResolve
+    );
+    std::vector<std::pair<App::DocumentObject*, std::vector<std::string>>> redirected;
+
+    auto redirect = [&redirected](App::DocumentObject* root, const char* selectedSubName) {
+        auto* obj = findDeleteTarget(root, selectedSubName);
+        std::string subName;
+        if (!obj) {
+            obj = root;
+            if (selectedSubName && selectedSubName[0]) {
+                App::ElementNamePair elementName;
+                obj = App::GeoFeature::resolveElement(root, selectedSubName, elementName);
+                subName = elementName.oldName;
+            }
+        }
+        if (!obj) {
+            return;
+        }
+
+        auto existing = std::ranges::find(redirected, obj, [](const auto& item) {
+            return item.first;
+        });
+        if (existing == redirected.end()) {
+            existing = redirected.insert(redirected.end(), {obj, {}});
+        }
+        if (!subName.empty()
+            && std::ranges::find(existing->second, subName) == existing->second.end()) {
+            existing->second.push_back(subName);
+        }
+    };
+
+    for (auto& selection : selections) {
+        auto* root = selection.getObject();
+        if (!root) {
+            continue;
+        }
+
+        if (selection.getSubNames().empty()) {
+            redirect(root, nullptr);
+        }
+        else {
+            for (const auto& subName : selection.getSubNames()) {
+                redirect(root, subName.c_str());
+            }
+        }
+    }
+
+    std::vector<SelectionObject> result;
+    result.reserve(redirected.size());
+    for (auto& [obj, subNames] : redirected) {
+        result.emplace_back(obj, std::move(subNames));
+    }
+    return result;
+}
+
+}  // namespace
+
 DEF_STD_CMD_A(StdCmdDelete)
 
 StdCmdDelete::StdCmdDelete()
@@ -1562,7 +1646,7 @@ void StdCmdDelete::activated(int iMsg)
         if (!deletedSelectionOfEditDocument) {
             std::set<QString> affectedLabels;
             bool more = false;
-            auto sels = Selection().getSelectionEx();
+            auto sels = getDeleteSelection();
             bool autoDeletion = true;
             bool forceDeletion = false;
             for (auto& sel : sels) {

--- a/src/Gui/Selection/SelectionObject.cpp
+++ b/src/Gui/Selection/SelectionObject.cpp
@@ -54,6 +54,11 @@ SelectionObject::SelectionObject(const Gui::SelectionChanges& msg)
 }
 
 SelectionObject::SelectionObject(const App::DocumentObject* obj)
+    : SelectionObject(obj, {})
+{}
+
+SelectionObject::SelectionObject(const App::DocumentObject* obj, std::vector<std::string> subNames)
+    : SubNames(std::move(subNames))
 {
     FeatName = obj->getNameInDocument();
     DocName = obj->getDocument()->getName();

--- a/src/Gui/Selection/SelectionObject.h
+++ b/src/Gui/Selection/SelectionObject.h
@@ -53,6 +53,8 @@ public:
      */
     explicit SelectionObject(const SelectionChanges& msg);
     explicit SelectionObject(const App::DocumentObject*);
+    SelectionObject(const App::DocumentObject*, std::vector<std::string> subNames);
+
     ~SelectionObject() override;
     /**
      * The default implementation returns an instance of @ref SelectionObjectPy.

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -753,6 +753,11 @@ bool ViewProvider::onDelete(const vector<string>& subNames)
     return del;
 }
 
+App::DocumentObject* ViewProvider::getDeleteTarget(App::DocumentObject*) const
+{
+    return nullptr;
+}
+
 bool ViewProvider::canDelete(App::DocumentObject*) const
 {
     return false;

--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -367,6 +367,16 @@ public:
      * @return          true if the deletion is approved by the view provider.
      */
     virtual bool onDelete(const std::vector<std::string>& subNames);
+    /** Allow a view provider to redirect deletion of a selected subobject path.
+     *
+     * The delete command calls this for each object in the selected path. The
+     * view provider belongs to the resolved object, while \a context is the
+     * corresponding object in the selection's document (for example, a Link).
+     *
+     * @return the object that should be deleted, or nullptr to use the normal
+     *         selection resolution.
+     */
+    virtual App::DocumentObject* getDeleteTarget(App::DocumentObject* context) const;
     /** Called before deletion
      *
      * Unlike onDelete(), this function is guaranteed to be called before

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -223,6 +223,35 @@ bool ViewProviderBody::isActiveBody()
     }
 }
 
+App::DocumentObject* ViewProviderBody::getDeleteTarget(App::DocumentObject* context) const
+{
+    auto* activeView = Gui::Application::Instance->activeView();
+    if (!activeView) {
+        return context;
+    }
+
+    App::DocumentObject* activeParent = nullptr;
+    std::string activeSubName;
+    auto* activeBody = activeView->getActiveObject<PartDesign::Body*>(
+        PDBODYKEY,
+        &activeParent,
+        &activeSubName
+    );
+    if (activeBody != getObject() || !activeParent) {
+        return context;
+    }
+
+    // getActiveObject() resolves links, so compare the stored activation path
+    // to distinguish two Link instances that reference the same Body.
+    for (auto* obj : activeParent->getSubObjectList(activeSubName.c_str())) {
+        if (obj && obj->getLinkedObject(true) == activeBody) {
+            return obj == context ? nullptr : context;
+        }
+    }
+
+    return context;
+}
+
 void ViewProviderBody::toggleActiveBody()
 {
     if (isActiveBody()) {

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -232,11 +232,8 @@ App::DocumentObject* ViewProviderBody::getDeleteTarget(App::DocumentObject* cont
 
     App::DocumentObject* activeParent = nullptr;
     std::string activeSubName;
-    auto* activeBody = activeView->getActiveObject<PartDesign::Body*>(
-        PDBODYKEY,
-        &activeParent,
-        &activeSubName
-    );
+    auto* activeBody
+        = activeView->getActiveObject<PartDesign::Body*>(PDBODYKEY, &activeParent, &activeSubName);
     if (activeBody != getObject() || !activeParent) {
         return context;
     }

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.h
@@ -72,6 +72,7 @@ public:
     void setOverrideMode(const std::string& mode) override;
 
     bool onDelete(const std::vector<std::string>&) override;
+    App::DocumentObject* getDeleteTarget(App::DocumentObject* context) const override;
 
     /// Update the children's highlighting when triggered
     void updateData(const App::Property* prop) override;


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/27740 by doing : 

- If body (or linkToBody) is active, then delete works as it does now. ie selection = Body.Pad001.Face3 deletes Pad001
- If body (or linkToBody) is not active, then whatever is selected, delete the whole body (or linkToBody).

Explanation video : 

https://github.com/user-attachments/assets/fd82e32e-8b72-470f-9e36-cb41a7fc7bcf


