### PR TITLE
CAM: do line-numbering in Path.Command world

### DIFF
--- a/src/Mod/CAM/CAMTests/TestOpenSBPPost.py
+++ b/src/Mod/CAM/CAMTests/TestOpenSBPPost.py
@@ -224,7 +224,7 @@ class TestOpenSBPPost(PathTestUtils.PathTestBase):
         """
         command = Path.Command("G1", {"X": 13.1})
         result = self.post._convert_linear_move(command)
-        self.assertIn(f"G1 X13.100", result)
+        self.assertIn("G1 X13.100", result)
 
     def test_linear_y(self):
         """G1 Y-only"""
@@ -998,12 +998,13 @@ class TestOpenSBPPost(PathTestUtils.PathTestBase):
 
         self.profile_op.Path = Path.Path(
             [
-                Path.Command("G1 X1 Y2 Z9"),  # "Z3"
+                Path.Command("G1 X1 Y2 Z9"),
                 Path.Command("G1 X1 Y2 Z3"),  # "Z3" is a shopbot command
             ]
         )
         gcode = self.post.export2()[0][1]
 
+        # We expect dup-params removed, and the command-name (dup command)
         self.no_unnumbered("Z3.000", gcode.splitlines())
 
     def test_G82(self):
@@ -1082,8 +1083,8 @@ class TestOpenSBPPost(PathTestUtils.PathTestBase):
 
         # First probe open
         file = "probe_results.txt"
-        open = Path.Command("(begin probe ...)", {}, {"probe_open": file})
-        gcode = self.post._convert_probe_open(open)
+        open_comment = Path.Command("(begin probe ...)", {}, {"probe_open": file})
+        gcode = self.post._convert_probe_open(open_comment)
 
         self.assertIn("CaptureZPos:", gcode, "Has subroutines once/job")
         self.assertRegex(
@@ -1094,8 +1095,8 @@ class TestOpenSBPPost(PathTestUtils.PathTestBase):
 
         # Second probe open (check subroutines added only once)
         file = "probe_results2.txt"
-        open = Path.Command("(begin probe ...)", {}, {"probe_open": file})
-        _ = self.post._convert_probe_open(open)
+        open_comment = Path.Command("(begin probe ...)", {}, {"probe_open": file})
+        _ = self.post._convert_probe_open(open_comment)
         subroutine_markers = [
             line for line in self.post.values["POST_JOB"].split("\n") if line in "CaptureZPos:"
         ]
@@ -1131,7 +1132,7 @@ IF &hit = 0 THEN GOTO FailedToTouch
         with self.assertRaisesRegex(Exception, "must have a Z and F"):
             _ = self.post._convert_probe(Path.Command(f"G38.2 F{5/60}"))
 
-        with self.assertRaisesRegex(Exception, "should only have Z and F"):
+        with self.assertRaisesRegex(Exception, "must only have Z,F and N"):
             _ = self.post._convert_probe(Path.Command(f"G38.2 X1 Z5 F{5/60}"))
 
     def test_convert_probe_close(self):
@@ -1149,7 +1150,6 @@ IF &hit = 0 THEN GOTO FailedToTouch
 
     @unittest.expectedFailure
     def test_todo(self):
-        self.assertTrue(False, "probe")
         self.assertTrue(False, "diff precision for mm|in")
         self.assertTrue(False, "test on machine G20/G21")
         self.assertTrue(False, "precision conversion should round +1 digit, then precision")
@@ -1158,7 +1158,5 @@ IF &hit = 0 THEN GOTO FailedToTouch
             "test_rapid_z should fail, should have 3 digits of precision? or test_rapid_xy should fail should have .0",
         )
         self.assertTrue(False, "do not like _convert_generic")
-        self.assertTrue(False, "test in/sec conversion")
         self.assertTrue(False, "block-delete isn't spb compatible")
-        self.assertTrue(False, "Add Must Line Number for modal resulting in Zn")
         # comments stripped, no-headers, etc.

--- a/src/Mod/CAM/CAMTests/TestPostProcessor.py
+++ b/src/Mod/CAM/CAMTests/TestPostProcessor.py
@@ -35,7 +35,9 @@ from Path.Post.Processor import PostProcessor, PostProcessorFactory, _HeaderBuil
 import Path.Post.Command as PathCommand
 from Path.Post.CAMErrors import CAMValueError
 from Path.Post.PostList import Postable
-from Machine.models.machine import Machine
+from Machine.models.machine import Machine, OutputUnits
+
+from CAMTests.PostTestMocks import MockJob, MockStock
 
 PathCommand.LOG_MODULE = Path.Log.thisModule()
 Path.Log.setLevel(Path.Log.Level.INFO, PathCommand.LOG_MODULE)
@@ -736,9 +738,7 @@ class TestConfigurationBundle(unittest.TestCase):
         """Invalid JSON raises"""
         pp = self._make_postprocessor()
         pp._job.PostProcessorPropertyOverrides = "not valid json {"
-        with self.assertRaisesRegex(
-            CAMValueError, "Invalid PostProcessorPropertyOverrides JSON"
-        ) as e:
+        with self.assertRaisesRegex(CAMValueError, "Invalid PostProcessorPropertyOverrides JSON"):
             pp._read_job_overrides()
 
     def test335_read_job_overrides_invalid_json(self):
@@ -757,11 +757,23 @@ class TestConfigurationBundle(unittest.TestCase):
 
 
 class TestPostProcessorMBPPMethods(unittest.TestCase):
+
+    @classmethod
+    def _make_job(cls, xmin=0.0, ymin=0.0, zmin=0.0, xmax=10.0, ymax=10.0, zmax=4.0):
+        """A shared MockJob whose stock spans the requested bounding box."""
+        job = MockJob()
+        job.Stock = MockStock(xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax, zmin=zmin, zmax=zmax)
+        return job
+
+    @classmethod
+    def setUpClass(cls):
+
+        cls.job = cls._make_job()
+        # we shouldn't need any of the arguments
+        cls.pp = PostProcessor(cls.job, "tooltip", "args", units="G21")
+
     def test_edit_postable_list(self):
         """test the several cases of appending/not-appending"""
-
-        # we shouldn't need any of the arguments
-        pp = PostProcessor(None, None, None, None)
 
         def initial_sections():
             # new each time
@@ -793,7 +805,7 @@ class TestPostProcessorMBPPMethods(unittest.TestCase):
 
         unmodified = initial_sections()
 
-        sections = pp._edit_postable_list(initial_sections(), lambda sn, i, ss: (None, None))
+        sections = self.pp._edit_postable_list(initial_sections(), lambda sn, i, ss: (None, None))
 
         # unchanged
         self.assertEqual(len(sections), len(unmodified))
@@ -817,8 +829,8 @@ class TestPostProcessorMBPPMethods(unittest.TestCase):
                     1,
                     [
                         Postable(
-                            label=f"append_p1",
-                            item_type=f"itemp1_a",
+                            label="append_p1",
+                            item_type="itemp1_a",
                             data={},
                             path=None,
                             source=None,
@@ -828,7 +840,7 @@ class TestPostProcessorMBPPMethods(unittest.TestCase):
             else:
                 return (None, None)
 
-        sections = pp._edit_postable_list(initial_sections(), append_s1_p1)
+        sections = self.pp._edit_postable_list(initial_sections(), append_s1_p1)
         self.assertEqual(len(sections), len(unmodified))
         self.assertEqual(
             sections[0][1][1].Name,
@@ -840,3 +852,138 @@ class TestPostProcessorMBPPMethods(unittest.TestCase):
             "append_p1",
             f"in section[1].Postable[1]---\n{to_str(sections)}\n---",
         )
+
+    def enable_line_numbering(self, prefix=None):
+        """Setup for line-numbering"""
+        self.pp.values.update(
+            {
+                "OUTPUT_LINE_NUMBERS": True,
+                "LINE_NUMBER_START": 100,
+                "LINE_INCREMENT": 10,
+            }
+        )
+        if prefix is not None:
+            self.pp.values["LINE_NUMBER_PREFIX"] = prefix
+
+    def test_line_number_ignores_blocks(self):
+        """Numbers Path.Commands but not "blocks" (item_type=="str")"""
+        self.enable_line_numbering()
+
+        # G1 X1
+        gcode1 = Postable(
+            label="gcode1",
+            item_type="operation",  # anything but 'str'
+            data={},
+            path=Path.Path([Path.Command("G1 X1")]),
+            source=None,
+        )
+
+        # 2 lines in block
+        block1 = Postable(
+            label="block1",
+            item_type="str",
+            data={"str": "line1\nline2\nG99"},  # G99 is NOT treated as parsed gcode
+            path=None,
+            source=None,
+        )
+
+        # G1 Y2
+        gcode2 = Postable(
+            label="gcode2",
+            item_type="operation",  # anything but 'str'
+            data={},
+            path=Path.Path([Path.Command("G1 Y2")]),
+            source=None,
+        )
+
+        postables = [gcode1, block1, gcode2]
+        self.pp._add_line_numbers([("section1", postables)])
+
+        # gcode1 is numbered
+        self.assertEqual(
+            len(gcode1.Path.Commands),
+            1,
+            f"Only expected the 1 command, but saw {gcode1.Path.Commands}",
+        )
+        # nb: parameters have floating point type
+        self.assertEqual(
+            gcode1.Path.Commands[0].Parameters.get("N", None),
+            100.0,
+            f"Expected N:100, but saw {gcode1.Path.Commands[0]}",
+        )
+
+        # block is not
+        block1.data["str"].split("\n")
+        self.assertEqual(
+            block1.data["str"], "line1\nline2\nG99", "Expected a block to be un-numbered"
+        )
+
+        # gcode2 is numbered
+        self.assertEqual(
+            len(gcode2.Path.Commands),
+            1,
+            f"Only expected the 1 command, but saw {gcode2.Path.Commands}",
+        )
+        # NB: counts the lines in block1, so next is 140:
+        self.assertEqual(
+            gcode2.Path.Commands[0].Parameters.get("N", None),
+            140.0,
+            f"Expected N:140, but saw {gcode2.Path.Commands[0]}",
+        )
+
+    def test_doesnt_renumber(self):
+        """Don't renumber gcode that already has an N"""
+        self.enable_line_numbering()
+
+        # G1 X1 N9: leave the N9
+        gcode1 = Postable(
+            label="gcode1",
+            item_type="operation",  # anything but 'str'
+            data={},
+            path=Path.Path([Path.Command("G1 X1 N9")]),
+            source=None,
+        )
+
+        postables = [gcode1]
+        self.pp._add_line_numbers([("section1", postables)])
+
+        # gcode1 is numbered
+        self.assertEqual(
+            len(gcode1.Path.Commands),
+            1,
+            f"Only expected the 1 command, but saw {gcode1.Path.Commands}",
+        )
+        # nb: parameters have floating point type
+        self.assertEqual(
+            gcode1.Path.Commands[0].Parameters.get("N", None),
+            9.0,
+            f"Expected undisturbed N:9, but saw {gcode1.Path.Commands[0]}",
+        )
+
+    def test_line_number_prefix(self):
+        """Uses the formatting.line_number_prefix"""
+        self.enable_line_numbering(prefix="%")
+        self.pp.values["OUTPUT_UNITS"] = OutputUnits.IMPERIAL
+
+        # G1 X1
+        gcode1 = Postable(
+            label="gcode1",
+            item_type="operation",  # anything but 'str'
+            data={},
+            path=Path.Path([Path.Command("G1 X1")]),
+            source=None,
+        )
+
+        postables = [gcode1]
+        self.pp._add_line_numbers([("section1", postables)])
+
+        self.assertEqual(
+            len(gcode1.Path.Commands),
+            1,
+            f"Only expected the 1 command, but saw {gcode1.Path.Commands}",
+        )
+
+        gcode = self.pp._convert_move(gcode1.Path.Commands[0])
+
+        # gcode1 has %n when converted
+        self.assertIn("%100", gcode, "Expected 'N100' to use % instead of N")

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -30,6 +30,7 @@ import importlib.util
 import json
 import os
 import sys
