### PR TITLE
Fix: Update X3DOM URLs to https for browser security

### DIFF
--- a/src/Gui/SoFCDB.cpp
+++ b/src/Gui/SoFCDB.cpp
@@ -702,9 +702,9 @@ bool Gui::SoFCDB::writeToX3DOM(SoNode* node, std::string& buffer)
         << "  <head>\n"
         << "    <meta charset=\"utf-8\"/>\n"
         << "    <title>FreeCAD X3DOM Export</title>\n"
-        << "    <script src=\"http://www.x3dom.org/download/x3dom.js\"> </script>\n"
+        << "    <script src=\"https://www.x3dom.org/download/x3dom.js\"> </script>\n"
         << "    <link rel=\"stylesheet\" type=\"text/css\" "
-           "href=\"http://www.x3dom.org/download/x3dom.css\"/>\n"
+           "href=\"https://www.x3dom.org/download/x3dom.css\"/>\n"
         << "  </head>\n"
         << "  <body>\n"
         << "    <div>\n";

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -2560,10 +2560,10 @@ bool MeshOutput::SaveX3DOM(std::ostream& out) const
            "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n";
     out << "<html xmlns='http://www.w3.org/1999/xhtml'>\n"
         << "  <head>\n"
-        << "    <script type='text/javascript' src='http://www.x3dom.org/download/x3dom.js'> "
+        << "    <script type='text/javascript' src='https://www.x3dom.org/download/x3dom.js'> "
            "</script>\n"
         << "    <link rel='stylesheet' type='text/css' "
-           "href='http://www.x3dom.org/download/x3dom.css'></link>\n"
+           "href='https://www.x3dom.org/download/x3dom.css'></link>\n"
         << "  </head>\n";
 
     auto onclick = [&out](const char* text) {


### PR DESCRIPTION
This PR addresses browser security blocking issues related to mixed content (http vs https) when exporting to X3DOM.

Previously, the hardcoded URLs in src/Gui/SoFCDB.cpp and src/Mod/Mesh/App/Core/MeshIO.cpp pointed to http resources. Modern browsers especially firefox blocks the output to be rendered on the browser due to the insecure link.

By updating these to https, the exported X3DOM viewer renders correctly.
the fix was just updating the link , it couldve be done in a cleaner way but given the complexity and the fact that i will have to update the whole class in the MeshIO.h to add a function i think this is the cleanest way to solve this issue for now.

Related Issue
Closes #30981

Testing
1- Verified code changes manually in source files.
2- Confirmed https URLs are correctly placed.
3- made sure that this issue do not exist elsewhere, the only place this bug existed other than the meshio.cpp was in the Gui SoFCDB.cpp
4- checked manually by using the function from the codebase and confirming the output.
see the image below. 

<img width="1842" height="1080" alt="image" src="https://github.com/user-attachments/assets/550de7bd-04ca-4613-94d0-6b8a291228c0" />
