### PR TITLE
TD: Fix transaction status when creating ProjGroup

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
@@ -885,10 +885,12 @@ void TaskDlgProjGroup::open()
 {
     if (!widget->getCreateMode())  {    //this is an edit session, start a transaction
         if (dynamic_cast<TechDraw::DrawProjGroup*>(view)) {
-            App::GetApplication().setActiveTransaction(App::TransactionName{.name="Edit Projection Group", .temporary=true});
+            App::GetApplication().setActiveTransaction(
+                App::TransactionName {.name = "Edit Projection Group", .temporary = false});
         }
         else {
-            App::GetApplication().setActiveTransaction(App::TransactionName{.name="Edit Part View", .temporary=true});
+            App::GetApplication().setActiveTransaction(
+                App::TransactionName {.name = "Edit Part View", .temporary = false});
         }
     }
 }


### PR DESCRIPTION
Commit f4665aa mistakenly left the trailing boolean parameter to `setActiveTransaction` set to `true`, even though the sense of the argument changed. This caused the bug reported in #30757.

Fixes #30757.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.