### PR TITLE
`codecs.open` modernization

### DIFF
--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -516,11 +516,10 @@ class BIM_Classification:
         preset = os.path.join(FreeCAD.getUserAppDataDir(), "BIM", "Classification", system + ".xml")
         if not os.path.exists(preset):
             return None
-        import codecs
         import re
 
         d = Item()
-        with codecs.open(preset, "r", "utf-8") as f:
+        with open(preset, "r", encoding="utf-8") as f:
             currentItem = d
             for l in f:
                 if "<Item>" in l:

--- a/src/Mod/BIM/bimcommands/BimTutorial.py
+++ b/src/Mod/BIM/bimcommands/BimTutorial.py
@@ -94,7 +94,6 @@ class BIM_Tutorial:
             QtCore.QTimer.singleShot(1000, self.load)
 
     def load(self, arg=None):
-        import codecs
         import re
         import sys
         from urllib.request import urlopen
@@ -133,7 +132,7 @@ class BIM_Tutorial:
         else:
             if not os.path.exists(os.path.dirname(offlineloc)):
                 os.makedirs(os.path.dirname(offlineloc))
-            f = codecs.open(offlineloc, "w", "utf-8")
+            f = open(offlineloc, "w", encoding="utf-8")
             f.write(html)
             f.close()
 

--- a/src/Mod/BIM/importers/importOBJ.py
+++ b/src/Mod/BIM/importers/importOBJ.py
@@ -31,7 +31,6 @@
 #  and supports exporting faces with more than 3 vertices
 #  and supports object colors / materials
 
-import codecs
 import ntpath
 import os
 from builtins import open as pyopen
