### PR TITLE
CAM: GUI Improvements: Move tool controller to its own tab

### DIFF
--- a/src/Mod/CAM/Gui/Resources/Path.qrc
+++ b/src/Mod/CAM/Gui/Resources/Path.qrc
@@ -127,6 +127,7 @@
         <file>panels/PageOpThreadMillingEdit.ui</file>
         <file>panels/PageOpWaterlineEdit.ui</file>
         <file>panels/PageOpVcarveEdit.ui</file>
+        <file>panels/PageToolControllerEdit.ui</file>
         <file>panels/PathEdit.ui</file>
         <file>panels/PointEdit.ui</file>
         <file>panels/PropertyBag.ui</file>

--- a/src/Mod/CAM/Gui/Resources/panels/FeedsSpeedsPresetEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/FeedsSpeedsPresetEdit.ui
@@ -77,9 +77,6 @@
      </item>
      <item row="3" column="1">
       <widget class="QDoubleSpinBox" name="surfaceSpeedSpin">
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
        <property name="decimals">
         <number>1</number>
        </property>
@@ -97,9 +94,6 @@
      </item>
      <item row="4" column="1">
       <widget class="Gui::QuantitySpinBox" name="chiploadSpin">
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
        <property name="minimum">
         <double>0.000000000000000</double>
        </property>
@@ -120,9 +114,6 @@
      </item>
      <item row="5" column="1">
       <widget class="QDoubleSpinBox" name="vertRatioSpin">
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
        <property name="decimals">
         <number>3</number>
        </property>
@@ -154,9 +145,6 @@
       </item>
       <item row="0" column="1">
        <widget class="Gui::QuantitySpinBox" name="rawFeedSpin">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
         <property name="minimum">
          <double>0.000000000000000</double>
         </property>
@@ -177,9 +165,6 @@
       </item>
       <item row="1" column="1">
        <widget class="QDoubleSpinBox" name="rawSpeedSpin">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
         <property name="decimals">
          <number>0</number>
         </property>

--- a/src/Mod/CAM/Gui/Resources/panels/PageDiametersEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageDiametersEdit.ui
@@ -26,9 +26,6 @@
      <property name="toolTip">
       <string>Start depth of the operation. The highest point in Z-axis the operation needs to process.</string>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
      <property name="minimum">
       <double>-999999999.000000000000000</double>
      </property>
@@ -62,9 +59,6 @@
     <widget class="Gui::QuantitySpinBox" name="maxDiameter">
      <property name="toolTip">
       <string>The depth of the operation which corresponds to the lowest value in Z-axis the operation needs to process.</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
      <property name="minimum">
       <double>-999999999.000000000000000</double>
@@ -101,7 +95,7 @@
      </property>
     </spacer>
    </item>
-  <item row="3" column="0" colspan="3">
+   <item row="3" column="0" colspan="3">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -114,7 +108,7 @@
      </property>
     </spacer>
    </item>
-   </layout>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/CAM/Gui/Resources/panels/PageHeightsEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageHeightsEdit.ui
@@ -68,9 +68,6 @@
          <property name="toolTip">
           <string>The height where lateral movement of the toolbit is not obstructed by any fixtures or the part / stock material itself.</string>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
          <property name="minimum">
           <double>-999999999.000000000000000</double>
          </property>
@@ -102,9 +99,6 @@
         <widget class="Gui::QuantitySpinBox" name="safeHeight">
          <property name="toolTip">
           <string>The height above which it is safe to move the tool bit with rapid movements. Below this height all lateral and downward movements are performed with feed rate speeds.</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
          <property name="minimum">
           <double>-999999999.000000000000000</double>
@@ -325,9 +319,6 @@ Tool Shape: safest - checks clearance using the cross section of the tool shape
        <widget class="Gui::QuantitySpinBox" name="CollisionClearance">
         <property name="toolTip">
          <string>Minimum clearance distance between the tool and any solid during linking moves. Applies to all linking modes.</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
         <property name="minimum">
          <double>0.000000000000000</double>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
@@ -15,39 +15,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QFrame" name="frame_2">
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Tool controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Coolant</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController"/>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <widget class="QFrame" name="frame">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
@@ -133,7 +100,7 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="20" column="1">
        <widget class="Gui::QuantitySpinBox" name="StockToLeave" native="true">
         <property name="toolTip">
-         <string>How much material to leave in the XY-plane (i.e. for finishing operation)</string>
+         <string>How much stock to leave on the walls for this operation</string>
         </property>
         <property name="unit" stdset="0">
          <string notr="true"/>
@@ -143,7 +110,7 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="20" column="0">
        <widget class="QLabel" name="label_12">
         <property name="text">
-         <string>XY stock to leave</string>
+         <string>Radial stock to leave</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpCustomEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpCustomEdit.ui
@@ -15,55 +15,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item row="0" column="0">
-    <widget class="QFrame" name="frame_2">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Tool controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Coolant mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController"/>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <widget class="QWidget" name="widget">
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
@@ -93,7 +44,7 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <widget class="QWidget" name="txtGCodeBox">
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">
@@ -109,7 +60,7 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="2" column="0">
     <widget class="QWidget" name="fileNameBox">
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">
@@ -132,7 +83,7 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="3" column="0">
     <widget class="QWidget" name="verticalSpacerBox">
      <layout class="QGridLayout" name="gridLayout_5">
       <item row="0" column="0">

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpDeburrEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpDeburrEdit.ui
@@ -15,95 +15,6 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
    <item row="0" column="0">
-    <widget class="QFrame" name="frame">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>125</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Tool controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>125</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Coolant mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_5">
      <property name="spacing">
       <number>6</number>
@@ -164,7 +75,7 @@
      </item>
     </layout>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="QWidget" name="widget">

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpDrillingEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpDrillingEdit.ui
@@ -53,48 +53,13 @@
         </item>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Tool Controller</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Coolant mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QComboBox" name="coolantController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
        <widget class="QCheckBox" name="KeepToolDownEnabled">
         <property name="toolTip">
          <string>Do not retract after every hole</string>
         </property>
         <property name="text">
          <string>Keep tool down</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
         </property>
        </widget>
       </item>
@@ -219,7 +184,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>toolController</tabstop>
   <tabstop>peckEnabled</tabstop>
   <tabstop>feedRetractEnabled</tabstop>
   <tabstop>dwellEnabled</tabstop>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpEngraveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpEngraveEdit.ui
@@ -15,53 +15,6 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0">
-    <widget class="QFrame" name="frame_2">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Tool controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Coolant mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <widget class="QWidget" name="widget">
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
@@ -84,7 +37,7 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
@@ -15,56 +15,9 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
-    <widget class="QFrame" name="frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="0">
-       <widget class="QLabel" name="label_1">
-        <property name="text">
-         <string>Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Coolant</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <widget class="QWidget" name="widget">
      <layout class="QFormLayout" name="formLayout">
-       <item row="0" column="0">
+      <item row="0" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
          <string>Start from</string>
@@ -113,44 +66,44 @@
        </widget>
       </item>
       <item row="4" column="0">
-        <widget class="QLabel" name="label_5">
-          <property name="text">
-            <string>Max pitch</string>
-          </property>
-        </widget>
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Max pitch</string>
+        </property>
+       </widget>
       </item>
       <item row="4" column="1">
-        <widget class="Gui::QuantitySpinBox" name="helixMaxPitch">
-          <property name="enabled">
-            <bool>true</bool>
-          </property>
-          <property name="minimum">
-            <number>0</number>
-          </property>
-          <property name="toolTip">
-            <string>The maximum allowable descent in a single revolution of the helix. Set to zero to disable limitation by pitch.</string>
-          </property>
-        </widget>
+       <widget class="Gui::QuantitySpinBox" name="helixMaxPitch">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="toolTip">
+         <string>The maximum allowable descent in a single revolution of the helix. Set to zero to disable limitation by pitch.</string>
+        </property>
+       </widget>
       </item>
       <item row="5" column="0">
-        <widget class="QLabel" name="label_5">
-          <property name="text">
-            <string>Max ramp angle</string>
-          </property>
-        </widget>
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Max ramp angle</string>
+        </property>
+       </widget>
       </item>
       <item row="5" column="1">
-        <widget class="Gui::QuantitySpinBox" name="helixMaxRampAngle">
-          <property name="enabled">
-            <bool>true</bool>
-          </property>
-          <property name="minimum">
-            <number>0</number>
-          </property>
-          <property name="toolTip">
-            <string>The maximum allowable ramp entry angle. Set to zero to disable limitation by ramp angle.</string>
-          </property>
-        </widget>
+       <widget class="Gui::QuantitySpinBox" name="helixMaxRampAngle">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="toolTip">
+         <string>The maximum allowable ramp entry angle. Set to zero to disable limitation by ramp angle.</string>
+        </property>
+       </widget>
       </item>
       <item row="6" column="0">
        <widget class="QLabel" name="label_6">
@@ -184,24 +137,24 @@
       <item row="7" column="0">
        <widget class="QLabel" name="label_7">
         <property name="text">
-         <string>Stock to leave (outer radial)</string>
+         <string>Radial stock to leave (outer)</string>
         </property>
        </widget>
       </item>
       <item row="7" column="1">
        <widget class="Gui::QuantitySpinBox" name="radialStockToLeaveOuter">
         <property name="enabled">
-          <bool>true</bool>
+         <bool>true</bool>
         </property>
         <property name="toolTip">
-         <string>Extra value to stay away from shape</string>
+         <string>How much stock to leave on the outer wall for this operation</string>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-  <item row="3" column="0">
+   <item row="2" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -214,14 +167,14 @@
      </property>
     </spacer>
    </item>
-   </layout>
+  </layout>
  </widget>
  <customwidgets>
-   <customwidget>
-     <class>Gui::QuantitySpinBox</class>
-     <extends>QWidget</extends>
-     <header>Gui/QuantitySpinBox.h</header>
-   </customwidget>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
  </customwidgets>
  <resources/>
  <connections/>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpMillFacingEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpMillFacingEdit.ui
