### PR TITLE
Gui: SplashSreen: restore visibility

### DIFF
--- a/src/Gui/SplashScreen.cpp
+++ b/src/Gui/SplashScreen.cpp
@@ -20,19 +20,20 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include <cstdlib>
 #include <QApplication>
 #include <QClipboard>
 #include <QDir>
+#include <QElapsedTimer>
 #include <QFile>
 #include <QFileInfo>
 #include <QMutex>
 #include <QPainter>
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
+#include <QThread>
 #include <QWaitCondition>
-
+#include <QWindow>
 
 #include <App/Application.h>
 #include <App/Metadata.h>
@@ -239,19 +240,6 @@ SplashScreen::~SplashScreen()
     delete messages;
 }
 
-// Whenever QSplashScreen gets a QEvent::Show or is about to be finish()ed, it will start
-// waiting for its window to be displayed and puts the main thread to sleep repeatedly as
-// long as it isn't reported as such. (see qtbase@52a4103 src/widgets/widgets/qsplashscreen.cpp:214)
-// Problem is QWidget::show() triggers QWidgetPrivate::setVisible() in turn sending a QEvent::Show,
-// but by that point the underlying QWindow may not have been flagged as visible yet.
-// On Linux with either X11 or Wayland, this disturbs the event loop, and QWindow visibility
-// will never be reported as these protocols require explicit flushing and event pulling from said
-// event loop, thus making the QSplashScreen waitForWidgetMapped() function wait for its default
-// timeout of 1000 ms, delaying the entire app's startup by a whole second or more.
-// Override SplashScreen::event() and QSplashScreen::finish() to bypass this entirely.
-// The window's visibility status is up to the event loops and compositors, it is out of our
-// control, so don't bother.
-
 void SplashScreen::finish(QWidget* w)
 {
     Q_UNUSED(w);
@@ -265,6 +253,33 @@ bool SplashScreen::event(QEvent* e)
         return QWidget::event(e);  // NOLINT(bugprone-parent-virtual-call)
     }
     return QSplashScreen::event(e);
+}
+
+void SplashScreen::show()
+{
+    QSplashScreen::show();
+
+    // Our repaint will call processEvents later on, no need to waste time here
+    if (messages->bErr) {
+        return;
+    }
+
+    // Show events are bypassed and splash window is already created by the above show()
+    // call. Now process pending events from underlying OS which actually brings splash
+    // into existence (such as X' MapNotify/Expose events or Wayland's xdg_surface
+    // configuration acknowledgement)
+    constexpr int TimeOut = 250;
+    constexpr int TimeSlice = 20;
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < TimeOut) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, TimeSlice);
+        QCoreApplication::sendPostedEvents();
+        if (windowHandle()->isExposed()) {
+            break;
+        }
+        QThread::msleep(TimeSlice);
+    }
 }
 
 /**

--- a/src/Gui/SplashScreen.h
+++ b/src/Gui/SplashScreen.h
@@ -43,6 +43,7 @@ public:
 
     void finish(QWidget* w);
 
+    void show();
     void setShowMessages(bool on);
 
     static QPixmap splashImage();

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -469,11 +469,6 @@ void StartupPostProcess::showMainWindow()
         throw;
     }
 
-    // Finish processing all events, including initializations, before
-    // hiding the splash and showing the main window
-    QCoreApplication::processEvents(QEventLoop::AllEvents);
-    QCoreApplication::sendPostedEvents();
-
     // stop splash screen and set immediately the active window that may be of interest
     // for scripts using Python binding for Qt
     mainWindow->stopSplasher();


### PR DESCRIPTION
Work around problems exposed by QTBUG-119225 and its fix both in Qt and FreeCAD code. Note that 250ms is arbitrarily choosen timeout never reached in practice; while loop terminates in first or second pass.

Unlike `QSplashScreen`, this `SplashScreen` is actually waiting for `isExposed()`. Refer to [1](https://github.com/qt/qtbase/blob/d8046ecc6efa84a180a42e3a724dcea43ac88249/src/gui/kernel/qwindow.cpp#L81-L93) and [2](https://github.com/qt/qtbase/commit/7835f9e60157987b4aafc9b860f925d775151b7c) for details.

Fixes: #16264

- [x] This PR is verified human output and it is ridiculous to demand such a checkbox instead simple S-o-b line known for ages and introduced for such purposes.


> [!NOTE]
> Although this PR fixes issue caused by #29917 for me, I do not want it merged. Actually #29917 is the very first change tacking the core of the problems reported in #16264 and needs only minor adjustments. Historically log output was always part of the splash screen, message after message appearing at the bottom of the splash in the 50ms intervals. Those intervals caused considerable startup slowdown while splash was shown, so people started inventing various shortcuts to overcome that (first disabling slash by default then disabling log output by default). I still do think idea introduced in #16334 is a way to go and I would be happy to be reconsidered (each logged line triggers `processEvents()` making it automagically work).