### PR TITLE
BIM: adding  bSDD contract model and IFC classification persistence

### DIFF
--- a/src/Mod/BIM/BimBsddContract.py
+++ b/src/Mod/BIM/BimBsddContract.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *                                                                         * 
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+"""Canonical bSDD contract and validation helpers."""
+
+
+def _as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [v for v in value if v not in [None, ""]]
+    return [value]
+
+
+def _first_non_empty(*values):
+    for value in values:
+        if value not in [None, ""]:
+            return value
+    return ""
+
+
+def _extract_active_ifc_type(obj):
+    if not obj:
+        return ""
+    for attr_name in ["IfcClass", "IfcType", "IfcRole"]:
+        value = getattr(obj, attr_name, "")
+        if value:
+            return str(value)
+    return ""
+
+
+def _extract_applicable_ifc_types(payload):
+    values = []
+    for key in ["relatedIfcEntities", "relatedIfcEntity", "applicableIfcClasses"]:
+        values.extend(_as_list(payload.get(key)))
+    return [str(value) for value in values if value]
+
+
+def _extract_dictionary_metadata(payload):
+    return {
+        "name": _first_non_empty(
+            payload.get("dictionaryName"),
+            payload.get("classificationName"),
+            payload.get("source"),
+        ),
+        "namespace_uri": _first_non_empty(
+            payload.get("dictionaryUri"),
+            payload.get("namespaceUri"),
+            payload.get("dictionaryNamespaceUri"),
+        ),
+        "version": _first_non_empty(
+            payload.get("dictionaryVersion"),
+            payload.get("version"),
+            payload.get("versionDate"),
+        ),
+    }
+
+
+def _extract_class_metadata(payload):
+    return {
+        "reference_code": _first_non_empty(
+            payload.get("referenceCode"),
+            payload.get("identification"),
+            payload.get("code"),
+        ),
+        "name": _first_non_empty(
+            payload.get("name"),
+            payload.get("description"),
+            payload.get("referenceCode"),
+        ),
+        "description": _first_non_empty(
+            payload.get("description"),
+            payload.get("definition"),
+            payload.get("name"),
+        ),
+        "uri": _first_non_empty(
+            payload.get("uri"),
+            payload.get("conceptUri"),
+            payload.get("location"),
+        ),
+    }
+
+
+def _extract_property_value(prop):
+    for key in [
+        "predefinedValue",
+        "defaultValue",
+        "value",
+        "valueExpression",
+        "exampleValue",
+    ]:
+        if prop.get(key) not in [None, ""]:
+            return prop.get(key)
+    return None
+
+
+def _extract_extended_properties(payload):
+    results = []
+    for prop in payload.get("classProperties", []) or []:
+        results.append(
+            {
+                "property_set": _first_non_empty(
+                    prop.get("propertySet"),
+                    prop.get("propertySetName"),
+                    prop.get("pset"),
+                ),
+                "name": _first_non_empty(prop.get("name"), prop.get("code")),
+                "data_type": _first_non_empty(
+                    prop.get("dataType"),
+                    prop.get("propertyDomainName"),
+                    prop.get("type"),
+                ),
+                "value": _extract_property_value(prop),
+                "allowed_values": prop.get("allowedValues") or prop.get("values") or [],
+                "uri": _first_non_empty(prop.get("uri"), prop.get("propertyUri")),
+            }
+        )
+    return results
+
+
+def merge_payloads(base_payload, detail_payload):
+    merged = {}
+    if isinstance(base_payload, dict):
+        merged.update(base_payload)
+    if isinstance(detail_payload, dict):
+        merged.update(detail_payload)
+        base_props = (base_payload or {}).get("classProperties") or []
+        detail_props = detail_payload.get("classProperties") or []
+        merged["classProperties"] = detail_props or base_props
+    return merged
+
+
+def build_canonical_contract(base_payload, detail_payload=None, active_object=None):
+    payload = merge_payloads(base_payload, detail_payload)
+    active_ifc_type = _extract_active_ifc_type(active_object)
+    applicable_ifc_types = _extract_applicable_ifc_types(payload)
+    is_applicable = (not applicable_ifc_types) or (active_ifc_type in applicable_ifc_types)
+    return {
+        "dictionary_metadata": _extract_dictionary_metadata(payload),
+        "class_metadata": _extract_class_metadata(payload),
+        "validation_filters": {
+            "applicable_ifc_types": applicable_ifc_types,
+            "active_ifc_type": active_ifc_type,
+            "is_applicable": is_applicable,
+        },
+        "extended_properties": _extract_extended_properties(payload),
+    }
+
+
+def refresh_contract_validation(contract, active_object=None):
+    refreshed = dict(contract or {})
+    validation = dict(refreshed.get("validation_filters", {}) or {})
+    applicable_ifc_types = list(validation.get("applicable_ifc_types") or [])
+    active_ifc_type = _extract_active_ifc_type(active_object)
+    validation["active_ifc_type"] = active_ifc_type
+    validation["is_applicable"] = (not applicable_ifc_types) or (
+        active_ifc_type in applicable_ifc_types
+    )
+    refreshed["validation_filters"] = validation
+    return refreshed
+
+
+def build_legacy_classification_string(contract):
+    dictionary_name = contract.get("dictionary_metadata", {}).get("name", "")
+    reference_code = contract.get("class_metadata", {}).get("reference_code", "")
+    name = contract.get("class_metadata", {}).get("name", "")
+    code = reference_code or name
+    if dictionary_name and code:
+        return "{} {}".format(dictionary_name, code)
+    return code or dictionary_name

