### PR TITLE
BIM: use line input for curtain wall segment

### DIFF
--- a/src/Mod/BIM/bimcommands/BimCurtainwall.py
+++ b/src/Mod/BIM/bimcommands/BimCurtainwall.py
@@ -112,7 +112,10 @@ class Arch_CurtainWall:
         self.points.append(point)
         if len(self.points) == 1:
             FreeCADGui.Snapper.getPoint(
-                last=self.points[0], callback=self.getPoint, hints=self.get_hints()
+                last=self.points[0],
+                callback=self.getPoint,
+                mode="line",
+                hints=self.get_hints(),
             )
         elif len(self.points) == 2:
             self.wp._restore()

--- a/src/Mod/BIM/bimtests/TestArchCurtainWallGui.py
+++ b/src/Mod/BIM/bimtests/TestArchCurtainWallGui.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
+# *   Copyright (c) 2026 LubuSeb                                            *
 # *                                                                         *
 # *   This file is part of FreeCAD.                                         *
 # *                                                                         *
@@ -22,15 +22,41 @@
 # *                                                                         *
 # ***************************************************************************
 
-"""Import all Arch module unit tests in GUI mode."""
+"""GUI tests for the Arch Curtain Wall command."""
 
-from bimtests.TestArchImportersGui import TestArchImportersGui
-from bimtests.TestArchAxisGui import TestArchAxisGui
-from bimtests.TestArchBuildingPartGui import TestArchBuildingPartGui
-from bimtests.TestArchStairsGui import TestArchStairsGui
-from bimtests.TestArchReportGui import TestArchReportGui
-from bimtests.TestArchSiteGui import TestArchSiteGui
-from bimtests.TestArchWallGui import TestArchWallGui
-from bimtests.TestArchCurtainWallGui import TestArchCurtainWallGui
-from bimtests.TestWebGLExportGui import TestWebGLExportGui
-from bimtests.TestArchCoveringGui import TestArchCoveringGui
+from unittest.mock import patch
+
+import FreeCAD
+import FreeCADGui
+
+from bimcommands.BimCurtainwall import Arch_CurtainWall
+from bimtests import TestArchBaseGui
+
+
+class TestArchCurtainWallGui(TestArchBaseGui.TestArchBaseGui):
+
+    def test_second_interactive_point_uses_line_mode(self):
+        """The second point needs line mode so length/angle input is segment-relative."""
+
+        calls = []
+
+        def fake_get_point(**kwargs):
+            calls.append(kwargs)
+
+        command = Arch_CurtainWall()
+
+        try:
+            FreeCADGui.Selection.clearSelection()
+            with patch("FreeCADGui.Snapper.getPoint", side_effect=fake_get_point):
+                command.Activated()
+                command.getPoint(FreeCAD.Vector(0, 0, 0))
+                command.getPoint(None)
+        finally:
+            FreeCADGui.Selection.clearSelection()
+            if getattr(FreeCAD, "activeDraftCommand", None) is command:
+                FreeCAD.activeDraftCommand = None
+
+        self.assertEqual(len(calls), 2)
+        self.assertNotIn("mode", calls[0])
+        self.assertEqual(calls[1]["mode"], "line")
+        self.assertEqual(calls[1]["last"], FreeCAD.Vector(0, 0, 0))


### PR DESCRIPTION
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

This PR was prepared with AI assistance, but I reviewed, tested, and take responsibility for the changes.

## Issues
Fixes #30583

## Summary
The interactive Curtain Wall command was requesting the second picked point with Draft's generic point UI. That makes typed numeric input behave like point-coordinate entry instead of segment length/angle entry from the first point.

This changes the second `Snapper.getPoint()` call to `mode=line`, matching the segment-based input flow used by other BIM/Draft line-style tools. It also adds a GUI regression test that verifies the second point request uses line mode.

## Before and After Images
N/A - this is a command input-mode fix for numeric entry, not a visual UI layout change.

## Tests
- `python -m py_compile src/Mod/BIM/bimcommands/BimCurtainwall.py src/Mod/BIM/bimtests/TestArchCurtainWallGui.py src/Mod/BIM/TestArchGui.py`
- `git diff --check`

I could not run the FreeCAD GUI test runner on this Windows machine because `FreeCADCmd` is not available on PATH or in this worktree.