### PR TITLE
[Gui]: Strip rich-text formatting from search results in preferences

### DIFF
--- a/src/Gui/Dialogs/DlgPreferencesImp.cpp
+++ b/src/Gui/Dialogs/DlgPreferencesImp.cpp
@@ -49,6 +49,7 @@
 #include <QTimer>
 #include <QToolButton>
 #include <QToolTip>
+#include <QTextDocument>
 #include <QProcess>
 #include <QPushButton>
 #include <QWindow>
@@ -1642,21 +1643,21 @@ void PreferencesSearchController::searchWidgetType(
     for (WidgetType* widget : widgets) {
         QString widgetText;
 
-        // Get text based on widget type
+        // Get text based on widget type and strip any rich text formatting
         if constexpr (std::is_same_v<WidgetType, QLabel>) {
-            widgetText = widget->text();
+            widgetText = toPlainText(widget->text());
         }
         else if constexpr (std::is_same_v<WidgetType, QCheckBox>) {
-            widgetText = widget->text();
+            widgetText = toPlainText(widget->text());
         }
         else if constexpr (std::is_same_v<WidgetType, QGroupBox>) {
-            widgetText = widget->title();
+            widgetText = toPlainText(widget->title());
         }
         else if constexpr (std::is_same_v<WidgetType, QRadioButton>) {
-            widgetText = widget->text();
+            widgetText = toPlainText(widget->text());
         }
         else if constexpr (std::is_same_v<WidgetType, QPushButton>) {
-            widgetText = widget->text();
+            widgetText = toPlainText(widget->text());
         }
 
         if (!widgetText.isEmpty()) {
@@ -1677,16 +1678,17 @@ void PreferencesSearchController::searchWidgetType(
             }
         }
 
-        // search tooltip text for all widget types
-        QString tooltip = widget->toolTip();
-        if (!tooltip.isEmpty()) {
+        // normalise text and search tooltip text for all widget types
+        QString plainTooltip = toPlainText(widget->toolTip());
+        if (!plainTooltip.isEmpty()) {
+
             int tooltipScore = 0;
-            if (fuzzyMatch(searchText, tooltip, tooltipScore)) {
+            if (fuzzyMatch(searchText, plainTooltip, tooltipScore)) {
                 SearchResult result {
                     .groupName = groupName,
                     .pageName = pageName,
                     .widget = widget,
-                    .matchText = QStringLiteral("Tooltip: ") + tooltip,
+                    .matchText = QStringLiteral("Tooltip: ") + plainTooltip,
                     .groupBoxName = findGroupBoxForWidget(widget),
                     .tabName = tabName,
                     .pageDisplayName = pageDisplayName,
@@ -1713,7 +1715,7 @@ void PreferencesSearchController::searchWidgetType(
             }
 
             for (int i = 0; i < widget->count(); ++i) {
-                QString itemText = widget->itemText(i);
+                QString itemText = toPlainText(widget->itemText(i));
                 if (!itemText.isEmpty()) {
                     int itemScore = 0;
                     if (fuzzyMatch(searchText, itemText, itemScore)) {
@@ -1907,6 +1909,16 @@ bool PreferencesSearchController::fuzzyMatch(
 
     score = 0;
     return false;
+}
+
+QString PreferencesSearchController::toPlainText(const QString& text)
+{
+    if (Qt::mightBeRichText(text)) {
+        QTextDocument doc;
+        doc.setHtml(text);
+        return doc.toPlainText();
+    }
+    return text;
 }
 
 void PreferencesSearchController::ensureSearchBoxFocus()

--- a/src/Gui/Dialogs/DlgPreferencesImp.h
+++ b/src/Gui/Dialogs/DlgPreferencesImp.h
@@ -146,6 +146,7 @@ private:
     int calculatePopupHeight(int popupWidth) const;
     void applyHighlightToWidget(QWidget* widget);
     static QString getHighlightStyleForWidget(QWidget* widget);
+    static QString toPlainText(const QString& text);
 
     // Search result navigation
     void selectNextSearchResult();


### PR DESCRIPTION
Follow-up to #31079 per discussion there. Removes remaining HTML formatting from .ui files across src/Gui/PreferencePages/ and several workbenches (Mesh, Part, Spreadsheet) which were not displaying correctly in the preferences search preview. Also to facilitate easier translation. Plain text and quotes used in place of bold and italic (as in other areas of the GUI).

I had some trouble getting the 'What's This' popups to work in preferences, so there are no screenshots, but the formatting follows the style of the tooltips.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Before and After Images
Before:
<img width="687" height="422" alt="image" src="https://github.com/user-attachments/assets/9eff69c9-e3dc-41b1-bd7f-50f2fafdba1c" />
<img width="672" height="420" alt="image" src="https://github.com/user-attachments/assets/ef979170-29c0-4dfb-9279-316f6ea657ee" />
<img width="628" height="426" alt="image" src="https://github.com/user-attachments/assets/dcd7511b-de4b-4357-be0b-0bd7f2605b6e" />
<img width="472" height="490" alt="image" src="https://github.com/user-attachments/assets/bfa0e40d-be22-44b4-afd4-6a0ef8789076" />
<img width="745" height="485" alt="image" src="https://github.com/user-attachments/assets/78cb34af-4b74-47d3-8cf9-ad53d7dc22a1" />

After:
<img width="377" height="236" alt="image" src="https://github.com/user-attachments/assets/aa16ab51-0cb0-4bb4-a53f-9f21b24b51b0" />
<img width="388" height="170" alt="image" src="https://github.com/user-attachments/assets/3fbf5895-cac4-4dda-80bc-7673cad1982e" />
<img width="387" height="230" alt="image" src="https://github.com/user-attachments/assets/b671e169-35f2-41cc-9a2f-a79ad6b2b03c" />
<img width="392" height="231" alt="image" src="https://github.com/user-attachments/assets/85183d28-271a-4349-a7bf-8a257c0733a7" />
<img width="392" height="240" alt="image" src="https://github.com/user-attachments/assets/e61078a3-7a67-46ea-b570-111fe3726f3a" />
