### PR TITLE
CAM: Engrave - Allow to select shape outside the Job

### DIFF
--- a/src/Mod/CAM/Path/Op/Gui/Engrave.py
+++ b/src/Mod/CAM/Path/Op/Gui/Engrave.py
@@ -27,7 +27,6 @@ import Path
 import Path.Op.Engrave as PathEngrave
 import Path.Op.Gui.Base as PathOpGui
 import PathGui
-import PathScripts.PathUtils as PathUtils
 
 from PySide import QtCore, QtGui
 
@@ -68,14 +67,7 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
         added = False
         shapes = self.obj.BaseShapes
         for sel in selection:
-            job = PathUtils.findParentJob(self.obj)
-            base = job.Proxy.resourceClone(job, sel.Object)
-            if not base:
-                Path.Log.notice(
-                    (translate("CAM", "%s is not a Base Model object of the job %s") + "\n")
-                    % (sel.Object.Label, job.Label)
-                )
-                continue
+            base = sel.Object
             if base in shapes:
                 Path.Log.notice(
                     (translate("CAM", "Base shape %s already in the list") + "\n")

--- a/src/Mod/CAM/Path/Op/Gui/Vcarve.py
+++ b/src/Mod/CAM/Path/Op/Gui/Vcarve.py
@@ -59,16 +59,12 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
         added = False
         shapes = self.obj.BaseShapes
         for sel in selection:
-            job = PathUtils.findParentJob(self.obj)
-            base = job.Proxy.resourceClone(job, sel.Object)
-            if not base:
-                Path.Log.notice(
-                    (translate("CAM", "%s is not a Base Model object of the job %s") + "\n")
-                    % (sel.Object.Label, job.Label)
-                )
-                continue
+            base = sel.Object
             if base in shapes:
-                Path.Log.notice("Base shape %s already in the list".format(sel.Object.Label))
+                Path.Log.notice(
+                    (translate("CAM", "Base shape %s already in the list") + "\n")
+                    % (sel.Object.Label)
+                )
                 continue
             if base.isDerivedFrom("Part::Part2DObject"):
                 if sel.HasSubObjects:


### PR DESCRIPTION
**Profile**, **Pocket_Shape**, **Adaptive** allows to select geometry from model which not in group `Job.Model`
**Engrave** and **Vcarve** restrict this
I suggest to change this

Often **Engrave** uses with imported **SVG**
In this case there is no reason to keep clone of geometry and it obvious to use it directly