### PR TITLE
App: Fix parameter name in getOutListProp doc comment

### DIFF
--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -510,7 +510,7 @@ public:
      * The dependency edge registers both the object and the property (if
      * applicable) this object links to.
      *
-     * @param[in] option Options for computing the OutList.
+     * @param[in] options Options for computing the OutList.
      *
      * @return the vector of dependency edges.
      *
@@ -524,7 +524,7 @@ public:
      * The dependency edge registers both the object and the property (if
      * applicable) this object links to.
      *
-     * @param[in] option Options for computing the OutList.
+     * @param[in] options Options for computing the OutList.
      * @param[in,out] res The vector to fill with the objects this object depends on.
      *
      * @see OutListOption for available options.
@@ -537,7 +537,7 @@ public:
     /**
      * @brief Get a list of objects this object links to.
      *
-     * @param[in] option Options for computing the OutList.
+     * @param[in] options Options for computing the OutList.
      *
      * @return A vector of objects this object links to.
      *
@@ -548,7 +548,7 @@ public:
     /**
      * @brief Get a list of objects this object links to.
      *
-     * @param[in] option Options for computing the OutList.
+     * @param[in] options Options for computing the OutList.
      *
      * @param[in,out] res The vector to fill with the objects this object depends on.
      *


### PR DESCRIPTION
## Description

Both `App::DocumentObject::getOutListProp` overloads document the first argument as `@param[in] option`, but the parameter is actually named `options`:

```cpp
std::vector<DepEdge> getOutListProp(int options);
void getOutListProp(int options, std::vector<DepEdge>& res);
```

This corrects the Doxygen `@param` name to match the signature. Documentation-only change; no behaviour is affected.
