### PR TITLE
Gui: Improve (Pre)Selection Colors

### DIFF
--- a/src/Gui/PreferencePackTemplates/TechDraw_Colors.cfg
+++ b/src/Gui/PreferencePackTemplates/TechDraw_Colors.cfg
@@ -14,9 +14,9 @@
             <FCParamGroup Name="Colors">
               <FCUInt Name="Hatch" Value="255"/>
               <FCUInt Name="Background" Value="3553874943"/>
-              <FCUInt Name="PreSelectColor" Value="4294902015"/>
+              <FCUInt Name="PreSelectColor" Value="180944895"/>
               <FCUInt Name="HiddenColor" Value="255"/>
-              <FCUInt Name="SelectColor" Value="16711935"/>
+              <FCUInt Name="SelectColor" Value="11272191"/>
               <FCUInt Name="NormalColor" Value="255"/>
               <FCUInt Name="CutSurfaceColor" Value="3553874943"/>
               <FCUInt Name="GeomHatch" Value="255"/>

--- a/src/Gui/PreferencePackTemplates/Window_Colors.cfg
+++ b/src/Gui/PreferencePackTemplates/Window_Colors.cfg
@@ -17,14 +17,14 @@
           <FCBool Name="EnableBacklight" Value="0"/>
           <FCBool Name="Gradient" Value="1"/>
           <FCBool Name="RadialGradient" Value="0"/>
-          <FCUInt Name="HighlightColor" Value="4294907903"/>
+          <FCUInt Name="HighlightColor" Value="180944895"/>
           <FCBool Name="RandomColor" Value="0"/>
-          <FCUInt Name="SelectionColor" Value="704588287"/>
+          <FCUInt Name="SelectionColor" Value="11272191"/>
           <FCBool Name="Simple" Value="0"/>
           <FCBool Name="UseBackgroundColorMid" Value="0"/>
         </FCParamGroup>
         <FCParamGroup Name="TreeView">
-          <FCUInt Name="TreeEditColor" Value="4042260735"/>
+          <FCUInt Name="TreeEditColor" Value="11272191"/>
           <FCUInt Name="TreeActiveColor" Value="3537037823"/>
         </FCParamGroup>
         <FCParamGroup Name="MainWindow">

--- a/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
@@ -83,8 +83,8 @@
               <FCUInt Name="Hatch" Value="255"/>
               <FCUInt Name="HiddenColor" Value="255"/>
               <FCUInt Name="NormalColor" Value="255"/>
-              <FCUInt Name="PreSelectColor" Value="4240710143"/>
-              <FCUInt Name="SelectColor" Value="1958221567"/>
+              <FCUInt Name="PreSelectColor" Value="180944895"/>
+              <FCUInt Name="SelectColor" Value="11272191"/>
               <FCUInt Name="LightTextColor" Value="4294967295"/>
             </FCParamGroup>
             <FCParamGroup Name="Decorations">
@@ -102,14 +102,14 @@
           <FCUInt Name="colorWarning" Value="4287913983"/>
         </FCParamGroup>
         <FCParamGroup Name="Themes">
-          <FCUInt Name="ThemeAccentColor1" Value="1252392959"/>
+          <FCUInt Name="ThemeAccentColor1" Value="11272191"/>
           <FCUInt Name="ThemeAccentColor2" Value="3027763199"/>
           <FCUInt Name="ThemeAccentColor3" Value="1434171135"/>
         </FCParamGroup>
         <FCParamGroup Name="TreeView">
           <FCInt Name="ItemBackgroundPadding" Value="11"/>
           <FCUInt Name="TreeActiveColor" Value="899696639"/>
-          <FCUInt Name="TreeEditColor" Value="1434171135"/>
+          <FCUInt Name="TreeEditColor" Value="11272191"/>
         </FCParamGroup>
         <FCParamGroup Name="View">
           <FCBool Name="Gradient" Value="0"/>
