### PR TITLE
Sketcher: harden OVP input against invalid view projection

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchControllableHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchControllableHandler.h
@@ -85,7 +85,9 @@ public:
         Base::Vector2d onSketchPos = snapHandle.compute();
         toolWidgetManager.mouseMoved(onSketchPos);
 
-        toolWidgetManager.enforceControlParameters(onSketchPos);
+        if (!toolWidgetManager.enforceControlParameters(onSketchPos)) {
+            return;
+        }
         updateDataAndDrawToPosition(onSketchPos);
         toolWidgetManager.adaptParameters(onSketchPos);
     }
@@ -95,7 +97,9 @@ public:
         // ensure controller state is initialized even if no mouseMove occurred
         // ie. when a modal dialog blocks input before the first click
         toolWidgetManager.mouseMoved(onSketchPos);
-        toolWidgetManager.enforceControlParameters(onSketchPos);
+        if (!toolWidgetManager.enforceControlParameters(onSketchPos)) {
+            return false;
+        }
         updateDataAndDrawToPosition(onSketchPos);
         toolWidgetManager.adaptParameters(onSketchPos);
 

--- a/src/Mod/Sketcher/Gui/DrawSketchController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchController.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <cmath>
+
 #include <Base/Console.h>
 #include <Base/Tools2D.h>
 #include <Gui/EditableDatumLabel.h>
@@ -286,16 +288,20 @@ public:
     }
 
     /** @brief function triggered by the handler to ensure its operating position takes into
-     * account widget mandated parameters */
-    void enforceControlParameters(Base::Vector2d& onSketchPos)
+     * account widget mandated parameters. Returns false if the enforced position is not finite. */
+    bool enforceControlParameters(Base::Vector2d& onSketchPos)
     {
-        prevCursorPosition = onSketchPos;
-
         doEnforceControlParameters(onSketchPos);  // specialisation interface
 
+        if (!isFiniteSketchPosition(onSketchPos)) {
+            return false;
+        }
+
+        prevCursorPosition = onSketchPos;
         lastControlEnforcedPosition = onSketchPos;  // store enforced cursor position.
 
         afterEnforceControlParameters();  // NVI
+        return true;
     }
 
     /** function that is called by the handler when the construction mode changed */
@@ -878,6 +884,11 @@ private:
         return (ovpVisibilityManager.isVisibility(
             OnViewParameterVisibilityManager::OnViewParameterVisibility::Hidden
         ));
+    }
+
+    static bool isFiniteSketchPosition(const Base::Vector2d& onSketchPos)
+    {
+        return std::isfinite(onSketchPos.x) && std::isfinite(onSketchPos.y);
     }
     //@}
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cmath>
+
 #include <QApplication>
 
 #include <Gui/BitmapFactory.h>
@@ -499,6 +501,15 @@ private:
             firstCurve = getHighestCurveIndex() + 1;
 
             createShape(false);
+            if (ShapeGeometry.empty()) {
+                THROWM(
+                    Base::ValueError,
+                    QT_TRANSLATE_NOOP(
+                        "Notifications",
+                        "Cannot create a rectangle with zero length or width"
+                    ) "\n"
+                );
+            }
 
             openCommand(QT_TRANSLATE_NOOP("Command", "Add sketch box"));
 
@@ -824,8 +835,7 @@ private:
 
     bool canGoToNextMode() override
     {
-        if (state() == SelectMode::SeekSecond
-            && (length < Precision::Confusion() || width < Precision::Confusion())) {
+        if (state() == SelectMode::SeekSecond && !updateRectangleMetrics()) {
             return false;
         }
 
@@ -900,11 +910,7 @@ private:
 
         Base::Vector2d vecL = corner2 - corner1;
         Base::Vector2d vecW = corner4 - corner1;
-        length = vecL.Length();
-        width = vecW.Length();
-        angle = vecL.Angle();
-        if (length < Precision::Confusion() || width < Precision::Confusion()
-            || fmod(fabs(angle123), std::numbers::pi) < Precision::Confusion()) {
+        if (!updateRectangleMetrics()) {
             return;
         }
 
@@ -935,6 +941,29 @@ private:
                 finishRectangleCreation(thicknessNotZero);
             }
         }
+    }
+
+    bool updateRectangleMetrics()
+    {
+        Base::Vector2d vecL = corner2 - corner1;
+        Base::Vector2d vecW = corner4 - corner1;
+
+        length = vecL.Length();
+        width = vecW.Length();
+        angle = vecL.Angle();
+
+        auto isFinite = [](const Base::Vector2d& point) {
+            return std::isfinite(point.x) && std::isfinite(point.y);
+        };
+        auto hasNonDegenerateAngle = [](double angle) {
+            return std::isfinite(angle)
+                && fmod(fabs(angle), std::numbers::pi) >= Precision::Confusion();
+        };
+
+        return isFinite(corner1) && isFinite(corner2) && isFinite(corner3) && isFinite(corner4)
+            && std::isfinite(length) && std::isfinite(width) && std::isfinite(angle)
+            && length >= Precision::Confusion() && width >= Precision::Confusion()
+            && hasNonDegenerateAngle(angle123) && hasNonDegenerateAngle(angle412);
     }
 
     void createFirstRectangleGeometries(Base::Vector2d vecL, Base::Vector2d vecW, double L1, double L2)
