### PR TITLE
Fix Navigation tooltip shows the same icon on Linux

### DIFF
--- a/src/Mod/Tux/NavigationIndicatorGui.py
+++ b/src/Mod/Tux/NavigationIndicatorGui.py
@@ -20,6 +20,8 @@
 
 """Navigation indicator for FreeCAD."""
 
+import base64
+
 import Tux_rc
 import FreeCAD as App
 import FreeCADGui as Gui
@@ -28,6 +30,28 @@ from PySide import QtCore
 
 mw = Gui.getMainWindow()
 statusBar = mw.statusBar()
+
+_iconTagCache = {}
+
+
+def icon(name):
+    """Build an <img> tag embedding a navigation icon as a PNG data URI.
+    This works around an SVG caching bug in Qt version <= 6.11.1.
+    """
+
+    if name not in _iconTagCache:
+        pixmap = QtGui.QIcon(":/icons/" + name + ".svg").pixmap(128, 128)
+        buffer = QtCore.QBuffer()
+        buffer.open(QtCore.QIODevice.WriteOnly)
+        pixmap.save(buffer, "PNG")
+        data = base64.b64encode(bytes(buffer.data())).decode()
+        _iconTagCache[name] = (
+            "<img width='64' height='64' src='data:image/png;base64," + data + "'>"
+        )
+
+    return _iconTagCache[name]
+
+
 p = App.ParamGet("User parameter:Tux/NavigationIndicator")
 pView = App.ParamGet("User parameter:BaseApp/Preferences/View")
 pMWin = App.ParamGet("User parameter:BaseApp/Preferences/MainWindow")
@@ -123,11 +147,11 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Left.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Scroll.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Middle.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_ShiftMiddle.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_LeftRight.svg'></td>
+      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_ShiftMiddle") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_LeftRight") + """</td>
      </tr>
     </table>
     <b>"""
@@ -161,11 +185,11 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Left.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Scroll.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_MiddleLeft.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_MiddleRight.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Middle.svg'></td>
+      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_MiddleLeft") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_MiddleRight") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
      </tr>
     </table>
     <b>"""
@@ -202,12 +226,12 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Left.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Scroll.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_LeftMove.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_AltLeft.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Right.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_LeftRight.svg'></td>
+      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_LeftMove") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_AltLeft") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Right") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_LeftRight") + """</td>
      </tr>
      <tr>
       <th><small>"""
@@ -230,12 +254,12 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/Navigation_Gesture_SelectTouch.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Gesture_ZoomTouch.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Gesture_RotateTouch.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Gesture_PanTouch.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Gesture_PanTouchAlt.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Gesture_TiltTouch.svg'></td>
+      <td align='center'>""" + icon("Navigation_Gesture_SelectTouch") + """</td>
+      <td align='center'>""" + icon("Navigation_Gesture_ZoomTouch") + """</td>
+      <td align='center'>""" + icon("Navigation_Gesture_RotateTouch") + """</td>
+      <td align='center'>""" + icon("Navigation_Gesture_PanTouch") + """</td>
+      <td align='center'>""" + icon("Navigation_Gesture_PanTouchAlt") + """</td>
+      <td align='center'>""" + icon("Navigation_Gesture_TiltTouch") + """</td>
      </tr>
     </table>
     <p><small><b>"""
@@ -277,12 +301,12 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Left.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Scroll.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_AltRight.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_AltLeft.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_AltMiddle.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_AltLeftRight.svg'></td>
+      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_AltRight") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_AltLeft") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_AltMiddle") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_AltLeftRight") + """</td>
      </tr>
      <tr>
       <th><small>"""
@@ -305,12 +329,12 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/Navigation_Gesture_SelectTouch.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Gesture_ZoomTouch.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Gesture_RotateTouch.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Gesture_PanTouch.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Gesture_PanTouchAlt.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Gesture_TiltTouch.svg'></td>
+      <td align='center'>""" + icon("Navigation_Gesture_SelectTouch") + """</td>
+      <td align='center'>""" + icon("Navigation_Gesture_ZoomTouch") + """</td>
+      <td align='center'>""" + icon("Navigation_Gesture_RotateTouch") + """</td>
+      <td align='center'>""" + icon("Navigation_Gesture_PanTouch") + """</td>
+      <td align='center'>""" + icon("Navigation_Gesture_PanTouchAlt") + """</td>
+      <td align='center'>""" + icon("Navigation_Gesture_TiltTouch") + """</td>
      </tr>
     </table>
     <p><small><b>"""
@@ -352,12 +376,12 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Left.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Scroll.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_CtrlLeft.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_CtrlRight.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_CtrlMiddle.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Middle.svg'></td>
+      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_CtrlLeft") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_CtrlRight") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_CtrlMiddle") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
      </tr>
     </table>"""
     )
