### PR TITLE
[1.1] Fix #30706: Allow Macro dirs as sources of PropertyPythonObject

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -172,6 +172,7 @@ def InitApplications():
 
     # to have all the module-paths available in FreeCADGuiInit.py:
     FreeCAD.__ModDirs__ = list(ModDict.values())
+    FreeCAD.__MacroDirs__ = list({os.path.realpath(MacroDir), os.path.realpath(MacroStd), SystemWideMacroDir})
 
     # this allows importing with:
     # from FreeCAD.Module import package

--- a/src/App/PropertyPythonObject.cpp
+++ b/src/App/PropertyPythonObject.cpp
@@ -150,14 +150,16 @@ bool isAllowedModule(const std::string& moduleName)
     // This is populated during startup by FreeCADInit.py and includes built-in workbenches,
     // user addons, and any additional configured module paths.
     Py::Module freecad(PyImport_ImportModule("FreeCAD"), true);
-    if (!freecad.hasAttr("__ModDirs__")) {
-        throw Py::RuntimeError("FreeCAD.__ModDirs__ not set -- FreeCADInit.py has not run yet");
+    if (!freecad.hasAttr("__ModDirs__") or !freecad.hasAttr("__MacroDirs__")) {
+        throw Py::RuntimeError("FreeCAD.__ModDirs__ or FreeCAD.__MacroDirs__ not set -- FreeCADInit.py has not run yet");
     }
-    Py::List modDirs(freecad.getAttr("__ModDirs__"));
+    Py::List allowedDirs(freecad.getAttr("__ModDirs__"));
+    allowedDirs.extend(freecad.getAttr("__MacroDirs__"));
+    const int allowedDirsSize = static_cast<int>(allowedDirs.size());
 
     auto isUnderFreeCAD = [&](const std::string& path) {
-        for (int i = 0; i < static_cast<int>(modDirs.size()); ++i) {
-            if (isUnderDirectory(path, Py::String(modDirs[i]).as_std_string())) {
+        for (int i = 0; i < allowedDirsSize; ++i) {
+            if (isUnderDirectory(path, Py::String(allowedDirs[i]).as_std_string())) {
                 return true;
             }
         }


### PR DESCRIPTION
Backport of #30794 to releases/FreeCAD-1-1. The Python half is adapted to 1.1's InitApplications() since main's InitPipeline refactor is not on this branch.