### PR TITLE
CAM: Fix errors in ToolBit restore and tab widget

### DIFF
--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -1896,18 +1896,24 @@ class IconTabWidget(QtGui.QTabWidget):
             try:
                 ancestor.removeEventFilter(self)
             except RuntimeError:
-                pass  # ancestor already destroyed
+                pass  # ancestor's c++ object was deleted before the timer fired
         self._filteredAncestors = []
 
     def eventFilter(self, obj, event):
-        if event.type() == QtCore.QEvent.Resize:
+        if isinstance(event, QtCore.QEvent) and event.type() == QtCore.QEvent.Resize:
             self._scheduleUpdate()
         return super(IconTabWidget, self).eventFilter(obj, event)
 
     def _scheduleUpdate(self):
         # Defer until the event loop catches up so ancestor geometry (dock/
         # scroll area) has settled before we measure available width.
-        QtCore.QTimer.singleShot(0, lambda: self._updateTabLabels(self.currentIndex()))
+        def _deferredUpdate():
+            try:
+                self._updateTabLabels(self.currentIndex())
+            except RuntimeError:
+                pass  # widget's c++ object was deleed before the timer fired
+
+        QtCore.QTimer.singleShot(0, _deferredUpdate)
 
     def _availableWidth(self):
         """Width to fit tabs into: the nearest ancestor QScrollArea's viewport

--- a/src/Mod/CAM/Path/Tool/toolbit/models/base.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/models/base.py
@@ -1023,6 +1023,8 @@ class ToolBit(Asset, ABC):
         return state
 
     def __setstate__(self, state):
+        if not state:
+            return
         self.__dict__.update(state)
         # Seed _extra_attrs from _obj_data so unrecognised keys survive round-trips.
         self._extra_attrs = state.get("_obj_data", {})


### PR DESCRIPTION
ToolBit.__setstate__: guard against a None state so documents with a stale/legacy serialized value load instead of raising TypeError.

IconTabWidget: guard eventFilter and the deferred tab-label update against stale Qt objects so intermittent AttributeError/RuntimeError no longer surface when ancestor widgets are torn down.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.