### PR TITLE
BIM: show arrow cursor when IFC import dialog is open

### DIFF
--- a/src/Mod/BIM/nativeifc/ifc_import.py
+++ b/src/Mod/BIM/nativeifc/ifc_import.py
@@ -161,7 +161,13 @@ def get_options(strategy=None, shapemode=None, switchwb=None, silent=False):
         dlg.checkLoadMaterials.setChecked(materials)
         dlg.checkLoadLayers.setChecked(layers)
         dlg.comboSingleDoc.setCurrentIndex(1 - int(singledoc))
+
+        from PySide import QtCore, QtGui
+
+        QtGui.QApplication.setOverrideCursor(QtCore.Qt.ArrowCursor)
         result = dlg.exec_()
+        QtGui.QApplication.restoreOverrideCursor()
+
         if not result:
             return None, None, None
         strategy = dlg.comboStrategy.currentIndex()


### PR DESCRIPTION
Fixes #16408.

Same solution as used for STEP import in the Part WB.

No AI was used.