### PR TITLE
Fix Backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -38,6 +38,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.GH_TOKEN_FOR_CI_RUNNERS }}
+          repository: ${{ github.event.pull_request.base.repo.full_name }}
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Create backport pull requests
         uses: korthout/backport-action@66065406958f46e82238fd59546f5a99e69e22aa # v4.5.2


### PR DESCRIPTION
Fix backport action which fails on every PR.
Now it explicitly checks out the trusted base repo/ref which should satisfy checkout action without using allow-unsafe-pr-checkout: true (which would make it run too).
See https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target