+import itertools
 from typing import Any, Dict, List, Optional, Tuple, Union
 import datetime
 from contextlib import contextmanager
@@ -45,6 +46,7 @@ import Path.Post.Utils as PostUtils
 from Path.Post.PostList import Postable
 from Path.Post.DrillCycleExpander import DrillCycleExpander
 from Path.Post.CAMErrors import CAMError, CAMValueError, CAMAttributeError
+from Path.Post.UtilsParse import format_command_line
 from Path.Base.MachineState import MachineState
 from Machine.models.machine import MachineFactory, OutputUnits
 
@@ -1080,6 +1082,57 @@ class PostProcessor:
 
         return gcodeheader
 
+    def _add_line_numbers(self, postables):
+        """Add N word if we are line-numbering
+        Subclasses are expected to render N as line-number (if present)
+            the default _convert_move() will do that
+        Numbering does not know about the subclass inserting/removing commands/lines,
+            so is NOT the physical line-number.
+
+        Subclasses can override to customize.
+        """
+        if not self.values["OUTPUT_LINE_NUMBERS"]:
+            return
+
+        Path.Log.track("Line numbering")
+
+        start = self.values["LINE_NUMBER_START"]
+        increment = self.values["LINE_INCREMENT"]
+
+        for section_name, sublist in postables:
+            # per section
+            line_number = itertools.count(start, increment)
+
+            for item in sublist:
+
+                # count 'str' lines, because it might be gcode/commands
+                if item.item_type == "str":
+                    str_lines = item.data["str"].count("\n")
+                    if item.data["str"] != "" and not item.data["str"].endswith("\n"):
+                        # count last line
+                        str_lines += 1
+                    for _ in range(0, str_lines):
+                        next(line_number)
+
+                # number Path.Command's
+                elif item.Path:
+                    new_commands = []
+                    for command in item.Path.Commands:
+
+                        # don't count comments
+                        if command.Name.startswith("("):
+                            new_commands.append(command)
+                            continue
+
+                        # Have to remake, because we change Parameters
+                        # _convert_move() does the LINE_NUMBER_PREFIX
+                        new_params = {"N": next(line_number)}
+                        new_params.update(command.Parameters)
+                        new_commands.append(
+                            Path.Command(command.Name, new_params, command.Annotations)
+                        )
+                    item.path = Path.Path(new_commands)
+
     def _expand_canned_cycles(self, postables):
         """Terminate canned drill cycles in postable paths.
 
@@ -1896,7 +1949,6 @@ class PostProcessor:
             deduplicate_repeated_commands,
             suppress_redundant_axes_words,
             filter_inefficient_moves,
-            insert_line_numbers,
         )
 
         if not gcode_lines:
@@ -1920,11 +1972,6 @@ class PostProcessor:
 
         if body_part and self.values["FILTER_INEFFICIENT_MOVES"]:
             body_part = filter_inefficient_moves(body_part)
-
-        if body_part and self.values["OUTPUT_LINE_NUMBERS"]:
-            start = self.values["LINE_NUMBER_START"]
-            increment = self.values["LINE_INCREMENT"]
-            body_part = insert_line_numbers(body_part, start=start, increment=increment)
 
         final_lines = header_part + body_part
         return final_lines
@@ -2059,8 +2106,12 @@ class PostProcessor:
         self._expand_tool_change(postables)
         self._expand_rotary_move(postables)
 
-        # must be last
+        # must be last expansion
         self._expand_bcnc_postamble(postables)
+
+        # Add line-numbers to all Path.Command's (if option is on)
+        # must be last
+        self._add_line_numbers(postables)
 
         Path.Log.debug(postables)
 
@@ -2607,7 +2658,6 @@ class PostProcessor:
 
         This method can be overridden by derived postprocessors to customize rapid move handling.
         """
