### PR TITLE
Draft: Attachment support for nodes

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -486,6 +486,9 @@ class DraftToolBar:
         )  # Required to detect snap cycling in case of Z constraining.
         self.zValue.setText(FreeCAD.Units.Quantity(0, FreeCAD.Units.Length).UserString)
         self.pointButton = self._pushbutton("addButton", bl, icon="Draft_AddPoint")
+        self.attachNodeButton = self._pushbutton(
+            "attachNodeButton", bl, icon=":/icons/tools/Part_Attachment.svg"
+        )
 
         # text
 
@@ -613,6 +616,7 @@ class DraftToolBar:
         self.angleValue.textEdited.connect(self.checkSpecialChars)
         self.zValue.returnPressed.connect(self.validatePoint)
         self.pointButton.clicked.connect(self.validatePoint)
+        self.attachNodeButton.clicked.connect(self.attachNode)
         self.radiusValue.returnPressed.connect(self.validatePoint)
         self.angleValue.returnPressed.connect(self.validatePoint)
         self.textValue.textChanged.connect(self.checkEnterText)
@@ -705,6 +709,10 @@ class DraftToolBar:
         self.zValue.setToolTip(translate("draft", "Z coordinate of the point"))
         self.pointButton.setText(translate("draft", "Enter Point"))
         self.pointButton.setToolTip(translate("draft", "Enter a point with given coordinates"))
+        self.attachNodeButton.setText(translate("draft", "Attach"))
+        self.attachNodeButton.setToolTip(
+            translate("draft", "Attaches the edited node to a selected vertex or point")
+        )
         self.labellength.setText(translate("draft", "Length"))
         self.labelangle.setText(translate("draft", "Angle"))
         self._sync_field_label_widths()
@@ -973,6 +981,7 @@ class DraftToolBar:
         self.yValue.hide()
         self.zValue.hide()
         self.pointButton.hide()
+        self.attachNodeButton.hide()
         self.lengthValue.hide()
         self.angleValue.hide()
         self.isRelative.hide()
@@ -1067,6 +1076,7 @@ class DraftToolBar:
         self.new_point = None
         self.last_point = None
         self.pointButton.show()
+        self.attachNodeButton.hide()
         if rel:
             self.isRelative.show()
         todo.delay(self.setFocus, None)
@@ -1153,6 +1163,7 @@ class DraftToolBar:
             self.state.append(self.labellength.isVisible())
             self.state.append(self.labelangle.isVisible())
             self.state.append(self.pointButton.isVisible())
+            self.state.append(self.attachNodeButton.isVisible())
             self.state.append(self.lengthValue.isVisible())
             self.state.append(self.angleValue.isVisible())
             self.state.append(self.isRelative.isVisible())
@@ -1179,12 +1190,14 @@ class DraftToolBar:
                 if self.state[8]:
                     self.pointButton.show()
                 if self.state[9]:
-                    self.lengthValue.show()
+                    self.attachNodeButton.show()
                 if self.state[10]:
-                    self.angleValue.show()
+                    self.lengthValue.show()
                 if self.state[11]:
-                    self.isRelative.show()
+                    self.angleValue.show()
                 if self.state[12]:
+                    self.isRelative.show()
+                if self.state[13]:
                     self.isGlobal.show()
                 self.state = None
 
@@ -1421,6 +1434,12 @@ class DraftToolBar:
 
     def acceptPointInput(self):
         self._locks.unlock_all()
+
+    def attachNode(self):
+        """Attach or detach the current Draft_Edit node."""
+        if self.sourceCmd and hasattr(self.sourceCmd, "attachCurrentNode"):
+            return self.sourceCmd.attachCurrentNode()
+        return False
 
     def finish(self, cont=None):
         """finish button action"""

--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -55,6 +55,7 @@ from draftguitools import gui_edit_part_objects as edit_part
 from draftguitools import gui_edit_sketcher_objects as edit_sketcher
 from draftguitools import gui_tool_utils
 from draftguitools import gui_trackers as trackers
