### PR TITLE
Packaging: keep bundled Coin/Pivy out of the package environment

### DIFF
--- a/package/rattler-build/linux/create_bundle.sh
+++ b/package/rattler-build/linux/create_bundle.sh
@@ -61,6 +61,12 @@ if ! "${conda_env}/bin/freecadcmd" --safe-mode --version; then
     exit 1
 fi
 
+echo "Running FreeCAD bundled Pivy smoke test..."
+if ! "${conda_env}/bin/freecadcmd" --safe-mode --console "import pivy; from pivy import coin; print(pivy.__file__); print(coin.SoDB.getVersion())"; then
+    echo "FreeCAD bundled Pivy smoke test failed; the Linux bundle cannot import the bundled Coin/Pivy runtime."
+    exit 1
+fi
+
 curl -LO https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$(uname -m).AppImage
 chmod a+x appimagetool-$(uname -m).AppImage
 

--- a/package/rattler-build/osx/create_bundle.sh
+++ b/package/rattler-build/osx/create_bundle.sh
@@ -83,6 +83,12 @@ if ! "${conda_env}/bin/freecadcmd" --safe-mode --version; then
     exit 1
 fi
 
+echo "Running FreeCAD bundled Pivy smoke test..."
+if ! "${conda_env}/bin/freecadcmd" --safe-mode --console "import pivy; from pivy import coin; print(pivy.__file__); print(coin.SoDB.getVersion())"; then
+    echo "FreeCAD bundled Pivy smoke test failed; the macOS bundle cannot import the bundled Coin/Pivy runtime."
+    exit 1
+fi
+
 # move plugins into their final location (Library only exists for macOS < 15.0 builds)
 if [ -d "${conda_env}/Library" ]; then
     mv ${conda_env}/Library ${conda_env}/..

--- a/package/rattler-build/pixi.lock
+++ b/package/rattler-build/pixi.lock
@@ -35,7 +35,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/calculix-2.23-pl5321h3af09bb_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cgal-cpp-6.0.1-h6aadc51_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/coin3d-4.0.3-hd74d64a_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/contourpy-1.3.3-py311h724c32c_4.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
@@ -45,7 +44,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/eigen-3.4.0-h171cf75_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/eigen-abi-3.4.0.100-h3bcb7cf_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/expat-2.7.3-hecca717_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-7.1.1-gpl_h127656b_906.conda
       - conda: https://prefix.dev/conda-forge/linux-64/flann-1.9.2-h3ef53d8_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/fltk-1.3.10-hff38c0f_0.conda
@@ -216,7 +214,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/pcl-1.15.0-h679aaff_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.45-hc749103_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pillow-12.1.0-py311hf88fc01_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pivy-0.6.9-py311qt6h646dae5_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/proj-9.5.1-h0054346_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/propcache-0.3.1-py311h2dc5d0c_0.conda
@@ -237,7 +234,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.2.24-h68140b3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/smesh-9.9.0.0-hb7ebc10_14.conda
       - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/soqt6-1.6.3-h23d7b0e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/sqlite-3.51.2-hbc0de68_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-3.0.2-h5888daf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tbb-2022.3.0-h8d10470_1.conda
@@ -335,7 +331,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/xlrd-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/xlutils-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/xlwt-1.3.0-py_1.tar.bz2
-      - conda_source: freecad[37876015] @ .
+      - conda_source: freecad[6c707e0d] @ .
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aiohttp-3.13.3-py311hf076524_0.conda
@@ -359,7 +355,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cairo-1.18.4-h83712da_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/calculix-2.23-pl5321h7aeeb6d_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cgal-cpp-6.0.1-hcda14ae_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/coin3d-4.0.3-h411181d_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/contourpy-1.3.3-py311h04741b4_4.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6c5dea3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
@@ -369,7 +364,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/eigen-3.4.0-hdc560ac_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/eigen-abi-3.4.0.100-h9a8c16c_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/epoxy-1.5.10-he30d5cf_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/expat-2.7.3-hfae3067_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ffmpeg-7.1.1-gpl_h30b7fc1_906.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/flann-1.9.2-hca6fa18_4.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/fltk-1.3.10-hc36ef9c_0.conda
@@ -535,7 +529,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pcl-1.15.0-h29e8f2a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pcre2-10.45-hf4ec17f_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pillow-12.1.0-py311h8e17b9e_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/pivy-0.6.9-py311qt6ha5dee78_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/proj-9.5.1-h9655f4d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/propcache-0.3.1-py311h58d527c_0.conda
@@ -557,7 +550,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/shapely-2.1.2-py311hb862c81_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/smesh-9.9.0.0-h3752d33_14.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/snappy-1.2.2-he774c54_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/soqt6-1.6.3-h808f404_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/sqlite-3.51.2-he8854b5_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/svt-av1-3.0.2-h5ad3122_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/tbb-2022.3.0-h0eac15c_1.conda
@@ -653,7 +645,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/xlrd-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/xlutils-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/xlwt-1.3.0-py_1.tar.bz2
-      - conda_source: freecad[2868ec82] @ .
+      - conda_source: freecad[82a8351e] @ .
       osx-64:
       - conda: https://prefix.dev/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
@@ -723,7 +715,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/cairo-1.18.4-h950ec3b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/calculix-2.23-pl5321h40d3c7f_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/cgal-cpp-6.0.1-h20ba9b8_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/coin3d-4.0.3-h9b6ce5f_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/contourpy-1.3.3-py311h9d13916_4.conda
       - conda: https://prefix.dev/conda-forge/osx-64/cyrus-sasl-2.1.28-h610c526_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
@@ -733,7 +724,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/eigen-3.4.0-hfc0b2d5_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/eigen-abi-3.4.0.100-h6bcb275_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/epoxy-1.5.10-h8616949_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/expat-2.7.3-heffb93a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/ffmpeg-7.1.1-gpl_h7f5d84f_106.conda
       - conda: https://prefix.dev/conda-forge/osx-64/flann-1.9.2-hf045e91_4.conda
       - conda: https://prefix.dev/conda-forge/osx-64/fltk-1.3.10-h11de4b3_0.conda
@@ -870,7 +860,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/pcl-1.15.0-h96d8db5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/pcre2-10.45-hf733adb_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/pillow-12.1.0-py311h127dec8_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/pivy-0.6.9-py311qt6h268aa71_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/pixman-0.46.4-ha059160_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/proj-9.5.1-h5273da6_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/propcache-0.3.1-py311ha3cf9ac_0.conda
@@ -890,7 +879,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/shapely-2.1.2-py311hda9c9d0_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/smesh-9.9.0.0-h9ba7290_14.conda
       - conda: https://prefix.dev/conda-forge/osx-64/snappy-1.2.2-h01f5ddf_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/soqt6-1.6.3-h667e493_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/sqlite-3.51.2-h5af3ad2_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/svt-av1-3.0.2-h240833e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/tbb-2022.3.0-hf0c99ee_1.conda
@@ -917,7 +905,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/zlib-ng-2.3.2-h8bce59a_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
-      - conda_source: freecad[4439f4df] @ .
+      - conda_source: freecad[25e33b5a] @ .
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
@@ -987,7 +975,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/cairo-1.18.4-h6a3b0d2_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/calculix-2.23-pl5321h484372f_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cgal-cpp-6.0.1-h39a0b02_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/coin3d-4.0.3-h705ab75_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/contourpy-1.3.3-py311h7d85929_4.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cyrus-sasl-2.1.28-ha1cbb27_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
@@ -997,7 +984,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/eigen-3.4.0-h49c215f_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/eigen-abi-3.4.0.100-h485a483_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/epoxy-1.5.10-hc919400_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/expat-2.7.3-haf25636_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ffmpeg-7.1.1-gpl_h20db955_106.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/flann-1.9.2-h5d00db4_4.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/fltk-1.3.10-h46aaf7c_0.conda
@@ -1134,7 +1120,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/pcl-1.15.0-hd09b3b3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pcre2-10.45-ha881caa_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pillow-12.1.0-py311hd37aea2_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/pivy-0.6.9-py311qt6ha36b4a8_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/proj-9.5.1-h1318a7e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/propcache-0.3.1-py311h4921393_0.conda
@@ -1154,7 +1139,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/shapely-2.1.2-py311hd4fb369_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/smesh-9.9.0.0-h10d9485_14.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/soqt6-1.6.3-hd20b56a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/sqlite-3.51.2-h85ec8f2_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/svt-av1-3.0.2-h8ab69cd_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tbb-2022.3.0-h66ce52b_1.conda
@@ -1181,7 +1165,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-ng-2.3.2-hed4e4f5_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - conda_source: freecad[fc70dd10] @ .
+      - conda_source: freecad[0ce6190b] @ .
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
@@ -1251,14 +1235,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/cairo-1.18.4-h5782bbf_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/calculix-2.23-pl5321h31c5caf_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/cgal-cpp-6.0.1-h31bd75c_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/coin3d-4.0.3-h192c3d0_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/contourpy-1.3.3-py311h275cad7_4.conda
       - conda: https://prefix.dev/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/debugpy-1.8.19-py311h5dfdfe8_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/double-conversion-3.3.1-he0c23c2_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/eigen-3.4.0-h477610d_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/eigen-abi-3.4.0.100-hc11354d_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/expat-2.7.3-hac47afa_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/ffmpeg-7.1.1-gpl_h70aa942_910.conda
       - conda: https://prefix.dev/conda-forge/win-64/flann-1.9.2-h48fefe0_4.conda
       - conda: https://prefix.dev/conda-forge/win-64/fltk-1.3.10-h5d05227_0.conda
@@ -1366,7 +1348,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/pcl-1.15.0-hcec6b29_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/pcre2-10.45-h99c9b8b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/pillow-12.1.0-py311h17b8079_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/pivy-0.6.9-py311qt6hd279cb5_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/pixman-0.46.4-h5112557_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/proj-9.5.1-h4f671f6_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/propcache-0.3.1-py311h5082efb_0.conda
@@ -1385,7 +1366,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/shapely-2.1.2-py311h362461e_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/smesh-9.9.0.0-h4c8b7ef_14.conda
       - conda: https://prefix.dev/conda-forge/win-64/snappy-1.2.2-h7fa0ca8_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/soqt6-1.6.3-h796eb14_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/sqlite-3.51.2-hdb435a2_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/svt-av1-3.1.2-hac47afa_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/tbb-2022.3.0-hd094cb3_1.conda
@@ -1418,7 +1398,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/zlib-ng-2.3.2-h0261ad2_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - conda_source: freecad[9600b26b] @ .
+      - conda_source: freecad[c450b9e9] @ .
   package:
     channels:
     - url: https://prefix.dev/pixi-build-backends/
@@ -2079,26 +2059,6 @@ packages:
   run_exports: {}
   size: 22330508
   timestamp: 1771383666798
-- conda: https://prefix.dev/conda-forge/linux-64/coin3d-4.0.3-hd74d64a_2.conda
-  sha256: 953d004ee7a2be78c717cecaf5bb959fea1faefb86106322c19c06dafa3c0e12
-  md5: b3addb85bc05327f73bf69a9ed73b890
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - expat
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
-  - libgl >=1.7.0,<2.0a0
-  - libglu
-  - libstdcxx >=13
-  - xorg-libxi >=1.8.2,<2.0a0
-  - xorg-libxt >=1.3.0,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - coin3d >=4.0.3,<4.1.0a0
-  size: 3247920
-  timestamp: 1728502926513
 - conda: https://prefix.dev/conda-forge/linux-64/compilers-1.10.0-ha770c72_0.conda
   sha256: 17661cca0b6b70156a5d4a639c926bff0106576b5af5c8cab7afd9cd3cfa287b
   md5: 993ae32cac4879279af74ba12aa0979c
@@ -2300,31 +2260,6 @@ packages:
   license_family: MIT
   size: 411735
   timestamp: 1758743520805
-- conda: https://prefix.dev/conda-forge/linux-64/expat-2.7.3-hecca717_0.conda
-  sha256: c5d573e6831fb41177fb5ae0f1ee09caed55a868ec9887bc80ccc22c3e57b9b4
-  md5: c81f6fa1865526f5ab1e6b669b3ee877
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libexpat 2.7.3 hecca717_0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 143991
-  timestamp: 1763549744569
-- conda: https://prefix.dev/conda-forge/linux-64/expat-2.8.1-hecca717_1.conda
-  sha256: bc1e8177a4ebbbfcda98b6f4a1575f3337e69f0d2f1025a84570533ca27b89eb
-  md5: e211a78613b9d50a096644b97cede8f7
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libexpat 2.8.1 hecca717_1
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  run_exports:
-    weak:
-    - libexpat >=2.8.1,<3.0a0
-  size: 147797
-  timestamp: 1781203608158
 - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-7.1.1-gpl_h127656b_906.conda
   sha256: e8e93a1afd93bed11ccf2a2224d2b92b2af8758c89576ed87ff4df7f3269604f
   md5: 28cffcba871461840275632bc4653ce3
@@ -5998,22 +5933,6 @@ packages:
   run_exports: {}
   size: 1056849
   timestamp: 1775060059882
-- conda: https://prefix.dev/conda-forge/linux-64/pivy-0.6.9-py311qt6h646dae5_2.conda
-  sha256: 91d304f8129e30375f2e94f4b633c2d29a80bd26c886b4a8cc71c448dbb32c44
-  md5: bdf887cfa02e1557809a6b6c84150656
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - coin3d >=4.0.3,<4.1.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - qt6-main >=6.7.3,<6.9.0a0
-  - soqt6 >=1.6.3,<1.6.4.0a0
-  license: ISC
-  run_exports: {}
-  size: 2546272
-  timestamp: 1728930682918
 - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
   sha256: 43d37bc9ca3b257c5dd7bf76a8426addbdec381f6786ff441dc90b1a49143b6a
   md5: c01af13bdc553d1a8fbfff6e8db075f0
@@ -6490,24 +6409,6 @@ packages:
     - snappy >=1.2.2,<1.3.0a0
   size: 45829
   timestamp: 1762948049098
