### PR TITLE
Sketcher: Fix constraints rendering above covering solids (#30249)

### DIFF
--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -292,9 +292,8 @@ SoDatumLabel::SoDatumLabel()
     m_TextSwitch->addChild(m_TextSeparator);
 
     m_TextDepth = new SoDepthBuffer;
-    m_TextDepth->test.setValue(false);
+    m_TextDepth->test.setValue(true);
     m_TextDepth->write.setValue(false);
-    m_TextDepth->function.setValue(SoDepthBuffer::ALWAYS);
     m_TextSeparator->addChild(m_TextDepth);
 
     auto* textLightModel = new SoLightModel;

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -38,6 +38,7 @@
 #include <Inventor/SbVec3f.h>
 #include <Inventor/SoPickedPoint.h>
 #include <Inventor/nodes/SoAnnotation.h>
+#include <Inventor/nodes/SoDepthBuffer.h>
 #include <Inventor/nodes/SoDrawStyle.h>
 #include <Inventor/nodes/SoGroup.h>
 #include <Inventor/nodes/SoImage.h>
@@ -3069,6 +3070,13 @@ void EditModeConstraintCoinManager::createEditModeInventorNodes()
     // affecting depth state for other nodes (#28639).
     // See also issues #25840 and #11603.
     auto* constrAnnotation = new SoAnnotation();
+
+    // Depth-test against whatever is already in the depth buffer so a
+    // covering solid from another object occludes constraints (#30249).
+    auto* constrDepth = new SoDepthBuffer;
+    constrDepth->test.setValue(true);
+    constrDepth->write.setValue(false);
+    constrAnnotation->addChild(constrDepth);
 
     editModeScenegraphNodes.constrGroup = new SmSwitchboard();
     editModeScenegraphNodes.constrGroup->setName("ConstraintGroup");


### PR DESCRIPTION
Constraint icons are wrapped in SoAnnotation (see #25840/#28639), which
bypasses depth testing for its subtree. With no per-node depth override, icons
always rendered on top of everything, including an unrelated solid from
another object sitting in front of the sketch plane.

Add a SoDepthBuffer covering the constraints, like SoDatumLabel uses for
line/arrow geometry. This is still depth-tested against whatever is already in
the buffer without write depth itself so constraints don't occlude each other
or the sketch's own geometry. Also switch SoDatumLabel's text depth node from
test=false to test=true, matching its own geometry, so dimension text is
occluded.

Verified visually in the GUI. Constraint icons and dimension text are now
correctly hidden behind a covering solid, and remain visible when nothing
obstructs them.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
Closes #30249

## Before and After Images
Before:

<img width="2560" height="1575" alt="cropped_screenshot-20260715-225012" src="https://github.com/user-attachments/assets/111fcc69-37b5-4013-b4b5-05fb260e1513" />
<img width="2560" height="1575" alt="cropped_screenshot-20260715-225435" src="https://github.com/user-attachments/assets/3fe1d5e1-c2a0-4848-8140-fbfa551bb1bc" />

After:

<img width="2560" height="1575" alt="cropped_screenshot-20260715-225022" src="https://github.com/user-attachments/assets/4fb7236b-b6ae-49ee-bc1f-009e51d07ddb" />
<img width="2560" height="1575" alt="cropped_screenshot-20260715-225448" src="https://github.com/user-attachments/assets/12583ad0-4683-47a6-be0e-77394944aba6" />