### PR TITLE
CAM: G0 should not have F param for most machines

### DIFF
--- a/src/Mod/CAM/CAMTests/TestOpenSBPPost.py
+++ b/src/Mod/CAM/CAMTests/TestOpenSBPPost.py
@@ -87,22 +87,6 @@ class TestOpenSBPPost(PathTestUtils.PathTestBase):
         self.post.apply_configuration_bundle()
         import json
 
-        if self._first_time:  # FIXME: disable when dev is done
-            self.__class__._first_time = False
-            print(f"## _mach setup: { self.post._machine.__class__.__name__}")
-            try:
-                adump = json.dumps(self.post._machine.to_dict(), sort_keys=True, indent=2)
-            except TypeError:
-                adump = str(self.post._machine.to_dict())
-            print("---_machine\n{adump}\n---")
-            try:
-                adump = json.dumps(
-                    self.post._machine.postprocessor_properties, sort_keys=True, indent=2
-                )
-            except TypeError:
-                adump = str(self.post._machine.postprocessor_properties)
-            print(f"--.postprocessor_properties\n{adump}")
-
         self.post._machine.name = "Test ShopBot Machine"
         toolhead = Toolhead(
             name="Default Toolhead",
@@ -223,6 +207,12 @@ class TestOpenSBPPost(PathTestUtils.PathTestBase):
         command = Path.Command("G0", {"Y": 20.0, "Z": 5.0})
         result = self.post._convert_rapid_move(command)
         self.assertIn("G0 Y20.000 Z5.000", result)
+
+    def test_rapid_f(self):
+        """Output F for G0 is the default for us"""
+        command = Path.Command("G0 X1 F8")
+        gcode = self.post._convert_rapid_move(command)
+        self.assertIn(" F", gcode)
 
     # -------------------------------------------------------------------------
     # Linear move (G1) → Move commands

--- a/src/Mod/CAM/CAMTests/TestPostOutput.py
+++ b/src/Mod/CAM/CAMTests/TestPostOutput.py
@@ -751,6 +751,44 @@ class TestExport2Integration(unittest.TestCase):
             "version": 1,
         }
 
+    def test002_g0_convert(self):
+
+        # Default, no G0 F's
+
+        machine = self._create_machine()
+        post = self._create_postprocessor(machine)
+
+        # convert_command_to_gcode: No spurious F
+        cmd = Path.Command("G0 X1")
+        gcode = post.convert_command_to_gcode(cmd)
+        self.assertNotIn(" F", gcode)
+
+        # convert_command_to_gcode: No F by default for G0
+        cmd = Path.Command("G0 X1 F9")
+        gcode = post.convert_command_to_gcode(cmd)
+        self.assertNotIn(" F", gcode)
+
+        # Output G0 F's if asked
+
+        machine.processing.f_for_rapid_moves = True
+        post = self._create_postprocessor(machine)
+
+        # convert_command_to_gcode level: no spurious F
+        cmd = Path.Command("G0 X1")
+        gcode = post.convert_command_to_gcode(cmd)
+        self.assertNotIn(" F", gcode)
+
+        # convert_command_to_gcode level: include F
+        cmd = Path.Command("G0 X1 F8")
+        gcode = post.convert_command_to_gcode(cmd)
+        self.assertIn(" F", gcode)
+
+        # Don't output G0 F's if they are zero (e.g. tool wasn't setup with rapid speed)
+
+        cmd = Path.Command("G0 X1 F0")
+        gcode = post.convert_command_to_gcode(cmd)
+        self.assertNotIn(" F", gcode)
+
     # ===== 010-019: Basic smoke tests =====
 
     def test010_export2_returns_gcode_sections(self):

--- a/src/Mod/CAM/Machine/models/machine.py
+++ b/src/Mod/CAM/Machine/models/machine.py
@@ -169,6 +169,7 @@ class ProcessingOptions:
     tool_change: bool = True  # Enable tool change commands
     translate_drill_cycles: bool = False  # Expand canned drill cycles to G0/G1 moves
     translate_rapid_moves: bool = False
+    f_for_rapid_moves = False
     xy_before_z_after_tool_change: bool = (
         False  # Decompose first move after tool change: XY first, then Z
     )

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -310,7 +310,7 @@ class PostProcessor:
             + Constants.GCODE_NON_CONFORMING
         )
 
