### PR TITLE
Core: Add VP actions to view right click for consistency.

### DIFF
--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -2351,7 +2351,7 @@ void NavigationStyle::openPopupMenu(const SbVec2s& position)
             contextMenu->addSeparator();
         }
     }
-    
+
     QMenu* objectMenu = nullptr;
     QList<QAction*> objectActions;
     auto selection = Gui::Selection().getSelectionEx();

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -45,6 +45,7 @@
 
 #include <Base/Interpreter.h>
 #include <App/Application.h>
+#include <App/DocumentObject.h>
 
 #include "Navigation/NavigationStyle.h"
 #include "Navigation/NavigationStylePy.h"
@@ -52,6 +53,7 @@
 #include "Camera.h"
 #include "Command.h"
 #include "Action.h"
+#include "Document.h"
 #include "Inventor/SoMouseWheelEvent.h"
 #include "MenuManager.h"
 #include "MouseSelection.h"
@@ -61,6 +63,7 @@
 #include "SoFullPathHelper.h"
 #include "View3DInventorViewer.h"
 #include "ViewParams.h"
+#include "ViewProviderDocumentObject.h"
 
 using namespace Gui;
 
@@ -2345,6 +2348,59 @@ void NavigationStyle::openPopupMenu(const SbVec2s& position)
         }
         else {
             contextMenu->addAction(pickAction);
+            contextMenu->addSeparator();
+        }
+    }
+    
+    QMenu* objectMenu = nullptr;
+    QList<QAction*> objectActions;
+    auto selection = Gui::Selection().getSelectionEx();
+
+    if (selection.size() == 1) {
+        App::DocumentObject* selectedObject = selection.front().getObject();
+        auto* selectedViewProvider
+            = Gui::Application::Instance->getViewProvider<Gui::ViewProviderDocumentObject>(
+                selectedObject
+            );
+
+        if (selectedViewProvider) {
+            objectMenu = new QMenu(contextMenu);
+            selectedViewProvider->setupContextMenu(objectMenu, contextMenu, SLOT(close()));
+            objectActions = objectMenu->actions();
+
+            if (!objectActions.empty()) {
+                contextMenu->setDefaultAction(objectActions.front());
+
+                for (auto* action : objectActions) {
+                    if (posAction) {
+                        contextMenu->insertAction(posAction, action);
+                    }
+                    else {
+                        contextMenu->addAction(action);
+                    }
+                }
+
+                if (posAction) {
+                    contextMenu->insertSeparator(posAction);
+                }
+                else {
+                    contextMenu->addSeparator();
+                }
+
+                QObject::connect(
+                    contextMenu,
+                    &QMenu::triggered,
+                    [objectActions, selectedViewProvider](QAction* selectedAction) {
+                        if (objectActions.contains(selectedAction)
+                            && selectedAction->data().isValid()) {
+                            selectedViewProvider->getDocument()->setEdit(
+                                selectedViewProvider,
+                                selectedAction->data().toInt()
+                            );
+                        }
+                    }
+                );
+            }
         }
     }
 

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -67,6 +67,24 @@
 
 using namespace Gui;
 
+NavigationStyleContextMenuReceiver::NavigationStyleContextMenuReceiver(
+    ViewProviderDocumentObject* viewProvider,
+    QObject* parent
+)
+    : QObject(parent)
+    , viewProvider(viewProvider)
+{}
+
+void NavigationStyleContextMenuReceiver::startEditing()
+{
+    auto action = qobject_cast<QAction*>(sender());
+    if (!action || !viewProvider) {
+        return;
+    }
+
+    viewProvider->getDocument()->setEdit(viewProvider, action->data().toInt());
+}
+
 class FCSphereSheetProjector: public SbSphereSheetProjector
 {
     using inherited = SbSphereSheetProjector;
@@ -2365,7 +2383,9 @@ void NavigationStyle::openPopupMenu(const SbVec2s& position)
 
         if (selectedViewProvider) {
             objectMenu = new QMenu(contextMenu);
-            selectedViewProvider->setupContextMenu(objectMenu, contextMenu, SLOT(close()));
+            auto receiver =
+                new NavigationStyleContextMenuReceiver(selectedViewProvider, objectMenu);
+            selectedViewProvider->setupContextMenu(objectMenu, receiver, SLOT(startEditing()));
             objectActions = objectMenu->actions();
 
             if (!objectActions.empty()) {
@@ -2386,20 +2406,6 @@ void NavigationStyle::openPopupMenu(const SbVec2s& position)
                 else {
                     contextMenu->addSeparator();
                 }
-
-                QObject::connect(
-                    contextMenu,
-                    &QMenu::triggered,
-                    [objectActions, selectedViewProvider](QAction* selectedAction) {
-                        if (objectActions.contains(selectedAction)
-                            && selectedAction->data().isValid()) {
-                            selectedViewProvider->getDocument()->setEdit(
-                                selectedViewProvider,
-                                selectedAction->data().toInt()
-                            );
-                        }
-                    }
-                );
             }
         }
     }

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -2590,20 +2590,20 @@ void NavigationStyle::openPopupMenu(const SbVec2s& position)
 
     QMenu* objectMenu = nullptr;
     QList<QAction*> objectActions;
