### PR TITLE
Consolidate FCBak files into subdirectory

### DIFF
--- a/src/App/BackupPolicy.cpp
+++ b/src/App/BackupPolicy.cpp
@@ -23,6 +23,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/regex.hpp>
+#include <filesystem>
 #include <string>
 
 #include <Base/TimeInfo.h>
@@ -71,8 +72,9 @@ void BackupPolicy::applyStandard(const std::string& sourcename, const std::strin
     if (Base::FileInfo fi(targetname); fi.exists()) {
         if (numberOfFiles > 0) {
             int nSuff = 0;
+            std::string backupDirPath = ensureBackupDirectory(fi);
             std::string fn = fi.fileName();
-            Base::FileInfo di(fi.dirPath());
+            Base::FileInfo di(backupDirPath);
             std::vector<Base::FileInfo> backup;
             std::vector<Base::FileInfo> files = di.getDirectoryContent();
             for (const Base::FileInfo& it : files) {
@@ -106,7 +108,7 @@ void BackupPolicy::applyStandard(const std::string& sourcename, const std::strin
             else {
                 // create a new backup file
                 std::stringstream str;
-                str << fi.filePath() << (nSuff + 1);
+                str << getBackupFilePath(backupDirPath, fi.fileName()) << (nSuff + 1);
                 fn = str.str();
             }
 
@@ -133,13 +135,25 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
     std::string ext = fi.extension();
     std::string bn;   // full path with no extension but with "."
     std::string pbn;  // base name of the project + "."
+    std::string backupDirPath;
     if (!ext.empty()) {
-        bn = fi.filePath().substr(0, fi.filePath().length() - ext.length());
+        bn = fi.fileName().substr(0, fi.fileName().length() - ext.length());
         pbn = fi.fileName().substr(0, fi.fileName().length() - ext.length());
     }
     else {
-        bn = fi.filePath() + ".";
+        bn = fi.fileName() + ".";
         pbn = fi.fileName() + ".";
+    }
+
+    if (fi.exists() && numberOfFiles > 0) {
+        backupDirPath = ensureBackupDirectory(fi);
+        bn = getBackupFilePath(backupDirPath, bn);
+    }
+    else if (!ext.empty()) {
+        bn = fi.filePath().substr(0, fi.filePath().length() - ext.length());
+    }
+    else {
+        bn = fi.filePath() + ".";
     }
 
     bool backupManagementError = false;  // Note error and report at the end
@@ -150,7 +164,7 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
             {
                 // Remove all extra backups
                 std::string filename = fi.fileName();
-                Base::FileInfo di(fi.dirPath());
+                Base::FileInfo di(backupDirPath);
                 std::vector<Base::FileInfo> backup;
                 std::vector<Base::FileInfo> files = di.getDirectoryContent();
                 for (const Base::FileInfo& it : files) {
@@ -372,4 +386,34 @@ bool BackupPolicy::renameFileNoErase(Base::FileInfo fi, const std::string& newNa
         return fi.renameFile(newName.c_str());
     }
     return false;
+}
+
+std::string BackupPolicy::getBackupDirectoryPath(const Base::FileInfo& target)
+{
+    auto backupDir = Base::FileInfo::stringToPath(target.dirPath()) / "freecad-backups";
+    return Base::FileInfo::pathToString(backupDir);
+}
+
+std::string BackupPolicy::getBackupFilePath(const std::string& backupDir,
+                                            const std::string& fileName)
+{
+    auto backupPath = Base::FileInfo::stringToPath(backupDir) / fileName;
+    return Base::FileInfo::pathToString(backupPath);
+}
+
+std::string BackupPolicy::ensureBackupDirectory(const Base::FileInfo& target)
+{
+    std::string backupDirPath = getBackupDirectoryPath(target);
+    Base::FileInfo backupDir(backupDirPath);
+
+    if (backupDir.exists()) {
+        if (!backupDir.isDir()) {
+            throw Base::FileException("Backup path is not a directory", backupDir);
+        }
+    }
+    else if (!backupDir.createDirectories()) {
+        throw Base::FileException("Cannot create backup directory", backupDir);
+    }
+
+    return backupDirPath;
 }

--- a/src/App/BackupPolicy.cpp
+++ b/src/App/BackupPolicy.cpp
@@ -55,6 +55,18 @@ void BackupPolicy::setDateFormat(const std::string& fmt)
 }
 void BackupPolicy::apply(const std::string& sourcename, const std::string& targetname)
 {
+    if (numberOfFiles <= 0) {
+        if (Base::FileInfo fi(targetname); fi.exists()) {
+            fi.deleteFile();
+        }
+
+        if (Base::FileInfo tmp(sourcename); !tmp.renameFile(targetname.c_str())) {
+            throw Base::FileException("Cannot rename tmp save file to project file",
+                                      Base::FileInfo(targetname));
+        }
+        return;
+    }
+
     switch (policy) {
         case Standard:
             applyStandard(sourcename, targetname);
@@ -69,71 +81,66 @@ void BackupPolicy::applyStandard(const std::string& sourcename, const std::strin
 {
     // if saving the project data succeeded rename to the actual file name
     if (Base::FileInfo fi(targetname); fi.exists()) {
-        if (numberOfFiles > 0) {
-            bool backupManagementError = false;
-            try {
-                int nSuff = 0;
-                std::string backupDirPath = ensureBackupDirectory(fi);
-                std::string fn = fi.fileName();
-                Base::FileInfo di(backupDirPath);
-                std::vector<Base::FileInfo> backup;
-                std::vector<Base::FileInfo> files = di.getDirectoryContent();
-                for (const Base::FileInfo& it : files) {
-                    if (std::string file = it.fileName(); file.substr(0, fn.length()) == fn) {
-                        // starts with the same file name
-                        std::string suf(file.substr(fn.length()));
-                        if (!suf.empty()) {
-                            std::string::size_type nPos = suf.find_first_not_of("0123456789");
-                            if (nPos == std::string::npos) {
-                                // store all backup files
-                                backup.push_back(it);
-                                nSuff =
-                                    std::max<int>(nSuff, static_cast<int>(std::atol(suf.c_str())));
-                            }
+        bool backupManagementError = false;
+        try {
+            int nSuff = 0;
+            std::string backupDirPath = ensureBackupDirectory(fi);
+            std::string fn = fi.fileName();
+            Base::FileInfo di(backupDirPath);
+            std::vector<Base::FileInfo> backup;
+            std::vector<Base::FileInfo> files = di.getDirectoryContent();
+            for (const Base::FileInfo& it : files) {
+                if (std::string file = it.fileName(); file.substr(0, fn.length()) == fn) {
+                    // starts with the same file name
+                    std::string suf(file.substr(fn.length()));
+                    if (!suf.empty()) {
+                        std::string::size_type nPos = suf.find_first_not_of("0123456789");
+                        if (nPos == std::string::npos) {
+                            // store all backup files
+                            backup.push_back(it);
+                            nSuff =
+                                std::max<int>(nSuff, static_cast<int>(std::atol(suf.c_str())));
                         }
                     }
-                }
-
-                if (!backup.empty() && static_cast<int>(backup.size()) >= numberOfFiles) {
-                    // delete the oldest backup file we found
-                    Base::FileInfo del = backup.front();
-                    for (const Base::FileInfo& it : backup) {
-                        if (it.lastModified() < del.lastModified()) {
-                            del = it;
-                        }
-                    }
-
-                    del.deleteFile();
-                    fn = del.filePath();
-                }
-                else {
-                    // create a new backup file
-                    std::stringstream str;
-                    str << getBackupFilePath(backupDirPath, fi.fileName()) << (nSuff + 1);
-                    fn = str.str();
-                }
-
-                if (!fi.renameFile(fn.c_str())) {
-                    backupManagementError = true;
-                    Base::Console().warning("Cannot rename project file to backup file\n");
                 }
             }
-            catch (...) {
+
+            if (!backup.empty() && static_cast<int>(backup.size()) >= numberOfFiles) {
+                // delete the oldest backup file we found
+                Base::FileInfo del = backup.front();
+                for (const Base::FileInfo& it : backup) {
+                    if (it.lastModified() < del.lastModified()) {
+                        del = it;
+                    }
+                }
+
+                del.deleteFile();
+                fn = del.filePath();
+            }
+            else {
+                // create a new backup file
+                std::stringstream str;
+                str << getBackupFilePath(backupDirPath, fi.fileName()) << (nSuff + 1);
+                fn = str.str();
+            }
+
+            if (!fi.renameFile(fn.c_str())) {
                 backupManagementError = true;
-                Base::Console().warning("Cannot manage backup file history\n");
-            }
-
-            if (backupManagementError && fi.exists()) {
-                try {
-                    fi.deleteFile();
-                }
-                catch (...) {
-                    Base::Console().warning("Cannot remove existing project file before save\n");
-                }
+                Base::Console().warning("Cannot rename project file to backup file\n");
             }
         }
-        else {
-            fi.deleteFile();
+        catch (...) {
+            backupManagementError = true;
+            Base::Console().warning("Cannot manage backup file history\n");
+        }
+
+        if (backupManagementError && fi.exists()) {
+            try {
+                fi.deleteFile();
+            }
+            catch (...) {
+                Base::Console().warning("Cannot remove existing project file before save\n");
+            }
         }
     }
 
@@ -153,6 +160,7 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
     std::string bn;   // full path with no extension but with "."
     std::string pbn;  // base name of the project + "."
     std::string backupDirPath;
+    
     if (!ext.empty()) {
         bn = fi.fileName().substr(0, fi.fileName().length() - ext.length());
         pbn = fi.fileName().substr(0, fi.fileName().length() - ext.length());
@@ -162,7 +170,7 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
         pbn = fi.fileName() + ".";
     }
 
-    if (fi.exists() && numberOfFiles > 0) {
+    if (fi.exists()) {
         try {
             backupDirPath = ensureBackupDirectory(fi);
         }
@@ -172,19 +180,12 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
         }
         bn = getBackupFilePath(backupDirPath, bn);
     }
-    else if (!ext.empty()) {
-        bn = fi.filePath().substr(0, fi.filePath().length() - ext.length());
-    }
-    else {
-        bn = fi.filePath() + ".";
-    }
 
     if (fi.exists()) {
-        if (numberOfFiles > 0) {
-            try {
-                // replace . by - in format to avoid . between base name and extension
-                boost::replace_all(saveBackupDateFormat, ".", "-");
-                {
+        try {
+            // replace . by - in format to avoid . between base name and extension
+            boost::replace_all(saveBackupDateFormat, ".", "-");
+            {
                 // Remove all extra backups
                 std::string filename = fi.fileName();
                 Base::FileInfo di(backupDirPath);
@@ -207,7 +208,7 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
                         if ((startsWith(file, filename) && (file.length() > filename.length())
                              && checkDigits(file.substr(filename.length())))
                             ||
-                            // .FCBak case : The bame starts with the base name of the project +
+                            // .FCBak case : The name starts with the base name of the project +
                             // "."
                             // + complement with no "." + ".FCBak"
                             ((fextUp == "FCBAK") && startsWith(file, pbn)
@@ -240,10 +241,10 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
                         }
                     }
                 }
-                }  // end remove backup
+            }  // end remove backup
 
-                // create a new backup file
-                {
+            // create a new backup file
+            {
                 int ext2 = 1;
                 if (useFCBakExtension) {
                     std::stringstream str;
@@ -344,22 +345,11 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
                     // throw Base::FileException("File not saved: Cannot rename project file to
                     // backup file", fi);
                 }
-                }
-            }
-            catch (...) {
-                backupManagementError = true;
-                Base::Console().warning("Cannot manage backup file history\n");
             }
         }
-        else {
-            try {
-                fi.deleteFile();
-            }
-            catch (...) {
-                Base::Console().warning("Cannot remove backup file: %s\n",
-                                        fi.fileName().c_str());
-                backupManagementError = true;
-            }
+        catch (...) {
+            backupManagementError = true;
+            Base::Console().warning("Cannot manage backup file history\n");
         }
     }
 

--- a/src/App/BackupPolicy.cpp
+++ b/src/App/BackupPolicy.cpp
@@ -23,7 +23,6 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/regex.hpp>
-#include <filesystem>
 #include <string>
 
 #include <Base/TimeInfo.h>
@@ -299,12 +298,15 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
                     }
                 }
                 else {
+                    const std::string backupBasePath =
+                        getBackupFilePath(backupDirPath, fi.fileName());
+
                     // changed but simpler and solves also the delay sometimes introduced by
                     // google drive
                     while (ext2 < numberOfFiles + 10) {
                         // linux just replace the file if exists, and then the existence is to
                         // be tested before rename
-                        if (renameFileNoErase(fi, fi.filePath() + std::to_string(ext2))) {
+                        if (renameFileNoErase(fi, backupBasePath + std::to_string(ext2))) {
                             break;
                         }
                         ext2++;

--- a/src/App/BackupPolicy.cpp
+++ b/src/App/BackupPolicy.cpp
@@ -70,49 +70,66 @@ void BackupPolicy::applyStandard(const std::string& sourcename, const std::strin
     // if saving the project data succeeded rename to the actual file name
     if (Base::FileInfo fi(targetname); fi.exists()) {
         if (numberOfFiles > 0) {
-            int nSuff = 0;
-            std::string backupDirPath = ensureBackupDirectory(fi);
-            std::string fn = fi.fileName();
-            Base::FileInfo di(backupDirPath);
-            std::vector<Base::FileInfo> backup;
-            std::vector<Base::FileInfo> files = di.getDirectoryContent();
-            for (const Base::FileInfo& it : files) {
-                if (std::string file = it.fileName(); file.substr(0, fn.length()) == fn) {
-                    // starts with the same file name
-                    std::string suf(file.substr(fn.length()));
-                    if (!suf.empty()) {
-                        std::string::size_type nPos = suf.find_first_not_of("0123456789");
-                        if (nPos == std::string::npos) {
-                            // store all backup files
-                            backup.push_back(it);
-                            nSuff =
-                                std::max<int>(nSuff, static_cast<int>(std::atol(suf.c_str())));
+            bool backupManagementError = false;
+            try {
+                int nSuff = 0;
+                std::string backupDirPath = ensureBackupDirectory(fi);
+                std::string fn = fi.fileName();
+                Base::FileInfo di(backupDirPath);
+                std::vector<Base::FileInfo> backup;
+                std::vector<Base::FileInfo> files = di.getDirectoryContent();
+                for (const Base::FileInfo& it : files) {
+                    if (std::string file = it.fileName(); file.substr(0, fn.length()) == fn) {
+                        // starts with the same file name
+                        std::string suf(file.substr(fn.length()));
+                        if (!suf.empty()) {
+                            std::string::size_type nPos = suf.find_first_not_of("0123456789");
+                            if (nPos == std::string::npos) {
+                                // store all backup files
+                                backup.push_back(it);
+                                nSuff =
+                                    std::max<int>(nSuff, static_cast<int>(std::atol(suf.c_str())));
+                            }
                         }
                     }
                 }
-            }
 
-            if (!backup.empty() && static_cast<int>(backup.size()) >= numberOfFiles) {
-                // delete the oldest backup file we found
-                Base::FileInfo del = backup.front();
-                for (const Base::FileInfo& it : backup) {
-                    if (it.lastModified() < del.lastModified()) {
-                        del = it;
+                if (!backup.empty() && static_cast<int>(backup.size()) >= numberOfFiles) {
+                    // delete the oldest backup file we found
+                    Base::FileInfo del = backup.front();
+                    for (const Base::FileInfo& it : backup) {
+                        if (it.lastModified() < del.lastModified()) {
+                            del = it;
+                        }
                     }
+
+                    del.deleteFile();
+                    fn = del.filePath();
+                }
+                else {
+                    // create a new backup file
+                    std::stringstream str;
+                    str << getBackupFilePath(backupDirPath, fi.fileName()) << (nSuff + 1);
+                    fn = str.str();
                 }
 
-                del.deleteFile();
-                fn = del.filePath();
+                if (!fi.renameFile(fn.c_str())) {
+                    backupManagementError = true;
+                    Base::Console().warning("Cannot rename project file to backup file\n");
+                }
             }
-            else {
-                // create a new backup file
-                std::stringstream str;
-                str << getBackupFilePath(backupDirPath, fi.fileName()) << (nSuff + 1);
-                fn = str.str();
+            catch (...) {
+                backupManagementError = true;
+                Base::Console().warning("Cannot manage backup file history\n");
             }
 
-            if (!fi.renameFile(fn.c_str())) {
-                Base::Console().warning("Cannot rename project file to backup file\n");
+            if (backupManagementError && fi.exists()) {
+                try {
+                    fi.deleteFile();
+                }
+                catch (...) {
+                    Base::Console().warning("Cannot remove existing project file before save\n");
+                }
             }
         }
         else {
@@ -129,6 +146,7 @@ void BackupPolicy::applyStandard(const std::string& sourcename, const std::strin
 void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::string& targetname)
 {
     Base::FileInfo fi(targetname);
+    bool backupManagementError = false;  // Note error and report at the end
 
     std::string fn = sourcename;
     std::string ext = fi.extension();
@@ -145,7 +163,13 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
     }
 
     if (fi.exists() && numberOfFiles > 0) {
-        backupDirPath = ensureBackupDirectory(fi);
+        try {
+            backupDirPath = ensureBackupDirectory(fi);
+        }
+        catch (...) {
+            backupManagementError = true;
+            backupDirPath = fi.dirPath();
+        }
         bn = getBackupFilePath(backupDirPath, bn);
     }
     else if (!ext.empty()) {
@@ -155,12 +179,12 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
         bn = fi.filePath() + ".";
     }
 
-    bool backupManagementError = false;  // Note error and report at the end
     if (fi.exists()) {
         if (numberOfFiles > 0) {
-            // replace . by - in format to avoid . between base name and extension
-            boost::replace_all(saveBackupDateFormat, ".", "-");
-            {
+            try {
+                // replace . by - in format to avoid . between base name and extension
+                boost::replace_all(saveBackupDateFormat, ".", "-");
+                {
                 // Remove all extra backups
                 std::string filename = fi.fileName();
                 Base::FileInfo di(backupDirPath);
@@ -216,10 +240,10 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
                         }
                     }
                 }
-            }  // end remove backup
+                }  // end remove backup
 
-            // create a new backup file
-            {
+                // create a new backup file
+                {
                 int ext2 = 1;
                 if (useFCBakExtension) {
                     std::stringstream str;
@@ -314,11 +338,17 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
                 }
 
                 if (ext2 >= numberOfFiles + 10) {
+                    backupManagementError = true;
                     Base::Console().error(
                         "File not saved: Cannot rename project file to backup file\n");
                     // throw Base::FileException("File not saved: Cannot rename project file to
                     // backup file", fi);
                 }
+                }
+            }
+            catch (...) {
+                backupManagementError = true;
+                Base::Console().warning("Cannot manage backup file history\n");
             }
         }
         else {
@@ -333,6 +363,15 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
         }
     }
 
+    if (backupManagementError && fi.exists()) {
+        try {
+            fi.deleteFile();
+        }
+        catch (...) {
+            Base::Console().warning("Cannot remove existing project file before save\n");
+        }
+    }
+
     Base::FileInfo tmp(sourcename);
     if (!tmp.renameFile(targetname.c_str())) {
         throw Base::FileException(
@@ -341,9 +380,8 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
     }
 
     if (backupManagementError) {
-        throw Base::FileException(
-            "Warning: Save complete, but error while managing backup history.",
-            fi);
+        Base::Console().warning(
+            "Save complete, but error while managing backup history.\n");
     }
 }
 
@@ -382,10 +420,16 @@ bool BackupPolicy::checkDigits(const std::string& cmpl) const
 
 bool BackupPolicy::renameFileNoErase(Base::FileInfo fi, const std::string& newName)
 {
-    // linux just replaces the file if it exists, so the existence is to be tested before rename
-    const Base::FileInfo nf(newName);
-    if (!nf.exists()) {
-        return fi.renameFile(newName.c_str());
+    // Linux can replace existing files on rename, so we check target existence first.
+    // Permission errors while probing backup paths must not abort project save.
+    try {
+        const Base::FileInfo nf(newName);
+        if (!nf.exists()) {
+            return fi.renameFile(newName.c_str());
+        }
+    }
+    catch (...) {
+        return false;
     }
     return false;
 }

--- a/src/App/BackupPolicy.h
+++ b/src/App/BackupPolicy.h
@@ -57,6 +57,9 @@ private:
                               const std::string& ext) const;
     bool checkDigits(const std::string& cmpl) const;
     bool renameFileNoErase(Base::FileInfo fi, const std::string& newName);
+    static std::string getBackupDirectoryPath(const Base::FileInfo& target);
+    static std::string getBackupFilePath(const std::string& backupDir, const std::string& fileName);
+    static std::string ensureBackupDirectory(const Base::FileInfo& target);
 
 private:
     Policy policy {Standard};

--- a/tests/src/App/BackupPolicy.cpp
+++ b/tests/src/App/BackupPolicy.cpp
@@ -72,8 +72,8 @@ protected:
     std::filesystem::path createTempFile(const std::string& filename)
     {
         std::filesystem::path p = _tempDir.path() / filename;
-        std::ofstream fileStream(p.string());
-        fileStream << "Test data";
+        std::ofstream fileStream(p.string()); 
+       fileStream << "Test data";
         fileStream.close();
         return p;
     }
@@ -149,12 +149,13 @@ TEST_F(BackupPolicyTest, StandardWithOneFileNoPreviousBackups)
     setPolicyTerms(App::BackupPolicy::Policy::Standard, 1, false, "%Y-%m-%d_%H-%M-%S");
     auto source = createTempFile("source.fcstd");
     auto target = createTempFile("target.fcstd");
+    auto backupDir = target.parent_path() / "freecad-backups";
 
     // Act
     apply(source.string(), target.string());
 
     // Assert
-    EXPECT_TRUE(std::filesystem::exists(target.string() + "1"));
+    EXPECT_TRUE(std::filesystem::exists(backupDir / (target.filename().string() + "1")));
 }
 
 TEST_F(BackupPolicyTest, StandardWithOneFileOnePreviousBackup)
@@ -162,15 +163,18 @@ TEST_F(BackupPolicyTest, StandardWithOneFileOnePreviousBackup)
     // Arrange
     setPolicyTerms(App::BackupPolicy::Policy::Standard, 1, false, "%Y-%m-%d_%H-%M-%S");
     auto source = createTempFile("source.fcstd");
+    auto backupDir = source.parent_path() / "freecad-backups";
+    std::filesystem::create_directories(backupDir);
+
     auto target = createTempFile("target.fcstd");
-    auto backup = createTempFile("target.fcstd1");
+    auto backup = createTempFile(backupDir / "target.fcstd1");
 
     // Act
     apply(source.string(), target.string());
 
     // Assert
-    EXPECT_TRUE(std::filesystem::exists(backup));
-    EXPECT_FALSE(std::filesystem::exists(target.string() + "2"));
+    EXPECT_TRUE(std::filesystem::exists(backupDir / backup.filename()));
+    EXPECT_FALSE(std::filesystem::exists(backupDir / (target.filename().string() + "2")));
 }
 
 TEST_F(BackupPolicyTest, StandardWithTwoFilesOnePreviousBackup)
@@ -178,15 +182,18 @@ TEST_F(BackupPolicyTest, StandardWithTwoFilesOnePreviousBackup)
     // Arrange
     setPolicyTerms(App::BackupPolicy::Policy::Standard, 2, false, "%Y-%m-%d_%H-%M-%S");
     auto source = createTempFile("source.fcstd");
+    auto backupDir = source.parent_path() / "freecad-backups";
+    std::filesystem::create_directories(backupDir);
+
     auto target = createTempFile("target.fcstd");
-    auto backup = createTempFile("target.fcstd1");
+    auto backup = createTempFile(backupDir / "target.fcstd1");
 
     // Act
     apply(source.string(), target.string());
 
     // Assert
-    EXPECT_TRUE(std::filesystem::exists(backup));
-    EXPECT_TRUE(std::filesystem::exists(target.string() + "2"));
+    EXPECT_TRUE(std::filesystem::exists(backupDir / backup.filename()));
+    EXPECT_TRUE(std::filesystem::exists(backupDir / (target.filename().string() + "2")));
 }
 
 TEST_F(BackupPolicyTest, StandardWithTwoFilesOnePreviousBackupUnexpectedSuffix)
@@ -194,17 +201,20 @@ TEST_F(BackupPolicyTest, StandardWithTwoFilesOnePreviousBackupUnexpectedSuffix)
     // Arrange
     setPolicyTerms(App::BackupPolicy::Policy::Standard, 2, false, "%Y-%m-%d_%H-%M-%S");
     auto source = createTempFile("source.fcstd");
+    auto backupDir = source.parent_path() / "freecad-backups";
+    std::filesystem::create_directories(backupDir);
+    
     auto target = createTempFile("target.fcstd");
-    auto backup = createTempFile("target.fcstd1");
-    auto weird = createTempFile("target.fcstd2a");
+    auto backup = createTempFile(backupDir / "target.fcstd1");
+    auto weird = createTempFile(backupDir / "target.fcstd2a");
 
     // Act
     apply(source.string(), target.string());
 
     // Assert
     EXPECT_TRUE(std::filesystem::exists(backup));
-    EXPECT_TRUE(std::filesystem::exists(target.string() + "2"));
-    EXPECT_TRUE(std::filesystem::exists(weird));
+    EXPECT_TRUE(std::filesystem::exists(backupDir / (backup.filename().string() + "2")));
+    EXPECT_TRUE(std::filesystem::exists(backupDir / weird.filename())); // What is this doing if not testing the test?
 }
 
 TEST_F(BackupPolicyTest, StandardWithTwoFilesOnePreviousBackupOutOfSequenceNumber)
@@ -212,17 +222,20 @@ TEST_F(BackupPolicyTest, StandardWithTwoFilesOnePreviousBackupOutOfSequenceNumbe
     // Arrange
     setPolicyTerms(App::BackupPolicy::Policy::Standard, 2, false, "%Y-%m-%d_%H-%M-%S");
     auto source = createTempFile("source.fcstd");
+    auto backupDir = source.parent_path() / "freecad-backups";
+    std::filesystem::create_directories(backupDir);
+
     auto target = createTempFile("target.fcstd");
-    auto backup = createTempFile("target.fcstd1");
-    auto weird = createTempFile("target.fcstd999");
+    auto backup = createTempFile(backupDir / "target.fcstd1");
+    auto weird = createTempFile(backupDir / "target.fcstd999");
 
     // Act
     apply(source.string(), target.string());
 
     // Assert
     EXPECT_TRUE(std::filesystem::exists(backup));
-    bool check1 = std::filesystem::exists(target.string() + "2");
-    bool check2 = std::filesystem::exists(weird);
+    bool check1 = std::filesystem::exists(backupDir / (target.filename().string() + "2"));
+    bool check2 = std::filesystem::exists(backupDir / weird.filename()); 
     EXPECT_NE(check1, check2);  // Only one or the other can exist (we don't know which because it
                                 // depends on file modification date)
 }
@@ -240,7 +253,7 @@ TEST_F(BackupPolicyTest, StandardWithFCBakSet)
     // Assert
     EXPECT_TRUE(std::filesystem::exists(target.string() + "1"));  // No FCBak extension for Standard
 }
-
+ 
 TEST_F(BackupPolicyTest, TimestampSourceDoesNotExist)
 {
     // Arrange

--- a/tests/src/App/BackupPolicy.cpp
+++ b/tests/src/App/BackupPolicy.cpp
@@ -72,8 +72,8 @@ protected:
     std::filesystem::path createTempFile(const std::string& filename)
     {
         std::filesystem::path p = _tempDir.path() / filename;
-        std::ofstream fileStream(p.string()); 
-       fileStream << "Test data";
+        std::ofstream fileStream(p.string());
+        fileStream << "Test data";
         fileStream.close();
         return p;
     }
@@ -203,7 +203,7 @@ TEST_F(BackupPolicyTest, StandardWithTwoFilesOnePreviousBackupUnexpectedSuffix)
     auto source = createTempFile("source.fcstd");
     auto backupDir = source.parent_path() / "freecad-backups";
     std::filesystem::create_directories(backupDir);
-    
+
     auto target = createTempFile("target.fcstd");
     auto backup = createTempFile(backupDir / "target.fcstd1");
     auto weird = createTempFile(backupDir / "target.fcstd2a");
@@ -214,7 +214,8 @@ TEST_F(BackupPolicyTest, StandardWithTwoFilesOnePreviousBackupUnexpectedSuffix)
     // Assert
     EXPECT_TRUE(std::filesystem::exists(backup));
     EXPECT_TRUE(std::filesystem::exists(backupDir / (backup.filename().string() + "2")));
-    EXPECT_TRUE(std::filesystem::exists(backupDir / weird.filename())); // What is this doing if not testing the test?
+    EXPECT_TRUE(std::filesystem::exists(backupDir / weird.filename()));  // What is this doing if
+                                                                         // not testing the test?
 }
 
 TEST_F(BackupPolicyTest, StandardWithTwoFilesOnePreviousBackupOutOfSequenceNumber)
@@ -235,7 +236,7 @@ TEST_F(BackupPolicyTest, StandardWithTwoFilesOnePreviousBackupOutOfSequenceNumbe
     // Assert
     EXPECT_TRUE(std::filesystem::exists(backup));
     bool check1 = std::filesystem::exists(backupDir / (target.filename().string() + "2"));
-    bool check2 = std::filesystem::exists(backupDir / weird.filename()); 
+    bool check2 = std::filesystem::exists(backupDir / weird.filename());
     EXPECT_NE(check1, check2);  // Only one or the other can exist (we don't know which because it
                                 // depends on file modification date)
 }
@@ -253,7 +254,7 @@ TEST_F(BackupPolicyTest, StandardWithFCBakSet)
     // Assert
     EXPECT_TRUE(std::filesystem::exists(target.string() + "1"));  // No FCBak extension for Standard
 }
- 
+
 TEST_F(BackupPolicyTest, TimestampSourceDoesNotExist)
 {
     // Arrange


### PR DESCRIPTION
This change causes backup files (FCBak and FCStd#) to be saved beside the active project in a subdirectory named freecad-backups.

Even for a small project, backup files can quickly create clutter in the file manager, making it difficult to stay organized. In solving this, I have taken the approach of option #1 from this discussion (https://forum.freecad.org/viewtopic.php?p=852180#p852180), which is to mimic the behavior of KiCAD. It provides a cleaner workspace than the current approach and the most intuitive location of backup files.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by [Claude] ([Sonnet 4.6])

## Before and After Images
These are on two different computers, so slightly different, but you get the idea.
Before:
<img width="1208" height="865" alt="FCBak_clutter" src="https://github.com/user-attachments/assets/ccfbce76-ff91-4d99-b4c7-081b7c23b2e0" />

After:
<img width="857" height="635" alt="backup_consolidation_after" src="https://github.com/user-attachments/assets/c9d4d7d0-b5a3-4045-ab93-4fa9c34fc59b" />



## Still Needed
I have tested this on Linux but need others to test it on Windows and Mac. Please test to make sure that even if write access is lost to freecad-backups/ the original project file will still be saved.

