### PR TITLE
CAM: SelectLoop - Modifiers

### DIFF
--- a/src/Mod/CAM/PathCommands.py
+++ b/src/Mod/CAM/PathCommands.py
@@ -29,6 +29,8 @@ import Path.Dressup.Utils as PathDressup
 import PathScripts.PathUtils as PathUtils
 
 from PySide.QtCore import QT_TRANSLATE_NOOP
+from PySide.QtCore import Qt
+from PySide.QtWidgets import QApplication
 
 if FreeCAD.GuiUp:
     import FreeCADGui
@@ -50,25 +52,27 @@ class _CommandSelectLoop:
             "Accel": "P, L",
             "ToolTip": QT_TRANSLATE_NOOP(
                 "CAM_SelectLoop",
-                "Completes the selection of edges or faces that forms a loop"
-                "\n\nSelect vertical faces: searching loops faces which forms the walls."
-                "\n\nSelect horizontal face: searching inner edges of the face or coplanar faces."
-                "\n\nSelect one edge: searching loop edges in horizontal plane"
-                "\nor wire which contain selected edge."
-                "\n\nSelect two edges: searching loop edges in wires of the shape"
-                "\nor tangent edges."
-                "\n\nSelect three or more edges: searching horizontal wires."
-                "\n\nWithout sub selection all edges of the shape will be selected.",
+                "Completes the selection of edges or faces that forms a loop."
+                "\nWorks in described sequence, but can be forced by modifier key."
+                "\n\nFace selection:"
+                "\n    Vertical face: searching loops faces which forms the walls."
+                "\n    Horizontal face: searching inner edges of the face (CTRL),"
+                "\n        outer edges of the face (CTRL + ALT)"
+                "\n        or horizontal faces at the same height (SHIFT)."
+                "\n    Otherwise select all edges of the face (ALT)."
+                "\n\nEdge selection:"
+                "\n    One edge: searching loop edges in horizontal plane."
+                "\n    Two edges: searching loop edges in wires of the shape or tangent edges (CTRL)."
+                "\n    Otherwise searching horizontal wires which contain selected edges (ALT)."
+                "\n\nWithout sub selection:"
+                "\n    Select all edges, faces (ALT) or vertexes (CTRL) of the model.",
             ),
             "CmdType": "ForEdit",
         }
 
     def IsActive(self):
-        selection = FreeCADGui.Selection.getSelectionEx()
-        if not selection:
-            return False
-
-        return True
+        selection = FreeCADGui.Selection.getSelection()
+        return selection and hasattr(selection[0], "Shape")
 
     def Activated(self):
         selection = FreeCADGui.Selection.getSelectionEx()
@@ -76,39 +80,68 @@ class _CommandSelectLoop:
             return
         if any(not s.Object.isDerivedFrom("Part::Feature") for s in selection):
             return
+        for sel in selection:
+            for name in sel.SubElementNames:
+                if "Vertex" in name:  # remove vertexes from selection
+                    FreeCADGui.Selection.removeSelection(sel.Object, name)
+        selection = FreeCADGui.Selection.getSelectionEx()
 
+        kmods = getKeyboardModifiers()
         newSelection = []
         for sel in selection:
             obj = sel.Object
             obj.recompute()  # need in some cases to get identical hash codes
             subs = sel.SubObjects
-            edges = None
-            names = None
+            edges = []
+            names = []
 
             if not sel.SubObjects:
-                names = [f"Edge{i}" for i in range(1, len(obj.Shape.Edges) + 1)]
+                if kmods == ["ALT"]:
+                    names = [f"Face{i}" for i in range(1, len(obj.Shape.Faces) + 1)]
+                elif kmods == ["CTRL"]:
+                    names = [f"Vertex{i}" for i in range(1, len(obj.Shape.Vertexes) + 1)]
+                else:
+                    names = [f"Edge{i}" for i in range(1, len(obj.Shape.Edges) + 1)]
 
             elif all(isinstance(sub, Part.Face) for sub in subs):
                 # face(s) selected
