### PR TITLE
Fem: Add options to reverse master/slave for Contact and Tie.

### DIFF
--- a/src/Mod/Fem/App/FemConstraintContact.cpp
+++ b/src/Mod/Fem/App/FemConstraintContact.cpp
@@ -77,6 +77,20 @@ ConstraintContact::ConstraintContact()
         "Enable thermal contact"
     );
     ADD_PROPERTY_TYPE(
+        ReversedMaster,
+        (false),
+        "ConstraintContact",
+        App::PropertyType(App::Prop_None),
+        "Use reversed normal direction for master references"
+    );
+    ADD_PROPERTY_TYPE(
+        ReversedSlave,
+        (false),
+        "ConstraintContact",
+        App::PropertyType(App::Prop_None),
+        "Use reversed normal direction for slave references"
+    );
+    ADD_PROPERTY_TYPE(
         ThermalContactConductance,
         (std::vector<std::string> {}),
         "ConstraintContact",

--- a/src/Mod/Fem/App/FemConstraintContact.h
+++ b/src/Mod/Fem/App/FemConstraintContact.h
@@ -52,6 +52,8 @@ public:
     App::PropertyStiffnessDensity StickSlope;
     App::PropertyBool EnableThermalContact;
     App::PropertyStringList ThermalContactConductance;
+    App::PropertyBoolList ReversedMaster;
+    App::PropertyBoolList ReversedSlave;
     App::PropertyEnumeration SurfaceBehavior;
 
     // etc

--- a/src/Mod/Fem/Gui/Resources/ui/ConstraintTie.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/ConstraintTie.ui
@@ -64,6 +64,20 @@
           </property>
          </widget>
         </item>
+        <item row="3" column="0">
+         <widget class="QCheckBox" name="ckb_rev_master">
+          <property name="text">
+           <string>Reverse master</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QCheckBox" name="ckb_rev_slave">
+          <property name="text">
+           <string>Reverse slave</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>

--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
@@ -90,6 +90,8 @@ TaskFemConstraintContact::TaskFemConstraintContact(
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
     bool friction = pcConstraint->Friction.getValue();
+    auto revMaster = pcConstraint->ReversedMaster.getValues();
+    auto revSlave = pcConstraint->ReversedSlave.getValues();
 
     // Fill data into dialog elements
     ui->spbSlope->setUnit(pcConstraint->Slope.getUnit());
@@ -105,6 +107,9 @@ TaskFemConstraintContact::TaskFemConstraintContact(
     ui->spbAdjust->bind(pcConstraint->Adjust);
 
     ui->ckbFriction->setChecked(friction);
+
+    ui->ckbRevMaster->setChecked(revMaster.empty() ? false : revMaster.at(0));
+    ui->ckbRevSlave->setChecked(revSlave.empty() ? false : revSlave.at(0));
 
     ui->spbFrictionCoeff->setMinimum(0);
     ui->spbFrictionCoeff->setMaximum(std::numeric_limits<float>::max());
@@ -535,6 +540,21 @@ const std::string TaskFemConstraintContact::getStickSlope() const
     return ui->spbStickSlope->value().getSafeUserString();
 }
 
+const std::vector<bool> TaskFemConstraintContact::getRevMaster() const
+{
+    int count = ui->lw_referencesMaster->model()->rowCount();
+    std::vector<bool> rev(count, ui->ckbRevMaster->isChecked());
+    return rev;
+}
+
+const std::vector<bool> TaskFemConstraintContact::getRevSlave() const
+{
+    int count = ui->lw_referencesSlave->model()->rowCount();
+    std::vector<bool> rev(count, ui->ckbRevSlave->isChecked());
+    return rev;
+}
+
+
 void TaskFemConstraintContact::changeEvent(QEvent*)
 {}
 
@@ -593,6 +613,30 @@ bool TaskDlgFemConstraintContact::accept()
             "App.ActiveDocument.%s.StickSlope = \"%s\"",
             name.c_str(),
             parameterContact->getStickSlope().c_str()
+        );
+
+        auto rev_master = parameterContact->getRevMaster();
+        std::string rev_master_str {""};
+        for (bool b : rev_master) {
+            rev_master_str.append(b ? "True," : "False,");
+        }
+        Gui::Command::doCommand(
+            Gui::Command::Doc,
+            "App.ActiveDocument.%s.ReversedMaster = [%s]",
+            name.c_str(),
+            rev_master_str.c_str()
+        );
+
+        auto rev_slave = parameterContact->getRevSlave();
+        std::string rev_slave_str {""};
+        for (bool b : rev_slave) {
+            rev_slave_str.append(b ? "True," : "False,");
+        }
+        Gui::Command::doCommand(
+            Gui::Command::Doc,
+            "App.ActiveDocument.%s.ReversedSlave = [%s]",
+            name.c_str(),
+            rev_slave_str.c_str()
         );
     }
     catch (const Base::Exception& e) {

--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.h
@@ -52,6 +52,8 @@ public:
     bool getFriction() const;
     const std::string getStickSlope() const;
     double getFrictionCoeff() const;
+    const std::vector<bool> getRevMaster() const;
+    const std::vector<bool> getRevSlave() const;
 
 private Q_SLOTS:
     void onReferenceDeletedSlave();

--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.ui
@@ -135,7 +135,6 @@
      </property>
     </widget>
    </item>
-
    <item>
     <widget class="QGroupBox" name="gpbParameter">
      <property name="sizePolicy">
@@ -247,6 +246,20 @@
         </property>
         <property name="value" stdset="0">
          <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QCheckBox" name="ckbRevMaster">
+        <property name="text">
+         <string>Reverse master</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QCheckBox" name="ckbRevSlave">
+        <property name="text">
+         <string>Reverse slave</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Fem/femobjects/constraint_tie.py
+++ b/src/Mod/Fem/femobjects/constraint_tie.py
@@ -106,6 +106,24 @@ class ConstraintTie(base_fempythonobject.BaseFemPythonObject):
                 value=1,
             )
         )
