### PR TITLE
PartDesign: SubShapeBinder - Do not add Binder to single not activated Body

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -415,7 +415,7 @@ void CmdPartDesignSubShapeBinder::activated(int iMsg)
     }
 
     std::string FeatName;
-    PartDesign::Body* pcActiveBody = PartDesignGui::getBody(false, true, true, &parent, &parentSub);
+    PartDesign::Body* pcActiveBody = PartDesignGui::getBody(false, false, true, &parent, &parentSub);
     FeatName = getUniqueObjectName("Binder", pcActiveBody);
     if (parent) {
         decltype(values) links;

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -130,21 +130,15 @@ PartDesign::Body* getBody(
     PartDesign::Body* activeBody = nullptr;
     Gui::MDIView* activeView = Gui::Application::Instance->activeView();
 
-    if (activeView) {
-        auto doc = activeView->getAppDocument();
-        bool singleBodyDocument = doc->countObjectsOfType<PartDesign::Body>() == 1;
-        if (assertModern) {
-            activeBody = activeView->getActiveObject<PartDesign::Body*>(PDBODYKEY, topParent, subname);
-
-            if (!activeBody && singleBodyDocument && autoActivate) {
-                auto bodies = doc->getObjectsOfType(PartDesign::Body::getClassTypeId());
-                App::DocumentObject* body = nullptr;
-                if (bodies.size() == 1) {
-                    body = bodies[0];
-                    activeBody = makeBodyActive(body, doc, topParent, subname);
-                }
+    if (activeView && assertModern) {
+        activeBody = activeView->getActiveObject<PartDesign::Body*>(PDBODYKEY, topParent, subname);
+        if (!activeBody) {
+            auto doc = activeView->getAppDocument();
+            auto bodies = doc->getObjectsOfType(PartDesign::Body::getClassTypeId());
+            if (autoActivate && (bodies.size() == 1)) {
+                activeBody = makeBodyActive(bodies[0], doc, topParent, subname);
             }
-            if (!activeBody && messageIfNot) {
+            else if (messageIfNot) {
                 DlgActiveBody dia(
                     Gui::getMainWindow(),
                     doc,


### PR DESCRIPTION
Fixes #30253

### Changes
- Do not activate automatically single `Body` object in document and do not add new **Binder** to this `Body`
- Refactored method `getBody()`

### Description
If document contains only one `Body`, it does not mean that **Binder** should be added to this `Body` 
Project can contains many objects, complicated structures and one `Body`
Add **Binder** to this single `Body`, which is not active, can be destructive, e.g. in **CAM** project

Example:
- Selected face on the **Tube**
- `Binder` created in `Body` which not have any relation to work stuff
<img width="891" height="502" alt="628014336-b59ecf82-e08f-400d-b0e3-b8678c137041" src="https://github.com/user-attachments/assets/1030d6a1-ae13-4371-a14c-b56fc10f23c9" />

https://github.com/user-attachments/assets/59ea617b-9c44-49c5-9bc1-47cc64ed6d65