--- a/src/Mod/BIM/BimBsddContract.py
+++ b/src/Mod/BIM/BimBsddContract.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 # ***************************************************************************
-# *                                                                         * 
+# *                                                                         *
 # *   This file is part of FreeCAD.                                         *
 # *                                                                         *
 # *   FreeCAD is free software: you can redistribute it and/or modify it    *

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -63,6 +63,7 @@ SET(Arch_SRCS
     ArchSketchObject.py
     BimSelect.py
     BimStatus.py
+    BimBsddContract.py
     TestArch.py
     TestArchGui.py
     ArchReport.py

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -269,6 +269,8 @@ SET(bimtests_SRCS
     bimtests/TestArchStairsGui.py
     bimtests/TestArchReport.py
     bimtests/TestArchReportGui.py
+    bimtests/TestBsddContract.py
+    bimtests/TestIfcClassification.py
 )
 
 set(bimtests_FIXTURES

--- a/src/Mod/BIM/TestArch.py
+++ b/src/Mod/BIM/TestArch.py
@@ -50,3 +50,5 @@ from bimtests.TestArchComponent import TestArchComponent
 from bimtests.TestWebGLExport import TestWebGLExport
 from bimtests.TestArchReport import TestArchReport
 from bimtests.TestArchCovering import TestArchCovering
+from bimtests.TestBsddContract import TestBsddContract
+from bimtests.TestIfcClassification import TestIfcClassification

--- a/src/Mod/BIM/bimtests/TestBsddContract.py
+++ b/src/Mod/BIM/bimtests/TestBsddContract.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# ***************************************************************************
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+import unittest
+
+import BimBsddContract
+
+
+class _MockObject:
+    IfcClass = "IfcWall"
+
+
+class TestBsddContract(unittest.TestCase):
+
+    def test_builds_canonical_contract(self):
+        payload = {
+            "dictionaryName": "IFC",
+            "dictionaryUri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/latest",
+            "dictionaryVersion": "4.3",
+            "referenceCode": "IfcWall",
+            "name": "Wall",
+            "description": "A wall element.",
+            "uri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/latest/class/IfcWall",
+            "relatedIfcEntities": ["IfcWall"],
+            "classProperties": [
+                {
+                    "propertySet": "Pset_WallCommon",
+                    "name": "IsExternal",
+                    "dataType": "Boolean",
+                    "predefinedValue": "TRUE",
+                }
+            ],
+        }
+
+        contract = BimBsddContract.build_canonical_contract(payload, active_object=_MockObject())
+
+        self.assertEqual(contract["dictionary_metadata"]["name"], "IFC")
+        self.assertEqual(
+            contract["dictionary_metadata"]["namespace_uri"],
+            "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/latest",
+        )
+        self.assertEqual(contract["class_metadata"]["reference_code"], "IfcWall")
+        self.assertEqual(contract["class_metadata"]["name"], "Wall")
+        self.assertTrue(contract["validation_filters"]["is_applicable"])
+        self.assertEqual(contract["validation_filters"]["active_ifc_type"], "IfcWall")
+        self.assertEqual(contract["extended_properties"][0]["property_set"], "Pset_WallCommon")
+
+    def test_merge_payloads_prefers_detail_properties(self):
+        base_payload = {
+            "referenceCode": "IfcWall",
+            "name": "Wall",
+            "classProperties": [{"name": "BaseProp"}],
+        }
+        detail_payload = {
+            "description": "Detailed wall",
+            "classProperties": [{"name": "DetailProp"}],
+        }
+
+        merged = BimBsddContract.merge_payloads(base_payload, detail_payload)
+
+        self.assertEqual(merged["referenceCode"], "IfcWall")
+        self.assertEqual(merged["description"], "Detailed wall")
+        self.assertEqual(merged["classProperties"][0]["name"], "DetailProp")
+
+    def test_builds_legacy_classification_string(self):
+        contract = {
+            "dictionary_metadata": {"name": "IFC"},
+            "class_metadata": {"reference_code": "IfcWall", "name": "Wall"},
+        }
+        self.assertEqual(
+            BimBsddContract.build_legacy_classification_string(contract), "IFC IfcWall"
+        )
+
+    def test_refreshes_validation_for_target_object(self):
+        class SlabObject:
+            IfcClass = "IfcSlab"
+
+        payload = {
+            "referenceCode": "IfcWall",
+            "name": "Wall",
+            "relatedIfcEntities": ["IfcWall"],
+        }
+        contract = BimBsddContract.build_canonical_contract(payload, active_object=_MockObject())
+        self.assertTrue(contract["validation_filters"]["is_applicable"])
+
+        refreshed = BimBsddContract.refresh_contract_validation(contract, SlabObject())
+
+        self.assertEqual(refreshed["validation_filters"]["active_ifc_type"], "IfcSlab")
+        self.assertFalse(refreshed["validation_filters"]["is_applicable"])
+        self.assertTrue(contract["validation_filters"]["is_applicable"])
+
+    def test_extract_applicable_ifc_types_collects_scalar_and_list_keys(self):
+        payload = {
+            "relatedIfcEntity": "IfcWall",
+            "relatedIfcEntities": ["IfcSlab", ""],
+            "applicableIfcClasses": ("IfcBeam", None),
+        }
+
+        values = BimBsddContract._extract_applicable_ifc_types(payload)
+
+        self.assertEqual(values, ["IfcSlab", "IfcWall", "IfcBeam"])
+
+    def test_extract_property_value_prefers_predefined_then_default(self):
+        prop = {"predefinedValue": "TRUE", "defaultValue": "FALSE"}
+        self.assertEqual(BimBsddContract._extract_property_value(prop), "TRUE")
+
+        prop = {"defaultValue": "FALSE", "exampleValue": "TRUE"}
+        self.assertEqual(BimBsddContract._extract_property_value(prop), "FALSE")
+
+    def test_missing_property_value_does_not_fall_back_to_allowed_enum(self):
+        payload = {
+            "referenceCode": "IfcWall",
+            "name": "Wall",
+            "classProperties": [
+                {
+                    "propertySet": "Pset_WallCommon",
+                    "name": "Status",
+                    "dataType": "String",
+                    "allowedValues": [{"value": "NEW"}, {"value": "EXISTING"}],
+                }
+            ],
+        }
+
+        contract = BimBsddContract.build_canonical_contract(payload, active_object=_MockObject())
+
+        self.assertEqual(contract["extended_properties"][0]["name"], "Status")
+        self.assertIsNone(contract["extended_properties"][0]["value"])

--- a/src/Mod/BIM/bimtests/TestIfcClassification.py
+++ b/src/Mod/BIM/bimtests/TestIfcClassification.py
@@ -159,9 +159,9 @@ class TestIfcClassification(unittest.TestCase):
             "extended_properties": [],
         }
 
-        with patch.object(ifc_classification.ifc_tools, "get_ifcfile", return_value=None), patch.object(
-            ifc_classification.ifc_tools, "get_ifc_element", return_value=None
-        ):
+        with patch.object(
+            ifc_classification.ifc_tools, "get_ifcfile", return_value=None
+        ), patch.object(ifc_classification.ifc_tools, "get_ifc_element", return_value=None):
             self.assertFalse(ifc_classification.apply_canonical_contract(obj, contract))
 
     def test_apply_canonical_contract_writes_standard_code_and_calls_helpers(self):
@@ -178,7 +178,9 @@ class TestIfcClassification(unittest.TestCase):
             "legacy_string": "IFC IfcWall",
         }
 