+        prop.append(
+            _PropHelper(
+                type="App::PropertyBoolList",
+                name="ReversedMaster",
+                group="Geometry",
+                doc="Use reversed normal direction for master references",
+                value=[False],
+            )
+        )
+        prop.append(
+            _PropHelper(
+                type="App::PropertyBoolList",
+                name="ReversedSlave",
+                group="Geometry",
+                doc="Use reversed normal direction for slave references",
+                value=[False],
+            )
+        )
 
         return prop
 

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_contact.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_contact.py
@@ -55,25 +55,36 @@ def get_after_write_constraint():
 
 
 def write_meshdata_constraint(f, femobj, contact_obj, ccxwriter):
+    # use False as default for reversed values
+    rev_slave = [False] * len(femobj["ContactSlaveFaces"])
+    for i, v in enumerate(contact_obj.ReversedSlave[: len(rev_slave)]):
+        rev_slave[i] = v
+
+    rev_master = [False] * len(femobj["ContactMasterFaces"])
+    for i, v in enumerate(contact_obj.ReversedMaster[: len(rev_master)]):
+        rev_master[i] = v
+
     # slave DEP
     f.write(f"*SURFACE, NAME=DEP{contact_obj.Name}\n")
-    for refs, surf, is_sub_el in femobj["ContactSlaveFaces"]:
+    for (refs, surf, is_sub_el), rev in zip(femobj["ContactSlaveFaces"], rev_slave):
         if is_sub_el:
             for elem, fno in surf:
                 f.write(f"{elem},S{fno}\n")
         else:
+            fno = 1 if rev else 2
             for elem in surf:
-                f.write(f"{elem},S2\n")
+                f.write(f"{elem},S{fno}\n")
 
     # master IND
     f.write(f"*SURFACE, NAME=IND{contact_obj.Name}\n")
-    for refs, surf, is_sub_el in femobj["ContactMasterFaces"]:
+    for (refs, surf, is_sub_el), rev in zip(femobj["ContactMasterFaces"], rev_master):
         if is_sub_el:
             for elem, fno in surf:
                 f.write(f"{elem},S{fno}\n")
         else:
+            fno = 1 if rev else 2
             for elem in surf:
-                f.write(f"{elem},S2\n")
+                f.write(f"{elem},S{fno}\n")
 
 
 def write_constraint(f, femobj, contact_obj, ccxwriter):

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_tie.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_tie.py
@@ -58,25 +58,36 @@ def get_after_write_constraint():
 
 
 def write_meshdata_constraint(f, femobj, tie_obj, ccxwriter):
+    # use False as default for reversed values
+    rev_slave = [False] * len(femobj["TieSlaveFaces"])
+    for i, v in enumerate(tie_obj.ReversedSlave[: len(rev_slave)]):
+        rev_slave[i] = v
+
+    rev_master = [False] * len(femobj["TieMasterFaces"])
+    for i, v in enumerate(tie_obj.ReversedMaster[: len(rev_master)]):
+        rev_master[i] = v
+
     # slave DEP
     f.write(f"*SURFACE, NAME=TIE_DEP{tie_obj.Name}\n")
