### PR TITLE
Draft: Preserve the chain start after constraining the first dimension

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -303,6 +303,11 @@ class Dimension(gui_base_original.Creator):
                 self.chain = self.node[2]
                 self.node = [self.node[1]]
                 self.link = None
+                self.point1 = None
+                self.point2 = None
+                self.proj_point1 = None
+                self.proj_point2 = None
+                self.force = 0
 
     def selectEdge(self):
         """Toggle the select mode to the opposite state."""

--- a/src/Mod/Draft/drafttests/test_dimension_gui.py
+++ b/src/Mod/Draft/drafttests/test_dimension_gui.py
@@ -30,6 +30,7 @@ import os
 import re
 import tempfile
 import xml.etree.ElementTree as ET
+from unittest import mock
 
 import Draft
 import DraftVecUtils
@@ -37,7 +38,9 @@ import FreeCAD as App
 import FreeCADGui as Gui
 from FreeCAD import Vector
 
+from draftguitools import gui_dimensions
 from drafttests import test_base
+from draftutils.todo import ToDo
 
 
 class DraftGuiDimension(test_base.DraftTestCaseDoc):
@@ -337,6 +340,51 @@ class DraftGuiDimension(test_base.DraftTestCaseDoc):
             if original_name in App.listDocuments():
                 self.doc = App.getDocument(original_name)
             os.unlink(temp_file.name)
+
+    def test_constrained_first_dimension_keeps_chain_start(self):
+        """The next chained dimension should start at the constrained endpoint."""
+        # Regression test for:
+        # https://github.com/FreeCAD/FreeCAD/issues/29764
+        Gui.activateWorkbench("DraftWorkbench")
+        Gui.activateView("Gui::View3DInventor", True)
+
+        start = Vector(0, 0, 0)
+        endpoint = Vector(100, 0, 0)
+        next_point = Vector(200, 0, 0)
+        dim_line = Vector(0, 20, 0)
+
+        command = gui_dimensions.Dimension()
+        command.Activated()
+        try:
+            command.ui.chainedMode = True
+            command.node = [start, endpoint, dim_line]
+
+            # Match the state left by Shift-constraining the first dimension.
+            command.point1 = start
+            command.point2 = endpoint
+            command.proj_point1 = start
+            command.proj_point2 = endpoint
+            command.force = 2
+            command.createObject()
+
+            move_event = {
+                "Type": "SoLocation2Event",
+                "Position": (0, 0),
+                "ShiftDown": False,
+                "CtrlDown": False,
+                "AltDown": False,
+            }
+            with mock.patch.object(
+                gui_dimensions.gui_tool_utils,
+                "getPoint",
+                return_value=(next_point, None, {}),
+            ):
+                command.action(move_event)
+
+            self.assertTrue(command.node[0].isEqual(endpoint, 1e-7))
+        finally:
+            command.finish(cont=None)
+            ToDo.doTasks()
 
     def test_angular_dimension_svg_overshoots_after_restore_and_in_techdraw(self):
         """Angular dimension overshoots survive restore in SVG and propagate into TechDraw DraftView."""


### PR DESCRIPTION
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Summary

In chained dimension mode, constraining the first dimension with Shift left temporary endpoint state behind. On the next mouse move, that stale state replaced the chain start with the original first point, producing a 200 mm dimension instead of 100 mm in the reported example.

This change clears the completed segment's temporary constraint points, projected points, and force value when moving to the next chained segment. The chain direction, dimension-line position, and new endpoint remain unchanged.

The GUI regression test reproduces the constrained state, moves to the next point without Shift, and checks that the chain start remains at the first segment's endpoint.

## Testing

- Focused GUI regression test: passed on FreeCAD weekly 2026.07.15.
- `git diff --check`: passed.

## Issues

Fixes #29764

## Before and After Images

Not applicable. This PR does not change the visual UI layout.

## AI assistance

I used OpenAI Codex (GPT-5) to assist with codebase navigation, root-cause analysis, test design, and patch preparation. I reviewed, understood, and tested the resulting change.
