### PR TITLE
CAM: Task Panel GUI Update

### DIFF
--- a/src/Mod/CAM/Gui/Resources/Path.qrc
+++ b/src/Mod/CAM/Gui/Resources/Path.qrc
@@ -29,6 +29,8 @@
         <file>icons/CAM_FacePocket.svg</file>
         <file>icons/CAM_FaceProfile.svg</file>
         <file>icons/CAM_Heights.svg</file>
+        <file>icons/CAM_HeightsDiagram.svg</file>
+        <file>icons/CAM_HeightsDiagram_NoFinish.svg</file>
         <file>icons/CAM_Helix.svg</file>
         <file>icons/CAM_Inspect.svg</file>
         <file>icons/CAM_Job.svg</file>

--- a/src/Mod/CAM/Gui/Resources/icons/CAM_HeightsDiagram.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/CAM_HeightsDiagram.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="90"
+   height="235"
+   viewBox="0 0 90 235"
+   version="1.1"
+   id="svg5"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><rect
+     style="font-variation-settings:normal;vector-effect:none;fill:#c6ae4f;fill-opacity:0.5;stroke:none;stroke-width:2.93105;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+     id="rect11"
+     width="65.954269"
+     height="39.764408"
+     x="0.073337339"
+     y="62.76754" /><path
+     style="fill:none;stroke:#ffffff;stroke-width:2.14639;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4.29285, 2.14639;stroke-dashoffset:2.14639;stroke-opacity:0.3"
+     d="M 0.0710472,125.58382 H 66.027966"
+     id="path15" /><path
+     style="fill:#000000;stroke-width:1.99997;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99997, 7.99991;stroke-dashoffset:0;stop-color:#000000"
+     d="M 66.040191,-4.1999986 V 175.80002"
+     id="path4446" /><path
+     style="fill:none;stroke:#ffffff;stroke-width:2.14639;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4.29285, 2.14639;stroke-dashoffset:2.14639;stroke-opacity:0.3"
+     d="M 0.0710472,147.48283 H 66.027964"
+     id="path16" /><rect
+     style="font-variation-settings:normal;vector-effect:none;fill:#8be869;fill-opacity:0.301961;stroke:none;stroke-width:2.14638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+     id="rect9"
+     width="51.96426"
+     height="82.986603"
+     x="14.06364"
+     y="102.53192" /><path
+     style="fill:none;stroke:#ffffff;stroke-width:2.14638;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4.29284, 2.14638;stroke-dashoffset:2.14638;stroke-opacity:0.3"
+     d="M 0.0710472,169.38167 H 66.027568"
+     id="path17" /><path
+     style="fill:#646464;fill-opacity:1;stroke:#ffffff;stroke-width:2.12822;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+     d="m 1.06411,103.67378 20.991242,-2.8e-4 v 1.49723 77.75296 h 42.981632 l -2.1e-4,51.0122 H 1.06411 Z"
+     id="path1" /><path
+     style="fill:none;stroke:#999999;stroke-width:2.10442;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stop-color:#000000"
+     d="m 68.506308,169.40468 h 6.534023 l 2.481108,-3.42032 v -3.67385 -11.42918 l -2.528485,-3.42102 h -6.486646"
+     id="path584-7" /><path
+     style="font-variation-settings:normal;fill:none;fill-opacity:1;stroke:#999999;stroke-width:2.097;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+     d="m 68.30895,64.083817 h 7.555269 L 80.605,58.178104 h 8.429"
+     id="path4" /><path
+     style="font-variation-settings:normal;fill:none;fill-opacity:1;stroke:#999999;stroke-width:2.097;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+     d="m 68.506309,103.66144 h 6.546209 l 2.284814,-2.28858 3.267668,-3.05786 8.429,-5.9e-5"
+     id="path4-5" /><path
+     style="font-variation-settings:normal;fill:none;fill-opacity:1;stroke:#999999;stroke-width:2.097;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+     d="m 68.525836,183.21291 6.749444,-4e-5 2.226453,3.58154 3.26e-4,27.30469 3.102941,2.99998 8.429,-2e-5"
+     id="path4-5-2" /><path
+     style="font-variation-settings:normal;fill:none;fill-opacity:1;stroke:#999999;stroke-width:2.097;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+     d="m 68.350408,24.357587 h 7.97135 L 80.605,17.884765 h 8.429"
+     id="path5" /><path
+     style="fill:none;stroke:#999999;stroke-width:2.1044;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stop-color:#000000"
+     d="m 68.506303,125.60637 h 6.53401 l 2.481083,-3.42046 v -3.67369 -11.42946 l -2.528461,-3.42082 -6.486632,-5e-4"
+     id="path8" /><path
+     id="path9"
+     style="font-variation-settings:normal;vector-effect:none;fill:none;fill-opacity:1;stroke:#999999;stroke-width:2.14638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+     d="M 77.519719,176.38322 H 89.034 m -20.508164,6.82965 h 6.519081 l 2.456996,-3.36335 v -3.55202 -3.55208 l -2.503912,-3.36375 h -6.472165" /><rect
+     style="font-variation-settings:normal;vector-effect:none;fill:#ff6e6e;fill-opacity:0.301961;stroke:none;stroke-width:2.21071;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+     id="rect10"
+     width="65.954216"
+     height="39.764408"
+     x="0.073337339"
+     y="23.003119" /><path
+     id="path11"
+     style="font-variation-settings:normal;vector-effect:none;fill:none;fill-opacity:1;stroke:#999999;stroke-width:2.09697;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+     d="m 77.50559,136.53336 11.52841,-2e-5 m -20.5312,10.97621 h 6.522481 l 2.462464,-3.42136 v -3.67533 -11.43391 l -2.509503,-3.42192 H 68.5028" /><path
+     style="fill:none;stroke:#ffffff;stroke-width:2.146;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4.29208009,2.146;stroke-dashoffset:2.146;stroke-opacity:0.3"
+     d="M 0.0710472,103.68447 H 66.027568"
+     id="path12" /><path
+     style="fill:none;stroke:#ffffff;stroke-width:2.14639;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4.29286, 2.14639;stroke-dashoffset:2.14639;stroke-opacity:0.3"
+     d="M 0.0733456,63.920088 H 66.027578"
+     id="path13" /><path
+     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.14639;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4.29286, 2.14639;stroke-dashoffset:2.14639;stroke-opacity:0.3"
+     d="M 0.0733456,24.155709 H 66.027578"
+     id="path14" /><metadata
+     id="metadata199">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title>CAM_HeightsDiagram</dc:title>
+        <dc:date>2026-07-06</dc:date>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/CAM/Gui/Resources/icons/CAM_HeightsDiagram.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[Connor] Billy Huddleston</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata></svg>

