### PR TITLE
Import: Preserve SVG group and layer hierarchy on import

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-svg.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-svg.ui
@@ -133,6 +133,29 @@ a raw wire from the original shape is added</string>
        </layout>
       </item>
       <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_12">
+        <item>
+         <widget class="Gui::PrefCheckBox" name="checkBox_handleGroups">
+          <property name="toolTip">
+           <string>Check to reproduce the SVG group/layer hierarchy as nested FreeCAD groups instead of importing all objects flat</string>
+          </property>
+          <property name="text">
+           <string>Preserve groups and layers</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>svgHandleGroups</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_5">
         <item>
          <widget class="QLabel" name="label_3">

--- a/src/Mod/Draft/drafttests/test_svg.py
+++ b/src/Mod/Draft/drafttests/test_svg.py
@@ -45,6 +45,7 @@ import draftfunctions.svgshapes as svgshapes
 import importSVG
 from drafttests import auxiliary as aux
 from drafttests import test_base
+from draftutils import params
 from draftutils.messages import _msg
 
 try:
@@ -208,6 +209,62 @@ class DraftSVGExportRegression(test_base.DraftTestCaseDoc):
 
         self.assertIn("<circle ", svg)
         self.assertNotIn("fill-rule: evenodd", svg)
+
+
+class DraftSVGImportGroups(test_base.DraftTestCaseDoc):
+    """Test importing SVG groups and layers as nested document groups."""
+
+    SVG = """<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+     width="100" height="100">
+  <g id="layer1" inkscape:label="Layer 1">
+    <rect x="0" y="0" width="10" height="10"/>
+    <g id="child">
+      <circle cx="5" cy="5" r="2"/>
+    </g>
+    <g id="empty"/>
+  </g>
+</svg>
+"""
+
+    def _import_svg(self, handle_groups):
+        old_value = params.get_param("svgHandleGroups")
+        params.set_param("svgHandleGroups", handle_groups)
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                in_file = os.path.join(temp_dir, "groups.svg")
+                with open(in_file, "w", encoding="utf-8") as svg_file:
+                    svg_file.write(self.SVG)
+                importSVG.insert(in_file, self.doc.Name)
+        finally:
+            params.set_param("svgHandleGroups", old_value)
+
+    def _get_groups(self):
+        return [obj for obj in self.doc.Objects if obj.isDerivedFrom("App::DocumentObjectGroup")]
+
+    def test_import_nested_groups(self):
+        """Import an SVG with nested groups and check the group hierarchy."""
+        self._import_svg(True)
+
+        groups = {obj.Label: obj for obj in self._get_groups()}
+        self.assertEqual(sorted(groups), ["Layer 1", "child"])
+        layer = groups["Layer 1"]
+        child = groups["child"]
+        self.assertIsNone(layer.getParentGroup())
+        self.assertEqual(child.getParentGroup().Name, layer.Name)
+        layer_shapes = [obj for obj in layer.Group if obj.isDerivedFrom("Part::Feature")]
+        self.assertEqual(len(layer_shapes), 1)
+        child_shapes = [obj for obj in child.Group if obj.isDerivedFrom("Part::Feature")]
+        self.assertEqual(len(child_shapes), 1)
+
+    def test_import_flat_when_disabled(self):
+        """Import the same SVG without groups when the preference is disabled."""
+        self._import_svg(False)
+
+        self.assertEqual(self._get_groups(), [])
+        shapes = [obj for obj in self.doc.Objects if obj.isDerivedFrom("Part::Feature")]
+        self.assertEqual(len(shapes), 2)
 
 
 ## @}

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -520,10 +520,12 @@ class svgHandler(xml.sax.ContentHandler):
         self.make_cuts = params.get_param("svgMakeCuts")
         self.add_wire_for_invalid_face = params.get_param("svgAddWireForInvalidFace")
         self.deviation = params.get_param("svgDeviation")
+        self.handle_groups = params.get_param("svgHandleGroups")
         self.count = 0
         self.transform = None
         self.grouptransform = []
         self.groupstyles = []
+        self.currentgroup = None
         self.lastdim = None
         self.viewbox = None
         self.svgdpi = 1.0
@@ -556,6 +558,33 @@ class svgHandler(xml.sax.ContentHandler):
             if self.fill:
                 v.ShapeColor = self.fill
 
