### PR TITLE
CAM: don't modify tools when starting new simulator

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
+++ b/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
@@ -160,10 +160,8 @@ class CAMSimulation:
         """Get the edge profile of a tool solid. Basically locating the
         side edge that OCC creates on any revolved object
         """
-        originalPlacement = tool.Placement
-        tool.Placement = Placement(Vector(0, 0, 0), Rotation(Vector(0, 0, 1), 0), Vector(0, 0, 0))
-        shape = tool.Shape
-        tool.Placement = originalPlacement
+        shape = tool.Shape.copy()
+        shape.Placement = Placement()
         sideEdgeList = []
         for _i, edge in enumerate(shape.Edges):
             if not edge.isClosed():


### PR DESCRIPTION
Before this PR, in SimulatorGL.py, the placement of the tool object was temporarily modified and then reset to it's original value. Even though this left the tool in the correct state, it still caused a recompute of the tool and therefore all operations that use that tool. Every time the simulator was started. As some operations can take a lot of time to compute, this could be very annoying.

Now we just make a temporary copy of the tool and modify that. Since the tools are usually very simple geometry, just one PartDesign Revolution, there is no appreciable performance or memory penalty.