### PR TITLE
Part: Delay angular deflection warning until editing is finished

### DIFF
--- a/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
@@ -55,9 +55,9 @@ DlgSettings3DViewPart::DlgSettings3DViewPart(QWidget* parent)
     );
     connect(
         ui->maxAngularDeflection,
-        qOverload<double>(&QDoubleSpinBox::valueChanged),
+        &QDoubleSpinBox::editingFinished,
         this,
-        &DlgSettings3DViewPart::onMaxAngularDeflectionValueChanged
+        &DlgSettings3DViewPart::onMaxAngularDeflectionEditingFinished
     );
     ParameterGrp::handle hPart = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Part"
@@ -92,11 +92,14 @@ void DlgSettings3DViewPart::onMaxDeviationValueChanged(double vMaxDev)
     }
 }
 
-void DlgSettings3DViewPart::onMaxAngularDeflectionValueChanged(double vMaxAngle)
+void DlgSettings3DViewPart::onMaxAngularDeflectionEditingFinished()
 {
     if (!this->isVisible()) {
         return;
     }
+
+    double vMaxAngle = ui->maxAngularDeflection->value();
+
     /**
      *  The lower threshold of 2.0 was determined by testing
      *  as laid out in the table as per comment hyperlink:

--- a/src/Mod/Part/Gui/DlgSettings3DViewPartImp.h
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPartImp.h
@@ -51,7 +51,7 @@ protected:
 
 private:
     void onMaxDeviationValueChanged(double);
-    void onMaxAngularDeflectionValueChanged(double);
+    void onMaxAngularDeflectionEditingFinished();
 
 private:
     std::unique_ptr<Ui_DlgSettings3DViewPart> ui;


### PR DESCRIPTION
This change delays evaluation of the Maximum Angular Deflection value until editing is finished, allowing values beginning with 1 (such as 14 or 15) to be entered without being interrupted by a warning dialog.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
Fixes #31315

## Before and After Images

Attached recordings demonstrate:
- Entering `14` is no longer interrupted while typing.
- Entering `1` only triggers the warning after editing is finished.

https://github.com/user-attachments/assets/a315ef40-d43d-4f75-b0f5-d38a7f8acd9a

https://github.com/user-attachments/assets/1d3a363e-471c-40b9-ae36-4d1ad97f4ba6

