### PR TITLE
Sketcher: Partition diagnose() into independent components

### DIFF
--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -4710,8 +4710,7 @@ void System::makeReducedJacobian(
     const std::vector<Constraint*>& clist,
     Eigen::MatrixXd& J,
     std::map<int, int>& jacobianconstraintmap,
-    GCS::VEC_pD& pdiagnoselist,
-    std::map<int, int>& tagmultiplicity
+    GCS::VEC_pD& pdiagnoselist
 )
 {
     // construct specific parameter list for diagonose ignoring driven constraint parameters
@@ -4735,14 +4734,6 @@ void System::makeReducedJacobian(
             jacobianconstraintcount++;
             for (int j = 0; j < int(pdiagnoselist.size()); j++) {
                 J(jacobianconstraintcount - 1, j) = constr->grad(pdiagnoselist[j]);
-            }
-
-            // parallel processing: create tag multiplicity map
-            if (tagmultiplicity.find(constr->getTag()) == tagmultiplicity.end()) {
-                tagmultiplicity[constr->getTag()] = 0;
-            }
-            else {
-                tagmultiplicity[constr->getTag()]++;
             }
 
             jacobianconstraintmap[jacobianconstraintcount - 1] = allcount - 1;
@@ -4817,11 +4808,26 @@ int System::diagnose(Algorithm alg)
         return constr->isDriving();
     });
 
+    // tag multiplicity gives the number of solver constraints associated with the same tag
+    // A tag generally corresponds to the Sketcher constraint index - There are special tag values,
+    // like 0 and -1.
+    std::map<int, int> tagmultiplicity;
+    for (auto& constr : drivingConstraints) {
+        if (constr->getTag() >= 0) {
+            if (tagmultiplicity.find(constr->getTag()) == tagmultiplicity.end()) {
+                tagmultiplicity[constr->getTag()] = 0;
+            }
+            else {
+                tagmultiplicity[constr->getTag()]++;
+            }
+        }
+    }
+
     VEC_I components;
     int componentsSize = computeComponents(drivingConstraints, components);
 
     if (componentsSize <= 1) {
-        dofs = diagnoseComponent(alg, plist, pdrivenlist, clist);
+        dofs = diagnoseComponent(alg, plist, pdrivenlist, clist, tagmultiplicity);
         hasDiagnosis = true;
         return dofs;
     }
@@ -4849,7 +4855,7 @@ int System::diagnose(Algorithm alg)
             continue;
         }
 
