### PR TITLE
Build: Update version to 1.1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ project(FreeCAD)
 
 set(PACKAGE_VERSION_MAJOR "1")
 set(PACKAGE_VERSION_MINOR "1")
-set(PACKAGE_VERSION_PATCH "1") # number of patch release (e.g. "4" for the 0.18.4 release)
+set(PACKAGE_VERSION_PATCH "2") # number of patch release (e.g. "4" for the 0.18.4 release)
 set(PACKAGE_VERSION_SUFFIX "") # either "dev" for development snapshot or "" (empty string)
 set(PACKAGE_BUILD_VERSION "0") # used when the same FreeCAD version will be re-released (for example using an updated LibPack)
 string(TIMESTAMP PACKAGE_COPYRIGHT_YEAR "%Y")

--- a/package/fedora/freecad.spec
+++ b/package/fedora/freecad.spec
@@ -16,7 +16,7 @@
 
 Name:           freecad
 Epoch:          1
-Version:        1.1.1
+Version:        1.1.2
 Release:        1%{?dist}
 
 Summary:        A general purpose 3D CAD modeler

--- a/package/rattler-build/pixi.lock
+++ b/package/rattler-build/pixi.lock
@@ -4221,7 +4221,7 @@ packages:
   timestamp: 1765632825351
 - conda: .
   name: freecad
-  version: 1.1.1
+  version: 1.1.2
   build: h3c70cbc_0
   subdir: win-64
   variants:
@@ -4282,7 +4282,7 @@ packages:
   - tbb >=2022.3.0
 - conda: .
   name: freecad
-  version: 1.1.1
+  version: 1.1.2
   build: h6d4d2f9_0
   subdir: linux-aarch64
   variants:
@@ -4344,7 +4344,7 @@ packages:
   - yaml-cpp >=0.8.0,<0.9.0a0
 - conda: .
   name: freecad
-  version: 1.1.1
+  version: 1.1.2
   build: h81b34b9_0
   subdir: linux-64
   variants:
@@ -4407,7 +4407,7 @@ packages:
   - yaml-cpp >=0.8.0,<0.9.0a0
 - conda: .
   name: freecad
-  version: 1.1.1
+  version: 1.1.2
   build: hc347f7b_0
   subdir: osx-64
   variants:
@@ -4467,7 +4467,7 @@ packages:
   - yaml-cpp >=0.8.0,<0.9.0a0
 - conda: .
   name: freecad
-  version: 1.1.1
+  version: 1.1.2
   build: he8ea13f_0
   subdir: osx-arm64
   variants:

--- a/package/rattler-build/pixi.toml
+++ b/package/rattler-build/pixi.toml
@@ -9,7 +9,7 @@ preview = ["pixi-build"]
 
 [package]
 name = "freecad"
-version = "1.1.1"
+version = "1.1.2"
 homepage = "https://freecad.org"
 repository = "https://github.com/FreeCAD/FreeCAD"
 description = "FreeCAD"

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "1.1.1"
+  version: "1.1.2"
 
 package:
   name: freecad


### PR DESCRIPTION
Bumps the FreeCAD version on the 1.1 release branch to 1.1.2.

NOTE: Don't merge until we decide what to do with https://github.com/FreeCAD/FreeCAD/pull/31249

NOTE 2: Also consider
* https://github.com/FreeCAD/FreeCAD/pull/31267
* https://github.com/FreeCAD/FreeCAD/pull/31269
* https://github.com/FreeCAD/FreeCAD/pull/31271
* https://github.com/FreeCAD/FreeCAD/pull/31272