### PR TITLE
Sketcher: accept empty internal face results

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -401,11 +401,16 @@ Part::TopoShape SketchObject::buildInternals(const Part::TopoShape &edges) const
 
     try {
         Part::TopoShape result(getID(), getDocument()->getStringHasher());
-        result = result.makeElementFace(edges.getSubTopoShapes(TopAbs_WIRE),
-                /*op*/"",
-                /*maker*/"Part::FaceMakerBuildFace",
-                /*pln*/nullptr
-        );
+        try {
+            result = result.makeElementFace(edges.getSubTopoShapes(TopAbs_WIRE),
+                    /*op*/"",
+                    /*maker*/"Part::FaceMakerBuildFace",
+                    /*pln*/nullptr
+            );
+        }
+        catch (const Part::NullShapeException&) {
+            // An open-only sketch has no bounded regions, so a null face result is expected.
+        }
 
         // Append open wires (edges not part of any closed face)
         Part::WireJoiner joiner;


### PR DESCRIPTION
Some sketches contain only open geometry, so there are no bounded faces for `FaceMakerBuildFace` to produce. In that case, FreeCAD currently reports a misleading warning when the face maker returns an empty result.

This change treats that specific empty result as expected and continues processing the sketch normally. Other face-making and geometry errors still produce warnings as before.

This keeps valid cases such as diagonals, intersections, and T-junctions working by leaving the existing face-maker logic unchanged.