-                edges = PathUtils.innerEdgesFromFace(obj, subs[0])
-                if not edges:
-                    if all(Path.Geom.isVertical(face) for face in subs):
-                        names = PathUtils.horizontalFaceLoops(obj, subs)
-                    elif Path.Geom.isHorizontal(subs[0]):
-                        names = PathUtils.horizontalFacesAtHeight(obj, subs[0].CenterOfMass.z)
-                    if not names:
-                        edges = [e for sub in subs for e in sub.Edges]
-
-            elif isinstance(subs[0], Part.Edge):
-                if len(subs) == 1:
-                    # one edge selected: searching horizontal edge loop
-                    edges = PathUtils.horizontalEdgeLoop(obj, subs[0])
-                elif len(subs) == 2:
-                    # two edges selected: searching wire in shape which contain both edges
-                    edges = PathUtils.loopdetect(obj, subs[0], subs[1])
+                if kmods == ["CTRL"]:
+                    edges = [e for f in subs for e in PathUtils.innerEdgesFromFace(obj, f)]
+                elif set(kmods) == set(("ALT", "CTRL")):
+                    edges = [e for sub in subs for e in sub.OuterWire.Edges]
+                elif kmods == ["SHIFT"]:
+                    names = [
+                        e
+                        for f in subs
+                        for e in PathUtils.horizontalFacesAtHeight(obj, f.CenterOfMass.z)
+                    ]
+                elif kmods == ["ALT"]:
+                    edges = [e for sub in subs for e in sub.Edges]
+                else:
+                    edges = PathUtils.innerEdgesFromFace(obj, subs[0])
                     if not edges:
-                        # two edges selected: searching edges in tangency
-                        edges = PathUtils.tangentEdgeLoop(obj, subs[0], subs[1])
+                        if all(Path.Geom.isVertical(face) for face in subs):
+                            names = PathUtils.horizontalFaceLoops(obj, subs)
+                        elif Path.Geom.isHorizontal(subs[0]):
+                            names = PathUtils.horizontalFacesAtHeight(obj, subs[0].CenterOfMass.z)
+                        if not names:
+                            edges = [e for sub in subs for e in sub.Edges]
+
+            elif all(isinstance(sub, Part.Edge) for sub in subs):
+                if kmods == ["CTRL"] and len(subs) >= 2:
+                    edges = PathUtils.tangentEdgeLoop(obj, subs[0], subs[1])
+                elif kmods == ["ALT"]:
+                    edges = PathUtils.wiresdetect(obj, subs)
+                else:
+                    if len(subs) == 1:
+                        # one edge selected: searching horizontal edge loop
+                        edges = PathUtils.horizontalEdgeLoop(obj, subs[0])
+                    elif len(subs) == 2:
+                        # two edges selected: searching wire in shape which contain both edges
+                        edges = PathUtils.loopdetect(obj, subs[0], subs[1])
+                        if not edges:
+                            # two edges selected: searching edges in tangency
+                            edges = PathUtils.tangentEdgeLoop(obj, subs[0], subs[1])
 
                 if not edges:
                     # searching all horizontal wires which contains selected edges
@@ -126,7 +159,8 @@ class _CommandSelectLoop:
                     translate(
                         "CAM_SelectLoop",
                         "Closed loop detection failed in model %s."
-                        " This type of selection not supported yet." % obj.Label,
+                        "\nThis type of selection did not give result or not supported yet."
+                        % obj.Label,
                     )
                 )
 
@@ -280,3 +314,22 @@ def findShape(shape, subname=None, subtype=None):
             if sobj.isEqual(ret):
                 return obj
     return ret
+
+
+def getKeyboardModifiers():
+    """getKeyboardModifiers() ... returns list of holding modifier keys
+    Modifiers names: "ALT", "CTRL", "SHIFT"
+    Returns [] if no any modifier key holding
+    Returns ["ALT", "CTRL"] if holding Alt and Ctrl buttons
+    """
+    k = int(QApplication.queryKeyboardModifiers().value)
+    if k == int(Qt.NoModifier.value):
+        return []
+    modifiers = []
+    if k & int(Qt.AltModifier.value):
+        modifiers.append("ALT")
+    if k & int(Qt.ShiftModifier.value):
+        modifiers.append("SHIFT")
+    if k & int(Qt.ControlModifier.value):
+        modifiers.append("CTRL")
+    return modifiers

