### PR TITLE
Assembly: Fix wrong BOM nested quantities

### DIFF
--- a/src/Mod/Assembly/App/BomObject.cpp
+++ b/src/Mod/Assembly/App/BomObject.cpp
@@ -144,8 +144,6 @@ void BomObject::generateBOM()
 {
     saveCustomColumnData();
     clearAll();
-    obj_list.clear();
-    obj_mirrored_list.clear();
     size_t row = 0;
     size_t col = 0;
 
@@ -179,7 +177,13 @@ void BomObject::addObjectChildrenToBom(
     int quantityColIndex = getColumnIndex("Quantity");
     bool hasQuantityCol = hasQuantityColumn();
 
-    size_t siblingsInitialRow = row;
+    struct SiblingBomEntry
+    {
+        App::DocumentObject* object;
+        bool isMirrored;
+        size_t row;
+    };
+    std::vector<SiblingBomEntry> siblings;
 
     if (index != "") {
         index = index + ".";
@@ -212,21 +216,20 @@ void BomObject::addObjectChildrenToBom(
             continue;
         }
 
-        if (hasQuantityCol && row != siblingsInitialRow) {
+        if (hasQuantityCol) {
             // Check if the object is not already in (case of links). And if so just increment.
             // Note: an object can be used in several parts. In which case we do no want to blindly
             // increment.
             // We also check if the Mirror state matches. Mirrored parts should not group with
             // non-mirrored parts.
             bool found = false;
-            for (size_t i = siblingsInitialRow; i <= row; ++i) {
-                size_t idInList = i - 1;  // -1 for the header
-                if (idInList < obj_list.size() && child == obj_list[idInList]
-                    && idInList < obj_mirrored_list.size()
-                    && isMirrored == obj_mirrored_list[idInList]) {
-
-                    int qty = std::stoi(getText(i, quantityColIndex)) + 1;
-                    setCell(App::CellAddress(i, quantityColIndex), std::to_string(qty).c_str());
+            for (auto& sibling : siblings) {
+                if (child == sibling.object && isMirrored == sibling.isMirrored) {
+                    int qty = std::stoi(getText(sibling.row, quantityColIndex)) + 1;
+                    setCell(
+                        App::CellAddress(sibling.row, quantityColIndex),
+                        std::to_string(qty).c_str()
+                    );
                     found = true;
                     break;
                 }
@@ -239,7 +242,9 @@ void BomObject::addObjectChildrenToBom(
         std::string sub_index = index + std::to_string(sub_i);
         ++sub_i;
 
-        addObjectToBom(child, row, sub_index, isMirrored);
+        size_t childRow = row;
+        addObjectToBom(child, childRow, sub_index, isMirrored);
+        siblings.push_back({child, isMirrored, childRow});
         ++row;
 
         if ((child->isDerivedFrom<AssemblyObject>() && detailSubAssemblies.getValue())
@@ -271,8 +276,6 @@ bool BomObject::isObjMirrored(App::DocumentObject* obj)
 
 void BomObject::addObjectToBom(App::DocumentObject* obj, size_t row, std::string index, bool isMirrored)
 {
-    obj_list.push_back(obj);
-    obj_mirrored_list.push_back(isMirrored);
     size_t col = 0;
     for (auto& columnName : columnsNames.getValues()) {
         if (columnName == "Index") {

--- a/src/Mod/Assembly/App/BomObject.cpp
+++ b/src/Mod/Assembly/App/BomObject.cpp
@@ -256,14 +256,14 @@ bool BomObject::isObjMirrored(App::DocumentObject* obj)
     // We multiply scales to handle nested mirroring (e.g., Mirrored LinkElement inside Mirrored
     // LinkGroup = Normal).
     double accumulatedScale = 1.0;
-    if (auto element = static_cast<App::LinkElement*>(obj)) {
+    if (auto* element = freecad_cast<App::LinkElement*>(obj)) {
         accumulatedScale *= element->Scale.getValue();
 
-        if (auto group = element->getLinkGroup()) {
+        if (auto* group = element->getLinkGroup()) {
             accumulatedScale *= group->Scale.getValue();
         }
     }
-    else if (auto link = static_cast<App::Link*>(obj)) {
+    else if (auto* link = freecad_cast<App::Link*>(obj)) {
         accumulatedScale *= link->Scale.getValue();
     }
     return accumulatedScale < 0.0;

--- a/src/Mod/Assembly/App/BomObject.h
+++ b/src/Mod/Assembly/App/BomObject.h
@@ -92,8 +92,6 @@ public:
     App::PropertyBool onlyParts;
 
     std::vector<BomDataElement> dataElements;
-    std::vector<App::DocumentObject*> obj_list;
-    std::vector<bool> obj_mirrored_list;
 
 private:
     std::string getBomPropertyValue(App::DocumentObject* obj, const std::string& baseName);


### PR DESCRIPTION
Assisted-by: GPT-5.5

## Summary
Fixes Assembly BOM quantity grouping for nested parts.
The current row-indexed grouping state can cause wrong BOM results when parts are nested, because entries from different hierarchy levels may be considered together. 
This PR scopes grouping to sibling entries while walking each BOM level, so repeated linked parts are grouped only where appropriate.

The first commit also fixes a mirrored-link detection crash. 
That bug fix is included because the BOM grouping fix exercises the mirrored-state path and exposed the unsafe cast.

## Before and after case, for the following assembly:
<img width="797" height="639" alt="image" src="https://github.com/user-attachments/assets/52a4a1e0-51ff-42ca-9e41-7b9860cfdbdf" />

### Before (wrong)
The M6 nuts are all under the "knob" subassembly, even though only 1 of them really belongs there 
<img width="564" height="307" alt="image" src="https://github.com/user-attachments/assets/88d1baa7-743d-4efd-a5b0-b6d7cd1ef87f" />

### After (right)
The M6 nuts are in the right places, both under the knob and under the main assembly
<img width="552" height="336" alt="image" src="https://github.com/user-attachments/assets/4d2a4d8e-c21b-4886-be6d-63f32969b0cc" />
