### PR TITLE
Tests: Fix Windows App, Base, and Gui test executable generation

### DIFF
--- a/tests/src/App/CMakeLists.txt
+++ b/tests/src/App/CMakeLists.txt
@@ -32,7 +32,6 @@ add_executable(App_tests_run
 target_compile_definitions(App_tests_run PRIVATE DATADIR="${CMAKE_SOURCE_DIR}/data")
 
 target_link_libraries(App_tests_run PRIVATE
-    GTest::gtest_main
     GTest::gmock_main
     ${Python3_LIBRARIES}
     FreeCADApp

--- a/tests/src/Base/CMakeLists.txt
+++ b/tests/src/Base/CMakeLists.txt
@@ -46,7 +46,6 @@ add_executable(Base_tests_run
 setup_qt_test(InventorBuilder)
 
 target_link_libraries(Base_tests_run PRIVATE
-    GTest::gtest_main
     GTest::gmock_main
     FreeCADApp
     ${Python3_LIBRARIES}

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -20,7 +20,6 @@ add_executable(Gui_tests_run
 setup_qt_test(QuantitySpinBox)
 
 target_link_libraries(Gui_tests_run PRIVATE
-    GTest::gtest_main
     GTest::gmock_main
     FreeCADApp
     FreeCADGui

--- a/tests/src/zipios++/CMakeLists.txt
+++ b/tests/src/zipios++/CMakeLists.txt
@@ -8,7 +8,6 @@ add_executable(Zipios_tests_run
 
 target_link_libraries(Zipios_tests_run PRIVATE
     GTest::gtest_main
-    GTest::gmock_main
     ${Python3_LIBRARIES}
     FreeCADApp
 )


### PR DESCRIPTION
On Windows, the App, Base, and Gui test suites were running suspiciously quickly -- that turned out to be because they were discovering zero tests due to having two different `main` methods, one from the `GTest::gtest_main` and one from `GTest::gmock_main`. Getting rid of one of them gets the test harness actually running on Windows (still not called in CI, though, this is purely local).

ETA: Oh look, zipios too. Fixed that as well, since it was so similar. Not very high-value, but may as well have it working.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.