### PR TITLE
[ArchWall] & Draft-Offsets: T-Joint Support (Stage 1)

### DIFF
--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -1089,8 +1089,8 @@ class _Wall(ArchComponent.Component):
                             self.basewires = wallBaseShapeEdgesInfo.get(
                                 "wallAxis"
                             )  # 'wallEdges'  # widths, aligns, offsets?
-                            pointOnObject = wallBaseShapeEdgesInfo.get('pointOnObject')
-                            trimEdges = wallBaseShapeEdgesInfo.get('trimEdges')
+                            pointOnObject = wallBaseShapeEdgesInfo.get("pointOnObject")
+                            trimEdges = wallBaseShapeEdgesInfo.get("trimEdges")
                             clEdgeSameIndex = obj.Base.Proxy.clEdgeSameIndex
                     # Sort Sketch edges consistently with below procedures
                     # without using Sketch.Shape.Edges - found the latter order
@@ -1432,12 +1432,15 @@ class _Wall(ArchComponent.Component):
 
                             # if edges in Sketch has pointOnObject constraints,
                             # form T-Joint for corresponding wall segments
-                            if (clEdgeSameIndex and pointOnObject and
-                                not w2.isClosed() and not w1.isClosed()
+                            if (
+                                clEdgeSameIndex
+                                and pointOnObject
+                                and not w2.isClosed()
+                                and not w1.isClosed()
                             ):
                                 self.joint_enabled = True
                                 # check 1st/last edge in the wire, cl[0/-1], if it has pointOnObject Constraint
-                                startEndOfEdges = [0,-1]
+                                startEndOfEdges = [0, -1]
                                 for se in startEndOfEdges:
                                     # get cluster edges list, for [i] of self.basewires
                                     cl = clEdgeSameIndex[i]
@@ -1445,9 +1448,9 @@ class _Wall(ArchComponent.Component):
                                     lenPOObj = len(pointOnObject)
                                     for j in range(lenPOObj):
                                         # Get 1st edge vertex used in ptOnObject
-                                        #0: Curve itself, 1: Starting point, 2: Ending point
-                                        #vertex = firstPos -1
-                                        consI1Pos = pointOnObject[j][0][1]  #constriant[I].FirstPos
+                                        # 0: Curve itself, 1: Starting point, 2: Ending point
+                                        # vertex = firstPos -1
+                                        consI1Pos = pointOnObject[j][0][1]  # constriant[I].FirstPos
                                         consI1PosV = consI1Pos - 1
                                         # Check if 1st edge in the wire, cl[0/-1], has pointOnEdge constraint
                                         # and if only 1 edge, and both end may has constraints,
@@ -1457,16 +1460,20 @@ class _Wall(ArchComponent.Component):
                                         if not (cl[se] == pointOnObject[j][0][0]):
                                             continue
                                         if len(cEdgesF2) == 1:
-                                            if not( (se == 0 and consI1PosV == 1) or
-                                                    (se == -1 and consI1PosV == 0)  ):
+                                            if not (
+                                                (se == 0 and consI1PosV == 1)
+                                                or (se == -1 and consI1PosV == 0)
+                                            ):
                                                 continue
                                         # Cut 1st edge in wire cl[0] with trimEdges
                                         #
                                         # Get 1st edge other end vertex opposite to ptOnObject to test
-                                        #0: Curve itself, 1: Starting point, 2: Ending point
-                                        #vertex = firstPos -1
-                                        consI1PosVEnd = consI1PosV ^ 1  #xor, x ^ 1 : 1 -> 0, 0 -> 1, x ^ 3 : 2 -> 1, 1 -> 2
-                                        
+                                        # 0: Curve itself, 1: Starting point, 2: Ending point
+                                        # vertex = firstPos -1
+                                        consI1PosVEnd = (
+                                            consI1PosV ^ 1
+                                        )  # xor, x ^ 1 : 1 -> 0, 0 -> 1, x ^ 3 : 2 -> 1, 1 -> 2
+
                                         # 1. Get 1st edge of 'OffsetMode'(None) wire in the Wire cl[0]
                                         cEdgesF2eSe = cEdgesF2[se]
                                         # Check if edges[0] / [se] was reversed: yes if brNEdges2[0] present (not None), invert if so
@@ -1474,24 +1481,36 @@ class _Wall(ArchComponent.Component):
                                             consI1PosVEnd2 = consI1PosVEnd ^ 1  # reverse direction
                                             reversed2 = True
                                         else:
-                                            consI1PosVEnd2 = consI1PosVEnd                                            
+                                            consI1PosVEnd2 = consI1PosVEnd
                                             reversed2 = False
                                         cEdgesF2Test = cEdgesF2eSe.Vertexes[consI1PosVEnd2]
                                         # check starting point pos and if edge direction was reversed
                                         # extend edge by doubling length (extend to infinity not works)
-                                        cEdgesF2eSeLs = Part.LineSegment(cEdgesF2eSe.Vertexes[0].Point, cEdgesF2eSe.Vertexes[1].Point)
-                                        if (consI1PosV ^ reversed2):  # if consI1PosV XOR reversed Cases
+                                        cEdgesF2eSeLs = Part.LineSegment(
+                                            cEdgesF2eSe.Vertexes[0].Point,
+                                            cEdgesF2eSe.Vertexes[1].Point,
+                                        )
+                                        if (
+                                            consI1PosV ^ reversed2
+                                        ):  # if consI1PosV XOR reversed Cases
                                             cEdgesF2eSeLsLP = cEdgesF2eSeLs.LastParameter
-                                            cEdgesF2eSeExtLs = cEdgesF2eSeLs.trim(0,cEdgesF2eSeLsLP*2)
+                                            cEdgesF2eSeExtLs = cEdgesF2eSeLs.trim(
+                                                0, cEdgesF2eSeLsLP * 2
+                                            )
                                         else:
                                             cEdgesF2eSeLsLP = cEdgesF2eSeLs.LastParameter
-                                            cEdgesF2eSeExtLs = cEdgesF2eSeLs.trim(-cEdgesF2eSeLsLP,cEdgesF2eSeLsLP)
+                                            cEdgesF2eSeExtLs = cEdgesF2eSeLs.trim(
+                                                -cEdgesF2eSeLsLP, cEdgesF2eSeLsLP
+                                            )
                                         cEdgesF2eSeExtLsS = cEdgesF2eSeExtLs.toShape()
                                         cEdgesF2eSeCut = cEdgesF2eSeExtLsS.cut(trimEdges[j])
                                         cEdgesF2eSeCutEdges = cEdgesF2eSeCut.Edges
                                         # Check each vertex of resulted cutted edges to find which is connected
                                         for e2 in cEdgesF2eSeCutEdges:
-                                            ptOnEdge = any(DraftGeomUtils.isPtOnEdge(v.Point,cEdgesF2Test) for v in e2.Vertexes)
+                                            ptOnEdge = any(
+                                                DraftGeomUtils.isPtOnEdge(v.Point, cEdgesF2Test)
+                                                for v in e2.Vertexes
+                                            )
                                             # if found, update cEdgesF2[0] with trimmed / extended one
                                             if ptOnEdge:
                                                 # Update cEdgesF2 list
@@ -1506,21 +1525,33 @@ class _Wall(ArchComponent.Component):
                                             consI1PosVEnd1 = consI1PosVEnd ^ 1  # reverse direction
                                             reversed1 = True
                                         else:
-                                            consI1PosVEnd1 = consI1PosVEnd                                            
+                                            consI1PosVEnd1 = consI1PosVEnd
                                             reversed1 = False
                                         cEdgesF1Test = cEdgesF1eSe.Vertexes[consI1PosVEnd1]
-                                        cEdgesF1eSeLs = Part.LineSegment(cEdgesF1eSe.Vertexes[0].Point, cEdgesF1eSe.Vertexes[1].Point)
-                                        if (consI1PosV ^ reversed1):  # if consI1PosV XOR reversed Cases
+                                        cEdgesF1eSeLs = Part.LineSegment(
+                                            cEdgesF1eSe.Vertexes[0].Point,
+                                            cEdgesF1eSe.Vertexes[1].Point,
+                                        )
+                                        if (
+                                            consI1PosV ^ reversed1
+                                        ):  # if consI1PosV XOR reversed Cases
                                             cEdgesF1eSeLsLP = cEdgesF1eSeLs.LastParameter
-                                            cEdgesF1eSeExtLs = cEdgesF1eSeLs.trim(0,cEdgesF1eSeLsLP*2)
+                                            cEdgesF1eSeExtLs = cEdgesF1eSeLs.trim(
+                                                0, cEdgesF1eSeLsLP * 2
+                                            )
                                         else:
                                             cEdgesF1eSeLsLP = cEdgesF1eSeLs.LastParameter
-                                            cEdgesF1eSeExtLs = cEdgesF1eSeLs.trim(-cEdgesF1eSeLsLP,cEdgesF1eSeLsLP)
+                                            cEdgesF1eSeExtLs = cEdgesF1eSeLs.trim(
+                                                -cEdgesF1eSeLsLP, cEdgesF1eSeLsLP
+                                            )
                                         cEdgesF1eSeExtLsS = cEdgesF1eSeExtLs.toShape()
                                         cEdgesF1eSeCut = cEdgesF1eSeExtLsS.cut(trimEdges[j])
                                         cEdgesF1eSeCutEdges = cEdgesF1eSeCut.Edges
                                         for e1 in cEdgesF1eSeCutEdges:
-                                            ptOnEdge = any(DraftGeomUtils.isPtOnEdge(v.Point,cEdgesF1Test) for v in e1.Vertexes)
+                                            ptOnEdge = any(
+                                                DraftGeomUtils.isPtOnEdge(v.Point, cEdgesF1Test)
+                                                for v in e1.Vertexes
+                                            )
                                             if ptOnEdge:
                                                 cEdgesF1[se] = e1
                                                 anyEdgeF1Replaced = True

--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -558,6 +558,7 @@ class _Wall(ArchComponent.Component):
                 # else:  # Seems no need ...
                 # obj.PropertySet = 'Default'
 
+        self.joint_enabled = False
         extdata = self.getExtrusionData(obj)
         if extdata:
             base_faces = extdata[0]
@@ -579,7 +580,8 @@ class _Wall(ArchComponent.Component):
                     and obj.Material.Materials
                 )
                 if not is_multi_layer:
