### PR TITLE
Base: Add cast to unsigned char when using isdigit

### DIFF
--- a/src/Base/UniqueNameManager.cpp
+++ b/src/Base/UniqueNameManager.cpp
@@ -24,6 +24,7 @@
 #include "UniqueNameManager.h"
 
 #include <algorithm>
+#include <cctype>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -34,7 +35,7 @@ std::tuple<std::string_view, std::string_view, unsigned int, Base::UnlimitedUnsi
 {
     auto suffixStart = getNameSuffixStartPosition(name);
     auto digitsStart = std::find_if_not(suffixStart, name.crend(), [](char c) {
-        return std::isdigit(c);
+        return std::isdigit(static_cast<unsigned char>(c)) != 0;
     });
     unsigned int digitCount = digitsStart - suffixStart;
     return {
@@ -53,10 +54,10 @@ bool Base::UniqueNameManager::haveSameBaseName(std::string_view first, std::stri
         return false;
     }
     auto firstDigitsStart = std::find_if_not(firstSuffixStart, first.crend(), [](char c) {
-        return std::isdigit(c);
+        return std::isdigit(static_cast<unsigned char>(c)) != 0;
     });
     auto secondDigitsStart = std::find_if_not(secondSuffixStart, second.crend(), [](char c) {
-        return std::isdigit(c);
+        return std::isdigit(static_cast<unsigned char>(c)) != 0;
     });
     return std::equal(firstDigitsStart, first.crend(), secondDigitsStart, second.crend());
 }

--- a/tests/src/Base/UniqueNameManager.cpp
+++ b/tests/src/Base/UniqueNameManager.cpp
@@ -122,4 +122,21 @@ TEST(UniqueNameManager, UniqueNameWith9NDigits)
     manager.addExactName("Compound123456789");
     EXPECT_EQ(manager.makeUniqueName("Compound", 3), "Compound123456790");
 }
+
+// NOTE: This test only actually *tests* something in a Windows Debug build: on all other platforms
+// it will pass irrespective of whether the bug is present.
+TEST(UniqueNameManager, NonAsciiNameIsHandled)  // NOLINT
+{
+    // Regression: decomposeName() called std::isdigit() on raw (signed) char bytes. The "é" in
+    // "café" is UTF-8 0xC3 0xA9, which is negative as a signed char, so the unguarded
+    // std::isdigit() was undefined behavior and aborted on the MSVC debug CRT.
+    Base::UniqueNameManager manager;
+    manager.addExactName("café");  // <-- This would crash on Debug MSVC prior to the fix.
+    EXPECT_TRUE(manager.containsName("café"));
+
+    // The non-ASCII bytes must not be mistaken for digits: the base name is preserved and a numeric
+    // suffix is appended when the name conflicts.
+    EXPECT_EQ(manager.makeUniqueName("café", 1), "café1");
+}
+
 // NOLINTEND(cppcoreguidelines-*,readability-*)


### PR DESCRIPTION
I got bit by this while working on #30712 -- now that I have a full debug build on Windows some of these edge cases/hidden UB are coming out to haunt me...

On a system where `char` is signed (MSVC/x86-64), a non-ASCII UTF-8 byte is negative: "café" ends in é = UTF-8 0xC3 0xA9, i.e. char values -61 and -23. Passing those to `std::isdigit` is undefined behavior, and the MSVC debug CRT has an explicit `_ASSERTE((c >= -1) && (c <= 255))` in its `isctype` path. So when I try to set a label to "café", I get an immediate crash on the assertion. Casting it to an `unsigned char` fixes the assertion and allows the check to continue as expected. This will only affect debug builds on Windows; Release build have magic of some kind that makes it work anyway, and on Linux and macOS, glibc and libc++ handle the `isdigit` calculation differently.

NOTE: I included a unit test for this, but that test *only* functions as a test on MSVC Debug builds (which our CI does not use). So the test will pass irrespective of the presence of this bug on almost everyone's builds. 

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.