### PR TITLE
TechDraw: add coarse HLR deflection properties

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -127,6 +127,10 @@ DrawViewPart::DrawViewPart()
     //properties that control HLR algo
     ADD_PROPERTY_TYPE(CoarseView, (Preferences::getPreferenceGroup("General")->GetBool("CoarseView", false)),
         sgroup, App::Prop_None, "Coarse View on/off");
+    ADD_PROPERTY_TYPE(CoarseDeflection, (0.10), sgroup, App::Prop_None,
+                  "Linear deflection used by the polygon approximation HLR. Only used when CoarseView is true.");
+    ADD_PROPERTY_TYPE(CoarseAngularDeflection, (0.50), sgroup, App::Prop_None,
+                  "Angular deflection in radians used by the polygon approximation HLR. Only used when CoarseView is true.");
     ADD_PROPERTY_TYPE(SmoothVisible, (Preferences::getPreferenceGroup("HLR")->GetBool("SmoothViz", true)),
         sgroup, App::Prop_None, "Show Visible Smooth lines");
     ADD_PROPERTY_TYPE(SeamVisible, (Preferences::getPreferenceGroup("HLR")->GetBool("SeamViz", false)),
@@ -265,6 +269,7 @@ short DrawViewPart::mustExecute() const
         || SmoothVisible.isTouched() || SeamVisible.isTouched() || IsoVisible.isTouched()
         || HardHidden.isTouched() || SmoothHidden.isTouched() || SeamHidden.isTouched()
         || IsoHidden.isTouched() || IsoCount.isTouched() || CoarseView.isTouched()
+        || CoarseDeflection.isTouched() || CoarseAngularDeflection.isTouched()
         || CosmeticVertexes.isTouched() || CosmeticEdges.isTouched() || CenterLines.isTouched()) {
         return 1;
     }
@@ -357,7 +362,7 @@ TechDraw::GeometryObjectPtr DrawViewPart::buildGeometryObject(const TopoDS_Shape
     if (CoarseView.getValue()) {
         //the polygon approximation HLR process runs quickly, so doesn't need to be in a
         //separate thread
-        go->projectShapeWithPolygonAlgo(shape, viewAxis);
+        go->projectShapeWithPolygonAlgo(shape, viewAxis, CoarseDeflection.getValue(), CoarseAngularDeflection.getValue());
         return go;
     }
 

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -120,6 +120,9 @@ public:
     App::PropertyDistance Focus;
 
     App::PropertyBool CoarseView;
+    App::PropertyDistance CoarseDeflection;
+    App::PropertyFloat CoarseAngularDeflection;
+    
     App::PropertyBool SeamVisible;
     App::PropertyBool SmoothVisible;
     //App::PropertyBool   OutlinesVisible;

--- a/src/Mod/TechDraw/App/GeometryObject.cpp
+++ b/src/Mod/TechDraw/App/GeometryObject.cpp
@@ -283,7 +283,7 @@ void GeometryObject::makeTDGeometry()
 
 
 //!set up a hidden line remover and project a shape with it
-void GeometryObject::projectShapeWithPolygonAlgo(const TopoDS_Shape& input, const gp_Ax2& viewAxis)
+void GeometryObject::projectShapeWithPolygonAlgo(const TopoDS_Shape& input, const gp_Ax2& viewAxis, double deflection, double angularDeflection)
 {
 //    Base::Console().message("GO::projectShapeWithPolygonAlgo()\n");
     // Clear previous Geometry
@@ -308,7 +308,9 @@ void GeometryObject::projectShapeWithPolygonAlgo(const TopoDS_Shape& input, cons
     try {
         // HLRBRep_PolyAlgo will fail if the whole input shape has not been meshed.
         // meshing the faces is not sufficient.
-        BRepMesh_IncrementalMesh(inCopy, 0.10);
+        const double safeDeflection = std::max(deflection, Precision::Confusion());
+        const double safeAngularDeflection = std::max(angularDeflection, Precision::Angular());
+        BRepMesh_IncrementalMesh(inCopy, safeDeflection, false, safeAngularDeflection);
 
         brep_hlrPoly = new HLRBRep_PolyAlgo();
         brep_hlrPoly->Load(inCopy);

--- a/src/Mod/TechDraw/App/GeometryObject.h
+++ b/src/Mod/TechDraw/App/GeometryObject.h
@@ -80,7 +80,7 @@ public:
     void setEdgeGeometry(BaseGeomPtrVector newGeoms) { edgeGeom = newGeoms; }
 
     void projectShape(const TopoDS_Shape& input, const gp_Ax2& viewAxis);
-    void projectShapeWithPolygonAlgo(const TopoDS_Shape& input, const gp_Ax2& viewAxis);
+    void projectShapeWithPolygonAlgo(const TopoDS_Shape& input, const gp_Ax2& viewAxis, double deflection = 0.1, double angularDeflection = 0.5);
     static TopoDS_Shape projectSimpleShape(const TopoDS_Shape& shape, const gp_Ax2& CS, bool invertYRequired = true);
     static TopoDS_Shape simpleProjection(const TopoDS_Shape& shape, const gp_Ax2& projCS);
     static TopoDS_Shape projectFace(const TopoDS_Shape& face, const gp_Ax2& CS);


### PR DESCRIPTION
## Summary

Adds two per-view TechDraw properties for CoarseView polygon HLR:

- `CoarseDeflection`
- `CoarseAngularDeflection`

These values are passed to `BRepMesh_IncrementalMesh()` when `CoarseView` is enabled, replacing the previously hardcoded linear deflection value.

Defaults preserve the previous behavior as much as possible:
- `CoarseDeflection = 0.10`
- `CoarseAngularDeflection = 0.50`

The properties only affect the polygon HLR path used by CoarseView.

This change was assisted by ChatGPT / GPT-5.5 Thinking, and I reviewed, tested, and take responsibility for the final code.

## Issues

No issue linked.

<img alt="coarse_deflection_accuracy_properties" src="https://github.com/user-attachments/assets/c5fff5dc-1f30-43a6-a581-1ec2d154b40f" />


Note:
For high accuracy for the HLR the performance are actually lower in coarse view vs without. More research is needed
