### PR TITLE
Sketcher: Increase contrast of default face color

### DIFF
--- a/src/Gui/PreferencePackTemplates/Sketcher_Colors.cfg
+++ b/src/Gui/PreferencePackTemplates/Sketcher_Colors.cfg
@@ -3,6 +3,13 @@
   <FCParamGroup Name="Root">
     <FCParamGroup Name="BaseApp">
       <FCParamGroup Name="Preferences">
+        <FCParamGroup Name="Mod">
+          <FCParamGroup Name="Sketcher">
+            <FCParamGroup Name="General">
+              <FCUInt Name="SketchFaceColor" Value="4120838208"/>
+            </FCParamGroup>
+          </FCParamGroup>
+        </FCParamGroup>
         <FCParamGroup Name="View">
           <FCUInt Name="SketchEdgeColor" Value="4294967295"/>
           <FCUInt Name="SketchVertexColor" Value="4294967295"/>

--- a/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
@@ -66,6 +66,7 @@
             <FCParamGroup Name="General">
               <FCUInt Name="GridDivLineColor" Value="1230002175"/>
               <FCUInt Name="GridLineColor" Value="1230002175"/>
+              <FCUInt Name="SketchFaceColor" Value="4292098880"/>
             </FCParamGroup>
           </FCParamGroup>
           <FCParamGroup Name="Spreadsheet">

--- a/src/Gui/PreferencePacks/FreeCAD Light/FreeCAD Light.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Light/FreeCAD Light.cfg
@@ -70,6 +70,7 @@
             <FCParamGroup Name="General">
               <FCUInt Name="GridDivLineColor" Value="3082800383"/>
               <FCUInt Name="GridLineColor" Value="3082800383"/>
+              <FCUInt Name="SketchFaceColor" Value="4120838208"/>
             </FCParamGroup>
           </FCParamGroup>
           <FCParamGroup Name="Spreadsheet">

--- a/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
@@ -965,10 +965,10 @@
          <string>Color of internal faces formed by intersecting geometry or closed loops in the sketch</string>
         </property>
         <property name="color" stdset="0">
-         <color alpha="62">
-          <red>84</red>
-          <green>171</green>
-          <blue>255</blue>
+         <color alpha="64">
+          <red>245</red>
+          <green>159</green>
+          <blue>0</blue>
          </color>
         </property>
         <property name="prefEntry" stdset="0">

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -199,7 +199,7 @@ void ViewProviderSketch::ParameterObserver::updateShapeAppearanceProperty(const 
     auto matProp = static_cast<App::PropertyMaterialList*>(property);
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
-    unsigned long shcol = hGrp->GetUnsigned(string.c_str(), 0x54abff40);
+    unsigned long shcol = hGrp->GetUnsigned(string.c_str(), 0xf59f0040);
     float r = ((shcol >> 24) & 0xff) / 255.0;
     float g = ((shcol >> 16) & 0xff) / 255.0;
     float b = ((shcol >> 8) & 0xff) / 255.0;


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
The blue of the Make Internal faces in Sketcher makes it difficult to spot preselection and selection color.
This changes it to an amber color which has good contrast against the background (classic, light, dark), the default shape color and (pre)selection colors. It is also a bit darker than the yellow "show plane" color for sketches.

The color is set in both themes and for resetting the preferences.
- Light/default/safe mode: #F59F00 at 25% opacity
- Dark theme: #FFD43B at 25% opacity

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
#### Before:

https://github.com/user-attachments/assets/8de2cef2-f9e6-4b46-89a3-5bba6ee024be


#### After:

https://github.com/user-attachments/assets/569c5605-57b2-4b7f-9cdf-1f5d456413b4

https://github.com/user-attachments/assets/234bff08-dfc2-4299-aa27-86b185da683e



With show plane TRUE:
<img width="657" height="649" alt="Bildschirmfoto 2026-07-16 um 11 08 23" src="https://github.com/user-attachments/assets/dc5e4c46-4231-4bbf-91a8-e4ffc2c0ac46" />


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
