### PR TITLE
Build: Make sure that CMake can find executables in the LibPack's scipts directory

### DIFF
--- a/cMake/UseLibPack3.cmake
+++ b/cMake/UseLibPack3.cmake
@@ -1,6 +1,10 @@
 set(ENV{PATH} "${FREECAD_LIBPACK_DIR};$ENV{PATH}")
 list(PREPEND CMAKE_PREFIX_PATH "${FREECAD_LIBPACK_DIR}")
 
+# Python console-script entry points (e.g. mypy's stubgen) are installed under bin/Scripts, which is
+# not one of the directories find_program() searches by default. Add it so those tools are found.
+list(APPEND CMAKE_PROGRAM_PATH "${FREECAD_LIBPACK_DIR}/bin/Scripts")
+
 # Make really, really, REALLY sure that CMake doesn't do that thing where it decides that the LibPack's Python isn't
 # good enough, and just finds some other one to use. If there is a problem with the LibPack's Python, that is a fatal
 # error and should stop generation.


### PR DESCRIPTION
In order for our newly-incorporated Coin/Pivy setup to run stubgen, we need to tell CMake to look in the appropriate path. This is a build-time only binary location.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
