### PR TITLE
Make it possible to invoke multiple tests at once

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2431,8 +2431,8 @@ void parseProgramOptions(int ac, char ** av, const std::string& exe, boost::prog
     ("log-file", boost::program_options::value<std::string>(), "Unlike --write-log this allows logging to an arbitrary file")
     ("user-cfg,u", boost::program_options::value<std::string>(),"User config file to load/save user settings")
     ("system-cfg,s", boost::program_options::value<std::string>(),"System config file to load/save system settings")
-    ("run-test,t", boost::program_options::value<std::string>()->implicit_value(""),"Run a given test case (use 0 (zero) to run all tests). If no argument is provided then return list of all available tests.")
-    ("run-open,r", boost::program_options::value<std::string>()->implicit_value(""),"Run a given test case (use 0 (zero) to run all tests). If no argument is provided then return list of all available tests.  Keeps UI open after test(s) complete.")
+    ("run-test,t", boost::program_options::value<std::vector<std::string>>()->composing()->implicit_value(std::vector<std::string>{""}, ""),"Run one or more test cases (repeat -t for multiple). Use 0 (zero) to run all tests. If no argument is provided then return list of all available tests.")
+    ("run-open,r", boost::program_options::value<std::vector<std::string>>()->composing()->implicit_value(std::vector<std::string>{""}, ""),"Run one or more test cases (repeat -r for multiple). Use 0 (zero) to run all tests. If no argument is provided then return list of all available tests.  Keeps UI open after test(s) complete.")
     ("module-path,M", boost::program_options::value< std::vector<std::string> >()->composing(),"Additional module paths")
     ("macro-path,E", boost::program_options::value< std::vector<std::string> >()->composing(),"Additional macro paths")
     ("python-path,P", boost::program_options::value< std::vector<std::string> >()->composing(),"Additional python paths")
@@ -2659,15 +2659,23 @@ void processProgramOptions(const boost::program_options::variables_map& vm, std:
     }
 
     if (vm.contains("run-test") || vm.contains("run-open")) {
-        std::string testCase = vm.contains("run-open") ? vm["run-open"].as<std::string>() : vm["run-test"].as<std::string>();
+        std::vector<std::string> testCases;
+        for (const std::string& key : {"run-open", "run-test"}) {
+            if (vm.contains(key)) {
+                auto v = vm[key].as<std::vector<std::string>>();
+                testCases.insert(testCases.end(), v.begin(), v.end());
+            }
+        }
 
-        if ( "0" == testCase) {
-            testCase = "TestApp.All";
+        if (testCases.size() == 1) {
+            if (testCases[0] == "0") {
+                testCases[0] = "TestApp.All";
+            }
+            else if (testCases[0].empty()) {
+                testCases[0] = "TestApp.PrintAll";
+            }
         }
-        else if (testCase.empty()) {
-            testCase = "TestApp.PrintAll";
-        }
-        mConfig["TestCase"] = std::move(testCase);
+        mConfig["TestCase"] = boost::join(testCases, ",");
         mConfig["RunMode"] = "Internal";
         mConfig["ScriptFileName"] = "FreeCADTest";
         mConfig["ExitTests"] = vm.contains("run-open") ? "no" : "yes";

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2660,21 +2660,30 @@ void processProgramOptions(const boost::program_options::variables_map& vm, std:
 
     if (vm.contains("run-test") || vm.contains("run-open")) {
         std::vector<std::string> testCases;
+        bool runAll = false;
+        bool printAll = false;
         for (const std::string& key : {"run-open", "run-test"}) {
             if (vm.contains(key)) {
                 auto v = vm[key].as<std::vector<std::string>>();
+                for (const auto& s : v) {
+                    if (s == "0") {
+                        runAll = true;
+                    }
+                    else if (s.empty()) {
+                        printAll = true;
+                    }
+                }
                 testCases.insert(testCases.end(), v.begin(), v.end());
             }
         }
 
-        if (testCases.size() == 1) {
-            if (testCases[0] == "0") {
-                testCases[0] = "TestApp.All";
-            }
-            else if (testCases[0].empty()) {
-                testCases[0] = "TestApp.PrintAll";
-            }
+        if (printAll) {
+            testCases = {"TestApp.PrintAll"};
         }
+        else if (runAll) {
+            testCases = {"TestApp.All"};
+        }
+
         mConfig["TestCase"] = boost::join(testCases, ",");
         mConfig["RunMode"] = "Internal";
         mConfig["ScriptFileName"] = "FreeCADTest";

--- a/src/Mod/Test/TestApp.py
+++ b/src/Mod/Test/TestApp.py
@@ -93,8 +93,15 @@ def TestText(s):
 
 
 def RunConfiguredTextTest():
-    test_case = FreeCAD.ConfigGet("TestCase")
-    return TestText(test_case)
+    test_cases = FreeCAD.ConfigGet("TestCase").split(",")
+    if len(test_cases) == 1:
+        return TestText(test_cases[0])
+    suite = unittest.TestSuite()
+    for tc in test_cases:
+        suite.addTest(tryLoadingTest(tc))
+    r = unittest.TextTestRunner(stream=sys.stdout, verbosity=2)
+    sys.stdout.flush()
+    return r.run(suite)
 
 
 def Test(s):


### PR DESCRIPTION
Fixes: #31401

This PR makes it possible to run multiple groups of tests by specifying the `-t` or `-r` flag multiple times.

```
$ ./bin/FreeCAD -t CAMTests.TestPathAdaptive --console
...
Ran 16 tests in 3.820s

```

```
$ ./bin/FreeCAD -t CAMTests.TestAreaOperations --console
...
Ran 15 tests in 0.001s
```

```
$ ./bin/FreeCAD -t CAMTests.TestPathAdaptive -t CAMTests.TestAreaOperations --console
...
Ran 31 tests in 3.821s
```