### PR TITLE
CAM: Job - Fix Cycle Time for dress-ups

### DIFF
--- a/src/Mod/CAM/Path/Main/Job.py
+++ b/src/Mod/CAM/Path/Main/Job.py
@@ -21,6 +21,7 @@
 # *                                                                         *
 # ***************************************************************************
 
+from Path.Op.Util import getCycleTimeEstimate
 from Path.Post.Processor import PostProcessorFactory  # PostProcessor,
 from PySide import QtCore
 from PySide.QtCore import QT_TRANSLATE_NOOP
@@ -747,34 +748,15 @@ class ObjectJob:
 
     def getCycleTime(self):
         seconds = 0
-
-        if len(self.obj.Operations.Group):
-            for op in self.obj.Operations.Group:
-
-                # Skip inactive operations
-                if PathUtil.opProperty(op, "Active") is False:
-                    continue
-
-                # Skip operations that don't have a cycletime attribute
-                if PathUtil.opProperty(op, "CycleTime") is None:
-                    continue
-
-                formattedCycleTime = PathUtil.opProperty(op, "CycleTime")
-                opCycleTime = 0
-                try:
-                    # Convert the formatted time from HH:MM:SS to just seconds
-                    opCycleTime = sum(
-                        x * int(t)
-                        for x, t in zip([1, 60, 3600], reversed(formattedCycleTime.split(":")))
-                    )
-                except Exception:
-                    continue
-
-                if opCycleTime > 0:
-                    seconds = seconds + opCycleTime
-
-        cycleTimeString = time.strftime("%H:%M:%S", time.gmtime(seconds))
-        self.obj.CycleTime = cycleTimeString
+        errorStr = ""
+        for op in self.obj.Operations.Group:
+            result = getCycleTimeEstimate(op, formatted=False)
+            if isinstance(result, (int, float)):
+                seconds += result
+            else:
+                errorStr = f" ({op.Label}: {result})"
+        timeStr = time.strftime("%H:%M:%S", time.gmtime(seconds))
+        self.obj.CycleTime = f"{timeStr}{errorStr}"
 
     def addOperation(self, op, before=None, removeBefore=False):
         group = self.obj.Operations.Group

--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -28,8 +28,7 @@ import Path
 import Path.Base.Util as PathUtil
 import Path.Geom
 import PathScripts.PathUtils as PathUtils
-import math
-import time
+from Path.Op.Util import getCycleTimeEstimate
 
 # lazily loaded modules
 from lazy_loader.lazy_loader import LazyLoader
@@ -718,7 +717,7 @@ class ObjectOp(object):
                     if hasattr(shape, "ShapeType"):
                         Path.Log.debug(f"  Shape type: {shape.ShapeType}")
                     if hasattr(shape, "isNull") and shape.isNull():
-                        Path.Log.warning(f"  Transformed shape is null, using original")
+                        Path.Log.warning("  Transformed shape is null, using original")
                         shape = base_obj.Shape
                     elif hasattr(shape, "Volume") and shape.Volume < 1e-9:
                         Path.Log.debug(f"  Transformed shape has very small volume: {shape.Volume}")
@@ -727,7 +726,7 @@ class ObjectOp(object):
                     if hasattr(shape, "Faces"):
                         Path.Log.debug(f"  Shape has {len(shape.Faces)} faces")
                         if len(shape.Faces) == 0:
-                            Path.Log.warning(f"  Transformed shape has no faces!")
+                            Path.Log.warning("  Transformed shape has no faces!")
 
                     proxy_cache[key] = _TransformedShapeProxy(base_obj, shape)
                 else:
@@ -1495,48 +1494,6 @@ class Compass:
         for k, v in report_data.items():
             Path.Log.debug(f"  {k:15s}: {v}")
         return report_data
-
-
-def getCycleTimeEstimate(obj):
-    tc = obj.ToolController
-
-    if tc is None or tc.ToolNumber == 0:
-        Path.Log.error(translate("CAM", "No Tool Controller selected."))
-        return translate("CAM", "Tool Error")
-
-    hFeedrate = tc.HorizFeed.Value
-    vFeedrate = tc.VertFeed.Value
-    hRapidrate = tc.HorizRapid.Value
-    vRapidrate = tc.VertRapid.Value
-
-    if hFeedrate == 0 or vFeedrate == 0:
-        if not Path.Preferences.suppressAllSpeedsWarning():
-            Path.Log.warning(
-                translate(
-                    "CAM",
-                    "Tool Controller feedrates required to calculate the cycle time.",
-                )
-            )
-        return translate("CAM", "Tool Feedrate Error")
-
-    if (hRapidrate == 0 or vRapidrate == 0) and not Path.Preferences.suppressRapidSpeedsWarning():
-        Path.Log.warning(
-            translate(
-                "CAM",
-                "Add Tool Controller Rapid Speeds on the SetupSheet for more accurate cycle times.",
-            )
-        )
-
-    # Get the cycle time in seconds
-    seconds = obj.Path.getCycleTime(hFeedrate, vFeedrate, hRapidrate, vRapidrate)
-
-    if math.isnan(seconds):
-        return translate("CAM", "Cycletime Error")
-
-    # Convert the cycle time to a HH:MM:SS format
-    cycleTime = time.strftime("%H:%M:%S", time.gmtime(seconds))
-
-    return cycleTime
 
 
 def SetupPropertiesLinking():

