### PR TITLE
Fix crash on spaceball motion before a window is active

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1208,8 +1208,10 @@ static View3DInventorViewer* spaceballMotionEventTarget()
 {
     // check if the active window has a 3d view
 
-    if (auto viewer = getMainWindow()->activeWindow()->findChild<View3DInventorViewer*>()) {
-        return viewer;
+    if (auto active = getMainWindow()->activeWindow()) {
+        if (auto viewer = active->findChild<View3DInventorViewer*>()) {
+            return viewer;
+        }
     }
 
     // check active view for the document


### PR DESCRIPTION
activeWindow() is nullptr during startup; guard it before findChild() instead of dereferencing. Fixes #30017