### PR TITLE
Spreadsheet: Fix configuration table cell reference shifts on insert/remove

### DIFF
--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -1008,6 +1008,187 @@ void PropertySheet::moveCell(
     signaller.tryInvoke();
 }
 
+namespace
+{
+Expression* shiftIfNeeded(const NumberExpression* num, App::DocumentObject* owner, int pivot, int count)
+{
+    long value = 0;
+    if (!num->isInteger(&value) || value - 1 < pivot) {
+        return nullptr;
+    }
+    return new NumberExpression(owner, Base::Quantity(double(value + count)));
+}
+
+Expression*
+shiftAddressLiteral(const Expression* e, App::DocumentObject* owner, int pivot, int count)
+{
+    if (auto* num = freecad_cast<const NumberExpression*>(e)) {
+        return shiftIfNeeded(num, owner, pivot, count);
+    }
+
+    auto* op = freecad_cast<const OperatorExpression*>(e);
+    if (!op || op->getOperator() != OperatorExpression::ADD) {
+        return nullptr;
+    }
+
+    if (auto* left = freecad_cast<const NumberExpression*>(op->getLeft())) {
+        Expression* shifted = shiftIfNeeded(left, owner, pivot, count);
+        if (!shifted) {
+            return nullptr;
+        }
+        return new OperatorExpression(owner, shifted, OperatorExpression::ADD, op->getRight()->copy().release());
+    }
+
+    if (auto* right = freecad_cast<const NumberExpression*>(op->getRight())) {
+        Expression* shifted = shiftIfNeeded(right, owner, pivot, count);
+        if (!shifted) {
+            return nullptr;
+        }
+        return new OperatorExpression(owner, op->getLeft()->copy().release(), OperatorExpression::ADD, shifted);
+    }
+
+    return nullptr;
+}
+
+App::ExpressionPtr shiftBindingExpression(
+    const Expression* e,
+    App::DocumentObject* owner,
+    int rowPivot,
+    int rowCount,
+    int colPivot,
+    int colCount
+)
+{
+    auto* tuple = freecad_cast<const FunctionExpression*>(e);
+    if (!tuple || tuple->getFunction() != FunctionExpression::TUPLE
+        || tuple->getArgs().size() != 3) {
+        return {};
+    }
+
+    bool changed = false;
+    std::vector<Expression*> newArgs;
+    newArgs.push_back(tuple->getArgs()[0]->copy().release());  // target ".cells", unchanged
+
+    for (std::size_t i = 1; i <= 2; ++i) {
+        auto* addr = freecad_cast<const FunctionExpression*>(tuple->getArgs()[i]);
+        if (!addr || addr->getFunction() != FunctionExpression::ADDRESS
+            || addr->getArgs().size() != 3) {
+            for (auto* a : newArgs) {
+                delete a;
+            }
+            return {};
+        }
+
+        Expression* newRow = rowCount
+            ? shiftAddressLiteral(addr->getArgs()[0], owner, rowPivot, rowCount)
+            : nullptr;
+        Expression* newCol = colCount
+            ? shiftAddressLiteral(addr->getArgs()[1], owner, colPivot, colCount)
+            : nullptr;
+        changed = changed || newRow || newCol;
+
+        std::vector<Expression*> addrArgs;
+        addrArgs.push_back(newRow ? newRow : addr->getArgs()[0]->copy().release());
+        addrArgs.push_back(newCol ? newCol : addr->getArgs()[1]->copy().release());
+        addrArgs.push_back(addr->getArgs()[2]->copy().release());  // address mode, unchanged
+        newArgs.push_back(new FunctionExpression(
+            owner,
+            FunctionExpression::ADDRESS,
+            std::string(),
+            std::move(addrArgs)
+        ));
+    }
+
+    if (!changed) {
+        for (auto* a : newArgs) {
+            delete a;
+        }
+        return {};
+    }
+    return App::ExpressionPtr(
+        new FunctionExpression(owner, FunctionExpression::TUPLE, std::string(), std::move(newArgs))
+    );
+}
+}  // namespace
+
+void PropertySheet::shiftBindingsRows(int row, int count)
+{
+    if (!owner || !count) {
+        return;
+    }
+
+    for (const auto& entry : owner->ExpressionEngine.getExpressions()) {
+        CellAddress from, to;
+        bool href = false;
+        if (!isBindingPath(entry.first, &from, &to, &href)) {
+            continue;
+        }
+
+        CellAddress newFrom(from), newTo(to);
+        if (from.row() >= row) {
+            newFrom.setRow(from.row() + count);
+        }
+        if (to.row() >= row) {
+            newTo.setRow(to.row() + count);
+        }
+
+        auto newExpr = shiftBindingExpression(entry.second, owner, row, count, 0, 0);
+        if (newFrom == from && newTo == to && !newExpr) {
+            continue;
+        }
+
+        ObjectIdentifier newPath(*this);
+        newPath << ObjectIdentifier::SimpleComponent(href ? "BindHiddenRef" : "Bind");
+        newPath << ObjectIdentifier::SimpleComponent(newFrom.toString().c_str());
+        newPath << ObjectIdentifier::SimpleComponent(newTo.toString().c_str());
+
+        std::shared_ptr<Expression> expr(
+            newExpr ? newExpr.release() : entry.second->copy().release()
+        );
+        owner->clearExpression(entry.first);
+        owner->setExpression(newPath, expr);
+    }
+}
+
+void PropertySheet::shiftBindingsColumns(int col, int count)
+{
+    if (!owner || !count) {
+        return;
+    }
+
+    for (const auto& entry : owner->ExpressionEngine.getExpressions()) {
+        CellAddress from, to;
+        bool href = false;
+        if (!isBindingPath(entry.first, &from, &to, &href)) {
+            continue;
+        }
+
+        CellAddress newFrom(from), newTo(to);
+        if (from.col() >= col) {
+            newFrom.setCol(from.col() + count);
+        }
+        if (to.col() >= col) {
+            newTo.setCol(to.col() + count);
+        }
+
+        auto newExpr = shiftBindingExpression(entry.second, owner, 0, 0, col, count);
+        if (newFrom == from && newTo == to && !newExpr) {
+            continue;
+        }
+
+        ObjectIdentifier newPath(*this);
+        newPath << ObjectIdentifier::SimpleComponent(href ? "BindHiddenRef" : "Bind");
+        newPath << ObjectIdentifier::SimpleComponent(newFrom.toString().c_str());
+        newPath << ObjectIdentifier::SimpleComponent(newTo.toString().c_str());
+
+        std::shared_ptr<Expression> expr(
+            newExpr ? newExpr.release() : entry.second->copy().release()
+        );
+        owner->clearExpression(entry.first);
+        owner->setExpression(newPath, expr);
+    }
+}
+
 void PropertySheet::insertRows(int row, int count)
 {
     std::vector<CellAddress> keys;
@@ -1055,6 +1236,7 @@ void PropertySheet::insertRows(int row, int count)
     owner->getDocument()->renameObjectIdentifiers(renames, [docObj](const App::DocumentObject* obj) {
         return obj != docObj;
     });
+    shiftBindingsRows(row, count);
     signaller.tryInvoke();
 }
 
