### PR TITLE
Sketcher: Migrate constraint orientation after resolving external geos

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1374,7 +1374,7 @@ void SketchObject::onSketchRestore()
         synchroniseGeometryState();
 
         // Orientations must be migrated after external refs
-        // are resolved because their underlying geometry might 
+        // are resolved because their underlying geometry might
         // get accessed
         migrateConstraintOrientations();
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1372,6 +1372,12 @@ void SketchObject::onSketchRestore()
             acceptGeometry();
 
         synchroniseGeometryState();
+
+        // Orientations must be migrated after external refs
+        // are resolved because their underlying geometry might 
+        // get accessed
+        migrateConstraintOrientations();
+
         // this may happen when saving a sketch directly in edit mode
         // but never performed a recompute before
         if (Shape.getValue().IsNull() && hasConflicts() == 0) {
@@ -1467,16 +1473,6 @@ void SketchObject::migrateSketch()
 
             g->deleteExtension(Part::GeometryMigrationExtension::getClassTypeId());
         }
-    }
-
-    {
-        // Migrate point-line, circle-circle and circle-line distance from abs to signed
-        auto constraints = Constraints.getValues();
-        for (auto& constr : constraints) {
-            setOrientation(constr, false);
-        }
-
-        Constraints.setValues(std::move(constraints));
     }
 
     /* parabola axis as internal geometry */

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -1086,6 +1086,7 @@ protected:
 
     // migration functions
     void migrateSketch();
+    void migrateConstraintOrientations();
 
     static void appendConstraintsMsg(
         const std::vector<int>& vector,

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -1513,6 +1513,16 @@ void SketchObject::setOrientation(Constraint* constr, bool reset)
         setOrientationTangent(constr);
     }
 }
+// Migrate point-line, circle-circle and circle-line distance from abs to signed
+void SketchObject::migrateConstraintOrientations()
+{
+    auto constraints = Constraints.getValues();
+    for (auto& constr : constraints) {
+        setOrientation(constr, false);
+    }
+
+    Constraints.setValues(std::move(constraints));
+}
 std::unique_ptr<Constraint>
 SketchObject::getConstraintAfterDeletingGeo(const Constraint* constr,
                                             const int deletedGeoId) const


### PR DESCRIPTION

The migration would run before external geometries would be resolved so, for instance, tangent between a real arc and a projected line would yield a nullptr for the line and the orientation routine would fail

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues

Fix: #30930
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->


<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
