### PR TITLE
Fem: Add electrostatic spark gap example

### DIFF
--- a/src/Mod/Fem/CMakeLists.txt
+++ b/src/Mod/Fem/CMakeLists.txt
@@ -109,6 +109,7 @@ SET(FemExamples_SRCS
     femexamples/material_nl_platewithhole.py
     femexamples/mystran_plate.py
     femexamples/rc_wall_2d.py
+    femexamples/spark_gap.py
     femexamples/square_pipe_end_twisted_edgeforces.py
     femexamples/square_pipe_end_twisted_nodeforces.py
     femexamples/thermomech_bimetal.py

--- a/src/Mod/Fem/femexamples/spark_gap.py
+++ b/src/Mod/Fem/femexamples/spark_gap.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *   Copyright (c) 2026 Mario Passaglia <mpassaglia[at]cbc.uba.ar          *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+
+import FreeCAD
+from FreeCAD import Vector
+
+import ObjectsFem
+import Materials
+import Part
+
+from . import manager
+from .meshes import generate_mesh
+
+
+def get_information():
+    return {
+        "name": "Axisymmetric spark gap",
+        "meshtype": "face",
+        "meshelement": "Tria6",
+        "constraints": ["electromagnetic"],
+        "solvers": ["elmer", "calculix"],
+        "material": "fluid",
+        "equations": ["electrostatic"],
+    }
+
+
+def get_explanation(header=""):
+    return (
+        header
+        + """
+
+To run the example from Python console use:
+from femexamples.spark_gap import setup
+setup()
+
+Spark gap - Axisymmetric model
+The electrodes are represented by their profiles
+"""
+    )
+
+
+def setup(doc=None, solvertype="elmer"):
+
+    # init FreeCAD document
+    if doc is None:
+        doc = manager.init_doc()
+
+    # explanation object
+    # just keep the following line and change text string in get_explanation method
+    manager.add_explanation_obj(doc, get_explanation(manager.get_header(get_information())))
+
+    # wire defining the electrode profiles and border
+    d = 20.0
+    r_border = 100.0
+
+    # voltage points
+    p1 = Vector(0.0, 0.0, 0.0)
+    p2 = Vector(10.0, 20.0, 0.0)
+    p3 = Vector(2.0, 20.0, 0.0)
+    p4 = Vector(2, (r_border**2 - 2**2)**0.5, 0.0)
+    
+    # ground points    
+    p5 = Vector(2, -(r_border**2 - 2**2)**0.5, 0.0)
+    p6 = Vector(0, -d, 0.0)
+    p7 = Vector(30, -d, 0.0)
+    p8 = Vector(30, -d - 5, 0.0)
+    p9 = Vector(2, -d - 5, 0.0)
+    contour = Part.makePolygon([p5, p9, p8, p7, p6, p1, p2, p3, p4])
+
+    # border
+    p10 = Vector(r_border, 0.0, 0.0)
+    border = Part.ArcOfCircle(p5, p10, p4).toShape()
+
+    shape = Part.makeFace(Part.Wire([contour, border]))
+    face = FreeCAD.ActiveDocument.addObject("Part::Feature", "Face")
+    face.Shape = shape
+    
+    # analysis
+    analysis = ObjectsFem.makeAnalysis(doc, "Analysis")
+
+    # solver
+    if solvertype == "elmer":
+        solver_obj = ObjectsFem.makeSolverElmer(doc, "SolverElmer")
+        solver_obj.CoordinateSystem = "Axi Symmetric"
+        equation_electrostatic = ObjectsFem.makeEquationElectrostatic(doc, solver_obj)
+        equation_electrostatic.CalculateElectricFlux = True
+    elif solvertype == "calculix":
+        solver_obj = ObjectsFem.makeSolverCalculiX(doc, "SolverCalculiX")
+        solver_obj.AnalysisType = "electromagnetic"
+        solver_obj.ElectromagneticMode = "electrostatic"
+        solver_obj.ModelSpace = "axisymmetric"
+        geom2d_obj = ObjectsFem.makeElementGeometry2D(doc)
+        analysis.addObject(geom2d_obj)
+    else:
+        FreeCAD.Console.PrintWarning(
+            "Unknown or unsupported solver type: {}. "
+            "No solver object was created.\n".format(solvertype)
+        )
+        return doc
+
+    analysis.addObject(solver_obj)
+
+    # materials
+    mat_manager = Materials.MaterialManager()
+
+    # air around the objects and inside the coil
+    air = mat_manager.getMaterial("94370b96-c97e-4a3f-83b2-11d7461f7da7")
+    air_obj = ObjectsFem.makeMaterialFluid(doc, "Air")
+    air_obj.UUID = air.UUID
+    air_obj.Material = air.Properties
+    air_obj.References = [(face, ("Face1",))]
+    analysis.addObject(air_obj)
+
+    # voltage
+    voltage_obj = ObjectsFem.makeConstraintElectromagnetic(doc, "Voltage")
+    voltage_obj.References = [(face, ("Edge6", "Edge7", "Edge8"))]
+    voltage_obj.Potential = "1000 V"
+    voltage_obj.BoundaryCondition = "Dirichlet"
+    analysis.addObject(voltage_obj)
+
+    # ground voltage
+    ground_obj = ObjectsFem.makeConstraintElectromagnetic(doc, "Ground")
+    ground_obj.References = [(face, ("Edge1", "Edge2", "Edge3", "Edge4"))]
+    ground_obj.Potential = "0 V"
+    ground_obj.BoundaryCondition = "Dirichlet"
+    analysis.addObject(ground_obj)
+
+    # border
+    border_obj = ObjectsFem.makeConstraintElectromagnetic(doc, "Border")
+    border_obj.References = [(face, ("Edge9",))]
+    border_obj.ElectricFluxDensity = "0 C/mm^2"
+    border_obj.BoundaryCondition = "Neumann"
+    analysis.addObject(border_obj)
+
+    # symmetry
+    symmetry_obj = ObjectsFem.makeConstraintElectromagnetic(doc, "Symmetry")
+    symmetry_obj.References = [(face, ("Edge5",))]
+    symmetry_obj.ElectricFluxDensity = "0 C/mm^2"
+    symmetry_obj.BoundaryCondition = "Neumann"
+    analysis.addObject(symmetry_obj)
+
+    # mesh
+    femmesh_obj = analysis.addObject(ObjectsFem.makeMeshGmsh(doc, manager.get_meshname()))[0]
+    femmesh_obj.Shape = face
+    femmesh_obj.ElementOrder = "2nd"
+    femmesh_obj.CharacteristicLengthMax = "5 mm"
+    femmesh_obj.ViewObject.Visibility = False
+
+    # mesh_region
+    mesh_region = ObjectsFem.makeMeshRegion(doc, femmesh_obj, name="MeshRegion")
+    mesh_region.CharacteristicLength = "1.0 mm"
+    mesh_region.References = [
+        (face, ("Edge4", "Edge5", "Edge6")),
+    ]
+    mesh_region.ViewObject.Visibility = False
+
+    # set view
+    doc.recompute()
+    if FreeCAD.GuiUp:
+        import FemGui
+        face.ViewObject.Transparency = 50
+        face.ViewObject.Document.activeView().fitAll()
+        FemGui.setActiveAnalysis(analysis)
+
+    # generate the mesh
+    generate_mesh.mesh_from_mesher(femmesh_obj, "gmsh")
+
+    doc.recompute()
+    return doc


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Add electrostatic spark gap example for Elmer and CalculiX using axisymmetric model.
For the electrodes, only the relevant boundary is generated.

@FEA-eng 
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
