### PR TITLE
Draft: Prevent navigation box selection during snapping

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -1523,10 +1523,16 @@ class Snapper:
         def click(event_cb):
             if not self.ui.mouse:
                 return
+
             event = event_cb.getEvent()
-            if event.getButton() == 1:
-                if event.getState() == coin.SoMouseButtonEvent.DOWN:
-                    accept()
+            if (
+                event.getButton() == coin.SoMouseButtonEvent.BUTTON1
+                and event.getState() == coin.SoButtonEvent.DOWN
+            ):
+                # The active Draft command owns this pointer interaction.
+                # Prevent navigation styles from arming LMB box selection.
+                event_cb.setHandled()
+                accept()
 
         def accept():
             try:


### PR DESCRIPTION
Mark the LMB event as handled before the Draft snapper removes its callback. This prevents navigation styles from retaining the pending box-selection start position for the same click.

Video of the issue from @maxwxyz 

https://github.com/user-attachments/assets/03b8796b-eeaf-4944-9925-068d3703b05a

