### PR TITLE
[1.1] PD: Add FuzzyTolerance property

### DIFF
--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -725,7 +725,9 @@ static PyObject* makeShape(const char* op, const TopoShape& shape, PyObject* arg
         std::vector<TopoShape> shapes;
         shapes.push_back(shape);
         getPyShapes(pcObj, shapes);
-        return Py::new_reference_to(shape2pyshape(TopoShape().makeElementBoolean(op, shapes, 0, tol)));
+        return Py::new_reference_to(
+            shape2pyshape(TopoShape().makeElementBoolean(op, shapes, nullptr, tol))
+        );
     }
     PY_CATCH_OCC
 }

--- a/src/Mod/PartDesign/App/FeatureBoolean.cpp
+++ b/src/Mod/PartDesign/App/FeatureBoolean.cpp
@@ -143,7 +143,7 @@ App::DocumentObjectExecReturn* Boolean::execute()
         }
 
         try {
-            result.makeElementBoolean(op, shapes);
+            result.makeElementBoolean(op, shapes, nullptr, FuzzyTolerance.getValue());
         }
         catch (Standard_Failure& e) {
             FC_ERR("Boolean operation failed: " << e.GetMessageString());

--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -750,7 +750,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
                     default:
                         maker = Part::OpCodes::Fuse;
                 }
-                result.makeElementBoolean(maker, {base, prism});
+                result.makeElementBoolean(maker, {base, prism}, nullptr, FuzzyTolerance.getValue());
             }
             catch (Standard_Failure&) {
                 return new App::DocumentObjectExecReturn(

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -2020,7 +2020,7 @@ App::DocumentObjectExecReturn* Hole::execute()
                 result = compound;
             }
             else {
-                result.makeElementBoolean(maker, {base, compound});
+                result.makeElementBoolean(maker, {base, compound}, nullptr, FuzzyTolerance.getValue());
             }
             result = getSolid(result);
             retry = false;
@@ -2042,7 +2042,7 @@ App::DocumentObjectExecReturn* Hole::execute()
             for (auto& hole : holes) {
                 ++i;
                 try {
-                    result.makeElementBoolean(maker, {base, hole});
+                    result.makeElementBoolean(maker, {base, hole}, nullptr, FuzzyTolerance.getValue());
                 }
                 catch (Standard_Failure&) {
                     std::string msg(

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -354,7 +354,7 @@ App::DocumentObjectExecReturn* Loft::execute()
                 );
         }
         try {
-            boolOp.makeElementBoolean(maker, {base, result});
+            boolOp.makeElementBoolean(maker, {base, result}, nullptr, FuzzyTolerance.getValue());
         }
         catch (Standard_Failure&) {
             return new App::DocumentObjectExecReturn(

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -563,7 +563,7 @@ App::DocumentObjectExecReturn* Pipe::execute()
             //                        because you would expect this to be set to the feature's shape,
             //                        but boolOp is the topoShape that is actually being copied
 
-            boolOp.makeElementBoolean(maker.c_str(), {base, result});
+            boolOp.makeElementBoolean(maker.c_str(), {base, result}, nullptr, FuzzyTolerance.getValue());
 
             if (!isSingleSolidRuleSatisfied(boolOp.getShape())) {
                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(

--- a/src/Mod/PartDesign/App/FeaturePrimitive.cpp
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.cpp
@@ -124,7 +124,7 @@ App::DocumentObjectExecReturn* FeaturePrimitive::execute(const TopoDS_Shape& pri
                 );
         }
         try {
-            boolOp.makeElementBoolean(maker, {base, primitiveShape});
+            boolOp.makeElementBoolean(maker, {base, primitiveShape}, nullptr, FuzzyTolerance.getValue());
         }
         catch (Standard_Failure&) {
             return new App::DocumentObjectExecReturn(

--- a/src/Mod/PartDesign/App/FeatureRefine.cpp
+++ b/src/Mod/PartDesign/App/FeatureRefine.cpp
@@ -50,7 +50,7 @@ FeatureRefine::FeatureRefine()
     );
     ADD_PROPERTY_TYPE(
         FuzzyTolerance,
-        (0.0),
+        (-1.0),
         "Part Design",
         (App::PropertyType)(App::Prop_None),
         "Fuzzy tolerance:\n"

--- a/src/Mod/PartDesign/App/FeatureRefine.cpp
+++ b/src/Mod/PartDesign/App/FeatureRefine.cpp
@@ -37,16 +37,30 @@ using namespace PartDesign;
 namespace PartDesign
 {
 PROPERTY_SOURCE(PartDesign::FeatureRefine, PartDesign::Feature)
+const App::PropertyFloatConstraint::Constraints floatFuzzy = {-1.0, 1.0, 0.0001};
 
 FeatureRefine::FeatureRefine()
 {
     ADD_PROPERTY_TYPE(
         Refine,
-        (0),
+        (false),
         "Part Design",
         (App::PropertyType)(App::Prop_None),
         "Refine shape (clean up redundant edges) after operations"
     );
+    ADD_PROPERTY_TYPE(
+        FuzzyTolerance,
+        (0.0),
+        "Part Design",
+        (App::PropertyType)(App::Prop_None),
+        "Fuzzy tolerance:\n"
+        "If value > 0: use the value\n"
+        "If value = 0: leave default value\n"
+        "If value < 0: determine value"
+    );
+    FuzzyTolerance.setConstraints(&floatFuzzy);
+
+
     // init Refine property
     Base::Reference<ParameterGrp> hGrp = App::GetApplication()
                                              .GetUserParameter()

--- a/src/Mod/PartDesign/App/FeatureRefine.h
+++ b/src/Mod/PartDesign/App/FeatureRefine.h
@@ -45,6 +45,7 @@ public:
     FeatureRefine();
 
     App::PropertyBool Refine;
+    App::PropertyFloatConstraint FuzzyTolerance;
 
 protected:
     // store the shape before refinement


### PR DESCRIPTION
Backport of #29984 to releases/FreeCAD-1-1. FeatureHole.cpp adapted to 1.1's 2-arg makeElementBoolean call sites. It's a bit of a judgement call whether this constitutes a "feature" or a "bug fix." The PR allows users to choose between the pre-1.1 way non-fuzzy behavior, the 1.1.x auto-fuzzy behavior, and a new "set the fuzziness manually" behavior. The original reason we added the fuzziness was to fix some files, but it breaks some *other* files, so this PR allows the option. You could argue it fixes a regression. Or that it is an entirely new feature (it's in 26.3dev, of course).