-                    should_fuse_solids = True
+                    if not self.joint_enabled:
+                        should_fuse_solids = True
 
             # Generate solids
             solids = []
@@ -1039,6 +1041,7 @@ class _Wall(ArchComponent.Component):
         if self.ensureBase(obj):
             if hasattr(obj.Base, "Shape"):
                 if obj.Base.Shape:
+                    clEdgeSameIndex = None
                     if obj.Base.Shape.Solids:
                         return None
 
@@ -1086,7 +1089,9 @@ class _Wall(ArchComponent.Component):
                             self.basewires = wallBaseShapeEdgesInfo.get(
                                 "wallAxis"
                             )  # 'wallEdges'  # widths, aligns, offsets?
-
+                            pointOnObject = wallBaseShapeEdgesInfo.get('pointOnObject')
+                            trimEdges = wallBaseShapeEdgesInfo.get('trimEdges')
+                            clEdgeSameIndex = obj.Base.Proxy.clEdgeSameIndex
                     # Sort Sketch edges consistently with below procedures
                     # without using Sketch.Shape.Edges - found the latter order
                     # in some corner case != getSortedClusters()
@@ -1413,22 +1418,132 @@ class _Wall(ArchComponent.Component):
                                     )
                             w2 = wNe2[0]
                             w1 = wNe1[0]
