### PR TITLE
Allow Toggle Axis Cross in sketcher

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2439,6 +2439,7 @@ StdCmdAxisCross::StdCmdAxisCross()
     sStatusTip = sToolTipText;
     sWhatsThis = "Std_AxisCross";
     sPixmap = "Std_AxisCross";
+    eType = Alter3DView;
     sAccel = "A,C";
 }
 


### PR DESCRIPTION
Enable the `Toggle Axis Cross` action while in the sketcher 

After more evaluation, it seems plausible that the action is disabled because the default accelerator keys A C conflict with sketcher accelerators. I had missed this as I was driving the actions exclusively through the mouse. 

As a user, I'd rather have the menu option available than have it removed due the keybinding conflict and appreciate the consideration.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
- Fixes #30948

