### PR TITLE
Part: Mirror respects placement of a link to a placed object

### DIFF
--- a/src/Mod/Part/App/FeatureMirroring.cpp
+++ b/src/Mod/Part/App/FeatureMirroring.cpp
@@ -36,6 +36,7 @@
 #include <TopoDS.hxx>
 #include <TopoDS_Face.hxx>
 #include <TopExp_Explorer.hxx>
+#include <TopLoc_Location.hxx>
 
 
 #include <Mod/Part/App/PrimitiveFeature.h>
@@ -324,6 +325,17 @@ App::DocumentObjectExecReturn* Mirroring::execute()
                 BRepBuilderAPI_Transform mkTrf(shape.getShape(), trsf, Standard_True);
                 shape = TopoShape(mkTrf.Shape());
             }
+        }
+
+        // An App::Link's inherited placement lives in the shape's location rather than its
+        // Placement; bake it into the geometry (preserving the element map) so it survives
+        // storage of the mirrored shape. Plain features already store their location correctly.
+        if (link->hasExtension(App::LinkBaseExtension::getExtensionClassTypeId())
+            && !shape.getShape().Location().IsIdentity()) {
+            Base::Matrix4D mat;
+            TopoShape::convertToMatrix(shape.getShape().Location().Transformation(), mat);
+            shape.setShape(shape.getShape().Located(TopLoc_Location()), false);
+            shape.transformShape(mat, true);
         }
 
         gp_Ax2 ax2(gp_Pnt(base.x, base.y, base.z), gp_Dir(norm.x, norm.y, norm.z));


### PR DESCRIPTION
This is a fix for part of #30945, fixing the Part Mirror half. (The Draft Array part is in a separate PR.) I have tested and verified this fix. If you load an old design with the placement problem, you have to force rebuild the objects.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.


## Problem
Part Mirror of an `App::Link` ignores the placement when the link inherits it from the linked object (Link Transform on, the link's own Placement identity). The mirrored body lands unplaced.

Repro: [mirror-array-link-bug.FCStd.zip](https://github.com/user-attachments/files/29261377/mirror-array-link-bug.FCStd.zip)

## Cause
`getTopoShape(link, ResolveLink)` returns the linked shape with the placement carried in its `TopLoc_Location`. `makeElementMirror` mirrors it correctly, but `Part::Feature` shape storage drops the location, exposing the unplaced local geometry.

## Fix
Bake the location into the geometry before mirroring. No-op for shapes whose placement is already baked (location identity), e.g. plain `Part::Feature` sources — so no change for non-link mirrors.

## Testing
Mirror of a placed extrusion and of a link to that extrusion both land in the correct place; verified that plain (non-link, identity-placement) mirrors are unchanged.

## AI disclosure
Assisted by Claude Opus 4.8. I reviewed, tested, and verified the change and take responsibility for it.
