### PR TITLE
sketcher: fix issue #28240 split edge tool: fix split dropping point constraints on the split edge

### DIFF
--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -1041,9 +1041,11 @@ int SketchObject::split(int GeoId, const Base::Vector3d& point)
         return !allConstraints[i]->involvesGeoIdAndPosId(GeoId, PointPos::none);
     });
 
+    std::vector<const Part::Geometry*> newGeosConst(newGeos.begin(), newGeos.end());
+
     for (const auto& oldConstrId : idsOfOldConstraints) {
         Constraint* con = allConstraints[oldConstrId];
-        deriveConstraintsForPieces(GeoId, newIds, con, newConstraints);
+        deriveConstraintsForPieces(GeoId, newIds, newGeosConst, con, newConstraints);
     }
 
     // This also seems to reset SketchObject::Geometry.


### PR DESCRIPTION
this PR aims at resolving the below linked freecad issue. currently when using the split edge tool in the sketcher workbench constraints can be lost when splitting an edge. this was reported as a regression from version 1.0.2 of freecad. this PR aims at restoring the functionality that was available in version 1.0.2 apparently using the split edge tool it can call `deriveConstraintsForPieces()` with four arguments or it can use five. this pr has the split tool using the five argument overload directly.

i also created a debug branch to print various debug information for stepping through the issue that can be seen below.

- https://github.com/ipatch/FreeCAD/tree/ipatch.tshoot.28240-split-edge-tool-DBG

- [x] upload some screenshots below using github web ui. presently editing this PR message in neovim

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->

Assisted-by Opus 4.8


## Issues

- https://github.com/FreeCAD/FreeCAD/issues/28240

## Before and After Images

<img width="2731" height="2142" alt="image" src="https://github.com/user-attachments/assets/91d47d3a-d86c-4803-a852-e9a8baa7a3e7" />

before adding the split

---

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/6b45ef3e-9b69-445e-bb11-f448ded08832" />

after adding the split with the changes from this PR

---

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/b0e484d5-5e1c-4437-84ee-317a60fb01bc" />

**without the fix** see how one the point on object constraints has been removed due to the use of the split edge tool.