+from draftobjects import base as draft_base
 
 COLORS = {
     "default": utils.get_rgba_tuple(params.get_param("snapcolor"))[:3],
@@ -206,6 +207,7 @@ class Edit(gui_base_original.Modifier):
         self.edited_objects = []
         self.obj = None
         self.editing = None
+        self.node_attachment_pick = False
 
         # event callbacks
         self.selection_callback = None
@@ -236,6 +238,7 @@ class Edit(gui_base_original.Modifier):
         self.gui_tools_repository.add("Rectangle", edit_draft.DraftRectangleGuiTools())
         self.gui_tools_repository.add("Polygon", edit_draft.DraftPolygonGuiTools())
         self.gui_tools_repository.add("Ellipse", edit_draft.DraftEllipseGuiTools())
+        self.gui_tools_repository.add("Point", edit_draft.DraftPointGuiTools())
         self.gui_tools_repository.add(
             "Dimension", edit_draft.DraftDimensionGuiTools()
         )  # Backward compatibility
@@ -341,6 +344,7 @@ class Edit(gui_base_original.Modifier):
         self.unregister_selection_callback()
         self.unregister_editing_callbacks()
         self.editing = None
+        self.node_attachment_pick = False
         self.finalizeGhost()
         Gui.Snapper.setSelectMode(False)
 
@@ -383,6 +387,14 @@ class Edit(gui_base_original.Modifier):
                 Gui.InputHint(
                     translate("draft", "%1 options for hovered node/edge"),
                     Gui.UserInput.KeyE,
+                ),
+                Gui.InputHint(translate("draft", "%1 finish"), Gui.UserInput.KeyEscape),
+            ]
+        if self.node_attachment_pick:
+            return [
+                Gui.InputHint(
+                    translate("draft", "%1 pick vertex or point to attach"),
+                    Gui.UserInput.MouseLeft,
                 ),
                 Gui.InputHint(translate("draft", "%1 finish"), Gui.UserInput.KeyEscape),
             ]
@@ -476,6 +488,9 @@ class Edit(gui_base_original.Modifier):
         if event.getState() in (coin.SoKeyboardEvent.DOWN, coin.SoKeyboardEvent.UP):
             key = event.getKey()
             if key == coin.SoKeyboardEvent.ESCAPE:
+                if self.node_attachment_pick:
+                    self.cancelNodeAttachmentPick()
+                    return
                 self.finish()
             if key == coin.SoKeyboardEvent.E:
                 self.display_tracker_menu(event)
@@ -490,6 +505,9 @@ class Edit(gui_base_original.Modifier):
         if (
             event.getState() == coin.SoMouseButtonEvent.DOWN and event.getButton() == event.BUTTON1
         ):  # left click
+            if self.node_attachment_pick:
+                self.pickNodeAttachmentTarget(event)
+                return
             if not event.wasAltDown():
                 if self.editing is None:
 
