### PR TITLE
Gui: add global selection mode filtering for box selection

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -437,6 +437,8 @@ ActionGroup::ActionGroup(Command* pcCmd, QObject* parent)
     , _dropDown(false)
     , _isMode(false)
     , _rememberLast(true)
+    , _hasToolButtonStyle(false)
+    , _toolButtonStyle(Qt::ToolButtonIconOnly)
 {
     _group = new QActionGroup(this);
     connect(_group, &QActionGroup::triggered, this, qOverload<QAction*>(&ActionGroup::onActivated));
@@ -474,6 +476,7 @@ void ActionGroup::addTo(QWidget* widget)
             QToolButton* tb = widget->findChildren<QToolButton*>().constLast();
             tb->setPopupMode(QToolButton::MenuButtonPopup);
             tb->setObjectName(QStringLiteral("qt_toolbutton_menubutton"));
+            updateToolButton(tb);
             QList<QAction*> acts = groupAction()->actions();
             auto menu = new QMenu(tb);
             menu->addActions(acts);
@@ -563,6 +566,60 @@ void ActionGroup::setCheckedAction(int index)
         this->action()->setToolTip(act->toolTip());
     }
     this->setProperty("defaultAction", QVariant(index));
+}
+
+void ActionGroup::setToolButtonStyle(Qt::ToolButtonStyle style)
+{
+    _toolButtonStyle = style;
+    _hasToolButtonStyle = true;
+    updateToolButtons();
+}
+
+void ActionGroup::setToolButtonText(const QString& text)
+{
+    _toolButtonText = text;
+    updateToolButtons();
+}
+
+void ActionGroup::updateToolButtons() const
+{
+    auto updateWidget = [this](QWidget* widget) {
+        if (auto toolbar = qobject_cast<QToolBar*>(widget)) {
+            if (auto button = qobject_cast<QToolButton*>(toolbar->widgetForAction(action()))) {
+                updateToolButton(button);
+            }
+        }
+        else if (auto button = qobject_cast<QToolButton*>(widget)) {
+            updateToolButton(button);
+        }
+    };
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    const auto associatedObjects = action()->associatedObjects();
+    for (auto object : associatedObjects) {
+        if (auto widget = qobject_cast<QWidget*>(object)) {
+            updateWidget(widget);
+        }
+    }
+#else
+    const auto widgets = action()->associatedWidgets();
+    for (auto widget : widgets) {
+        updateWidget(widget);
+    }
+#endif
+}
+
+void ActionGroup::updateToolButton(QToolButton* button) const
+{
+    if (!button) {
+        return;
+    }
+    if (_hasToolButtonStyle) {
+        button->setToolButtonStyle(_toolButtonStyle);
+    }
+    if (!_toolButtonText.isNull()) {
+        button->setText(_toolButtonText);
+    }
 }
 
 /**

--- a/src/Gui/Action.h
+++ b/src/Gui/Action.h
@@ -28,7 +28,10 @@
 #include <QComboBox>
 #include <QKeySequence>
 #include <QMap>
+#include <Qt>
 #include <FCGlobal.h>
+
+class QToolButton;
 
 namespace Gui
 {
@@ -163,6 +166,8 @@ public:
     QList<QAction*> actions() const;
     int checkedAction() const;
     void setCheckedAction(int);
+    void setToolButtonStyle(Qt::ToolButtonStyle style);
+    void setToolButtonText(const QString& text);
 
     QActionGroup* groupAction() const
     {
@@ -182,10 +187,17 @@ Q_SIGNALS:
     void aboutToShow(QMenu*);
 
 private:
+    void updateToolButtons() const;
+    void updateToolButton(QToolButton* button) const;
+
+private:
     QActionGroup* _group;
     bool _dropDown;
     bool _isMode;
     bool _rememberLast;
+    bool _hasToolButtonStyle;
+    Qt::ToolButtonStyle _toolButtonStyle;
+    QString _toolButtonText;
 
 private:
     Q_DISABLE_COPY(ActionGroup)

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -1014,6 +1014,21 @@ int indexFromSelectionFilterMode(SelectionFilterMode mode)
     }
 }
 
+void updateSelectionModeAction(Gui::ActionGroup* actionGroup, SelectionFilterMode mode)
+{
+    if (!actionGroup) {
+        return;
+    }
+
+    const int index = indexFromSelectionFilterMode(mode);
+    actionGroup->setCheckedAction(index);
+
+    const auto actions = actionGroup->actions();
+    if (index >= 0 && index < actions.size()) {
+        actionGroup->setToolButtonText(actions[index]->text());
+    }
+}
+
 }  // namespace
 
 StdCmdSelectionMode::StdCmdSelectionMode()
@@ -1033,6 +1048,7 @@ Gui::Action* StdCmdSelectionMode::createAction()
     auto pcAction = new Gui::ActionGroup(this, Gui::getMainWindow());
     pcAction->setDropDownMenu(true);
     pcAction->setIsMode(true);
+    pcAction->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
     applyCommandData(this->className(), pcAction);
 
     QAction* any = pcAction->addAction(QString());
@@ -1065,7 +1081,6 @@ Gui::Action* StdCmdSelectionMode::createAction()
     face->setObjectName(QStringLiteral("Std_SelectionModeFace"));
     face->setWhatsThis(QString::fromLatin1(getWhatsThis()));
 
-    pcAction->setCheckedAction(indexFromSelectionFilterMode(Selection().getSelectionFilterMode()));
     _pcAction = pcAction;
     languageChange();
     return pcAction;
@@ -1099,6 +1114,8 @@ void StdCmdSelectionMode::languageChange()
 
     actions[4]->setText(QCoreApplication::translate("Std_SelectionMode", "Face"));
     actions[4]->setToolTip(QCoreApplication::translate("Std_SelectionMode", "Only select faces"));
+
+    updateSelectionModeAction(pcAction, Selection().getSelectionFilterMode());
 }
 
 void StdCmdSelectionMode::activated(int iMsg)
@@ -1109,18 +1126,18 @@ void StdCmdSelectionMode::activated(int iMsg)
 
     Selection().setSelectionFilterMode(selectionFilterModeFromIndex(iMsg));
 
-    if (auto actionGroup = qobject_cast<Gui::ActionGroup*>(_pcAction)) {
-        actionGroup->setCheckedAction(iMsg);
-    }
+    updateSelectionModeAction(
+        qobject_cast<Gui::ActionGroup*>(_pcAction),
+        selectionFilterModeFromIndex(iMsg)
+    );
 }
 
 bool StdCmdSelectionMode::isActive()
 {
-    if (auto actionGroup = qobject_cast<Gui::ActionGroup*>(_pcAction)) {
-        actionGroup->setCheckedAction(
-            indexFromSelectionFilterMode(Selection().getSelectionFilterMode())
-        );
-    }
+    updateSelectionModeAction(
+        qobject_cast<Gui::ActionGroup*>(_pcAction),
+        Selection().getSelectionFilterMode()
+    );
     return Gui::Application::Instance->activeDocument();
 }
 

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -958,6 +958,173 @@ bool StdCmdDrawStyle::isActive()
 }
 
 //===========================================================================
+// Std_SelectionMode
+//===========================================================================
+class StdCmdSelectionMode: public Gui::Command
+{
+public:
+    StdCmdSelectionMode();
+    ~StdCmdSelectionMode() override = default;
+    void languageChange() override;
+    const char* className() const override
+    {
+        return "StdCmdSelectionMode";
+    }
+
+protected:
+    void activated(int iMsg) override;
+    bool isActive() override;
+    Gui::Action* createAction() override;
+};
+
+namespace
+{
+
+SelectionFilterMode selectionFilterModeFromIndex(int index)
+{
+    switch (index) {
+        case 1:
+            return SelectionFilterMode::Object;
+        case 2:
+            return SelectionFilterMode::Vertex;
+        case 3:
+            return SelectionFilterMode::Edge;
+        case 4:
+            return SelectionFilterMode::Face;
+        case 0:
+        default:
+            return SelectionFilterMode::Any;
+    }
+}
+
+int indexFromSelectionFilterMode(SelectionFilterMode mode)
+{
+    switch (mode) {
+        case SelectionFilterMode::Object:
+            return 1;
+        case SelectionFilterMode::Vertex:
+            return 2;
+        case SelectionFilterMode::Edge:
+            return 3;
+        case SelectionFilterMode::Face:
+            return 4;
+        case SelectionFilterMode::Any:
+        default:
+            return 0;
+    }
+}
+
+}  // namespace
+
+StdCmdSelectionMode::StdCmdSelectionMode()
+    : Command("Std_SelectionMode")
+{
+    sGroup = "Standard-View";
+    sMenuText = QT_TR_NOOP("Selection Mode");
+    sToolTipText = QT_TR_NOOP("Changes the selection mode");
+    sStatusTip = sToolTipText;
+    sWhatsThis = "Std_SelectionMode";
+    sPixmap = "clear-selection";
+    eType = AlterSelection;
+}
+
+Gui::Action* StdCmdSelectionMode::createAction()
+{
+    auto pcAction = new Gui::ActionGroup(this, Gui::getMainWindow());
+    pcAction->setDropDownMenu(true);
+    pcAction->setIsMode(true);
+    applyCommandData(this->className(), pcAction);
+
+    QAction* any = pcAction->addAction(QString());
+    any->setCheckable(true);
+    any->setIcon(BitmapFactory().iconFromTheme("clear-selection"));
+    any->setObjectName(QStringLiteral("Std_SelectionModeAny"));
+    any->setWhatsThis(QString::fromLatin1(getWhatsThis()));
+
+    QAction* object = pcAction->addAction(QString());
+    object->setCheckable(true);
+    object->setIcon(BitmapFactory().iconFromTheme("Feature"));
+    object->setObjectName(QStringLiteral("Std_SelectionModeObject"));
+    object->setWhatsThis(QString::fromLatin1(getWhatsThis()));
+
+    QAction* vertex = pcAction->addAction(QString());
+    vertex->setCheckable(true);
+    vertex->setIcon(BitmapFactory().iconFromTheme("vertex-selection"));
+    vertex->setObjectName(QStringLiteral("Std_SelectionModeVertex"));
+    vertex->setWhatsThis(QString::fromLatin1(getWhatsThis()));
+
+    QAction* edge = pcAction->addAction(QString());
+    edge->setCheckable(true);
+    edge->setIcon(BitmapFactory().iconFromTheme("edge-selection"));
+    edge->setObjectName(QStringLiteral("Std_SelectionModeEdge"));
+    edge->setWhatsThis(QString::fromLatin1(getWhatsThis()));
+
+    QAction* face = pcAction->addAction(QString());
+    face->setCheckable(true);
+    face->setIcon(BitmapFactory().iconFromTheme("face-selection"));
+    face->setObjectName(QStringLiteral("Std_SelectionModeFace"));
+    face->setWhatsThis(QString::fromLatin1(getWhatsThis()));
+
+    pcAction->setCheckedAction(indexFromSelectionFilterMode(Selection().getSelectionFilterMode()));
+    _pcAction = pcAction;
+    languageChange();
+    return pcAction;
+}
+
+void StdCmdSelectionMode::languageChange()
+{
+    Command::languageChange();
+
+    if (!_pcAction) {
+        return;
+    }
+
+    auto pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
+    QList<QAction*> actions = pcAction->actions();
+    if (actions.size() < 5) {
+        return;
+    }
+
+    actions[0]->setText(QCoreApplication::translate("Std_SelectionMode", "Any"));
+    actions[0]->setToolTip(QCoreApplication::translate("Std_SelectionMode", "Allow any selection"));
+
+    actions[1]->setText(QCoreApplication::translate("Std_SelectionMode", "Object"));
+    actions[1]->setToolTip(QCoreApplication::translate("Std_SelectionMode", "Only select objects"));
+
+    actions[2]->setText(QCoreApplication::translate("Std_SelectionMode", "Vertex"));
+    actions[2]->setToolTip(QCoreApplication::translate("Std_SelectionMode", "Only select vertices"));
+
+    actions[3]->setText(QCoreApplication::translate("Std_SelectionMode", "Edge"));
+    actions[3]->setToolTip(QCoreApplication::translate("Std_SelectionMode", "Only select edges"));
+
+    actions[4]->setText(QCoreApplication::translate("Std_SelectionMode", "Face"));
+    actions[4]->setToolTip(QCoreApplication::translate("Std_SelectionMode", "Only select faces"));
+}
+
+void StdCmdSelectionMode::activated(int iMsg)
+{
+    if (iMsg < 0 || iMsg > 4) {
+        iMsg = 0;
+    }
+
+    Selection().setSelectionFilterMode(selectionFilterModeFromIndex(iMsg));
+
+    if (auto actionGroup = qobject_cast<Gui::ActionGroup*>(_pcAction)) {
+        actionGroup->setCheckedAction(iMsg);
+    }
+}
+
+bool StdCmdSelectionMode::isActive()
+{
+    if (auto actionGroup = qobject_cast<Gui::ActionGroup*>(_pcAction)) {
+        actionGroup->setCheckedAction(
+            indexFromSelectionFilterMode(Selection().getSelectionFilterMode())
+        );
+    }
+    return Gui::Application::Instance->activeDocument();
+}
+
+//===========================================================================
 // Std_ToggleVisibility
 //===========================================================================
 DEF_STD_CMD_A(StdCmdToggleVisibility)
@@ -4300,6 +4467,7 @@ void CreateViewStdCommands()
     rcCmdMgr.addCommand(new StdPerspectiveCamera());
     rcCmdMgr.addCommand(new StdCmdToggleClipPlane());
     rcCmdMgr.addCommand(new StdCmdDrawStyle());
+    rcCmdMgr.addCommand(new StdCmdSelectionMode());
     rcCmdMgr.addCommand(new StdCmdViewSaveCamera());
     rcCmdMgr.addCommand(new StdCmdViewRestoreCamera());
     rcCmdMgr.addCommand(new StdCmdFreezeViews());

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2868,8 +2868,9 @@ StdBoxSelection::StdBoxSelection()
 
 static void doSelect(void* ud, SoEventCallback* cb)
 {
-    bool selectElement = ud ? true : false;
     auto viewer = static_cast<Gui::View3DInventorViewer*>(cb->getUserData());
+    App::Document* doc = App::GetApplication().getActiveDocument();
+    bool selectElement = ud || boxSelectionUsesElementGate(doc);
 
     viewer->setSelectionEnabled(true);
     cb->setHandled();

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -58,6 +58,7 @@
 #include "Navigation/NavigationAnimator.h"
 #include "Navigation/NavigationAnimation.h"
 #include "Selection.h"
+#include "Selection/BoxSelection.h"
 #include "SoFullPathHelper.h"
 #include "View3DInventorViewer.h"
 #include "ViewParams.h"
@@ -1769,7 +1770,13 @@ bool NavigationStyle::tryStartBoxSelection(const SoLocation2Event* const ev, boo
         return false;
     }
 
-    return tryStartBoxSelection(*selectionStartPosition, ev, additiveSelection, false);
+    App::Document* doc = App::GetApplication().getActiveDocument();
+    return tryStartBoxSelection(
+        *selectionStartPosition,
+        ev,
+        additiveSelection,
+        boxSelectionUsesElementGate(doc)
+    );
 }
 
 bool NavigationStyle::handleSelectionDragMotion(

--- a/src/Gui/Selection/BoxSelection.cpp
+++ b/src/Gui/Selection/BoxSelection.cpp
@@ -22,6 +22,7 @@
 #include "BoxSelection.h"
 
 #include <memory>
+#include <unordered_set>
 #include <vector>
 
 #include <CXX/Objects.hxx>
@@ -203,14 +204,27 @@ std::vector<std::string> getBoxSelection(
         auto data = static_cast<Data::ComplexGeoDataPy*>(pyobj)->getComplexGeoDataPtr();
         const auto& allAllowedDocumentTypes = data->getElementTypes();
 
+        auto filteredTypes = Gui::Selection().getSelectionFilterModeTypes(allAllowedDocumentTypes);
+        bool useFilteredTypes = Gui::Selection().isSelectionFilterModeElement();
         if (selectionGate) {
-            auto filteredTypes = selectionGate->getGatedTypes(allAllowedDocumentTypes);
-            if (!filteredTypes.empty()) {
-                for (const auto& type : filteredTypes) {
-                    findObjectsOfTypeInBox(type, proj, data, polygon, ret, mode);
+            auto gateTypes = selectionGate->getGatedTypes(allAllowedDocumentTypes);
+            if (!gateTypes.empty()) {
+                if (useFilteredTypes) {
+                    std::erase_if(filteredTypes, [&gateTypes](const auto& type) {
+                        return !gateTypes.contains(type);
+                    });
                 }
-                return ret;
+                else {
+                    filteredTypes = gateTypes;
+                    useFilteredTypes = true;
+                }
             }
+        }
+        if (useFilteredTypes) {
+            for (const auto& type : filteredTypes) {
+                findObjectsOfTypeInBox(type, proj, data, polygon, ret, mode);
+            }
+            return ret;
         }
 
         for (auto type : allAllowedDocumentTypes) {
@@ -268,6 +282,13 @@ std::vector<std::string> getBoxSelection(
 
 bool Gui::boxSelectionUsesElementGate(const App::Document* doc)
 {
+    if (Gui::Selection().isSelectionFilterModeElement()) {
+        return true;
+    }
+    if (Gui::Selection().getSelectionFilterMode() == SelectionFilterMode::Object) {
+        return false;
+    }
+
     const auto selectionGate = SelectionSingleton::instance().getSelectionGate(doc);
     if (!selectionGate) {
         return false;

--- a/src/Gui/Selection/BoxSelection.cpp
+++ b/src/Gui/Selection/BoxSelection.cpp
@@ -161,18 +161,19 @@ std::vector<std::string> getBoxSelection(
     auto bbox3 = vp->getBoundingBox(nullptr, transform);
     Base::BoundBox2d bbox;
     const bool isBBox3Valid = bbox3.IsValid();
-    if (isBBox3Valid && selectionGate == nullptr) {
+    if (isBBox3Valid) {
         bbox = bbox3.Transformed(mat).ProjectBox(&proj);
 
         // check if both two boundary points are inside polygon, only
         // valid since we know the given polygon is a box.
-        if (polygon.Contains(Base::Vector2d(bbox.MinX, bbox.MinY))
+        if (!selectElement && selectionGate == nullptr
+            && polygon.Contains(Base::Vector2d(bbox.MinX, bbox.MinY))
             && polygon.Contains(Base::Vector2d(bbox.MaxX, bbox.MaxY))) {
             ret.emplace_back("");
             return ret;
         }
 
-        if (!bbox.Intersect(polygon)) {
+        if (!selectElement && selectionGate == nullptr && !bbox.Intersect(polygon)) {
             return ret;
         }
     }
@@ -264,6 +265,26 @@ std::vector<std::string> getBoxSelection(
 }
 
 }  // namespace
+
+bool Gui::boxSelectionUsesElementGate(const App::Document* doc)
+{
+    const auto selectionGate = SelectionSingleton::instance().getSelectionGate(doc);
+    if (!selectionGate) {
+        return false;
+    }
+
+    static const std::vector<const char*> representativeElementTypes {
+        "Face",
+        "Edge",
+        "Vertex",
+        "Volume",
+        "Mesh",
+        "Segment",
+    };
+
+    const auto gatedTypes = selectionGate->getGatedTypes(representativeElementTypes);
+    return !gatedTypes.empty() && gatedTypes.size() < representativeElementTypes.size();
+}
 
 void Gui::applyBoxSelection(
     View3DInventorViewer* viewer,

--- a/src/Gui/Selection/BoxSelection.h
+++ b/src/Gui/Selection/BoxSelection.h
@@ -27,6 +27,11 @@
 
 class SbVec2s;
 
+namespace App
+{
+class Document;
+}
+
 namespace Gui
 {
 class View3DInventorViewer;
@@ -48,5 +53,10 @@ GuiExport void applyBoxSelection(
     bool selectElement = false,
     bool additive = false
 );
+
+/**
+ * @brief Return whether the active selection gate narrows box selection to subelements.
+ */
+GuiExport bool boxSelectionUsesElementGate(const App::Document* doc);
 
 }  // namespace Gui

