### PR TITLE
BIM: fix error in #30001

### DIFF
--- a/src/Mod/BIM/nativeifc/ifc_psets.py
+++ b/src/Mod/BIM/nativeifc/ifc_psets.py
@@ -295,7 +295,7 @@ def load_psets(obj):
 
     show_psets(obj)
     if isinstance(obj, FreeCAD.DocumentObject) and hasattr(obj, "Group"):
-        for child in group:
+        for child in obj.Group:
             load_psets(child)
     elif isinstance(obj, FreeCAD.Document):
         for child in obj.Objects:


### PR DESCRIPTION
The group variable did not exist after #30001. My bad.

No AI was used.