### PR TITLE
PartDesign: Helix 2 sides

### DIFF
--- a/src/Gui/Inventor/Draggers/Gizmo.cpp
+++ b/src/Gui/Inventor/Draggers/Gizmo.cpp
@@ -307,9 +307,7 @@ void LinearGizmo::draggingContinued()
         value = snapToStep(value, baseStep * getCoarseLinearSnapMultiplier());
     }
 
-    // TODO: Need to change the lower limit to sudoThis->property->minimum() once the
-    // two direction extrude work gets merged
-    value = std::clamp(value, dragger->translationIncrement.getValue(), property->maximum());
+    value = std::clamp(value, property->minimum(), property->maximum());
 
     property->setValue(value);
     setDragLength(value);

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -146,10 +146,7 @@ Helix::Helix()
         (30.0),
         "Side2",
         App::Prop_None,
-        QT_TRANSLATE_NOOP(
-            "App::Property",
-            "The height of the second helix side's path, not accounting for the extent of the profile."
-        )
+        QT_TRANSLATE_NOOP("App::Property", "The height of the second helix side's path, not accounting for the extent of the profile.")
     );
     Height2.enableNegative(true);
     ADD_PROPERTY_TYPE(
@@ -412,8 +409,8 @@ App::DocumentObjectExecReturn* Helix::execute()
             //   interactive usage to just go back to another mode and everything keeps working
         }
         if (twoSides) {
-            if ((height2Abs < Precision::Confusion())
-                && (std::abs(growth) < Precision::Confusion()) && turns > 1.0) {
+            if ((height2Abs < Precision::Confusion()) && (std::abs(growth) < Precision::Confusion())
+                && turns > 1.0) {
                 return new App::DocumentObjectExecReturn(
                     QT_TRANSLATE_NOOP("Exception", "Error: either height 2 or growth must not be zero!")
                 );
@@ -594,20 +591,15 @@ App::DocumentObjectExecReturn* Helix::execute()
         else {
             try {
                 const auto fuseSubSolids = [](TopoShape& shape) {
-                    if (shape.hasSubShape(TopAbs_SOLID)
-                        && shape.countSubShapes(TopAbs_SOLID) > 1) {
-                        shape.makeElementFuse(
-                            shape.getSubTopoShapes(TopAbs_SOLID),
-                            Part::OpCodes::Fuse
-                        );
+                    if (shape.hasSubShape(TopAbs_SOLID) && shape.countSubShapes(TopAbs_SOLID) > 1) {
+                        shape.makeElementFuse(shape.getSubTopoShapes(TopAbs_SOLID), Part::OpCodes::Fuse);
                     }
                 };
 
                 TopoShape combined(0, getDocument()->getStringHasher());
                 combined.makeElementFuse(sideShapes, Part::OpCodes::Sweep);
                 fuseSubSolids(combined);
-                if (combined.hasSubShape(TopAbs_SOLID)
-                    && combined.countSubShapes(TopAbs_SOLID) > 1) {
+                if (combined.hasSubShape(TopAbs_SOLID) && combined.countSubShapes(TopAbs_SOLID) > 1) {
                     combined.makeElementXor(sideShapes, Part::OpCodes::Sweep);
                     fuseSubSolids(combined);
                 }
@@ -1016,8 +1008,7 @@ void Helix::onChanged(const App::Property* prop)
 
 void Helix::setReadWriteStatusForMode(HelixMode inputMode)
 {
-    const bool twoSides = static_cast<HelixSideMode>(SideType.getValue())
-        == HelixSideMode::two_sides;
+    const bool twoSides = static_cast<HelixSideMode>(SideType.getValue()) == HelixSideMode::two_sides;
 
     Height2.setStatus(App::Property::ReadOnly, true);
     Turns2.setStatus(App::Property::ReadOnly, true);

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -22,7 +22,9 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <cmath>
 #include <limits>
+#include <vector>
 #include <BRepAdaptor_Surface.hxx>
 #include <Mod/Part/App/FCBRepAlgoAPI_Common.h>
 #include <Mod/Part/App/FCBRepAlgoAPI_Cut.h>
@@ -48,8 +50,10 @@
 #include <Base/Exception.h>
 #include <Base/Placement.h>
 #include <Base/Tools.h>
+#include <App/Document.h>
 
 #include <Mod/Part/App/TopoShape.h>
+#include <Mod/Part/App/TopoShapeOpCode.h>
 #include <Mod/Part/App/FaceMakerCheese.h>
 
 #include "FeatureHelix.h"
@@ -58,6 +62,7 @@ using namespace PartDesign;
 
 const char* Helix::ModeEnums[]
     = {"pitch-height-angle", "pitch-turns-angle", "height-turns-angle", "height-turns-growth", nullptr};
+const char* Helix::SideTypesEnums[] = {"One side", "Two sides", "Symmetric", nullptr};
 
 PROPERTY_SOURCE(PartDesign::Helix, PartDesign::ProfileBased)
 
@@ -111,6 +116,14 @@ Helix::Helix()
     );
     Mode.setEnums(ModeEnums);
     ADD_PROPERTY_TYPE(
+        SideType,
+        (long(HelixSideMode::one_side)),
+        group,
+        App::Prop_None,
+        QT_TRANSLATE_NOOP("App::Property", "Type of sides definition.")
+    );
+    SideType.setEnums(SideTypesEnums);
+    ADD_PROPERTY_TYPE(
         Pitch,
         (10.0),
         group,
@@ -127,6 +140,18 @@ Helix::Helix()
             "The height of the helix' path, not accounting for the extent of the profile."
         )
     );
+    Height.enableNegative(true);
+    ADD_PROPERTY_TYPE(
+        Height2,
+        (30.0),
+        "Side2",
+        App::Prop_None,
+        QT_TRANSLATE_NOOP(
+            "App::Property",
+            "The height of the second helix side's path, not accounting for the extent of the profile."
+        )
+    );
+    Height2.enableNegative(true);
     ADD_PROPERTY_TYPE(
         Turns,
         (3.0),
@@ -135,6 +160,14 @@ Helix::Helix()
         QT_TRANSLATE_NOOP("App::Property", "The number of turns in the helix.")
     );
     Turns.setConstraints(&floatTurns);
+    ADD_PROPERTY_TYPE(
+        Turns2,
+        (3.0),
+        "Side2",
+        App::Prop_None,
+        QT_TRANSLATE_NOOP("App::Property", "The number of turns in the second helix side.")
+    );
+    Turns2.setConstraints(&floatTurns);
     ADD_PROPERTY_TYPE(
         Angle,
         (0.0),
@@ -217,7 +250,10 @@ Helix::Helix()
 short Helix::mustExecute() const
 {
     if (Placement.isTouched() || ReferenceAxis.isTouched() || Axis.isTouched() || Base.isTouched()
-        || Angle.isTouched()) {
+        || SideType.isTouched() || Mode.isTouched() || Pitch.isTouched() || Height.isTouched()
+        || Height2.isTouched() || Turns.isTouched() || Turns2.isTouched() || Angle.isTouched()
+        || Growth.isTouched() || LeftHanded.isTouched() || Outside.isTouched()
+        || Tolerance.isTouched()) {
         return 1;
     }
     return ProfileBased::mustExecute();
@@ -229,67 +265,145 @@ App::DocumentObjectExecReturn* Helix::execute()
         return App::DocumentObject::StdReturn;
     }
 
+    struct HelixSideParameters
+    {
+        double height;
+        double turns;
+        double angle;
+        double growth;
+        bool reversed;
+    };
+
+    const auto heightMagnitude = [](double height) {
+        return std::abs(height);
+    };
+    const auto isNegativeHeight = [](double height) {
+        return height < -Precision::Confusion();
+    };
+    const auto reverseForSide = [&](double signedHeight, bool oppositeSide) {
+        bool reversed = Reversed.getValue();
+        if (oppositeSide) {
+            reversed = !reversed;
+        }
+        if (isNegativeHeight(signedHeight)) {
+            reversed = !reversed;
+        }
+        return reversed;
+    };
+    const auto angleGrowth = [](double pitch, double angle) {
+        return pitch * tan(Base::toRadians(angle));
+    };
+
+    const auto sideMode = static_cast<HelixSideMode>(SideType.getValue());
+    const bool twoSides = sideMode == HelixSideMode::two_sides;
+
     // Validate and normalize parameters
     HelixMode mode = static_cast<HelixMode>(Mode.getValue());
+    double pitch = Pitch.getValue();
+    double height = Height.getValue();
+    double heightAbs = heightMagnitude(height);
+    double turns = Turns.getValue();
+    double height2 = Height2.getValue();
+    double height2Abs = heightMagnitude(height2);
+    double turns2 = Turns2.getValue();
+    double angle = Angle.getValue();
+    double growth = Growth.getValue();
+
     if (mode == HelixMode::pitch_height_angle) {
-        if (Pitch.getValue() < Precision::Confusion()) {
+        if (pitch < Precision::Confusion()) {
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "Error: Pitch too small!")
             );
         }
-        if (Height.getValue() < Precision::Confusion()) {
+        if (heightAbs < Precision::Confusion()) {
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "Error: height too small!")
             );
         }
-        Turns.setValue(Height.getValue() / Pitch.getValue());
-        Growth.setValue(Pitch.getValue() * tan(Base::toRadians(Angle.getValue())));
+        turns = heightAbs / pitch;
+        growth = angleGrowth(pitch, angle);
+        Turns.setValue(turns);
+        Growth.setValue(growth);
+        if (twoSides) {
+            if (height2Abs < Precision::Confusion()) {
+                return new App::DocumentObjectExecReturn(
+                    QT_TRANSLATE_NOOP("Exception", "Error: height 2 too small!")
+                );
+            }
+            turns2 = height2Abs / pitch;
+            Turns2.setValue(turns2);
+        }
     }
     else if (mode == HelixMode::pitch_turns_angle) {
-        if (Pitch.getValue() < Precision::Confusion()) {
+        if (pitch < Precision::Confusion()) {
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "Error: pitch too small!")
             );
         }
-        if (Turns.getValue() < Precision::Confusion()) {
+        if (turns < Precision::Confusion()) {
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "Error: turns too small!")
             );
         }
-        Height.setValue(Turns.getValue() * Pitch.getValue());
-        Growth.setValue(Pitch.getValue() * tan(Base::toRadians(Angle.getValue())));
+        height = turns * pitch;
+        heightAbs = height;
+        growth = angleGrowth(pitch, angle);
+        Height.setValue(height);
+        Growth.setValue(growth);
+        if (twoSides) {
+            if (turns2 < Precision::Confusion()) {
+                return new App::DocumentObjectExecReturn(
+                    QT_TRANSLATE_NOOP("Exception", "Error: turns 2 too small!")
+                );
+            }
+            height2 = turns2 * pitch;
+            height2Abs = height2;
+            Height2.setValue(height2);
+        }
     }
     else if (mode == HelixMode::height_turns_angle) {
-        if (Height.getValue() < Precision::Confusion()) {
+        if (heightAbs < Precision::Confusion()) {
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "Error: height too small!")
             );
         }
-        if (Turns.getValue() < Precision::Confusion()) {
+        if (turns < Precision::Confusion()) {
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "Error: turns too small!")
             );
         }
-        Pitch.setValue(Height.getValue() / Turns.getValue());
-        Growth.setValue(Pitch.getValue() * tan(Base::toRadians(Angle.getValue())));
+        if (twoSides && height2Abs < Precision::Confusion()) {
+            return new App::DocumentObjectExecReturn(
+                QT_TRANSLATE_NOOP("Exception", "Error: height 2 too small!")
+            );
+        }
+        const double totalHeight = twoSides ? heightAbs + height2Abs : heightAbs;
+        pitch = totalHeight / turns;
+        growth = angleGrowth(pitch, angle);
+        Pitch.setValue(pitch);
+        Growth.setValue(growth);
+        if (twoSides) {
+            Turns2.setValue(height2Abs / pitch);
+        }
     }
     else if (mode == HelixMode::height_turns_growth) {
-        if (Turns.getValue() < Precision::Confusion()) {
+        if (turns < Precision::Confusion()) {
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "Error: turns too small!")
             );
         }
-        if ((Height.getValue() < Precision::Confusion())
-            && (abs(Growth.getValue()) < Precision::Confusion()) && Turns.getValue() > 1.0) {
+        const double totalHeight = twoSides ? heightAbs + height2Abs : heightAbs;
+        if ((totalHeight < Precision::Confusion()) && (std::abs(growth) < Precision::Confusion())
+            && turns > 1.0) {
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "Error: either height or growth must not be zero!")
             );
         }