--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -33,7 +33,7 @@ import Path.Base.Generator.linking as linking
 import Path.Base.MachineState as PathMachineState
 import Path.Op.Base as PathOp
 import Path.Op.CircularHoleBase as PathCircularHoleBase
-import PathScripts.PathUtils as PathUtils
+from Path.Op.Util import drillTipLength
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 __title__ = "CAM Drilling Operation"
@@ -281,9 +281,9 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
         # Calculate offsets to add to target edge
         endoffset = 0.0
         if obj.ExtraOffset == "Drill Tip":
-            endoffset = PathUtils.drillTipLength(self.tool)
+            endoffset = drillTipLength(self.tool)
         elif obj.ExtraOffset == "2x Drill Tip":
-            endoffset = PathUtils.drillTipLength(self.tool) * 2
+            endoffset = drillTipLength(self.tool) * 2
 
         # compute the drilling targets
         edgelist = []
@@ -443,9 +443,9 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
         # Calculate offsets to add to target edge
         endoffset = 0.0
         if obj.ExtraOffset == "Drill Tip":
-            endoffset = PathUtils.drillTipLength(self.tool)
+            endoffset = drillTipLength(self.tool)
         elif obj.ExtraOffset == "2x Drill Tip":
-            endoffset = PathUtils.drillTipLength(self.tool) * 2
+            endoffset = drillTipLength(self.tool) * 2
 
         # compute the tapping targets
         edgelist = []

--- a/src/Mod/CAM/Path/Op/Gui/Array.py
+++ b/src/Mod/CAM/Path/Op/Gui/Array.py
@@ -23,10 +23,10 @@ import DraftVecUtils
 import FreeCAD
 import FreeCADGui
 import Path
-import Path.Op.Base as PathOp
 import PathScripts.PathUtils as PathUtils
 import Path.Base.Util as PathUtil
 from Path.Dressup.Utils import toolController
+from Path.Op.Util import getCycleTimeEstimate
 import tsp_solver
 
 import random
@@ -288,7 +288,7 @@ class ObjectArray:
                 "Path",
                 QT_TRANSLATE_NOOP("App::Property", "Operations cycle time estimation"),
             )
-            obj.CycleTime = self.getCycleTimeEstimate(obj)
+            obj.CycleTime = getCycleTimeEstimate(obj)
 
         if not hasattr(obj, "ReverseDirection"):
             obj.addProperty(
@@ -383,7 +383,7 @@ class ObjectArray:
         )
 
         obj.Path = pa.getPath()
-        obj.CycleTime = PathOp.getCycleTimeEstimate(obj)
+        obj.CycleTime = getCycleTimeEstimate(obj)
 
     def isBaseCompatible(self, obj):
         if not obj.Base:

--- a/src/Mod/CAM/Path/Op/Tapping.py
+++ b/src/Mod/CAM/Path/Op/Tapping.py
@@ -32,7 +32,7 @@ import Path.Base.Generator.tapping as tapping
 import Path.Base.MachineState as PathMachineState
 import Path.Op.Base as PathOp
 import Path.Op.CircularHoleBase as PathCircularHoleBase
-import PathScripts.PathUtils as PathUtils
+from Path.Op.Util import drillTipLength
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 __title__ = "Path Tapping Operation"
@@ -176,9 +176,9 @@ class ObjectTapping(PathCircularHoleBase.ObjectOp):
         # Calculate offsets to add to target edge
         endoffset = 0.0
         if obj.ExtraOffset == "Drill Tip":
-            endoffset = PathUtils.drillTipLength(self.tool)
+            endoffset = drillTipLength(self.tool)
         elif obj.ExtraOffset == "2x Drill Tip":
