### PR TITLE
Draft: Add cloned objects to the active Part

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -57,6 +57,7 @@ SET(Draft_tests
     drafttests/test_airfoildat.py
     drafttests/test_array.py
     drafttests/test_base.py
+    drafttests/test_clone_gui.py
     drafttests/test_creation.py
     drafttests/test_dimension_gui.py
     drafttests/test_draftgeomutils.py

--- a/src/Mod/Draft/TestDraftGui.py
+++ b/src/Mod/Draft/TestDraftGui.py
@@ -103,6 +103,7 @@ from drafttests.test_pivy import DraftPivy as DraftTestGui03
 from drafttests.test_dimension_gui import DraftGuiDimension as DraftTestGui04
 from drafttests.test_manual_input_gui import DraftGuiManualInput as DraftTestGui05
 from drafttests.test_lines_gui import DraftGuiLines as DraftTestGui06
+from drafttests.test_clone_gui import DraftGuiClone as DraftTestGui07
 
 # Use the modules so that code checkers don't complain (flake8)
 True if DraftTestGui01 else False
@@ -111,3 +112,4 @@ True if DraftTestGui03 else False
 True if DraftTestGui04 else False
 True if DraftTestGui05 else False
 True if DraftTestGui06 else False
+True if DraftTestGui07 else False

--- a/src/Mod/Draft/draftguitools/gui_clone.py
+++ b/src/Mod/Draft/draftguitools/gui_clone.py
@@ -109,6 +109,7 @@ class Clone(gui_base_original.Modifier):
         for idx, obj in enumerate(objs_shape):
             cmd = "Draft.make_clone(FreeCAD.ActiveDocument." + obj.Name + ")"
             Gui.doCommand("clone" + str(idx) + " = " + cmd)
+            Gui.doCommand("Draft.autogroup(clone" + str(idx) + ")")
         App.ActiveDocument.commitTransaction()
         App.ActiveDocument.recompute()
 

--- a/src/Mod/Draft/drafttests/test_clone_gui.py
+++ b/src/Mod/Draft/drafttests/test_clone_gui.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2026 CCNUdhj                                            *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+"""Unit tests for the Draft Clone GUI command."""
+
+from unittest import mock
+
+import FreeCADGui as Gui
+from draftguitools import gui_clone
+from drafttests import test_base
+
+
+class DraftGuiClone(test_base.DraftTestCaseDoc):
+    """Test the Clone command's GUI-specific behavior."""
+
+    def setUp(self):
+        """Create a document and initialize the Draft GUI."""
+        super().setUp()
+        Gui.activateWorkbench("DraftWorkbench")
+        Gui.activateView("Gui::View3DInventor", True)
+
+    def tearDown(self):
+        """Reset GUI state and close the temporary document."""
+        Gui.Selection.clearSelection()
+        Gui.activeView().setActiveObject("part", None)
+        super().tearDown()
+
+    def test_clone_is_added_to_active_part(self):
+        """A clone created inside an active Part should stay in that Part."""
+        # Regression test for:
+        # https://github.com/FreeCAD/FreeCAD/issues/30013
+        part = self.doc.addObject("App::Part", "Part")
+        body = self.doc.addObject("PartDesign::Body", "Body")
+        part.addObject(body)
+        Gui.activeView().setActiveObject("part", part)
+        Gui.Selection.addSelection(body)
+
+        command = gui_clone.Clone()
+        with mock.patch.object(command, "finish"):
+            command.proceed()
+        Gui.updateGui()
+
+        clone = self.doc.getObject("Clone")
+        self.assertIsNotNone(clone)
+        self.assertIn(clone, part.Group)


### PR DESCRIPTION
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Summary

The Draft Clone GUI command created clones at the document root even when an `App::Part` was active. This change calls `Draft.autogroup()` after each clone is created, allowing the existing active-container logic to place it in the active Part and adjust its placement when needed.

A GUI regression test clones a Body inside an active Part and verifies that the clone belongs to `part.Group`.

## Testing

- Focused GUI regression test: passed on FreeCAD weekly 2026.07.15.
- `TestDraftGui`: 39/39 passed during independent validation.
- `git diff --check`: passed.

## Issues

Fixes #30013

## Before and After Images

Not applicable. This PR does not change the visual UI layout.

## AI assistance

I used OpenAI Codex (GPT-5) to assist with codebase navigation, root-cause analysis, test design, and patch preparation. I reviewed, understood, and tested the resulting change.