-- conda: https://prefix.dev/conda-forge/linux-64/soqt6-1.6.3-h23d7b0e_0.conda
-  sha256: c8201aa5a9d22f41c0d5f42b7c0e497ecf7159feec8636a7daf6fa02950930d8
-  md5: 37672c8be048696b5fc10be22e8c9435
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - coin3d >=4.0.3,<4.1.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - qt6-main >=6.7.3,<6.9.0a0
-  constrains:
-  - soqt <0
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - soqt6 >=1.6.3,<1.6.4.0a0
-  size: 321109
-  timestamp: 1728082619106
 - conda: https://prefix.dev/conda-forge/linux-64/sqlite-3.51.2-hbc0de68_0.conda
   sha256: 65436099fd33e4471348d614c1de9235fdd4e5b7d86a5a12472922e6b6628951
   md5: a6adeaa8efb007e2e1ab3e45768ea987
@@ -7831,25 +7732,6 @@ packages:
   run_exports: {}
   size: 21507482
   timestamp: 1771383802433
-- conda: https://prefix.dev/conda-forge/linux-aarch64/coin3d-4.0.3-h411181d_2.conda
-  sha256: 3e4d579ffc07c0f1d8efa3de0f785e31c1a411691f63fe9fba7c43fb7de4a893
-  md5: 22b408993640d52937a14c554ea3e588
-  depends:
-  - expat
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
-  - libgl >=1.7.0,<2.0a0
-  - libglu
-  - libstdcxx >=13
-  - xorg-libxi >=1.8.2,<2.0a0
-  - xorg-libxt >=1.3.0,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - coin3d >=4.0.3,<4.1.0a0
-  size: 3070895
-  timestamp: 1728503092503
 - conda: https://prefix.dev/conda-forge/linux-aarch64/compilers-1.10.0-h8af1aa0_0.conda
   sha256: 3dac4aba396991809adbf74b7b467d4cf1034f1963e65ebf6efb6878e3280bd0
   md5: 5dde5330d359cfa0747d4190fa05acae
@@ -8044,29 +7926,6 @@ packages:
   license_family: MIT
   size: 422103
   timestamp: 1758743388115
-- conda: https://prefix.dev/conda-forge/linux-aarch64/expat-2.7.3-hfae3067_0.conda
-  sha256: a113f31d0d2645e9991ad8685ca5a8699a70ddc314f87317702d6e36fbcfeb88
-  md5: b3389e27c0cf1f8df60114cf03ed7575
-  depends:
-  - libexpat 2.7.3 hfae3067_0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 137213
-  timestamp: 1763549921101
-- conda: https://prefix.dev/conda-forge/linux-aarch64/expat-2.8.1-hfae3067_1.conda
-  sha256: e4cc29e20435f2787031eafaf100496cb700d2ebc246e91211cbde023b2600b4
-  md5: 4bcb07322aecccd75514fd585ad0b719
-  depends:
-  - libexpat 2.8.1 hfae3067_1
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  run_exports:
-    weak:
-    - libexpat >=2.8.1,<3.0a0
-  size: 141254
-  timestamp: 1781203579915
 - conda: https://prefix.dev/conda-forge/linux-aarch64/ffmpeg-7.1.1-gpl_h30b7fc1_906.conda
   sha256: 157dbd7fdd226448343f962c7fcb4c5b5c2fa12dd1e0f1f88f4c16559522c02d
   md5: 74fb3d97aeebfb19ed743f2a2f2e9ec3
@@ -11650,22 +11509,6 @@ packages:
   run_exports: {}
   size: 1036955
   timestamp: 1775060067775
-- conda: https://prefix.dev/conda-forge/linux-aarch64/pivy-0.6.9-py311qt6ha5dee78_2.conda
-  sha256: 13a8555314fa8cfdd655aee4a8d7b5d3f3eeb79a3db6d3e00ec652ed4d875dac
-  md5: 4f5fccb87e79b0e4357a9f18bebb4934
-  depends:
-  - coin3d >=4.0.3,<4.1.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  - qt6-main >=6.7.3,<6.9.0a0
-  - soqt6 >=1.6.3,<1.6.4.0a0
-  license: ISC
-  run_exports: {}
-  size: 2339203
-  timestamp: 1728930647221
 - conda: https://prefix.dev/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
   sha256: e6b0846a998f2263629cfeac7bca73565c35af13251969f45d385db537a514e4
   md5: 1587081d537bd4ae77d1c0635d465ba5
@@ -12135,23 +11978,6 @@ packages:
     - snappy >=1.2.2,<1.3.0a0
   size: 47096
   timestamp: 1762948094646
-- conda: https://prefix.dev/conda-forge/linux-aarch64/soqt6-1.6.3-h808f404_0.conda
-  sha256: e42c6ef58dc3371bb43029788ed1d7ddf1fa7a3fd83fb1d78d63db5815bebb74
-  md5: 4935d0d9baa48d929d88026dfe82c073
-  depends:
-  - coin3d >=4.0.3,<4.1.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - qt6-main >=6.7.3,<6.9.0a0
-  constrains:
-  - soqt <0
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - soqt6 >=1.6.3,<1.6.4.0a0
-  size: 318319
-  timestamp: 1728082634827
 - conda: https://prefix.dev/conda-forge/linux-aarch64/sqlite-3.51.2-he8854b5_0.conda
   sha256: 64379f78864e4426a0cb37594554059d91d85c252977d13207a73489e2d043a0
   md5: a88ceca6a1c833360b88204e1b5287b0
@@ -14859,21 +14685,6 @@ packages:
   run_exports: {}
   size: 18992980
   timestamp: 1771384442992
-- conda: https://prefix.dev/conda-forge/osx-64/coin3d-4.0.3-h9b6ce5f_2.conda
-  sha256: 0b2ab0b12925ffdbe20659817173d19373cf152890be56e8c1f0e8cdc2d89b5d
-  md5: 025850bb0c18049d92f20e2c2b31a403
-  depends:
-  - __osx >=10.13
-  - expat
-  - libcxx >=17
-  - libexpat >=2.6.3,<3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - coin3d >=4.0.3,<4.1.0a0
-  size: 2405105
-  timestamp: 1728503297185
 - conda: https://prefix.dev/conda-forge/osx-64/compiler-rt-18.1.8-he914875_2.conda
   sha256: b3d23e4e53cf22c110d3816f3faa83dc0eb9842a7c3a98e4307977b7b6576bd8
   md5: 56e9de1d62975db80c58b00dd620c158
@@ -15049,29 +14860,6 @@ packages:
   license_family: MIT
   size: 283016
   timestamp: 1758743470535
-- conda: https://prefix.dev/conda-forge/osx-64/expat-2.7.3-heffb93a_0.conda
-  sha256: 3a43defa87a48a77e46700302e6298967c14dfdaa326d26e7431ab6da3d6060f
-  md5: 84e2a6d95d3a63f3971da8f7b810c7a7
-  depends:
-  - __osx >=10.13
-  - libexpat 2.7.3 heffb93a_0
-  license: MIT
-  license_family: MIT
-  size: 135469
-  timestamp: 1763549907363
-- conda: https://prefix.dev/conda-forge/osx-64/expat-2.8.1-hcc62823_1.conda
-  sha256: 5d738eb05771e181cf2ea1e63046caa61ccd9fe45ba4720399f5f0aeada372d5
-  md5: c74610f2af492e29a28848880c048d09
-  depends:
-  - __osx >=11.0
-  - libexpat 2.8.1 hcc62823_1
-  license: MIT
-  license_family: MIT
-  run_exports:
-    weak:
-    - libexpat >=2.8.1,<3.0a0
-  size: 141090
-  timestamp: 1781204342752
 - conda: https://prefix.dev/conda-forge/osx-64/ffmpeg-7.1.1-gpl_h7f5d84f_106.conda
   sha256: 6e53fc999865aef13c12bfa70d63ec5d673809624a5203abcdd4fd36a21a3ddb
   md5: 246fcb794eff5df5c5627edb300b45a4
@@ -18162,21 +17950,6 @@ packages:
   run_exports: {}
   size: 988490
   timestamp: 1775060319565
-- conda: https://prefix.dev/conda-forge/osx-64/pivy-0.6.9-py311qt6h268aa71_2.conda
-  sha256: db402c17176620b22cf1a78c548db29147fb8ed183bf3f8eff51d5e30a62525e
-  md5: 8e9c69a0ceb24eb0826d588e4c62c1ff
-  depends:
-  - __osx >=10.13
-  - coin3d >=4.0.3,<4.1.0a0
-  - libcxx >=17
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - qt6-main >=6.7.3,<6.9.0a0
-  - soqt6 >=1.6.3,<1.6.4.0a0
-  license: ISC
-  run_exports: {}
-  size: 2149704
-  timestamp: 1728930715328
 - conda: https://prefix.dev/conda-forge/osx-64/pixman-0.46.4-ha059160_1.conda
   sha256: ff8b679079df25aa3ed5daf3f4e3a9c7ee79e7d4b2bd8a21de0f8e7ec7207806
   md5: 742a8552e51029585a32b6024e9f57b4
@@ -18621,23 +18394,6 @@ packages:
     - snappy >=1.2.2,<1.3.0a0
   size: 40023
   timestamp: 1762948053450
-- conda: https://prefix.dev/conda-forge/osx-64/soqt6-1.6.3-h667e493_0.conda
-  sha256: f7fd8b27eb202efdc4d7c660b5cc37dfc942adc63d54f928ac403581db953523
-  md5: 60fc4f49510c680dd54edc31cd5bced0
-  depends:
-  - __osx >=10.13
-  - coin3d >=4.0.3,<4.1.0a0
-  - libcxx >=17
-  - qt6-main >=6.7.3,<6.9.0a0
-  constrains:
-  - soqt <0
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - soqt6 >=1.6.3,<1.6.4.0a0
-  size: 261592
-  timestamp: 1728082747427
 - conda: https://prefix.dev/conda-forge/osx-64/sqlite-3.51.2-h5af3ad2_0.conda
   sha256: 89fde12f2a5e58edb9bd1497558a77df9c090878971559bcf0c8513e0966795e
   md5: 9eef7504045dd9eb1be950b2f934d542
@@ -19530,21 +19286,6 @@ packages:
   run_exports: {}
   size: 17746308
   timestamp: 1771384392762
-- conda: https://prefix.dev/conda-forge/osx-arm64/coin3d-4.0.3-h705ab75_2.conda
-  sha256: 6b54ae5e50dd2bc11a1a745af2c13903edccc6adbda84ce4c1854ca5c26c6e62
-  md5: f8fcb03c7b397831923ea47ca27e3e0e
-  depends:
-  - __osx >=11.0
-  - expat
-  - libcxx >=17
-  - libexpat >=2.6.3,<3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - coin3d >=4.0.3,<4.1.0a0
-  size: 2266738
-  timestamp: 1728503278809
 - conda: https://prefix.dev/conda-forge/osx-arm64/compiler-rt-18.1.8-h855ad52_2.conda
   sha256: 93a26ec6d7e3d93db2d80c794e9710fc422d436680da165e78d7ff73b8ef6c12
   md5: 8fa0332f248b2f65fdd497a888ab371e
@@ -19722,29 +19463,6 @@ packages:
   license_family: MIT
   size: 296347
   timestamp: 1758743805063
-- conda: https://prefix.dev/conda-forge/osx-arm64/expat-2.7.3-haf25636_0.conda
-  sha256: 43175c9c1f8a259776a215fe2a77c6a29cf79cc47ee1a98f5267ae47f904c9c8
-  md5: 884f1698556805bc43c42e80c9c19f3d
-  depends:
-  - __osx >=11.0
-  - libexpat 2.7.3 haf25636_0
-  license: MIT
-  license_family: MIT
-  size: 131515
-  timestamp: 1763550010595
-- conda: https://prefix.dev/conda-forge/osx-arm64/expat-2.8.1-hf6b4638_1.conda
-  sha256: 0f1f9c2f72a18f41c2096bd245425a7c43bc82d1aac24025ea308055352639b9
-  md5: 79cef10347b58a6d3c10cc78614efda6
-  depends:
-  - __osx >=11.0
-  - libexpat 2.8.1 hf6b4638_1
-  license: MIT
-  license_family: MIT
-  run_exports:
-    weak:
-    - libexpat >=2.8.1,<3.0a0
-  size: 136056
-  timestamp: 1781203642860
 - conda: https://prefix.dev/conda-forge/osx-arm64/ffmpeg-7.1.1-gpl_h20db955_106.conda
   sha256: b44b3aa9cd8e4a271ae7e4aa0707681076c047499c54fba510df0ffa4fdf1ca7
   md5: 23d6ecf002d2c8c2c694b5a7f3b41917
@@ -22874,22 +22592,6 @@ packages:
   run_exports: {}
   size: 979746
   timestamp: 1775060469004
-- conda: https://prefix.dev/conda-forge/osx-arm64/pivy-0.6.9-py311qt6ha36b4a8_2.conda
-  sha256: e1ff2b772e5875cec08e7e44a5801130a9c754e2071fb2ea2eb14c0331dcad32
-  md5: 3f5f67fbcd1eae692dcbc6fa61175c26
-  depends:
-  - __osx >=11.0
-  - coin3d >=4.0.3,<4.1.0a0
-  - libcxx >=17
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  - qt6-main >=6.7.3,<6.9.0a0
-  - soqt6 >=1.6.3,<1.6.4.0a0
-  license: ISC
-  run_exports: {}
-  size: 2084254
-  timestamp: 1728930938979
 - conda: https://prefix.dev/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
   sha256: 29c9b08a9b8b7810f9d4f159aecfd205fce051633169040005c0b7efad4bc718
   md5: 17c3d745db6ea72ae2fce17e7338547f
@@ -23344,23 +23046,6 @@ packages:
     - snappy >=1.2.2,<1.3.0a0
   size: 38883
   timestamp: 1762948066818
-- conda: https://prefix.dev/conda-forge/osx-arm64/soqt6-1.6.3-hd20b56a_0.conda
-  sha256: b800fad0d87a7bc88fe3c47e03749f9c0777687eb5e209d7db3909efa349f27a
-  md5: efcc605289339a5fc4cc65ddf4336127
-  depends:
-  - __osx >=11.0
-  - coin3d >=4.0.3,<4.1.0a0
-  - libcxx >=17
-  - qt6-main >=6.7.3,<6.9.0a0
-  constrains:
-  - soqt <0
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - soqt6 >=1.6.3,<1.6.4.0a0
-  size: 258332
-  timestamp: 1728082869198
 - conda: https://prefix.dev/conda-forge/osx-arm64/sqlite-3.51.2-h85ec8f2_0.conda
   sha256: 63c2bbb58e5ca58232cbe61754b85d0a080e5360291cebd52653e000bb0ae8fd
   md5: 7821b42fed75ef394d401f59f70e0732
