### PR TITLE
Gui: Remove the hidden anchor from picking calculations

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1125,9 +1125,14 @@ void View3DInventorViewer::init()
     auto hiddenAnchor = new SoSkipBoundingGroup();
     hiddenAnchor->mode = SoSkipBoundingGroup::EXCLUDE_BBOX;
     auto hiddenSep = new SoSeparator();
+    // The zero scale that hides the cube also makes the model matrix singular, so keep it out of
+    // the ray-casting calculations during object picking.
+    auto hiddenPickStyle = new SoPickStyle();
+    hiddenPickStyle->style = SoPickStyle::UNPICKABLE;
     auto hiddenScale = new SoScale();
     hiddenScale->scaleFactor = SbVec3f(0, 0, 0);
     auto hiddenCube = new SoCube();
+    hiddenSep->addChild(hiddenPickStyle);
     hiddenSep->addChild(hiddenScale);
     hiddenSep->addChild(hiddenCube);
     hiddenAnchor->addChild(hiddenSep);


### PR DESCRIPTION
When using a debug build of coin and moving the mouse over a 3D scene, I was getting repeating instances of:
```
Coin warning in SbMatrix::inverse(): Matrix is singular.
Coin warning in SbDPLine::setValue(): The two points defining the line is equal => line is invalid.
Coin warning in SbLine::setValue(): The two points defining the line is equal => line is invalid.
Coin warning in SbPlane::intersect(): Intersecting line doesn't have a direction.
Coin warning in SbPlane::intersect(): Intersecting line doesn't have a direction.
Coin warning in SbPlane::intersect(): Intersecting line doesn't have a direction.
Coin warning in SbPlane::intersect(): Intersecting line doesn't have a direction.
Coin warning in SbPlane::intersect(): Intersecting line doesn't have a direction.
Coin warning in SbPlane::intersect(): Intersecting line doesn't have a direction.
```

This all traced back to the way that the hidden cube we've added to make transparency work correctly in empty scenes was being hidden (by setting its scale to zero). That made its matrix singular, which resulted in the first error, which then just cascaded down into all the others. The fix is to make sure that object isn't even in the picking hierarchy, since obviously it can't (and shouldn't) be picked.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
