### PR TITLE
PartDesign: avoid final feature flash before preview

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderPreviewExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPreviewExtension.cpp
@@ -27,17 +27,126 @@
 #include <Inventor/nodes/SoPickStyle.h>
 #include <Inventor/nodes/SoPolygonOffset.h>
 #include <Inventor/nodes/SoTransform.h>
+#include <Inventor/actions/SoGetBoundingBoxAction.h>
+#include <Inventor/SbSphere.h>
+#include <Inventor/nodes/SoCamera.h>
+#include <Inventor/nodes/SoOrthographicCamera.h>
+#include <Inventor/nodes/SoPerspectiveCamera.h>
+#include <Inventor/SoRenderManager.h>
+
+#include <algorithm>
+#include <cmath>
 
 #include "ViewProviderPreviewExtension.h"
 #include "ViewProviderExt.h"
 
 #include <App/Document.h>
+#include <Gui/Application.h>
+#include <Gui/Document.h>
 #include <Gui/Utilities.h>
+#include <Gui/View3DInventor.h>
+#include <Gui/View3DInventorViewer.h>
 #include <Gui/Inventor/So3DAnnotation.h>
 #include <Mod/Part/App/PreviewExtension.h>
 #include <Mod/Part/App/Tools.h>
 
 using namespace PartGui;
+
+namespace
+{
+
+void expandActiveViewClippingToPreview(const Gui::ViewProvider* viewProvider)
+{
+    if (!viewProvider || !Gui::Application::Instance) {
+        return;
+    }
+
+    auto* guiDocument = Gui::Application::Instance->activeDocument();
+    if (!guiDocument) {
+        return;
+    }
+
+    auto* view = dynamic_cast<Gui::View3DInventor*>(guiDocument->getActiveView());
+    if (!view || !view->containsViewProvider(viewProvider)) {
+        return;
+    }
+
+    auto* viewer = view->getViewer();
+    auto* renderManager = viewer ? viewer->getSoRenderManager() : nullptr;
+    auto* camera = renderManager ? renderManager->getCamera() : nullptr;
+    if (!camera) {
+        return;
+    }
+
+    SoGetBoundingBoxAction bboxAction(renderManager->getViewportRegion());
+    bboxAction.apply(viewProvider->getRoot());
+    const SbBox3f bbox = bboxAction.getBoundingBox();
+    if (bbox.isEmpty()) {
+        return;
+    }
+
+    SbSphere sphere;
+    sphere.circumscribe(bbox);
+    const float radius = sphere.getRadius();
+    if (!(radius > 0.0F) || !std::isfinite(radius)) {
+        return;
+    }
+
+    SbVec3f direction;
+    camera->orientation.getValue().multVec(SbVec3f(0.0F, 0.0F, -1.0F), direction);
+
+    float centerDepth = (sphere.getCenter() - camera->position.getValue()).dot(direction);
+    if (!std::isfinite(centerDepth)) {
+        return;
+    }
+
+    const bool perspective = camera->isOfType(SoPerspectiveCamera::getClassTypeId());
+    const bool orthographic = camera->isOfType(SoOrthographicCamera::getClassTypeId());
+    const float minNearDistance = perspective ? std::max(radius * 1.0e-4F, 1.0e-5F) : 0.0F;
+    const float minClipSpan = std::max(radius * 1.0e-3F, 1.0e-4F);
+    bool changed = false;
+
+    // The preview can extend towards the camera before the view is refit to the resulting feature.
+    // For orthographic views, move the camera along the viewing direction so zoom and pan stay stable.
+    if (orthographic && centerDepth - radius < minNearDistance) {
+        const float offset = minNearDistance - (centerDepth - radius) + minClipSpan;
+        camera->position = camera->position.getValue() - offset * direction;
+        camera->focalDistance = camera->focalDistance.getValue() + offset;
+        centerDepth += offset;
+        changed = true;
+    }
+    else if (centerDepth + radius <= minNearDistance) {
+        return;
+    }
+
+    const float requiredNearDistance = std::max(minNearDistance, centerDepth - radius);
+    const float requiredFarDistance
+        = std::max(centerDepth + radius, requiredNearDistance + minClipSpan);
+
+    if (!std::isfinite(requiredNearDistance) || !std::isfinite(requiredFarDistance)) {
+        return;
+    }
+
+    const float currentNearDistance = camera->nearDistance.getValue();
+    const float currentFarDistance = camera->farDistance.getValue();
+
+    if (!std::isfinite(currentNearDistance) || (perspective && currentNearDistance <= 0.0F)
+        || requiredNearDistance < currentNearDistance) {
+        camera->nearDistance = requiredNearDistance;
+        changed = true;
+    }
+
+    if (!std::isfinite(currentFarDistance) || requiredFarDistance > currentFarDistance) {
+        camera->farDistance = requiredFarDistance;
+        changed = true;
+    }
+
+    if (changed) {
+        renderManager->scheduleRedraw();
+    }
+}
+
+}  // namespace
 
 SO_NODE_SOURCE(SoPreviewShape);
 