-        Pitch.setValue(Height.getValue() / Turns.getValue());
-        if (Height.getValue() > 0) {
-            Angle.setValue(
-                Base::toDegrees(atan(Turns.getValue() * Growth.getValue() / Height.getValue()))
-            );
+        pitch = totalHeight / turns;
+        Pitch.setValue(pitch);
+        if (totalHeight > 0) {
+            angle = Base::toDegrees(atan(turns * growth / totalHeight));
+            Angle.setValue(angle);
         }
         else {
             // On purpose, we're doing nothing here; the else-branch is just for this comment.
@@ -297,10 +411,58 @@ App::DocumentObjectExecReturn* Helix::execute()
             // - we don't void the angle (somehow) so that it keeps its value. This allows in
             //   interactive usage to just go back to another mode and everything keeps working
         }
+        if (twoSides) {
+            if ((height2Abs < Precision::Confusion())
+                && (std::abs(growth) < Precision::Confusion()) && turns > 1.0) {
+                return new App::DocumentObjectExecReturn(
+                    QT_TRANSLATE_NOOP("Exception", "Error: either height 2 or growth must not be zero!")
+                );
+            }
+            if (pitch > Precision::Confusion()) {
+                Turns2.setValue(height2Abs / pitch);
+            }
+            else {
+                Turns2.setValue(turns / 2.0);
+            }
+        }
     }
     else {
         return new App::DocumentObjectExecReturn(
             QT_TRANSLATE_NOOP("Exception", "Error: unsupported mode")
+        );
+    }
+
+    const bool heightTurnsMode = mode == HelixMode::height_turns_angle
+        || mode == HelixMode::height_turns_growth;
+    double side1Turns = turns;
+    if (twoSides && heightTurnsMode) {
+        side1Turns = pitch > Precision::Confusion() ? heightAbs / pitch : turns / 2.0;
+    }
+
+    std::vector<HelixSideParameters> helixSides;
+    helixSides.push_back({heightAbs, side1Turns, angle, growth, reverseForSide(height, false)});
+
+    if (sideMode == HelixSideMode::two_sides) {
+        double side2Turns = turns;
+        double side2Angle = -angle;
+        double side2Growth = -growth;
+        if (mode == HelixMode::pitch_height_angle || mode == HelixMode::pitch_turns_angle) {
+            side2Turns = turns2;
+        }
+        else if (heightTurnsMode) {
+            side2Turns = pitch > Precision::Confusion() ? height2Abs / pitch : turns / 2.0;
+        }
+        helixSides.push_back(
+            {height2Abs, side2Turns, side2Angle, side2Growth, reverseForSide(height2, true)}
+        );
+    }
+    else if (sideMode == HelixSideMode::symmetric) {
+        helixSides.clear();
+        helixSides.push_back(
+            {heightAbs / 2.0, turns / 2.0, angle, growth, reverseForSide(height, false)}
+        );
+        helixSides.push_back(
+            {heightAbs / 2.0, turns / 2.0, angle, growth, reverseForSide(height, true)}
         );
     }
 
