### PR TITLE
Part: Ensure filename is properly escaped

### DIFF
--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1209,13 +1209,11 @@ void CmdPartImportCurveNet::activated(int iMsg)
     if (!fn.isEmpty()) {
         QFileInfo fi;
         fi.setFile(fn);
+        const std::string baseName = Base::Tools::escapeEncodeFilename(fi.baseName().toStdString());
+        const std::string fileName = Base::Tools::escapeEncodeFilename(fn.toStdString());
         openCommand(QT_TRANSLATE_NOOP("Command", "Import Curve Net"));
-        doCommand(
-            Doc,
-            "f = App.activeDocument().addObject(\"Part::CurveNet\",\"%s\")",
-            (const char*)fi.baseName().toLatin1()
-        );
-        doCommand(Doc, "f.FileName = \"%s\"", (const char*)fn.toLatin1());
+        doCommand(Doc, "f = App.activeDocument().addObject(\"Part::CurveNet\",\"%s\")", baseName.c_str());
+        doCommand(Doc, "f.FileName = \"%s\"", fileName.c_str());
         commitCommand();
         updateActive();
     }


### PR DESCRIPTION
Part had one instance I could find of a filename not being escaped before being used to construct a command string. The string is coming from a file dialog which will have already dealt with backslashes and newlines, so we only need to escape quote characters, which is what `escapeEncodeFilename()` does.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.