### PR TITLE
[1.1] CAM: Fix case when CAM operation `Safe height`, `Start depth`, and `Final depth` are the same value. (#27258)

### DIFF
--- a/src/Mod/CAM/PathScripts/PathUtils.py
+++ b/src/Mod/CAM/PathScripts/PathUtils.py
@@ -369,8 +369,13 @@ def getEnvelope(partshape, subshape=None, depthparams=None):
     newPlace = FreeCAD.Placement(Vector(0, 0, zShift), sec.Placement.Rotation)
     sec.Placement = newPlace
 
-    # Extrude the section to top of Boundbox or desired height
-    envelopeshape = sec.extrude(Vector(0, 0, eLength))
+    if Path.Geom.isRoughly(eLength, 0):
+        # For 2D operations (e.g. laser cutting) use the section directly without extrusion
+        envelopeshape = sec
+    else:
+        # Extrude the section to top of Boundbox or desired height
+        envelopeshape = sec.extrude(Vector(0, 0, eLength))
+
     if Path.Log.getLevel(Path.Log.thisModule()) == Path.Log.Level.DEBUG:
         removalshape = FreeCAD.ActiveDocument.addObject("Part::Feature", "Envelope")
         removalshape.Shape = envelopeshape


### PR DESCRIPTION
Backport of #27258 to releases/FreeCAD-1-1.