### PR TITLE
Draft: autogroup clones in the active part

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_clone.py
+++ b/src/Mod/Draft/draftguitools/gui_clone.py
@@ -109,6 +109,7 @@ class Clone(gui_base_original.Modifier):
         for idx, obj in enumerate(objs_shape):
             cmd = "Draft.make_clone(FreeCAD.ActiveDocument." + obj.Name + ")"
             Gui.doCommand("clone" + str(idx) + " = " + cmd)
+            Gui.doCommand("Draft.autogroup(clone" + str(idx) + ")")
         App.ActiveDocument.commitTransaction()
         App.ActiveDocument.recompute()
 


### PR DESCRIPTION
## Summary

- call `Draft.autogroup()` for every object created by the Draft Clone GUI command
- reuse the existing Draft autogroup behavior for active Parts, Layers, and other supported containers
- leave programmatic `Draft.make_clone()` behavior unchanged

## Root cause

The Clone GUI command creates each clone with `Draft.make_clone()`, but unlike other Draft GUI creation commands it did not invoke `Draft.autogroup()` afterwards. As a result, a clone created while an `App::Part` was active stayed at the document root.

## User impact

Clones created from the GUI now respect the active Part and keep the placement handling already implemented by `Draft.autogroup()`.

## Validation

- branch is one commit ahead of `main`
- diff is limited to one added line in `src/Mod/Draft/draftguitools/gui_clone.py`
- the inserted Python statement compiles successfully
- no local FreeCAD GUI build was available for an end-to-end manual test

Closes #30013