-                            face = DraftGeomUtils.bind(w1, w2, per_segment=True)
-                            cEdgesF2 = wNe2[1]
+
+                            cEdgesF2 = wNe2[1]  # offsetMode=None ("Offset")
+                            cEdgesF1 = wNe1[1]  # offsetMode="BasewireMode"
                             cEdges2 = wNe2[2]
-                            oEdges2 = wNe2[3]
-                            cEdgesF1 = wNe1[1]
                             cEdges1 = wNe1[2]
-                            oEdges1 = wNe1[3]
+                            nEdges2 = wNe2[3]
+                            nEdges1 = wNe1[3]
+                            brNEdges2 = wNe2[4]  # before reversing
+                            brNEdges1 = wNe1[4]
+                            anyEdgeF1Replaced = False
+                            anyEdgeF2Replaced = False
+
+                            # if edges in Sketch has pointOnObject constraints,
+                            # form T-Joint for corresponding wall segments
+                            if (clEdgeSameIndex and pointOnObject and
+                                not w2.isClosed() and not w1.isClosed()
+                            ):
+                                self.joint_enabled = True
+                                # check 1st/last edge in the wire, cl[0/-1], if it has pointOnObject Constraint
+                                startEndOfEdges = [0,-1]
+                                for se in startEndOfEdges:
+                                    # get cluster edges list, for [i] of self.basewires
+                                    cl = clEdgeSameIndex[i]
+                                    # loop all pointOnObject Constraint against wires
+                                    lenPOObj = len(pointOnObject)
+                                    for j in range(lenPOObj):
+                                        # Get 1st edge vertex used in ptOnObject
+                                        #0: Curve itself, 1: Starting point, 2: Ending point
+                                        #vertex = firstPos -1
+                                        consI1Pos = pointOnObject[j][0][1]  #constriant[I].FirstPos
+                                        consI1PosV = consI1Pos - 1
+                                        # Check if 1st edge in the wire, cl[0/-1], has pointOnEdge constraint
+                                        # and if only 1 edge, and both end may has constraints,
+                                        # test one end first:  set rule that to go ahead
+                                        # - startEndOfEdges is 0, and firstPos Vertex = 1 :  | <1-0
+                                        # - startEndOfEdges is -1, and firstPos Vertex = 0 :     1-0> |
+                                        if not (cl[se] == pointOnObject[j][0][0]):
+                                            continue
+                                        if len(cEdgesF2) == 1:
+                                            if not( (se == 0 and consI1PosV == 1) or
+                                                    (se == -1 and consI1PosV == 0)  ):
+                                                continue
+                                        # Cut 1st edge in wire cl[0] with trimEdges
+                                        #
+                                        # Get 1st edge other end vertex opposite to ptOnObject to test
+                                        #0: Curve itself, 1: Starting point, 2: Ending point
+                                        #vertex = firstPos -1
+                                        consI1PosVEnd = consI1PosV ^ 1  #xor, x ^ 1 : 1 -> 0, 0 -> 1, x ^ 3 : 2 -> 1, 1 -> 2
+                                        
+                                        # 1. Get 1st edge of 'OffsetMode'(None) wire in the Wire cl[0]
+                                        cEdgesF2eSe = cEdgesF2[se]
+                                        # Check if edges[0] / [se] was reversed: yes if brNEdges2[0] present (not None), invert if so
+                                        if brNEdges2[se]:
+                                            consI1PosVEnd2 = consI1PosVEnd ^ 1  # reverse direction
+                                            reversed2 = True
+                                        else:
+                                            consI1PosVEnd2 = consI1PosVEnd                                            
+                                            reversed2 = False
+                                        cEdgesF2Test = cEdgesF2eSe.Vertexes[consI1PosVEnd2]
+                                        # check starting point pos and if edge direction was reversed
+                                        # extend edge by doubling length (extend to infinity not works)
+                                        cEdgesF2eSeLs = Part.LineSegment(cEdgesF2eSe.Vertexes[0].Point, cEdgesF2eSe.Vertexes[1].Point)
+                                        if (consI1PosV ^ reversed2):  # if consI1PosV XOR reversed Cases
+                                            cEdgesF2eSeLsLP = cEdgesF2eSeLs.LastParameter
+                                            cEdgesF2eSeExtLs = cEdgesF2eSeLs.trim(0,cEdgesF2eSeLsLP*2)
+                                        else:
+                                            cEdgesF2eSeLsLP = cEdgesF2eSeLs.LastParameter
+                                            cEdgesF2eSeExtLs = cEdgesF2eSeLs.trim(-cEdgesF2eSeLsLP,cEdgesF2eSeLsLP)
+                                        cEdgesF2eSeExtLsS = cEdgesF2eSeExtLs.toShape()
+                                        cEdgesF2eSeCut = cEdgesF2eSeExtLsS.cut(trimEdges[j])
+                                        cEdgesF2eSeCutEdges = cEdgesF2eSeCut.Edges
+                                        # Check each vertex of resulted cutted edges to find which is connected
+                                        for e2 in cEdgesF2eSeCutEdges:
+                                            ptOnEdge = any(DraftGeomUtils.isPtOnEdge(v.Point,cEdgesF2Test) for v in e2.Vertexes)
+                                            # if found, update cEdgesF2[0] with trimmed / extended one
+                                            if ptOnEdge:
+                                                # Update cEdgesF2 list
+                                                cEdgesF2[se] = e2
+                                                anyEdgeF2Replaced = True
+                                                break
+
+                                        # 2. Get 1st edge of 'BasewireMode'(None) wire in the Wire cl[0]
+                                        cEdgesF1eSe = cEdgesF1[se]
+                                        # Check if edges[0] / [se] was reversed: yes if brNEdges1[0] present (not None), invert if so
+                                        if brNEdges1[se]:
+                                            consI1PosVEnd1 = consI1PosVEnd ^ 1  # reverse direction
+                                            reversed1 = True
+                                        else:
+                                            consI1PosVEnd1 = consI1PosVEnd                                            
+                                            reversed1 = False
+                                        cEdgesF1Test = cEdgesF1eSe.Vertexes[consI1PosVEnd1]
+                                        cEdgesF1eSeLs = Part.LineSegment(cEdgesF1eSe.Vertexes[0].Point, cEdgesF1eSe.Vertexes[1].Point)
+                                        if (consI1PosV ^ reversed1):  # if consI1PosV XOR reversed Cases
+                                            cEdgesF1eSeLsLP = cEdgesF1eSeLs.LastParameter
+                                            cEdgesF1eSeExtLs = cEdgesF1eSeLs.trim(0,cEdgesF1eSeLsLP*2)
+                                        else:
+                                            cEdgesF1eSeLsLP = cEdgesF1eSeLs.LastParameter
+                                            cEdgesF1eSeExtLs = cEdgesF1eSeLs.trim(-cEdgesF1eSeLsLP,cEdgesF1eSeLsLP)
+                                        cEdgesF1eSeExtLsS = cEdgesF1eSeExtLs.toShape()
+                                        cEdgesF1eSeCut = cEdgesF1eSeExtLsS.cut(trimEdges[j])
+                                        cEdgesF1eSeCutEdges = cEdgesF1eSeCut.Edges
+                                        for e1 in cEdgesF1eSeCutEdges:
+                                            ptOnEdge = any(DraftGeomUtils.isPtOnEdge(v.Point,cEdgesF1Test) for v in e1.Vertexes)
+                                            if ptOnEdge:
+                                                cEdgesF1[se] = e1
+                                                anyEdgeF1Replaced = True
+                                                break
+                                        # if any (or?) both wire has edge replaced
+                                        if anyEdgeF2Replaced and anyEdgeF1Replaced:
+                                            break
+                            # Update w2/w1 only if any edge is replaced
+                            if anyEdgeF2Replaced:
+                                w2 = Part.Wire(cEdgesF2)
+                            if anyEdgeF1Replaced:
+                                w1 = Part.Wire(cEdgesF1)
+                            # TODO Should have trimEdges cut by Left/Right Edge
+                            #      Left/Right Edge to make 'end cap' edge
+
+                            face = DraftGeomUtils.bind(w1, w2, per_segment=True)
                             self.connectEdges.extend(cEdges2)
                             self.connectEdges.extend(cEdges1)
