### PR TITLE
3rdParty/Clipper: Don't track clipper.version.h in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ ui_*.h
 /src/Tools/offlinedoc/*.txt
 /src/Tools/offlinedoc/localwiki/
 /src/Mod/CAM/research/
+/src/3rdParty/Clipper2/Clipper2Lib/include/clipper2/clipper.version.h
 OpenSCAD_rc.py
 tags
 /CMakeUserPresets.json

--- a/src/3rdParty/Clipper2/Clipper2Lib/include/clipper2/clipper.version.h
+++ b/src/3rdParty/Clipper2/Clipper2Lib/include/clipper2/clipper.version.h
@@ -1,6 +1,0 @@
-#ifndef CLIPPER_VERSION_H
-#define CLIPPER_VERSION_H
-
-constexpr auto CLIPPER2_VERSION = "2.0.1";
-
-#endif  // CLIPPER_VERSION_H


### PR DESCRIPTION
Clipper generates its `clipper.version.h` inside its own source tree during CMake -- setting aside the non-idiomatic decision to put that file in the source tree on their part, the least we can do is not track that file in git (if we do, then it gets touched all the time on Windows because the line endings get flipped). This removes it and adds it to .gitignore.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
