### PR TITLE
ConsoleSequencer: log to console instead of printf

### DIFF
--- a/src/Base/Sequencer.cpp
+++ b/src/Base/Sequencer.cpp
@@ -28,6 +28,7 @@
 #include <cstdio>
 
 #include "Sequencer.h"
+#include "Console.h"
 
 using namespace Base;
 
@@ -214,7 +215,7 @@ using Base::ConsoleSequencer;
 
 void ConsoleSequencer::setText(const char* pszTxt)
 {
-    printf("%s...\n", pszTxt);
+    Base::Console().log("%s...\n", pszTxt);
 }
 
 void ConsoleSequencer::startStep()
@@ -223,14 +224,14 @@ void ConsoleSequencer::startStep()
 void ConsoleSequencer::nextStep(bool /*canAbort*/)
 {
     if (this->nTotalSteps != 0) {
-        printf("\t\t\t\t\t\t(%d %%)\t\r", progressInPercent());
+        Base::Console().log("\t\t\t\t\t\t(%d %%)\t\r", progressInPercent());
     }
 }
 
 void ConsoleSequencer::resetData()
 {
     SequencerBase::resetData();
-    printf("\t\t\t\t\t\t\t\t\r");
+    Base::Console().log("\t\t\t\t\t\t\t\t\r");
 }
 
 // ---------------------------------------------------------


### PR DESCRIPTION
The motivation for this was that running console tests was spamming stdout more than necessary. For example:

```
$ bin/FreeCADCmd -t TestPartDesignApp.TestHelix.testGiantHelixAdditive
FreeCAD 26.3.0, Libs: 26.3.0devR47654 (Git)
(C) 2001-2026 FreeCAD contributors
FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.

testGiantHelixAdditive (PartDesignTests.TestHelix.TestHelix.testGiantHelixAdditive)
Test giant helix added to Cylinder ... Processing......
Processing......
Processing......
Processing......						
[...]
Processing......
Processing......						
```

This is a consequence of https://github.com/FreeCAD/FreeCAD/pull/27380 hooking the OCCT progress indicator to a FC `SequencerBase`. By default, in console mode, the sequencer is a `ConsoleSequencer` that `printf`'s to stdout. In order to avoid spamming the console during CLI tests, the ConsoleSequencer now prints to the log, and the command above does not have parasite logging anymore.

@3x380V Do you think this is an acceptable solution to the problem?

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
