### PR TITLE
Fix crash with gears project

### DIFF
--- a/src/App/Datums.cpp
+++ b/src/App/Datums.cpp
@@ -195,7 +195,7 @@ App::DatumElement* LocalCoordinateSystem::getDatumElement(const char* role) cons
 App::Line* LocalCoordinateSystem::getAxis(const char* role) const
 {
     App::DatumElement* feat = getDatumElement(role);
-    if (feat->isDerivedFrom<App::Line>()) {
+    if (feat && feat->isDerivedFrom<App::Line>()) {
         return static_cast<App::Line*>(feat);
     }
     std::stringstream err;
@@ -207,7 +207,7 @@ App::Line* LocalCoordinateSystem::getAxis(const char* role) const
 App::Plane* LocalCoordinateSystem::getPlane(const char* role) const
 {
     App::DatumElement* feat = getDatumElement(role);
-    if (feat->isDerivedFrom<App::Plane>()) {
+    if (feat && feat->isDerivedFrom<App::Plane>()) {
         return static_cast<App::Plane*>(feat);
     }
     std::stringstream err;
@@ -219,7 +219,7 @@ App::Plane* LocalCoordinateSystem::getPlane(const char* role) const
 App::Point* LocalCoordinateSystem::getPoint(const char* role) const
 {
     App::DatumElement* feat = getDatumElement(role);
-    if (feat->isDerivedFrom<App::Point>()) {
+    if (feat && feat->isDerivedFrom<App::Point>()) {
         return static_cast<App::Point*>(feat);
     }
     std::stringstream err;

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1181,7 +1181,9 @@ void SketchObject::onExternalGeoChanged()
     }
 
     auto objs = ExternalGeometry.getValues();
-    assert(externalGeoRef.size() == objs.size());
+    if (externalGeoRef.size() != objs.size()) {
+        throw Base::RuntimeError("Inconsistency with external geometries");
+    }
     auto itObj = objs.begin();
     auto subs = ExternalGeometry.getSubValues();
     auto itSub = subs.begin();

--- a/src/Mod/Sketcher/App/SketchObjectExternal.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectExternal.cpp
@@ -2320,7 +2320,9 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
     auto Types       = ExternalTypes.getValues();
     auto Objects     = ExternalGeometry.getValues();
     auto SubElements = ExternalGeometry.getSubValues();
-    assert(externalGeoRef.size() == Objects.size());
+    if (externalGeoRef.size() != Objects.size()) {
+        throw Base::RuntimeError("Inconsistency with external geometries");
+    }
     auto keys = externalGeoRef;
 
     // re-check for any missing geometry element. The code here has a side


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Cherry-picked from https://codeberg.org/xwzCAD/FreeCAD/pulls/264

Check for null pointer when accessing datum element by role.
Replace assert() by throwing an exception in SketchObject::rebuildExternalGeometry

This fixes https://github.com/FreeCAD/FreeCAD/issues/31148