@@ -172,7 +171,7 @@ def export(exportList, filename, colors=None):
     optionally colors can be a dict containing ["objectName:colorTuple"]
     pairs for use in non-GUI mode."""
 
-    outfile = codecs.open(filename, "wb", encoding="utf8")
+    outfile = pyopen(filename, "w", encoding="utf8")
     ver = FreeCAD.Version()
     outfile.write("# FreeCAD v" + ver[0] + "." + ver[1] + " build" + ver[2] + " Arch module\n")
     outfile.write("# https://www.freecad.org\n")

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_fluidsection.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_fluidsection.py
@@ -26,7 +26,6 @@ __author__ = "Bernd Hahnebach"
 __url__ = "https://www.freecad.org"
 
 
-import codecs
 import os
 from os.path import join
 
@@ -115,7 +114,7 @@ def handle_fluidsection_liquid_inlet_outlet(inpfile, ccxwriter):
         meshtools.use_correct_fluidinout_ele_def(
             ccxwriter.FluidInletoutlet_ele, ccxwriter.femmesh_file, ccxwriter.fluid_inout_nodes_file
         )
-        inpfile = codecs.open(ccxwriter.file_name, "a", encoding="utf-8")
+        inpfile = open(ccxwriter.file_name, "a", encoding="utf-8")
 
     return inpfile
 

--- a/src/Mod/Fem/femsolver/calculix/write_mesh.py
+++ b/src/Mod/Fem/femsolver/calculix/write_mesh.py
@@ -26,7 +26,6 @@ __author__ = "Bernd Hahnebach"
 __url__ = "https://www.freecad.org"
 
 
-import codecs
 from os.path import join
 
 from femmesh import meshtools
@@ -82,7 +81,7 @@ def write_mesh(ccxwriter):
             edgeVariant=edge_variant,
         )
 
-        inpfile = codecs.open(ccxwriter.file_name, "w", encoding="utf-8")
+        inpfile = open(ccxwriter.file_name, "w", encoding="utf-8")
         inpfile.write("{}\n".format(59 * "*"))
         inpfile.write(f"** {write_name}\n")
         inpfile.write(f"*INCLUDE,INPUT={file_name_split}\n")
@@ -99,7 +98,7 @@ def write_mesh(ccxwriter):
         )
 
         # reopen file with "append" to add all the rest
-        inpfile = codecs.open(ccxwriter.femmesh_file, "a", encoding="utf-8")
+        inpfile = open(ccxwriter.femmesh_file, "a", encoding="utf-8")
         inpfile.write("\n\n")
 
     return inpfile

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -461,10 +461,7 @@ void CmdTechDrawView::activated(int iMsg)
                     auto filespec = DU::cleanFilespecBackslash(
                         Base::Tools::escapeEncodeFilename(filename.toStdString()));
                     openCommand(QT_TRANSLATE_NOOP("Command", "Create Symbol"));
-                    doCommand(Doc, "import codecs");
-                    doCommand(Doc,
-                              "f = codecs.open(\"%s\", 'r', encoding=\"utf-8\")",
-                              filespec.c_str());
+                    doCommand(Doc, "f = open(\"%s\", 'r', encoding=\"utf-8\")", filespec.c_str());
                     doCommand(Doc, "svg = f.read()");
                     doCommand(Doc, "f.close()");
                     doCommand(Doc,
@@ -1571,8 +1568,7 @@ void CmdTechDrawSymbol::activated(int iMsg)
         auto filespec = DU::cleanFilespecBackslash(
             Base::Tools::escapeEncodeFilename(filename.toStdString()));
         openCommand(QT_TRANSLATE_NOOP("Command", "Create Symbol"));
-        doCommand(Doc, "import codecs");
-        doCommand(Doc, "f = codecs.open(\"%s\", 'r', encoding=\"utf-8\")",  filespec.c_str());
+        doCommand(Doc, "f = open(\"%s\", 'r', encoding=\"utf-8\")", filespec.c_str());
         doCommand(Doc, "svg = f.read()");
         doCommand(Doc, "f.close()");
         doCommand(Doc, "App.activeDocument().addObject('TechDraw::DrawViewSymbol', '%s')",

--- a/src/Mod/TechDraw/TDTest/DrawViewScaleTypeTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawViewScaleTypeTest.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import codecs
 import os
 import tempfile
 import unittest
@@ -31,7 +30,7 @@ class DrawViewScaleTypeTest(unittest.TestCase):
     def _addPageSymbol(self):
         sym = self.document.addObject("TechDraw::DrawViewSymbol", "ScaleSym")
         path = os.path.dirname(os.path.abspath(__file__))
-        with codecs.open(path + "/TestSymbol.svg", "r", encoding="utf-8") as f:
+        with open(path + "/TestSymbol.svg", "r", encoding="utf-8") as f:
             sym.Symbol = f.read()
         self.page.addView(sym)
         sym.ScaleType = "Page"

--- a/src/Mod/TechDraw/TDTest/DrawViewSymbolTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawViewSymbolTest.py
@@ -1,6 +1,5 @@
 
 import FreeCAD
-import codecs
 import os
 import unittest
 from .TechDrawTestUtilities import createPageWithSVGTemplate
@@ -22,7 +21,7 @@ class DrawViewSymbolTest(unittest.TestCase):
         sym = FreeCAD.ActiveDocument.addObject("TechDraw::DrawViewSymbol", "TestSymbol")
         path = os.path.dirname(os.path.abspath(__file__))
         symbolFileSpec = path + "/TestSymbol.svg"
-        f = codecs.open(symbolFileSpec, "r", encoding="utf-8")
+        f = open(symbolFileSpec, "r", encoding="utf-8")
         svg = f.read()
         f.close()
         sym.Symbol = svg
@@ -41,7 +40,7 @@ class DrawViewSymbolTest(unittest.TestCase):
         )
         path = os.path.dirname(os.path.abspath(__file__))
         symbolFileSpec = path + "/TestNonAsciiSymbol.svg"
-        f = codecs.open(symbolFileSpec, "r", encoding="utf-8")
+        f = open(symbolFileSpec, "r", encoding="utf-8")
         svg = f.read()
         f.close()
         sym.Symbol = svg

--- a/src/Mod/TechDraw/TechDrawTools/CommandFillTemplateFields.py
+++ b/src/Mod/TechDraw/TechDrawTools/CommandFillTemplateFields.py
@@ -30,7 +30,6 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
-import codecs
 import csv
 import os.path
 
@@ -82,7 +81,7 @@ class CommandFillTemplateFields:
                         "CreatedDateChkLst",
                         "LastModifiedDateChkLst",
                     ]
-                    with codecs.open(file_path, encoding="utf-8") as fp:
+                    with open(file_path, encoding="utf-8", newline="") as fp:
                         reader = csv.DictReader(fp)
                         page = obj
                         texts = page.Template.EditableTexts

--- a/src/Mod/TechDraw/TechDrawTools/TaskFillTemplateFields.py
+++ b/src/Mod/TechDraw/TechDrawTools/TaskFillTemplateFields.py
@@ -34,7 +34,6 @@ import FreeCADGui as Gui
 import datetime
 from datetime import date
 import csv
-import codecs
 from fractions import Fraction
 import os.path
 import TechDraw
@@ -62,7 +61,7 @@ listofkeys = [
 file_path = App.getResourceDir() + "Mod/TechDraw/CSVdata/FillTemplateFields.csv"
 
 if os.path.exists(file_path):
-    with codecs.open(file_path, encoding="utf-8") as fp:
+    with open(file_path, encoding="utf-8", newline="") as fp:
         reader = csv.DictReader(fp)
         if listofkeys == reader.fieldnames:
             for row in reader:

--- a/src/Mod/Test/Metadata.py
+++ b/src/Mod/Test/Metadata.py
@@ -23,7 +23,6 @@
 import FreeCAD
 import unittest
 import os
-import codecs
 import tempfile
 
 
@@ -120,7 +119,7 @@ class TestMetadata(unittest.TestCase):
         # Issue 7112
         try:
             filename = os.path.join(tempfile.gettempdir(), b"H\xc3\xa5vard.xml".decode("utf-8"))
-            xmlfile = codecs.open(filename, mode="w", encoding="utf-8")
+            xmlfile = open(filename, mode="w", encoding="utf-8")
             xmlfile.write(r"""<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>test</name>

--- a/src/Tools/LicenseChecker.py
+++ b/src/Tools/LicenseChecker.py
@@ -5,7 +5,7 @@
 #
 # Utility to search for source, header and Python files with a missing license text
 
-import codecs, os
+import os
 
 ext = [".cpp", ".cxx", ".cc", ".c", ".hpp", ".hxx", ".hh", ".h", ".inl", ".inc", ".py"]
 flt = [
@@ -79,7 +79,7 @@ def traverse(path, ext, flt):
 
 
 def parsefile(fn):
-    data = codecs.open(fn, "r", "utf-8")
+    data = open(fn, "r", encoding="utf-8")
     try:
         lines = data.readlines()
         data.close()


### PR DESCRIPTION
Python's `codecs.open` function is deprecated, and debug builds of Python yell about its use. This sweep should eliminate all of our non-submodule uses of that function.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.