### PR TITLE
Gui: reword document recovery dialogs to avoid "transient directory"

### DIFF
--- a/src/Gui/DocumentRecovery.cpp
+++ b/src/Gui/DocumentRecovery.cpp
@@ -648,12 +648,9 @@ void DocumentRecovery::onDeleteSection()
 {
     QMessageBox msgBox(this);
     msgBox.setIcon(QMessageBox::Warning);
-    msgBox.setWindowTitle(tr("Cleanup"));
-    msgBox.setText(tr("Delete the selected transient directories?"));
-    msgBox.setInformativeText(
-        tr("When deleting the selected transient directory it is not possible to recover any files "
-           "afterwards.")
-    );
+    msgBox.setWindowTitle(tr("Delete"));
+    msgBox.setText(tr("Delete the selected recovery documents?"));
+    msgBox.setInformativeText(tr("Recovery documents cannot be restored after deletion."));
     msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     msgBox.setDefaultButton(QMessageBox::No);
     int ret = msgBox.exec();
@@ -685,8 +682,8 @@ void DocumentRecovery::onButtonCleanupClicked()
     QMessageBox msgBox(this);
     msgBox.setIcon(QMessageBox::Warning);
     msgBox.setWindowTitle(tr("Cleanup"));
-    msgBox.setText(tr("Delete all transient directories?"));
-    msgBox.setInformativeText(tr("When deleting all transient directories it is not possible to recover any files afterwards."));
+    msgBox.setText(tr("Delete all recovery documents?"));
+    msgBox.setInformativeText(tr("Recovery documents cannot be restored after deletion."));
     msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     msgBox.setDefaultButton(QMessageBox::No);
     int ret = msgBox.exec();
@@ -703,7 +700,7 @@ void DocumentRecovery::onButtonCleanupClicked()
     handler.checkForPreviousCrashes(
         std::bind(&DocumentRecovery::cleanup, this, sp::_1, sp::_2, sp::_3)
     );
-    DlgCheckableMessageBox::showMessage(tr("Delete"), tr("Transient directories deleted."));
+    DlgCheckableMessageBox::showMessage(tr("Cleanup"), tr("Recovery documents deleted."));
     reject();
 }
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Simplify the dialog in the document recovery scene to remove confusing "transient directory" terminology.
Note: 
- Renamed the delete window title from Cleanup to Delete
- Renamed cleanup confirmation title from Delete to Cleanup


<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes #31179

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

| | Before | After |
|---|---|---|
| **Cleanup** | <img width="400" alt="cleanup_before" src="https://github.com/user-attachments/assets/87b872bb-14d5-4ba9-a393-7d0f6f1300c4" /> | <img width="400" alt="cleanup_after" src="https://github.com/user-attachments/assets/26b2aa44-9e80-484d-ae31-8bd265550d5b" /> |
| **Cleanup confirm** | <img width="400" alt="cleanup_confirm_before" src="https://github.com/user-attachments/assets/1b06a59c-82c4-4142-b99b-8f669048ba94" /> | <img width="400" alt="cleanup_confirm_after" src="https://github.com/user-attachments/assets/914b8fc8-92f7-4e7e-ab3f-d9fb3357818d" /> |
| **Delete** | <img width="400" alt="delete_before" src="https://github.com/user-attachments/assets/3eb66ce2-51d3-4d83-a68b-ea30d1079630" /> | <img width="400" alt="delete_after" src="https://github.com/user-attachments/assets/108cf2a7-3e8f-4fe9-b92c-32b720cda34f" /> |

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
