### PR TITLE
Sketcher: fix drag snapping to horizontal axis when released over a constraint icon

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2320,7 +2320,8 @@ bool EditModeConstraintCoinManager::resolveIconScreenGeometry(
     // getScreenCoordinates() expects sketch coordinates and applies the editing
     // placement itself.
     SbVec3f iconSketchPos = absPos + scaleFactor * trans;
-    iconScreenCenter = ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, iconSketchPos);
+    iconScreenCenter
+        = ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, iconSketchPos);
 
     if (pickedPoint) {
         // Consumers of pickedPoint (e.g. the mouse press/release handlers, which

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2316,11 +2316,25 @@ bool EditModeConstraintCoinManager::resolveIconScreenGeometry(
         }
     }
 
-    SbVec3f iconWorldPos = absPos + scaleFactor * trans;
-    iconScreenCenter = ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, iconWorldPos);
+    // Position of the icon in sketch-plane (edit scenegraph local) coordinates.
+    // getScreenCoordinates() expects sketch coordinates and applies the editing
+    // placement itself.
+    SbVec3f iconSketchPos = absPos + scaleFactor * trans;
+    iconScreenCenter = ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, iconSketchPos);
 
     if (pickedPoint) {
-        *pickedPoint = Base::convertTo<Base::Vector3d>(iconWorldPos);
+        // Consumers of pickedPoint (e.g. the mouse press/release handlers, which
+        // project it back onto the sketch plane) expect GLOBAL coordinates, so the
+        // sketch-plane position must be transformed by the editing placement. The
+        // icon's z-offset is a rendering artifact and is dropped. Returning the
+        // untransformed position made the drag-commit position collapse onto the
+        // sketch's horizontal axis on any sketch whose plane is not the global XY
+        // plane (geometry "snapping to the horizontal axis" when a drag ended on
+        // top of a constraint icon).
+        Base::Placement placement = ViewProviderSketchCoinAttorney::getEditingPlacement(viewProvider);
+        Base::Vector3d localPoint(iconSketchPos[0], iconSketchPos[1], 0.0);
+        placement.getRotation().multVec(localPoint, localPoint);
+        *pickedPoint = localPoint + placement.getPosition();
     }
 
     return true;


### PR DESCRIPTION
Dragging geometry in a sketch attached to any plane other than the global XY plane sometimes teleports the dragged geometry onto the sketch's horizontal axis when the mouse is released. From what I can tell this issue popped up before and was fixed, but appears to still be an issue.

When I asked AI to trace the history of the issue while researching it gave the following: 
"Since a27c3f0ae9 (2026-05-27, "Sketcher: prefer constraint icons over overlapping geometry", part of #30412), dragging geometry in a sketch attached to any plane other than the global XY plane sometimes teleports the dragged geometry onto the sketch's horizontal axis when the mouse is released. This is the surviving manifestation of the #30412 regression family: reported as #30660 (closed as duplicate of #30606), not covered by the #30608/#30671 fixes that led to #30606 being closed.
is the surviving manifestation of the #30412 regression family: reported as #30660 (closed as duplicate of #30606), not covered by the #30608/#30671 fixes that led to #30606 being closed."

On a sketch attached to any plane other than the global XY plane the round trip collapses the position onto the sketch's horizontal axis (sketch v = icon z-offset ~ 0.004). Releasing a drag with the cursor inside a constraint icon's hit box when dragging an edge near its midpoint, where its Horizontal/Vertical icon is drawn -- then committed the drag to that corrupted position, teleporting the dragged geometry onto the horizontal axis.

Transform the icon position by the editing placement before returning it, mirroring sketchPlanePointToWorld() used by the other preselection paths, and rename the misleading iconWorldPos variable to iconSketchPos (getScreenCoordinates() expects sketch coordinates and applies the placement itself, so the screen-space hit test was already correct).

ROOT CAUSE:
The screen-space constraint-icon preselection added in a27c3f0ae9 returns the icon position through a `pickedPoint` out-parameter (`EditModeConstraintCoinManager::resolveIconScreenGeometry`). The position is computed from the icon's `SoZoomTranslation` nodes, which live inside the edit scenegraph — i.e. it is in **sketch-plane (local) coordinates** — but it was stored unconverted in a variable named `iconWorldPos` and returned as-is.

The frame convention is established by the surrounding code: the very next line passes the same value to `getScreenCoordinates()`, whose parameter is named `sketchcoordinates` and which applies the editing placement itself (so the icon's screen-space hit test was and remains correct). Every other preselection path converts to global coordinates before setting the result (`sketchPlanePointToWorld()` for the screen-space geometry detectors, `SoPickedPoint::getPoint()` for Coin picks) — the icon path was the one exception.

The consumer that makes the bug visible is `mouseButtonPressed`: on release it substitutes the picked point for the cursor ray and projects it onto the sketch plane assuming **global** coordinates. For a sketch on the XZ plane, projecting the local point `(u_icon, v_icon, z_icon)` along the view direction collapses it to sketch `(u_icon, z_icon)` — with `z_icon ≈ 0.004` being the constraint icon layer's z-offset, i.e. a point *on the horizontal axis*. `commitDragMove` then faithfully commits the drag to that corrupted target.

Captured with temporary instrumentation on an XZ sketch (dragging a vertical edge; note the drag steps are correct and the corruption enters exactly at release):

    doDragStep:     x=105.7805  y=-87.3502   ← last mouse-move, correct
    commitDragMove: x=101.2252  y=0.0040     ← release: y = icon z-offset

On an XY-plane sketch, local and global coordinates coincide, so the bug is invisible there — which is why it survived unnoticed: it only manifests on non-XY sketch planes, only on press/release (moves use the raw cursor ray), and only when the cursor lands in a constraint icon's padded hit box.

FIX:
Transform the icon position by the editing placement before returning it, mirroring the `sketchPlanePointToWorld()` convention used by the other preselection paths (the icon's z-offset is a rendering artifact and is dropped, likewise mirroring that function). The misleading `iconWorldPos` variable is renamed to `iconSketchPos`.

The screen-space hit test is intentionally untouched — it was already operating in the correct frame.

TESTING:
- Manual, debug build, sketch on XZ plane: the reproduction above no longer snaps; edge drags released over H/V icons commit to the cursor position (verified via the same instrumentation, since removed). Normal drags, point drags and dimension-label drags behave as before.
- XY-plane sketches: unaffected by construction (identity placement).
- Sketcher C++ test suite: 107/107 pass (the change is GUI-only; no App/solver code is touched).

I'll note that I am still a new participant to this repository and genuinely want to help. I have the utmost respect for any maintainers who work through all these PRs. Ill do my best to integrate any feedback and adjust to how things are done here. 

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted by Claude Fable & Opus 4.8


## Issues
fixes issue #31412

## Before and After Images
N/A