-    auto selection = Gui::Selection().getSelectionEx();
+    App::DocumentObject* preselectedObject
+        = Gui::Selection().getPreselection().Object.getObject();
 
-    if (selection.size() == 1) {
-        App::DocumentObject* selectedObject = selection.front().getObject();
-        auto* selectedViewProvider
+    if (preselectedObject) {
+        auto* preselectedViewProvider
             = Gui::Application::Instance->getViewProvider<Gui::ViewProviderDocumentObject>(
-                selectedObject
+                preselectedObject
             );
 
-        if (selectedViewProvider) {
+        if (preselectedViewProvider) {
             objectMenu = new QMenu(contextMenu);
             auto receiver =
-                new NavigationStyleContextMenuReceiver(selectedViewProvider, objectMenu);
-            selectedViewProvider->setupContextMenu(objectMenu, receiver, SLOT(startEditing()));
+                new NavigationStyleContextMenuReceiver(preselectedViewProvider, objectMenu);
+            preselectedViewProvider->setupContextMenu(objectMenu, receiver, SLOT(startEditing()));
             objectActions = objectMenu->actions();
             if (!objectActions.empty()) {
                 contextMenu->setDefaultAction(objectActions.front());

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -2590,8 +2590,7 @@ void NavigationStyle::openPopupMenu(const SbVec2s& position)
 
     QMenu* objectMenu = nullptr;
     QList<QAction*> objectActions;
-    App::DocumentObject* preselectedObject
-        = Gui::Selection().getPreselection().Object.getObject();
+    App::DocumentObject* preselectedObject = Gui::Selection().getPreselection().Object.getObject();
 
     if (preselectedObject) {
         auto* preselectedViewProvider
@@ -2601,8 +2600,7 @@ void NavigationStyle::openPopupMenu(const SbVec2s& position)
 
         if (preselectedViewProvider) {
             objectMenu = new QMenu(contextMenu);
-            auto receiver =
-                new NavigationStyleContextMenuReceiver(preselectedViewProvider, objectMenu);
+            auto receiver = new NavigationStyleContextMenuReceiver(preselectedViewProvider, objectMenu);
             preselectedViewProvider->setupContextMenu(objectMenu, receiver, SLOT(startEditing()));
             objectActions = objectMenu->actions();
             if (!objectActions.empty()) {

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -51,6 +51,7 @@
 
 #include <Base/Interpreter.h>
 #include <App/Application.h>
+#include <App/DocumentObject.h>
 
 #include "Navigation/NavigationStyle.h"
 #include "Navigation/NavigationStylePy.h"
@@ -58,6 +59,7 @@
 #include "Camera.h"
 #include "Command.h"
 #include "Action.h"
+#include "Document.h"
 #include "Inventor/SoMouseWheelEvent.h"
 #include "MenuManager.h"
 #include "MouseSelection.h"
@@ -67,8 +69,27 @@
 #include "SoFullPathHelper.h"
 #include "View3DInventorViewer.h"
 #include "ViewParams.h"
+#include "ViewProviderDocumentObject.h"
 
 using namespace Gui;
+
+NavigationStyleContextMenuReceiver::NavigationStyleContextMenuReceiver(
+    ViewProviderDocumentObject* viewProvider,
+    QObject* parent
+)
+    : QObject(parent)
+    , viewProvider(viewProvider)
+{}
+
+void NavigationStyleContextMenuReceiver::startEditing()
+{
+    auto action = qobject_cast<QAction*>(sender());
+    if (!action || !viewProvider) {
+        return;
+    }
+
+    viewProvider->getDocument()->setEdit(viewProvider, action->data().toInt());
+}
 
 namespace
 {
@@ -2555,7 +2576,7 @@ void NavigationStyle::openPopupMenu(const SbVec2s& position)
     // store the right-click position for potential use by Clarify Selection
     rightClickPosition = position;
 
-    // ask workbenches and view provider, ...
+    // ask workbenches
     MenuItem view;
     Gui::Application::Instance->setupContextMenu("View", &view);
 
@@ -2566,6 +2587,48 @@ void NavigationStyle::openPopupMenu(const SbVec2s& position)
     // Add Clarify Selection option if there are objects under cursor
     bool separator = false;
     auto posAction = !contextMenu->actions().empty() ? contextMenu->actions().front() : nullptr;
+
+    QMenu* objectMenu = nullptr;
+    QList<QAction*> objectActions;
+    auto selection = Gui::Selection().getSelectionEx();
+
+    if (selection.size() == 1) {
+        App::DocumentObject* selectedObject = selection.front().getObject();
+        auto* selectedViewProvider
+            = Gui::Application::Instance->getViewProvider<Gui::ViewProviderDocumentObject>(
+                selectedObject
+            );
+
+        if (selectedViewProvider) {
+            objectMenu = new QMenu(contextMenu);
+            auto receiver =
+                new NavigationStyleContextMenuReceiver(selectedViewProvider, objectMenu);
+            selectedViewProvider->setupContextMenu(objectMenu, receiver, SLOT(startEditing()));
+            objectActions = objectMenu->actions();
+            if (!objectActions.empty()) {
+                contextMenu->setDefaultAction(objectActions.front());
+
+                for (auto* action : objectActions) {
+                    if (posAction) {
+                        contextMenu->insertAction(posAction, action);
+                    }
+                    else {
+                        contextMenu->addAction(action);
+                    }
+                }
+
+                if (posAction) {
+                    contextMenu->insertSeparator(posAction);
+                }
+                else {
+                    contextMenu->addSeparator();
+                }
+            }
+        }
+    }
+
+    // Add Clarify Selection option if there are objects under cursor
+    bool separator = false;
 
     // Get picked objects at position
     SoRayPickAction rp(viewer->getSoRenderManager()->getViewportRegion());

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -2584,8 +2584,6 @@ void NavigationStyle::openPopupMenu(const SbVec2s& position)
     MenuManager::getInstance()->setupContextMenu(&view, *contextMenu);
     contextMenu->setAttribute(Qt::WA_DeleteOnClose);
 
-    // Add Clarify Selection option if there are objects under cursor
-    bool separator = false;
     auto posAction = !contextMenu->actions().empty() ? contextMenu->actions().front() : nullptr;
 
     QMenu* objectMenu = nullptr;

--- a/src/Gui/Navigation/NavigationStyle.h
+++ b/src/Gui/Navigation/NavigationStyle.h
@@ -37,6 +37,7 @@
 
 #include <QEvent>
 #include <QAction>
+#include <QObject>
 #include <Base/BaseClass.h>
 #include <Base/SmartPtrPy.h>
 #include <Gui/Namespace.h>
@@ -61,6 +62,22 @@ class View3DInventorViewer;
 class NavigationAnimator;
 class AbstractMouseSelection;
 class NavigationAnimation;
+class ViewProviderDocumentObject;
+
+
+class NavigationStyleContextMenuReceiver: public QObject
+{
+    Q_OBJECT
+
+public:
+    NavigationStyleContextMenuReceiver(ViewProviderDocumentObject* viewProvider, QObject* parent);
+
+public Q_SLOTS:
+    void startEditing();
+
+private:
+    ViewProviderDocumentObject* viewProvider {nullptr};
+};
 
 /**
  * @author Werner Mayer

--- a/src/Gui/Navigation/NavigationStyle.h
+++ b/src/Gui/Navigation/NavigationStyle.h
@@ -37,6 +37,7 @@
 
 #include <QEvent>
 #include <QAction>
+#include <QObject>
 #include <Base/BaseClass.h>
 #include <Base/SmartPtrPy.h>
 #include <Gui/Namespace.h>
@@ -61,6 +62,21 @@ class View3DInventorViewer;
 class NavigationAnimator;
 class AbstractMouseSelection;
 class NavigationAnimation;
+class ViewProviderDocumentObject;
+
+class NavigationStyleContextMenuReceiver: public QObject
+{
+    Q_OBJECT
+
+public:
+    NavigationStyleContextMenuReceiver(ViewProviderDocumentObject* viewProvider, QObject* parent);
+
+public Q_SLOTS:
+    void startEditing();
+
+private:
+    ViewProviderDocumentObject* viewProvider {nullptr};
+};
 
 /**
  * @author Werner Mayer

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3948,7 +3948,8 @@ void ViewProviderSketch::attach(App::DocumentObject* pcFeat)
 
 void ViewProviderSketch::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
 {
-    menu->addAction(tr("Edit Sketch"), receiver, member);
+    QAction* act = menu->addAction(tr("Edit Sketch"), receiver, member);
+    act->setData(QVariant((int)ViewProvider::Default));
     // Call the extensions
     ViewProvider::setupContextMenu(menu, receiver, member);
 }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -4122,7 +4122,8 @@ void ViewProviderSketch::attach(App::DocumentObject* pcFeat)
 
 void ViewProviderSketch::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
 {
-    menu->addAction(tr("Edit Sketch"), receiver, member);
+    QAction* act = menu->addAction(tr("Edit Sketch"), receiver, member);
+    act->setData(QVariant((int)ViewProvider::Default));
     // Call the extensions
     ViewProvider::setupContextMenu(menu, receiver, member);
 }


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/30989

After this PR, right clicking on a single object on the view will show the object specific actions : 

<img width="566" height="392" alt="image" src="https://github.com/user-attachments/assets/489ab939-29ec-47c5-8985-e9d6fa3b2414" />

Making the view menu more consistent with the tree menu.

This is done in particular because it was asked for joints in assembly : https://github.com/FreeCAD/FreeCAD/issues/27412

@FreeCAD/design-working-group 