### PR TITLE
CAM: Job - Stock cylinder

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathStock.py
+++ b/src/Mod/CAM/CAMTests/TestPathStock.py
@@ -88,6 +88,20 @@ class TestPathStock(PathTestBase):
         stock = PathStock.CreateCylinder(self.job, 37, 24)
         self.assertEqual(37, stock.Radius)
         self.assertEqual(24, stock.Height)
+        self.assertEqual("Z", stock.Axis)
+        self.assertCoincide(stock.Shape.Faces[0].Surface.Axis, FreeCAD.Vector(0, 0, 1))
+
+        stock = PathStock.CreateCylinder(self.job, 37, 24, axis="X")
+        self.assertEqual(37, stock.Radius)
+        self.assertEqual(24, stock.Height)
+        self.assertEqual("X", stock.Axis)
+        self.assertCoincide(stock.Shape.Faces[0].Surface.Axis, FreeCAD.Vector(1, 0, 0))
+
+        stock = PathStock.CreateCylinder(self.job, 37, 24, axis="Y")
+        self.assertEqual(37, stock.Radius)
+        self.assertEqual(24, stock.Height)
+        self.assertEqual("Y", stock.Axis)
+        self.assertCoincide(stock.Shape.Faces[0].Surface.Axis, FreeCAD.Vector(0, 1, 0))
 
         placement = FreeCAD.Placement(FreeCAD.Vector(3, 8, -4), FreeCAD.Vector(0, 0, 1), -90)
         stock = PathStock.CreateCylinder(self.job, 1, 88, placement)

--- a/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
@@ -217,23 +217,33 @@
             <widget class="QFrame" name="stockCreateCylinder">
              <layout class="QGridLayout" name="gridLayout_10">
               <item row="0" column="1">
+               <widget class="QLabel" name="stockCylinderAxisLabel">
+                <property name="text">
+                 <string>Axis</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QComboBox" name="stockCylinderAxis"/>
+              </item>
+              <item row="1" column="1">
                <widget class="QLabel" name="stockCylinderRadiusLabel">
                 <property name="text">
                  <string>Radius</string>
                 </property>
                </widget>
               </item>
-              <item row="0" column="2">
+              <item row="1" column="2">
                <widget class="Gui::QuantitySpinBox" name="stockCylinderRadius"/>
               </item>
-              <item row="1" column="1">
+              <item row="2" column="1">
                <widget class="QLabel" name="stockCylinderHeightLabel">
                 <property name="text">
                  <string>Height</string>
                 </property>
                </widget>
               </item>
-              <item row="1" column="2">
+              <item row="2" column="2">
                <widget class="Gui::QuantitySpinBox" name="stockCylinderHeight"/>
               </item>
              </layout>

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -679,7 +679,7 @@ class StockCreateCylinderEdit(StockEdit):
 
     def getFields(self, obj, fields=None):
         if fields is None:
-            fields = ["radius", "height"]
+            fields = ("axis", "radius", "height")
         try:
             if self.IsStock(obj):
                 if "radius" in fields:
@@ -690,6 +690,8 @@ class StockCreateCylinderEdit(StockEdit):
                     obj.Stock.Height = FreeCAD.Units.Quantity(
                         self.form.stockCylinderHeight.property("rawValue"), FreeCAD.Units.Length
                     )
+                if "axis" in fields and hasattr(self.form, "stockCylinderAxis"):
+                    obj.Stock.Axis = str(self.form.stockCylinderAxis.currentData())
             else:
                 Path.Log.error(translate("CAM_Job", "Stock not a cylinder!"))
         except Exception:
@@ -697,15 +699,38 @@ class StockCreateCylinderEdit(StockEdit):
 
     def setFields(self, obj):
         if self.force or not self.IsStock(obj):
-            self.setStock(obj, PathStock.CreateCylinder(obj))
+            self.setStock(obj, PathStock.CreateCylinder(obj, axis=self.axis))
             self.force = False
         self.setLengthField(self.form.stockCylinderRadius, obj.Stock.Radius)
         self.setLengthField(self.form.stockCylinderHeight, obj.Stock.Height)
+        if hasattr(self.form, "stockCylinderAxis"):
+            self.selectComboBoxText(self.form.stockCylinderAxis, obj.Stock.Axis)
 
     def setupUi(self, obj):