@@ -1152,6 +1334,7 @@ void PropertySheet::removeRows(int row, int count)
     owner->getDocument()->renameObjectIdentifiers(renames, [docObj](const App::DocumentObject* obj) {
         return obj != docObj;
     });
+    shiftBindingsRows(row + count, -count);
     signaller.tryInvoke();
 }
 
@@ -1202,6 +1385,7 @@ void PropertySheet::insertColumns(int col, int count)
     owner->getDocument()->renameObjectIdentifiers(renames, [docObj](const App::DocumentObject* obj) {
         return obj != docObj;
     });
+    shiftBindingsColumns(col, count);
     signaller.tryInvoke();
 }
 
@@ -1299,6 +1483,7 @@ void PropertySheet::removeColumns(int col, int count)
     owner->getDocument()->renameObjectIdentifiers(renames, [docObj](const App::DocumentObject* obj) {
         return obj != docObj;
     });
+    shiftBindingsColumns(col + count, -count);
     signaller.tryInvoke();
 }
 

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -1019,8 +1019,7 @@ Expression* shiftIfNeeded(const NumberExpression* num, App::DocumentObject* owne
     return new NumberExpression(owner, Base::Quantity(double(value + count)));
 }
 
-Expression*
-shiftAddressLiteral(const Expression* e, App::DocumentObject* owner, int pivot, int count)
+Expression* shiftAddressLiteral(const Expression* e, App::DocumentObject* owner, int pivot, int count)
 {
     if (auto* num = freecad_cast<const NumberExpression*>(e)) {
         return shiftIfNeeded(num, owner, pivot, count);
@@ -1036,7 +1035,12 @@ shiftAddressLiteral(const Expression* e, App::DocumentObject* owner, int pivot, 
         if (!shifted) {
             return nullptr;
         }
-        return new OperatorExpression(owner, shifted, OperatorExpression::ADD, op->getRight()->copy().release());
+        return new OperatorExpression(
+            owner,
+            shifted,
+            OperatorExpression::ADD,
+            op->getRight()->copy().release()
+        );
     }
 
     if (auto* right = freecad_cast<const NumberExpression*>(op->getRight())) {
@@ -1044,7 +1048,12 @@ shiftAddressLiteral(const Expression* e, App::DocumentObject* owner, int pivot, 
         if (!shifted) {
             return nullptr;
         }
-        return new OperatorExpression(owner, op->getLeft()->copy().release(), OperatorExpression::ADD, shifted);
+        return new OperatorExpression(
+            owner,
+            op->getLeft()->copy().release(),
+            OperatorExpression::ADD,
+            shifted
+        );
     }
 
     return nullptr;
@@ -1060,8 +1069,7 @@ App::ExpressionPtr shiftBindingExpression(
 )
 {
     auto* tuple = freecad_cast<const FunctionExpression*>(e);
-    if (!tuple || tuple->getFunction() != FunctionExpression::TUPLE
-        || tuple->getArgs().size() != 3) {
+    if (!tuple || tuple->getFunction() != FunctionExpression::TUPLE || tuple->getArgs().size() != 3) {
         return {};
     }
 
@@ -1091,12 +1099,9 @@ App::ExpressionPtr shiftBindingExpression(
         addrArgs.push_back(newRow ? newRow : addr->getArgs()[0]->copy().release());
         addrArgs.push_back(newCol ? newCol : addr->getArgs()[1]->copy().release());
         addrArgs.push_back(addr->getArgs()[2]->copy().release());  // address mode, unchanged
-        newArgs.push_back(new FunctionExpression(
-            owner,
-            FunctionExpression::ADDRESS,
-            std::string(),
-            std::move(addrArgs)
-        ));
+        newArgs.push_back(
+            new FunctionExpression(owner, FunctionExpression::ADDRESS, std::string(), std::move(addrArgs))
+        );
     }
 
     if (!changed) {
@@ -1142,9 +1147,7 @@ void PropertySheet::shiftBindingsRows(int row, int count)
         newPath << ObjectIdentifier::SimpleComponent(newFrom.toString().c_str());
         newPath << ObjectIdentifier::SimpleComponent(newTo.toString().c_str());
 
-        std::shared_ptr<Expression> expr(
-            newExpr ? newExpr.release() : entry.second->copy().release()
-        );
+        std::shared_ptr<Expression> expr(newExpr ? newExpr.release() : entry.second->copy().release());
         owner->clearExpression(entry.first);
         owner->setExpression(newPath, expr);
     }
@@ -1181,9 +1184,7 @@ void PropertySheet::shiftBindingsColumns(int col, int count)
         newPath << ObjectIdentifier::SimpleComponent(newFrom.toString().c_str());
         newPath << ObjectIdentifier::SimpleComponent(newTo.toString().c_str());
 
-        std::shared_ptr<Expression> expr(
-            newExpr ? newExpr.release() : entry.second->copy().release()
-        );
+        std::shared_ptr<Expression> expr(newExpr ? newExpr.release() : entry.second->copy().release());
         owner->clearExpression(entry.first);
         owner->setExpression(newPath, expr);
     }

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -1189,6 +1189,145 @@ void PropertySheet::shiftBindingsColumns(int col, int count)
     }
 }
 
+namespace
+{
+bool shiftRangeKey(
+    const std::string& key,
+    int rowPivot,
+    int rowCount,
+    int colPivot,
+    int colCount,
+    std::string& newKey
+)
+{
+    auto sep = key.find(':');
+    if (sep == std::string::npos) {
+        return false;
+    }
+
+    CellAddress from;
+    try {
+        from = CellAddress(key.substr(0, sep));
+    }
+    catch (Base::Exception&) {
+        return false;
+    }
+    if (!from.isValid()) {
+        return false;
+    }
+
+    std::string endStr = key.substr(sep + 1);
+    bool growing = (endStr == "-" || endStr == "|");
+    CellAddress to;
+    if (!growing) {
+        try {
+            to = CellAddress(endStr);
+        }
+        catch (Base::Exception&) {
+            return false;
+        }
+        if (!to.isValid()) {
+            return false;
+        }
+    }
+
+    bool changed = false;
+    CellAddress newFrom(from);
+    if (rowCount && from.row() >= rowPivot) {
+        newFrom.setRow(from.row() + rowCount);
+        changed = true;
+    }
+    if (colCount && from.col() >= colPivot) {
+        newFrom.setCol(from.col() + colCount);
+        changed = true;
+    }
+
+    if (growing) {
+        if (!changed) {
+            return false;
+        }
+        newKey = newFrom.toString() + ":" + endStr;
+        return true;
+    }
+
+    CellAddress newTo(to);
+    if (rowCount && to.row() >= rowPivot) {
+        newTo.setRow(to.row() + rowCount);
+        changed = true;
+    }
+    if (colCount && to.col() >= colPivot) {
+        newTo.setCol(to.col() + colCount);
+        changed = true;
+    }
+    if (!changed) {
+        return false;
+    }
+    newKey = newFrom.toString() + ":" + newTo.toString();
+    return true;
+}
+
+void shiftRangeReferences(Sheet* owner, int rowPivot, int rowCount, int colPivot, int colCount)
+{
+    auto* doc = owner->getDocument();
+    std::map<ObjectIdentifier, ObjectIdentifier> renames;
+
+    for (auto* obj : doc->getObjects()) {
+        for (const auto& entry : obj->ExpressionEngine.getExpressions()) {
+            if (!entry.second) {
+                continue;
+            }
+            for (const auto& idEntry : entry.second->getIdentifiers()) {
+                const ObjectIdentifier& id = idEntry.first;
+                if (id.getDocumentObject() != owner) {
+                    continue;
+                }
+                const auto& comps = id.getComponents();
+                if (comps.size() < 2) {
+                    continue;
+                }
+                const auto& last = comps.back();
+                const auto& prev = comps[comps.size() - 2];
+                if (!last.isMap() || !prev.isSimple() || prev.getName() != "cells") {
+                    continue;
+                }
+
+                std::string newKey;
+                if (!shiftRangeKey(last.getName(), rowPivot, rowCount, colPivot, colCount, newKey)) {
+                    continue;
+                }
+
+                ObjectIdentifier newId(id);
+                newId.setComponent(
+                    static_cast<int>(comps.size()) - 1,
+                    ObjectIdentifier::MapComponent(newKey)
+                );
+                renames[id] = newId;
+            }
+        }
+    }
+
+    if (!renames.empty()) {
+        doc->renameObjectIdentifiers(renames);
+    }
+}
+}  // namespace
+
+void PropertySheet::shiftRangeReferencesRows(int row, int count)
+{
+    if (!owner || !count) {
+        return;
+    }
+    shiftRangeReferences(owner, row, count, 0, 0);
+}
+
+void PropertySheet::shiftRangeReferencesColumns(int col, int count)
+{
+    if (!owner || !count) {
+        return;
+    }
+    shiftRangeReferences(owner, 0, 0, col, count);
+}
+
 void PropertySheet::insertRows(int row, int count)
 {
     std::vector<CellAddress> keys;
@@ -1237,6 +1376,7 @@ void PropertySheet::insertRows(int row, int count)
         return obj != docObj;
     });
     shiftBindingsRows(row, count);
+    shiftRangeReferencesRows(row, count);
     signaller.tryInvoke();
 }
 
