### PR TITLE
PartDesign: sync Body visual properties to features on creation (Fixe…

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -311,6 +311,29 @@ void ViewProviderBody::updateData(const App::Property* prop)
     if (prop == &body->Group || prop == &body->BaseFeature) {
         // ensure all model features are in visual body mode
         setVisualBodyMode(true);
+
+        if (!isRestoring()) {
+            const char* propNames[] = {
+                "ShapeColor",
+                "ShapeAppearance",
+                "Transparency",
+                "LineColor",
+                "LineMaterial",
+                "LineWidth",
+                "PointColor",
+                "PointMaterial",
+                "PointSize",
+                "DrawStyle",
+                "Lighting",
+                "Deviation",
+                "AngularDeflection"
+            };
+            for (const char* pName : propNames) {
+                if (App::Property* p = this->getPropertyByName(pName)) {
+                    unifyVisualProperty(p);
+                }
+            }
+        }
     }
 
     if (prop == &body->Tip) {


### PR DESCRIPTION
This PR fixes an issue where custom visual properties (such as PointSize, LineWidth, ShapeColor, etc.) set on a PartDesign Body are visually reset when a new feature is added to the body. It implements a synchronization loop in `ViewProviderBody::updateData()` that pushes the Body's current visual properties to newly added child features whenever the Body's Group changes.

This ensures the user's view tab preferences persist seamlessly across operations.

*(Note: This PR was prepared with AI assistance using Gemini 3.1 Pro, and the required Git trailer has been added to the commit message.)*


<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->

## Issues
fixes #31068

