### PR TITLE
CAM: Helix op - Set default cone angle

### DIFF
--- a/src/Mod/CAM/Path/Op/Gui/Selection.py
+++ b/src/Mod/CAM/Path/Op/Gui/Selection.py
@@ -1,33 +1,32 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2015 Dan Falck <ddfalck@gmail.com>
+# SPDX-FileCopyrightText: 2021 Schildkroet
+# SPDX-FileNotice: Part of the FreeCAD project.
 
-# ***************************************************************************
-# *   Copyright (c) 2015 Dan Falck <ddfalck@gmail.com>                      *
-# *   Copyright (c) 2021 Schildkroet                                        *
-# *                                                                         *
-# *   This program is free software; you can redistribute it and/or modify  *
-# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
-# *   as published by the Free Software Foundation; either version 2 of     *
-# *   the License, or (at your option) any later version.                   *
-# *   for detail see the LICENTE text file.                                 *
-# *                                                                         *
-# *   This program is distributed in the hope that it will be useful,       *
-# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-# *   GNU Library General Public License for more details.                  *
-# *                                                                         *
-# *   You should have received a copy of the GNU Library General Public     *
-# *   License along with this program; if not, write to the Free Software   *
-# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-# *   USA                                                                   *
-# *                                                                         *
-# ***************************************************************************
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
 
 """Selection gates and observers to control selectability while building Path operations"""
 
 import FreeCAD
 import FreeCADGui
+import Part
 import Path
-import Path.Base.Drillable as Drillable
+from Path.Base.Drillable import isDrillable
 import math
 
 if False:
@@ -37,7 +36,7 @@ else:
     Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 
 
-class PathBaseGate(object):
+class PathBaseGate:
     pass
 
 
@@ -133,7 +132,28 @@ class DRILLGate(PathBaseGate):
         subobj = shape.getElement(sub)
         if subobj.ShapeType not in ["Edge", "Face"]:
             return False
-        return Drillable.isDrillable(shape, subobj, vector=None, allowPartial=True)
+        return isDrillable(shape, subobj, vector=None, allowPartial=True)
+
+
+class HELIXGate(PathBaseGate):
+    def allow(self, doc, obj, sub):
+        try:
+            shape = obj.Shape
+        except Exception:
+            return False
+
+        if not sub or sub[0:4] not in ("Edge", "Face"):
+            return False
+
+        subShape = shape.getElement(sub)
+        if isDrillable(shape, subShape, vector=None, allowPartial=True):
+            return True
+        if subShape.ShapeType == "Edge":
+            return isinstance(subShape.Curve, Part.Circle)
+        if subShape.ShapeType == "Face":
+            return isinstance(subShape.Surface, (Part.Cylinder, Part.Cone))
+
+        return False
 
 
 class TAPGate(PathBaseGate):
@@ -145,7 +165,7 @@ class TAPGate(PathBaseGate):
         subobj = shape.getElement(sub)
         if subobj.ShapeType not in ["Edge", "Face"]:
             return False
-        return Drillable.isDrillable(shape, subobj, vector=None)
+        return isDrillable(shape, subobj, vector=None)
 
 
 class FACEGate(PathBaseGate):
@@ -248,7 +268,7 @@ class TURNGate(PathBaseGate):
         if hasattr(obj, "Shape") and sub:
             shape = obj.Shape
             subobj = shape.getElement(sub)
-            return Drillable.isDrillable(shape, subobj, vector=None)
+            return isDrillable(shape, subobj, vector=None)
         else:
             return False
 
@@ -280,6 +300,12 @@ def drillselect():
     FreeCADGui.Selection.addSelectionGate(DRILLGate())
     if not Path.Preferences.suppressSelectionModeWarning():
         FreeCAD.Console.PrintWarning("Drilling Select Mode\n")
+
+
+def helixselect():
+    FreeCADGui.Selection.addSelectionGate(HELIXGate())
+    if not Path.Preferences.suppressSelectionModeWarning():
+        FreeCAD.Console.PrintWarning("Helix Select Mode\n")
 
 
 def tapselect():
