### PR TITLE
Tux: Fix orbit and navigation style selection

### DIFF
--- a/src/Mod/Tux/NavigationIndicatorGui.py
+++ b/src/Mod/Tux/NavigationIndicatorGui.py
@@ -53,11 +53,12 @@ class IndicatorButton(QtGui.QPushButton):
         return super(IndicatorButton, self).changeEvent(event)
 
     def onChange(self, paramGrp, param):
-        if param == "NavigationStyle":
+        if param in ("NavigationStyle", "OrbitStyle", "SameStyleForAllViews"):
             setCurrent()
 
     def mousePressEvent(self, event):
         RePopulateIcons()
+        setCurrent()
         return super(IndicatorButton, self).mousePressEvent(event)
 
 
@@ -780,6 +781,9 @@ a12.setText("Touchpad  ")
 a12.setData("Gui::TouchpadNavigationStyle")
 a12.setObjectName("Indicator_NavigationTouchpad")
 
+for action in gStyle.actions():
+    action.setCheckable(True)
+
 RePopulateIcons()
 
 menu.addMenu(menuSettings)
@@ -862,6 +866,8 @@ def onOrbit():
     elif aRoundedArcball.isChecked():
         pView.SetInt("OrbitStyle", 4)
 
+    onOrbitShow()
+
 
 def onOrbitShow():
     """Set turntable or trackball orbit style."""
@@ -881,9 +887,36 @@ def onOrbitShow():
     gOrbit.blockSignals(False)
 
 
+def getActiveView():
+    """Return the active 3D view, if one is available."""
+
+    doc = getattr(Gui, "ActiveDocument", None)
+    return getattr(doc, "ActiveView", None)
+
+
+def getCurrentNavigationStyle():
+    """Return the navigation style for the current status-bar scope."""
+
+    if not pView.GetBool("SameStyleForAllViews", 1):
+        view = getActiveView()
+        if view and hasattr(view, "getNavigationType"):
+            return view.getNavigationType()
+
+    return pView.GetString("NavigationStyle")
+
+
 def onMenu(action):
     """Set navigation style on selection."""
-    pView.SetString("NavigationStyle", action.data())
+
+    style = action.data()
+    if pView.GetBool("SameStyleForAllViews", 1):
+        pView.SetString("NavigationStyle", style)
+    else:
+        view = getActiveView()
+        if view and hasattr(view, "setNavigationType"):
+            view.setNavigationType(style)
+
+    setCurrent()
 
 
 def setCurrent():
@@ -892,12 +925,13 @@ def setCurrent():
 
     s = False
     actions = gStyle.actions()
-    current = pView.GetString("NavigationStyle")
+    current = getCurrentNavigationStyle()
 
     if current and current != "Undefined":
         for i in actions:
             if i.data() == current:
                 s = True
+                i.setChecked(True)
                 setCompact(i)
                 menu.setDefaultAction(i)
                 indicator.setIcon(i.icon())
@@ -913,12 +947,19 @@ def setCurrent():
     else:
         a0.setVisible(True)
         a0.setEnabled(True)
+        a0.setChecked(True)
         setCompact(a0)
         menu.setDefaultAction(a0)
         indicator.setIcon(a0.icon())
         indicator.setToolTip(a0.toolTip())
 
     gStyle.blockSignals(False)
+
+
+def onActiveWindowChanged(window):
+    """Refresh when the active MDI view changes."""
+
+    setCurrent()
 
 
 if p.GetBool("Compact", 0):
@@ -943,9 +984,15 @@ mw.addStatusBarItem(
 
 setCurrent()
 
+mdiAreaClass = getattr(QtGui, "QMdiArea", None)
+mdiArea = mw.findChild(mdiAreaClass) if mdiAreaClass else None
+if mdiArea:
+    mdiArea.subWindowActivated.connect(onActiveWindowChanged)
+
 gStyle.triggered.connect(onMenu)
 gOrbit.triggered.connect(onOrbit)
 aCompact.triggered.connect(onCompact)
 aTooltip.triggered.connect(onTooltip)
+menu.aboutToShow.connect(setCurrent)
 menuOrbit.aboutToShow.connect(onOrbitShow)
 menu.aboutToHide.connect(indicator.clearFocus)


### PR DESCRIPTION
#30349 introduced a regression: Selection of navigation styles and orbit styles would not update it.
The widget was still relying only on preference writes. To fix it this makes update/check the current style more explicitly.

Also fixed:
- Navigation style menu actions are now checkable, so the menu state reflects the currently selected style
- Orbit style changes refresh the menu state immediately
- The indicator now reacts to both NavigationStyle and OrbitStyle preference changes

Assisted-by: GPT-5.5


<img width="274" height="382" alt="2026-06-28_14-00-31" src="https://github.com/user-attachments/assets/422fbef5-d959-44f4-bf80-590b1bd7e073" />