@@ -356,54 +518,107 @@ App::DocumentObjectExecReturn* Helix::execute()
 
         base.move(invObjLoc);
 
-        TopoDS_Shape result;
+        auto makeHelixSide = [&](const HelixSideParameters& side) {
+            const bool isConstantRadius = std::fabs(side.angle) < Precision::Confusion()
+                && std::fabs(side.growth) < Precision::Confusion();
+            const bool splitAtTurns = isConstantRadius && helixSides.size() == 1;
+            const double breakAtTurn = splitAtTurns ? 1.0 : 1000.0;
 
-        // generate the helix path
-        TopoDS_Shape path;
-        if (Angle.getValue() == 0.) {
-            // breaking the path at each turn prevents an OCC issue
-            path = generateHelixPath();
+            TopoDS_Shape path = generateHelixPath(
+                side.turns,
+                side.height,
+                side.angle,
+                side.growth,
+                side.reversed,
+                breakAtTurn
+            );
+
+            TopoDS_Shape face = sketchshape;
+            face.Move(invObjLoc);
+
+            Bnd_Box bounds;
+            BRepBndLib::Add(path, bounds);
+            double size = sqrt(bounds.SquareExtent());
+            ShapeFix_ShapeTolerance fix;
+            fix.LimitTolerance(path, Precision::Confusion() * 1e-6 * size);
+            // We introduce final part tolerance with the second call to LimitTolerance below,
+            // however OCCT has a bug where the side-walls of the Pipe disappear with very large
+            // (km range) pieces. Increasing a tiny bit of extra tolerance to the path fixes this.
+            // This will in any case be less than the tolerance lower limit below, but sufficient to
+            // avoid the bug.
+
+            BRepOffsetAPI_MakePipe mkPS(
+                TopoDS::Wire(path),
+                face,
+                GeomFill_Trihedron::GeomFill_IsFrenet,
+                Standard_False
+            );
+            TopoDS_Shape sideResult = mkPS.Shape();
+
+            BRepClass3d_SolidClassifier SC(sideResult);
+            SC.PerformInfinitePoint(Precision::Confusion());
+            if (SC.State() == TopAbs_IN) {
+                sideResult.Reverse();
+            }
+
+            fix.LimitTolerance(sideResult, Precision::Confusion() * size * Tolerance.getValue());
+            // Significant precision reduction due to helical approximation - needed to allow
+            // fusion to succeed.
+
+            // try to auto-fix possible invalid result
+            ShapeFix_Solid fixer;
+            fixer.Init(TopoDS::Solid(sideResult));
+            if (fixer.Perform()) {
+                sideResult = fixer.Solid();
+            }
+
+            return sideResult;
+        };
+
+        std::vector<TopoShape> sideShapes;
+        sideShapes.reserve(helixSides.size());
+        for (const auto& side : helixSides) {
+            TopoDS_Shape sideShape = makeHelixSide(side);
+            sideShapes.emplace_back(sideShape, 0, getDocument()->getStringHasher());
+        }
+
+        TopoDS_Shape result;
+        if (sideShapes.empty()) {
+            return new App::DocumentObjectExecReturn(
+                QT_TRANSLATE_NOOP("Exception", "Error: No helix geometry was generated.")
+            );
+        }
+        else if (sideShapes.size() == 1) {
+            result = sideShapes.front().getShape();
         }
         else {
-            // don't break the path or the generated solid is invalid
-            path = generateHelixPath(1000.);
-        }
+            try {
+                const auto fuseSubSolids = [](TopoShape& shape) {
+                    if (shape.hasSubShape(TopAbs_SOLID)
+                        && shape.countSubShapes(TopAbs_SOLID) > 1) {
+                        shape.makeElementFuse(
+                            shape.getSubTopoShapes(TopAbs_SOLID),
+                            Part::OpCodes::Fuse
+                        );
+                    }
+                };
 
-        TopoDS_Shape face = sketchshape;
-        face.Move(invObjLoc);
-
-        Bnd_Box bounds;
-        BRepBndLib::Add(path, bounds);
-        double size = sqrt(bounds.SquareExtent());
-        ShapeFix_ShapeTolerance fix;
-        fix.LimitTolerance(path, Precision::Confusion() * 1e-6 * size);  // needed to produce valid
-                                                                         // Pipe for very big parts
-        // We introduce final part tolerance with the second call to LimitTolerance below, however
-        // OCCT has a bug where the side-walls of the Pipe disappear with very large (km range)
-        // pieces increasing a tiny bit of extra tolerance to the path fixes this. This will in any
-        // case be less than the tolerance lower limit below, but sufficient to avoid the bug
-
-        BRepOffsetAPI_MakePipe
-            mkPS(TopoDS::Wire(path), face, GeomFill_Trihedron::GeomFill_IsFrenet, Standard_False);
-        result = mkPS.Shape();
-
-        BRepClass3d_SolidClassifier SC(result);
-        SC.PerformInfinitePoint(Precision::Confusion());
-        if (SC.State() == TopAbs_IN) {
-            result.Reverse();
-        }
-
-        fix.LimitTolerance(
-            result,
-            Precision::Confusion() * size * Tolerance.getValue()
-        );  // significant precision reduction due to helical approximation - needed to allow fusion
-            // to succeed
-
-        // try to auto-fix possible invalid result
-        ShapeFix_Solid fixer;
-        fixer.Init(TopoDS::Solid(result));
-        if (fixer.Perform()) {
-            result = fixer.Solid();
+                TopoShape combined(0, getDocument()->getStringHasher());
+                combined.makeElementFuse(sideShapes, Part::OpCodes::Sweep);
+                fuseSubSolids(combined);
+                if (combined.hasSubShape(TopAbs_SOLID)
+                    && combined.countSubShapes(TopAbs_SOLID) > 1) {
+                    combined.makeElementXor(sideShapes, Part::OpCodes::Sweep);
+                    fuseSubSolids(combined);
+                }
+                result = combined.getShape();
+            }
+            catch (const Base::Exception& e) {
+                return new App::DocumentObjectExecReturn(e.what());
+            }
+            catch (const Standard_Failure& e) {
+                return new App::DocumentObjectExecReturn(e.GetMessageString());
+            }
         }
 
         AddSubShape.setValue(result);
@@ -536,14 +751,16 @@ void Helix::updateAxis()
     Axis.setValue(dir.x, dir.y, dir.z);
 }
 