@@ -181,6 +290,8 @@ void ViewProviderPreviewExtension::showPreview(bool enable)
         if (annotationRoot->findChild(pcPreviewRoot) < 0) {
             annotationRoot->addChild(pcPreviewRoot);
         }
+
+        expandActiveViewClippingToPreview(getExtendedViewProvider());
     }
     else {
         annotationRoot->removeChild(pcPreviewRoot);
@@ -230,6 +341,9 @@ void ViewProviderPreviewExtension::updatePreviewShape(Part::TopoShape shape, SoP
     try {
         updatePreviewShape(preview, shape);
         preview->transform.setValue(Base::convertTo<SbMatrix>(shape.getTransform()));
+        if (_isPreviewEnabled) {
+            expandActiveViewClippingToPreview(getExtendedViewProvider());
+        }
     }
     catch (Standard_Failure& e) {
         Base::Console().userTranslatedNotification(

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -622,6 +622,8 @@ static void finishFeature(
         FCMD_OBJ_HIDE(prevSolidFeature);
     }
 
+    PartDesignGui::ViewProvider::applyPreviewDisplayPreferences(feature);
+
     if (updateDocument) {
         cmd->updateActive();
     }
@@ -888,6 +890,7 @@ void prepareProfileBased(
 
         FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::" << which << "','" << FeatName << "')");
         auto Feat = pcActiveBody->getDocument()->getObject(FeatName.c_str());
+        PartDesignGui::ViewProvider::applyPreviewDisplayPreferences(Feat);
 
         auto objCmd = Gui::Command::getObjectCmd(feature);
 
@@ -1189,10 +1192,13 @@ void prepareProfileBased(
 
 void finishProfileBased(const Gui::Command* cmd, const Part::Feature* sketch, App::DocumentObject* Feat)
 {
+    // Enter edit mode before hiding the source profile so the view transitions directly
+    // from the profile to the configured preview instead of briefly showing an empty view.
+    finishFeature(cmd, Feat);
+
     if (sketch && sketch->isDerivedFrom<Part::Part2DObject>()) {
         FCMD_OBJ_HIDE(sketch);
     }
-    finishFeature(cmd, Feat);
 }
 
 void prepareProfileBased(Gui::Command* cmd, const std::string& which, double length)
@@ -2164,12 +2170,12 @@ void prepareTransformed(
         msg += which;
         cmd->openCommand(msg.c_str());
         FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::" << which << "','" << FeatName << "')");
+        auto Feat = pcActiveBody->getDocument()->getObject(FeatName.c_str());
+        PartDesignGui::ViewProvider::applyPreviewDisplayPreferences(Feat);
         // FIXME: There seems to be kind of a race condition here, leading to sporadic errors like
         // Exception (Thu Sep  6 11:52:01 2012): 'App.Document' object has no attribute 'Mirrored'
         Gui::Command::updateActive();  // Helps to ensure that the object already exists when the
                                        // next command comes up
-
-        auto Feat = pcActiveBody->getDocument()->getObject(FeatName.c_str());
 
         if (features.empty()) {
             FCMD_OBJ_CMD(Feat, "TransformMode = \"Whole shape\"");

--- a/src/Mod/PartDesign/Gui/CommandPrimitive.cpp
+++ b/src/Mod/PartDesign/Gui/CommandPrimitive.cpp
@@ -39,6 +39,7 @@
 
 #include "DlgActiveBody.h"
 #include "Utils.h"
+#include "ViewProvider.h"
 #include "WorkflowManager.h"
 
 using namespace std;
@@ -135,6 +136,7 @@ void CmdPrimtiveCompAdditive::activated(int iMsg)
         return;
     }
     FCMD_OBJ_CMD(pcActiveBody, "addObject(" << getObjectCmd(prm) << ")");
+    PartDesignGui::ViewProvider::applyPreviewDisplayPreferences(prm);
     Gui::Command::updateActive();
 
     auto base = prm->BaseFeature.getValue();
@@ -320,9 +322,10 @@ void CmdPrimtiveCompSubtractive::activated(int iMsg)
         pcActiveBody,
         "newObject('PartDesign::Subtractive" << shapeType << "','" << FeatName << "')"
     );
+    auto Feat = pcActiveBody->getDocument()->getObject(FeatName.c_str());
+    PartDesignGui::ViewProvider::applyPreviewDisplayPreferences(Feat);
     Gui::Command::updateActive();
 
-    auto Feat = pcActiveBody->getDocument()->getObject(FeatName.c_str());
     copyVisual(Feat, "ShapeAppearance", prevSolid);
     copyVisual(Feat, "LineColor", prevSolid);
     copyVisual(Feat, "PointColor", prevSolid);

--- a/src/Mod/PartDesign/Gui/TaskFeatureParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeatureParameters.cpp
@@ -53,8 +53,7 @@ TaskPreviewParameters::TaskPreviewParameters(ViewProvider* vp, QWidget* parent)
     , vp(vp)
     , ui(std::make_unique<Ui_TaskPreviewParameters>())
 {
-    vp->showPreviousFeature(!hGrp->GetBool("ShowFinal", false));
-    vp->showPreview(hGrp->GetBool("ShowTransparentPreview", true));
+    vp->applyPreviewDisplayPreferences();
 
     auto* proxy = new QWidget(this);
     ui->setupUi(proxy);

--- a/src/Mod/PartDesign/Gui/TaskFeatureParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskFeatureParameters.h
@@ -52,10 +52,6 @@ public Q_SLOTS:
 private:
     ViewProvider* vp;
     std::unique_ptr<Ui_TaskPreviewParameters> ui;
-
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/Mod/PartDesign/Preview"
-    );
 };
 
 /// Convenience class to collect common methods for all SketchBased features

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -31,6 +31,7 @@
 
 #include <Base/Exception.h>
 #include <Base/ServiceProvider.h>
+#include <App/Application.h>
 #include <App/Document.h>
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
@@ -166,6 +167,7 @@ bool ViewProvider::setEdit(int ModNum)
 
         // start the edit dialog if
         if (!featureDlg) {
+            applyPreviewDisplayPreferences(true);
             featureDlg = this->getEditDialog();
             if (!featureDlg) {  // Shouldn't generally happen
                 throw Base::RuntimeError("Failed to create new edit dialog.");
@@ -187,6 +189,25 @@ TaskDlgFeatureParameters* ViewProvider::getEditDialog()
 }
 
 
+void ViewProvider::restoreDefaultEditVisibility()
+{
+    auto* feature = getObject<PartDesign::Feature>();
+    auto* body = feature ? PartDesign::Body::findBodyOf(feature) : nullptr;
+    const bool editedFeatureIsVisibleResult = feature && (!body || body->Tip.getValue() == feature);
+
+    // A Body only shows its tip as the final result. If an older feature was edited,
+    // put the pre-edit visible feature back instead of showing the edited one.
+    if (editedFeatureIsVisibleResult) {
+        show();
+    }
+    else if (previouslyShownViewProvider) {
+        previouslyShownViewProvider->show();
+    }
+
+    previouslyShownViewProvider = nullptr;
+}
+
+
 void ViewProvider::unsetEdit(int ModNum)
 {
     showPreview(false);
@@ -196,16 +217,19 @@ void ViewProvider::unsetEdit(int ModNum)
         Gui::Command::assureWorkbench(oldWb.c_str());
     }
 
-    // ensure that after edit we still show the same feature
-    if (previouslyShownViewProvider) {
-        previouslyShownViewProvider->show();
-    }
-
     if (ModNum == ViewProvider::Default) {
+        restoreDefaultEditVisibility();
+
         // when pressing ESC make sure to close the dialog
         Gui::Control().closeDialog();
     }
     else {
+        // ensure that after edit we still show the same feature
+        if (previouslyShownViewProvider) {
+            previouslyShownViewProvider->show();
+            previouslyShownViewProvider = nullptr;
+        }
+
         PartGui::ViewProviderPart::unsetEdit(ModNum);
     }
 }
@@ -417,6 +441,40 @@ void ViewProvider::showPreviousFeature(bool enable)
     else {
         baseFeatureViewProvider->hide();
         show();
+    }
+}
+
+void ViewProvider::applyPreviewDisplayPreferences(App::DocumentObject* obj, bool refreshPreview)
+{
+    if (!obj) {
+        return;
+    }
+
+    auto* viewProvider = freecad_cast<ViewProvider*>(Gui::Application::Instance->getViewProvider(obj));
+    if (viewProvider) {
+        viewProvider->applyPreviewDisplayPreferences(refreshPreview);
+    }
+}
+
+void ViewProvider::applyPreviewDisplayPreferences(bool refreshPreview)
+{
+    auto hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/PartDesign/Preview"
+    );
+
+    showPreviousFeature(!hGrp->GetBool("ShowFinal", false));
+
+    if (!refreshPreview) {
+        return;
+    }
+
+    const bool enablePreview = hGrp->GetBool("ShowTransparentPreview", true);
+    showPreview(enablePreview);
+
+    if (enablePreview) {
+        if (auto* feature = getObject<PartDesign::Feature>()) {
+            feature->recomputePreview();
+        }
     }
 }
 

--- a/src/Mod/PartDesign/Gui/ViewProvider.h
+++ b/src/Mod/PartDesign/Gui/ViewProvider.h
@@ -88,6 +88,10 @@ public:
     Part::TopoShape getPreviewShape() const override;
     /// Toggles visibility of the preview
     void showPreviousFeature(bool);
+    /// Applies PartDesign preview visibility preferences to a feature view provider.
+    static void applyPreviewDisplayPreferences(App::DocumentObject* obj, bool refreshPreview = false);
+    /// Applies PartDesign preview visibility preferences to this feature.
+    void applyPreviewDisplayPreferences(bool refreshPreview = false);
 
     PyObject* getPyObject() override;
 
@@ -123,6 +127,8 @@ protected:
     bool isSetTipIcon {false};
 
 private:
+    void restoreDefaultEditVisibility();
+
     Gui::CoinPtr<PartGui::SoPreviewShape> pcToolPreview;
 };
 


### PR DESCRIPTION
## Issue

When creating a PartDesign feature with transparent preview enabled, feature creation can recompute and update the view before the task panel applies the preview display preferences. If `Show final result` is disabled, the newly-created feature can briefly render as the final opaque shape before the dialog hides it and shows the transparent preview overlay, causing the flash reported in #23505.

There was also a related transient startup artifact after removing the final-feature flash: the preview can extend toward the active camera before the view has been refit to the resulting feature, which can make the transparent preview render for a few frames with a clipped/artificial face.

## Solution

Move the preview preference policy onto `PartDesignGui::ViewProvider::applyPreviewDisplayPreferences()` and apply it from feature edit entry. This makes normal task-dialog entry refresh the final/previous-feature visibility state and transparent-preview state from a central hook instead of relying on every task panel to duplicate the preference handling.

Keep command-side calls only at the timing-sensitive points before `updateActive()`, where edit mode has not started yet and the flash can otherwise occur. Those call sites now invoke the view-provider API, so command code requests the early state without owning the preference policy.

Reuse the same view-provider helper from `TaskPreviewParameters`, restore accepted tip-feature visibility from `ViewProvider::unsetEdit()`, and defer hiding profile-based source sketches until edit mode and preview preferences are established. This keeps Pad/Pocket startup transitioning from the visible profile directly to the configured preview, and keeps accepted results visible after edit cleanup.

Finally, expand the active view clipping for preview geometry in the shared Part preview extension. For orthographic views, the camera is moved backward along its view direction while preserving orientation, height, zoom, and pan.

https://github.com/user-attachments/assets/747a012e-a248-4fbe-9b8a-9229e99da349


Fixes #23505