@@ -18,52 +18,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QFrame" name="toolOptions">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <property name="bottomMargin">
-       <number>3</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="toolController_label">
-        <property name="text">
-         <string>Tool controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string> The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="coolantController_label">
-        <property name="text">
-         <string>Coolant mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <widget class="QFrame" name="facingOptions">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
@@ -186,9 +140,6 @@
         <property name="toolTip">
          <string>Distance to extend cuts beyond polygon boundary for tool disengagement</string>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
         <property name="minimum">
          <double>-999999999.000000000000000</double>
         </property>
@@ -209,9 +160,6 @@
         <property name="toolTip">
          <string>Extends the boundary in both direction</string>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
         <property name="minimum">
          <double>-999999999.000000000000000</double>
         </property>
@@ -223,17 +171,14 @@
       <item row="6" column="0">
        <widget class="QLabel" name="axialStockToLeave_label">
         <property name="text">
-         <string>Stock To Leave (axial)</string>
+         <string>Axial stock to leave</string>
         </property>
        </widget>
       </item>
       <item row="6" column="1">
        <widget class="Gui::QuantitySpinBox" name="axialStockToLeave">
         <property name="toolTip">
-         <string>Stock to leave for the operation</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <string>How much stock to leave on the floor for this operation</string>
         </property>
         <property name="minimum">
          <double>0.000000000000000</double>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpPocketFullEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpPocketFullEdit.ui
@@ -15,53 +15,6 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
    <item row="0" column="0">
-    <widget class="QFrame" name="frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
-       <widget class="QLabel" name="toolController_label">
-        <property name="text">
-         <string>Tool controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="coolantController_label">
-        <property name="text">
-         <string>Coolant Mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <widget class="QWidget" name="facingWidget">
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
@@ -71,7 +24,7 @@
         </property>
        </widget>
       </item>
-     <item row="0" column="1">
+      <item row="0" column="1">
        <widget class="QComboBox" name="boundaryShape">
         <property name="toolTip">
          <string>Specify if the facing should be restricted by the actual shape of the selected face (or the part if no face is selected), or if the bounding box should be faced off.
@@ -80,10 +33,10 @@ The latter can be used to face of the entire stock area to ensure uniform height
         </property>
        </widget>
       </item>
-      </layout>
+     </layout>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <widget class="QWidget" name="widget">
      <layout class="QFormLayout" name="formLayout">
       <property name="fieldGrowthPolicy">
@@ -225,7 +178,7 @@ The latter can be used to face of the entire stock area to ensure uniform height
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="2" column="0">
     <widget class="QWidget" name="pocketWidget">
      <layout class="QGridLayout" name="gridLayout">
       <item row="1" column="0">
@@ -290,7 +243,7 @@ The latter can be used to face of the entire stock area to ensure uniform height
      </layout>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="4" column="0">
     <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpProbeEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpProbeEdit.ui
@@ -15,45 +15,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QFrame" name="frame_2">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Tool controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Probe grid points</string>
@@ -83,7 +44,7 @@
         </property>
        </widget>
       </item>
-     <item row="0" column="4">
+      <item row="0" column="4">
        <widget class="QSpinBox" name="PointCountY">
         <property name="minimum">
          <number>3</number>
@@ -93,7 +54,7 @@
         </property>
        </widget>
       </item>
-      </layout>
+     </layout>
     </widget>
    </item>
    <item>
@@ -116,7 +77,7 @@
         </property>
        </widget>
       </item>
-     <item row="2" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
          <string>Y offset</string>
@@ -130,7 +91,7 @@
         </property>
        </widget>
       </item>
-      </layout>
+     </layout>
     </widget>
    </item>
    <item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpProfileFullEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpProfileFullEdit.ui
@@ -15,53 +15,6 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
    <item row="0" column="0">
-    <widget class="QFrame" name="frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Tool controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Coolant mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <widget class="QWidget" name="widget">
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
@@ -105,12 +58,12 @@
       <item row="2" column="0">
        <widget class="QLabel" name="extraOffsetLabel">
         <property name="text">
-         <string>Extra offset</string>
+         <string>Radial stock to leave</string>
         </property>
        </widget>
       </item>
      <item row="2" column="1">
-       <widget class="Gui::InputField" name="extraOffset">
+       <widget class="Gui::QuantitySpinBox" name="extraOffset">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -118,7 +71,7 @@
          </sizepolicy>
         </property>
         <property name="toolTip">
-         <string>The amount of extra material left by this operation in relation to the target shape</string>
+         <string>How much stock to leave on the walls for this operation</string>
         </property>
        </widget>
       </item>
@@ -147,7 +100,7 @@
        </widget>
       </item>
      <item row="4" column="1">
-       <widget class="Gui::InputField" name="stepover">
+       <widget class="Gui::QuantitySpinBox" name="stepover">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -162,7 +115,7 @@
       </layout>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <widget class="QWidget" name="widget_2">
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="1">
@@ -233,7 +186,7 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="2" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -250,13 +203,12 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Gui::InputField</class>
-   <extends>QLineEdit</extends>
-   <header>Gui/InputField.h</header>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>Gui/QuantitySpinBox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>toolController</tabstop>
   <tabstop>cutSide</tabstop>
   <tabstop>direction</tabstop>
   <tabstop>extraOffset</tabstop>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpRotarySurfaceEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpRotarySurfaceEdit.ui
@@ -15,152 +15,176 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QFrame" name="toolOptions">
-     <property name="frameShape"><enum>QFrame::StyledPanel</enum></property>
-     <property name="frameShadow"><enum>QFrame::Raised</enum></property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="toolController_label">
-        <property name="text"><string>Tool Controller</string></property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip"><string>Tool controller that supplies the cutter geometry, feed and speed for this operation.</string></property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="coolantController_label">
-        <property name="text"><string>Coolant</string></property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController">
-        <property name="toolTip"><string>Coolant mode emitted at the start of the operation.</string></property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <widget class="QFrame" name="rotaryOptions">
-     <property name="frameShape"><enum>QFrame::StyledPanel</enum></property>
-     <property name="frameShadow"><enum>QFrame::Raised</enum></property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
        <widget class="QLabel" name="cutMode_label">
-        <property name="text"><string>Cut Mode</string></property>
+        <property name="text">
+         <string>Cut Mode</string>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="cutMode">
-        <property name="toolTip"><string>Climb: rotary advances in the positive direction. Conventional: rotary advances in the negative direction. Affects the sign of A in cutting moves; pick to match how the cutter engages the material on your machine.</string></property>
+        <property name="toolTip">
+         <string>Climb: rotary advances in the positive direction. Conventional: rotary advances in the negative direction. Affects the sign of A in cutting moves; pick to match how the cutter engages the material on your machine.</string>
+        </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="cutPattern_label">
-        <property name="text"><string>Cut Pattern</string></property>
+        <property name="text">
+         <string>Cut Pattern</string>
+        </property>
        </widget>
       </item>
       <item row="1" column="1">
        <widget class="QComboBox" name="cutPattern">
-        <property name="toolTip"><string>Spiral: continuous helical sweep — fastest, best surface continuity. Parallel: axial zig-zag passes stepped over angularly. Rings: full-revolution rings stepped axially. All three produce continuous 4-axis XYZA motion.</string></property>
+        <property name="toolTip">
+         <string>Spiral: continuous helical sweep — fastest, best surface continuity. Parallel: axial zig-zag passes stepped over angularly. Rings: full-revolution rings stepped axially. All three produce continuous 4-axis XYZA motion.</string>
+        </property>
        </widget>
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="feedMode_label">
-        <property name="text"><string>Feed Mode</string></property>
+        <property name="text">
+         <string>Feed Mode</string>
+        </property>
        </widget>
       </item>
       <item row="2" column="1">
        <widget class="QComboBox" name="feedMode">
-        <property name="toolTip"><string>How the tool controller's HorizFeed is interpreted. Axial Only: emit F=HorizFeed on every cut move; the controller's own feed math determines how the rotary keeps up — F values in the G-code are constant. Surface Speed: scale F per move so the cutter contact point holds HorizFeed (mm/min) along the surface — F = HorizFeed × 360 / (2π·r). F varies with radius and is capped by Max Feed.</string></property>
+        <property name="toolTip">
+         <string>How the tool controller's HorizFeed is interpreted. Axial Only: emit F=HorizFeed on every cut move; the controller's own feed math determines how the rotary keeps up — F values in the G-code are constant. Surface Speed: scale F per move so the cutter contact point holds HorizFeed (mm/min) along the surface — F = HorizFeed × 360 / (2π·r). F varies with radius and is capped by Max Feed.</string>
+        </property>
        </widget>
       </item>
       <item row="3" column="0">
        <widget class="QLabel" name="startX_label">
-        <property name="text"><string>Start X</string></property>
+        <property name="text">
+         <string>Start X</string>
+        </property>
        </widget>
       </item>
       <item row="3" column="1">
        <widget class="Gui::InputField" name="startX">
-        <property name="toolTip"><string>Axial start position along the rotary axis (mm). Defines the lower end of the surfaced region.</string></property>
+        <property name="toolTip">
+         <string>Axial start position along the rotary axis (mm). Defines the lower end of the surfaced region.</string>
+        </property>
        </widget>
       </item>
       <item row="4" column="0">
        <widget class="QLabel" name="stopX_label">
-        <property name="text"><string>Stop X</string></property>
+        <property name="text">
+         <string>Stop X</string>
+        </property>
        </widget>
       </item>
       <item row="4" column="1">
        <widget class="Gui::InputField" name="stopX">
-        <property name="toolTip"><string>Axial stop position along the rotary axis (mm). Must be greater than Start X.</string></property>
+        <property name="toolTip">
+         <string>Axial stop position along the rotary axis (mm). Must be greater than Start X.</string>
+        </property>
        </widget>
       </item>
       <item row="5" column="0">
        <widget class="QLabel" name="startAngle_label">
