### PR TITLE
TD: harden face creation

### DIFF
--- a/src/Mod/TechDraw/App/DrawComplexSection.cpp
+++ b/src/Mod/TechDraw/App/DrawComplexSection.cpp
@@ -191,6 +191,9 @@ TopoDS_Shape DrawComplexSection::makeCuttingTool(double dMax)
     if (debugSection()) {
         BRepTools::Write(cuttingTool, "DCSmakeCuttingTool_cuttingToo.brep");//debug
     }
+    if (cuttingTool.IsNull()) {
+        return {};
+    }
 
     // save the tool face for shading/hatching of cut surface
     auto extrudeDir = Base::convertTo<gp_Dir>(getReferenceAxis());
@@ -1469,10 +1472,14 @@ TopoDS_Shape DrawComplexSection::profileToSolid(const TopoDS_Wire& closedProfile
     if (!mkFace.IsDone()) {
         throw Base::RuntimeError("Complex section could not create face from closed profile");
     }
+    const TopoDS_Face& face = mkFace.Face();
+    if (face.IsNull()) {
+        return {};
+    }
 
     auto extrudeVector = getReferenceAxis() * dMax * 2;
 
-    BRepPrimAPI_MakePrism mkPrism(mkFace.Face(), Base::convertTo<gp_Vec>(extrudeVector));
+    BRepPrimAPI_MakePrism mkPrism(face, Base::convertTo<gp_Vec>(extrudeVector));
     auto profileSolid = mkPrism.Shape();
 
      return profileSolid;
@@ -1649,6 +1656,9 @@ TopoDS_Shape DrawComplexSection::cuttingToolFromProfile(const TopoDS_Wire& inPro
     }
 
     TopoDS_Shape solid = profileToSolid(profileWireClosed, dMax);
+    if (solid.IsNull()) {
+        return {};
+    }
     solid = ShapeUtils::moveShape(solid, getReferenceAxis() * -dMax);
     return solid;
 }


### PR DESCRIPTION
Cherry-pick https://codeberg.org/xwzCAD/FreeCAD/pulls/266

It can happen that inside DrawComplexSection::makeCuttingTool() the class BRepBuilderAPI_MakeFace returns a null face because the passed wire is not closed.

So before passing the face to BRepPrimAPI_MakePrism make sure it's not null, otherwise return from the method immediately.
