### PR TITLE
CAM: Fix ToolBit serialization dropping unknown top-level keys on save

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathToolBitSerializer.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolBitSerializer.py
@@ -151,6 +151,27 @@ class TestFCTBSerializer(_BaseToolBitSerializerTestCase):
             deserialized_bit.get_length(), FreeCAD.Units.Quantity(15.0, FreeCAD.Units.Length)
         )
 
+    def test_unknown_keys_preserved_on_roundtrip(self):
+        """Unknown top-level keys must survive deserialize -> serialize."""
+        fctb_data = (
+            b'{"name": "Test Tool", "pocket": null, "my_ext": {"foo": 1}, '
+            b'"shape": "endmill", '
+            b'"parameter": {"Diameter": "4.12 mm", "Length": "15.0 mm"}, "attribute": {}}'
+        )
+        shape = ToolBitShapeEndmill("endmill")
+        dependencies: Mapping[AssetUri, Asset] = {AssetUri.build("toolbitshape", "endmill"): shape}
+
+        toolbit = self.serializer_class.deserialize(
+            fctb_data, id="test_id", dependencies=dependencies
+        )
+        serialized = self.serializer_class.serialize(toolbit)
+        data = json.loads(serialized.decode("utf-8"))
+
+        self.assertIn("pocket", data)
+        self.assertIsNone(data["pocket"])
+        self.assertIn("my_ext", data)
+        self.assertEqual(data["my_ext"], {"foo": 1})
+
 
 class TestYamlToolBitSerializer(_BaseToolBitSerializerTestCase):
     serializer_class = YamlToolBitSerializer

--- a/src/Mod/CAM/Path/Tool/toolbit/models/base.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/models/base.py
@@ -108,6 +108,8 @@ class ToolBit(Asset, ABC):
         # This is what the user selected and should be saved back to disk
         # If not provided, default to the class name (e.g., "Endmill")
         self._shape_type = attrs.get("shape-type") if attrs else tool_bit_shape.name
+        # Unknown top-level keys; merged back on save so third-party extensions survive round-trips.
+        self._extra_attrs: dict = {}
 
     def __eq__(self, other):
         """Compare ToolBit objects based on their unique ID."""
@@ -229,6 +231,8 @@ class ToolBit(Asset, ABC):
                 )
 
         toolbit._update_tool_properties()
+        # Snapshot all keys; to_dict() lets native keys take precedence, unknown ones pass through.
+        toolbit._extra_attrs = dict(attrs)
         return toolbit
 
     @classmethod
@@ -979,6 +983,12 @@ class ToolBit(Asset, ABC):
                     f"(type {type(value).__name__}, value {value}): {e}"
                 )
 
+        # Merge unrecognised keys back so they aren't dropped on save.
+        extra = getattr(self, "_extra_attrs", {})
+        for k, v in extra.items():
+            if k not in attrs:
+                attrs[k] = v
+
         Path.Log.debug(f"to_dict output for {self.obj.Label}: {attrs}")
         return attrs
 
@@ -1011,6 +1021,11 @@ class ToolBit(Asset, ABC):
         }
 
         return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        # Seed _extra_attrs from _obj_data so unrecognised keys survive round-trips.
+        self._extra_attrs = state.get("_obj_data", {})
 
     def get_spindle_direction(self) -> toolchange.SpindleDirection:
         """


### PR DESCRIPTION
This PR preserves unknown top-level keys in .fctb files during a save round-trip, ensuring the keys are not silently dropped when editing a toolbit.

Fixes: #30709

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