-        <property name="text"><string>Start Angle</string></property>
+        <property name="text">
+         <string>Start Angle</string>
+        </property>
        </widget>
       </item>
       <item row="5" column="1">
        <widget class="Gui::InputField" name="startAngle">
-        <property name="toolTip"><string>Angular start position (degrees, unwound). Where the rotary begins; allows partial-revolution surfacing.</string></property>
+        <property name="toolTip">
+         <string>Angular start position (degrees, unwound). Where the rotary begins; allows partial-revolution surfacing.</string>
+        </property>
        </widget>
       </item>
       <item row="6" column="0">
        <widget class="QLabel" name="stopAngle_label">
-        <property name="text"><string>Stop Angle</string></property>
+        <property name="text">
+         <string>Stop Angle</string>
+        </property>
        </widget>
       </item>
       <item row="6" column="1">
        <widget class="Gui::InputField" name="stopAngle">
-        <property name="toolTip"><string>Angular stop position (degrees, unwound). 360 covers a full revolution; warns at execute if it exceeds the machine's rotary axis limits.</string></property>
+        <property name="toolTip">
+         <string>Angular stop position (degrees, unwound). 360 covers a full revolution; warns at execute if it exceeds the machine's rotary axis limits.</string>
+        </property>
        </widget>
       </item>
       <item row="7" column="0">
        <widget class="QLabel" name="stepOver_label">
-        <property name="text"><string>Step Over</string></property>
+        <property name="text">
+         <string>Step Over</string>
+        </property>
        </widget>
       </item>
       <item row="7" column="1">
        <widget class="Gui::InputField" name="stepOver">
-        <property name="toolTip"><string>Axial advance per full revolution (mm). Spiral: pitch. Rings: distance between rings. Parallel: also drives the angular stepover, derived as StepOver / max_radius.</string></property>
+        <property name="toolTip">
+         <string>Axial advance per full revolution (mm). Spiral: pitch. Rings: distance between rings. Parallel: also drives the angular stepover, derived as StepOver / max_radius.</string>
+        </property>
        </widget>
       </item>
       <item row="8" column="0">
        <widget class="QLabel" name="angularResolution_label">
-        <property name="text"><string>Angular Resolution</string></property>
+        <property name="text">
+         <string>Angular Resolution</string>
+        </property>
        </widget>
       </item>
       <item row="8" column="1">
        <widget class="Gui::InputField" name="angularResolution">
-        <property name="toolTip"><string>Angular sample density along the cutting direction (degrees). Smaller = smoother surface but more G-code; 5–15° is typical.</string></property>
+        <property name="toolTip">
+         <string>Angular sample density along the cutting direction (degrees). Smaller = smoother surface but more G-code; 5–15° is typical.</string>
+        </property>
        </widget>
       </item>
       <item row="9" column="0">
        <widget class="QLabel" name="radialStockToLeave_label">
-        <property name="text"><string>Radial Stock To Leave</string></property>
+        <property name="text">
+         <string>Radial stock to leave</string>
+        </property>
        </widget>
       </item>
       <item row="9" column="1">
        <widget class="Gui::InputField" name="radialStockToLeave">
-        <property name="toolTip"><string>Radial offset added to the cutter Z so the cutter stays this far above the part surface (mm). Use a small positive value for a finish allowance; 0 cuts directly to the surface.</string></property>
+        <property name="toolTip">
+         <string>How much stock to leave on the walls for this operation. Use a small positive value for a finish allowance; 0 cuts directly to the surface.</string>
+        </property>
        </widget>
       </item>
       <item row="10" column="0">
        <widget class="QLabel" name="maxFeed_label">
-        <property name="text"><string>Max Feed</string></property>
+        <property name="text">
+         <string>Max Feed</string>
+        </property>
        </widget>
       </item>
       <item row="10" column="1">
        <widget class="Gui::InputField" name="maxFeed">
-        <property name="toolTip"><string>Upper cap on the effective rotary feed rate emitted in cutting moves (mm/min). Prevents the rotary from being asked to spin arbitrarily fast as the cut approaches the centerline. 0 = unset; falls back to max(HorizRapid, VertRapid, 1000). When Feed Mode = Surface Speed, the surface feed is scaled down so the rotary stays at this cap; clamp events are summarized in the log at end of path.</string></property>
+        <property name="toolTip">
+         <string>Upper cap on the effective rotary feed rate emitted in cutting moves (mm/min). Prevents the rotary from being asked to spin arbitrarily fast as the cut approaches the centerline. 0 = unset; falls back to max(HorizRapid, VertRapid, 1000). When Feed Mode = Surface Speed, the surface feed is scaled down so the rotary stays at this cap; clamp events are summarized in the log at end of path.</string>
+        </property>
        </widget>
       </item>
       <item row="11" column="0" colspan="2">
        <widget class="QCheckBox" name="boundaryFromFaces">
-        <property name="text"><string>Restrict to Selected Faces</string></property>
-        <property name="toolTip"><string>When checked, restricts the toolpath to the projected (axial, angular) region of the faces selected on the part. When unchecked, the toolpath covers the full Start X…Stop X / Start Angle…Stop Angle window.</string></property>
+        <property name="text">
+         <string>Restrict to Selected Faces</string>
+        </property>
+        <property name="toolTip">
+         <string>When checked, restricts the toolpath to the projected (axial, angular) region of the faces selected on the part. When unchecked, the toolpath covers the full Start X…Stop X / Start Angle…Stop Angle window.</string>
+        </property>
        </widget>
       </item>
      </layout>
@@ -168,8 +192,15 @@
    </item>
    <item>
     <spacer name="verticalSpacer">
-     <property name="orientation"><enum>Qt::Vertical</enum></property>
-     <property name="sizeHint" stdset="0"><size><width>20</width><height>40</height></size></property>
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
     </spacer>
    </item>
   </layout>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpSlotEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpSlotEdit.ui
@@ -18,52 +18,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QFrame" name="toolOptions">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <property name="bottomMargin">
-       <number>3</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="toolController_label">
-        <property name="text">
-         <string>Tool controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string> The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="coolantController_label">
-        <property name="text">
-         <string>Coolant mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <widget class="QFrame" name="featureReferences">
      <layout class="QGridLayout" name="gridLayout_3">
       <property name="topMargin">
@@ -286,7 +240,7 @@
         </property>
        </widget>
       </item>
-     <item row="0" column="1">
+      <item row="0" column="1">
        <widget class="Gui::InputField" name="geo1Extension">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -328,7 +282,7 @@
         </property>
        </widget>
       </item>
-      </layout>
+     </layout>
     </widget>
    </item>
    <item>
@@ -430,8 +384,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>toolController</tabstop>
-  <tabstop>coolantController</tabstop>
   <tabstop>geo1Reference</tabstop>
   <tabstop>geo2Reference</tabstop>
   <tabstop>geo1Extension</tabstop>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpSurfaceEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpSurfaceEdit.ui
@@ -15,53 +15,6 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
-    <widget class="QFrame" name="frame_2">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="toolController_label">
-        <property name="text">
-         <string>Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="coolantController_label">
-        <property name="text">
-         <string>Coolant mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <widget class="QWidget" name="widget">
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
@@ -295,7 +248,7 @@
         </property>
        </widget>
       </item>
-     <item row="15" column="1">
+      <item row="15" column="1">
        <widget class="QCheckBox" name="optimizeStepOverTransitions">
         <property name="toolTip">
          <string>Enable separate optimization of transitions between, and breaks within, each step over path.</string>
@@ -305,10 +258,10 @@
         </property>
        </widget>
       </item>
-      </layout>
+     </layout>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpTappingEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpTappingEdit.ui
@@ -31,59 +31,6 @@
     </widget>
    </item>
    <item row="1" column="0" colspan="3">
-    <widget class="QFrame" name="frame">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The tool and its settings to be used for this operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Coolant mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>ToolController</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The tool and its settings to be used for this operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="3">
     <layout class="QGridLayout" name="gridLayout">
      <item row="4" column="4">
       <widget class="QLabel" name="dwellTimelabel">
@@ -137,7 +84,7 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
+   <item row="2" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -160,7 +107,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>toolController</tabstop>
   <tabstop>dwellEnabled</tabstop>
  </tabstops>
  <resources/>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpThreadMillingEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpThreadMillingEdit.ui
@@ -15,39 +15,6 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QFrame" name="frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Thread</string>
@@ -109,10 +76,7 @@
       </item>
       <item row="4" column="1">
        <widget class="Gui::QuantitySpinBox" name="threadMajor">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
+        </widget>
       </item>
       <item row="5" column="0">
        <widget class="QLabel" name="label_2">
@@ -123,10 +87,7 @@
       </item>
       <item row="5" column="1">
        <widget class="Gui::QuantitySpinBox" name="threadMinor">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
+        </widget>
       </item>
       <item row="6" column="0">
        <widget class="QLabel" name="threadPitchLabel">
@@ -137,17 +98,11 @@
       </item>
       <item row="6" column="1">
        <widget class="Gui::QuantitySpinBox" name="threadPitch">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
+        </widget>
       </item>
       <item row="7" column="1">
        <widget class="QSpinBox" name="threadTPI">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
+        </widget>
       </item>
       <item row="7" column="0">
        <widget class="QLabel" name="threadTPILabel">
@@ -159,7 +114,7 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
       <string>Operation</string>
@@ -174,9 +129,6 @@
       </item>
       <item row="0" column="1">
        <widget class="QSpinBox" name="opPasses">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
         <property name="minimum">
          <number>1</number>
         </property>
@@ -202,7 +154,7 @@
      </layout>
     </widget>
    </item>
-  <item row="3" column="0">
+   <item row="2" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -215,7 +167,7 @@
      </property>
     </spacer>
    </item>
