### PR TITLE
CAM: Helix op - Start cone helix from bottom

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
@@ -174,16 +174,6 @@ G0 X11.250000 Y5.000000 Z23.000000"
         args["edge"] = edg
         self.assertRaises(ValueError, generator.generate, **args)
 
-    def test09(self):
-        """Test Helix Generator with inverted vertical edge"""
-        args = _resetArgs()
-        v1 = FreeCAD.Vector(5, 5, 18)
-        v2 = FreeCAD.Vector(5, 5, 20)
-        edg = Part.makeLine(v1, v2)
-        args["edge"] = edg
-
-        self.assertRaises(ValueError, generator.generate, **args)
-
     def test10(self):
         """Test Helix Retraction"""
 

--- a/src/Mod/CAM/Path/Base/Generator/helix.py
+++ b/src/Mod/CAM/Path/Base/Generator/helix.py
@@ -59,12 +59,19 @@ def generate(
 
     generate(edge, outer_radius, pitch)  # generate helix commands
         edge: vertical line in the center of helix
+              if cone helix, direction of edge define direction of helix
         outer_radius: radius of the outer helix Path
         pitch: vertical step for one turn of helix
         step: distance between helicies, by default create only one helix
         tool_diameter: non zero value using for create retract from wall
         inner_radius: radius of the inner helix Path
         retract_height: height to move between helicies
+        direction: CW or CCW
+        startAt: Inside or Outside
+        finish_circle: add final cirle to the bottom
+        cone_angle_rad: inclination of the helix
+        dir_angle_rad: move start point around the center
+        ramp_angle_rad: the maximum allowable ramp entry angle
 
     import Path.Base.Generator.helix as helix
     helixCommands = helix.generate(**args)
@@ -77,18 +84,24 @@ def generate(
 
     if not isinstance(edge, Part.Edge):
         raise TypeError("Invalid type for edge")
-    topCenterPoint = edge.Vertexes[0].Point
-    bottomCenterPoint = edge.Vertexes[1].Point
-    helixHeight = topCenterPoint.z - bottomCenterPoint.z
 
     if not isinstance(edge.Curve, Part.Line):
         raise TypeError("Invalid type for edge curve")
 
+    p0 = edge.Vertexes[0].Point
+    p1 = edge.Vertexes[1].Point
+    if p0.z > p1.z:
+        start_from_bottom = False
+        topCenterPoint = p0
+        bottomCenterPoint = p1
+    else:
+        start_from_bottom = True
+        topCenterPoint = p1
+        bottomCenterPoint = p0
+    helixHeight = topCenterPoint.z - bottomCenterPoint.z
+
     if not Path.Geom.isVertical(edge):
         raise ValueError("edge is not aligned with Z axis")
-
-    if topCenterPoint.z < bottomCenterPoint.z:
-        raise ValueError("start point is below end point")
 
     if not isinstance(outer_radius, (float, int)):
         raise TypeError("Invalid type for outer radius")
@@ -273,36 +286,41 @@ def generate(
         which forms cone helix inclined by angle
         Each full turn is three 120 degrees arcs"""
 
+        center = bottomCenterPoint if start_from_bottom else topCenterPoint
         topRadius = bottomRadius + math.tan(cone_angle_rad) * helixHeight
-        dx = topRadius * math.cos(dir_angle_rad)
-        dy = topRadius * math.sin(dir_angle_rad)
+        startRadius, endRadius = topRadius, bottomRadius
+        if start_from_bottom:
+            startRadius, endRadius = endRadius, startRadius
+        dx = startRadius * math.cos(dir_angle_rad)
+        dy = startRadius * math.sin(dir_angle_rad)
 
         commandlist = []
         arcCmdName = "G2" if direction == "CW" else "G3"
-        commandlist.append(
-            Path.Command("G0", {"X": topCenterPoint.x + dx, "Y": topCenterPoint.y + dy})
-        )
-        commandlist.append(Path.Command("G1", {"Z": topCenterPoint.z}))
+        commandlist.append(Path.Command("G0", {"X": center.x + dx, "Y": center.y + dy}))
+        commandlist.append(Path.Command("G1", {"Z": center.z}))
 
-        lengthOneTurn = math.tau * bottomRadius
+        lengthOneTurn = math.tau * startRadius
         depthPerOneCircle = min(lengthOneTurn * math.tan(ramp_angle_rad), pitch)
         turncount = Path.Geom.ceil(helixHeight / depthPerOneCircle)
         stepsPerRev = 6
         stepRotate = math.tau / stepsPerRev  # step angle for rotate
         stepRotate = -stepRotate if direction == "CCW" else stepRotate
         iters = turncount * stepsPerRev
-        stepRadius = (topRadius - bottomRadius) / iters  # step size for spiral radius
+        stepRadius = (startRadius - endRadius) / iters  # step size for spiral radius
         stepZ = helixHeight / iters
+        if start_from_bottom:
+            stepZ = -stepZ
         count = 0
         angle = math.pi / 2 - dir_angle_rad
-        arcR = topRadius
-        arcZ = topCenterPoint.z
+        arcR = startRadius
+        arcZ = center.z
         arcPoints = []
         while count <= iters:
-            arcX = topCenterPoint.x + arcR * math.sin(angle)
-            arcY = topCenterPoint.y + arcR * math.cos(angle)
+            arcX = center.x + arcR * math.sin(angle)
+            arcY = center.y + arcR * math.cos(angle)
             arcPoints.append(FreeCAD.Vector(arcX, arcY, arcZ))  # Get all points of arcs
             if count == iters:
+                arcR = endRadius
                 break
             angle += stepRotate
             arcR -= stepRadius
@@ -327,9 +345,9 @@ def generate(
         if finish_circle:
             dx = arcR * math.cos(dir_angle_rad)
             dy = arcR * math.sin(dir_angle_rad)
-            p1 = FreeCAD.Vector(topCenterPoint.x - dx, topCenterPoint.y - dy, 0)
+            p1 = FreeCAD.Vector(center.x - dx, center.y - dy, 0)
             commandlist.append(Path.Command(arcCmdName, {"X": p1.x, "Y": p1.y, "I": -dx, "J": -dy}))
-            p2 = FreeCAD.Vector(topCenterPoint.x + dx, topCenterPoint.y + dy, 0)
+            p2 = FreeCAD.Vector(center.x + dx, center.y + dy, 0)
             commandlist.append(Path.Command(arcCmdName, {"X": p2.x, "Y": p2.y, "I": dx, "J": dy}))
 
         return commandlist

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -297,6 +297,15 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 "\nSet to zero to disable limitation by ramp angle",
             ),
         )
+        obj.addProperty(
+            "App::PropertyBool",
+            "StartConeFromBottom",
+            "Helix Drill",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Allows to process cone helix from bottom to top",
+            ),
+        )
 
         for n in self.helixOpPropertyEnumerations():
             setattr(obj, n[0], n[1])
@@ -306,6 +315,9 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
     def opOnChanged(self, obj, prop):
         if not obj.Document.Restoring:
             self.opCheckParameters(obj)
+
+        if prop == "HelixConeAngle":
+            self.opUpdateEditorModes(obj)
 
         super().opOnChanged(obj, prop)
 
@@ -320,6 +332,11 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         obj.setEditorMode("OverrideProfileDiameter", 2)  # hide
         obj.setEditorMode("RetractFromWall", 2)  # hide
         obj.setEditorMode("SingleHelix", 2)  # hide
+        obj.setEditorMode("StartConeFromBottom", 2)  # hide
+
+    def opUpdateEditorModes(self, obj):
+        mode = 0 if obj.HelixConeAngle else 2
+        obj.setEditorMode("StartConeFromBottom", mode)
 
     def opSetDefaultValues(self, obj, job):
         obj.CutMode = "Conventional"
@@ -544,8 +561,19 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 obj.Direction = ("CW", "CCW")
                 obj.Direction = new_dir
             obj.CutMode = _caclulateCutMode(obj.Direction, obj.StartAt)
+        if not hasattr(obj, "StartConeFromBottom"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "StartConeFromBottom",
+                "Helix Drill",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Allows to process cone helix from bottom to top",
+                ),
+            )
 
         self.opSetEditorModes(obj)
+        self.opUpdateEditorModes(obj)
 
     # Automatic calculation angle of direction
     def getDirAngle(self, obj, holes, i):
@@ -728,7 +756,10 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 if isRoughly(centerBottom.z, obj.FinalDepth.Value):
                     centerBottom.z = obj.FinalDepth.Value
 
-                args["edge"] = Part.makeLine(centerTop, centerBottom)
+                if obj.StartConeFromBottom:
+                    args["edge"] = Part.makeLine(centerBottom, centerTop)
+                else:
+                    args["edge"] = Part.makeLine(centerTop, centerBottom)
                 retractHeight = centerTop.z + retractDistance
 
                 if isRoughly(args["inner_radius"], 0) or isRoughly(args["outer_radius"], 0):
@@ -748,7 +779,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                         self.commandlist.extend(linkingMoves)
                         machinestate.addCommands(linkingMoves)
                     drillStep = obj.HelixMaxPitch.Value or obj.StepDown.Value
-                    drillSteps = math.ceil(round((centerTop.z - centerBottom.z) / drillStep, 6))
+                    drillSteps = Path.Geom.ceil((centerTop.z - centerBottom.z) / drillStep)
                     for iDrill in range(1, drillSteps + 1):
                         # drilling in peck mode
                         zDrill = centerTop.z - drillStep * iDrill
@@ -775,7 +806,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                     self.commandlist.extend(helixCommands[1:])
                     machinestate.addCommands(self.commandlist[-2:])
 
-                if obj.SpiralMill:
+                if obj.SpiralMill and not (obj.HelixConeAngle and obj.StartConeFromBottom):
                     if obj.Side == "Inside":
                         spiralInnerRadius = toolradius + obj.RadialStockToLeaveInner.Value
                         spiralOuterRadius = (


### PR DESCRIPTION
### Changes
Added property `StartConeFromBottom`, which allows to process cone helix from bottom to top
Property `StartConeFromBottom` ignores and hidden if `HelixConeAngle` is 0

If mill cone from the top, only tip of the tool cut material
If mill from the bottom, side of the tool cut material 

<img width="1666" height="419" alt="Screenshot_20260627_193850_hor" src="https://github.com/user-attachments/assets/705c587e-6608-4c55-ac7e-6d6dc346b99b" />

<img width="1794" height="449" alt="Screenshot_20260627_194109_hor" src="https://github.com/user-attachments/assets/25aada66-3aa9-4495-bf34-81301d663487" />

