### PR TITLE
Gui: Add missing GIL when running a macro with output redirection

### DIFF
--- a/src/Gui/Macro.cpp
+++ b/src/Gui/Macro.cpp
@@ -390,8 +390,13 @@ void MacroManager::run(MacroType eType, const char* sName)
                                         .GetGroup("BaseApp")
                                         ->GetGroup("Preferences")
                                         ->GetGroup("OutputWindow");
-        PyObject* pyout = hGrp->GetBool("RedirectPythonOutput", true) ? new OutputStdout : nullptr;
-        PyObject* pyerr = hGrp->GetBool("RedirectPythonErrors", true) ? new OutputStderr : nullptr;
+        PyObject* pyout {nullptr};
+        PyObject* pyerr {nullptr};
+        {
+            Base::PyGILStateLocker lock;
+            pyout = hGrp->GetBool("RedirectPythonOutput", true) ? new OutputStdout : nullptr;
+            pyerr = hGrp->GetBool("RedirectPythonErrors", true) ? new OutputStderr : nullptr;
+        }
         PythonRedirector std_out("stdout", pyout);
         PythonRedirector std_err("stderr", pyerr);
         // The given path name is expected to be Utf-8


### PR DESCRIPTION
Ran across with in a Windows Debug build when trying to run a macro. We need to hold the GIL while constructing the `OutputStdout` and `OutputStderr`.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