+        if hasattr(self.form, "stockCylinderAxis"):
+            self.axis = self.form.stockCylinderAxis.currentData()
+            self.populateCombobox(self.form.stockCylinderAxis, ("X", "Y", "Z"))
+        else:
+            self.axis = "Z"
         self.setFields(obj)
         self.form.stockCylinderRadius.textChanged.connect(lambda: self.getFields(obj, ["radius"]))
         self.form.stockCylinderHeight.textChanged.connect(lambda: self.getFields(obj, ["height"]))
+        if hasattr(self.form, "stockCylinderAxis"):
+            self.form.stockCylinderAxis.currentIndexChanged.connect(
+                lambda: self.getFields(obj, ["axis"])
+            )
+
+    def populateCombobox(self, widget, enumTups):
+        widget.clear()
+        for name in enumTups:
+            widget.addItem(name, name)
+
+    def selectComboBoxText(self, widget, text):
+        newindex = widget.findData(text)
+        if newindex >= 0:
+            widget.blockSignals(True)
+            widget.setCurrentIndex(newindex)
+            widget.blockSignals(False)
 
 
 class StockFromExistingEdit(StockEdit):

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -664,7 +664,7 @@ class StockCreateCylinderEdit(StockEdit):
 
     def getFields(self, obj, fields=None):
         if fields is None:
-            fields = ["radius", "height"]
+            fields = ("axis", "radius", "height")
         try:
             if self.IsStock(obj):
                 if "radius" in fields:
@@ -675,6 +675,8 @@ class StockCreateCylinderEdit(StockEdit):
                     obj.Stock.Height = FreeCAD.Units.Quantity(
                         self.form.stockCylinderHeight.property("rawValue"), FreeCAD.Units.Length
                     )
+                if "axis" in fields:
+                    obj.Stock.Axis = str(self.form.stockCylinderAxis.currentData())
             else:
                 Path.Log.error(translate("CAM_Job", "Stock not a cylinder!"))
         except Exception:
@@ -682,15 +684,33 @@ class StockCreateCylinderEdit(StockEdit):
 
     def setFields(self, obj):
         if self.force or not self.IsStock(obj):
-            self.setStock(obj, PathStock.CreateCylinder(obj))
+            self.setStock(obj, PathStock.CreateCylinder(obj, axis=self.axis))
             self.force = False
         self.setLengthField(self.form.stockCylinderRadius, obj.Stock.Radius)
         self.setLengthField(self.form.stockCylinderHeight, obj.Stock.Height)
+        self.selectComboBoxText(self.form.stockCylinderAxis, obj.Stock.Axis)
 
     def setupUi(self, obj):
+        self.axis = self.form.stockCylinderAxis.currentData()
+        self.populateCombobox(self.form.stockCylinderAxis, ("X", "Y", "Z"))
         self.setFields(obj)
         self.form.stockCylinderRadius.textChanged.connect(lambda: self.getFields(obj, ["radius"]))
         self.form.stockCylinderHeight.textChanged.connect(lambda: self.getFields(obj, ["height"]))
+        self.form.stockCylinderAxis.currentIndexChanged.connect(
+            lambda: self.getFields(obj, ["axis"])
+        )
+
+    def populateCombobox(self, widget, enumTups):
+        widget.clear()
+        for name in enumTups:
+            widget.addItem(name, name)
+
+    def selectComboBoxText(self, widget, text):
+        newindex = widget.findData(text)
+        if newindex >= 0:
+            widget.blockSignals(True)
+            widget.setCurrentIndex(newindex)
+            widget.blockSignals(False)
 
 
 class StockFromExistingEdit(StockEdit):

--- a/src/Mod/CAM/Path/Main/Stock.py
+++ b/src/Mod/CAM/Path/Main/Stock.py
@@ -323,9 +323,17 @@ class StockCreateCylinder(Stock):
             "Stock",
             QT_TRANSLATE_NOOP("App::Property", "Height of this stock cylinder"),
         )
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "Axis",
+            "Stock",
+            QT_TRANSLATE_NOOP("App::Property", "Axis of this stock cylinder"),
+        )
 
         obj.Radius = 2
         obj.Height = 10
+        obj.Axis = ("X", "Y", "Z")
+        obj.Axis = "Z"
 
         obj.Proxy = self
 
@@ -341,13 +349,32 @@ class StockCreateCylinder(Stock):
         if obj.Height < self.MinExtent:
             obj.Height = self.MinExtent
 