-    for refs, surf, is_sub_el in femobj["TieSlaveFaces"]:
+    for (refs, surf, is_sub_el), rev in zip(femobj["TieSlaveFaces"], rev_slave):
         if is_sub_el:
             for elem, fno in surf:
                 f.write(f"{elem},S{fno}\n")
         else:
+            fno = 1 if rev else 2
             for elem in surf:
-                f.write(f"{elem},S2\n")
+                f.write(f"{elem},S{fno}\n")
 
     # master IND
     f.write(f"*SURFACE, NAME=TIE_IND{tie_obj.Name}\n")
-    for refs, surf, is_sub_el in femobj["TieMasterFaces"]:
+    for (refs, surf, is_sub_el), rev in zip(femobj["TieMasterFaces"], rev_master):
         if is_sub_el:
             for elem, fno in surf:
                 f.write(f"{elem},S{fno}\n")
         else:
+            fno = 1 if rev else 2
             for elem in surf:
-                f.write(f"{elem},S2\n")
+                f.write(f"{elem},S{fno}\n")
 
 
 def write_constraint(f, femobj, tie_obj, ccxwriter):

--- a/src/Mod/Fem/femtaskpanels/task_constraint_tie.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_tie.py
@@ -48,49 +48,60 @@ class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
         super().__init__(obj)
 
         # parameter widget
