### PR TITLE
Sketcher: preserve cursor position on drag release

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -330,10 +330,13 @@ struct GeometryScreenPreselector
                     result.clear();
                     result.Kind = SketcherGui::EditModeCoinManager::PreselectionResult::HitKind::Edge;
                     result.GeoIndex = geoIndex;
-                    result.setPickedPoint(sketchPlanePointToWorld(
-                        startPoint[0] + (endPoint[0] - startPoint[0]) * interpolation,
-                        startPoint[1] + (endPoint[1] - startPoint[1]) * interpolation
-                    ));
+                    result.setPickedPoint(
+                        SketcherGui::sketchPlanePointToWorld(
+                            sketchPlacement,
+                            startPoint[0] + (endPoint[0] - startPoint[0]) * interpolation,
+                            startPoint[1] + (endPoint[1] - startPoint[1]) * interpolation
+                        )
+                    );
                     bestDistanceSquared = bestCurveDistanceSquared;
                     found = true;
                 }
@@ -381,16 +384,13 @@ private:
         result.Kind = SketcherGui::EditModeCoinManager::PreselectionResult::HitKind::Point;
         result.PointIndex = coinMapping.getPointVertexId(pointIndex, layerIndex);
         result.setPickedPoint(
-            sketchPlanePointToWorld(pointValues[pointIndex][0], pointValues[pointIndex][1])
+            SketcherGui::sketchPlanePointToWorld(
+                sketchPlacement,
+                pointValues[pointIndex][0],
+                pointValues[pointIndex][1]
+            )
         );
         return true;
-    }
-
-    Base::Vector3d sketchPlanePointToWorld(double x, double y) const
-    {
-        Base::Vector3d point(x, y, 0.0);
-        sketchPlacement.getRotation().multVec(point, point);
-        return point + sketchPlacement.getPosition();
     }
 
     float getPointHitRadius(int pointIndex, int layerIndex, float extraRadiusPx) const

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2316,11 +2316,20 @@ bool EditModeConstraintCoinManager::resolveIconScreenGeometry(
         }
     }
 
-    SbVec3f iconWorldPos = absPos + scaleFactor * trans;
-    iconScreenCenter = ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, iconWorldPos);
+    // Icon positions are in sketch coordinates. Keep that frame for screen
+    // projection and convert pickedPoint to global coordinates below.
+    SbVec3f iconSketchPos = absPos + scaleFactor * trans;
+    iconScreenCenter
+        = ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, iconSketchPos);
 
     if (pickedPoint) {
-        *pickedPoint = Base::convertTo<Base::Vector3d>(iconWorldPos);
+        // The icon's z offset is only for rendering; return a point on the sketch
+        // plane in global coordinates.
+        *pickedPoint = sketchPlanePointToWorld(
+            ViewProviderSketchCoinAttorney::getEditingPlacement(viewProvider),
+            iconSketchPos[0],
+            iconSketchPos[1]
+        );
     }
 
     return true;

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -31,6 +31,7 @@
 
 #include <App/Application.h>
 #include <App/Transactions.h>
+#include <Base/Placement.h>
 #include <Base/Quantity.h>
 #include <Base/UnitsApi.h>
 #include <Gui/CommandT.h>
@@ -47,6 +48,17 @@
 using namespace std;
 using namespace SketcherGui;
 using namespace Sketcher;