-TopoDS_Shape Helix::generateHelixPath(double breakAtTurn)
+TopoDS_Shape Helix::generateHelixPath(
+    double turns,
+    double height,
+    double angle,
+    double growth,
+    bool reversed,
+    double breakAtTurn
+)
 {
-    double turns = Turns.getValue();
-    double height = Height.getValue();
     bool leftHanded = LeftHanded.getValue();
-    bool reversed = Reversed.getValue();
-    double angle = Angle.getValue();
-    double growth = Growth.getValue();
 
     if (fabs(angle) < Precision::Confusion()) {
         angle = 0.0;
@@ -788,7 +1005,7 @@ void Helix::handleChangedPropertyType(Base::XMLReader& reader, const char* TypeN
 
 void Helix::onChanged(const App::Property* prop)
 {
-    if (prop == &Mode) {
+    if (prop == &Mode || prop == &SideType) {
         // Depending on the mode, the derived properties are set read-only
         auto inputMode = static_cast<HelixMode>(Mode.getValue());
         setReadWriteStatusForMode(inputMode);
@@ -799,14 +1016,22 @@ void Helix::onChanged(const App::Property* prop)
 
 void Helix::setReadWriteStatusForMode(HelixMode inputMode)
 {
+    const bool twoSides = static_cast<HelixSideMode>(SideType.getValue())
+        == HelixSideMode::two_sides;
+
+    Height2.setStatus(App::Property::ReadOnly, true);
+    Turns2.setStatus(App::Property::ReadOnly, true);
+
     switch (inputMode) {
         case HelixMode::pitch_height_angle:
             // primary input:
             Pitch.setStatus(App::Property::ReadOnly, false);
             Height.setStatus(App::Property::ReadOnly, false);
+            Height2.setStatus(App::Property::ReadOnly, !twoSides);
             Angle.setStatus(App::Property::ReadOnly, false);
             // derived props:
             Turns.setStatus(App::Property::ReadOnly, true);
+            Turns2.setStatus(App::Property::ReadOnly, true);
             Growth.setStatus(App::Property::ReadOnly, true);
             break;
 
@@ -814,36 +1039,44 @@ void Helix::setReadWriteStatusForMode(HelixMode inputMode)
             // primary input:
             Pitch.setStatus(App::Property::ReadOnly, false);
             Turns.setStatus(App::Property::ReadOnly, false);
+            Turns2.setStatus(App::Property::ReadOnly, !twoSides);
             Angle.setStatus(App::Property::ReadOnly, false);
             // derived props:
             Height.setStatus(App::Property::ReadOnly, true);
+            Height2.setStatus(App::Property::ReadOnly, true);
             Growth.setStatus(App::Property::ReadOnly, true);
             break;
 
         case HelixMode::height_turns_angle:
             // primary input:
             Height.setStatus(App::Property::ReadOnly, false);
+            Height2.setStatus(App::Property::ReadOnly, !twoSides);
             Turns.setStatus(App::Property::ReadOnly, false);
             Angle.setStatus(App::Property::ReadOnly, false);
             // derived props:
             Pitch.setStatus(App::Property::ReadOnly, true);
+            Turns2.setStatus(App::Property::ReadOnly, true);
             Growth.setStatus(App::Property::ReadOnly, true);
             break;
 
         case HelixMode::height_turns_growth:
             // primary input:
             Height.setStatus(App::Property::ReadOnly, false);
+            Height2.setStatus(App::Property::ReadOnly, !twoSides);
             Turns.setStatus(App::Property::ReadOnly, false);
             Growth.setStatus(App::Property::ReadOnly, false);
             // derived props:
             Pitch.setStatus(App::Property::ReadOnly, true);
             Angle.setStatus(App::Property::ReadOnly, true);
+            Turns2.setStatus(App::Property::ReadOnly, true);
             break;
 
         default:
             Pitch.setStatus(App::Property::ReadOnly, false);
             Height.setStatus(App::Property::ReadOnly, false);
+            Height2.setStatus(App::Property::ReadOnly, false);
             Turns.setStatus(App::Property::ReadOnly, false);
+            Turns2.setStatus(App::Property::ReadOnly, false);
             Angle.setStatus(App::Property::ReadOnly, false);
             Growth.setStatus(App::Property::ReadOnly, false);
             break;

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -582,7 +582,7 @@ App::DocumentObjectExecReturn* Helix::execute()
         TopoDS_Shape result;
         if (sideShapes.empty()) {
             return new App::DocumentObjectExecReturn(
-                QT_TRANSLATE_NOOP("Exception", "Error: No helix geometry was generated.")
+                QT_TRANSLATE_NOOP("Exception", "Error: No helix geometry was generated!")
             );
         }
         else if (sideShapes.size() == 1) {

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -120,7 +120,10 @@ Helix::Helix()
         (long(HelixSideMode::one_side)),
         group,
         App::Prop_None,
-        QT_TRANSLATE_NOOP("App::Property", "Whether the helix extends on one side, two sides, or symmetrically.")
+        QT_TRANSLATE_NOOP(
+            "App::Property",
+            "Whether the helix extends on one side, two sides, or symmetrically."
+        )
     );
     SideType.setEnums(SideTypesEnums);
     ADD_PROPERTY_TYPE(

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -120,7 +120,7 @@ Helix::Helix()
         (long(HelixSideMode::one_side)),
         group,
         App::Prop_None,
-        QT_TRANSLATE_NOOP("App::Property", "Type of sides definition.")
+        QT_TRANSLATE_NOOP("App::Property", "Whether the helix extends on one side, two sides, or symmetrically.")
     );
     SideType.setEnums(SideTypesEnums);
     ADD_PROPERTY_TYPE(

--- a/src/Mod/PartDesign/App/FeatureHelix.h
+++ b/src/Mod/PartDesign/App/FeatureHelix.h
@@ -40,6 +40,13 @@ enum class HelixMode
     height_turns_growth
 };
 
+enum class HelixSideMode
+{
+    one_side,
+    two_sides,
+    symmetric
+};
+
 class PartDesignExport Helix: public ProfileBased
 {
     PROPERTY_HEADER_WITH_OVERRIDE(PartDesign::Helix);
@@ -51,11 +58,14 @@ public:
     App::PropertyVector Axis;
     App::PropertyLength Pitch;
     App::PropertyLength Height;
+    App::PropertyLength Height2;
     App::PropertyFloatConstraint Turns;
+    App::PropertyFloatConstraint Turns2;
     App::PropertyBool LeftHanded;
     App::PropertyAngle Angle;
     App::PropertyDistance Growth;
     App::PropertyEnumeration Mode;
+    App::PropertyEnumeration SideType;
     App::PropertyBool Outside;
     App::PropertyBool HasBeenEdited;
     App::PropertyFloatConstraint Tolerance;
@@ -84,7 +94,14 @@ protected:
     void updateAxis();
 
     /// generate helix and move it to the right location.
-    TopoDS_Shape generateHelixPath(double breakAtTurn = 1.);
+    TopoDS_Shape generateHelixPath(
+        double turns,
+        double height,
+        double angle,
+        double growth,
+        bool reversed,
+        double breakAtTurn = 1.
+    );
 
     // project shape on plane. Used for detecting self intersection.
     TopoDS_Shape projectShape(const TopoDS_Shape& input, const gp_Ax2& plane);
@@ -107,6 +124,7 @@ protected:
 
 private:
     static const char* ModeEnums[];
+    static const char* SideTypesEnums[];
 
     // Sets the read-only status bit for properties depending on the input mode.
     void setReadWriteStatusForMode(HelixMode inputMode);

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -27,6 +27,7 @@
 #include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <App/Origin.h>
+#include <limits>
 #include <Base/Console.h>
 #include <Base/Converter.h>
 #include <Base/Tools.h>
@@ -60,6 +61,8 @@ TaskHelixParameters::TaskHelixParameters(PartDesignGui::ViewProviderHelix* Helix
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
     ui->setupUi(proxy);
+    ui->height->setMinimum(-std::numeric_limits<double>::max());
+    ui->height2->setMinimum(-std::numeric_limits<double>::max());
     this->groupLayout()->addWidget(proxy);
 
     initializeHelix();
@@ -95,11 +98,14 @@ void TaskHelixParameters::assignProperties()
     propGrowth = &(helix->Growth);
     propPitch = &(helix->Pitch);
     propHeight = &(helix->Height);
+    propHeight2 = &(helix->Height2);
     propTurns = &(helix->Turns);
+    propTurns2 = &(helix->Turns2);
     propReferenceAxis = &(helix->ReferenceAxis);
     propLeftHanded = &(helix->LeftHanded);
     propReversed = &(helix->Reversed);
     propMode = &(helix->Mode);
+    propSideType = &(helix->SideType);
     propOutside = &(helix->Outside);
 }
 
@@ -107,17 +113,23 @@ void TaskHelixParameters::setValuesFromProperties()
 {
     double pitch = propPitch->getValue();
     double height = propHeight->getValue();
+    double height2 = propHeight2->getValue();
     double turns = propTurns->getValue();
+    double turns2 = propTurns2->getValue();
     double angle = propAngle->getValue();
     double growth = propGrowth->getValue();
     bool leftHanded = propLeftHanded->getValue();
     bool reversed = propReversed->getValue();
     int index = propMode->getValue();
+    int sideIndex = propSideType->getValue();
     bool outside = propOutside->getValue();
 
+    translateSidesList(sideIndex);
     ui->pitch->setValue(pitch);
     ui->height->setValue(height);
+    ui->height2->setValue(height2);
     ui->turns->setValue(turns);
+    ui->turns2->setValue(turns2);
     ui->coneAngle->setValue(angle);
     ui->coneAngle->setMinimum(propAngle->getMinimum());
     ui->coneAngle->setMaximum(propAngle->getMaximum());
@@ -133,7 +145,9 @@ void TaskHelixParameters::bindProperties()
     auto helix = getObject<PartDesign::Helix>();
     ui->pitch->bind(helix->Pitch);
     ui->height->bind(helix->Height);
+    ui->height2->bind(helix->Height2);
     ui->turns->bind(helix->Turns);
+    ui->turns2->bind(helix->Turns2);
     ui->coneAngle->bind(helix->Angle);
     ui->growth->bind(helix->Growth);
 }
@@ -147,8 +161,12 @@ void TaskHelixParameters::connectSlots()
             this, &TaskHelixParameters::onPitchChanged);
     connect(ui->height, qOverload<double>(&QuantitySpinBox::valueChanged),
             this, &TaskHelixParameters::onHeightChanged);
+    connect(ui->height2, qOverload<double>(&QuantitySpinBox::valueChanged),
+            this, &TaskHelixParameters::onHeight2Changed);
     connect(ui->turns, qOverload<double>(&QuantitySpinBox::valueChanged),
             this, &TaskHelixParameters::onTurnsChanged);
+    connect(ui->turns2, qOverload<double>(&QuantitySpinBox::valueChanged),
+            this, &TaskHelixParameters::onTurns2Changed);
     connect(ui->coneAngle, qOverload<double>(&QuantitySpinBox::valueChanged),
             this, &TaskHelixParameters::onAngleChanged);
     connect(ui->growth, qOverload<double>(&QuantitySpinBox::valueChanged),
@@ -163,6 +181,8 @@ void TaskHelixParameters::connectSlots()
             this, &TaskHelixParameters::onUpdateView);
     connect(ui->inputMode, qOverload<int>(&QComboBox::activated),
             this, &TaskHelixParameters::onModeChanged);
+    connect(ui->sidesMode, qOverload<int>(&QComboBox::activated),
+            this, &TaskHelixParameters::onSidesModeChanged);
     connect(ui->checkBoxOutside, &QCheckBox::toggled,
             this, &TaskHelixParameters::onOutsideChanged);
     // clang-format on
@@ -273,6 +293,15 @@ int TaskHelixParameters::addCurrentLink()
     return indexOfCurrent;
 }
 
+void TaskHelixParameters::translateSidesList(int index)
+{
+    ui->sidesMode->clear();
+    ui->sidesMode->addItem(tr("One sided"));
+    ui->sidesMode->addItem(tr("Two sided"));
+    ui->sidesMode->addItem(tr("Symmetric"));
+    ui->sidesMode->setCurrentIndex(index);
+}
+
 void TaskHelixParameters::addAxisToCombo(
     App::DocumentObject* linkObj,
     std::string linkSubname,
@@ -317,7 +346,9 @@ void TaskHelixParameters::adaptVisibilityToMode()
 {
     bool isPitchVisible = false;
     bool isHeightVisible = false;
+    bool isHeight2Visible = false;
     bool isTurnsVisible = false;
+    bool isTurns2Visible = false;
     bool isOutsideVisible = false;
     bool isAngleVisible = false;
     bool isGrowthVisible = false;
@@ -328,23 +359,29 @@ void TaskHelixParameters::adaptVisibilityToMode()
     }
 
     HelixMode mode = static_cast<HelixMode>(propMode->getValue());
+    const bool isTwoSided = static_cast<PartDesign::HelixSideMode>(propSideType->getValue())
+        == PartDesign::HelixSideMode::two_sides;
     if (mode == HelixMode::pitch_height_angle) {
         isPitchVisible = true;
         isHeightVisible = true;
+        isHeight2Visible = isTwoSided;
         isAngleVisible = true;
     }
     else if (mode == HelixMode::pitch_turns_angle) {
         isPitchVisible = true;
         isTurnsVisible = true;
+        isTurns2Visible = isTwoSided;
         isAngleVisible = true;
     }
     else if (mode == HelixMode::height_turns_angle) {
         isHeightVisible = true;
+        isHeight2Visible = isTwoSided;
         isTurnsVisible = true;
         isAngleVisible = true;
     }
     else if (mode == HelixMode::height_turns_growth) {
         isHeightVisible = true;
+        isHeight2Visible = isTwoSided;
         isTurnsVisible = true;
         isGrowthVisible = true;
     }
@@ -358,8 +395,14 @@ void TaskHelixParameters::adaptVisibilityToMode()
     ui->height->setVisible(isHeightVisible);
     ui->labelHeight->setVisible(isHeightVisible);
 
+    ui->height2->setVisible(isHeight2Visible);
+    ui->labelHeight2->setVisible(isHeight2Visible);
+
     ui->turns->setVisible(isTurnsVisible);
     ui->labelTurns->setVisible(isTurnsVisible);
+
+    ui->turns2->setVisible(isTurns2Visible);
+    ui->labelTurns2->setVisible(isTurns2Visible);
 
     ui->coneAngle->setVisible(isAngleVisible);
     ui->labelConeAngle->setVisible(isAngleVisible);
@@ -387,6 +430,10 @@ void TaskHelixParameters::assignToolTipsFromPropertyDocs()
     ui->inputMode->setToolTip(toolTip);
     ui->labelInputMode->setToolTip(toolTip);
 
+    toolTip = QApplication::translate(propCategory, helix->SideType.getDocumentation());
+    ui->sidesMode->setToolTip(toolTip);
+    ui->labelSideMode->setToolTip(toolTip);
+
     toolTip = QApplication::translate(propCategory, helix->Pitch.getDocumentation());
     ui->pitch->setToolTip(toolTip);
     ui->labelPitch->setToolTip(toolTip);
@@ -395,9 +442,17 @@ void TaskHelixParameters::assignToolTipsFromPropertyDocs()
     ui->height->setToolTip(toolTip);
     ui->labelHeight->setToolTip(toolTip);
 
+    toolTip = QApplication::translate(propCategory, helix->Height2.getDocumentation());
+    ui->height2->setToolTip(toolTip);
+    ui->labelHeight2->setToolTip(toolTip);
+
     toolTip = QApplication::translate(propCategory, helix->Turns.getDocumentation());
     ui->turns->setToolTip(toolTip);
     ui->labelTurns->setToolTip(toolTip);
+
+    toolTip = QApplication::translate(propCategory, helix->Turns2.getDocumentation());
+    ui->turns2->setToolTip(toolTip);
+    ui->labelTurns2->setToolTip(toolTip);
 
     toolTip = QApplication::translate(propCategory, helix->Angle.getDocumentation());
     ui->coneAngle->setToolTip(toolTip);
@@ -446,6 +501,19 @@ void TaskHelixParameters::onHeightChanged(double len)
         propHeight->setValue(len);
         recomputeFeature();
         updateUI();
+
+        setGizmoPositions();
+    }
+}
+
+void TaskHelixParameters::onHeight2Changed(double len)
+{
+    if (getObject()) {
+        propHeight2->setValue(len);
+        recomputeFeature();
+        updateUI();
+
+        setGizmoPositions();
     }
 }
 
@@ -453,6 +521,15 @@ void TaskHelixParameters::onTurnsChanged(double len)
 {
     if (getObject()) {
         propTurns->setValue(len);
+        recomputeFeature();
+        updateUI();
+    }
+}
+
+void TaskHelixParameters::onTurns2Changed(double len)
+{
+    if (getObject()) {
+        propTurns2->setValue(len);
         recomputeFeature();
         updateUI();
     }
@@ -549,12 +626,36 @@ void TaskHelixParameters::onModeChanged(int index)
 
     ui->pitch->setValue(propPitch->getValue());
     ui->height->setValue(propHeight->getValue());
+    ui->height2->setValue(propHeight2->getValue());
     ui->turns->setValue(propTurns->getValue());
+    ui->turns2->setValue(propTurns2->getValue());
     ui->coneAngle->setValue(propAngle->getValue());
     ui->growth->setValue(propGrowth->getValue());
 
     recomputeFeature();
     updateUI();
+
+    setGizmoPositions();
+}
+
+void TaskHelixParameters::onSidesModeChanged(int index)
+{
+    switch (static_cast<PartDesign::HelixSideMode>(index)) {
+        case PartDesign::HelixSideMode::one_side:
+            propSideType->setValue("One side");
+            break;
+        case PartDesign::HelixSideMode::two_sides:
+            propSideType->setValue("Two sides");
+            break;
+        case PartDesign::HelixSideMode::symmetric:
+            propSideType->setValue("Symmetric");
+            break;
+    }
+
+    recomputeFeature();
+    updateUI();
+
+    setGizmoPositions();
 }
 
 void TaskHelixParameters::onLeftHandedChanged(bool on)
@@ -614,8 +715,10 @@ void TaskHelixParameters::changeEvent(QEvent* e)
         // save current indexes
         int axis = ui->axis->currentIndex();
         int mode = ui->inputMode->currentIndex();
+        int sidesMode = ui->sidesMode->currentIndex();
         ui->retranslateUi(proxy);
         assignToolTipsFromPropertyDocs();
+        translateSidesList(sidesMode);
 
         // Axes added by the user cannot be restored
         fillAxisCombo(true);
@@ -704,10 +807,13 @@ void TaskHelixParameters::apply()  // NOLINT
     std::string axis = buildLinkSingleSubPythonStr(obj, sub);
     auto tobj = getObject();
     FCMD_OBJ_CMD(tobj, "ReferenceAxis = " << axis);
+    FCMD_OBJ_CMD(tobj, "SideType = " << propSideType->getValue());
     FCMD_OBJ_CMD(tobj, "Mode = " << propMode->getValue());
     FCMD_OBJ_CMD(tobj, "Pitch = " << propPitch->getValue());
     FCMD_OBJ_CMD(tobj, "Height = " << propHeight->getValue());
+    FCMD_OBJ_CMD(tobj, "Height2 = " << propHeight2->getValue());
     FCMD_OBJ_CMD(tobj, "Turns = " << propTurns->getValue());
+    FCMD_OBJ_CMD(tobj, "Turns2 = " << propTurns2->getValue());
     FCMD_OBJ_CMD(tobj, "Angle = " << propAngle->getValue());
     FCMD_OBJ_CMD(tobj, "Growth = " << propGrowth->getValue());
     FCMD_OBJ_CMD(tobj, "LeftHanded = " << (propLeftHanded->getValue() ? 1 : 0));
@@ -721,17 +827,19 @@ void TaskHelixParameters::setupGizmos(ViewProviderHelix* vp)
     }
 
     heightGizmo = new Gui::LinearGizmo(ui->height);
+    heightGizmo2 = new Gui::LinearGizmo(ui->height2);
 
     connect(ui->inputMode, qOverload<int>(&QComboBox::currentIndexChanged), [this](int index) {
-        bool isPitchTurnsAngle = index == static_cast<int>(HelixMode::pitch_turns_angle);
-        heightGizmo->setVisibility(!isPitchTurnsAngle);
+        (void)index;
+        setGizmoPositions();
+    });
+    connect(ui->sidesMode, qOverload<int>(&QComboBox::currentIndexChanged), [this](int) {
+        setGizmoPositions();
     });
 
-    gizmoContainer = GizmoContainer::create({heightGizmo}, vp);
+    gizmoContainer = GizmoContainer::create({heightGizmo, heightGizmo2}, vp);
 
     setGizmoPositions();
-
-    ui->inputMode->currentIndexChanged(ui->inputMode->currentIndex());
     showDraggerHints();
 }
 
@@ -748,9 +856,24 @@ void TaskHelixParameters::setGizmoPositions()
     }
     gizmoContainer->visible = true;
     Part::TopoShape profileShape = helix->getProfileShape();
+    const auto mode = static_cast<HelixMode>(propMode->getValue());
+    const auto sideMode = static_cast<PartDesign::HelixSideMode>(propSideType->getValue());
+    const bool usesHeight = mode != HelixMode::pitch_turns_angle;
+    const bool usesHeight2 = sideMode == PartDesign::HelixSideMode::two_sides
+        && (mode == HelixMode::pitch_height_angle || mode == HelixMode::height_turns_angle
+            || mode == HelixMode::height_turns_growth);
+
+    heightGizmo->setVisibility(usesHeight);
+    heightGizmo2->setVisibility(usesHeight2);
+    heightGizmo->setMultFactor(
+        sideMode == PartDesign::HelixSideMode::symmetric ? 0.5 : 1.0
+    );
+    heightGizmo2->setMultFactor(1.0);
+
     double reversed = propReversed->getValue() ? -1.0 : 1.0;
     auto profileCentre = getMidPointFromProfile(profileShape);
     Base::Vector3d axisDir = helix->Axis.getValue() * reversed;
+    Base::Vector3d axisDir2 = helix->Axis.getValue() * -reversed;
     Base::Vector3d basePos = helix->Base.getValue();
 
     // Project the centre point of the helix to a plane passing through the com of the profile
@@ -758,6 +881,7 @@ void TaskHelixParameters::setGizmoPositions()
     Base::Vector3d pos = basePos + axisDir.Dot(profileCentre - basePos) * axisDir;
 
     heightGizmo->Gizmo::setDraggerPlacement(pos, axisDir);
+    heightGizmo2->Gizmo::setDraggerPlacement(pos, axisDir2);
 }
 
 

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -865,9 +865,7 @@ void TaskHelixParameters::setGizmoPositions()
 
     heightGizmo->setVisibility(usesHeight);
     heightGizmo2->setVisibility(usesHeight2);
-    heightGizmo->setMultFactor(
-        sideMode == PartDesign::HelixSideMode::symmetric ? 0.5 : 1.0
-    );
+    heightGizmo->setMultFactor(sideMode == PartDesign::HelixSideMode::symmetric ? 0.5 : 1.0);
     heightGizmo2->setMultFactor(1.0);
 
     double reversed = propReversed->getValue() ? -1.0 : 1.0;

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.h
@@ -74,17 +74,21 @@ private:
     int addCurrentLink();
     void assignToolTipsFromPropertyDocs();
     void adaptVisibilityToMode();
+    void translateSidesList(int index);
 
 private Q_SLOTS:
     void onPitchChanged(double);
     void onHeightChanged(double);
+    void onHeight2Changed(double);
     void onTurnsChanged(double);
+    void onTurns2Changed(double);
     void onAngleChanged(double);
     void onGrowthChanged(double);
     void onAxisChanged(int);
     void onLeftHandedChanged(bool);
     void onReversedChanged(bool);
     void onModeChanged(int);
+    void onSidesModeChanged(int);
     void onOutsideChanged(bool);
 
 
@@ -99,13 +103,16 @@ protected:
     // mirrors of helixes's properties
     App::PropertyLength* propPitch;
     App::PropertyLength* propHeight;
+    App::PropertyLength* propHeight2;
     App::PropertyFloatConstraint* propTurns;
+    App::PropertyFloatConstraint* propTurns2;
     App::PropertyBool* propLeftHanded;
     App::PropertyBool* propReversed;
     App::PropertyLinkSub* propReferenceAxis;
     App::PropertyAngle* propAngle;
     App::PropertyDistance* propGrowth;
     App::PropertyEnumeration* propMode;
+    App::PropertyEnumeration* propSideType;
     App::PropertyBool* propOutside;
 
 
@@ -135,6 +142,7 @@ private:
 
     std::unique_ptr<Gui::GizmoContainer> gizmoContainer;
     Gui::LinearGizmo* heightGizmo = nullptr;
+    Gui::LinearGizmo* heightGizmo2 = nullptr;
     void setupGizmos(ViewProviderHelix* vp);
     void setGizmoPositions();
 };

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.ui
@@ -37,7 +37,7 @@
      <item>
       <widget class="QLabel" name="labelSideMode">
        <property name="text">
-        <string>Side mode</string>
+        <string>Sides</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.ui
@@ -33,6 +33,20 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutSideMode">
+     <item>
+      <widget class="QLabel" name="labelSideMode">
+       <property name="text">
+        <string>Side mode</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="sidesMode"/>
+     </item>
+    </layout>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLabel" name="labelAxis">
@@ -172,6 +186,30 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutHeight2">
+     <item>
+      <widget class="QLabel" name="labelHeight2">
+       <property name="text">
+        <string>Height 2</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::QuantitySpinBox" name="height2">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+       <property name="value">
+        <double>30.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayoutTurns">
      <item>
       <widget class="QLabel" name="labelTurns">
@@ -182,6 +220,30 @@
      </item>
      <item>
       <widget class="Gui::QuantitySpinBox" name="turns">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>3.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutTurns2">
+     <item>
+      <widget class="QLabel" name="labelTurns2">
+       <property name="text">
+        <string>Turns 2</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::QuantitySpinBox" name="turns2">
        <property name="keyboardTracking">
         <bool>false</bool>
        </property>
@@ -303,11 +365,14 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>sidesMode</tabstop>
   <tabstop>axis</tabstop>
   <tabstop>inputMode</tabstop>
   <tabstop>pitch</tabstop>
   <tabstop>height</tabstop>
+  <tabstop>height2</tabstop>
   <tabstop>turns</tabstop>
+  <tabstop>turns2</tabstop>
   <tabstop>coneAngle</tabstop>
   <tabstop>growth</tabstop>
   <tabstop>checkBoxLeftHanded</tabstop>

--- a/src/Mod/PartDesign/PartDesignTests/TestHelix.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestHelix.py
@@ -40,33 +40,6 @@ class TestHelix(unittest.TestCase):
     def setUp(self):
         self.Doc = FreeCAD.newDocument("PartDesignTestHelix")
 
-    def createRectangleHelix(self, bodyName):
-        body = self.Doc.addObject("PartDesign::Body", bodyName)
-        sketch = self.Doc.addObject("Sketcher::SketchObject", bodyName + "Sketch")
-        body.addObject(sketch)
-        TestSketcherApp.CreateRectangleSketch(sketch, (0, 0), (5, 5))
-        self.Doc.recompute()
-
-        helix = self.Doc.addObject("PartDesign::AdditiveHelix", bodyName + "Helix")
-        body.addObject(helix)
-        helix.Profile = sketch
-        helix.ReferenceAxis = (sketch, "V_Axis")
-        helix.Placement = FreeCAD.Placement(
-            FreeCAD.Vector(0, 0, 0),
-            FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), 0),
-            FreeCAD.Vector(0, 0, 0),
-        )
-        helix.Pitch = 50
-        helix.Height = 150
-        helix.Turns = 3
-        helix.Angle = 0
-        helix.Mode = 0
-        return helix
-
-    def assertBoundBoxesAlmostEqual(self, first, second):
-        for attr in ("XMin", "XMax", "YMin", "YMax", "ZMin", "ZMax"):
-            self.assertAlmostEqual(getattr(first, attr), getattr(second, attr), places=6)
-
     def testHelicalTubeCase(self):
         body = self.Doc.addObject("PartDesign::Body", "Body")
         sketch = body.newObject("Sketcher::SketchObject", "Sketch")
