### PR TITLE
Sketcher: fix out-of-bounds read rendering the edit-mode axis cross

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -1543,6 +1543,13 @@ void EditModeCoinManager::createEditModeInventorNodes()
 
     editModeScenegraphNodes.RootCrossCoordinate = new SoCoordinate3;
     editModeScenegraphNodes.RootCrossCoordinate->setName("RootCrossCoordinate");
+    // The cross is two lines (H and V axes); RootCrossSet->numVertices is set to {2, 2}
+    // in EditModeGeometryCoinManager, i.e. 4 coordinates. updateAxesLength() fills the
+    // real positions later, but it runs from a camera-update handler, not before the
+    // first render. Pre-size the coordinate buffer to 4 so the line set can never read
+    // past it (a fresh SoCoordinate3 holds a single default point), which otherwise
+    // causes an out-of-bounds read in SoLineSet::GLRender on entering edit mode.
+    editModeScenegraphNodes.RootCrossCoordinate->point.setNum(4);
     crossRoot->addChild(editModeScenegraphNodes.RootCrossCoordinate);
 
     editModeScenegraphNodes.RootCrossSet = new SoLineSet;

--- a/src/Mod/Sketcher/SketcherTests/TestSketchEditModeAxisCrossGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketchEditModeAxisCrossGui.py
@@ -81,9 +81,7 @@ class SketchEditModeAxisCrossTest(unittest.TestCase):
         view = FreeCADGui.ActiveDocument.ActiveView
         root = view.getViewer().getSceneGraph()
 
-        line_set = _find_node_by_name(
-            root, coin.SoLineSet.getClassTypeId(), "RootCrossLineSet"
-        )
+        line_set = _find_node_by_name(root, coin.SoLineSet.getClassTypeId(), "RootCrossLineSet")
         coordinate = _find_node_by_name(
             root, coin.SoCoordinate3.getClassTypeId(), "RootCrossCoordinate"
         )