@@ -375,7 +401,7 @@ def select(op):
     opsel["Drilling"] = drillselect
     opsel["Tapping"] = tapselect
     opsel["Engrave"] = engraveselect
-    opsel["Helix"] = drillselect
+    opsel["Helix"] = helixselect
     opsel["MillFace"] = pocketselect
     opsel["MillFacing"] = pocketselect
     opsel["Pocket"] = pocketselect

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -297,6 +297,15 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 "\nSet to zero to disable limitation by ramp angle",
             ),
         )
+        obj.addProperty(
+            "App::PropertyBool",
+            "StartConeFromBottom",
+            "Helix Drill",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Allows to process cone helix from bottom to top",
+            ),
+        )
 
         for n in self.helixOpPropertyEnumerations():
             setattr(obj, n[0], n[1])
@@ -307,7 +316,23 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         if not obj.Document.Restoring:
             self.opCheckParameters(obj)
 
+        if prop == "HelixConeAngle":
+            self.opUpdateEditorModes(obj)
+
         super().opOnChanged(obj, prop)
+
+    def initAfterBase(self, obj):
+        obj.HelixConeAngle = self.coneAngle(obj)
+        obj.Side = Path.Op.Util.getOpSide(obj, default="Inside")
+
+    def coneAngle(self, obj):
+        subs = [base.Shape.getElement(n) for base, names in obj.Base for n in names]
+        if all(isinstance(sub, Part.Face) and isinstance(sub.Surface, Part.Cone) for sub in subs):
+            angles = [round(sub.Surface.SemiAngle, Path.Geom.Decimal) for sub in subs]
+            if len(set(angles)) == 1:
+                angle = angles[0] if subs[0].Surface.Axis.z > 0 else -angles[0]
+                return math.degrees(angle)
+        return 0
 
     def opSetEditorModes(self, obj):
         obj.setEditorMode("Direction", ("ReadOnly", "Hidden"))
@@ -320,6 +345,11 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         obj.setEditorMode("OverrideProfileDiameter", 2)  # hide
         obj.setEditorMode("RetractFromWall", 2)  # hide
         obj.setEditorMode("SingleHelix", 2)  # hide
+        obj.setEditorMode("StartConeFromBottom", 2)  # hide
+
+    def opUpdateEditorModes(self, obj):
+        mode = 0 if obj.HelixConeAngle else 2
+        obj.setEditorMode("StartConeFromBottom", mode)
 
     def opSetDefaultValues(self, obj, job):
         obj.CutMode = "Conventional"
@@ -544,8 +574,19 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 obj.Direction = ("CW", "CCW")
                 obj.Direction = new_dir
             obj.CutMode = _caclulateCutMode(obj.Direction, obj.StartAt)
+        if not hasattr(obj, "StartConeFromBottom"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "StartConeFromBottom",
+                "Helix Drill",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Allows to process cone helix from bottom to top",
+                ),
+            )
 
         self.opSetEditorModes(obj)
+        self.opUpdateEditorModes(obj)
 
     # Automatic calculation angle of direction
     def getDirAngle(self, obj, holes, i):
@@ -626,19 +667,15 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             "direction": obj.Direction,
             "startAt": obj.StartAt,
             "finish_circle": obj.FinishHelixCircle,
-            "cone_angle_rad": None,
+            "cone_angle_rad": math.radians(obj.HelixConeAngle.Value),
             "dir_angle_rad": None,
             "ramp_angle_rad": math.radians(obj.HelixMaxRampAngle) or math.pi / 2,
+            "start_from_bottom": obj.StartConeFromBottom,
         }
 
         if obj.RetractFromWall:
             # do not send tooldiameter to generator for vertical retract
             args["tool_diameter"] = tooldiameter
-
-        if obj.Side == "Inside":
-            args["cone_angle_rad"] = math.radians(obj.HelixConeAngle.Value)
-        else:
-            args["cone_angle_rad"] = -math.radians(obj.HelixConeAngle.Value)
 
         machinestate = PathMachineState.MachineState()
         self.commandlist.append(Path.Command("(helix cut operation)"))
