### PR TITLE
TechDraw: Fix section line color

### DIFF
--- a/src/Mod/TechDraw/Gui/QGISectionLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.cpp
@@ -97,15 +97,18 @@ void QGISectionLine::draw()
     update();
 }
 
+//! makes the small lines connecting the ends of the main section line to the arrowheads.
 void QGISectionLine::makeExtensionLine()
 {
-    QPen extendPen;
-    extendPen.setWidthF(getWidth());
-    extendPen.setColor(getSectionColor());
-    extendPen.setStyle(Qt::SolidLine);
-    extendPen.setCapStyle(Qt::FlatCap);
+    // start with the current settings for the rest of the graphic
+    QPen extendPen{m_pen};
+
+    // change the unique attributes
+    extendPen.setStyle(Qt::SolidLine);      // main section line might not be continuous, but arrow shafts should be
+    extendPen.setCapStyle(Qt::FlatCap);     // prevents ugly overlaps at main line and arrow points
     m_extend->setPen(extendPen);
 
+    // make the lines
     QPainterPath pp;
 
     pp.moveTo(m_beginExt1);

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -856,8 +856,7 @@ void QGIViewPart::drawComplexSectionLine(TechDraw::DrawViewSection* viewSection,
     QGISectionLine* sectionLine = new QGISectionLine();
     addToGroupWithoutUpdate(sectionLine);
     sectionLine->setSymbol(const_cast<char*>(viewSection->SectionSymbol.getValue()));
-    Base::Color color = Preferences::getAccessibleColor(vp->SectionLineColor.getValue());
-    sectionLine->setSectionColor(color.asValue<QColor>());
+
     sectionLine->setPathMode(true);
     sectionLine->setPath(wirePath);
     sectionLine->setEnds(vStart, vEnd);
@@ -884,6 +883,9 @@ void QGIViewPart::drawComplexSectionLine(TechDraw::DrawViewSection* viewSection,
     } else {
         sectionLine->setShowLine(false);
     }
+
+    Base::Color color = Preferences::getAccessibleColor(vp->SectionLineColor.getValue());
+    sectionLine->setSectionColor(color.asValue<QColor>());
 
     auto font = sectionVp->SectionLineFont.getValue();
     auto fontSize = sectionVp->SectionLineFontsize.getValue();

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -748,8 +748,6 @@ void QGIViewPart::drawSectionLine(TechDraw::DrawViewSection* viewSection, bool b
         QGISectionLine* sectionLine = new QGISectionLine();
         addToGroupWithoutUpdate(sectionLine);
         sectionLine->setSymbol(const_cast<char*>(viewSection->SectionSymbol.getValue()));
-        Base::Color color = Preferences::getAccessibleColor(vp->SectionLineColor.getValue());
-        sectionLine->setSectionColor(color.asValue<QColor>());
         sectionLine->setPathMode(false);
 
         //make the section line a little longer
@@ -792,6 +790,9 @@ void QGIViewPart::drawSectionLine(TechDraw::DrawViewSection* viewSection, bool b
         } else {
             sectionLine->setShowLine(false);
         }
+
+        Base::Color color = Preferences::getAccessibleColor(vp->SectionLineColor.getValue());
+        sectionLine->setSectionColor(color.asValue<QColor>());
 
         auto font = sectionVp->SectionLineFont.getValue();
         auto fontSize = sectionVp->SectionLineFontsize.getValue();


### PR DESCRIPTION
This PR implements a fix for issue #31384.

The fix adjusts the setting of color for simple and complex section lines.

Before:
<img width="944" height="677" alt="SectionLineColor_before" src="https://github.com/user-attachments/assets/337d4bab-77e0-4af5-9be0-57af377b21a7" />

After:
<img width="1014" height="745" alt="SectionLineColor_after" src="https://github.com/user-attachments/assets/42d18374-df99-4d6a-85cc-a4a05566889c" />


- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