@@ -129,6 +129,7 @@
           <FCUInt Name="CursorTextColor" Value="2914369023"/>
           <FCUInt Name="DeactivatedConstrDimColor" Value="2257491711"/>
           <FCUInt Name="DefaultShapeColor" Value="1920565503"/>
+          <FCUInt Name="DefaultShapeLineColor" Value="255"/>
           <FCUInt Name="EditedEdgeColor" Value="4059297279"/>
           <FCUInt Name="EditedVertexColor" Value="4199699199"/>
           <FCUInt Name="ExprBasedConstrDimColor" Value="4252898559"/>
@@ -138,11 +139,11 @@
           <FCUInt Name="FullyConstraintConstructionPointColor" Value="4205291519"/>
           <FCUInt Name="FullyConstraintElementColor" Value="11173887"/>
           <FCUInt Name="FullyConstraintInternalAlignmentColor" Value="2462511359"/>
-          <FCUInt Name="HighlightColor" Value="611232767"/>
+          <FCUInt Name="HighlightColor" Value="180944895"/>
           <FCUInt Name="InternalAlignedGeoColor" Value="865792255"/>
-          <FCUInt Name="InvalidSketchColor" Value="4252898559"/>
+          <FCUInt Name="InvalidSketchColor" Value="4285333759"/>
           <FCUInt Name="NonDrivingConstrDimColor" Value="865792255"/>
-          <FCUInt Name="SelectionColor" Value="899696639"/>
+          <FCUInt Name="SelectionColor" Value="11272191"/>
           <FCUInt Name="SketchEdgeColor" Value="4059297279"/>
           <FCUInt Name="SketchVertexColor" Value="4059297279"/>
         </FCParamGroup>

--- a/src/Gui/PreferencePacks/FreeCAD Light/FreeCAD Light.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Light/FreeCAD Light.cfg
@@ -88,8 +88,8 @@
               <FCUInt Name="LightTextColor" Value="1230002175"/>
               <FCUInt Name="NormalColor" Value="556083711"/>
               <FCUInt Name="PageColor" Value="4294967295"/>
-              <FCUInt Name="PreSelectColor" Value="4120838399"/>
-              <FCUInt Name="SelectColor" Value="1722290175"/>
+              <FCUInt Name="PreSelectColor" Value="180944895"/>
+              <FCUInt Name="SelectColor" Value="11272191"/>
               <FCUInt Name="TemplateUnderlineColor" Value="995875839"/>
             </FCParamGroup>
             <FCParamGroup Name="Decorations">
@@ -116,13 +116,13 @@
           <FCUInt Name="colorWarning" Value="4252787455"/>
         </FCParamGroup>
         <FCParamGroup Name="Themes">
-          <FCUInt Name="ThemeAccentColor1" Value="1252392959"/>
+          <FCUInt Name="ThemeAccentColor1" Value="11272191"/>
           <FCUInt Name="ThemeAccentColor2" Value="3027763199"/>
           <FCUInt Name="ThemeAccentColor3" Value="1434171135"/>
         </FCParamGroup>
         <FCParamGroup Name="TreeView">
           <FCUInt Name="TreeActiveColor" Value="1538528255"/>
-          <FCUInt Name="TreeEditColor" Value="563609599"/>
+          <FCUInt Name="TreeEditColor" Value="11272191"/>
         </FCParamGroup>
         <FCParamGroup Name="View">
           <FCBool Name="Gradient" Value="0"/>
@@ -142,7 +142,7 @@
           <FCUInt Name="CursorTextColor" Value="556083711"/>
           <FCUInt Name="DeactivatedConstrDimColor" Value="2257491711"/>
           <FCUInt Name="DefaultShapeColor" Value="2914369023"/>
-          <FCUInt Name="DefaultShapeLineColor" Value="421075455"/>
+          <FCUInt Name="DefaultShapeLineColor" Value="255"/>
           <FCUInt Name="DefaultShapeVertexColor" Value="421075455"/>
           <FCUInt Name="EditedEdgeColor" Value="1230002175"/>
           <FCUInt Name="EditedVertexColor" Value="556083711"/>
