### PR TITLE
CAM: OpStartDepth - Removed dependence from StepDown

### DIFF
--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -947,15 +947,9 @@ class ObjectOp(object):
                 obj.OpFinalDepth = zmin
             zmin = obj.OpFinalDepth.Value
 
-            def minZmax(z):
-                if hasattr(obj, "StepDown") and not Path.Geom.isRoughly(obj.StepDown.Value, 0):
-                    return z + obj.StepDown.Value
-                else:
-                    return z + 1
-
             # ensure zmax is higher than zmin
-            if (zmax - 0.0001) <= zmin:
-                zmax = minZmax(zmin)
+            if zmax < zmin or Path.Geom.isRoughly(zmax, zmin):
+                zmax = zmin
 
             # update start depth if requested and required
             if not Path.Geom.isRoughly(obj.OpStartDepth.Value, zmax):

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -581,6 +581,16 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         tooldiameter = obj.ToolController.Tool.Diameter.Value
         toolradius = tooldiameter / 2
 
+        if obj.StartDepth < obj.FinalDepth or isRoughly(obj.StartDepth.Value, obj.FinalDepth.Value):
+            obj.Path = Path.Path()
+            Path.Log.warning("StartDepth should be greater than FinalDepth")
+            return
+
+        if obj.StepDown < 0 or isRoughly(obj.StepDown.Value, 0):
+            obj.Path = Path.Path()
+            Path.Log.warning("StepDown should be greater than 0")
+            return
+
         if safeHeight > clearanceHeight:
             Path.Log.warning(
                 f"SafeHeight ({safeHeight}) is above ClearanceHeight ({clearanceHeight}). "


### PR DESCRIPTION
### Changes
- Removed dependency `OpStartDepth` from `StepDown`
- Added checks to exclude errors in **Helix** op related with incorrect `StartDepth`, `FinalDepth` and `StepDown`
 
### Description 

- `OpStartDepth` should not depend from `StepDown`

- While changing tool diameter get incorrect path
Need recompute operation twice to get correct `OpStartDepth`

- In **Helix** op `StepDown` is a full work depth, which calculated as `StartDepth - FinalDepth`
  If `StartDepth` depend from `StepDown`, it creates cyclic dependency

### Steps to reproduce
- Add **Cube**
- Create **Job**
- Create **Pocket_Shape** op for top face or create **MillFacing** op
 
Test project: [x0y0.zip](https://github.com/user-attachments/files/29950009/x0y0.zip)

<img width="956" height="684" alt="Screenshot_20260712_132922_hor_lossy" src="https://github.com/user-attachments/assets/d62f16dc-8477-47cb-9859-74ff50746362" />

---

**Before**
Even after increased `StepDown`, still get two depth passes, because `StartDepth` also increased
Need remove expression from `StartDepth` to get needed result

https://github.com/user-attachments/assets/6f128c55-1cd3-42fe-89b8-f76750e6449a

---

**After**

https://github.com/user-attachments/assets/cd62fb16-bb15-40df-8896-2a6b3d6acc80
