### PR TITLE
Part: avoid angular deflection warning while typing

### DIFF
--- a/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
@@ -47,6 +47,7 @@ DlgSettings3DViewPart::DlgSettings3DViewPart(QWidget* parent)
     , checkValue(false)
 {
     ui->setupUi(this);
+    ui->maxAngularDeflection->setKeyboardTracking(false);
     connect(
         ui->maxDeviation,
         qOverload<double>(&QDoubleSpinBox::valueChanged),

--- a/tests/src/Mod/Part/CMakeLists.txt
+++ b/tests/src/Mod/Part/CMakeLists.txt
@@ -2,6 +2,10 @@
 
 add_subdirectory(App)
 
+if(BUILD_GUI)
+    add_subdirectory(Gui)
+endif()
+
 target_link_libraries(Part_tests_run
     GTest::gtest_main
     ${Python3_LIBRARIES}

--- a/tests/src/Mod/Part/Gui/CMakeLists.txt
+++ b/tests/src/Mod/Part/Gui/CMakeLists.txt
@@ -1,0 +1,5 @@
+setup_qt_test(DlgSettings3DViewPart)
+
+target_link_libraries(DlgSettings3DViewPart_Tests_run
+    PartGui
+)

--- a/tests/src/Mod/Part/Gui/DlgSettings3DViewPart.cpp
+++ b/tests/src/Mod/Part/Gui/DlgSettings3DViewPart.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <QApplication>
+#include <QDoubleSpinBox>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QTest>
+#include <QTimer>
+
+#include <Mod/Part/Gui/DlgSettings3DViewPartImp.h>
+#include <src/App/InitApplication.h>
+
+class TestDlgSettings3DViewPart: public QObject
+{
+    Q_OBJECT
+
+public:
+    TestDlgSettings3DViewPart()
+    {
+        tests::initApplication();
+    }
+
+private Q_SLOTS:
+    void angularDeflectionWaitsForEditingFinished()
+    {
+        PartGui::DlgSettings3DViewPart page;
+        page.setAttribute(Qt::WA_DontShowOnScreen);
+        page.show();
+
+        auto* spinBox = page.findChild<QDoubleSpinBox*>("maxAngularDeflection");
+        QVERIFY(spinBox);
+        auto* lineEdit = spinBox->findChild<QLineEdit*>();
+        QVERIFY(lineEdit);
+
+        bool warningShown = false;
+        QTimer closeWarning;
+        connect(&closeWarning, &QTimer::timeout, [&warningShown]() {
+            auto* messageBox = qobject_cast<QMessageBox*>(QApplication::activeModalWidget());
+            if (messageBox) {
+                warningShown = true;
+                messageBox->accept();
+            }
+        });
+        closeWarning.start(1);
+
+        lineEdit->selectAll();
+        QTest::keyClicks(lineEdit, "1");
+        QVERIFY(!warningShown);
+
+        QTest::keyClicks(lineEdit, "5");
+        QTest::keyClick(lineEdit, Qt::Key_Return);
+        QVERIFY(!warningShown);
+
+        lineEdit->selectAll();
+        QTest::keyClicks(lineEdit, "1");
+        QVERIFY(!warningShown);
+
+        QTest::keyClick(lineEdit, Qt::Key_Return);
+        QVERIFY(warningShown);
+        page.hide();
+    }
+};
+
+QTEST_MAIN(TestDlgSettings3DViewPart)
+
+#include "DlgSettings3DViewPart.moc"


### PR DESCRIPTION
Withdrawn. Keeping the local work intact.