### PR TITLE
Robot: Ensure filenames are properly escaped

### DIFF
--- a/src/Mod/Robot/Gui/Command.cpp
+++ b/src/Mod/Robot/Gui/Command.cpp
@@ -25,6 +25,7 @@
 #include <QMessageBox>
 
 
+#include <Base/Tools.h>
 #include <Gui/Application.h>
 #include <Gui/Command.h>
 #include <Gui/Control.h>
@@ -216,12 +217,14 @@ void CmdRobotConstraintAxle::activated([[maybe_unused]] int msg)
 
     openCommand("Place robot");
     doCommand(Doc, "App.activeDocument().addObject(\"Robot::RobotObject\",\"%s\")", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.RobotVrmlFile = \"%s\"", FeatName.c_str(), WrlPath.c_str());
+    const std::string wrlPath = Base::Tools::escapeEncodeString(WrlPath);
+    const std::string kinematicPath = Base::Tools::escapeEncodeString(KinematicPath);
+    doCommand(Doc, "App.activeDocument().%s.RobotVrmlFile = \"%s\"", FeatName.c_str(), wrlPath.c_str());
     doCommand(
         Doc,
         "App.activeDocument().%s.RobotKinematicFile = \"%s\"",
         FeatName.c_str(),
-        KinematicPath.c_str()
+        kinematicPath.c_str()
     );
     updateActive();
     commitCommand();

--- a/src/Mod/Robot/Gui/CommandExport.cpp
+++ b/src/Mod/Robot/Gui/CommandExport.cpp
@@ -25,6 +25,7 @@
 #include <QMessageBox>
 
 
+#include <Base/Tools.h>
 #include <Gui/Application.h>
 #include <Gui/Command.h>
 #include <Gui/Document.h>
@@ -102,12 +103,13 @@ void CmdRobotExportKukaCompact::activated(int)
     }
 
     doCommand(Doc, "from KukaExporter import ExportCompactSub");
+    const std::string fileName = Base::Tools::escapeEncodeString(fn.toStdString());
     doCommand(
         Doc,
         "ExportCompactSub(App.activeDocument().%s,App.activeDocument().%s,'%s')",
         pcRobotObject->getNameInDocument(),
         pcTrajectoryObject->getNameInDocument(),
-        (const char*)fn.toLatin1()
+        fileName.c_str()
     );
 }
 
@@ -184,12 +186,13 @@ void CmdRobotExportKukaFull::activated(int)
     }
 
     doCommand(Doc, "from KukaExporter import ExportFullSub");
+    const std::string fileName = Base::Tools::escapeEncodeString(fn.toStdString());
     doCommand(
         Doc,
         "ExportFullSub(App.activeDocument().%s,App.activeDocument().%s,'%s')",
         pcRobotObject->getNameInDocument(),
         pcTrajectoryObject->getNameInDocument(),
-        (const char*)fn.toLatin1()
+        fileName.c_str()
     );
 }
 


### PR DESCRIPTION
Make sure that filenames are properly escaped when used to interpolate a Python command.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