-        self.parameterWidget = FreeCADGui.PySideUic.loadUi(
+        self.parameter_widget = FreeCADGui.PySideUic.loadUi(
             FreeCAD.getHomePath() + "Mod/Fem/Resources/ui/ConstraintTie.ui"
         )
         QtCore.QObject.connect(
-            self.parameterWidget.spb_tolerance,
+            self.parameter_widget.spb_tolerance,
             QtCore.SIGNAL("valueChanged(Base::Quantity)"),
             self.tolerance_changed,
         )
         QtCore.QObject.connect(
-            self.parameterWidget.ckb_adjust, QtCore.SIGNAL("toggled(bool)"), self.adjust_changed
+            self.parameter_widget.ckb_adjust, QtCore.SIGNAL("toggled(bool)"), self.adjust_changed
         )
         QtCore.QObject.connect(
-            self.parameterWidget.ckb_rev_master,
+            self.parameter_widget.ckb_rev_master,
             QtCore.SIGNAL("toggled(bool)"),
             self.reversed_master_changed,
         )
         QtCore.QObject.connect(
-            self.parameterWidget.ckb_rev_slave,
+            self.parameter_widget.ckb_rev_slave,
             QtCore.SIGNAL("toggled(bool)"),
             self.reversed_slave_changed,
         )
         self.init_parameter_widget()
-
+        # split references, last is master
+        references = [(feat, (sub,)) for feat, sub_list in obj.References for sub in sub_list]
         # geometry selection widget
-        self.selectionWidget = selection_widgets.GeometryElementsSelection(
-            obj.References, ["Edge", "Face"], False, False
+        self.sel_master = selection_widgets.GeometryElementsSelection(
+            references[-1:], ["Edge", "Face"], False, False
         )
+        self.sel_master.setWindowTitle(self.sel_master.tr("Master Geometry Reference Selector"))
+        self.sel_master.setMaximumHeight(200)
+        self.sel_slave = selection_widgets.GeometryElementsSelection(
+            references[:-1], ["Edge", "Face"], False, False
+        )
+        self.sel_slave.setWindowTitle(self.sel_slave.tr("Slave Geometry Reference Selector"))
+        self.sel_slave.setMaximumHeight(200)
 
         # form made from param and selection widget
-        self.form = [self.selectionWidget, self.parameterWidget]
+        self.form = [self.sel_master, self.sel_slave, self.parameter_widget]
 
     def accept(self):
         # check values
-        items = len(self.selectionWidget.references)
+        items = len(self.sel_master.references) + len(self.sel_slave.references)
         FreeCAD.Console.PrintMessage(
-            f"Task panel: found references: {items}\n{self.selectionWidget.references}\n"
+            f"Task panel: found master references: {items}\n{self.sel_master.references}\n"
+        )
+        FreeCAD.Console.PrintMessage(
+            f"Task panel: found slave references: {items}\n{self.sel_slave.references}\n"
         )
 
         if items != 2:
             msgBox = QtGui.QMessageBox()
             msgBox.setIcon(QtGui.QMessageBox.Question)
             msgBox.setText(
-                f"Constraint Tie requires exactly two faces\n\nfound references: {items}"
+                f"Constraint Tie requires exactly one master and one slave references\n\nfound references: {items}"
             )
             msgBox.setWindowTitle("FreeCAD FEM Constraint Tie")
             retryButton = msgBox.addButton(QtGui.QMessageBox.Retry)
@@ -103,14 +114,16 @@ class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
                 pass
         self.obj.Tolerance = self.tolerance
         self.obj.Adjust = self.adjust
-        self.obj.References = self.selectionWidget.references
+        self.obj.References = self.sel_slave.references + self.sel_master.references
         self.obj.ReversedMaster = self.reversed_master
         self.obj.ReversedSlave = self.reversed_slave
-        self.selectionWidget.finish_selection()
+        self.sel_master.finish_selection()
+        self.sel_slave.finish_selection()
         return super().accept()
 
     def reject(self):
-        self.selectionWidget.finish_selection()
+        self.sel_master.finish_selection()
+        self.sel_slave.finish_selection()
         return super().reject()
 
     def init_parameter_widget(self):
@@ -118,13 +131,15 @@ class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
         self.adjust = self.obj.Adjust
         self.reversed_master = self.obj.ReversedMaster
         self.reversed_slave = self.obj.ReversedSlave
-        FreeCADGui.ExpressionBinding(self.parameterWidget.spb_tolerance).bind(self.obj, "Tolerance")
-        self.parameterWidget.spb_tolerance.setProperty("value", self.tolerance)
-        self.parameterWidget.ckb_adjust.setChecked(self.adjust)
-        self.parameterWidget.ckb_rev_master.setChecked(
+        FreeCADGui.ExpressionBinding(self.parameter_widget.spb_tolerance).bind(
+            self.obj, "Tolerance"
+        )
+        self.parameter_widget.spb_tolerance.setProperty("value", self.tolerance)
+        self.parameter_widget.ckb_adjust.setChecked(self.adjust)
+        self.parameter_widget.ckb_rev_master.setChecked(
             False if not self.reversed_master else self.reversed_master[0]
         )
-        self.parameterWidget.ckb_rev_slave.setChecked(
+        self.parameter_widget.ckb_rev_slave.setChecked(
             False if not self.reversed_slave else self.reversed_slave[0]
         )
 

--- a/src/Mod/Fem/femtaskpanels/task_constraint_tie.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_tie.py
@@ -59,6 +59,16 @@ class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
         QtCore.QObject.connect(
             self.parameterWidget.ckb_adjust, QtCore.SIGNAL("toggled(bool)"), self.adjust_changed
         )
+        QtCore.QObject.connect(
+            self.parameterWidget.ckb_rev_master,
+            QtCore.SIGNAL("toggled(bool)"),
+            self.reversed_master_changed,
+        )
+        QtCore.QObject.connect(
+            self.parameterWidget.ckb_rev_slave,
+            QtCore.SIGNAL("toggled(bool)"),
+            self.reversed_slave_changed,
+        )
         self.init_parameter_widget()
 
         # geometry selection widget
@@ -94,6 +104,8 @@ class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
         self.obj.Tolerance = self.tolerance
         self.obj.Adjust = self.adjust
         self.obj.References = self.selectionWidget.references
+        self.obj.ReversedMaster = self.reversed_master
+        self.obj.ReversedSlave = self.reversed_slave
         self.selectionWidget.finish_selection()
         return super().accept()
 
@@ -104,12 +116,26 @@ class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
     def init_parameter_widget(self):
         self.tolerance = self.obj.Tolerance
         self.adjust = self.obj.Adjust
+        self.reversed_master = self.obj.ReversedMaster
+        self.reversed_slave = self.obj.ReversedSlave
         FreeCADGui.ExpressionBinding(self.parameterWidget.spb_tolerance).bind(self.obj, "Tolerance")
         self.parameterWidget.spb_tolerance.setProperty("value", self.tolerance)
         self.parameterWidget.ckb_adjust.setChecked(self.adjust)
+        self.parameterWidget.ckb_rev_master.setChecked(
+            False if not self.reversed_master else self.reversed_master[0]
+        )
+        self.parameterWidget.ckb_rev_slave.setChecked(
+            False if not self.reversed_slave else self.reversed_slave[0]
+        )
 
     def tolerance_changed(self, base_quantity_value):
         self.tolerance = base_quantity_value
 
     def adjust_changed(self, bool_value):
         self.adjust = bool_value
+
+    def reversed_master_changed(self, bool_value):
+        self.reversed_master = [bool_value]
+
+    def reversed_slave_changed(self, bool_value):
+        self.reversed_slave = [bool_value]


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Add option to reverse master and slave references for Contact and Tie constraints.
Note that the properties are of type `PropertyBoolList`. The idea is to relax the limitation to select only one master and only one slave references.

Also, add a separate selector for master and slave references for Tie object.
@FEA-eng 
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
fixes #13311, fixes #13111
## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
