### PR TITLE
Allow `-Werror` for OCCT 8

### DIFF
--- a/cMake/FreeCadMacros.cmake
+++ b/cMake/FreeCadMacros.cmake
@@ -407,3 +407,8 @@ function(target_compile_warn_error ProjectName)
     endif()
 endfunction()
 
+function(disable_occt8_deprecation_warnings)
+    if (OCC_VERSION_STRING VERSION_GREATER_EQUAL "8.0.0")
+        add_compile_definitions(-DOCCT_NO_DEPRECATED)
+    endif()
+endfunction()

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2669,7 +2669,7 @@ void processProgramOptions(const boost::program_options::variables_map& vm, std:
         std::vector<std::string> testCases;
         bool runAll = false;
         bool printAll = false;
-        for (const std::string& key : {"run-open", "run-test"}) {
+        for (const char* key : {"run-open", "run-test"}) {
             if (vm.contains(key)) {
                 auto v = vm[key].as<std::vector<std::string>>();
                 for (const auto& s : v) {

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -758,7 +758,11 @@ void NaviCubeImplementation::createCubeFaceTextures()
 
         // Coin backend: store as a Coin-managed texture (SoTexture2).
         // Mirror to match the OpenGL texture coordinate origin (bottom-left).
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+        const QImage rgba = image.flipped().convertToFormat(QImage::Format_RGBA8888);
+#else
         const QImage rgba = image.mirrored().convertToFormat(QImage::Format_RGBA8888);
+#endif
         const int w = rgba.width();
         const int h = rgba.height();
         std::vector<unsigned char> pixels(static_cast<size_t>(w) * static_cast<size_t>(h) * 4U);

--- a/src/Gui/PreferencePackManager.cpp
+++ b/src/Gui/PreferencePackManager.cpp
@@ -257,7 +257,7 @@ void Gui::PreferencePackManager::importConfig(
 
 // TODO(Shvedov): Is this suitable place for this method? It is more generic,
 // and maybe more suitable place at Application?
-std::vector<std::filesystem::path> Gui::PreferencePackManager::modPaths() const
+std::vector<std::filesystem::path> Gui::PreferencePackManager::modPaths()
 {
     auto userModPath = fs::path(Base::FileInfo::stringToPath(App::Application::getUserAppDataDir()))
         / "Mod";

--- a/src/Gui/PreferencePackManager.h
+++ b/src/Gui/PreferencePackManager.h
@@ -201,7 +201,7 @@ public:
     /**
      * Get a list of all mod directories.
      */
-    std::vector<std::filesystem::path> modPaths() const;
+    static std::vector<std::filesystem::path> modPaths();
 
     /**
      * Get the path to the saved preference packs.

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -628,7 +628,7 @@ bool QuantitySpinBox::isNormalized()
             return true;
         }
     }
-    catch (Base::Exception) {
+    catch (const Base::Exception&) {
         // The exception is intentionally ignored here and should be handled,
         // when the value is assigned
         return false;

--- a/src/Mod/Assembly/CMakeLists.txt
+++ b/src/Mod/Assembly/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+if(OCC_VERSION_STRING VERSION_GREATER_EQUAL "8.0.0")
+    add_definitions(-DOCCT_NO_DEPRECATED)
+endif()
+
 if (NOT FREECAD_USE_EXTERNAL_ONDSELSOLVER)
 include_directories(
     ${CMAKE_SOURCE_DIR}/src/3rdParty/OndselSolver

--- a/src/Mod/Assembly/CMakeLists.txt
+++ b/src/Mod/Assembly/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+disable_occt8_deprecation_warnings()
+
 if (NOT FREECAD_USE_EXTERNAL_ONDSELSOLVER)
 include_directories(
     ${CMAKE_SOURCE_DIR}/src/3rdParty/OndselSolver

--- a/src/Mod/CAM/App/Area.cpp
+++ b/src/Mod/CAM/App/Area.cpp
@@ -3784,7 +3784,6 @@ std::list<TopoDS_Shape> Area::sortWires(
         auto best_it = shape_list.begin();
         for (auto it = best_it; it != shape_list.end(); ++it) {
             double d;
-            gp_Pnt pt;
             if (it->myPlanar && current_it == shape_list.end()) {
                 d = it->myPln.SquareDistance(pstart);
             }

--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+if(OCC_VERSION_STRING VERSION_GREATER_EQUAL "8.0.0")
+    add_definitions(-DOCCT_NO_DEPRECATED)
+endif()
+
 add_subdirectory(App)
 add_subdirectory(libarea)
 add_subdirectory(PathSimulator)

--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+disable_occt8_deprecation_warnings()
+
 add_subdirectory(App)
 add_subdirectory(libarea)
 add_subdirectory(PathSimulator)

--- a/src/Mod/Fem/CMakeLists.txt
+++ b/src/Mod/Fem/CMakeLists.txt
@@ -1,3 +1,6 @@
+if(OCC_VERSION_STRING VERSION_GREATER_EQUAL "8.0.0")
+    add_definitions(-DOCCT_NO_DEPRECATED)
+endif()
 
 if(BUILD_FEM_VTK)
     add_definitions(-DFC_USE_VTK)

--- a/src/Mod/Fem/CMakeLists.txt
+++ b/src/Mod/Fem/CMakeLists.txt
@@ -1,3 +1,4 @@
+disable_occt8_deprecation_warnings()
 
 if(BUILD_FEM_VTK)
     add_definitions(-DFC_USE_VTK)

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -1774,7 +1774,7 @@ void ImpExpDxfWrite::exportShape(const TopoDS_Shape input)
 {
     // export Edges
     TopExp_Explorer edges(input, TopAbs_EDGE);
-    for (int i = 1; edges.More(); edges.Next(), i++) {
+    for (; edges.More(); edges.Next()) {
         const TopoDS_Edge& edge = TopoDS::Edge(edges.Current());
         BRepAdaptor_Curve adapt(edge);
         if (adapt.GetType() == GeomAbs_Circle) {
@@ -1890,7 +1890,7 @@ void ImpExpDxfWrite::exportShape(const TopoDS_Shape input)
     if (optionExpPoints) {
         TopExp_Explorer verts(input, TopAbs_VERTEX);
         std::vector<gp_Pnt> duplicates;
-        for (int i = 1; verts.More(); verts.Next(), i++) {
+        for (; verts.More(); verts.Next()) {
             const TopoDS_Vertex& v = TopoDS::Vertex(verts.Current());
             gp_Pnt p = BRep_Tool::Pnt(v);
             duplicates.push_back(p);

--- a/src/Mod/Import/CMakeLists.txt
+++ b/src/Mod/Import/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+if(OCC_VERSION_STRING VERSION_GREATER_EQUAL "8.0.0")
+    add_definitions(-DOCCT_NO_DEPRECATED)
+endif()
+
 add_subdirectory(App)
 if(BUILD_GUI)
     add_subdirectory(Gui)

--- a/src/Mod/Import/CMakeLists.txt
+++ b/src/Mod/Import/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+disable_occt8_deprecation_warnings()
+
 add_subdirectory(App)
 if(BUILD_GUI)
     add_subdirectory(Gui)

--- a/src/Mod/Inspection/App/CMakeLists.txt
+++ b/src/Mod/Inspection/App/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+if(OCC_VERSION_STRING VERSION_GREATER_EQUAL "8.0.0")
+    add_definitions(-DOCCT_NO_DEPRECATED)
+endif()
+
 set(Inspection_LIBS
     FreeCADApp
     Mesh

--- a/src/Mod/Inspection/App/CMakeLists.txt
+++ b/src/Mod/Inspection/App/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+disable_occt8_deprecation_warnings()
+
 set(Inspection_LIBS
     FreeCADApp
     Mesh

--- a/src/Mod/JtReader/App/JrJt/Element_Header.h
+++ b/src/Mod/JtReader/App/JrJt/Element_Header.h
@@ -46,7 +46,7 @@ struct Element_Header
         read(cont, zLib);
     };
 
-    inline void read(Context& cont, bool zLib = false)
+    inline void read(Context& cont, [[maybe_unused]] bool zLib = false)
     {
         // only zip less implemented so far...
         assert(zLib == false);

--- a/src/Mod/Measure/CMakeLists.txt
+++ b/src/Mod/Measure/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+if(OCC_VERSION_STRING VERSION_GREATER_EQUAL "8.0.0")
+    add_definitions(-DOCCT_NO_DEPRECATED)
+endif()
+
 add_subdirectory(App)
 
 set(Measure_Scripts

--- a/src/Mod/Measure/CMakeLists.txt
+++ b/src/Mod/Measure/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+disable_occt8_deprecation_warnings()
+
 add_subdirectory(App)
 
 set(Measure_Scripts

--- a/src/Mod/Mesh/App/Core/IO/Writer3MF.cpp
+++ b/src/Mod/Mesh/App/Core/IO/Writer3MF.cpp
@@ -131,10 +131,9 @@ bool Writer3MF::SaveObject(std::ostream& str, int id, const MeshKernel& mesh, co
 
     // vertices
     str << Base::blanks(4) << "<vertices>\n";
-    std::size_t index = 0;
-    for (auto it = rPoints.begin(); it != rPoints.end(); ++it, ++index) {
-        str << Base::blanks(5) << "<vertex x=\"" << it->x << "\" y=\"" << it->y << "\" z=\""
-            << it->z << "\" />\n";
+    for (const auto& rPoint : rPoints) {
+        str << Base::blanks(5) << "<vertex x=\"" << rPoint.x << "\" y=\"" << rPoint.y << "\" z=\""
+            << rPoint.z << "\" />\n";
     }
     str << Base::blanks(4) << "</vertices>\n";
 

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -1748,13 +1748,12 @@ bool MeshOutput::SaveSMF(std::ostream& out) const
 
     // vertices
     Base::Vector3f pt;
-    std::size_t index = 0;
-    for (auto it = rPoints.begin(); it != rPoints.end(); ++it, ++index) {
+    for (const auto& rPoint : rPoints) {
         if (this->apply_transform) {
-            pt = this->_transform * *it;
+            pt = this->_transform * rPoint;
         }
         else {
-            pt.Set(it->x, it->y, it->z);
+            pt.Set(rPoint.x, rPoint.y, rPoint.z);
         }
 
         out << "v " << pt.x << " " << pt.y << " " << pt.z << '\n';

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -1753,13 +1753,12 @@ bool MeshOutput::SaveSMF(std::ostream& out) const
 
     // vertices
     Base::Vector3f pt;
-    std::size_t index = 0;
-    for (auto it = rPoints.begin(); it != rPoints.end(); ++it, ++index) {
+    for (const auto& rPoint : rPoints) {
         if (this->apply_transform) {
-            pt = this->_transform * *it;
+            pt = this->_transform * rPoint;
         }
         else {
-            pt.Set(it->x, it->y, it->z);
+            pt.Set(rPoint.x, rPoint.y, rPoint.z);
         }
 
         out << "v " << pt.x << " " << pt.y << " " << pt.z << '\n';

--- a/src/Mod/Mesh/App/WildMagic4/Wm4ApprCylinderFit3.cpp
+++ b/src/Mod/Mesh/App/WildMagic4/Wm4ApprCylinderFit3.cpp
@@ -112,7 +112,7 @@ Real CylinderFit3<Real>::UpdateDirection (int iQuantity,
 
     // compute direction of steepest descent
     Vector3<Real> kVDir = Vector3<Real>::ZERO;
-    Real fAMean = (Real)0.0, fAAMean = (Real)0.0;
+    [[maybe_unused]] Real fAMean = (Real)0.0, fAAMean = (Real)0.0;
     for (i = 0; i < iQuantity; i++)
     {
         kDelta = akPoint[i] - rkC;

--- a/src/Mod/Mesh/Gui/ViewProviderTransformDemolding.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderTransformDemolding.cpp
@@ -147,9 +147,8 @@ void ViewProviderMeshTransformDemolding::calcMaterialIndex(const SbRotation& rot
     SbVec3f Up(0, 0, 1);
     SbVec3f result;
 
-    int i = 0;
-    for (auto it = normalVector.begin(); it != normalVector.end(); ++it, i++) {
-        rot.multVec(*it, result);
+    for (auto& it : normalVector) {
+        rot.multVec(it, result);
     }
 }
 

--- a/src/Mod/Mesh/Gui/ViewProviderTransformDemolding.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderTransformDemolding.cpp
@@ -147,9 +147,8 @@ void ViewProviderMeshTransformDemolding::calcMaterialIndex(const SbRotation& rot
     SbVec3f Up(0, 0, 1);
     SbVec3f result;
 
-    int i = 0;
-    for (auto it = normalVector.begin(); it != normalVector.end(); ++it, i++) {
-        rot.multVec(*it, result);
+    for (auto& normal : normalVector) {
+        rot.multVec(normal, result);
     }
 }
 

--- a/src/Mod/MeshPart/CMakeLists.txt
+++ b/src/Mod/MeshPart/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+if(OCC_VERSION_STRING VERSION_GREATER_EQUAL "8.0.0")
+    add_definitions(-DOCCT_NO_DEPRECATED)
+endif()
+
 add_subdirectory(App)
 if(BUILD_GUI)
     add_subdirectory(Gui)

--- a/src/Mod/MeshPart/CMakeLists.txt
+++ b/src/Mod/MeshPart/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+disable_occt8_deprecation_warnings()
+
 add_subdirectory(App)
 if(BUILD_GUI)
     add_subdirectory(Gui)

--- a/src/Mod/Part/App/Tools.cpp
+++ b/src/Mod/Part/App/Tools.cpp
@@ -160,8 +160,7 @@ Handle(Geom_Surface) Part::Tools::makeSurface(
 
     TColStd_ListIteratorOfListOfTransient anIt(theBoundaries);
     if (anIt.More()) {
-        int i = 1;
-        for (; anIt.More(); anIt.Next(), i++) {
+        for (; anIt.More(); anIt.Next()) {
             const Handle(Standard_Transient) & aCur = anIt.Value();
             if (aCur.IsNull()) {
                 assert(0);

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -502,11 +502,13 @@ PyObject* TopoShapePy::dumpToString(PyObject* args) const
         PyErr_SetString(PartExceptionOCCError, e.what());
         return nullptr;
     }
+#if OCC_VERSION_HEX < 0x080000
     catch (Standard_Failure& e) {
 
         PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
         return nullptr;
     }
+#endif
 }
 
 PyObject* TopoShapePy::exportBrepToString(PyObject* args) const
@@ -529,10 +531,12 @@ PyObject* TopoShapePy::exportBrepToString(PyObject* args) const
         PyErr_SetString(PartExceptionOCCError, e.what());
         return nullptr;
     }
+#if OCC_VERSION_HEX < 0x080000
     catch (Standard_Failure& e) {
         PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
         return nullptr;
     }
+#endif
 }
 
 PyObject* TopoShapePy::importBrep(PyObject* args)
@@ -619,10 +623,12 @@ PyObject* TopoShapePy::importBrepFromString(PyObject* args)
         PyErr_SetString(PartExceptionOCCError, e.what());
         return nullptr;
     }
+#if OCC_VERSION_HEX < 0x080000
     catch (Standard_Failure& e) {
         PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
         return nullptr;
     }
+#endif
 
     Py_Return;
 }

--- a/src/Mod/Part/CMakeLists.txt
+++ b/src/Mod/Part/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+if(OCC_VERSION_STRING VERSION_GREATER_EQUAL "8.0.0")
+    add_definitions(-DOCCT_NO_DEPRECATED)
+endif()
+
 if(BUILD_TRACY_FRAME_PROFILER)
     add_definitions(-DBUILD_TRACY_FRAME_PROFILER)
 endif()

--- a/src/Mod/Part/CMakeLists.txt
+++ b/src/Mod/Part/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+disable_occt8_deprecation_warnings()
+
 if(BUILD_TRACY_FRAME_PROFILER)
     add_definitions(-DBUILD_TRACY_FRAME_PROFILER)
 endif()

--- a/src/Mod/PartDesign/CMakeLists.txt
+++ b/src/Mod/PartDesign/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+if(OCC_VERSION_STRING VERSION_GREATER_EQUAL "8.0.0")
+    add_definitions(-DOCCT_NO_DEPRECATED)
+endif()
+
 add_subdirectory(App)
 if(BUILD_GUI)
     add_subdirectory(Gui)

--- a/src/Mod/PartDesign/CMakeLists.txt
+++ b/src/Mod/PartDesign/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+disable_occt8_deprecation_warnings()
+
 add_subdirectory(App)
 if(BUILD_GUI)
     add_subdirectory(Gui)

--- a/src/Mod/ReverseEngineering/CMakeLists.txt
+++ b/src/Mod/ReverseEngineering/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+if(OCC_VERSION_STRING VERSION_GREATER_EQUAL "8.0.0")
+    add_definitions(-DOCCT_NO_DEPRECATED)
+endif()
+
 add_subdirectory(App)
 if(BUILD_GUI)
     add_subdirectory(Gui)

--- a/src/Mod/ReverseEngineering/CMakeLists.txt
+++ b/src/Mod/ReverseEngineering/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+disable_occt8_deprecation_warnings()
+
 add_subdirectory(App)
 if(BUILD_GUI)
     add_subdirectory(Gui)

--- a/src/Mod/Robot/App/kdl_cp/chainiksolverpos_lma.cpp
+++ b/src/Mod/Robot/App/kdl_cp/chainiksolverpos_lma.cpp
@@ -72,7 +72,11 @@ ChainIkSolverPos_LMA::ChainIkSolverPos_LMA(
 	A(_chain.getNrOfJoints(), _chain.getNrOfJoints()),
 	tmp(_chain.getNrOfJoints()),
 	ldlt(_chain.getNrOfJoints()),
-	svd(6, _chain.getNrOfJoints(),Eigen::ComputeThinU | Eigen::ComputeThinV),
+#if EIGEN_VERSION_AT_LEAST(5, 0, 0)
+        svd(6, _chain.getNrOfJoints()),
+#else
+        svd(6, _chain.getNrOfJoints(),Eigen::ComputeThinU | Eigen::ComputeThinV),
+#endif
 	diffq(_chain.getNrOfJoints()),
 	q_new(_chain.getNrOfJoints()),
 	original_Aii(_chain.getNrOfJoints())
@@ -98,7 +102,11 @@ ChainIkSolverPos_LMA::ChainIkSolverPos_LMA(
 	q(_chain.getNrOfJoints()),
 	A(_chain.getNrOfJoints(), _chain.getNrOfJoints()),
 	ldlt(_chain.getNrOfJoints()),
-	svd(6, _chain.getNrOfJoints(),Eigen::ComputeThinU | Eigen::ComputeThinV),
+#if EIGEN_VERSION_AT_LEAST(5, 0, 0)
+        svd(6, _chain.getNrOfJoints()),
+#else
+        svd(6, _chain.getNrOfJoints(),Eigen::ComputeThinU | Eigen::ComputeThinV),
+#endif
 	diffq(_chain.getNrOfJoints()),
 	q_new(_chain.getNrOfJoints()),
 	original_Aii(_chain.getNrOfJoints())

--- a/src/Mod/Robot/App/kdl_cp/chainiksolverpos_lma.hpp
+++ b/src/Mod/Robot/App/kdl_cp/chainiksolverpos_lma.hpp
@@ -227,7 +227,11 @@ private:
     MatrixXq A;
     VectorXq tmp;
     Eigen::LDLT<MatrixXq> ldlt;
+#if EIGEN_VERSION_AT_LEAST(5, 0, 0)
+     Eigen::JacobiSVD<MatrixXq, Eigen::ComputeThinU | Eigen::ComputeThinV> svd;
+#else
     Eigen::JacobiSVD<MatrixXq> svd;
+#endif
     VectorXq diffq;
     VectorXq q_new;
     VectorXq original_Aii;

--- a/src/Mod/Robot/CMakeLists.txt
+++ b/src/Mod/Robot/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+if(OCC_VERSION_STRING VERSION_GREATER_EQUAL "8.0.0")
+    add_definitions(-DOCCT_NO_DEPRECATED)
+endif()
+
 add_subdirectory(App)
 if(BUILD_GUI)
     add_subdirectory(Gui)

--- a/src/Mod/Robot/CMakeLists.txt
+++ b/src/Mod/Robot/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+disable_occt8_deprecation_warnings()
+
 add_subdirectory(App)
 if(BUILD_GUI)
     add_subdirectory(Gui)

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -2157,8 +2157,7 @@ int SketchObject::addCopy(
             currentrowfirstgeoid = cgeoid;
         }
 
-        int index = 0;
-        for (auto it = newgeoIdList.cbegin(); it != newgeoIdList.cend(); ++it, ++index) {
+        for (auto it = newgeoIdList.cbegin(); it != newgeoIdList.cend(); ++it) {
             const Part::Geometry* geo = getGeometry(*it);
 
             Part::Geometry* geocopy;

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -2193,8 +2193,7 @@ int SketchObject::addCopy(
             currentrowfirstgeoid = cgeoid;
         }
 
-        int index = 0;
-        for (auto it = newgeoIdList.cbegin(); it != newgeoIdList.cend(); ++it, ++index) {
+        for (auto it = newgeoIdList.cbegin(); it != newgeoIdList.cend(); ++it) {
             const Part::Geometry* geo = getGeometry(*it);
 
             Part::Geometry* geocopy;

--- a/src/Mod/Sketcher/CMakeLists.txt
+++ b/src/Mod/Sketcher/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+if(OCC_VERSION_STRING VERSION_GREATER_EQUAL "8.0.0")
+    add_definitions(-DOCCT_NO_DEPRECATED)
+endif()
+
 add_subdirectory(App)
 if(BUILD_GUI)
     add_subdirectory(Gui)

--- a/src/Mod/Sketcher/CMakeLists.txt
+++ b/src/Mod/Sketcher/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+disable_occt8_deprecation_warnings()
+
 add_subdirectory(App)
 if(BUILD_GUI)
     add_subdirectory(Gui)

--- a/src/Mod/Surface/CMakeLists.txt
+++ b/src/Mod/Surface/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+if(OCC_VERSION_STRING VERSION_GREATER_EQUAL "8.0.0")
+    add_definitions(-DOCCT_NO_DEPRECATED)
+endif()
+
 add_subdirectory(App)
 if(BUILD_GUI)
     add_subdirectory(Gui)

--- a/src/Mod/Surface/CMakeLists.txt
+++ b/src/Mod/Surface/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+disable_occt8_deprecation_warnings()
+
 add_subdirectory(App)
 if(BUILD_GUI)
     add_subdirectory(Gui)

--- a/src/Mod/TechDraw/App/DrawComplexSection.cpp
+++ b/src/Mod/TechDraw/App/DrawComplexSection.cpp
@@ -337,7 +337,7 @@ void DrawComplexSection::makeAlignedPieces(const TopoDS_Shape& rawShape)
 
     // faceNormals are not in the same order as the faces(sometimes??).
     TopExp_Explorer expFaces(m_toolFaceShape, TopAbs_FACE);
-    for (int iPiece = 0; expFaces.More(); expFaces.Next(), iPiece++) {
+    for (; expFaces.More(); expFaces.Next()) {
         TopoDS_Face face = TopoDS::Face(expFaces.Current());
         if (!isFacePlanar(face)) {
             // TODO: continue blocks curved profile segments (which doesn't work right).
@@ -1034,7 +1034,7 @@ std::vector<TopoDS_Face> DrawComplexSection::faceShapeIntersect(const TopoDS_Fac
     }
     std::vector<TopoDS_Face> intersectFaceList;
     TopExp_Explorer expFaces(intersect, TopAbs_FACE);
-    for (int i = 1; expFaces.More(); expFaces.Next(), i++) {
+    for (; expFaces.More(); expFaces.Next()) {
         intersectFaceList.push_back(TopoDS::Face(expFaces.Current()));
     }
     return intersectFaceList;
@@ -1409,7 +1409,7 @@ DrawComplexSection::getSegmentViewDirections(const TopoDS_Wire& profileWire,
     // are all these shenanigans necessary?
     // no guarantee of order from TopExp_Explorer.  Need to match faces to the profile segment that
     // generated it?
-    for (int iFace = 0; expFaces.More(); expFaces.Next(), iFace++) {
+    for (; expFaces.More(); expFaces.Next()) {
         auto shape = expFaces.Current();
         auto face = TopoDS::Face(shape);
         auto normal = Base::convertTo<Base::Vector3d>(getFaceNormal(face));

--- a/src/Mod/TechDraw/App/DrawComplexSection.cpp
+++ b/src/Mod/TechDraw/App/DrawComplexSection.cpp
@@ -340,7 +340,7 @@ void DrawComplexSection::makeAlignedPieces(const TopoDS_Shape& rawShape)
 
     // faceNormals are not in the same order as the faces(sometimes??).
     TopExp_Explorer expFaces(m_toolFaceShape, TopAbs_FACE);
-    for (int iPiece = 0; expFaces.More(); expFaces.Next(), iPiece++) {
+    for (; expFaces.More(); expFaces.Next()) {
         TopoDS_Face face = TopoDS::Face(expFaces.Current());
         if (!isFacePlanar(face)) {
             // TODO: continue blocks curved profile segments (which doesn't work right).
@@ -1037,7 +1037,7 @@ std::vector<TopoDS_Face> DrawComplexSection::faceShapeIntersect(const TopoDS_Fac
     }
     std::vector<TopoDS_Face> intersectFaceList;
     TopExp_Explorer expFaces(intersect, TopAbs_FACE);
-    for (int i = 1; expFaces.More(); expFaces.Next(), i++) {
+    for (; expFaces.More(); expFaces.Next()) {
         intersectFaceList.push_back(TopoDS::Face(expFaces.Current()));
     }
     return intersectFaceList;
@@ -1412,7 +1412,7 @@ DrawComplexSection::getSegmentViewDirections(const TopoDS_Wire& profileWire,
     // are all these shenanigans necessary?
     // no guarantee of order from TopExp_Explorer.  Need to match faces to the profile segment that
     // generated it?
-    for (int iFace = 0; expFaces.More(); expFaces.Next(), iFace++) {
+    for (; expFaces.More(); expFaces.Next()) {
         auto shape = expFaces.Current();
         auto face = TopoDS::Face(shape);
         auto normal = Base::convertTo<Base::Vector3d>(getFaceNormal(face));

--- a/src/Mod/TechDraw/App/DrawProjectSplit.cpp
+++ b/src/Mod/TechDraw/App/DrawProjectSplit.cpp
@@ -703,7 +703,7 @@ int DrawProjectSplit::isSubset(const TopoDS_Edge &edge0, const TopoDS_Edge &edge
     }
     std::vector<TopoDS_Edge> commonEdgeList;
     TopExp_Explorer edges(aRes, TopAbs_EDGE);
-    for (int i = 1; edges.More(); edges.Next(), i++) {
+    for (; edges.More(); edges.Next()) {
         commonEdgeList.push_back(TopoDS::Edge(edges.Current()));
     }
     if (commonEdgeList.empty()) {
@@ -740,7 +740,7 @@ std::vector<TopoDS_Edge> DrawProjectSplit::fuseEdges(const TopoDS_Edge &edge0, c
         return edgeList;     //empty result
     }
     TopExp_Explorer edges(aRes, TopAbs_EDGE);
-    for (int i = 1; edges.More(); edges.Next(), i++) {
+    for (; edges.More(); edges.Next()) {
         edgeList.push_back(TopoDS::Edge(edges.Current()));
     }
     return edgeList;

--- a/src/Mod/TechDraw/App/DrawProjectSplit.cpp
+++ b/src/Mod/TechDraw/App/DrawProjectSplit.cpp
@@ -80,7 +80,6 @@ std::vector<TopoDS_Edge> DrawProjectSplit::getEdgesForWalker(TopoDS_Shape shape,
     BRepBuilderAPI_Copy BuilderCopy(shape);
     TopoDS_Shape copyShape = BuilderCopy.Shape();
 
-    gp_Pnt inputCenter(0, 0, 0);
     TopoDS_Shape scaledShape;
     scaledShape = ShapeUtils::scaleShape(copyShape,
                                        scale);

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -1381,8 +1381,6 @@ std::pair<Base::Vector3d, Base::Vector3d> DrawViewPart::getDirsFromFront(ProjDir
     gp_Dir gYDir = anchorCS.YDirection();
     gp_Ax1 gUpAxis(gOrg, gYDir);
     gp_Ax2 newCS;
-    gp_Dir gNewDir;
-    gp_Dir gNewXDir;
 
     double angle = std::numbers::pi / 2.0;//90*
 

--- a/src/Mod/TechDraw/CMakeLists.txt
+++ b/src/Mod/TechDraw/CMakeLists.txt
@@ -1,3 +1,6 @@
+if(OCC_VERSION_STRING VERSION_GREATER_EQUAL "8.0.0")
+    add_definitions(-DOCCT_NO_DEPRECATED)
+endif()
 
 add_definitions(-DMOD_TECHDRAW_HANDLE_FACES=1)
 

--- a/src/Mod/TechDraw/CMakeLists.txt
+++ b/src/Mod/TechDraw/CMakeLists.txt
@@ -1,3 +1,4 @@
+disable_occt8_deprecation_warnings()
 
 add_definitions(-DMOD_TECHDRAW_HANDLE_FACES=1)
 


### PR DESCRIPTION
Currently FreeCAD can compile against both OCCT 7 and OCCT 8.  Since https://github.com/FreeCAD/FreeCAD/pull/30228 and https://github.com/FreeCAD/FreeCAD/pull/30299 the CI changes all warnings into errors with the `-Werror` flag.  This causes future builds of FreeCAD with OCCT 8 in the CI to break because OCCT 8 has deprecated many API calls that FreeCAD makes use of.

This PR ensures that builds of FreeCAD with both OCCT 7 and 8 can build with `-Werror`.

Several approaches have been attempted:
1. Make FreeCAD's code base as close to OCCT 8 as possible: OCCT 8 has migration scripts to modernize a code base.  This doesn't work for FreeCAD because FreeCAD will have to compile against OCCT 7 for a while as well.  The only migration that succeeded was for the standard types, but for all other migrations, it would require version guards in many places.  This makes the code much more difficult to read.
2. Add a specific header file that would define `OCCT_NO_DEPRECATED` to mute the deprecated warnings from OCCT.  This was leading to an extra file and inclusions of that header in many files.
3. Add `OCCT_NO_DEPRECATED` as part of the build system.  This turned out to be the best solution with the least amount of changes.  Only the relevant CMakeFiles are touched by this PR and the scope is as small as possible.  As an example, if the App package of a module requires the `OCCT_NO_DEPRECATED` define but the Gui does not, then the define is only in the CMakeFile of the App package.

The implication is that FreeCAD remains an OCCT 7 code base with minimal version guards for OCCT 8.  Once FreeCAD does not have to support OCCT 7 any longer, we can use OCCT's scripts to migrate the code base to OCCT 8.

This PR has been tested to compile to OCCT 7.6.3 and OCCT 8 (including `V8_0_0_p1`)




<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->



<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->


<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
