### PR TITLE
Gui: Fix corner axis letter placement

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -546,6 +546,8 @@ struct OverlayAxisCrossState
         SoTexture2* texture {nullptr};
         SoVertexProperty* vertices {nullptr};
         SoFaceSet* quad {nullptr};
+        int width {0};
+        int height {0};
     };
 
     Letter xLetter;
@@ -640,6 +642,8 @@ struct OverlayAxisCrossState
         lettersRoot->addChild(lettersMaterial);
 
         auto buildLetter = [](Letter& out, int w, int h) {
+            out.width = w;
+            out.height = h;
             out.root = new SoSeparator;
 
             out.position = new SoTranslation;
@@ -4957,18 +4961,25 @@ void View3DInventorViewer::drawAxisCross()
     vv.getMatrices(affine, projection);
 
     const SbMatrix comb = model.multRight(projection);
-    SbVec3f xpos;
-    comb.multVecMatrix(SbVec3f(1, 0, 0), xpos);
-    xpos[0] = (1 + xpos[0]) * static_cast<float>(viewWidth) / 2.0f;
-    xpos[1] = (1 + xpos[1]) * static_cast<float>(viewHeight) / 2.0f;
-    SbVec3f ypos;
-    comb.multVecMatrix(SbVec3f(0, 1, 0), ypos);
-    ypos[0] = (1 + ypos[0]) * static_cast<float>(viewWidth) / 2.0f;
-    ypos[1] = (1 + ypos[1]) * static_cast<float>(viewHeight) / 2.0f;
-    SbVec3f zpos;
-    comb.multVecMatrix(SbVec3f(0, 0, 1), zpos);
-    zpos[0] = (1 + zpos[0]) * static_cast<float>(viewWidth) / 2.0f;
-    zpos[1] = (1 + zpos[1]) * static_cast<float>(viewHeight) / 2.0f;
+    auto projectOverlayPoint = [&comb](const SbVec3f& point) {
+        SbVec3f projected;
+        comb.multVecMatrix(point, projected);
+        return projected;
+    };
+
+    // Anchor each letter slightly past its axis tip so centered glyphs do not
+    // sit on top of the arrow geometry.
+    constexpr float letterDistance = 1.15f;
+    auto projectLetterAnchor = [&projectOverlayPoint](const SbVec3f& axis) {
+        return projectOverlayPoint(axis * letterDistance);
+    };
+
+    const SbVec3f xTipProjected = projectOverlayPoint(SbVec3f(1, 0, 0));
+    const SbVec3f yTipProjected = projectOverlayPoint(SbVec3f(0, 1, 0));
+    const SbVec3f zTipProjected = projectOverlayPoint(SbVec3f(0, 0, 1));
+    const SbVec3f xLetterProjected = projectLetterAnchor(SbVec3f(1, 0, 0));
+    const SbVec3f yLetterProjected = projectLetterAnchor(SbVec3f(0, 1, 0));
+    const SbVec3f zLetterProjected = projectLetterAnchor(SbVec3f(0, 0, 1));
 
     auto& overlay = overlayAxisCrossState();
     overlay.ensureCreated();
@@ -4991,9 +5002,9 @@ void View3DInventorViewer::drawAxisCross()
     overlay.zMaterial->diffuseColor.setValue(m_zColor.r, m_zColor.g, m_zColor.b);
 
     std::array<std::pair<float, SoNode*>, 3> axes = {
-        std::pair<float, SoNode*> {xpos[2], overlay.xAxis},
-        std::pair<float, SoNode*> {ypos[2], overlay.yAxis},
-        std::pair<float, SoNode*> {zpos[2], overlay.zAxis},
+        std::pair<float, SoNode*> {xTipProjected[2], overlay.xAxis},
+        std::pair<float, SoNode*> {yTipProjected[2], overlay.yAxis},
+        std::pair<float, SoNode*> {zTipProjected[2], overlay.zAxis},
     };
     std::sort(axes.begin(), axes.end(), [](const auto& a, const auto& b) {
         return a.first > b.first;
@@ -5003,26 +5014,57 @@ void View3DInventorViewer::drawAxisCross()
         overlay.axisGroup->addChild(axis.second);
     }
 
-    overlay.lettersCamera->aspectRatio.setValue(
-        static_cast<float>(viewWidth) / static_cast<float>(viewHeight)
+    const float miniViewportSize = static_cast<float>(pixelarea);
+    const float miniViewportCenter = miniViewportSize / 2.0f;
+
+    overlay.lettersCamera->aspectRatio.setValue(1.0f);
+    overlay.lettersCamera->height.setValue(miniViewportSize);
+
+    // Axis endpoints are projected into centered [-1, 1] coordinates. Convert
+    // them into the square overlay viewport's local pixel space before mapping
+    // them back to the centered coordinate system used by the letters camera.
+    auto toMiniViewportPixel = [miniViewportSize](const SbVec3f& projectedEndpoint) {
+        return SbVec2f(
+            (1.0f + projectedEndpoint[0]) * miniViewportSize / 2.0f,
+            (1.0f + projectedEndpoint[1]) * miniViewportSize / 2.0f
+        );
+    };
+
+    // Keep labels proportional to the corner widget, with readable bounds for
+    // very small or very large viewports. These values are framebuffer pixels
+    // because the letters camera is sized to the square overlay viewport.
+    constexpr float letterHeightFraction = 0.07f;
+    constexpr float minLetterHeight = 8.0f;
+    constexpr float maxLetterHeight = 18.0f;
+    const float deviceScale = static_cast<float>(devicePixelRatio());
+    const float targetLetterHeight = std::clamp(
+        miniViewportSize * letterHeightFraction,
+        minLetterHeight * deviceScale,
+        maxLetterHeight * deviceScale
     );
-    overlay.lettersCamera->height.setValue(static_cast<float>(viewHeight));
+    const float letterScale = targetLetterHeight / static_cast<float>(XPM_HEIGHT);
+    overlay.xLetter.scale->scaleFactor.setValue(letterScale, letterScale, 1.0f);
+    overlay.yLetter.scale->scaleFactor.setValue(letterScale, letterScale, 1.0f);
+    overlay.zLetter.scale->scaleFactor.setValue(letterScale, letterScale, 1.0f);
 
-    // The overlay viewport above is sized in physical framebuffer pixels, so
-    // the axis letters must scale by the device pixel ratio to keep the same
-    // perceived size as the axis cross on HiDPI displays.
-    const float scale = static_cast<float>(axiscrossSize) / 30.0f
-        * static_cast<float>(devicePixelRatio());
-    overlay.xLetter.scale->scaleFactor.setValue(scale, scale, 1.0f);
-    overlay.yLetter.scale->scaleFactor.setValue(scale, scale, 1.0f);
-    overlay.zLetter.scale->scaleFactor.setValue(scale, scale, 1.0f);
+    auto placeLetter = [letterScale, miniViewportCenter, toMiniViewportPixel](
+                           OverlayAxisCrossState::Letter& letter,
+                           const SbVec3f& projectedEndpoint
+                       ) {
+        const SbVec2f local = toMiniViewportPixel(projectedEndpoint);
+        const float halfLetterWidth = static_cast<float>(letter.width) * letterScale / 2.0f;
+        const float halfLetterHeight = static_cast<float>(letter.height) * letterScale / 2.0f;
 
-    overlay.xLetter.position->translation
-        .setValue(xpos[0] - 0.5f * viewWidth, xpos[1] - 0.5f * viewHeight, 0.0f);
-    overlay.yLetter.position->translation
-        .setValue(ypos[0] - 0.5f * viewWidth, ypos[1] - 0.5f * viewHeight, 0.0f);
-    overlay.zLetter.position->translation
-        .setValue(zpos[0] - 0.5f * viewWidth, zpos[1] - 0.5f * viewHeight, 0.0f);
+        letter.position->translation.setValue(
+            local[0] - miniViewportCenter - halfLetterWidth,
+            local[1] - miniViewportCenter - halfLetterHeight,
+            0.0f
+        );
+    };
+
+    placeLetter(overlay.xLetter, xLetterProjected);
+    placeLetter(overlay.yLetter, yLetterProjected);
+    placeLetter(overlay.zLetter, zLetterProjected);
 
     overlay.xLetter.texture->image.setValue(SbVec2s(XPM_WIDTH, XPM_HEIGHT), 4, XPM_pixel_data);
     overlay.yLetter.texture->image.setValue(SbVec2s(YPM_WIDTH, YPM_HEIGHT), 4, YPM_pixel_data);

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -29,6 +29,7 @@ SET(Test_SRCS
     TestRubberbandSelection.py
     TestCoinNodeSnapshots.py
     TestCoinSelectionVisual.py
+    TestCornerAxisCrossVisual.py
     TestViewProviderLink.py
 )
 

--- a/src/Mod/Test/InitGui.py
+++ b/src/Mod/Test/InitGui.py
@@ -101,6 +101,7 @@ FreeCAD.__unit_test__ += [
     "TestGraphicsViewWrapping",
     "TestRubberbandSelection",
     "TestCoinSelectionVisual",
+    "TestCornerAxisCrossVisual",
     "TestCoinNodeSnapshots",
     "TestViewProviderLink",
 ]

--- a/src/Mod/Test/TestCornerAxisCrossVisual.py
+++ b/src/Mod/Test/TestCornerAxisCrossVisual.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""GUI visual regression test for corner coordinate system axis letters.
+
+This covers a regression where the default 10% corner coordinate system drew
+the colored axes but not the X/Y/Z letter textures. Instead of comparing a full
+golden screenshot, the test captures the same view with the corner overlay
+hidden and visible, then looks for newly drawn low-saturation, non-white
+pixels in the corner crop. With a white background, the default black/gray
+letter pixels are easy to separate from the saturated red/green/blue axis lines
+without depending on exact antialiasing or full-frame rendering details.
+
+Run with:
+    FreeCAD -t TestCornerAxisCrossVisual
+"""
+
+import time
+import unittest
+
+import FreeCAD
+import FreeCADGui
+from PySide6 import QtWidgets
+
+
+class TestCornerAxisCrossVisual(unittest.TestCase):
+    """Verify that the default-size corner coordinate system draws axis letters."""
+
+    _CORNER_SIZE_PERCENT = 10
+    _MIN_NEW_LETTER_PIXELS = 12
+
+    def setUp(self):
+        self.doc = FreeCAD.newDocument("TestCornerAxisCrossVisual")
+        FreeCADGui.ActiveDocument = FreeCADGui.getDocument(self.doc.Name)
+        self.view = FreeCADGui.ActiveDocument.ActiveView
+        self.viewer = self.view.getViewer()
+
+        self._had_axis_cross = self.view.hasAxisCross()
+        self._had_corner_cross = self.view.isCornerCrossVisible()
+        self._corner_cross_size = self.view.getCornerCrossSize()
+        self._had_navi_cube = self.viewer.isEnabledNaviCube()
+
+    def tearDown(self):
+        self.view.setAxisCross(self._had_axis_cross)
+        self.view.setCornerCrossSize(self._corner_cross_size)
+        self.view.setCornerCrossVisible(self._had_corner_cross)
+        self.viewer.setEnabledNaviCube(self._had_navi_cube)
+
+        if FreeCAD.getDocument(self.doc.Name):
+            FreeCAD.closeDocument(self.doc.Name)
+
+    def test_default_corner_axis_cross_shows_axis_letters(self):
+        self.view.setAxisCross(False)
+        self.viewer.setEnabledNaviCube(False)
+        self.view.setCornerCrossSize(self._CORNER_SIZE_PERCENT)
+
+        self.view.setCornerCrossVisible(False)
+        self._prepare_view()
+        before = self._grab_framebuffer()
+
+        self.view.setCornerCrossVisible(True)
+        self._flush_gui()
+        after = self._grab_framebuffer()
+
+        # Compare against the hidden-overlay frame so the assertion is local to
+        # newly drawn corner overlay pixels, not the user's theme or viewport.
+        crop = self._corner_crop(after)
+        new_letter_pixels = self._new_low_saturation_non_white_pixel_count(before, after, crop)
+
+        self.assertGreaterEqual(
+            new_letter_pixels,
+            self._MIN_NEW_LETTER_PIXELS,
+            (
+                "Default-size corner coordinate system did not render visible axis "
+                f"letter pixels; found {new_letter_pixels} new low-saturation "
+                f"non-white pixels in crop {crop}"
+            ),
+        )
+
+    def _prepare_view(self):
+        self.viewer.setGradientBackground("")
+        self.viewer.setBackgroundColor(1.0, 1.0, 1.0)
+        self.view.setCameraType("Orthographic")
+        self.view.viewAxometric()
+        self._flush_gui()
+
+    def _flush_gui(self):
+        for _ in range(6):
+            FreeCADGui.updateGui()
+            QtWidgets.QApplication.processEvents()
+            self.view.redraw()
+            time.sleep(0.05)
+
+    def _grab_framebuffer(self):
+        try:
+            image = self.viewer.grabFramebuffer()
+        except RuntimeError:
+            image = self._grab_viewport().toImage()
+        self.assertFalse(image.isNull(), "3D view framebuffer capture returned a null image")
+        return image
+
+    def _grab_viewport(self):
+        graphics_view = self.view.graphicsView()
+        viewport = graphics_view.viewport()
+        viewport.repaint()
+        self._flush_gui()
+
+        screen = viewport.screen()
+        if screen is not None:
+            pixmap = screen.grabWindow(int(viewport.winId()))
+            if not pixmap.isNull():
+                return pixmap
+
+        return viewport.grab()
+
+    def _corner_crop(self, image):
+        width = image.width()
+        height = image.height()
+        axis_size = int(min(width, height) * self._CORNER_SIZE_PERCENT / 100.0)
+        crop_size = max(72, int(axis_size * 1.8))
+        crop_size = min(crop_size, width, height)
+        return (width - crop_size, height - crop_size, width, height)
+
+    def _new_low_saturation_non_white_pixel_count(self, before, after, crop):
+        left, top, right, bottom = crop
+        count = 0
+        for y in range(top, bottom):
+            for x in range(left, right):
+                after_rgb = self._rgb(after, x, y)
+                is_letter_pixel = self._is_low_saturation_non_white_pixel(after_rgb)
+                changed = self._changed_enough(self._rgb(before, x, y), after_rgb)
+                if is_letter_pixel and changed:
+                    count += 1
+        return count
+
+    @staticmethod
+    def _rgb(image, x, y):
+        color = image.pixelColor(x, y)
+        return (color.red(), color.green(), color.blue())
+
+    @staticmethod
+    def _is_low_saturation_non_white_pixel(rgb):
+        # Default and shipped preference-pack letter colors are black or gray.
+        # The colored axes are saturated, and the test background is white.
+        return max(rgb) < 245 and max(rgb) - min(rgb) < 55
+
+    @staticmethod
+    def _changed_enough(before, after):
+        return sum(abs(a - b) for a, b in zip(before, after)) > 45


### PR DESCRIPTION
Fixes a regression in axis overlay letters rendering reported by @mnesarco on Discord.

The corner coordinate system axis letters disappeared at the default 10% size after the OpenGL-to-Coin overlay conversion. The axis geometry still rendered, and increasing the relative size to 50% made the letters visible, which pointed to the letter quads being positioned/scaled in the wrong coordinate space rather than to missing textures or disabled UI state.

This fixes the overlay by projecting the axis endpoints once, preserving projected depth for axis ordering, and mapping the X/Y/Z letter positions into the corner mini viewport's own physical pixel space. The letters camera now uses that mini viewport size directly, so the bitmap letter quads behave like the previous pixel-based rendering path while remaining in the Coin overlay implementation.

A focused GUI visual regression test was added for the default 10% corner coordinate system. It captures the view with the overlay hidden and visible, then asserts that new dark neutral pixels appear in the corner crop where the axis letters should be. This avoids brittle full-image golden baselines while still covering the regression.

Assisted-by: GPT-5.5-xhigh

<img width="1132" height="779" alt="image" src="https://github.com/user-attachments/assets/78eb22fc-52cd-4609-ad9d-9f8d3708b030" />