--- a/src/Mod/Sketcher/SketcherTests/TestSketchEditModeAxisCrossGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketchEditModeAxisCrossGui.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Regression test for the Sketcher edit-mode axis-cross out-of-bounds crash.
+
+Entering a sketch's edit mode builds the edit-mode scene graph. The axis cross
+(``RootCrossLineSet``) declares ``numVertices = {2, 2}`` (i.e. four coordinates
+for the two axis lines), but its coordinate node was only populated later by
+``updateAxesLength()`` -- which runs from a camera-update handler, not before the
+first render. A freshly created ``SoCoordinate3`` holds a single default point, so
+the first render read past the coordinate array in ``SoLineSet::GLRender`` (a heap
+out-of-bounds read that crashed FreeCAD, often surfacing at an unrelated allocation).
+
+This test enters edit mode and asserts the cross line set never claims more
+vertices than its coordinate node provides.
+"""
+
+import unittest
+
+import FreeCAD
+import FreeCADGui
+import Part
+import Sketcher
+
+try:
+    from pivy import coin
+
+    PIVY_AVAILABLE = True
+except ImportError:
+    PIVY_AVAILABLE = False
+
+
+def _find_node_by_name(root, type_id, name):
+    sa = coin.SoSearchAction()
+    sa.setType(type_id)
+    sa.setInterest(coin.SoSearchAction.ALL)
+    sa.apply(root)
+    paths = sa.getPaths()
+    for i in range(paths.getLength()):
+        node = paths[i].getTail()
+        node_name = node.getName().getString() if node.getName() else ""
+        if node_name == name:
+            return node
+    return None
+
+
+class SketchEditModeAxisCrossTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not FreeCAD.GuiUp:
+            raise unittest.SkipTest("Cannot run GUI tests in a CLI environment.")
+        if not PIVY_AVAILABLE:
+            raise unittest.SkipTest("pivy (coin) not available.")
+
+    def setUp(self):
+        self.doc = FreeCAD.newDocument("AxisCrossEditModeTest")
+
+    def tearDown(self):
+        try:
+            FreeCADGui.ActiveDocument.resetEdit()
+        except Exception:
+            pass
+        FreeCAD.closeDocument(self.doc.Name)
+
+    def test_axis_cross_coordinate_buffer_is_sufficient(self):
+        """Entering edit mode must not leave the axis cross with fewer
+        coordinates than its numVertices claims (would read out of bounds)."""
+        sketch = self.doc.addObject("Sketcher::SketchObject", "Sketch")
+        line0 = sketch.addGeometry(
+            Part.LineSegment(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(10, 0, 0)), False
+        )
+        line1 = sketch.addGeometry(
+            Part.LineSegment(FreeCAD.Vector(0, 5, 0), FreeCAD.Vector(10, 5, 0)), False
+        )
+        # Point-to-line distance: the configuration that triggered the crash.
+        sketch.addConstraint(Sketcher.Constraint("Distance", line1, 1, line0, 0, 5.0))
+        self.doc.recompute()
+
+        FreeCADGui.ActiveDocument.setEdit(sketch.Name)
+        FreeCADGui.updateGui()
+
+        view = FreeCADGui.ActiveDocument.ActiveView
+        root = view.getViewer().getSceneGraph()
+
+        line_set = _find_node_by_name(
+            root, coin.SoLineSet.getClassTypeId(), "RootCrossLineSet"
+        )
+        coordinate = _find_node_by_name(
+            root, coin.SoCoordinate3.getClassTypeId(), "RootCrossCoordinate"
+        )
+        self.assertIsNotNone(line_set, "RootCrossLineSet not found in edit scene graph")
+        self.assertIsNotNone(coordinate, "RootCrossCoordinate not found in edit scene graph")
+
+        num_vertices = line_set.numVertices
+        claimed = sum(num_vertices[i] for i in range(num_vertices.getNum()))
+        available = coordinate.point.getNum()
+
+        self.assertLessEqual(
+            claimed,
+            available,
+            f"RootCrossLineSet claims {claimed} vertices but RootCrossCoordinate "
+            f"provides only {available} points (out-of-bounds read in GLRender).",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/Sketcher/TestSketcherGui.py
+++ b/src/Mod/Sketcher/TestSketcherGui.py
@@ -3,6 +3,7 @@ from SketcherTests.TestConstraintPreselectionGui import SketcherGuiTestCases
 from SketcherTests.TestOnViewParameterGui import TestOnViewParameterGui
 from SketcherTests.TestPlacementUpdate import TestSketchPlacementUpdate
 from SketcherTests.TestExternalFacePreselection import TestExternalFacePreselection
+from SketcherTests.TestSketchEditModeAxisCrossGui import SketchEditModeAxisCrossTest
 
 # Use the module so that code checkers don't complain (flake8)
 (
@@ -11,5 +12,6 @@ from SketcherTests.TestExternalFacePreselection import TestExternalFacePreselect
     and TestSketchPlacementUpdate
     and TestOnViewParameterGui
     and TestExternalFacePreselection
+    and SketchEditModeAxisCrossTest
     else False
 )


### PR DESCRIPTION
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

This PR fixes two related crashes when editing a sketch (originally hit while working with reference dimensions). Both were diagnosed and verified with Guard Malloc.

## Issues
Fixes #30914

## Summary

**1. Out-of-bounds read entering edit mode (axis cross).**
`RootCrossLineSet`'s `numVertices` is set to `{2, 2}` (4 coordinates for the H/V axes) in `EditModeGeometryCoinManager::processGeometry`, but `RootCrossCoordinate` is only filled later by `EditModeCoinManager::updateAxesLength()` (from a camera-update handler, not before the first render). A fresh `SoCoordinate3` holds a single default point, so the first paint reads 4 coordinates from a 1-point buffer → OOB read in `SoLineSet::GLRender`.
Fix: pre-size `RootCrossCoordinate` to 4 points at creation. Includes a GUI regression test.

**2. Use-after-free dragging with driven/reference dimensions.**
The solver caches raw `Constraint*` (`Sketch::Constrs[i].constr`). A managed operation during a drag can replace a `Constraint` object (e.g. a driven/reference dimension whose value updates) without rebuilding the solver, leaving a dangling pointer that the next temporary-move solve dereferences in `Sketch::captureGroupStates()` / `updateNonDrivingConstraints()`. Being a heap UAF, it surfaced at varying unrelated allocations and looked intermittent / like file corruption.
Fix: re-point the solver's cached constraint pointers at the current objects in `SketchObject::moveGeometriesTemporary()`, immediately before each drag solve (lightweight `updateConstraints()` re-sync; constraint count is stable during a drag).

Both verified under Guard Malloc: entering edit mode, and dragging with multiple reference and driving dimensions, no longer fault.

## AI disclosure
Work assisted by Claude Opus 4.8. I reviewed, tested (Guard Malloc), and verified all changes and take responsibility for them.

## Before and After Images
N/A — crash fixes, no visible GUI change.