-        from Path.Post.UtilsParse import format_command_line
 
         # Extract command components
         command_name = command.Name
@@ -2619,6 +2669,12 @@ class PostProcessor:
 
         # Build command line
         command_line = []
+
+        # line numbers as prefix
+        if params.get("N", None) is not None:
+            prefix = self.values["LINE_NUMBER_PREFIX"]
+            command_line.append(f"{prefix}{ int(params['N']):d}")
+
         command_line.append(command_name)
 
         # Format parameters with clean, stateless implementation

--- a/src/Mod/CAM/Path/Post/scripts/opensbp_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/opensbp_post.py
@@ -40,9 +40,7 @@ import Path
 
 Path.Log.debug(f"### RELOADED {__file__}")
 import Constants
-
 from Path.Post.Processor import PostProcessor
-from Path.Post.GcodeProcessingUtils import insert_line_numbers
 
 translate = FreeCAD.Qt.translate
 
@@ -273,32 +271,32 @@ class OpenSBPPost(PostProcessor):
         return super().convert_command_to_gcode(command)
 
     def _convert_move(self, command):
-        # FIXME: use Path.Command world _add_line_numbers when implemented
-        gcode = super()._convert_move(command)
 
-        if self.values["OUTPUT_LINE_NUMBERS"]:
-            # It will be taken care of later (everything line-numbered)
+        # Some gcode starts with the same command as shopbot commands
+        # and shopbot will assume they are shopbot
+        # unless they start with gcode line-numbering: Nxxxx
+        if (
+            command.Name in self.GCodeLineNumberRequired
+            # modal can omit the command, leaving a Zn... as the first parameter -> head of string
+            or command.Name[0] in self.GCodeLineNumberRequiredParameters
+        ) and "N" not in command.Parameters:
+            # Shouldn't happen if OUTPUT_LINE_NUMBERS==True
+
+            # But, we don't know what the line-number should be, so:
+            start = self.values["LINE_NUMBER_START"]
+            params = command.Parameters()
+            params["N"] = start
+            command = Path.Command(command.Name, params)
+
+        gcode = super()._convert_move(command)
+        if gcode is None or gcode == "":
             return gcode
 
         # We have to do this in string world
         result = []
         gcode_lines = gcode.split("\n")
         for line in gcode_lines:
