### PR TITLE
Gui: fix flat Light Sources preview rendering

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -57,6 +57,7 @@
 #include <Inventor/annex/Profiler/SoProfiler.h>
 #include <Inventor/annex/Profiler/elements/SoProfilerElement.h>
 #include <Inventor/details/SoDetail.h>
+#include <Inventor/elements/SoGLLazyElement.h>
 #include <Inventor/elements/SoLightModelElement.h>
 #include <Inventor/elements/SoOverrideElement.h>
 #include <Inventor/elements/SoViewportRegionElement.h>
@@ -272,6 +273,29 @@ void setOverlayCacheContext(SoGLRenderAction& action, const View3DInventorViewer
     }
 }
 
+/**
+ * Reset the main render action's lazy GL cache after overlay rendering.
+ *
+ * Overlay render actions share the viewer's OpenGL context, but keep their own
+ * Coin lazy state. They can leave the real GL state different from what the
+ * main render action has cached, so reset the cache and let the next traversal
+ * resend the state through Coin instead of restoring individual GL flags here.
+ */
+void resetMainLazyGLState(const View3DInventorViewer* viewer)
+{
+    if (!viewer || !viewer->getSoRenderManager()) {
+        return;
+    }
+
+    SoGLRenderAction* mainAction = viewer->getSoRenderManager()->getGLRenderAction();
+    if (!mainAction || !mainAction->getState()) {
+        return;
+    }
+
+    SoGLLazyElement::getInstance(mainAction->getState())
+        ->reset(mainAction->getState(), SoLazyElement::ALL_MASK);
+}
+
 SoSeparator* create2DOverlayRoot(int viewportWidth, int viewportHeight)
 {
     auto* root = new SoSeparator;
@@ -303,6 +327,7 @@ void applyOverlay(SoNode* root, int viewportWidth, int viewportHeight, const Vie
     setOverlayCacheContext(action, viewer);
     action.setTransparencyType(SoGLRenderAction::BLEND);
     action.apply(root);
+    resetMainLazyGLState(viewer);
 }
 
 struct OverlayImageState
@@ -5260,15 +5285,21 @@ void View3DInventorViewer::drawAxisCross()
     SbViewportRegion vp = this->getSoRenderManager()->getViewportRegion();
     vp.setViewportPixels(origin[0], origin[1], pixelarea, pixelarea);
 
-    SoGLRenderAction axisAction(vp);
-    setOverlayCacheContext(axisAction, this);
-    axisAction.setTransparencyType(SoGLRenderAction::BLEND);
-    axisAction.apply(overlay.axisRoot);
+    {
+        SoGLRenderAction axisAction(vp);
+        setOverlayCacheContext(axisAction, this);
+        axisAction.setTransparencyType(SoGLRenderAction::BLEND);
+        axisAction.apply(overlay.axisRoot);
+    }
 
-    SoGLRenderAction letterAction(vp);
-    setOverlayCacheContext(letterAction, this);
-    letterAction.setTransparencyType(SoGLRenderAction::BLEND);
-    letterAction.apply(overlay.lettersRoot);
+    {
+        SoGLRenderAction letterAction(vp);
+        setOverlayCacheContext(letterAction, this);
+        letterAction.setTransparencyType(SoGLRenderAction::BLEND);
+        letterAction.apply(overlay.lettersRoot);
+    }
+
+    resetMainLazyGLState(this);
 }
 
 void View3DInventorViewer::drawSingleBackground(const QColor& col)


### PR DESCRIPTION
The Light Sources preferences preview could render as a flat, unlit sphere when using a solid background.

The preview scene itself still had the expected Coin lighting state: traversal reached the sphere with a PHONG light model and active light nodes. The actual OpenGL lighting state, however, could already be disabled by earlier viewer overlay rendering. Some overlays are rendered through temporary `SoGLRenderAction` instances that share the same OpenGL context as the main render action, but keep independent Coin lazy state. That can leave the real GL state different from what the main render action still has cached.

This patch resets the main render action's `SoGLLazyElement` cache after overlay render actions that share its context. The next traversal then resends the GL state it depends on through Coin, so the Light Sources preview is shaded correctly again without directly toggling legacy OpenGL lighting state.

I tested a few alternatives before settling on this:
- `SoGLRenderAction::invalidateState()` at this point crashes because the current `renderScene()` still holds and uses the existing `SoState`.
- Explicitly restoring `GL_LIGHTING` works, but directly touches legacy OpenGL state.
- Appending Coin light-model restore nodes or callbacks to the overlay scenegraphs did not resynchronize the main render action state.

<img width="964" height="932" alt="image" src="https://github.com/user-attachments/assets/64a603cf-a743-4437-9157-4729c2025b85" />