-        return [
+        return [  # FIXME: this list does not match _merge_machine_config(), nor machine_editor.py
             {
                 "name": "file_extension",
                 "type": "string",
@@ -545,6 +545,16 @@ class PostProcessor:
                 "help": translate(
                     "CAM",
                     "Decimals of precision for spindle-speed",
+                ),
+            },
+            {
+                "name": "f_for_rapid_moves",
+                "type": "bool",
+                "label": translate("CAM", "Output F parameter for G0 (rapid)"),
+                "default": False,
+                "help": translate(
+                    "CAM",
+                    "Whether to output the F parameter for G0 (rapid moves)",
                 ),
             },
         ]
@@ -835,14 +845,12 @@ class PostProcessor:
         self.values["OUTPUT_DOUBLES"] = getattr(duplicates, "parameters", False)
 
         # Processing options
-        self.values["SPLIT_ARCS"] = self._machine.processing.split_arcs
-        self.values["TRANSLATE_RAPID_MOVES"] = self._machine.processing.translate_rapid_moves
-        self.values["TRANSLATE_DRILL_CYCLES"] = self._machine.processing.translate_drill_cycles
-        self.values["TOOL_CHANGE"] = self._machine.processing.tool_change  # boolean
-        self.values["XY_BEFORE_Z_AFTER_TOOL_CHANGE"] = (
-            self._machine.processing.xy_before_z_after_tool_change
-        )
-        self.values["FILTER_INEFFICIENT_MOVES"] = self._machine.processing.filter_inefficient_moves
+        for (
+            option
+        ) in "split_arcs f_for_rapid_moves translate_rapid_moves translate_drill_cycles tool_change xy_before_z_after_tool_change filter_inefficient_moves".split(
+            " "
+        ):
+            self.values[option.upper()] = getattr(self._machine.processing, option)
 
     def _apply_schema_defaults(self):
         """Populate postprocessor_properties with schema defaults for missing keys.
@@ -891,16 +899,16 @@ class PostProcessor:
         Returns:
             dict: The final postprocessor property bundle.
         """
-        schema = self.get_full_property_schema()
-        schema_keys = {x["name"] for x in schema}
-        # HACK: not really schema-keys, but no-where else to deal with
-        schema_keys |= set("comment selected_fixtures job_author".split(" "))
-
         # Stage 1 — machine postprocessor_properties
         bundle = {}
         bundle.update(self._machine.postprocessor_properties)
 
         # Stage 2 — schema defaults for missing keys
+        schema = self.get_full_property_schema()
+        schema_keys = {x["name"] for x in schema}
+        # HACK: not really schema-keys, but no-where else to deal with
+        schema_keys |= set("comment selected_fixtures job_author".split(" "))
+
         for prop in schema:
             name = prop.get("name", "")
             if name and name not in bundle:
@@ -2622,16 +2630,22 @@ class PostProcessor:
         for parameter in parameter_order:
             if parameter in params:
                 # Check if we should suppress duplicate parameters
+                current_value = params[parameter]
                 if not self.values["OUTPUT_DOUBLES"]:
                     # Suppress parameters that haven't changed
-                    current_value = params[parameter]
                     if (
                         parameter in self._modal_state
                         and self._modal_state[parameter] == current_value
                     ):
                         continue  # Skip this parameter
+                elif (
+                    parameter == "F"
+                    and command_name in Constants.GCODE_MOVE_RAPID
+                    and (not self.values["F_FOR_RAPID_MOVES"] or current_value == 0.0)
+                ):
+                    continue  # no F for G0, or the F is 0.0 which should be skipped too
 
-                formatted_value = self.format_parameter(parameter, params[parameter])
+                formatted_value = self.format_parameter(parameter, current_value)
                 command_line.append(f"{parameter}{formatted_value}")
 
                 self._modal_state[parameter] = params[parameter]

--- a/src/Mod/CAM/Path/Post/scripts/opensbp_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/opensbp_post.py
@@ -137,6 +137,9 @@ class OpenSBPPost(PostProcessor):
         for prop in common_props:
             if prop["name"] == "file_extension":
                 prop["default"] = "sbp"
+            elif prop["name"] == "f_for_rapid_moves":
+                # Use G0's F by default
+                prop["default"] = True
 
             # FIXME: show but don't allow edit in UI
 
@@ -243,7 +246,10 @@ class OpenSBPPost(PostProcessor):
         # These schema defaults are r/o: force them
         for property_name in (
             "supported_commands drill_cycles_to_translate"
-            " translate_drill_cycles output_tool_length_offset".split(" ")
+            " translate_drill_cycles output_tool_length_offset"
+            " f_for_rapid_moves".split(  # FIXME: the merge logic doesn't respect our updated default
+                " "
+            )
         ):
             self.values[property_name.upper()] = schema[property_name]["default"]
 


### PR DESCRIPTION
A side-effect of including F in Path.Commands for G0 caused output to generate something like `G0 X Y Z F...`. Most machines do not want F.

Shopbot would like it.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

