### PR TITLE
CAM: Escape user input to avoid code injection

### DIFF
--- a/src/Mod/CAM/Gui/AppPathGuiPy.cpp
+++ b/src/Mod/CAM/Gui/AppPathGuiPy.cpp
@@ -32,6 +32,7 @@
 
 #include <Base/FileInfo.h>
 #include <Base/Interpreter.h>
+#include <Base/Tools.h>
 #include <Gui/Command.h>
 #include <Gui/WaitCursor.h>
 
@@ -77,6 +78,9 @@ private:
         if (!fi.exists()) {
             throw Py::RuntimeError("File not found");
         }
+        // EncodedName is interpolated into Python commands below; escape it to prevent
+        // code injection.
+        EncodedName = Base::Tools::escapeEncodeFilename(EncodedName);
 
         Gui::WaitCursor wc;
         wc.restoreCursor();
@@ -150,6 +154,9 @@ private:
         if (!fi.exists()) {
             throw Py::RuntimeError("File not found");
         }
+        // EncodedName is interpolated into Python commands below; escape it to prevent
+        // code injection.
+        EncodedName = Base::Tools::escapeEncodeFilename(EncodedName);
 
         Gui::WaitCursor wc;
         wc.restoreCursor();
@@ -231,6 +238,9 @@ private:
 
         std::string EncodedName = std::string(Name);
         PyMem_Free(Name);
+        // EncodedName is interpolated into Python commands below; escape it to prevent
+        // code injection.
+        EncodedName = Base::Tools::escapeEncodeFilename(EncodedName);
         Gui::WaitCursor wc;
         wc.restoreCursor();
 
@@ -260,7 +270,9 @@ private:
                 return Py::None();
             }
             std::string processor = Dlg.getProcessor();
-            std::string arguments = Dlg.getArguments();
+            // Post-processor arguments are free-form user text interpolated into a Python
+            // command; escape them to prevent code injection.
+            std::string arguments = Base::Tools::escapeEncodeString(Dlg.getArguments());
 
             std::ostringstream pre;
             std::ostringstream cmd;


### PR DESCRIPTION
Make sure that any use of user-controlled input text that gets interpolated into a Python command string is correctly escaped. Note that I'm using `escapeEncodeFilename()` for the filenames because that's what we seem to do pretty much everywhere else in the codebase where we're handling similar cases, but it is totally reliant on that filename coming from some source that we trust to have removed backslashes and newlines. If that's not actually true here, we should use `escapeEncodeString()` instead.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
