### PR TITLE
Build: Make sure older LibPacks use their internal Coin and Pivy

### DIFF
--- a/cMake/UseLibPack3.cmake
+++ b/cMake/UseLibPack3.cmake
@@ -47,6 +47,15 @@ endif()
 find_package(yaml-cpp REQUIRED PATHS ${FREECAD_LIBPACK_DIR}/lib/cmake NO_DEFAULT_PATH)
 message(STATUS "Found LibPack 3 yaml-cpp ${yaml-cpp_VERSION}")
 
+# LibPacks older than 3.5.3 do not ship the build-time dependencies required to
+# compile the bundled Coin and Pivy (notably the Expat CMake config), but they do
+# provide prebuilt Coin and Pivy. Fall back to those automatically on old LibPacks.
+if(NOT FREECAD_USE_EXTERNAL_COIN_PIVY AND FREECAD_LIBPACK_VERSION VERSION_LESS "3.5.3")
+    message(STATUS "LibPack ${FREECAD_LIBPACK_VERSION} predates 3.5.3 which cannot build the "
+                   "bundled Coin and Pivy; using the LibPack's prebuilt Coin and Pivy instead.")
+    set(FREECAD_USE_EXTERNAL_COIN_PIVY ON)
+endif()
+
 if(FREECAD_USE_EXTERNAL_COIN_PIVY)
     find_package(Coin REQUIRED PATHS ${FREECAD_LIBPACK_DIR}/lib/cmake NO_DEFAULT_PATH)
 


### PR DESCRIPTION
LibPacks used to always include Coin and Pivy -- now that we have those vendored, we need to make sure that there is no conflict during the build when using those old LibPacks. The next release, 3.5.3, will be built without them, hence the version gate.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.