-        shape = Part.makeCylinder(obj.Radius, obj.Height)
+        if obj.Axis == "X":  # along X
+            axisVec = FreeCAD.Vector(1, 0, 0)
+        elif obj.Axis == "Y":  # along Y
+            axisVec = FreeCAD.Vector(0, 1, 0)
+        else:  # along Z
+            axisVec = FreeCAD.Vector(0, 0, 1)
+
+        shape = Part.makeCylinder(obj.Radius, obj.Height, FreeCAD.Vector(0, 0, 0), axisVec, 360)
         shape.Placement = obj.Placement
         obj.Shape = shape
 
     def onChanged(self, obj, prop):
-        if prop in ["Radius", "Height"] and "Restore" not in obj.State:
+        if prop in ("Axis", "Radius", "Height") and "Restore" not in obj.State:
             self.execute(obj)
+
+    def onDocumentRestored(self, obj):
+        super().onDocumentRestored(obj)
+        if not hasattr(obj, "Axis"):
+            obj.addProperty(
+                "App::PropertyEnumeration",
+                "Axis",
+                "Stock",
+                QT_TRANSLATE_NOOP("App::Property", "Axis of this stock cylinder"),
+            )
+            obj.Axis = ("X", "Y", "Z")
+            obj.Axis = "Z"
 
 
 def SetupStockObject(obj, stockType):
@@ -449,10 +476,13 @@ def CreateBox(job, extent=None, placement=None):
     return obj
 
 
-def CreateCylinder(job, radius=None, height=None, placement=None):
+def CreateCylinder(job, radius=None, height=None, placement=None, axis=None):
     base = _getBase(job)
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", "Stock")
     obj.Proxy = StockCreateCylinder(obj)
+
+    if axis:
+        obj.Axis = axis
 
     if radius:
         obj.Radius = radius
@@ -461,15 +491,29 @@ def CreateCylinder(job, radius=None, height=None, placement=None):
         obj.Height = height
     elif base:
         bb = shapeBoundBox(base.Group)
-        obj.Radius = math.sqrt(bb.XLength**2 + bb.YLength**2) / 2.0
-        obj.Height = max(bb.ZLength, 1)
+        if axis == "X":  # along X
+            obj.Height = max(bb.XLength, 1)
+            obj.Radius = math.hypot(bb.YLength, bb.ZLength) / 2
+        elif axis == "Y":  # along Y
+            obj.Height = max(bb.YLength, 1)
+            obj.Radius = math.hypot(bb.XLength, bb.ZLength) / 2
+        else:  # along Z
+            obj.Height = max(bb.ZLength, 1)
+            obj.Radius = math.hypot(bb.XLength, bb.YLength) / 2
 
     if placement:
         obj.Placement = placement
     elif base:
         bb = shapeBoundBox(base.Group)
-        origin = FreeCAD.Vector((bb.XMin + bb.XMax) / 2, (bb.YMin + bb.YMax) / 2, bb.ZMin)
-        obj.Placement = FreeCAD.Placement(origin, FreeCAD.Vector(), 0)
+        if axis == "X":  # along X
+            origin = FreeCAD.Vector(bb.XMin, bb.Center.y, bb.Center.z)
+            obj.Placement = FreeCAD.Placement(origin, FreeCAD.Vector(0, 0, 1), 0)
+        elif axis == "Y":  # along Y
+            origin = FreeCAD.Vector(bb.Center.x, bb.YMin, bb.Center.z)
+            obj.Placement = FreeCAD.Placement(origin, FreeCAD.Vector(0, 0, 1), 0)
+        else:  # along Z
+            origin = FreeCAD.Vector(bb.Center.x, bb.Center.y, bb.ZMin)
+            obj.Placement = FreeCAD.Placement(origin, FreeCAD.Vector(0, 0, 1), 0)
 
     SetupStockObject(obj, StockType.CreateCylinder)
     return obj

--- a/src/Mod/CAM/Path/Main/Stock.py
+++ b/src/Mod/CAM/Path/Main/Stock.py
@@ -299,9 +299,17 @@ class StockCreateCylinder(Stock):
             "Stock",
             QT_TRANSLATE_NOOP("App::Property", "Height of this stock cylinder"),
         )
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "Axis",
+            "Stock",
+            QT_TRANSLATE_NOOP("App::Property", "Axis of this stock cylinder"),
+        )
 
         obj.Radius = 2
         obj.Height = 10
+        obj.Axis = ("X", "Y", "Z")
+        obj.Axis = "Z"
 
         obj.Proxy = self
 
@@ -317,13 +325,29 @@ class StockCreateCylinder(Stock):
         if obj.Height < self.MinExtent:
             obj.Height = self.MinExtent
 
