### PR TITLE
Replace new QImage::mirrored usage by QImage::flipped

### DIFF
--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -770,7 +770,11 @@ void NaviCubeImplementation::createCubeFaceTextures()
 
         // Coin backend: store as a Coin-managed texture (SoTexture2).
         // Mirror to match the OpenGL texture coordinate origin (bottom-left).
+#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
         const QImage rgba = image.mirrored().convertToFormat(QImage::Format_RGBA8888);
+#else
+        const QImage rgba = image.flipped(Qt::Vertical).convertToFormat(QImage::Format_RGBA8888);
+#endif
         const int w = rgba.width();
         const int h = rgba.height();
         std::vector<unsigned char> pixels(static_cast<size_t>(w) * static_cast<size_t>(h) * 4U);


### PR DESCRIPTION
Similar to https://github.com/FreeCAD/FreeCAD/pull/27563 to fix new usage introduced by https://github.com/FreeCAD/FreeCAD/pull/29030

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