-   </layout>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpVcarveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpVcarveEdit.ui
@@ -15,53 +15,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QFrame" name="frame_2">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Coolant Mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <layout class="QFormLayout" name="formLayout">
      <item row="0" column="0">
       <widget class="QLabel" name="label_2">
@@ -128,7 +81,7 @@
      <item row="4" column="1">
       <widget class="Gui::QuantitySpinBox" name="finishingPassZOffset">
        <property name="toolTip">
-        <string>Endmill offset for the finishing pass run. Use small value like -0.2 mm to help clean &quot;fuzzy skin&quot; or other artefacts.</string>
+        <string>Endmill offset for the finishing pass run. Use small value like -0.2 mm to help clean "fuzzy skin" or other artefacts.</string>
        </property>
        <property name="unit" stdset="0">
         <string notr="true"/>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpWaterlineEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpWaterlineEdit.ui
@@ -15,49 +15,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QFrame" name="frame_2">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="toolController_label">
-        <property name="text">
-         <string>Tool controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="coolantController_label">
-        <property name="text">
-         <string>Coolant mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <widget class="QWidget" name="widget">
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
@@ -212,16 +169,16 @@ A step over of 100% results in no overlap between two different cycles.</string>
         </property>
        </widget>
       </item>
-     <item row="7" column="1">
-      <widget class="Gui::InputField" name="minSampleInterval">
-       <property name="toolTip">
-        <string>Set the minimum sampling resolution. Smaller values quickly increase processing time.</string>
-       </property>
-       <property name="unit" stdset="0">
-        <string notr="true">mm</string>
-       </property>
-      </widget>
-     </item>
+      <item row="7" column="1">
+       <widget class="Gui::InputField" name="minSampleInterval">
+        <property name="toolTip">
+         <string>Set the minimum sampling resolution. Smaller values quickly increase processing time.</string>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true">mm</string>
+        </property>
+       </widget>
+      </item>
       <item row="8" column="1">
        <widget class="QCheckBox" name="optimizeEnabled">
         <property name="toolTip">
@@ -258,8 +215,6 @@ A step over of 100% results in no overlap between two different cycles.</string>
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>toolController</tabstop>
-  <tabstop>coolantController</tabstop>
   <tabstop>algorithmSelect</tabstop>
   <tabstop>boundBoxSelect</tabstop>
   <tabstop>layerMode</tabstop>

--- a/src/Mod/CAM/Gui/Resources/panels/PageToolControllerEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageToolControllerEdit.ui
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>140</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">Form</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="../Path.qrc">
+    <normaloff>:/icons/CAM_ToolController.svg</normaloff>:/icons/CAM_ToolController.svg</iconset>
+  </property>
+  <layout class="QGridLayout" name="outerLayout">
+   <item row="0" column="0">
+    <widget class="QFrame" name="frame">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="toolControllerLabel">
+        <property name="text">
+         <string>Tool controller</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="toolController">
+        <property name="toolTip">
+         <string>The tool and its settings to be used for this operation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="coolantControllerLabel">
+        <property name="text">
+         <string>Coolant mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="coolantController">
+        <property name="toolTip">
+         <string>The coolant mode to be used for this operation</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>toolController</tabstop>
+  <tabstop>coolantController</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/CAM/Gui/Resources/panels/ToolControllerEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/ToolControllerEdit.ui
@@ -18,7 +18,11 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="tcOperationCountLabel" />
+    <widget class="QLabel" name="tcOperationCountLabel">
+     <property name="styleSheet">
+      <string notr="true">QLabel { padding-bottom: 12px; }</string>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QGroupBox" name="groupBox_4">
@@ -73,9 +77,6 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
         <property name="minimum">
          <double>0.000000000000000</double>
         </property>
@@ -101,9 +102,6 @@
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
         <property name="minimum">
          <double>0.000000000000000</double>
@@ -131,9 +129,6 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
         <property name="minimum">
          <double>0.000000000000000</double>
         </property>
@@ -159,9 +154,6 @@
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
         <property name="minimum">
          <double>0.000000000000000</double>
@@ -189,9 +181,6 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
         <property name="minimum">
          <double>0.000000000000000</double>
         </property>
@@ -218,9 +207,6 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
         <property name="minimum">
          <double>0.000000000000000</double>
         </property>
@@ -246,9 +232,6 @@
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
         <property name="minimum">
          <double>0.000000000000000</double>

--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -1597,7 +1597,7 @@ class PathAdaptive(PathOp.ObjectOp):
             "Adaptive",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "How much stock to leave in the XY plane (eg for finishing operation)",
+                "Set how much stock to leave on the walls for the operation.",
             ),
         )
         obj.addProperty(
@@ -1606,7 +1606,7 @@ class PathAdaptive(PathOp.ObjectOp):
             "Adaptive",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "How much stock to leave along the Z axis (eg for finishing operation). This property is only used if the ModelAwareExperiment is enabled.",
+                "Set how much stock to leave on the floor for the operation. This property is only used if the ModelAwareExperiment is enabled.",
             ),
         )
         obj.addProperty(
@@ -1863,7 +1863,7 @@ class PathAdaptive(PathOp.ObjectOp):
                 "Adaptive",
                 QT_TRANSLATE_NOOP(
                     "App::Property",
-                    "How much stock to leave along the Z axis (eg for finishing operation)",
+                    "Set how much stock to leave on the floor for the operation.",
                 ),
             )
 

--- a/src/Mod/CAM/Path/Op/Gui/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Gui/Adaptive.py
@@ -59,16 +59,19 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.stepOver.valueChanged.connect(lambda: self.updateStepOverDistance(obj))
         self.form.stepOverDistance.valueChanged.connect(lambda: self.updateStepOverPercent(obj))
         self.form.stepOverDistance.editingFinished.connect(lambda: self.updateStepOverDistance(obj))
-        self.form.toolController.currentIndexChanged.connect(
-            lambda: self.updateStepOverDistance(obj)
-        )
+
+    def updateData(self, obj, prop):
+        """updateData(obj, prop) ... react to ToolController changes made on the
+        shared Tool Controller page to keep step over distance in sync with the
+        (possibly new) tool diameter."""
+        if prop == "ToolController":
+            self.updateStepOverDistance(obj)
 
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
         signals = []
         signals.append(self.form.Side.currentIndexChanged)
         signals.append(self.form.OperationType.currentIndexChanged)
-        signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.stepOver.valueChanged)
         signals.append(self.form.Tolerance.valueChanged)
         signals.append(self.form.HelixMaxRampAngle.valueChanged)
@@ -79,7 +82,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.LiftDistance.valueChanged)
         signals.append(self.form.KeepToolDownRatio.valueChanged)
         signals.append(self.form.StockToLeave.valueChanged)
-        signals.append(self.form.coolantController.currentIndexChanged)
         if hasattr(self.form.ForceInsideOut, "checkStateChanged"):  # Qt version >= 6.7.0
             signals.append(self.form.ForceInsideOut.checkStateChanged)
             signals.append(self.form.FinishingProfile.checkStateChanged)
@@ -151,8 +153,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.FinishingProfile.setChecked(obj.FinishingProfile)
         self.form.useOutline.setChecked(obj.UseOutline)
         self.form.useRestMachining.setChecked(obj.UseRestMachining)
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
         self.form.StopButton.setChecked(obj.Stopped)
         obj.setEditorMode("AdaptiveInputState", 2)  # hide this property
         obj.setEditorMode("AdaptiveOutputState", 2)  # hide this property
@@ -196,8 +196,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             self.form.StopButton.setChecked(False)  # reset the button
             obj.StopProcessing = True
 
-        self.updateToolController(obj, self.form.toolController)
-        self.updateCoolant(obj, self.form.coolantController)
         obj.setEditorMode("AdaptiveInputState", 2)  # hide this property
         obj.setEditorMode("AdaptiveOutputState", 2)  # hide this property
         obj.setEditorMode("StopProcessing", 2)  # hide this property

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -28,6 +28,7 @@ import Path.Base.Gui.GetPoint as PathGetPoint
 import Path.Base.Gui.Util as PathGuiUtil
 import Path.Base.SetupSheet as PathSetupSheet
 import Path.Base.Util as PathUtil
+import Path.Dressup.Utils as PathDressupUtils
 import Path.Main.Job as PathJob
 import Path.Op.Base as PathOp
 import Path.Op.Gui.Selection as PathSelection
@@ -609,14 +610,10 @@ class TaskPanelPage(object):
                 self.obj.ToolController = tc
                 self.setupToolController()
 
-    def updateToolControllerEditorVisibility(self):
-        if self.form.editToolController.isChecked():
-            self.tcEditor.controller.show()
-        else:
-            self.tcEditor.controller.hide()
-
     def resetToolController(self, job, tc):
         if self.obj is None:
+            return
+        if job != self.job:
             return
         self.obj.ToolController = tc
         self.setupToolController()
@@ -665,58 +662,69 @@ class TaskPanelPage(object):
 
         self.resetTCCombo()
 
-        if hasattr(self.form, "editToolController"):
-            layout = self.form.editToolController.parent().layout()
-            oldEditor = self.tcEditor
+        layout = self.form.toolController.parent().layout()
+        oldEditor = self.tcEditor
 
-            # Count the number of times the tool controller is used in other operations
-            # If it is used in other operations, we will offer the "copy tool controller" button
-            tcCount = 0
-            for job in PathUtils.GetJobs():
-                for op in job.Operations.Group:
-                    if op == self.obj:
-                        continue
-                    elif hasattr(op, "ToolController") and op.ToolController == obj.ToolController:
-                        tcCount += 1
+        # Count operations sharing this tool controller, unwrapping dressups since
+        # Operations.Group holds the dressup, not the base op the TC lives on.
+        tcCount = 0
+        selfBase = PathDressupUtils.baseOp(self.obj)
+        for job in PathUtils.GetJobs():
+            for op in job.Operations.Group:
+                opBase = PathDressupUtils.baseOp(op)
+                if opBase == selfBase:
+                    continue
+                elif (
+                    hasattr(opBase, "ToolController")
+                    and opBase.ToolController == obj.ToolController
+                ):
+                    tcCount += 1
 
