### PR TITLE
Sketcher: Fixed inccorect radius constraint in arc of ellipse

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -712,6 +712,8 @@ void DSHArcOfEllipseController::addConstraints()
     int majorLine = firstCurve + 1;
     int minorLine = firstCurve + 2;
 
+    bool isFirstMajor = handler->firstRadius() > handler->secondRadius;
+
     double majorRadius = std::max(handler->firstRadius(), handler->secondRadius);
     double minorRadius = std::min(handler->firstRadius(), handler->secondRadius);
 
@@ -719,9 +721,11 @@ void DSHArcOfEllipseController::addConstraints()
 
     bool x0set = onViewParameters[OnViewParameter::First]->isSet;
     bool y0set = onViewParameters[OnViewParameter::Second]->isSet;
-    bool majorRadiusSet = onViewParameters[OnViewParameter::Third]->isSet;
     bool firstAxisSet = onViewParameters[OnViewParameter::Fourth]->isSet;
-    bool minorRadiusSet = onViewParameters[OnViewParameter::Fifth]->isSet;
+    bool majorRadiusSet = isFirstMajor ? onViewParameters[OnViewParameter::Third]->isSet
+                                       : onViewParameters[OnViewParameter::Fifth]->isSet;
+    bool minorRadiusSet = isFirstMajor ? onViewParameters[OnViewParameter::Fifth]->isSet
+                                       : onViewParameters[OnViewParameter::Third]->isSet;
     // cant constrain the angles
 
     auto constraintx0 = [&]() {


### PR DESCRIPTION
The major and minor radiuses was confused for the first and second set OVP causing the wrong radius to be set.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted by: GitHub Copilot inline suggestions using OpenAI GPT-5 mini.

## Before:

https://github.com/user-attachments/assets/6e1aeda4-c86a-4fd9-bc73-0e0b7e1c4bea

## After:

https://github.com/user-attachments/assets/3739062b-fb52-4bd9-a005-cfb4098ba3b0
