### PR TITLE
Handle also xerces-c exceptions in commands

### DIFF
--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -23,6 +23,8 @@
 #include <Inventor/SbSphere.h>
 #include <Inventor/actions/SoGetBoundingBoxAction.h>
 #include <Inventor/nodes/SoOrthographicCamera.h>
+#include <xercesc/util/XMLException.hpp>
+#include <xercesc/util/XMLString.hpp>
 #include <sstream>
 #include <QApplication>
 #include <QByteArray>
@@ -516,6 +518,11 @@ void Command::_invoke(int id, bool disablelog)
         e.reportException();
         // Pop-up a dialog for FreeCAD-specific exceptions
         QMessageBox::critical(Gui::getMainWindow(), QObject::tr("Exception"), QLatin1String(e.what()));
+    }
+    catch (const XERCES_CPP_NAMESPACE::XMLException& e) {
+        char* message = XERCES_CPP_NAMESPACE::XMLString::transcode(e.getMessage());
+        Base::Console().error("XML exception thrown (%s)\n", message);
+        XERCES_CPP_NAMESPACE::XMLString::release(&message);
     }
     catch (std::exception& e) {
         Base::Console().error("C++ exception thrown (%s)\n", e.what());

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -268,7 +268,7 @@ void StdCmdImport::activated(int iMsg)
     );
     if (!fileList.isEmpty()) {
         const auto& selectedFilter = formatList[selectedFilterIndex];
-        hPath->SetASCII("FileImportFilter", selectedFilter.name.toLatin1().constData());
+        hPath->SetASCII("FileImportFilter", selectedFilter.name.toUtf8());
         SelectModule::Dict dict
             = SelectModule::importHandler(fileList, selectedFilter.toFilterString());
 


### PR DESCRIPTION
Cherry-pick from https://codeberg.org/xwzCAD/FreeCAD/pulls/261/

ParameterGrp::SetASCII() expects a utf-8 encoded string as argument.
If e.g. a latin1 string is passed the decoding may fail and an exception
is thrown.

Fix the command StdCmdImport to use QString's toUtf8() instead of
toLatin1() method.