@@ -24193,22 +23878,6 @@ packages:
   run_exports: {}
   size: 15742645
   timestamp: 1771384342226
-- conda: https://prefix.dev/conda-forge/win-64/coin3d-4.0.3-h192c3d0_2.conda
-  sha256: 87c3d3eee8c6323a7d0a972110b2439836ce1d6605ea5717d70a53f1ef0a245c
-  md5: 4e5d643a1995b3ab856503e6c653e95c
-  depends:
-  - expat
-  - libexpat >=2.6.3,<3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - coin3d >=4.0.3,<4.1.0a0
-  size: 3012993
-  timestamp: 1728504053172
 - conda: https://prefix.dev/conda-forge/win-64/compiler-rt-19.1.7-h49e36cd_1.conda
   sha256: b942211b4557680dae103a6de69f411d85973b499bc7db9bf5dd0a66f0836f3b
   md5: ebd0e08326cd166eb95a9956875303c3
@@ -24350,33 +24019,6 @@ packages:
   run_exports: {}
   size: 13138
   timestamp: 1771922281096
-- conda: https://prefix.dev/conda-forge/win-64/expat-2.7.3-hac47afa_0.conda
-  sha256: b91490d9ac1b8e1f7eb45b36746c21c71ad7f751c2ea2dd4e9e80a229952f1b8
-  md5: c55cee28229fcbcd132d900db283650f
-  depends:
-  - libexpat 2.7.3 hac47afa_0
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: MIT
-  license_family: MIT
-  size: 128638
-  timestamp: 1763550100961
-- conda: https://prefix.dev/conda-forge/win-64/expat-2.8.1-hac47afa_1.conda
-  sha256: 8eff79bb4637f916eb15eb0af588958294383cbd61efb876c623fc0e05633165
-  md5: d63696fc7573fd16ed8e6a48cd7e124b
-  depends:
-  - libexpat 2.8.1 hac47afa_1
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: MIT
-  license_family: MIT
-  run_exports:
-    weak:
-    - libexpat >=2.8.1,<3.0a0
-  size: 132855
-  timestamp: 1781203738759
 - conda: https://prefix.dev/conda-forge/win-64/ffmpeg-7.1.1-gpl_h70aa942_910.conda
   sha256: 49d38240ff7bfde5c53d6ae20c98ee65b82b1d0d8e1dcb5e2515de839b8678f3
   md5: 35d77007b30682debfbf97ad6cebbbda
@@ -26984,23 +26626,6 @@ packages:
   run_exports: {}
   size: 960875
   timestamp: 1775060119774
-- conda: https://prefix.dev/conda-forge/win-64/pivy-0.6.9-py311qt6hd279cb5_2.conda
-  sha256: 3dc86dbe0d917ecdaf321e4a73f2d066803e444dfcb855ba04a4f4898ecdf204
-  md5: 3d2bada5799035e977e7d0ddcf3a182b
-  depends:
-  - coin3d >=4.0.3,<4.1.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - qt6-main >=6.7.3,<6.9.0a0
-  - soqt6 >=1.6.3,<1.6.4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: ISC
-  run_exports: {}
-  size: 2686230
-  timestamp: 1728931162505
 - conda: https://prefix.dev/conda-forge/win-64/pixman-0.46.4-h5112557_1.conda
   sha256: 246fce4706b3f8b247a7d6142ba8d732c95263d3c96e212b9d63d6a4ab4aff35
   md5: 08c8fa3b419df480d985e304f7884d35
@@ -27424,24 +27049,6 @@ packages:
     - snappy >=1.2.2,<1.3.0a0
   size: 67417
   timestamp: 1762948090450
-- conda: https://prefix.dev/conda-forge/win-64/soqt6-1.6.3-h796eb14_0.conda
-  sha256: c0fe037f622380b551313f72944790adaf43f6155609aca8a716638ac1d8e192
-  md5: 0496a0fe733111cbd8dd0ba285fb73f5
-  depends:
-  - coin3d >=4.0.3,<4.1.0a0
-  - qt6-main >=6.7.3,<6.9.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - soqt <0
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - soqt6 >=1.6.3,<1.6.4.0a0
-  size: 250216
-  timestamp: 1728083269744
 - conda: https://prefix.dev/conda-forge/win-64/sqlite-3.51.2-hdb435a2_0.conda
   sha256: 8194c1326f052852dd827f5277ba381228a968e841d410eb18c622cf851b11ba
   md5: bc9265bd9f30f9ded263cb762a4fc847
@@ -28083,10 +27690,10 @@ packages:
     - zstd >=1.5.7,<1.6.0a0
   size: 388453
   timestamp: 1764777142545
-- conda_source: freecad[2868ec82] @ .
+- conda_source: freecad[0ce6190b] @ .
   variants:
-    build_platform: linux-aarch64
-    target_platform: linux-aarch64
+    build_platform: osx-arm64
+    target_platform: osx-arm64
   depends:
   - av
   - blas * openblas*
@@ -28111,7 +27718,6 @@ packages:
   - opencamlib
   - pandas
   - pip
-  - pivy
   - ply
   - pycollada
   - pyside6
@@ -28126,10 +27732,6 @@ packages:
   - typing_extensions
   - vtk
   - xlutils
-  - libspnav
-  - qt6-wayland
-  - xcb-util-cursor ==0.1.5
-  - coin3d >=4.0.3,<4.1.0a0
   - fmt >=12.1.0,<12.2.0a0
   - libfreetype >=2.14.3
   - libfreetype6 >=2.14.3
@@ -28143,406 +27745,117 @@ packages:
   - yaml-cpp >=0.8.0,<0.9.0a0
   - libzlib >=1.3.2,<2.0a0
   build_packages:
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/binutils-2.45.1-default_hf1166c9_102.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45.1-default_h5f4c503_102.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45.1-default_hf1166c9_102.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/c-compiler-1.10.0-h6561dab_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/cairo-1.18.4-h83712da_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/ccache-4.13.6-h185addb_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/clang-21-21.1.0-default_he95a3c9_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/clang-21.1.0-default_h395f21b_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/clangxx-21.1.0-default_h4b04f8d_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/cmake-4.2.3-hc9d863e_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/compilers-1.10.0-h8af1aa0_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/conda-gcc-specs-13.4.0-hc20859d_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/cxx-compiler-1.10.0-heb6c788_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6c5dea3_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/dbus-1.16.2-heda779d_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/double-conversion-3.3.1-h5ad3122_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/doxygen-1.13.2-h5e0f5ae_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/fortran-compiler-1.10.0-h25a59a9_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc-13.4.0-h2e72a27_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-13.4.0-hc0d58d9_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_linux-aarch64-13.4.0-hb656077_27.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/gfortran-13.4.0-hb5ee532_7.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-13.4.0-h29c24b5_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/gfortran_linux-aarch64-13.4.0-h64f55b8_27.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/gtest-1.17.0-h17cf362_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/gxx-13.4.0-hb5ee532_7.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-13.4.0-h4f637f2_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/gxx_linux-aarch64-13.4.0-h4bf53ff_27.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/harfbuzz-11.4.5-he4899c9_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang-cpp20.1-20.1.8-default_he95a3c9_16.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang-cpp21.1-21.1.0-default_he95a3c9_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang13-21.1.0-default_h94a09a5_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libcups-2.3.3-h5cdc715_5.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libcurl-8.18.0-h7bfdcfb_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libdrm-2.4.127-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libffi-3.4.6-he21f813_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libglib-2.84.3-h75d4a95_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libhiredis-1.3.0-h5ad3122_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libhwloc-2.12.1-default_h6f258fa_1000.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libjpeg-turbo-3.1.4.1-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libllvm20-20.1.8-h2b567e5_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libllvm21-21.1.0-h2b567e5_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libnsl-2.0.1-h86ecc28_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libntlm-1.4-hf897c2e_1002.tar.bz2
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libpciaccess-0.19-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libpq-17.7-haf03d9f_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libsanitizer-13.4.0-hc708448_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libspnav-1.1-h68df207_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libsqlite-3.53.2-h022381a_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libtiff-4.7.1-hdb009f0_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libuv-1.52.1-h80f16a2_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxkbcommon-1.11.0-h95ca766_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxml2-2.13.9-he58860d_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/mimalloc-3.2.7-h7ac5ae9_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/mold-2.40.4-h4c4c02a_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/mysql-common-9.3.0-h3f5c77f_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/mysql-libs-9.3.0-h11569fd_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/ninja-1.13.2-hdc560ac_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/pcre2-10.45-hf4ec17f_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/python-3.11.14-hcfbf8c2_1_cpython.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/qt6-main-6.8.3-he176c03_4.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/rhash-1.4.6-h86ecc28_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/sed-4.10-he1c5539_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/swig-4.3.1-hb663fc2_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/tbb-2022.3.0-h0eac15c_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.24.0-h698ed42_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-0.4.1-hca56bd8_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-cursor-0.1.5-h86ecc28_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.47-h80f16a2_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxcomposite-0.4.7-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxcursor-1.2.3-h86ecc28_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxext-1.3.7-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxfixes-6.0.2-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxi-1.8.3-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxrandr-1.5.5-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxtst-1.2.5-h57736b2_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.7-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h57736b2_1008.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xxhash-0.8.3-hd794028_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_osx-arm64-18.1.8-he32a8d3_2.conda
   - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
   - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
   - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
   - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
   - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_18.conda
