### PR TITLE
Add dimension constraint line style preferences

### DIFF
--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -220,6 +220,7 @@ SoDatumLabel::SoDatumLabel()
     SO_NODE_ADD_FIELD(name, ("osifont"));
     SO_NODE_ADD_FIELD(size, (10.F));
     SO_NODE_ADD_FIELD(lineWidth, (2.F));
+    SO_NODE_ADD_FIELD(linePattern, (0b1111111111111111));
     SO_NODE_ADD_FIELD(sampling, (2.F));
 
     SO_NODE_ADD_FIELD(datumtype, (SoDatumLabel::DISTANCE));
@@ -264,6 +265,7 @@ SoDatumLabel::SoDatumLabel()
     m_Root->addChild(m_GeometryColor);
 
     m_DrawStyle = new SoDrawStyle;
+    m_DrawStyle->linePattern.connectFrom(&this->linePattern);
     m_DrawStyle->lineWidth.connectFrom(&this->lineWidth);
     m_Root->addChild(m_DrawStyle);
 

--- a/src/Gui/SoDatumLabel.h
+++ b/src/Gui/SoDatumLabel.h
@@ -28,6 +28,7 @@
 #include <Inventor/fields/SoSFColor.h>
 #include <Inventor/fields/SoSFEnum.h>
 #include <Inventor/fields/SoSFFloat.h>
+#include <Inventor/fields/SoSFUShort.h>
 #include <Inventor/fields/SoSFImage.h>
 #include <Inventor/fields/SoSFInt32.h>
 #include <Inventor/fields/SoSFName.h>
@@ -103,6 +104,7 @@ public:
     SoSFImage image;
     SoSFFloat lineWidth;
     SoSFFloat sampling;
+    SoSFUShort linePattern;
     bool useAntialiasing;
 
 protected:

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -550,6 +550,10 @@ void EditModeCoinManager::ParameterObserver::initParameters()
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
              updateWidth(drawingParameters.ExternalWidth, param, 2);
          }},
+        {"DimensionalConstraintLineWidth",
+         [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
+             updateWidth(drawingParameters.DimensionalConstraintLineWidth, param, 2);
+         }},
         {"ExternalDefiningWidth",
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
              updateWidth(drawingParameters.ExternalDefiningWidth, param, 2);
@@ -561,6 +565,10 @@ void EditModeCoinManager::ParameterObserver::initParameters()
         {"EdgePattern",
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
              updatePattern(drawingParameters.CurvePattern, param, 0b1111111111111111);
+         }},
+        {"DimensionalConstraintLinePattern",
+         [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
+             updatePattern(drawingParameters.DimensionalConstraintLinePattern, param, 0b1111111111111111);
          }},
         {"ConstructionPattern",
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
@@ -2241,6 +2249,8 @@ void EditModeCoinManager::updateInventorWidths()
         = drawingParameters.ExternalDefiningWidth * drawingParameters.pixelScalingFactor;
     editModeScenegraphNodes.InformationDrawStyle->lineWidth = drawingParameters.InformationWidth
         * drawingParameters.pixelScalingFactor;
+    editModeScenegraphNodes.CurvesExternalDefiningDrawStyle->lineWidth
+        = drawingParameters.ExternalDefiningWidth * drawingParameters.pixelScalingFactor;
 }
 
 void EditModeCoinManager::updateInventorPatterns()

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -550,6 +550,10 @@ void EditModeCoinManager::ParameterObserver::initParameters()
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
              updateWidth(drawingParameters.ExternalWidth, param, 2);
          }},
+        {"DimensionalConstraintLineWidth",
+         [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
+             updateWidth(drawingParameters.DimensionalConstraintLineWidth, param, 2);
+         }},
         {"ExternalDefiningWidth",
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
              updateWidth(drawingParameters.ExternalDefiningWidth, param, 2);
@@ -561,6 +565,10 @@ void EditModeCoinManager::ParameterObserver::initParameters()
         {"EdgePattern",
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
              updatePattern(drawingParameters.CurvePattern, param, 0b1111111111111111);
+         }},
+        {"DimensionalConstraintLinePattern",
+         [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
+             updatePattern(drawingParameters.DimensionalConstraintLinePattern, param, 0b1111111111111111);
          }},
         {"ConstructionPattern",
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
@@ -2247,6 +2255,8 @@ void EditModeCoinManager::updateInventorWidths()
         = drawingParameters.ExternalDefiningWidth * drawingParameters.pixelScalingFactor;
     editModeScenegraphNodes.InformationDrawStyle->lineWidth = drawingParameters.InformationWidth
         * drawingParameters.pixelScalingFactor;
+    editModeScenegraphNodes.CurvesExternalDefiningDrawStyle->lineWidth
+        = drawingParameters.ExternalDefiningWidth * drawingParameters.pixelScalingFactor;
 }
 
 void EditModeCoinManager::updateInventorPatterns()

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -147,12 +147,13 @@ struct DrawingParameters
     // transparency of axis when occluded
     float occludedAxisTransparency = 0.9f;
 
