### PR TITLE
Fix assembly subassembly refresh

### DIFF
--- a/src/Mod/Assembly/App/AssemblyLink.cpp
+++ b/src/Mod/Assembly/App/AssemblyLink.cpp
@@ -102,6 +102,14 @@ void AssemblyLink::onChanged(const App::Property* prop)
         return;
     }
 
+    if (prop == &Group) {
+        for (auto* obj : getInList()) {
+            if (auto* assemblyLink = freecad_cast<AssemblyLink*>(obj)) {
+                assemblyLink->updateContents();
+            }
+        }
+    }
+
     if (prop == &Rigid) {
         Base::Placement movePlc;
 
@@ -224,6 +232,12 @@ void AssemblyLink::onChanged(const App::Property* prop)
         return;
     }
     App::Part::onChanged(prop);
+}
+
+void AssemblyLink::onDocumentRestored()
+{
+    App::Part::onDocumentRestored();
+    updateContents();
 }
 
 void AssemblyLink::updateParentJoints()

--- a/src/Mod/Assembly/App/AssemblyLink.h
+++ b/src/Mod/Assembly/App/AssemblyLink.h
@@ -97,6 +97,7 @@ public:
 protected:
     /// get called by the container whenever a property has been changed
     void onChanged(const App::Property* prop) override;
+    void onDocumentRestored() override;
 };
 
 

--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -140,6 +140,11 @@ App::DocumentObjectExecReturn* AssemblyObject::execute()
 void AssemblyObject::onChanged(const App::Property* prop)
 {
     if (prop == &Group) {
+        for (auto* obj : getInList()) {
+            if (auto* assemblyLink = freecad_cast<AssemblyLink*>(obj)) {
+                assemblyLink->updateContents();
+            }
+        }
         updateSolveStatus();
     }
     App::Part::onChanged(prop);


### PR DESCRIPTION
This PR fixes stale subassembly contents in parent assemblies.

When a linked subassembly is changed, parent assemblies can keep outdated mirrored children inside `AssemblyLink`. Removed parts may remain as broken links until the user deletes and reinserts the subassembly.

The change makes `AssemblyLink` refresh its mirrored contents when linked assembly groups change and when documents are restored from disk. This keeps parent assemblies synchronized with changed subassemblies while preserving the existing `AssemblyLink` architecture.

Assisted by GPT-5.5.

## Issues
Fixes #25717  
Fixes #26789  
Related to #27339  
Related to #27651

## Testing
Create an assembly and a parent assembly, delete an object from the subassembly. In upstream you will get a missing link, which will prevent the parent from updating it's state. After this PR this is fixed

<img width="1390" height="859" alt="assembly_delete_fix" src="https://github.com/user-attachments/assets/464db959-ac65-4c3a-ad0f-601db529213b" />



* Note
A warning about the missing link will still appear, as the refresh solving the problem initiate only after it. 
I think it is ok for now, in case any unexpected behavior will arise from this PR the warning will alert this could be a possible cause.