### PR TITLE
[1.1] Escape strings when passing to interpreter

### DIFF
--- a/src/Base/Tools.cpp
+++ b/src/Base/Tools.cpp
@@ -222,6 +222,12 @@ std::string Base::Tools::escapeEncodeString(const std::string& s)
             case '\'':
                 result += "\\\'";
                 break;
+            case '\n':
+                result += "\\n";
+                break;
+            case '\r':
+                result += "\\r";
+                break;
             default:
                 result += s.at(i);
                 break;

--- a/src/Mod/MeshPart/Gui/Tessellation.cpp
+++ b/src/Mod/MeshPart/Gui/Tessellation.cpp
@@ -334,7 +334,8 @@ void Tessellation::process(int method, App::Document* doc, const std::list<App::
                 continue;
             }
 
-            QString label = QString::fromUtf8(sobj->Label.getValue());
+            std::string label = sobj->Label.getValue();
+            label = Base::Tools::escapeEncodeString(label);
 
             QString param = getMeshingParameters(method, sobj);
 
@@ -347,7 +348,13 @@ void Tessellation::process(int method, App::Document* doc, const std::list<App::
                               "__mesh__.Label=\"%5 (Meshed)\"\n"
                               "del __doc__, __mesh__, __part__, __shape__\n"
             )
-                              .arg(QString::fromUtf8(doc->getName()), objname, subname, param, label);
+                              .arg(
+                                  QString::fromUtf8(doc->getName()),
+                                  objname,
+                                  subname,
+                                  param,
+                                  QString::fromUtf8(label.c_str())
+                              );
 
             Gui::Command::runCommand(Gui::Command::Doc, cmd.toUtf8());
 

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1269,7 +1269,8 @@ void CmdPartMakeSolid::activated(int iMsg)
         nullptr,
         Gui::ResolveMode::FollowLink
     );
