### PR TITLE
Revert "Gui: Implement automatic preselection check "

### DIFF
--- a/src/Gui/Selection/SoFCUnifiedSelection.cpp
+++ b/src/Gui/Selection/SoFCUnifiedSelection.cpp
@@ -77,7 +77,6 @@
 #include <App/Document.h>
 #include <App/GeoFeature.h>
 #include <App/ElementNamingUtils.h>
-#include <Base/Console.h>
 #include <Base/Tools.h>
 #include <Base/UnitsApi.h>
 
@@ -179,50 +178,6 @@ std::size_t choosePreferredPick(const std::vector<Candidate>& picked)
 }
 
 }  // namespace Gui::SelectionPickPolicy
-
-// *************************************************************************
-
-void AutoPreselection::setEnabled(SbBool on)
-{
-    if (!enabled && on) {
-        resetFrameCounter();
-    }
-
-    enabled = on;
-}
-
-SbBool AutoPreselection::shouldDisablePreselection() const
-{
-    if (!enabled) {
-        return false;
-    }
-
-    return std::all_of(frames.cbegin(), frames.cend(), [](const auto& time) {
-        return time.frmpersec > 0.0 && time.frmpersec < MinimumFPS;
-    });
-}
-
-void AutoPreselection::resetFrameCounter()
-{
-    framecount = 0;
-    for (auto& it : frames) {
-        it.reset();
-    }
-
-    totalcoin = 0.0;
-}
-
-void AutoPreselection::addFrametime(double picktime)
-{
-    auto index = framecount % FrameCount;
-    framecount++;
-
-    totalcoin += (picktime - frames[index].traversal);
-    double coinfps = totalcoin / std::min(framecount, FrameCount);
-
-    frames[index].traversal = picktime;
-    frames[index].frmpersec = 1.0 / coinfps;
-}
 
 // *************************************************************************
 
@@ -554,7 +509,7 @@ void SoFCUnifiedSelection::doAction(SoAction* action)
             }
         }
         else if (
-            preselectionMode.getValue() != SoFCUnifiedSelection::OFF
+            preselectionMode.getValue() != OFF
             && preselectAction->SelChange.Type == SelectionChanges::SetPreselect
         ) {
             if (currentHighlightPath) {
@@ -623,7 +578,7 @@ void SoFCUnifiedSelection::doAction(SoAction* action)
 
     if (action->getTypeId() == SoFCSelectionAction::getClassTypeId()) {
         auto selectionAction = static_cast<SoFCSelectionAction*>(action);
-        if (selectionMode.getValue() == SoFCUnifiedSelection::ON
+        if (selectionMode.getValue() == ON
             && (selectionAction->SelChange.Type == SelectionChanges::AddSelection
                 || selectionAction->SelChange.Type == SelectionChanges::RmvSelection)) {
             // selection changes inside the 3d view are handled in handleEvent()
@@ -705,7 +660,7 @@ void SoFCUnifiedSelection::doAction(SoAction* action)
             }
         }
         else if (
-            selectionMode.getValue() == SoFCUnifiedSelection::ON
+            selectionMode.getValue() == ON
             && selectionAction->SelChange.Type == SelectionChanges::SetSelection
         ) {
             std::vector<ViewProvider*> vps;
@@ -935,7 +890,7 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
                 return false;
             }
 
-            if (ok && preselectionMode == SoFCUnifiedSelection::OFF) {
+            if (ok && preselectionMode == OFF) {
                 snprintf(
                     buf,
                     512,
@@ -1044,7 +999,7 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
             type = hasNext ? SoSelectionElementAction::All : SoSelectionElementAction::Append;
         }
 
-        if (preselectionMode == SoFCUnifiedSelection::OFF) {
+        if (preselectionMode == OFF) {
             snprintf(
                 buf,
                 512,
@@ -1097,10 +1052,7 @@ void SoFCUnifiedSelection::handleEvent(SoHandleEventAction* action)
         // NOTE: If preselection is off then we do not check for a picked point because otherwise
         // this search may slow down extremely the system on really big data sets. In this case we
         // just check for a picked point if the data set has been selected.
-        if (preselectionMode == SoFCUnifiedSelection::AUTO
-            || preselectionMode == SoFCUnifiedSelection::ON) {
-            autoPreselect.setEnabled(preselectionMode == SoFCUnifiedSelection::AUTO);
-            SbTime picktime = SbTime::getTimeOfDay();
+        if (preselectionMode == AUTO || preselectionMode == ON) {
             // check to see if the mouse is over our geometry...
             auto infos = this->getPickedList(action, true);
             if (!infos.empty()) {
@@ -1114,16 +1066,6 @@ void SoFCUnifiedSelection::handleEvent(SoHandleEventAction* action)
                     // because only from there the SoGLWidgetElement delivers the OpenGL window
                     this->touch();
                 }
-            }
-
-            picktime = SbTime::getTimeOfDay() - picktime;
-            autoPreselect.addFrametime(picktime.getValue());
-            if (autoPreselect.shouldDisablePreselection()) {
-                autoPreselect.setEnabled(false);
-                this->preselectionMode.setValue(SoFCUnifiedSelection::OFF);
-                Base::Console().warning(
-                    "Preselection disabled because picking performance is too slow\n"
-                );
             }
         }
     }

--- a/src/Gui/Selection/SoFCUnifiedSelection.h
+++ b/src/Gui/Selection/SoFCUnifiedSelection.h
@@ -68,37 +68,6 @@ GuiExport std::size_t choosePreferredPick(const std::vector<Candidate>& picked);
 class Document;
 class ViewProviderDocumentObject;
 
-class AutoPreselection
-{
-public:
-    void setEnabled(SbBool on);
-    void addFrametime(double picktime);
-    SbBool shouldDisablePreselection() const;
-
-private:
-    void resetFrameCounter();
-
-private:
-    SbBool enabled = false;
-
-    struct Time
-    {
-        double traversal = 0.0;
-        double frmpersec = 0.0;
-        void reset()
-        {
-            traversal = 0.0;
-            frmpersec = 0.0;
-        }
-    };
-
-    static constexpr std::size_t FrameCount = 100;
-    static constexpr double MinimumFPS = 1000.0;
-    std::array<Time, FrameCount> frames;
-    double totalcoin = 0.0;
-    std::size_t framecount = 0;
-};
-
 /**  Unified Selection node
  *  This is the new selection node for the 3D Viewer which will
  *  gradually remove all the low level selection nodes in the view
@@ -194,7 +163,6 @@ private:
     // -1 = not handled, 0 = not selected, 1 = selected
     int32_t preSelection;
     SoColorPacker colorpacker;
-    AutoPreselection autoPreselect;
 };
 
 class GuiExport SoFCPathAnnotation: public SoSeparator


### PR DESCRIPTION
Reverts FreeCAD/FreeCAD#29978

At least on my Windows system it always triggers the warning and disables preselection. It is not clear to the user how to enable it as the preselection preference is still checked.

Even the simplest example files triggers a lot of warnings and hides preview of the transform tool:

https://github.com/user-attachments/assets/4aecb471-43b3-41ec-b093-7e5f137ea0cf


