### PR TITLE
[Core (GUI)] Add rich-text formatting to tooltip to force proper text wrapping

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsNotificationArea.ui
+++ b/src/Gui/PreferencePages/DlgSettingsNotificationArea.ui
@@ -29,9 +29,8 @@
       <item row="2" column="0">
        <widget class="QGroupBox" name="NonIntrusiveNotificationsEnabled">
         <property name="toolTip">
-         <string>Enables non-intrusive pop-up notifications above the status bar notification area. Pop-up notifications can be manually dismissed by clicking on them, and also automatically dismissed by specifying a maximum and minimum duration for them to be displayed.
-
-Additionally, pop-up notifications can be disabled. In this case the user can still use the notification area as a quick-access location to view notifications, without the distracton of an additional pop-up.</string>
+         <string>&lt;html&gt;Enables non-intrusive pop-up notifications above the status bar notification area. Pop-up notifications can be manually dismissed by clicking on them, and also automatically dismissed by specifying a maximum and minimum duration for them to be displayed.
+Additionally, pop-up notifications can be disabled. In this case the user can still use the notification area as a quick-access location to view notifications, without the distracton of an additional pop-up.&lt;/html&gt;</string>
         </property>
         <property name="title">
          <string>Enable Pop-Up Notifications</string>

--- a/src/Mod/Draft/Resources/ui/preferences-dwg.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dwg.ui
@@ -97,7 +97,7 @@
       <item>
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Note:&lt;/span&gt; DXF options apply to DWG files as well.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>Note: DXF options apply to DWG files as well.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>


### PR DESCRIPTION
Adds <html></html> tags to a tooltip in the General/Notification Area preferences page. The tooltip was previously formatted as plain text, but due to its length it was rendering poorly and spanning the whole screen. Qt doesn't auto-wrap plain text tooltips, so adding the tags forces it to use rich text formatting which does wrap, like other tooltips on the same page.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
Fixes #31408 

## Before and After Images
Before:
<img width="1761" height="718" alt="Screenshot 2026-07-17 225850" src="https://github.com/user-attachments/assets/d84769df-d652-466b-8904-d935e3d8f436" />

After:
<img width="558" height="296" alt="Screenshot 2026-07-17 225355" src="https://github.com/user-attachments/assets/cdbab405-7a02-479d-a86a-0c2885222663" />


This PR ties in to #31212 which prevents the html tags from showing up in the search results, which are painted as plain text.