### PR TITLE
BIM: fix version check for pipe width-height flip

### DIFF
--- a/src/Mod/BIM/ArchPipe.py
+++ b/src/Mod/BIM/ArchPipe.py
@@ -172,7 +172,7 @@ class _ArchPipe(ArchComponent.Component):
         self.setProperties(obj)
         if (
             obj.ProfileType == "Rectangle"
-            and FreeCAD.ActiveDocument.getProgramVersion().split()[0] <= "1.1R42474"
+            and FreeCAD.ActiveDocument.getProgramVersion().split()[0] < "1.1"
         ):
             # in older versions Height and Width are inverted
             obj.Height, obj.Width = obj.Width, obj.Height


### PR DESCRIPTION
Fixes #31121.

The code tried to target a specific dev version, but since the document version number can have at least 3 formats in v1.1 this is too problematic.

See https://github.com/FreeCAD/FreeCAD/issues/31121#issuecomment-4881299613.

No AI was used