-            endoffset = PathUtils.drillTipLength(self.tool) * 2
+            endoffset = drillTipLength(self.tool) * 2
 
         # http://linuxcnc.org/docs/html/gcode/g-code.html#gcode:g98-g99
         self.commandlist.append(

--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -25,8 +25,8 @@
 import FreeCAD
 import Path
 import Path.Dressup.Utils as PathDressup
-import PathScripts.PathUtils as PathUtils
 import math
+import time
 
 # lazily loaded modules
 from lazy_loader.lazy_loader import LazyLoader
@@ -571,7 +571,7 @@ def getClearedAreas(currentOp, bbox):
         tool = baseOp.ToolController.Tool
         diameter = tool.Diameter.getValueAs("mm")
         # for drills, dz translates to the full width part of the tool
-        dz = 0 if not hasattr(tool, "TipAngle") else -PathUtils.drillTipLength(tool)
+        dz = 0 if not hasattr(tool, "TipAngle") else -drillTipLength(tool)
         opPath = _stripRotaryAxes(op.Path) if rotated else op.Path
         clearedAreas.append(opPath.getClearedArea(diameter, z + dz, bbox))
     return clearedAreas
@@ -648,3 +648,77 @@ def getOpSide(obj, default="Outside"):
             return "Outside"
 
     return default
+
+
+def getCycleTimeEstimate(obj, formatted=True):
+    """getCycleTimeEstimate(obj, formated=True) ... Returns operation cycle time estimation
+    If formatted=True returns string which describes time in format 'hh:mm:ss'
+    If formatted=False returns seconds as a float value"""
+    baseOp = PathDressup.baseOp(obj)
+    tc = baseOp.ToolController
+
+    if tc is None or tc.ToolNumber == 0:
+        Path.Log.error(translate("CAM", "No Tool Controller selected."))
+        return translate("CAM", "Tool Error")
+
+    hFeedrate = tc.HorizFeed.Value
+    vFeedrate = tc.VertFeed.Value
+    hRapidrate = tc.HorizRapid.Value
+    vRapidrate = tc.VertRapid.Value
+
+    if hFeedrate == 0 or vFeedrate == 0:
+        if not Path.Preferences.suppressAllSpeedsWarning():
+            Path.Log.warning(
+                translate(
+                    "CAM",
+                    "Tool Controller feedrates required to calculate the cycle time.",
+                )
+            )
+        return translate("CAM", "Tool Feedrate Error")
+
+    if (hRapidrate == 0 or vRapidrate == 0) and not Path.Preferences.suppressRapidSpeedsWarning():
+        Path.Log.warning(
+            translate(
+                "CAM",
+                "Add Tool Controller Rapid Speeds on the SetupSheet for more accurate cycle times.",
+            )
+        )
+
+    # Get the cycle time in seconds
+    seconds = obj.Path.getCycleTime(hFeedrate, vFeedrate, hRapidrate, vRapidrate)
+
+    if math.isnan(seconds):
+        return translate("CAM", "Cycletime Error")
+
+    if formatted:  # Convert the cycle time to a HH:MM:SS format
+        return time.strftime("%H:%M:%S", time.gmtime(seconds))
+    else:
+        return seconds
+
+
+def drillTipLength(tool):
+    """returns the length of the drillbit tip."""
+
+    if not hasattr(tool, "TipAngle"):
+        Path.Log.error(translate("Path", "Selected tool is not a drill"))
+        return 0.0
+
+    angle = tool.TipAngle
+
+    if angle <= 0 or angle >= 180:
+        Path.Log.error(
+            translate("Path", "Invalid Cutting Edge Angle %.2f, must be >0° and <=180°") % angle
+        )
+        return 0.0
+
+    theta = math.radians(angle)
+    length = (float(tool.Diameter) / 2) / math.tan(theta / 2)
+
+    if length < 0:
+        Path.Log.error(
+            translate("Path", "Cutting Edge Angle (%.2f) results in negative tool tip length")
+            % angle
+        )
+        return 0.0
+
+    return length

--- a/src/Mod/CAM/PathScripts/PathUtils.py
+++ b/src/Mod/CAM/PathScripts/PathUtils.py
@@ -691,34 +691,6 @@ def guessDepths(objshape, subs=None):
     return depth_params(clearance, safe, start, 1.0, 0.0, final, user_depths=None, equalstep=False)
 
 
-def drillTipLength(tool):
-    """returns the length of the drillbit tip."""
-
-    if not hasattr(tool, "TipAngle"):
-        Path.Log.error(translate("Path", "Selected tool is not a drill"))
-        return 0.0
-
-    angle = tool.TipAngle
-
-    if angle <= 0 or angle >= 180:
-        Path.Log.error(
-            translate("Path", "Invalid Cutting Edge Angle %.2f, must be >0° and <=180°") % angle
-        )
-        return 0.0
-
-    theta = math.radians(angle)
-    length = (float(tool.Diameter) / 2) / math.tan(theta / 2)
-
-    if length < 0:
-        Path.Log.error(
-            translate("Path", "Cutting Edge Angle (%.2f) results in negative tool tip length")
-            % angle
-        )
-        return 0.0
-
-    return length
-
-
 class depth_params(object):
     """calculates the intermediate depth values for various operations given the starting, ending, and stepdown parameters
     (self, clearance_height, safe_height, start_depth, step_down, z_finish_depth, final_depth, [user_depths=None], equalstep=False)


### PR DESCRIPTION
Fixes #31109 
- #31109 
---

### Changes

- Moved method `getCycleTimeEstimate()` to `Path.Op.Util`
- Added ability to return string (formatted result "HH:MM:SS") or float (seconds)
- While get total cycle time of the Job, calculate cycle time for each operation instead of parse CylceTime property  from base operation
   This allows to get correct time for op which not have property `CycleTime`, e.g. dress-ups
- Add error message if needed, which inform user about problem
   <img width="1286" height="265" alt="Screenshot_20260708_175858_hor" src="https://github.com/user-attachments/assets/757e87ba-963f-4271-bdde-0eee73352f0e" />

