### PR TITLE
[FIX] Crash, when closing document while Measure tool is open

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -2852,7 +2852,10 @@ int Document::openCommand(const char* sName)
 
 void Document::commitCommand()
 {
-    getDocument()->commitTransaction();
+    auto doc = getDocument();
+    if (doc) {
+        doc->commitTransaction();
+    }
 }
 
 void Document::abortCommand()

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -260,12 +260,12 @@ TaskMeasure::TaskMeasure()
         mTargetDoc = doc;
 
         m_deletedConnection = Gui::Application::Instance->signalDeleteDocument.connect(
-                [this, doc](const Gui::Document& deletedDoc) {
-                    if (&deletedDoc == doc) {
-                        this->mTargetDoc = nullptr;
-                    }
+            [this, doc](const Gui::Document& deletedDoc) {
+                if (&deletedDoc == doc) {
+                    this->mTargetDoc = nullptr;
                 }
-            );
+            }
+        );
         mTargetDoc->openCommand("Add Measurement");
     }
 

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -258,6 +258,14 @@ TaskMeasure::TaskMeasure()
 
     if (auto* doc = Gui::Application::Instance->activeDocument()) {
         mTargetDoc = doc;
+
+        m_deletedConnection = Gui::Application::Instance->signalDeleteDocument.connect(
+                [this, doc](const Gui::Document& deletedDoc) {
+                    if (&deletedDoc == doc) {
+                        this->mTargetDoc = nullptr;
+                    }
+                }
+            );
         mTargetDoc->openCommand("Add Measurement");
     }
 


### PR DESCRIPTION
Closes #30932

I fixed an issue reported in #30932 where the program crashes after closing a document while using the measure tool.

I ran the program using AddressSanitizer  and discovered a UAF bug in the MeasureGui workbench. The crash was caused by an object lifetime mismatch where the GUI dialog maintained a pointer to a document that was in the process of being deallocated.

```The MeasureGui::TaskMeasure``` class stores a raw pointer (mTargetDoc) to the current ```Gui::Document```. When the document is closed, ```App::Application``` destroys the ```Gui::Document```, but the TaskMeasure instance remains alive and unaware of the destruction.

so basically the user initiates a document close / Gui::Document memory is deallocated
The GUI event loop triggers TaskMeasure::reject()
TaskMeasure attempts to call mTargetDoc->commitCommand()
The program attempts to dereference the dangling pointer, leading to a memory access violation and an immediate crash.

Initially, I tried basic defensive programming by checking mTargetDoc against nullptr, but that was ineffective because the class didn't set the pointer to null when the document was destroyed. After investigating the codebase, I found that I could hook into the internal FastSignals to detect when the document is being closed so I implemented an observer pattern to manage the object lifetime using Gui::Application::Instance->signalDeleteDocument signal. When the document closes, the signal triggers a callback that explicitly sets mTargetDoc to nullptr before the document memory is unmapped.

it was fun :3