### PR TITLE
clang-tidy: remove boost-use-ranges check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,boost-*,bugprone-*,
+Checks:          'clang-diagnostic-*,clang-analyzer-*,boost-use-to-string,bugprone-*,
 performance-*,readability-*,portability-*,modernize-*,cppcoreguidelines-*,google-explicit-constructor,
 concurrency-*,-modernize-use-trailing-return-type, -modernize-use-nodiscard,-readability-identifier-length,
 -readability-redundant-access-specifiers,-readability-qualified-auto,-readability-implicit-bool-conversion,


### PR DESCRIPTION
https://github.com/FreeCAD/FreeCAD/labels/Type%3A%20Code%20Quality

Boost is eventually going to be removed, and .clang-tidy's "boost-*" entry enables both `boost-use-ranges` & `boost-use-to-string`.

`boost-use-to-string` is fine as it migrates us away from boost to the STL, but `boost-use-ranges` is actively harmful as it suggest using Boost versions of algorithms when we have `std::ranges` at our disposal and the currently enabled `modernize-use-ranges` provides the proper advice already.

- [x] No clanker was used in the making of any of this

## Issues

* Works toward #26882