@@ -97,99 +70,6 @@ class TestHelix(unittest.TestCase):
 
         self.Doc.recompute()
         self.assertEqual(len(helix.Shape.Solids), 1)
-
-    def testNegativeHeightActsAsReverse(self):
-        """Test negative height produces the same shape as reversed"""
-        negative = self.createRectangleHelix("NegativeHeightBody")
-        negative.Height = -150
-        negative.Reversed = False
-
-        reversedHelix = self.createRectangleHelix("ReversedHeightBody")
-        reversedHelix.Height = 150
-        reversedHelix.Reversed = True
-
-        self.Doc.recompute()
-        self.assertAlmostEqual(negative.Shape.Volume, reversedHelix.Shape.Volume, places=6)
-        self.assertBoundBoxesAlmostEqual(negative.Shape.BoundBox, reversedHelix.Shape.BoundBox)
-
-    def testTwoSidedPitchHeightAngle(self):
-        """Test two-sided helix in pitch-height-angle mode"""
-        helix = self.createRectangleHelix("TwoSidedPitchHeightBody")
-        helix.SideType = "Two sides"
-        helix.Mode = 0
-        helix.Pitch = 50
-        helix.Height = 150
-        helix.Height2 = 100
-        self.Doc.recompute()
-
-        self.assertAlmostEqual(helix.Turns, 3)
-        self.assertAlmostEqual(helix.Turns2, 2)
-        self.assertLess(helix.Shape.BoundBox.YMin, 0)
-        self.assertGreater(helix.Shape.BoundBox.YMax, 0)
-        self.assertAlmostEqual(helix.Shape.Volume, pi * 25 * 5 * 5, places=2)
-
-    def testTwoSidedPitchTurnsAngle(self):
-        """Test two-sided helix in pitch-turns-angle mode"""
-        helix = self.createRectangleHelix("TwoSidedPitchTurnsBody")
-        helix.SideType = "Two sides"
-        helix.Mode = 1
-        helix.Pitch = 50
-        helix.Turns = 3
-        helix.Turns2 = 2
-        self.Doc.recompute()
-
-        self.assertAlmostEqual(helix.Height, 150)
-        self.assertAlmostEqual(helix.Height2, 100)
-        self.assertLess(helix.Shape.BoundBox.YMin, 0)
-        self.assertGreater(helix.Shape.BoundBox.YMax, 0)
-        self.assertAlmostEqual(helix.Shape.Volume, pi * 25 * 5 * 5, places=2)
-
-    def testTwoSidedHeightTurnsAngleUsesTotalTurns(self):
-        """Test two-sided height-turns-angle uses turns across both sides"""
-        helix = self.createRectangleHelix("TwoSidedHeightTurnsBody")
-        helix.SideType = "Two sides"
-        helix.Mode = 2
-        helix.Height = 150
-        helix.Height2 = 100
-        helix.Turns = 5
-        self.Doc.recompute()
-
-        self.assertAlmostEqual(helix.Pitch, 50)
-        self.assertAlmostEqual(helix.Turns2, 2)
-        self.assertAlmostEqual(helix.Shape.Volume, pi * 25 * 5 * 5, places=2)
-
-    def testTwoSidedAngleShrinksSecondSide(self):
-        """Test two-sided cone angle uses opposite growth for the second side"""
-        twoSided = self.createRectangleHelix("TwoSidedAngleBody")
-        twoSided.SideType = "Two sides"
-        twoSided.Mode = 0
-        twoSided.Pitch = 50
-        twoSided.Height = 100
-        twoSided.Height2 = 100
-        twoSided.Angle = 20
-
-        symmetric = self.createRectangleHelix("SymmetricAngleBody")
-        symmetric.SideType = "Symmetric"
-        symmetric.Mode = 0
-        symmetric.Pitch = 50
-        symmetric.Height = 200
-        symmetric.Angle = 20
-
-        self.Doc.recompute()
-        self.assertLess(twoSided.Shape.Volume, symmetric.Shape.Volume)
-
-    def testSymmetricPitchHeightAngle(self):
-        """Test symmetric helix in pitch-height-angle mode"""
-        helix = self.createRectangleHelix("SymmetricPitchHeightBody")
-        helix.SideType = "Symmetric"
-        helix.Mode = 0
-        helix.Pitch = 50
-        helix.Height = 150
-        self.Doc.recompute()
-
-        self.assertLess(helix.Shape.BoundBox.YMin, 0)
-        self.assertGreater(helix.Shape.BoundBox.YMax, 0)
-        self.assertAlmostEqual(helix.Shape.Volume, pi * 25 * 5 * 3, places=2)
 
     def testCircleQ1(self):
         """Test helix based on circle in Quadrant 1"""

