### PR TITLE
Build: Make CMake's output a bit cleaner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,9 @@ if(POLICY CMP0177)
     cmake_policy(SET CMP0177 NEW)
 endif()
 
+# Make CMake output a bit more focused
+set(CMAKE_REQUIRED_QUIET TRUE)
+
 
 option(FREECAD_USE_CCACHE "Auto detect and use ccache during compilation" ON)
 


### PR DESCRIPTION
By default CMake prints out a fairly verbose set of test results, e.g.
```
 │ │ -- Looking for sys/types.h
 │ │ -- Looking for sys/types.h - found
 │ │ -- Looking for stdint.h
 │ │ -- Looking for stdint.h - found
 │ │ -- Looking for stddef.h
 │ │ -- Looking for stddef.h - found
 │ │ -- Check size of int8_t
 │ │ -- Check size of int8_t - done
 │ │ -- Check size of uint8_t
 │ │ -- Check size of uint8_t - done
 │ │ -- Check size of int16_t
 │ │ -- Check size of int16_t - done
 │ │ -- Check size of uint16_t
 │ │ -- Check size of uint16_t - done
 │ │ -- Check size of int32_t
 │ │ -- Check size of int32_t - done
 │ │ -- Check size of uint32_t
 │ │ -- Check size of uint32_t - done
```

This is mostly just noise when the tests succeed, so I propose that we ask CMake to be a bit quieter. It of course will still write errors and warnings, but this sort of extra-verbose output of what amount to internals doesn't seem useful.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.