@@ -513,6 +531,8 @@ class Edit(gui_base_original.Modifier):
         Update tracker position and update preview ghost.
         """
         event = event_callback.getEvent()
+        if self.node_attachment_pick:
+            return
         if self.editing is not None:
             self.updateTrackerAndGhost(event)
         else:
@@ -540,6 +560,7 @@ class Edit(gui_base_original.Modifier):
 
         self.ui.lineUi(title=translate("draft", "Edit Node"), icon="Draft_Edit")
         self.ui.continueCmd.hide()
+        self.configureNodeAttachmentButton(obj, node_idx)
         self.editing = node_idx
         self.trackers[obj.Name][node_idx].off()
 
@@ -565,6 +586,7 @@ class Edit(gui_base_original.Modifier):
 
     def endEditing(self, obj, nodeIndex, v=None):
         """Terminate editing and start object updating process."""
+        self.node_attachment_pick = False
         self.finalizeGhost()
         self.trackers[obj.Name][nodeIndex].on()
         Gui.Snapper.setSelectMode(True)
@@ -580,6 +602,24 @@ class Edit(gui_base_original.Modifier):
         self.ui.editUi()
         self.node = []
         self.editing = None
+        self.showTrackers()
+        gui_tool_utils.redraw_3d_view()
+        self.update_hints()
+
+    def finishEditingAfterAttachment(self, obj, node_idx):
+        """Terminate node editing after changing node attachment state."""
+        self.node_attachment_pick = False
+        self.finalizeGhost()
+        try:
+            self.trackers[obj.Name][node_idx].on()
+        except (KeyError, IndexError):
+            pass
+        Gui.Snapper.setSelectMode(True)
+        self.alt_edit_mode = 0
+        self.ui.editUi()
+        self.node = []
+        self.editing = None
+        self.resetTrackers(obj)
         self.showTrackers()
         gui_tool_utils.redraw_3d_view()
         self.update_hints()
@@ -767,6 +807,138 @@ class Edit(gui_base_original.Modifier):
     def evaluate_menu_action(self, action):
         callback = action.data()
         callback()
+
+    def supports_node_attachments(self, obj):
+        """Return True for Draft objects with direct coordinate edit nodes."""
+        return utils.get_type(obj) in ("Wire", "BSpline", "BezCurve", "Point")
+
+    def configureNodeAttachmentButton(self, obj, node_idx):
+        """Show and configure the node attachment button in the task panel."""
+        if not self.supports_node_attachments(obj):
+            self.ui.attachNodeButton.hide()
+            return
+
+        self.ui.attachNodeButton.show()
+        self.ui.attachNodeButton.setCheckable(False)
+        self.ui.attachNodeButton.setChecked(False)
+        self.updateNodeAttachmentButton(obj, node_idx)
+
+    def updateNodeAttachmentButton(self, obj, node_idx):
+        if draft_base.get_point_attachment_map(obj).get(node_idx):
+            self.ui.attachNodeButton.setText(translate("draft", "Detach"))
+            self.ui.attachNodeButton.setToolTip(
+                translate("draft", "Removes the attachment from this node")
+            )
+        elif self.node_attachment_pick:
+            self.ui.attachNodeButton.setText(translate("draft", "Pick Target"))
+            self.ui.attachNodeButton.setToolTip(
+                translate("draft", "Selects a vertex or point object in the 3D view")
+            )
+        else:
+            self.ui.attachNodeButton.setText(translate("draft", "Attach"))
+            self.ui.attachNodeButton.setToolTip(
+                translate("draft", "Attaches this node to the selected vertex or point")
+            )
+
+    def attachCurrentNode(self):
+        """Attach, detach, or enter target-pick mode for the edited node."""
+        if self.obj is None or self.editing is None:
+            return False
+        if not self.supports_node_attachments(self.obj):
+            return False
+
+        if draft_base.get_point_attachment_map(self.obj).get(self.editing):
+            self.remove_node_attachment(self.obj, self.editing)
+            self.finishEditingAfterAttachment(self.obj, self.editing)
+            return True
+
+        link = self.get_selected_point_attachment_link(self.obj)
+        if link:
+            self.attach_node_to_link(self.obj, self.editing, link)
+            self.finishEditingAfterAttachment(self.obj, self.editing)
+            return True
+
+        self.node_attachment_pick = True
+        Gui.Snapper.setSelectMode(True)
+        self.updateNodeAttachmentButton(self.obj, self.editing)
+        self.update_hints()
+        App.Console.PrintMessage(
+            translate("draft", "Pick a vertex or point object to attach this node") + "\n"
+        )
+        return True
+
+    def cancelNodeAttachmentPick(self):
+        """Cancel the target-pick step and return to normal node editing."""
+        self.node_attachment_pick = False
+        Gui.Snapper.setSelectMode(False)
+        if self.obj is not None and self.editing is not None:
+            self.updateNodeAttachmentButton(self.obj, self.editing)
+        self.update_hints()
+
+    def pickNodeAttachmentTarget(self, event):
+        """Attach the edited node to the target picked in the 3D view."""
+        if self.obj is None or self.editing is None:
+            self.node_attachment_pick = False
+            return
+
+        pos = event.getPosition().getValue()
+        link = self.get_point_attachment_link_at_position(self.obj, pos)
+        if not link:
+            App.Console.PrintWarning(
+                translate("draft", "Pick a vertex or point object to attach this node") + "\n"
+            )
+            return
+
+        self.attach_node_to_link(self.obj, self.editing, link)
+        self.finishEditingAfterAttachment(self.obj, self.editing)
+
+    def attach_node_to_link(self, obj, node_idx, link):
+        App.ActiveDocument.openTransaction(translate("draft", "Attach node"))
+        draft_base.set_point_attachment(obj, node_idx, link)
+        obj.recompute()
+        App.ActiveDocument.commitTransaction()
+
+    def remove_node_attachment(self, obj, node_idx):
+        App.ActiveDocument.openTransaction(translate("draft", "Remove node attachment"))
+        draft_base.remove_point_attachment(obj, node_idx)
+        obj.recompute()
+        App.ActiveDocument.commitTransaction()
+
+    def get_selected_point_attachment_link(self, target_obj):
+        """Return the first selected external vertex as a LinkSub entry."""
+        for sel in Gui.Selection.getSelectionEx("", 0):
+            if sel.Object is target_obj:
+                continue
+            for subname, subobj in zip(sel.SubElementNames, sel.SubObjects):
+                if getattr(subobj, "ShapeType", None) == "Vertex":
+                    return (sel.Object, (subname,))
+            if not sel.SubElementNames:
+                link = (sel.Object, ("",))
+                if draft_base.point_from_attachment_link(link) is not None:
+                    return link
+        return None
+
+    def get_point_attachment_link_at_position(self, target_obj, pos):
+        """Return an attachable LinkSub entry picked at a screen position."""
+        for info in self.view.getObjectsInfo((pos[0], pos[1])) or []:
+            if not info:
+                continue
+            obj = info.get("ParentObject")
+            if isinstance(obj, str):
+                obj = App.ActiveDocument.getObject(obj)
+            if obj is None:
+                obj = App.ActiveDocument.getObject(info.get("Object", ""))
+            if obj is None:
+                continue
+            if obj is target_obj:
+                continue
+            component = info.get("SubName", info.get("Component", ""))
+            if component.startswith("Vertex"):
+                return (obj, (component,))
+            link = (obj, ("",))
+            if draft_base.point_from_attachment_link(link) is not None:
+                return link
+        return None
 
     # -------------------------------------------------------------------------
     # EDIT OBJECT TOOLS

--- a/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
@@ -56,6 +56,7 @@ import DraftVecUtils
 from draftutils.translate import translate
 import draftutils.utils as utils
 from draftutils.messages import _err
+from draftobjects import base as draft_base
 
 import draftguitools.gui_trackers as trackers
 
@@ -176,6 +177,7 @@ class DraftWireGuiTools(GuiTools):
         if obj.Closed and edgeIndex == len(obj.Points):
             # last segment when object is closed
             newPoints.append(edit_command.localize_vector(obj, newPoint))
+        draft_base.shift_point_attachments(obj, edgeIndex, 1)
         obj.Points = newPoints
 
         obj.recompute()
@@ -187,6 +189,7 @@ class DraftWireGuiTools(GuiTools):
 
         pts = obj.Points
         pts.pop(node_idx)
+        draft_base.shift_point_attachments(obj, node_idx, -1)
         obj.Points = pts
 
         obj.recompute()
@@ -196,12 +199,15 @@ class DraftWireGuiTools(GuiTools):
         obj.recompute()
 
     def reverse_wire(self, obj):
+        point_count = len(obj.Points)
         obj.Points = reversed(obj.Points)
+        draft_base.reverse_point_attachments(obj, point_count)
         obj.recompute()
 
     def set_first_point(self, obj, node_idx):
         pts = obj.Points
         obj.Points = pts[node_idx:] + pts[0:node_idx]
+        draft_base.rotate_point_attachments(obj, len(pts), node_idx)
         obj.recompute()
 
 
@@ -245,10 +251,12 @@ class DraftBSplineGuiTools(DraftWireGuiTools):
         for i in range(len(uPoints) - 1):
             if (uNewPoint > uPoints[i]) and (uNewPoint < uPoints[i + 1]):
                 pts.insert(i + 1, pt)
+                draft_base.shift_point_attachments(obj, i + 1, 1)
                 break
         # DNC: fix: add points to last segment if curve is closed
         if obj.Closed and (uNewPoint > uPoints[-1]):
             pts.append(pt)
+            draft_base.shift_point_attachments(obj, len(pts) - 1, 1)
         obj.Points = pts
 
         obj.recompute()
@@ -572,6 +580,19 @@ class DraftPolygonGuiTools(GuiTools):
         elif node_idx == 1:
             obj.Radius = v.Length
         obj.recompute()
+
+
+class DraftPointGuiTools(GuiTools):
+
+    def get_edit_points(self, obj):
+        return [App.Vector(0, 0, 0)]
+
+    def update_object_from_edit_points(self, obj, node_idx, v, alt_edit_mode=0):
+        point = obj.Placement.multVec(v)
+        obj.X = point.x
+        obj.Y = point.y
+        obj.Z = point.z
+        obj.Placement.Base = point
 
 
 class DraftDimensionGuiTools(GuiTools):
@@ -927,6 +948,7 @@ class DraftBezCurveGuiTools(GuiTools):
 
         pts = obj.Points
         pts.pop(node_idx)
+        draft_base.shift_point_attachments(obj, node_idx, -1)
         obj.Points = pts
         obj.Proxy.resetcontinuity(obj)
         obj.recompute()
@@ -936,7 +958,9 @@ class DraftBezCurveGuiTools(GuiTools):
         obj.recompute()
 
     def reverse_wire(self, obj):
+        point_count = len(obj.Points)
         obj.Points = reversed(obj.Points)
+        draft_base.reverse_point_attachments(obj, point_count)
         obj.recompute()
 
 

--- a/src/Mod/Draft/draftobjects/base.py
+++ b/src/Mod/Draft/draftobjects/base.py
@@ -30,6 +30,193 @@
 
 ## \addtogroup draftobjects
 # @{
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import FreeCAD as App
+
+ATTACHED_NODES_PROP = "AttachedNodes"
+ATTACHED_NODE_INDEXES_PROP = "AttachedNodeIndexes"
+
+
+def assure_point_attachment_properties(obj):
+    """Add generic node attachment properties to a Draft object."""
+    if ATTACHED_NODES_PROP not in obj.PropertiesList:
+        _tip = QT_TRANSLATE_NOOP(
+            "App::Property",
+            "Geometry references used to drive individual Draft edit nodes",
+        )
+        obj.addProperty(
+            "App::PropertyLinkSubListGlobal",
+            ATTACHED_NODES_PROP,
+            "Node Attachments",
+            _tip,
+            locked=True,
+        )
+    if ATTACHED_NODE_INDEXES_PROP not in obj.PropertiesList:
+        _tip = QT_TRANSLATE_NOOP(
+            "App::Property",
+            "Zero-based indexes of Draft edit nodes driven by AttachedNodes",
+        )
+        obj.addProperty(
+            "App::PropertyIntegerList",
+            ATTACHED_NODE_INDEXES_PROP,
+            "Node Attachments",
+            _tip,
+            locked=True,
+        )
+
+
+def has_point_attachments(obj):
+    """Return True if the object has at least one attached edit node."""
+    return (
+        hasattr(obj, ATTACHED_NODES_PROP)
+        and hasattr(obj, ATTACHED_NODE_INDEXES_PROP)
+        and bool(getattr(obj, ATTACHED_NODES_PROP))
+        and bool(getattr(obj, ATTACHED_NODE_INDEXES_PROP))
+    )
+
+
+def _subnames_from_link(link):
+    if len(link) < 2:
+        return ()
+    subnames = link[1]
+    if isinstance(subnames, str):
+        return (subnames,) if subnames else ()
+    return tuple(subnames)
+
+
+def point_from_attachment_link(link):
+    """Resolve a LinkSub entry to a point in global coordinates."""
+    if not link:
+        return None
+    obj = link[0]
+    if obj is None:
+        return None
+
+    subnames = _subnames_from_link(link)
+    subname = subnames[0] if subnames else ""
+    if subname:
+        try:
+            subobj = obj.getSubObject(subname)
+        except (AttributeError, ValueError, TypeError, ReferenceError):
+            subobj = None
+        if subobj is not None and getattr(subobj, "ShapeType", None) == "Vertex":
+            return subobj.Point
+
+    shape = getattr(obj, "Shape", None)
+    if shape is not None and not shape.isNull() and len(shape.Vertexes) == 1:
+        return shape.Vertexes[0].Point
+
+    if hasattr(obj, "getGlobalPlacement"):
+        return obj.getGlobalPlacement().Base
+    if hasattr(obj, "Placement"):
+        return App.Vector(obj.Placement.Base)
+    return None
+
+
+def get_point_attachment_map(obj):
+    """Return a dict mapping node index to LinkSub entry."""
+    if not has_point_attachments(obj):
+        return {}
+    return dict(zip(obj.AttachedNodeIndexes, get_flat_point_attachment_links(obj)))
+
+
+def get_flat_point_attachment_links(obj):
+    """Return one LinkSub entry per stored attached node."""
+    links = []
+    for link in obj.AttachedNodes:
+        source = link[0]
+        subnames = _subnames_from_link(link)
+        if subnames:
+            for subname in subnames:
+                links.append((source, (subname,)))
+        else:
+            links.append((source, ("",)))
+    return links
+
+
+def apply_point_attachments(obj, points):
+    """Return a copy of points with attached nodes updated from their links."""
+    if not has_point_attachments(obj):
+        return points
+
+    result = list(points)
+    inv_placement = obj.getGlobalPlacement().inverse()
+    for node_idx, link in get_point_attachment_map(obj).items():
+        if node_idx < 0 or node_idx >= len(result):
+            continue
+        point = point_from_attachment_link(link)
+        if point is not None:
+            result[node_idx] = inv_placement.multVec(point)
+    return result
+
+
+def apply_point_attachment_to_point(obj):
+    """Return the global point for an attached Draft Point, or None."""
+    link = get_point_attachment_map(obj).get(0)
+    if link:
+        return point_from_attachment_link(link)
+    return None
+
+
+def set_point_attachment(obj, node_idx, link):
+    """Attach a Draft edit node to a LinkSub entry."""
+    assure_point_attachment_properties(obj)
+    links_by_index = get_point_attachment_map(obj)
+    links_by_index[node_idx] = link
+    _set_point_attachment_map(obj, links_by_index)
+
+
+def remove_point_attachment(obj, node_idx):
+    """Remove the attachment for a Draft edit node."""
+    if not has_point_attachments(obj):
+        return
+    links_by_index = get_point_attachment_map(obj)
+    links_by_index.pop(node_idx, None)
+    _set_point_attachment_map(obj, links_by_index)
+
+
+def shift_point_attachments(obj, start_idx, delta):
+    """Shift stored node indexes after a point insertion or deletion."""
+    if not has_point_attachments(obj):
+        return
+    shifted = {}
+    for node_idx, link in get_point_attachment_map(obj).items():
+        if delta < 0 and node_idx == start_idx:
+            continue
+        if node_idx >= start_idx:
+            node_idx += delta
+        if node_idx >= 0:
+            shifted[node_idx] = link
+    _set_point_attachment_map(obj, shifted)
+
+
+def reverse_point_attachments(obj, point_count):
+    """Reverse stored node indexes after reversing a point-list object."""
+    if not has_point_attachments(obj):
+        return
+    reversed_links = {}
+    for node_idx, link in get_point_attachment_map(obj).items():
+        if 0 <= node_idx < point_count:
+            reversed_links[point_count - node_idx - 1] = link
+    _set_point_attachment_map(obj, reversed_links)
+
+
+def rotate_point_attachments(obj, point_count, first_idx):
+    """Move node attachments with a point-list rotation."""
+    if not has_point_attachments(obj) or point_count <= 0:
+        return
+    rotated_links = {}
+    for node_idx, link in get_point_attachment_map(obj).items():
+        if 0 <= node_idx < point_count:
+            rotated_links[(node_idx - first_idx) % point_count] = link
+    _set_point_attachment_map(obj, rotated_links)
+
+
+def _set_point_attachment_map(obj, links_by_index):
+    items = sorted(links_by_index.items())
+    obj.AttachedNodeIndexes = [idx for idx, _link in items]
+    obj.AttachedNodes = [link for _idx, link in items]
 
 
 class DraftObject(object):

--- a/src/Mod/Draft/draftobjects/bezcurve.py
+++ b/src/Mod/Draft/draftobjects/bezcurve.py
@@ -36,6 +36,7 @@ import FreeCAD as App
 from draftutils import gui_utils
 from draftutils import params
 from draftobjects.base import DraftObject
+from draftobjects import base as draft_base
 
 
 class BezCurve(DraftObject):
@@ -71,19 +72,26 @@ class BezCurve(DraftObject):
         obj.Continuity = []
         # obj.setEditorMode("Degree", 2)
         obj.setEditorMode("Continuity", 1)
+        draft_base.assure_point_attachment_properties(obj)
 
     def onDocumentRestored(self, obj):
         super().onDocumentRestored(obj)
+        draft_base.assure_point_attachment_properties(obj)
         gui_utils.restore_view_object(
             obj, vp_module="view_bezcurve", vp_class="ViewProviderBezCurve"
         )
 
     def execute(self, fp):
-        if self.props_changed_placement_only():
+        if self.props_changed_placement_only() and not draft_base.has_point_attachments(fp):
             fp.positionBySupport()
             self.props_changed_clear()
             return
 
+        fp.positionBySupport()
+        if fp.Points:
+            attached_points = draft_base.apply_point_attachments(fp, fp.Points)
+            if attached_points != fp.Points:
+                fp.Points = attached_points
         self.createGeometry(fp)
         fp.positionBySupport()
         self.props_changed_clear()

--- a/src/Mod/Draft/draftobjects/bspline.py
+++ b/src/Mod/Draft/draftobjects/bspline.py
@@ -34,6 +34,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 from draftobjects.base import DraftObject
+from draftobjects import base as draft_base
 from draftutils import gui_utils
 from draftutils import params
 
@@ -60,9 +61,11 @@ class BSpline(DraftObject):
         obj.Closed = False
         obj.Points = []
         self.assureProperties(obj)
+        draft_base.assure_point_attachment_properties(obj)
 
     def onDocumentRestored(self, obj):
         super().onDocumentRestored(obj)
+        draft_base.assure_point_attachment_properties(obj)
         gui_utils.restore_view_object(obj, vp_module="view_bspline", vp_class="ViewProviderBSpline")
 
     def assureProperties(self, obj):  # for Compatibility with older versions
@@ -96,7 +99,9 @@ class BSpline(DraftObject):
                 fp.Parameterization = 1.0
 
     def execute(self, obj):
-        if self.props_changed_placement_only() or not obj.Points:
+        if (
+            self.props_changed_placement_only() and not draft_base.has_point_attachments(obj)
+        ) or not obj.Points:
             obj.positionBySupport()
             self.props_changed_clear()
             return
@@ -104,6 +109,10 @@ class BSpline(DraftObject):
         import Part
 
         self.assureProperties(obj)
+        obj.positionBySupport()
+        attached_points = draft_base.apply_point_attachments(obj, obj.Points)
+        if attached_points != obj.Points:
+            obj.Points = attached_points
 
         self.knotSeq = self.parameterization(obj.Points, obj.Parameterization, obj.Closed)
         plm = obj.Placement

--- a/src/Mod/Draft/draftobjects/point.py
+++ b/src/Mod/Draft/draftobjects/point.py
@@ -35,6 +35,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 from draftobjects.base import DraftObject
+from draftobjects import base as draft_base
 from draftutils import gui_utils
 
 
@@ -58,16 +59,26 @@ class Point(DraftObject):
         obj.Z = z
 
         obj.setPropertyStatus("Placement", "Hidden")
+        draft_base.assure_point_attachment_properties(obj)
 
     def onDocumentRestored(self, obj):
         super().onDocumentRestored(obj)
+        draft_base.assure_point_attachment_properties(obj)
         gui_utils.restore_view_object(obj, vp_module="view_point", vp_class="ViewProviderPoint")
 
     def execute(self, obj):
         base = obj.Placement.Base
+        attached_point_global = draft_base.apply_point_attachment_to_point(obj)
+        if attached_point_global is not None:
+            attached_point = obj.Placement.multVec(
+                obj.getGlobalPlacement().inverse().multVec(attached_point_global)
+            )
+            obj.X = attached_point.x
+            obj.Y = attached_point.y
+            obj.Z = attached_point.z
         xyz_vec = App.Vector(obj.X.Value, obj.Y.Value, obj.Z.Value)
 
-        if self.props_changed_placement_only():
+        if self.props_changed_placement_only() and attached_point_global is None:
             if base != xyz_vec:
                 obj.X = base.x
                 obj.Y = base.y

--- a/src/Mod/Draft/draftobjects/wire.py
+++ b/src/Mod/Draft/draftobjects/wire.py
@@ -38,6 +38,7 @@ import DraftVecUtils
 from draftgeoutils import faces as geo_faces
 from draftgeoutils import fillets as geo_fillets
 from draftobjects.base import DraftObject
+from draftobjects import base as draft_base
 from draftutils import gui_utils
 from draftutils import params
 from draftutils.messages import _log
@@ -91,9 +92,11 @@ class Wire(DraftObject):
 
         obj.MakeFace = params.get_param("MakeFaceMode")
         obj.Closed = False
+        draft_base.assure_point_attachment_properties(obj)
 
     def onDocumentRestored(self, obj):
         super().onDocumentRestored(obj)
+        draft_base.assure_point_attachment_properties(obj)
         gui_utils.restore_view_object(obj, vp_module="view_wire", vp_class="ViewProviderWire")
 
         vobj = getattr(obj, "ViewObject", None)
@@ -122,7 +125,7 @@ class Wire(DraftObject):
         _log("v1.1, " + obj.Name + ", migrated view properties")
 
     def execute(self, obj):
-        if self.props_changed_placement_only(
+        if self.props_changed_placement_only(obj) and not draft_base.has_point_attachments(
             obj
         ):  # Supplying obj is required because of `Base` and `Tool`.
             obj.positionBySupport()
@@ -131,6 +134,12 @@ class Wire(DraftObject):
             return
 
         import Part
+
+        obj.positionBySupport()
+        if obj.Points:
+            attached_points = draft_base.apply_point_attachments(obj, obj.Points)
+            if attached_points != obj.Points:
+                obj.Points = attached_points
 
         plm = obj.Placement
         if obj.Base and (not obj.Tool):

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -38,6 +38,7 @@ import FreeCAD as App
 import Part
 import Draft
 from FreeCAD import Vector
+from draftobjects import base as draft_base
 from drafttests import auxiliary as aux
 from drafttests import test_base
 from draftutils.messages import _msg
@@ -611,6 +612,43 @@ class DraftModification(test_base.DraftTestCaseDoc):
         self.doc.recompute()
 
         self.assertTrue(obj.Shape.BoundBox.XLength == 1, "'{}' failed".format(operation))
+
+    def test_attached_draft_nodes(self):
+        """Check if attached Draft nodes follow referenced vertices."""
+        operation = "Attached Draft nodes"
+        _msg("  Test '{}'".format(operation))
+
+        box = self.doc.addObject("Part::Box", "Box")
+        container = self.doc.addObject("App::Part", "Container")
+        container.Placement.Base = Vector(100, 0, 0)
+        wire = Draft.make_wire([Vector(0, 0, 0), Vector(1, 1, 1), Vector(2, 2, 2)])
+        point = Draft.make_point(0, 0, 0)
+        container.addObject(wire)
+        container.addObject(point)
+        self.doc.recompute()
+
+        draft_base.set_point_attachment(wire, 1, (box, ("Vertex4",)))
+        draft_base.set_point_attachment(wire, 2, (box, ("Vertex2",)))
+        draft_base.set_point_attachment(point, 0, (box, ("Vertex4",)))
+        self.doc.recompute()
+
+        wire.Points = wire.Points[1:] + wire.Points[:1]
+        draft_base.rotate_point_attachments(wire, len(wire.Points), 1)
+        wire.Points = list(reversed(wire.Points))
+        draft_base.reverse_point_attachments(wire, len(wire.Points))
+
+        box.Length = 20
+        self.doc.recompute()
+
+        vertex4 = draft_base.point_from_attachment_link((box, ("Vertex4",)))
+        vertex2 = draft_base.point_from_attachment_link((box, ("Vertex2",)))
+        wire_node_1 = wire.getGlobalPlacement().multVec(wire.Points[1])
+        wire_node_2 = wire.getGlobalPlacement().multVec(wire.Points[2])
+        point_position = point.getGlobalPlacement().Base
+
+        self.assertTrue(wire_node_1.isEqual(vertex2, 1e-6), "'{}' failed".format(operation))
+        self.assertTrue(wire_node_2.isEqual(vertex4, 1e-6), "'{}' failed".format(operation))
+        self.assertTrue(point_position.isEqual(vertex4, 1e-6), "'{}' failed".format(operation))
 
     def test_draft_to_techdraw(self):
         """Create a solid, and then a DraftView on a TechDraw page."""


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

Adds persistent attachment support for Draft object nodes:
- Provides an attachment action in the Draft Edit task dialog for selected nodes
- Keeps node attachments correct when points are inserted, deleted, reversed, or reordered
- Adds tests for attachment

Assisted-by: GPT-5.6
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/19283
## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/97412681-fe9b-4d18-b9ba-da107dd50af1



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
