### PR TITLE
Gui: guard selection gate removal without GUI app

### DIFF
--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -1198,10 +1198,12 @@ void SelectionSingleton::rmvSelectionGate()
         delete ActiveGate;
         ActiveGate = nullptr;
 
-        if (Gui::Document* doc = Gui::Application::Instance->activeDocument()) {
-            // if a document is about to be closed it has no MDI view any more
-            if (Gui::MDIView* mdi = doc->getActiveView()) {
-                mdi->restoreOverrideCursor();
+        if (Gui::Application::Instance) {
+            if (Gui::Document* doc = Gui::Application::Instance->activeDocument()) {
+                // if a document is about to be closed it has no MDI view any more
+                if (Gui::MDIView* mdi = doc->getActiveView()) {
+                    mdi->restoreOverrideCursor();
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #31395.

The headless GUI selection test can call `rmvSelectionGate()` without a `Gui::Application` instance. Guard the active-document cursor cleanup so gate removal remains safe when the GUI application is unavailable.
