### PR TITLE
FEM: Switch to direct C++ set of text values

### DIFF
--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
@@ -418,23 +418,17 @@ std::string TaskFemConstraintDisplacement::get_spinzRotation() const
 
 std::string TaskFemConstraintDisplacement::get_xFormula() const
 {
-    QString xFormula = ui->DisplacementXFormulaLE->text();
-    xFormula.replace(QStringLiteral("\""), QStringLiteral("\\\""));
-    return xFormula.toStdString();
+    return ui->DisplacementXFormulaLE->text().toStdString();
 }
 
 std::string TaskFemConstraintDisplacement::get_yFormula() const
 {
-    QString yFormula = ui->DisplacementYFormulaLE->text();
-    yFormula.replace(QStringLiteral("\""), QStringLiteral("\\\""));
-    return yFormula.toStdString();
+    return ui->DisplacementYFormulaLE->text().toStdString();
 }
 
 std::string TaskFemConstraintDisplacement::get_zFormula() const
 {
-    QString zFormula = ui->DisplacementZFormulaLE->text();
-    zFormula.replace(QStringLiteral("\""), QStringLiteral("\\\""));
-    return zFormula.toStdString();
+    return ui->DisplacementZFormulaLE->text().toStdString();
 }
 
 bool TaskFemConstraintDisplacement::get_dispxfree() const
@@ -529,6 +523,7 @@ bool TaskDlgFemConstraintDisplacement::accept()
     std::string name = ConstraintView->getObject()->getNameInDocument();
     const TaskFemConstraintDisplacement* parameterDisplacement
         = static_cast<const TaskFemConstraintDisplacement*>(parameter);
+    auto* constraint = static_cast<Fem::ConstraintDisplacement*>(ConstraintView->getObject());
 
     try {
         Gui::Command::doCommand(
@@ -537,36 +532,23 @@ bool TaskDlgFemConstraintDisplacement::accept()
             name.c_str(),
             parameterDisplacement->get_spinxDisplacement().c_str()
         );
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            "App.ActiveDocument.%s.xDisplacementFormula = \"%s\"",
-            name.c_str(),
-            parameterDisplacement->get_xFormula().c_str()
-        );
+        // Formula fields are free-form user text and must never be interpolated into a
+        // Python command; set the property directly to avoid code injection.
+        constraint->xDisplacementFormula.setValue(parameterDisplacement->get_xFormula());
         Gui::Command::doCommand(
             Gui::Command::Doc,
             "App.ActiveDocument.%s.yDisplacement = \"%s\"",
             name.c_str(),
             parameterDisplacement->get_spinyDisplacement().c_str()
         );
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            "App.ActiveDocument.%s.yDisplacementFormula = \"%s\"",
-            name.c_str(),
-            parameterDisplacement->get_yFormula().c_str()
-        );
+        constraint->yDisplacementFormula.setValue(parameterDisplacement->get_yFormula());
         Gui::Command::doCommand(
             Gui::Command::Doc,
             "App.ActiveDocument.%s.zDisplacement = \"%s\"",
             name.c_str(),
             parameterDisplacement->get_spinzDisplacement().c_str()
         );
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            "App.ActiveDocument.%s.zDisplacementFormula = \"%s\"",
-            name.c_str(),
-            parameterDisplacement->get_zFormula().c_str()
-        );
+        constraint->zDisplacementFormula.setValue(parameterDisplacement->get_zFormula());
         Gui::Command::doCommand(
             Gui::Command::Doc,
             "App.ActiveDocument.%s.xRotation = \"%s\"",


### PR DESCRIPTION
Address GHSA-2rq3-gx3h-489q by eliminating the Python `doCommand()` entirely. An alternative would be to fix the escaping, but this is more robust (not requiring any escaping at all so completely eliminating the attack vector), at the cost of not recording this action action into a macro. @marioalexis84 and @FEA-eng if you'd prefer that fix let me know and I'll close this one.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
