### PR TITLE
TD: Ensure quotes in a filename are properly escaped

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskHatch.cpp
+++ b/src/Mod/TechDraw/Gui/TaskHatch.cpp
@@ -26,6 +26,7 @@
 #include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <Base/Console.h>
+#include <Base/Tools.h>
 #include <Base/Vector3D.h>
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
@@ -208,6 +209,7 @@ void TaskHatch::createHatch()
 
     auto filespec = ui->fcFile->fileName().toStdString();
     filespec = DU::cleanFilespecBackslash(filespec);
+    filespec = Base::Tools::escapeEncodeFilename(filespec);
     Command::doCommand(Command::Doc, "App.activeDocument().%s.HatchPattern = '%s'",
                        FeatName.c_str(),
                        filespec.c_str());
@@ -238,6 +240,7 @@ void TaskHatch::updateHatch()
 
     auto filespec = ui->fcFile->fileName().toStdString();
     filespec = DU::cleanFilespecBackslash(filespec);
+    filespec = Base::Tools::escapeEncodeFilename(filespec);
     Command::doCommand(Command::Doc, "App.activeDocument().%s.HatchPattern = '%s'",
                        FeatName.c_str(),
                        filespec.c_str());


### PR DESCRIPTION
Make sure that the hatch filename is fully-escaped (the previous line in both instances ensures there are no backslashes, and this is coming from a `QLineEdit` which can't have newlines, so the only characters we have to worry about escaping are quotes, which is what `escapeEncodeFilename` does).

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
