### PR TITLE
Draft: Fix lock issues

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -872,6 +872,7 @@ class DraftToolBar:
 
     def redraw(self):
         """utility function that is performed after each clicked point"""
+        self.acceptPointInput()
         self.checkLocal()
 
     def setFocus(self, f=None):
@@ -1408,11 +1409,15 @@ class DraftToolBar:
                     else:
                         self.new_point = self.get_new_point(delta)
                         self.sourceCmd.numericInput(*self.new_point)
+                    self.acceptPointInput()
             elif self.textValue.isVisible():
                 return False
             else:
                 FreeCADGui.ActiveDocument.resetEdit()
         return True
+
+    def acceptPointInput(self):
+        self._locks.unlock_all()
 
     def finish(self, cont=None):
         """finish button action"""

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -372,6 +372,9 @@ class DraftToolBar:
     def _is_field_locked(self, key):
         return self._locks.is_locked(key)
 
+    def has_point_constraints(self):
+        return self._locks.any_locked()
+
     def _set_field_locked(self, key, locked):
         if locked:
             field = getattr(self, self._LOCK_FIELDS.get(key, ""), None)

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -1273,6 +1273,8 @@ class Snapper:
         provider = self.pointConstraintProvider
         if provider is None:
             return point
+        if hasattr(provider, "has_point_constraints") and not provider.has_point_constraints():
+            return point
         locked = provider.constrain_point(point, lastpoint)
         if noTracker or locked is None:
             return locked
@@ -1636,6 +1638,11 @@ class Snapper:
             self.radiusTracker.update(self.radius)
             self.radiusTracker.on()
 
+    def hideRadius(self):
+        """Hide the snap radius indicator."""
+        if self.radiusTracker:
+            self.radiusTracker.off()
+
     def isEnabled(self, snap):
         """Returns true if the given snap is on"""
         if "Lock" in self.active_snaps and snap in self.active_snaps:
@@ -1754,6 +1761,8 @@ class Snapper:
                 self.trackers[8].append(self.extLine2)
                 self.trackers[9].append(self.holdTracker)
             self.activeview = v
+
+        self.hideRadius()
 
         if not update_grid:
             return

--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -306,6 +306,9 @@ class TaskPanelCircularArray:
                 setattr(constrained, key, value)
         return constrained
 
+    def has_point_constraints(self):
+        return self.locks.any_locked()
+
     def get_axis(self):
         """Get the axis that will be used for the array. NOT IMPLEMENTED.
 

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -283,6 +283,9 @@ class TaskPanelPolarArray:
                 setattr(constrained, key, value)
         return constrained
 
+    def has_point_constraints(self):
+        return self.locks.any_locked()
+
     def get_axis(self):
         """Get the axis that will be used for the array. NOT IMPLEMENTED.
 

--- a/src/Mod/Draft/drafttests/test_manual_input_gui.py
+++ b/src/Mod/Draft/drafttests/test_manual_input_gui.py
@@ -339,11 +339,13 @@ class DraftGuiManualInput(test_base.DraftTestCaseDoc):
 
     def test_snap_marker_uses_resolved_angle_point(self):
         class Tracker:
+            Visible = False
+
             def setCoords(self, point):
                 self.point = App.Vector(point)
 
             def on(self):
-                pass
+                self.Visible = True
 
         self._open_point_ui()
         self.tb.globalMode = True


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Manual input locks now clear after each accepted point cycle:
- mouse placement
- task-panel placement

Indicator is hidden whenever snap trackers are prepared so command startup does not leave the yellow circle visible.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/31082
Fixes https://github.com/FreeCAD/FreeCAD/issues/31081

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/cf5c2ee0-6ea1-4d8b-a355-3a4963186b6f




<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
