### PR TITLE
Base: Harden FCStd Reader against XXE

### DIFF
--- a/src/Base/Reader.cpp
+++ b/src/Base/Reader.cpp
@@ -28,6 +28,7 @@
 #include <string>
 #include <xercesc/sax2/XMLReaderFactory.hpp>
 #include <xercesc/sax2/Attributes.hpp>
+#include <xercesc/util/XMLUni.hpp>
 
 #include <locale>
 
@@ -67,6 +68,8 @@ Base::XMLReader::XMLReader(const char* FileName, std::istream& str)
     parser->setContentHandler(this);
     parser->setLexicalHandler(this);
     parser->setErrorHandler(this);
+    parser->setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, true);
+    parser->setFeature(XMLUni::fgXercesLoadExternalDTD, false);
 
     try {
         StdInputSource file(str, _File.filePath().c_str());


### PR DESCRIPTION
Address GHSA-cp6c-87x9-xf49 by turning on the Xerces-C options to harden the Base parser against XML External Entity injection. We've already done this for the Parameter parser in an earlier PR, but missed this one.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

(I note that I am using the proposed fix from the obviously-AI-generated vulnerability report, so it should have the "Assisted-by" flag, except that I don't know what model the reporter used.