-            self.tcEditor = Path.Tool.Gui.Controller.ToolControllerEditor(
-                obj.ToolController,
-                False,
-                self.tcEditorChanged,
-                True,
-                True,
+        self.tcEditor = Path.Tool.Gui.Controller.ToolControllerEditor(
+            obj.ToolController,
+            False,
+            self.tcEditorChanged,
+            True,
+            True,
+        )
+        self.tcEditor.setupUi()
+
+        if tcCount == 1:
+            labelStr = FreeCAD.Qt.translate(
+                "CAM_Operation", "This tool controller is used by 1 other operation."
             )
-            self.tcEditor.setupUi()
-
+        else:
             labelStr = FreeCAD.Qt.translate(
                 "CAM_Operation", "This tool controller is used by {0} other operations."
             ).format(tcCount)
-            self.tcEditor.controller.tcOperationCountLabel.setText(labelStr)
-
-            # add to layout -- requires a grid layout
-            if isinstance(layout, QtWidgets.QGridLayout):
-                layout.addWidget(
-                    self.tcEditor.controller, layout.rowCount(), 0, 1, layout.columnCount()
-                )
-            else:
-                Path.Log.error(
-                    "Panel uses a layout incompatible with editing tool controllers. Report a bug: it should be a QGridLayout"
-                )
-
-            self.updateToolControllerEditorVisibility()
-            self.tcEditor.updateUi()
-            checkbox = self.form.editToolController
-            checkboxSignal = (
-                checkbox.checkStateChanged
-                if hasattr(checkbox, "checkStateChanged")
-                else checkbox.stateChanged
+        showCountLabel = tcCount > 0
+        self.tcEditor.controller.tcOperationCountLabel.setWordWrap(True)
+        self.tcEditor.controller.tcOperationCountLabel.setText(
+            '<img src=":/icons/Warning.svg" width="24" height="24" style="vertical-align: bottom;"> {0}'.format(
+                labelStr
             )
-            checkboxSignal.connect(self.updateToolControllerEditorVisibility)
+        )
+        self.tcEditor.controller.tcOperationCountLabel.setVisible(showCountLabel)
 
-            if oldEditor:
-                oldEditor.updateToolController()
-                oldEditor.controller.hide()
-                layout.removeWidget(oldEditor.controller)
+        # add to layout -- requires a grid layout
+        if isinstance(layout, QtWidgets.QGridLayout):
+            layout.addWidget(
+                self.tcEditor.controller, layout.rowCount(), 0, 1, layout.columnCount()
+            )
+        else:
+            Path.Log.error(
+                "Panel uses a layout incompatible with editing tool controllers. Report a bug: it should be a QGridLayout"
+            )
+
+        self.tcEditor.controller.show()
+        self.tcEditor.updateUi()
+
+        if oldEditor:
+            oldEditor.updateToolController()
+            oldEditor.controller.hide()
+            layout.removeWidget(oldEditor.controller)
+            oldEditor.controller.setParent(None)
+            oldEditor.controller.deleteLater()
 
     def updateToolController(self, obj, combo):
         """updateToolController(obj, combo) ...
@@ -1326,6 +1334,47 @@ class TaskPanelHeightsPage(TaskPanelPage):
             self.form.finalDepthSet.setEnabled(False)
 
 
+class TaskPanelToolControllerPage(TaskPanelPage):
+    """Page controller for tool controller, coolant and tool controller editing."""
+
+    def __init__(self, obj, features):
+        super(TaskPanelToolControllerPage, self).__init__(obj, features)
+
+        self.panelTitle = "Tool Controller"
+        self.OpIcon = ":/icons/CAM_ToolController.svg"
+        self.setIcon(self.OpIcon)
+
+    def getForm(self):
+        return FreeCADGui.PySideUic.loadUi(":/panels/PageToolControllerEdit.ui")
+
+    def haveCoolant(self):
+        return PathOp.FeatureCoolant & self.features
+
+    def initPage(self, obj):
+        if not self.haveCoolant():
+            self.form.coolantControllerLabel.hide()
+            self.form.coolantController.hide()
+
+    def getTitle(self, obj):
+        return translate("PathOp", "Tool Controller")
+
+    def getFields(self, obj):
+        self.updateToolController(obj, self.form.toolController)
+        if self.haveCoolant():
+            self.updateCoolant(obj, self.form.coolantController)
+
+    def setFields(self, obj):
+        self.setupToolController(obj, self.form.toolController)
+        if self.haveCoolant():
+            self.setupCoolant(obj, self.form.coolantController)
+
+    def getSignalsForUpdate(self, obj):
+        signals = [self.form.toolController.currentIndexChanged]
+        if self.haveCoolant():
+            signals.append(self.form.coolantController.currentIndexChanged)
+        return signals
+
+
 class TaskPanelDiametersPage(TaskPanelPage):
     """Page controller for diameters."""
 
@@ -1421,6 +1470,12 @@ class TaskPanel(object):
                 self.featurePages.append(opPage.taskPanelDiametersPage(obj, features))
             else:
                 self.featurePages.append(TaskPanelDiametersPage(obj, features))
+
+        if (PathOp.FeatureTool | PathOp.FeatureCoolant) & features:
+            if hasattr(opPage, "taskPanelToolControllerPage"):
+                self.featurePages.append(opPage.taskPanelToolControllerPage(obj, features))
+            else:
+                self.featurePages.append(TaskPanelToolControllerPage(obj, features))
 
         self.featurePages.append(opPage)
 
@@ -1776,16 +1831,22 @@ def SetupOperation(name, objFactory, opPageClass, pixmap, menuText, toolTip, set
 
 class _AdaptiveTabBar(QtGui.QTabBar):
     """QTabBar that clamps the width of icon-only tabs (empty tabText) to
-    ICON_ONLY_MAX_WIDTH. Tabs with a label are left at whatever the native
+    iconOnlyMaxWidth. Tabs with a label are left at whatever the native
     style computes for them -- we only ever shrink the hint, never invent one,
     so icon+text tabs keep correct native layout."""
 
-    ICON_ONLY_MAX_WIDTH = 38
+    # Extra width, beyond the icon itself, to accommodate the QSS padding/margin
+    # set on QTabBar::tab in IconTabWidget (6px padding each side + ~2px border).
+    ICON_PADDING = 14
+
+    def __init__(self, *args, **kwargs):
+        super(_AdaptiveTabBar, self).__init__(*args, **kwargs)
+        self.iconOnlyMaxWidth = 24 + self.ICON_PADDING
 
     def tabSizeHint(self, index):
         size = super(_AdaptiveTabBar, self).tabSizeHint(index)
         if not self.tabText(index):
-            size.setWidth(min(size.width(), self.ICON_ONLY_MAX_WIDTH))
+            size.setWidth(min(size.width(), self.iconOnlyMaxWidth))
         return size
 
 
@@ -1803,7 +1864,11 @@ class IconTabWidget(QtGui.QTabWidget):
         tabbar = self.tabBar()
         tabbar.setUsesScrollButtons(False)
         tabbar.setElideMode(QtCore.Qt.ElideNone)
-        tabbar.setIconSize(QtCore.QSize(20, 20))
+        iconSize = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/General").GetInt(
+            "ToolbarIconSize", 24
+        )
+        tabbar.setIconSize(QtCore.QSize(iconSize, iconSize))
+        tabbar.iconOnlyMaxWidth = iconSize + _AdaptiveTabBar.ICON_PADDING
         tabbar.setLayoutDirection(QtCore.Qt.LeftToRight)
         # Force padding and margin to make themes match.
         tabbar.setStyleSheet("""
@@ -1900,7 +1965,9 @@ class IconTabWidget(QtGui.QTabWidget):
         self._filteredAncestors = []
 
     def eventFilter(self, obj, event):
-        if isinstance(event, QtCore.QEvent) and event.type() == QtCore.QEvent.Resize:
+        if not isinstance(event, QtCore.QEvent):
+            return False
+        if event.type() == QtCore.QEvent.Resize:
             self._scheduleUpdate()
         return super(IconTabWidget, self).eventFilter(obj, event)
 

--- a/src/Mod/CAM/Path/Op/Gui/Custom.py
+++ b/src/Mod/CAM/Path/Op/Gui/Custom.py
@@ -70,8 +70,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def getFields(self, obj):
         """getFields(obj) ... transfers values from UI to obj's properties"""
-        self.updateToolController(obj, self.form.toolController)
-        self.updateCoolant(obj, self.form.coolantController)
         if obj.Source != str(self.form.source.currentData()):
             obj.Source = str(self.form.source.currentData())
         if obj.GcodeFile != str(self.form.fileName.text()):
@@ -81,8 +79,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
         self.selectInComboBox(obj.Source, self.form.source)
         self.form.fileName.setText(obj.GcodeFile)
         self.editor.setText("\n".join(obj.Gcode))
@@ -92,8 +88,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
         signals = []
-        signals.append(self.form.toolController.currentIndexChanged)
-        signals.append(self.form.coolantController.currentIndexChanged)
         signals.append(self.form.source.currentIndexChanged)
         signals.append(self.form.fileName.editingFinished)
         signals.append(self.editor.textChanged)

--- a/src/Mod/CAM/Path/Op/Gui/Deburr.py
+++ b/src/Mod/CAM/Path/Op/Gui/Deburr.py
@@ -92,9 +92,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         if obj.Direction != str(self.form.direction.currentData()):
             obj.Direction = str(self.form.direction.currentData())
 
-        self.updateToolController(obj, self.form.toolController)
-        self.updateCoolant(obj, self.form.coolantController)
-
     def setFields(self, obj):
         self.form.value_W.setText(
             FreeCAD.Units.Quantity(obj.Width.Value, FreeCAD.Units.Length).UserString
@@ -102,8 +99,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.value_h.setText(
             FreeCAD.Units.Quantity(obj.ExtraDepth.Value, FreeCAD.Units.Length).UserString
         )
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
         self.form.joinRound.setChecked("Round" == obj.Join)
         self.form.joinMiter.setChecked("Miter" == obj.Join)
         self.form.joinFrame.hide()
@@ -119,7 +114,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals = []
         signals.append(self.form.joinMiter.clicked)
         signals.append(self.form.joinRound.clicked)
-        signals.append(self.form.coolantController.currentIndexChanged)
         signals.append(self.form.direction.currentIndexChanged)
         signals.append(self.form.value_W.valueChanged)
         signals.append(self.form.value_h.valueChanged)

--- a/src/Mod/CAM/Path/Op/Gui/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Gui/Drilling.py
@@ -180,9 +180,6 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         if obj.ExtraOffset != str(self.form.ExtraOffset.currentData()):
             obj.ExtraOffset = str(self.form.ExtraOffset.currentData())
 
-        self.updateToolController(obj, self.form.toolController)
-        self.updateCoolant(obj, self.form.coolantController)
-
     def setFields(self, obj):
         """setFields(obj) ... update UI with obj properties' values"""
         Path.Log.track()
@@ -232,9 +229,6 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
 
         self.selectInComboBox(obj.ExtraOffset, self.form.ExtraOffset)
 
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
-
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals which cause the receiver to update the model"""
         signals = []
@@ -252,8 +246,6 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
             signals.append(self.form.dwellEnabled.stateChanged)
             signals.append(self.form.peckEnabled.stateChanged)
             signals.append(self.form.chipBreakEnabled.stateChanged)
-        signals.append(self.form.toolController.currentIndexChanged)
-        signals.append(self.form.coolantController.currentIndexChanged)
         signals.append(self.form.ExtraOffset.currentIndexChanged)
         if hasattr(self.form.KeepToolDownEnabled, "checkStateChanged"):  # Qt version >= 6.7.0
             signals.append(self.form.KeepToolDownEnabled.checkStateChanged)

--- a/src/Mod/CAM/Path/Op/Gui/Engrave.py
+++ b/src/Mod/CAM/Path/Op/Gui/Engrave.py
@@ -141,21 +141,15 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         """getFields(obj) ... transfers values from UI to obj's properties"""
         if obj.StartVertex != self.form.startVertex.value():
             obj.StartVertex = self.form.startVertex.value()
-        self.updateToolController(obj, self.form.toolController)
-        self.updateCoolant(obj, self.form.coolantController)
 
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
         self.form.startVertex.setValue(obj.StartVertex)
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
 
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
         signals = []
         signals.append(self.form.startVertex.editingFinished)
-        signals.append(self.form.toolController.currentIndexChanged)
-        signals.append(self.form.coolantController.currentIndexChanged)
         return signals
 
     def taskPanelBaseGeometryPage(self, obj, features):

--- a/src/Mod/CAM/Path/Op/Gui/Helix.py
+++ b/src/Mod/CAM/Path/Op/Gui/Helix.py
@@ -87,9 +87,6 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         if obj.StepOver != self.form.stepOver.value():
             obj.StepOver = self.form.stepOver.value()
 
-        self.updateToolController(obj, self.form.toolController)
-        self.updateCoolant(obj, self.form.coolantController)
-
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
         Path.Log.track()
@@ -99,9 +96,6 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
 
         self.selectInComboBox(obj.CutMode, self.form.cutMode)
         self.selectInComboBox(obj.StartAt, self.form.startAt)
-
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
 
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
@@ -114,8 +108,6 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
 
         signals.append(self.form.cutMode.currentIndexChanged)
         signals.append(self.form.startAt.currentIndexChanged)
-        signals.append(self.form.toolController.currentIndexChanged)
-        signals.append(self.form.coolantController.currentIndexChanged)
 
         return signals
 

--- a/src/Mod/CAM/Path/Op/Gui/MillFacing.py
+++ b/src/Mod/CAM/Path/Op/Gui/MillFacing.py
@@ -75,8 +75,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def getFields(self, obj):
         """getFields(obj) ... transfers values from UI to obj's properties"""
-        self.updateToolController(obj, self.form.toolController)
-        self.updateCoolant(obj, self.form.coolantController)
 
         if obj.CutMode != str(self.form.cutMode.currentData()):
             obj.CutMode = str(self.form.cutMode.currentData())
@@ -106,8 +104,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
 
         # Reflect current CutMode and ClearingPattern in UI
         self.selectInComboBox(obj.CutMode, self.form.cutMode)
@@ -137,8 +133,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
         signals = []
-        signals.append(self.form.toolController.currentIndexChanged)
-        signals.append(self.form.coolantController.currentIndexChanged)
         signals.append(self.form.cutMode.currentIndexChanged)
         signals.append(self.form.clearingPattern.currentIndexChanged)
         signals.append(self.form.axialStockToLeave.editingFinished)

--- a/src/Mod/CAM/Path/Op/Gui/PocketBase.py
+++ b/src/Mod/CAM/Path/Op/Gui/PocketBase.py
@@ -119,8 +119,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             obj.ClearingPattern = str(self.form.clearingPattern.currentData())
 
         PathGuiUtil.updateInputField(obj, "ExtraOffset", self.form.extraOffset)
-        self.updateToolController(obj, self.form.toolController)
-        self.updateCoolant(obj, self.form.coolantController)
         self.updateAngle(obj)
 
         if obj.UseStartPoint != self.form.useStartPoint.isChecked():
@@ -163,8 +161,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
         self.selectInComboBox(obj.ClearingPattern, self.form.clearingPattern)
         self.selectInComboBox(obj.CutMode, self.form.cutMode)
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
 
         if FeatureFacing & self.pocketFeatures():
             self.selectInComboBox(obj.BoundaryShape, self.form.boundaryShape)
@@ -178,13 +174,11 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.clearingPattern.currentIndexChanged)
         signals.append(self.form.stepOver.editingFinished)
         signals.append(self.form.angle.editingFinished)
-        signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.extraOffset.editingFinished)
         signals.append(self.form.useStartPoint.clicked)
         signals.append(self.form.useRestMachining.clicked)
         signals.append(self.form.useOutline.clicked)
         signals.append(self.form.minTravel.clicked)
-        signals.append(self.form.coolantController.currentIndexChanged)
 
         if FeatureFacing & self.pocketFeatures():
             signals.append(self.form.boundaryShape.currentIndexChanged)

--- a/src/Mod/CAM/Path/Op/Gui/Probe.py
+++ b/src/Mod/CAM/Path/Op/Gui/Probe.py
@@ -48,6 +48,21 @@ else:
 translate = FreeCAD.Qt.translate
 
 
+class TaskPanelToolControllerPage(PathOpGui.TaskPanelToolControllerPage):
+    """Tool Controller page that reports Probe's probe tool requirement."""
+
+    def getFields(self, obj):
+        try:
+            super(TaskPanelToolControllerPage, self).getFields(obj)
+        except PathUtils.PathNoTCExistsException:
+            title = translate("CAM", "No valid toolcontroller")
+            message = translate(
+                "CAM",
+                "This operation requires a tool controller with a probe tool",
+            )
+            self.show_error_message(title, message)
+
+
 class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     """Page controller class for the Probing operation."""
 
@@ -63,20 +78,8 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         obj.PointCountY = self.form.PointCountY.value()
         obj.OutputFileName = str(self.form.OutputFileName.text())
 
-        try:
-            self.updateToolController(obj, self.form.toolController)
-        except PathUtils.PathNoTCExistsException:
-            title = translate("CAM", "No valid toolcontroller")
-            message = translate(
-                "CAM",
-                "This operation requires a tool controller with a probe tool",
-            )
-
-            self.show_error_message(title, message)
-
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
-        self.setupToolController(obj, self.form.toolController)
         self.form.Xoffset.setText(
             FreeCAD.Units.Quantity(obj.Xoffset.Value, FreeCAD.Units.Length).UserString
         )
@@ -90,7 +93,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
         signals = []
-        signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.PointCountX.valueChanged)
         signals.append(self.form.PointCountY.valueChanged)
         signals.append(self.form.OutputFileName.editingFinished)
