### PR TITLE
Draft: Array respects placement of a link to a placed object

### DIFF
--- a/src/Mod/Draft/draftobjects/array.py
+++ b/src/Mod/Draft/draftobjects/array.py
@@ -430,9 +430,17 @@ class Array(DraftLink):
                 )
                 raise TypeError(_info)
 
+        # obj.Base.Placement is not the effective placement of the base's geometry:
+        # for a link it ignores the linked object's placement and LinkTransform. Use
+        # the base shape's placement, which reflects whatever the base resolves to.
+        base_placement = obj.Base.Placement
+        base_shape = getattr(obj.Base, "Shape", None)
+        if base_shape is not None and not base_shape.isNull():
+            base_placement = base_shape.Placement
+
         if obj.ArrayType == "ortho":
             pls = rect_placements(
-                obj.Base.Placement,
+                base_placement,
                 obj.IntervalX,
                 obj.IntervalY,
                 obj.IntervalZ,
@@ -443,11 +451,11 @@ class Array(DraftLink):
         elif obj.ArrayType == "polar":
             av = obj.IntervalAxis if hasattr(obj, "IntervalAxis") else None
             pls = polar_placements(
-                obj.Base.Placement, center, obj.Angle.Value, obj.NumberPolar, axis, av
+                base_placement, center, obj.Angle.Value, obj.NumberPolar, axis, av
             )
         elif obj.ArrayType == "circular":
             pls = circ_placements(
-                obj.Base.Placement,
+                base_placement,
                 obj.RadialDistance,
                 obj.TangentialDistance,
                 axis,


### PR DESCRIPTION
This is a fix for part of #30945, fixing the Draft Array half. (The Part Mirror part is in a separate PR.) I have tested and verified this fix. If you load an old design with the placement problem, you have to force rebuild the objects.


- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.


## Problem
Draft Array of an `App::Link` ignores the placement when the link inherits it from the linked object (Link Transform on, the link's own Placement identity). The array is built at the wrong location.

Repro: [mirror-array-link-bug.FCStd.zip](https://github.com/user-attachments/files/29261377/mirror-array-link-bug.FCStd.zip)

## Cause
`Array.execute()` seeds the rect/polar/circular placements from `obj.Base.Placement`, which is identity for such a link. The real placement is inherited from the linked object and only shows up in the shape.

## Fix
Seed from the base shape's placement instead (`obj.Base.Shape.Placement`) — the same value `buildShape()` already normalizes against. No change for non-link bases, where the two are identical.

## Testing
Arrays of a placed extrusion and of a link to it now match, in both `use_link` modes (link arrays and non-link arrays); non-link bases unchanged.

## AI disclosure
Assisted by Claude Opus 4.8. I reviewed, tested, and verified the change and take responsibility for it.