-  - conda: https://prefix.dev/conda-forge/noarch/libdrm-cos7-aarch64-2.4.97-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-aarch64-13.4.0-h7bedc8d_119.conda
-  - conda: https://prefix.dev/conda-forge/noarch/libglvnd-cos7-aarch64-1.0.1-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/libglvnd-glx-cos7-aarch64-1.0.1-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/libselinux-cos7-aarch64-2.5-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/libsepol-cos7-aarch64-2.5-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-aarch64-13.4.0-hfee918e_119.conda
-  - conda: https://prefix.dev/conda-forge/noarch/libx11-common-cos7-aarch64-1.6.7-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/libx11-cos7-aarch64-1.6.7-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/libxau-cos7-aarch64-1.0.8-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/libxcb-cos7-aarch64-1.13-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/libxdamage-cos7-aarch64-1.1.4-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/libxext-cos7-aarch64-1.3.3-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/libxfixes-cos7-aarch64-5.0.3-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/libxi-cos7-aarch64-1.7.9-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/libxi-devel-cos7-aarch64-1.7.9-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/libxxf86vm-cos7-aarch64-1.1.4-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/mesa-dri-drivers-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/mesa-khr-devel-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/mesa-libegl-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/mesa-libegl-devel-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/mesa-libgbm-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/mesa-libgl-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/mesa-libgl-devel-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/mesa-libglapi-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/libgfortran-devel_osx-arm64-13.4.0-ha240a38_1.conda
   - conda: https://prefix.dev/conda-forge/noarch/noqt5-1.0-hd8ed1ab_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/pixman-cos7-aarch64-0.34.0-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-aarch64-2.17-h68829e0_18.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/xorg-x11-server-common-cos7-aarch64-1.20.4-ha675448_1106.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/xorg-x11-server-xvfb-cos7-aarch64-1.20.4-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/c-compiler-1.10.0-hdf49b6b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/cairo-1.18.4-h6a3b0d2_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ccache-4.13.6-h414bf82_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/cctools-1021.4-hb4fb6a3_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/cctools_osx-arm64-1021.4-h12580ec_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/clang-18-18.1.8-default_hf3020a7_18.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/clang-18.1.8-default_hf9bcbb7_18.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/clang_impl_osx-arm64-18.1.8-h2ae9ea5_25.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/clang_osx-arm64-18.1.8-h07b0088_25.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/clangxx-18.1.8-default_h65f67e2_18.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/clangxx_impl_osx-arm64-18.1.8-h555f467_25.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/clangxx_osx-arm64-18.1.8-h07b0088_25.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/cmake-4.2.3-h8cb302d_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/compiler-rt-18.1.8-h855ad52_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/compilers-1.10.0-hce30654_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/cxx-compiler-1.10.0-hba80287_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/cyrus-sasl-2.1.28-ha1cbb27_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/double-conversion-3.3.1-h286801f_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/doxygen-1.13.2-h493aca8_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/fontconfig-2.18.1-h2b252f5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/fortran-compiler-1.10.0-h5692697_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/freetype-2.14.3-hce30654_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/gfortran-13.4.0-h3ef1dbf_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/gfortran_impl_osx-arm64-13.4.0-he7ca382_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/gfortran_osx-arm64-13.4.0-h3c33bd0_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/graphite2-1.3.15-hf6b4638_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/gtest-1.17.0-ha393de7_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/harfbuzz-11.4.5-hf4e55d4_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/isl-0.26-imath32_h347afa1_101.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ld64-954.16-h4c6efb1_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ld64_osx-arm64-954.16-h9d5fcb0_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libclang-cpp18.1-18.1.8-default_hf3020a7_18.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libclang13-22.1.8-default_h6dd9417_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libcurl-8.18.0-he38603e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-devel-18.1.8-h6dc3340_8.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libdeflate-1.25-hc11a715_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libglib-2.84.3-h587fa63_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libhiredis-1.3.0-h286801f_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libjpeg-turbo-3.1.4.1-h84a0fba_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libllvm18-18.1.8-default_h8e162e0_12.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libllvm22-22.1.8-h89af1be_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libntlm-1.8-h5505292_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libpq-17.7-h944245b_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libsigtool-0.1.3-h98dc951_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.53.2-h1b79a29_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libtiff-4.7.1-h4030677_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libwebp-base-1.6.0-h07db88b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libxml2-16-2.15.1-h0ff4647_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libxml2-2.15.1-h9329255_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-tools-18-18.1.8-default_h8e162e0_12.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-tools-18.1.8-default_h8e162e0_12.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/mysql-common-9.3.0-hd7719f6_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/mysql-libs-9.3.0-ha8be5b7_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ninja-1.13.2-h49c215f_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/openldap-2.6.10-hbe55e7a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/pcre2-10.45-ha881caa_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.11.14-hec0b533_1_cpython.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/qt6-main-6.8.3-hc9525f7_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/rhash-1.4.6-h5505292_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/sigtool-0.1.3-h98dc951_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/sigtool-codesign-0.1.3-h98dc951_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/swig-4.3.1-hdecd427_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/xxhash-0.8.3-haa4e116_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
   host_packages:
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/aiohttp-3.14.1-py311hf076524_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/blosc-1.21.6-hb4dfabd_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/brotli-1.2.0-hd651790_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/brotli-bin-1.2.0-he30d5cf_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/cairo-1.18.4-h83712da_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/coin3d-4.0.3-h411181d_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/contourpy-1.3.3-py311h04741b4_4.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6c5dea3_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/dbus-1.16.2-heda779d_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/double-conversion-3.3.1-h5ad3122_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/eigen-3.4.0-h7ac5ae9_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/eigen-abi-3.4.0.100-h9a8c16c_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/expat-2.8.1-hfae3067_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/ffmpeg-7.1.1-gpl_h8d881e6_910.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/flann-1.9.2-hca6fa18_4.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/fmt-12.1.0-h20c602a_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/fonttools-4.63.0-py311h164a683_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/freeglut-3.2.2-hddf9bb5_4.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/freeimage-3.18.0-he4296dc_25.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/frozenlist-1.8.0-py311h91c1192_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/gdk-pixbuf-2.42.12-h90308e0_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/gl2ps-1.4.2-hd9db0c5_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/glew-2.1.0-h01db608_2.tar.bz2
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/harfbuzz-11.4.5-he4899c9_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-1.14.3-nompi_h6ed7ac7_109.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/imath-3.2.2-h92288e7_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/jasper-4.2.9-h850eeee_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/jsoncpp-1.9.6-h34915d9_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/kiwisolver-1.5.0-py311h229e7f7_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/lcms2-2.19.1-h9d5b58d_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libabseil-20250512.1-cxx17_h201e9ed_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libaec-1.1.5-hff7e48a_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libass-0.17.4-hcfe818d_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libboost-1.86.0-h6339299_4.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libboost-devel-1.86.0-h37bb5a9_4.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libboost-headers-1.86.0-h8af1aa0_4.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlicommon-1.2.0-he30d5cf_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlidec-1.2.0-he30d5cf_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlienc-1.2.0-he30d5cf_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libcap-2.78-hf9559e3_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libcblas-3.11.0-8_hd72aa62_openblas.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang-cpp20.1-20.1.8-default_he95a3c9_16.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang13-21.1.0-default_h94a09a5_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libcups-2.3.3-h5cdc715_5.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libcurl-8.18.0-h7bfdcfb_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libdrm-2.4.127-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libffi-3.4.6-he21f813_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libflac-1.5.0-he9c94f4_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libglib-2.84.3-h75d4a95_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libglu-9.0.3-h5ad3122_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libhwloc-2.12.1-default_h6f258fa_1000.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libjpeg-turbo-3.1.4.1-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/liblapack-3.11.0-8_h88aeb00_openblas.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libllvm20-20.1.8-h2b567e5_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libllvm21-21.1.0-h2b567e5_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libnetcdf-4.9.2-nompi_h1c53c35_116.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libnsl-2.0.1-h86ecc28_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libntlm-1.4-hf897c2e_1002.tar.bz2
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libogg-1.3.5-h86ecc28_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenblas-0.3.33-pthreads_h9d3fd7e_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-2025.2.0-hcd21e76_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2025.2.0-hcd21e76_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2025.2.0-h3890994_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-auto-plugin-2025.2.0-h3890994_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2025.2.0-he07c6df_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-ir-frontend-2025.2.0-he07c6df_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2025.2.0-h07d5dce_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2025.2.0-h07d5dce_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2025.2.0-hfae3067_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2025.2.0-h38473e3_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2025.2.0-hfae3067_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopus-1.6.1-h80f16a2_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libpciaccess-0.19-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libpq-17.7-haf03d9f_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libprotobuf-6.31.1-h61c7711_5.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libraw-0.22.1-h6c2e892_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/librsvg-2.58.4-h3ac5bce_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libsndfile-1.2.2-h30591a0_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libspnav-1.1-h68df207_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libsqlite-3.53.2-h022381a_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libsystemd0-257.13-hfcc8634_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libtheora-1.1.1-h68df207_1006.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libtiff-4.7.1-hdb009f0_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libudev1-257.13-hfcc8634_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libunwind-1.8.3-h6470e1d_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/liburing-2.12-hfefdfc9_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libusb-1.0.29-h06eaf92_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libvorbis-1.3.7-h7ac5ae9_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libvulkan-loader-1.4.341.0-h8b8848b_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxkbcommon-1.11.0-h95ca766_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxml2-2.13.9-he58860d_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxslt-1.1.43-h4552c8e_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libzip-1.11.2-h3e8f909_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/matplotlib-base-3.10.9-py311hb9c6b48_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/mpg123-1.32.9-h65af167_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py311hfca10b7_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/multidict-6.7.1-py311h164a683_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/mysql-common-9.3.0-h3f5c77f_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/mysql-libs-9.3.0-h11569fd_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/nlohmann_json-3.12.0-h7ac5ae9_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-1.26.4-py311h69ead2a_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/occt-7.8.1-all_h78e3548_203.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/openexr-3.4.12-h27f6aed_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/openh264-2.6.0-h0564a2a_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/openjph-0.28.1-h55827e0_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/pango-1.56.4-he55ef5b_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/pcl-1.15.0-h29e8f2a_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/pcre2-10.45-hf4ec17f_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/pillow-12.2.0-py311h8e17b9e_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/pivy-0.6.9-py311qt6ha5dee78_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/proj-9.5.1-h9655f4d_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/propcache-0.5.2-py311h164a683_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/pugixml-1.15-h6ef32b0_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/pulseaudio-client-17.0-h2f84921_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/pyside6-6.8.3-py311habb2604_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/python-3.11.14-hcfbf8c2_1_cpython.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/qt6-main-6.8.3-he176c03_4.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/rapidjson-1.1.0.post20240409-h5ad3122_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/sdl2-2.32.56-h7ac5ae9_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/sdl3-3.2.24-h506f210_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/sed-4.10-he1c5539_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/smesh-9.9.0.0-h3752d33_14.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/snappy-1.2.2-he774c54_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/soqt6-1.6.3-h808f404_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/sqlite-3.53.2-he8854b5_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/svt-av1-3.1.2-hfae3067_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/tbb-2022.3.0-h0eac15c_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/unicodedata2-17.0.1-py311h19352d5_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/utfcpp-4.09-h8af1aa0_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/vtk-9.3.1-qt_py311h3356f26_216.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/vtk-base-9.3.1-qt_py311h412eec7_216.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/vtk-io-ffmpeg-9.3.1-qt_py311h3356f26_216.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.24.0-h698ed42_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-0.4.1-hca56bd8_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-cursor-0.1.6-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xerces-c-3.3.0-h595f43b_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.47-h80f16a2_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxcomposite-0.4.7-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxcursor-1.2.3-h86ecc28_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxext-1.3.7-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxfixes-6.0.2-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxi-1.8.3-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxrandr-1.5.5-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxtst-1.2.5-h57736b2_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.7-he30d5cf_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h57736b2_1008.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/yaml-cpp-0.8.0-h5ad3122_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/yarl-1.24.2-py311h164a683_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/zlib-ng-2.3.3-ha7cb516_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
   - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.2-pyhd8ed1ab_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
@@ -28570,7 +27883,538 @@ packages:
   - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
   - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.7-pyhd8ed1ab_0.conda