@@ -775,7 +812,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                     self.commandlist.extend(helixCommands[1:])
                     machinestate.addCommands(self.commandlist[-2:])
 
-                if obj.SpiralMill:
+                if obj.SpiralMill and not (obj.HelixConeAngle and obj.StartConeFromBottom):
                     if obj.Side == "Inside":
                         spiralInnerRadius = toolradius + obj.RadialStockToLeaveInner.Value
                         spiralOuterRadius = (

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -23,9 +23,9 @@ import FreeCAD
 import Part
 import Path
 import Path.Base.FeedRate as PathFeedRate
-import Path.Base.Generator.helix as helix
-import Path.Base.Generator.linking as linking
-import Path.Base.Generator.spiral as spiral
+from Path.Base.Generator import helix
+from Path.Base.Generator import linking
+from Path.Base.Generator import spiral
 import Path.Op.Base as PathOp
 import Path.Op.CircularHoleBase as PathCircularHoleBase
 import Path.Base.Language as PathLanguage
@@ -61,14 +61,10 @@ def _caclulatePathDirection(obj):
 
 def _caclulateCutMode(direction, side):
     """Calculates the cut mode from path direction and cut side"""
-    if direction == "CW" and side == "Inside":
+    if (direction == "CW" and side == "Inside") or (direction == "CCW" and side == "Outside"):
         return "Conventional"
-    elif direction == "CW" and side == "Outside":
+    elif (direction == "CW" and side == "Outside") or (direction == "CCW" and side == "Inside"):
         return "Climb"
-    elif direction == "CCW" and side == "Inside":
-        return "Climb"
-    elif direction == "CCW" and side == "Outside":
-        return "Conventional"
     else:
         raise ValueError(f"No mapping for '{direction}'/'{side}'")
 
@@ -94,8 +90,8 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 (translate("CAM_Helix", "CCW"), "CCW"),
             ],  # this is the direction that the profile runs
             "StartAt": [
-                (translate("PathProfile", "Inside"), "Inside"),
-                (translate("PathProfile", "Outside"), "Outside"),
+                (translate("CAM_Helix", "Inside"), "Inside"),
+                (translate("CAM_Helix", "Outside"), "Outside"),
             ],  # side of profile that cutter is on in relation to direction of profile
             "CutMode": [
                 (translate("CAM_Helix", "Climb"), "Climb"),
@@ -110,7 +106,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         if dataType == "raw":
             return enums
 
-        data = list()
+        data = []
         idx = 0 if dataType == "translated" else 1
 
         Path.Log.debug(enums)
@@ -322,7 +318,27 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         super().opOnChanged(obj, prop)
 
     def initAfterBase(self, obj):
+        obj.HelixConeAngle = self.coneAngle(obj) or 0
         obj.Side = Path.Op.Util.getOpSide(obj, default="Inside")
+
+    def coneAngle(self, obj, verbose=False):
+        subs = [base.Shape.getElement(n) for base, names in self.baseShapes(obj) for n in names]
+        if all(isinstance(sub, Part.Face) and isinstance(sub.Surface, Part.Cone) for sub in subs):
+            angles = [round(sub.Surface.SemiAngle, Path.Geom.Decimal) for sub in subs]
+            if len(set(angles)) == 1:
+                angle = angles[0] if subs[0].Surface.Axis.z > 0 else -angles[0]
+                return math.degrees(angle)
+            elif verbose:
+                Path.Log.warning(translate("CAM_Helix", "Faces Cone angle is not identical"))
+                return None
+        elif verbose:
+            Path.Log.warning(
+                translate(
+                    "CAM_Helix", "Automatic cone angle definition allowed only for cone faces"
+                )
+            )
+            return None
+        return 0
 
     def opSetEditorModes(self, obj):
         obj.setEditorMode("Direction", ("ReadOnly", "Hidden"))
@@ -359,7 +375,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 obj.OverrideProfileDiameter = 0
                 Path.Log.warning(
                     translate(
-                        "PathHelix",
+                        "CAM_Helix",
                         "OverrideProfileDiameter can not be less than tool diameter {}".format(
                             tooldiam
                         ),
@@ -528,11 +544,10 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 ),
             )
             expressions = dict(obj.ExpressionEngine)
-            stepDownExpr = expressions.get("StepDown")
-            if stepDownExpr:
+            if stepDownExpr := expressions.get("StepDown"):
                 obj.setExpression("HelixMaxPitch", stepDownExpr)
             else:
-                obj.StepDown
+                obj.HelixMaxPitch = obj.StepDown
             obj.setExpression("StepDown", "StartDepth - FinalDepth")
         if not hasattr(obj, "HelixMaxRampAngle"):
             obj.addProperty(
@@ -666,7 +681,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             "direction": obj.Direction,
             "startAt": obj.StartAt,
             "finish_circle": obj.FinishHelixCircle,
-            "cone_angle_rad": None,
+            "cone_angle_rad": math.radians(obj.HelixConeAngle.Value),
             "dir_angle_rad": None,
             "ramp_angle_rad": math.radians(obj.HelixMaxRampAngle) or math.pi / 2,
         }
@@ -674,11 +689,6 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         if obj.RetractFromWall:
             # do not send tooldiameter to generator for vertical retract
             args["tool_diameter"] = tooldiameter
-
-        if obj.Side == "Inside":
-            args["cone_angle_rad"] = math.radians(obj.HelixConeAngle.Value)
-        else:
-            args["cone_angle_rad"] = -math.radians(obj.HelixConeAngle.Value)
 
         machinestate = PathMachineState.MachineState()
         self.commandlist.append(Path.Command("(helix cut operation)"))
@@ -733,9 +743,8 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                     args["outer_radius"] = (
                         hole["d"] / 2 + toolradius + obj.RadialStockToLeaveOuter.Value
                     )
-                    if args["inner_radius"] > args["outer_radius"]:
-                        # exclude overlap inner and outer helices
-                        args["inner_radius"] = args["outer_radius"]
+                    # exclude overlap inner and outer helices
+                    args["inner_radius"] = min(args["inner_radius"], args["outer_radius"])
 
             if (args["outer_radius"] < 0 and not isRoughly(args["outer_radius"], 0)) or (
                 args["inner_radius"] < 0 and not isRoughly(args["inner_radius"], 0)
@@ -748,7 +757,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 posXString = posXQty.getUserPreferred("Length")[0]
                 posYString = posYQty.getUserPreferred("Length")[0]
                 posStr = f"X = {posXString}, Y = {posYString}"
-                Path.Log.warning(translate("PathHelix", "Skipped hole at position %s") % posStr)
+                Path.Log.warning(translate("CAM_Helix", "Skipped hole at position %s") % posStr)
                 continue
 
             # Split depth by step down
@@ -838,7 +847,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                     if spiralOuterRadius <= spiralInnerRadius:
                         Path.Log.warning(
                             translate(
-                                "PathHelix",
+                                "CAM_Helix",
                                 "Spiral outer radius {} is equal or less than inner {}".format(
                                     spiralOuterRadius, spiralInnerRadius
                                 ),


### PR DESCRIPTION
### Description

**Helix** op can process not only cylindrical shape, but also cone
Suggested to define cone angle automatically if it safely

### Changes

- Set default property `HelixConeAngle` while create **Helix** op, if all base geometry is `Part.Cone` and all surfaces has identical angle
- Added new method to `Selection`, which allows to select face of cone while editing **Helix** op 

---

Test project: [cone2.zip](https://github.com/user-attachments/files/31012899/cone2.zip)

<img width="1086" height="442" alt="Screenshot_20260813_065351_hor" src="https://github.com/user-attachments/assets/66b55cfa-4add-414f-a98a-00c242c8f6d8" />

https://github.com/user-attachments/assets/69d1eb92-362d-4d76-86f4-bf8428735b01

> [!NOTE]
> Video demonstrates changes in Gui from #31620 