-    runCommand(Doc, "import Part");
+    addModule(Doc, "Part");
+    openCommand("Make solid");
     for (auto it : objs) {
         const TopoDS_Shape& shape = Part::Feature::getShape(
             it,
@@ -1278,6 +1279,9 @@ void CmdPartMakeSolid::activated(int iMsg)
         if (!shape.IsNull()) {
             TopAbs_ShapeEnum type = shape.ShapeType();
             QString str;
+            QString name = QString::fromLatin1(it->getNameInDocument());
+            std::string label = it->Label.getValue();
+            label = Base::Tools::escapeEncodeString(label);
             if (type == TopAbs_SOLID) {
                 Base::Console().message(
                     "%s is ignored because it is already a solid.\n",
@@ -1293,10 +1297,7 @@ void CmdPartMakeSolid::activated(int iMsg)
                           "__o__.Shape=__s__\n"
                           "del __s__, __o__"
                 )
-                          .arg(
-                              QLatin1String(it->getNameInDocument()),
-                              QLatin1String(it->Label.getValue())
-                          );
+                          .arg(name, QString::fromUtf8(label.c_str()));
             }
             else if (type == TopAbs_SHELL) {
                 str = QStringLiteral(
@@ -1307,10 +1308,7 @@ void CmdPartMakeSolid::activated(int iMsg)
                           "__o__.Shape=__s__\n"
                           "del __s__, __o__"
                 )
-                          .arg(
-                              QLatin1String(it->getNameInDocument()),
-                              QLatin1String(it->Label.getValue())
-                          );
+                          .arg(name, QString::fromUtf8(label.c_str()));
             }
             else {
                 Base::Console().message(
@@ -1321,7 +1319,7 @@ void CmdPartMakeSolid::activated(int iMsg)
 
             try {
                 if (!str.isEmpty()) {
-                    runCommand(Doc, str.toLatin1());
+                    runCommand(Doc, str.toUtf8());
                 }
             }
             catch (const Base::Exception& e) {
@@ -1329,6 +1327,8 @@ void CmdPartMakeSolid::activated(int iMsg)
             }
         }
     }
+
+    commitCommand();
 }
 
 bool CmdPartMakeSolid::isActive()
@@ -1371,6 +1371,8 @@ void CmdPartReverseShape::activated(int iMsg)
             name += "_rev";
             name = getUniqueObjectName(name.c_str());
 
+            std::string label = it->Label.getValue();
+            label = Base::Tools::escapeEncodeString(label);
             QString str = QStringLiteral(
                               "__o__=App.ActiveDocument.addObject(\"Part::Reverse\",\"%1\")\n"
                               "__o__.Source=App.ActiveDocument.%2\n"
@@ -1380,11 +1382,11 @@ void CmdPartReverseShape::activated(int iMsg)
                               .arg(
                                   QString::fromLatin1(name.c_str()),
                                   QString::fromLatin1(it->getNameInDocument()),
-                                  QString::fromLatin1(it->Label.getValue())
+                                  QString::fromUtf8(label.c_str())
                               );
 
             try {
-                runCommand(Doc, str.toLatin1());
+                runCommand(Doc, str.toUtf8());
                 copyVisual(name.c_str(), "ShapeAppearance", it->getNameInDocument());
                 copyVisual(name.c_str(), "LineColor", it->getNameInDocument());
                 copyVisual(name.c_str(), "PointColor", it->getNameInDocument());

--- a/src/Mod/Part/Gui/CommandParametric.cpp
+++ b/src/Mod/Part/Gui/CommandParametric.cpp
@@ -23,10 +23,13 @@
  ***************************************************************************/
 
 
+#include <string>
+
 #include <QApplication>
 
 
 #include <App/Part.h>
+#include <Base/Tools.h>
 #include <Gui/Application.h>
 #include <Gui/Command.h>
 #include <Gui/Document.h>
@@ -77,13 +80,13 @@ CmdPartCylinder::CmdPartCylinder()
 void CmdPartCylinder::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QString cmd;
-    cmd = qApp->translate("CmdPartCylinder", "Cylinder");
-    openCommand((const char*)cmd.toUtf8());
+    std::string name = qApp->translate("CmdPartCylinder", "Cylinder").toUtf8().toStdString();
+    name = Base::Tools::escapeEncodeString(name);
+    openCommand(name.c_str());
 
     runCommand(Doc, "App.ActiveDocument.addObject(\"Part::Cylinder\",\"Cylinder\")");
-    cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
-              .arg(qApp->translate("CmdPartCylinder", "Cylinder"));
+    QString cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
+                      .arg(QString::fromUtf8(name.c_str()));
     runCommand(Doc, cmd.toUtf8());
     runCommand(Doc, getAutoGroupCommandStr().toUtf8());
     commitCommand();
@@ -121,13 +124,13 @@ CmdPartBox::CmdPartBox()
 void CmdPartBox::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QString cmd;
-    cmd = qApp->translate("CmdPartBox", "Cube");
-    openCommand((const char*)cmd.toUtf8());
+    std::string name = qApp->translate("CmdPartBox", "Cube").toUtf8().toStdString();
+    name = Base::Tools::escapeEncodeString(name);
+    openCommand(name.c_str());
 
     runCommand(Doc, "App.ActiveDocument.addObject(\"Part::Box\",\"Box\")");
-    cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
-              .arg(qApp->translate("CmdPartBox", "Cube"));
+    QString cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
+                      .arg(QString::fromUtf8(name.c_str()));
     runCommand(Doc, cmd.toUtf8());
     runCommand(Doc, getAutoGroupCommandStr().toUtf8());
     commitCommand();
@@ -165,13 +168,13 @@ CmdPartSphere::CmdPartSphere()
 void CmdPartSphere::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QString cmd;
-    cmd = qApp->translate("CmdPartSphere", "Sphere");
-    openCommand((const char*)cmd.toUtf8());
+    std::string name = qApp->translate("CmdPartSphere", "Sphere").toUtf8().toStdString();
+    name = Base::Tools::escapeEncodeString(name);
+    openCommand(name.c_str());
 
     runCommand(Doc, "App.ActiveDocument.addObject(\"Part::Sphere\",\"Sphere\")");
-    cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
-              .arg(qApp->translate("CmdPartSphere", "Sphere"));
+    QString cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
+                      .arg(QString::fromUtf8(name.c_str()));
     runCommand(Doc, cmd.toUtf8());
     runCommand(Doc, getAutoGroupCommandStr().toUtf8());
     commitCommand();
@@ -209,13 +212,13 @@ CmdPartCone::CmdPartCone()
 void CmdPartCone::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QString cmd;
-    cmd = qApp->translate("CmdPartCone", "Cone");
-    openCommand((const char*)cmd.toUtf8());
+    std::string name = qApp->translate("CmdPartCone", "Cone").toUtf8().toStdString();
+    name = Base::Tools::escapeEncodeString(name);
+    openCommand(name.c_str());
 
     runCommand(Doc, "App.ActiveDocument.addObject(\"Part::Cone\",\"Cone\")");
-    cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
-              .arg(qApp->translate("CmdPartCone", "Cone"));
+    QString cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
+                      .arg(QString::fromUtf8(name.c_str()));
     runCommand(Doc, cmd.toUtf8());
     runCommand(Doc, getAutoGroupCommandStr().toUtf8());
     commitCommand();
@@ -253,13 +256,13 @@ CmdPartTorus::CmdPartTorus()
 void CmdPartTorus::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QString cmd;
-    cmd = qApp->translate("CmdPartTorus", "Torus");
-    openCommand((const char*)cmd.toUtf8());
+    std::string name = qApp->translate("CmdPartTorus", "Torus").toUtf8().toStdString();
+    name = Base::Tools::escapeEncodeString(name);
+    openCommand(name.c_str());
 
     runCommand(Doc, "App.ActiveDocument.addObject(\"Part::Torus\",\"Torus\")");
-    cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
-              .arg(qApp->translate("CmdPartTorus", "Torus"));
+    QString cmd = QStringLiteral("App.ActiveDocument.ActiveObject.Label = \"%1\"")
+                      .arg(QString::fromUtf8(name.c_str()));
     runCommand(Doc, cmd.toUtf8());
     runCommand(Doc, getAutoGroupCommandStr().toUtf8());
     commitCommand();

--- a/src/Mod/Part/Gui/Mirroring.cpp
+++ b/src/Mod/Part/Gui/Mirroring.cpp
@@ -352,8 +352,7 @@ bool Mirroring::accept()
     double basez = ui->baseZ->value().getValue();
     for (auto item : items) {
         shape = item->data(0, Qt::UserRole).toString();
-        std::string escapedstr = Base::Tools::escapedUnicodeFromUtf8(item->text(0).toUtf8());
-        label = QString::fromStdString(escapedstr);
+        label = item->text(0);
         selectionString = QString::fromStdString(selection);
 
         // if we already have the suffix " (Mirror #<number>)" remove it
@@ -362,6 +361,8 @@ bool Mirroring::accept()
             label = label.left(pos);
         }
         label.append(QStringLiteral(" (Mirror #%1)").arg(++count));
+        std::string escapedLabel = Base::Tools::escapeEncodeString(label.toUtf8().toStdString());
+        label = QString::fromUtf8(escapedLabel.c_str());
 
         QString code = QStringLiteral(
                            "__doc__=FreeCAD.getDocument(\"%1\")\n"
@@ -404,7 +405,13 @@ TaskMirroring::TaskMirroring()
 
 bool TaskMirroring::accept()
 {
-    return widget->accept();
+    try {
+        return widget->accept();
+    }
+    catch (const Base::Exception& e) {
+        e.reportException();
+        return false;
+    }
 }
 
 bool TaskMirroring::reject()

--- a/src/Mod/Part/TestPartGui.py
+++ b/src/Mod/Part/TestPartGui.py
@@ -85,6 +85,48 @@ class PartGuiViewProviderTestCases(unittest.TestCase):
         FreeCAD.closeDocument("PartGuiTest")
 
 
+class PartMirrorGuiTestCases(unittest.TestCase):
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("PartMirrorGuiTest")
+
+    def tearDown(self):
+        if FreeCADGui.Control.activeDialog():
+            FreeCADGui.Control.closeDialog()
+        FreeCADGui.Selection.clearSelection()
+        FreeCAD.closeDocument(self.Doc.Name)
+
+    def mirrorBoxWithLabel(self, label):
+        if not FreeCAD.GuiUp:
+            self.skipTest("This test requires a graphical user interface (GUI).")
+
+        box = self.Doc.addObject("Part::Box", "Box")
+        box.Label = label
+        self.Doc.recompute()
+
+        FreeCADGui.Selection.clearSelection()
+        FreeCADGui.Selection.addSelection(self.Doc.Name, box.Name)
+        FreeCADGui.runCommand("Part_Mirror")
+        self.assertTrue(FreeCADGui.Control.activeDialog(), "Part Mirror task dialog did not open.")
+
+        FreeCADGui.Control.activeTaskDialog().accept()
+        QtWidgets.QApplication.processEvents()
+
+        mirrors = [obj for obj in self.Doc.Objects if obj.isDerivedFrom("Part::Mirroring")]
+        self.assertEqual(1, len(mirrors))
+        return mirrors[0].Label
+
+    def testMirrorLabelWithUnicodeIsNotDoubleEscaped(self):
+        self.assertEqual("caf\u00e9 (Mirror #1)", self.mirrorBoxWithLabel("caf\u00e9"))
+
+    def testMirrorLabelEscapesQuotesBeforePythonCommand(self):
+        label = 'a");print("Erasing your hard drive, please stand by....")'
+        self.assertEqual(f"{label} (Mirror #1)", self.mirrorBoxWithLabel(label))
+
+    def testMirrorLabelWithNewlinesIsNotMangled(self):
+        label = "a\nb\nc"
+        self.assertEqual(f"{label} (Mirror #1)", self.mirrorBoxWithLabel(label))
+
+
 class SectionCutTestCases(unittest.TestCase):
     def setUp(self):
         self.Doc = FreeCAD.newDocument("SectionCut")

--- a/tests/src/Base/Tools.cpp
+++ b/tests/src/Base/Tools.cpp
@@ -113,6 +113,16 @@ TEST(BaseToolsSuite, TestEscapeQuotesFromString)
     EXPECT_EQ(Base::Tools::escapeQuotesFromString("\""), "\\\"");
     EXPECT_EQ(Base::Tools::escapeQuotesFromString("\\"), "\\");
 }
+
+TEST(BaseToolsSuite, TestEscapeEncodeString)
+{
+    EXPECT_EQ(Base::Tools::escapeEncodeString("a\\b"), "a\\\\b");
+    EXPECT_EQ(Base::Tools::escapeEncodeString("a\"b"), "a\\\"b");
+    EXPECT_EQ(Base::Tools::escapeEncodeString("a'b"), "a\\\'b");
+    EXPECT_EQ(Base::Tools::escapeEncodeString("a\nb"), "a\\nb");
+    EXPECT_EQ(Base::Tools::escapeEncodeString("a\rb"), "a\\rb");
+    EXPECT_EQ(Base::Tools::escapeEncodeString("plain"), "plain");
+}
 TEST(BaseToolsSuite, TestGetIdentifier)
 {
     // ASCII and edge cases


### PR DESCRIPTION
Backport of #30712 to releases/FreeCAD-1-1.