### PR TITLE
PD: Remove exception in the case of orphan Feature

### DIFF
--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -425,12 +425,6 @@ Part::TopoShape Feature::getBaseTopoShape(bool silent) const
 
     if (BaseObject != BaseFeature.getValue()) {
         auto body = getFeatureBody();
-        if (!body) {
-            if (silent) {
-                return result;
-            }
-            throw Base::RuntimeError("Missing container body");
-        }
         if (BaseObject->isDerivedFrom<PartDesign::ShapeBinder>()
             || BaseObject->isDerivedFrom<PartDesign::SubShapeBinder>()) {
             if (silent) {

--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -466,13 +466,6 @@ Part::TopoShape Feature::getBaseTopoShape(bool silent) const
     }
 
     if (BaseObject != BaseFeature.getValue()) {
-        auto body = getFeatureBody();
-        if (!body) {
-            if (silent) {
-                return result;
-            }
-            throw Base::RuntimeError("Missing container body");
-        }
         if (BaseObject->isDerivedFrom<PartDesign::ShapeBinder>()
             || BaseObject->isDerivedFrom<PartDesign::SubShapeBinder>()) {
             if (silent) {


### PR DESCRIPTION
Many old files (v0.15 and older) were created with Part Design features that exist outside (and often completely without) a PD Body. While this workflow is no longer permitted, the files should continue to load. This commit removes the check and throw.

I have checked that all cases that call `getFeatureBody()` verify that they *have* a body before they use it, so removing this check should not cause any further issues (and indeed, the check was only added as part of the TNP mitigation merge, so has not been in the codebase that long).

Fixes #30252

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.