### PR TITLE
Measurement: Fixed division by 0 in face edge angle measurement

### DIFF
--- a/src/Mod/Measure/App/MeasureAngle.cpp
+++ b/src/Mod/Measure/App/MeasureAngle.cpp
@@ -353,6 +353,16 @@ bool MeasureAngle::computeOriginFaceEdge(TopoDS_Shape& s1)
     Base::Vector3d normalVec(faceNormal.X(), faceNormal.Y(), faceNormal.Z());
     edgeDirVec.ProjectToPlane(Base::Vector3d(0, 0, 0), normalVec);
 
+    if (edgeDirVec.Length() < Precision::Confusion()) {
+        if (faceIsS1) {
+            outOrigin = faceLoc;
+        }
+        else {
+            outOrigin = edgeLoc;
+        }
+        return true;
+    }
+
     gp_Vec projection(edgeDirVec.x, edgeDirVec.y, edgeDirVec.z);
     projection.Normalize();
 
@@ -425,6 +435,10 @@ bool MeasureAngle::setDirections(TopoDS_Shape& s1)
         Base::Vector3d edgeDirVec(edgeDir.X(), edgeDir.Y(), edgeDir.Z());
         Base::Vector3d normalVec(faceNormal.X(), faceNormal.Y(), faceNormal.Z());
         edgeDirVec.ProjectToPlane(Base::Vector3d(0, 0, 0), normalVec);
+
+        if (edgeDirVec.Length() < Precision::Confusion()) {
+            return true;
+        }
 
         gp_Vec projection(edgeDirVec.x, edgeDirVec.y, edgeDirVec.z);
         projection.Normalize();

--- a/tests/src/Mod/Measure/App/CMakeLists.txt
+++ b/tests/src/Mod/Measure/App/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 add_executable(Measure_tests_run
+        MeasureAngle.cpp
         MeasureDistance.cpp
 )
 

--- a/tests/src/Mod/Measure/App/MeasureAngle.cpp
+++ b/tests/src/Mod/Measure/App/MeasureAngle.cpp
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <algorithm>
+#include <cmath>
+
+#include <src/App/InitApplication.h>
+
+#include <App/Document.h>
+#include <Mod/Measure/App/MeasureAngle.h>
+#include <Mod/Part/App/PartFeature.h>
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <Precision.hxx>
+#include <gp_Pln.hxx>
+#include <gtest/gtest.h>
+
+class MeasureAngle: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        document = App::GetApplication().newDocument("MeasureAngle");
+    }
+
+    void TearDown() override
+    {
+        App::GetApplication().closeDocument(document->getName());
+    }
+
+    App::Document* document {};
+};
+
+TEST_F(MeasureAngle, EdgeParallelToFaceNormal)
+{
+    auto face = document->addObject<Part::Feature>("Face");
+    face->Shape.setValue(BRepBuilderAPI_MakeFace(
+                             gp_Pln(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0)),
+                             -10.0,
+                             10.0,
+                             -10.0,
+                             10.0
+    )
+                             .Face());
+
+    auto edge = document->addObject<Part::Feature>("Edge");
+    edge->Shape.setValue(BRepBuilderAPI_MakeEdge(gp_Pnt(0.0, 0.0, 5.0), gp_Pnt(0.0, 0.0, 10.0)).Edge());
+
+    auto measure = document->addObject<Measure::MeasureAngle>("Angle");
+    measure->Element1.setValue(face, {"Face1"});
+    measure->Element2.setValue(edge, {"Edge1"});
+    document->recompute();
+
+    const double angle = measure->Angle.getValue();
+    // Allow for 0, 180, or -180
+    const double deviation = std::min(std::abs(angle), std::abs(std::abs(angle) - 180.0));
+    EXPECT_NEAR(deviation, 0.0, Precision::Angular());
+}


### PR DESCRIPTION
When measuring a edge that is parallel with a face normal it did a division by 0 causing an error, and in some cases it gave the wrong answer do to floating point.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Before

https://github.com/user-attachments/assets/c546db93-8527-4008-88cc-743a6b55d69d

## After
<img width="772" height="600" alt="Skjermbilde" src="https://github.com/user-attachments/assets/733e9ff8-c0b7-4e00-b6eb-7028dd81898e" />

## Test
I added a new test case in a new file `MeasureAngle.cpp` for this to avoid regression for this edge case, allowing for 0° or 180° as an answer.
All previous measurement tests succeed. 
Test writing assisted by: OpenAI Codex, GPT 5.5