### PR TITLE
FEM: Avoid SWIG warnings when removing clipping planes

### DIFF
--- a/src/Mod/Fem/CMakeLists.txt
+++ b/src/Mod/Fem/CMakeLists.txt
@@ -740,6 +740,7 @@ endif(BUILD_FEM_VTK_PYTHON)
 
 SET(FemGuiTests_SRCS
     femtest/gui/__init__.py
+    femtest/gui/test_clipping_plane.py
     femtest/gui/test_open.py
 )
 

--- a/src/Mod/Fem/TestFemGui.py
+++ b/src/Mod/Fem/TestFemGui.py
@@ -23,6 +23,8 @@
 
 # Gui Unit tests for the FEM module
 from femtest.gui.test_open import TestObjectOpen as FemGuiTest01
+from femtest.gui.test_clipping_plane import TestClippingPlaneCommands as FemGuiTest02
 
 # dummy usage to get flake8 and lgtm quiet
 False if FemGuiTest01.__name__ else True
+False if FemGuiTest02.__name__ else True

--- a/src/Mod/Fem/femcommands/commands.py
+++ b/src/Mod/Fem/femcommands/commands.py
@@ -29,6 +29,8 @@ __url__ = "https://www.freecad.org"
 #  \ingroup FEM
 #  \brief FreeCAD FEM command definitions
 
+import warnings
+
 import FreeCAD
 import FreeCADGui
 from FreeCAD import Qt
@@ -171,13 +173,19 @@ class _ClippingPlaneRemoveAll(CommandManager):
         return resources
 
     def Activated(self):
-        line1 = "for node in list(sg.getChildren()):\n"
-        line2 = "    if isinstance(node, coin.SoClipPlane):\n"
-        line3 = "        sg.removeChild(node)"
-        FreeCADGui.doCommand("from pivy import coin")
-        FreeCADGui.doCommand("sg = Gui.ActiveDocument.ActiveView.getSceneGraph()")
-        FreeCADGui.doCommand("nodes = sg.getChildren()")
-        FreeCADGui.doCommand(line1 + line2 + line3)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"builtin type (SwigPyPacked|SwigPyObject|swigvarlink) has no __module__ attribute",
+                category=DeprecationWarning,
+            )
+            from pivy import coin
+
+            scene_graph = FreeCADGui.ActiveDocument.ActiveView.getSceneGraph()
+
+        for node in list(scene_graph.getChildren()):
+            if isinstance(node, coin.SoClipPlane):
+                scene_graph.removeChild(node)
 
 
 class _ConstantVacuumPermittivity(CommandManager):

--- a/src/Mod/Fem/femtest/gui/test_clipping_plane.py
+++ b/src/Mod/Fem/femtest/gui/test_clipping_plane.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2026 CCNUdhj                                            *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+"""GUI tests for FEM clipping-plane commands."""
+
+import unittest
+import warnings
+
+import FreeCAD as App
+import FreeCADGui as Gui
+from femcommands import commands
+
+
+class TestClippingPlaneCommands(unittest.TestCase):
+    """Test clipping-plane command behavior."""
+
+    def setUp(self):
+        """Create an empty document with a 3D view."""
+        self.document = App.newDocument(self.__class__.__name__)
+        Gui.activateView("Gui::View3DInventor", True)
+
+    def tearDown(self):
+        """Close the temporary document."""
+        App.closeDocument(self.document.Name)
+
+    def test_remove_all_without_planes_emits_no_swig_warning(self):
+        """Removing from an empty scene should not emit the SWIG warning."""
+        # Regression test for:
+        # https://github.com/FreeCAD/FreeCAD/issues/28735
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            commands._ClippingPlaneRemoveAll().Activated()
+
+        messages = [str(item.message) for item in caught]
+        self.assertFalse(any("SwigPyObject" in message for message in messages), messages)
+
+        from pivy import coin
+
+        scene_graph = Gui.ActiveDocument.ActiveView.getSceneGraph()
+        marker = coin.SoSeparator()
+        scene_graph.addChild(marker)
+        scene_graph.addChild(coin.SoClipPlane())
+        scene_graph.addChild(coin.SoClipPlane())
+        try:
+            commands._ClippingPlaneRemoveAll().Activated()
+            children = list(scene_graph.getChildren())
+            self.assertIn(marker, children)
+            self.assertFalse(any(isinstance(node, coin.SoClipPlane) for node in children))
+        finally:
+            scene_graph.removeChild(marker)


### PR DESCRIPTION
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Summary

The first use of Remove All Clipping Planes in a session emitted Pivy/SWIG `DeprecationWarning` messages when no clipping planes existed. The command executed Pivy import and scene-graph operations as several Python-console command strings, even though it only changes temporary view state.

This change uses the scene-graph API directly, consistent with the Add Clipping Plane command. It suppresses only the known Pivy/SWIG missing-`__module__` deprecation messages while importing Pivy and obtaining the scene graph, and continues to remove only `coin.SoClipPlane` nodes.

The GUI regression test verifies that the warning is absent, two clipping planes are removed, and an unrelated scene node remains.

## Testing

- Focused GUI regression test: passed on FreeCAD weekly 2026.07.15.
- `TestFemGui`: 4/4 passed.
- `git diff --check`: passed.

## Issues

Fixes #28735

## Before and After Images

Not applicable. This PR does not change the visual UI layout.

## AI assistance

I used OpenAI Codex (GPT-5) to assist with codebase navigation, root-cause analysis, test design, and patch preparation. I reviewed, understood, and tested the resulting change.
