### PR TITLE
Fix: Add Linked Properties to Expression Completer

### DIFF
--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -316,13 +316,11 @@ public:
                     }
                 }
             }
-            
-            FC_TRACE(
-                "Cached properties for " << obj->getNameInDocument()
-                                      << " (" << this->namedPropsCache[obj].size()
-                                      << " props)"
-            );
 
+            FC_TRACE(
+                "Cached properties for " << obj->getNameInDocument() << " ("
+                                         << this->namedPropsCache[obj].size() << " props)"
+            );
         }
         return this->namedPropsCache[obj];
     }

--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -293,8 +293,36 @@ public:
     ) const
     {
         if (!this->namedPropsCache.contains(obj)) {
-            this->namedPropsCache[obj];
-            obj->getPropertyNamedList(this->namedPropsCache[obj]);
+            auto& list = this->namedPropsCache[obj];
+            obj->getPropertyNamedList(list);
+
+            // If this object is a link-like object (App::Link, LinkGroup, a linked
+            // VarSet, etc.), also pull in the linked object's properties so that
+            // expressions like <<Link>>.SomeLinkedProp complete correctly.
+            App::DocumentObject* linked = obj->getLinkedObject(true);
+            if (linked && linked != obj) {
+                std::vector<std::pair<const char*, App::Property*>> linkedProps;
+                linked->getPropertyNamedList(linkedProps);
+
+                std::set<std::string> existingNames;
+                for (auto& p : list) {
+                    existingNames.insert(p.first);
+                }
+                for (auto& p : linkedProps) {
+                    // don't clobber a same-named property that already exists
+                    // directly on obj
+                    if (existingNames.insert(p.first).second) {
+                        list.push_back(p);
+                    }
+                }
+            }
+            
+            FC_TRACE(
+                "Cached properties for " << obj->getNameInDocument()
+                                      << " (" << this->namedPropsCache[obj].size()
+                                      << " props)"
+            );
+
         }
         return this->namedPropsCache[obj];
     }


### PR DESCRIPTION
This fix is an alternative solution to https://github.com/FreeCAD/FreeCAD/pull/28022. This PR focuses on adding linked properties to the expression completer model and does not change the global object properties. It does this by simply appending the linked properties during the initial `getCachedPropertyNamedList` call. 


- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.


## Issues
Closes https://github.com/FreeCAD/FreeCAD/issues/12252
Closes https://github.com/FreeCAD/FreeCAD/issues/17104


## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

Before:
(working on redownloading/building recent version):

After:
<img width="349" height="213" alt="image" src="https://github.com/user-attachments/assets/99d69aab-82c0-4104-91f3-3eddf7c34036" />

