### PR TITLE
Draft: Do not lock input with shortcuts

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_field_locks.py
+++ b/src/Mod/Draft/draftguitools/gui_field_locks.py
@@ -89,7 +89,7 @@ class InputFieldLockGroup:
             )
         )
         action.triggered.connect(lambda checked=False, k=key: self.unlock(k))
-        field.textEdited.connect(lambda text, k=key: self._queue_edit(k))
+        field.textEdited.connect(lambda text, k=key: self._queue_edit(k, text))
         flt = _FieldLockFilter(self, key)
         field.installEventFilter(flt)
         self._filters.append(flt)
@@ -97,17 +97,20 @@ class InputFieldLockGroup:
         self._actions[key] = action
         self._locked[key] = False
 
-    def _queue_edit(self, key):
+    def _queue_edit(self, key, text):
         if not self._active:
             return
         revision = self._edit_revisions.get(key, 0) + 1
         self._edit_revisions[key] = revision
-        QtCore.QTimer.singleShot(0, lambda k=key, r=revision: self._finish_edit(k, r))
+        QtCore.QTimer.singleShot(
+            0,
+            lambda k=key, t=text, r=revision: self._finish_edit(k, t, r),
+        )
 
-    def _finish_edit(self, key, revision):
+    def _finish_edit(self, key, text, revision):
         if not self._active or self._edit_revisions.get(key) != revision:
             return
-        locked = self._has_lockable_input(key)
+        locked = self._has_lockable_input(key, text)
         self.set_locked(key, locked)
 
     def queue_locked_value_refresh(self, key):


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Fix Draft input locking so command shortcuts like X and E do not accidentally lock the focused coordinate field.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

No AI used.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/31254
Fixes https://github.com/FreeCAD/FreeCAD/issues/31255


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