-        shape = Part.makeCylinder(obj.Radius, obj.Height)
+        if obj.Axis == "X":  # along X
+            axisVec = FreeCAD.Vector(1, 0, 0)
+        elif obj.Axis == "Y":  # along Y
+            axisVec = FreeCAD.Vector(0, 1, 0)
+        else:  # along Z
+            axisVec = FreeCAD.Vector(0, 0, 1)
+
+        shape = Part.makeCylinder(obj.Radius, obj.Height, FreeCAD.Vector(0, 0, 0), axisVec, 360)
         shape.Placement = obj.Placement
         obj.Shape = shape
 
     def onChanged(self, obj, prop):
-        if prop in ["Radius", "Height"] and "Restore" not in obj.State:
+        if prop in ("Axis", "Radius", "Height") and "Restore" not in obj.State:
             self.execute(obj)
+
+    def onDocumentRestored(self, obj):
+        if not hasattr(obj, "Axis"):
+            obj.addProperty(
+                "App::PropertyEnumeration",
+                "Axis",
+                "Stock",
+                QT_TRANSLATE_NOOP("App::Property", "Axis of this stock cylinder"),
+            )
 
 
 def SetupStockObject(obj, stockType):
@@ -419,10 +443,13 @@ def CreateBox(job, extent=None, placement=None):
     return obj
 
 
-def CreateCylinder(job, radius=None, height=None, placement=None):
+def CreateCylinder(job, radius=None, height=None, placement=None, axis=None):
     base = _getBase(job)
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", "Stock")
     obj.Proxy = StockCreateCylinder(obj)
+
+    if axis:
+        obj.Axis = axis
 
     if radius:
         obj.Radius = radius
@@ -431,15 +458,29 @@ def CreateCylinder(job, radius=None, height=None, placement=None):
         obj.Height = height
     elif base:
         bb = shapeBoundBox(base.Group)
-        obj.Radius = math.sqrt(bb.XLength**2 + bb.YLength**2) / 2.0
-        obj.Height = max(bb.ZLength, 1)
+        if axis == "X":  # along X
+            obj.Height = max(bb.XLength, 1)
+            obj.Radius = math.hypot(bb.YLength, bb.ZLength) / 2
+        elif axis == "Y":  # along Y
+            obj.Height = max(bb.YLength, 1)
+            obj.Radius = math.hypot(bb.XLength, bb.ZLength) / 2
+        else:  # along Z
+            obj.Height = max(bb.ZLength, 1)
+            obj.Radius = math.hypot(bb.XLength, bb.YLength) / 2
 
     if placement:
         obj.Placement = placement
     elif base:
         bb = shapeBoundBox(base.Group)
-        origin = FreeCAD.Vector((bb.XMin + bb.XMax) / 2, (bb.YMin + bb.YMax) / 2, bb.ZMin)
-        obj.Placement = FreeCAD.Placement(origin, FreeCAD.Vector(), 0)
+        if axis == "X":  # along X
+            origin = FreeCAD.Vector(bb.XMin, bb.Center.y, bb.Center.z)
+            obj.Placement = FreeCAD.Placement(origin, FreeCAD.Vector(0, 0, 1), 0)
+        elif axis == "Y":  # along Y
+            origin = FreeCAD.Vector(bb.Center.x, bb.YMin, bb.Center.z)
+            obj.Placement = FreeCAD.Placement(origin, FreeCAD.Vector(0, 0, 1), 0)
+        else:  # along Z
+            origin = FreeCAD.Vector(bb.Center.x, bb.Center.y, bb.ZMin)
+            obj.Placement = FreeCAD.Placement(origin, FreeCAD.Vector(0, 0, 1), 0)
 
     SetupStockObject(obj, StockType.CreateCylinder)
     return obj


### PR DESCRIPTION
Forum: [Can't align/size stock with model](https://forum.freecad.org/viewtopic.php?t=106310)

Automatically define axis of cylinder stock is not trivial
Instead of use only Z default axis, suggested give user opportunity to select axis manually

Test project: [rod.zip](https://github.com/user-attachments/files/31016250/rod.zip)

<img width="928" height="328" alt="Screenshot_20260805_124728_lossy" src="https://github.com/user-attachments/assets/38694d3f-6176-4d8b-bcdf-8db529b2de98" />

https://github.com/user-attachments/assets/ad492ccd-1025-407c-b230-be3a2b1f21db