### PR TITLE
Fix build against Qt5 (2)

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -28,6 +28,7 @@
 #include <QClipboard>
 #include <QDateTime>
 #include <QMessageBox>
+#include <QScopeGuard>
 #include <QTextStream>
 #include <QTreeWidgetItem>
 

--- a/src/Gui/Dialogs/DlgAddProperty.cpp
+++ b/src/Gui/Dialogs/DlgAddProperty.cpp
@@ -182,7 +182,7 @@ int DlgAddProperty::findLabelRow(const char* labelName, QFormLayout* layout)
         }
 
         if (auto label = qobject_cast<QLabel*>(labelItem->widget())) {
-            if (label->objectName() == QString::fromLatin1(labelName)) {
+            if (label->objectName() == QString::fromStdString(labelName)) {
                 return row;
             }
         }
@@ -326,13 +326,13 @@ void DlgAddProperty::initializeTypes()
 
     const auto addTypes = [this, &lastType](const std::vector<Base::Type>& types) {
         for (const auto& type : types) {
-            ui->comboBoxType->addItem(QString::fromLatin1(type.getName()));
+            const auto name = type.getName();
+            ui->comboBoxType->addItem(QString::fromUtf8(name.data(), name.size()));
             if (type == lastType) {
                 ui->comboBoxType->setCurrentIndex(ui->comboBoxType->count() - 1);
             }
         }
     };
-
 
     const auto addSeparator = [this]() {
         ui->comboBoxType->addItem(QStringLiteral("──────────────────────"));
@@ -705,8 +705,8 @@ void DlgAddProperty::removeEditor()
 
 bool DlgAddProperty::isEnumPropertyItem() const
 {
-    return ui->comboBoxType->currentText()
-        == QString::fromLatin1(App::PropertyEnumeration::getClassTypeId().getName());
+    return ui->comboBoxType->currentText().toStdString()
+        == App::PropertyEnumeration::getClassTypeId().getName();
 }
 
 QVariant DlgAddProperty::getEditorData() const
@@ -983,7 +983,10 @@ App::Property* DlgAddProperty::createProperty()
         critical(
             QObject::tr("Add property"),
             QObject::tr("Failed to add property to '%1': %2")
-                .arg(QString::fromLatin1(container->getFullName().c_str()), QString::fromUtf8(e.what()))
+                .arg(
+                    QString::fromStdString(container->getFullName().c_str()),
+                    QString::fromUtf8(e.what())
+                )
         );
         return nullptr;
     }

--- a/src/Gui/Dialogs/DlgPropertyLink.cpp
+++ b/src/Gui/Dialogs/DlgPropertyLink.cpp
@@ -1124,7 +1124,7 @@ QTreeWidgetItem* DlgPropertyLink::createTypeItem(Base::Type type)
         item = new QTreeWidgetItem(item);
     }
     item->setExpanded(true);
-    item->setText(0, QString::fromUtf8(type.getName()));
+    item->setText(0, QString::fromUtf8(type.getName().data(), type.getName().size()));
     if (type == App::DocumentObject::getClassTypeId()) {
         item->setFlags(Qt::ItemIsEnabled);
     }

--- a/src/Gui/EditorView.cpp
+++ b/src/Gui/EditorView.cpp
@@ -949,7 +949,11 @@ void SearchBar::highlightSearchResults(const SearchResults& matches)
     }
 
     cleaned += searchSelections;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    textEditor->setExtraSelections(cleaned.toList());
+#else
     textEditor->setExtraSelections(cleaned);
+#endif
 }
 
 void SearchBar::findPrevious()

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
@@ -363,13 +363,11 @@ void DlgSettingsNavigation::retranslate()
     // add submenu at the end to select navigation style
     std::map<Base::Type, std::string> styles = UserNavigationStyle::getUserFriendlyNames();
     for (const auto& style : styles) {
-        QByteArray data(style.first.getName());
-        QString name = QApplication::translate(
-            std::string {style.first.getName()}.c_str(),
-            style.second.c_str()
-        );
+        const auto name = style.first.getName();
+        QByteArray data(name.data(), name.size());
+        QString styleName = QApplication::translate(std::string {name}.c_str(), style.second.c_str());
 
-        ui->comboNavigationStyle->addItem(name, data);
+        ui->comboNavigationStyle->addItem(styleName, data);
     }
 }
 

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 
+#include <QAction>
 #include <QApplication>
 #include <QClipboard>
 #include <QDockWidget>