-- conda_source: freecad[37876015] @ .
+  - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/aiohttp-3.14.1-py311h6771f6e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/blosc-1.21.6-h7dd00d9_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/brotli-1.2.0-h7d5ae5b_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/brotli-bin-1.2.0-hc919400_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/cairo-1.18.4-h6a3b0d2_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/contourpy-1.3.3-py311h7d85929_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/cyrus-sasl-2.1.28-ha1cbb27_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/dbus-1.16.2-hda038a8_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/double-conversion-3.3.1-h286801f_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/eigen-3.4.0-h784d473_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/eigen-abi-3.4.0.100-h485a483_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ffmpeg-7.1.1-gpl_h93d53e2_110.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/flann-1.9.2-h5d00db4_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/fmt-12.1.0-h403dcb5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/fontconfig-2.18.1-h2b252f5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/fonttools-4.63.0-py311hc290fe0_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/freeimage-3.18.0-h87663b4_25.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/freetype-2.14.3-hce30654_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/fribidi-1.0.16-hc919400_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/frozenlist-1.8.0-py311hf75086c_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/gdk-pixbuf-2.42.12-h7af3d76_3.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/gl2ps-1.4.2-h8fb3f6e_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/glew-2.1.0-h9f76cd9_2.tar.bz2
+  - conda: https://prefix.dev/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/graphite2-1.3.15-hf6b4638_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/harfbuzz-11.4.5-hf4e55d4_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-1.14.3-nompi_ha698983_109.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/imath-3.2.2-h3470cca_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/jasper-4.2.9-h7543a42_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/jsoncpp-1.9.6-h726d253_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/jxrlib-1.1-h93a5062_3.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/kiwisolver-1.5.0-py311h7d85929_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
+  - conda: https://prefix.dev/conda-forge/osx-arm64/lcms2-2.19.1-hdfa7624_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libabseil-20250512.1-cxx17_hd41c47c_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libaec-1.1.5-h8664d51_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libass-0.17.4-hcbd7ca7_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libboost-1.86.0-hf493ff8_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libboost-devel-1.86.0-hf450f58_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libboost-headers-1.86.0-hce30654_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlienc-1.2.0-hc919400_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libclang-cpp18.1-18.1.8-default_hf3020a7_18.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libclang13-21.1.0-default_h6e8f826_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libcurl-8.18.0-he38603e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libdeflate-1.25-hc11a715_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libglib-2.84.3-h587fa63_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libhwloc-2.12.1-default_h88f92a7_1000.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libjpeg-turbo-3.1.4.1-h84a0fba_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libllvm18-18.1.8-default_h3f49643_9.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libllvm21-21.1.0-h846d351_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_h610d594_116.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libntlm-1.8-h5505292_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libogg-1.3.5-h48c0fde_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-2025.2.0-h56e7ac4_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2025.2.0-h56e7ac4_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2025.2.0-he81eb65_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-auto-plugin-2025.2.0-he81eb65_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-hetero-plugin-2025.2.0-h273c05f_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-ir-frontend-2025.2.0-h273c05f_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-onnx-frontend-2025.2.0-h6386500_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-paddle-frontend-2025.2.0-h6386500_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2025.2.0-hec049ff_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2025.2.0-hee62d61_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2025.2.0-hec049ff_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libopus-1.6.1-h1a92334_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libpq-17.7-h944245b_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libprotobuf-6.31.1-h29102cf_5.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libraw-0.22.1-h2d05ff4_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/librsvg-2.58.4-h266df6f_3.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.53.2-h1b79a29_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libtheora-1.1.1-h99b78c6_1006.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libtiff-4.7.1-h4030677_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libusb-1.0.29-hbc156a2_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libvorbis-1.3.7-h81086ad_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libvpx-1.14.1-h7bae524_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libvulkan-loader-1.4.341.0-h3feff0a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libwebp-base-1.6.0-h07db88b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libxml2-2.13.9-h4a9ca0c_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libxslt-1.1.43-h429d6fd_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libzip-1.11.2-h1336266_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/matplotlib-base-3.10.9-py311h68bafec_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py311h572238d_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/multidict-6.7.1-py311ha275503_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/mysql-common-9.3.0-hd7719f6_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/mysql-libs-9.3.0-ha8be5b7_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-1.26.4-py311h7125741_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/occt-7.8.1-all_h869bdd7_203.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/openexr-3.4.12-h481d188_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/openh264-2.6.0-hb5b2745_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/openjph-0.28.1-h2a4d681_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/openldap-2.6.10-hbe55e7a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/pango-1.56.4-h875632e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/pcl-1.15.0-hd09b3b3_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/pcre2-10.45-ha881caa_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/pillow-12.2.0-py311hd37aea2_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/proj-9.5.1-h1318a7e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/propcache-0.5.2-py311hc290fe0_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/pugixml-1.15-hd3d436d_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/pyside6-6.8.3-py311h8511715_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.11.14-hec0b533_1_cpython.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/qt6-main-6.8.3-hc9525f7_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/rapidjson-1.1.0.post20240409-ha1acc90_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/sdl2-2.32.56-h248ca61_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/sdl3-3.4.10-h6fa9c73_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/sed-4.10-h5c09db4_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/smesh-9.9.0.0-h10d9485_14.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/sqlite-3.53.2-h85ec8f2_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/svt-av1-3.1.2-h12ba402_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/tbb-2022.3.0-h66ce52b_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/unicodedata2-17.0.1-py311hc949640_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/utfcpp-4.09-hce30654_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/vtk-9.3.1-qt_py311he4b582b_216.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/vtk-base-9.3.1-qt_py311hb64ca2f_216.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/vtk-io-ffmpeg-9.3.1-qt_py311he4b582b_216.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
+  - conda: https://prefix.dev/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
+  - conda: https://prefix.dev/conda-forge/osx-arm64/xerces-c-3.3.0-hd62221f_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/yaml-cpp-0.8.0-ha1acc90_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/yarl-1.24.2-py311hc290fe0_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+- conda_source: freecad[25e33b5a] @ .
+  variants:
+    build_platform: osx-64
+    target_platform: osx-64
+  depends:
+  - av
+  - blas * openblas*
+  - blinker
+  - calculix
+  - debugpy
+  - defusedxml
+  - docutils
+  - gmsh
+  - graphviz
+  - ifcopenshell
+  - lark
+  - lxml
+  - matplotlib-base
+  - nine
+  - noqt5
+  - numpy >=1.26,<2
+  - numpy >=1.26.4,<2.0a0
+  - occt >=7.8,<7.9
+  - occt >=7.8.1,<7.8.2.0a0
+  - olefile
+  - opencamlib
+  - pandas
+  - pip
+  - ply
+  - pycollada
+  - pyside6
+  - python >=3.11,<3.12
+  - pythonocc-core
+  - pyyaml
+  - qt6-main >=6.8,<6.9
+  - qt6-main >=6.8.3,<6.9.0a0
+  - requests
+  - scipy
+  - sympy
+  - typing_extensions
+  - vtk
+  - xlutils
+  - fmt >=12.1.0,<12.2.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - pcl >=1.15.0,<1.15.1.0a0
+  - python_abi 3.11.* *_cp311
+  - smesh >=9.9.0.0,<9.9.1.0a0
+  - vtk-base >=9.3.1,<9.3.2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  build_packages:
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_osx-64-18.1.8-h138dee1_2.conda
+  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+  - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/libgfortran-devel_osx-64-13.4.0-hbfa0f67_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/noqt5-1.0-hd8ed1ab_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/c-compiler-1.10.0-h09a7c41_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/cairo-1.18.4-h950ec3b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/ccache-4.13.6-h894318c_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/cctools-1021.4-ha66f10e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/cctools_osx-64-1021.4-h508880d_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/clang-18-18.1.8-default_h9399c5b_18.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/clang-18.1.8-default_h1323312_18.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/clang_impl_osx-64-18.1.8-h6a44ed1_25.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/clang_osx-64-18.1.8-h7e5c614_25.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/clangxx-18.1.8-default_h4cf342a_18.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/clangxx_impl_osx-64-18.1.8-h4b7810f_25.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/clangxx_osx-64-18.1.8-h7e5c614_25.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/cmake-4.2.3-h965d0ab_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/compiler-rt-18.1.8-he914875_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/compilers-1.10.0-h694c41f_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/cxx-compiler-1.10.0-h20888b2_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/cyrus-sasl-2.1.28-h610c526_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/double-conversion-3.3.1-h240833e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/doxygen-1.13.2-h27064b9_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/fontconfig-2.18.1-h7a4440b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/fortran-compiler-1.10.0-h02557f8_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/freetype-2.14.3-h694c41f_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/gfortran-13.4.0-hcc3c99d_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/gfortran_impl_osx-64-13.4.0-h61474f3_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/gfortran_osx-64-13.4.0-h3223c34_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/graphite2-1.3.15-hcc62823_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/gtest-1.17.0-h9275861_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/harfbuzz-11.4.5-h0ffbb26_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/isl-0.26-imath32_h2e86a7b_101.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/ld64-954.16-h4e51db5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/ld64_osx-64-954.16-h28b3ac7_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/lerc-4.1.0-h35c7297_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libclang-cpp18.1-18.1.8-default_h9399c5b_18.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libclang13-22.1.8-default_h2429e1b_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libcurl-8.18.0-h9348e2b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libcxx-22.1.8-h19cb2f5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libcxx-devel-18.1.8-h7c275be_8.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libdeflate-1.25-h517ebb2_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libedit-3.1.20250104-pl5321ha958ccf_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libfreetype-2.14.3-h694c41f_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libfreetype6-2.14.3-h58fbd8d_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libglib-2.84.3-h5fed8df_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libhiredis-1.3.0-h240833e_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libintl-0.25.1-h3184127_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libjpeg-turbo-3.1.4.1-ha1e9b39_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libllvm18-18.1.8-default_h9399c5b_12.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libllvm22-22.1.8-hab754da_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libnghttp2-1.68.1-h70048d4_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libntlm-1.8-h6e16a3a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libpng-1.6.58-he930e7c_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libpq-17.7-h1e038c5_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libsigtool-0.1.3-hc0f2934_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libsqlite-3.53.2-h77d7759_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libtiff-4.7.1-ha0a348c_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libuv-1.52.1-ha3d0635_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libwebp-base-1.6.0-hb807250_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libxml2-16-2.15.1-ha1d9b0f_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libxml2-2.15.1-h7b7ecba_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/llvm-openmp-22.1.8-h0d3cbff_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/llvm-tools-18-18.1.8-default_h9399c5b_12.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/llvm-tools-18.1.8-default_h9399c5b_12.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/mpc-1.4.0-h31caf2d_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/mpfr-4.2.2-h31caf2d_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/mysql-common-9.3.0-hd00b0ec_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/mysql-libs-9.3.0-h062309a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/ninja-1.13.2-hfc0b2d5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/openldap-2.6.10-hd8a590d_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/openssl-3.6.3-hc881268_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/pcre2-10.45-hf733adb_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/pixman-0.46.4-ha059160_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/python-3.11.14-h3999593_1_cpython.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/qt6-main-6.8.3-he2a6cc6_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/rhash-1.4.6-h6e16a3a_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/sigtool-0.1.3-hc0f2934_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/sigtool-codesign-0.1.3-hc0f2934_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/swig-4.3.1-h7b1c113_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/xxhash-0.8.3-h13e91ac_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+  host_packages:
+  - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.2-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+  - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/noqt5-1.0-hd8ed1ab_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.3-pyhfe8187e_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.3-pyh648e204_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+  - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.7-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/aiohttp-3.14.1-py311ha95a472_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/blosc-1.21.6-hd145fbb_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/brotli-1.2.0-hf139dec_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/brotli-bin-1.2.0-h8616949_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/cairo-1.18.4-h950ec3b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/contourpy-1.3.3-py311h9d13916_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/cyrus-sasl-2.1.28-h610c526_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/dbus-1.16.2-h27bd348_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/double-conversion-3.3.1-h240833e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/eigen-3.4.0-h2fb4741_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/eigen-abi-3.4.0.100-h6bcb275_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/ffmpeg-7.1.1-gpl_hf226373_110.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/flann-1.9.2-hf045e91_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/fontconfig-2.18.1-h7a4440b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/fonttools-4.63.0-py311ha8ae342_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/freeimage-3.18.0-h0f7f9a8_25.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/freetype-2.14.3-h694c41f_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/fribidi-1.0.16-h8616949_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/frozenlist-1.8.0-py311ha09d3ca_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/gdk-pixbuf-2.42.12-h5720e38_3.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/gl2ps-1.4.2-hb468ce4_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/glew-2.1.0-h046ec9c_2.tar.bz2
+  - conda: https://prefix.dev/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/graphite2-1.3.15-hcc62823_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/harfbuzz-11.4.5-h0ffbb26_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/hdf5-1.14.3-nompi_h1607680_109.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/imath-3.2.2-h55e386d_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/jasper-4.2.9-hbeb4536_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/jsoncpp-1.9.6-h466cfd8_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/jxrlib-1.1-h10d778d_3.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/kiwisolver-1.5.0-py311h2886188_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/lame-3.100-hb7f2c08_1003.tar.bz2
+  - conda: https://prefix.dev/conda-forge/osx-64/lcms2-2.19.1-h5ea7634_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/lerc-4.1.0-h35c7297_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libabseil-20250512.1-cxx17_hfc00f1c_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libaec-1.1.5-he7c3a48_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libass-0.17.4-h87c4fc2_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libblas-3.11.0-8_he492b99_openblas.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libboost-1.86.0-hb2bbd1d_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libboost-devel-1.86.0-h8409faf_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libboost-headers-1.86.0-h694c41f_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libbrotlicommon-1.2.0-h8616949_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libbrotlidec-1.2.0-h8616949_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libbrotlienc-1.2.0-h8616949_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libcblas-3.11.0-8_h9b27e0a_openblas.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libclang-cpp18.1-18.1.8-default_h9399c5b_18.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libclang13-21.1.0-default_h7f9524c_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libcurl-8.18.0-h9348e2b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libcxx-22.1.8-h19cb2f5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libdeflate-1.25-h517ebb2_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libedit-3.1.20250104-pl5321ha958ccf_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libfreetype-2.14.3-h694c41f_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libfreetype6-2.14.3-h58fbd8d_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libglib-2.84.3-h5fed8df_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libhwloc-2.12.1-default_h8c32e24_1000.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libintl-0.25.1-h3184127_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libjpeg-turbo-3.1.4.1-ha1e9b39_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/liblapack-3.11.0-8_h859234e_openblas.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libllvm18-18.1.8-default_hd2a208e_9.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libllvm21-21.1.0-h9b4ebcc_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libnetcdf-4.9.2-nompi_hf3c7182_116.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libnghttp2-1.68.1-h70048d4_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libntlm-1.8-h6e16a3a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libogg-1.3.5-he3325bb_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libopenblas-0.3.33-openmp_h9e49c7b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-2025.2.0-h346e020_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-auto-batch-plugin-2025.2.0-heda8b29_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-auto-plugin-2025.2.0-heda8b29_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-hetero-plugin-2025.2.0-hd57c75b_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2025.2.0-h346e020_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-ir-frontend-2025.2.0-hd57c75b_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-onnx-frontend-2025.2.0-ha4fb624_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-paddle-frontend-2025.2.0-ha4fb624_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-pytorch-frontend-2025.2.0-hbc7d668_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-tensorflow-frontend-2025.2.0-hd87add6_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2025.2.0-hbc7d668_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libopus-1.6.1-hc6ced15_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libpng-1.6.58-he930e7c_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libpq-17.7-h1e038c5_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libprotobuf-6.31.1-h774df25_5.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libraw-0.22.1-h3650196_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/librsvg-2.58.4-h21a6cfa_3.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libsqlite-3.53.2-h77d7759_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libtheora-1.1.1-hfdf4475_1006.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libtiff-4.7.1-ha0a348c_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libusb-1.0.29-h2287256_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libvorbis-1.3.7-ha059160_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libvpx-1.14.1-hf036a51_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libvulkan-loader-1.4.341.0-ha6bc089_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libwebp-base-1.6.0-hb807250_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libxml2-2.13.9-he1bc88e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libxslt-1.1.43-h59ddae0_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libzip-1.11.2-h31df5bb_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/llvm-openmp-22.1.8-h0d3cbff_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/lz4-c-1.10.0-h240833e_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/matplotlib-base-3.10.9-py311hc159c88_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/msgpack-python-1.2.0-py311hd8befaf_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/multidict-6.7.1-py311h42ed68f_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/mysql-common-9.3.0-hd00b0ec_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/mysql-libs-9.3.0-h062309a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/nlohmann_json-3.12.0-h06076ce_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/numpy-1.26.4-py311hc43a94b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/occt-7.8.1-all_ha9a7d59_203.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/openexr-3.4.12-hfe7f346_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/openh264-2.6.0-h4883158_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/openjpeg-2.5.4-h52bb76a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/openjph-0.28.1-h2c0e27e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/openldap-2.6.10-hd8a590d_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/openssl-3.6.3-hc881268_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/pango-1.56.4-h6ef8af8_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/pcl-1.15.0-h96d8db5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/pcre2-10.45-hf733adb_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/pillow-12.2.0-py311h27c473c_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/pixman-0.46.4-ha059160_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/proj-9.5.1-h5273da6_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/propcache-0.5.2-py311ha8ae342_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/pugixml-1.15-h46091d4_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/pyside6-6.8.3-py311h4ef2287_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/python-3.11.14-h3999593_1_cpython.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/qt6-main-6.8.3-he2a6cc6_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/rapidjson-1.1.0.post20240409-h92383a6_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/sdl2-2.32.56-h53ec75d_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/sdl3-3.4.10-hf9078ff_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/sed-4.10-hb63749c_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/smesh-9.9.0.0-h9ba7290_14.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/snappy-1.2.2-h01f5ddf_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/sqlite-3.53.2-hd4d344e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/svt-av1-3.1.2-h21dd04a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/tbb-2022.3.0-hf0c99ee_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/unicodedata2-17.0.1-py311hc71d4c3_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/utfcpp-4.09-h694c41f_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/vtk-9.3.1-qt_py311hb7aed01_216.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/vtk-base-9.3.1-qt_py311h12068e6_216.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/vtk-io-ffmpeg-9.3.1-qt_py311hb7aed01_216.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/x264-1!164.3095-h775f41a_2.tar.bz2
+  - conda: https://prefix.dev/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
+  - conda: https://prefix.dev/conda-forge/osx-64/xerces-c-3.3.0-hd0321b6_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/xorg-libxau-1.0.12-h8616949_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h8616949_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/yaml-cpp-0.8.0-h92383a6_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/yarl-1.24.2-py311ha8ae342_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/zlib-ng-2.3.3-h8bce59a_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+- conda_source: freecad[6c707e0d] @ .
   variants:
     build_platform: linux-64
     target_platform: linux-64
@@ -28598,7 +28442,6 @@ packages:
   - opencamlib
   - pandas
   - pip
-  - pivy
   - ply
   - pycollada
   - pyside6
@@ -28617,7 +28460,6 @@ packages:
   - qt6-wayland
   - xcb-util-cursor ==0.1.5
   - __glibc >=2.17,<3.0.a0
-  - coin3d >=4.0.3,<4.1.0a0
   - fmt >=12.1.0,<12.2.0a0
   - libfreetype >=2.14.3
   - libfreetype6 >=2.14.3
@@ -28817,7 +28659,6 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
   - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/coin3d-4.0.3-hd74d64a_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/contourpy-1.3.3-py311h724c32c_4.conda
   - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
@@ -28825,7 +28666,6 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-64/double-conversion-3.3.1-h5888daf_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/eigen-3.4.0-h54a6638_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/eigen-abi-3.4.0.100-h3bcb7cf_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/expat-2.8.1-hecca717_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-7.1.1-gpl_h127656b_906.conda
   - conda: https://prefix.dev/conda-forge/linux-64/flann-1.9.2-h3ef53d8_3.conda
   - conda: https://prefix.dev/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda
@@ -28976,7 +28816,6 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-64/pcl-1.15.0-h679aaff_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.45-hc749103_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/pillow-12.2.0-py311hf88fc01_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/pivy-0.6.9-py311qt6h646dae5_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/proj-9.5.1-h0054346_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/propcache-0.5.2-py311h3778330_0.conda
@@ -28994,7 +28833,6 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-64/sed-4.10-h19d0853_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/smesh-9.9.0.0-hb7ebc10_14.conda
   - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/soqt6-1.6.3-h23d7b0e_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/sqlite-3.53.2-hbc0de68_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-3.0.2-h5888daf_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/tbb-2022.3.0-h8d10470_1.conda
