### PR TITLE
BIM: Avoid Qt warning in the Reorder Children panel

### DIFF
--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -265,6 +265,7 @@ SET(bimtests_SRCS
     bimtests/TestArchStairsGui.py
     bimtests/TestArchReport.py
     bimtests/TestArchReportGui.py
+    bimtests/TestBimReorderGui.py
 )
 
 set(bimtests_FIXTURES

--- a/src/Mod/BIM/bimcommands/BimReorder.py
+++ b/src/Mod/BIM/bimcommands/BimReorder.py
@@ -61,7 +61,9 @@ class BIM_Reorder_TaskPanel:
         self.obj = obj
         self.form = FreeCADGui.PySideUic.loadUi(":/ui/dialogReorder.ui")
         self.form.setWindowIcon(QtGui.QIcon(":/icons/BIM_Reorder.svg"))
-        self.form.pushButton.clicked.connect(self.form.listWidget.sortItems)
+        self.form.pushButton.clicked.connect(
+            lambda _checked=False: self.form.listWidget.sortItems()
+        )
         for child in self.obj.Group:
             i = QtGui.QListWidgetItem(child.Label)
             i.setIcon(child.ViewObject.Icon)

--- a/src/Mod/BIM/bimtests/TestBimReorderGui.py
+++ b/src/Mod/BIM/bimtests/TestBimReorderGui.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
+# *   Copyright (c) 2026 CCNUdhj                                            *
 # *                                                                         *
 # *   This file is part of FreeCAD.                                         *
 # *                                                                         *
@@ -22,16 +22,42 @@
 # *                                                                         *
 # ***************************************************************************
 
-"""Import all Arch module unit tests in GUI mode."""
+"""GUI tests for the BIM Reorder Children command."""
 
-from bimtests.TestArchImportersGui import TestArchImportersGui
-from bimtests.TestArchAxisGui import TestArchAxisGui
-from bimtests.TestArchBuildingPartGui import TestArchBuildingPartGui
-from bimtests.TestArchStairsGui import TestArchStairsGui
-from bimtests.TestArchReportGui import TestArchReportGui
-from bimtests.TestArchSiteGui import TestArchSiteGui
-from bimtests.TestArchWallGui import TestArchWallGui
-from bimtests.TestArchWindowGui import TestArchWindowGui
-from bimtests.TestWebGLExportGui import TestWebGLExportGui
-from bimtests.TestArchCoveringGui import TestArchCoveringGui
-from bimtests.TestBimReorderGui import TestBimReorderGui
+from PySide import QtCore
+
+from bimcommands import BimReorder
+from bimtests.TestArchBaseGui import TestArchBaseGui
+
+
+class TestBimReorderGui(TestArchBaseGui):
+    """Test the Reorder Children task panel."""
+
+    def test_sort_connection_has_no_qt_warning(self):
+        """Opening the task panel should not register an invalid Qt method."""
+        # Regression test for:
+        # https://github.com/FreeCAD/FreeCAD/issues/29817
+        group = self.document.addObject("App::DocumentObjectGroup", "Group")
+        child_z = self.document.addObject("App::FeaturePython", "ChildZ")
+        child_z.Label = "Z"
+        child_a = self.document.addObject("App::FeaturePython", "ChildA")
+        child_a.Label = "A"
+        group.Group = [child_z, child_a]
+
+        messages = []
+        old_handler = QtCore.qInstallMessageHandler(
+            lambda _msg_type, _context, message: messages.append(message)
+        )
+        try:
+            panel = BimReorder.BIM_Reorder_TaskPanel(group)
+        finally:
+            QtCore.qInstallMessageHandler(old_handler)
+
+        self.assertFalse(any("addMetaMethod" in message for message in messages), messages)
+
+        panel.form.pushButton.click()
+        labels = [
+            panel.form.listWidget.item(index).text()
+            for index in range(panel.form.listWidget.count())
+        ]
+        self.assertEqual(labels, ["A", "Z"])


### PR DESCRIPTION
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Summary

Opening the Reorder Children task panel produced an `addMetaMethod` / `No Wrapper found` warning because the button signal was connected directly to the C++-bound `QListWidget.sortItems` method.

This change routes the signal through a small Python callback. It preserves the existing alphabetical sorting behavior while preventing PySide from trying to register the bound method dynamically.

The GUI regression test captures Qt messages, verifies that the warning is absent, clicks the sort button, and checks that the item order changes from `Z, A` to `A, Z`.

## Testing

- Focused GUI regression test: passed on FreeCAD weekly 2026.07.15.
- `TestArchGui`: 41/41 passed during independent validation.
- `git diff --check`: passed.

## Issues

Fixes #29817

## Before and After Images

Not applicable. This PR does not change the visual UI layout.

## AI assistance

I used OpenAI Codex (GPT-5) to assist with codebase navigation, root-cause analysis, test design, and patch preparation. I reviewed, understood, and tested the resulting change.
