### PR TITLE
Assembly: Add "Edit joint" context menu entry for joints

### DIFF
--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -1234,7 +1234,15 @@ class ViewProviderJoint:
                 Since no data were serialized nothing needs to be done here."""
         return None
 
+    def setupContextMenu(self, vobj, menu):
+        action = menu.addAction(translate("Assembly", "Edit Joint"))
+        action.triggered.connect(lambda: self.editJoint(vobj))
+        return False
+
     def doubleClicked(self, vobj):
+        return self.editJoint(vobj)
+
+    def editJoint(self, vobj):
         App.ActiveDocument.abortTransaction()  # Close the auto-transaction
 
         task = Gui.Control.activeTaskDialog()


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/27412

After this PR "Edit Joint" appears in the menu when right clicking the tree: 

<img width="600" height="237" alt="image" src="https://github.com/user-attachments/assets/07f4fd83-d641-4ceb-b183-7cc22be44845" />

And after https://github.com/FreeCAD/FreeCAD/pull/30990 merge you then also have 'Edit joint' appearing in the menu when clicking on 3d: 

<img width="613" height="316" alt="image" src="https://github.com/user-attachments/assets/8bc24ceb-4526-4170-b483-7a10c982dbe3" />