@@ -1335,6 +1475,7 @@ void PropertySheet::removeRows(int row, int count)
         return obj != docObj;
     });
     shiftBindingsRows(row + count, -count);
+    shiftRangeReferencesRows(row + count, -count);
     signaller.tryInvoke();
 }
 
@@ -1386,6 +1527,7 @@ void PropertySheet::insertColumns(int col, int count)
         return obj != docObj;
     });
     shiftBindingsColumns(col, count);
+    shiftRangeReferencesColumns(col, count);
     signaller.tryInvoke();
 }
 
@@ -1484,6 +1626,7 @@ void PropertySheet::removeColumns(int col, int count)
         return obj != docObj;
     });
     shiftBindingsColumns(col + count, -count);
+    shiftRangeReferencesColumns(col + count, -count);
     signaller.tryInvoke();
 }
 

--- a/src/Mod/Spreadsheet/App/PropertySheet.h
+++ b/src/Mod/Spreadsheet/App/PropertySheet.h
@@ -318,6 +318,14 @@ private:
 
     void clearAlias(App::CellAddress address);
 
+    /*! Shift any configuration-table binding affected by inserting/removing
+     *  @a count rows at @a row, so the table keeps tracking the same cells
+     *  after the operation. */
+    void shiftBindingsRows(int row, int count);
+
+    /*! Column counterpart of shiftBindingsRows(). */
+    void shiftBindingsColumns(int col, int count);
+
     void moveAlias(App::CellAddress currPos, App::CellAddress newPos);
 
     void moveCell(

--- a/src/Mod/Spreadsheet/App/PropertySheet.h
+++ b/src/Mod/Spreadsheet/App/PropertySheet.h
@@ -326,6 +326,14 @@ private:
     /*! Column counterpart of shiftBindingsRows(). */
     void shiftBindingsColumns(int col, int count);
 
+    /*! Shift any "cells[<<from:to>>]" / "cells[<<from:->>]" range reference
+     *  to this sheet found anywhere in the document, so it keeps tracking the
+     *  same cells after inserting/removing @a count rows at @a row. */
+    void shiftRangeReferencesRows(int row, int count);
+
+    /*! Column counterpart of shiftRangeReferencesRows(). */
+    void shiftRangeReferencesColumns(int col, int count);
+
     void moveAlias(App::CellAddress currPos, App::CellAddress newPos);
 
     void moveCell(

--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -1121,6 +1121,105 @@ class SpreadsheetCases(unittest.TestCase):
         sheet.insertRows("2", 1)
         self.assertEqual(sheet.getContents("B4"), "=B3")
 
+    def _makeConfigTableBind(self, sheet, obj):
+        """Set up a minimal vertical configuration table binding, without
+        relying on the "growing range" mechanism used for the list of variant
+        names, so this exercises only the ".cells.Bind.<from>.<to>" shifting,
+        independent of the "cells[<<from:to>>]" one.
+        """
+        # Row 0: header + fixed (non-growing) list of variant names.
+        sheet.set("B1", "Variant0")
+        sheet.set("C1", "Variant1")
+        # Rows 1-2: parameter cells, dynamically bound to whichever variant
+        # column Obj.Config currently selects.
+        sheet.set("A2", "10")
+        sheet.set("A3", "20")
+        sheet.set("B2", "100")
+        sheet.set("B3", "101")
+        sheet.set("C2", "200")
+        sheet.set("C3", "201")
+
+        obj.addProperty("App::PropertyEnumeration", "Config", "", "", 0, False, True)
+        obj.setExpression("Config.Enum", "Spreadsheet.cells[<<B1:C1>>]")
+        self.doc.recompute()
+
+        sheet.set("A1", "=hiddenref(Obj.Config.String)")
+        sheet.setExpression(
+            ".cells.Bind.A2.A3",
+            "tuple(.cells; address(2; 2+hiddenref(Obj.Config); 4); "
+            "address(3; 2+hiddenref(Obj.Config); 4))",
+        )
+        self.doc.recompute()
+
+    def testConfigTableBindInsertRows(self):
+        """Regression test for issue 14672: inserting rows must shift a
+        configuration table's ".cells.Bind" binding along with everything
+        else, not just the ordinary cells."""
+        sheet = self.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")
+        obj = self.doc.addObject("App::FeaturePython", "Obj")
+        self._makeConfigTableBind(sheet, obj)
+
+        obj.Config = "Variant1"
+        self.doc.recompute()
+        self.assertEqual(sheet.get("A2"), 200.0)
+        self.assertEqual(sheet.get("A3"), 201.0)
+
+        sheet.insertRows("2", 1)
+        self.doc.recompute()
+
+        self.assertIn("hiddenref", sheet.getContents("A1"))
+        self.assertEqual(sheet.get("A3"), 200.0)
+        self.assertEqual(sheet.get("A4"), 201.0)
+
+        obj.Config = "Variant0"
+        self.doc.recompute()
+        self.assertEqual(sheet.get("A3"), 100.0)
+        self.assertEqual(sheet.get("A4"), 101.0)
+
+    def testConfigTableBindRemoveRows(self):
+        """Regression test for issue 14672: removing rows must shift a
+        configuration table's ".cells.Bind" binding along with everything
+        else."""
+        sheet = self.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")
+        obj = self.doc.addObject("App::FeaturePython", "Obj")
+        sheet.set("B1", "Variant0")
+        sheet.set("C1", "Variant1")
+        sheet.set("A3", "10")
+        sheet.set("A4", "20")
+        sheet.set("B3", "100")
+        sheet.set("B4", "101")
+        sheet.set("C3", "200")
+        sheet.set("C4", "201")
+
+        obj.addProperty("App::PropertyEnumeration", "Config", "", "", 0, False, True)
+        obj.setExpression("Config.Enum", "Spreadsheet.cells[<<B1:C1>>]")
+        self.doc.recompute()
+
+        sheet.set("A1", "=hiddenref(Obj.Config.String)")
+        sheet.setExpression(
+            ".cells.Bind.A3.A4",
+            "tuple(.cells; address(3; 2+hiddenref(Obj.Config); 4); "
+            "address(4; 2+hiddenref(Obj.Config); 4))",
+        )
+        self.doc.recompute()
+
+        obj.Config = "Variant0"
+        self.doc.recompute()
+        self.assertEqual(sheet.get("A3"), 100.0)
+        self.assertEqual(sheet.get("A4"), 101.0)
+
+        sheet.removeRows("2", 1)
+        self.doc.recompute()
+
+        self.assertIn("hiddenref", sheet.getContents("A1"))
+        self.assertEqual(sheet.get("A2"), 100.0)
+        self.assertEqual(sheet.get("A3"), 101.0)
+
+        obj.Config = "Variant1"
+        self.doc.recompute()
+        self.assertEqual(sheet.get("A2"), 200.0)
+        self.assertEqual(sheet.get("A3"), 201.0)
+
     def testConfigTableRangeInsertRows(self):
         """Regression test for issue 14672: inserting rows must shift a
         "cells[<<from:to>>]" growing-range reference, even though it lives on
@@ -1158,6 +1257,91 @@ class SpreadsheetCases(unittest.TestCase):
         self.doc.recompute()
 
         self.assertEqual(obj.getEnumerationsOfProperty("Config"), ["Variant0", "Variant1"])
+
+    def testConfigTableBindInsertColumns(self):
+        """Regression test for issue 14672: inserting columns must shift a
+        configuration table's ".cells.Bind" binding along with everything
+        else."""
+        sheet = self.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")
+        obj = self.doc.addObject("App::FeaturePython", "Obj")
+
+        sheet.set("A2", "Variant0")
+        sheet.set("A3", "Variant1")
+        sheet.set("B2", "100")
+        sheet.set("C2", "101")
+        sheet.set("B3", "200")
+        sheet.set("C3", "201")
+
+        obj.addProperty("App::PropertyEnumeration", "Config", "", "", 0, False, True)
+        obj.setExpression("Config.Enum", "Spreadsheet.cells[<<A2:|>>]")
+        self.doc.recompute()
+
+        sheet.set("A1", "=hiddenref(Obj.Config.String)")
+        sheet.setExpression(
+            ".cells.Bind.B1.C1",
+            "tuple(.cells; address(2+hiddenref(Obj.Config); 2; 4); "
+            "address(2+hiddenref(Obj.Config); 3; 4))",
+        )
+        self.doc.recompute()
+
+        obj.Config = "Variant1"
+        self.doc.recompute()
+        self.assertEqual(sheet.get("B1"), 200.0)
+        self.assertEqual(sheet.get("C1"), 201.0)
+
+        sheet.insertColumns("B", 1)
+        self.doc.recompute()
+
+        self.assertIn("hiddenref", sheet.getContents("A1"))
+        self.assertEqual(sheet.get("C1"), 200.0)
+        self.assertEqual(sheet.get("D1"), 201.0)
+
+        obj.Config = "Variant0"
+        self.doc.recompute()
+        self.assertEqual(sheet.get("C1"), 100.0)
+        self.assertEqual(sheet.get("D1"), 101.0)
+
+    def testConfigTableBindRemoveColumns(self):
+        """Regression test for issue 14672: removing columns must shift a
+        configuration table's ".cells.Bind" binding along with everything
+        else."""
+        sheet = self.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")
+        obj = self.doc.addObject("App::FeaturePython", "Obj")
+        sheet.set("A2", "Variant0")
+        sheet.set("A3", "Variant1")
+        sheet.set("C2", "100")
+        sheet.set("D2", "101")
+        sheet.set("C3", "200")
+        sheet.set("D3", "201")
+
+        obj.addProperty("App::PropertyEnumeration", "Config", "", "", 0, False, True)
+        obj.setExpression("Config.Enum", "Spreadsheet.cells[<<A2:|>>]")
+        self.doc.recompute()
+
+        sheet.set("A1", "=hiddenref(Obj.Config.String)")
+        sheet.setExpression(
+            ".cells.Bind.C1.D1",
+            "tuple(.cells; address(2+hiddenref(Obj.Config); 3; 4); "
+            "address(2+hiddenref(Obj.Config); 4; 4))",
+        )
+        self.doc.recompute()
+
+        obj.Config = "Variant0"
+        self.doc.recompute()
+        self.assertEqual(sheet.get("C1"), 100.0)
+        self.assertEqual(sheet.get("D1"), 101.0)
+
+        sheet.removeColumns("B", 1)
+        self.doc.recompute()
+
+        self.assertIn("hiddenref", sheet.getContents("A1"))
+        self.assertEqual(sheet.get("B1"), 100.0)
+        self.assertEqual(sheet.get("C1"), 101.0)
+
+        obj.Config = "Variant1"
+        self.doc.recompute()
+        self.assertEqual(sheet.get("B1"), 200.0)
+        self.assertEqual(sheet.get("C1"), 201.0)
 
     def testConfigTableRangeInsertColumns(self):
         """Regression test for issue 14672: inserting columns must shift a

--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -1121,6 +1121,83 @@ class SpreadsheetCases(unittest.TestCase):
         sheet.insertRows("2", 1)
         self.assertEqual(sheet.getContents("B4"), "=B3")
 
+    def testConfigTableRangeInsertRows(self):
+        """Regression test for issue 14672: inserting rows must shift a
+        "cells[<<from:to>>]" growing-range reference, even though it lives on
+        a different object than the sheet being modified."""
+        sheet = self.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")
+        obj = self.doc.addObject("App::FeaturePython", "Obj")
+        sheet.set("B1", "Variant0")
+        sheet.set("C1", "Variant1")
+
+        obj.addProperty("App::PropertyEnumeration", "Config", "", "", 0, False, True)
+        obj.setExpression("Config.Enum", "Spreadsheet.cells[<<B1:->>]")
+        self.doc.recompute()
+        self.assertEqual(obj.getEnumerationsOfProperty("Config"), ["Variant0", "Variant1"])
+
+        sheet.insertRows("1", 1)
+        self.doc.recompute()
+
+        self.assertEqual(obj.getEnumerationsOfProperty("Config"), ["Variant0", "Variant1"])
+
+    def testConfigTableRangeRemoveRows(self):
+        """Regression test for issue 14672: removing rows must shift a
+        "cells[<<from:to>>]" growing-range reference living on another
+        object."""
+        sheet = self.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")
+        obj = self.doc.addObject("App::FeaturePython", "Obj")
+        sheet.set("B2", "Variant0")
+        sheet.set("C2", "Variant1")
+
+        obj.addProperty("App::PropertyEnumeration", "Config", "", "", 0, False, True)
+        obj.setExpression("Config.Enum", "Spreadsheet.cells[<<B2:->>]")
+        self.doc.recompute()
+        self.assertEqual(obj.getEnumerationsOfProperty("Config"), ["Variant0", "Variant1"])
+
+        sheet.removeRows("1", 1)
+        self.doc.recompute()
+
+        self.assertEqual(obj.getEnumerationsOfProperty("Config"), ["Variant0", "Variant1"])
+
+    def testConfigTableRangeInsertColumns(self):
+        """Regression test for issue 14672: inserting columns must shift a
+        "cells[<<from:to>>]" growing-range reference living on another
+        object (the column-direction counterpart of
+        testConfigTableRangeInsertRows)."""
+        sheet = self.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")
+        obj = self.doc.addObject("App::FeaturePython", "Obj")
+        sheet.set("B1", "Variant0")
+        sheet.set("B2", "Variant1")
+
+        obj.addProperty("App::PropertyEnumeration", "Config", "", "", 0, False, True)
+        obj.setExpression("Config.Enum", "Spreadsheet.cells[<<B1:|>>]")
+        self.doc.recompute()
+        self.assertEqual(obj.getEnumerationsOfProperty("Config"), ["Variant0", "Variant1"])
+
+        sheet.insertColumns("A", 1)
+        self.doc.recompute()
+
+        self.assertEqual(obj.getEnumerationsOfProperty("Config"), ["Variant0", "Variant1"])
+
+    def testConfigTableRangeRemoveColumns(self):
+        """Regression test for issue 14672: removing columns must shift a
+        "cells[<<from:to>>]" growing-range reference living on another
+        object."""
+        sheet = self.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")
+        obj = self.doc.addObject("App::FeaturePython", "Obj")
+        sheet.set("C1", "Variant0")
+        sheet.set("C2", "Variant1")
+
+        obj.addProperty("App::PropertyEnumeration", "Config", "", "", 0, False, True)
+        obj.setExpression("Config.Enum", "Spreadsheet.cells[<<C1:|>>]")
+        self.doc.recompute()
+        self.assertEqual(obj.getEnumerationsOfProperty("Config"), ["Variant0", "Variant1"])
+
+        sheet.removeColumns("A", 1)
+        self.doc.recompute()
+
+        self.assertEqual(obj.getEnumerationsOfProperty("Config"), ["Variant0", "Variant1"])
+
     def testRenameAlias(self):
         """Test renaming of alias1 to alias2 in a spreadsheet"""
         sheet = self.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")


### PR DESCRIPTION
A configuration table's variant list relies on two mechanisms that inserting/removing rows or columns didn't know how to shift, so they would point at the wrong cells afterward:

- `.cells.Bind.<from>.<to>` the binding path, stored as a literal address tuple inside an expression.
- `cells[<<from:to>>]` growing-range references used as the `PropertyEnumeration`'s Enum to list variant names, stored as a key on the `ObjectIdentifier` rather than a `VariableExpression`, so it falls outside every existing rename/move-cells path

This adds `shiftBindingsRows()`/`shiftBindingsColumns()` and `shiftRangeReferencesRows()`/`shiftRangeReferencesColumns()` to `PropertySheet` to keep both tracking the same cells across insert/remove of rows and columns


- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
Fixes #14672.

## Before and After Images
N/A