### PR TITLE
Gui: validate recovery project using absolute path

### DIFF
--- a/src/Gui/DocumentRecovery.cpp
+++ b/src/Gui/DocumentRecovery.cpp
@@ -487,10 +487,10 @@ DocumentRecoveryPrivate::Info DocumentRecoveryPrivate::getRecoveryInfo(const QFi
 
 /// Rough check to see if the ZIP data is valid. No CRC calculation, just a fast iteration over the
 /// contents to see if it seems basically OK.
-bool zipDataIsValid(const QString& zipData)
+bool zipDataIsValid(const QString& fcstdFile)
 {
     try {
-        zipios::ZipFile zf(zipData.toStdString());
+        zipios::ZipFile zf(fcstdFile.toStdString());
         auto entries = zf.entries();
         int n = 0;
         for (auto it = entries.begin(); it != entries.end(); ++it) {
@@ -569,15 +569,17 @@ bool DocumentRecoveryPrivate::isValidProject(const QFileInfo& fi) const
         return false;
     }
 
-    if (!zipDataIsValid(fi.fileName())) {
+    const QString projectFile = fi.absoluteFilePath();
+
+    if (!zipDataIsValid(projectFile)) {
         return false;
     }
 
-    if (!xmlFilesAreValid(fi.fileName())) {
+    if (!xmlFilesAreValid(projectFile)) {
         return false;
     }
 
-    App::ProjectFile project(fi.absoluteFilePath().toStdString());
+    App::ProjectFile project(projectFile.toStdString());
     return project.loadDocument();
 }
 


### PR DESCRIPTION
This fixes a cwd-dependent validation bug in document recovery.

Recovery metadata stores the original project file as a full path. Before this change, `DocumentRecoveryPrivate::isValidProject()` checked whether that original file looked like a valid FCStd project using only `QFileInfo::fileName()`, then loaded it through `App::ProjectFile` using `QFileInfo::absoluteFilePath()`.

For example, if recovery metadata points to:

```text
/home/alice/Downloads/Shed.FCStd
```

but FreeCAD is launched with `/home/alice` as its current working directory, the old validation checked:

```text
/home/alice/Shed.FCStd
```

while the final load used:

```text
/home/alice/Downloads/Shed.FCStd
```

That could make recovery report the original project as corrupted even when the actual original file was valid.

This change computes the absolute project path once and uses it for the ZIP check, XML check, and final `App::ProjectFile` load. It also renames the local `zipDataIsValid()` parameter from `zipData` to `fcstdFile`, since that helper takes a project file path rather than ZIP data.

## Context

I found this while investigating #30967. The uploaded recovery cache from that issue recovered successfully on current `main` in my local smoke test, so this PR should not be treated as a confirmed fix for the reported crash/stall. It fixes a concrete recovery correctness issue discovered during that investigation.
