### PR TITLE
Gui: Restore ShapeMaterial compatibility alias for links

### DIFF
--- a/src/Gui/ViewProviderLinkPyImp.cpp
+++ b/src/Gui/ViewProviderLinkPyImp.cpp
@@ -20,9 +20,11 @@
  *                                                                          *
  ****************************************************************************/
 
+#include <cstring>
 #include <sstream>
 
 #include <Base/PlacementPy.h>
+#include <App/PropertyStandard.h>
 
 // generated out of ViewProviderLink.pyi
 #include "ViewProviderLinkPy.h"
@@ -61,12 +63,25 @@ Py::Object ViewProviderLinkPy::getLinkView() const
     return Py::Object(getViewProviderLinkPtr()->getPyLinkView(), true);
 }
 
-PyObject* ViewProviderLinkPy::getCustomAttributes(const char* /*attr*/) const
+PyObject* ViewProviderLinkPy::getCustomAttributes(const char* attr) const
 {
+    if (strcmp(attr, "ShapeMaterial") == 0) {
+        // Deprecated Python compatibility alias for ShapeAppearance[0].
+        App::PropertyMaterial prop;
+        prop.setValue(getViewProviderLinkPtr()->ShapeAppearance[0]);
+        return prop.getPyObject();
+    }
     return nullptr;
 }
 
-int ViewProviderLinkPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
+int ViewProviderLinkPy::setCustomAttributes(const char* attr, PyObject* obj)
 {
+    if (strcmp(attr, "ShapeMaterial") == 0) {
+        // Deprecated Python compatibility alias for ShapeAppearance[0].
+        App::PropertyMaterial prop;
+        prop.setPyObject(obj);
+        getViewProviderLinkPtr()->ShapeAppearance.setValue(prop.getValue());
+        return 1;
+    }
     return 0;
 }

--- a/src/Mod/Test/TestViewProviderLink.py
+++ b/src/Mod/Test/TestViewProviderLink.py
@@ -216,6 +216,31 @@ class TestViewProviderLink(unittest.TestCase):
         if self.FreeCAD.getDocument(self.doc.Name):
             self.FreeCAD.closeDocument(self.doc.Name)
 
+    def test_shape_material_compatibility_attribute(self):
+        box = self.doc.addObject("Part::Box", "Box")
+        link = self.doc.addObject("App::Link", "Link")
+        link.setLink(box)
+
+        self.doc.recompute()
+
+        self.assertTrue(hasattr(box.ViewObject, "ShapeMaterial"))
+        self.assertTrue(hasattr(link.ViewObject, "ShapeMaterial"))
+
+        material = link.ViewObject.ShapeMaterial
+        material.DiffuseColor = (0.2, 0.4, 0.6, 1.0)
+        material.Transparency = 0.35
+        link.ViewObject.ShapeMaterial = material
+
+        self.assertEqual(
+            link.ViewObject.ShapeAppearance[0].DiffuseColor,
+            material.DiffuseColor,
+        )
+        self.assertAlmostEqual(link.ViewObject.ShapeAppearance[0].Transparency, 0.35)
+        self.assertEqual(
+            link.ViewObject.ShapeMaterial.DiffuseColor,
+            material.DiffuseColor,
+        )
+
     def test_apply_element_color_override_api(self):
         root = self.coin.SoSeparator()
         sel_root = _instantiate(self.coin, "SoFCSelectionRoot")


### PR DESCRIPTION
`App::Link` view providers migrated from `ShapeMaterial` to `ShapeAppearance`, but unlike normal view providers their Python wrapper no longer exposed the deprecated `ShapeMaterial` compatibility attribute. That breaks existing macros and scripts that check or assign `link.ViewObject.ShapeMaterial`, even though the same access still works on regular geometry view objects.

This keeps the current data model intact and adds only a runtime compatibility alias in `ViewProviderLinkPyImp`: `ShapeMaterial` now reads and writes `ShapeAppearance[0]`. The existing saved-file migration already restores persisted `ShapeMaterial` into `ShapeAppearance`, so this fills the missing Python API path without adding duplicate persisted state.

Fixes #30978
