### PR TITLE
Draft: update handling of inCommandShortcut hints to support multiple characters

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_tool_utils.py
+++ b/src/Mod/Draft/draftguitools/gui_tool_utils.py
@@ -98,6 +98,16 @@ def _get_hint_mod_copy():
     return [Gui.InputHint(translate("draft", "Hold %1 copy"), key)]
 
 
+def _get_hint_in_cmd_shortcut(shortcut_param):
+    shortcut = params.get_param(shortcut_param)
+    if not shortcut:
+        # Empty string.
+        return ""
+    # In command shortcuts support multiple characters where each individual
+    # character is recognized separately. We only display the 1st character.
+    return shortcut[0].upper()
+
+
 def _get_hint_select_object(multiple=True):
     if multiple:
         text = translate("draft", "%1 select objects to modify")
@@ -108,9 +118,9 @@ def _get_hint_select_object(multiple=True):
 
 def _get_hint_xyz_constrain():
     pattern = re.compile("[A-Z]")
-    shortcut_x = params.get_param("inCommandShortcutRestrictX").upper()
-    shortcut_y = params.get_param("inCommandShortcutRestrictY").upper()
-    shortcut_z = params.get_param("inCommandShortcutRestrictZ").upper()
+    shortcut_x = _get_hint_in_cmd_shortcut("inCommandShortcutRestrictX")
+    shortcut_y = _get_hint_in_cmd_shortcut("inCommandShortcutRestrictY")
+    shortcut_z = _get_hint_in_cmd_shortcut("inCommandShortcutRestrictZ")
     if (
         pattern.fullmatch(shortcut_x)
         and pattern.fullmatch(shortcut_y)
@@ -127,7 +137,7 @@ def _get_hint_xyz_constrain():
 
 def _get_hint_relative():
     pattern = re.compile("[A-Z]")
-    shortcut = params.get_param("inCommandShortcutRelative").upper()
+    shortcut = _get_hint_in_cmd_shortcut("inCommandShortcutRelative")
     if pattern.fullmatch(shortcut):
         key = getattr(Gui.UserInput, "Key" + shortcut)
         return [Gui.InputHint(translate("draft", "%1 toggle relative"), key)]
@@ -136,7 +146,7 @@ def _get_hint_relative():
 
 def _get_hint_global():
     pattern = re.compile("[A-Z]")
-    shortcut = params.get_param("inCommandShortcutGlobal").upper()
+    shortcut = _get_hint_in_cmd_shortcut("inCommandShortcutGlobal")
     if pattern.fullmatch(shortcut):
         key = getattr(Gui.UserInput, "Key" + shortcut)
         return [Gui.InputHint(translate("draft", "%1 toggle global"), key)]
@@ -145,7 +155,7 @@ def _get_hint_global():
 
 def _get_hint_continue():
     pattern = re.compile("[A-Z]")
-    shortcut = params.get_param("inCommandShortcutContinue").upper()
+    shortcut = _get_hint_in_cmd_shortcut("inCommandShortcutContinue")
     if pattern.fullmatch(shortcut):
         key = getattr(Gui.UserInput, "Key" + shortcut)
         return [Gui.InputHint(translate("draft", "%1 toggle continue"), key)]
@@ -155,7 +165,7 @@ def _get_hint_continue():
 def _get_hint_select_edge():
     mod_key = _HINT_MOD_KEYS[params.get_param("modalt")]
     pattern = re.compile("[A-Z]")
-    shortcut = params.get_param("inCommandShortcutSelectEdge").upper()
+    shortcut = _get_hint_in_cmd_shortcut("inCommandShortcutSelectEdge")
     if pattern.fullmatch(shortcut):
         shortcut_key = getattr(Gui.UserInput, "Key" + shortcut)
         return [


### PR DESCRIPTION
In v26.3 the Draft in command shortcuts support multiple character where each character is recognized separately. This PR updates the hints to handle this as well: only the 1st character is displayed in the hint.

No AI was used.