-        with patch.object(ifc_classification.ifc_tools, "get_ifcfile", return_value=ifcfile), patch.object(
+        with patch.object(
+            ifc_classification.ifc_tools, "get_ifcfile", return_value=ifcfile
+        ), patch.object(
             ifc_classification.ifc_tools, "get_ifc_element", return_value=element
         ), patch.object(
             ifc_classification, "_upsert_classification_root", return_value=classification

--- a/src/Mod/BIM/bimtests/TestIfcClassification.py
+++ b/src/Mod/BIM/bimtests/TestIfcClassification.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# ***************************************************************************
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+import unittest
+from unittest.mock import patch
+
+from nativeifc import ifc_classification
+
+
+class _MockObject:
+    def __init__(self, ifc_class="IfcWall", standard_code=""):
+        self.IfcClass = ifc_class
+        self.StandardCode = standard_code
+        self.Label = "Mock Wall"
+
+
+class _ExistingClassification:
+    def __init__(self, name="", source="", location="", edition=""):
+        self.Name = name
+        self.Source = source
+        self.Location = location
+        self.Edition = edition
+
+
+class _ExistingReference:
+    def __init__(
+        self,
+        identification=None,
+        item_reference=None,
+        location="",
+        referenced_source=None,
+    ):
+        self.Identification = identification
+        self.ItemReference = item_reference
+        self.Location = location
+        self.ReferencedSource = referenced_source
+
+
+class _MockIfcFile:
+    def __init__(self, classifications=None, references=None, projects=None, relations=None):
+        self._classifications = classifications or []
+        self._references = references or []
+        self._projects = projects or []
+        self._relations = relations or []
+
+    def by_type(self, type_name):
+        mapping = {
+            "IfcClassification": self._classifications,
+            "IfcClassificationReference": self._references,
+            "IfcProject": self._projects,
+            "IfcRelAssociatesClassification": self._relations,
+        }
+        return mapping.get(type_name, [])
+
+
+class TestIfcClassification(unittest.TestCase):
+
+    def test_classification_match_requires_namespace_not_name_alone(self):
+        classification = _ExistingClassification(
+            name="IFC",
+            source="https://example.org/uri/ifc/older",
+            edition="4.0",
+        )
+        metadata = {
+            "name": "IFC",
+            "namespace_uri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/latest",
+            "version": "4.3",
+        }
+
+        self.assertFalse(
+            ifc_classification._classification_matches_dictionary(classification, metadata)
+        )
+
+    def test_classification_match_allows_name_only_reuse_without_namespace(self):
+        classification = _ExistingClassification(name="Uniclass", edition="2015")
+        metadata = {"name": "Uniclass", "version": "2015"}
+
+        self.assertTrue(
+            ifc_classification._classification_matches_dictionary(classification, metadata)
+        )
+
+    def test_coerce_contract_value_handles_boolean_numeric_and_empty(self):
+        self.assertTrue(ifc_classification._coerce_contract_value("TRUE", "Boolean"))
+        self.assertFalse(ifc_classification._coerce_contract_value("NO", "Boolean"))
+        self.assertEqual(ifc_classification._coerce_contract_value("42", "Integer"), 42)
+        self.assertEqual(ifc_classification._coerce_contract_value("3.5", "Real"), 3.5)
+        self.assertIsNone(ifc_classification._coerce_contract_value("", "String"))
+        self.assertEqual(ifc_classification._coerce_contract_value("UNDEFINED", "String"), "")
+
+    def test_find_classification_reference_matches_reference_code(self):
+        classification = object()
+        reference = _ExistingReference(
+            identification="IfcWall",
+            referenced_source=classification,
+        )
+        ifcfile = _MockIfcFile(references=[reference])
+
+        found = ifc_classification._find_classification_reference(
+            ifcfile,
+            classification,
+            {"reference_code": "IfcWall"},
+        )
+
+        self.assertIs(found, reference)
+
+    def test_find_classification_reference_matches_uri(self):
+        classification = object()
+        reference = _ExistingReference(
+            location="https://example.org/class/IfcWall",
+            referenced_source=classification,
+        )
+        ifcfile = _MockIfcFile(references=[reference])
+
+        found = ifc_classification._find_classification_reference(
+            ifcfile,
+            classification,
+            {"uri": "https://example.org/class/IfcWall"},
+        )
+
+        self.assertIs(found, reference)
+
+    def test_apply_canonical_contract_rejects_inapplicable_ifc_type(self):
+        obj = _MockObject(ifc_class="IfcSlab")
+        contract = {
+            "validation_filters": {"applicable_ifc_types": ["IfcWall"]},
+            "dictionary_metadata": {},
+            "class_metadata": {},
+            "extended_properties": [],
+        }
+
+        with self.assertRaises(ValueError):
+            ifc_classification.apply_canonical_contract(obj, contract)
+
+    def test_apply_canonical_contract_returns_false_without_ifc_context(self):
+        obj = _MockObject()
+        contract = {
+            "validation_filters": {"applicable_ifc_types": ["IfcWall"]},
+            "dictionary_metadata": {},
+            "class_metadata": {},
+            "extended_properties": [],
+        }
+
+        with patch.object(ifc_classification.ifc_tools, "get_ifcfile", return_value=None), patch.object(
+            ifc_classification.ifc_tools, "get_ifc_element", return_value=None
+        ):
+            self.assertFalse(ifc_classification.apply_canonical_contract(obj, contract))
+
+    def test_apply_canonical_contract_writes_standard_code_and_calls_helpers(self):
+        obj = _MockObject(ifc_class="IfcWall")
+        ifcfile = object()
+        element = object()
+        classification = object()
+        reference = object()
+        contract = {
+            "validation_filters": {"applicable_ifc_types": ["IfcWall"]},
+            "dictionary_metadata": {"name": "IFC"},
+            "class_metadata": {"reference_code": "IfcWall"},
+            "extended_properties": [],
+            "legacy_string": "IFC IfcWall",
+        }
+
+        with patch.object(ifc_classification.ifc_tools, "get_ifcfile", return_value=ifcfile), patch.object(
+            ifc_classification.ifc_tools, "get_ifc_element", return_value=element
+        ), patch.object(
+            ifc_classification, "_upsert_classification_root", return_value=classification
+        ) as mock_root, patch.object(
+            ifc_classification, "_upsert_classification_reference", return_value=reference
+        ) as mock_ref, patch.object(
+            ifc_classification, "_ensure_reference_relation", return_value=True
+        ) as mock_rel, patch.object(
+            ifc_classification, "_upsert_extended_properties"
+        ) as mock_props:
+            result = ifc_classification.apply_canonical_contract(obj, contract)
+
+        self.assertTrue(result)
+        self.assertEqual(obj.StandardCode, "IFC IfcWall")
+        mock_root.assert_called_once_with(ifcfile, contract["dictionary_metadata"])
+        mock_ref.assert_called_once_with(ifcfile, classification, contract["class_metadata"])
+        mock_rel.assert_called_once_with(ifcfile, reference, element)
+        mock_props.assert_called_once_with(obj, contract, ifcfile, element)
+
+    def test_upsert_extended_properties_skips_empty_values(self):
+        obj = _MockObject()
+        element = object()
+        ifcfile = object()
+        contract = {
+            "extended_properties": [
+                {
+                    "property_set": "Pset_WallCommon",
+                    "name": "Status",
+                    "data_type": "String",
+                    "value": "",
+                }
+            ]
+        }
+
+        with patch("nativeifc.ifc_psets.get_pset") as mock_get_pset, patch.object(
+            ifc_classification.ifc_tools, "api_run"
+        ) as mock_api_run, patch("nativeifc.ifc_psets.show_psets") as mock_show_psets:
+            ifc_classification._upsert_extended_properties(obj, contract, ifcfile, element)
+
+        mock_get_pset.assert_not_called()
+        mock_api_run.assert_not_called()
+        mock_show_psets.assert_called_once_with(obj)
+
+    def test_upsert_extended_properties_creates_and_edits_pset(self):
+        obj = _MockObject()
+        element = object()
+        ifcfile = object()
+        existing_pset = object()
+        contract = {
+            "extended_properties": [
+                {
+                    "property_set": "Pset_WallCommon",
+                    "name": "IsExternal",
+                    "data_type": "Boolean",
+                    "value": "TRUE",
+                }
+            ]
+        }
+
+        with patch("nativeifc.ifc_psets.get_pset", return_value=None), patch.object(
+            ifc_classification.ifc_tools, "api_run", side_effect=[existing_pset, None]
+        ) as mock_api_run, patch("nativeifc.ifc_psets.show_psets") as mock_show_psets:
+            ifc_classification._upsert_extended_properties(obj, contract, ifcfile, element)
+
+        self.assertEqual(mock_api_run.call_count, 2)
+        first_call = mock_api_run.call_args_list[0]
+        second_call = mock_api_run.call_args_list[1]
+        self.assertEqual(first_call.args[0], "pset.add_pset")
+        self.assertEqual(second_call.args[0], "pset.edit_pset")
+        self.assertEqual(second_call.kwargs["properties"], {"IsExternal": True})
+        mock_show_psets.assert_called_once_with(obj)

--- a/src/Mod/BIM/nativeifc/ifc_classification.py
+++ b/src/Mod/BIM/nativeifc/ifc_classification.py
@@ -22,6 +22,7 @@
 # *                                                                         *
 # ***************************************************************************
 
+import FreeCAD
 
 from . import ifc_tools  # lazy import
 
@@ -109,3 +110,298 @@ def show_classification(obj):
                     cname = ref.Name or ref.Identification
                     obj.Classification = sname + " " + cname
                     break
+
+
+def _first_non_empty(*values):
+    for value in values:
+        if value not in [None, ""]:
+            return value
+    return ""
+
+
+def _get_object_ifc_type(obj):
+    for attr_name in ["IfcClass", "IfcType", "IfcRole"]:
+        value = getattr(obj, attr_name, "")
+        if value:
+            return str(value)
+    return ""
+
+
+def _coerce_contract_value(value, data_type="", allowed_values=None):
+    if isinstance(value, dict):
+        value = _first_non_empty(value.get("value"), value.get("code"), value.get("name"))
+    if isinstance(value, str):
+        upper_value = value.strip().upper()
+        if upper_value in ["TRUE", ".T.", "YES"]:
+            return True
+        if upper_value in ["FALSE", ".F.", "NO"]:
+            return False
+        if upper_value in ["UNKNOWN", "UNDEFINED", "NOTDEFINED", "N/A"]:
+            return ""
+        lowered_type = (data_type or "").lower()
+        if "int" in lowered_type:
+            try:
+                return int(value)
+            except Exception:
+                pass
+        if any(token in lowered_type for token in ["real", "float", "number", "numeric"]):
+            try:
+                return float(value)
+            except Exception:
+                pass
+        try:
+            if "." in value:
+                return float(value)
+            return int(value)
+        except Exception:
+            return value
+    if value in [None, ""]:
+        return None
+    return value
+
+
+def _get_project_element(ifcfile):
+    projects = ifcfile.by_type("IfcProject")
+    return projects[0] if projects else None
+
+
+def _get_classification_namespace(classification):
+    for attr_name in ["Source", "Location"]:
+        value = getattr(classification, attr_name, "")
+        if value:
+            return value
+    return ""
+
+
+def _classification_matches_dictionary(classification, dictionary_metadata):
+    target_name = dictionary_metadata.get("name", "")
+    target_namespace = dictionary_metadata.get("namespace_uri", "")
+    target_version = dictionary_metadata.get("version", "")
+    classification_name = getattr(classification, "Name", "") or ""
+    classification_namespace = _get_classification_namespace(classification)
+    classification_version = getattr(classification, "Edition", "") or ""
+
+    if target_namespace:
+        if classification_namespace != target_namespace:
+            return False
+        if target_version and classification_version and classification_version != target_version:
+            return False
+        return True
+
+    if classification_namespace:
+        return False
+    if target_name and classification_name != target_name:
+        return False
+    if target_version and classification_version and classification_version != target_version:
+        return False
+    return bool(target_name)
+
+
+def _ensure_project_classification_relation(ifcfile, classification):
+    project = _get_project_element(ifcfile)
+    if not project:
+        return
+    for rel in ifcfile.by_type("IfcRelAssociatesClassification"):
+        if rel.RelatingClassification == classification and project in rel.RelatedObjects:
+            return
+    owner_history = None
+    try:
+        owner_history = ifc_tools.ifcopenshell.api.owner.create_owner_history(ifcfile)
+    except Exception as err:
+        FreeCAD.Console.PrintLog(
+            "IFC classification: proceeding without project owner history: {}\n".format(err)
+        )
+    ifcfile.create_entity(
+        "IfcRelAssociatesClassification",
+        GlobalId=ifc_tools.ifcopenshell.guid.new(),
+        OwnerHistory=owner_history,
+        RelatedObjects=[project],
+        RelatingClassification=classification,
+    )
+
+
+def _find_classification_root(ifcfile, dictionary_metadata):
+    for classification in ifcfile.by_type("IfcClassification"):
+        if _classification_matches_dictionary(classification, dictionary_metadata):
+            return classification
+    return None
+
+
+def _upsert_classification_root(ifcfile, dictionary_metadata):
+    classification = _find_classification_root(ifcfile, dictionary_metadata)
+    if not classification:
+        classification = ifc_tools.api_run(
+            "classification.add_classification",
+            ifcfile,
+            classification=dictionary_metadata.get("name", "bSDD"),
+        )
+    attrs = {}
+    if dictionary_metadata.get("name"):
+        attrs["Name"] = dictionary_metadata["name"]
+    if dictionary_metadata.get("namespace_uri") and hasattr(classification, "Source"):
+        attrs["Source"] = dictionary_metadata["namespace_uri"]
+    if dictionary_metadata.get("namespace_uri") and hasattr(classification, "Location"):
+        attrs["Location"] = dictionary_metadata["namespace_uri"]
+    if dictionary_metadata.get("version") and hasattr(classification, "Edition"):
+        attrs["Edition"] = dictionary_metadata["version"]
+    if attrs:
+        ifc_tools.api_run(
+            "classification.edit_classification",
+            ifcfile,
+            classification=classification,
+            attributes=attrs,
+        )
+    _ensure_project_classification_relation(ifcfile, classification)
+    return classification
+
+
+def _get_reference_identification(reference):
+    identification = getattr(reference, "Identification", None)
+    if not identification:
+        identification = getattr(reference, "ItemReference", None)
+    return identification
+
+
+def _find_classification_reference(ifcfile, classification, class_metadata):
+    reference_code = class_metadata.get("reference_code", "")
+    concept_uri = class_metadata.get("uri", "")
+    for reference in ifcfile.by_type("IfcClassificationReference"):
+        if getattr(reference, "ReferencedSource", None) != classification:
+            continue
+        if reference_code and _get_reference_identification(reference) == reference_code:
+            return reference
+        if concept_uri and getattr(reference, "Location", "") == concept_uri:
+            return reference
+    return None
+
+
+def _upsert_classification_reference(ifcfile, classification, class_metadata):
+    reference = _find_classification_reference(ifcfile, classification, class_metadata)
+    if not reference:
+        reference = ifcfile.createIfcClassificationReference(
+            Name=class_metadata.get("name", ""),
+            ReferencedSource=classification,
+        )
+    attrs = {"Name": class_metadata.get("name", "")}
+    if class_metadata.get("description") and hasattr(reference, "Description"):
+        attrs["Description"] = class_metadata["description"]
+    if class_metadata.get("uri") and hasattr(reference, "Location"):
+        attrs["Location"] = class_metadata["uri"]
+    identification_attr = (
+        "ItemReference" if hasattr(reference, "ItemReference") else "Identification"
+    )
+    if class_metadata.get("reference_code"):
+        attrs[identification_attr] = class_metadata["reference_code"]
+    ifc_tools.api_run(
+        "classification.edit_reference",
+        ifcfile,
+        reference=reference,
+        attributes=attrs,
+    )
+    return reference
+
+
+def _find_reference_relation(ifcfile, reference):
+    for rel in ifcfile.by_type("IfcRelAssociatesClassification"):
+        if rel.RelatingClassification == reference:
+            return rel
+    return None
+
+
+def _ensure_reference_relation(ifcfile, reference, element):
+    rel = _find_reference_relation(ifcfile, reference)
+    if rel:
+        related_objects = set(rel.RelatedObjects)
+        if element in related_objects:
+            return False
+        related_objects.add(element)
+        rel.RelatedObjects = list(related_objects)
+        try:
+            ifc_tools.ifcopenshell.api.owner.update_owner_history(ifcfile, element=rel)
+        except Exception:
+            pass
+        return True
+    owner_history = None
+    try:
+        owner_history = ifc_tools.ifcopenshell.api.owner.create_owner_history(ifcfile)
+    except Exception as err:
+        FreeCAD.Console.PrintLog(
+            "IFC classification: proceeding without reference owner history: {}\n".format(err)
+        )
+    ifcfile.create_entity(
+        "IfcRelAssociatesClassification",
+        GlobalId=ifc_tools.ifcopenshell.guid.new(),
+        OwnerHistory=owner_history,
+        RelatedObjects=[element],
+        RelatingClassification=reference,
+    )
+    return True
+
+
+def _upsert_extended_properties(obj, contract, ifcfile, element):
+    from . import ifc_psets  # lazy import
+
+    for prop in contract.get("extended_properties", []):
+        pset_name = prop.get("property_set", "")
+        prop_name = prop.get("name", "")
+        if not pset_name or not prop_name:
+            continue
+        coerced_value = _coerce_contract_value(
+            prop.get("value"), prop.get("data_type", ""), prop.get("allowed_values", [])
+        )
+        if coerced_value in [None, ""]:
+            continue
+        pset = ifc_psets.get_pset(pset_name, element)
+        if not pset:
+            pset = ifc_tools.api_run("pset.add_pset", ifcfile, product=element, name=pset_name)
+        ifc_tools.api_run(
+            "pset.edit_pset",
+            ifcfile,
+            pset=pset,
+            properties={prop_name: coerced_value},
+        )
+    try:
+        ifc_psets.show_psets(obj)
+    except Exception as err:
+        FreeCAD.Console.PrintLog(
+            "IFC classification: failed to refresh psets UI for {}: {}\n".format(
+                getattr(obj, "Label", "<unnamed>"), err
+            )
+        )
+
+
+def apply_canonical_contract(obj, contract):
+    """Applies a canonical bSDD contract to a native IFC object."""
+
+    validation = contract.get("validation_filters", {})
+    applicable_ifc_types = validation.get("applicable_ifc_types") or []
+    active_ifc_type = _get_object_ifc_type(obj)
+    is_applicable = (not applicable_ifc_types) or (active_ifc_type in applicable_ifc_types)
+    if applicable_ifc_types and not is_applicable:
+        raise ValueError(
+            "Classification is not applicable to IFC type {}".format(
+                active_ifc_type or validation.get("active_ifc_type", "")
+            )
+        )
+    ifcfile = ifc_tools.get_ifcfile(obj)
+    element = ifc_tools.get_ifc_element(obj, ifcfile)
+    if not ifcfile or not element:
+        return False
+
+    classification = _upsert_classification_root(ifcfile, contract.get("dictionary_metadata", {}))
+    reference = _upsert_classification_reference(
+        ifcfile, classification, contract.get("class_metadata", {})
+    )
+    _ensure_reference_relation(ifcfile, reference, element)
+    _upsert_extended_properties(obj, contract, ifcfile, element)
+
+    legacy_string = _first_non_empty(
+        contract.get("legacy_string"),
+        "{} {}".format(
+            contract.get("dictionary_metadata", {}).get("name", ""),
+            contract.get("class_metadata", {}).get("reference_code", ""),
+        ).strip(),
+    )
+    if hasattr(obj, "StandardCode") and legacy_string:
+        obj.StandardCode = legacy_string
+    return True

--- a/src/Mod/BIM/nativeifc/ifc_classification.py
+++ b/src/Mod/BIM/nativeifc/ifc_classification.py
@@ -130,6 +130,8 @@ def _get_object_ifc_type(obj):
 def _coerce_contract_value(value, data_type="", allowed_values=None):
     if isinstance(value, dict):
         value = _first_non_empty(value.get("value"), value.get("code"), value.get("name"))
+    if value in [None, ""]:
+        return None
     if isinstance(value, str):
         upper_value = value.strip().upper()
         if upper_value in ["TRUE", ".T.", "YES"]:
@@ -155,8 +157,6 @@ def _coerce_contract_value(value, data_type="", allowed_values=None):
             return int(value)
         except Exception:
             return value
-    if value in [None, ""]:
-        return None
     return value
 
 


### PR DESCRIPTION
  Second Pr Breakdown of the  #30733
 **This PR introduces the semantic mapping layer for the bSDD integration in BIM.**

  The goal of this change is to take the raw bSDD payloads produced by the network layer and convert them into a stable FreeCAD-side contract that can be validated, reused, and finally written into native IFC data without leaking API-specific field names into the rest of the workbench. I chose this split so UI code does not need to understand bSDD payload inconsistencies, and IFC persistence code does not need to depend directly on transient REST response shapes.

  `BimBsddContract.py` defines that canonical contract:

  - `merge_payloads()` combines base concept payloads and detail/property payloads into one consistent structure, with detail-side `classProperties` taking precedence when available.

  - `build_canonical_contract()` transforms the merged bSDD payload into a normalized dictionary with `dictionary_metadata`, `class_metadata`, `validation_filters`, and `extended_properties`.
 the extraction helpers intentionally collapse multiple possible bSDD field aliases, for example dictionaryUri vs namespaceUri, referenceCode vs identification, and relatedIfcEntities vs applicableIfcClasses, so later code can consume one internal schema instead of many API variants.

  - `_extract_active_ifc_type()` and `_extract_applicable_ifc_types()` compute applicability against the currently selected IFC object, which lets the contract carry validation  state alongside the metadata instead of forcing every caller to recompute it.

  - `_extract_extended_properties()` converts bSDD property definitions into a compact, IFC-ready shape with property set name, property name, data type, value, allowed values, and URI.

  - `_extract_property_value()` is deliberately conservative: it prefers explicit values like `predefinedValue` or `defaultValue` and does not silently invent a value from the allowed enum list. That avoids writing semantic data the user never actually selected.

  - `refresh_contract_validation()` lets the same canonical contract be revalidated against another target object without rebuilding the whole structure from the original  payloads.

  - `build_legacy_classification_string()` preserves the existing FreeCAD-style System Code string representation so the new semantic path remains compatible with legacy StandardCode / Classification behavior.

  **`ifc_classification.py` then applies that canonical contract into the IFC model:**

  -` apply_canonical_contract()` is the main entry point. It validates IFC applicability first, then resolves the IFC file and element, upserts the classification root,upserts the classification reference, ensures the reference relation exists, writes extended properties, and finally mirrors the resulting legacy classification string  back into `StandardCode`.

  -` _classification_matches_dictionary()` uses namespace URI and version when available, not just name matching. I chose this because dictionary names alone are not strong enough to distinguish different classification roots safely, especially when bSDD points to versioned or namespaced systems.

  - `_upsert_classification_root()` either reuses an existing `IfcClassification` or creates one, then updates name, namespace, and edition fields so the IFC model stores the bSDD dictionary identity explicitly rather than only a display label.

  - `_ensure_project_classification_relation()` ensures the project itself is associated with the classification root, which keeps the IFC classification structure properly anchored in the model instead of only attaching references to individual products.

  - `_find_classification_reference()` and `_upsert_classification_reference()` reuse references by code or URI when possible, so repeated applications of the same bSDD class do not create duplicate IFC references.

  - `_ensure_reference_relation() `reuses and extends existing `IfcRelAssociatesClassification` relationships instead of creating redundant links for every application.
  - `_coerce_contract_value()` converts bSDD property values into IFC-appropriate Python values such as booleans, ints, floats, or empty values. This is important because property data arrives as loose JSON values, but IFC property sets need typed values to remain meaningful.

  -` _upsert_extended_properties()` maps canonical contract properties into IFC property sets using `ifc_psets`, creates missing `psets` when needed, skips empty values deliberately, and refreshes the visible `pset` state afterward.
