### PR TITLE
App: Prevent directory traversal in included file

### DIFF
--- a/src/App/PropertyFile.cpp
+++ b/src/App/PropertyFile.cpp
@@ -42,6 +42,27 @@ using namespace Base;
 using namespace std;
 
 
+namespace
+{
+/**
+ * @brief Check that an embedded file name from a restored document is a plain basename.
+ *
+ * PropertyFileIncluded::Save() always stores basenames (via FileInfo::fileName()), so a
+ * document that carries a name with any directory component, an absolute path, or a
+ * <tt>.</tt>/<tt>..</tt> reference is malicious.
+ *
+ * @param[in] name The file name taken from the document XML.
+ * @return @c true if @p name is a safe basename, @c false if it must be rejected.
+ */
+bool isPlainFileName(const std::string& name)
+{
+    if (name == "." || name == "..") {
+        return false;
+    }
+    return Base::FileInfo(name).fileName() == name;
+}
+}  // namespace
+
 //**************************************************************************
 // PropertyFileIncluded
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -400,6 +421,10 @@ void PropertyFileIncluded::Restore(Base::XMLReader& reader)
     if (reader.hasAttribute("file")) {
         string file(reader.getAttribute<const char*>("file"));
         if (!file.empty()) {
+            if (!isPlainFileName(file)) {
+                throw Base::FileException(
+                    "PropertyFileIncluded::Restore(): rejected unsafe embedded file name");
+            }
             // initiate a file read
             reader.addFile(file.c_str(), this);
             // is in the document transient path
@@ -413,6 +438,10 @@ void PropertyFileIncluded::Restore(Base::XMLReader& reader)
     else if (reader.hasAttribute("data")) {
         string file(reader.getAttribute<const char*>("data"));
         if (!file.empty()) {
+            if (!isPlainFileName(file)) {
+                throw Base::FileException(
+                    "PropertyFileIncluded::Restore(): rejected unsafe embedded file name");
+            }
             // is in the document transient path
             aboutToSetValue();
             _cValue = getDocTransientPath() + "/" + file;

--- a/tests/src/App/CMakeLists.txt
+++ b/tests/src/App/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(App_tests_run
         MappedName.cpp
         Metadata.cpp
         ProjectFile.cpp
+        PropertyFile.cpp
         Property.h
         Property.cpp
         PropertyExpressionEngine.cpp

--- a/tests/src/App/PropertyFile.cpp
+++ b/tests/src/App/PropertyFile.cpp
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <ranges>
+#include <sstream>
+#include <string>
+
+#include <Base/Exception.h>
+#include <Base/Reader.h>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <App/PropertyFile.h>
+
+#include "InitApplication.h"
+
+namespace
+{
+void restoreFileIncluded(App::PropertyFileIncluded& prop, const std::string& fileIncludedElement)
+{
+    std::string xml = "<?xml version='1.0' encoding='utf-8'?>\n";
+    xml += "<Property name='File' type='App::PropertyFileIncluded'>\n";
+    xml += fileIncludedElement;
+    xml += "\n</Property>\n";
+
+    std::stringstream data(xml);
+    Base::XMLReader reader("Document.xml", data);
+    prop.Restore(reader);
+}
+}  // namespace
+
+// Regression tests for GHSA-5vqh-3v38-jw2r: a crafted .FCStd must not be able to escape the
+// document transient directory through the "file" or "data" attributes of a FileIncluded element.
+class PropertyFileIncludedTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+    void SetUp() override
+    {
+        _doc = App::GetApplication().newDocument("PropertyFileIncludedTest");
+        _object = _doc->addObject("App::VarSet", "VarSet");
+        _property = static_cast<App::PropertyFileIncluded*>(
+            _object->addDynamicProperty("App::PropertyFileIncluded", "File")
+        );
+    }
+    void TearDown() override
+    {
+        App::GetApplication().closeDocument(_doc->getName());
+    }
+    App::Document* _doc {nullptr};
+    App::DocumentObject* _object {nullptr};
+    App::PropertyFileIncluded* _property {nullptr};
+};
+
+TEST_F(PropertyFileIncludedTest, rejectsParentTraversalInFileAttribute)
+{
+    EXPECT_THROW(
+        restoreFileIncluded(*_property, "<FileIncluded file='../../../.bashrc'/>"),
+        Base::FileException
+    );
+    EXPECT_TRUE(std::string(_property->getValue()).empty());
+}
+
+TEST_F(PropertyFileIncludedTest, rejectsBackslashTraversalInFileAttribute)
+{
+    EXPECT_THROW(
+        restoreFileIncluded(*_property, "<FileIncluded file='..\\..\\.bashrc'/>"),
+        Base::FileException
+    );
+    EXPECT_TRUE(std::string(_property->getValue()).empty());
+}
+
+TEST_F(PropertyFileIncludedTest, rejectsAbsolutePathInFileAttribute)
+{
+    EXPECT_THROW(
+        restoreFileIncluded(*_property, "<FileIncluded file='/etc/passwd'/>"),
+        Base::FileException
+    );
+    EXPECT_TRUE(std::string(_property->getValue()).empty());
+}
+
+TEST_F(PropertyFileIncludedTest, rejectsSubdirectoryInFileAttribute)
+{
+    EXPECT_THROW(
+        restoreFileIncluded(*_property, "<FileIncluded file='sub/payload'/>"),
+        Base::FileException
+    );
+    EXPECT_TRUE(std::string(_property->getValue()).empty());
+}
+
+TEST_F(PropertyFileIncludedTest, rejectsDotDotInFileAttribute)
+{
+    EXPECT_THROW(restoreFileIncluded(*_property, "<FileIncluded file='..'/>"), Base::FileException);
+    EXPECT_TRUE(std::string(_property->getValue()).empty());
+}
+
+TEST_F(PropertyFileIncludedTest, rejectsParentTraversalInDataAttribute)
+{
+    EXPECT_THROW(
+        restoreFileIncluded(*_property, "<FileIncluded data='../../../.bashrc'/>"),
+        Base::FileException
+    );
+    EXPECT_TRUE(std::string(_property->getValue()).empty());
+}
+
+TEST_F(PropertyFileIncludedTest, acceptsPlainBasename)
+{
+    // A legitimate basename (as always produced by Save()) must still restore and resolve inside
+    // the document transient directory.
+    EXPECT_NO_THROW(restoreFileIncluded(*_property, "<FileIncluded file='PartShape.brp'/>"));
+
+    // getDocTransientPath() normalizes backslashes to forward slashes, so normalize the expected
+    // transient directory the same way before comparing.
+    std::string transientDir = _doc->TransientDir.getValue();
+    std::ranges::replace(transientDir, '\\', '/');
+    EXPECT_EQ(std::string(_property->getValue()), transientDir + "/PartShape.brp");
+}


### PR DESCRIPTION
Address GHSA-5vqh-3v38-jw2r, which points out that we aren't sanitizing `FileIncluded` in our XML read. Basically, if the filename is something that can't be written by `Base::FileInfo::fileName()`, reject it.

Assisted by Claude Opus 4.8.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