@@ -2831,6 +2860,10 @@ void DSHRectangleController::computeNextDrawSketchHandlerMode()
         case SelectMode::SeekSecond: {
             if (onViewParameters[OnViewParameter::Third]->hasFinishedEditing
                 && onViewParameters[OnViewParameter::Fourth]->hasFinishedEditing) {
+
+                if (!handler->canGoToNextMode()) {
+                    return;
+                }
 
                 if (handler->roundCorners || handler->makeFrame
                     || handler->constructionMethod() == ConstructionMethod::ThreePoints

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -113,6 +113,19 @@ using namespace SketcherGui;
 using namespace Sketcher;
 namespace sp = std::placeholders;
 
+namespace
+{
+bool isFiniteVector(const SbVec3f& vector)
+{
+    return std::isfinite(vector[0]) && std::isfinite(vector[1]) && std::isfinite(vector[2]);
+}
+
+bool isFiniteVector(const Base::Vector3d& vector)
+{
+    return std::isfinite(vector.x) && std::isfinite(vector.y) && std::isfinite(vector.z);
+}
+}  // namespace
+
 /************** ViewProviderSketch::ParameterObserver *********************/
 
 template<typename T>
@@ -1078,11 +1091,19 @@ void ViewProviderSketch::setAngleSnapping(bool enable, Base::Vector2d referenceP
     snapManager->setAngleSnapping(enable, referencePoint);
 }
 
-void ViewProviderSketch::getProjectingLine(const SbVec2s& pnt,
+bool ViewProviderSketch::getProjectingLine(const SbVec2s& pnt,
                                            const Gui::View3DInventorViewer* viewer,
                                            SbLine& line) const
 {
+    if (!viewer || !viewer->getSoRenderManager()) {
+        return false;
+    }
+
     const SbViewportRegion& vp = viewer->getSoRenderManager()->getViewportRegion();
+    const SbVec2s viewportPixels = vp.getViewportSizePixels();
+    if (viewportPixels[0] <= 0 || viewportPixels[1] <= 0) {
+        return false;
+    }
 
     short x, y;
     pnt.getValue(x, y);
@@ -1091,8 +1112,13 @@ void ViewProviderSketch::getProjectingLine(const SbVec2s& pnt,
     VPsize.getValue(dX, dY);
 
     float fRatio = vp.getViewportAspectRatio();
-    float pX = (float)x / float(vp.getViewportSizePixels()[0]);
-    float pY = (float)y / float(vp.getViewportSizePixels()[1]);
+    if (!std::isfinite(dX) || !std::isfinite(dY) || !std::isfinite(fRatio)
+        || fRatio <= std::numeric_limits<float>::epsilon()) {
+        return false;
+    }
+
+    float pX = static_cast<float>(x) / static_cast<float>(viewportPixels[0]);
+    float pY = static_cast<float>(y) / static_cast<float>(viewportPixels[1]);
 
     // now calculate the real points respecting aspect ratio information
     //
@@ -1103,12 +1129,19 @@ void ViewProviderSketch::getProjectingLine(const SbVec2s& pnt,
         pY = (pY - 0.5f * dY) / fRatio + 0.5f * dY;
     }
 
+    if (!std::isfinite(pX) || !std::isfinite(pY)) {
+        return false;
+    }
+
     SoCamera* pCam = viewer->getSoRenderManager()->getCamera();
-    if (!pCam)
-        return;
+    if (!pCam) {
+        return false;
+    }
+
     SbViewVolume vol = pCam->getViewVolume();
 
     vol.projectPointToLine(SbVec2f(pX, pY), line);
+    return isFiniteVector(line.getPosition()) && isFiniteVector(line.getDirection());
 }
 
 Base::Placement ViewProviderSketch::getEditingPlacement() const
@@ -1124,9 +1157,13 @@ Base::Placement ViewProviderSketch::getEditingPlacement() const
     return Base::Placement(editDoc->getEditingTransform());
 }
 
-void ViewProviderSketch::getCoordsOnSketchPlane(const SbVec3f& point, const SbVec3f& normal,
+bool ViewProviderSketch::getCoordsOnSketchPlane(const SbVec3f& point, const SbVec3f& normal,
                                                 double& u, double& v) const
 {
+    if (!isFiniteVector(point) || !isFiniteVector(normal)) {
+        return false;
+    }
+
     // Plane form
     Base::Vector3d R0(0, 0, 0), RN(0, 0, 1), RX(1, 0, 0), RY(0, 1, 0);
 
@@ -1141,16 +1178,36 @@ void ViewProviderSketch::getCoordsOnSketchPlane(const SbVec3f& point, const SbVe
 
     // line
     Base::Vector3d R1(point[0], point[1], point[2]), RA(normal[0], normal[1], normal[2]);
-    if (fabs(RN * RA) < std::numeric_limits<float>::epsilon())
-        throw Base::ZeroDivisionError("View direction is parallel to sketch plane");
+    if (!isFiniteVector(R0) || !isFiniteVector(RN) || !isFiniteVector(RX) || !isFiniteVector(RY)
+        || !isFiniteVector(R1) || !isFiniteVector(RA)) {
+        return false;
+    }
+
+    const double denominator = RN * RA;
+    if (!std::isfinite(denominator) || fabs(denominator) < std::numeric_limits<float>::epsilon()) {
+        return false;
+    }
+
     // intersection point on plane
-    Base::Vector3d S = R1 + ((RN * (R0 - R1)) / (RN * RA)) * RA;
+    const double distance = (RN * (R0 - R1)) / denominator;
+    if (!std::isfinite(distance)) {
+        return false;
+    }
+
+    Base::Vector3d S = R1 + distance * RA;
+    if (!isFiniteVector(S)) {
+        return false;
+    }
 
     // distance to x Axle of the sketch
     S.TransformToCoordinateSystem(R0, RX, RY);
+    if (!isFiniteVector(S)) {
+        return false;
+    }
 
     u = S.x;
     v = S.y;
+    return std::isfinite(u) && std::isfinite(v);
 }
 
 bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVec2s& cursorPos,
@@ -1163,7 +1220,9 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
 
     // Calculate 3d point to the mouse position
     SbLine line;
-    getProjectingLine(cursorPos, viewer, line);
+    if (!getProjectingLine(cursorPos, viewer, line)) {
+        return false;
+    }
     SbVec3f point = line.getPosition();
     SbVec3f normal = line.getDirection();
 
@@ -1196,13 +1255,10 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
     const bool hasSelectionPoint = resolvedClickResult.hasPickedPoint() || static_cast<bool>(pp);
 
     std::unique_ptr<SnapManager::SnapHandle> snapHandle;
-    try {
-        getCoordsOnSketchPlane(pos, normal, x, y);
-        snapHandle = std::make_unique<SnapManager::SnapHandle>(snapManager.get(), Base::Vector2d(x, y));
-    }
-    catch (const Base::ZeroDivisionError&) {
+    if (!getCoordsOnSketchPlane(pos, normal, x, y)) {
         return false;
     }
+    snapHandle = std::make_unique<SnapManager::SnapHandle>(snapManager.get(), Base::Vector2d(x, y));
 
     // Left Mouse button ****************************************************
     if (Button == 1) {
@@ -1751,17 +1807,16 @@ bool ViewProviderSketch::mouseMove(const SbVec2s& cursorPos, Gui::View3DInventor
 
     // Calculate 3d point to the mouse position
     SbLine line;
-    getProjectingLine(cursorPos, viewer, line);
-
-    std::unique_ptr<SnapManager::SnapHandle> snapHandle;
-    try {
-        double x, y;
-        getCoordsOnSketchPlane(line.getPosition(), line.getDirection(), x, y);
-        snapHandle = std::make_unique<SnapManager::SnapHandle>(snapManager.get(), Base::Vector2d(x, y));
-    }
-    catch (const Base::ZeroDivisionError&) {
+    if (!getProjectingLine(cursorPos, viewer, line)) {
         return false;
     }
+
+    std::unique_ptr<SnapManager::SnapHandle> snapHandle;
+    double x, y;
+    if (!getCoordsOnSketchPlane(line.getPosition(), line.getDirection(), x, y)) {
+        return false;
+    }
+    snapHandle = std::make_unique<SnapManager::SnapHandle>(snapManager.get(), Base::Vector2d(x, y));
 
     bool preselectChanged = false;
     if (Mode != STATUS_SELECT_Point && Mode != STATUS_SELECT_Edge
@@ -1966,20 +2021,35 @@ void ViewProviderSketch::initDragging(int geoId, Sketcher::PointPos pos, Gui::Vi
     }
     dragAutoConstraintHandler->initDragging(drag.Dragged);
 
+    auto cancelDrag = [&]() {
+        if (dragAutoConstraintHandler) {
+            dragAutoConstraintHandler->clear();
+        }
+        drag.reset();
+        setSketchMode(STATUS_NONE);
+    };
+
     auto setRelative = [&]() {
         drag.relative = true;
 
         // Calculate the click position and use it as the initial point
         SbLine line2;
-        getProjectingLine(DoubleClick::prvCursorPos, viewer, line2);
+        if (!getProjectingLine(DoubleClick::prvCursorPos, viewer, line2)) {
+            cancelDrag();
+            return false;
+        }
 
         double x, y;
-        getCoordsOnSketchPlane(line2.getPosition(), line2.getDirection(), x, y);
+        if (!getCoordsOnSketchPlane(line2.getPosition(), line2.getDirection(), x, y)) {
+            cancelDrag();
+            return false;
+        }
 
         auto snapHandle = std::make_unique<SnapManager::SnapHandle>(snapManager.get(), Base::Vector2d(x, y));
         Base::Vector2d snappedPos = snapHandle->compute();
         drag.xInit = snappedPos.x;
         drag.yInit = snappedPos.y;
+        return true;
     };
 
     if (drag.Dragged.size() == 1 && pos == Sketcher::PointPos::none) {
@@ -2056,7 +2126,9 @@ void ViewProviderSketch::initDragging(int geoId, Sketcher::PointPos pos, Gui::Vi
         if (geo->is<Part::GeomLineSegment>() || geo->is<Part::GeomBSplineCurve>()
             || isEllipse(*geo) || isArcOfEllipse(*geo)
             || isArcOfHyperbola(*geo) || isArcOfParabola(*geo)) {
-            setRelative();
+            if (!setRelative()) {
+                return;
+            }
         }
 
         if (geo->is<Part::GeomBSplineCurve>()) {
@@ -2069,7 +2141,9 @@ void ViewProviderSketch::initDragging(int geoId, Sketcher::PointPos pos, Gui::Vi
         }
     }
     else if (drag.Dragged.size() > 1) {
-        setRelative();
+        if (!setRelative()) {
+            return;
+        }
     }
 
     getSketchObject()->initTemporaryMove(drag.Dragged, false);
@@ -5074,17 +5148,13 @@ double ViewProviderSketch::getRotation(SbVec3f pos0, SbVec3f pos1) const
     if (!pCam)
         return 0;
 
-    try {
-        SbViewVolume vol = pCam->getViewVolume();
-
-        getCoordsOnSketchPlane(pos0, vol.getProjectionDirection(), x0, y0);
-        getCoordsOnSketchPlane(pos1, vol.getProjectionDirection(), x1, y1);
-
-        return Base::toDegrees(-atan2((y1 - y0), (x1 - x0)));
-    }
-    catch (const Base::ZeroDivisionError&) {
+    SbViewVolume vol = pCam->getViewVolume();
+    if (!getCoordsOnSketchPlane(pos0, vol.getProjectionDirection(), x0, y0)
+        || !getCoordsOnSketchPlane(pos1, vol.getProjectionDirection(), x1, y1)) {
         return 0;
     }
+
+    return Base::toDegrees(-atan2((y1 - y0), (x1 - x0)));
 }
 
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -835,10 +835,11 @@ private:
     /** @name geometry and coordinates auxiliary functions */
     //@{
     /// give the coordinates of a line on the sketch plane in sketcher (2D) coordinates
-    void getCoordsOnSketchPlane(const SbVec3f& point, const SbVec3f& normal, double& u, double& v) const;
+    /// returns false when the input cannot produce finite sketch coordinates
+    bool getCoordsOnSketchPlane(const SbVec3f& point, const SbVec3f& normal, double& u, double& v) const;
 
-    /// give projecting line of position
-    void getProjectingLine(const SbVec2s&, const Gui::View3DInventorViewer* viewer, SbLine&) const;
+    /// give projecting line of position, returns false for invalid view projection state
+    bool getProjectingLine(const SbVec2s&, const Gui::View3DInventorViewer* viewer, SbLine&) const;
     //@}
 
     /** @name preselection functions */

--- a/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
@@ -89,24 +89,47 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
 
         view = FreeCADGui.ActiveDocument.ActiveView
         view.viewTop()
+        view.fitAll()
         self.pump(100)
 
         viewport = view.graphicsView().viewport()
-        first_point = self.viewport_to_qpoint(
-            view, viewport, view.getPointOnScreen(FreeCAD.Vector(0, 0, 0))
-        )
-        self.assertTrue(
-            viewport.rect().contains(first_point),
-            f"Expected {first_point} to fall inside the sketch viewport {viewport.rect()}",
-        )
+        origin = FreeCAD.Vector(0, 0, 0)
+
+        def wait_for_origin_point():
+            first_point = None
+
+            def origin_is_framed():
+                nonlocal first_point
+
+                width, height = view.getSize()
+                if width <= 0 or height <= 0:
+                    return False
+
+                view.fitAll()
+                point = self.viewport_to_qpoint(view, viewport, view.getPointOnScreen(origin))
+                interior_rect = viewport.rect().adjusted(20, 20, -20, -20)
+                if not interior_rect.contains(point):
+                    return False
+
+                first_point = point
+                return True
+
+            self.assertTrue(
+                self.wait_until(origin_is_framed, timeout_ms=5000, step_ms=100),
+                "Expected the sketch origin to project to an interior viewport point",
+            )
+            self.assertIsNotNone(first_point)
+            return first_point
+
+        FreeCADGui.runCommand("Sketcher_CreateRectangle")
+        self.pump(250)
+
+        first_point = wait_for_origin_point()
 
         move_target = self.clamp_to_widget(
             viewport,
             QtCore.QPoint(first_point.x() + 80, first_point.y() - 60),
         )
-
-        FreeCADGui.runCommand("Sketcher_CreateRectangle")
-        self.pump(250)
 
         self.move(viewport, first_point)
         self.click(viewport, first_point)


### PR DESCRIPTION
## Problem

The rectangle OVP acceptance test has been failing intermittently in CI, for example in the `test_rectangle_ovp_enter_finishes_without_crash` failure from the PR #31061 workflow run:

https://github.com/FreeCAD/FreeCAD/actions/runs/28428002398?pr=31061

The failure was not caused by rectangle command creation alone. In full GUI test execution, the active 3D view can briefly have an invalid camera/projection state. When the rectangle test synthesized mouse input during that window, sketch-plane projection produced non-finite coordinates, so accepting the width/height OVPs did not create the expected rectangle.

## Solution

This hardens the flow at the source instead of masking it in the rectangle tool:

- Reject invalid view projection results before constructing `SnapHandle` objects.
- Stop controllable draw handlers when enforced sketch positions are non-finite.
- Validate rectangle metrics before advancing from OVP input or committing geometry.
- Update the rectangle OVP GUI test to wait until the sketch origin projects to an interior viewport point before clicking.
- Fix OVP text entry so first typed input replaces the formatted initial spinbox value instead of appending to it.

## Why This Shape

A rectangle-specific fallback to `(0, 0)` would make the CI test pass, but it would hide the actual bad state and could create geometry at an arbitrary origin. Ignoring invalid projection input at the view-provider boundary is safer and applies to other sketch tools too.

The test now also waits for the GUI camera/view readiness that real mouse input depends on, making it less sensitive to full-suite timing.

