### PR TITLE
CI: Pin Windows runners to windows-2022

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -79,7 +79,7 @@ jobs:
           - { target: linux-arm64, os: ubuntu-22.04-arm }
           - { target: osx-64, os: macos-15-intel }
           - { target: osx-arm64, os: macos-latest }
-          - { target: win-64, os: windows-latest }
+          - { target: win-64, os: windows-2022 }
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/sub_buildPixi.yml
+++ b/.github/workflows/sub_buildPixi.yml
@@ -71,7 +71,7 @@ jobs:
       max-parallel: 6
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-2022, ubuntu-latest, macos-latest]
 
     steps:
     - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/sub_buildWindows.yml
+++ b/.github/workflows/sub_buildWindows.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   Build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     continue-on-error: ${{ inputs.allowedToFail }}
     env:
       CCACHE_COMPILERCHECK: "%compiler%" # default:mtime


### PR DESCRIPTION
GitHub's windows-latest label now resolves to windows-2025, on which the MSVC toolchain is not detected (CMake fails with 'CMAKE_C_COMPILER not set, after EnableLanguage'), breaking all Windows CI on this branch. Pin the Windows jobs to windows-2022 to restore the previously working environment. This fix has already been applied to main.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
