### PR TITLE
Draft: increase center point tolerance for angular dimensions

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -488,7 +488,7 @@ class Dimension(gui_base_original.Creator):
                                                 for i in [0, 1]:
                                                     pt = e.Vertexes[i].Point
                                                     if pt.isEqual(
-                                                        self.center, 0.00001
+                                                        self.center, 0.0001
                                                     ):  # A relatively high tolerance is required.
                                                         pt = e.Vertexes[
                                                             i - 1


### PR DESCRIPTION
Reported on the forum:
https://forum.freecad.org/viewtopic.php?t=106283

An angular dimension is based on a list of 4 angles derived from the center point of the dimension and the endpoints of the 2 selected edges. Endpoints that are (almost) equal to the center are disregarded as they would result in faulty values. The tolerance that was used proved to be too small in some cases.

No AI was used.