### PR TITLE
TechDraw: Improve selection and hovering of leader lines

### DIFF
--- a/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
@@ -104,6 +104,30 @@ QGILeaderLine::QGILeaderLine()
                      &QGILeaderLine::onLineEditFinished);
 }
 
+QPainterPath QGILeaderLine::shape() const
+{
+    QPainterPath path;
+
+    if (m_line) {
+        QPainterPathStroker stroker;
+        stroker.setWidth(PreferencesGui::edgeFuzz() * 2.0);
+        stroker.setCapStyle(Qt::RoundCap);
+        stroker.setJoinStyle(Qt::RoundJoin);
+        QPainterPath stroked = stroker.createStroke(m_line->path());
+        path.addPath(mapFromItem(m_line, stroked));
+    }
+    if (m_arrow1 && m_arrow1->isVisible()) {
+        QPainterPath ap = mapFromItem(m_arrow1, m_arrow1->path());
+        path.addPath(ap);
+    }
+    if (m_arrow2 && m_arrow2->isVisible()) {
+        QPainterPath ap = mapFromItem(m_arrow2, m_arrow2->path());
+        path.addPath(ap);
+    }
+
+    return path;
+}
+
 void QGILeaderLine::setLeaderFeature(TechDraw::DrawLeaderLine* feat)
 {
     //    Base::Console().message("QGILL::setLeaderFeature()\n");
@@ -634,7 +658,7 @@ QColor QGILeaderLine::prefNormalColor()
 
 QRectF QGILeaderLine::boundingRect() const
 {
-    return childrenBoundingRect();
+    return shape().controlPointRect();
 }
 
 void QGILeaderLine::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.h
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.h
@@ -68,6 +68,7 @@ public:
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
                QWidget* widget = nullptr) override;
     QRectF boundingRect() const override;
+    QPainterPath shape() const override;
 
     void drawBorder() override;
     void updateView(bool update = false) override;


### PR DESCRIPTION
This PR improves the selection of leader lines in TechDraw by making `QGILeaderLine` override `shape()`, so that selection uses the actual line geometry instead of the group's bounding rectangle as the hit region.  This is an improvement because the bounding rect selection style can easily block selection to other items. A small edge fuzz was also added to help the selectability of the thin lines from the existing `edgeFuzz` preference in TechDraw advanced settings.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
None existing

## Before  
<img width="900" height="867" alt="leader_before" src="https://github.com/user-attachments/assets/fd308c7d-0d20-4f72-8ca1-eea7df7b0283" />


## After

<img width="900" height="813" alt="leader_after" src="https://github.com/user-attachments/assets/52b40f7d-7695-4de3-b232-60f041a08c9c" />