--- a/src/Mod/CAM/Gui/Resources/icons/CAM_HeightsDiagram_NoFinish.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/CAM_HeightsDiagram_NoFinish.svg
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="90"
+   height="235"
+   viewBox="0 0 90 235"
+   version="1.1"
+   id="svg5"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><rect
+     style="font-variation-settings:normal;vector-effect:none;fill:#c6ae4f;fill-opacity:0.5;stroke:none;stroke-width:2.93105;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+     id="rect11"
+     width="65.954269"
+     height="39.764408"
+     x="0.073337339"
+     y="62.76754" /><path
+     style="fill:none;stroke:#ffffff;stroke-width:2.14639;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4.29285, 2.14639;stroke-dashoffset:2.14639;stroke-opacity:0.3"
+     d="M 0.0710472,125.58382 H 66.027966"
+     id="path15" /><path
+     style="fill:#000000;stroke-width:1.99997;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1.99997, 7.99991;stroke-dashoffset:0;stop-color:#000000"
+     d="M 66.040191,-4.1999986 V 175.80002"
+     id="path4446" /><path
+     style="fill:none;stroke:#ffffff;stroke-width:2.14639;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4.29285, 2.14639;stroke-dashoffset:2.14639;stroke-opacity:0.3"
+     d="M 0.0710472,147.48283 H 66.027964"
+     id="path16" /><rect
+     style="font-variation-settings:normal;vector-effect:none;fill:#8be869;fill-opacity:0.301961;stroke:none;stroke-width:1.92137;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+     id="rect9"
+     width="51.96426"
+     height="66.5"
+     x="14.06364"
+     y="102.53192" /><path
+     style="fill:none;stroke:#ffffff;stroke-width:2.14638;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4.29284, 2.14638;stroke-dashoffset:2.14638;stroke-opacity:0.3"
+     d="m 0.0710472,169.382 65.9565208,-3.3e-4"
+     id="path17" /><path
+     style="fill:#646464;fill-opacity:1;stroke:#ffffff;stroke-width:2.12822;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+     d="m 1.06411,103.67378 20.991242,-2.8e-4 v 1.49723 64.21127 h 42.981632 l -2.1e-4,64.55389 H 1.06411 Z"
+     id="path1" /><path
+     style="fill:none;stroke:#999999;stroke-width:2.10442;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stop-color:#000000"
+     d="m 68.506308,169.40468 h 6.534023 l 2.481108,-3.42032 v -3.67385 -11.42918 l -2.528485,-3.42102 h -6.486646"
+     id="path584-7" /><path
+     style="font-variation-settings:normal;fill:none;fill-opacity:1;stroke:#999999;stroke-width:2.097;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+     d="m 68.30895,64.083817 h 7.555269 L 80.605,58.178104 h 8.429"
+     id="path4" /><path
+     style="font-variation-settings:normal;fill:none;fill-opacity:1;stroke:#999999;stroke-width:2.097;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+     d="m 68.506309,103.66144 h 6.546209 l 2.284814,-2.28858 3.267668,-3.05786 8.429,-5.9e-5"
+     id="path4-5" /><path
+     style="font-variation-settings:normal;fill:none;fill-opacity:1;stroke:#999999;stroke-width:2.097;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+     d="m 68.350408,24.357587 h 7.97135 L 80.605,17.884765 h 8.429"
+     id="path5" /><path
+     style="fill:none;stroke:#999999;stroke-width:2.1044;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stop-color:#000000"
+     d="m 68.506303,125.60637 h 6.53401 l 2.481083,-3.42046 v -3.67369 -11.42946 l -2.528461,-3.42082 -6.486632,-5e-4"
+     id="path8" /><path
+     id="path9"
+     style="font-variation-settings:normal;vector-effect:none;fill:none;fill-opacity:1;stroke:#999999;stroke-width:2.14638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+     d="m 80.605,176.383 8.429,2.2e-4 m -20.508164,-7.00155 h 6.472165 L 80.605,176.383" /><rect
+     style="font-variation-settings:normal;vector-effect:none;fill:#ff6e6e;fill-opacity:0.301961;stroke:none;stroke-width:2.21071;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+     id="rect10"
+     width="65.954216"
+     height="39.764408"
+     x="0.073337339"
+     y="23.003119" /><path
+     id="path11"
+     style="font-variation-settings:normal;vector-effect:none;fill:none;fill-opacity:1;stroke:#999999;stroke-width:2.09697;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+     d="m 77.50559,136.53336 11.52841,-2e-5 m -20.5312,10.97621 h 6.522481 l 2.462464,-3.42136 v -3.67533 -11.43391 l -2.509503,-3.42192 H 68.5028" /><path
+     style="fill:none;stroke:#ffffff;stroke-width:2.146;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4.29208009,2.146;stroke-dashoffset:2.146;stroke-opacity:0.3"
+     d="M 0.0710472,103.68447 H 66.027568"
+     id="path12" /><path
+     style="fill:none;stroke:#ffffff;stroke-width:2.14639;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4.29286, 2.14639;stroke-dashoffset:2.14639;stroke-opacity:0.3"
+     d="M 0.0733456,63.920088 H 66.027578"
+     id="path13" /><path
+     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.14639;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4.29286, 2.14639;stroke-dashoffset:2.14639;stroke-opacity:0.3"
+     d="M 0.0733456,24.155709 H 66.027578"
+     id="path14" /><metadata
+     id="metadata199">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title>CAM_HeightsDiagram_NoFinish</dc:title>
+        <dc:date>2026-07-06</dc:date>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/CAM/Gui/Resources/icons/CAM_HeightsDiagram_NoFinish.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[Connor] Billy Huddleston</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata></svg>

