### PR TITLE
PD: Remove deprecated PD Datum suggestions

### DIFF
--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -159,20 +159,6 @@ void Workbench::activated()
         "PartDesign_Body"
     ));
 
-    const char* Vertex1[] = {
-        "PartDesign_Point",
-        "PartDesign_Line",
-        "PartDesign_Plane",
-        "PartDesign_CoordinateSystem",
-        nullptr
-    };
-    Watcher.push_back(new Gui::TaskView::TaskWatcherCommands(
-        "SELECT Part::Feature SUBELEMENT Vertex COUNT 1..",
-        Vertex1,
-        "Datum objects",
-        "PartDesign_CoordinateSystem"
-    ));
-
     const char* Edge[] = {
         "PartDesign_Fillet",
         "PartDesign_Chamfer",
@@ -187,20 +173,6 @@ void Workbench::activated()
         Edge,
         "Edge Tools",
         "PartDesign_Body"
-    ));
-
-    const char* Edge1[] = {
-        "PartDesign_Point",
-        "PartDesign_Line",
-        "PartDesign_Plane",
-        "PartDesign_CoordinateSystem",
-        nullptr
-    };
-    Watcher.push_back(new Gui::TaskView::TaskWatcherCommands(
-        "SELECT Part::Feature SUBELEMENT Edge COUNT 1..",
-        Edge1,
-        "Datum objects",
-        "PartDesign_CoordinateSystem"
     ));
 
     const char* Face[] = {
@@ -220,20 +192,6 @@ void Workbench::activated()
         Face,
         "Face Tools",
         "PartDesign_Body"
-    ));
-
-    const char* Face1[] = {
-        "PartDesign_Point",
-        "PartDesign_Line",
-        "PartDesign_Plane",
-        "PartDesign_CoordinateSystem",
-        nullptr
-    };
-    Watcher.push_back(new Gui::TaskView::TaskWatcherCommands(
-        "SELECT Part::Feature SUBELEMENT Face COUNT 1",
-        Face1,
-        "Datum objects",
-        "PartDesign_CoordinateSystem"
     ));
 
     const char* Body[] = {"PartDesign_NewSketch", nullptr};
@@ -282,48 +240,12 @@ void Workbench::activated()
         "PartDesign_Body"
     ));
 
-    const char* Plane3[] = {
-        "PartDesign_Point",
-        "PartDesign_Line",
-        "PartDesign_Plane",
-        "PartDesign_CoordinateSystem",
-        nullptr
-    };
-    Watcher.push_back(new Gui::TaskView::TaskWatcherCommands(
-        "SELECT App::Plane COUNT 1",
-        Plane3,
-        "Datum objects",
-        "PartDesign_CoordinateSystem"
-    ));
-
-    const char* Plane4[] = {
-        "PartDesign_Point",
-        "PartDesign_Line",
-        "PartDesign_Plane",
-        "PartDesign_CoordinateSystem",
-        nullptr
-    };
-    Watcher.push_back(new Gui::TaskView::TaskWatcherCommands(
-        "SELECT PartDesign::Plane COUNT 1",
-        Plane4,
-        "Datum objects",
-        "PartDesign_CoordinateSystem"
-    ));
-
     const char* Line[] = {"Part_DatumPoint", "Part_DatumLine", "Part_DatumPlane", nullptr};
     Watcher.push_back(new Gui::TaskView::TaskWatcherCommands(
         "SELECT PartDesign::Line COUNT 1",
         Line,
         "Helper Tools",
         "PartDesign_Body"
-    ));
-
-    const char* Line1[] = {"PartDesign_Point", "PartDesign_Line", "PartDesign_Plane", nullptr};
-    Watcher.push_back(new Gui::TaskView::TaskWatcherCommands(
-        "SELECT PartDesign::Line COUNT 1",
-        Line1,
-        "Datum objects",
-        "PartDesign_CoordinateSystem"
     ));
 
     const char* Point[]
@@ -333,20 +255,6 @@ void Workbench::activated()
         Point,
         "Helper Tools",
         "PartDesign_Body"
-    ));
-
-    const char* Point1[] = {
-        "PartDesign_Point",
-        "PartDesign_Line",
-        "PartDesign_Plane",
-        "PartDesign_CoordinateSystem",
-        nullptr
-    };
-    Watcher.push_back(new Gui::TaskView::TaskWatcherCommands(
-        "SELECT PartDesign::Point COUNT 1",
-        Point1,
-        "Datum objects",
-        "PartDesign_CoordinateSystem"
     ));
 
     const char* NoSel[] = {"PartDesign_Body", nullptr};


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Removes the task dialog suggestion for the deprecated PartDesign Datums. The "new" core datums are already displayed above.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
<img width="361" height="517" alt="Bildschirmfoto 2026-07-16 um 10 43 28" src="https://github.com/user-attachments/assets/002b37ce-52e7-4428-9f91-f94889aaccaf" />

<img width="415" height="399" alt="Bildschirmfoto 2026-07-16 um 10 54 06" src="https://github.com/user-attachments/assets/fef2a463-915f-42e4-828b-345cce6bb62a" />



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