-    int CurveWidth = 2;             // width of normal edges
-    int ConstructionWidth = 1;      // width of construction edges
-    int InternalWidth = 1;          // width of internal edges
-    int ExternalWidth = 1;          // width of external edges
-    int ExternalDefiningWidth = 1;  // width of external defining edges
-    int InformationWidth = 1;       // width of information edges
+    int CurveWidth = 2;                      // width of normal edges
+    int ConstructionWidth = 1;               // width of construction edges
+    int InternalWidth = 1;                   // width of internal edges
+    int ExternalWidth = 1;                   // width of external edges
+    int ExternalDefiningWidth = 1;           // width of external defining edges
+    int InformationWidth = 1;                // width of information edges
+    int DimensionalConstraintLineWidth = 2;  // width of dimensional constraint lines
 
     unsigned int CurvePattern = 0b1111111111111111;             // pattern of normal edges
     unsigned int ConstructionPattern = 0b1111110011111100;      // pattern of construction edges
@@ -160,6 +161,8 @@ struct DrawingParameters
     unsigned int ExternalPattern = 0b1111110011111100;          // pattern of external edges
     unsigned int ExternalDefiningPattern = 0b1111111111111111;  // pattern of external defining edges
     unsigned int InformationPattern = 0b1111110011111100;  // pattern of information layer edges
+    unsigned int DimensionalConstraintLinePattern = 0b1111111111111111;  // pattern of dimensional
+                                                                         // constraints lines
     //@}
 
     DrawingParameters()

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -147,19 +147,22 @@ struct DrawingParameters
     // transparency of axis when occluded
     float occludedAxisTransparency = 0.9f;
 
-    int CurveWidth = 2;             // width of normal edges
-    int ConstructionWidth = 1;      // width of construction edges
-    int InternalWidth = 1;          // width of internal edges
-    int ExternalWidth = 1;          // width of external edges
-    int ExternalDefiningWidth = 1;  // width of external defining edges
-    int InformationWidth = 1;       // width of information edges
+    int CurveWidth = 2;                      // width of normal edges
+    int ConstructionWidth = 1;               // width of construction edges
+    int InternalWidth = 1;                   // width of internal edges
+    int ExternalWidth = 1;                   // width of external edges
+    int ExternalDefiningWidth = 1;           // width of external defining edges
+    int InformationWidth = 1;                // width of information edges
+    int DimensionalConstraintLineWidth = 2;  // width of dimensional constraint lines
 
     unsigned int CurvePattern = 0b1111111111111111;             // pattern of normal edges
     unsigned int ConstructionPattern = 0b1111110011111100;      // pattern of construction edges
     unsigned int InternalPattern = 0b1111110011111100;          // pattern of internal edges
     unsigned int ExternalPattern = 0b1111110011111100;          // pattern of external edges
     unsigned int ExternalDefiningPattern = 0b1111111111111111;  // pattern of external defining edges
-    unsigned int InformationPattern = 0b1111110011111100;  // pattern of information layer edges
+    unsigned int InformationPattern = 0b1111110011111100;       // pattern of information layer edges
+    unsigned int DimensionalConstraintLinePattern = 0b1111111111111111;  // pattern of dimensional
+                                                                         // constraints lines
     //@}
 
     DrawingParameters()

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -160,7 +160,7 @@ struct DrawingParameters
     unsigned int InternalPattern = 0b1111110011111100;          // pattern of internal edges
     unsigned int ExternalPattern = 0b1111110011111100;          // pattern of external edges
     unsigned int ExternalDefiningPattern = 0b1111111111111111;  // pattern of external defining edges
-    unsigned int InformationPattern = 0b1111110011111100;       // pattern of information layer edges
+    unsigned int InformationPattern = 0b1111110011111100;  // pattern of information layer edges
     unsigned int DimensionalConstraintLinePattern = 0b1111111111111111;  // pattern of dimensional
                                                                          // constraints lines
     //@}

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -1954,7 +1954,9 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                     text->name.setValue(drawingParameters.labelFontName.toStdString().c_str());
                 }
                 text->size.setValue(drawingParameters.labelFontSize);
