### PR TITLE
CAM: DressupPathBoundary - Fix initial stock selection

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -757,26 +757,18 @@ class StockFromExistingEdit(StockEdit):
         # dropdown list. This is important because the `currentIndexChanged` signal
         # will in the end result in the stock object being recreated in `getFields`
         # method, discarding any changes made (like position in respect to origin).
-        try:
-            self.form.stockExisting.blockSignals(True)
-            self.form.stockExisting.clear()
-            stockName = obj.Stock.Label if obj.Stock else None
-            index = -1
-            for i, solid in enumerate(self.candidates(obj)):
-                self.form.stockExisting.addItem(solid.Label, solid)
-                label = "{}-{}".format(self.StockLabelPrefix, solid.Label)
+        self.form.stockExisting.blockSignals(True)
+        self.form.stockExisting.clear()
 
-                # stockName has index suffix (since cloned), label has no index
-                # => ridgid string comparison fails
-                # Instead of ridgid string comparison use partial (needle in haystack)
-                # string comparison
-                # if label == stockName: # ridgid string comparison
-                if label in stockName:  # partial string comparison
-                    index = i
+        stockBaseName = obj.Stock.Objects[0].Name if getattr(obj.Stock, "Objects", None) else None
+        index = 0
+        for i, solid in enumerate(self.candidates(obj)):
+            self.form.stockExisting.addItem(solid.Label, solid)
+            if stockBaseName == solid.Name:
+                index = i
 
-            self.form.stockExisting.setCurrentIndex(index if index != -1 else 0)
-        finally:
-            self.form.stockExisting.blockSignals(False)
+        self.form.stockExisting.setCurrentIndex(index)
+        self.form.stockExisting.blockSignals(False)
 
         if not self.IsStock(obj):
             self.getFields(obj)


### PR DESCRIPTION
While open **Task** panel of **DressupPathBoundary**
shows first solid object in document instead of object which was selected last time

This happens because to define base model uses label of the model
Such way appropriate for **Job** `Stock`
But this way incorrect for model of **DressupPathBoundary** 

### Changes

- Simplified code
- Use link to original object to solve issue described above

---

**Test project:** [shallow_helix.zip](https://github.com/user-attachments/files/29640942/shallow_helix.zip)

<img width="1099" height="247" alt="1_hor" src="https://github.com/user-attachments/assets/41ed3d53-53f3-43e7-9423-f9ba18ea2db7" />