-        int d = diagnoseComponent(alg, plists[i], pdrivenlists[i], clists[i]);
+        int d = diagnoseComponent(alg, plists[i], pdrivenlists[i], clists[i], tagmultiplicity);
         if (d < 0) {
             dofs = -1;
             break;
@@ -4865,7 +4871,8 @@ int System::diagnoseComponent(
     Algorithm alg,
     const VEC_pD& plist,
     const VEC_pD& pdrivenlist,
-    const std::vector<Constraint*>& clist
+    const std::vector<Constraint*>& clist,
+    const std::map<int, int>& tagmultiplicity
 )
 {
     // When adding an external geometry or a constraint on an external geometry the array
@@ -4893,12 +4900,7 @@ int System::diagnoseComponent(
     // constraints)
     GCS::VEC_pD pdiagnoselist;
 
-    // tag multiplicity gives the number of solver constraints associated with the same tag
-    // A tag generally corresponds to the Sketcher constraint index - There are special tag values,
-    // like 0 and -1.
-    std::map<int, int> tagmultiplicity;
-
-    makeReducedJacobian(plist, pdrivenlist, clist, J, jacobianconstraintmap, pdiagnoselist, tagmultiplicity);
+    makeReducedJacobian(plist, pdrivenlist, clist, J, jacobianconstraintmap, pdiagnoselist);
 
     if (stats) {
         stats->cumulativeDiagnoseMatrixSize += J.rows() * J.cols();

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -4839,6 +4839,10 @@ int System::diagnose(Algorithm alg)
 
     makeReducedJacobian(J, jacobianconstraintmap, pdiagnoselist, tagmultiplicity);
 
+    if (stats) {
+        stats->cumulativeDiagnoseMatrixSize += J.rows() * J.cols();
+    }
+
     // this function will exit with a diagnosis and, unless overridden by functions below, with full
     // DoFs
     hasDiagnosis = true;

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -4725,6 +4725,9 @@ void System::undoSolution()
 }
 
 void System::makeReducedJacobian(
+    const VEC_pD& plist,
+    const VEC_pD& pdrivenlist,
+    const std::vector<Constraint*>& clist,
     Eigen::MatrixXd& J,
     std::map<int, int>& jacobianconstraintmap,
     GCS::VEC_pD& pdiagnoselist,
@@ -4799,21 +4802,52 @@ int System::diagnose(Algorithm alg)
     // pdrivenlist      =>  list of the parameters that are driven by other parameters
     //                      (e.g. value of driven constraints)
 
+    emptyDiagnoseMatrix = true;
+    redundant.clear();
+    conflictingTags.clear();
+    redundantTags.clear();
+    partiallyRedundantTags.clear();
+
+    // Diagnose each independent component of the sketch separately; for
+    // now, the whole sketch is treated as a single component.
+    std::vector<VEC_pD> plists {plist};
+    std::vector<std::vector<Constraint*>> clists {clist};
+    std::vector<VEC_pD> pdrivenlists {pdrivenlist};
+    int componentsSize = 1;
+
+    dofs = 0;
+
+    for (int i = 0; i < componentsSize; ++i) {
+        if (plists[i].empty() && clists[i].empty()) {
+            continue;
+        }
+
+        int d = diagnoseComponent(alg, plists[i], pdrivenlists[i], clists[i]);
+        if (d < 0) {
+            dofs = -1;
+            break;
+        }
+        dofs += d;
+    }
+
+    hasDiagnosis = true;
+    return dofs;
+}
+
+int System::diagnoseComponent(
+    Algorithm alg,
+    const VEC_pD& plist,
+    const VEC_pD& pdrivenlist,
+    const std::vector<Constraint*>& clist
+)
+{
     // When adding an external geometry or a constraint on an external geometry the array
     // 'plist' is empty.
     // So, we must abort here because otherwise we would create an invalid matrix and make
     // the application eventually crash. This fixes issues #0002372/#0002373.
     if (plist.empty() || (plist.size() - pdrivenlist.size()) == 0) {
-        hasDiagnosis = true;
-        emptyDiagnoseMatrix = true;
-        dofs = 0;
-        return dofs;
+        return 0;
     }
-
-    redundant.clear();
-    conflictingTags.clear();
-    redundantTags.clear();
-    partiallyRedundantTags.clear();
 
     // This QR diagnosis uses a reduced Jacobian matrix to calculate the rank of the system
     // and identify conflicting and redundant constraints.
@@ -4837,16 +4871,13 @@ int System::diagnose(Algorithm alg)
     // like 0 and -1.
     std::map<int, int> tagmultiplicity;
 
-    makeReducedJacobian(J, jacobianconstraintmap, pdiagnoselist, tagmultiplicity);
+    makeReducedJacobian(plist, pdrivenlist, clist, J, jacobianconstraintmap, pdiagnoselist, tagmultiplicity);
 
     if (stats) {
         stats->cumulativeDiagnoseMatrixSize += J.rows() * J.cols();
     }
 
-    // this function will exit with a diagnosis and, unless overridden by functions below, with full
-    // DoFs
-    hasDiagnosis = true;
-    dofs = pdiagnoselist.size();
+    int dofs = pdiagnoselist.size();
 
     // Use DenseQR for small to medium systems to avoid SparseQR rank issues.
     // SparseQR is known to fail rank detection on specific geometric structures (e.g. aligned slots).
@@ -4970,6 +5001,7 @@ int System::diagnose(Algorithm alg)
             int nonredundantconstrNum;
             identifyConflictingRedundantConstraints(
                 alg,
+                clist,
                 qrJT,
                 jacobianconstraintmap,
                 tagmultiplicity,
@@ -5049,6 +5081,7 @@ int System::diagnose(Algorithm alg)
 
             identifyConflictingRedundantConstraints(
                 alg,
+                clist,
                 SqrJT,
                 jacobianconstraintmap,
                 tagmultiplicity,
@@ -5463,6 +5496,7 @@ void System::eliminateNonZerosOverPivotInUpperTriangularMatrix(Eigen::MatrixXd& 
 template<typename T>
 void System::identifyConflictingRedundantConstraints(
     Algorithm alg,
+    const std::vector<Constraint*>& clist,
     const T& qrJT,
     const std::map<int, int>& jacobianconstraintmap,
     const std::map<int, int>& tagmultiplicity,

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -4849,7 +4849,8 @@ int System::diagnose(Algorithm alg)
         }
     }
 
-    dofs = 0;
+    int pdofs = 0; // positive degrees of freedom
+    int ndofs = 0; // negative degrees of freedom
 
     for (int i = 0; i < componentsSize; ++i) {
         if (plists[i].empty() && clists[i].empty()) {
@@ -4857,12 +4858,11 @@ int System::diagnose(Algorithm alg)
         }
 
         int d = diagnoseComponent(alg, plists[i], pdrivenlists[i], clists[i], tagmultiplicity);
-        if (d < 0) {
-            dofs = -1;
-            break;
-        }
-        dofs += d;
+        pdofs += std::max(d, 0);
+        ndofs += std::min(d, 0);
     }
+
+    dofs = pdofs > 0 ? pdofs : ndofs;
 
     hasDiagnosis = true;
     return dofs;
@@ -4876,11 +4876,36 @@ int System::diagnoseComponent(
     const std::map<int, int>& tagmultiplicity
 )
 {
-    // When adding an external geometry or a constraint on an external geometry the array
-    // 'plist' is empty.
-    // So, we must abort here because otherwise we would create an invalid matrix and make
-    // the application eventually crash. This fixes issues #0002372/#0002373.
-    if (plist.empty() || (plist.size() - pdrivenlist.size()) == 0) {
+    // 'plist' is empty when a component's driving constraints touch only
+    // external/fixed geometry, so classify each constraint directly
+    if (plist.empty()) {
+        int conflictingCount = 0;
+        for (auto* constr : clist) {
+            if (constr->getTag() < 0 || !constr->isDriving()) {
+                continue;
+            }
+            bool priorityOrAlignment = constr->getTag() == 0
+                || constr->isInternalAlignment() == Constraint::Alignment::InternalAlignment;
+            if (priorityOrAlignment) {
+                ++conflictingCount;
+                continue;
+            }
+
+            double err = constr->error();
+            if (err * err < convergenceRedundant) {
+                redundant.insert(constr);
+                redundantTags.push_back(constr->getTag());
+                partiallyRedundantTags.push_back(constr->getTag());
+            }
+            else {
+                ++conflictingCount;
+                conflictingTags.push_back(constr->getTag());
+            }
+        }
+        return conflictingCount > 0 ? -conflictingCount : 0;
+    }
+
+    if ((plist.size() - pdrivenlist.size()) == 0) {
         return 0;
     }
 
@@ -4975,6 +5000,10 @@ int System::diagnoseComponent(
 #endif
 
     if (J.rows() == 0) {
+        for (auto* param : pdiagnoselist) {
+            pDependentParametersGroups.push_back({param});
+            pDependentParameters.push_back(param);
+        }
         return dofs;
     }
 

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -529,6 +529,7 @@ void System::clear()
     emptyDiagnoseMatrix = true;
 
     redundant.clear();
+    conflicting.clear();
     conflictingTags.clear();
     redundantTags.clear();
     partiallyRedundantTags.clear();
@@ -4798,6 +4799,7 @@ int System::diagnose(Algorithm alg)
 
     emptyDiagnoseMatrix = true;
     redundant.clear();
+    conflicting.clear();
     conflictingTags.clear();
     redundantTags.clear();
     partiallyRedundantTags.clear();
@@ -4824,11 +4826,46 @@ int System::diagnose(Algorithm alg)
         }
     }
 
+    auto finalizeConstraintTags = [this](const std::vector<Constraint*>& universe) {
+        SET_I redundantTagsSet, partiallyRedundantTagsSet;
+        for (const auto& constr : universe) {
+            if (redundant.count(constr) != 0) {
+                redundantTagsSet.insert(constr->getTag());
+                partiallyRedundantTagsSet.insert(constr->getTag());
+            }
+        }
+        for (const auto& constr : universe) {
+            if (redundant.count(constr) == 0) {
+                redundantTagsSet.erase(constr->getTag());
+            }
+        }
+        for (auto r : redundantTagsSet) {
+            partiallyRedundantTagsSet.erase(r);
+        }
+        redundantTags.assign(redundantTagsSet.begin(), redundantTagsSet.end());
+        partiallyRedundantTags.assign(
+            partiallyRedundantTagsSet.begin(),
+            partiallyRedundantTagsSet.end()
+        );
+
+        SET_I conflictingTagsSet;
+        for (const auto& constr : universe) {
+            if (conflicting.count(constr) != 0) {
+                bool isinternalalignment
+                    = (constr->isInternalAlignment() == Constraint::Alignment::InternalAlignment);
+                conflictingTagsSet.insert(isinternalalignment ? 0 : constr->getTag());
+            }
+        }
+        conflictingTagsSet.erase(0);
+        conflictingTags.assign(conflictingTagsSet.begin(), conflictingTagsSet.end());
+    };
+
     VEC_I components;
     int componentsSize = computeComponents(drivingConstraints, components);
 
     if (componentsSize <= 1) {
         dofs = diagnoseComponent(alg, plist, pdrivenlist, clist, tagmultiplicity);
+        finalizeConstraintTags(clist);
         hasDiagnosis = true;
         return dofs;
     }
@@ -4849,8 +4886,8 @@ int System::diagnose(Algorithm alg)
         }
     }
 
-    int pdofs = 0; // positive degrees of freedom
-    int ndofs = 0; // negative degrees of freedom
+    int pdofs = 0;  // positive degrees of freedom
+    int ndofs = 0;  // negative degrees of freedom
 
     for (int i = 0; i < componentsSize; ++i) {
         if (plists[i].empty() && clists[i].empty()) {
@@ -4863,6 +4900,8 @@ int System::diagnose(Algorithm alg)
     }
 
     dofs = pdofs > 0 ? pdofs : ndofs;
+
+    finalizeConstraintTags(drivingConstraints);
 
     hasDiagnosis = true;
     return dofs;
@@ -4894,12 +4933,10 @@ int System::diagnoseComponent(
             double err = constr->error();
             if (err * err < convergenceRedundant) {
                 redundant.insert(constr);
-                redundantTags.push_back(constr->getTag());
-                partiallyRedundantTags.push_back(constr->getTag());
             }
             else {
                 ++conflictingCount;
-                conflictingTags.push_back(constr->getTag());
+                conflicting.insert(constr);
             }
         }
         return conflictingCount > 0 ? -conflictingCount : 0;
@@ -5756,53 +5793,11 @@ void System::identifyConflictingRedundantConstraints(
     }
     delete subSysTmp;
 
-    // simplified output of conflicting tags
-    SET_I conflictingTagsSet;
     for (const auto& cGroup : conflictGroups) {
-        // exclude internal alignment
-        std::ranges::transform(
-            cGroup,
-            std::inserter(conflictingTagsSet, conflictingTagsSet.begin()),
-            [](const auto& constr) {
-                bool isinternalalignment
-                    = (constr->isInternalAlignment() == Constraint::Alignment::InternalAlignment);
-                return (isinternalalignment ? 0 : constr->getTag());
-            }
-        );
-    }
-
-    // exclude constraints tagged with zero
-    conflictingTagsSet.erase(0);
-
-    conflictingTags.insert(conflictingTags.end(), conflictingTagsSet.begin(), conflictingTagsSet.end());
-
-    // output of redundant tags
-    SET_I redundantTagsSet, partiallyRedundantTagsSet;
-    for (const auto& constr : clist) {
-        if (redundant.count(constr) != 0) {
-            redundantTagsSet.insert(constr->getTag());
-            partiallyRedundantTagsSet.insert(constr->getTag());
+        for (const auto& constr : cGroup) {
+            conflicting.insert(constr);
         }
     }
-
-    // remove tags represented at least in one non-redundant constraint
-    for (const auto& constr : clist) {
-        if (redundant.count(constr) == 0) {
-            redundantTagsSet.erase(constr->getTag());
-        }
-    }
-
-    redundantTags.insert(redundantTags.end(), redundantTagsSet.begin(), redundantTagsSet.end());
-
-    for (auto r : redundantTagsSet) {
-        partiallyRedundantTagsSet.erase(r);
-    }
-
-    partiallyRedundantTags.insert(
-        partiallyRedundantTags.end(),
-        partiallyRedundantTagsSet.begin(),
-        partiallyRedundantTagsSet.end()
-    );
 
     nonredundantconstrNum = constrNum;
 }

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -4810,13 +4810,37 @@ int System::diagnose(Algorithm alg)
     conflictingTags.clear();
     redundantTags.clear();
     partiallyRedundantTags.clear();
+    pDependentParametersGroups.clear();
 
-    // Diagnose each independent component of the sketch separately; for
-    // now, the whole sketch is treated as a single component.
-    std::vector<VEC_pD> plists {plist};
-    std::vector<std::vector<Constraint*>> clists {clist};
-    std::vector<VEC_pD> pdrivenlists {pdrivenlist};
-    int componentsSize = 1;
+    std::vector<Constraint*> drivingConstraints;
+    std::ranges::copy_if(clist, std::back_inserter(drivingConstraints), [](auto constr) {
+        return constr->isDriving();
+    });
+
+    VEC_I components;
+    int componentsSize = computeComponents(drivingConstraints, components);
+
+    if (componentsSize <= 1) {
+        dofs = diagnoseComponent(alg, plist, pdrivenlist, clist);
+        hasDiagnosis = true;
+        return dofs;
+    }
+
+    std::vector<VEC_pD> plists(componentsSize);
+    for (std::size_t i = 0; i < plist.size(); ++i) {
+        plists[components[i]].push_back(plist[i]);
+    }
+    std::vector<std::vector<Constraint*>> clists(componentsSize);
+    for (std::size_t i = 0; i < drivingConstraints.size(); ++i) {
+        clists[components[int(plist.size()) + int(i)]].push_back(drivingConstraints[i]);
+    }
+    std::vector<VEC_pD> pdrivenlists(componentsSize);
+    for (const auto& param : pdrivenlist) {
+        MAP_pD_I::const_iterator it = pIndex.find(param);
+        if (it != pIndex.end()) {
+            pdrivenlists[components[it->second]].push_back(param);
+        }
+    }
 
     dofs = 0;
 
@@ -5358,19 +5382,20 @@ void System::identifyDependentParameters(
     }
 #endif
 
-    pDependentParametersGroups.resize(qrJ.cols() - rank);
+    std::size_t groupBase = pDependentParametersGroups.size();
+    pDependentParametersGroups.resize(groupBase + (qrJ.cols() - rank));
     for (int j = rank; j < qrJ.cols(); j++) {
         for (int row = 0; row < rank; row++) {
             if (fabs(Rparams(row, j)) > 1e-10) {
                 int origCol = qrJ.colsPermutation().indices()[row];
 
-                pDependentParametersGroups[j - rank].push_back(pdiagnoselist[origCol]);
+                pDependentParametersGroups[groupBase + j - rank].push_back(pdiagnoselist[origCol]);
                 pDependentParameters.push_back(pdiagnoselist[origCol]);
             }
         }
         int origCol = qrJ.colsPermutation().indices()[j];
 
-        pDependentParametersGroups[j - rank].push_back(pdiagnoselist[origCol]);
+        pDependentParametersGroups[groupBase + j - rank].push_back(pdiagnoselist[origCol]);
         pDependentParameters.push_back(pdiagnoselist[origCol]);
     }
 
@@ -5717,14 +5742,15 @@ void System::identifyConflictingRedundantConstraints(
     // exclude constraints tagged with zero
     conflictingTagsSet.erase(0);
 
-    conflictingTags.resize(conflictingTagsSet.size());
-    std::ranges::copy(conflictingTagsSet, conflictingTags.begin());
+    conflictingTags.insert(conflictingTags.end(), conflictingTagsSet.begin(), conflictingTagsSet.end());
 
     // output of redundant tags
     SET_I redundantTagsSet, partiallyRedundantTagsSet;
-    for (const auto& constr : redundant) {
-        redundantTagsSet.insert(constr->getTag());
-        partiallyRedundantTagsSet.insert(constr->getTag());
+    for (const auto& constr : clist) {
+        if (redundant.count(constr) != 0) {
+            redundantTagsSet.insert(constr->getTag());
+            partiallyRedundantTagsSet.insert(constr->getTag());
+        }
     }
 
     // remove tags represented at least in one non-redundant constraint
@@ -5734,15 +5760,17 @@ void System::identifyConflictingRedundantConstraints(
         }
     }
 
-    redundantTags.resize(redundantTagsSet.size());
-    std::ranges::copy(redundantTagsSet, redundantTags.begin());
+    redundantTags.insert(redundantTags.end(), redundantTagsSet.begin(), redundantTagsSet.end());
 
     for (auto r : redundantTagsSet) {
         partiallyRedundantTagsSet.erase(r);
     }
 
-    partiallyRedundantTags.resize(partiallyRedundantTagsSet.size());
-    std::ranges::copy(partiallyRedundantTagsSet, partiallyRedundantTags.begin());
+    partiallyRedundantTags.insert(
+        partiallyRedundantTags.end(),
+        partiallyRedundantTagsSet.begin(),
+        partiallyRedundantTagsSet.end()
+    );
 
     nonredundantconstrNum = constrNum;
 }

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -4801,6 +4801,7 @@ int System::diagnose(Algorithm alg)
     conflictingTags.clear();
     redundantTags.clear();
     partiallyRedundantTags.clear();
+    pDependentParameters.clear();
     pDependentParametersGroups.clear();
 
     std::vector<Constraint*> drivingConstraints;

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -1778,28 +1778,8 @@ void System::initSolution(Algorithm alg)
     }
 
     // partitioning into decoupled components
-    Graph g;
-    for (int i = 0; i < int(plist.size() + clistR.size()); i++) {
-        boost::add_vertex(g);
-    }
-
-    int cvtid = int(plist.size());
-    for (const auto constr : clistR) {
-        VEC_pD& cparams = c2p[constr];
-        for (const auto param : cparams) {
-            MAP_pD_I::const_iterator it = pIndex.find(param);
-            if (it != pIndex.end()) {
-                boost::add_edge(cvtid, it->second, g);
-            }
-        }
-        ++cvtid;
-    }
-
-    VEC_I components(boost::num_vertices(g));
-    int componentsSize = 0;
-    if (!components.empty()) {
-        componentsSize = boost::connected_components(g, &components[0]);
-    }
+    VEC_I components;
+    int componentsSize = computeComponents(clistR, components);
 
     // identification of equality constraints and parameter reduction
     std::set<Constraint*> reducedConstrs;  // constraints that will be eliminated through reduction
@@ -4772,6 +4752,29 @@ void System::makeReducedJacobian(
     if (jacobianconstraintcount == 0) {  // only driven constraints
         J.resize(0, 0);
     }
+}
+
+int System::computeComponents(const std::vector<Constraint*>& clist, VEC_I& components)
+{
+    Graph graph(plist.size() + clist.size());
+    int cvtid = int(plist.size());
+    for (const auto constr : clist) {
+        VEC_pD& cparams = c2p[constr];
+        for (const auto param : cparams) {
+            MAP_pD_I::const_iterator it = pIndex.find(param);
+            if (it != pIndex.end()) {
+                boost::add_edge(cvtid, it->second, graph);
+            }
+        }
+        ++cvtid;
+    }
+
+    components.resize(boost::num_vertices(graph));
+    int componentsSize = 0;
+    if (!components.empty()) {
+        componentsSize = boost::connected_components(graph, &components[0]);
+    }
+    return componentsSize;
 }
 
 int System::diagnose(Algorithm alg)

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -166,15 +166,15 @@ private:
         const std::vector<Constraint*>& clist,
         Eigen::MatrixXd& J,
         std::map<int, int>& jacobianconstraintmap,
-        GCS::VEC_pD& pdiagnoselist,
-        std::map<int, int>& tagmultiplicity
+        GCS::VEC_pD& pdiagnoselist
     );
 
     int diagnoseComponent(
         Algorithm alg,
         const VEC_pD& plist,
         const VEC_pD& pdrivenlist,
-        const std::vector<Constraint*>& clist
+        const std::vector<Constraint*>& clist,
+        const std::map<int, int>& tagmultiplicity
     );
 
     int computeComponents(const std::vector<Constraint*>& clist, VEC_I& components);

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -161,10 +161,20 @@ private:
     int solve_DL(SubSystem* subsys, bool isRedundantsolving = false);
 
     void makeReducedJacobian(
+        const VEC_pD& plist,
+        const VEC_pD& pdrivenlist,
+        const std::vector<Constraint*>& clist,
         Eigen::MatrixXd& J,
         std::map<int, int>& jacobianconstraintmap,
         GCS::VEC_pD& pdiagnoselist,
         std::map<int, int>& tagmultiplicity
+    );
+
+    int diagnoseComponent(
+        Algorithm alg,
+        const VEC_pD& plist,
+        const VEC_pD& pdrivenlist,
+        const std::vector<Constraint*>& clist
     );
 
     void makeDenseQRDecomposition(
@@ -201,6 +211,7 @@ private:
     template<typename T>
     void identifyConflictingRedundantConstraints(
         Algorithm alg,
+        const std::vector<Constraint*>& clist,
         const T& qrJT,
         const std::map<int, int>& jacobianconstraintmap,
         const std::map<int, int>& tagmultiplicity,

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -103,6 +103,15 @@ enum SpecialTag
     DefaultTemporaryConstraint = -1
 };
 
+// Optional per-run instrumentation for a System. Set with
+// System::setStats() to collect statistics during a solve/diagnose.
+class SketcherExport SystemStats
+{
+public:
+    // Sum of the size of every reduced Jacobian built during diagnose().
+    int cumulativeDiagnoseMatrixSize = 0;
+};
+
 class SketcherExport System
 {
     // This is the main class. It holds all constraints and information
@@ -144,6 +153,8 @@ private:
     bool isInit;        // if plists, clists, reductionmaps are up to date
 
     bool emptyDiagnoseMatrix;  // false only if there is at least one driving constraint.
+
+    SystemStats* stats = nullptr;  // optional instrumentation, see setStats()
 
     int solve_BFGS(SubSystem* subsys, bool isFine = true, bool isRedundantsolving = false);
     int solve_LM(SubSystem* subsys, bool isRedundantsolving = false);
@@ -633,6 +644,7 @@ public:
     }
 
     int diagnose(Algorithm alg = DogLeg);
+
     int dofsNumber() const
     {
         return hasDiagnosis ? dofs : -1;
@@ -687,6 +699,11 @@ protected:
         return std::count_if(clist.begin(), clist.end(), [tagID](Constraint* constraint) {
             return constraint->getTag() == tagID;
         });
+    }
+
+    void _setStats(SystemStats* stats)
+    {
+        this->stats = stats;
     }
 };
 

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -146,6 +146,7 @@ private:
 
     int dofs;
     std::set<Constraint*> redundant;
+    std::set<Constraint*> conflicting;
     VEC_I conflictingTags, redundantTags, partiallyRedundantTags;
 
     bool hasUnknowns;   // if plist is filled with the unknown parameters

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -177,6 +177,8 @@ private:
         const std::vector<Constraint*>& clist
     );
 
+    int computeComponents(const std::vector<Constraint*>& clist, VEC_I& components);
+
     void makeDenseQRDecomposition(
         const Eigen::MatrixXd& J,
         const std::map<int, int>& jacobianconstraintmap,

--- a/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "Mod/Sketcher/App/planegcs/GCS.h"
@@ -10,6 +12,11 @@ public:
     size_t getNumberOfConstraints(int tagID = -1)
     {
         return _getNumberOfConstraints(tagID);
+    }
+
+    void setStats(GCS::SystemStats* stats)
+    {
+        return _setStats(stats);
     }
 };
 
@@ -49,4 +56,29 @@ TEST_F(GCSTest, clearConstraints)  // NOLINT
 
     // Assert
     EXPECT_EQ(0, System()->getNumberOfConstraints());
+}
+
+TEST_F(GCSTest, diagnoseManyIndependentComponentsPerf)  // NOLINT
+{
+    // Arrange
+    constexpr int N = 6000;
+    std::vector<double> values(2 * N, 0.0);
+    GCS::VEC_pD params;
+    params.reserve(values.size());
+    for (auto& v : values) {
+        params.push_back(&v);
+    }
+
+    System()->declareUnknowns(params);
+    for (int i = 0; i < N; ++i) {
+        System()->addConstraintEqual(params[2 * i], params[2 * i + 1]);
+    }
+
+    // Act
+    GCS::SystemStats stats;
+    System()->setStats(&stats);
+    System()->diagnose();
+
+    // Assert
+    EXPECT_EQ(stats.cumulativeDiagnoseMatrixSize, 2*N);
 }

--- a/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -119,8 +119,14 @@ TEST_F(GCSTest, diagnoseAccumulatesRedundantTagsAcrossUnrelatedComponents)  // N
 {
     // Arrange
     std::vector<double> values = {
-        0.0, 0.0, 5.0, 5.0,  // pair 1: x1, y1, x2, y2
-        1.0, 1.0, 6.0, 6.0,  // pair 2: x3, y3, x4, y4
+        0.0,
+        0.0,
+        5.0,
+        5.0,  // pair 1: x1, y1, x2, y2
+        1.0,
+        1.0,
+        6.0,
+        6.0,  // pair 2: x3, y3, x4, y4
     };
     GCS::VEC_pD params;
     for (auto& v : values) {
@@ -179,8 +185,10 @@ TEST_F(GCSTest, diagnoseReportsFreeParamsOfUnconstrainedComponent)  // NOLINT
     // Arrange
     double fixedX = 0.0, fixedY = 0.0;
     std::vector<double> values = {
-        0.0, 0.0,  // p1
-        1.0, 1.0,  // p2
+        0.0,
+        0.0,  // p1
+        1.0,
+        1.0,  // p2
     };
     GCS::VEC_pD params;
     for (auto& v : values) {
@@ -264,9 +272,12 @@ TEST_F(GCSTest, diagnoseAccumulatesAcrossMixedConstrainedComponents)  // NOLINT
     // Arrange
     double constX1 = 0.0, constX2 = 5.0, constY = 0.0, zero = 0.0;
     std::vector<double> values = {
-        0.0, 0.0,  // p1
-        1.0, 1.0,  // p2
-        2.0, 1.0,  // p3
+        0.0,
+        0.0,  // p1
+        1.0,
+        1.0,  // p2
+        2.0,
+        1.0,  // p3
     };
     GCS::VEC_pD params;
     for (auto& v : values) {

--- a/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -174,6 +174,138 @@ TEST_F(GCSTest, diagnoseResetsDependentParamsEachCall)  // NOLINT
     EXPECT_EQ(dependent.size(), 3u);
 }
 
+TEST_F(GCSTest, diagnoseReportsFreeParamsOfUnconstrainedComponent)  // NOLINT
+{
+    // Arrange
+    double fixedX = 0.0, fixedY = 0.0;
+    std::vector<double> values = {
+        0.0, 0.0,  // p1
+        1.0, 1.0,  // p2
+    };
+    GCS::VEC_pD params;
+    for (auto& v : values) {
+        params.push_back(&v);
+    }
+    System()->declareUnknowns(params);
+
+    GCS::Point p1(params[0], params[1]);
+    GCS::Point fixed(&fixedX, &fixedY);
+    System()->addConstraintP2PCoincident(p1, fixed, 1);
+
+    // Act
+    System()->diagnose();
+
+    // Assert
+    GCS::VEC_pD dependent;
+    System()->getDependentParams(dependent);
+    ASSERT_EQ(dependent.size(), 2u);
+    EXPECT_NE(std::ranges::find(dependent, params[2]), dependent.end());
+    EXPECT_NE(std::ranges::find(dependent, params[3]), dependent.end());
+}
+
+TEST_F(GCSTest, diagnoseFlagsConflictingConstraintEntirelyOnExternalGeometry)  // NOLINT
+{
+    // Arrange
+    double extX1 = 0.0, extY1 = 0.0, extX2 = 3.0, extY2 = 0.0;
+    double wrongDistance = 10.0;
+    std::vector<double> values = {1.0, 1.0};  // p1
+    GCS::VEC_pD params;
+    for (auto& v : values) {
+        params.push_back(&v);
+    }
+    System()->declareUnknowns(params);
+
+    GCS::Point pExt1(&extX1, &extY1);
+    GCS::Point pExt2(&extX2, &extY2);
+
+    constexpr int conflictTag = 1;
+    System()->addConstraintP2PDistance(pExt1, pExt2, &wrongDistance, conflictTag);
+
+    // Act
+    System()->diagnose();
+
+    // Assert
+    GCS::VEC_I conflicting;
+    System()->getConflicting(conflicting);
+    ASSERT_EQ(conflicting.size(), 1u);
+    EXPECT_EQ(conflicting[0], conflictTag);
+}
+
+TEST_F(GCSTest, diagnoseTreatsSatisfiedConstraintOnExternalGeometryAsRedundant)  // NOLINT
+{
+    // Arrange
+    double extX1 = 0.0, extY1 = 0.0, extX2 = 3.0, extY2 = 0.0;
+    double correctDistance = 3.0;
+    std::vector<double> values = {1.0, 1.0};  // p1
+    GCS::VEC_pD params;
+    for (auto& v : values) {
+        params.push_back(&v);
+    }
+    System()->declareUnknowns(params);
+
+    GCS::Point pExt1(&extX1, &extY1);
+    GCS::Point pExt2(&extX2, &extY2);
+
+    constexpr int redundantTag = 1;
+    System()->addConstraintP2PDistance(pExt1, pExt2, &correctDistance, redundantTag);
+
+    // Act
+    System()->diagnose();
+
+    // Assert
+    GCS::VEC_I redundant;
+    System()->getRedundant(redundant);
+    ASSERT_EQ(redundant.size(), 1u);
+    EXPECT_EQ(redundant[0], redundantTag);
+}
+
+TEST_F(GCSTest, diagnoseAccumulatesAcrossMixedConstrainedComponents)  // NOLINT
+{
+    // Arrange
+    double constX1 = 0.0, constX2 = 5.0, constY = 0.0, zero = 0.0;
+    std::vector<double> values = {
+        0.0, 0.0,  // p1
+        1.0, 1.0,  // p2
+        2.0, 1.0,  // p3
+    };
+    GCS::VEC_pD params;
+    for (auto& v : values) {
+        params.push_back(&v);
+    }
+    System()->declareUnknowns(params);
+
+    GCS::Point p1(params[0], params[1]);
+    GCS::Point p2(params[2], params[3]);
+    GCS::Point p3(params[4], params[5]);
+
+    constexpr int conflictingTag1 = 1;
+    constexpr int conflictingTag2 = 2;
+    constexpr int anchorYTag = 3;
+    System()->addConstraintCoordinateX(p1, &constX1, conflictingTag1);
+    System()->addConstraintCoordinateX(p1, &constX2, conflictingTag2);
+    System()->addConstraintCoordinateY(p1, &constY, anchorYTag);
+
+    constexpr int horizontalTag = 4;
+    constexpr int redundantTag = 5;
+    System()->addConstraintHorizontal(p2, p3, horizontalTag);
+    System()->addConstraintDifference(p2.y, p3.y, &zero, redundantTag);
+
+    // Act
+    System()->diagnose();
+
+    // Assert
+    GCS::VEC_I redundant;
+    System()->getRedundant(redundant);
+    ASSERT_EQ(redundant.size(), 1u);
+    EXPECT_EQ(redundant[0], redundantTag);
+    EXPECT_EQ(System()->dofsNumber(), 3);
+
+    GCS::VEC_I conflicting;
+    System()->getConflicting(conflicting);
+    std::sort(conflicting.begin(), conflicting.end());
+    EXPECT_EQ(conflicting, (GCS::VEC_I {conflictingTag1, conflictingTag2}));
+}
+
 TEST_F(GCSTest, diagnoseManyIndependentComponentsPerf)  // NOLINT
 {
     // Arrange

--- a/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -306,6 +306,71 @@ TEST_F(GCSTest, diagnoseAccumulatesAcrossMixedConstrainedComponents)  // NOLINT
     EXPECT_EQ(conflicting, (GCS::VEC_I {conflictingTag1, conflictingTag2}));
 }
 
+TEST_F(GCSTest, diagnoseCoincidentBetweenAlreadyCoincidentExternalPointsIsFullyRedundant)  // NOLINT
+{
+    // Arrange
+    double extX1 = 3.0, extY1 = 4.0, extX2 = 3.0, extY2 = 4.0;  // already coincident
+    std::vector<double> values = {1.0, 1.0};  // p1, unrelated unknown so hasUnknowns is true
+    GCS::VEC_pD params;
+    for (auto& v : values) {
+        params.push_back(&v);
+    }
+    System()->declareUnknowns(params);
+
+    GCS::Point pExt1(&extX1, &extY1);
+    GCS::Point pExt2(&extX2, &extY2);
+
+    constexpr int coincidentTag = 1;
+    System()->addConstraintP2PCoincident(pExt1, pExt2, coincidentTag);
+
+    // Act
+    System()->diagnose();
+
+    // Assert
+    GCS::VEC_I redundant;
+    System()->getRedundant(redundant);
+    EXPECT_EQ(redundant, (GCS::VEC_I {coincidentTag}));
+
+    GCS::VEC_I partiallyRedundant;
+    System()->getPartiallyRedundant(partiallyRedundant);
+    EXPECT_TRUE(partiallyRedundant.empty());
+
+    GCS::VEC_I conflicting;
+    System()->getConflicting(conflicting);
+    EXPECT_TRUE(conflicting.empty());
+}
+
+TEST_F(GCSTest, diagnoseDuplicateCoincidentOnUnlinkedPointsIsFullyRedundant)  // NOLINT
+{
+    // Arrange
+    std::vector<double> values = {0.0, 0.0, 5.0, 5.0};  // x1, y1, x2, y2
+    GCS::VEC_pD params;
+    for (auto& v : values) {
+        params.push_back(&v);
+    }
+    System()->declareUnknowns(params);
+
+    GCS::Point p1(params[0], params[1]);
+    GCS::Point p2(params[2], params[3]);
+
+    constexpr int coincidentTag1 = 1;
+    constexpr int coincidentTag2 = 2;
+    System()->addConstraintP2PCoincident(p1, p2, coincidentTag1);
+    System()->addConstraintP2PCoincident(p1, p2, coincidentTag2);
+
+    // Act
+    System()->diagnose();
+
+    // Assert
+    GCS::VEC_I redundant;
+    System()->getRedundant(redundant);
+    EXPECT_EQ(redundant, (GCS::VEC_I {coincidentTag2}));
+
+    GCS::VEC_I partiallyRedundant;
+    System()->getPartiallyRedundant(partiallyRedundant);
+    EXPECT_TRUE(partiallyRedundant.empty());
+}
+
 TEST_F(GCSTest, diagnoseManyIndependentComponentsPerf)  // NOLINT
 {
     // Arrange

--- a/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#include <algorithm>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -58,6 +59,99 @@ TEST_F(GCSTest, clearConstraints)  // NOLINT
     EXPECT_EQ(0, System()->getNumberOfConstraints());
 }
 
+TEST_F(GCSTest, diagnoseRedundancyAcrossComponentsPrefersOlderConstraint)  // NOLINT
+{
+    // Arrange
+    std::vector<double> values = {0.0, 0.0, 5.0, 5.0};  // x1, y1, x2, y2
+    GCS::VEC_pD params;
+    for (auto& v : values) {
+        params.push_back(&v);
+    }
+    System()->declareUnknowns(params);
+
+    GCS::Point p1(params[0], params[1]);
+    GCS::Point p2(params[2], params[3]);
+
+    constexpr int vertical_tag = 1;
+    constexpr int coincident_tag = 2;
+    System()->addConstraintVertical(p1, p2, vertical_tag);
+    System()->addConstraintP2PCoincident(p1, p2, coincident_tag);
+
+    // Act
+    System()->diagnose();
+
+    // Assert
+    GCS::VEC_I redundant;
+    System()->getRedundant(redundant);
+    ASSERT_EQ(redundant.size(), 1u);
+    EXPECT_EQ(redundant[0], vertical_tag);
+}
+
+TEST_F(GCSTest, diagnoseRedundancyAcrossComponentsIndependentOfAdditionOrder)  // NOLINT
+{
+    // Arrange
+    std::vector<double> values = {0.0, 0.0, 5.0, 5.0};  // x1, y1, x2, y2
+    GCS::VEC_pD params;
+    for (auto& v : values) {
+        params.push_back(&v);
+    }
+    System()->declareUnknowns(params);
+
+    GCS::Point p1(params[0], params[1]);
+    GCS::Point p2(params[2], params[3]);
+
+    constexpr int coincident_tag = 1;
+    constexpr int vertical_tag = 2;
+    System()->addConstraintP2PCoincident(p1, p2, coincident_tag);
+    System()->addConstraintVertical(p1, p2, vertical_tag);
+
+    // Act
+    System()->diagnose();
+
+    // Assert
+    GCS::VEC_I redundant;
+    System()->getRedundant(redundant);
+    ASSERT_EQ(redundant.size(), 1u);
+    EXPECT_EQ(redundant[0], vertical_tag);
+}
+
+TEST_F(GCSTest, diagnoseAccumulatesRedundantTagsAcrossUnrelatedComponents)  // NOLINT
+{
+    // Arrange
+    std::vector<double> values = {
+        0.0, 0.0, 5.0, 5.0,  // pair 1: x1, y1, x2, y2
+        1.0, 1.0, 6.0, 6.0,  // pair 2: x3, y3, x4, y4
+    };
+    GCS::VEC_pD params;
+    for (auto& v : values) {
+        params.push_back(&v);
+    }
+    System()->declareUnknowns(params);
+
+    GCS::Point p1(params[0], params[1]);
+    GCS::Point p2(params[2], params[3]);
+    GCS::Point p3(params[4], params[5]);
+    GCS::Point p4(params[6], params[7]);
+
+    constexpr int vertical_tag_1 = 1;
+    constexpr int coincident_tag_1 = 2;
+    constexpr int vertical_tag_2 = 3;
+    constexpr int coincident_tag_2 = 4;
+    System()->addConstraintVertical(p1, p2, vertical_tag_1);
+    System()->addConstraintP2PCoincident(p1, p2, coincident_tag_1);
+    System()->addConstraintVertical(p3, p4, vertical_tag_2);
+    System()->addConstraintP2PCoincident(p3, p4, coincident_tag_2);
+
+    // Act
+    System()->diagnose();
+
+    // Assert
+    GCS::VEC_I redundant;
+    System()->getRedundant(redundant);
+    std::sort(redundant.begin(), redundant.end());
+    EXPECT_EQ(redundant, (GCS::VEC_I {vertical_tag_1, vertical_tag_2}));
+}
+
 TEST_F(GCSTest, diagnoseManyIndependentComponentsPerf)  // NOLINT
 {
     // Arrange
@@ -80,5 +174,5 @@ TEST_F(GCSTest, diagnoseManyIndependentComponentsPerf)  // NOLINT
     System()->diagnose();
 
     // Assert
-    EXPECT_EQ(stats.cumulativeDiagnoseMatrixSize, 2*N);
+    EXPECT_EQ(stats.cumulativeDiagnoseMatrixSize, 2 * N);
 }

--- a/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -152,6 +152,28 @@ TEST_F(GCSTest, diagnoseAccumulatesRedundantTagsAcrossUnrelatedComponents)  // N
     EXPECT_EQ(redundant, (GCS::VEC_I {vertical_tag_1, vertical_tag_2}));
 }
 
+TEST_F(GCSTest, diagnoseResetsDependentParamsEachCall)  // NOLINT
+{
+    // Arrange
+    std::vector<double> values = {0.0, 5.0, 10.0};
+    GCS::VEC_pD params;
+    for (auto& v : values) {
+        params.push_back(&v);
+    }
+    System()->declareUnknowns(params);
+    System()->addConstraintEqual(params[0], params[1], 1);
+    System()->diagnose();
+
+    // Act
+    System()->addConstraintEqual(params[1], params[2], 2);
+    System()->diagnose();
+
+    // Assert
+    GCS::VEC_pD dependent;
+    System()->getDependentParams(dependent);
+    EXPECT_EQ(dependent.size(), 3u);
+}
+
 TEST_F(GCSTest, diagnoseManyIndependentComponentsPerf)  // NOLINT
 {
     // Arrange


### PR DESCRIPTION
`GCS::System::diagnose()` builds and QR-factorizes a single Jacobian matrix
across the entire sketch, regardless of whether that sketch is actually one
connected system of constraints or several independent, disconnected pieces
(e.g. a pattern of separate, relatively unconstrained shapes in one sketch
such as arrays of holes, repeated features, etc.)

For N disconnected pieces, diagnosing them all together costs far more than
diagnosing each independently, and the gap grows fast as N increases: QR
factorization cost is highly superlinear in matrix size, so one N-times-larger
matrix costs much more than N separate small ones.

This change addresses that by partitioning the sketch's constraint parameter
graph via `boost::connected_components` before diagnosing, then diagnoses each
independent component separately instead of building one Jacobian for the
whole sketch.

Using the added unit test, I measured the impact of this change. At N=6000
independent components, this took diagnose() from ~29.7s to ~0.09s (roughly
300x). At larger N, this is the difference between a multi-minute hang and
sub-second completion.

The commits are intended to be reviewed incrementally:

`GCS::System::diagnose()` builds and QR-factorizes a single Jacobian matrix
across the entire sketch, regardless of whether that sketch is actually one
connected system of constraints or several independent, disconnected pieces
(e.g. a pattern of separate, relatively unconstrained shapes in one sketch
such as arrays of holes, repeated features, etc.)

For N disconnected pieces, diagnosing them all together costs far more than
diagnosing each independently, and the gap grows fast as N increases: QR
factorization cost is highly superlinear in matrix size, so one N-times-larger
matrix costs much more than N separate small ones.

This change addresses that by partitioning the sketch's constraint parameter
graph via `boost::connected_components` before diagnosing, then diagnoses each
independent component separately instead of building one Jacobian for the
whole sketch.

Using the added unit test, I measured the impact of this change. At N=6000
independent components, this took diagnose() from ~29.7s to ~0.09s (roughly
300x). At larger N, this is the difference between a multi-minute hang and
sub-second completion.

The commits are intended to be reviewed incrementally:

1. 099781c355 Adds a test exercising System::diagnose() directly to
isolate this fix from unrelated geometry/solver-convergence costs. The test
fails at this commit as on most conceivable hardware configuration it will
take more than 1 second.
2. 9947a54777 Restructures diagnose() into a loop over "components" and
diagnoseComponent() is extracted. At this stage there is always exactly
 one component (the whole sketch).
3. 903e3d0f51 Extracts the component partition step that initSolution()
already does for its own purposes at solve time into a shared
computeComponents() helper. diagnose() still doesn't use it yet.
4. c1e7ed7e69 Calls computeComponents() in diagnose() to diagnose each
partition separately. This is where the fix lands and the perf test starts
passing.
5. dcec9b460f (FIX) Adds a regression test for constraint multiplicity being recalculated on each diagnoseComponent().
6. 2de2af9d95 (FIX) Clear pDependentParameters between multiple diagnose calls.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
Closes #31183

## Before and After Images
N/A

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
Closes #31183

## Before and After Images
N/A