### PR TITLE
Sketcher: fix flaky TestExternalFacePreselection camera framing (#30993)

### DIFF
--- a/src/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py
+++ b/src/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py
@@ -227,6 +227,9 @@ class TestExternalFacePreselection(SketcherGuiTestCase):
             width, height = view.getSize()
             if width <= 0 or height <= 0:
                 return False
+            # Re-fit each probe: offscreen the viewport size/aspect may not be
+            # settled when fitAll() first runs, so fit until it frames the face.
+            view.fitAll()
             screen_x, screen_y = view.getPointOnScreen(face_center_3d)
             margin_x = width * 0.1
             margin_y = height * 0.1


### PR DESCRIPTION
This fixes https://github.com/FreeCAD/FreeCAD/issues/30993. The fix is AI-generated, but it's a one-liner. 

I can't think if a good way to test this. It usually doesn't fail. It just flakes out occasionally when running CI on github. So it NOT failing in CI won't tell us much. It usually doesn't fail without the fix anyway. 

So someone who understands this test better than me can validate it by inspection. Claude Code thinks this will fix the problem.

## AI explanation

testFacePickableUnderExternalTool called fitAll() once before checking that the Pad face is framed. Offscreen, the viewport size/aspect is not always settled at that point, so the camera framed against a not-ready viewport and the face center stayed at the viewport edge for the whole wait window. Re-fit inside the wait loop so it self-corrects once the viewport is ready.

Assisted-by: Claude Opus 4.8 (claude-opus-4-8)

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Actually, checking the "not unverified AI output" box is a lie, unless you count "AI came up with the solution and thinks it's right." I cannot test this at home since I don't have an Ubuntu box. However, when github's CI completes, it'll probably succeed, and **then** we can call it tested. Kinda.