@@ -156,11 +156,11 @@
           <FCUInt Name="HeadlightColor" Value="4059297279"/>
           <FCUInt Name="HiddenLineBackground" Value="4294967040"/>
           <FCUInt Name="HiddenLineFaceColor" Value="4294967040"/>
-          <FCUInt Name="HighlightColor" Value="7995647"/>
+          <FCUInt Name="HighlightColor" Value="180944895"/>
           <FCUInt Name="InternalAlignedGeoColor" Value="995875839"/>
-          <FCUInt Name="InvalidSketchColor" Value="4252898559"/>
+          <FCUInt Name="InvalidSketchColor" Value="4285333759"/>
           <FCUInt Name="NonDrivingConstrDimColor" Value="2257491711"/>
-          <FCUInt Name="SelectionColor" Value="995875839"/>
+          <FCUInt Name="SelectionColor" Value="11272191"/>
           <FCUInt Name="ShadowGroundColor" Value="2105376000"/>
           <FCUInt Name="ShadowLightColor" Value="4043177728"/>
           <FCUInt Name="SketchEdgeColor" Value="556083711"/>

--- a/src/Gui/PreferencePages/DlgSettingsSelection.ui
+++ b/src/Gui/PreferencePages/DlgSettingsSelection.ui
@@ -30,9 +30,9 @@
         </property>
         <property name="color">
          <color>
-          <red>28</red>
-          <green>173</green>
-          <blue>28</blue>
+          <red>0</red>
+          <green>171</green>
+          <blue>255</blue>
          </color>
         </property>
         <property name="prefEntry" stdset="0">
@@ -135,9 +135,9 @@ A larger value makes it easier to select elements, but may prevent selection of 
         </property>
         <property name="color">
          <color>
-          <red>225</red>
-          <green>225</green>
-          <blue>20</blue>
+          <red>10</red>
+          <green>200</green>
+          <blue>255</blue>
          </color>
         </property>
         <property name="prefEntry" stdset="0">

--- a/src/Gui/PreferencePages/DlgSettingsUI.ui
+++ b/src/Gui/PreferencePages/DlgSettingsUI.ui
@@ -55,9 +55,9 @@
           </property>
           <property name="color" stdset="0">
            <color>
-            <red>85</red>
-            <green>123</green>
-            <blue>182</blue>
+            <red>0</red>
+            <green>171</green>
+            <blue>255</blue>
            </color>
           </property>
           <property name="prefEntry" stdset="0">

--- a/src/Gui/PreferencePages/DlgSettingsViewColor.ui
+++ b/src/Gui/PreferencePages/DlgSettingsViewColor.ui
@@ -342,9 +342,9 @@
           </property>
           <property name="color" stdset="0">
            <color>
-            <red>94</red>
-            <green>170</green>
-            <blue>35</blue>
+            <red>0</red>
+            <green>171</green>
+            <blue>255</blue>
            </color>
           </property>
           <property name="prefEntry" stdset="0">

--- a/src/Gui/Selection/SelectionColors.h
+++ b/src/Gui/Selection/SelectionColors.h
@@ -32,13 +32,13 @@ namespace Gui::SelectionColors
 inline SbColor highlightFallbackColor()
 {
     // Keep this aligned with the generic Selection preferences page defaults.
-    return SbColor(225.0f / 255.0f, 225.0f / 255.0f, 20.0f / 255.0f);
+    return SbColor(10.0f / 255.0f, 200.0f / 255.0f, 1.0f);
 }
 
 inline SbColor selectionFallbackColor()
 {
     // Keep this aligned with the generic Selection preferences page defaults.
-    return SbColor(28.0f / 255.0f, 173.0f / 255.0f, 28.0f / 255.0f);
+    return SbColor(0.0f, 171.0f / 255.0f, 1.0f);
 }
 
 inline SbColor viewPreferenceColor(const char* key, const SbColor& fallback)

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -4459,7 +4459,7 @@ void DocumentItem::slotInEdit(const Gui::ViewProviderDocumentObject& v)
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/TreeView"
     );