--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -23,9 +23,12 @@
  ***************************************************************************/
 
 
+#include <algorithm>
 #include <array>
-#include <set>
 #include <cstdint>
+#include <iterator>
+#include <set>
+#include <string_view>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <QApplication>
@@ -70,6 +73,42 @@ FC_LOG_LEVEL_INIT("Selection", false, true, true)
 using namespace Gui;
 using namespace std;
 namespace sp = std::placeholders;
+
+namespace
+{
+
+const char* elementPrefixForSelectionFilterMode(SelectionFilterMode mode)
+{
+    switch (mode) {
+        case SelectionFilterMode::Vertex:
+            return "Vertex";
+        case SelectionFilterMode::Edge:
+            return "Edge";
+        case SelectionFilterMode::Face:
+            return "Face";
+        case SelectionFilterMode::Any:
+        case SelectionFilterMode::Object:
+            return nullptr;
+    }
+
+    return nullptr;
+}
+
+bool matchesSelectionFilterModeElement(SelectionFilterMode mode, std::string_view element)
+{
+    const char* prefix = elementPrefixForSelectionFilterMode(mode);
+    if (!prefix) {
+        return false;
+    }
+
+    if (element.starts_with(prefix)) {
+        return true;
+    }
+
+    return mode == SelectionFilterMode::Face && element.starts_with("InternalFace");
+}
+
+}  // namespace
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
@@ -540,7 +579,7 @@ SelectionSingleton::SelectionAllowance SelectionSingleton::isSelectionAllowed(
     const SelectionDescription& sel
 )
 {
-    if (!context.info || !context.info->gate) {
+    if (!context.info) {
         return {.allowed = true, .reason = ""};
     }
     const char* subelement = nullptr;
@@ -552,7 +591,12 @@ SelectionSingleton::SelectionAllowance SelectionSingleton::isSelectionAllowed(
     );
 
 
-    if (!context.info->gate->allow(pObject ? pObject->getDocument() : sel.pDoc, pObject, subelement)) {
+    if (!isAllowedBySelectionFilterMode(subelement)) {
+        return {.allowed = false, .reason = QT_TR_NOOP("Selection not allowed by selection mode")};
+    }
+
+    if (context.info->gate
+        && !context.info->gate->allow(pObject ? pObject->getDocument() : sel.pDoc, pObject, subelement)) {
         std::string copyNotAllowedReason = context.info->gate->notAllowedReason;
         context.info->gate->notAllowedReason.clear();
         return {.allowed = false, .reason = copyNotAllowedReason};
@@ -859,10 +903,11 @@ bool SelectionSingleton::testSelection(
     }
 
     auto foundContext = docSelectionContext.find(pDoc);
-    if (foundContext == docSelectionContext.end() || !foundContext->second.gate) {
+    const SelectionInfo* info = foundContext != docSelectionContext.end() ? &foundContext->second
+                                                                          : nullptr;
+    if ((!info || !info->gate) && selectionFilterMode == SelectionFilterMode::Any) {
         return true;
     }
-    const auto& info = foundContext->second;
 
     const char* objectName = pObject->getNameInDocument();
     if (!objectName) {
@@ -876,17 +921,29 @@ bool SelectionSingleton::testSelection(
         pSubName,
         ResolveMode::NoResolve,
         temp,
-        &info.selList
+        info ? &info->selList : nullptr
     );
     if (ret < 0) {
         return false;
     }
 
     const char* subelement = nullptr;
-    auto gateObject
-        = getObjectOfType(temp, App::DocumentObject::getClassTypeId(), info.resolveMode, &subelement);
+    auto gateObject = getObjectOfType(
+        temp,
+        App::DocumentObject::getClassTypeId(),
+        info ? info->resolveMode : ResolveMode::NoResolve,
+        &subelement
+    );
 
-    auto* gate = info.gate;
+    if (!isAllowedBySelectionFilterMode(subelement)) {
+        return false;
+    }
+
+    if (!info || !info->gate) {
+        return true;
+    }
+
+    auto* gate = info->gate;
     std::string notAllowedReason = gate->notAllowedReason;
     bool allowed
         = gate->allow(gateObject ? gateObject->getDocument() : temp.pDoc, gateObject, subelement);
@@ -902,6 +959,62 @@ bool SelectionSingleton::hasSelectionGate(App::Document* pDoc) const
 
     auto foundContext = docSelectionContext.find(pDoc);
     return foundContext != docSelectionContext.end() && foundContext->second.gate;
+}
+
+bool SelectionSingleton::hasSelectionConstraint(App::Document* pDoc) const
+{
+    return selectionFilterMode != SelectionFilterMode::Any || hasSelectionGate(pDoc);
+}
+
+void SelectionSingleton::setSelectionFilterMode(SelectionFilterMode mode)
+{
+    selectionFilterMode = mode;
+}
+
+SelectionFilterMode SelectionSingleton::getSelectionFilterMode() const
+{
+    return selectionFilterMode;
+}
+
+bool SelectionSingleton::isSelectionFilterModeElement() const
+{
+    return elementPrefixForSelectionFilterMode(selectionFilterMode) != nullptr;
+}
+
+bool SelectionSingleton::isAllowedBySelectionFilterMode(const char* subelement) const
+{
+    switch (selectionFilterMode) {
+        case SelectionFilterMode::Any:
+            return true;
+        case SelectionFilterMode::Object:
+            return !subelement || !subelement[0];
+        case SelectionFilterMode::Vertex:
+        case SelectionFilterMode::Edge:
+        case SelectionFilterMode::Face:
+            return subelement && matchesSelectionFilterModeElement(selectionFilterMode, subelement);
+    }
+
+    return true;
+}
+
+std::unordered_set<std::string> SelectionSingleton::getSelectionFilterModeTypes(
+    const std::vector<const char*>& allTypesForGeometry
+) const
+{
+    std::unordered_set<std::string> allowedTypes;
+    if (!isSelectionFilterModeElement()) {
+        return allowedTypes;
+    }
+
+    std::ranges::copy_if(
+        allTypesForGeometry.begin(),
+        allTypesForGeometry.end(),
+        std::inserter(allowedTypes, allowedTypes.begin()),
+        [this](const char* type) {
+            return type && matchesSelectionFilterModeElement(selectionFilterMode, type);
+        }
+    );
+    return allowedTypes;
 }
 
 int SelectionSingleton::setPreselect(
@@ -936,7 +1049,8 @@ int SelectionSingleton::setPreselect(
     }
     auto context = getSelectionContext(pDocName);
 
-    if (context.info->gate && signal != SelectionChanges::MsgSource::Internal) {
+    if ((context.info->gate || selectionFilterMode != SelectionFilterMode::Any)
+        && signal != SelectionChanges::MsgSource::Internal) {
         App::ElementNamePair elementName;
         auto pObject = pDoc->getObject(pObjectName);
         if (!pObject) {
@@ -944,7 +1058,7 @@ int SelectionSingleton::setPreselect(
         }
 
         const char* subelement = pSubName;
-        if (context.info->resolveMode != ResolveMode::NoResolve) {
+        if (context.info->gate && context.info->resolveMode != ResolveMode::NoResolve) {
             auto& newElementName = elementName.newName;
             auto& oldElementName = elementName.oldName;
             pObject = App::GeoFeature::resolveElement(pObject, pSubName, elementName);
@@ -959,10 +1073,21 @@ int SelectionSingleton::setPreselect(
                 subelement = oldElementName.c_str();
             }
         }
-        if (!context.info->gate->allow(pObject->getDocument(), pObject, subelement)) {
+        SelectionAllowance allowance {.allowed = true, .reason = ""};
+        if (!isAllowedBySelectionFilterMode(subelement)) {
+            allowance
+                = {.allowed = false, .reason = QT_TR_NOOP("Selection not allowed by selection mode")};
+        }
+        else if (
+            context.info->gate
+            && !context.info->gate->allow(pObject->getDocument(), pObject, subelement)
+        ) {
+            allowance = {.allowed = false, .reason = context.info->gate->notAllowedReason};
+        }
+        if (!allowance.allowed) {
             QString msg;
-            if (context.info->gate->notAllowedReason.length() > 0) {
-                msg = QObject::tr(context.info->gate->notAllowedReason.c_str());
+            if (allowance.reason.length() > 0) {
+                msg = QObject::tr(allowance.reason.c_str());
             }
             else {
                 msg = QCoreApplication::translate("SelectionFilter", "Not allowed:");

--- a/src/Gui/Selection/Selection.h
+++ b/src/Gui/Selection/Selection.h
@@ -318,6 +318,15 @@ public:
     std::string notAllowedReason;
 };
 
+enum class SelectionFilterMode
+{
+    Any,
+    Object,
+    Vertex,
+    Edge,
+    Face
+};
+
 /** The Selection class
  *  The selection singleton keeps track of the selection state of
  *  the whole application. It gets messages from all entities which can
@@ -423,6 +432,15 @@ public:
         const char* pSubName = nullptr
     ) const;
     bool hasSelectionGate(App::Document* pDoc) const;
+    bool hasSelectionConstraint(App::Document* pDoc) const;
+
+    void setSelectionFilterMode(SelectionFilterMode mode);
+    SelectionFilterMode getSelectionFilterMode() const;
+    bool isSelectionFilterModeElement() const;
+    bool isAllowedBySelectionFilterMode(const char* subelement) const;
+    std::unordered_set<std::string> getSelectionFilterModeTypes(
+        const std::vector<const char*>& allTypesForGeometry
+    ) const;
 
     std::string getSelectedElement(App::DocumentObject*, const char* pSubName) const;
 
@@ -895,6 +913,7 @@ protected:
 
 
     std::map<App::Document*, SelectionInfo> docSelectionContext;
+    SelectionFilterMode selectionFilterMode {SelectionFilterMode::Any};
 
     struct SelectionAllowance
     {

--- a/src/Gui/Selection/SoFCUnifiedSelection.cpp
+++ b/src/Gui/Selection/SoFCUnifiedSelection.cpp
@@ -118,20 +118,21 @@ namespace Gui::SelectionPickPolicy
 
 bool canFinalizeSinglePick(const std::vector<Candidate>& picked)
 {
-    bool foundSelectionGate = false;
+    bool foundSelectionConstraint = false;
     for (const auto& info : picked) {
-        if (!info.hasGate) {
+        if (!info.hasConstraint) {
             continue;
         }
 
-        foundSelectionGate = true;
-        if (info.passesGate) {
+        foundSelectionConstraint = true;
+        if (info.passesConstraint) {
             return true;
         }
     }
 
-    // Preserve the existing first-object behavior unless an active gate rejected every pick so far.
-    return !foundSelectionGate;
+    // Preserve the existing first-object behavior unless an active constraint rejected every pick
+    // so far.
+    return !foundSelectionConstraint;
 }
 
 std::size_t choosePreferredPick(const std::vector<Candidate>& picked)
@@ -166,9 +167,9 @@ std::size_t choosePreferredPick(const std::vector<Candidate>& picked)
         }
     }
 
-    if (!picked[preferred].passesGate) {
+    if (!picked[preferred].passesConstraint) {
         for (std::size_t i = 0; i < picked.size(); ++i) {
-            if (picked[i].passesGate) {
+            if (picked[i].passesConstraint) {
                 preferred = i;
                 break;
             }
@@ -369,7 +370,7 @@ int SoFCUnifiedSelection::getPriority(const SoPickedPoint* p)
     return 0;
 }
 
-bool SoFCUnifiedSelection::passesSelectionGate(const PickedInfo& info)
+bool SoFCUnifiedSelection::passesSelectionConstraint(const PickedInfo& info)
 {
     if (!info.vpd) {
         return false;
@@ -380,10 +381,11 @@ bool SoFCUnifiedSelection::passesSelectionGate(const PickedInfo& info)
         return false;
     }
 
-    return Selection().testSelection(obj->getDocument(), obj, info.element.c_str());
+    const bool objectMode = Gui::Selection().getSelectionFilterMode() == SelectionFilterMode::Object;
+    return Selection().testSelection(obj->getDocument(), obj, objectMode ? "" : info.element.c_str());
 }
 
-bool SoFCUnifiedSelection::hasSelectionGate(const PickedInfo& info)
+bool SoFCUnifiedSelection::hasSelectionConstraint(const PickedInfo& info)
 {
     if (!info.vpd) {
         return false;
@@ -394,7 +396,7 @@ bool SoFCUnifiedSelection::hasSelectionGate(const PickedInfo& info)
         return false;
     }
 
-    return Selection().hasSelectionGate(obj->getDocument());
+    return Selection().hasSelectionConstraint(obj->getDocument());
 }
 
 SelectionPickPolicy::Candidate SoFCUnifiedSelection::getPickCandidate(
@@ -407,8 +409,8 @@ SelectionPickPolicy::Candidate SoFCUnifiedSelection::getPickCandidate(
     candidate.owner = info.vpd;
     candidate.priority = getPriority(info.pp);
     candidate.isAnnotation = doc && info.pp && isAnnotationPick(info.pp, doc);
-    candidate.hasGate = hasSelectionGate(info);
-    candidate.passesGate = passesSelectionGate(info);
+    candidate.hasConstraint = hasSelectionConstraint(info);
+    candidate.passesConstraint = passesSelectionConstraint(info);
 
     if (firstPicked && info.pp && firstPicked->pp) {
         candidate.closeToFirst = info.pp->getPoint().equals(firstPicked->pp->getPoint(), 0.2F);
@@ -770,11 +772,12 @@ bool SoFCUnifiedSelection::setPreselect(const PickedInfo& info)
     }
 
     const auto& pt = info.pp->getPoint();
+    const bool objectMode = Gui::Selection().getSelectionFilterMode() == SelectionFilterMode::Object;
     return setPreselect(
         Gui::toFullPath(info.pp->getPath()),
-        info.pp->getDetail(),
+        objectMode ? nullptr : info.pp->getDetail(),
         info.vpd,
-        info.element.c_str(),
+        objectMode ? "" : info.element.c_str(),
         pt[0],
         pt[1],
         pt[2]
@@ -854,6 +857,7 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
         return false;
     }
 
+    const bool objectMode = Gui::Selection().getSelectionFilterMode() == SelectionFilterMode::Object;
     std::vector<SelectionSingleton::SelObj> sels;
     if (infos.size() > 1) {
         for (auto& info : infos) {
@@ -868,7 +872,7 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
             sel.DocName = sel.pDoc->getName();
             sel.FeatName = sel.pObject->getNameInDocument();
             sel.TypeName = sel.pObject->getTypeId().getName();
-            sel.SubName = info.element.c_str();
+            sel.SubName = objectMode ? "" : info.element.c_str();
             const auto& pt = info.pp->getPoint();
             sel.x = pt[0];
             sel.y = pt[1];
@@ -889,6 +893,9 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
     const char* docname = vpd->getObject()->getDocument()->getName();
 
     auto getFullSubElementName = [vpd](std::string& subName) {
+        if (subName.empty()) {
+            return;
+        }
         App::ElementNamePair elementName;
         App::GeoFeature::resolveElement(vpd->getObject(), subName.c_str(), elementName);
         if (!elementName.newName.empty()) {  // If we have a mapped name use it
@@ -907,12 +914,12 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
     SoSelectionElementAction::Type type = SoSelectionElementAction::None;
     auto preselectionMode = static_cast<SelectionModes>(this->preselectionMode.getValue());
     static char buf[513];
-    auto subName = info.element;
+    auto subName = objectMode ? std::string() : info.element;
     std::string objectName = objname;
 
     if (ctrlDown) {
-        if (Gui::Selection().isSelected(docname, objname, info.element.c_str(), ResolveMode::NoResolve)) {
-            Gui::Selection().rmvSelection(docname, objname, info.element.c_str(), &sels);
+        if (Gui::Selection().isSelected(docname, objname, subName.c_str(), ResolveMode::NoResolve)) {
+            Gui::Selection().rmvSelection(docname, objname, subName.c_str(), &sels);
             return true;
         }
         else {
@@ -942,7 +949,7 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
                     "Selected: %s.%s.%s (%g, %g, %g)",
                     docname,
                     objname,
-                    info.element.c_str(),
+                    subName.c_str(),
                     fabs(pt[0]) > 1e-7 ? pt[0] : 0.0,
                     fabs(pt[1]) > 1e-7 ? pt[1] : 0.0,
                     fabs(pt[2]) > 1e-7 ? pt[2] : 0.0
@@ -950,20 +957,27 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
 
                 getMainWindow()->showMessage(QString::fromLatin1(buf));
             }
-            detailPath->truncate(0);
-            if (vpd->getDetailPath(info.element.c_str(), detailPath, true, detNext)
-                && detailPath->getLength()) {
-                pPath = detailPath;
-                det = detNext;
-                FC_TRACE("select next " << objectName << ", " << subName);
-                if (ok) {
-                    type = hasNext ? SoSelectionElementAction::All : SoSelectionElementAction::Append;
-                }
-                else {
-                    // don't apply any visual action when selection fails -
-                    // in a case when we press ctrl and select a geometry that should be
-                    // filtered out, we don't want to apply any visual action
-                    pPath = nullptr;
+            if (objectMode) {
+                det = nullptr;
+                type = ok ? SoSelectionElementAction::All : SoSelectionElementAction::None;
+            }
+            else {
+                detailPath->truncate(0);
+                if (vpd->getDetailPath(info.element.c_str(), detailPath, true, detNext)
+                    && detailPath->getLength()) {
+                    pPath = detailPath;
+                    det = detNext;
+                    FC_TRACE("select next " << objectName << ", " << subName);
+                    if (ok) {
+                        type = hasNext ? SoSelectionElementAction::All
+                                       : SoSelectionElementAction::Append;
+                    }
+                    else {
+                        // don't apply any visual action when selection fails -
+                        // in a case when we press ctrl and select a geometry that should be
+                        // filtered out, we don't want to apply any visual action
+                        pPath = nullptr;
+                    }
                 }
             }
         }
@@ -984,44 +998,49 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
 
         // We need to convert the short name in the selection to a full element path to look it up
         // Ex:  Body.Pad.Face9  to Body.Pad.;g3;SKT;:H12dc,E;FAC;:H12dc:4,F;:G0;XTR;:H12dc:8,F.Face9
-        getFullSubElementName(subName);
-        std::string subSelected
-            = Gui::Selection().getSelectedElement(vpd->getObject(), subName.c_str());
+        if (objectMode) {
+            det = nullptr;
+        }
+        else {
+            getFullSubElementName(subName);
+            std::string subSelected
+                = Gui::Selection().getSelectedElement(vpd->getObject(), subName.c_str());
 
-        FC_TRACE(
-            "select " << (!subSelected.empty() ? subSelected : "'null'") << ", " << objectName
-                      << ", " << subName
-        );
-        std::string newElement;
-        if (!subSelected.empty()) {
-            newElement = Data::newElementName(subSelected.c_str());
-            subSelected = newElement.c_str();
-            std::string nextsub;
-            size_t next = subSelected.rfind('.');
-            if (next != std::string::npos && next != 0) {
-                if (next == subSelected.size() - 1) {
-                    // The convention of dot separated SubName demands a mandatory
-                    // ending dot for every object name reference inside SubName.
-                    // The non-object sub-element, however, must not end with a dot.
-                    // So, next[1]==0 here means current selection is a whole object
-                    // selection (because no sub-element), so we shall search
-                    // upwards for the second last dot, which is the end of the
-                    // parent name of the current selected object
-                    next = subSelected.rfind('.', next - 1);
+            FC_TRACE(
+                "select " << (!subSelected.empty() ? subSelected : "'null'") << ", " << objectName
+                          << ", " << subName
+            );
+            std::string newElement;
+            if (!subSelected.empty()) {
+                newElement = Data::newElementName(subSelected.c_str());
+                subSelected = newElement.c_str();
+                std::string nextsub;
+                size_t next = subSelected.rfind('.');
+                if (next != std::string::npos && next != 0) {
+                    if (next == subSelected.size() - 1) {
+                        // The convention of dot separated SubName demands a mandatory
+                        // ending dot for every object name reference inside SubName.
+                        // The non-object sub-element, however, must not end with a dot.
+                        // So, next[1]==0 here means current selection is a whole object
+                        // selection (because no sub-element), so we shall search
+                        // upwards for the second last dot, which is the end of the
+                        // parent name of the current selected object
+                        next = subSelected.rfind('.', next - 1);
+                    }
+                    if (next != std::string::npos) {
+                        nextsub = subSelected.substr(0, next + 1);
+                    }
                 }
-                if (next != std::string::npos) {
-                    nextsub = subSelected.substr(0, next + 1);
-                }
-            }
-            if (!nextsub.empty() || !subSelected.empty()) {
-                hasNext = true;
-                subName = nextsub;
-                detailPath->truncate(0);
-                if (vpd->getDetailPath(subName.c_str(), detailPath, true, detNext)
-                    && detailPath->getLength()) {
-                    pPath = detailPath;
-                    det = detNext;
-                    FC_TRACE("select next " << objectName << ", " << subName);
+                if (!nextsub.empty() || !subSelected.empty()) {
+                    hasNext = true;
+                    subName = nextsub;
+                    detailPath->truncate(0);
+                    if (vpd->getDetailPath(subName.c_str(), detailPath, true, detNext)
+                        && detailPath->getLength()) {
+                        pPath = detailPath;
+                        det = detNext;
+                        FC_TRACE("select next " << objectName << ", " << subName);
+                    }
                 }
             }
         }
@@ -1041,7 +1060,8 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
             Gui::SelectionChanges::PickedPoint::Valid
         );
         if (ok) {
-            type = hasNext ? SoSelectionElementAction::All : SoSelectionElementAction::Append;
+            type = (hasNext || objectMode) ? SoSelectionElementAction::All
+                                           : SoSelectionElementAction::Append;
         }
 
         if (preselectionMode == SoFCUnifiedSelection::OFF) {

--- a/src/Gui/Selection/SoFCUnifiedSelection.h
+++ b/src/Gui/Selection/SoFCUnifiedSelection.h
@@ -56,8 +56,8 @@ struct Candidate
     int priority {0};
     bool closeToFirst {false};
     bool isAnnotation {false};
-    bool hasGate {false};
-    bool passesGate {false};
+    bool hasConstraint {false};
+    bool passesConstraint {false};
 };
 
 GuiExport bool canFinalizeSinglePick(const std::vector<Candidate>& picked);
@@ -157,8 +157,8 @@ private:
         std::string element;
     };
 
-    static bool passesSelectionGate(const PickedInfo&);
-    static bool hasSelectionGate(const PickedInfo&);
+    static bool passesSelectionConstraint(const PickedInfo&);
+    static bool hasSelectionConstraint(const PickedInfo&);
     static SelectionPickPolicy::Candidate getPickCandidate(
         const PickedInfo&,
         const Document*,

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -648,7 +648,7 @@ void StdWorkbench::setupContextMenu(const char* recipient, MenuItem* item) const
                   << "Separator" << "Std_ViewRotateLeft" << "Std_ViewRotateRight";
 
         *item << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_AlignToSelection"
-              << "Std_DrawStyle" << StdViews << "Separator"
+              << "Std_DrawStyle" << "Std_SelectionMode" << StdViews << "Separator"
               << "Std_ViewDockUndockFullscreen";
 
         if (!sels.empty()) {
@@ -755,7 +755,7 @@ MenuItem* StdWorkbench::setupMenuBar() const
     view->setCommand("&View");
     *view << "Std_ViewCreate" << "Std_OrthographicCamera" << "Std_PerspectiveCamera"
           << "Std_MainFullscreen" << "Separator" << stdviews << "Std_FreezeViews" << "Std_DrawStyle"
-          << "Std_SelBoundingBox"
+          << "Std_SelectionMode" << "Std_SelBoundingBox"
           << "Separator" << zoom << "Std_ViewDockUndockFullscreen"
           << "Std_ViewIvIssueCamPos"
           << "Std_AxisCross"
@@ -878,7 +878,7 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     auto view = new ToolBarItem(root);
     view->setCommand("View");
     *view << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_ViewGroup" << "Std_AlignToSelection"
-          << "Separator" << "Std_DrawStyle" << "Separator"
+          << "Separator" << "Std_DrawStyle" << "Std_SelectionMode" << "Separator"
           << "Std_Measure" << "Std_MassProperties";
 
     // Individual views

--- a/src/Mod/Part/Gui/CommandFilter.cpp
+++ b/src/Mod/Part/Gui/CommandFilter.cpp
@@ -31,6 +31,7 @@
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>
 #include <Gui/MainWindow.h>
+#include <Gui/Selection/Selection.h>
 #include <Gui/View3DInventor.h>
 
 //===============================================================================
@@ -202,7 +203,7 @@ PartCmdVertexSelection::PartCmdVertexSelection()
 void PartCmdVertexSelection::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.Selection.addSelectionGate('SELECT Part::Feature SUBELEMENT Vertex SELECT App::Link SUBELEMENT Vertex')");
+    Gui::Selection().setSelectionFilterMode(Gui::SelectionFilterMode::Vertex);
 }
 
 
@@ -227,7 +228,7 @@ PartCmdEdgeSelection::PartCmdEdgeSelection()
 void PartCmdEdgeSelection::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.Selection.addSelectionGate('SELECT Part::Feature SUBELEMENT Edge SELECT App::Link SUBELEMENT Edge')");
+    Gui::Selection().setSelectionFilterMode(Gui::SelectionFilterMode::Edge);
 }
 
 
@@ -252,12 +253,7 @@ PartCmdFaceSelection::PartCmdFaceSelection()
 void PartCmdFaceSelection::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(
-        Command::Gui,
-        "Gui.Selection.addSelectionGate('SELECT Part::Feature SUBELEMENT Face "
-        "SELECT App::Link SUBELEMENT Face "
-        "SELECT Part::Part2DObject SUBELEMENT InternalFace')"
-    );
+    Gui::Selection().setSelectionFilterMode(Gui::SelectionFilterMode::Face);
 }
 
 
@@ -282,6 +278,7 @@ PartCmdRemoveSelectionGate::PartCmdRemoveSelectionGate()
 void PartCmdRemoveSelectionGate::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+    Gui::Selection().setSelectionFilterMode(Gui::SelectionFilterMode::Any);
     doCommand(Command::Gui, "Gui.Selection.removeSelectionGate()");
 }
 

--- a/src/Mod/Part/Gui/WorkbenchManipulator.cpp
+++ b/src/Mod/Part/Gui/WorkbenchManipulator.cpp
@@ -33,28 +33,11 @@ void WorkbenchManipulator::modifyMenuBar([[maybe_unused]] Gui::MenuItem* menuBar
 
 void WorkbenchManipulator::modifyToolBars(Gui::ToolBarItem* toolBar)
 {
-    addSelectionFilter(toolBar);
     addDatums(toolBar);
 }
 
 void WorkbenchManipulator::modifyDockWindows([[maybe_unused]] Gui::DockWindowItems* dockWindow)
 {}
-
-void WorkbenchManipulator::addSelectionFilter(Gui::ToolBarItem* toolBar)
-{
-    if (auto view = toolBar->findItem("View")) {
-        auto add = new Gui::ToolBarItem();  // NOLINT
-        add->setCommand("Part_SelectFilter");
-        auto items = view->getItems();
-        auto drawStyleIdx = items.indexOf(view->findItem("Std_DrawStyle"));
-        if (drawStyleIdx >= 0 && drawStyleIdx + 1 < items.size()) {
-            view->insertItem(items.at(drawStyleIdx + 1), add);
-        }
-        else {
-            view->appendItem(add);
-        }
-    }
-}
 
 void WorkbenchManipulator::addDatums(Gui::ToolBarItem* toolBar)
 {

--- a/src/Mod/Part/Gui/WorkbenchManipulator.h
+++ b/src/Mod/Part/Gui/WorkbenchManipulator.h
@@ -52,7 +52,6 @@ protected:
     void modifyDockWindows([[maybe_unused]] Gui::DockWindowItems* dockWindow) override;
 
 private:
-    static void addSelectionFilter(Gui::ToolBarItem* toolBar);
     static void addDatums(Gui::ToolBarItem* toolBar);
 };
 

--- a/src/Mod/Test/TestRubberbandSelection.py
+++ b/src/Mod/Test/TestRubberbandSelection.py
@@ -112,6 +112,8 @@ class TestRubberbandSelection(unittest.TestCase):
         self._refresh_view()
 
     def tearDown(self):
+        self._set_selection_mode(0, require=False)
+        FreeCADGui.Selection.removeSelectionGate()
         FreeCADGui.Selection.clearSelection()
         if hasattr(self, "view_preferences"):
             self.view_preferences.SetBool("EnableSelection", self.old_enable_selection)
@@ -147,7 +149,7 @@ class TestRubberbandSelection(unittest.TestCase):
             self.assertTrue(sub_elements)
             self.assertTrue(all(name.startswith("Face") for name in sub_elements))
         finally:
-            FreeCADGui.Selection.removeSelectionGate()
+            self._set_selection_mode(0)
 
     def test_plain_drag_keeps_object_selection_when_object_filter_is_active(self):
         self._ensure_selection_objects()
@@ -162,6 +164,36 @@ class TestRubberbandSelection(unittest.TestCase):
             self.assertEqual(self._selected_sub_element_names(self.left_box), set())
         finally:
             FreeCADGui.Selection.removeSelectionGate()
+
+    def test_plain_drag_selects_faces_when_global_face_mode_is_active(self):
+        self._ensure_selection_objects()
+        self.view.setNavigationType("Gui::CADNavigationStyle")
+        self._refresh_view()
+
+        self._set_selection_mode(4)
+        try:
+            self._drag_select(self._selection_rect(self.left_box))
+
+            self.assertEqual(self._selected_names(), {self.left_box.Name})
+            sub_elements = self._selected_sub_element_names(self.left_box)
+            self.assertTrue(sub_elements)
+            self.assertTrue(all(name.startswith("Face") for name in sub_elements))
+        finally:
+            self._set_selection_mode(0)
+
+    def test_plain_drag_keeps_object_selection_when_global_object_mode_is_active(self):
+        self._ensure_selection_objects()
+        self.view.setNavigationType("Gui::CADNavigationStyle")
+        self._refresh_view()
+
+        self._set_selection_mode(1)
+        try:
+            self._drag_select(self._selection_rect(self.left_box))
+
+            self.assertEqual(self._selected_names(), {self.left_box.Name})
+            self.assertEqual(self._selected_sub_element_names(self.left_box), set())
+        finally:
+            self._set_selection_mode(0)
 
     def test_ctrl_drag_adds_in_supported_styles(self):
         self._ensure_selection_objects()
@@ -423,6 +455,15 @@ class TestRubberbandSelection(unittest.TestCase):
             if selection.ObjectName == obj.Name:
                 sub_element_names.update(selection.SubElementNames)
         return sub_element_names
+
+    def _set_selection_mode(self, mode_index, require=True):
+        if "Std_SelectionMode" not in FreeCADGui.listCommands():
+            if require:
+                self.fail("Std_SelectionMode is unavailable")
+            return
+
+        FreeCADGui.runCommand("Std_SelectionMode", mode_index)
+        self._process_events()
 
     def _send_mouse_event(self, event_type, pos, button, buttons, modifiers):
         self._refresh_view_widgets()

--- a/src/Mod/Test/TestRubberbandSelection.py
+++ b/src/Mod/Test/TestRubberbandSelection.py
@@ -36,6 +36,10 @@ try:
     import Part
 except ImportError:
     Part = None
+try:
+    import PartGui
+except ImportError:
+    PartGui = None
 from PySide import QtCore, QtGui
 
 LEFT_BUTTON = QtCore.Qt.LeftButton
@@ -124,6 +128,40 @@ class TestRubberbandSelection(unittest.TestCase):
 
                 self._drag_select(self._selection_rect(self.left_box))
                 self.assertEqual(self._selected_names(), {self.left_box.Name})
+
+    def test_plain_drag_selects_faces_when_part_face_filter_is_active(self):
+        self._ensure_selection_objects()
+        if PartGui is None or "Part_FaceSelection" not in FreeCADGui.listCommands():
+            self.skipTest("Part GUI selection commands are unavailable in this build")
+
+        self.view.setNavigationType("Gui::CADNavigationStyle")
+        self._refresh_view()
+
+        FreeCADGui.runCommand("Part_FaceSelection")
+        self._process_events()
+        try:
+            self._drag_select(self._selection_rect(self.left_box))
+
+            self.assertEqual(self._selected_names(), {self.left_box.Name})
+            sub_elements = self._selected_sub_element_names(self.left_box)
+            self.assertTrue(sub_elements)
+            self.assertTrue(all(name.startswith("Face") for name in sub_elements))
+        finally:
+            FreeCADGui.Selection.removeSelectionGate()
+
+    def test_plain_drag_keeps_object_selection_when_object_filter_is_active(self):
+        self._ensure_selection_objects()
+        self.view.setNavigationType("Gui::CADNavigationStyle")
+        self._refresh_view()
+
+        FreeCADGui.Selection.addSelectionGate("SELECT Part::Feature")
+        try:
+            self._drag_select(self._selection_rect(self.left_box))
+
+            self.assertEqual(self._selected_names(), {self.left_box.Name})
+            self.assertEqual(self._selected_sub_element_names(self.left_box), set())
+        finally:
+            FreeCADGui.Selection.removeSelectionGate()
 
     def test_ctrl_drag_adds_in_supported_styles(self):
         self._ensure_selection_objects()
@@ -378,6 +416,13 @@ class TestRubberbandSelection(unittest.TestCase):
 
     def _selected_names(self):
         return {obj.Name for obj in FreeCADGui.Selection.getSelection()}
+
+    def _selected_sub_element_names(self, obj):
+        sub_element_names = set()
+        for selection in FreeCADGui.Selection.getSelectionEx(self.doc.Name):
+            if selection.ObjectName == obj.Name:
+                sub_element_names.update(selection.SubElementNames)
+        return sub_element_names
 
     def _send_mouse_event(self, event_type, pos, button, buttons, modifiers):
         self._refresh_view_widgets()

--- a/tests/src/Gui/SelectionTest.cpp
+++ b/tests/src/Gui/SelectionTest.cpp
@@ -75,16 +75,16 @@ Gui::SelectionPickPolicy::Candidate pickCandidate(
     const void* owner,
     int priority,
     bool closeToFirst,
-    bool hasGate,
-    bool passesGate
+    bool hasConstraint,
+    bool passesConstraint
 )
 {
     Gui::SelectionPickPolicy::Candidate candidate;
     candidate.owner = owner;
     candidate.priority = priority;
     candidate.closeToFirst = closeToFirst;
-    candidate.hasGate = hasGate;
-    candidate.passesGate = passesGate;
+    candidate.hasConstraint = hasConstraint;
+    candidate.passesConstraint = passesConstraint;
     return candidate;
 }
 


### PR DESCRIPTION
This PR makes box selection respect active selection constraints and adds a global selection mode control for Object / Vertex / Edge / Face filtering.

The main behavior change is that plain drag box selection and `Std_BoxSelection` no longer ignore active selection gates. If a face/edge/vertex selection gate is active, box selection now selects matching sub-elements instead of whole objects.

It also adds a global `Std_SelectionMode` dropdown in the existing View toolbar/menu. The dropdown exposes:

- Any
- Object
- Vertex
- Edge
- Face

The toolbar button shows the active mode text, so the current filter is visible without opening the menu.

## Details

The new global selection mode lives in `Gui::Selection` and is applied consistently across:

- preselection
- normal selection
- box selection
- unified selection gate checks

`Object` mode normalizes selection to whole-object selection. `Vertex`, `Edge`, and `Face` modes restrict sub-element selection by prefix, including box selection’s geometry traversal.

Box selection now combines constraints when both are present:

- legacy selection gates
- the new global selection mode

For example, if a Part face gate is active, box selection collects faces. If the global mode is set to Object, box selection keeps whole-object behavior. If the global mode is Face, box selection selects faces without requiring a Part-specific command first.

The existing Part selection filter commands are preserved for compatibility, but they now route through the global selection mode. This keeps existing command IDs, shortcuts, macros, and custom toolbars working while avoiding a duplicate default Part toolbar entry.

## UI

A new `Std_SelectionMode` dropdown is added next to the existing View toolbar controls. It uses the existing command/action infrastructure and opts into text beside icon only for this control, so the toolbar shows the active mode directly.

The Part workbench no longer injects its own default `Part_SelectFilter` toolbar item, since the global selector is now the default visible control.

## Tests

Added regression coverage for rubber-band selection with:

- Part face filter active
- Part object/clear filter behavior
- global Face mode active
- global Object mode active

https://github.com/user-attachments/assets/332850fa-cb6a-4df5-8e4b-a310cfc644d6