@@ -491,12 +492,11 @@ PythonConsole::PythonConsole(QWidget* parent)
     connect(flusher, &QTimer::timeout, this, &PythonConsole::flushOutput);
     flusher->start(100);
 
-    clearAction = addAction(
-        QIcon(QStringLiteral(":/icons/edit-delete.svg")),
-        tr("Clear Console"),
-        QKeySequence(Qt::CTRL | Qt::Key_L)
-    );
+    clearAction
+        = new QAction(QIcon(QStringLiteral(":/icons/edit-delete.svg")), tr("Clear Console"), this);
+    clearAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_L));
     clearAction->setShortcutContext(Qt::WidgetShortcut);
+    addAction(clearAction);
     QObject::connect(clearAction, &QAction::triggered, this, &PythonConsole::onClearConsole);
 }
 

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -962,9 +962,9 @@ void PropertyEditor::removeProperties(const std::unordered_set<App::Property*>& 
     App::GetApplication().commitTransaction(tid);
 }
 
-static inline std::string indent(int level)
+static inline QString indent(int level)
 {
-    return std::string(2 * level, ' ');
+    return QString(2 * level, ' ');
 }
 
 void PropertyEditor::getPropUsesObj(

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -685,9 +685,9 @@ QVariant PropertyItem::dataPropertyName(int role) const
         return {};
     }
     if (role == Qt::ToolTipRole) {
-        QString type
-            = QStringLiteral("Type: %1\nName: %2")
-                  .arg(QString::fromLatin1(propertyItems[0]->getTypeId().getName()), objectName());
+        const auto name = propertyItems[0]->getTypeId().getName();
+        QString type = QStringLiteral("Type: %1\nName: %2")
+                           .arg(QString::fromLatin1(name.data(), name.size()), objectName());
 
         QString doc = PropertyItem::toolTip(propertyItems[0]).toString();
         if (doc.isEmpty()) {

--- a/src/Mod/CAM/PathSimulator/AppGL/ViewCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/ViewCAMSimulator.cpp
@@ -332,7 +332,7 @@ ViewCAMSimulator& ViewCAMSimulator::instance(Gui::Document* doc)
         // therefore becoming a "passive" view. Messages where then also delivered to passive views
         // but that caused some issues in the Assembly workbench. See issue #29901.
 
-        auto old = viewCAMSimulator.get();
+        auto old = viewCAMSimulator.data();
 
         viewCAMSimulator = old->clone(doc);
         getMainWindow()->addWindow(viewCAMSimulator);

--- a/src/Mod/Material/Gui/DlgInspectAppearance.cpp
+++ b/src/Mod/Material/Gui/DlgInspectAppearance.cpp
@@ -169,13 +169,13 @@ void DlgInspectAppearance::update(std::vector<Gui::ViewProvider*>& views)
                 ui->editSubShape->setText(QStringLiteral(""));
             }
 
-            auto subShapeType = QString::fromUtf8(obj->getTypeId().getName());
-            subShapeType.remove(subShapeType.indexOf(QStringLiteral("::")), subShapeType.size());
-            ui->editSubShapeType->setText(subShapeType);
-            ui->editShapeType->setText(QString::fromUtf8(obj->getTypeId().getName()));
+            auto shapeType = obj->getTypeId().getName();
+            auto subShapeType = shapeType.substr(0, shapeType.find("::"));
+            ui->editSubShapeType->setText(QString::fromUtf8(subShapeType.data(), subShapeType.size()));
+            ui->editShapeType->setText(QString::fromUtf8(shapeType.data(), shapeType.size()));
 
             ui->tabAppearance->clear();
-            if (labelProp && QString::fromUtf8(labelProp->getValue()).size() > 0) {
+            if (labelProp && labelProp->getValue()) {
                 auto* prop =
                     dynamic_cast<App::PropertyMaterialList*>(view->getPropertyByName("ShapeAppearance"));
                 if (prop) {

--- a/src/Mod/Material/Gui/DlgInspectMaterial.cpp
+++ b/src/Mod/Material/Gui/DlgInspectMaterial.cpp
@@ -185,14 +185,17 @@ void DlgInspectMaterial::update(std::vector<Gui::ViewProvider*>& views)
                 ui->editSubShape->setText(QStringLiteral(""));
             }
 
-            auto subShapeType = QString::fromUtf8(obj->getTypeId().getName());
-            subShapeType.remove(subShapeType.indexOf(QStringLiteral("::")), subShapeType.size());
-            appendClip(tr("Type: ") + subShapeType);
-            ui->editSubShapeType->setText(subShapeType);
-            appendClip(tr("TypeID: ") + QString::fromUtf8(obj->getTypeId().getName()));
-            ui->editShapeType->setText(QString::fromUtf8(obj->getTypeId().getName()));
+            auto shapeType = obj->getTypeId().getName();
+            auto subShapeType = shapeType.substr(0, shapeType.find("::"));
+            auto qShapeType = QString::fromUtf8(shapeType.data(), shapeType.size());
+            auto qSubShapeType = QString::fromUtf8(subShapeType.data(), subShapeType.size());
 
-            if (labelProp && QString::fromUtf8(labelProp->getValue()).size() > 0) {
+            appendClip(tr("Type: ") + qSubShapeType);
+            ui->editSubShapeType->setText(qSubShapeType);
+            appendClip(tr("TypeID: ") + qShapeType);
+            ui->editShapeType->setText(qShapeType);
+
+            if (labelProp && labelProp->getValue()) {
                 auto* prop = dynamic_cast<Materials::PropertyMaterial*>(
                     obj->getPropertyByName("ShapeMaterial"));
                 if (prop) {

--- a/src/Mod/Start/App/DisplayedFilesModel.cpp
+++ b/src/Mod/Start/App/DisplayedFilesModel.cpp
@@ -64,7 +64,9 @@ static bool freecadCanOpen(const QString& extension)
 
 DisplayedFilesModel::DisplayedFilesModel(QObject* parent)
     : QAbstractListModel(parent)
-{}
+{
+    qRegisterMetaType<FileStats>("FileStats");
+}
 
 
 int DisplayedFilesModel::rowCount(const QModelIndex& parent) const

--- a/src/Mod/Start/App/DisplayedFilesModel.h
+++ b/src/Mod/Start/App/DisplayedFilesModel.h
@@ -83,3 +83,5 @@ private:
 };
 
 }  // namespace Start
+
+Q_DECLARE_METATYPE(Start::FileStats)

--- a/src/Mod/Start/Gui/GeneralSettingsWidget.cpp
+++ b/src/Mod/Start/Gui/GeneralSettingsWidget.cpp
@@ -248,13 +248,11 @@ void GeneralSettingsWidget::retranslateUi()
     );
     std::map<Base::Type, std::string> styles = Gui::UserNavigationStyle::getUserFriendlyNames();
     for (const auto& style : styles) {
-        QByteArray data(style.first.getName());
-        QString name = QApplication::translate(
-            std::string {style.first.getName()}.c_str(),
-            style.second.c_str()
-        );
-        _navigationStyleComboBox->addItem(name, data);
-        if (navStyleName == style.first.getName()) {
+        const auto name = style.first.getName();
+        QByteArray data(name.data(), name.size());
+        QString styleName = QApplication::translate(std::string {name}.c_str(), style.second.c_str());
+        _navigationStyleComboBox->addItem(styleName, data);
+        if (navStyleName == name) {
             _navigationStyleComboBox->setCurrentIndex(_navigationStyleComboBox->count() - 1);
         }
     }


### PR DESCRIPTION
Despite the existence of #29470 (which deals only with low hanging fruit anyway) and `SetupQt.cmake` threatening to remove Qt5 support in August, here's patchset to keep Qt5 alive. For sure it is not complete, but builds and is enough to work with Part, PartDesign and Assembly4. Other workbenches were not tested and I was told BIM (https://github.com/FreeCAD/FreeCAD/issues/29470#issuecomment-4472763698) and CAM (https://github.com/FreeCAD/FreeCAD/issues/29395#issuecomment-4264163329) do not work with Qt5. These are left as an exercise to whoever needs them.

> [!NOTE]
> Now much time was spent here, it is just a rebase of a branch I'm using when working with FreeCAD. Debian 13 links Qt apps against Qt5, so allowing FreeCAD to do the same considerably lowers memory pressure. Perhaps there are bits worth merging anyway, others require polishing and will be polished in case I'm not alone desiring Qt5 build. With that in mind, opening as a draft.