### PR TITLE
Draft: Fix typos in docstring parameter names

### DIFF
--- a/src/Mod/Draft/draftmake/make_bezcurve.py
+++ b/src/Mod/Draft/draftmake/make_bezcurve.py
@@ -48,7 +48,7 @@ def make_bezcurve(pointslist, closed=False, placement=None, face=None, support=N
 
     Parameters
     ----------
-    pointlist : [Base.Vector]
+    pointslist : [Base.Vector]
         List of points to create the polyline.
         Instead of a pointslist, you can also pass a Part Wire.
         TODO: Change the name so!

--- a/src/Mod/Draft/draftmake/make_block.py
+++ b/src/Mod/Draft/draftmake/make_block.py
@@ -46,7 +46,7 @@ def make_block(objectslist):
 
     Parameters
     ----------
-    objectlist : list
+    objectslist : list
         Major radius of the ellipse.
 
     """

--- a/src/Mod/Draft/draftmake/make_bspline.py
+++ b/src/Mod/Draft/draftmake/make_bspline.py
@@ -48,7 +48,7 @@ def make_bspline(pointslist, closed=False, placement=None, face=None, support=No
 
     Parameters
     ----------
-    pointlist : [Base.Vector]
+    pointslist : [Base.Vector]
         List of points to create the polyline.
         Instead of a pointslist, you can also pass a Part Wire.
         TODO: Change the name so!

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -795,7 +795,7 @@ def get_rgb(color, testbw=True):
     ----------
     color : list or tuple with RGB values
         The values must be in the 0.0-1.0 range.
-    testwb : bool (default = True)
+    testbw : bool (default = True)
         Pure white will be converted into pure black.
     """
     r = str(hex(int(color[0] * 255)))[2:].zfill(2)


### PR DESCRIPTION
<!-- Please check the appropriate boxes -->

## Description

Several docstrings in the Draft workbench misspell their parameter names so the documented name does not match the function signature:

- `make_block` documents `objectlist` instead of `objectslist`.
- `make_bezcurve` and `make_bspline` document `pointlist` instead of `pointslist`.
- `get_rgb` documents `testwb` instead of `testbw`.

This corrects the typos so the documented names match the signatures. Documentation-only change; no behaviour is affected.