+    def _add_object(self, otype, name):
+        """Create a document object and place it in the current group."""
+        obj = self.doc.addObject(otype, name)
+        self._place_in_group(obj)
+        return obj
+
+    def _place_in_group(self, obj):
+        """Place an existing document object in the current group."""
+        if obj is not None and self.currentgroup is not None:
+            self.currentgroup.addObject(obj)
+
+    def _open_group(self, attrs):
+        """Open a document group for an SVG <g>/<a> element."""
+        grp = self.doc.addObject("App::DocumentObjectGroup", "Group")
+        grp.Label = attrs.get("inkscape:label") or attrs.get("id") or "Group"
+        self._place_in_group(grp)
+        self.currentgroup = grp
+
+    def _close_group(self):
+        """Close the current group, removing it if it received no content."""
+        grp = self.currentgroup
+        if grp is None:
+            return
+        self.currentgroup = grp.getParentGroup()
+        if not grp.Group:
+            self.doc.removeObject(grp.Name)
+
     def __addShapeToDoc(self, named_shape):
         """Create a named document object from a name/shape tuple
 
@@ -576,7 +605,7 @@ class svgHandler(xml.sax.ContentHandler):
             else:
                 shape = aWires[0]
 
-        obj = self.doc.addObject("Part::Feature", name)
+        obj = self._add_object("Part::Feature", name)
         obj.Shape = shape
         self.format(obj)
 
@@ -755,6 +784,8 @@ class svgHandler(xml.sax.ContentHandler):
             m = FreeCAD.Matrix()
         if name == "g" or name == "a":
             self.grouptransform.append(m)
+            if self.handle_groups:
+                self._open_group(attrs)
         elif name == "freecad:used":
             # use tag acts as g tag but has x,y attribute
             x = data.get("x", 0)
@@ -816,6 +847,7 @@ class svgHandler(xml.sax.ContentHandler):
                 p3 = data["freecad:dimpoint"]
                 p3 = Vector(float(p3[0]), -float(p3[1]), 0)
                 obj = make_dimension.make_dimension(p1, p2, p3)
+                self._place_in_group(obj)
                 self.applyTrans(obj)
                 self.format(obj)
                 self.lastdim = obj
@@ -908,7 +940,7 @@ class svgHandler(xml.sax.ContentHandler):
             if self.fill:
                 sh = Part.Face(sh)
             sh = self.applyTrans(sh)
-            obj = self.doc.addObject("Part::Feature", pathname)
+            obj = self._add_object("Part::Feature", pathname)
             obj.Shape = sh
             self.format(obj)
 
@@ -920,7 +952,7 @@ class svgHandler(xml.sax.ContentHandler):
             p2 = Vector(data["x2"], -data["y2"], 0)
             sh = Part.LineSegment(p1, p2).toShape()
             sh = self.applyTrans(sh)
-            obj = self.doc.addObject("Part::Feature", pathname)
+            obj = self._add_object("Part::Feature", pathname)
             obj.Shape = sh
             self.format(obj)
 
@@ -955,7 +987,7 @@ class svgHandler(xml.sax.ContentHandler):
                     if self.fill and sh.isClosed():
                         sh = Part.Face(sh)
                     sh = self.applyTrans(sh)
-                    obj = self.doc.addObject("Part::Feature", pathname)
+                    obj = self._add_object("Part::Feature", pathname)
                     obj.Shape = sh
                     self.format(obj)
 
@@ -981,7 +1013,7 @@ class svgHandler(xml.sax.ContentHandler):
             if self.fill:
                 sh = Part.Face(sh)
             sh = self.applyTrans(sh)
-            obj = self.doc.addObject("Part::Feature", pathname)
+            obj = self._add_object("Part::Feature", pathname)
             obj.Shape = sh
             self.format(obj)
 
@@ -997,7 +1029,7 @@ class svgHandler(xml.sax.ContentHandler):
                 sh = Part.Face(sh)
             sh.translate(c)
             sh = self.applyTrans(sh)
-            obj = self.doc.addObject("Part::Feature", pathname)
+            obj = self._add_object("Part::Feature", pathname)
             obj.Shape = sh
             self.format(obj)
 
@@ -1031,7 +1063,7 @@ class svgHandler(xml.sax.ContentHandler):
         """Read characters from the given string."""
         if self.text:
             _msg("reading characters {}".format(content))
-            obj = self.doc.addObject("App::Annotation", "Text")
+            obj = self._add_object("App::Annotation", "Text")
             # use ignore to not break import if char is not found in latin1
             obj.LabelText = content.encode("latin1", "ignore")
             vec = Vector(self.x, -self.y, 0)
@@ -1066,6 +1098,8 @@ class svgHandler(xml.sax.ContentHandler):
             self.grouptransform.pop()
             if self.groupstyles:
                 self.groupstyles.pop()
+        if name == "g" or name == "a":
+            self._close_group()
 
     def applyTrans(self, sh):
         """Apply transformation to the shape and return the new shape.

--- a/src/Mod/OpenSCAD/importCSG.py
+++ b/src/Mod/OpenSCAD/importCSG.py
@@ -858,7 +858,10 @@ def processSVG(fname, ext):
     # Set up the parser
     parser = xml.sax.make_parser()
     parser.setFeature(xml.sax.handler.feature_external_ges, False)
-    parser.setContentHandler(svgHandler())
+    handler = svgHandler()
+    # Only the imported shapes are consumed below, so force a flat import.
+    handler.handle_groups = False
+    parser.setContentHandler(handler)
     parser._cont_handler.doc = docSVG
 
     # pathName is a Global


### PR DESCRIPTION
Adding SVG Grouping imports.

Freecad imports SVG ignoring groups and internal categories, this PR remedies that.

## AI assistance disclosure

This change was developed with assistance from Claude (Opus 4.8). I have reviewed and tested it and take responsibility for it. Disclosed in the commit via `Assisted-by: claude-opus-4-8 (Opus 4.8)`.

<!-- Per the FreeCAD AI policy, tick this box yourself once the description above is in your own words: -->
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
<!-- No issue linked; this is a capability addition. Link one here if you open a Problem Report (e.g. "closes #NNNN"). -->

## Before and After Images
<!-- Add screenshots of the new preferences checkbox and the resulting object tree. -->