-            command_name, *_ = line.split(" ", 1)
-
-            if (
-                command_name in self.GCodeLineNumberRequired
-                # modal can omit the command, leaving a Zn... as the first parameter -> head of string
-                or command_name[0] in self.GCodeLineNumberRequiredParameters
-            ):
-                # Line-numbering can't work properly, the progress isn't saved anywhere after
-                # calling insert_line_numbers()
-                start = self.values["LINE_NUMBER_START"]
-                increment = self.values["LINE_INCREMENT"]
-                result.append("' LN required")
-                result.extend(insert_line_numbers(gcode.split("\n"), start, increment))
-            else:
-                result.append(line)
+            result.append(line)
 
         return "\n".join(result)
 
@@ -613,8 +611,8 @@ class OpenSBPPost(PostProcessor):
         # FIXME: allow default F from MachineState when implemented?
         if len(required) != 2:
             raise Exception(f"A probing move (G38.2) must have a Z and F, only saw: {command}")
-        if len(command.Parameters) > 2:
-            raise Exception(f"A probing move (G38.2) should only have Z and F, saw {command}")
+        if len(command.Parameters) > 2 and "N" not in command.Parameters:
+            raise Exception(f"A probing move (G38.2) must only have Z,F and N, saw {command}")
 
         # G1, we aren't jogging, we are doing a slow, deliberate move, i.e. ~"feed".
         probe_movement = self._convert_move(Path.Command("G1", required))


### PR DESCRIPTION
Gcode line-numbering previously was done by re-parsing the stringified output. Now Path.Commands are numbered, and later stringified.

There used to be potential for corruption of non-gcode output (e.g. shopbot has some native "M" commands). We also have a rule that "blocks" (literal blobs) are not to be converted/edited, so now we skip over them properly.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