-                text->lineWidth = 2 * drawingParameters.pixelScalingFactor;
+                text->lineWidth = drawingParameters.DimensionalConstraintLineWidth
+                    * drawingParameters.pixelScalingFactor;
+                text->linePattern = drawingParameters.DimensionalConstraintLinePattern;
                 text->useAntialiasing = false;
                 sep->addChild(text);
                 editModeScenegraphNodes.constrGroup->addChild(sep);

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -687,6 +687,8 @@ SketcherSettingsAppearance::SketcherSettingsAppearance(QWidget* parent)
     ui->ExternalDefiningPattern->setItemDelegate(lineStyleDelegate);
     ui->InformationPattern->setIconSize(LineIconSize);
     ui->InformationPattern->setItemDelegate(lineStyleDelegate);
+    ui->DimensionalConstraintLinePattern->setIconSize(LineIconSize);
+    ui->DimensionalConstraintLinePattern->setItemDelegate(lineStyleDelegate);
 
     for (auto style : PenStyles) {
         ui->EdgePattern->addItem(QString(), QVariant(style.pattern));
@@ -695,6 +697,7 @@ SketcherSettingsAppearance::SketcherSettingsAppearance(QWidget* parent)
         ui->ExternalPattern->addItem(QString(), QVariant(style.pattern));
         ui->ExternalDefiningPattern->addItem(QString(), QVariant(style.pattern));
         ui->InformationPattern->addItem(QString(), QVariant(style.pattern));
+        ui->DimensionalConstraintLinePattern->addItem(QString(), QVariant(style.pattern));
     }
 }
 
@@ -727,6 +730,7 @@ bool SketcherSettingsAppearance::event(QEvent* event)
             ui->ExternalPattern->setItemIcon(i, icon);
             ui->ExternalDefiningPattern->setItemIcon(i, icon);
             ui->InformationPattern->setItemIcon(i, icon);
+            ui->DimensionalConstraintLinePattern->setItemIcon(i, icon);
         }
         return true;
     }
@@ -767,6 +771,7 @@ void SketcherSettingsAppearance::saveSettings()
     ui->ExternalWidth->onSave();
     ui->ExternalDefiningWidth->onSave();
     ui->InformationWidth->onSave();
+    ui->DimensionalConstraintLineWidth->onSave();
 
     ui->InternalFaceColor->onSave();
 
@@ -796,6 +801,12 @@ void SketcherSettingsAppearance::saveSettings()
     data = ui->InformationPattern->itemData(ui->InformationPattern->currentIndex());
     pattern = data.toInt();
     hGrp->SetInt("InformationPattern", pattern);
+
+    data = ui->DimensionalConstraintLinePattern->itemData(
+        ui->DimensionalConstraintLinePattern->currentIndex()
+    );
+    pattern = data.toInt();
+    hGrp->SetInt("DimensionalConstraintLinePattern", pattern);
 }
 
 void SketcherSettingsAppearance::loadSettings()
@@ -832,6 +843,7 @@ void SketcherSettingsAppearance::loadSettings()
     ui->ExternalWidth->onRestore();
     ui->ExternalDefiningWidth->onRestore();
     ui->InformationWidth->onRestore();
+    ui->DimensionalConstraintLineWidth->onRestore();
 
     ui->InternalFaceColor->setAllowTransparency(true);
     ui->InternalFaceColor->onRestore();
@@ -880,6 +892,13 @@ void SketcherSettingsAppearance::loadSettings()
         index = 0;
     }
     ui->InformationPattern->setCurrentIndex(index);