@@ -29066,10 +28904,10 @@ packages:
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
   - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.49-hd8ed1ab_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.7-pyhd8ed1ab_0.conda
-- conda_source: freecad[4439f4df] @ .
+- conda_source: freecad[82a8351e] @ .
   variants:
-    build_platform: osx-64
-    target_platform: osx-64
+    build_platform: linux-aarch64
+    target_platform: linux-aarch64
   depends:
   - av
   - blas * openblas*
@@ -29094,7 +28932,6 @@ packages:
   - opencamlib
   - pandas
   - pip
-  - pivy
   - ply
   - pycollada
   - pyside6
@@ -29109,7 +28946,9 @@ packages:
   - typing_extensions
   - vtk
   - xlutils
-  - coin3d >=4.0.3,<4.1.0a0
+  - libspnav
+  - qt6-wayland
+  - xcb-util-cursor ==0.1.5
   - fmt >=12.1.0,<12.2.0a0
   - libfreetype >=2.14.3
   - libfreetype6 >=2.14.3
@@ -29123,117 +28962,402 @@ packages:
   - yaml-cpp >=0.8.0,<0.9.0a0
   - libzlib >=1.3.2,<2.0a0
   build_packages:
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/binutils-2.45.1-default_hf1166c9_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45.1-default_h5f4c503_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45.1-default_hf1166c9_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/c-compiler-1.10.0-h6561dab_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/cairo-1.18.4-h83712da_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/ccache-4.13.6-h185addb_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/clang-21-21.1.0-default_he95a3c9_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/clang-21.1.0-default_h395f21b_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/clangxx-21.1.0-default_h4b04f8d_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/cmake-4.2.3-hc9d863e_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/compilers-1.10.0-h8af1aa0_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/conda-gcc-specs-13.4.0-hc20859d_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/cxx-compiler-1.10.0-heb6c788_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6c5dea3_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/dbus-1.16.2-heda779d_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/double-conversion-3.3.1-h5ad3122_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/doxygen-1.13.2-h5e0f5ae_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/fortran-compiler-1.10.0-h25a59a9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc-13.4.0-h2e72a27_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-13.4.0-hc0d58d9_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_linux-aarch64-13.4.0-hb656077_27.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/gfortran-13.4.0-hb5ee532_7.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-13.4.0-h29c24b5_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/gfortran_linux-aarch64-13.4.0-h64f55b8_27.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/gtest-1.17.0-h17cf362_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/gxx-13.4.0-hb5ee532_7.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-13.4.0-h4f637f2_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/gxx_linux-aarch64-13.4.0-h4bf53ff_27.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/harfbuzz-11.4.5-he4899c9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang-cpp20.1-20.1.8-default_he95a3c9_16.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang-cpp21.1-21.1.0-default_he95a3c9_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang13-21.1.0-default_h94a09a5_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libcups-2.3.3-h5cdc715_5.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libcurl-8.18.0-h7bfdcfb_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libdrm-2.4.127-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libffi-3.4.6-he21f813_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libglib-2.84.3-h75d4a95_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libhiredis-1.3.0-h5ad3122_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libhwloc-2.12.1-default_h6f258fa_1000.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libjpeg-turbo-3.1.4.1-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libllvm20-20.1.8-h2b567e5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libllvm21-21.1.0-h2b567e5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libnsl-2.0.1-h86ecc28_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libntlm-1.4-hf897c2e_1002.tar.bz2
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libpciaccess-0.19-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libpq-17.7-haf03d9f_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libsanitizer-13.4.0-hc708448_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libspnav-1.1-h68df207_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libsqlite-3.53.2-h022381a_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libtiff-4.7.1-hdb009f0_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libuv-1.52.1-h80f16a2_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxkbcommon-1.11.0-h95ca766_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxml2-2.13.9-he58860d_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/mimalloc-3.2.7-h7ac5ae9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/mold-2.40.4-h4c4c02a_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/mysql-common-9.3.0-h3f5c77f_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/mysql-libs-9.3.0-h11569fd_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/ninja-1.13.2-hdc560ac_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/pcre2-10.45-hf4ec17f_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/python-3.11.14-hcfbf8c2_1_cpython.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/qt6-main-6.8.3-he176c03_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/rhash-1.4.6-h86ecc28_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/sed-4.10-he1c5539_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/swig-4.3.1-hb663fc2_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/tbb-2022.3.0-h0eac15c_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.24.0-h698ed42_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-0.4.1-hca56bd8_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-cursor-0.1.5-h86ecc28_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.47-h80f16a2_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxcomposite-0.4.7-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxcursor-1.2.3-h86ecc28_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxext-1.3.7-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxfixes-6.0.2-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxi-1.8.3-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxrandr-1.5.5-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxtst-1.2.5-h57736b2_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.7-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h57736b2_1008.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xxhash-0.8.3-hd794028_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_osx-64-18.1.8-h138dee1_2.conda
   - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
   - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
   - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
   - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
   - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/libgfortran-devel_osx-64-13.4.0-hbfa0f67_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_18.conda
+  - conda: https://prefix.dev/conda-forge/noarch/libdrm-cos7-aarch64-2.4.97-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-aarch64-13.4.0-h7bedc8d_119.conda
+  - conda: https://prefix.dev/conda-forge/noarch/libglvnd-cos7-aarch64-1.0.1-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/libglvnd-glx-cos7-aarch64-1.0.1-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/libselinux-cos7-aarch64-2.5-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/libsepol-cos7-aarch64-2.5-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-aarch64-13.4.0-hfee918e_119.conda
+  - conda: https://prefix.dev/conda-forge/noarch/libx11-common-cos7-aarch64-1.6.7-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/libx11-cos7-aarch64-1.6.7-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/libxau-cos7-aarch64-1.0.8-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/libxcb-cos7-aarch64-1.13-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/libxdamage-cos7-aarch64-1.1.4-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/libxext-cos7-aarch64-1.3.3-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/libxfixes-cos7-aarch64-5.0.3-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/libxi-cos7-aarch64-1.7.9-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/libxi-devel-cos7-aarch64-1.7.9-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/libxxf86vm-cos7-aarch64-1.1.4-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/mesa-dri-drivers-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/mesa-khr-devel-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/mesa-libegl-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/mesa-libegl-devel-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/mesa-libgbm-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/mesa-libgl-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/mesa-libgl-devel-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/mesa-libglapi-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
   - conda: https://prefix.dev/conda-forge/noarch/noqt5-1.0-hd8ed1ab_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pixman-cos7-aarch64-0.34.0-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-aarch64-2.17-h68829e0_18.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/c-compiler-1.10.0-h09a7c41_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/cairo-1.18.4-h950ec3b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/ccache-4.13.6-h894318c_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/cctools-1021.4-ha66f10e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/cctools_osx-64-1021.4-h508880d_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/clang-18-18.1.8-default_h9399c5b_18.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/clang-18.1.8-default_h1323312_18.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/clang_impl_osx-64-18.1.8-h6a44ed1_25.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/clang_osx-64-18.1.8-h7e5c614_25.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/clangxx-18.1.8-default_h4cf342a_18.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/clangxx_impl_osx-64-18.1.8-h4b7810f_25.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/clangxx_osx-64-18.1.8-h7e5c614_25.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/cmake-4.2.3-h965d0ab_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/compiler-rt-18.1.8-he914875_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/compilers-1.10.0-h694c41f_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/cxx-compiler-1.10.0-h20888b2_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/cyrus-sasl-2.1.28-h610c526_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/double-conversion-3.3.1-h240833e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/doxygen-1.13.2-h27064b9_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/fontconfig-2.18.1-h7a4440b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/fortran-compiler-1.10.0-h02557f8_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/freetype-2.14.3-h694c41f_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/gfortran-13.4.0-hcc3c99d_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/gfortran_impl_osx-64-13.4.0-h61474f3_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/gfortran_osx-64-13.4.0-h3223c34_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/graphite2-1.3.15-hcc62823_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/gtest-1.17.0-h9275861_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/harfbuzz-11.4.5-h0ffbb26_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/isl-0.26-imath32_h2e86a7b_101.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/ld64-954.16-h4e51db5_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/ld64_osx-64-954.16-h28b3ac7_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/lerc-4.1.0-h35c7297_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libclang-cpp18.1-18.1.8-default_h9399c5b_18.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libclang13-22.1.8-default_h2429e1b_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libcurl-8.18.0-h9348e2b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libcxx-22.1.8-h19cb2f5_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libcxx-devel-18.1.8-h7c275be_8.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libdeflate-1.25-h517ebb2_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libedit-3.1.20250104-pl5321ha958ccf_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libfreetype-2.14.3-h694c41f_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libfreetype6-2.14.3-h58fbd8d_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libglib-2.84.3-h5fed8df_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libhiredis-1.3.0-h240833e_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libintl-0.25.1-h3184127_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libjpeg-turbo-3.1.4.1-ha1e9b39_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libllvm18-18.1.8-default_h9399c5b_12.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libllvm22-22.1.8-hab754da_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libnghttp2-1.68.1-h70048d4_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libntlm-1.8-h6e16a3a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libpng-1.6.58-he930e7c_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libpq-17.7-h1e038c5_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libsigtool-0.1.3-hc0f2934_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libsqlite-3.53.2-h77d7759_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libtiff-4.7.1-ha0a348c_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libuv-1.52.1-ha3d0635_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libwebp-base-1.6.0-hb807250_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libxml2-16-2.15.1-ha1d9b0f_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libxml2-2.15.1-h7b7ecba_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/llvm-openmp-22.1.8-h0d3cbff_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/llvm-tools-18-18.1.8-default_h9399c5b_12.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/llvm-tools-18.1.8-default_h9399c5b_12.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/mpc-1.4.0-h31caf2d_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/mpfr-4.2.2-h31caf2d_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/mysql-common-9.3.0-hd00b0ec_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/mysql-libs-9.3.0-h062309a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/ninja-1.13.2-hfc0b2d5_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/openldap-2.6.10-hd8a590d_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/openssl-3.6.3-hc881268_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/pcre2-10.45-hf733adb_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/pixman-0.46.4-ha059160_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/python-3.11.14-h3999593_1_cpython.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/qt6-main-6.8.3-he2a6cc6_4.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/rhash-1.4.6-h6e16a3a_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/sigtool-0.1.3-hc0f2934_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/sigtool-codesign-0.1.3-hc0f2934_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/swig-4.3.1-h7b1c113_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/xxhash-0.8.3-h13e91ac_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+  - conda: https://prefix.dev/conda-forge/noarch/xorg-x11-server-common-cos7-aarch64-1.20.4-ha675448_1106.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/xorg-x11-server-xvfb-cos7-aarch64-1.20.4-ha675448_1106.tar.bz2
   host_packages:
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/aiohttp-3.14.1-py311hf076524_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/blosc-1.21.6-hb4dfabd_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/brotli-1.2.0-hd651790_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/brotli-bin-1.2.0-he30d5cf_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/cairo-1.18.4-h83712da_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/contourpy-1.3.3-py311h04741b4_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6c5dea3_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/dbus-1.16.2-heda779d_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/double-conversion-3.3.1-h5ad3122_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/eigen-3.4.0-h7ac5ae9_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/eigen-abi-3.4.0.100-h9a8c16c_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/ffmpeg-7.1.1-gpl_h8d881e6_910.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/flann-1.9.2-hca6fa18_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/fmt-12.1.0-h20c602a_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/fonttools-4.63.0-py311h164a683_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/freeglut-3.2.2-hddf9bb5_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/freeimage-3.18.0-he4296dc_25.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/frozenlist-1.8.0-py311h91c1192_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/gdk-pixbuf-2.42.12-h90308e0_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/gl2ps-1.4.2-hd9db0c5_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/glew-2.1.0-h01db608_2.tar.bz2
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/harfbuzz-11.4.5-he4899c9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-1.14.3-nompi_h6ed7ac7_109.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/imath-3.2.2-h92288e7_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/jasper-4.2.9-h850eeee_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/jsoncpp-1.9.6-h34915d9_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/kiwisolver-1.5.0-py311h229e7f7_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/lcms2-2.19.1-h9d5b58d_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libabseil-20250512.1-cxx17_h201e9ed_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libaec-1.1.5-hff7e48a_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libass-0.17.4-hcfe818d_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libboost-1.86.0-h6339299_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libboost-devel-1.86.0-h37bb5a9_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libboost-headers-1.86.0-h8af1aa0_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlicommon-1.2.0-he30d5cf_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlidec-1.2.0-he30d5cf_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlienc-1.2.0-he30d5cf_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libcap-2.78-hf9559e3_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libcblas-3.11.0-8_hd72aa62_openblas.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang-cpp20.1-20.1.8-default_he95a3c9_16.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang13-21.1.0-default_h94a09a5_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libcups-2.3.3-h5cdc715_5.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libcurl-8.18.0-h7bfdcfb_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libdrm-2.4.127-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libffi-3.4.6-he21f813_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libflac-1.5.0-he9c94f4_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libglib-2.84.3-h75d4a95_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libglu-9.0.3-h5ad3122_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libhwloc-2.12.1-default_h6f258fa_1000.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libjpeg-turbo-3.1.4.1-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/liblapack-3.11.0-8_h88aeb00_openblas.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libllvm20-20.1.8-h2b567e5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libllvm21-21.1.0-h2b567e5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libnetcdf-4.9.2-nompi_h1c53c35_116.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libnsl-2.0.1-h86ecc28_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libntlm-1.4-hf897c2e_1002.tar.bz2
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libogg-1.3.5-h86ecc28_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenblas-0.3.33-pthreads_h9d3fd7e_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-2025.2.0-hcd21e76_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2025.2.0-hcd21e76_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2025.2.0-h3890994_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-auto-plugin-2025.2.0-h3890994_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2025.2.0-he07c6df_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-ir-frontend-2025.2.0-he07c6df_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2025.2.0-h07d5dce_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2025.2.0-h07d5dce_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2025.2.0-hfae3067_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2025.2.0-h38473e3_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2025.2.0-hfae3067_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libopus-1.6.1-h80f16a2_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libpciaccess-0.19-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libpq-17.7-haf03d9f_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libprotobuf-6.31.1-h61c7711_5.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libraw-0.22.1-h6c2e892_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/librsvg-2.58.4-h3ac5bce_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libsndfile-1.2.2-h30591a0_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libspnav-1.1-h68df207_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libsqlite-3.53.2-h022381a_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libsystemd0-257.13-hfcc8634_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libtheora-1.1.1-h68df207_1006.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libtiff-4.7.1-hdb009f0_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libudev1-257.13-hfcc8634_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libunwind-1.8.3-h6470e1d_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/liburing-2.12-hfefdfc9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libusb-1.0.29-h06eaf92_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libvorbis-1.3.7-h7ac5ae9_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libvulkan-loader-1.4.341.0-h8b8848b_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxkbcommon-1.11.0-h95ca766_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxml2-2.13.9-he58860d_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libxslt-1.1.43-h4552c8e_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libzip-1.11.2-h3e8f909_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/matplotlib-base-3.10.9-py311hb9c6b48_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/mpg123-1.32.9-h65af167_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py311hfca10b7_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/multidict-6.7.1-py311h164a683_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/mysql-common-9.3.0-h3f5c77f_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/mysql-libs-9.3.0-h11569fd_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/nlohmann_json-3.12.0-h7ac5ae9_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-1.26.4-py311h69ead2a_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/occt-7.8.1-all_h78e3548_203.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/openexr-3.4.12-h27f6aed_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/openh264-2.6.0-h0564a2a_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/openjph-0.28.1-h55827e0_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/pango-1.56.4-he55ef5b_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/pcl-1.15.0-h29e8f2a_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/pcre2-10.45-hf4ec17f_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/pillow-12.2.0-py311h8e17b9e_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/proj-9.5.1-h9655f4d_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/propcache-0.5.2-py311h164a683_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/pugixml-1.15-h6ef32b0_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/pulseaudio-client-17.0-h2f84921_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/pyside6-6.8.3-py311habb2604_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/python-3.11.14-hcfbf8c2_1_cpython.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/qt6-main-6.8.3-he176c03_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/rapidjson-1.1.0.post20240409-h5ad3122_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/sdl2-2.32.56-h7ac5ae9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/sdl3-3.2.24-h506f210_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/sed-4.10-he1c5539_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/smesh-9.9.0.0-h3752d33_14.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/snappy-1.2.2-he774c54_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/sqlite-3.53.2-he8854b5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/svt-av1-3.1.2-hfae3067_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/tbb-2022.3.0-h0eac15c_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/unicodedata2-17.0.1-py311h19352d5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/utfcpp-4.09-h8af1aa0_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/vtk-9.3.1-qt_py311h3356f26_216.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/vtk-base-9.3.1-qt_py311h412eec7_216.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/vtk-io-ffmpeg-9.3.1-qt_py311h3356f26_216.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.24.0-h698ed42_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-0.4.1-hca56bd8_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-cursor-0.1.6-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xerces-c-3.3.0-h595f43b_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.47-h80f16a2_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxcomposite-0.4.7-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxcursor-1.2.3-h86ecc28_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxext-1.3.7-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxfixes-6.0.2-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxi-1.8.3-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxrandr-1.5.5-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxtst-1.2.5-h57736b2_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.7-he30d5cf_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h57736b2_1008.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/yaml-cpp-0.8.0-h5ad3122_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/yarl-1.24.2-py311h164a683_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/zlib-ng-2.3.3-ha7cb516_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
   - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.2-pyhd8ed1ab_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
