### PR TITLE
Fix/sketcher use-after-free bug

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -1279,6 +1279,15 @@ inline int SketchObject::initTemporaryBSplinePieceMove(
 inline int SketchObject::
     moveGeometriesTemporary(std::vector<GeoElementId> geoEltIds, Base::Vector3d toPoint, bool relative /*=false*/)
 {
+    // Re-sync the solver's cached Constraint* before solving: a driven/reference dimension
+    // can replace a Constraint object mid-drag, leaving solvedSketch.Constrs dangling (UAF).
+    const std::vector<Constraint*>& currentConstraints = Constraints.getValues();
+    std::vector<int> constraintIds(currentConstraints.size());
+    for (std::size_t i = 0; i < currentConstraints.size(); ++i) {
+        constraintIds[i] = static_cast<int>(i);
+    }
+    solvedSketch.updateConstraints(constraintIds, currentConstraints);
+
     return solvedSketch.moveGeometries(geoEltIds, toPoint, relative);
 }
 inline int SketchObject::moveGeometryTemporary(int geoId, PointPos pos, Base::Vector3d toPoint, bool relative /*=false*/)


### PR DESCRIPTION
Another update: Since the out-of-bounds bug was fixed by another PR, all that's left is the use-after-free bug.

---

This is an update to my prior PR. The test is removed, the comments are more sensible, and the broken test is removed. Also, hopefully, the CI tests will complete without error.

The contents of the PR are AI generated. I tested and verified the contents.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Two related crashes when editing a sketch (originally hit with reference dimensions). Both diagnosed and verified with Guard Malloc.

Repro (crashes without the fix; open `Sketch015` — sometimes immediately, sometimes after moving points or adding a distance constraint): [drawer.FCStd.zip](https://github.com/user-attachments/files/29216304/drawer.FCStd.zip)

## Issues
Fixes #30914

## Summary

**1. Out-of-bounds read entering edit mode (axis cross).**
`RootCrossLineSet` draws 4 coordinates (H/V axes), but `RootCrossCoordinate` is a fresh `SoCoordinate3` (one default point) until `updateAxesLength()` fills it later from a camera-update handler — so the first render reads past the buffer (`SoLineSet::GLRender`). Fix: pre-size it to 4 points at creation.

**2. Use-after-free dragging with driven/reference dimensions.**
The solver caches raw `Constraint*`. A driven/reference dimension can replace its `Constraint` object mid-drag without rebuilding the solver, leaving a dangling pointer that the next temporary-move solve dereferences (`captureGroupStates()` / `updateNonDrivingConstraints()`). As a heap UAF it surfaced at unrelated allocations and looked intermittent / like file corruption. Fix: re-sync the cached pointers from the current constraint list in `moveGeometriesTemporary()` before each drag solve.

## AI disclosure
Work assisted by Claude Opus 4.8. I reviewed, tested (Guard Malloc), and verified all changes and take responsibility for them.
