### PR TITLE
Sketcher: Fix for elliptical arc OVP input for 2nd axis length being …

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -522,6 +522,7 @@ void DSHArcOfEllipseController::doEnforceControlParameters(Base::Vector2d& onSke
 
             if (secondRadiusParam->isSet) {
                 secondRadius = secondRadiusParam->getValue();
+                handler->secondRadius = secondRadius;
                 handler->secondRadiusSet = true;
                 if (secondRadius < Precision::Confusion() && secondRadiusParam->hasFinishedEditing) {
                     handler->secondRadiusSet = false;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -512,6 +512,7 @@ void DSHArcOfHyperbolaController::doEnforceControlParameters(Base::Vector2d& onS
 
             if (secondRadiusParam->isSet) {
                 minorRadius = secondRadiusParam->getValue();
+                handler->minorRadius = minorRadius;
                 handler->minorRadiusSet = true;
                 if (minorRadius < Precision::Confusion() && secondRadiusParam->hasFinishedEditing) {
                     handler->minorRadiusSet = false;


### PR DESCRIPTION

Essentially the member `secondRadius` is not set, but only the local `secondRadius` in `doEnforceControlParameters` and the `secondRadiusSet` flag is set to `True` , so when `updateDataAndDrawToPosition` runs, it sees the flag and skips recomputing `secondRadius `from the mouse, assuming it's already been set correctly by the OVP code. But `handler->secondRadius` is still the old mouse-derived value . So the geometry drawn to screen uses the stale radius.

- [ ✅] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
fixes #31241 

## Before and After Images
<img width="487" height="382" alt="Screenshot 2026-07-12 at 12 18 03 AM" src="https://github.com/user-attachments/assets/9baeab6f-7e33-459d-8b46-44cf86e94d62" />
<img width="487" height="382" alt="Screenshot 2026-07-12 at 12 18 30 AM" src="https://github.com/user-attachments/assets/d10e706a-c83b-4f5b-8f56-4642128e8f07" />