--- a/src/Mod/CAM/PathCommands.py
+++ b/src/Mod/CAM/PathCommands.py
@@ -26,7 +26,7 @@ import Part
 import Path
 
 import Path.Dressup.Utils as PathDressup
-import PathScripts.PathUtils as PathUtils
+from PathScripts import PathUtils
 
 from PySide.QtCore import QT_TRANSLATE_NOOP
 from PySide.QtCore import Qt
@@ -55,7 +55,8 @@ class _CommandSelectLoop:
                 "Completes the selection of edges or faces that forms a loop."
                 "\nWorks in described sequence, but can be forced by modifier key."
                 "\n\nFace selection:"
-                "\n    Vertical face: searching loops faces which forms the walls."
+                "\n    Vertical face: searching loops faces which forms the walls"
+                "\n        or vertical faces with same center height (SHIFT)."
                 "\n    Horizontal face: searching inner edges of the face (CTRL),"
                 "\n        outer edges of the face (CTRL + ALT)"
                 "\n        or horizontal faces at the same height (SHIFT)."
@@ -107,13 +108,11 @@ class _CommandSelectLoop:
                 # face(s) selected
                 if kmods == ["CTRL"]:
                     edges = [e for f in subs for e in PathUtils.innerEdgesFromFace(obj, f)]
-                elif set(kmods) == set(("ALT", "CTRL")):
+                elif set(kmods) == {"ALT", "CTRL"}:
                     edges = [e for sub in subs for e in sub.OuterWire.Edges]
                 elif kmods == ["SHIFT"]:
                     names = [
-                        e
-                        for f in subs
-                        for e in PathUtils.horizontalFacesAtHeight(obj, f.CenterOfMass.z)
+                        n for f in subs for n in PathUtils.facesAtHeight(obj, f.CenterOfMass.z, f)
                     ]
                 elif kmods == ["ALT"]:
                     edges = [e for sub in subs for e in sub.Edges]
@@ -123,7 +122,7 @@ class _CommandSelectLoop:
                         if all(Path.Geom.isVertical(face) for face in subs):
                             names = PathUtils.horizontalFaceLoops(obj, subs)
                         elif Path.Geom.isHorizontal(subs[0]):
-                            names = PathUtils.horizontalFacesAtHeight(obj, subs[0].CenterOfMass.z)
+                            names = PathUtils.facesAtHeight(obj, subs[0].CenterOfMass.z, subs[0])
                         if not names:
                             edges = [e for sub in subs for e in sub.Edges]
 

--- a/src/Mod/CAM/PathScripts/PathUtils.py
+++ b/src/Mod/CAM/PathScripts/PathUtils.py
@@ -179,38 +179,39 @@ def tangentEdgeLoop(obj, edge1, edge2):
 
     loop = [edge1]
     hashes = [edge1.hashCode()]
-    startPoint = edge1.Vertexes[0].Point
-    lastEdge = edge1
-    lastIndex = -1
+    if Path.Geom.edgeConnectsTo(edge2, edge1.Vertexes[0].Point):
+        startPoint = edge1.Vertexes[-1].Point
+        nextIndex = 0
+    else:
+        startPoint = edge1.Vertexes[0].Point
+        nextIndex = -1
+
     objEdges = obj.Shape.Edges
-    for i in range(len(objEdges)):
-        if Path.Geom.pointsCoincide(lastEdge.Vertexes[lastIndex].Point, startPoint):
+    for i in range(len(objEdges) - 1):
+        if Path.Geom.pointsCoincide(loop[-1].Vertexes[nextIndex].Point, startPoint):
             # stop because return to start point and loop is closed
             break
 
