### PR TITLE
CAM: Helix op - Fix updateSortingVisibility()

### DIFF
--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -307,6 +307,8 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         if not obj.Document.Restoring:
             self.opCheckParameters(obj)
 
+        super().opOnChanged(obj, prop)
+
     def opSetEditorModes(self, obj):
         obj.setEditorMode("Direction", ("ReadOnly", "Hidden"))
         obj.setPropertyStatus("Direction", ("ReadOnly", "Output"))


### PR DESCRIPTION
Properties `StartPoint`, `EndPoint` and `UseEndPoint` should be hidden, if **Manual** sorting selected

`updateSortingVisibility()` missed in **Helix** op, because `CircularHoleBase.ObjectHelix.opOnChanged()` overridden by `Helix.ObjectHelix.opOnChanged()` 

https://github.com/FreeCAD/FreeCAD/blob/fa3bb6fde9eef0c7788b8351b2981d329426ee18/src/Mod/CAM/Path/Op/CircularHoleBase.py#L131-L134

https://github.com/FreeCAD/FreeCAD/blob/fa3bb6fde9eef0c7788b8351b2981d329426ee18/src/Mod/CAM/Path/Op/CircularHoleBase.py#L123-L129

<img width="696" height="280" alt="Screenshot_20260628_204113_hor" src="https://github.com/user-attachments/assets/15ed30c5-35f6-486b-80a5-b87c408fedb9" />
