### PR TITLE
CAM: DressupRampEntry - Ramp angle from horizont

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py
@@ -90,6 +90,12 @@ class ObjectDressup:
                 " but motion commands are passed through as is.",
             ),
         )
+        obj.addProperty(
+            "App::PropertyBool",
+            "RampVertical",
+            "Path",
+            QT_TRANSLATE_NOOP("App::Property", "Calculate ramp angle from vertical plane"),
+        )
 
         # populate the enumerations
         for n in self.propertyEnumerations():
@@ -142,7 +148,7 @@ class ObjectDressup:
         return None
 
     def onChanged(self, obj, prop):
-        if prop == "UseStartDepth":
+        if prop == "UseStartDepth" and not obj.Document.Restoring:
             self.setEditorProperties(obj)
         if prop == "Path" and obj.ViewObject:
             obj.ViewObject.signalChangeIcon()
@@ -150,10 +156,9 @@ class ObjectDressup:
     def setEditorProperties(self, obj):
         mode = 0 if obj.UseStartDepth else 2
         obj.setEditorMode("DressupStartDepth", mode)
+        obj.setEditorMode("RampVertical", 2)
 
     def onDocumentRestored(self, obj):
-        self.setEditorProperties(obj)
-
         # Remove RampFeedRate + CustomFeedRate properties, but keep the values around temporarily
         # This is required for tool controller migration: if a TC migrates with onDocumentRestored
         # called after this, the prior ramp feed rate still needs to be accessible.
@@ -168,6 +173,17 @@ class ObjectDressup:
                     tmp = exp
             obj.Proxy.CustomFeedRate = tmp
             obj.removeProperty("CustomFeedRate")
+
+        if not hasattr(obj, "RampVertical"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "RampVertical",
+                "Path",
+                QT_TRANSLATE_NOOP("App::Property", "Calculate ramp angle from vertical plane"),
+            )
+            obj.RampVertical = True
+
+        self.setEditorProperties(obj)
 
     def setup(self, obj):
         obj.Angle = 60
@@ -196,10 +212,12 @@ class ObjectDressup:
         elif obj.Angle <= 0:
             obj.Angle = 0.1
 
+        angle_rad = math.radians(obj.Angle.Value)
+
         args = {
             "commands": PathUtils.getPathWithPlacement(obj.Base).Commands,
             "method": obj.Proxy.propertyEnumerations(dataType="data")[0][1].index(obj.Method),
-            "angle_rad": math.pi / 2 - math.radians(obj.Angle.Value),
+            "angle_rad": math.pi / 2 - angle_rad if obj.RampVertical else angle_rad,
             "tc": PathDressup.toolController(obj.Base),
             "ignoreAbove": obj.DressupStartDepth.Value if obj.UseStartDepth else None,
         }

--- a/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py
@@ -23,9 +23,9 @@ import FreeCAD
 import FreeCADGui
 import Path
 import Path.Dressup.Utils as PathDressup
-import PathScripts.PathUtils as PathUtils
 
 from Path.Base.Generator.ramp_entry import RampEntry
+from PathScripts import PathUtils
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import math
@@ -130,7 +130,7 @@ class ObjectDressup:
         if dataType == "raw":
             return enums
 
-        data = list()
+        data = []
         idx = 0 if dataType == "translated" else 1
 
         Path.Log.debug(enums)


### PR DESCRIPTION
In **Helix** op and **Adaptive** op ramp angle calculates from horizontal plane
In **DressupRampEntry** ramp angle calculates from vertical plane
Suggested to align this

### Changes 
Added hidden property `RampVertical` to keep behavior in old projects

https://github.com/FreeCAD/FreeCAD/blob/15bc96ae8ff1447f994a2e00319dcbae9a874231/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py#L215-L218

---

<img width="802" height="498" alt="Screenshot_20260718_102002_hor_lossy" src="https://github.com/user-attachments/assets/db9e21bf-7709-42bc-b5b6-a6533a727b42" />