@@ -98,6 +100,11 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.Yoffset.valueChanged)
         self.form.SetOutputFileName.clicked.connect(self.SetOutputFileName)
         return signals
+
+    def taskPanelToolControllerPage(self, obj, features):
+        """taskPanelToolControllerPage(obj, features) ... report Probe's probe
+        tool requirement if an incompatible tool controller is selected."""
+        return TaskPanelToolControllerPage(obj, features)
 
     def SetOutputFileName(self):
         filename = QtGui.QFileDialog.getSaveFileName(

--- a/src/Mod/CAM/Path/Op/Gui/Profile.py
+++ b/src/Mod/CAM/Path/Op/Gui/Profile.py
@@ -46,9 +46,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     FeatureProcessing ... Are the processing check boxes supported by the operation
     """
 
-    # def initPage(self, obj):
-    #     self.setTitle("Profile - " + obj.Label)
-    #     self.updateVisibility()
+    def initPage(self, obj):
+        self.form.extraOffset.setProperty("unit", obj.OffsetExtra.getUserPreferred()[2])
+        self.form.stepover.setProperty("unit", obj.Stepover.getUserPreferred()[2])
 
     def profileFeatures(self):
         """profileFeatures() ... return which of the optional profile features are supported.
@@ -70,9 +70,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def getFields(self, obj):
         """getFields(obj) ... transfers values from UI to obj's properties"""
-        self.updateToolController(obj, self.form.toolController)
-        self.updateCoolant(obj, self.form.coolantController)
-
         if obj.Side != str(self.form.cutSide.currentData()):
             obj.Side = str(self.form.cutSide.currentData())
         if obj.Direction != str(self.form.direction.currentData()):
@@ -95,18 +92,11 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
-
         self.selectInComboBox(obj.Side, self.form.cutSide)
         self.selectInComboBox(obj.Direction, self.form.direction)
-        self.form.extraOffset.setText(
-            FreeCAD.Units.Quantity(obj.OffsetExtra.Value, FreeCAD.Units.Length).UserString
-        )
+        self.form.extraOffset.setProperty("rawValue", obj.OffsetExtra.Value)
         self.form.numPasses.setValue(obj.NumPasses)
-        self.form.stepover.setText(
-            FreeCAD.Units.Quantity(obj.Stepover.Value, FreeCAD.Units.Length).UserString
-        )
+        self.form.stepover.setProperty("rawValue", obj.Stepover.Value)
 
         self.form.useCompensation.setChecked(obj.UseComp)
         self.form.useStartPoint.setChecked(obj.UseStartPoint)
@@ -119,8 +109,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
         signals = []
-        signals.append(self.form.toolController.currentIndexChanged)
-        signals.append(self.form.coolantController.currentIndexChanged)
         signals.append(self.form.cutSide.currentIndexChanged)
         signals.append(self.form.direction.currentIndexChanged)
         signals.append(self.form.extraOffset.editingFinished)

--- a/src/Mod/CAM/Path/Op/Gui/RotarySurface.py
+++ b/src/Mod/CAM/Path/Op/Gui/RotarySurface.py
@@ -77,8 +77,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         return form
 
     def getFields(self, obj):
-        self.updateToolController(obj, self.form.toolController)
-        self.updateCoolant(obj, self.form.coolantController)
 
         if obj.CutMode != str(self.form.cutMode.currentData()):
             obj.CutMode = str(self.form.cutMode.currentData())
@@ -103,8 +101,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             obj.BoundaryFromFaces = self.form.boundaryFromFaces.isChecked()
 
     def setFields(self, obj):
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
         self.selectInComboBox(obj.CutMode, self.form.cutMode)
         self.selectInComboBox(obj.CutPattern, self.form.cutPattern)
         self.selectInComboBox(obj.FeedMode, self.form.feedMode)
@@ -132,8 +128,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def getSignalsForUpdate(self, obj):
         signals = [
-            self.form.toolController.currentIndexChanged,
-            self.form.coolantController.currentIndexChanged,
             self.form.cutMode.currentIndexChanged,
             self.form.cutPattern.currentIndexChanged,
             self.form.feedMode.currentIndexChanged,

--- a/src/Mod/CAM/Path/Op/Gui/Slot.py
+++ b/src/Mod/CAM/Path/Op/Gui/Slot.py
@@ -78,9 +78,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
         self.updateQuantitySpinBoxes()
 
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
-
         enums = [t[1] for t in self.propEnums["Reference1"]]
         if "Reference1" in self.ENUMS:
             enums = self.ENUMS["Reference1"]
@@ -114,8 +111,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     def getFields(self, obj):
         """getFields(obj) ... transfers values from UI to obj's properties"""
         debugMsg("getFields()")
-        self.updateToolController(obj, self.form.toolController)
-        self.updateCoolant(obj, self.form.coolantController)
 
         val = obj.getEnumerationsOfProperty("Reference1")[self.form.geo1Reference.currentIndex()]
         obj.Reference1 = val
@@ -137,8 +132,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
         debugMsg("getSignalsForUpdate()")
         signals = []
-        signals.append(self.form.toolController.currentIndexChanged)
-        signals.append(self.form.coolantController.currentIndexChanged)
         signals.append(self.form.geo1Extension.editingFinished)
         signals.append(self.form.geo1Reference.currentIndexChanged)
         signals.append(self.form.geo2Extension.editingFinished)

--- a/src/Mod/CAM/Path/Op/Gui/Surface.py
+++ b/src/Mod/CAM/Path/Op/Gui/Surface.py
@@ -72,8 +72,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def getFields(self, obj):
         """getFields(obj) ... transfers values from UI to obj's properties"""
-        self.updateToolController(obj, self.form.toolController)
-        self.updateCoolant(obj, self.form.coolantController)
 
         if obj.BoundBox != str(self.form.boundBoxSelect.currentData()):
             obj.BoundBox = str(self.form.boundBoxSelect.currentData())
@@ -141,8 +139,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
         self.selectInComboBox(obj.BoundBox, self.form.boundBoxSelect)
         self.selectInComboBox(obj.ScanType, self.form.scanType)
         self.selectInComboBox(obj.LayerMode, self.form.layerMode)
@@ -203,8 +199,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
         signals = []
-        signals.append(self.form.toolController.currentIndexChanged)
-        signals.append(self.form.coolantController.currentIndexChanged)
         signals.append(self.form.boundBoxSelect.currentIndexChanged)
         signals.append(self.form.scanType.currentIndexChanged)
         signals.append(self.form.layerMode.currentIndexChanged)

--- a/src/Mod/CAM/Path/Op/Gui/Tapping.py
+++ b/src/Mod/CAM/Path/Op/Gui/Tapping.py
@@ -121,9 +121,6 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         if obj.ExtraOffset != str(self.form.ExtraOffset.currentData()):
             obj.ExtraOffset = str(self.form.ExtraOffset.currentData())
 
-        self.updateToolController(obj, self.form.toolController)
-        self.updateCoolant(obj, self.form.coolantController)
-
     def setFields(self, obj):
         """setFields(obj) ... update UI with obj properties' values"""
         Path.Log.track()
@@ -147,9 +144,6 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
 
         self.selectInComboBox(obj.ExtraOffset, self.form.ExtraOffset)
 
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
-
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals which cause the receiver to update the model"""
         signals = []
@@ -160,8 +154,6 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         signals.append(self.form.dwellEnabled.stateChanged)
         #        signals.append(self.form.peckEnabled.stateChanged)
         #        signals.append(self.form.chipBreakEnabled.stateChanged)
-        signals.append(self.form.toolController.currentIndexChanged)
-        signals.append(self.form.coolantController.currentIndexChanged)
         signals.append(self.form.ExtraOffset.currentIndexChanged)
 
         return signals

--- a/src/Mod/CAM/Path/Op/Gui/ThreadMilling.py
+++ b/src/Mod/CAM/Path/Op/Gui/ThreadMilling.py
@@ -67,6 +67,21 @@ def fillThreads(form, dataFile, defaultSelect):
     form.threadName.blockSignals(False)
 
 
+class TaskPanelToolControllerPage(PathOpGui.TaskPanelToolControllerPage):
+    """Tool Controller page that reports ThreadMilling's threadmilling tool requirement."""
+
+    def getFields(self, obj):
+        try:
+            super(TaskPanelToolControllerPage, self).getFields(obj)
+        except PathUtils.PathNoTCExistsException:
+            title = translate("CAM", "No valid toolcontroller")
+            message = translate(
+                "CAM",
+                "This operation requires a tool controller with a threadmilling tool",
+            )
+            self.show_error_message(title, message)
+
+
 class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
     """Controller for the thread milling operation's page"""
 
@@ -105,17 +120,6 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         obj.LeadInOut = self.form.leadInOut.checkState() == QtCore.Qt.Checked
         obj.TPI = self.form.threadTPI.value()
 
-        try:
-            self.updateToolController(obj, self.form.toolController)
-        except PathUtils.PathNoTCExistsException:
-            title = translate("CAM", "No valid toolcontroller")
-            message = translate(
-                "CAM",
-                "This operation requires a tool controller with a threadmilling tool",
-            )
-
-            self.show_error_message(title, message)
-
     def setFields(self, obj):
         """setFields(obj) ... update UI with obj properties' values"""
         Path.Log.track()
@@ -139,7 +143,6 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         self.minorDia.updateWidget()
         self.pitch.updateWidget()
 
-        self.setupToolController(obj, self.form.toolController)
         self._updateFromThreadType()
 
     def _isThreadCustom(self):
@@ -234,14 +237,17 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         else:  # Qt version < 6.7.0
             signals.append(self.form.leadInOut.stateChanged)
 
-        signals.append(self.form.toolController.currentIndexChanged)
-
         return signals
 
     def registerSignalHandlers(self, obj):
         self.form.threadType.currentIndexChanged.connect(self._updateFromThreadType)
         self.form.threadName.currentIndexChanged.connect(self._updateFromThreadName)
         self.form.threadFit.valueChanged.connect(self._updateFromThreadName)
+
+    def taskPanelToolControllerPage(self, obj, features):
+        """taskPanelToolControllerPage(obj, features) ... report ThreadMilling's
+        threadmilling tool requirement if an incompatible tool controller is selected."""
+        return TaskPanelToolControllerPage(obj, features)
 
 
 Command = PathOpGui.SetupOperation(

--- a/src/Mod/CAM/Path/Op/Gui/Vcarve.py
+++ b/src/Mod/CAM/Path/Op/Gui/Vcarve.py
@@ -117,6 +117,21 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
         return self.super().updateBase()
 
 
+class TaskPanelToolControllerPage(PathOpGui.TaskPanelToolControllerPage):
+    """Tool Controller page that reports Vcarve's v-bit tool requirement."""
+
+    def getFields(self, obj):
+        try:
+            super(TaskPanelToolControllerPage, self).getFields(obj)
+        except PathUtils.PathNoTCExistsException:
+            title = translate("CAM", "No valid toolcontroller")
+            message = translate(
+                "CAM",
+                "This operation requires a tool controller with a v-bit tool",
+            )
+            self.show_error_message(title, message)
+
+
 class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     """Page controller class for the Vcarve operation."""
 
@@ -167,19 +182,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
         self.finishingPassZOffsetSpinBox.updateProperty()
 
-        self.updateCoolant(obj, self.form.coolantController)
-
-        try:
-            self.updateToolController(obj, self.form.toolController)
-        except PathUtils.PathNoTCExistsException:
-            title = translate("CAM", "No valid toolcontroller")
-            message = translate(
-                "CAM",
-                "This operation requires a tool controller with a v-bit tool",
-            )
-
-            self.show_error_message(title, message)
-
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
         self.form.discretize.setValue(obj.Discretize)
@@ -188,9 +190,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.optimizeMovementsEnabled.setChecked(obj.OptimizeMovements)
 
         self.finishingPassZOffsetSpinBox.updateWidget()
-
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
 
         self.updateFormConditionalState(self.form)
 
@@ -204,13 +203,17 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
         signals.append(self.form.optimizeMovementsEnabled.stateChanged)
 
-        signals.append(self.form.toolController.currentIndexChanged)
-        signals.append(self.form.coolantController.currentIndexChanged)
         return signals
 
     def taskPanelBaseGeometryPage(self, obj, features):
         """taskPanelBaseGeometryPage(obj, features) ... return page for adding base geometries."""
         return TaskPanelBaseGeometryPage(obj, features)
+
+    def taskPanelToolControllerPage(self, obj, features):
+        """taskPanelToolControllerPage(obj, features) ... Vcarve requires a v-bit
+        tool, so report that requirement if an incompatible tool controller is
+        selected."""
+        return TaskPanelToolControllerPage(obj, features)
 
 
 Command = PathOpGui.SetupOperation(

--- a/src/Mod/CAM/Path/Op/Gui/Waterline.py
+++ b/src/Mod/CAM/Path/Op/Gui/Waterline.py
@@ -67,8 +67,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def getFields(self, obj):
         """getFields(obj) ... transfers values from UI to obj's properties"""
-        self.updateToolController(obj, self.form.toolController)
-        self.updateCoolant(obj, self.form.coolantController)
 
         if obj.Algorithm != str(self.form.algorithmSelect.currentData()):
             obj.Algorithm = str(self.form.algorithmSelect.currentData())
@@ -95,8 +93,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
         self.selectInComboBox(obj.Algorithm, self.form.algorithmSelect)
         self.selectInComboBox(obj.BoundBox, self.form.boundBoxSelect)
         self.selectInComboBox(obj.LayerMode, self.form.layerMode)
@@ -122,8 +118,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
         signals = []
-        signals.append(self.form.toolController.currentIndexChanged)
-        signals.append(self.form.coolantController.currentIndexChanged)
         signals.append(self.form.algorithmSelect.currentIndexChanged)
         signals.append(self.form.boundBoxSelect.currentIndexChanged)
         signals.append(self.form.layerMode.currentIndexChanged)

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -169,7 +169,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             "Helix Drill",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "Offset inner radius"
+                "Set how much stock to leave on the inner wall for the operation."
                 "\nDefault inner radius for Internal profile is Tool radius,"
                 " and can not be less than (-ToolRadius)"
                 "\nFor External profile - profile radius",
@@ -181,7 +181,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             "Helix Drill",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "Extra offset from the profile",
+                "Set how much stock to leave on the outer wall for the operation.",
             ),
         )
         obj.addProperty(
@@ -365,7 +365,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 "Helix Drill",
                 QT_TRANSLATE_NOOP(
                     "App::Property",
-                    "Offset inner radius"
+                    "Set how much stock to leave on the inner wall for the operation."
                     "\nDefault inner radius is Tool radius"
                     " and can not be less than (-ToolRadius)"
                     "\nFor External profile - profile radius",
@@ -381,7 +381,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 "Helix Drill",
                 QT_TRANSLATE_NOOP(
                     "App::Property",
-                    "Extra offset from the profile",
+                    "Set how much stock to leave on the outer wall for the operation.",
                 ),
             )
         if hasattr(obj, "OffsetExtra"):

--- a/src/Mod/CAM/Path/Op/MillFacing.py
+++ b/src/Mod/CAM/Path/Op/MillFacing.py
@@ -163,7 +163,7 @@ class ObjectMillFacing(PathOp.ObjectOp):
                 "Facing",
                 QtCore.QT_TRANSLATE_NOOP(
                     "App::Property",
-                    "Set the stock to leave for the operation.",
+                    "Set how much stock to leave on the floor for the operation.",
                 ),
             ),
             (

--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -141,7 +141,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                 "Profile",
                 QT_TRANSLATE_NOOP(
                     "App::Property",
-                    "Extra value to stay away from final profile- good for roughing toolpath",
+                    "Set how much stock to leave on the walls for the operation.",
                 ),
             ),
             (

--- a/src/Mod/CAM/Path/Op/RotarySurface.py
+++ b/src/Mod/CAM/Path/Op/RotarySurface.py
@@ -168,7 +168,7 @@ class ObjectRotarySurface(PathOp.ObjectOp):
                 "RadialStockToLeave",
                 "Rotary",
                 QtCore.QT_TRANSLATE_NOOP(
-                    "App::Property", "Radial finish allowance left on the surface."
+                    "App::Property", "Set how much stock to leave on the walls for the operation."
                 ),
             ),
             (

--- a/src/Mod/CAM/Path/Tool/Controller.py
+++ b/src/Mod/CAM/Path/Tool/Controller.py
@@ -482,8 +482,11 @@ def copyTC(tc, job):
         try:
             if prop not in ["Label", "Label2"]:
                 setattr(newtc, prop, getattr(tc, prop))
-        except RuntimeError:
-            # Ignore errors for read-only properties
+        except (RuntimeError, AttributeError):
+            # RuntimeError: read-only property.
+            # AttributeError: prop is a dynamically-added property (e.g. the
+            # Feeds & Speeds wizard's FeedSpeedProvenance/OpTypeHint) that
+            # exists on tc but was never added to the freshly-created newtc.
             pass
     for attr, expr in tc.ExpressionEngine:
         newtc.setExpression(attr, expr)

--- a/src/Mod/CAM/Path/Tool/Gui/Controller.py
+++ b/src/Mod/CAM/Path/Tool/Gui/Controller.py
@@ -208,6 +208,7 @@ class ToolControllerEditor(object):
         self.form.tc_layout.addWidget(self.controller)
         if not asDialog:
             self.form.buttonBox.hide()
+        self.controller.tcOperationCountLabel.setTextFormat(QtCore.Qt.RichText)
         if not showCountLabel:
             self.controller.tcOperationCountLabel.hide()
         self.obj = obj
@@ -308,6 +309,8 @@ class ToolControllerEditor(object):
                 obj.blockSignals(True)
 
             self.controller.tcName.setText(tc.Label)
+            if not self.controller.tcName.hasFocus():
+                self.controller.tcName.setCursorPosition(0)
             self.controller.tcNumber.setValue(tc.ToolNumber)
             self.horizFeed.updateWidget()
             self.horizRapid.updateWidget()
@@ -369,6 +372,9 @@ class ToolControllerEditor(object):
             self.editor.setupUI()
 
         self.controller.tcName.textChanged.connect(self.changed)
+        self.controller.tcName.editingFinished.connect(
+            lambda: self.controller.tcName.setCursorPosition(0)
+        )
         self.controller.tcNumber.editingFinished.connect(self.changed)
         self.vertFeed.widget.textChanged.connect(self.changed)
         self.horizFeed.widget.textChanged.connect(self.changed)

--- a/src/Mod/CAM/Path/Tool/Gui/FeedsSpeedsDialog.py
+++ b/src/Mod/CAM/Path/Tool/Gui/FeedsSpeedsDialog.py
@@ -315,6 +315,7 @@ class FeedsSpeedsDialog(QtWidgets.QDialog):
 
     def __init__(self, tc, parent=None):
         super().__init__(parent)
+        self._centered = False
         self.tc = tc
         ensure_tc_properties(tc)
         self.toolbit = _toolbit_from_tc(tc)
@@ -329,6 +330,17 @@ class FeedsSpeedsDialog(QtWidgets.QDialog):
         self.setWindowTitle(translate("CAM_FeedsSpeeds", "Suggest Feeds & Speeds"))
         self._build_ui()
         self._refresh()
+
+    def showEvent(self, event) -> None:
+        super().showEvent(event)
+        if not self._centered:
+            self._centered = True
+            screen = QtWidgets.QApplication.primaryScreen()
+            if screen is not None:
+                geo = screen.availableGeometry()
+                frame = self.frameGeometry()
+                frame.moveCenter(geo.center())
+                self.move(frame.topLeft())
 
     def _build_ui(self) -> None:
         outer = QtWidgets.QVBoxLayout(self)


### PR DESCRIPTION
This PR contains a number of GUI improvements, most notably moving the tool controller editor out of each individual operation page and into its own dedicated tab.

* Moved tool controller editing out of each individual operation page and into a single dedicated tab shared across all operation types.
* Removed the "Edit Tool Controller" checkbox; the editor is always visible now.
* Tab icons now follow the user's Toolbar Icon Size preference instead of a hardcoded size; icon-only tab width scales with it too.
* Fixed bare-number entry defaulting to mm in Profile's stock-to-leave/stepover fields regardless of document units.
* Fixed AttributeError copying a tool controller that had been through the Feeds & Speeds wizard.
* Tool controller Name field now shows the start of the name, not the end, when too narrow.
* Feeds & Speeds Wizard dialog now opens centered on screen.
* Renamed stock-to-leave labels/tooltips to "Radial"/"Axial stock to leave" across Profile, Adaptive, MillFacing, Helix, RotarySurface.
* Removed forced right-alignment from numeric fields in Heights, Diameters, tool controller editor, Feeds & Speeds presets, MillFacing, ThreadMilling.
* Added an icon to the "used by other operations" warning label.
* Fixed the operation count for that warning to unwrap dressups instead of comparing ToolController directly against the job's Operations group.
* Fixed a crash in IconTabWidget.eventFilter where the non-QEvent guard didn't also cover the base-class call.
* Fixed a widget leak in the tool controller editor — the old editor frame is now disposed with deleteLater instead of just hidden and detached.
* Fixed a crash when a different job's tool controller list changed while another job's panel was open (cross-document PropertyLink error).

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<img width="472" height="753" alt="image" src="https://github.com/user-attachments/assets/c90797c7-1cc9-4556-9422-d8a09db7110f" />