--- a/src/Mod/CAM/Gui/Resources/panels/PageHeightsEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageHeightsEdit.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>282</width>
-    <height>242</height>
+    <height>420</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,67 +17,290 @@
    <iconset resource="../Path.qrc">
     <normaloff>:/icons/CAM_Heights.svg</normaloff>:/icons/CAM_Heights.svg</iconset>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_9">
-     <property name="text">
-      <string>Clearance height</string>
-     </property>
-    </widget>
+  <layout class="QVBoxLayout" name="outerLayout">
+   <item>
+    <layout class="QHBoxLayout" name="diagramFieldsLayout">
+     <item alignment="Qt::AlignTop">
+      <widget class="QLabel" name="heightsDiagram">
+       <property name="minimumSize">
+        <size>
+         <width>90</width>
+         <height>235</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>90</width>
+         <height>235</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item alignment="Qt::AlignTop">
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0" colspan="2">
+        <widget class="QLabel" name="label_9">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>34</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>34</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Clearance</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="Gui::QuantitySpinBox" name="clearanceHeight">
+         <property name="toolTip">
+          <string>The height where lateral movement of the toolbit is not obstructed by any fixtures or the part / stock material itself.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+         <property name="minimum">
+          <double>-999999999.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>999999999.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="2">
+        <widget class="QLabel" name="label_7">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>34</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>34</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Retract</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="Gui::QuantitySpinBox" name="safeHeight">
+         <property name="toolTip">
+          <string>The height above which it is safe to move the tool bit with rapid movements. Below this height all lateral and downward movements are performed with feed rate speeds.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+         <property name="minimum">
+          <double>-999999999.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>999999999.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="QLabel" name="startDepthLabel">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>34</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>34</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Start</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="Gui::QuantitySpinBox" name="startDepth">
+         <property name="toolTip">
+          <string>Start height of the operation. The highest point in Z-axis the operation needs to process.</string>
+         </property>
+         <property name="minimum" stdset="0">
+          <double>-999999999.000000000000000</double>
+         </property>
+         <property name="maximum" stdset="0">
+          <double>999999999.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="3">
+        <widget class="QToolButton" name="startDepthSet">
+         <property name="toolTip">
+          <string>Transfer the Z value of the selected feature as the start height for the operation</string>
+         </property>
+         <property name="text">
+          <string notr="true">…</string>
+         </property>
+         <property name="icon">
+          <iconset>
+           <normaloff>:/icons/button_left.svg</normaloff>:/icons/button_left.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="stepDownLabel">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>34</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>34</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Step down</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="2">
+        <widget class="Gui::QuantitySpinBox" name="stepDown">
+         <property name="toolTip">
+          <string>The depth in Z-axis the operation moves downwards between layers. This value depends on the tool being used, the material to be cut, available cooling and many other factors. Consult the tool manufacturers data sheets for the proper value.</string>
+         </property>
+         <property name="minimum" stdset="0">
+          <double>-999999999.000000000000000</double>
+         </property>
+         <property name="maximum" stdset="0">
+          <double>999999999.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0" colspan="2">
+        <widget class="QLabel" name="finishDepthLabel">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>34</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>34</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Finish step down</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <widget class="Gui::QuantitySpinBox" name="finishDepth">
+         <property name="toolTip">
+          <string>Height of the final cut of the operation. Can be used to produce a cleaner finish.</string>
+         </property>
+         <property name="minimum" stdset="0">
+          <double>-999999999.000000000000000</double>
+         </property>
+         <property name="maximum" stdset="0">
+          <double>999999999.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="2">
+        <widget class="QLabel" name="finalDepthLabel">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>34</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>34</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Final</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="2">
+        <widget class="Gui::QuantitySpinBox" name="finalDepth">
+         <property name="toolTip">
+          <string>The height of the operation which corresponds to the lowest value in Z-axis the operation needs to process.</string>
+         </property>
+         <property name="minimum" stdset="0">
+          <double>-999999999.000000000000000</double>
+         </property>
+         <property name="maximum" stdset="0">
+          <double>999999999.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="3">
+        <widget class="QToolButton" name="finalDepthSet">
+         <property name="toolTip">
+          <string>Transfer the Z value of the selected feature as the final height for the operation</string>
+         </property>
+         <property name="text">
+          <string notr="true">…</string>
+         </property>
+         <property name="icon">
+          <iconset>
+           <normaloff>:/icons/button_left.svg</normaloff>:/icons/button_left.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0" colspan="4">
+        <spacer name="fieldsExpander">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
    </item>
