### PR TITLE
App: remove UTF8 detail from Label tooltips

### DIFF
--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -68,8 +68,8 @@ DocumentObject::DocumentObject()
     : ExpressionEngine()
 {
     // define Label of type 'Output' to avoid being marked as touched after relabeling
-    ADD_PROPERTY_TYPE(Label, ("Unnamed"), "Base", Prop_Output, "User name of the object (UTF8)");
-    ADD_PROPERTY_TYPE(Label2, (""), "Base", Prop_Hidden, "User description of the object (UTF8)");
+    ADD_PROPERTY_TYPE(Label, ("Unnamed"), "Base", Prop_Output, "User name of the object");
+    ADD_PROPERTY_TYPE(Label2, (""), "Base", Prop_Hidden, "User description of the object");
     Label2.setStatus(App::Property::Output, true);
     ADD_PROPERTY_TYPE(ExpressionEngine, (), "Base", Prop_Hidden, "Property expressions");
 


### PR DESCRIPTION
This PR removes the “UTF8” implementation detail from the user-facing descriptions for the `Label` and `Label2` properties.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues

Closes #30941

## Before and After Images

Not included. This is a string-only tooltip description change in `src/App/DocumentObject.cpp`; I did not run a full local FreeCAD GUI build.

### Summary

Updated the following property descriptions:

- `Label`: from `User name of the object (UTF8)` to `User name of the object`
- `Label2`: from `User description of the object (UTF8)` to `User description of the object`

### Validation

- Located the affected strings in `src/App/DocumentObject.cpp`.
- Updated only the two user-facing property descriptions.
- Ran `git diff --check`.
- Ran  `git diff `.