+
+    pattern = hGrp->GetInt("DimensionalConstraintLinePattern", 0b1111111111111111);
+    index = ui->DimensionalConstraintLinePattern->findData(QVariant(pattern));
+    if (index < 0) {
+        index = 0;
+    }
+    ui->DimensionalConstraintLinePattern->setCurrentIndex(index);
 }
 
 /**

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -688,6 +688,9 @@ SketcherSettingsAppearance::SketcherSettingsAppearance(QWidget* parent)
     ui->ExternalDefiningPattern->setItemDelegate(lineStyleDelegate);
     ui->InformationPattern->setIconSize(LineIconSize);
     ui->InformationPattern->setItemDelegate(lineStyleDelegate);
+    ui->DimensionalConstraintLinePattern->setIconSize(LineIconSize);
+    ui->DimensionalConstraintLinePattern->setItemDelegate(lineStyleDelegate);
+
     const QBrush brush = palette().windowText();
     for (auto style : PenStyles) {
         ui->EdgePattern->addItem(QString(), QVariant(style.pattern));
@@ -696,6 +699,7 @@ SketcherSettingsAppearance::SketcherSettingsAppearance(QWidget* parent)
         ui->ExternalPattern->addItem(QString(), QVariant(style.pattern));
         ui->ExternalDefiningPattern->addItem(QString(), QVariant(style.pattern));
         ui->InformationPattern->addItem(QString(), QVariant(style.pattern));
+        ui->DimensionalConstraintLinePattern->addItem(QString(), QVariant(style.pattern));
     }
 }
 
@@ -721,6 +725,7 @@ bool SketcherSettingsAppearance::event(QEvent* event)
             ui->ExternalPattern->setItemIcon(i, icon);
             ui->ExternalDefiningPattern->setItemIcon(i, icon);
             ui->InformationPattern->setItemIcon(i, icon);
+            ui->DimensionalConstraintLinePattern->setItemIcon(i, icon);
         }
         return true;
     }
@@ -761,6 +766,7 @@ void SketcherSettingsAppearance::saveSettings()
     ui->ExternalWidth->onSave();
     ui->ExternalDefiningWidth->onSave();
     ui->InformationWidth->onSave();
+    ui->DimensionalConstraintLineWidth->onSave();
 
     ui->InternalFaceColor->onSave();
 
@@ -790,6 +796,12 @@ void SketcherSettingsAppearance::saveSettings()
     data = ui->InformationPattern->itemData(ui->InformationPattern->currentIndex());
     pattern = data.toInt();
     hGrp->SetInt("InformationPattern", pattern);
+
+    data = ui->DimensionalConstraintLinePattern->itemData(
+        ui->DimensionalConstraintLinePattern->currentIndex()
+    );
+    pattern = data.toInt();
+    hGrp->SetInt("DimensionalConstraintLinePattern", pattern);
 }
 
 void SketcherSettingsAppearance::loadSettings()
@@ -826,6 +838,7 @@ void SketcherSettingsAppearance::loadSettings()
     ui->ExternalWidth->onRestore();
     ui->ExternalDefiningWidth->onRestore();
     ui->InformationWidth->onRestore();
+    ui->DimensionalConstraintLineWidth->onRestore();
 
     ui->InternalFaceColor->setAllowTransparency(true);
     ui->InternalFaceColor->onRestore();
@@ -874,6 +887,13 @@ void SketcherSettingsAppearance::loadSettings()
         index = 0;
     }
     ui->InformationPattern->setCurrentIndex(index);
+
+    pattern = hGrp->GetInt("DimensionalConstraintLinePattern", 0b1111111111111111);
+    index = ui->DimensionalConstraintLinePattern->findData(QVariant(pattern));
+    if (index < 0) {
+        index = 0;
+    }
+    ui->DimensionalConstraintLinePattern->setCurrentIndex(index);
 }
 
 /**

--- a/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
@@ -815,6 +815,143 @@
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
        <layout class="QGridLayout" name="gridLayout_2">
+        <item row="1" column="0">
+          <widget class="QLabel" name="labelOtherItem">
+            <property name="minimumSize">
+            <size>
+              <width>200</width>
+              <height>0</height>
+            </size>
+            </property>
+            <property name="text">
+            <string></string>
+            </property>
+          </widget>
+          </item>
+          <item row="1" column="1">
+          <widget class="QLabel" name="labelOtherColor">
+            <property name="minimumSize">
+            <size>
+              <width>95</width>
+              <height>0</height>
+            </size>
+            </property>
+            <property name="text">
+            <string>Color</string>
+            </property>
+          </widget>
+          </item>
+          <item row="1" column="2">
+          <widget class="QLabel" name="labelOtherSpacing">
+            <property name="minimumSize">
+            <size>
+              <width>105</width>
+              <height>0</height>
+            </size>
+            </property>
+            <property name="text">
+            <string></string>
+            </property>
+          </widget>
+          </item>
+          <item row="1" column="3">
+          <widget class="QLabel" name="labelOtherLinetype">
+            <property name="text">
+            <string>Line Type</string>
+            </property>
+          </widget>
+          </item>
+          <item row="1" column="4">
+          <widget class="QLabel" name="labelOtherWidth">
+            <property name="text">
+            <string>Width</string>
+            </property>
+          </widget>
+          </item>
+          <item row="1" column="5">
+          <spacer name="horizontalSpacer_other">
+            <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+            <size>
+              <width>40</width>
+              <height>20</height>
+            </size>
+            </property>
+          </spacer>
+          </item>
+          <item row="5" column="0">
+          <widget class="QLabel" name="dimensionalConstraintTitle">
+            <property name="minimumSize">
+            <size>
+              <width>200</width>
+              <height>0</height>
+            </size>
+            </property>
+            <property name="text">
+            <string>Dimensional constraints</string>
+            </property>
+          </widget>
+          </item>
+          <item row="5" column="1">
+            <widget class="Gui::PrefColorButton" name="DatumColor">
+              <property name="toolTip">
+              <string>Color of dimensional driving constraints in edit mode</string>
+              </property>
+              <property name="color" stdset="0">
+              <color>
+                <red>255</red>
+                <green>38</green>
+                <blue>0</blue>
+              </color>
+              </property>
+              <property name="prefEntry" stdset="0">
+              <cstring>ConstrainedDimColor</cstring>
+              </property>
+              <property name="prefPath" stdset="0">
+              <cstring>View</cstring>
+              </property>
+            </widget>
+          </item>
+          <item row="5" column="3">
+          <widget class="QComboBox" name="DimensionalConstraintLinePattern">
+            <property name="toolTip">
+            <string>Line pattern of dimensional constraints in edit mode</string>
+            </property>
+            <property name="currentIndex">
+            <number>-1</number>
+            </property>
+          </widget>
+          </item>
+          <item row="5" column="4">
+          <widget class="Gui::PrefSpinBox" name="DimensionalConstraintLineWidth">
+            <property name="toolTip">
+            <string>Width of dimensional constraints in edit mode</string>
+            </property>
+            <property name="unit" stdset="0">
+            <string notr="true">px</string>
+            </property>
+            <property name="suffix">
+            <string notr="true"> px</string>
+            </property>
+            <property name="minimum">
+            <number>1</number>
+            </property>
+            <property name="maximum">
+            <number>4</number>
+            </property>
+            <property name="value">
+            <number>2</number>
+            </property>
+            <property name="prefEntry" stdset="0">
+            <cstring>DimensionalConstraintLineWidth</cstring>
+            </property>
+            <property name="prefPath" stdset="0">
+            <cstring>Mod/Sketcher/View</cstring>
+            </property>
+          </widget>
+        </item>
         <item row="10" column="0">
          <widget class="QLabel" name="label_14">
           <property name="minimumSize">
@@ -842,33 +979,6 @@
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>ConstrainedIcoColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="11" column="0">
-         <widget class="QLabel" name="label_15">
-          <property name="text">
-           <string>Dimensional constraints</string>
-          </property>
-         </widget>
-        </item>
-        <item row="11" column="1">
-         <widget class="Gui::PrefColorButton" name="DatumColor">
-          <property name="toolTip">
-           <string>Color of dimensional driving constraints in edit mode</string>
-          </property>
-          <property name="color" stdset="0">
-           <color>
-            <red>255</red>
-            <green>38</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ConstrainedDimColor</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>View</cstring>


### PR DESCRIPTION
As a user, I want to tone down dominant elements in the scene to match the visual styling I expect or prefer. This update allows users or theme authors to adjust the width and pattern of dimensional constraint lines to achieve this result.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: Claude Sonnet 5

The AI disclosure has been added as required although the bulk of this change comes about from focused personal efforts over many weeks, intent on replicating existing behavior to achieve the desired result.

## Caveats/Concerns
1. Since the dimension constraint lines have arrow endpoint adornments, line widths above a certain size grow bigger than the arrows becoming invalid shapes. Limiting the range can mitigate this but might be unexpected.
2. Logic for line styles is placed in SoDatumLabel and achieves the desired effect but dynamically updating after Preference changes didn't have a clear solution. Feedback in this area could address this limitation. As it is, the scene must be closed and reopened to see the effect of User Preference changes.

## Issues
Related to #18006 
Related to #30685 - in so much as the general gist of `Axis line weight should be user-configurable` was that line weights are far heavier in FreeCAD than anything I've used before, and as a user I can't reduce the noise and tune the visual elements to my preferences

### Sketcher - Before
<img width="600" alt="image" src="https://github.com/user-attachments/assets/4e2050e4-9dd0-4465-8433-52f4b85a3be9" />

### Sketcher - After
<img width="600" alt="image" src="https://github.com/user-attachments/assets/8bcca3a4-79e1-4134-a06d-7969127c089d" />


### Preferences
| Before  | After |
| ---- | ---- |
| <img width="600" alt="image" src="https://github.com/user-attachments/assets/a737074b-a0e5-45c7-bb24-6202e802ecf5" /> |<img width="600" alt="image" src="https://github.com/user-attachments/assets/cd593b53-eeb8-47b5-b35f-1c0519d124d3" />|


