### PR TITLE
Draft: SVG import preference checkbox label to sentence case

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-svg.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-svg.ui
@@ -117,7 +117,7 @@ a raw wire from the original shape is added</string>
            <string>Check to cut shapes according to the even/odd SVG fill rule</string>
           </property>
           <property name="text">
-           <string>Apply Cuts</string>
+           <string>Apply cuts</string>
           </property>
           <property name="checked">
            <bool>true</bool>


### PR DESCRIPTION
Checkbox labels should be sentence case.
"Apply Cuts" -> "Apply cuts"