### PR TITLE
Fix: macOS 15+ builds for QuickLook preview

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -11,6 +11,13 @@ source:
 
 build:
   number: 0
+  script:
+    # The build runs inside a pixi/rattler-build sandbox that does not inherit the
+    # host environment, so forward the deployment target through explicitly.
+    # Without this, build.sh falls back to its default and the macOS 15 package
+    # builds the legacy QuickLook generator instead of the modern .appex.
+    env:
+      MACOS_DEPLOYMENT_TARGET: ${{ env.get("MACOS_DEPLOYMENT_TARGET", default="11.0") }}
 
 requirements:
   build:


### PR DESCRIPTION
Hi,

End of June, the CI's Pixi version was bumped from 0.58 to 0.68: among other things, this new version hardens the Pixi build environment (which is great). 

However, the CI needs a minor change to the Pixi recipe (one line fix) for the FreeCAD macOS 15+ builds to keep providing the QuickLook Preview feature brought in a previous PR. The fix simply lets the `MACOS_DEPLOYMENT_TARGET` discriminator env variable slip from the CI into to the Pixi build environment. Otherwise, following the Pixi version bump, that env var is not passed anymore to the Pixi build and all "macOS15" builds actually contain the deprecated qlgenerators, which don't work anymore on macOS 15+, as reported by #31393.

I tested this locally, and you can check [FreeCAD_fix-quicklook-appex-pixi-2026.07.19-macOS15-arm64.dmg](https://github.com/graelo/FreeCAD/releases/download/fix-quicklook-appex-pixi-2026.07.19/FreeCAD_fix-quicklook-appex-pixi-2026.07.19-macOS15-arm64.dmg) from my fork, built a couple hours ago from my run https://github.com/graelo/FreeCAD/actions/runs/29683251232

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Research of the root cause was assisted-by Claude (Opus 4.8).