-
                             del widths[0:edgeNum]
                             del aligns[0:edgeNum]
                             del offsets[0:edgeNum]
 
                             if face:
-
                                 if layers and (layers[i] < 0):
                                     # layers with negative values are not drawn
                                     continue

--- a/src/Mod/Draft/draftgeoutils/offsets.py
+++ b/src/Mod/Draft/draftgeoutils/offsets.py
@@ -24,6 +24,7 @@
 # *                                                                         *
 # ***************************************************************************
 """Provides various functions to work with offsets."""
+
 ## @package offsets
 # \ingroup draftgeoutils
 # \brief Provides various functions to work with offsets.

--- a/src/Mod/Draft/draftgeoutils/offsets.py
+++ b/src/Mod/Draft/draftgeoutils/offsets.py
@@ -24,7 +24,6 @@
 # *                                                                         *
 # ***************************************************************************
 """Provides various functions to work with offsets."""
-
 ## @package offsets
 # \ingroup draftgeoutils
 # \brief Provides various functions to work with offsets.
@@ -268,8 +267,8 @@ def offsetWire(
         # for backward compatibility with previous getNormal implementation
         if norm is None:
             norm = App.Vector(0, 0, 1)
-
     nedges = []
+    brNEdges = []  # before reversing edges
     if occ:
         length = abs(dvec.Length)
         if not length:
@@ -464,6 +463,11 @@ def offsetWire(
             # TODO arc always in counter-clockwise directinon
             # ... ( not necessarily 'reversed')
             if curOrientation == "Reversed":
+                # save in a list the nedge before reversing
+                if not nedge.isClosed():
+                    brNEdges.append(nedge)
+                else:
+                    brNEdges.append(None)
                 if not isinstance(curredge.Curve, (Part.Circle, Part.Ellipse)):
                     # assume straight line, reverse it
                     nedge = Part.Edge(nedge.Vertexes[1], nedge.Vertexes[0])
@@ -479,6 +483,8 @@ def offsetWire(
                     ).toShape()
                     # TODO any better solution than to calculate midpoint
                     # of arc to reverse?
+            else:
+                brNEdges.append(None)
 
         elif offsetMode in ["BasewireMode"]:
             if not (curOrientation == firstOrientation) != (curDir == firstDir):
@@ -505,6 +511,11 @@ def offsetWire(
                 elif curAlign == "Center":
                     nedge = offset(curredge, delta, trim=True)
             if curOrientation == "Reversed":
+                # save in a list the nedge before reversing
+                if not nedge.isClosed():
+                    brNEdges.append(nedge)
+                else:
+                    brNEdges.append(None)
                 if not isinstance(curredge.Curve, (Part.Circle, Part.Ellipse)):
                     # assume straight line, reverse it
                     nedge = Part.Edge(nedge.Vertexes[1], nedge.Vertexes[0])
@@ -520,6 +531,9 @@ def offsetWire(
                     ).toShape()
                     # TODO any better solution than to calculate midpoint
                     # of arc to reverse?
+            else:
+                brNEdges.append(None)
+
         else:
             print(" something wrong ")
             return None
@@ -549,7 +563,7 @@ def offsetWire(
         return w
     else:
         if wireNedge:
-            return (wire, connectEdgesF, connectEdges, nedges)
+            return (wire, connectEdgesF, connectEdges, nedges, brNEdges)
         else:
             return wire
 


### PR DESCRIPTION
FC Forum Discussion:
- [ArchWall] Joint Types between Wall Segment
(https://forum.freecad.org/viewtopic.php?p=894807#p894807)
- [BIM] Join walls meeting at an angle
 (https://forum.freecad.org/viewtopic.php?p=895570&sid=fcf61359980118260916cf83805226cd#p895570)

1st Stage
  ArchWall support to T-Joint condition :
  - For edges in Base Sketch with PointOnObject constraint, 'Trim-Ex' algorithm is added to remove/extend wall segment portion to touching wall segment.
  - Draft-offsets.py ground work to support the algorithm is added.
  - Currently, ArchSketch had groundwork done to provide information about PoinOnObject and 'Trim-Ex' information to support this feature.

2nd Stage
  - The above-said functions about PointOnObject constraint and 'Trim-Ex' information to support stock ordinary Sketch would be studied and added.
  - Remarks: Ordinary Sketch has limited support on other features e.g. variant Width, Align, Offset for individual Wall Segment.


[EDIT - 1]

**1.  Left/Right:  Before / After PR**

<img width="1920" height="1036" alt="image" src="https://github.com/user-attachments/assets/8ddb42be-32a9-42ac-b9d1-2f2bc3a881db" />


.

**2. Left/Right:  FC After PR / IFC Export to IFCOpenShell Viewer**

<img width="1920" height="996" alt="Screenshot from 2026-07-12 12-31-15" src="https://github.com/user-attachments/assets/514936f2-eb05-48ff-9c0a-5def123b3ee4" />

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