@@ -386,11 +410,11 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/Navigation_Mouse_ShiftLeft.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Scroll.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_MiddleLeft.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Left.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Middle.svg'></td>
+      <td align='center'>""" + icon("Navigation_Mouse_ShiftLeft") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_MiddleLeft") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
      </tr>
     </table>
     <b>"""
@@ -427,12 +451,12 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Left.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Scroll.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Middle.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Left.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_MiddleRight.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Right.svg'></td>
+      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_MiddleRight") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Right") + """</td>
      </tr>
     </table>"""
     )
@@ -461,11 +485,11 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Left.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Scroll.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_ShiftMiddle.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Middle.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_LeftRight.svg'></td>
+      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_ShiftMiddle") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_LeftRight") + """</td>
      </tr>
     </table>
     <b>"""
@@ -502,12 +526,12 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Left.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Scroll.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_MiddleLeft.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Middle.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_MiddleRight.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_ShiftMiddle.svg'></td>
+      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_MiddleLeft") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_MiddleRight") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_ShiftMiddle") + """</td>
      </tr>
     </table>
     <b>"""
@@ -541,11 +565,11 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Left.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Scroll.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_ShiftMiddle.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Middle.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_CtrlMiddle.svg'></td>
+      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_ShiftMiddle") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_CtrlMiddle") + """</td>
      </tr>
     </table>
     <b>"""
@@ -576,10 +600,10 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Left.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Scroll.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Right.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Middle.svg'></td>
+      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Right") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
      </tr>
     </table>"""
     )
@@ -611,12 +635,12 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Left.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_Scroll.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_ShiftCtrlMove.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_AltMove.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_ShiftLeft.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Mouse_ShiftMove.svg'></td>
+      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_ShiftCtrlMove") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_AltMove") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_ShiftLeft") + """</td>
+      <td align='center'>""" + icon("Navigation_Mouse_ShiftMove") + """</td>
      </tr>
      <tr>
       <th><small>"""
@@ -636,11 +660,11 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/Navigation_Touchpad_Left.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Touchpad_ShiftCtrlTouch.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Touchpad_AltTouch.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Touchpad_ShiftLeftTouch.svg'></td>
-      <td align='center'><img src=':/icons/Navigation_Touchpad_ShiftTouch.svg'></td>
+      <td align='center'>""" + icon("Navigation_Touchpad_Left") + """</td>
+      <td align='center'>""" + icon("Navigation_Touchpad_ShiftCtrlTouch") + """</td>
+      <td align='center'>""" + icon("Navigation_Touchpad_AltTouch") + """</td>
+      <td align='center'>""" + icon("Navigation_Touchpad_ShiftLeftTouch") + """</td>
+      <td align='center'>""" + icon("Navigation_Touchpad_ShiftTouch") + """</td>
      </tr>
     </table>
     <p><small><b>"""

--- a/src/Mod/Tux/NavigationIndicatorGui.py
+++ b/src/Mod/Tux/NavigationIndicatorGui.py
@@ -147,11 +147,21 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_ShiftMiddle") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_LeftRight") + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Left")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Scroll")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Middle")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_ShiftMiddle")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_LeftRight")
+        + """</td>
      </tr>
     </table>
     <b>"""
@@ -185,11 +195,21 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_MiddleLeft") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_MiddleRight") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Left")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Scroll")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_MiddleLeft")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_MiddleRight")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Middle")
+        + """</td>
      </tr>
     </table>
     <b>"""
@@ -226,12 +246,24 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_LeftMove") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_AltLeft") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Right") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_LeftRight") + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Left")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Scroll")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_LeftMove")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_AltLeft")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Right")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_LeftRight")
+        + """</td>
      </tr>
      <tr>
       <th><small>"""
@@ -254,12 +286,24 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'>""" + icon("Navigation_Gesture_SelectTouch") + """</td>
-      <td align='center'>""" + icon("Navigation_Gesture_ZoomTouch") + """</td>
-      <td align='center'>""" + icon("Navigation_Gesture_RotateTouch") + """</td>
-      <td align='center'>""" + icon("Navigation_Gesture_PanTouch") + """</td>
-      <td align='center'>""" + icon("Navigation_Gesture_PanTouchAlt") + """</td>
-      <td align='center'>""" + icon("Navigation_Gesture_TiltTouch") + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Gesture_SelectTouch")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Gesture_ZoomTouch")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Gesture_RotateTouch")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Gesture_PanTouch")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Gesture_PanTouchAlt")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Gesture_TiltTouch")
+        + """</td>
      </tr>
     </table>
     <p><small><b>"""
@@ -301,12 +345,24 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_AltRight") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_AltLeft") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_AltMiddle") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_AltLeftRight") + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Left")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Scroll")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_AltRight")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_AltLeft")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_AltMiddle")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_AltLeftRight")
+        + """</td>
      </tr>
      <tr>
       <th><small>"""
@@ -329,12 +385,24 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'>""" + icon("Navigation_Gesture_SelectTouch") + """</td>
-      <td align='center'>""" + icon("Navigation_Gesture_ZoomTouch") + """</td>
-      <td align='center'>""" + icon("Navigation_Gesture_RotateTouch") + """</td>
-      <td align='center'>""" + icon("Navigation_Gesture_PanTouch") + """</td>
-      <td align='center'>""" + icon("Navigation_Gesture_PanTouchAlt") + """</td>
-      <td align='center'>""" + icon("Navigation_Gesture_TiltTouch") + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Gesture_SelectTouch")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Gesture_ZoomTouch")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Gesture_RotateTouch")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Gesture_PanTouch")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Gesture_PanTouchAlt")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Gesture_TiltTouch")
+        + """</td>
      </tr>
     </table>
     <p><small><b>"""