@@ -29261,180 +29385,7 @@ packages:
   - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
   - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.7-pyhd8ed1ab_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/aiohttp-3.14.1-py311ha95a472_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/blosc-1.21.6-hd145fbb_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/brotli-1.2.0-hf139dec_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/brotli-bin-1.2.0-h8616949_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/cairo-1.18.4-h950ec3b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/coin3d-4.0.3-h9b6ce5f_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/contourpy-1.3.3-py311h9d13916_4.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/cyrus-sasl-2.1.28-h610c526_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/dbus-1.16.2-h27bd348_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/double-conversion-3.3.1-h240833e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/eigen-3.4.0-h2fb4741_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/eigen-abi-3.4.0.100-h6bcb275_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/expat-2.8.1-hcc62823_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/ffmpeg-7.1.1-gpl_hf226373_110.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/flann-1.9.2-hf045e91_4.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/fontconfig-2.18.1-h7a4440b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/fonttools-4.63.0-py311ha8ae342_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/freeimage-3.18.0-h0f7f9a8_25.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/freetype-2.14.3-h694c41f_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/fribidi-1.0.16-h8616949_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/frozenlist-1.8.0-py311ha09d3ca_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/gdk-pixbuf-2.42.12-h5720e38_3.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/gl2ps-1.4.2-hb468ce4_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/glew-2.1.0-h046ec9c_2.tar.bz2
-  - conda: https://prefix.dev/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/graphite2-1.3.15-hcc62823_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/harfbuzz-11.4.5-h0ffbb26_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/hdf5-1.14.3-nompi_h1607680_109.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/imath-3.2.2-h55e386d_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/jasper-4.2.9-hbeb4536_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/jsoncpp-1.9.6-h466cfd8_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/jxrlib-1.1-h10d778d_3.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/kiwisolver-1.5.0-py311h2886188_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/lame-3.100-hb7f2c08_1003.tar.bz2
-  - conda: https://prefix.dev/conda-forge/osx-64/lcms2-2.19.1-h5ea7634_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/lerc-4.1.0-h35c7297_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libabseil-20250512.1-cxx17_hfc00f1c_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libaec-1.1.5-he7c3a48_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libass-0.17.4-h87c4fc2_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libblas-3.11.0-8_he492b99_openblas.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libboost-1.86.0-hb2bbd1d_4.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libboost-devel-1.86.0-h8409faf_4.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libboost-headers-1.86.0-h694c41f_4.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libbrotlicommon-1.2.0-h8616949_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libbrotlidec-1.2.0-h8616949_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libbrotlienc-1.2.0-h8616949_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libcblas-3.11.0-8_h9b27e0a_openblas.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libclang-cpp18.1-18.1.8-default_h9399c5b_18.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libclang13-21.1.0-default_h7f9524c_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libcurl-8.18.0-h9348e2b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libcxx-22.1.8-h19cb2f5_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libdeflate-1.25-h517ebb2_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libedit-3.1.20250104-pl5321ha958ccf_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libfreetype-2.14.3-h694c41f_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libfreetype6-2.14.3-h58fbd8d_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libglib-2.84.3-h5fed8df_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libhwloc-2.12.1-default_h8c32e24_1000.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libintl-0.25.1-h3184127_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libjpeg-turbo-3.1.4.1-ha1e9b39_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/liblapack-3.11.0-8_h859234e_openblas.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libllvm18-18.1.8-default_hd2a208e_9.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libllvm21-21.1.0-h9b4ebcc_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libnetcdf-4.9.2-nompi_hf3c7182_116.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libnghttp2-1.68.1-h70048d4_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libntlm-1.8-h6e16a3a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libogg-1.3.5-he3325bb_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libopenblas-0.3.33-openmp_h9e49c7b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-2025.2.0-h346e020_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-auto-batch-plugin-2025.2.0-heda8b29_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-auto-plugin-2025.2.0-heda8b29_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-hetero-plugin-2025.2.0-hd57c75b_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2025.2.0-h346e020_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-ir-frontend-2025.2.0-hd57c75b_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-onnx-frontend-2025.2.0-ha4fb624_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-paddle-frontend-2025.2.0-ha4fb624_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-pytorch-frontend-2025.2.0-hbc7d668_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-tensorflow-frontend-2025.2.0-hd87add6_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2025.2.0-hbc7d668_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libopus-1.6.1-hc6ced15_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libpng-1.6.58-he930e7c_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libpq-17.7-h1e038c5_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libprotobuf-6.31.1-h774df25_5.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libraw-0.22.1-h3650196_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/librsvg-2.58.4-h21a6cfa_3.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libsqlite-3.53.2-h77d7759_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libtheora-1.1.1-hfdf4475_1006.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libtiff-4.7.1-ha0a348c_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libusb-1.0.29-h2287256_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libvorbis-1.3.7-ha059160_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libvpx-1.14.1-hf036a51_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libvulkan-loader-1.4.341.0-ha6bc089_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libwebp-base-1.6.0-hb807250_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libxml2-2.13.9-he1bc88e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libxslt-1.1.43-h59ddae0_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libzip-1.11.2-h31df5bb_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/llvm-openmp-22.1.8-h0d3cbff_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/lz4-c-1.10.0-h240833e_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/matplotlib-base-3.10.9-py311hc159c88_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/msgpack-python-1.2.0-py311hd8befaf_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/multidict-6.7.1-py311h42ed68f_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/mysql-common-9.3.0-hd00b0ec_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/mysql-libs-9.3.0-h062309a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/nlohmann_json-3.12.0-h06076ce_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/numpy-1.26.4-py311hc43a94b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/occt-7.8.1-all_ha9a7d59_203.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/openexr-3.4.12-hfe7f346_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/openh264-2.6.0-h4883158_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/openjpeg-2.5.4-h52bb76a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/openjph-0.28.1-h2c0e27e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/openldap-2.6.10-hd8a590d_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/openssl-3.6.3-hc881268_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/pango-1.56.4-h6ef8af8_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/pcl-1.15.0-h96d8db5_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/pcre2-10.45-hf733adb_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/pillow-12.2.0-py311h27c473c_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/pivy-0.6.9-py311qt6h268aa71_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/pixman-0.46.4-ha059160_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/proj-9.5.1-h5273da6_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/propcache-0.5.2-py311ha8ae342_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/pugixml-1.15-h46091d4_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/pyside6-6.8.3-py311h4ef2287_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/python-3.11.14-h3999593_1_cpython.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/qt6-main-6.8.3-he2a6cc6_4.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/rapidjson-1.1.0.post20240409-h92383a6_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/sdl2-2.32.56-h53ec75d_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/sdl3-3.4.10-hf9078ff_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/sed-4.10-hb63749c_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/smesh-9.9.0.0-h9ba7290_14.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/snappy-1.2.2-h01f5ddf_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/soqt6-1.6.3-h667e493_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/sqlite-3.53.2-hd4d344e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/svt-av1-3.1.2-h21dd04a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/tbb-2022.3.0-hf0c99ee_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/unicodedata2-17.0.1-py311hc71d4c3_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/utfcpp-4.09-h694c41f_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/vtk-9.3.1-qt_py311hb7aed01_216.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/vtk-base-9.3.1-qt_py311h12068e6_216.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/vtk-io-ffmpeg-9.3.1-qt_py311hb7aed01_216.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/x264-1!164.3095-h775f41a_2.tar.bz2
-  - conda: https://prefix.dev/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
-  - conda: https://prefix.dev/conda-forge/osx-64/xerces-c-3.3.0-hd0321b6_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/xorg-libxau-1.0.12-h8616949_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h8616949_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/yaml-cpp-0.8.0-h92383a6_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/yarl-1.24.2-py311ha8ae342_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/zlib-ng-2.3.3-h8bce59a_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
-- conda_source: freecad[9600b26b] @ .
+- conda_source: freecad[c450b9e9] @ .
   variants:
     build_platform: win-64
     target_platform: win-64
@@ -29462,7 +29413,6 @@ packages:
   - opencamlib
   - pandas
   - pip
-  - pivy
   - ply
   - pycollada
   - pyside6
@@ -29477,7 +29427,6 @@ packages:
   - typing_extensions
   - vtk
   - xlutils
-  - coin3d >=4.0.3,<4.1.0a0
   - fmt >=12.1.0,<12.2.0a0
   - libfreetype >=2.14.3
   - libfreetype6 >=2.14.3
@@ -29608,13 +29557,11 @@ packages:
   - conda: https://prefix.dev/conda-forge/win-64/brotli-bin-1.2.0-hfd05255_1.conda
   - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
   - conda: https://prefix.dev/conda-forge/win-64/cairo-1.18.4-h5782bbf_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/coin3d-4.0.3-h192c3d0_2.conda
   - conda: https://prefix.dev/conda-forge/win-64/contourpy-1.3.3-py311h275cad7_4.conda
   - conda: https://prefix.dev/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
   - conda: https://prefix.dev/conda-forge/win-64/double-conversion-3.3.1-he0c23c2_0.conda
   - conda: https://prefix.dev/conda-forge/win-64/eigen-3.4.0-h5112557_2.conda
   - conda: https://prefix.dev/conda-forge/win-64/eigen-abi-3.4.0.100-hc11354d_2.conda
-  - conda: https://prefix.dev/conda-forge/win-64/expat-2.8.1-hac47afa_1.conda
   - conda: https://prefix.dev/conda-forge/win-64/ffmpeg-7.1.1-gpl_h70aa942_910.conda
   - conda: https://prefix.dev/conda-forge/win-64/flann-1.9.2-h48fefe0_4.conda
   - conda: https://prefix.dev/conda-forge/win-64/fmt-12.1.0-h7f4e812_0.conda
@@ -29706,7 +29653,6 @@ packages:
   - conda: https://prefix.dev/conda-forge/win-64/pcl-1.15.0-hcec6b29_0.conda
   - conda: https://prefix.dev/conda-forge/win-64/pcre2-10.45-h99c9b8b_0.conda
   - conda: https://prefix.dev/conda-forge/win-64/pillow-12.2.0-py311h17b8079_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/pivy-0.6.9-py311qt6hd279cb5_2.conda
   - conda: https://prefix.dev/conda-forge/win-64/pixman-0.46.4-h5112557_1.conda
   - conda: https://prefix.dev/conda-forge/win-64/proj-9.5.1-h4f671f6_0.conda
   - conda: https://prefix.dev/conda-forge/win-64/propcache-0.5.2-py311h3f79411_0.conda
@@ -29721,7 +29667,6 @@ packages:
   - conda: https://prefix.dev/conda-forge/win-64/sdl3-3.4.10-h5112557_0.conda
   - conda: https://prefix.dev/conda-forge/win-64/smesh-9.9.0.0-h4c8b7ef_14.conda
   - conda: https://prefix.dev/conda-forge/win-64/snappy-1.2.2-h7fa0ca8_1.conda