+
+Base::Vector3d SketcherGui::sketchPlanePointToWorld(
+    const Base::Placement& sketchPlacement,
+    double x,
+    double y
+)
+{
+    Base::Vector3d point(x, y, 0.0);
+    sketchPlacement.multVec(point, point);
+    return point;
+}
 
 bool Sketcher::isCircle(const Part::Geometry& geom)
 {

--- a/src/Mod/Sketcher/Gui/Utils.h
+++ b/src/Mod/Sketcher/Gui/Utils.h
@@ -35,6 +35,11 @@
 #include "AutoConstraint.h"
 #include "ViewProviderSketchGeometryExtension.h"
 
+namespace Base
+{
+class Placement;
+}
+
 namespace App
 {
 class DocumentObject;
@@ -85,6 +90,9 @@ enum OffsetMode : bool
 
 // to improve readability, expose the enum cases directly in the namespace
 using enum OffsetMode;
+
+/// Convert a point from sketch-plane coordinates to global coordinates.
+Base::Vector3d sketchPlanePointToWorld(const Base::Placement& sketchPlacement, double x, double y);
 
 /// This function tries to auto-recompute the active document if the option
 /// is set in the user parameter. If the option is not set nothing will be done

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -1218,6 +1218,9 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
     }
     assert(isInEditMode());
 
+    const bool isDragRelease = Button == 1 && !pressed
+        && (Mode == STATUS_SKETCH_Drag || Mode == STATUS_SKETCH_DragConstraint);
+
     // Calculate 3d point to the mouse position
     SbLine line;
     if (!getProjectingLine(cursorPos, viewer, line)) {
@@ -1226,12 +1229,15 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
     SbVec3f point = line.getPosition();
     SbVec3f normal = line.getDirection();
 
-    // use scoped_ptr to make sure that instance gets deleted in all cases
-    boost::scoped_ptr<SoPickedPoint> pp(this->getPointOnRay(cursorPos, viewer));
-    EditModeCoinManager::PreselectionResult clickResult
-        = getPreselectionResultAtViewportPos(cursorPos, viewer);
-    EditModeCoinManager::PreselectionResult resolvedClickResult
-        = resolveClickPreselectionResult(clickResult, cursorPos, viewer);
+    boost::scoped_ptr<SoPickedPoint> pp;
+    EditModeCoinManager::PreselectionResult resolvedClickResult;
+    if (!isDragRelease) {
+        // use scoped_ptr to make sure that instance gets deleted in all cases
+        pp.reset(this->getPointOnRay(cursorPos, viewer));
+        EditModeCoinManager::PreselectionResult clickResult
+            = getPreselectionResultAtViewportPos(cursorPos, viewer);
+        resolvedClickResult = resolveClickPreselectionResult(clickResult, cursorPos, viewer);
+    }
 
     // Radius maximum to allow double click event
     const int dblClickRadius = 5;
@@ -1241,16 +1247,19 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
     SbVec3f pos = point;
     Base::Vector3d selectionPoint = Base::convertTo<Base::Vector3d>(point);
 
+    // Object-derived picked points are appropriate for selection. During a drag
+    // release, however, the cursor-to-sketch-plane intersection is the authoritative
+    // input to snapping; an icon's picked point represents its center.
     if (resolvedClickResult.hasPickedPoint()) {
-        pos = Base::convertTo<SbVec3f>(resolvedClickResult.pickedPoint());
         selectionPoint = resolvedClickResult.pickedPoint();
+        pos = Base::convertTo<SbVec3f>(selectionPoint);
     }
     else if (pp) {
+        selectionPoint = Base::convertTo<Base::Vector3d>(pp->getPoint());
         const SoDetail* detail = pp->getDetail();
         if (detail && detail->getTypeId() == SoPointDetail::getClassTypeId()) {
             pos = pp->getPoint();
         }
-        selectionPoint = Base::convertTo<Base::Vector3d>(pp->getPoint());
     }
     const bool hasSelectionPoint = resolvedClickResult.hasPickedPoint() || static_cast<bool>(pp);
 


### PR DESCRIPTION
This PR combines the coordinate-frame fix from #31413 with the remaining drag-release correction for #31412.

When Sketcher geometry or a constraint label is dragged and released over a constraint icon, the icon preselection returns the icon center as its picked point. On non-XY sketch planes, that point previously caused the geometry to commit to the wrong location.

The first commit converts the icon position from sketch-local coordinates to global coordinates, fixing the horizontal-axis teleport. The follow-up commit makes drag releases use the raw cursor-to-sketch-plane intersection, so the final position no longer snaps to the icon center.

The original coordinate-frame fix was authored by Dustin Hartlyn, who is credited as co-author of the follow-up. AI assistance is disclosed in the commit trailers.
