### PR TITLE
PartDesign: sync Body visual properties to newly added features

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -325,7 +325,9 @@ void ViewProviderBody::updateData(const App::Property* prop)
 
         if (!isRestoring()) {
             std::unordered_set<App::DocumentObject*> previousSet(
-                m_previousGroup.begin(), m_previousGroup.end());
+                m_previousGroup.begin(),
+                m_previousGroup.end()
+            );
 
             for (auto* feature : currentGroup) {
                 if (feature && feature->isDerivedFrom<PartDesign::Feature>()

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -25,6 +25,7 @@
 
 #include <Inventor/actions/SoGetBoundingBoxAction.h>
 #include <QMenu>
+#include <unordered_set>
 
 #include <App/Document.h>
 #include <App/Origin.h>
@@ -311,6 +312,31 @@ void ViewProviderBody::updateData(const App::Property* prop)
     if (prop == &body->Group || prop == &body->BaseFeature) {
         // ensure all model features are in visual body mode
         setVisualBodyMode(true);
+
+        // Detect which features are genuinely new (present in current group but absent
+        // from our previous snapshot). We apply the Body's visual properties only to
+        // those new features so that existing features with individually-customised
+        // colours are never overwritten.
+        //
+        // The snapshot is updated even during restore so that after a document loads,
+        // m_previousGroup already contains all the restored features and only features
+        // added by the user afterwards are treated as new.
+        const auto& currentGroup = body->Group.getValues();
+
+        if (!isRestoring()) {
+            std::unordered_set<App::DocumentObject*> previousSet(
+                m_previousGroup.begin(), m_previousGroup.end());
+
+            for (auto* feature : currentGroup) {
+                if (feature && feature->isDerivedFrom<PartDesign::Feature>()
+                    && previousSet.find(feature) == previousSet.end()) {
+                    // This feature was not in the group before — apply Body's visuals to it.
+                    applyBodyVisualPropsToFeature(feature);
+                }
+            }
+        }
+
+        m_previousGroup = currentGroup;
     }
 
     if (prop == &body->Tip) {
@@ -419,6 +445,51 @@ void ViewProviderBody::unifyVisualProperty(const App::Property* prop)
         if (Gui::ViewProvider* vp = gdoc->getViewProvider(feature)) {
             if (auto fprop = vp->getPropertyByName(prop->getName())) {
                 fprop->Paste(*prop);
+            }
+        }
+    }
+}
+
+void ViewProviderBody::applyBodyVisualPropsToFeature(App::DocumentObject* feature)
+{
+    if (!pcObject || !feature) {
+        return;
+    }
+
+    Gui::Document* gdoc = Gui::Application::Instance->getDocument(pcObject->getDocument());
+    if (!gdoc) {
+        return;
+    }
+
+    Gui::ViewProvider* vp = gdoc->getViewProvider(feature);
+    if (!vp) {
+        return;
+    }
+
+    // List of visual properties that should be inherited from the Body when a new
+    // feature is first added. Deliberately excludes Visibility, Selectable, etc.
+    // which are managed separately.
+    static const char* propNames[] = {
+        "ShapeColor",
+        "ShapeAppearance",
+        "Transparency",
+        "LineColor",
+        "LineMaterial",
+        "LineWidth",
+        "PointColor",
+        "PointMaterial",
+        "PointSize",
+        "DrawStyle",
+        "Lighting",
+        "Deviation",
+        "AngularDeflection",
+        nullptr
+    };
+
+    for (int i = 0; propNames[i]; ++i) {
+        if (App::Property* bodyProp = this->getPropertyByName(propNames[i])) {
+            if (App::Property* featureProp = vp->getPropertyByName(propNames[i])) {
+                featureProp->Paste(*bodyProp);
             }
         }
     }

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.h
@@ -110,9 +110,14 @@ protected:
     void unifyVisualProperty(const App::Property* prop);
     /// Set Feature viewprovider into visual body mode
     void setVisualBodyMode(bool bodymode);
+    /// Apply the Body's current visual properties to a single newly-added feature
+    void applyBodyVisualPropsToFeature(App::DocumentObject* feature);
 
 private:
     static const char* BodyModeEnum[];
+
+    /// Snapshot of body->Group from the previous updateData() call, used to detect newly-added features
+    std::vector<App::DocumentObject*> m_previousGroup;
 
     void afterRecompute(const App::Document&, const std::vector<App::DocumentObject*>& recomputedObjs);
     fastsignals::scoped_connection m_RecomputedConn;


### PR DESCRIPTION



This fixes an issue where custom visual properties (PointSize, LineWidth, ShapeColor, etc.) set on a PartDesign Body are visually reset when a new feature is added. New features were initialized with default visual properties, ignoring the Body's current settings.

The fix tracks the Body's `Group` contents between `updateData()` calls. When the Group changes, it diffs against the previous snapshot to find genuinely new features, and copies the Body's visual properties only to those. Existing features with individually customized colors are never touched.

**Key design choice:** The previous approach (PR #31161, which I closed) incorrectly re-applied the Body's properties to *all* features on every Group change, which would have broken per-feature color customization. This version only targets newly added features.



- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues

Fixes #31068

## Approach

- Added `m_previousGroup` snapshot to `ViewProviderBody` to track group changes
- In `updateData()`, diff current vs previous group to detect new features
- New helper `applyBodyVisualPropsToFeature()` copies Body visual props to a single feature
- Snapshot updates even during `isRestoring()` so document reload doesn't trigger false positives
