### PR TITLE
CAM: Revert getMDIViews(true) and make new simulator an active view

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -2681,7 +2681,7 @@ MDIView* Document::getActiveView() const
     MDIView* active = getMainWindow()->activeWindow();
 
     // get all MDI views of the document
-    std::list<MDIView*> mdis = getMDIViews(true);
+    std::list<MDIView*> mdis = getMDIViews();
 
     // check whether the active view is part of this document
     bool ok = false;
@@ -2786,7 +2786,7 @@ void Document::setActiveWindow(Gui::MDIView* view)
     }
 
     // get all MDI views of the document
-    std::list<MDIView*> mdis = getMDIViews(true);
+    std::list<MDIView*> mdis = getMDIViews();
 
     // this document is not active
     if (std::ranges::find(mdis, active) == mdis.end()) {

--- a/src/Mod/CAM/PathSimulator/AppGL/CAMSim.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/CAMSim.cpp
@@ -43,7 +43,7 @@ void CAMSim::BeginSimulation(const Part::TopoShape& stock, float quality)
 
 void CAMSim::resetSimulation(Gui::Document* doc)
 {
-    DlgCAMSimulator::instance()->resetSimulation(doc);
+    DlgCAMSimulator::instance(doc)->resetSimulation();
 }
 
 void CAMSim::addTool(

--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
@@ -185,9 +185,9 @@ void DlgCAMSimulator::cloneFrom(const DlgCAMSimulator& from)
     mState = std::make_unique<MillSimulationState>(state);
 }
 
-DlgCAMSimulator* DlgCAMSimulator::instance()
+DlgCAMSimulator* DlgCAMSimulator::instance(Gui::Document* doc)
 {
-    return &ViewCAMSimulator::instance().dlg();
+    return &ViewCAMSimulator::instance(doc).dlg();
 }
 
 void DlgCAMSimulator::setAnimating(bool animating)
@@ -218,10 +218,8 @@ void DlgCAMSimulator::startSimulation(const Part::TopoShape& stock, float qualit
     Q_EMIT simulationStarted();
 }
 
-void DlgCAMSimulator::resetSimulation(Gui::Document* doc)
+void DlgCAMSimulator::resetSimulation()
 {
-    Q_EMIT documentChanged(doc);
-
     mNeedsClear = true;
 
     mGCode.clear();

--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.h
@@ -94,11 +94,11 @@ public:
     void connectTo(GuiDisplay& gui, Dummy3DViewer& dv);
     void cloneFrom(const DlgCAMSimulator& from);
 
-    static DlgCAMSimulator* instance();
+    static DlgCAMSimulator* instance(Gui::Document* doc = nullptr);
 
     void setAnimating(bool animating);
     void startSimulation(const Part::TopoShape& stock, float quality);
-    void resetSimulation(Gui::Document* doc);
+    void resetSimulation();
 
     void addGcodeCommand(const char* cmd);
     void addTool(
@@ -119,7 +119,6 @@ public:
     void setPathColor(const QColor& normal, const QColor& rapid);
 
 Q_SIGNALS:
-    void documentChanged(Gui::Document* doc);
     void simulationStarted();
 
 protected:

--- a/src/Mod/CAM/PathSimulator/AppGL/ViewCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/ViewCAMSimulator.cpp
@@ -72,9 +72,6 @@ ViewCAMSimulator::ViewCAMSimulator(Gui::Document* pcDocument, QWidget* parent, Q
 
     mDlg->connectTo(*mGui, *mDummyViewer);
 
-    connect(mDlg, &DlgCAMSimulator::documentChanged, this, [this](Gui::Document* doc) {
-        setDocument(doc);
-    });
     connect(mDlg, &DlgCAMSimulator::simulationStarted, this, &ViewCAMSimulator::onSimulationStarted);
 
     // call apply settings only after mDummyViewer and mDlg have been initialized
@@ -237,7 +234,7 @@ void ViewCAMSimulator::onSimulationStarted()
 
     // window title and activate
 
-    App::Document* doc = App::GetApplication().getActiveDocument();
+    App::Document* doc = getAppDocument();
     setWindowTitle(tr("%1 - New CAM Simulator").arg(QString::fromUtf8(doc->getName())));
 
     Gui::getMainWindow()->setActiveWindow(this);
@@ -286,7 +283,12 @@ void ViewCAMSimulator::applySettings()
 
 ViewCAMSimulator* ViewCAMSimulator::clone()
 {
-    auto viewCam = new ViewCAMSimulator(_pcDocument, nullptr);
+    return clone(nullptr);
+}
+
+ViewCAMSimulator* ViewCAMSimulator::clone(Gui::Document* doc)
+{
+    auto viewCam = new ViewCAMSimulator(doc ? doc : getGuiDocument(), nullptr);
 
     viewCam->cloneFrom(*this);
     viewCam->mDlg->cloneFrom(*mDlg);
@@ -300,11 +302,42 @@ ViewCAMSimulator* ViewCAMSimulator::clone()
     return viewCam;
 }
 
-ViewCAMSimulator& ViewCAMSimulator::instance()
+ViewCAMSimulator& ViewCAMSimulator::instance(Gui::Document* doc)
 {
+    // The first call comes from CAMSim::resetSimulation giving us the correct document. All
+    // subsequent calls don't provide a document and just use the one from resetSimulation.
+
     if (!viewCAMSimulator) {
-        viewCAMSimulator = new ViewCAMSimulator(nullptr, nullptr);
+        // No simulator exists so we create a new one. We need to make sure that we provide a valid
+        // document to the constructor. Otherwise the newly created MDIView will be considered
+        // "passive" and will not be able to receive messages from e.g. the view menu.
+
+        if (!doc) {
+            throw std::invalid_argument("trying to create a ViewCAMSimulator without a document");
+        }
+
+        viewCAMSimulator = new ViewCAMSimulator(doc, nullptr);
         getMainWindow()->addWindow(viewCAMSimulator);
+    }
+    else if (doc && doc != viewCAMSimulator->getGuiDocument()) {
+        // If a document is provided, we make sure that the returned instance belongs to that
+        // document. Looking at the constructor of MDIView, it seems the document of a view should
+        // not be changed after creating the view (even though there is a setDocument function in
+        // BaseView, the constructor of MDIView sets some variables, e.g. ActiveObjects that don't
+        // seem to be updated when calling setDocument in BaseView). If the document is different,
+        // we clone the simulator with the new document. Cloning the simulator is reasonably fast
+        // and should not be noticeable to the user.
+
+        // There was a previous attempt where the simulator was initialized without a document and
+        // therefore becoming a "passive" view. Messages where then also delivered to passive views
+        // but that caused some issues in the Assembly workbench. See issue #29901.
+
+        auto old = viewCAMSimulator.get();
+
+        viewCAMSimulator = old->clone(doc);
+        getMainWindow()->addWindow(viewCAMSimulator);
+
+        old->deleteSelf();
     }
 
     return *viewCAMSimulator;

--- a/src/Mod/CAM/PathSimulator/AppGL/ViewCAMSimulator.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/ViewCAMSimulator.h
@@ -51,8 +51,9 @@ public:
     );
 
     ViewCAMSimulator* clone() override;
+    ViewCAMSimulator* clone(Gui::Document* doc);
 
-    static ViewCAMSimulator& instance();
+    static ViewCAMSimulator& instance(Gui::Document* doc = nullptr);
     DlgCAMSimulator& dlg();
 
     bool onMsg(const char* pMsg) override;


### PR DESCRIPTION
Trying to fix #29901

@PaddleStroke can you check if it works as expected?

The inclusion of non-document-bound views (aka "passive" views) in Document::getActiveView seems to have caused an issue in the Assembly workbench. Views becoming "passive" by not being bound to a document and multiple active views (per document and global) still makes no sense to me.

This PR attempts to solve the issue by reverting to the previous behaviour of Document::getActiveView. This makes it necessary for the new CAM simulator to become an active view, i.e. we need to provide a document to the constructor of MDIView. There can not be multiple new CAM simulators at the same time due to the way OpenGL functions are called. The easy solution is to clone the simulator providing the new document and deleting the old one. That's fast enough that the user should not notice.

There is a setDocument function in BaseView but I'm not sure this can be used safely to change the document of a MDIView? The constructor of MDIView initializes some variables and it seems they are not updated when calling setDocument in the BaseView. If it would be possible to change the document after the constructor has been called, the cloning thing would not be neccessary. Anyone knows more about this?