-    unsigned long col = hGrp->GetUnsigned("TreeEditColor", 563609599);
+    unsigned long col = hGrp->GetUnsigned("TreeEditColor", 11272191);
     QColor color(Base::Color::fromPackedRGB<QColor>(col));
 
     if (!getTree()->editingItem) {

--- a/src/Gui/TreeParams.cpp
+++ b/src/Gui/TreeParams.cpp
@@ -124,7 +124,7 @@ public:
         funcs["TreeActiveAutoExpand"] = &TreeParamsP::updateTreeActiveAutoExpand;
         TreeActiveColor = handle->GetUnsigned("TreeActiveColor", 1538528255);
         funcs["TreeActiveColor"] = &TreeParamsP::updateTreeActiveColor;
-        TreeEditColor = handle->GetUnsigned("TreeEditColor", 563609599);
+        TreeEditColor = handle->GetUnsigned("TreeEditColor", 11272191);
         funcs["TreeEditColor"] = &TreeParamsP::updateTreeEditColor;
         SelectingGroupColor = handle->GetUnsigned("SelectingGroupColor", 1082163711);
         funcs["SelectingGroupColor"] = &TreeParamsP::updateSelectingGroupColor;
@@ -289,7 +289,7 @@ public:
     // Auto generated code (Tools/params_utils.py:296)
     static void updateTreeEditColor(TreeParamsP* self)
     {
-        auto v = self->handle->GetUnsigned("TreeEditColor", 2459042047);
+        auto v = self->handle->GetUnsigned("TreeEditColor", 11272191);
         if (self->TreeEditColor != v) {
             self->TreeEditColor = v;
             TreeParams::onTreeEditColorChanged();
@@ -1009,7 +1009,7 @@ const unsigned long& TreeParams::getTreeEditColor()
 // Auto generated code (Tools/params_utils.py:366)
 const unsigned long& TreeParams::defaultTreeEditColor()
 {
-    const static unsigned long def = 2459042047;
+    const static unsigned long def = 11272191;
     return def;
 }
 

--- a/src/Gui/TreeParams.py
+++ b/src/Gui/TreeParams.py
@@ -61,7 +61,7 @@ Params = [
     ParamBool("KeepRootOrder", True),
     ParamBool("TreeActiveAutoExpand", True),
     ParamUInt("TreeActiveColor", 0xE6E6FFFF, on_change=True),
-    ParamUInt("TreeEditColor", 0x929200FF, on_change=True),
+    ParamUInt("TreeEditColor", 0x00ABFFFF, on_change=True),
     ParamUInt("SelectingGroupColor", 0x408081FF, on_change=True),
     ParamBool("TreeActiveBold", True, on_change=True),
     ParamBool("TreeActiveItalic", False, on_change=True),

--- a/src/Gui/ViewParams.cpp
+++ b/src/Gui/ViewParams.cpp
@@ -307,7 +307,7 @@ void ViewParams::setup()
     addParameter("AnnotationTextColor", Unsigned {4294967295UL});
     addParameter("MarkerSize", Int {9});
     addParameter("DefaultLinkColor", Unsigned {0x66FFFF00});
-    addParameter("DefaultShapeLineColor", Unsigned {421075455UL});
+    addParameter("DefaultShapeLineColor", Unsigned {255UL});
     addParameter("DefaultShapeVertexColor", Unsigned {421075455UL});
     addParameter("DefaultShapeColor", Unsigned {0xCCCCCC00});
     addParameter("DefaultShapeTransparency", Int {0});

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
@@ -70,31 +70,21 @@ Base::Color Vcolor = Base::Color(static_cast<uint32_t>(VColorLong));
 SbColor DrawingParameters::CrossColorH(Hcolor.r, Hcolor.g, Hcolor.b);
 SbColor DrawingParameters::CrossColorV(Vcolor.r, Vcolor.g, Vcolor.b);
 
-SbColor DrawingParameters::InvalidSketchColor(1.0f, 0.42f, 0.0f);    // #FF6D00 -> (255,109,  0)
-SbColor DrawingParameters::FullyConstrainedColor(0.0f, 1.0f, 0.0f);  // #00FF00 -> (  0,255,  0)
-SbColor DrawingParameters::FullyConstraintInternalAlignmentColor(
-    0.87f,
-    0.87f,
-    0.78f
-);                                                                     // #DEDEC8 -> (222,222,200)
-SbColor DrawingParameters::InternalAlignedGeoColor(0.7f, 0.7f, 0.5f);  // #B2B27F -> (178,178,127)
-SbColor DrawingParameters::FullyConstraintElementColor(
-    0.50f,
-    0.81f,
-    0.62f
-);                                                                       // #80D0A0 -> (128,208,160)
-SbColor DrawingParameters::CurveColor(1.0f, 1.0f, 1.0f);                 // #FFFFFF -> (255,255,255)
-SbColor DrawingParameters::PreselectColor(0.88f, 0.88f, 0.0f);           // #E1E100 -> (225,225,  0)
-SbColor DrawingParameters::SelectColor(0.11f, 0.68f, 0.11f);             // #1CAD1C -> ( 28,173, 28)
-SbColor DrawingParameters::PreselectSelectedColor(0.36f, 0.48f, 0.11f);  // #5D7B1C -> ( 93,123, 28)
-SbColor DrawingParameters::CurveExternalColor(0.8f, 0.2f, 0.6f);         // #CC3399 -> (204, 51,153)
-SbColor DrawingParameters::CurveExternalDefiningColor(0.8f, 0.2f, 0.6f);  // #CC3399 -> (204, 51,153)
-SbColor DrawingParameters::CurveDraftColor(0.0f, 0.0f, 0.86f);  // #0000DC -> (  0,  0,220)
-SbColor DrawingParameters::FullyConstraintConstructionElementColor(
-    0.56f,
-    0.66f,
-    0.99f
-);  // #8FA9FD -> (143,169,253)
+// clang-format off
+SbColor DrawingParameters::InvalidSketchColor(1.0f, 0.42f, 0.0f);                           // #FF6D00 -> (255,109,  0)
+SbColor DrawingParameters::FullyConstrainedColor(0.0f, 1.0f, 0.0f);                         // #00FF00 -> (  0,255,  0)
+SbColor DrawingParameters::FullyConstraintInternalAlignmentColor(0.87f, 0.87f, 0.78f);      // #DEDEC8 -> (222,222,200)
+SbColor DrawingParameters::InternalAlignedGeoColor(0.7f, 0.7f, 0.5f);                       // #B2B27F -> (178,178,127)
+SbColor DrawingParameters::FullyConstraintElementColor(0.50f, 0.81f, 0.62f);                // #80D0A0 -> (128,208,160)
+SbColor DrawingParameters::CurveColor(1.0f, 1.0f, 1.0f);                                    // #FFFFFF -> (255,255,255)
+SbColor DrawingParameters::PreselectColor(10.0f / 255.0f, 200.0f / 255.0f, 1.0f);           // #0AC8FF -> ( 10,200,255)
+SbColor DrawingParameters::SelectColor(0.0f, 171.0f / 255.0f, 1.0f);                        // #00ABFF -> (  0,171,255)
+SbColor DrawingParameters::PreselectSelectedColor(5.0f / 255.0f, 186.0f / 255.0f, 1.0f);    // #05BAFF -> (  5,186,255)
+SbColor DrawingParameters::CurveExternalColor(0.8f, 0.2f, 0.6f);                            // #CC3399 -> (204, 51,153)
+SbColor DrawingParameters::CurveExternalDefiningColor(0.8f, 0.2f, 0.6f);                    // #CC3399 -> (204, 51,153)
+SbColor DrawingParameters::CurveDraftColor(0.0f, 0.0f, 0.86f);                              // #0000DC -> (  0,  0,220)
+SbColor DrawingParameters::FullyConstraintConstructionElementColor(0.56f, 0.66f, 0.99f);    // #8FA9FD -> (143,169,253)
+// clang-format on
 
 SbColor DrawingParameters::ConstrDimColor(1.0f, 0.149f, 0.0f);  // #FF2600 -> (255, 38,  0)
 SbColor DrawingParameters::ConstrIcoColor(1.0f, 0.149f, 0.0f);  // #FF2600 -> (255, 38,  0)

--- a/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
@@ -228,10 +228,11 @@ void ThemeSelectorWidget::themeChanged(Theme newTheme)
         "User parameter:BaseApp/Preferences/Themes"
     );
     const unsigned long nonExistentColor = -1434171135;
+    const unsigned long defaultAccentColor1 = 11272191;
     const unsigned long defaultAccentColor = 1434171135;
     unsigned long longAccentColor1 = hGrp->GetUnsigned("ThemeAccentColor1", nonExistentColor);
     if (longAccentColor1 == nonExistentColor) {
-        hGrp->SetUnsigned("ThemeAccentColor1", defaultAccentColor);
+        hGrp->SetUnsigned("ThemeAccentColor1", defaultAccentColor1);
         hGrp->SetUnsigned("ThemeAccentColor2", defaultAccentColor);
         hGrp->SetUnsigned("ThemeAccentColor3", defaultAccentColor);
     }

--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -89,7 +89,7 @@ Base::Color Preferences::selectColor()
                                              .GetGroup("BaseApp")
                                              ->GetGroup("Preferences")
                                              ->GetGroup("View");
-    unsigned int defColor = hGrp->GetUnsigned("SelectionColor", 0x00FF00FF);//#00FF00 lime
+    unsigned int defColor = hGrp->GetUnsigned("SelectionColor", 0x00ABFFFF);  //#00ABFF blue
 
     Base::Color fcColor;
     fcColor.setPackedValue(getPreferenceGroup("Colors")->GetUnsigned("SelectColor", defColor));
@@ -103,7 +103,7 @@ Base::Color Preferences::preselectColor()
                                              .GetGroup("BaseApp")
                                              ->GetGroup("Preferences")
                                              ->GetGroup("View");
-    unsigned int defColor = hGrp->GetUnsigned("HighlightColor", 0xFFFF00FF);//#FFFF00 yellow
+    unsigned int defColor = hGrp->GetUnsigned("HighlightColor", 0x0AC8FFFF);  //#0AC8FF cyan
 
     Base::Color fcColor;
     fcColor.setPackedValue(getPreferenceGroup("Colors")->GetUnsigned("PreSelectColor", defColor));

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
@@ -185,9 +185,9 @@
           </property>
           <property name="color">
            <color>
-            <red>255</red>
-            <green>255</green>
-            <blue>0</blue>
+            <red>10</red>
+            <green>200</green>
+            <blue>255</blue>
            </color>
           </property>
           <property name="prefEntry" stdset="0">
@@ -443,8 +443,8 @@
           <property name="color">
            <color>
             <red>0</red>
-            <green>255</green>
-            <blue>0</blue>
+            <green>171</green>
+            <blue>255</blue>
            </color>
           </property>
           <property name="prefEntry" stdset="0">


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

- Changes selection and preselection color to be better visible in all themes and closer to each other instead of blue/green.
- Preselectiong elements which are on top or bordering selected elements do still have contrast and are visible.
- Changes TechDraw preselection and selection color to the same colors as everywhere instead of orange and green.
- Update FreeCAD themes to use the same selection colors
- Changes active body color and accent color to the same

I tested it already with https://github.com/FreeCAD/FreeCAD/pull/30697 applied.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/24061

## Before and After Images


https://github.com/user-attachments/assets/279ac18a-491c-4a6f-b2ac-6937730608c7


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
