### PR TITLE
Gui: Fix Coin debug warnings from scene graph ownership

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -348,8 +348,32 @@ struct MainWindowP
     fastsignals::advanced_scoped_connection connParam;
     ParameterGrp::handle hGrp;
     bool _restoring = false;
+    bool coinRealTimeSensorSuspended = false;
+    SbTime savedRealTimeInterval;
     QTime _showNormal;
     void restoreWindowState(const QByteArray&);
+
+    void suspendCoinRealTimeSensor()
+    {
+        if (coinRealTimeSensorSuspended) {
+            return;
+        }
+
+        savedRealTimeInterval = SoDB::getRealTimeInterval();
+        SoDB::enableRealTimeSensor(false);
+        coinRealTimeSensorSuspended = true;
+    }
+
+    void resumeCoinRealTimeSensor()
+    {
+        if (!coinRealTimeSensorSuspended) {
+            return;
+        }
+
+        SoDB::setRealTimeInterval(savedRealTimeInterval);
+        SoDB::enableRealTimeSensor(true);
+        coinRealTimeSensorSuspended = false;
+    }
 };
 
 }  // namespace Gui
@@ -2664,16 +2688,13 @@ void MainWindow::changeEvent(QEvent* e)
         App::GetApplication().retranslateExportTypes();
     }
     else if (e->type() == QEvent::ActivationChange) {
-        static SbTime savedRealTimeInterval = SoDB::getRealTimeInterval();
         if (isActiveWindow()) {
             QMdiSubWindow* mdi = d->mdiArea->currentSubWindow();
             setActiveSubWindow(mdi);
-            SoDB::enableRealTimeSensor(true);
-            SoDB::setRealTimeInterval(savedRealTimeInterval);
+            d->resumeCoinRealTimeSensor();
         }
         else {
-            savedRealTimeInterval = SoDB::getRealTimeInterval();
-            SoDB::enableRealTimeSensor(false);
+            d->suspendCoinRealTimeSensor();
         }
     }
     else {

--- a/src/Gui/TextureMapping.cpp
+++ b/src/Gui/TextureMapping.cpp
@@ -103,7 +103,7 @@ void TextureMapping::reject()
 {
     if (this->grp) {
         this->grp->removeChild(this->tex);
-        if (this->grp->findChild(this->env) > -1) {
+        if (this->grp->findChild(this->env) >= 0) {
             this->grp->removeChild(this->env);
         }
         this->grp->unref();
@@ -184,7 +184,9 @@ void TextureMapping::onCheckEnvToggled(bool b)
         this->grp->insertChild(this->env, 2);
     }
     else {
-        this->grp->removeChild(this->env);
+        if (this->grp->findChild(this->env) >= 0) {
+            this->grp->removeChild(this->env);
+        }
     }
 }
 

--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -851,6 +851,7 @@ class ViewProviderBuildingPart:
 
         self.Object = vobj.Object
         self.clip = None
+        self.clip_scene_graph = None
         from pivy import coin
 
         self.sep = coin.SoGroup()
@@ -931,6 +932,16 @@ class ViewProviderBuildingPart:
         "get the colors of objects inside this BuildingPart"
 
         return Draft.get_diffuse_color(Draft.get_group_contents(obj, walls=True))
+
+    def removeClipPlane(self):
+
+        if not self.clip:
+            return
+        sg = self.clip_scene_graph
+        if sg and sg.findChild(self.clip) >= 0:
+            sg.removeChild(self.clip)
+        self.clip = None
+        self.clip_scene_graph = None
 
     def onChanged(self, vobj, prop):
 
@@ -1044,19 +1055,14 @@ class ViewProviderBuildingPart:
                             and not hasattr(child, "ChildrenOverride")
                         ):
                             setattr(child.ViewObject, prop[8:], getattr(vobj, prop))
-        elif prop in ["CutView", "CutMargin"]:
-            if (
-                hasattr(vobj, "CutView")
-                and FreeCADGui.ActiveDocument.ActiveView
-                and hasattr(FreeCADGui.ActiveDocument.ActiveView, "getSceneGraph")
-            ):
-                sg = FreeCADGui.ActiveDocument.ActiveView.getSceneGraph()
-                if vobj.CutView:
+        elif prop in ["CutView", "CutMargin"] and hasattr(vobj, "CutView"):
+            if vobj.CutView:
+                active_view = getattr(FreeCADGui.ActiveDocument, "ActiveView", None)
+                if active_view and hasattr(active_view, "getSceneGraph"):
+                    sg = active_view.getSceneGraph()
                     from pivy import coin
 
-                    if self.clip:
-                        sg.removeChild(self.clip)
-                        self.clip = None
+                    self.removeClipPlane()
                     for o in Draft.get_group_contents(vobj.Object.Group, walls=True):
                         if hasattr(o.ViewObject, "Lighting"):
                             o.ViewObject.Lighting = "One side"
@@ -1078,13 +1084,12 @@ class ViewProviderBuildingPart:
                     plane = coin.SbPlane(coin.SbVec3f(norm.x, norm.y, norm.z), dist)
                     self.clip.plane.setValue(plane)
                     sg.insertChild(self.clip, 0)
-                else:
-                    if getattr(self, "clip", None):
-                        sg.removeChild(self.clip)
-                        self.clip = None
-                    for o in Draft.get_group_contents(vobj.Object.Group, walls=True):
-                        if hasattr(o.ViewObject, "Lighting"):
-                            o.ViewObject.Lighting = "Two side"
+                    self.clip_scene_graph = sg
+            else:
+                self.removeClipPlane()
+                for o in Draft.get_group_contents(vobj.Object.Group, walls=True):
+                    if hasattr(o.ViewObject, "Lighting"):
+                        o.ViewObject.Lighting = "Two side"
         elif prop == "Visibility":
             # turn clipping off when turning the object off
             if hasattr(vobj, "Visibility") and not (vobj.Visibility) and hasattr(vobj, "CutView"):
@@ -1114,10 +1119,7 @@ class ViewProviderBuildingPart:
 
     def onDelete(self, vobj, subelements):
 
-        if self.clip:
-            sg = FreeCADGui.ActiveDocument.ActiveView.getSceneGraph()
-            sg.removeChild(self.clip)
-            self.clip = None
+        self.removeClipPlane()
         for o in Draft.get_group_contents(vobj.Object.Group, walls=True):
             if hasattr(o.ViewObject, "Lighting"):
                 o.ViewObject.Lighting = "Two side"

--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -1264,6 +1264,7 @@ class _ViewProviderSectionPlane:
 
         self.Object = vobj.Object
         self.clip = None
+        self.clip_scene_graph = None
         self.main_transform = gui_utils.find_coin_node(vobj.RootNode, coin.SoTransform)
         self.mat1 = coin.SoMaterial()
         self.mat2 = coin.SoMaterial()
@@ -1402,6 +1403,16 @@ class _ViewProviderSectionPlane:
             vobj.CutView = False
             vobj.CutView = True
 
+    def removeClipPlane(self):
+
+        if not self.clip:
+            return
+        sg = self.clip_scene_graph
+        if sg and sg.findChild(self.clip) >= 0:
+            sg.removeChild(self.clip)
+        self.clip = None
+        self.clip_scene_graph = None
+
     def onChanged(self, vobj, prop):
 
         if prop == "LineColor":
@@ -1456,17 +1467,12 @@ class _ViewProviderSectionPlane:
             # self.txtfont.size = l1
         elif prop == "LineWidth":
             self.drawstyle.lineWidth = vobj.LineWidth
-        elif prop in ["CutView", "CutMargin"]:
-            if (
-                hasattr(vobj, "CutView")
-                and FreeCADGui.ActiveDocument.ActiveView
-                and hasattr(FreeCADGui.ActiveDocument.ActiveView, "getSceneGraph")
-            ):
-                sg = FreeCADGui.ActiveDocument.ActiveView.getSceneGraph()
-                if vobj.CutView:
-                    if self.clip:
-                        sg.removeChild(self.clip)
-                        self.clip = None
+        elif prop in ["CutView", "CutMargin"] and hasattr(vobj, "CutView"):
+            if vobj.CutView:
+                active_view = getattr(FreeCADGui.ActiveDocument, "ActiveView", None)
+                if active_view and hasattr(active_view, "getSceneGraph"):
+                    sg = active_view.getSceneGraph()
+                    self.removeClipPlane()
                     for o in Draft.get_group_contents(vobj.Object.Objects, walls=True):
                         if hasattr(o.ViewObject, "Lighting"):
                             o.ViewObject.Lighting = "One side"
@@ -1488,10 +1494,9 @@ class _ViewProviderSectionPlane:
                     plane = coin.SbPlane(coin.SbVec3f(norm.x, norm.y, norm.z), dist)
                     self.clip.plane.setValue(plane)
                     sg.insertChild(self.clip, 0)
-                else:
-                    if self.clip:
-                        sg.removeChild(self.clip)
-                        self.clip = None
+                    self.clip_scene_graph = sg
+            else:
+                self.removeClipPlane()
         elif prop == "ShowLabel":
             if vobj.ShowLabel:
                 self.txt.string = vobj.Object.Label or " "

--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -1616,6 +1616,7 @@ class _ViewProviderSite:
         """
 
         self.Object = vobj.Object
+        self.trueNorthRotationSceneGraph = None
         from pivy import coin
 
         basesep = coin.SoSeparator()
@@ -1937,6 +1938,7 @@ class _ViewProviderSite:
         self.trueNorthRotation = coin.SoTransform()
         sg = FreeCADGui.ActiveDocument.ActiveView.getSceneGraph()
         sg.insertChild(self.trueNorthRotation, 0)
+        self.trueNorthRotationSceneGraph = sg
         self.updateTrueNorthRotation()
 
     def removeTrueNorthRotation(self):
@@ -1945,14 +1947,11 @@ class _ViewProviderSite:
             return
         if self.trueNorthRotation is None:
             return
-        if not FreeCADGui.ActiveDocument.ActiveView:
-            return
-        if not hasattr(FreeCADGui.ActiveDocument.ActiveView, "getSceneGraph"):
-            return
-
-        sg = FreeCADGui.ActiveDocument.ActiveView.getSceneGraph()
-        sg.removeChild(self.trueNorthRotation)
+        sg = self.trueNorthRotationSceneGraph
+        if sg and sg.findChild(self.trueNorthRotation) >= 0:
+            sg.removeChild(self.trueNorthRotation)
         self.trueNorthRotation = None
+        self.trueNorthRotationSceneGraph = None
 
     def updateTrueNorthRotation(self):
 

--- a/src/Mod/Draft/drafttests/test_dimension_gui.py
+++ b/src/Mod/Draft/drafttests/test_dimension_gui.py
@@ -108,6 +108,25 @@ class DraftGuiDimension(test_base.DraftTestCaseDoc):
         vobj.ArrowTypeEnd = "Dot"
         return dimension
 
+    def test_linear_dimension_marks_stay_under_line_switches(self):
+        """Updating linear dimensions keeps arrow and overshoot nodes under ShowLine switches."""
+        dimension = Draft.make_dimension(Vector(0, 0, 0), Vector(10, 0, 0), Vector(0, 2, 0))
+        vobj = dimension.ViewObject
+
+        vobj.ArrowTypeStart = "Dot"
+        vobj.ArrowTypeEnd = "Dot"
+        vobj.DimOvershoot = 1
+        vobj.ExtOvershoot = 2
+        self.doc.recompute()
+
+        proxy = dimension.ViewObject.Proxy
+        nodes = (proxy.marks, proxy.marksDimOvershoot, proxy.marksExtOvershoot)
+        for node in nodes:
+            self.assertGreaterEqual(proxy.lineswitch_wld.findChild(node), 0)
+            self.assertGreaterEqual(proxy.lineswitch_scr.findChild(node), 0)
+            self.assertEqual(proxy.node_wld.findChild(node), -1)
+            self.assertEqual(proxy.node_scr.findChild(node), -1)
+
     def getAngularSvg(self, dimension):
         """Return the Draft SVG body used by TechDraw DraftView for this dimension."""
         Gui.updateGui()

--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -222,6 +222,10 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
     of circular edges, and circumferences.
     """
 
+    ARROW_MARKS_INDEX = 2
+    DIM_OVERSHOOT_MARKS_INDEX = 3
+    EXT_OVERSHOOT_MARKS_INDEX = 4
+
     def set_graphics_properties(self, vobj, properties):
         """Set graphics properties only if they don't already exist."""
         super().set_graphics_properties(vobj, properties)
@@ -677,8 +681,8 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
 
         Remove the existing nodes.
         """
-        self.node_wld.removeChild(self.marks)
-        self.node_scr.removeChild(self.marks)
+        self.lineswitch_wld.removeChild(self.marks)
+        self.lineswitch_scr.removeChild(self.marks)
 
     def draw_dim_arrows(self, vobj):
         """Draw dimension arrows."""
@@ -720,13 +724,13 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
         s2.addChild(gui_utils.dim_symbol(symbol_end, invert=True))
         self.marks.addChild(s2)
 
-        self.node_wld.insertChild(self.marks, 2)
-        self.node_scr.insertChild(self.marks, 2)
+        self.lineswitch_wld.insertChild(self.marks, self.ARROW_MARKS_INDEX)
+        self.lineswitch_scr.insertChild(self.marks, self.ARROW_MARKS_INDEX)
 
     def remove_dim_overshoot(self):
         """Remove the dimension overshoot lines."""
-        self.node_wld.removeChild(self.marksDimOvershoot)
-        self.node_scr.removeChild(self.marksDimOvershoot)
+        self.lineswitch_wld.removeChild(self.marksDimOvershoot)
+        self.lineswitch_scr.removeChild(self.marksDimOvershoot)
 
     def draw_dim_overshoot(self, vobj):
         """Draw dimension overshoot lines."""
@@ -750,13 +754,13 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
             s2.addChild(gui_utils.dimDash((0, 0, 0), (1, 0, 0)))
             self.marksDimOvershoot.addChild(s2)
 
-        self.node_wld.insertChild(self.marksDimOvershoot, 2)
-        self.node_scr.insertChild(self.marksDimOvershoot, 2)
+        self.lineswitch_wld.insertChild(self.marksDimOvershoot, self.DIM_OVERSHOOT_MARKS_INDEX)
+        self.lineswitch_scr.insertChild(self.marksDimOvershoot, self.DIM_OVERSHOOT_MARKS_INDEX)
 
     def remove_ext_overshoot(self):
         """Remove dimension extension overshoot lines."""
-        self.node_wld.removeChild(self.marksExtOvershoot)
-        self.node_scr.removeChild(self.marksExtOvershoot)
+        self.lineswitch_wld.removeChild(self.marksExtOvershoot)
+        self.lineswitch_scr.removeChild(self.marksExtOvershoot)
 
     def draw_ext_overshoot(self, vobj):
         """Draw dimension extension overshoot lines."""
@@ -779,8 +783,8 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
             s2.addChild(gui_utils.dimDash((0, 0, 0), (-1, 0, 0)))
             self.marksExtOvershoot.addChild(s2)
 
-        self.node_wld.insertChild(self.marksExtOvershoot, 2)
-        self.node_scr.insertChild(self.marksExtOvershoot, 2)
+        self.lineswitch_wld.insertChild(self.marksExtOvershoot, self.EXT_OVERSHOOT_MARKS_INDEX)
+        self.lineswitch_scr.insertChild(self.marksExtOvershoot, self.EXT_OVERSHOOT_MARKS_INDEX)
 
     def is_linked_to_circle(self):
         """Return true if the dimension measures a circular edge."""

--- a/src/Mod/Part/Gui/ViewProviderPreviewExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPreviewExtension.cpp
@@ -182,7 +182,7 @@ void ViewProviderPreviewExtension::showPreview(bool enable)
             annotationRoot->addChild(pcPreviewRoot);
         }
     }
-    else {
+    else if (annotationRoot->findChild(pcPreviewRoot) >= 0) {
         annotationRoot->removeChild(pcPreviewRoot);
     }
 }

--- a/src/Mod/PartDesign/Gui/ViewProviderHole.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderHole.cpp
@@ -730,7 +730,10 @@ void ViewProviderHole::updateOverlay()
     auto it = m_threadOverlays.find(hole);
     if (it != m_threadOverlays.end()) {
         SoSwitch* existingSwitch = it->second;
-        bodyVp->getRoot()->removeChild(existingSwitch);
+        SoGroup* root = bodyVp->getRoot();
+        if (root && root->findChild(existingSwitch) >= 0) {
+            root->removeChild(existingSwitch);
+        }
         existingSwitch->unref();
         m_threadOverlays.erase(it);
     }


### PR DESCRIPTION
## Summary
Debug builds route Coin diagnostics into FreeCAD's console, so latent scene graph ownership issues show up as messages such as:

- `Coin warning in SoDB::enableRealTimeSensor(): realtime sensor already on`
- `Coin error in SoGroup::removeChild(): tried to remove non-existent child ...`

This PR fixes the FreeCAD-side callers instead of suppressing Coin diagnostics.

## Changes
- Only re-enable Coin's realtime sensor if FreeCAD previously disabled it during window deactivation.
- Keep Draft linear dimension arrow and overshoot mark nodes under their `ShowLine` switch parents when updating, with a GUI regression test.
- Guard optional GUI, Part, and PartDesign Coin node removals by checking child membership first.
- Track the owning scene graph for BIM `CutView` clip planes and true-north transform nodes, then remove from that owner only if the node is still present.

