### PR TITLE
CI: fix Pixi Linux runtime library lookup

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupCoin3D.cmake
+++ b/cMake/FreeCAD_Helpers/SetupCoin3D.cmake
@@ -126,6 +126,12 @@ macro(SetupBundledCoinPivy)
         "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/3rdParty/coin/include>"
         "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/3rdParty/coin/include>"
     )
+    if (UNIX AND NOT APPLE)
+        # Coin directly loads sibling libraries such as libEGL.  The RUNPATH of
+        # a library that loads Coin is not used to resolve Coin's dependencies.
+        # Keep the bundled library relocatable in both Pixi and AppImage installs.
+        set_property(TARGET Coin PROPERTY INSTALL_RPATH "$ORIGIN")
+    endif ()
     install(TARGETS Coin
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} NAMELINK_SKIP


### PR DESCRIPTION
## Changes

- Give bundled Coin an `$ORIGIN` install RUNPATH on Linux and other non-macOS Unix platforms.
- Keep Coin’s runtime dependency lookup relocatable in both Pixi and AppImage installations.
- Avoid changing `LD_LIBRARY_PATH` globally.
- Avoid relying on the runner’s system EGL installation.

## Root cause

Bundled `libCoin.so` directly depends on `libEGL.so.1`.

During installation, CMake removed Coin’s build-time runtime path and replaced it with an empty RUNPATH. Although the FreeCAD library loading Coin has its own runtime path, RUNPATH is not inherited when resolving Coin’s direct dependencies.

Consequently, the loader fell back to the host system for `libEGL.so.1`. The Pixi Ubuntu CI began failing when the updated runner image no longer provided that system fallback, despite Pixi already containing `libEGL.so.1`.

## Fix

Set bundled Coin’s install RUNPATH to `$ORIGIN`.

Coin and its runtime dependencies are installed together in the same library directory:

- `${CONDA_PREFIX}/lib` in the Pixi environment
- `AppDir/usr/lib` in the AppImage

Using `$ORIGIN` therefore expresses the actual installation layout while keeping the result relocatable.

Related: https://github.com/FreeCAD/FreeCAD/pull/31187