### PR TITLE
Ensure checkBoxLineGroup property value is synced with restored state

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -218,6 +218,7 @@ void SketcherSettings::loadSettings()
     ui->checkBoxHorVerAuto->onRestore();
     setProperty("checkBoxHorVerAuto", ui->checkBoxHorVerAuto->isChecked());
     ui->checkBoxLineGroup->onRestore();
+    setProperty("checkBoxLineGroup", ui->checkBoxLineGroup->isChecked());
     ui->checkBoxAddExtGeo->onRestore();
     ui->checkBoxMakeInternals->onRestore();
 

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -217,6 +217,7 @@ void SketcherSettings::loadSettings()
     ui->checkBoxHorVerAuto->onRestore();
     setProperty("checkBoxHorVerAuto", ui->checkBoxHorVerAuto->isChecked());
     ui->checkBoxLineGroup->onRestore();
+    setProperty("checkBoxLineGroup", ui->checkBoxLineGroup->isChecked());
     ui->checkBoxAddExtGeo->onRestore();
     ui->checkBoxMakeInternals->onRestore();
 


### PR DESCRIPTION
- Fixes #31087

Ensures the local `checkBoxLineGroup` property is synced with restored state and that subsequent evaluation in `SketcherSettings::checkForRestart()` can compare for a dirty indication and subsequent `Restart Required` warning. The previous failure to sync the property on load, meant inconsistent evaluation and a constant warning when loaded pref values did not match the default `false` value of the uninitialized field.

**Concisely** - The fix simply ensures the flag that produces the prompt isn't always dirty 


I have confirmed that this fix eliminates the unexpected dialog when zero or more changes occur that are not tracked by  `checkForRestart` and that the `checkBoxLineGroup` user preference continues to persist as expected and **does** in fact trigger the `Restart Required` warning.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
#31087

| Before | After |
|----- | ----- |
| <img width="318" height="130" alt="Image" src="https://github.com/user-attachments/assets/0d64bed4-6e2c-4580-9706-cf05ecf70199" /> | *No non-applicable restart warnings on save* |