@@ -376,12 +444,24 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_CtrlLeft") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_CtrlRight") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_CtrlMiddle") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Left")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Scroll")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_CtrlLeft")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_CtrlRight")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_CtrlMiddle")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Middle")
+        + """</td>
      </tr>
     </table>"""
     )
@@ -410,11 +490,21 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'>""" + icon("Navigation_Mouse_ShiftLeft") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_MiddleLeft") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_ShiftLeft")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Scroll")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_MiddleLeft")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Left")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Middle")
+        + """</td>
      </tr>
     </table>
     <b>"""
@@ -451,12 +541,24 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_MiddleRight") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Right") + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Left")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Scroll")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Middle")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Left")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_MiddleRight")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Right")
+        + """</td>
      </tr>
     </table>"""
     )
@@ -485,11 +587,21 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_ShiftMiddle") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_LeftRight") + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Left")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Scroll")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_ShiftMiddle")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Middle")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_LeftRight")
+        + """</td>
      </tr>
     </table>
     <b>"""
@@ -526,12 +638,24 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_MiddleLeft") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_MiddleRight") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_ShiftMiddle") + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Left")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Scroll")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_MiddleLeft")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Middle")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_MiddleRight")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_ShiftMiddle")
+        + """</td>
      </tr>
     </table>
     <b>"""
@@ -565,11 +689,21 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_ShiftMiddle") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_CtrlMiddle") + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Left")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Scroll")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_ShiftMiddle")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Middle")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_CtrlMiddle")
+        + """</td>
      </tr>
     </table>
     <b>"""
@@ -600,10 +734,18 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Right") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Middle") + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Left")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Scroll")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Right")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Middle")
+        + """</td>
      </tr>
     </table>"""
     )
@@ -635,12 +777,24 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'>""" + icon("Navigation_Mouse_Left") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_Scroll") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_ShiftCtrlMove") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_AltMove") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_ShiftLeft") + """</td>
-      <td align='center'>""" + icon("Navigation_Mouse_ShiftMove") + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Left")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_Scroll")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_ShiftCtrlMove")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_AltMove")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_ShiftLeft")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Mouse_ShiftMove")
+        + """</td>
      </tr>
      <tr>
       <th><small>"""
@@ -660,11 +814,21 @@ def retranslateUi():
         + """</small></th>
      </tr>
      <tr>
-      <td align='center'>""" + icon("Navigation_Touchpad_Left") + """</td>
-      <td align='center'>""" + icon("Navigation_Touchpad_ShiftCtrlTouch") + """</td>
-      <td align='center'>""" + icon("Navigation_Touchpad_AltTouch") + """</td>
-      <td align='center'>""" + icon("Navigation_Touchpad_ShiftLeftTouch") + """</td>
-      <td align='center'>""" + icon("Navigation_Touchpad_ShiftTouch") + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Touchpad_Left")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Touchpad_ShiftCtrlTouch")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Touchpad_AltTouch")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Touchpad_ShiftLeftTouch")
+        + """</td>
+      <td align='center'>"""
+        + icon("Navigation_Touchpad_ShiftTouch")
+        + """</td>
      </tr>
     </table>
     <p><small><b>"""


### PR DESCRIPTION
Qt's image loader can render every distinct SVG referenced via ':/icons/...' in one QTextDocument as the same cached pixmap, so every control in the Navigation Style tooltip showed the same icon. This is a [Qt bug](https://qt-project.atlassian.net//browse/QTBUG-147255) (see fix (QPixmapCache key omits the image name, see upstream fix https://github.com/qt/qtbase/commit/642371546331c90c1dee2f5598a1344cb2a425b6), already fixed upstream but not yet in any released Qt version.

Work around it the same way Gui::InputHintWidget does by rasterizing each icon and embeding it as a base64 PNG data URI in the <img> tag, rather than referencing the Qt resource path directly.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
Fixes #31152

## Before and After Images
Before:
<img width="940" height="399" alt="tooltip_crop" src="https://github.com/user-attachments/assets/85c7cad2-1854-45f5-8e20-043cdca9a4a9" />

After:
<img width="650" height="340" alt="latest_crop" src="https://github.com/user-attachments/assets/61f5c412-5373-4ad8-a658-4766756649c0" />


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
