### PR TITLE
Build: Silence spam from translation system during build

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupQt.cmake
+++ b/cMake/FreeCAD_Helpers/SetupQt.cmake
@@ -103,7 +103,7 @@ configure_file(${CMAKE_SOURCE_DIR}/src/QtWidgets.h.cmake ${CMAKE_BINARY_DIR}/src
 function(qt_find_and_add_translation _qm_files _tr_dir _qm_dir)
     file(GLOB _ts_files ${_tr_dir})
     set_source_files_properties(${_ts_files} PROPERTIES OUTPUT_LOCATION ${_qm_dir})
-    qt_add_translation("${_qm_files}" ${_ts_files})
+    qt_add_translation("${_qm_files}" ${_ts_files} OPTIONS -silent)
     set("${_qm_files}" "${${_qm_files}}" PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
During a Ninja build, we get nice compact output, making it clear when there is a compiler warning or error... right up until you hit translation code. Then you get spammed by Qt's translation code with status messages that you don't need and don't care about. This eliminates those.

Before:
```
[3211/5427] Generating Language/FreeCAD_fi.qm
Updating '/Users/chennes/Documents/FreeCAD/build/release/src/Gui/Language/FreeCAD_fi.qm'...
    Generated 2613 translation(s) (1602 finished and 1011 unfinished)
```

After:
```
[3211/5427] Generating Language/FreeCAD_fi.qm
```

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.