### PR TITLE
Fix automoc warning about non existant UI file

### DIFF
--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
@@ -287,6 +287,3 @@ ViewProviderFemPostSphereFunction::ViewProviderFemPostSphereFunction()
 }
 
 ViewProviderFemPostSphereFunction::~ViewProviderFemPostSphereFunction() = default;
-
-
-#include "moc_ViewProviderFemPostFunction.cpp"


### PR DESCRIPTION
Warning in build log was: `AutoMoc: [...]/source-FreeCAD/src/Mod/Fem/Gui/ViewProviderFemPostFunction.h: note: No relevant classes found. No output generated.`

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