-  - conda: https://prefix.dev/conda-forge/win-64/soqt6-1.6.3-h796eb14_0.conda
   - conda: https://prefix.dev/conda-forge/win-64/sqlite-3.53.2-hdb435a2_0.conda
   - conda: https://prefix.dev/conda-forge/win-64/svt-av1-3.1.2-hac47afa_0.conda
   - conda: https://prefix.dev/conda-forge/win-64/tbb-2022.3.0-hd094cb3_1.conda
@@ -29747,371 +29692,3 @@ packages:
   - conda: https://prefix.dev/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
   - conda: https://prefix.dev/conda-forge/win-64/zlib-ng-2.3.3-h0261ad2_1.conda
   - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-- conda_source: freecad[fc70dd10] @ .
-  variants:
-    build_platform: osx-arm64
-    target_platform: osx-arm64
-  depends:
-  - av
-  - blas * openblas*
-  - blinker
-  - calculix
-  - debugpy
-  - defusedxml
-  - docutils
-  - gmsh
-  - graphviz
-  - ifcopenshell
-  - lark
-  - lxml
-  - matplotlib-base
-  - nine
-  - noqt5
-  - numpy >=1.26,<2
-  - numpy >=1.26.4,<2.0a0
-  - occt >=7.8,<7.9
-  - occt >=7.8.1,<7.8.2.0a0
-  - olefile
-  - opencamlib
-  - pandas
-  - pip
-  - pivy
-  - ply
-  - pycollada
-  - pyside6
-  - python >=3.11,<3.12
-  - pythonocc-core
-  - pyyaml
-  - qt6-main >=6.8,<6.9
-  - qt6-main >=6.8.3,<6.9.0a0
-  - requests
-  - scipy
-  - sympy
-  - typing_extensions
-  - vtk
-  - xlutils
-  - coin3d >=4.0.3,<4.1.0a0
-  - fmt >=12.1.0,<12.2.0a0
-  - libfreetype >=2.14.3
-  - libfreetype6 >=2.14.3
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - libboost >=1.86.0,<1.87.0a0
-  - pcl >=1.15.0,<1.15.1.0a0
-  - python_abi 3.11.* *_cp311
-  - smesh >=9.9.0.0,<9.9.1.0a0
-  - vtk-base >=9.3.1,<9.3.2.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
-  - libzlib >=1.3.2,<2.0a0
-  build_packages:
-  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_osx-arm64-18.1.8-he32a8d3_2.conda
-  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-  - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/libgfortran-devel_osx-arm64-13.4.0-ha240a38_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/noqt5-1.0-hd8ed1ab_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/c-compiler-1.10.0-hdf49b6b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/cairo-1.18.4-h6a3b0d2_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/ccache-4.13.6-h414bf82_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/cctools-1021.4-hb4fb6a3_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/cctools_osx-arm64-1021.4-h12580ec_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/clang-18-18.1.8-default_hf3020a7_18.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/clang-18.1.8-default_hf9bcbb7_18.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/clang_impl_osx-arm64-18.1.8-h2ae9ea5_25.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/clang_osx-arm64-18.1.8-h07b0088_25.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/clangxx-18.1.8-default_h65f67e2_18.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/clangxx_impl_osx-arm64-18.1.8-h555f467_25.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/clangxx_osx-arm64-18.1.8-h07b0088_25.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/cmake-4.2.3-h8cb302d_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/compiler-rt-18.1.8-h855ad52_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/compilers-1.10.0-hce30654_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/cxx-compiler-1.10.0-hba80287_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/cyrus-sasl-2.1.28-ha1cbb27_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/double-conversion-3.3.1-h286801f_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/doxygen-1.13.2-h493aca8_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/fontconfig-2.18.1-h2b252f5_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/fortran-compiler-1.10.0-h5692697_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/freetype-2.14.3-hce30654_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/gfortran-13.4.0-h3ef1dbf_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/gfortran_impl_osx-arm64-13.4.0-he7ca382_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/gfortran_osx-arm64-13.4.0-h3c33bd0_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/graphite2-1.3.15-hf6b4638_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/gtest-1.17.0-ha393de7_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/harfbuzz-11.4.5-hf4e55d4_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/isl-0.26-imath32_h347afa1_101.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/ld64-954.16-h4c6efb1_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/ld64_osx-arm64-954.16-h9d5fcb0_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libclang-cpp18.1-18.1.8-default_hf3020a7_18.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libclang13-22.1.8-default_h6dd9417_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libcurl-8.18.0-he38603e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-devel-18.1.8-h6dc3340_8.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libdeflate-1.25-hc11a715_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libglib-2.84.3-h587fa63_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libhiredis-1.3.0-h286801f_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libjpeg-turbo-3.1.4.1-h84a0fba_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libllvm18-18.1.8-default_h8e162e0_12.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libllvm22-22.1.8-h89af1be_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libntlm-1.8-h5505292_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libpq-17.7-h944245b_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libsigtool-0.1.3-h98dc951_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.53.2-h1b79a29_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libtiff-4.7.1-h4030677_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libwebp-base-1.6.0-h07db88b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libxml2-16-2.15.1-h0ff4647_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libxml2-2.15.1-h9329255_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-tools-18-18.1.8-default_h8e162e0_12.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-tools-18.1.8-default_h8e162e0_12.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/mysql-common-9.3.0-hd7719f6_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/mysql-libs-9.3.0-ha8be5b7_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/ninja-1.13.2-h49c215f_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/openldap-2.6.10-hbe55e7a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/pcre2-10.45-ha881caa_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.11.14-hec0b533_1_cpython.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/qt6-main-6.8.3-hc9525f7_4.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/rhash-1.4.6-h5505292_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/sigtool-0.1.3-h98dc951_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/sigtool-codesign-0.1.3-h98dc951_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/swig-4.3.1-hdecd427_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/xxhash-0.8.3-haa4e116_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-  host_packages:
-  - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.2-pyhd8ed1ab_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
-  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-  - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-  - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/noqt5-1.0-hd8ed1ab_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
-  - conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.3-pyhfe8187e_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.3-pyh648e204_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.11-8_cp311.conda
-  - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.7-pyhd8ed1ab_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/aiohttp-3.14.1-py311h6771f6e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/blosc-1.21.6-h7dd00d9_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/brotli-1.2.0-h7d5ae5b_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/brotli-bin-1.2.0-hc919400_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/cairo-1.18.4-h6a3b0d2_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/coin3d-4.0.3-h705ab75_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/contourpy-1.3.3-py311h7d85929_4.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/cyrus-sasl-2.1.28-ha1cbb27_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/dbus-1.16.2-hda038a8_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/double-conversion-3.3.1-h286801f_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/eigen-3.4.0-h784d473_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/eigen-abi-3.4.0.100-h485a483_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/expat-2.8.1-hf6b4638_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/ffmpeg-7.1.1-gpl_h93d53e2_110.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/flann-1.9.2-h5d00db4_4.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/fmt-12.1.0-h403dcb5_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/fontconfig-2.18.1-h2b252f5_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/fonttools-4.63.0-py311hc290fe0_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/freeimage-3.18.0-h87663b4_25.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/freetype-2.14.3-hce30654_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/fribidi-1.0.16-hc919400_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/frozenlist-1.8.0-py311hf75086c_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/gdk-pixbuf-2.42.12-h7af3d76_3.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/gl2ps-1.4.2-h8fb3f6e_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/glew-2.1.0-h9f76cd9_2.tar.bz2
-  - conda: https://prefix.dev/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/graphite2-1.3.15-hf6b4638_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/harfbuzz-11.4.5-hf4e55d4_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-1.14.3-nompi_ha698983_109.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/imath-3.2.2-h3470cca_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/jasper-4.2.9-h7543a42_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/jsoncpp-1.9.6-h726d253_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/jxrlib-1.1-h93a5062_3.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/kiwisolver-1.5.0-py311h7d85929_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
-  - conda: https://prefix.dev/conda-forge/osx-arm64/lcms2-2.19.1-hdfa7624_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libabseil-20250512.1-cxx17_hd41c47c_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libaec-1.1.5-h8664d51_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libass-0.17.4-hcbd7ca7_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libboost-1.86.0-hf493ff8_4.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libboost-devel-1.86.0-hf450f58_4.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libboost-headers-1.86.0-hce30654_4.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlienc-1.2.0-hc919400_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libclang-cpp18.1-18.1.8-default_hf3020a7_18.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libclang13-21.1.0-default_h6e8f826_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libcurl-8.18.0-he38603e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libdeflate-1.25-hc11a715_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libglib-2.84.3-h587fa63_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libhwloc-2.12.1-default_h88f92a7_1000.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libjpeg-turbo-3.1.4.1-h84a0fba_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libllvm18-18.1.8-default_h3f49643_9.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libllvm21-21.1.0-h846d351_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_h610d594_116.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libntlm-1.8-h5505292_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libogg-1.3.5-h48c0fde_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-2025.2.0-h56e7ac4_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2025.2.0-h56e7ac4_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2025.2.0-he81eb65_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-auto-plugin-2025.2.0-he81eb65_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-hetero-plugin-2025.2.0-h273c05f_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-ir-frontend-2025.2.0-h273c05f_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-onnx-frontend-2025.2.0-h6386500_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-paddle-frontend-2025.2.0-h6386500_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2025.2.0-hec049ff_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2025.2.0-hee62d61_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2025.2.0-hec049ff_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libopus-1.6.1-h1a92334_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libpq-17.7-h944245b_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libprotobuf-6.31.1-h29102cf_5.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libraw-0.22.1-h2d05ff4_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/librsvg-2.58.4-h266df6f_3.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.53.2-h1b79a29_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libtheora-1.1.1-h99b78c6_1006.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libtiff-4.7.1-h4030677_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libusb-1.0.29-hbc156a2_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libvorbis-1.3.7-h81086ad_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libvpx-1.14.1-h7bae524_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libvulkan-loader-1.4.341.0-h3feff0a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libwebp-base-1.6.0-h07db88b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libxml2-2.13.9-h4a9ca0c_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libxslt-1.1.43-h429d6fd_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libzip-1.11.2-h1336266_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/matplotlib-base-3.10.9-py311h68bafec_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py311h572238d_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/multidict-6.7.1-py311ha275503_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/mysql-common-9.3.0-hd7719f6_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/mysql-libs-9.3.0-ha8be5b7_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-1.26.4-py311h7125741_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/occt-7.8.1-all_h869bdd7_203.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/openexr-3.4.12-h481d188_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/openh264-2.6.0-hb5b2745_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/openjph-0.28.1-h2a4d681_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/openldap-2.6.10-hbe55e7a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/pango-1.56.4-h875632e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/pcl-1.15.0-hd09b3b3_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/pcre2-10.45-ha881caa_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/pillow-12.2.0-py311hd37aea2_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/pivy-0.6.9-py311qt6ha36b4a8_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/proj-9.5.1-h1318a7e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/propcache-0.5.2-py311hc290fe0_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/pugixml-1.15-hd3d436d_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/pyside6-6.8.3-py311h8511715_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.11.14-hec0b533_1_cpython.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/qt6-main-6.8.3-hc9525f7_4.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/rapidjson-1.1.0.post20240409-ha1acc90_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/sdl2-2.32.56-h248ca61_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/sdl3-3.4.10-h6fa9c73_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/sed-4.10-h5c09db4_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/smesh-9.9.0.0-h10d9485_14.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/soqt6-1.6.3-hd20b56a_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/sqlite-3.53.2-h85ec8f2_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/svt-av1-3.1.2-h12ba402_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/tbb-2022.3.0-h66ce52b_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/unicodedata2-17.0.1-py311hc949640_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/utfcpp-4.09-hce30654_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/vtk-9.3.1-qt_py311he4b582b_216.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/vtk-base-9.3.1-qt_py311hb64ca2f_216.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/vtk-io-ffmpeg-9.3.1-qt_py311he4b582b_216.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
-  - conda: https://prefix.dev/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
-  - conda: https://prefix.dev/conda-forge/osx-arm64/xerces-c-3.3.0-hd62221f_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/yaml-cpp-0.8.0-ha1acc90_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/yarl-1.24.2-py311hc290fe0_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -100,7 +100,6 @@ requirements:
         - cross-python_${{ target_platform }}
 
   host:
-    - coin3d ==4.0.3
     - eigen >=3.3,<5
     - fmt >=12.1,<12.2
     - freetype
@@ -112,7 +111,6 @@ requirements:
     - numpy>=1.26,<2
     - occt>=7.8,<7.9
     - pcl
-    - pivy
     - ply
     - pybind11
     - pyside6
@@ -161,7 +159,6 @@ requirements:
     - opencamlib
     - pandas
     - pip
-    - pivy
     - ply
     - pycollada
     - pyside6

--- a/package/rattler-build/windows/create_bundle.sh
+++ b/package/rattler-build/windows/create_bundle.sh
@@ -133,6 +133,12 @@ if ! "$SIGN_DIR/bin/freecadcmd.exe" --safe-mode --version; then
   exit 1
 fi
 
+echo "Running FreeCAD bundled Pivy smoke test..."
+if ! "$SIGN_DIR/bin/freecadcmd.exe" --safe-mode --console "import pivy; from pivy import coin; print(pivy.__file__); print(coin.SoDB.getVersion())"; then
+  echo "FreeCAD bundled Pivy smoke test failed; the Windows bundle cannot import the bundled Coin/Pivy runtime."
+  exit 1
+fi
+
 7z a -t7z -mx9 -mmt=${NUMBER_OF_PROCESSORS} ${version_name}.7z ${version_name} -bb
 # create hash
 sha256sum ${version_name}.7z > ${version_name}.7z-SHA256.txt


### PR DESCRIPTION
Fixes #31185.

This addresses the bundled Coin/Pivy regression introduced by the switch away from the pixi-provided Coin/Pivy stack.

The first change ports the bundled Coin runtime install control from #31122, disabling Coin's standalone install rules and installing only the bundled Coin runtime with FreeCAD.

The second change removes external coin3d and pivy from the rattler package environment and regenerates the lockfile so release bundles cannot accidentally ship or resolve against the pixi Coin/Pivy libraries. It also hardens the Linux, macOS, and Windows bundle scripts with a packaged-artifact smoke test that imports `from pivy import coin`.

Together these changes should keep `_coin` and the shipped Coin runtime in sync and prevent the runtime mismatch reported in #31185