-   <item row="0" column="1">
-    <widget class="Gui::QuantitySpinBox" name="clearanceHeight">
-     <property name="toolTip">
-      <string>The height where lateral movement of the toolbit is not obstructed by any fixtures or the part / stock material itself.</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="minimum">
-      <double>-999999999.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>999999999.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Safe height</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="Gui::QuantitySpinBox" name="safeHeight">
-     <property name="toolTip">
-      <string>The height above which it is safe to move the tool bit with rapid movements. Below this height all lateral and downward movements are performed with feed rate speeds.</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="minimum">
-      <double>-999999999.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>999999999.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="2">
+   <item>
     <widget class="QGroupBox" name="groupBoxLinking">
      <property name="title">
       <string>Linking</string>
      </property>
      <layout class="QGridLayout" name="gridLayoutLinking">
-      <item row="0" column="0">
+      <item row="0" column="1">
        <widget class="QLabel" name="labelCollisionAvoidanceStrategy">
         <property name="text">
          <string>Collision Avoidance Strategy</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="0" column="2">
        <widget class="QComboBox" name="CollisionAvoidanceStrategy">
         <property name="toolTip">
          <string>How collision detection is performed when the tool moves between features.
@@ -91,14 +314,14 @@ Tool Shape: safest - checks clearance using the cross section of the tool shape
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="1" column="1">
        <widget class="QLabel" name="labelCollisionClearance">
         <property name="text">
          <string>Collision Clearance</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="1" column="2">
        <widget class="Gui::QuantitySpinBox" name="CollisionClearance">
         <property name="toolTip">
          <string>Minimum clearance distance between the tool and any solid during linking moves. Applies to all linking modes.</string>
@@ -117,7 +340,7 @@ Tool Shape: safest - checks clearance using the cross section of the tool shape
      </layout>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -130,7 +353,7 @@ Tool Shape: safest - checks clearance using the cross section of the tool shape
      </property>
     </spacer>
    </item>
-   </layout>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>
@@ -139,6 +362,16 @@ Tool Shape: safest - checks clearance using the cross section of the tool shape
    <header>Gui/QuantitySpinBox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>clearanceHeight</tabstop>
+  <tabstop>safeHeight</tabstop>
+  <tabstop>startDepth</tabstop>
+  <tabstop>stepDown</tabstop>
+  <tabstop>finishDepth</tabstop>
+  <tabstop>finalDepth</tabstop>
+  <tabstop>startDepthSet</tabstop>
+  <tabstop>finalDepthSet</tabstop>
+ </tabstops>
  <resources>
   <include location="../Path.qrc"/>
  </resources>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
