### PR TITLE
CAM: CommandPathPostSelected - refactoring

### DIFF
--- a/src/Mod/CAM/Path/Post/Command.py
+++ b/src/Mod/CAM/Path/Post/Command.py
@@ -204,6 +204,8 @@ class CommandPathPost:
         """
         Path.Log.debug(self.candidate.Name)
 
+        self.operations = getattr(self, "operations", None)
+
         # Determine if we use new flow (machine-based) or old flow (legacy)
         # New flow: Job has Machine property -> get postprocessor from machine config -> use export2()
         # Old flow: Job lacks Machine -> get postprocessor from job property -> use export()
@@ -213,7 +215,7 @@ class CommandPathPost:
         if use_new_flow and FreeCAD.GuiUp:
             from Path.Post.Gui.DlgPostProcess import PostProcessDialog
 
-            dlg = PostProcessDialog(self.candidate)
+            dlg = PostProcessDialog(self.candidate, self.operations)
             if dlg.exec_() != QtGui.QDialog.DialogCode.Accepted:
                 return
             # Files were written by the dialog's Save button; record the transaction and return.
@@ -258,10 +260,15 @@ class CommandPathPost:
             return
 
         # Get postprocessor (same factory for both flows)
-        postprocessor = PostProcessorFactory.get_post_processor(
-            self.candidate,
-            postprocessor_name,
-        )
+        if self.operations:
+            postprocessor = PostProcessorFactory.get_post_processor(
+                self.operations, postprocessor_name
+            )
+        else:
+            postprocessor = PostProcessorFactory.get_post_processor(
+                self.candidate,
+                postprocessor_name,
+            )
 
         # Call appropriate export method
         if use_new_flow:
@@ -372,9 +379,10 @@ class CommandPathPostSelected(CommandPathPost):
             # find 'job' for operation inside 'Array' with multi tool controller
             baseOp = FreeCAD.ActiveDocument.getObject(selection[0].Base[0])
             job = PathUtils.findParentJob(baseOp)
+        self.candidate = job
 
         opCandidates = [op for op in selection if hasattr(op, "Path") and "Job" not in op.Name]
-        operations = []
+        self.operations = None
         if opCandidates and job.Operations.Group != opCandidates:
             msgBox = QtGui.QMessageBox()
             msgBox.setWindowTitle("Post Process")
@@ -392,65 +400,9 @@ class CommandPathPostSelected(CommandPathPost):
                 print(
                     f"Post process only selected operations: {', '.join([op.Name for op in opCandidates])}"
                 )
-                operations = opCandidates
+                self.operations = {"job": job, "operations": opCandidates}
 
-        postprocessor_name = _resolve_post_processor_name(job)
-        Path.Log.debug(f"Post Processor: {postprocessor_name}")
-
-        if not postprocessor_name:
-            FreeCAD.ActiveDocument.abortTransaction()
-            return
-
-        # get a postprocessor
-        postprocessor = PostProcessorFactory.get_post_processor(
-            {"job": job, "operations": operations}, postprocessor_name
-        )
-
-        post_data = postprocessor.export()
-        # None is returned if there was an error during argument processing
-        # otherwise the "usual" post_data data structure is returned.
-        if not post_data:
-            FreeCAD.ActiveDocument.abortTransaction()
-            return
-
-        policy = Path.Preferences.defaultOutputPolicy()
-        generator = FilenameGenerator(job=job)
-        generated_filename = generator.generate_filenames()
-
-        for item in post_data:
-            subpart, gcode = item
-
-            # get a name for the file
-            subpart = "" if subpart == "allitems" else subpart
-            Path.Log.debug(subpart)
-            generator.set_subpartname(subpart)
-            fname = next(generated_filename)
-
-            if gcode is not None:
-                # Show editor if user preference is enabled and GUI is available
-                final_gcode = gcode
-                if FreeCAD.GuiUp and Path.Preferences.showEditorOnPostProcess():
-                    if len(gcode) > 100000:
-                        FreeCAD.Console.PrintWarning(
-                            "Skipping editor since output is greater than 100kb\n"
-                        )
-                    else:
-                        dia = GCodeEditorDialog(gcode, refactored=True)
-                        # Enable OK button so user can accept without editing
-                        dia.buttons.button(QtGui.QDialogButtonBox.Ok).setDisabled(False)
-                        editor_result = dia.exec_()
-                        if editor_result == 1:  # User clicked OK
-                            final_gcode = dia.editor.toPlainText()
-                        else:
-                            # User cancelled - skip writing this file
-                            FreeCAD.Console.PrintMessage(f"Post-processing cancelled for {fname}\n")
-                            continue
-
-                # write the results to the file
-                self._write_file(fname, final_gcode, policy)
-
-        FreeCAD.ActiveDocument.commitTransaction()
-        FreeCAD.ActiveDocument.recompute()
+        super().Activated()
 
 
 if FreeCAD.GuiUp:

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -89,8 +89,9 @@ class PostProcessDialog:
         config = dlg.config()
     """
 
-    def __init__(self, job):
+    def __init__(self, job, operations=None):
         self.job = job
+        self.operations = operations
         self.dialog = FreeCADGui.PySideUic.loadUi(":/panels/DlgPostProcess.ui")
         if self.dialog is None:
             raise RuntimeError(
@@ -567,7 +568,10 @@ class PostProcessDialog:
         for op in self._get_active_operations():
             item = QtGui.QTreeWidgetItem(tree)
             item.setText(0, op.Label)
-            item.setCheckState(0, QtCore.Qt.CheckState.Checked)
+            if not self.operations or op in self.operations["operations"]:
+                item.setCheckState(0, QtCore.Qt.CheckState.Checked)
+            else:
+                item.setCheckState(0, QtCore.Qt.CheckState.Unchecked)
             item.setFlags(
                 item.flags()
                 | QtCore.Qt.ItemFlag.ItemIsUserCheckable


### PR DESCRIPTION
Fixes #31723

---

### Changes

- Refactored `CommandPathPostSelected` to exclude code duplication and follows `use_new_flow`

- If used `CommandPathPostSelected` prepare list in MBPP dialog
   Uncheck operations which was not selected
   <img width="638" height="289" alt="Screenshot_20260705_131009_hor" src="https://github.com/user-attachments/assets/a39c67ac-5ec1-4e37-910f-5716b2647a85" />