### PR TITLE
Surface: Consider real shape placement

### DIFF
--- a/src/Mod/Surface/App/CMakeLists.txt
+++ b/src/Mod/Surface/App/CMakeLists.txt
@@ -45,6 +45,8 @@ SET(Surface_SRCS
   FeatureSewing.h
   FeatureCut.cpp
   FeatureCut.h
+  ShapeUtils.cpp
+  ShapeUtils.h
   Measure.cpp
   Measure.h
 )

--- a/src/Mod/Surface/App/FeatureFilling.cpp
+++ b/src/Mod/Surface/App/FeatureFilling.cpp
@@ -32,6 +32,7 @@
 #include <gp_Pnt.hxx>
 
 #include "FeatureFilling.h"
+#include "ShapeUtils.h"
 
 
 using namespace Surface;
@@ -144,7 +145,7 @@ void Filling::addConstraints(
 
             if (obj && obj->isDerivedFrom<Part::Feature>()) {
                 // get the sub-edge of the part's shape
-                const Part::TopoShape& shape = static_cast<Part::Feature*>(obj)->Shape.getShape();
+                const Part::TopoShape shape = getTopoShapeInGlobalCoordinates(obj);
                 TopoDS_Shape edge = shape.getSubShape(sub.c_str());
                 if (!edge.IsNull() && edge.ShapeType() == TopAbs_EDGE) {
                     GeomAbs_Shape cont = static_cast<GeomAbs_Shape>(contvals[index]);
@@ -223,7 +224,7 @@ void Filling::addConstraints(
             App::DocumentObject* obj = face_obj[index];
             const std::string& sub = face_sub[index];
             if (obj && obj->isDerivedFrom<Part::Feature>()) {
-                const Part::TopoShape& shape = static_cast<Part::Feature*>(obj)->Shape.getShape();
+                const Part::TopoShape shape = getTopoShapeInGlobalCoordinates(obj);
                 TopoDS_Shape face = shape.getSubShape(sub.c_str());
                 if (!face.IsNull() && face.ShapeType() == TopAbs_FACE) {
                     GeomAbs_Shape cont = static_cast<GeomAbs_Shape>(contvals[index]);
@@ -247,7 +248,7 @@ void Filling::addConstraints(BRepFill_Filling& builder, const App::PropertyLinkS
         App::DocumentObject* obj = it.first;
         std::vector<std::string> sub = it.second;
         if (obj && obj->isDerivedFrom<Part::Feature>()) {
-            const Part::TopoShape& shape = static_cast<Part::Feature*>(obj)->Shape.getShape();
+            const Part::TopoShape shape = getTopoShapeInGlobalCoordinates(obj);
             for (const auto& jt : sub) {
                 TopoDS_Shape subShape = shape.getSubShape(jt.c_str());
                 if (!subShape.IsNull() && subShape.ShapeType() == TopAbs_VERTEX) {
@@ -284,7 +285,7 @@ App::DocumentObjectExecReturn* Filling::execute()
         // Load the initial surface if set
         App::DocumentObject* initFace = InitialFace.getValue();
         if (initFace && initFace->isDerivedFrom<Part::Feature>()) {
-            const Part::TopoShape& shape = static_cast<Part::Feature*>(initFace)->Shape.getShape();
+            const Part::TopoShape shape = getTopoShapeInGlobalCoordinates(initFace);
             std::vector<std::string> subNames = InitialFace.getSubValues();
             for (const auto& it : subNames) {
                 TopoDS_Shape subShape = shape.getSubShape(it.c_str());

--- a/src/Mod/Surface/App/FeatureGeomFillSurface.cpp
+++ b/src/Mod/Surface/App/FeatureGeomFillSurface.cpp
@@ -50,6 +50,7 @@
 
 
 #include "FeatureGeomFillSurface.h"
+#include "ShapeUtils.h"
 
 
 using namespace Surface;
@@ -218,8 +219,8 @@ bool GeomFillSurface::getWire(TopoDS_Wire& aWire)
     ShapeValidator validator;
     for (const auto& set : boundary) {
         if (set.first->isDerivedFrom<Part::Feature>()) {
+            const Part::TopoShape ts = getTopoShapeInGlobalCoordinates(set.first);
             for (const auto& jt : set.second) {
-                const Part::TopoShape& ts = static_cast<Part::Feature*>(set.first)->Shape.getShape();
                 validator.checkAndAdd(ts, jt.c_str(), &aWD);
             }
         }

--- a/src/Mod/Surface/App/ShapeUtils.cpp
+++ b/src/Mod/Surface/App/ShapeUtils.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "ShapeUtils.h"
+
+#include <App/GeoFeature.h>
+#include <Mod/Part/App/PartFeature.h>
+
+namespace Surface
+{
+
+Part::TopoShape getTopoShapeInGlobalCoordinates(const App::DocumentObject* obj)
+{
+    Part::TopoShape shape = Part::Feature::getTopoShape(
+        obj,
+        Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform
+    );
+    if (shape.isNull()) {
+        return shape;
+    }
+
+    const auto geo = dynamic_cast<const App::GeoFeature*>(obj);
+    if (geo) {
+        const Base::Placement containerPlacement = geo->globalPlacement()
+            * geo->Placement.getValue().inverse();
+        shape.transformShape(containerPlacement.toMatrix(), false, true);
+    }
+    return shape;
+}
+
+}  // namespace Surface

--- a/src/Mod/Surface/App/ShapeUtils.h
+++ b/src/Mod/Surface/App/ShapeUtils.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <Mod/Part/App/TopoShape.h>
+
+namespace App
+{
+class DocumentObject;
+}
+
+namespace Surface
+{
+
+Part::TopoShape getTopoShapeInGlobalCoordinates(const App::DocumentObject* obj);
+
+}

--- a/src/Mod/Surface/CMakeLists.txt
+++ b/src/Mod/Surface/CMakeLists.txt
@@ -13,6 +13,7 @@ set(Surface_Scripts
 set(Surface_TestScripts
     SurfaceTests/__init__.py
     SurfaceTests/TestBlendCurve.py
+    SurfaceTests/TestGeomFillSurface.py
 )
 
 if(BUILD_GUI)

--- a/src/Mod/Surface/SurfaceTests/TestGeomFillSurface.py
+++ b/src/Mod/Surface/SurfaceTests/TestGeomFillSurface.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+import FreeCAD
+import Part
+
+App = FreeCAD
+
+
+class TestGeomFillSurface(unittest.TestCase):
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("SurfaceTestGeomFillSurface")
+
+    def testBoundaryListUsesTransformedShape(self):
+        line1 = self.Doc.addObject("Part::Feature", "Line1")
+        line1.Shape = Part.makeLine(App.Vector(0, 0, 0), App.Vector(0, 10, 0))
+        line1.Placement.Base = App.Vector(20, 0, 0)
+
+        line2 = self.Doc.addObject("Part::Feature", "Line2")
+        line2.Shape = Part.makeLine(App.Vector(10, 0, 0), App.Vector(10, 10, 0))
+        line2.Placement.Base = App.Vector(20, 0, 0)
+
+        surface = self.Doc.addObject("Surface::GeomFillSurface", "Surface")
+        surface.BoundaryList = [(line1, "Edge1"), (line2, "Edge1")]
+        self.Doc.recompute()
+
+        self.assertAlmostEqual(surface.Shape.BoundBox.XMin, 20)
+        self.assertAlmostEqual(surface.Shape.BoundBox.XMax, 30)
+
+    def testBoundaryListUsesParentGroupPlacement(self):
+        container = self.Doc.addObject("App::Part", "Part")
+        container.Placement.Base = App.Vector(20, 0, 0)
+
+        line1 = self.Doc.addObject("Part::Feature", "Line1")
+        line1.Shape = Part.makeLine(App.Vector(0, 0, 0), App.Vector(0, 10, 0))
+        container.addObject(line1)
+
+        line2 = self.Doc.addObject("Part::Feature", "Line2")
+        line2.Shape = Part.makeLine(App.Vector(10, 0, 0), App.Vector(10, 10, 0))
+        container.addObject(line2)
+
+        surface = self.Doc.addObject("Surface::GeomFillSurface", "Surface")
+        surface.BoundaryList = [(line1, "Edge1"), (line2, "Edge1")]
+        self.Doc.recompute()
+
+        self.assertAlmostEqual(surface.Shape.BoundBox.XMin, 20)
+        self.assertAlmostEqual(surface.Shape.BoundBox.XMax, 30)
+
+    def tearDown(self):
+        if hasattr(App, "KeepTestDoc") and App.KeepTestDoc:
+            return
+        FreeCAD.closeDocument("SurfaceTestGeomFillSurface")

--- a/src/Mod/Surface/TestSurfaceApp.py
+++ b/src/Mod/Surface/TestSurfaceApp.py
@@ -23,3 +23,4 @@
 
 # Unit test for the Surface module
 from SurfaceTests.TestBlendCurve import TestBlendCurve
+from SurfaceTests.TestGeomFillSurface import TestGeomFillSurface


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Split from https://github.com/FreeCAD/FreeCAD/pull/30575

- Surface features now handle support shapes with their real displayed placement
- Added a small shared helper instead of duplicating placement logic
- Filling and GeomFillSurface use that helper when reading linked support geometry

Assisted-by: GPT-5.5
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
- Fixes #29872