@@ -391,6 +391,9 @@ Larger values (further to the right) will calculate faster; smaller values (furt
    </item>
    <item>
     <widget class="QPushButton" name="StopButton">
+     <property name="maximumWidth">
+      <number>120</number>
+     </property>
      <property name="text">
       <string>Stop</string>
      </property>

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -37,7 +37,7 @@ import PathScripts.PathUtils as PathUtils
 import importlib
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
-from PySide import QtCore, QtGui, QtWidgets
+from PySide import QtCore, QtGui, QtSvg, QtWidgets
 
 __title__ = "CAM Operation UI base classes"
 __author__ = "sliptonic (Brad Collette)"
@@ -394,6 +394,7 @@ class TaskPanelPage(object):
         self.obj = obj
         self.job = PathUtils.findParentJob(obj)
         self.form = self.getForm()
+        self.setToolControllerMinWidth(self.form)
         self.signalDirtyChanged = None
         self.setClean()
         self.setTitle("-")
@@ -424,6 +425,12 @@ class TaskPanelPage(object):
         """setParent() ... used to transfer parent object link to child class.
         Do not overwrite."""
         self.parent = parent
+
+    def setToolControllerMinWidth(self, form):
+        """If form has a widget named toolController, set its minimum width to 80 if possible."""
+        if hasattr(form, "toolController"):
+            tc = getattr(form, "toolController")
+            tc.setMinimumWidth(80)
 
     def onDirtyChanged(self, callback):
         """onDirtyChanged(callback) ... set callback when dirty state changes."""
@@ -1094,7 +1101,7 @@ class TaskPanelBaseLocationPage(TaskPanelPage):
 
 
 class TaskPanelHeightsPage(TaskPanelPage):
-    """Page controller for heights."""
+    """Page controller for heights and depths."""
 
     def __init__(self, obj, features):
         super(TaskPanelHeightsPage, self).__init__(obj, features)
@@ -1102,93 +1109,16 @@ class TaskPanelHeightsPage(TaskPanelPage):
         # members initialized later
         self.clearanceHeight = None
         self.safeHeight = None
+        self.startDepth = None
+        self.finalDepth = None
+        self.finishDepth = None
+        self.stepDown = None
         self.panelTitle = "Heights"
         self.OpIcon = ":/icons/CAM_Heights.svg"
         self.setIcon(self.OpIcon)
 
     def getForm(self):
         return FreeCADGui.PySideUic.loadUi(":/panels/PageHeightsEdit.ui")
-
-    def initPage(self, obj):
-        self.safeHeight = PathGuiUtil.QuantitySpinBox(self.form.safeHeight, obj, "SafeHeight")
-        self.clearanceHeight = PathGuiUtil.QuantitySpinBox(
-            self.form.clearanceHeight, obj, "ClearanceHeight"
-        )
-
-        if PathOp.FeatureLinking & self.features:
-            self.CollisionClearance = PathGuiUtil.QuantitySpinBox(
-                self.form.CollisionClearance, obj, "CollisionClearance"
-            )
-            for mode in [
-                "Clearance Height",
-                "Retract Height",
-                "Line of Sight",
-                "Tool Diameter",
-                "Tool Shape",
-            ]:
-                self.form.CollisionAvoidanceStrategy.addItem(translate("CAM_Operation", mode), mode)
-        else:
-            self.form.groupBoxLinking.hide()
-
-    def getTitle(self, obj):
-        return translate("PathOp", "Heights")
-
-    def getFields(self, obj):
-        self.safeHeight.updateProperty()
-        self.clearanceHeight.updateProperty()
-        if PathOp.FeatureLinking & self.features:
-            self.CollisionClearance.updateProperty()
-            mode = self.form.CollisionAvoidanceStrategy.currentData()
-            if mode and obj.CollisionAvoidanceStrategy != mode:
-                obj.CollisionAvoidanceStrategy = mode
-
-    def setFields(self, obj):
-        self.safeHeight.updateWidget()
-        self.clearanceHeight.updateWidget()
-        if PathOp.FeatureLinking & self.features:
-            self.CollisionClearance.updateWidget()
-            index = self.form.CollisionAvoidanceStrategy.findData(obj.CollisionAvoidanceStrategy)
-            if index >= 0:
-                self.form.CollisionAvoidanceStrategy.blockSignals(True)
-                self.form.CollisionAvoidanceStrategy.setCurrentIndex(index)
-                self.form.CollisionAvoidanceStrategy.blockSignals(False)
-
-    def getSignalsForUpdate(self, obj):
-        signals = []
-        signals.append(self.form.safeHeight.editingFinished)
-        signals.append(self.form.clearanceHeight.editingFinished)
-        if PathOp.FeatureLinking & self.features:
-            signals.append(self.form.CollisionClearance.editingFinished)
-            signals.append(self.form.CollisionAvoidanceStrategy.currentIndexChanged)
-        return signals
-
-    def pageUpdateData(self, obj, prop):
-        if prop in [
-            "SafeHeight",
-            "ClearanceHeight",
-            "CollisionAvoidanceStrategy",
-            "CollisionClearance",
-        ]:
-            self.setFields(obj)
-
-
-class TaskPanelDepthsPage(TaskPanelPage):
-    """Page controller for depths."""
-
-    def __init__(self, obj, features):
-        super(TaskPanelDepthsPage, self).__init__(obj, features)
-
-        # members initialized later
-        self.startDepth = None
-        self.finalDepth = None
-        self.finishDepth = None
-        self.stepDown = None
-        self.panelTitle = "Depths"
-        self.OpIcon = ":/icons/CAM_Depths.svg"
-        self.setIcon(self.OpIcon)
-
-    def getForm(self):
-        return FreeCADGui.PySideUic.loadUi(":/panels/PageDepthsEdit.ui")
 
     def haveStartDepth(self):
         return PathOp.FeatureDepths & self.features
@@ -1205,6 +1135,10 @@ class TaskPanelDepthsPage(TaskPanelPage):
         return PathOp.FeatureStepDown & self.features
 
     def initPage(self, obj):
+        self.safeHeight = PathGuiUtil.QuantitySpinBox(self.form.safeHeight, obj, "SafeHeight")
+        self.clearanceHeight = PathGuiUtil.QuantitySpinBox(
+            self.form.clearanceHeight, obj, "ClearanceHeight"
+        )
 
         if self.haveStartDepth():
             self.startDepth = PathGuiUtil.QuantitySpinBox(self.form.startDepth, obj, "StartDepth")
@@ -1243,10 +1177,47 @@ class TaskPanelDepthsPage(TaskPanelPage):
             self.form.finishDepth.hide()
             self.form.finishDepthLabel.hide()
 
+        if PathOp.FeatureLinking & self.features:
+            self.CollisionClearance = PathGuiUtil.QuantitySpinBox(
+                self.form.CollisionClearance, obj, "CollisionClearance"
+            )
+            for mode in [
+                "Clearance Height",
+                "Retract Height",
+                "Line of Sight",
+                "Tool Diameter",
+                "Tool Shape",
+            ]:
+                self.form.CollisionAvoidanceStrategy.addItem(translate("CAM_Operation", mode), mode)
+        else:
+            self.form.groupBoxLinking.hide()
+
+        self.updateHeightsDiagram()
+
+    def updateHeightsDiagram(self):
+        """Render the Clearance/Retract/Start/StepDown/FinishStepDown/Final callout graphic as
+        a single fixed-size image, independent of the fields grid next to it."""
+        haveFinish = self.haveFinishDepth()
+        resource = (
+            ":/icons/CAM_HeightsDiagram.svg"
+            if haveFinish
+            else ":/icons/CAM_HeightsDiagram_NoFinish.svg"
+        )
+        renderer = QtSvg.QSvgRenderer(resource)
+        size = renderer.defaultSize()
+        pixmap = QtGui.QPixmap(size)
+        pixmap.fill(QtCore.Qt.transparent)
+        painter = QtGui.QPainter(pixmap)
+        renderer.render(painter, QtCore.QRectF(0, 0, size.width(), size.height()))
+        painter.end()
+        self.form.heightsDiagram.setPixmap(pixmap)
+
     def getTitle(self, obj):
-        return translate("PathOp", "Depths")
+        return translate("PathOp", "Heights")
 
     def getFields(self, obj):
+        self.safeHeight.updateProperty()
+        self.clearanceHeight.updateProperty()
         if self.haveStartDepth():
             self.startDepth.updateProperty()
         if self.haveFinalDepth():
@@ -1255,8 +1226,15 @@ class TaskPanelDepthsPage(TaskPanelPage):
             self.stepDown.updateProperty()
         if self.haveFinishDepth():
             self.finishDepth.updateProperty()
+        if PathOp.FeatureLinking & self.features:
+            self.CollisionClearance.updateProperty()
+            mode = self.form.CollisionAvoidanceStrategy.currentData()
+            if mode and obj.CollisionAvoidanceStrategy != mode:
+                obj.CollisionAvoidanceStrategy = mode
 
     def setFields(self, obj):
+        self.safeHeight.updateWidget()
+        self.clearanceHeight.updateWidget()
         if self.haveStartDepth():
             self.startDepth.updateWidget()
         if self.haveFinalDepth():
@@ -1265,10 +1243,19 @@ class TaskPanelDepthsPage(TaskPanelPage):
             self.stepDown.updateWidget()
         if self.haveFinishDepth():
             self.finishDepth.updateWidget()
+        if PathOp.FeatureLinking & self.features:
+            self.CollisionClearance.updateWidget()
+            index = self.form.CollisionAvoidanceStrategy.findData(obj.CollisionAvoidanceStrategy)
+            if index >= 0:
+                self.form.CollisionAvoidanceStrategy.blockSignals(True)
+                self.form.CollisionAvoidanceStrategy.setCurrentIndex(index)
+                self.form.CollisionAvoidanceStrategy.blockSignals(False)
         self.updateSelection(obj, FreeCADGui.Selection.getSelectionEx())
 
     def getSignalsForUpdate(self, obj):
         signals = []
+        signals.append(self.form.safeHeight.editingFinished)
+        signals.append(self.form.clearanceHeight.editingFinished)
         if self.haveStartDepth():
             signals.append(self.form.startDepth.editingFinished)
         if self.haveFinalDepth():
@@ -1277,7 +1264,23 @@ class TaskPanelDepthsPage(TaskPanelPage):
             signals.append(self.form.stepDown.editingFinished)
         if self.haveFinishDepth():
             signals.append(self.form.finishDepth.editingFinished)
+        if PathOp.FeatureLinking & self.features:
+            signals.append(self.form.CollisionClearance.editingFinished)
+            signals.append(self.form.CollisionAvoidanceStrategy.currentIndexChanged)
         return signals
+
+    def pageUpdateData(self, obj, prop):
+        if prop in [
+            "SafeHeight",
+            "ClearanceHeight",
+            "StartDepth",
+            "FinalDepth",
+            "StepDown",
+            "FinishDepth",
+            "CollisionAvoidanceStrategy",
+            "CollisionClearance",
+        ]:
+            self.setFields(obj)
 
     def registerSignalHandlers(self, obj):
         if self.haveStartDepth():
@@ -1288,10 +1291,6 @@ class TaskPanelDepthsPage(TaskPanelPage):
             self.form.finalDepthSet.clicked.connect(
                 lambda: self.depthSet(obj, self.finalDepth, "FinalDepth")
             )
-
-    def pageUpdateData(self, obj, prop):
-        if prop in ["StartDepth", "FinalDepth", "StepDown", "FinishDepth"]:
-            self.setFields(obj)
 
     def depthSet(self, obj, spinbox, prop):
         z = self.selectionZLevel(FreeCADGui.Selection.getSelectionEx())
@@ -1411,12 +1410,6 @@ class TaskPanel(object):
             else:
                 self.featurePages.append(TaskPanelBaseLocationPage(obj, features))
 
-        if PathOp.FeatureDepths & features or PathOp.FeatureStepDown & features:
-            if hasattr(opPage, "taskPanelDepthsPage"):
-                self.featurePages.append(opPage.taskPanelDepthsPage(obj, features))
-            else:
-                self.featurePages.append(TaskPanelDepthsPage(obj, features))
-
         if PathOp.FeatureHeights & features:
             if hasattr(opPage, "taskPanelHeightsPage"):
                 self.featurePages.append(opPage.taskPanelHeightsPage(obj, features))
@@ -1437,29 +1430,32 @@ class TaskPanel(object):
             page.onDirtyChanged(self.pageDirtyChanged)
 
         taskPanelLayout = Path.Preferences.defaultTaskPanelLayout()
+        self.taskPanelLayout = taskPanelLayout
 
         if taskPanelLayout < 2:
             opTitle = opPage.getTitle(obj)
             opPage.setTitle(translate("PathOp", "Operation"))
-            toolbox = QtGui.QToolBox()
+            tabwidget = IconTabWidget()
+            # tabwidget.setTabPosition(QtWidgets.QTabWidget.West)
             if taskPanelLayout == 0:
                 for page in self.featurePages:
-                    toolbox.addItem(page.form, page.getTitle(obj))
-                    itemIdx = toolbox.count() - 1
-                    if page.icon:
-                        toolbox.setItemIcon(itemIdx, QtGui.QIcon(page.icon))
-                toolbox.setCurrentIndex(len(self.featurePages) - 1)
+                    tabwidget.addTab(
+                        page.form,
+                        QtGui.QIcon(page.icon) if page.icon else QtGui.QIcon(),
+                        page.getTitle(obj),
+                    )
+                tabwidget.setCurrentIndex(len(self.featurePages) - 1)
             else:
                 for page in reversed(self.featurePages):
-                    toolbox.addItem(page.form, page.getTitle(obj))
-                    itemIdx = toolbox.count() - 1
-                    if page.icon:
-                        toolbox.setItemIcon(itemIdx, QtGui.QIcon(page.icon))
-            toolbox.setWindowTitle(opTitle)
+                    tabwidget.addTab(
+                        page.form,
+                        QtGui.QIcon(page.icon) if page.icon else QtGui.QIcon(),
+                        page.getTitle(obj),
+                    )
+            tabwidget.setWindowTitle(opTitle)
             if opPage.getIcon(obj):
-                toolbox.setWindowIcon(QtGui.QIcon(opPage.getIcon(obj)))
-
-            self.form = toolbox
+                tabwidget.setWindowIcon(QtGui.QIcon(opPage.getIcon(obj)))
+            self.form = tabwidget
         elif taskPanelLayout == 2:
             forms = []
             for page in self.featurePages:
@@ -1615,7 +1611,7 @@ class TaskPanel(object):
             page.pageUpdateData(obj, prop)
 
     def needsFullSpace(self):
-        return True
+        return self.taskPanelLayout >= 2
 
     def updateSelection(self):
         sel = FreeCADGui.Selection.getSelectionEx()
@@ -1776,6 +1772,171 @@ def SetupOperation(name, objFactory, opPageClass, pixmap, menuText, toolTip, set
         PathSetupSheet.RegisterOperation(name, objFactory, setupProperties)
 
     return command
+
+
+class _AdaptiveTabBar(QtGui.QTabBar):
+    """QTabBar that clamps the width of icon-only tabs (empty tabText) to
+    ICON_ONLY_MAX_WIDTH. Tabs with a label are left at whatever the native
+    style computes for them -- we only ever shrink the hint, never invent one,
+    so icon+text tabs keep correct native layout."""
+
+    ICON_ONLY_MAX_WIDTH = 38
+
+    def tabSizeHint(self, index):
+        size = super(_AdaptiveTabBar, self).tabSizeHint(index)
+        if not self.tabText(index):
+            size.setWidth(min(size.width(), self.ICON_ONLY_MAX_WIDTH))
+        return size
+
+
+class IconTabWidget(QtGui.QTabWidget):
+    """Tab widget that shows every tab's icon + label when there's room; if the
+    full set doesn't fit the available width, it falls back to icon-only tabs
+    (label as tooltip) for everything except the active tab. Avoiding the tab
+    bar's scroll (< >) buttons this way keeps every tab reachable at a glance.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(IconTabWidget, self).__init__(*args, **kwargs)
+        self.setStyleSheet("QTabWidget::tab-bar { alignment: left; }")
+        self.setTabBar(_AdaptiveTabBar())
+        tabbar = self.tabBar()
+        tabbar.setUsesScrollButtons(False)
+        tabbar.setElideMode(QtCore.Qt.ElideNone)
+        tabbar.setIconSize(QtCore.QSize(20, 20))
+        tabbar.setLayoutDirection(QtCore.Qt.LeftToRight)
+        # Force padding and margin to make themes match.
+        tabbar.setStyleSheet("""
+            QTabBar::tab {
+                min-width: 0px;
+                padding: 6px;
+                margin: 2px;
+            }
+            """)
+        self._tabLabels = {}
+        self._updatingLabels = False
+        self._filteredAncestors = []
+        self.currentChanged.connect(self._updateTabLabels)
+        self.currentChanged.connect(self._resizeToCurrentPage)
+
+    def sizeHint(self):
+        return self._currentPageSize(super(IconTabWidget, self).sizeHint(), "sizeHint")
+
+    def minimumSizeHint(self):
+        return self._currentPageSize(
+            super(IconTabWidget, self).minimumSizeHint(), "minimumSizeHint"
+        )
+
+    def _currentPageSize(self, fallback, hintName):
+        current = self.currentWidget()
+        if current is None:
+            return fallback
+        pageSize = getattr(current, hintName)()
+        tabBarSize = self.tabBar().sizeHint()
+        height = pageSize.height() + tabBarSize.height()
+        width = max(pageSize.width(), tabBarSize.width())
+        return QtCore.QSize(width, height)
+
+    def hasHeightForWidth(self):
+        current = self.currentWidget()
+        return current.hasHeightForWidth() if current is not None else False
+
+    def heightForWidth(self, width):
+        current = self.currentWidget()
+        if current is None or not current.hasHeightForWidth():
+            return super(IconTabWidget, self).heightForWidth(width)
+        return current.heightForWidth(width) + self.tabBar().sizeHint().height()
+
+    def _resizeToCurrentPage(self, _index):
+        self.updateGeometry()
+        target = self.sizeHint()
+        parent = self.parentWidget()
+        while parent is not None:
+            if isinstance(parent, QtGui.QScrollArea):
+                target = target.expandedTo(parent.viewport().size())
+                break
+            parent = parent.parentWidget()
+        self.resize(target)
+
+    def addTab(self, widget, icon, label):
+        if self.tabPosition() == QtGui.QTabWidget.West and not icon.isNull():
+            pixmap = icon.pixmap(32, 32)
+            transform = QtGui.QTransform().rotate(90)
+            rotated_pixmap = pixmap.transformed(transform, QtCore.Qt.SmoothTransformation)
+            icon = QtGui.QIcon(rotated_pixmap)
+        index = super(IconTabWidget, self).addTab(widget, icon, "")
+        self._tabLabels[index] = label
+        self.tabBar().setTabToolTip(index, label)
+        self._updateTabLabels(self.currentIndex())
+        return index
+
+    def resizeEvent(self, event):
+        super(IconTabWidget, self).resizeEvent(event)
+        self._scheduleUpdate()
+
+    def showEvent(self, event):
+        super(IconTabWidget, self).showEvent(event)
+        self._installAncestorFilters()
+        self._scheduleUpdate()
+
+    def hideEvent(self, event):
+        self._removeAncestorFilters()
+        super(IconTabWidget, self).hideEvent(event)
+
+    def _installAncestorFilters(self):
+        self._removeAncestorFilters()
+        parent = self.parentWidget()
+        while parent is not None:
+            parent.installEventFilter(self)
+            self._filteredAncestors.append(parent)
+            parent = parent.parentWidget()
+
+    def _removeAncestorFilters(self):
+        for ancestor in self._filteredAncestors:
+            try:
+                ancestor.removeEventFilter(self)
+            except RuntimeError:
+                pass  # ancestor already destroyed
+        self._filteredAncestors = []
+
+    def eventFilter(self, obj, event):
+        if event.type() == QtCore.QEvent.Resize:
+            self._scheduleUpdate()
+        return super(IconTabWidget, self).eventFilter(obj, event)
+
+    def _scheduleUpdate(self):
+        # Defer until the event loop catches up so ancestor geometry (dock/
+        # scroll area) has settled before we measure available width.
+        QtCore.QTimer.singleShot(0, lambda: self._updateTabLabels(self.currentIndex()))
+
+    def _availableWidth(self):
+        """Width to fit tabs into: the nearest ancestor QScrollArea's viewport
+        if there is one (since that's what actually resizes with the dock),
+        otherwise this widget's own width. Confirmed load-bearing: removing
+        this in testing made tabs stop reflowing on resize entirely, so
+        self.width() alone does not track the real available width here."""
+        parent = self.parentWidget()
+        while parent is not None:
+            if isinstance(parent, QtGui.QScrollArea):
+                return parent.viewport().width()
+            parent = parent.parentWidget()
+        return self.width()
+
+    def _updateTabLabels(self, current):
+        """Show every tab's label if they all fit; otherwise only the active tab."""
+        if self._updatingLabels or not self._tabLabels:
+            return
+        self._updatingLabels = True
+        try:
+            tabbar = self.tabBar()
+            for index, label in self._tabLabels.items():
+                tabbar.setTabText(index, label)
+            if tabbar.sizeHint().width() > self._availableWidth():
+                for index, label in self._tabLabels.items():
+                    if index != current:
+                        tabbar.setTabText(index, "")
+        finally:
+            self._updatingLabels = False
 
 
 FreeCADGui.addCommand("CAM_SetStartPoint", CommandSetStartPoint())


### PR DESCRIPTION
This PR switches from the QtGui.QToolBox() (Accordion) widget to QtWidgets.QTabWidget() (Tabs) widgit for the Task Panel GUI.

The new tabs expand to full width of the task panel if space allows, collapses to just display icons excecpt for the active tab if space is limited.

Merge Heights and Depths into one tab and add graphic icon with callouts.

Relabeled Safe Heights to Retract (label only, not the property)

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Heights and Depths with Finish Step down:
<img width="910" height="571" alt="HeightsDepths3" src="https://github.com/user-attachments/assets/4a5d7c56-8ba3-4d57-bb1f-aad3e99d0ad6" />

Heights and Depths without Finish Step down:
<img width="910" height="571" alt="HeightsDepths2" src="https://github.com/user-attachments/assets/0936be4b-2f4b-4e9c-aa87-693d319b5a4d" />

Heights and Depsh with linking below:
<img width="910" height="571" alt="HeightsDepths1" src="https://github.com/user-attachments/assets/48097ca5-4209-48b9-bd96-bb5acbd18a93" />

Showing tabs have hints for the sections:
<img width="450" height="395" alt="Screenshot from 2026-07-06 11-59-42" src="https://github.com/user-attachments/assets/e33439c5-c3e9-41fd-ad25-97fa5e0dbecf" />

Video of the tabs expanding and contracting based on width of panel.

https://github.com/user-attachments/assets/82956ff4-0b79-4e37-babf-2e4c16d311b1

