### PR TITLE
CAM: Fix PathDressup.toolController

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Utils.py
+++ b/src/Mod/CAM/Path/Dressup/Utils.py
@@ -72,6 +72,6 @@ def baseOp(path):
     return path
 
 
-def toolController(path):
+def toolController(path, default=None):
     """toolController(path) ... return the tool controller from the base op."""
-    return baseOp(path).ToolController
+    return getattr(baseOp(path), "ToolController", default)

--- a/src/Mod/CAM/Path/Dressup/Utils.py
+++ b/src/Mod/CAM/Path/Dressup/Utils.py
@@ -60,9 +60,7 @@ def isOp(obj):
     if not getattr(obj, "Proxy", None):
         return False
     proxy = obj.Proxy.__module__
-    if "Path.Op" not in proxy and "Path.Dressup" not in proxy:
-        return False
-    return True
+    return "Path.Op" in proxy or "Path.Dressup" in proxy
 
 
 def baseOp(path):

--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -654,9 +654,10 @@ def getCycleTimeEstimate(obj, formatted=True):
     """getCycleTimeEstimate(obj, formated=True) ... Returns operation cycle time estimation
     If formatted=True returns string which describes time in format 'hh:mm:ss'
     If formatted=False returns seconds as a float value"""
-    baseOp = PathDressup.baseOp(obj)
-    tc = baseOp.ToolController
+    if obj.Path.Length == 0:
+        return "0" if formatted else 0
 
+    tc = PathDressup.toolController(obj)
     if tc is None or tc.ToolNumber == 0:
         Path.Log.error(translate("CAM", "No Tool Controller selected."))
         return translate("CAM", "Tool Error")


### PR DESCRIPTION
Fixes #31829
- #31829

---

### Description

Fixes test failing `CAMTests.TestPostCore`

### Changes:

- `PathDressup.toolController()` returns `None` if TC not defined, instead of raise error

- Skip `getCycleTimeEstimate()`,  if path length is 0