### PR TITLE
CAM: MBPP Dialog - Add gcode lines numeration

### DIFF
--- a/src/Mod/CAM/Gui/DlgSettingsPathColor.cpp
+++ b/src/Mod/CAM/Gui/DlgSettingsPathColor.cpp
@@ -65,6 +65,7 @@ void DlgSettingsPathColor::saveSettings()
     ui->DefaultTaskPanelLayout->onSave();
     ui->HideFirstRapid->onSave();
     ui->PostProcessorShowEditor->onSave();
+    ui->MaxHighlighterSize->onSave();
 }
 
 void DlgSettingsPathColor::loadSettings()
@@ -82,6 +83,7 @@ void DlgSettingsPathColor::loadSettings()
     ui->DefaultTaskPanelLayout->onRestore();
     ui->HideFirstRapid->onRestore();
     ui->PostProcessorShowEditor->onRestore();
+    ui->MaxHighlighterSize->onRestore();
 }
 
 /**

--- a/src/Mod/CAM/Gui/DlgSettingsPathColor.ui
+++ b/src/Mod/CAM/Gui/DlgSettingsPathColor.ui
@@ -430,6 +430,37 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_15">
+        <property name="text">
+         <string>Maximum G-code length to use highlighter</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::PrefSpinBox" name="MaxHighlighterSize">
+        <property name="toolTip">
+         <string>Limits G-code length which will allow to use highlighter.
+Decrease value if gets perfomance problem in Inspect or export G-code windows.
+Set to zero to disable G-code highlighter.</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>999999999</number>
+        </property>
+        <property name="value">
+         <number>100000</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>MaxHighlighterSize</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/CAM</cstring>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/Mod/CAM/Gui/DlgSettingsPathColor.ui
+++ b/src/Mod/CAM/Gui/DlgSettingsPathColor.ui
@@ -430,6 +430,37 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_15">
+        <property name="text">
+         <string>Maximum lines of G-code to use highlighter</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::PrefSpinBox" name="MaxHighlighterSize">
+        <property name="toolTip">
+         <string>Limits lines of G-code which will allow to use highlighter.
+Decrease value if gets perfomance problem in Inspect or export G-code windows.
+Set to zero to disable G-code highlighter.</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>999999999</number>
+        </property>
+        <property name="value">
+         <number>1000</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>MaxHighlighterSize</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/CAM</cstring>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/Mod/CAM/Path/Main/Gui/Editor.py
+++ b/src/Mod/CAM/Path/Main/Gui/Editor.py
@@ -1,6 +1,57 @@
+import FreeCAD
 from PySide.QtWidgets import QWidget, QPlainTextEdit
-from PySide.QtGui import QPainter, QFont
-from PySide.QtCore import Qt, QRect, QSize
+from PySide import QtCore, QtGui
+
+
+class GCodeHighlighter(QtGui.QSyntaxHighlighter):
+    def __init__(self, parent=None):
+        def convertcolor(c):
+            return QtGui.QColor(int((c >> 24) & 0xFF), int((c >> 16) & 0xFF), int((c >> 8) & 0xFF))
+
+        super(GCodeHighlighter, self).__init__(parent)
+        p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Editor")
+        colors = []
+        c = p.GetUnsigned("Number")
+        if c:
+            colors.append(convertcolor(c))
+        else:
+            colors.append(QtCore.Qt.red)
+        c = p.GetUnsigned("Keyword")
+        if c:
+            colors.append(convertcolor(c))
+        else:
+            colors.append(QtGui.QColor(0, 170, 0))
+        c = p.GetUnsigned("Define name")
+        if c:
+            colors.append(convertcolor(c))
+        else:
+            colors.append(QtGui.QColor(160, 160, 164))
+
+        self.highlightingRules = []
+        numberFormat = QtGui.QTextCharFormat()
+        numberFormat.setForeground(colors[0])
+        self.highlightingRules.append((QtCore.QRegularExpression("[\\-0-9\\.]"), numberFormat))
+        keywordFormat = QtGui.QTextCharFormat()
+        keywordFormat.setForeground(colors[1])
+        keywordFormat.setFontWeight(QtGui.QFont.Bold)
+        keywordPatterns = ["\\bG[0-9]+\\b", "\\bM[0-9]+\\b"]
+        self.highlightingRules.extend(
+            [(QtCore.QRegularExpression(pattern), keywordFormat) for pattern in keywordPatterns]
+        )
+        speedFormat = QtGui.QTextCharFormat()
+        speedFormat.setFontWeight(QtGui.QFont.Bold)
+        speedFormat.setForeground(colors[2])
+        self.highlightingRules.append((QtCore.QRegularExpression("\\bF[0-9\\.]+\\b"), speedFormat))
+
+    def highlightBlock(self, text):
+        if self.enable:
+            for pattern, fmt in self.highlightingRules:
+                expression = QtCore.QRegularExpression(pattern)
+                index = expression.match(text)
+                while index.hasMatch():
+                    length = index.capturedLength()
+                    self.setFormat(index.capturedStart(), length, fmt)
+                    index = expression.match(text, index.capturedStart() + length)
 
 
 class LineNumberArea(QWidget):
@@ -9,12 +60,12 @@ class LineNumberArea(QWidget):
         self.editor = editor
 
     def sizeHint(self):
-        return QSize(self.editor.fontMetrics().horizontalAdvance("999") + 4, 0)
+        return QtCore.QSize(self.editor.fontMetrics().horizontalAdvance("999") + 4, 0)
 
     def paintEvent(self, event):
-        painter = QPainter(self)
-        painter.fillRect(event.rect(), Qt.black)
-        font = QFont()
+        painter = QtGui.QPainter(self)
+        painter.fillRect(event.rect(), QtCore.Qt.black)
+        font = QtGui.QFont()
         font.setFamily(self.editor.font().family())
         font.setFixedPitch(self.editor.font().fixedPitch())
         font.setPointSize(self.editor.font().pointSize())
@@ -26,15 +77,19 @@ class LineNumberArea(QWidget):
         bottom = top + self.editor.blockBoundingRect(block).height()
 
         while block.isValid() and top <= event.rect().bottom():
-            if block.isVisible() and bottom >= event.rect().top():
+            if (
+                block.isVisible()
+                and bottom >= event.rect().top()
+                and self.editor.toPlainText() != ""
+            ):
                 number = str(blockNumber + 1)
-                painter.setPen(Qt.gray)
+                painter.setPen(QtCore.Qt.gray)
                 painter.drawText(
                     -6,
                     int(top),
                     self.width(),
                     self.editor.fontMetrics().height(),
-                    Qt.AlignRight,
+                    QtCore.Qt.AlignRight,
                     number,
                 )
 
@@ -47,12 +102,24 @@ class LineNumberArea(QWidget):
 class CodeEditor(QPlainTextEdit):
     def __init__(self, parent=None):
         super().__init__(parent)
+
+        prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/CAM")
+        self.mhs = prefs.GetUnsigned("MaxHighlighterSize", 100000)
+        self.highLighter = GCodeHighlighter(self.document())
+        self.highLighter.enable = False
+
         self.lineNumberArea = LineNumberArea(self)
         self.blockCountChanged.connect(self.updateLineNumberAreaWidth)
         self.updateRequest.connect(self.updateLineNumberArea)
-        self.verticalScrollBar().valueChanged.connect(self.lineNumberArea.update)  # Simple update
-
+        self.verticalScrollBar().valueChanged.connect(self.lineNumberArea.update)
         self.updateLineNumberAreaWidth(0)  # Initial call
+
+        p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Editor")
+        font = QtGui.QFont()
+        font.setFamily(p.GetString("Font", "Courier"))
+        font.setFixedPitch(True)
+        font.setPointSize(p.GetInt("FontSize", 10))
+        self.setFont(font)
 
     def lineNumberAreaWidth(self):
         digits = 2
@@ -79,9 +146,16 @@ class CodeEditor(QPlainTextEdit):
         super().resizeEvent(event)
         cr = self.contentsRect()
         self.lineNumberArea.setGeometry(
-            QRect(cr.left(), cr.top(), self.lineNumberAreaWidth(), cr.height())
+            QtCore.QRect(cr.left(), cr.top(), self.lineNumberAreaWidth(), cr.height())
         )
 
     def setText(self, text):
         """Backward compatibility method for setText() calls."""
         self.setPlainText(text)
+
+    def setPlainText(self, text):
+        if len(text) > self.mhs:
+            self.highLighter.enable = False
+        else:
+            self.highLighter.enable = True
+        super().setPlainText(text)

--- a/src/Mod/CAM/Path/Main/Gui/Editor.py
+++ b/src/Mod/CAM/Path/Main/Gui/Editor.py
@@ -1,6 +1,77 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+import FreeCAD
 from PySide.QtWidgets import QWidget, QPlainTextEdit
-from PySide.QtGui import QPainter, QFont
-from PySide.QtCore import Qt, QRect, QSize
+from PySide import QtCore, QtGui
+
+
+class GCodeHighlighter(QtGui.QSyntaxHighlighter):
+    def __init__(self, parent=None):
+        def convertcolor(c):
+            return QtGui.QColor(int((c >> 24) & 0xFF), int((c >> 16) & 0xFF), int((c >> 8) & 0xFF))
+
+        super(GCodeHighlighter, self).__init__(parent)
+        p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Editor")
+        colors = []
+        c = p.GetUnsigned("Number")
+        if c:
+            colors.append(convertcolor(c))
+        else:
+            colors.append(QtCore.Qt.red)
+        c = p.GetUnsigned("Keyword")
+        if c:
+            colors.append(convertcolor(c))
+        else:
+            colors.append(QtGui.QColor(0, 170, 0))
+        c = p.GetUnsigned("Define name")
+        if c:
+            colors.append(convertcolor(c))
+        else:
+            colors.append(QtGui.QColor(160, 160, 164))
+
+        self.highlightingRules = []
+        numberFormat = QtGui.QTextCharFormat()
+        numberFormat.setForeground(colors[0])
+        self.highlightingRules.append((QtCore.QRegularExpression("[\\-0-9\\.]"), numberFormat))
+        keywordFormat = QtGui.QTextCharFormat()
+        keywordFormat.setForeground(colors[1])
+        keywordFormat.setFontWeight(QtGui.QFont.Bold)
+        keywordPatterns = ["\\bG[0-9]+\\b", "\\bM[0-9]+\\b"]
+        self.highlightingRules.extend(
+            [(QtCore.QRegularExpression(pattern), keywordFormat) for pattern in keywordPatterns]
+        )
+        speedFormat = QtGui.QTextCharFormat()
+        speedFormat.setFontWeight(QtGui.QFont.Bold)
+        speedFormat.setForeground(colors[2])
+        self.highlightingRules.append((QtCore.QRegularExpression("\\bF[0-9\\.]+\\b"), speedFormat))
+
+    def highlightBlock(self, text):
+        if self.enable:
+            for pattern, fmt in self.highlightingRules:
+                expression = QtCore.QRegularExpression(pattern)
+                index = expression.match(text)
+                while index.hasMatch():
+                    length = index.capturedLength()
+                    self.setFormat(index.capturedStart(), length, fmt)
+                    index = expression.match(text, index.capturedStart() + length)
 
 
 class LineNumberArea(QWidget):
@@ -9,12 +80,12 @@ class LineNumberArea(QWidget):
         self.editor = editor
 
     def sizeHint(self):
-        return QSize(self.editor.fontMetrics().horizontalAdvance("999") + 4, 0)
+        return QtCore.QSize(self.editor.fontMetrics().horizontalAdvance("999") + 4, 0)
 
     def paintEvent(self, event):
-        painter = QPainter(self)
-        painter.fillRect(event.rect(), Qt.black)
-        font = QFont()
+        painter = QtGui.QPainter(self)
+        painter.fillRect(event.rect(), QtCore.Qt.black)
+        font = QtGui.QFont()
         font.setFamily(self.editor.font().family())
         font.setFixedPitch(self.editor.font().fixedPitch())
         font.setPointSize(self.editor.font().pointSize())
@@ -26,15 +97,19 @@ class LineNumberArea(QWidget):
         bottom = top + self.editor.blockBoundingRect(block).height()
 
         while block.isValid() and top <= event.rect().bottom():
-            if block.isVisible() and bottom >= event.rect().top():
+            if (
+                block.isVisible()
+                and bottom >= event.rect().top()
+                and self.editor.toPlainText() != ""
+            ):
                 number = str(blockNumber + 1)
-                painter.setPen(Qt.gray)
+                painter.setPen(QtCore.Qt.gray)
                 painter.drawText(
                     -6,
                     int(top),
                     self.width(),
                     self.editor.fontMetrics().height(),
-                    Qt.AlignRight,
+                    QtCore.Qt.AlignRight,
                     number,
                 )
 
@@ -47,12 +122,24 @@ class LineNumberArea(QWidget):
 class CodeEditor(QPlainTextEdit):
     def __init__(self, parent=None):
         super().__init__(parent)
+
+        prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/CAM")
+        self.mhs = prefs.GetInt("MaxHighlighterSize", 1000)
+        self.highLighter = GCodeHighlighter(self.document())
+        self.highLighter.enable = False
+
         self.lineNumberArea = LineNumberArea(self)
         self.blockCountChanged.connect(self.updateLineNumberAreaWidth)
         self.updateRequest.connect(self.updateLineNumberArea)
-        self.verticalScrollBar().valueChanged.connect(self.lineNumberArea.update)  # Simple update
-
+        self.verticalScrollBar().valueChanged.connect(self.lineNumberArea.update)
         self.updateLineNumberAreaWidth(0)  # Initial call
+
+        p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Editor")
+        font = QtGui.QFont()
+        font.setFamily(p.GetString("Font", "Courier"))
+        font.setFixedPitch(True)
+        font.setPointSize(p.GetInt("FontSize", 10))
+        self.setFont(font)
 
     def lineNumberAreaWidth(self):
         digits = 2
@@ -79,9 +166,16 @@ class CodeEditor(QPlainTextEdit):
         super().resizeEvent(event)
         cr = self.contentsRect()
         self.lineNumberArea.setGeometry(
-            QRect(cr.left(), cr.top(), self.lineNumberAreaWidth(), cr.height())
+            QtCore.QRect(cr.left(), cr.top(), self.lineNumberAreaWidth(), cr.height())
         )
 
     def setText(self, text):
         """Backward compatibility method for setText() calls."""
         self.setPlainText(text)
+
+    def setPlainText(self, text):
+        if text.count("\n") > self.mhs:
+            self.highLighter.enable = False
+        else:
+            self.highLighter.enable = True
+        super().setPlainText(text)

--- a/src/Mod/CAM/Path/Main/Gui/Inspect.py
+++ b/src/Mod/CAM/Path/Main/Gui/Inspect.py
@@ -35,57 +35,6 @@ from Path.Main.Gui.Editor import CodeEditor
 translate = FreeCAD.Qt.translate
 
 
-class GCodeHighlighter(QtGui.QSyntaxHighlighter):
-    def __init__(self, parent=None):
-        def convertcolor(c):
-            return QtGui.QColor(int((c >> 24) & 0xFF), int((c >> 16) & 0xFF), int((c >> 8) & 0xFF))
-
-        super(GCodeHighlighter, self).__init__(parent)
-        p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Editor")
-        colors = []
-        c = p.GetUnsigned("Number")
-        if c:
-            colors.append(convertcolor(c))
-        else:
-            colors.append(QtCore.Qt.red)
-        c = p.GetUnsigned("Keyword")
-        if c:
-            colors.append(convertcolor(c))
-        else:
-            colors.append(QtGui.QColor(0, 170, 0))
-        c = p.GetUnsigned("Define name")
-        if c:
-            colors.append(convertcolor(c))
-        else:
-            colors.append(QtGui.QColor(160, 160, 164))
-
-        self.highlightingRules = []
-        numberFormat = QtGui.QTextCharFormat()
-        numberFormat.setForeground(colors[0])
-        self.highlightingRules.append((QtCore.QRegularExpression("[\\-0-9\\.]"), numberFormat))
-        keywordFormat = QtGui.QTextCharFormat()
-        keywordFormat.setForeground(colors[1])
-        keywordFormat.setFontWeight(QtGui.QFont.Bold)
-        keywordPatterns = ["\\bG[0-9]+\\b", "\\bM[0-9]+\\b"]
-        self.highlightingRules.extend(
-            [(QtCore.QRegularExpression(pattern), keywordFormat) for pattern in keywordPatterns]
-        )
-        speedFormat = QtGui.QTextCharFormat()
-        speedFormat.setFontWeight(QtGui.QFont.Bold)
-        speedFormat.setForeground(colors[2])
-        self.highlightingRules.append((QtCore.QRegularExpression("\\bF[0-9\\.]+\\b"), speedFormat))
-
-    def highlightBlock(self, text):
-
-        for pattern, fmt in self.highlightingRules:
-            expression = QtCore.QRegularExpression(pattern)
-            index = expression.match(text)
-            while index.hasMatch():
-                length = index.capturedLength()
-                self.setFormat(index.capturedStart(), length, fmt)
-                index = expression.match(text, index.capturedStart() + length)
-
-
 class GCodeEditorDialog(QtGui.QDialog):
     tool = None
 
@@ -114,15 +63,7 @@ class GCodeEditorDialog(QtGui.QDialog):
         self.selectionobj.ViewObject.LineWidth = 4
         self.selectionobj.ViewObject.NormalColor = highlightcolor
 
-        # self.editor = QtGui.QTextEdit()  # without lines enumeration
-        self.editor = CodeEditor()  # with lines enumeration
-        font = QtGui.QFont()
-        p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Editor")
-        font.setFamily(p.GetString("Font", "Courier"))
-        font.setFixedPitch(True)
-        font.setPointSize(p.GetInt("FontSize", 10))
-        self.editor.setFont(font)
-        self.editor.setPlainText("G01 X55 Y4.5 F300.0")
+        self.editor = CodeEditor()
         layout.addWidget(self.editor)
 
         # Note
@@ -137,12 +78,11 @@ class GCodeEditorDialog(QtGui.QDialog):
         lab.setWordWrap(True)
         layout.addWidget(lab)
 
-        # OK and Cancel buttons
         self.buttons = QtGui.QDialogButtonBox(
             QtGui.QDialogButtonBox.Close,
             QtCore.Qt.Horizontal,
             self,
-        )
+        )  # add Close button
 
         layout.addWidget(self.buttons)
         self.buttons.rejected.connect(self.reject)
@@ -216,39 +156,10 @@ class GCodeEditorDialog(QtGui.QDialog):
 def show(obj):
     "show(obj): shows the G-code data of the given Path object in a dialog"
 
-    prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/CAM")
-    # default Max Highlighter Size = 256 Ko
-    defaultMHS = 256 * 1024
-    mhs = prefs.GetUnsigned("inspecteditorMaxHighlighterSize", defaultMHS)
-
-    if hasattr(obj, "Path"):
-        if obj.Path:
-            dia = GCodeEditorDialog(obj)
-            dia.editor.setPlainText(obj.Path.toGCode())
-            gcodeSize = len(dia.editor.toPlainText())
-            if gcodeSize <= mhs:
-                # because of poor performance, syntax highlighting is
-                # limited to mhs octets (default 256 KB).
-                # It seems than the response time curve has an inflexion near 500 KB
-                # beyond 500 KB, the response time increases exponentially.
-                dia.highlighter = GCodeHighlighter(dia.editor.document())
-            else:
-                FreeCAD.Console.PrintMessage(
-                    translate(
-                        "Path",
-                        "GCode size too big ({} o), disabling syntax highlighter.".format(
-                            gcodeSize
-                        ),
-                    )
-                )
-            result = dia.exec_()
-            # exec_() returns 0 or 1 depending on the button pressed (Ok or Cancel)
-            if result:
-                p = Path.Path(dia.editor.toPlainText())
-                FreeCAD.ActiveDocument.openTransaction("Edit Path")
-                obj.Path = p
-                FreeCAD.ActiveDocument.commitTransaction()
-                FreeCAD.ActiveDocument.recompute()
+    if getattr(obj, "Path", None):
+        dia = GCodeEditorDialog(obj)
+        dia.editor.setPlainText(obj.Path.toGCode())
+        dia.exec_()
 
 
 class CommandPathInspect:
@@ -285,9 +196,8 @@ class CommandPathInspect:
 
         # if everything is ok, execute
         FreeCADGui.addModule("Path.Main.Gui.Inspect")
-        FreeCADGui.doCommand(
-            "Path.Main.Gui.Inspect.show(FreeCAD.ActiveDocument." + selection[0].Name + ")"
-        )
+        FreeCADGui.doCommand(f"obj = FreeCAD.ActiveDocument.getObject('{selection[0].Name}')")
+        FreeCADGui.doCommand("Path.Main.Gui.Inspect.show(obj)")
 
 
 if FreeCAD.GuiUp:

--- a/src/Mod/CAM/Path/Main/Gui/Inspect.py
+++ b/src/Mod/CAM/Path/Main/Gui/Inspect.py
@@ -1,28 +1,23 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2015 Yorik van Havre yorik@uncreated.net
+# SPDX-FileNotice: Part of the FreeCAD project.
 
-# ***************************************************************************
-# *   Copyright (c) 2015 Yorik van Havre <yorik@uncreated.net>              *
-# *                                                                         *
-# *   This file is part of the FreeCAD CAx development system.              *
-# *                                                                         *
-# *   This program is free software; you can redistribute it and/or modify  *
-# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
-# *   as published by the Free Software Foundation; either version 2 of     *
-# *   the License, or (at your option) any later version.                   *
-# *   for detail see the LICENCE text file.                                 *
-# *                                                                         *
-# *   FreeCAD is distributed in the hope that it will be useful,            *
-# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-# *   GNU Lesser General Public License for more details.                   *
-# *                                                                         *
-# *   You should have received a copy of the GNU Library General Public     *
-# *   License along with FreeCAD; if not, write to the Free Software        *
-# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-# *   USA                                                                   *
-# *                                                                         *
-# ***************************************************************************
-
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
 
 from PySide import QtCore, QtGui
 import FreeCAD
@@ -33,57 +28,6 @@ import PathScripts.PathUtils as PathUtils
 from Path.Main.Gui.Editor import CodeEditor
 
 translate = FreeCAD.Qt.translate
-
-
-class GCodeHighlighter(QtGui.QSyntaxHighlighter):
-    def __init__(self, parent=None):
-        def convertcolor(c):
-            return QtGui.QColor(int((c >> 24) & 0xFF), int((c >> 16) & 0xFF), int((c >> 8) & 0xFF))
-
-        super(GCodeHighlighter, self).__init__(parent)
-        p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Editor")
-        colors = []
-        c = p.GetUnsigned("Number")
-        if c:
-            colors.append(convertcolor(c))
-        else:
-            colors.append(QtCore.Qt.red)
-        c = p.GetUnsigned("Keyword")
-        if c:
-            colors.append(convertcolor(c))
-        else:
-            colors.append(QtGui.QColor(0, 170, 0))
-        c = p.GetUnsigned("Define name")
-        if c:
-            colors.append(convertcolor(c))
-        else:
-            colors.append(QtGui.QColor(160, 160, 164))
-
-        self.highlightingRules = []
-        numberFormat = QtGui.QTextCharFormat()
-        numberFormat.setForeground(colors[0])
-        self.highlightingRules.append((QtCore.QRegularExpression("[\\-0-9\\.]"), numberFormat))
-        keywordFormat = QtGui.QTextCharFormat()
-        keywordFormat.setForeground(colors[1])
-        keywordFormat.setFontWeight(QtGui.QFont.Bold)
-        keywordPatterns = ["\\bG[0-9]+\\b", "\\bM[0-9]+\\b"]
-        self.highlightingRules.extend(
-            [(QtCore.QRegularExpression(pattern), keywordFormat) for pattern in keywordPatterns]
-        )
-        speedFormat = QtGui.QTextCharFormat()
-        speedFormat.setFontWeight(QtGui.QFont.Bold)
-        speedFormat.setForeground(colors[2])
-        self.highlightingRules.append((QtCore.QRegularExpression("\\bF[0-9\\.]+\\b"), speedFormat))
-
-    def highlightBlock(self, text):
-
-        for pattern, fmt in self.highlightingRules:
-            expression = QtCore.QRegularExpression(pattern)
-            index = expression.match(text)
-            while index.hasMatch():
-                length = index.capturedLength()
-                self.setFormat(index.capturedStart(), length, fmt)
-                index = expression.match(text, index.capturedStart() + length)
 
 
 class GCodeEditorDialog(QtGui.QDialog):
@@ -114,15 +58,7 @@ class GCodeEditorDialog(QtGui.QDialog):
         self.selectionobj.ViewObject.LineWidth = 4
         self.selectionobj.ViewObject.NormalColor = highlightcolor
 
-        # self.editor = QtGui.QTextEdit()  # without lines enumeration
-        self.editor = CodeEditor()  # with lines enumeration
-        font = QtGui.QFont()
-        p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Editor")
-        font.setFamily(p.GetString("Font", "Courier"))
-        font.setFixedPitch(True)
-        font.setPointSize(p.GetInt("FontSize", 10))
-        self.editor.setFont(font)
-        self.editor.setPlainText("G01 X55 Y4.5 F300.0")
+        self.editor = CodeEditor()
         layout.addWidget(self.editor)
 
         # Note
@@ -137,12 +73,11 @@ class GCodeEditorDialog(QtGui.QDialog):
         lab.setWordWrap(True)
         layout.addWidget(lab)
 
-        # OK and Cancel buttons
         self.buttons = QtGui.QDialogButtonBox(
             QtGui.QDialogButtonBox.Close,
             QtCore.Qt.Horizontal,
             self,
-        )
+        )  # add Close button
 
         layout.addWidget(self.buttons)
         self.buttons.rejected.connect(self.reject)
@@ -216,39 +151,10 @@ class GCodeEditorDialog(QtGui.QDialog):
 def show(obj):
     "show(obj): shows the G-code data of the given Path object in a dialog"
 
-    prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/CAM")
-    # default Max Highlighter Size = 256 Ko
-    defaultMHS = 256 * 1024
-    mhs = prefs.GetUnsigned("inspecteditorMaxHighlighterSize", defaultMHS)
-
-    if hasattr(obj, "Path"):
-        if obj.Path:
-            dia = GCodeEditorDialog(obj)
-            dia.editor.setPlainText(obj.Path.toGCode())
-            gcodeSize = len(dia.editor.toPlainText())
-            if gcodeSize <= mhs:
-                # because of poor performance, syntax highlighting is
-                # limited to mhs octets (default 256 KB).
-                # It seems than the response time curve has an inflexion near 500 KB
-                # beyond 500 KB, the response time increases exponentially.
-                dia.highlighter = GCodeHighlighter(dia.editor.document())
-            else:
-                FreeCAD.Console.PrintMessage(
-                    translate(
-                        "Path",
-                        "GCode size too big ({} o), disabling syntax highlighter.".format(
-                            gcodeSize
-                        ),
-                    )
-                )
-            result = dia.exec_()
-            # exec_() returns 0 or 1 depending on the button pressed (Ok or Cancel)
-            if result:
-                p = Path.Path(dia.editor.toPlainText())
-                FreeCAD.ActiveDocument.openTransaction("Edit Path")
-                obj.Path = p
-                FreeCAD.ActiveDocument.commitTransaction()
-                FreeCAD.ActiveDocument.recompute()
+    if getattr(obj, "Path", None):
+        dia = GCodeEditorDialog(obj)
+        dia.editor.setPlainText(obj.Path.toGCode())
+        dia.exec_()
 
 
 class CommandPathInspect:

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -32,6 +32,7 @@ import FreeCAD
 import FreeCADGui
 import Path
 import Path.Preferences as PathPref
+from Path.Main.Gui.Editor import CodeEditor
 from PySide import QtCore, QtGui
 
 translate = FreeCAD.Qt.translate
@@ -142,6 +143,11 @@ class PostProcessDialog:
             self._on_output_files_context_menu
         )
         dlg.buttonSaveOutput.clicked.connect(self._save_output_files)
+
+        self.gcodeEditor = CodeEditor()
+        self.gcodeEditor.setToolTip(dlg.plainTextEditGcode.toolTip())
+        dlg.plainTextEditGcode.hide()
+        dlg.splitterOutput.addWidget(self.gcodeEditor)
 
     # ------------------------------------------------------------------
     # Population
@@ -957,7 +963,7 @@ class PostProcessDialog:
         dlg.listWidgetOutputFiles.blockSignals(True)
         dlg.listWidgetOutputFiles.clear()
         dlg.listWidgetOutputFiles.blockSignals(False)
-        dlg.plainTextEditGcode.setPlainText("")
+        self.gcodeEditor.setPlainText("")
         dlg.labelOutputStatus.setVisible(True)
         dlg.buttonSaveOutput.setEnabled(False)
         dlg.buttonApplyTemplate.setEnabled(False)
@@ -1157,7 +1163,7 @@ class PostProcessDialog:
         if lw.count() > 0:
             lw.setCurrentRow(0)  # triggers _on_output_file_selected
         else:
-            dlg.plainTextEditGcode.setPlainText("")
+            self.gcodeEditor.setPlainText("")
 
         n = len(self._generated_outputs)
         dlg.labelOutputStatus.setVisible(n == 0)
@@ -1170,11 +1176,11 @@ class PostProcessDialog:
         if previous is not None:
             prev_fname = previous.data(QtCore.Qt.ItemDataRole.UserRole)
             if prev_fname in self._generated_outputs:
-                self._generated_outputs[prev_fname] = dlg.plainTextEditGcode.toPlainText()
+                self._generated_outputs[prev_fname] = self.gcodeEditor.toPlainText()
 
         if current is not None:
             fname = current.data(QtCore.Qt.ItemDataRole.UserRole)
-            dlg.plainTextEditGcode.setPlainText(self._generated_outputs.get(fname, ""))
+            self.gcodeEditor.setPlainText(self._generated_outputs.get(fname, ""))
 
     def _on_output_files_context_menu(self, pos):
         """Show rename context menu on right-click."""
@@ -1218,7 +1224,7 @@ class PostProcessDialog:
         if current is not None:
             fname = current.data(QtCore.Qt.ItemDataRole.UserRole)
             if fname in self._generated_outputs:
-                self._generated_outputs[fname] = dlg.plainTextEditGcode.toPlainText()
+                self._generated_outputs[fname] = self.gcodeEditor.toPlainText()
 
     def _regenerate_filenames(self):
         """Re-apply the filename template to rename all items in the output list."""

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -32,6 +32,7 @@ import FreeCAD
 import FreeCADGui
 import Path
 import Path.Preferences as PathPref
+from Path.Main.Gui.Editor import CodeEditor
 from PySide import QtCore, QtGui
 
 translate = FreeCAD.Qt.translate
@@ -143,6 +144,11 @@ class PostProcessDialog:
             self._on_output_files_context_menu
         )
         dlg.buttonSaveOutput.clicked.connect(self._save_output_files)
+
+        self.gcodeEditor = CodeEditor()
+        self.gcodeEditor.setToolTip(dlg.plainTextEditGcode.toolTip())
+        dlg.plainTextEditGcode.hide()
+        dlg.splitterOutput.addWidget(self.gcodeEditor)
 
     # ------------------------------------------------------------------
     # Population
@@ -961,7 +967,7 @@ class PostProcessDialog:
         dlg.listWidgetOutputFiles.blockSignals(True)
         dlg.listWidgetOutputFiles.clear()
         dlg.listWidgetOutputFiles.blockSignals(False)
-        dlg.plainTextEditGcode.setPlainText("")
+        self.gcodeEditor.setPlainText("")
         dlg.labelOutputStatus.setVisible(True)
         dlg.buttonSaveOutput.setEnabled(False)
         dlg.buttonApplyTemplate.setEnabled(False)
@@ -1161,7 +1167,7 @@ class PostProcessDialog:
         if lw.count() > 0:
             lw.setCurrentRow(0)  # triggers _on_output_file_selected
         else:
-            dlg.plainTextEditGcode.setPlainText("")
+            self.gcodeEditor.setPlainText("")
 
         n = len(self._generated_outputs)
         dlg.labelOutputStatus.setVisible(n == 0)
@@ -1174,11 +1180,11 @@ class PostProcessDialog:
         if previous is not None:
             prev_fname = previous.data(QtCore.Qt.ItemDataRole.UserRole)
             if prev_fname in self._generated_outputs:
-                self._generated_outputs[prev_fname] = dlg.plainTextEditGcode.toPlainText()
+                self._generated_outputs[prev_fname] = self.gcodeEditor.toPlainText()
 
         if current is not None:
             fname = current.data(QtCore.Qt.ItemDataRole.UserRole)
-            dlg.plainTextEditGcode.setPlainText(self._generated_outputs.get(fname, ""))
+            self.gcodeEditor.setPlainText(self._generated_outputs.get(fname, ""))
 
     def _on_output_files_context_menu(self, pos):
         """Show rename context menu on right-click."""
@@ -1222,7 +1228,7 @@ class PostProcessDialog:
         if current is not None:
             fname = current.data(QtCore.Qt.ItemDataRole.UserRole)
             if fname in self._generated_outputs:
-                self._generated_outputs[fname] = dlg.plainTextEditGcode.toPlainText()
+                self._generated_outputs[fname] = self.gcodeEditor.toPlainText()
 
     def _regenerate_filenames(self):
         """Re-apply the filename template to rename all items in the output list."""

--- a/src/Mod/CAM/Path/Post/Utils.py
+++ b/src/Mod/CAM/Path/Post/Utils.py
@@ -32,7 +32,7 @@ from Path.Base.MachineState import MachineState
 from Path.Main.Gui.Editor import CodeEditor
 from Path.Geom import CmdMoveDrill
 
-from PySide import QtCore, QtGui
+from PySide import QtGui
 
 import FreeCAD
 import Path
@@ -190,34 +190,6 @@ class FilenameGenerator:
             yield os.path.normpath(full_path)
 
 
-class GCodeHighlighter(QtGui.QSyntaxHighlighter):
-    def __init__(self, parent=None):
-        super(GCodeHighlighter, self).__init__(parent)
-
-        keywordFormat = QtGui.QTextCharFormat()
-        keywordFormat.setForeground(QtCore.Qt.cyan)
-        keywordFormat.setFontWeight(QtGui.QFont.Bold)
-        keywordPatterns = ["\\bG[0-9]+\\b", "\\bM[0-9]+\\b"]
-
-        self.highlightingRules = [
-            (QtCore.QRegularExpression(pattern), keywordFormat) for pattern in keywordPatterns
-        ]
-
-        speedFormat = QtGui.QTextCharFormat()
-        speedFormat.setFontWeight(QtGui.QFont.Bold)
-        speedFormat.setForeground(QtCore.Qt.green)
-        self.highlightingRules.append((QtCore.QRegularExpression("\\bF[0-9\\.]+\\b"), speedFormat))
-
-    def highlightBlock(self, text):
-        for pattern, hlFormat in self.highlightingRules:
-            expression = QtCore.QRegularExpression(pattern)
-            index = expression.match(text)
-            while index.hasMatch():
-                length = index.capturedLength()
-                self.setFormat(index.capturedStart(), length, hlFormat)
-                index = expression.match(text, index.capturedStart() + length)
-
-
 class GCodeEditorDialog(QtGui.QDialog):
     def __init__(self, text="", parent=None, refactored=False):
         if parent is None:
@@ -226,15 +198,7 @@ class GCodeEditorDialog(QtGui.QDialog):
         self.setWindowTitle(translate("CAM", "CAM Export Gcode"))
         layout = QtGui.QVBoxLayout(self)
 
-        # self.editor = QtGui.QTextEdit()  # without lines enumeration
-        self.editor = CodeEditor()  # with lines enumeration
-
-        p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Editor")
-        font = QtGui.QFont()
-        font.setFamily(p.GetString("Font", "Courier"))
-        font.setFixedPitch(True)
-        font.setPointSize(p.GetInt("FontSize", 10))
-        self.editor.setFont(font)
+        self.editor = CodeEditor()
         self.editor.setPlainText(text)
         layout.addWidget(self.editor)
 
@@ -332,30 +296,10 @@ def fmt(num, dec, units):
 
 def editor(gcode):
     """Pops up a handy little editor to look at the code output."""
-    prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/CAM")
-    # default Max Highlighter Size = 512 Ko
-    defaultMHS = 512 * 1024
-    mhs = prefs.GetUnsigned("inspecteditorMaxHighlighterSize", defaultMHS)
-
     dia = GCodeEditorDialog()
     dia.editor.setText(gcode)
     dia.buttons.button(QtGui.QDialogButtonBox.Ok).setDisabled(True)
-    gcodeSize = len(dia.editor.toPlainText())
-    if gcodeSize <= mhs:
-        # because of poor performance, syntax highlighting is
-        # limited to mhs octets (default 512 KB).
-        # It seems than the response time curve has an inflexion near 500 KB
-        # beyond 500 KB, the response time increases exponentially.
-        dia.highlighter = GCodeHighlighter(dia.editor.document())
-    else:
-        FreeCAD.Console.PrintMessage(
-            translate(
-                "Path",
-                "GCode size too big ({} o), disabling syntax highlighter.".format(gcodeSize),
-            )
-        )
-    result = dia.exec_()
-    if result:  # If user selected 'OK' get modified G Code
+    if dia.exec_():  # If user selected 'OK' get modified G Code
         final = dia.editor.toPlainText()
     else:
         final = gcode

--- a/src/Mod/CAM/Path/Post/Utils.py
+++ b/src/Mod/CAM/Path/Post/Utils.py
@@ -1,28 +1,24 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2014 Yorik van Havre yorik@uncreated.net
+# SPDX-FileCopyrightText: 2022 Larry Woestman LarryWoestman2@gmail.com
+# SPDX-FileNotice: Part of the FreeCAD project.
 
-# ***************************************************************************
-# *   Copyright (c) 2014 Yorik van Havre <yorik@uncreated.net>              *
-# *   Copyright (c) 2022 Larry Woestman <LarryWoestman2@gmail.com>          *
-# *                                                                         *
-# *   This file is part of the FreeCAD CAx development system.              *
-# *                                                                         *
-# *   This program is free software; you can redistribute it and/or modify  *
-# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
-# *   as published by the Free Software Foundation; either version 2 of     *
-# *   the License, or (at your option) any later version.                   *
-# *   for detail see the LICENCE text file.                                 *
-# *                                                                         *
-# *   FreeCAD is distributed in the hope that it will be useful,            *
-# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-# *   GNU Lesser General Public License for more details.                   *
-# *                                                                         *
-# *   You should have received a copy of the GNU Library General Public     *
-# *   License along with FreeCAD; if not, write to the Free Software        *
-# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-# *   USA                                                                   *
-# *                                                                         *
-# ***************************************************************************
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
 
 """
 These are common functions and classes for creating custom post processors.
@@ -32,7 +28,7 @@ from Path.Base.MachineState import MachineState
 from Path.Main.Gui.Editor import CodeEditor
 from Path.Geom import CmdMoveDrill
 
-from PySide import QtCore, QtGui
+from PySide import QtGui
 
 import FreeCAD
 import Path
@@ -190,34 +186,6 @@ class FilenameGenerator:
             yield os.path.normpath(full_path)
 
 
-class GCodeHighlighter(QtGui.QSyntaxHighlighter):
-    def __init__(self, parent=None):
-        super(GCodeHighlighter, self).__init__(parent)
-
-        keywordFormat = QtGui.QTextCharFormat()
-        keywordFormat.setForeground(QtCore.Qt.cyan)
-        keywordFormat.setFontWeight(QtGui.QFont.Bold)
-        keywordPatterns = ["\\bG[0-9]+\\b", "\\bM[0-9]+\\b"]
-
-        self.highlightingRules = [
-            (QtCore.QRegularExpression(pattern), keywordFormat) for pattern in keywordPatterns
-        ]
-
-        speedFormat = QtGui.QTextCharFormat()
-        speedFormat.setFontWeight(QtGui.QFont.Bold)
-        speedFormat.setForeground(QtCore.Qt.green)
-        self.highlightingRules.append((QtCore.QRegularExpression("\\bF[0-9\\.]+\\b"), speedFormat))
-
-    def highlightBlock(self, text):
-        for pattern, hlFormat in self.highlightingRules:
-            expression = QtCore.QRegularExpression(pattern)
-            index = expression.match(text)
-            while index.hasMatch():
-                length = index.capturedLength()
-                self.setFormat(index.capturedStart(), length, hlFormat)
-                index = expression.match(text, index.capturedStart() + length)
-
-
 class GCodeEditorDialog(QtGui.QDialog):
     def __init__(self, text="", parent=None, refactored=False):
         if parent is None:
@@ -226,15 +194,7 @@ class GCodeEditorDialog(QtGui.QDialog):
         self.setWindowTitle(translate("CAM", "CAM Export Gcode"))
         layout = QtGui.QVBoxLayout(self)
 
-        # self.editor = QtGui.QTextEdit()  # without lines enumeration
-        self.editor = CodeEditor()  # with lines enumeration
-
-        p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Editor")
-        font = QtGui.QFont()
-        font.setFamily(p.GetString("Font", "Courier"))
-        font.setFixedPitch(True)
-        font.setPointSize(p.GetInt("FontSize", 10))
-        self.editor.setFont(font)
+        self.editor = CodeEditor()
         self.editor.setPlainText(text)
         layout.addWidget(self.editor)
 
@@ -332,30 +292,10 @@ def fmt(num, dec, units):
 
 def editor(gcode):
     """Pops up a handy little editor to look at the code output."""
-    prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/CAM")
-    # default Max Highlighter Size = 512 Ko
-    defaultMHS = 512 * 1024
-    mhs = prefs.GetUnsigned("inspecteditorMaxHighlighterSize", defaultMHS)
-
     dia = GCodeEditorDialog()
     dia.editor.setText(gcode)
     dia.buttons.button(QtGui.QDialogButtonBox.Ok).setDisabled(True)
-    gcodeSize = len(dia.editor.toPlainText())
-    if gcodeSize <= mhs:
-        # because of poor performance, syntax highlighting is
-        # limited to mhs octets (default 512 KB).
-        # It seems than the response time curve has an inflexion near 500 KB
-        # beyond 500 KB, the response time increases exponentially.
-        dia.highlighter = GCodeHighlighter(dia.editor.document())
-    else:
-        FreeCAD.Console.PrintMessage(
-            translate(
-                "Path",
-                "GCode size too big ({} o), disabling syntax highlighter.".format(gcodeSize),
-            )
-        )
-    result = dia.exec_()
-    if result:  # If user selected 'OK' get modified G Code
+    if dia.exec_():  # If user selected 'OK' get modified G Code
         final = dia.editor.toPlainText()
     else:
         final = gcode


### PR DESCRIPTION
### Changes
- Refactoring Gcode editor dialog
   - Moved font adjustment to class `CodeEditor` to exclude code duplication in **Inspect** and legacy **Export Gcode**
   - Moved compares length of the Gcode and parameter `MaxHighlighterSize` to class `CodeEditor`
- Use `CodeEditor` also inside MBPP dialog to show lines numbers of Gcode and use highlighter
   Now **Inspect**, **Custom**, legacy PP and MBPP use one class `CodeEditor`
- Added property to **CAM Preferences**, which allows to limit amount lines of the Gcode to use highlighter
  Set 0 to disable highlighter

<img width="1490" height="660" alt="Screenshot_20260715_162420_hor_lossy" src="https://github.com/user-attachments/assets/6aebff21-bb4c-4fdb-a95e-e68846a44817" />

<img width="1077" height="355" alt="Screenshot_20260812_101945_lossy" src="https://github.com/user-attachments/assets/7bd65075-7690-4ba2-9c5c-9a07fc7d5f35" />