### PR TITLE
BIM: Respect horizontal and vertical direction for preselected edges

### DIFF
--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -265,6 +265,7 @@ SET(bimtests_SRCS
     bimtests/TestArchStairsGui.py
     bimtests/TestArchReport.py
     bimtests/TestArchReportGui.py
+    bimtests/TestBimDimensionGui.py
 )
 
 set(bimtests_FIXTURES

--- a/src/Mod/BIM/TestArchGui.py
+++ b/src/Mod/BIM/TestArchGui.py
@@ -34,3 +34,4 @@ from bimtests.TestArchWallGui import TestArchWallGui
 from bimtests.TestArchWindowGui import TestArchWindowGui
 from bimtests.TestWebGLExportGui import TestWebGLExportGui
 from bimtests.TestArchCoveringGui import TestArchCoveringGui
+from bimtests.TestBimDimensionGui import TestBimDimensionGui

--- a/src/Mod/BIM/bimtests/TestBimDimensionGui.py
+++ b/src/Mod/BIM/bimtests/TestBimDimensionGui.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2026 CCNUdhj                                            *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+"""GUI tests for the BIM dimension commands."""
+
+import Part
+
+import FreeCAD as App
+import FreeCADGui as Gui
+from bimcommands import BimDimensions
+from bimtests.TestArchBaseGui import TestArchBaseGui
+
+
+class TestBimDimensionGui(TestArchBaseGui):
+    """Test BIM dimension command behavior."""
+
+    def test_preselected_edge_respects_horizontal_and_vertical_direction(self):
+        """A linked dimension should retain the direction of the command."""
+        # Regression test for:
+        # https://github.com/FreeCAD/FreeCAD/issues/29766
+        edge_object = self.document.addObject("Part::Feature", "DiagonalEdge")
+        edge_object.Shape = Part.makeLine(App.Vector(), App.Vector(10, 10, 0))
+        self.document.recompute()
+
+        cases = (
+            (BimDimensions.BIM_DimensionHorizontal, App.Vector(1, 0, 0)),
+            (BimDimensions.BIM_DimensionVertical, App.Vector(0, 1, 0)),
+        )
+        for command_class, expected_direction in cases:
+            with self.subTest(command=command_class.__name__):
+                Gui.Selection.clearSelection()
+                Gui.Selection.addSelection(edge_object, "Edge1")
+                command = command_class()
+                command.Activated()
+                try:
+                    command.node.append(App.Vector(5, 15, 0))
+                    before = set(self.document.Objects)
+                    command.createObject()
+                    command.finish(cont=None)
+                    command = None
+                    self.pump_gui_events()
+                    created = set(self.document.Objects) - before
+                    self.assertEqual(len(created), 1)
+                    dimension = created.pop()
+                    self.assertTrue(dimension.Direction.isEqual(expected_direction, 1e-7))
+                finally:
+                    if command is not None:
+                        command.finish(cont=None)

--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -282,12 +282,17 @@ class Dimension(gui_base_original.Creator):
             # Linear dimension
             if self.link:
                 # Linked to a straight edge
+                direction = None
                 if self.force == 1:
-                    self.create_linear_dimension_obj("Y")
+                    direction = "Y"
                 elif self.force == 2:
-                    self.create_linear_dimension_obj("X")
-                else:
-                    self.create_linear_dimension_obj()
+                    direction = "X"
+                elif self.dir:
+                    if self.dir.isEqual(self.wp.v, 1e-7):
+                        direction = "Y"
+                    elif self.dir.isEqual(self.wp.u, 1e-7):
+                        direction = "X"
+                self.create_linear_dimension_obj(direction)
             else:
                 # Not linked to any edge
                 self.create_linear_dimension()


### PR DESCRIPTION
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Summary

With a diagonal edge preselected, the first BIM horizontal or vertical dimension followed the edge instead of the direction selected by the command. The commands supplied the working-plane `u` or `v` direction, but the linked-dimension creation path ignored it unless a temporary Shift constraint was active.

This change reuses the supplied working-plane direction when choosing the linked dimension's X or Y direction, while keeping Shift constraints at higher priority.

The GUI regression test covers both `BIM_DimensionHorizontal` and `BIM_DimensionVertical` with a preselected diagonal edge.

## Testing

- Focused GUI regression test: passed on FreeCAD weekly 2026.07.15, including both horizontal and vertical subtests.
- `git diff --check`: passed.

## Issues

Fixes #29766

## Before and After Images

Not applicable. This PR does not change the visual UI layout.

## AI assistance

I used OpenAI Codex (GPT-5) to assist with codebase navigation, root-cause analysis, test design, and patch preparation. I reviewed, understood, and tested the resulting change.
