### PR TITLE
Add undo support for suppression state toggle

### DIFF
--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -257,11 +257,18 @@ void StdCmdToggleSuppress::activated(int iMsg)
     std::vector<Gui::SelectionSingleton::SelObj> sels = Gui::Selection().getCompleteSelection();
 
     Command::openCommand(QT_TRANSLATE_NOOP("Command", "Toggle suppress"));
-    for (Gui::SelectionSingleton::SelObj& sel : sels) {
-        if (App::DocumentObject* obj = sel.pObject) {
-            if (auto ext = obj->getExtensionByType<App::SuppressibleExtension>(true)) {
-                if (ext && !ext->Suppressed.testStatus(App::Property::Hidden)) {
-                    ext->Suppressed.setValue(!ext->Suppressed.getValue());
+    if (!sels.empty() && sels[0].pObject) {
+        App::Document* targetDoc = sels[0].pObject->getDocument();
+        App::AutoTransaction committer(targetDoc, "Toggle suppress");
+        for (Gui::SelectionSingleton::SelObj& sel : sels) {
+            if (App::DocumentObject* obj = sel.pObject) {
+                if (obj->getDocument() != targetDoc) {
+                    continue;  // Skip objects from other documents
+                }
+                if (auto ext = obj->getExtensionByType<App::SuppressibleExtension>(true)) {
+                    if (ext && !ext->Suppressed.testStatus(App::Property::Hidden)) {
+                        ext->Suppressed.setValue(!ext->Suppressed.getValue());
+                    }
                 }
             }
         }


### PR DESCRIPTION
Assisted-by: Claude Haiku 4.5 (Copilot)

## Summary
Wrap the Suppressed property toggle in App::AutoTransaction so that changing 
the suppression state from the context menu creates an undo entry. Previously, 
toggling suppression did not register with the undo system.

## Issues
Fixes #28594

## Changes
- Added App::AutoTransaction wrapper around the suppression toggle loop in 
  StdCmdToggleSuppress::activated()
- Validates all selections are from the same document and skips others
- All toggled items grouped as single undo action
- Property changes now register with undo/redo system

## Testing
- Toggle suppression from context menu on single and multiple features
- Verify undo (Ctrl+Z) reverses suppression state
- Verify all toggled items revert together with single undo

<img alt="suppressed_stack_fix" src="https://github.com/user-attachments/assets/262dacc8-e303-4fc9-a4eb-030046ad8dd9" />