--- a/src/Mod/PartDesign/PartDesignTests/TestHelix.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestHelix.py
@@ -40,6 +40,33 @@ class TestHelix(unittest.TestCase):
     def setUp(self):
         self.Doc = FreeCAD.newDocument("PartDesignTestHelix")
 
+    def createRectangleHelix(self, bodyName):
+        body = self.Doc.addObject("PartDesign::Body", bodyName)
+        sketch = self.Doc.addObject("Sketcher::SketchObject", bodyName + "Sketch")
+        body.addObject(sketch)
+        TestSketcherApp.CreateRectangleSketch(sketch, (0, 0), (5, 5))
+        self.Doc.recompute()
+
+        helix = self.Doc.addObject("PartDesign::AdditiveHelix", bodyName + "Helix")
+        body.addObject(helix)
+        helix.Profile = sketch
+        helix.ReferenceAxis = (sketch, "V_Axis")
+        helix.Placement = FreeCAD.Placement(
+            FreeCAD.Vector(0, 0, 0),
+            FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), 0),
+            FreeCAD.Vector(0, 0, 0),
+        )
+        helix.Pitch = 50
+        helix.Height = 150
+        helix.Turns = 3
+        helix.Angle = 0
+        helix.Mode = 0
+        return helix
+
+    def assertBoundBoxesAlmostEqual(self, first, second):
+        for attr in ("XMin", "XMax", "YMin", "YMax", "ZMin", "ZMax"):
+            self.assertAlmostEqual(getattr(first, attr), getattr(second, attr), places=6)
+
     def testHelicalTubeCase(self):
         body = self.Doc.addObject("PartDesign::Body", "Body")
         sketch = body.newObject("Sketcher::SketchObject", "Sketch")
