### PR TITLE
CAM: Helix op - Offer default side

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
@@ -18,13 +18,37 @@
     <widget class="QWidget" name="widget">
      <layout class="QFormLayout" name="formLayout">
       <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Side</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="side">
+        <property name="toolTip">
+         <string>Side of profile on which create Path</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Inside</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Outside</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
          <string>Start from</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="QComboBox" name="startAt">
         <property name="toolTip">
          <string>Specify if the helix operation should start at the inside and work its way outwards, or start at the outside and work its way to the center</string>

--- a/src/Mod/CAM/Path/Op/Gui/Helix.py
+++ b/src/Mod/CAM/Path/Op/Gui/Helix.py
@@ -61,7 +61,7 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         """getForm() ... return UI"""
         form = FreeCADGui.PySideUic.loadUi(":/panels/PageOpHelixEdit.ui")
 
-        comboToPropertyMap = [("startAt", "StartAt"), ("cutMode", "CutMode")]
+        comboToPropertyMap = [("side", "Side"), ("startAt", "StartAt"), ("cutMode", "CutMode")]
         enumTups = PathHelix.ObjectHelix.helixOpPropertyEnumerations(dataType="raw")
         self.populateCombobox(form, enumTups, comboToPropertyMap)
 
@@ -83,6 +83,8 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
             obj.CutMode = str(self.form.cutMode.currentData())
         if obj.StartAt != str(self.form.startAt.currentData()):
             obj.StartAt = str(self.form.startAt.currentData())
+        if obj.Side != str(self.form.side.currentData()):
+            obj.Side = str(self.form.side.currentData())
 
         if obj.StepOver != self.form.stepOver.value():
             obj.StepOver = self.form.stepOver.value()
@@ -96,6 +98,7 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
 
         self.selectInComboBox(obj.CutMode, self.form.cutMode)
         self.selectInComboBox(obj.StartAt, self.form.startAt)
+        self.selectInComboBox(obj.Side, self.form.side)
 
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
@@ -108,6 +111,7 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
 
         signals.append(self.form.cutMode.currentIndexChanged)
         signals.append(self.form.startAt.currentIndexChanged)
+        signals.append(self.form.side.currentIndexChanged)
 
         return signals
 

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -309,6 +309,9 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
 
         super().opOnChanged(obj, prop)
 
+    def initAfterBase(self, obj):
+        obj.Side = Path.Op.Util.getOpSide(obj, default="Inside")
+
     def opSetEditorModes(self, obj):
         obj.setEditorMode("Direction", ("ReadOnly", "Hidden"))
         obj.setPropertyStatus("Direction", ("ReadOnly", "Output"))
@@ -748,7 +751,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                         self.commandlist.extend(linkingMoves)
                         machinestate.addCommands(linkingMoves)
                     drillStep = obj.HelixMaxPitch.Value or obj.StepDown.Value
-                    drillSteps = math.ceil(round((centerTop.z - centerBottom.z) / drillStep, 6))
+                    drillSteps = Path.Geom.ceil((centerTop.z - centerBottom.z) / drillStep)
                     for iDrill in range(1, drillSteps + 1):
                         # drilling in peck mode
                         zDrill = centerTop.z - drillStep * iDrill


### PR DESCRIPTION
### Description

**Helix** op can process not only holes, but also outside perimeter of cylindrical shape
After #30488 we have a way to define side while create new operation
Lets use it also in **Helix** op

### Changes:

- Offer side while create **Helix** operation
- Added `Side` selection to **Task** panel 

Test project: [cone2.zip](https://github.com/user-attachments/files/30912149/cone2.zip)

<img width="740" height="514" alt="1_hor_lossy" src="https://github.com/user-attachments/assets/1b0f7394-2115-4c06-9c10-e1f7fda339e3" />

<img width="904" height="374" alt="Screenshot_20260625_104858_hor_lossy" src="https://github.com/user-attachments/assets/9bd832fd-03eb-4ef5-8629-5e425daf3e48" />