### PR TITLE
CAM: allow custom nonsupported

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathCustom.py
+++ b/src/Mod/CAM/CAMTests/TestPathCustom.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""Unit tests for the CAM Custom operation (Path.Op.Custom).
+
+These tests deliberately avoid loading documents from disk and avoid building
+a full Job/Stock/ToolController graph. The operation is small
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import Path
+from Path.Op import Custom
+from Path.Post.Processor import PostProcessor
+from Path.Post.PostList import Postable
+from Machine.models.machine import Machine, OutputUnits
+from CAMTests import PathTestUtils
+from CAMTests.PostTestMocks import MockJob, MockStock
+
+Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+
+
+def _make_job(xmin=0.0, ymin=0.0, zmin=0.0, xmax=10.0, ymax=10.0, zmax=4.0):
+    """A shared MockJob whose stock spans the requested bounding box."""
+    job = MockJob()
+    job.Stock = MockStock(xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax, zmin=zmin, zmax=zmax)
+    return job
+
+
+class TestPathCustomConverted(PathTestUtils.PathTestBase):
+    """Test Custom through Processor.py's _convert_item_commands()"""
+
+    @classmethod
+    def _make_op(cls, gcode):
+        """make the op and postable from lines of gcode or ["gcode",...] or [Path.Command...]"""
+        op = Custom.Create(name="dumy", obj=Mock(), parentJob=cls.job).Proxy
+        op.Active = True
+        op.commandlist = []
+        if isinstance(gcode, str):
+            gcode = gcode.rstrip().split("\n")
+        if isinstance(gcode, (list, tuple)):
+            gcode = [(s if isinstance(s, str) else s.toGCode()) for s in gcode]
+        custom_gcode = SimpleNamespace(Source="Text", Gcode=gcode)
+        op.opExecute(custom_gcode)
+
+        postable = Postable(
+            label="test custom",
+            item_type="operation",
+            data={},
+            path=Path.Path(op.commandlist),
+            source=None,
+        )
+        return op, postable
+
+    @classmethod
+    def setUpClass(cls):
+
+        cls.job = _make_job()
+        cls.pp = PostProcessor(cls.job, "tooltip", "args", units="G21")
+
+    def setUp(self):
+        self.pp._machine = Machine()
+        self.pp._machine.output.units = OutputUnits.METRIC
+        self.pp._merge_machine_config()
+
+    def test_supported(self):
+        """Processor allows supported gcode"""
+        _, postable = self._make_op("G1 X1")
+
+        output = []
+        self.pp._convert_item_commands(postable, output)
+        self.assertEqual(
+            "\n".join(output),
+            """(Begin Custom)
+G1 X1.000
+(End Custom)""",
+        )
+
+    def test_unsupported(self):
+        """Processor allows unsupported gcode"""
+        _, postable = self._make_op("G666 X1")
+
+        output = []
+        self.pp._convert_item_commands(postable, output)
+        self.assertEqual(
+            "\n".join(output),
+            """(Begin Custom)
+G666 X1.000
+(End Custom)""",
+        )

--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -565,6 +565,7 @@ SET(Tests_SRCS
     CAMTests/TestPathAdaptive.py
     CAMTests/TestPathCommandAnnotations.py
     CAMTests/TestPathCore.py
+    CAMTests/TestPathCustom.py
     CAMTests/TestPathDepthParams.py
     CAMTests/TestPathDressupArray.py
     CAMTests/TestPathDressupDogboneII.py

--- a/src/Mod/CAM/Constants.py
+++ b/src/Mod/CAM/Constants.py
@@ -194,3 +194,16 @@ GCODE_NON_CONFORMING = (
     + GCODE_RETURN_MODE
     + GCODE_CYCLE_CANCEL
 )
+
+
+# =============================================================================
+# Annotations
+# Use constants for keys, comment here for values/semantics
+# =============================================================================
+
+# For Path.Command
+
+# To skip Processor.py from checking a Path.Command against Supported & Non-Conforming
+# i.e. allow any gcode
+# absence for false; any non-false presence for true: use "True"
+ANNOT_ALLOW_UNSUPPORTED = "allow_unsupported"

--- a/src/Mod/CAM/Path/Op/Custom.py
+++ b/src/Mod/CAM/Path/Op/Custom.py
@@ -26,6 +26,7 @@ import re
 import os
 import Path
 import Path.Op.Base as PathOp
+import Constants
 
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -187,13 +188,16 @@ class ObjectCustom(PathOp.ObjectOp):
             for i, line in enumerate(obj.Gcode):
                 line = self.parseExpressions(obj, line, i)
                 try:
-                    newcommand = Path.Command(str(line))
+                    newcommand = Path.Command(
+                        str(line), {}, {Constants.ANNOT_ALLOW_UNSUPPORTED: "True"}
+                    )
                     self.commandlist.append(newcommand)
                 except ValueError:
                     errorNumLines.append(i)
                     if len(errorLines) < 7:
                         errorLines.append(f"{i}: {str(line).strip()}")
             if errorLines:
+                # FIXME: should throw
                 Path.Log.warning(
                     translate("PathCustom", "Total invalid lines in Custom Text G-code: %s")
                     % len(errorNumLines)

--- a/src/Mod/CAM/Path/Post/PostList.py
+++ b/src/Mod/CAM/Path/Post/PostList.py
@@ -190,11 +190,12 @@ def _wrap_op(op: Any) -> Postable:
     Data keys populated:
         "tool_controller" (Postable) - Present when the operation has a ToolController.
     """
-    data = {}
+    data = {}  # WHATIF: = op.postable_annotations()
     raw_tc = PathUtil.toolControllerForOp(op)
     if raw_tc is not None:
         data["tool_controller"] = _wrap_tc(raw_tc)
 
+    # For a don't-interpret-text-blob: data={'str': blob}
     return Postable(
         item_type="operation",
         label=op.Label,

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -2394,6 +2394,7 @@ class PostProcessor:
             command.Name not in supported
             and not command.Name.startswith("(")
             and not command.Name.startswith("T")
+            and not command.Annotations.get(Constants.ANNOT_ALLOW_UNSUPPORTED, False)
         ):
             raise CAMValueError(
                 f"Unsupported command: {command.Name}",

--- a/src/Mod/CAM/TestCAMApp.py
+++ b/src/Mod/CAM/TestCAMApp.py
@@ -76,6 +76,7 @@ from CAMTests.TestPostOutput import (
     TestExport2Integration,
 )
 
+from CAMTests.TestPathCustom import TestPathCustomConverted
 from CAMTests.TestPathPreferences import TestPathPreferences
 from CAMTests.TestPathPocket import TestPathPocket
 from CAMTests.TestPathProfile import TestPathProfile, TestPathOpenProfile


### PR DESCRIPTION
Custom tolerates non-supported gcodes again. Add Path.Command annotation, then check when post-processing. fixes #31021

Also, some questions. See #31021, and comments in this pr. 

Needs pr #31007
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