@@ -70,6 +97,99 @@ class TestHelix(unittest.TestCase):
 
         self.Doc.recompute()
         self.assertEqual(len(helix.Shape.Solids), 1)
+
+    def testNegativeHeightActsAsReverse(self):
+        """Test negative height produces the same shape as reversed"""
+        negative = self.createRectangleHelix("NegativeHeightBody")
+        negative.Height = -150
+        negative.Reversed = False
+
+        reversedHelix = self.createRectangleHelix("ReversedHeightBody")
+        reversedHelix.Height = 150
+        reversedHelix.Reversed = True
+
+        self.Doc.recompute()
+        self.assertAlmostEqual(negative.Shape.Volume, reversedHelix.Shape.Volume, places=6)
+        self.assertBoundBoxesAlmostEqual(negative.Shape.BoundBox, reversedHelix.Shape.BoundBox)
+
+    def testTwoSidedPitchHeightAngle(self):
+        """Test two-sided helix in pitch-height-angle mode"""
+        helix = self.createRectangleHelix("TwoSidedPitchHeightBody")
+        helix.SideType = "Two sides"
+        helix.Mode = 0
+        helix.Pitch = 50
+        helix.Height = 150
+        helix.Height2 = 100
+        self.Doc.recompute()
+
+        self.assertAlmostEqual(helix.Turns, 3)
+        self.assertAlmostEqual(helix.Turns2, 2)
+        self.assertLess(helix.Shape.BoundBox.YMin, 0)
+        self.assertGreater(helix.Shape.BoundBox.YMax, 0)
+        self.assertAlmostEqual(helix.Shape.Volume, pi * 25 * 5 * 5, places=2)
+
+    def testTwoSidedPitchTurnsAngle(self):
+        """Test two-sided helix in pitch-turns-angle mode"""
+        helix = self.createRectangleHelix("TwoSidedPitchTurnsBody")
+        helix.SideType = "Two sides"
+        helix.Mode = 1
+        helix.Pitch = 50
+        helix.Turns = 3
+        helix.Turns2 = 2
+        self.Doc.recompute()
+
+        self.assertAlmostEqual(helix.Height, 150)
+        self.assertAlmostEqual(helix.Height2, 100)
+        self.assertLess(helix.Shape.BoundBox.YMin, 0)
+        self.assertGreater(helix.Shape.BoundBox.YMax, 0)
+        self.assertAlmostEqual(helix.Shape.Volume, pi * 25 * 5 * 5, places=2)
+
+    def testTwoSidedHeightTurnsAngleUsesTotalTurns(self):
+        """Test two-sided height-turns-angle uses turns across both sides"""
+        helix = self.createRectangleHelix("TwoSidedHeightTurnsBody")
+        helix.SideType = "Two sides"
+        helix.Mode = 2
+        helix.Height = 150
+        helix.Height2 = 100
+        helix.Turns = 5
+        self.Doc.recompute()
+
+        self.assertAlmostEqual(helix.Pitch, 50)
+        self.assertAlmostEqual(helix.Turns2, 2)
+        self.assertAlmostEqual(helix.Shape.Volume, pi * 25 * 5 * 5, places=2)
+
+    def testTwoSidedAngleShrinksSecondSide(self):
+        """Test two-sided cone angle uses opposite growth for the second side"""
+        twoSided = self.createRectangleHelix("TwoSidedAngleBody")
+        twoSided.SideType = "Two sides"
+        twoSided.Mode = 0
+        twoSided.Pitch = 50
+        twoSided.Height = 100
+        twoSided.Height2 = 100
+        twoSided.Angle = 20
+
+        symmetric = self.createRectangleHelix("SymmetricAngleBody")
+        symmetric.SideType = "Symmetric"
+        symmetric.Mode = 0
+        symmetric.Pitch = 50
+        symmetric.Height = 200
+        symmetric.Angle = 20
+
+        self.Doc.recompute()
+        self.assertLess(twoSided.Shape.Volume, symmetric.Shape.Volume)
+
+    def testSymmetricPitchHeightAngle(self):
+        """Test symmetric helix in pitch-height-angle mode"""
+        helix = self.createRectangleHelix("SymmetricPitchHeightBody")
+        helix.SideType = "Symmetric"
+        helix.Mode = 0
+        helix.Pitch = 50
+        helix.Height = 150
+        self.Doc.recompute()
+
+        self.assertLess(helix.Shape.BoundBox.YMin, 0)
+        self.assertGreater(helix.Shape.BoundBox.YMax, 0)
+        self.assertAlmostEqual(helix.Shape.Volume, pi * 25 * 5 * 3, places=2)
 
     def testCircleQ1(self):
         """Test helix based on circle in Quadrant 1"""


### PR DESCRIPTION
Please squash.
Fix https://github.com/FreeCAD/FreeCAD/issues/20104

This PR adds the same Sides modes combobox (1 side, 2 sides, symmetric) to the helix tools.

<img width="1170" height="705" alt="image" src="https://github.com/user-attachments/assets/207853af-4142-4826-b47a-b2ed91d53515" />