-        lastPoint = lastEdge.Vertexes[lastIndex].Point
-        lastTangent = lastEdge.tangentAt(lastEdge.ParameterRange[lastIndex])
-        for e in objEdges:
-            if e.hashCode() in hashes:
+        point = loop[-1].Vertexes[nextIndex].Point
+        tangent = loop[-1].tangentAt(loop[-1].ParameterRange[nextIndex])
+        for candidate in objEdges:
+            if candidate.hashCode() in hashes:
                 # this edge is already in loop
                 continue
 
-            if Path.Geom.pointsCoincide(lastPoint, e.Vertexes[0].Point):
+            if Path.Geom.pointsCoincide(point, candidate.Vertexes[0].Point):
                 index = 0
-            elif Path.Geom.pointsCoincide(lastPoint, e.Vertexes[-1].Point):
+            elif Path.Geom.pointsCoincide(point, candidate.Vertexes[-1].Point):
                 index = -1
             else:
                 continue
 
-            tangent = e.tangentAt(e.ParameterRange[index])
-            if lastIndex == index:
-                tangent = -tangent
-            if Path.Geom.pointsCoincide(tangent, lastTangent, 0.05):
+            candidateTangent = candidate.tangentAt(candidate.ParameterRange[index])
+            if Path.Geom.compareVecs(tangent, candidateTangent, error=0.05):
                 # found next tangency edge
-                loop.append(e)
-                hashes.append(e.hashCode())
-                lastEdge = e
-                lastIndex = -1 if index == 0 else 0
+                loop.append(candidate)
+                hashes.append(candidate.hashCode())
+                nextIndex = -1 if index == 0 else 0
                 break
 
         else:
@@ -241,7 +242,7 @@ def horizontalFacesAtHeight(obj, z, tol=0.01):
     if len(names) > 1:
         return names
 
-    return None
+    return []
 
 
 def horizontalFaceLoops(obj, faces):

--- a/src/Mod/CAM/PathScripts/PathUtils.py
+++ b/src/Mod/CAM/PathScripts/PathUtils.py
@@ -232,12 +232,20 @@ def innerEdgesFromFace(obj, face):
     return edges
 
 
-def horizontalFacesAtHeight(obj, z, tol=0.01):
-    """horizontalCoplanarFaces(obj, z) ... returns a list of face names with requested height."""
+def facesAtHeight(obj, z, face=None, tol=0.01):
+    """facesAtHeight(obj, z) ... returns a list of face names with requested height.
+    Given face uses to define orientation and filters result"""
+    if face and Path.Geom.isHorizontal(face):  # accept only horizontal faces
+        filter_func = Path.Geom.isHorizontal
+    elif face and Path.Geom.isVertical(face):  # accept only vertical faces
+        filter_func = Path.Geom.isVertical
+    else:  # accept faces with any orientatiotn
+        filter_func = lambda _: True
+
     names = [
         f"Face{i}"
         for i, f in enumerate(obj.Shape.Faces, 1)
-        if Path.Geom.isHorizontal(f) and Path.Geom.isRoughly(f.CenterOfMass.z, z, tol)
+        if filter_func(f) and Path.Geom.isRoughly(f.CenterOfMass.z, z, tol)
     ]
     if len(names) > 1:
         return names


### PR DESCRIPTION
### Changes 
- Added common method `getKeyboardModifiers()` to return list of holding modifier keys (Alt, Ctrl, Shift)
- Allowed to use modifier keys to force specific methods of `SelectLoop` tool
- Added ability to select all faces and all vertexes from model with modifiers keys
- Improved method `tangentEdgeLoop()`
- Removes vertexes from selection which was selected by mistake
- Changed tool tip

<img width="780" height="490" alt="Screenshot_20260719_095658" src="https://github.com/user-attachments/assets/6a6e8fed-5cc2-49e4-aa5b-b4a991b98f62" />

---

Test project:  [cam_profile_individually_issue.zip](https://github.com/user-attachments/files/29851863/cam_profile_individually_issue.zip)

https://github.com/user-attachments/assets/825f4058-0cb7-4cd3-83e5-e08c3eaba295

