### PR TITLE
Sketcher: improved responsiveness — adding, editing, dimensioning, and deleting speed increase

### DIFF
--- a/src/Mod/Part/App/WireJoiner.cpp
+++ b/src/Mod/Part/App/WireJoiner.cpp
@@ -42,6 +42,11 @@
 #include <BRepTools.hxx>
 #include <BRepTools_WireExplorer.hxx>
 #include <gp_Pln.hxx>
+#include <ElCLib.hxx>
+#include <Extrema_ExtElC.hxx>
+#include <Extrema_POnCurv.hxx>
+#include <Geom_Line.hxx>
+#include <Geom_TrimmedCurve.hxx>
 #include <GeomAdaptor_Curve.hxx>
 #include <GeomLProp_CLProps.hxx>
 #include <GProp_GProps.hxx>
@@ -1218,7 +1223,84 @@ public:
         return true;
     }
 
-    void checkIntersection(
+    // Unwraps the (possibly trimmed) underlying Geom_Line of an edge; null if
+    // the edge is not backed by a real line (parameterization would not be
+    // arclength and the analytic fast path below would be unsound).
+    static Handle(Geom_Line) underlyingLine(const EdgeInfo& info)
+    {
+        Handle(Geom_Line) line = Handle(Geom_Line)::DownCast(info.curve);
+        if (line.IsNull()) {
+            Handle(Geom_TrimmedCurve) trimmed = Handle(Geom_TrimmedCurve)::DownCast(info.curve);
+            if (!trimmed.IsNull()) {
+                line = Handle(Geom_Line)::DownCast(trimmed->BasisCurve());
+            }
+        }
+        return line;
+    }
+
+    // Analytic line/line intersection. The generic path below builds a wire, a
+    // face and a ShapeAnalysis_Wire PER PAIR, which dominates the whole
+    // WireJoiner on dense line sketches (every pair of corner-touching edges
+    // pays it). Two straight segments intersect in at most one point, computed
+    // exactly by Extrema_ExtElC. Returns false (caller falls back to the
+    // generic path) for non-line curves and for near-parallel pairs, whose
+    // collinear-overlap semantics stay with the generic code.
+    bool checkIntersectionLinear(
+        const EdgeInfo& info,
+        const EdgeInfo& other,
+        std::set<IntersectInfo>& params1,
+        std::set<IntersectInfo>& params2
+    )
+    {
+        Handle(Geom_Line) line1 = underlyingLine(info);
+        Handle(Geom_Line) line2 = underlyingLine(other);
+        if (line1.IsNull() || line2.IsNull()) {
+            return false;
+        }
+
+        Extrema_ExtElC extrema(line1->Lin(), line2->Lin(), Precision::Angular());
+        if (!extrema.IsDone() || extrema.IsParallel() || extrema.NbExt() < 1) {
+            return false;
+        }
+
+        Extrema_POnCurv pointOn1;
+        Extrema_POnCurv pointOn2;
+        extrema.Points(1, pointOn1, pointOn2);
+
+        if (pointOn1.Value().SquareDistance(pointOn2.Value()) >= myTol2) {
+            return true;  // the lines pass each other: no intersection
+        }
+
+        // gp_Lin parameters equal the Geom_Line curve parameters (arclength),
+        // so they compare directly against the edges' parameter ranges; myTol
+        // maps 1:1 onto the parameter space of a line.
+        const double u1 = pointOn1.Parameter();
+        const double u2 = pointOn2.Parameter();
+        if (u1 < info.firstParam - myTol || u1 > info.lastParam + myTol
+            || u2 < other.firstParam - myTol || u2 > other.lastParam + myTol) {
+            return true;  // intersection lies outside the bounded segments
+        }
+
+        const gp_Pnt point((pointOn1.Value().XYZ() + pointOn2.Value().XYZ()) * 0.5);
+
+        // The generic path joins corner-touching edges into one wire and by
+        // design reports no intersection at their shared vertex; reproduce
+        // that. Two non-parallel straight lines intersect at most once, so if
+        // that point is a shared corner there is nothing else to report.
+        const bool atEndpoint1 = point.SquareDistance(info.p1) < myTol2
+            || point.SquareDistance(info.p2) < myTol2;
+        const bool atEndpoint2 = point.SquareDistance(other.p1) < myTol2
+            || point.SquareDistance(other.p2) < myTol2;
+        if (atEndpoint1 && atEndpoint2) {
+            return true;
+        }
+
+        pushIntersection(params1, u1, point, other.edge);
+        pushIntersection(params2, u2, point, info.edge);
+        return true;
+    }
+
+    void checkIntersectionGeneric(
         const EdgeInfo& info,
         const EdgeInfo& other,
         std::set<IntersectInfo>& params1,
@@ -1259,6 +1341,24 @@ public:
             pushIntersection(params1, points2d(i).ParamOnFirst(), points3d(i), other.edge);
             pushIntersection(params2, points2d(i).ParamOnSecond(), points3d(i), info.edge);
         }
+    }
+
+    void checkIntersection(
+        const EdgeInfo& info,
+        const EdgeInfo& other,
+        std::set<IntersectInfo>& params1,
+        std::set<IntersectInfo>& params2
+    )
+    {
+        // Two straight segments intersect in at most one point; use the
+        // analytic line/line fast path and fall back to the generic path
+        // when it declines.
+        if (info.isLinear && other.isLinear
+            && checkIntersectionLinear(info, other, params1, params2)) {
+            return;
+        }
+
+        checkIntersectionGeneric(info, other, params1, params2);
     }
 
     void pushIntersection(

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -233,6 +233,15 @@ int Sketch::setUpSketch(
             continue;
         }
         Base::hash_combine(topologyHash, static_cast<int>(c->Type));
+        // Equation-defining fields beyond the geo/pos wiring: retargeting an
+        // internal-alignment constraint (or changing its alignment type or
+        // orientation) can build a different solver equation while leaving Type
+        // and the geo/pos references unchanged. Orientation selects the Tangent
+        // (CCW/CW) and signed-Distance equation. Fold them all in so the cache is
+        // not reused across a structurally different system.
+        Base::hash_combine(topologyHash, static_cast<int>(c->AlignmentType));
+        Base::hash_combine(topologyHash, c->InternalAlignmentIndex);
+        Base::hash_combine(topologyHash, c->Orientation.toUnderlyingType());
         for (int j = 0; c->hasElement(j); ++j) {
             Base::hash_combine(topologyHash, c->getGeoId(j));
             Base::hash_combine(topologyHash, c->getPosIdAsInt(j));

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -24,6 +24,7 @@
 
 #include <cmath>
 #include <iostream>
+#include <algorithm>
 
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRep_Builder.hxx>
@@ -38,6 +39,7 @@
 #include <Base/Exception.h>
 #include <Base/Reader.h>
 #include <Base/TimeInfo.h>
+#include <Base/Tools.h>
 #include <Base/VectorPy.h>
 #include <Base/Writer.h>
 #include <Mod/Part/App/ArcOfCirclePy.h>
@@ -195,8 +197,6 @@ int Sketch::setUpSketch(
 {
     Base::TimeElapsed start_time;
 
-    clear();
-
     // The geometries that are in groups are going to be ignored by the solver.
     std::set<int> inGroupGeoIds;
     for (const auto& c : ConstraintList) {
@@ -207,6 +207,65 @@ int Sketch::setUpSketch(
             }
         }
     }
+
+    // Persistent diagnosis cache: fingerprint the constraint topology before
+    // clear() destroys the current solver state. The hash covers the wiring
+    // (Type, geoId, posId) of every effective constraint (driving, active,
+    // non-Group/Text/Block, not referencing grouped geometry) and the geometry
+    // type sequence. If it matches the previous call, the topology is
+    // unchanged and the cached diagnosis can be reused.
+    size_t topologyHash = 0;
+    for (const auto* c : ConstraintList) {
+        if (!c || c->Type == Group || c->Type == Text || c->Type == Block
+            || !c->isActive || !c->isDriving) {
+            continue;
+        }
+        // unenforceableConstraints isn't computed yet; approximate it — a
+        // constraint referencing grouped geometry is not enforced.
+        bool inGroup = false;
+        for (int j = 0; c->hasElement(j); ++j) {
+            if (inGroupGeoIds.count(c->getGeoId(j))) {
+                inGroup = true;
+                break;
+            }
+        }
+        if (inGroup) {
+            continue;
+        }
+        Base::hash_combine(topologyHash, static_cast<int>(c->Type));
+        for (int j = 0; c->hasElement(j); ++j) {
+            Base::hash_combine(topologyHash, c->getGeoId(j));
+            Base::hash_combine(topologyHash, c->getPosIdAsInt(j));
+        }
+    }
+    for (const auto* g : GeoList) {
+        if (!g) {
+            continue;
+        }
+        Base::hash_combine(topologyHash, g->getTypeId().getKey());
+        // The typeId alone misses parameter-count changes within a type;
+        // B-splines are the only sketcher geometry with a variable parameter
+        // count, and a knot/pole edit must not hit the cache.
+        if (const auto* bsp = dynamic_cast<const GeomBSplineCurve*>(g)) {
+            Base::hash_combine(topologyHash, bsp->countPoles());
+            Base::hash_combine(topologyHash, bsp->countKnots());
+            Base::hash_combine(topologyHash, bsp->getDegree());
+            Base::hash_combine(topologyHash, bsp->isPeriodic());
+        }
+    }
+
+    bool topologyUnchanged = (topologyHash == lastTopologyHash) && hasValidDiagnosis;
+
+    // Save diagnosis cache before clear() destroys the solver state
+    if (topologyUnchanged) {
+        cachedDiagnosis = GCSsys.saveDiagnosis();
+        hasCachedDiagnosis = true;
+    }
+    else {
+        hasCachedDiagnosis = false;
+    }
+
+    clear();
 
     std::vector<Part::Geometry*> intGeoList, extGeoList;
     std::copy(GeoList.begin(), GeoList.end() - extGeoCount, std::back_inserter(intGeoList));
@@ -290,12 +349,29 @@ int Sketch::setUpSketch(
     clearTemporaryConstraints();
     GCSsys.declareUnknowns(Parameters);
     GCSsys.declareDrivenParams(DrivenParameters);
+
+    // Restore the cached diagnosis if the topology is unchanged. Must run AFTER
+    // addConstraints() (which sets hasDiagnosis=false) and BEFORE initSolution()
+    // (which calls diagnose()).
+    if (topologyUnchanged && hasCachedDiagnosis) {
+        GCSsys.restoreDiagnosis(cachedDiagnosis);
+    }
+
     GCSsys.initSolution(defaultSolverRedundant);
+
+    // update fingerprint state after a successful initSolution
+    lastTopologyHash = topologyHash;
+    hasValidDiagnosis = true;
 
     // Post-analysis
     // Now that we have all the parameters information, we deal properly with the block constraints
     // if necessary
+    // Block-constraint sketches bypass the diagnosis cache because
+    // fixParametersAndDiagnose() calls invalidatedDiagnosis() which sets hasDiagnosis=false.
+    // This is acceptable — block constraints are rare.
     if (doesBlockAffectOtherConstraints) {
+        hasValidDiagnosis = false;
+        hasCachedDiagnosis = false;
 
         std::vector<double*> params_to_block;
 
@@ -5322,6 +5398,8 @@ int Sketch::initMove(const std::vector<GeoElementId>& geoEltIds, bool fine)
     InitParameters = MoveParameters;
 
     GCSsys.initSolution();
+    initToPoint = Base::Vector3d(0, 0, 0);
+    moveStep = 0;
     isInitMove = true;
 
     return 0;

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -216,8 +216,8 @@ int Sketch::setUpSketch(
     // unchanged and the cached diagnosis can be reused.
     size_t topologyHash = 0;
     for (const auto* c : ConstraintList) {
-        if (!c || c->Type == Group || c->Type == Text || c->Type == Block
-            || !c->isActive || !c->isDriving) {
+        if (!c || c->Type == Group || c->Type == Text || c->Type == Block || !c->isActive
+            || !c->isDriving) {
             continue;
         }
         // unenforceableConstraints isn't computed yet; approximate it — a

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -156,6 +156,17 @@ public:
         return MalformedConstraints;
     }
 
+    // diagnosis cache management
+    inline bool wasDiagnosisRestored() const
+    {
+        return hasCachedDiagnosis;
+    }
+    inline void invalidateDiagnosisCache()
+    {
+        hasValidDiagnosis = false;
+        hasCachedDiagnosis = false;
+    }
+
 public:
     std::set<std::pair<int, Sketcher::PointPos>> getDependencyGroup(int geoId, PointPos pos) const;
 
@@ -182,6 +193,7 @@ public:
     /** Resets the initialization of a point or curve drag
      */
     void resetInitMove();
+    inline bool isInitMoveActive() const { return isInitMove; }
 
     /** Limits a b-spline drag to the segment around `firstPoint`.
      */
@@ -612,6 +624,12 @@ private:
     std::vector<int> Redundant;
     std::vector<int> PartiallyRedundant;
     std::vector<int> MalformedConstraints;
+
+    // fingerprint for the diagnosis cache
+    size_t lastTopologyHash = 0;
+    bool hasValidDiagnosis = false;
+    GCS::DiagnosisCache cachedDiagnosis;
+    bool hasCachedDiagnosis = false;
 
     std::vector<double*> pDependentParametersList;
 

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -193,7 +193,10 @@ public:
     /** Resets the initialization of a point or curve drag
      */
     void resetInitMove();
-    inline bool isInitMoveActive() const { return isInitMove; }
+    inline bool isInitMoveActive() const
+    {
+        return isInitMove;
+    }
 
     /** Limits a b-spline drag to the segment around `firstPoint`.
      */

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -356,9 +356,13 @@ void SketchObject::buildShape()
         return;
     }
 
-    // update the skip-cache reference (takes ownership of the extracted
-    // clones) — called on every path that keeps or produces shapes
-    auto updateGeometryCache = [this, &geometries]() {
+    // Record the geometry the shape is being built from (takes ownership of the
+    // extracted clones). This deliberately leaves builtShapeValid == false: the
+    // cache is marked valid only once Shape and InternalShape have both been
+    // successfully assigned (each commit point sets builtShapeValid = true
+    // below), so an exception during the OCC rebuild cannot leave a "valid"
+    // cache describing a shape that was never committed.
+    auto recordGeometryCache = [this, &geometries]() {
         builtShapeGeometry.clear();
         builtShapeGeometry.reserve(geometries.size());
         for (auto geo : geometries) {
@@ -374,7 +378,7 @@ void SketchObject::buildShape()
             );
         }
         builtShapeMakeInternals = MakeInternals.getValue();
-        builtShapeValid = true;
+        builtShapeValid = false;
     };
 
     // island-local rebuild: when only some disjoint clusters moved, rebuild
@@ -387,10 +391,11 @@ void SketchObject::buildShape()
     }
 
     if (spliced) {
-        updateGeometryCache();
+        recordGeometryCache();
         internalElementMap.clear();
         InternalShape.setValue(splicedInternal);
         Shape.setValue(splicedResult);
+        builtShapeValid = true;  // commit only after both properties are assigned
         return;
     }
 
@@ -420,7 +425,7 @@ void SketchObject::buildShape()
         }
     }
 
-    updateGeometryCache();
+    recordGeometryCache();
 
     for (int i = 2; i < ExternalGeo.getSize(); ++i) {
         auto geo = ExternalGeo[i];
@@ -450,6 +455,7 @@ void SketchObject::buildShape()
         islandCache = ShapeIslandCache {};
         InternalShape.setValue(Part::TopoShape());
         Shape.setValue(Part::TopoShape());
+        builtShapeValid = true;  // commit only after both properties are assigned
         return;
     }
 
@@ -485,6 +491,10 @@ void SketchObject::buildShape()
     Shape.setValue(result);
 
     rebuildIslandCache(geoBoxes, result, internal, islandSpliceable && vertices.empty());
+
+    // commit the skip-cache only now that both Shape and InternalShape are
+    // assigned and the island cache has been rebuilt
+    builtShapeValid = true;
 }
 // clang-format off
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -85,13 +85,15 @@ bool isSameGeometryElement(const Part::Geometry* a, const Part::Geometry* b)
 {
     return a->getTypeId() == b->getTypeId()
         && Sketcher::GeometryFacade::getConstruction(a)
-            == Sketcher::GeometryFacade::getConstruction(b)
+        == Sketcher::GeometryFacade::getConstruction(b)
         && a->isSame(*b, Precision::Confusion(), Precision::Angular());
 }
 
 // content compare for the buildShape() skip-cache
-bool isSameShapeGeometry(const std::vector<std::unique_ptr<Part::Geometry>>& cached,
-                         const std::vector<Part::Geometry*>& current)
+bool isSameShapeGeometry(
+    const std::vector<std::unique_ptr<Part::Geometry>>& cached,
+    const std::vector<Part::Geometry*>& current
+)
 {
     if (cached.size() != current.size()) {
         return false;
@@ -325,8 +327,7 @@ void SketchObject::buildShape()
     auto geometries = solvedSketch.extractGeometry();
 
     auto isSameExternalGeometry = [this]() {
-        if (static_cast<int>(builtShapeExternal.size())
-            != std::max(ExternalGeo.getSize() - 2, 0)) {
+        if (static_cast<int>(builtShapeExternal.size()) != std::max(ExternalGeo.getSize() - 2, 0)) {
             return false;
         }
         for (int i = 2; i < ExternalGeo.getSize(); ++i) {
@@ -342,8 +343,7 @@ void SketchObject::buildShape()
         return true;
     };
 
-    const bool shapeCacheHit = builtShapeValid
-        && builtShapeMakeInternals == MakeInternals.getValue()
+    const bool shapeCacheHit = builtShapeValid && builtShapeMakeInternals == MakeInternals.getValue()
         && isSameShapeGeometry(builtShapeGeometry, geometries) && isSameExternalGeometry();
 
     if (shapeCacheHit) {
@@ -370,7 +370,8 @@ void SketchObject::buildShape()
             auto egf = ExternalGeometryFacade::getFacade(geo);
             builtShapeExternal.emplace_back(
                 std::unique_ptr<Part::Geometry>(geo->clone()),
-                egf->testFlag(ExternalGeometryExtension::Defining));
+                egf->testFlag(ExternalGeometryExtension::Defining)
+            );
         }
         builtShapeMakeInternals = MakeInternals.getValue();
         builtShapeValid = true;
@@ -576,8 +577,7 @@ void SketchObject::rebuildIslandCache(
 {
     islandCache = ShapeIslandCache {};
 
-    if (!spliceable || geoBoxes.size() < 2 || result.isNull()
-        || internal.isNull()) {
+    if (!spliceable || geoBoxes.size() < 2 || result.isNull() || internal.isNull()) {
         return;
     }
 
@@ -640,8 +640,7 @@ void SketchObject::rebuildIslandCache(
         for (std::size_t a = 0; a < memberIdx.size() && !merged; ++a) {
             for (std::size_t b = a + 1; b < memberIdx.size() && !merged; ++b) {
                 if (boxes[a].Intersect(boxes[b])) {
-                    memberIdx[a].insert(memberIdx[a].end(), memberIdx[b].begin(),
-                                        memberIdx[b].end());
+                    memberIdx[a].insert(memberIdx[a].end(), memberIdx[b].begin(), memberIdx[b].end());
                     boxes[a].Add(boxes[b]);
                     memberIdx.erase(memberIdx.begin() + b);
                     boxes.erase(boxes.begin() + b);
@@ -668,8 +667,10 @@ void SketchObject::rebuildIslandCache(
 
     // attribute the compounds' children to clusters; every child must land in
     // exactly one cluster box (they are pairwise disjoint)
-    auto attribute = [&cache](const std::vector<Part::TopoShape>& children,
-                              std::vector<std::vector<int>>& clusterIdx) {
+    auto attribute = [&cache](
+                         const std::vector<Part::TopoShape>& children,
+                         std::vector<std::vector<int>>& clusterIdx
+                     ) {
         clusterIdx.assign(cache.clusterBoxes.size(), {});
         for (std::size_t i = 0; i < children.size(); ++i) {
             Base::BoundBox3d box = children[i].getBoundBox();
@@ -810,8 +811,7 @@ bool SketchObject::trySpliceIslandDeletion(
     std::set<int> deadWires;
     std::set<int> deadFaces;
     for (int c : deletedClusters) {
-        if (islandCache.clusterWires[c].size() != 1
-            || islandCache.clusterFaces[c].size() != 1) {
+        if (islandCache.clusterWires[c].size() != 1 || islandCache.clusterFaces[c].size() != 1) {
             return false;
         }
         deadWires.insert(islandCache.clusterWires[c].front());
@@ -909,8 +909,9 @@ bool SketchObject::trySpliceIslandDeletion(
         FC_WARN("island deletion splice failed, falling back to full rebuild: " << e.what());
     }
     catch (Standard_Failure& e) {
-        FC_WARN("island deletion splice failed, falling back to full rebuild: "
-                << e.GetMessageString());
+        FC_WARN(
+            "island deletion splice failed, falling back to full rebuild: " << e.GetMessageString()
+        );
     }
     islandCache = ShapeIslandCache {};
     return false;
@@ -944,8 +945,7 @@ bool SketchObject::trySpliceIslands(
         const Part::Geometry* cached = builtShapeGeometry[i].get();
         const Part::Geometry* current = geometries[i];
         if (cached->getTypeId() != current->getTypeId()
-            || GeometryFacade::getConstruction(cached)
-                != GeometryFacade::getConstruction(current)) {
+            || GeometryFacade::getConstruction(cached) != GeometryFacade::getConstruction(current)) {
             return false;  // structural change
         }
         if (!cached->isSame(*current, Precision::Confusion(), Precision::Angular())) {
@@ -991,8 +991,7 @@ bool SketchObject::trySpliceIslands(
     try {
         for (int c : changedClusters) {
             // strict pairing: exactly one wire and one face to replace
-            if (islandCache.clusterWires[c].size() != 1
-                || islandCache.clusterFaces[c].size() != 1) {
+            if (islandCache.clusterWires[c].size() != 1 || islandCache.clusterFaces[c].size() != 1) {
                 return false;
             }
 
@@ -1018,10 +1017,12 @@ bool SketchObject::trySpliceIslands(
             }
 
             Part::TopoShape faceShape(getID(), getDocument()->getStringHasher());
-            faceShape = faceShape.makeElementFace(newWires,
-                    /*op*/"",
-                    /*maker*/"Part::FaceMakerBuildFace",
-                    /*pln*/nullptr);
+            faceShape = faceShape.makeElementFace(
+                newWires,
+                /*op*/ "",
+                /*maker*/ "Part::FaceMakerBuildFace",
+                /*pln*/ nullptr
+            );
             auto newFaces = faceShape.getSubTopoShapes(TopAbs_FACE);
             if (newFaces.size() != 1) {
                 return false;

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -55,6 +55,11 @@
 #include <Mod/Part/App/WireJoiner.h>
 
 #include <memory>
+#include <numeric>
+#include <set>
+#include <sstream>
+
+#include <TopoDS_Iterator.hxx>
 
 #include "GeoEnum.h"
 #include "SketchObject.h"
@@ -65,6 +70,40 @@
 
 #undef DEBUG
 // #define DEBUG
+
+namespace
+{
+// inflation applied to every bounding box before disjointness/attribution
+// tests; must cover the endpoint-merge tolerance of makeElementWires and the
+// intersection tolerance of FaceMaker/WireJoiner (both Precision::Confusion)
+constexpr double islandBoxTolerance = 1e-5;
+
+// the single definition of geometric identity used by the buildShape()
+// skip-cache and the island splicer: same type, same construction flag, same
+// content within OCC modeling tolerance
+bool isSameGeometryElement(const Part::Geometry* a, const Part::Geometry* b)
+{
+    return a->getTypeId() == b->getTypeId()
+        && Sketcher::GeometryFacade::getConstruction(a)
+            == Sketcher::GeometryFacade::getConstruction(b)
+        && a->isSame(*b, Precision::Confusion(), Precision::Angular());
+}
+
+// content compare for the buildShape() skip-cache
+bool isSameShapeGeometry(const std::vector<std::unique_ptr<Part::Geometry>>& cached,
+                         const std::vector<Part::Geometry*>& current)
+{
+    if (cached.size() != current.size()) {
+        return false;
+    }
+    for (std::size_t i = 0; i < cached.size(); ++i) {
+        if (!isSameGeometryElement(cached[i].get(), current[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+}  // namespace
 
 // clang-format off
 using namespace Sketcher;
@@ -284,12 +323,87 @@ void SketchObject::buildShape()
 
     // get the geometry after running the solver
     auto geometries = solvedSketch.extractGeometry();
+
+    auto isSameExternalGeometry = [this]() {
+        if (static_cast<int>(builtShapeExternal.size())
+            != std::max(ExternalGeo.getSize() - 2, 0)) {
+            return false;
+        }
+        for (int i = 2; i < ExternalGeo.getSize(); ++i) {
+            auto geo = ExternalGeo[i];
+            auto egf = ExternalGeometryFacade::getFacade(geo);
+            const auto& [cachedGeo, cachedDefining] = builtShapeExternal[i - 2];
+            if (egf->testFlag(ExternalGeometryExtension::Defining) != cachedDefining
+                || geo->getTypeId() != cachedGeo->getTypeId()
+                || !cachedGeo->isSame(*geo, Precision::Confusion(), Precision::Angular())) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    const bool shapeCacheHit = builtShapeValid
+        && builtShapeMakeInternals == MakeInternals.getValue()
+        && isSameShapeGeometry(builtShapeGeometry, geometries) && isSameExternalGeometry();
+
+    if (shapeCacheHit) {
+        // The solved geometry is content-identical to what Shape/InternalShape
+        // were built from: the OCC rebuild (edges/wires/FaceMaker/WireJoiner)
+        // would reproduce the same shapes, so keep the current property values.
+        for (auto geo : geometries) {
+            delete geo;
+        }
+        return;
+    }
+
+    // update the skip-cache reference (takes ownership of the extracted
+    // clones) — called on every path that keeps or produces shapes
+    auto updateGeometryCache = [this, &geometries]() {
+        builtShapeGeometry.clear();
+        builtShapeGeometry.reserve(geometries.size());
+        for (auto geo : geometries) {
+            builtShapeGeometry.emplace_back(geo);
+        }
+        builtShapeExternal.clear();
+        for (int i = 2; i < ExternalGeo.getSize(); ++i) {
+            auto geo = ExternalGeo[i];
+            auto egf = ExternalGeometryFacade::getFacade(geo);
+            builtShapeExternal.emplace_back(
+                std::unique_ptr<Part::Geometry>(geo->clone()),
+                egf->testFlag(ExternalGeometryExtension::Defining));
+        }
+        builtShapeMakeInternals = MakeInternals.getValue();
+        builtShapeValid = true;
+    };
+
+    // island-local rebuild: when only some disjoint clusters moved, rebuild
+    // just those and splice into the previous compounds
+    Part::TopoShape splicedResult;
+    Part::TopoShape splicedInternal;
+    bool spliced = false;
+    if (!shapeCacheHit) {
+        spliced = trySpliceIslands(geometries, splicedResult, splicedInternal);
+    }
+
+    if (spliced) {
+        updateGeometryCache();
+        internalElementMap.clear();
+        InternalShape.setValue(splicedInternal);
+        Shape.setValue(splicedResult);
+        return;
+    }
+
+    bool islandSpliceable = true;
+    std::vector<std::pair<int, Base::BoundBox3d>> geoBoxes;
+    geoBoxes.reserve(geometries.size());
+
     for (auto geo : geometries) {
         ++geoId;
         if (GeometryFacade::getConstruction(geo)) {
             continue;
         }
         if (geo->isDerivedFrom<Part::GeomPoint>()) {
+            islandSpliceable = false;
             int idx = getVertexIndexGeoPos(geoId - 1, Sketcher::PointPos::start);
             addVertex(
                 Part::TopoShape {TopoDS::Vertex(geo->toShape())},
@@ -299,12 +413,13 @@ void SketchObject::buildShape()
         else {
             auto indexedName = Data::IndexedName::fromConst("Edge", geoId);
             addEdge(geo, indexedName);
+            Base::BoundBox3d box = shapes.back().getBoundBox();
+            box.Enlarge(islandBoxTolerance);
+            geoBoxes.emplace_back(geoId - 1, box);
         }
     }
 
-    for (auto geo : geometries) {
-        delete geo;
-    }
+    updateGeometryCache();
 
     for (int i = 2; i < ExternalGeo.getSize(); ++i) {
         auto geo = ExternalGeo[i];
@@ -312,6 +427,8 @@ void SketchObject::buildShape()
         if (!egf->testFlag(ExternalGeometryExtension::Defining)) {
             continue;
         }
+
+        islandSpliceable = false;
 
         auto indexedName = Data::IndexedName::fromConst("ExternalEdge", i - 1);
 
@@ -329,10 +446,12 @@ void SketchObject::buildShape()
     internalElementMap.clear();
 
     if (shapes.empty() && vertices.empty()) {
+        islandCache = ShapeIslandCache {};
         InternalShape.setValue(Part::TopoShape());
         Shape.setValue(Part::TopoShape());
         return;
     }
+
     Part::TopoShape result(0, getDocument()->getStringHasher());
     if (vertices.empty()) {
         // Notice here we supply op code Part::OpCodes::Sketch to makeElementWires().
@@ -355,11 +474,16 @@ void SketchObject::buildShape()
         result.makeElementCompound(results);
     }
     result.Tag = getID();
-    InternalShape.setValue(buildInternals(result.located(TopLoc_Location())));
+
+    Part::TopoShape internal = buildInternals(result.located(TopLoc_Location()));
+    InternalShape.setValue(internal);
+
     // Must set Shape property after InternalShape so that
     // GeoFeature::updateElementReference() can run properly on change of Shape
     // property, because some reference may pointing to the InternalShape
     Shape.setValue(result);
+
+    rebuildIslandCache(geoBoxes, result, internal, islandSpliceable && vertices.empty());
 }
 // clang-format off
 
@@ -400,9 +524,11 @@ Part::TopoShape SketchObject::buildInternals(const Part::TopoShape &edges) const
         return Part::TopoShape();
 
     try {
+        const auto wires = edges.getSubTopoShapes(TopAbs_WIRE);
+
         Part::TopoShape result(getID(), getDocument()->getStringHasher());
         try {
-            result = result.makeElementFace(edges.getSubTopoShapes(TopAbs_WIRE),
+            result = result.makeElementFace(wires,
                     /*op*/"",
                     /*maker*/"Part::FaceMakerBuildFace",
                     /*pln*/nullptr
@@ -411,6 +537,11 @@ Part::TopoShape SketchObject::buildInternals(const Part::TopoShape &edges) const
         catch (const Part::NullShapeException&) {
             // An open-only sketch has no bounded regions, so a null face result is expected.
         }
+
+        // NOTE: do not try to skip the WireJoiner when all wires report
+        // isClosed() — TestSketcherApp has sketches (self-intersecting /
+        // degenerate closed wires whose face fails to build) where the
+        // tight-bound analysis still yields open wires.
 
         // Append open wires (edges not part of any closed face)
         Part::WireJoiner joiner;
@@ -434,6 +565,536 @@ Part::TopoShape SketchObject::buildInternals(const Part::TopoShape &edges) const
     }
     return Part::TopoShape();
 }
+
+// clang-format on
+void SketchObject::rebuildIslandCache(
+    const std::vector<std::pair<int, Base::BoundBox3d>>& geoBoxes,
+    const Part::TopoShape& result,
+    const Part::TopoShape& internal,
+    bool spliceable
+)
+{
+    islandCache = ShapeIslandCache {};
+
+    if (!spliceable || geoBoxes.size() < 2 || result.isNull()
+        || internal.isNull()) {
+        return;
+    }
+
+    // InternalShape must be faces only (single face or compound of faces): the
+    // splice reproduces exactly that structure. Open wires disable splicing.
+    if (internal.shapeType() != TopAbs_FACE) {
+        if (internal.shapeType() != TopAbs_COMPOUND) {
+            return;
+        }
+        for (TopoDS_Iterator it(internal.getShape()); it.More(); it.Next()) {
+            if (it.Value().ShapeType() != TopAbs_FACE) {
+                return;
+            }
+        }
+    }
+
+    // union-find over geometry bounding boxes
+    const int n = static_cast<int>(geoBoxes.size());
+    std::vector<int> parent(n);
+    std::iota(parent.begin(), parent.end(), 0);
+    auto find = [&parent](int i) {
+        while (parent[i] != i) {
+            parent[i] = parent[parent[i]];
+            i = parent[i];
+        }
+        return i;
+    };
+    for (int i = 0; i < n; ++i) {
+        for (int j = i + 1; j < n; ++j) {
+            if (geoBoxes[i].second.Intersect(geoBoxes[j].second)) {
+                int a = find(i);
+                int b = find(j);
+                if (a != b) {
+                    parent[b] = a;
+                }
+            }
+        }
+    }
+
+    // initial clusters
+    std::map<int, int> rootToCluster;
+    std::vector<std::vector<int>> memberIdx;  // indices into geoBoxes
+    std::vector<Base::BoundBox3d> boxes;
+    for (int i = 0; i < n; ++i) {
+        int root = find(i);
+        auto [it, isNew] = rootToCluster.emplace(root, static_cast<int>(memberIdx.size()));
+        if (isNew) {
+            memberIdx.emplace_back();
+            boxes.emplace_back();
+        }
+        memberIdx[it->second].push_back(i);
+        boxes[it->second].Add(geoBoxes[i].second);
+    }
+
+    // merge clusters whose UNION boxes overlap (covers nesting, e.g. a small
+    // profile inside a bigger one, which has no pairwise edge-box overlap)
+    bool merged = true;
+    while (merged && memberIdx.size() > 1) {
+        merged = false;
+        for (std::size_t a = 0; a < memberIdx.size() && !merged; ++a) {
+            for (std::size_t b = a + 1; b < memberIdx.size() && !merged; ++b) {
+                if (boxes[a].Intersect(boxes[b])) {
+                    memberIdx[a].insert(memberIdx[a].end(), memberIdx[b].begin(),
+                                        memberIdx[b].end());
+                    boxes[a].Add(boxes[b]);
+                    memberIdx.erase(memberIdx.begin() + b);
+                    boxes.erase(boxes.begin() + b);
+                    merged = true;
+                }
+            }
+        }
+    }
+
+    if (memberIdx.size() < 2) {
+        return;  // single cluster: nothing to splice
+    }
+
+    ShapeIslandCache cache;
+    cache.clusterGeos.resize(memberIdx.size());
+    cache.clusterBoxes = boxes;
+    for (std::size_t c = 0; c < memberIdx.size(); ++c) {
+        for (int i : memberIdx[c]) {
+            cache.clusterGeos[c].push_back(geoBoxes[i].first);
+            cache.geoToCluster[geoBoxes[i].first] = static_cast<int>(c);
+        }
+        std::sort(cache.clusterGeos[c].begin(), cache.clusterGeos[c].end());
+    }
+
+    // attribute the compounds' children to clusters; every child must land in
+    // exactly one cluster box (they are pairwise disjoint)
+    auto attribute = [&cache](const std::vector<Part::TopoShape>& children,
+                              std::vector<std::vector<int>>& clusterIdx) {
+        clusterIdx.assign(cache.clusterBoxes.size(), {});
+        for (std::size_t i = 0; i < children.size(); ++i) {
+            Base::BoundBox3d box = children[i].getBoundBox();
+            int owner = -1;
+            for (std::size_t c = 0; c < cache.clusterBoxes.size(); ++c) {
+                if (box.Intersect(cache.clusterBoxes[c])) {
+                    if (owner >= 0) {
+                        return false;  // ambiguous
+                    }
+                    owner = static_cast<int>(c);
+                }
+            }
+            if (owner < 0) {
+                return false;
+            }
+            clusterIdx[owner].push_back(static_cast<int>(i));
+        }
+        return true;
+    };
+
+    cache.wireShapes = result.getSubTopoShapes(TopAbs_WIRE);
+    cache.faceShapes = internal.getSubTopoShapes(TopAbs_FACE);
+    if (cache.wireShapes.size() < 2 || cache.faceShapes.empty()) {
+        return;
+    }
+
+    // Multi-wire faces (nested profiles/holes) are excluded: FaceMaker's
+    // postBuild() threads name-collision state across faces and maps hole
+    // wires at the compound level, which a spliced compound cannot reproduce
+    // exactly (e.g. a rect-in-rect sketch).
+    for (const auto& face : cache.faceShapes) {
+        if (face.countSubShapes(TopAbs_WIRE) != 1) {
+            return;
+        }
+    }
+
+    if (!attribute(cache.wireShapes, cache.clusterWires)
+        || !attribute(cache.faceShapes, cache.clusterFaces)) {
+        return;
+    }
+
+    cache.valid = true;
+    islandCache = std::move(cache);
+}
+
+bool SketchObject::trySpliceIslandDeletion(
+    const std::vector<Part::Geometry*>& geometries,
+    Part::TopoShape& newResult,
+    Part::TopoShape& newInternal
+)
+{
+    // Align: the new geometry list must be an ordered subsequence of the
+    // cached one (deletion preserves relative order). Any surviving geometry
+    // that moved or changed type breaks the alignment -> full rebuild.
+    std::vector<int> deletedOld;
+    std::size_t j = 0;
+    for (std::size_t i = 0; i < builtShapeGeometry.size(); ++i) {
+        const Part::Geometry* cached = builtShapeGeometry[i].get();
+        if (j < geometries.size() && isSameGeometryElement(cached, geometries[j])) {
+            ++j;
+        }
+        else {
+            deletedOld.push_back(static_cast<int>(i));
+        }
+    }
+    if (j != geometries.size()) {
+        return false;  // not a pure ordered deletion
+    }
+
+    // deleted construction geometry has no shape; collect the clusters of the
+    // shape-relevant deleted geometry
+    std::set<int> deletedClusters;
+    std::set<int> deletedShapeGeos;
+    for (int gi : deletedOld) {
+        if (GeometryFacade::getConstruction(builtShapeGeometry[gi].get())) {
+            continue;
+        }
+        auto it = islandCache.geoToCluster.find(gi);
+        if (it == islandCache.geoToCluster.end()) {
+            return false;  // unattributed shape-relevant geometry
+        }
+        deletedClusters.insert(it->second);
+        deletedShapeGeos.insert(gi);
+    }
+
+    if (deletedClusters.empty()) {
+        // Only construction geometry was deleted: the shapes are unchanged,
+        // but the surviving geometries' absolute indices shifted, so the
+        // cache's geo indexing must be re-keyed (the caller re-bases
+        // builtShapeGeometry to the new list).
+        std::map<int, int> oldToNew;
+        {
+            std::set<int> deletedSet(deletedOld.begin(), deletedOld.end());
+            int nj = 0;
+            for (std::size_t i = 0; i < builtShapeGeometry.size(); ++i) {
+                if (deletedSet.find(static_cast<int>(i)) == deletedSet.end()) {
+                    oldToNew[static_cast<int>(i)] = nj++;
+                }
+            }
+        }
+        std::map<int, int> geoToCluster;
+        std::vector<std::vector<int>> clusterGeos(islandCache.clusterGeos.size());
+        for (std::size_t c = 0; c < islandCache.clusterGeos.size(); ++c) {
+            for (int gi : islandCache.clusterGeos[c]) {
+                auto it = oldToNew.find(gi);
+                if (it == oldToNew.end()) {
+                    // a cluster references a deleted geometry; cannot happen for
+                    // construction-only deletions, but never keep a stale cache
+                    islandCache = ShapeIslandCache {};
+                    return false;
+                }
+                geoToCluster[it->second] = static_cast<int>(c);
+                clusterGeos[c].push_back(it->second);
+            }
+        }
+        islandCache.geoToCluster = std::move(geoToCluster);
+        islandCache.clusterGeos = std::move(clusterGeos);
+
+        newResult = Shape.getShape();
+        newInternal = InternalShape.getShape();
+        return true;
+    }
+
+    // every touched cluster must be deleted entirely: a partially deleted
+    // island changes its wire/face and needs the full pipeline
+    for (int c : deletedClusters) {
+        for (int gi : islandCache.clusterGeos[c]) {
+            if (deletedShapeGeos.find(gi) == deletedShapeGeos.end()) {
+                return false;
+            }
+        }
+    }
+    if (deletedClusters.size() >= islandCache.clusterBoxes.size()) {
+        return false;  // nothing left to reuse
+    }
+
+    // positions of the deleted clusters' children in the compounds
+    std::set<int> deadWires;
+    std::set<int> deadFaces;
+    for (int c : deletedClusters) {
+        if (islandCache.clusterWires[c].size() != 1
+            || islandCache.clusterFaces[c].size() != 1) {
+            return false;
+        }
+        deadWires.insert(islandCache.clusterWires[c].front());
+        deadFaces.insert(islandCache.clusterFaces[c].front());
+    }
+
+    std::vector<Part::TopoShape> wires;
+    std::vector<Part::TopoShape> faces;
+    for (std::size_t i = 0; i < islandCache.wireShapes.size(); ++i) {
+        if (deadWires.find(static_cast<int>(i)) == deadWires.end()) {
+            wires.push_back(islandCache.wireShapes[i]);
+        }
+    }
+    for (std::size_t i = 0; i < islandCache.faceShapes.size(); ++i) {
+        if (deadFaces.find(static_cast<int>(i)) == deadFaces.end()) {
+            faces.push_back(islandCache.faceShapes[i]);
+        }
+    }
+    if (wires.empty() || faces.empty()) {
+        return false;
+    }
+
+    try {
+        Part::TopoShape result(0, getDocument()->getStringHasher());
+        result.makeElementCompound(wires);
+        result.Tag = getID();
+
+        Part::TopoShape internal(getID(), getDocument()->getStringHasher());
+        internal.makeElementCompound(faces);
+
+        // re-key the cache against the new geometry indexing
+        std::map<int, int> oldToNew;
+        {
+            std::set<int> deletedSet(deletedOld.begin(), deletedOld.end());
+            int nj = 0;
+            for (std::size_t i = 0; i < builtShapeGeometry.size(); ++i) {
+                if (deletedSet.find(static_cast<int>(i)) == deletedSet.end()) {
+                    oldToNew[static_cast<int>(i)] = nj++;
+                }
+            }
+        }
+        auto newPos = [](const std::set<int>& dead, int old) {
+            int shift = 0;
+            for (int d : dead) {
+                if (d < old) {
+                    ++shift;
+                }
+                else {
+                    break;
+                }
+            }
+            return old - shift;
+        };
+
+        ShapeIslandCache cache;
+        cache.wireShapes = wires;
+        cache.faceShapes = faces;
+        for (std::size_t c = 0; c < islandCache.clusterGeos.size(); ++c) {
+            if (deletedClusters.find(static_cast<int>(c)) != deletedClusters.end()) {
+                continue;
+            }
+            std::vector<int> geos;
+            for (int gi : islandCache.clusterGeos[c]) {
+                auto it = oldToNew.find(gi);
+                if (it == oldToNew.end()) {
+                    return false;
+                }
+                geos.push_back(it->second);
+            }
+            const int nc = static_cast<int>(cache.clusterGeos.size());
+            for (int g : geos) {
+                cache.geoToCluster[g] = nc;
+            }
+            cache.clusterGeos.push_back(std::move(geos));
+            cache.clusterBoxes.push_back(islandCache.clusterBoxes[c]);
+            std::vector<int> cw;
+            std::vector<int> cf;
+            for (int w : islandCache.clusterWires[c]) {
+                cw.push_back(newPos(deadWires, w));
+            }
+            for (int f : islandCache.clusterFaces[c]) {
+                cf.push_back(newPos(deadFaces, f));
+            }
+            cache.clusterWires.push_back(std::move(cw));
+            cache.clusterFaces.push_back(std::move(cf));
+        }
+        cache.valid = cache.clusterBoxes.size() >= 2;
+        islandCache = std::move(cache);
+
+        newResult = result;
+        newInternal = internal;
+        return true;
+    }
+    catch (Base::Exception& e) {
+        FC_WARN("island deletion splice failed, falling back to full rebuild: " << e.what());
+    }
+    catch (Standard_Failure& e) {
+        FC_WARN("island deletion splice failed, falling back to full rebuild: "
+                << e.GetMessageString());
+    }
+    islandCache = ShapeIslandCache {};
+    return false;
+}
+
+bool SketchObject::trySpliceIslands(
+    const std::vector<Part::Geometry*>& geometries,
+    Part::TopoShape& newResult,
+    Part::TopoShape& newInternal
+)
+{
+    if (!islandCache.valid || !builtShapeValid
+        || builtShapeMakeInternals != MakeInternals.getValue() || !MakeInternals.getValue()) {
+        return false;
+    }
+    // strict scope: no external geometry beyond the axes
+    if (ExternalGeo.getSize() > 2 || !builtShapeExternal.empty()) {
+        return false;
+    }
+    if (builtShapeGeometry.size() != geometries.size()) {
+        if (geometries.size() < builtShapeGeometry.size()) {
+            // pure deletion of whole islands can be spliced too
+            return trySpliceIslandDeletion(geometries, newResult, newInternal);
+        }
+        return false;
+    }
+
+    // diff against the geometry the current shapes were built from
+    std::vector<int> changed;
+    for (std::size_t i = 0; i < geometries.size(); ++i) {
+        const Part::Geometry* cached = builtShapeGeometry[i].get();
+        const Part::Geometry* current = geometries[i];
+        if (cached->getTypeId() != current->getTypeId()
+            || GeometryFacade::getConstruction(cached)
+                != GeometryFacade::getConstruction(current)) {
+            return false;  // structural change
+        }
+        if (!cached->isSame(*current, Precision::Confusion(), Precision::Angular())) {
+            changed.push_back(static_cast<int>(i));
+        }
+    }
+    if (changed.empty()) {
+        return false;  // the skip-cache handles this
+    }
+
+    std::set<int> changedClusters;
+    for (int gi : changed) {
+        if (GeometryFacade::getConstruction(geometries[gi])) {
+            continue;  // construction geometry has no shape
+        }
+        auto it = islandCache.geoToCluster.find(gi);
+        if (it == islandCache.geoToCluster.end()) {
+            return false;  // unattributed shape-relevant geometry
+        }
+        changedClusters.insert(it->second);
+    }
+    if (changedClusters.empty()) {
+        // only construction geometry moved: the shapes are unchanged
+        newResult = Shape.getShape();
+        newInternal = InternalShape.getShape();
+        return true;
+    }
+    if (changedClusters.size() >= islandCache.clusterBoxes.size()) {
+        return false;  // nothing to reuse
+    }
+
+    // rebuild each changed cluster in isolation
+    struct RebuiltCluster
+    {
+        int cluster;
+        Part::TopoShape wire;
+        Part::TopoShape face;
+        Base::BoundBox3d box;
+    };
+    std::vector<RebuiltCluster> rebuilt;
+    rebuilt.reserve(changedClusters.size());
+
+    try {
+        for (int c : changedClusters) {
+            // strict pairing: exactly one wire and one face to replace
+            if (islandCache.clusterWires[c].size() != 1
+                || islandCache.clusterFaces[c].size() != 1) {
+                return false;
+            }
+
+            std::vector<Part::TopoShape> clusterEdges;
+            Base::BoundBox3d box;
+            for (int gi : islandCache.clusterGeos[c]) {
+                const Part::Geometry* geo = geometries[gi];
+                auto indexedName = Data::IndexedName::fromConst("Edge", gi + 1);
+                Part::TopoShape edge = getEdge(geo, convertSubName(indexedName, false).c_str());
+                if (edge.isNull()) {
+                    return false;
+                }
+                clusterEdges.push_back(edge);
+                box.Add(edge.getBoundBox());
+            }
+            box.Enlarge(islandBoxTolerance);
+
+            Part::TopoShape wireComp(0, getDocument()->getStringHasher());
+            wireComp.makeElementWires(clusterEdges, Part::OpCodes::Sketch);
+            auto newWires = wireComp.getSubTopoShapes(TopAbs_WIRE);
+            if (newWires.size() != 1) {
+                return false;
+            }
+
+            Part::TopoShape faceShape(getID(), getDocument()->getStringHasher());
+            faceShape = faceShape.makeElementFace(newWires,
+                    /*op*/"",
+                    /*maker*/"Part::FaceMakerBuildFace",
+                    /*pln*/nullptr);
+            auto newFaces = faceShape.getSubTopoShapes(TopAbs_FACE);
+            if (newFaces.size() != 1) {
+                return false;
+            }
+
+            // no open wires may appear
+            Part::WireJoiner joiner;
+            joiner.setTightBound(true);
+            joiner.setMergeEdges(true);
+            joiner.addShape(clusterEdges);
+            Part::TopoShape openWires(getID(), getDocument()->getStringHasher());
+            joiner.getOpenWires(openWires, "SKF");
+            if (!openWires.isNull()) {
+                return false;
+            }
+
+            rebuilt.push_back({c, newWires.front(), newFaces.front(), box});
+        }
+
+        // the moved clusters must remain disjoint from everything else
+        for (const auto& rb : rebuilt) {
+            for (std::size_t c = 0; c < islandCache.clusterBoxes.size(); ++c) {
+                if (static_cast<int>(c) == rb.cluster) {
+                    continue;
+                }
+                const Base::BoundBox3d* other = &islandCache.clusterBoxes[c];
+                for (const auto& rb2 : rebuilt) {
+                    if (rb2.cluster == static_cast<int>(c)) {
+                        other = &rb2.box;
+                        break;
+                    }
+                }
+                if (rb.box.Intersect(*other)) {
+                    return false;
+                }
+            }
+        }
+
+        // positional splice
+        std::vector<Part::TopoShape> wires = islandCache.wireShapes;
+        std::vector<Part::TopoShape> faces = islandCache.faceShapes;
+        for (const auto& rb : rebuilt) {
+            wires[islandCache.clusterWires[rb.cluster].front()] = rb.wire;
+            faces[islandCache.clusterFaces[rb.cluster].front()] = rb.face;
+        }
+
+        Part::TopoShape result(0, getDocument()->getStringHasher());
+        result.makeElementCompound(wires);
+        result.Tag = getID();
+
+        Part::TopoShape internal(getID(), getDocument()->getStringHasher());
+        internal.makeElementCompound(faces);
+
+        // commit to the cache
+        for (const auto& rb : rebuilt) {
+            islandCache.wireShapes[islandCache.clusterWires[rb.cluster].front()] = rb.wire;
+            islandCache.faceShapes[islandCache.clusterFaces[rb.cluster].front()] = rb.face;
+            islandCache.clusterBoxes[rb.cluster] = rb.box;
+        }
+
+        newResult = result;
+        newInternal = internal;
+        return true;
+    }
+    catch (Base::Exception& e) {
+        FC_WARN("island splice failed, falling back to full rebuild: " << e.what());
+    }
+    catch (Standard_Failure& e) {
+        FC_WARN("island splice failed, falling back to full rebuild: " << e.GetMessageString());
+    }
+    return false;
+}
+// clang-format off
 
 static const char *hasSketchMarker(const char *name) {
     static std::string marker(Part::TopoShape::elementMapPrefix()+Part::OpCodes::Sketch);
@@ -1034,6 +1695,16 @@ void SketchObject::onGeometryChanged()
     }
 
     if (internaltransaction) {
+        solverNeedsUpdate = true;
+        return;
+    }
+
+    // During an interactive drag, geometry property changes are triggered
+    // by the recompute system. The geometry is in a transitional state, so
+    // checkConstraintIndices() would fail against the partially-updated
+    // geometry. Defer the update until the drag ends.
+    if (isDragActive) {
+        solverNeedsUpdate = true;
         return;
     }
 
@@ -1045,6 +1716,11 @@ void SketchObject::onGeometryChanged()
         acceptGeometry();
         return;
     }
+
+    // External geometry edit — topology may have changed. Invalidate the
+    // diagnosis cache HERE (not at the top of the function) so that solver
+    // writeback (managedoperation == true) preserves the cache.
+    solvedSketch.invalidateDiagnosisCache();
 
     // this change was not effect via SketchObject, but using direct access to
     // properties, check input data
@@ -1078,6 +1754,17 @@ void SketchObject::onConstraintsChanged()
     }
 
     if (internaltransaction) {
+        solverNeedsUpdate = true;
+        return;
+    }
+
+    // During an interactive drag, constraint property changes are triggered
+    // by the recompute system, not by user constraint edits. The geometry is
+    // in a transitional state (new elements being added), so
+    // checkConstraintIndices() would fail and wipe all constraints. Defer
+    // the update until the drag ends.
+    if (isDragActive) {
+        solverNeedsUpdate = true;
         return;
     }
 

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -29,6 +29,7 @@
 #include <App/PropertyFile.h>
 #include <Base/Axis.h>
 #include <Base/Bitmask.h>
+#include <Base/BoundBox.h>
 #include <Mod/Part/App/Part2DObject.h>
 #include <Mod/Part/App/PropertyGeometryList.h>
 #include <Mod/Sketcher/App/PropertyConstraintList.h>
@@ -817,6 +818,20 @@ public: /* Solver exposed interface */
         Base::Vector3d toPoint,
         bool relative = false
     );
+    /** Cancels an interactive drag without committing it (e.g. undo/redo fired
+     * mid-drag). Clears the drag state so the next solve() rebuilds the solver
+     * from the current Geometry property instead of writing back stale
+     * drag-era solver geometry.
+     */
+    inline void cancelTemporaryMove()
+    {
+        if (isDragActive) {
+            isDragActive = false;
+            solverNeedsUpdate = true;
+            solvedSketch.resetInitMove();
+        }
+    }
+
     /// forwards a request to update an extension of a geometry of the solver to the solver.
     inline void updateSolverExtension(int geoId, std::unique_ptr<Part::GeometryExtension>&& ext)
     {
@@ -1219,6 +1234,11 @@ private:
     bool managedoperation;  // indicates whether changes to properties are the deed of SketchObject
                             // or not (for input validation)
 
+    // Tracks whether an interactive drag (moveGeometriesTemporary) is currently active.
+    // When true and solverNeedsUpdate is false, solve() skips setUpSketch() to preserve
+    // the solver's drag state instead of rebuilding from stale committed geometry.
+    bool isDragActive = false;
+
     // mapping from ExternalGeometry[*] to ExternalGeo[*].Id
     // Some external geometry may generate more than one projection
     std::map<std::string, std::vector<long>> externalGeoRefMap;
@@ -1242,15 +1262,85 @@ private:
     std::unique_ptr<GeoHistory> geoHistory;
 
     mutable std::map<std::string, std::string> internalElementMap;
+
+    // buildShape() skip-cache (transient, never persisted): the solved geometry
+    // the current Shape/InternalShape property values were built from. When the
+    // next execute() produces content-identical geometry (Geometry::isSame),
+    // the whole OCC rebuild (edges, wires, FaceMaker, WireJoiner) is skipped —
+    // it dominates recompute cost on dense sketches. A content compare is used
+    // instead of explicit invalidation so a stale cache can only cost a rebuild,
+    // never produce a wrong shape.
+    std::vector<std::unique_ptr<Part::Geometry>> builtShapeGeometry;
+    std::vector<std::pair<std::unique_ptr<Part::Geometry>, bool>> builtShapeExternal;
+    bool builtShapeMakeInternals = false;
+    bool builtShapeValid = false;
+
+    // Island-local rebuild (transient): the sketch's edges partition into
+    // bounding-box-disjoint clusters that cannot interact in makeElementWires
+    // (needs coincident endpoints), FaceMaker (nesting needs bbox containment)
+    // or WireJoiner (splits only at intersections). When a value edit moves the
+    // geometry of some clusters only, their wires/faces are rebuilt in
+    // isolation and spliced positionally into the previous compounds — the
+    // full build defines the sub-shape order, splicing preserves it. Strict
+    // preconditions (single wire+face per changed cluster, no open wires, no
+    // vertices/external geometry, boxes stay disjoint) fall back to the full
+    // rebuild.
+    struct ShapeIslandCache
+    {
+        bool valid = false;
+        std::map<int, int> geoToCluster;               // absolute geo index -> cluster
+        std::vector<std::vector<int>> clusterGeos;     // absolute geo indices per cluster
+        std::vector<Base::BoundBox3d> clusterBoxes;    // inflated, pairwise disjoint
+        std::vector<Part::TopoShape> wireShapes;       // Shape compound children in order
+        std::vector<Part::TopoShape> faceShapes;       // InternalShape children in order
+        std::vector<std::vector<int>> clusterWires;    // indices into wireShapes per cluster
+        std::vector<std::vector<int>> clusterFaces;    // indices into faceShapes per cluster
+    };
+    ShapeIslandCache islandCache;
+
+    bool trySpliceIslands(
+        const std::vector<Part::Geometry*>& geometries,
+        Part::TopoShape& newResult,
+        Part::TopoShape& newInternal
+    );
+
+    // pure whole-island deletion: drop the deleted clusters' wires/faces from
+    // the previous compounds instead of rebuilding everything
+    bool trySpliceIslandDeletion(
+        const std::vector<Part::Geometry*>& geometries,
+        Part::TopoShape& newResult,
+        Part::TopoShape& newInternal
+    );
+
+    void rebuildIslandCache(
+        const std::vector<std::pair<int, Base::BoundBox3d>>& geoBoxes,
+        const Part::TopoShape& result,
+        const Part::TopoShape& internal,
+        bool spliceable
+    );
 };
 
 inline int SketchObject::initTemporaryMove(std::vector<GeoElementId> moved, bool fine /*=true*/)
 {
+    // Rebuild the solver from the current geometry if stale. Called with
+    // isDragActive == false (set only AFTER initMove succeeds below).
+    // NOTE: this->setUpSketch() is the SketchObject zero-arg overload, which
+    // internally calls solvedSketch.setUpSketch(getCompleteGeometry(), ...).
     if (solverNeedsUpdate) {
-        solve();
+        this->setUpSketch();
     }
 
-    return solvedSketch.initMove(moved, fine);
+    // Add drag constraints. initMove() populates subSystemsAux (tag=-1)
+    // and sets isInitMove=true.
+    int result = solvedSketch.initMove(moved, fine);
+
+    // Set drag-active state ONLY after initMove() succeeds; if it threw or
+    // failed, the next solve() must rebuild from scratch.
+    if (result >= 0) {
+        isDragActive = true;
+    }
+
+    return result;
 }
 
 inline int SketchObject::initTemporaryMove(int geoId, PointPos pos, bool fine /*=true*/)

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -748,6 +748,12 @@ public:
     {
         return lastSolverStatus;
     }
+    /// true if the most recent setUpSketch() restored the diagnosis from the
+    /// topology-stable cache instead of recomputing it (primarily for tests)
+    inline bool wasDiagnosisRestored() const
+    {
+        return solvedSketch.wasDiagnosisRestored();
+    }
     /// gets solver SolveTime of last solver execution
     inline float getLastSolveTime() const
     {
@@ -1363,7 +1369,16 @@ inline int SketchObject::initTemporaryBSplinePieceMove(
         solve();
     }
 
-    return solvedSketch.initBSplinePieceMove(geoId, pos, firstPoint, fine);
+    int result = solvedSketch.initBSplinePieceMove(geoId, pos, firstPoint, fine);
+
+    // As in initTemporaryMove(): mark the drag active only after a successful
+    // init, so a solve()/recompute during the piece drag keeps the live solver
+    // state instead of rebuilding from the (stale) committed Geometry property.
+    if (result >= 0) {
+        isDragActive = true;
+    }
+
+    return result;
 }
 
 inline int SketchObject::

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -1288,13 +1288,13 @@ private:
     struct ShapeIslandCache
     {
         bool valid = false;
-        std::map<int, int> geoToCluster;               // absolute geo index -> cluster
-        std::vector<std::vector<int>> clusterGeos;     // absolute geo indices per cluster
-        std::vector<Base::BoundBox3d> clusterBoxes;    // inflated, pairwise disjoint
-        std::vector<Part::TopoShape> wireShapes;       // Shape compound children in order
-        std::vector<Part::TopoShape> faceShapes;       // InternalShape children in order
-        std::vector<std::vector<int>> clusterWires;    // indices into wireShapes per cluster
-        std::vector<std::vector<int>> clusterFaces;    // indices into faceShapes per cluster
+        std::map<int, int> geoToCluster;             // absolute geo index -> cluster
+        std::vector<std::vector<int>> clusterGeos;   // absolute geo indices per cluster
+        std::vector<Base::BoundBox3d> clusterBoxes;  // inflated, pairwise disjoint
+        std::vector<Part::TopoShape> wireShapes;     // Shape compound children in order
+        std::vector<Part::TopoShape> faceShapes;     // InternalShape children in order
+        std::vector<std::vector<int>> clusterWires;  // indices into wireShapes per cluster
+        std::vector<std::vector<int>> clusterFaces;  // indices into faceShapes per cluster
     };
     ShapeIslandCache islandCache;
 

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -95,10 +95,11 @@ int SketchObject::solve(bool updateGeoAfterSolving /*=true*/)
         // InitParameters, causing the next moveGeometries(relative=true) to
         // compute MoveParameters = stale_position + delta, snapping to origin.
         //
-        // Instead: keep solverNeedsUpdate=true and skip setUpSketch() entirely.
-        // The solver retains its live drag state. When the drag ends and
-        // isDragActive becomes false, the next solve() takes the non-drag branch
-        // and rebuilds from the (now-committed) Geometry property.
+        // Instead: skip setUpSketch() entirely so the solver retains its live
+        // drag state. (solverNeedsUpdate is still cleared below; that is harmless
+        // here — the post-drag rebuild is driven by isDragActive becoming false,
+        // at which point the non-drag branch always rebuilds from the
+        // now-committed Geometry property, regardless of solverNeedsUpdate.)
         //
         // New geometry created during drag is unconstrained, so it has no effect
         // on existing solver parameters — it stays where it was created until

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -76,22 +76,42 @@ void SketchObject::retrieveSolverDiagnostics()
 
 int SketchObject::solve(bool updateGeoAfterSolving /*=true*/)
 {
+    // Check if this solve() was called from outside a managed operation (e.g., a recompute
+    // triggered by the document). We capture this before the StateLocker so we can distinguish
+    // external calls from managed ones.
+    bool isExternalCall = !managedoperation;
+
     // no need to check input data validity as this is an sketchobject managed operation.
     Base::StateLocker lock(managedoperation, true);
 
-    // Reset the initial movement in case of a dragging operation was ongoing on the solver.
-    solvedSketch.resetInitMove();
-
-    // if updateGeoAfterSolving=false, the solver information is updated, but the Sketch is nothing
-    // updated. It is useful to avoid triggering an OnChange when the goeometry did not change but
-    // the solver needs to be updated.
-
-    // We should have an updated Sketcher (sketchobject) geometry or this solve() should not have
-    // happened therefore we update our sketch solver geometry with the SketchObject one.
-    //
-    // set up a sketch (including dofs counting and diagnosing of conflicts)
-    lastDoF = solvedSketch.setUpSketch(
-        getCompleteGeometry(), Constraints.getValues(), getExternalGeometryCount());
+    // During an interactive drag (isDragActive), the solver already has the correct state
+    // from moveGeometriesTemporary() calls. We must avoid destroying this state via
+    // setUpSketch() -> clear(), which would cause the geometry to snap back.
+    if (isDragActive) {
+        // During drag, NEVER rebuild the solver from getCompleteGeometry().
+        // The Geometry property is stale during drag (moveGeometriesTemporary()
+        // updates the solver's internal parameters directly, not the property).
+        // Rebuilding from stale geometry would snapshot pre-drag positions into
+        // InitParameters, causing the next moveGeometries(relative=true) to
+        // compute MoveParameters = stale_position + delta, snapping to origin.
+        //
+        // Instead: keep solverNeedsUpdate=true and skip setUpSketch() entirely.
+        // The solver retains its live drag state. When the drag ends and
+        // isDragActive becomes false, the next solve() takes the non-drag branch
+        // and rebuilds from the (now-committed) Geometry property.
+        //
+        // New geometry created during drag is unconstrained, so it has no effect
+        // on existing solver parameters — it stays where it was created until
+        // the post-drag rebuild.
+    } else {
+        // Normal (non-drag) path: reset any stale drag state from a previous operation,
+        // then rebuild the solver from the SketchObject's current geometry.
+        if (isExternalCall) {
+            solvedSketch.resetInitMove();
+        }
+        lastDoF = solvedSketch.setUpSketch(
+            getCompleteGeometry(), Constraints.getValues(), getExternalGeometryCount());
+    }
 
     // At this point we have the solver information about conflicting/redundant/over-constrained,
     // but the sketch is NOT solved. Some examples: Redundant: a vertical line, a horizontal line
@@ -130,8 +150,51 @@ int SketchObject::solve(bool updateGeoAfterSolving /*=true*/)
     }
     else {
         lastSolverStatus = solvedSketch.solve();
-        if (lastSolverStatus != 0) {// solving
+        if (lastSolverStatus != 0) {
             err = -1;
+        }
+    }
+
+    if (solvedSketch.wasDiagnosisRestored()) {
+        bool cacheInvalid = false;
+        // The restored diagnosis reflects PRE-solve residual state after
+        // setDatum(). Redundant/partially-redundant
+        // constraint residuals legitimately exceed 1e-4 because parameters have not
+        // yet been re-solved against the new datum. This is normal pre-solve state,
+        // NOT cache corruption. Only NaN (structural invalidity) justifies
+        // invalidation; a magnitude threshold destroys the cache on every
+        // measured-phase solve and defeats the delta-update optimization.
+        const auto& constraintTags = solvedSketch.getConflicting();
+        const auto& redundantTags = solvedSketch.getRedundant();
+        const auto& partialTags = solvedSketch.getPartiallyRedundant();
+
+        auto checkTag = [&](int tag) {
+            double errVal = solvedSketch.calculateConstraintError(tag);
+            if (std::isnan(errVal)) {
+                cacheInvalid = true;
+            }
+        };
+
+        for (int tag : constraintTags) {
+            checkTag(tag);
+        }
+        for (int tag : redundantTags) {
+            checkTag(tag);
+        }
+        for (int tag : partialTags) {
+            checkTag(tag);
+        }
+
+        if (cacheInvalid) {
+            solvedSketch.invalidateDiagnosisCache();
+            lastDoF = solvedSketch.setUpSketch(
+                getCompleteGeometry(), Constraints.getValues(),
+                getExternalGeometryCount());
+            retrieveSolverDiagnostics();
+            lastSolverStatus = solvedSketch.solve();
+            if (lastSolverStatus != 0) {
+                err = -1;
+            }
         }
     }
 

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -59,7 +59,7 @@ int SketchObject::moveGeometries(const std::vector<GeoElementId>& geoEltIds, con
     // geometry to that of of SketchObject upon moving. => use updateGeometry parameter = true then
 
 
-    if (updateGeoBeforeMoving || solverNeedsUpdate) {
+    if (updateGeoBeforeMoving || (solverNeedsUpdate && !isDragActive)) {
         lastDoF = solvedSketch.setUpSketch(
             getCompleteGeometry(), Constraints.getValues(), getExternalGeometryCount());
 
@@ -87,7 +87,11 @@ int SketchObject::moveGeometries(const std::vector<GeoElementId>& geoEltIds, con
         }
     }
 
-    solvedSketch.resetInitMove();// reset solver point moving mechanism
+    // The drag is now complete — geometry has been moved and committed via
+    // Geometry.setValues(). Clear isDragActive so the next solve() takes the
+    // normal (non-drag) path and rebuilds from the committed Geometry property.
+    isDragActive = false;
+    solverNeedsUpdate = true;
 
     return lastSolverStatus;
 }

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -488,7 +488,7 @@ System::System()
     , qrAlgorithm(EigenSparseQR)
     , autoChooseAlgorithm(true)
     , autoQRThreshold(1000)
-    , dogLegGaussStep(FullPivLU)
+    , dogLegGaussStep(SparseLDLT)
     , qrpivotThreshold(1E-13)
     , debugMode(Minimal)
     , LM_eps(1E-10)
@@ -2299,8 +2299,10 @@ int System::solve_DL(SubSystem* subsys, bool isRedundantsolving)
                << ", dogLegGaussStep: "
                << (dogLegGaussStep == FullPivLU
                        ? "FullPivLU"
-                       : (dogLegGaussStep == LeastNormFullPivLU ? "LeastNormFullPivLU"
-                                                                : "LeastNormLdlt"))
+                       : (dogLegGaussStep == LeastNormFullPivLU
+                              ? "LeastNormFullPivLU"
+                              : (dogLegGaussStep == LeastNormLdlt ? "LeastNormLdlt"
+                                                                  : "SparseLDLT")))
                << ", xsize: " << xsize << ", csize: " << csize << ", maxIter: " << maxIterNumber
                << "\n";
 
@@ -2308,9 +2310,16 @@ int System::solve_DL(SubSystem* subsys, bool isRedundantsolving)
         Base::Console().log(tmp.c_str());
     }
 
+    // Sparse LDLT solver infrastructure. Jx is assembled directly as a sparse
+    // matrix so J^T*J and the linear solve stay banded (O(N*bw^2)) instead of the
+    // O(N^2)/O(N^3) dense path — the dominant cost for dense/banded sketches.
+    Eigen::SparseMatrix<double> A_sparse;
+    Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>, Eigen::Upper> sparse_ldlt;
+    bool sparse_pattern_analyzed = false;  // analyzePattern() done once (topology is fixed per solve)
+
     Eigen::VectorXd x(xsize), x_new(xsize);
     Eigen::VectorXd fx(csize), fx_new(csize);
-    Eigen::MatrixXd Jx(csize, xsize), Jx_new(csize, xsize);
+    Eigen::SparseMatrix<double> Jx(csize, xsize), Jx_new(csize, xsize);
     Eigen::VectorXd g(xsize), h_sd(xsize), h_gn(xsize), h_dl(xsize);
 
     subsys->redirectParams();
@@ -2358,22 +2367,82 @@ int System::solve_DL(SubSystem* subsys, bool isRedundantsolving)
         }
 
         // get the steepest descent direction
-        alpha = g.squaredNorm() / (Jx * g).squaredNorm();
-        h_sd = alpha * g;
+        // Guard the denominator: if g lies in ker(J) (possible for rank-deficient J)
+        // then Jx*g == 0 and alpha would be inf/nan; fall back to alpha = 0 so the
+        // dogleg relies on the Gauss-Newton step instead of a degenerate SD step.
+        double Jxg_sq = (Jx * g).squaredNorm();
+        alpha = (Jxg_sq > 0.0) ? g.squaredNorm() / Jxg_sq : 0.0;
+        h_sd.noalias() = alpha * g;
 
         // get the gauss-newton step
         // https://forum.freecad.org/viewtopic.php?f=10&t=12769&start=50#p106220
         // https://forum.kde.org/viewtopic.php?f=74&t=129439#p346104
         switch (dogLegGaussStep) {
             case FullPivLU:
-                h_gn = Jx.fullPivLu().solve(-fx);
+                h_gn = Jx.toDense().fullPivLu().solve(-fx);
                 break;
-            case LeastNormFullPivLU:
-                h_gn = Jx.adjoint() * (Jx * Jx.adjoint()).fullPivLu().solve(-fx);
+            case LeastNormFullPivLU: {
+                Eigen::MatrixXd Jd = Jx.toDense();
+                h_gn = Jd.adjoint() * (Jd * Jd.adjoint()).fullPivLu().solve(-fx);
                 break;
-            case LeastNormLdlt:
-                h_gn = Jx.adjoint() * (Jx * Jx.adjoint()).ldlt().solve(-fx);
+            }
+            case LeastNormLdlt: {
+                Eigen::MatrixXd Jd = Jx.toDense();
+                h_gn = Jd.adjoint() * (Jd * Jd.adjoint()).ldlt().solve(-fx);
                 break;
+            }
+            case SparseLDLT: {
+                // Sparse Gauss-Newton step. Sketch systems are usually
+                // UNDER-constrained (csize < xsize: many free DOFs during a normal
+                // recompute or drag), which makes the normal-equations matrix
+                // J^T J (xsize x xsize) rank-deficient and SimplicialLDLT fail —
+                // the old path then fell back to a dense fullPivLU every iteration
+                // (O(N^3), the real bottleneck for dense sketches).
+                //
+                // Instead take the least-norm step via the smaller, full-rank
+                // system: solve (J J^T) y = -fx  (csize x csize, banded, SPD for
+                // independent constraints) with sparse LDLT, then h_gn = J^T y.
+                // For the over/at-constrained case (csize >= xsize) J^T J is the
+                // full-rank one, so use the normal equations there.
+                //
+                // The non-zero pattern is fixed for the whole solve (topology does
+                // not change), so analyzePattern() runs once. No LM damping: the
+                // dogleg trust region controls step length via delta.
+                //
+                // Robustness: SimplicialLDLT::info() only flags an EXACT zero pivot,
+                // so a merely rank-deficient (redundant/over-constrained) matrix can
+                // factorize "successfully" with ~1e-16 pivots and blow the solve up to
+                // NaN/Inf. We therefore also validate that h_gn is finite and fall
+                // back to a dense fullPivLU (which pivots through rank deficiency)
+                // whenever the sparse step is not usable.
+                bool underdetermined = (csize < xsize);
+                if (underdetermined) {
+                    A_sparse = Jx * Jx.transpose();  // csize x csize
+                }
+                else {
+                    A_sparse = Jx.transpose() * Jx;  // xsize x xsize
+                }
+                if (!sparse_pattern_analyzed) {
+                    sparse_ldlt.analyzePattern(A_sparse);
+                    sparse_pattern_analyzed = true;
+                }
+                sparse_ldlt.factorize(A_sparse);
+                if (sparse_ldlt.info() != Eigen::Success) {
+                    h_gn = Jx.toDense().fullPivLu().solve(-fx);
+                }
+                else if (underdetermined) {
+                    Eigen::VectorXd y = sparse_ldlt.solve(-fx);
+                    h_gn = Jx.transpose() * y;
+                }
+                else {
+                    h_gn = sparse_ldlt.solve(g);
+                }
+                if (!h_gn.allFinite()) {
+                    // Rank-deficient normal matrix slipped past info(); use dense.
+                    h_gn = Jx.toDense().fullPivLu().solve(-fx);
+                }
+                break;
+            }
         }
 
         double rel_error = (Jx * h_gn + fx).norm() / fx.norm();
@@ -2413,7 +2482,7 @@ int System::solve_DL(SubSystem* subsys, bool isRedundantsolving)
 
         // get the new values
         double err_new;
-        x_new = x + h_dl;
+        x_new.noalias() = x + h_dl;
         subsys->setParams(x_new);
         subsys->calcResidual(fx_new, err_new);
         subsys->calcJacobi(Jx_new);
@@ -4557,7 +4626,7 @@ int System::solve(SubSystem* subsysA, SubSystem* subsysB, bool /*isFine*/, bool 
     Eigen::VectorXd lambda(csizeA), lambda0(csizeA), lambdadir(csizeA);
     Eigen::VectorXd x(xsize), x0(xsize), xdir(xsize), xdir1(xsize);
     Eigen::VectorXd grad(xsize);
-    Eigen::VectorXd h(xsize);
+    Eigen::VectorXd h = Eigen::VectorXd::Zero(xsize);
     Eigen::VectorXd y(xsize);
     Eigen::VectorXd Bh(xsize);
 
@@ -4671,6 +4740,7 @@ int System::solve(SubSystem* subsysA, SubSystem* subsysB, bool /*isFine*/, bool 
         }
 
         double err = subsysA->error();
+
         if (h.norm() <= (isRedundantsolving ? convergenceRedundant : convergence) && err <= smallF) {
             break;
         }

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -2408,8 +2408,7 @@ int System::solve_DL(SubSystem* subsys, bool isRedundantsolving)
                        ? "FullPivLU"
                        : (dogLegGaussStep == LeastNormFullPivLU
                               ? "LeastNormFullPivLU"
-                              : (dogLegGaussStep == LeastNormLdlt ? "LeastNormLdlt"
-                                                                  : "SparseLDLT")))
+                              : (dogLegGaussStep == LeastNormLdlt ? "LeastNormLdlt" : "SparseLDLT")))
                << ", xsize: " << xsize << ", csize: " << csize << ", maxIter: " << maxIterNumber
                << "\n";
 

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -53,6 +53,7 @@
 #include <iostream>
 #include <limits>
 #include <numbers>
+#include <unordered_map>
 
 #include "GCS.h"
 #include "qp_eq.h"
@@ -546,6 +547,112 @@ void System::invalidatedDiagnosis()
     hasDiagnosis = false;
     pDependentParameters.clear();
     pDependentParametersGroups.clear();
+}
+
+DiagnosisCache System::saveDiagnosis() const
+{
+    DiagnosisCache cache;
+    cache.conflictingTags = conflictingTags;
+    cache.redundantTags = redundantTags;
+    cache.partiallyRedundantTags = partiallyRedundantTags;
+    cache.dofs = dofs;
+    cache.emptyDiagnoseMatrix = emptyDiagnoseMatrix;
+    cache.clistSize = clist.size();
+    cache.plistSize = plist.size();
+
+    std::unordered_map<Constraint*, int> constraintIndex;
+    constraintIndex.reserve(clist.size() * 2);
+    for (size_t i = 0; i < clist.size(); ++i) {
+        constraintIndex.emplace(clist[i], static_cast<int>(i));
+    }
+    std::unordered_map<double*, int> paramIndex;
+    paramIndex.reserve(plist.size() * 2);
+    for (size_t i = 0; i < plist.size(); ++i) {
+        paramIndex.emplace(plist[i], static_cast<int>(i));
+    }
+
+    for (auto* c : redundant) {
+        auto it = constraintIndex.find(c);
+        if (it != constraintIndex.end()) {
+            cache.redundantIndices.push_back(it->second);
+        }
+    }
+
+    for (auto* p : pDependentParameters) {
+        auto it = paramIndex.find(p);
+        if (it != paramIndex.end()) {
+            cache.dependentParamIndices.push_back(it->second);
+        }
+    }
+
+    cache.dependentParamGroupsIndices.resize(pDependentParametersGroups.size());
+    for (size_t g = 0; g < pDependentParametersGroups.size(); ++g) {
+        for (auto* p : pDependentParametersGroups[g]) {
+            auto it = paramIndex.find(p);
+            if (it != paramIndex.end()) {
+                cache.dependentParamGroupsIndices[g].push_back(it->second);
+            }
+        }
+    }
+
+    return cache;
+}
+
+void System::restoreDiagnosis(const DiagnosisCache& cache)
+{
+    // The cached entries are indices into clist/plist captured at save time.
+    // The caller's topology fingerprint keeps the constraint wiring and the
+    // geometry structure stable between save and restore, but cannot see
+    // everything (e.g. an edit that changes a geometry's parameter count), so
+    // a size mismatch — or any out-of-range index — means the mapping is
+    // stale and the restore must be abandoned in favor of a fresh diagnose().
+    auto abortRestore = [this]() {
+        redundant.clear();
+        invalidatedDiagnosis();
+    };
+
+    if (cache.clistSize != clist.size() || cache.plistSize != plist.size()) {
+        abortRestore();
+        return;
+    }
+
+    conflictingTags = cache.conflictingTags;
+    redundantTags = cache.redundantTags;
+    partiallyRedundantTags = cache.partiallyRedundantTags;
+    dofs = cache.dofs;
+    emptyDiagnoseMatrix = cache.emptyDiagnoseMatrix;
+
+    redundant.clear();
+    for (int idx : cache.redundantIndices) {
+        if (idx < 0 || idx >= static_cast<int>(clist.size())) {
+            abortRestore();
+            return;
+        }
+        redundant.insert(clist[idx]);
+    }
+
+    pDependentParameters.clear();
+    for (int idx : cache.dependentParamIndices) {
+        if (idx < 0 || idx >= static_cast<int>(plist.size())) {
+            abortRestore();
+            return;
+        }
+        pDependentParameters.push_back(plist[idx]);
+    }
+
+    pDependentParametersGroups.clear();
+    pDependentParametersGroups.resize(cache.dependentParamGroupsIndices.size());
+    for (size_t g = 0; g < cache.dependentParamGroupsIndices.size(); ++g) {
+        for (int idx : cache.dependentParamGroupsIndices[g]) {
+            if (idx < 0 || idx >= static_cast<int>(plist.size())) {
+                abortRestore();
+                return;
+            }
+            pDependentParametersGroups[g].push_back(plist[idx]);
+        }
+    }
+
+    hasDiagnosis = true;
 }
 
 void System::clearByTag(int tagId)

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -113,9 +113,9 @@ struct DiagnosisCache
     VEC_I conflictingTags;
     VEC_I redundantTags;
     VEC_I partiallyRedundantTags;
-    std::vector<int> redundantIndices;               // indices into clist
+    std::vector<int> redundantIndices;                          // indices into clist
     std::vector<std::vector<int>> dependentParamGroupsIndices;  // indices into plist
-    std::vector<int> dependentParamIndices;          // indices into plist
+    std::vector<int> dependentParamIndices;                     // indices into plist
     // sizes of clist/plist at save time; restoreDiagnosis() aborts on any
     // mismatch, since the cached indices would map onto different entries
     size_t clistSize = 0;

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -70,7 +70,9 @@ enum DogLegGaussStep
 {
     FullPivLU = 0,
     LeastNormFullPivLU = 1,
-    LeastNormLdlt = 2
+    LeastNormLdlt = 2,
+    SparseLDLT = 3  // Sparse LDLT: least-norm (J J^T) when under-constrained, else
+                    // normal equations (J^T J); dense fullPivLU fallback on failure
 };
 
 enum QRAlgorithm

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -105,6 +105,25 @@ enum SpecialTag
     DefaultTemporaryConstraint = -1
 };
 
+// DiagnosisCache stores the result of the expensive O(n³) diagnose() call so it
+// can be restored across consecutive setUpSketch() invocations when the
+// constraint topology has not changed (e.g., during setDatum() drags).
+struct DiagnosisCache
+{
+    VEC_I conflictingTags;
+    VEC_I redundantTags;
+    VEC_I partiallyRedundantTags;
+    std::vector<int> redundantIndices;               // indices into clist
+    std::vector<std::vector<int>> dependentParamGroupsIndices;  // indices into plist
+    std::vector<int> dependentParamIndices;          // indices into plist
+    // sizes of clist/plist at save time; restoreDiagnosis() aborts on any
+    // mismatch, since the cached indices would map onto different entries
+    size_t clistSize = 0;
+    size_t plistSize = 0;
+    int dofs = -1;
+    bool emptyDiagnoseMatrix = true;
+};
+
 class SketcherExport System
 {
     // This is the main class. It holds all constraints and information
@@ -678,6 +697,10 @@ public:
     }
 
     void invalidatedDiagnosis();
+
+    // save/restore diagnosis across topology-stable re-solves
+    DiagnosisCache saveDiagnosis() const;
+    void restoreDiagnosis(const DiagnosisCache& cache);
 
     // Unit testing interface - not intended for use by production code
 protected:

--- a/src/Mod/Sketcher/App/planegcs/SubSystem.cpp
+++ b/src/Mod/Sketcher/App/planegcs/SubSystem.cpp
@@ -114,7 +114,10 @@ void SubSystem::initialize(VEC_pD& params, MAP_pD_pD& reductionmap)
 
     c2p.clear();
     p2c.clear();
-    for (std::vector<Constraint*>::iterator constr = clist.begin(); constr != clist.end(); ++constr) {
+    p2c_rows_.clear();
+    int row = 0;
+    for (std::vector<Constraint*>::iterator constr = clist.begin(); constr != clist.end();
+         ++constr, ++row) {
         (*constr)->revertParams();  // ensure that the constraint points to the original parameters
         VEC_pD constr_params_orig = (*constr)->params();
         SET_pD constr_params;
@@ -129,6 +132,7 @@ void SubSystem::initialize(VEC_pD& params, MAP_pD_pD& reductionmap)
             //            jacobi.set(*constr, *p, 0.);
             c2p[*constr].push_back(*p);
             p2c[*p].push_back(*constr);
+            p2c_rows_[*p].push_back(row);  // clist index of *constr, aligned with p2c[*p]
         }
         //        (*constr)->redirectParams(pmap); // redirect parameters to pvec
     }
@@ -251,20 +255,84 @@ void SubSystem::calcResidual(Eigen::VectorXd& r, double& err)
     err *= 0.5;
 }
 
+// ---------------------------------------------------------------------------
+// calcJacobi() — Sparse Analytical Jacobian Assembly
+//
+// For each output column j we look up params[j]'s redirected pvals pointer and
+// visit ONLY the constraints that actually depend on it (via the p2c / p2c_rows_
+// adjacency built once in initialize()). This is O(nnz) — for banded/local
+// sketches O(N) — instead of the O(nparams × csize) dense grad() sweep.
+//
+// The column is j (the position in the passed-in `params`), so the result is
+// correct for ANY params array — `plist` (single-arg overload) or a differently
+// ordered union such as the SQP solver's `plistAB`. This mirrors calcGrad()'s
+// use of p2c and removes the earlier Equal fast path, whose cached column index
+// was keyed to `plist` and therefore produced wrong columns when called with
+// `plistAB` during dragging.
+// ---------------------------------------------------------------------------
 void SubSystem::calcJacobi(VEC_pD& params, Eigen::MatrixXd& jacobi)
 {
-    jacobi.setZero(csize, params.size());
-    for (int j = 0; j < int(params.size()); j++) {
+    int nparams = int(params.size());
+    jacobi.setZero(csize, nparams);
+
+    for (int j = 0; j < nparams; j++) {
         MAP_pD_pD::const_iterator pmapfind = pmap.find(params[j]);
-        if (pmapfind != pmap.end()) {
-            for (int i = 0; i < csize; i++) {
-                jacobi(i, j) = clist[i]->grad(pmapfind->second);
-            }
+        if (pmapfind == pmap.end()) {
+            continue;
+        }
+        double* pval = pmapfind->second;
+
+        auto cit = p2c.find(pval);
+        if (cit == p2c.end()) {
+            continue;
+        }
+        const std::vector<Constraint*>& constrs = cit->second;
+        const std::vector<int>& rows = p2c_rows_.find(pval)->second;  // 1:1 with constrs
+        for (std::size_t k = 0; k < constrs.size(); ++k) {
+            jacobi(rows[k], j) = constrs[k]->grad(pval);
         }
     }
 }
 
 void SubSystem::calcJacobi(Eigen::MatrixXd& jacobi)
+{
+    calcJacobi(plist, jacobi);
+}
+
+// Sparse counterpart of calcJacobi(): assembles the Jacobian directly into an
+// Eigen::SparseMatrix in O(nnz) via the p2c / p2c_rows_ adjacency. Same column
+// convention as the dense overload (column j == params[j]), so it is correct for
+// any params array. Used by the monolithic DogLeg path so that J^T*J and the
+// linear solve stay sparse (banded) instead of O(N^2)/O(N^3) dense.
+void SubSystem::calcJacobi(VEC_pD& params, Eigen::SparseMatrix<double>& jacobi)
+{
+    int nparams = int(params.size());
+    // called once per solver iteration: reuse the triplet buffer's capacity
+    jacobiTriplets_.clear();
+
+    for (int j = 0; j < nparams; j++) {
+        MAP_pD_pD::const_iterator pmapfind = pmap.find(params[j]);
+        if (pmapfind == pmap.end()) {
+            continue;
+        }
+        double* pval = pmapfind->second;
+
+        auto cit = p2c.find(pval);
+        if (cit == p2c.end()) {
+            continue;
+        }
+        const std::vector<Constraint*>& constrs = cit->second;
+        const std::vector<int>& rows = p2c_rows_.find(pval)->second;  // 1:1 with constrs
+        for (std::size_t k = 0; k < constrs.size(); ++k) {
+            jacobiTriplets_.emplace_back(rows[k], j, constrs[k]->grad(pval));
+        }
+    }
+
+    jacobi.resize(csize, nparams);
+    jacobi.setFromTriplets(jacobiTriplets_.begin(), jacobiTriplets_.end());
+}
+
+void SubSystem::calcJacobi(Eigen::SparseMatrix<double>& jacobi)
 {
     calcJacobi(plist, jacobi);
 }
@@ -277,7 +345,7 @@ void SubSystem::calcGrad(VEC_pD& params, Eigen::VectorXd& grad)
     for (int j = 0; j < int(params.size()); j++) {
         MAP_pD_pD::const_iterator pmapfind = pmap.find(params[j]);
         if (pmapfind != pmap.end()) {
-            std::vector<Constraint*> constrs = p2c[pmapfind->second];
+            const std::vector<Constraint*>& constrs = p2c[pmapfind->second];
             for (std::vector<Constraint*>::const_iterator constr = constrs.begin();
                  constr != constrs.end();
                  ++constr) {

--- a/src/Mod/Sketcher/App/planegcs/SubSystem.h
+++ b/src/Mod/Sketcher/App/planegcs/SubSystem.h
@@ -28,6 +28,7 @@
 #undef max
 
 #include <Eigen/Core>
+#include <Eigen/SparseCore>
 
 #include "Constraints.h"
 
@@ -46,6 +47,11 @@ private:
                      //        JacobianMatrix jacobi;  // jacobi matrix of the residuals
     std::map<Constraint*, VEC_pD> c2p;                // constraint to parameter adjacency list
     std::map<double*, std::vector<Constraint*>> p2c;  // parameter to constraint adjacency list
+    std::map<double*, std::vector<int>> p2c_rows_;    // parameter -> row (clist index) of each
+                                                      // constraint in p2c, aligned 1:1 with p2c;
+                                                      // used for sparse Jacobian assembly
+    std::vector<Eigen::Triplet<double>> jacobiTriplets_;  // reused across the sparse calcJacobi()
+                                                          // calls of a solve (one per iteration)
     void initialize(VEC_pD& params, MAP_pD_pD& reductionmap);  // called by the constructors
 public:
     SubSystem(std::vector<Constraint*>& clist_, VEC_pD& params);
@@ -79,6 +85,9 @@ public:
     void calcResidual(Eigen::VectorXd& r, double& err);
     void calcJacobi(VEC_pD& params, Eigen::MatrixXd& jacobi);
     void calcJacobi(Eigen::MatrixXd& jacobi);
+    // Sparse Jacobian assembly (O(nnz)) for the banded/dense monolithic DogLeg path.
+    void calcJacobi(VEC_pD& params, Eigen::SparseMatrix<double>& jacobi);
+    void calcJacobi(Eigen::SparseMatrix<double>& jacobi);
     void calcGrad(VEC_pD& params, Eigen::VectorXd& grad);
     void calcGrad(Eigen::VectorXd& grad);
 

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -308,9 +308,11 @@ Restart:
             hashInt(placementSig, static_cast<long long>(Constr->SecondPos));
             hashInt(placementSig, static_cast<long long>(Constr->ThirdPos));
             hashDouble(placementSig, Constr->getValue());
-            hashInt(placementSig,
-                    (Constr->isDriving ? 1 : 0) | (Constr->isActive ? 2 : 0)
-                        | (Constr->isInVirtualSpace ? 4 : 0));
+            hashInt(
+                placementSig,
+                (Constr->isDriving ? 1 : 0) | (Constr->isActive ? 2 : 0)
+                    | (Constr->isInVirtualSpace ? 4 : 0)
+            );
             hashDouble(placementSig, Constr->LabelDistance);
             hashDouble(placementSig, Constr->LabelPosition);
             hashCombine(placementSig, Constr->Name.data(), Constr->Name.size());
@@ -1857,7 +1859,8 @@ void EditModeConstraintCoinManager::updateConstraintColor(
             color.emplace_back();
             for (int t = 0; t < geometryLayerParameters.getSubLayerCount(); t++) {
                 CurvNum[l].push_back(
-                    editModeScenegraphNodes.CurvesMaterials[l][t]->diffuseColor.getNum());
+                    editModeScenegraphNodes.CurvesMaterials[l][t]->diffuseColor.getNum()
+                );
                 color[l].push_back(
                     editModeScenegraphNodes.CurvesMaterials[l][t]->diffuseColor.startEditing()
                 );
@@ -1867,12 +1870,13 @@ void EditModeConstraintCoinManager::updateConstraintColor(
 
     // If any color preference changed, every cached state is stale.
     std::size_t paletteHash = 14695981039346656037ULL;
-    for (const SbColor& c : {SketcherGui::DrawingParameters::ConstrDimColor,
-                             SketcherGui::DrawingParameters::NonDrivingConstrDimColor,
-                             SketcherGui::DrawingParameters::DeactivatedConstrDimColor,
-                             drawingParameters.ExprBasedConstrDimColor,
-                             SketcherGui::DrawingParameters::SelectColor,
-                             SketcherGui::DrawingParameters::PreselectColor}) {
+    for (const SbColor& c :
+         {SketcherGui::DrawingParameters::ConstrDimColor,
+          SketcherGui::DrawingParameters::NonDrivingConstrDimColor,
+          SketcherGui::DrawingParameters::DeactivatedConstrDimColor,
+          drawingParameters.ExprBasedConstrDimColor,
+          SketcherGui::DrawingParameters::SelectColor,
+          SketcherGui::DrawingParameters::PreselectColor}) {
         float rgb[3] = {c[0], c[1], c[2]};
         hashCombine(paletteHash, rgb, sizeof(rgb));
     }
@@ -1926,10 +1930,11 @@ void EditModeConstraintCoinManager::updateConstraintColor(
         // always be re-applied.
         {
             bool selected = ViewProviderSketchCoinAttorney::isConstraintSelected(viewProvider, i);
-            bool preselected =
-                ViewProviderSketchCoinAttorney::isConstraintPreselected(viewProvider, i);
-            bool isActive =
-                ViewProviderSketchCoinAttorney::isConstraintActiveInSketch(viewProvider, constraint);
+            bool preselected = ViewProviderSketchCoinAttorney::isConstraintPreselected(viewProvider, i);
+            bool isActive = ViewProviderSketchCoinAttorney::isConstraintActiveInSketch(
+                viewProvider,
+                constraint
+            );
             bool hasExpression = hasDatumLabel && !selected && !preselected
                 && ViewProviderSketchCoinAttorney::constraintHasExpression(viewProvider, i);
             unsigned char state = (selected ? 1 : 0) | (preselected ? 2 : 0) | (isActive ? 4 : 0)
@@ -2120,8 +2125,7 @@ bool EditModeConstraintCoinManager::trySyncConstraintNodes(
         return false;
     }
     if (vConstrPlacementHash.size() != oldN || vConstrColorState.size() != oldN
-        || static_cast<std::size_t>(editModeScenegraphNodes.constrGroup->getNumChildren())
-            != oldN) {
+        || static_cast<std::size_t>(editModeScenegraphNodes.constrGroup->getNumChildren()) != oldN) {
         return false;
     }
 
@@ -2272,124 +2276,124 @@ SoSeparator* EditModeConstraintCoinManager::createConstraintNode(
             mat->unref();
             return sep;
         } break;
-            case Horizontal:
-            case Vertical:
-            case Block: {
-                // #define CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL 0
-                sep->addChild(mat);
-                // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_TRANSLATION 1
-                sep->addChild(new SoZoomTranslation());
-                // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_ICON 2
-                sep->addChild(new SoImage());
-                // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_CONSTRAINTID 3
-                sep->addChild(new SoInfo());
-                // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_TRANSLATION 4
-                sep->addChild(new SoZoomTranslation());
-                // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_ICON 5
-                sep->addChild(new SoImage());
-                // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_CONSTRAINTID 6
-                sep->addChild(new SoInfo());
+        case Horizontal:
+        case Vertical:
+        case Block: {
+            // #define CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL 0
+            sep->addChild(mat);
+            // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_TRANSLATION 1
+            sep->addChild(new SoZoomTranslation());
+            // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_ICON 2
+            sep->addChild(new SoImage());
+            // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_CONSTRAINTID 3
+            sep->addChild(new SoInfo());
+            // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_TRANSLATION 4
+            sep->addChild(new SoZoomTranslation());
+            // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_ICON 5
+            sep->addChild(new SoImage());
+            // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_CONSTRAINTID 6
+            sep->addChild(new SoInfo());
 
-            } break;
-            case Group:
-            case Text: {
-                // For a group, we will draw a dashed rectangle.
-                // We need a Material, a DrawStyle, Coordinates, and a LineSet.
+        } break;
+        case Group:
+        case Text: {
+            // For a group, we will draw a dashed rectangle.
+            // We need a Material, a DrawStyle, Coordinates, and a LineSet.
 
-                // 1. Material (for color, reusing the one already created)
-                sep->addChild(mat);
+            // 1. Material (for color, reusing the one already created)
+            sep->addChild(mat);
 
-                // 2. DrawStyle (to make the line dashed)
-                auto* drawStyle = new SoDrawStyle();
-                drawStyle->linePattern = 0x0F0F;  // A standard 50% dashed pattern
-                sep->addChild(drawStyle);
+            // 2. DrawStyle (to make the line dashed)
+            auto* drawStyle = new SoDrawStyle();
+            drawStyle->linePattern = 0x0F0F;  // A standard 50% dashed pattern
+            sep->addChild(drawStyle);
 
-                // 3. Coordinates (for the 4 corners + 1 to close the loop)
-                auto* coords = new SoCoordinate3();
-                coords->point.setNum(5);  // Pre-allocate 5 points for a closed rectangle
-                sep->addChild(coords);
+            // 3. Coordinates (for the 4 corners + 1 to close the loop)
+            auto* coords = new SoCoordinate3();
+            coords->point.setNum(5);  // Pre-allocate 5 points for a closed rectangle
+            sep->addChild(coords);
 
-                // 4. LineSet (to connect the coordinates)
-                auto* lineSet = new SoLineSet();
-                lineSet->numVertices.set1Value(0, 5);  // A single polyline of 5 vertices
-                sep->addChild(lineSet);
+            // 4. LineSet (to connect the coordinates)
+            auto* lineSet = new SoLineSet();
+            lineSet->numVertices.set1Value(0, 5);  // A single polyline of 5 vertices
+            sep->addChild(lineSet);
 
-            } break;
-            case Coincident:  // no visual for coincident so far
-                break;
-            case Parallel:
-            case Perpendicular:
-            case Equal: {
-                // #define CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL 0
-                sep->addChild(mat);
-                // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_TRANSLATION 1
-                sep->addChild(new SoZoomTranslation());
-                // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_ICON 2
-                sep->addChild(new SoImage());
-                // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_CONSTRAINTID 3
-                sep->addChild(new SoInfo());
-                // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_TRANSLATION 4
-                sep->addChild(new SoZoomTranslation());
-                // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_ICON 5
-                sep->addChild(new SoImage());
-                // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_CONSTRAINTID 6
-                sep->addChild(new SoInfo());
+        } break;
+        case Coincident:  // no visual for coincident so far
+            break;
+        case Parallel:
+        case Perpendicular:
+        case Equal: {
+            // #define CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL 0
+            sep->addChild(mat);
+            // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_TRANSLATION 1
+            sep->addChild(new SoZoomTranslation());
+            // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_ICON 2
+            sep->addChild(new SoImage());
+            // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_CONSTRAINTID 3
+            sep->addChild(new SoInfo());
+            // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_TRANSLATION 4
+            sep->addChild(new SoZoomTranslation());
+            // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_ICON 5
+            sep->addChild(new SoImage());
+            // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_CONSTRAINTID 6
+            sep->addChild(new SoInfo());
 
-            } break;
-            case PointOnObject:
-            case Tangent:
-            case SnellsLaw: {
-                // #define CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL 0
-                sep->addChild(mat);
-                // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_TRANSLATION 1
-                sep->addChild(new SoZoomTranslation());
-                // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_ICON 2
-                sep->addChild(new SoImage());
-                // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_CONSTRAINTID 3
-                sep->addChild(new SoInfo());
+        } break;
+        case PointOnObject:
+        case Tangent:
+        case SnellsLaw: {
+            // #define CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL 0
+            sep->addChild(mat);
+            // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_TRANSLATION 1
+            sep->addChild(new SoZoomTranslation());
+            // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_ICON 2
+            sep->addChild(new SoImage());
+            // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_CONSTRAINTID 3
+            sep->addChild(new SoInfo());
 
-                if (it->Type == Tangent) {
-                    const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(it->First);
-                    const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(it->Second);
-                    if (!geo1 || !geo2) {
-                        Base::Console().developerWarning(
-                            "EditModeConstraintCoinManager",
-                            "Tangent constraint references non-existing geometry\n"
-                        );
-                    }
-                    else if (geo1->is<Part::GeomLineSegment>() && geo2->is<Part::GeomLineSegment>()) {
-                        // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_TRANSLATION 4
-                        sep->addChild(new SoZoomTranslation());
-                        // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_ICON 5
-                        sep->addChild(new SoImage());
-                        // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_CONSTRAINTID 6
-                        sep->addChild(new SoInfo());
-                    }
+            if (it->Type == Tangent) {
+                const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(it->First);
+                const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(it->Second);
+                if (!geo1 || !geo2) {
+                    Base::Console().developerWarning(
+                        "EditModeConstraintCoinManager",
+                        "Tangent constraint references non-existing geometry\n"
+                    );
                 }
+                else if (geo1->is<Part::GeomLineSegment>() && geo2->is<Part::GeomLineSegment>()) {
+                    // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_TRANSLATION 4
+                    sep->addChild(new SoZoomTranslation());
+                    // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_ICON 5
+                    sep->addChild(new SoImage());
+                    // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_CONSTRAINTID 6
+                    sep->addChild(new SoInfo());
+                }
+            }
 
-            } break;
-            case Symmetric: {
-                auto* arrows = new SoDatumLabel();
-                arrows->norm.setValue(norm);
-                arrows->string = "";
-                arrows->textColor = SketcherGui::DrawingParameters::ConstrDimColor;
-                arrows->lineWidth = 2 * drawingParameters.pixelScalingFactor;
+        } break;
+        case Symmetric: {
+            auto* arrows = new SoDatumLabel();
+            arrows->norm.setValue(norm);
+            arrows->string = "";
+            arrows->textColor = SketcherGui::DrawingParameters::ConstrDimColor;
+            arrows->lineWidth = 2 * drawingParameters.pixelScalingFactor;
 
-                // #define CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL 0
-                sep->addChild(arrows);
-                // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_TRANSLATION 1
-                sep->addChild(new SoTranslation());
-                // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_ICON 2
-                sep->addChild(new SoImage());
-                // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_CONSTRAINTID 3
-                sep->addChild(new SoInfo());
+            // #define CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL 0
+            sep->addChild(arrows);
+            // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_TRANSLATION 1
+            sep->addChild(new SoTranslation());
+            // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_ICON 2
+            sep->addChild(new SoImage());
+            // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_CONSTRAINTID 3
+            sep->addChild(new SoInfo());
 
-            } break;
-            case InternalAlignment: {
-            } break;
-            default:
-                break;
-        }
+        } break;
+        case InternalAlignment: {
+        } break;
+        default:
+            break;
+    }
 
     mat->unref();
     return sep;

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -77,6 +77,79 @@ using namespace Gui;
 using namespace SketcherGui;
 using namespace Sketcher;
 
+namespace
+{
+
+// FNV-1a accumulation used to fingerprint the inputs of a constraint's
+// placement update so unchanged constraints can be skipped.
+inline void hashCombine(std::size_t& seed, const void* data, std::size_t len)
+{
+    const auto* bytes = static_cast<const unsigned char*>(data);
+    for (std::size_t k = 0; k < len; ++k) {
+        seed ^= bytes[k];
+        seed *= 1099511628211ULL;
+    }
+}
+
+inline void hashDouble(std::size_t& seed, double v)
+{
+    hashCombine(seed, &v, sizeof(v));
+}
+
+inline void hashInt(std::size_t& seed, long long v)
+{
+    hashCombine(seed, &v, sizeof(v));
+}
+
+inline void hashVector(std::size_t& seed, const Base::Vector3d& v)
+{
+    hashDouble(seed, v.x);
+    hashDouble(seed, v.y);
+    hashDouble(seed, v.z);
+}
+
+// Fingerprint of a geometry's defining data as the placement code sees it.
+// Lines hash their endpoints directly; other curves hash five points sampled
+// along the parameter range (deterministic, so identical geometry always
+// yields an identical hash; different same-type geometry through five common
+// points does not occur in practice).
+std::size_t hashGeometry(const Part::Geometry* geo)
+{
+    std::size_t seed = 14695981039346656037ULL;
+    if (!geo) {
+        return 0;
+    }
+    hashInt(seed, static_cast<long long>(geo->getTypeId().getKey()));
+
+    if (const auto* line = dynamic_cast<const Part::GeomLineSegment*>(geo)) {
+        hashVector(seed, line->getStartPoint());
+        hashVector(seed, line->getEndPoint());
+        return seed;
+    }
+    if (const auto* point = dynamic_cast<const Part::GeomPoint*>(geo)) {
+        hashVector(seed, point->getPoint());
+        return seed;
+    }
+    if (const auto* curve = dynamic_cast<const Part::GeomCurve*>(geo)) {
+        try {
+            const double u0 = curve->getFirstParameter();
+            const double u1 = curve->getLastParameter();
+            hashDouble(seed, u0);
+            hashDouble(seed, u1);
+            for (int k = 0; k <= 4; ++k) {
+                hashVector(seed, curve->pointAtParameter(u0 + (u1 - u0) * k / 4.0));
+            }
+            return seed;
+        }
+        catch (const Base::Exception&) {
+            return 0;  // never skip on evaluation failure
+        }
+    }
+    return 0;
+}
+
+}  // namespace
+
 //**************************** EditModeConstraintCoinManager class ******************************
 
 EditModeConstraintCoinManager::EditModeConstraintCoinManager(
@@ -143,7 +216,9 @@ void EditModeConstraintCoinManager::processConstraints(const GeoListFacade& geol
 Restart:
     // check if a new constraint arrived
     if (constrlist.size() != vConstrType.size()) {
-        rebuildConstraintNodes(geolistfacade);
+        if (!trySyncConstraintNodes(geolistfacade, constrlist)) {
+            rebuildConstraintNodes(geolistfacade);
+        }
     }
 
     assert(int(constrlist.size()) == editModeScenegraphNodes.constrGroup->getNumChildren());
@@ -177,6 +252,27 @@ Restart:
             return normal;
         };
 
+    // Skip-unchanged support: fingerprint every input the update-switch below
+    // reads; a matching fingerprint means the coin nodes already hold the
+    // right values.
+    if (vConstrPlacementHash.size() != constrlist.size()) {
+        vConstrPlacementHash.assign(constrlist.size(), 0);
+    }
+    std::size_t globalSeed = 14695981039346656037ULL;
+    hashDouble(globalSeed, zConstrH);
+    hashInt(globalSeed, static_cast<long long>(Base::UnitsApi::getDecimals()));
+    hashInt(globalSeed, static_cast<long long>(Base::UnitsApi::getDefSchemaNum()));
+    std::map<int, std::size_t> geoStampCache;
+    auto geoStamp = [&](int geoId) -> std::size_t {
+        auto found = geoStampCache.find(geoId);
+        if (found != geoStampCache.end()) {
+            return found->second;
+        }
+        std::size_t h = hashGeometry(geolistfacade.getGeometryFromGeoId(geoId));
+        geoStampCache.emplace(geoId, h);
+        return h;
+    };
+
     // go through the constraints and update the position
     int i = 0;
     for (auto it = constrlist.begin(); it != constrlist.end(); ++it, i++) {
@@ -201,6 +297,45 @@ Restart:
                 // Constraint can refer to non-existent geometry during undo/redo
                 continue;
             }
+
+            // NOTE: geo indices are deliberately NOT part of the signature —
+            // the referenced geometry participates via its content stamp, so
+            // a pure renumbering (deletion of other geometry) does not force
+            // rewriting placements that are in fact unchanged.
+            std::size_t placementSig = globalSeed;
+            hashInt(placementSig, static_cast<long long>(Constr->Type));
+            hashInt(placementSig, static_cast<long long>(Constr->FirstPos));
+            hashInt(placementSig, static_cast<long long>(Constr->SecondPos));
+            hashInt(placementSig, static_cast<long long>(Constr->ThirdPos));
+            hashDouble(placementSig, Constr->getValue());
+            hashInt(placementSig,
+                    (Constr->isDriving ? 1 : 0) | (Constr->isActive ? 2 : 0)
+                        | (Constr->isInVirtualSpace ? 4 : 0));
+            hashDouble(placementSig, Constr->LabelDistance);
+            hashDouble(placementSig, Constr->LabelPosition);
+            hashCombine(placementSig, Constr->Name.data(), Constr->Name.size());
+            std::size_t g1 = geoStamp(Constr->First);
+            hashCombine(placementSig, &g1, sizeof(g1));
+            bool geoHashValid = (g1 != 0);
+            if (Constr->Second != GeoEnum::GeoUndef) {
+                std::size_t g2 = geoStamp(Constr->Second);
+                hashCombine(placementSig, &g2, sizeof(g2));
+                geoHashValid = geoHashValid && (g2 != 0);
+            }
+            if (Constr->Third != GeoEnum::GeoUndef) {
+                std::size_t g3 = geoStamp(Constr->Third);
+                hashCombine(placementSig, &g3, sizeof(g3));
+                geoHashValid = geoHashValid && (g3 != 0);
+            }
+            if (placementSig == 0 || !geoHashValid) {
+                placementSig = 0;  // unknown input -> always update
+            }
+
+            if (placementSig != 0 && vConstrPlacementHash[i] == placementSig) {
+                continue;  // inputs identical to the last update
+            }
+            // invalidate until the update below completes without throwing
+            vConstrPlacementHash[i] = 0;
 
             // distinguish different constraint types to build up
             switch (Constr->Type) {
@@ -1629,6 +1764,8 @@ Restart:
                 case NumConstraintTypes:
                     break;
             }
+
+            vConstrPlacementHash[i] = placementSig;  // update succeeded
         }
         catch (Base::Exception& e) {
             Base::Console().developerError(
@@ -1704,17 +1841,44 @@ void EditModeConstraintCoinManager::updateConstraintColor(
     std::vector<std::vector<int>> CurvNum;
     std::vector<std::vector<SbColor*>> color;  // curve color
 
-    for (int l = 0; l < geometryLayerParameters.getCoinLayerCount(); l++) {
-        PtNum.push_back(editModeScenegraphNodes.PointsMaterials[l]->diffuseColor.getNum());
-        pcolor.push_back(editModeScenegraphNodes.PointsMaterials[l]->diffuseColor.startEditing());
-        CurvNum.emplace_back();
-        color.emplace_back();
-        for (int t = 0; t < geometryLayerParameters.getSubLayerCount(); t++) {
-            CurvNum[l].push_back(editModeScenegraphNodes.CurvesMaterials[l][t]->diffuseColor.getNum());
-            color[l].push_back(
-                editModeScenegraphNodes.CurvesMaterials[l][t]->diffuseColor.startEditing()
-            );
+    // The point/curve material arrays are only written for selected
+    // coincident / internal-alignment constraints; open them lazily so the
+    // common no-selection pass never touches (and never notifies) them.
+    bool arraysOpen = false;
+    auto openArrays = [&]() {
+        if (arraysOpen) {
+            return;
         }
+        arraysOpen = true;
+        for (int l = 0; l < geometryLayerParameters.getCoinLayerCount(); l++) {
+            PtNum.push_back(editModeScenegraphNodes.PointsMaterials[l]->diffuseColor.getNum());
+            pcolor.push_back(editModeScenegraphNodes.PointsMaterials[l]->diffuseColor.startEditing());
+            CurvNum.emplace_back();
+            color.emplace_back();
+            for (int t = 0; t < geometryLayerParameters.getSubLayerCount(); t++) {
+                CurvNum[l].push_back(
+                    editModeScenegraphNodes.CurvesMaterials[l][t]->diffuseColor.getNum());
+                color[l].push_back(
+                    editModeScenegraphNodes.CurvesMaterials[l][t]->diffuseColor.startEditing()
+                );
+            }
+        }
+    };
+
+    // If any color preference changed, every cached state is stale.
+    std::size_t paletteHash = 14695981039346656037ULL;
+    for (const SbColor& c : {SketcherGui::DrawingParameters::ConstrDimColor,
+                             SketcherGui::DrawingParameters::NonDrivingConstrDimColor,
+                             SketcherGui::DrawingParameters::DeactivatedConstrDimColor,
+                             drawingParameters.ExprBasedConstrDimColor,
+                             SketcherGui::DrawingParameters::SelectColor,
+                             SketcherGui::DrawingParameters::PreselectColor}) {
+        float rgb[3] = {c[0], c[1], c[2]};
+        hashCombine(paletteHash, rgb, sizeof(rgb));
+    }
+    if (vConstrColorState.size() != constraints.size() || paletteHash != lastColorPaletteHash) {
+        vConstrColorState.assign(constraints.size(), staleColorState);
+        lastColorPaletteHash = paletteHash;
     }
 
     int maxNumberOfConstraints = std::min(
@@ -1754,7 +1918,32 @@ void EditModeConstraintCoinManager::updateConstraintColor(
             }
         }
 
-        auto selectpoint = [this, pcolor, PtNum](int geoid, Sketcher::PointPos pos) {
+        // Skip constraints whose resolved color state is unchanged since the
+        // last pass — writing an identical value to a coin field still
+        // notifies and invalidates render caches. Selected coincident /
+        // internal-alignment constraints write into the shared point/curve
+        // arrays (which updateGeometryColor has just reset), so they must
+        // always be re-applied.
+        {
+            bool selected = ViewProviderSketchCoinAttorney::isConstraintSelected(viewProvider, i);
+            bool preselected =
+                ViewProviderSketchCoinAttorney::isConstraintPreselected(viewProvider, i);
+            bool isActive =
+                ViewProviderSketchCoinAttorney::isConstraintActiveInSketch(viewProvider, constraint);
+            bool hasExpression = hasDatumLabel && !selected && !preselected
+                && ViewProviderSketchCoinAttorney::constraintHasExpression(viewProvider, i);
+            unsigned char state = (selected ? 1 : 0) | (preselected ? 2 : 0) | (isActive ? 4 : 0)
+                | (constraint->isDriving ? 8 : 0) | (hasExpression ? 16 : 0);
+            bool writesSharedArrays = selected
+                && (type == Sketcher::Coincident || type == Sketcher::InternalAlignment);
+            if (!writesSharedArrays && vConstrColorState[i] == state) {
+                continue;
+            }
+            vConstrColorState[i] = state;
+        }
+
+        auto selectpoint = [this, &openArrays, &pcolor, &PtNum](int geoid, Sketcher::PointPos pos) {
+            openArrays();
             if (geoid >= 0) {
                 auto multifieldIndex = coinMapping.getIndexLayer(geoid, pos);
 
@@ -1768,7 +1957,8 @@ void EditModeConstraintCoinManager::updateConstraintColor(
             }
         };
 
-        auto selectline = [this, color, CurvNum](int geoid) {
+        auto selectline = [this, &openArrays, &color, &CurvNum](int geoid) {
+            openArrays();
             if (geoid >= 0) {
                 auto multifieldIndex = coinMapping.getIndexLayer(geoid, Sketcher::PointPos::none);
 
@@ -1861,10 +2051,12 @@ void EditModeConstraintCoinManager::updateConstraintColor(
         }
     }
 
-    for (int l = 0; l < geometryLayerParameters.getCoinLayerCount(); l++) {
-        editModeScenegraphNodes.PointsMaterials[l]->diffuseColor.finishEditing();
-        for (int t = 0; t < geometryLayerParameters.getSubLayerCount(); t++) {
-            editModeScenegraphNodes.CurvesMaterials[l][t]->diffuseColor.finishEditing();
+    if (arraysOpen) {
+        for (int l = 0; l < geometryLayerParameters.getCoinLayerCount(); l++) {
+            editModeScenegraphNodes.PointsMaterials[l]->diffuseColor.finishEditing();
+            for (int t = 0; t < geometryLayerParameters.getSubLayerCount(); t++) {
+                editModeScenegraphNodes.CurvesMaterials[l][t]->diffuseColor.finishEditing();
+            }
         }
     }
 }
@@ -1910,60 +2102,176 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(const GeoListFacade& 
     rebuildConstraintNodes(geolistfacade, constrlist, norm);
 }
 
+bool EditModeConstraintCoinManager::trySyncConstraintNodes(
+    const GeoListFacade& geolistfacade,
+    const std::vector<Sketcher::Constraint*>& constrlist
+)
+{
+    // Incremental add/remove of constraint separators: aligning the old type
+    // sequence with the new one as an ordered subsequence identifies exactly
+    // which nodes to insert or drop, so the (expensive to build AND to
+    // first-render) surviving nodes are preserved.
+    const std::size_t oldN = vConstrType.size();
+    const std::size_t newN = constrlist.size();
+    if (oldN == newN) {
+        return true;
+    }
+    if (oldN == 0 || newN == 0) {
+        return false;
+    }
+    if (vConstrPlacementHash.size() != oldN || vConstrColorState.size() != oldN
+        || static_cast<std::size_t>(editModeScenegraphNodes.constrGroup->getNumChildren())
+            != oldN) {
+        return false;
+    }
+
+    // A Tangent separator's structure depends on its referenced geometry
+    // (line/line gets a second icon set), so type-only alignment is not safe
+    // for it — fall back to the full rebuild.
+    for (auto* c : constrlist) {
+        if (c->Type == Tangent) {
+            return false;
+        }
+    }
+    for (auto t : vConstrType) {
+        if (t == Tangent) {
+            return false;
+        }
+    }
+
+    if (newN < oldN) {
+        // removal: the new type sequence must be an ordered subsequence
+        std::vector<int> removed;
+        std::size_t j = 0;
+        for (std::size_t i = 0; i < oldN; ++i) {
+            if (j < newN && vConstrType[i] == constrlist[j]->Type) {
+                ++j;
+            }
+            else {
+                removed.push_back(static_cast<int>(i));
+            }
+        }
+        if (j != newN) {
+            return false;
+        }
+        for (auto rit = removed.rbegin(); rit != removed.rend(); ++rit) {
+            editModeScenegraphNodes.constrGroup->removeChild(*rit);
+            vConstrType.erase(vConstrType.begin() + *rit);
+            vConstrPlacementHash.erase(vConstrPlacementHash.begin() + *rit);
+            vConstrColorState.erase(vConstrColorState.begin() + *rit);
+        }
+    }
+    else {
+        // insertion: the old type sequence must be an ordered subsequence
+        std::vector<int> added;
+        std::size_t i = 0;
+        for (std::size_t j = 0; j < newN; ++j) {
+            if (i < oldN && vConstrType[i] == constrlist[j]->Type) {
+                ++i;
+            }
+            else {
+                added.push_back(static_cast<int>(j));
+            }
+        }
+        if (i != oldN) {
+            return false;
+        }
+
+        // sketch normal, as in rebuildConstraintNodes
+        Base::Vector3d RN(0, 0, 1);
+        Base::Placement Plz = ViewProviderSketchCoinAttorney::getEditingPlacement(viewProvider);
+        Base::Rotation tmp(Plz.getRotation());
+        tmp.multVec(RN, RN);
+        SbVec3f norm(RN.x, RN.y, RN.z);
+
+        for (int pos : added) {
+            auto* sep = createConstraintNode(constrlist[pos], geolistfacade, norm);
+            editModeScenegraphNodes.constrGroup->insertChild(sep, pos);
+            sep->unref();
+            vConstrType.insert(vConstrType.begin() + pos, constrlist[pos]->Type);
+            vConstrPlacementHash.insert(vConstrPlacementHash.begin() + pos, 0);
+            vConstrColorState.insert(vConstrColorState.begin() + pos, staleColorState);
+        }
+    }
+
+    // constraint ids and node targets shifted: the icon pass must rerun
+    lastIconQueueHash = 0;
+    return true;
+}
+
 void EditModeConstraintCoinManager::rebuildConstraintNodes(
     const GeoListFacade& geolistfacade,
     const std::vector<Sketcher::Constraint*> constrlist,
     SbVec3f norm
 )
 {
+    // freshly built nodes hold no placement, icon or color data yet
+    vConstrPlacementHash.assign(constrlist.size(), 0);
+    lastIconQueueHash = 0;
+    vConstrColorState.assign(constrlist.size(), staleColorState);
 
     for (auto it : constrlist) {
-        // root separator for one constraint
-        auto* sep = new SoSeparator();
-        sep->ref();
-        // no caching for frequently-changing data structures
-        sep->renderCaching = SoSeparator::OFF;
+        auto* sep = createConstraintNode(it, geolistfacade, norm);
+        vConstrType.push_back(it->Type);
+        editModeScenegraphNodes.constrGroup->addChild(sep);
+        sep->unref();
+    }
+}
 
-        // every constrained visual node gets its own material for preselection and selection
-        auto* mat = new SoMaterial;
-        mat->ref();
-        bool isActive = ViewProviderSketchCoinAttorney::isConstraintActiveInSketch(viewProvider, it);
-        mat->diffuseColor = isActive
-            ? (it->isDriving ? SketcherGui::DrawingParameters::ConstrDimColor
-                             : SketcherGui::DrawingParameters::NonDrivingConstrDimColor)
-            : SketcherGui::DrawingParameters::DeactivatedConstrDimColor;
+SoSeparator* EditModeConstraintCoinManager::createConstraintNode(
+    Sketcher::Constraint* it,
+    const GeoListFacade& geolistfacade,
+    SbVec3f norm
+)
+{
+    // root separator for one constraint
+    auto* sep = new SoSeparator();
+    sep->ref();
+    // no caching for frequently-changing data structures
+    // NOTE: switching to AUTO was tried (2026-07-12) once the placement/icon/
+    // color skips made these fields change-stable: no measurable render win —
+    // SoZoomTranslation makes the subtrees view-dependent, so Coin declines to
+    // cache them — and the first delete after enabling it spiked. Cutting the
+    // ~156 ms uncached traversal at dense sketches needs restructuring the
+    // nodes so view-dependent parts sit outside cacheable subtrees.
+    sep->renderCaching = SoSeparator::OFF;
+
+    // every constrained visual node gets its own material for preselection and selection
+    auto* mat = new SoMaterial;
+    mat->ref();
+    bool isActive = ViewProviderSketchCoinAttorney::isConstraintActiveInSketch(viewProvider, it);
+    mat->diffuseColor = isActive
+        ? (it->isDriving ? SketcherGui::DrawingParameters::ConstrDimColor
+                         : SketcherGui::DrawingParameters::NonDrivingConstrDimColor)
+        : SketcherGui::DrawingParameters::DeactivatedConstrDimColor;
 
 
-        // distinguish different constraint types to build up
-        switch (it->Type) {
-            case Distance:
-            case DistanceX:
-            case DistanceY:
-            case Radius:
-            case Diameter:
-            case Weight:
-            case Angle: {
-                auto* text = new SoDatumLabel();
-                text->norm.setValue(norm);
-                text->string = "";
-                text->textColor = isActive
-                    ? (it->isDriving ? SketcherGui::DrawingParameters::ConstrDimColor
-                                     : SketcherGui::DrawingParameters::NonDrivingConstrDimColor)
-                    : SketcherGui::DrawingParameters::DeactivatedConstrDimColor;
-                if (!drawingParameters.labelFontName.isEmpty()) {
-                    text->name.setValue(drawingParameters.labelFontName.toStdString().c_str());
-                }
-                text->size.setValue(drawingParameters.labelFontSize);
-                text->lineWidth = 2 * drawingParameters.pixelScalingFactor;
-                text->useAntialiasing = false;
-                sep->addChild(text);
-                editModeScenegraphNodes.constrGroup->addChild(sep);
-                vConstrType.push_back(it->Type);
-                // nodes not needed
-                sep->unref();
-                mat->unref();
-                continue;  // jump to next constraint
-            } break;
+    // distinguish different constraint types to build up
+    switch (it->Type) {
+        case Distance:
+        case DistanceX:
+        case DistanceY:
+        case Radius:
+        case Diameter:
+        case Weight:
+        case Angle: {
+            auto* text = new SoDatumLabel();
+            text->norm.setValue(norm);
+            text->string = "";
+            text->textColor = isActive
+                ? (it->isDriving ? SketcherGui::DrawingParameters::ConstrDimColor
+                                 : SketcherGui::DrawingParameters::NonDrivingConstrDimColor)
+                : SketcherGui::DrawingParameters::DeactivatedConstrDimColor;
+            if (!drawingParameters.labelFontName.isEmpty()) {
+                text->name.setValue(drawingParameters.labelFontName.toStdString().c_str());
+            }
+            text->size.setValue(drawingParameters.labelFontSize);
+            text->lineWidth = 2 * drawingParameters.pixelScalingFactor;
+            text->useAntialiasing = false;
+            sep->addChild(text);
+            mat->unref();
+            return sep;
+        } break;
             case Horizontal:
             case Vertical:
             case Block: {
@@ -1982,8 +2290,6 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                 // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_CONSTRAINTID 6
                 sep->addChild(new SoInfo());
 
-                // remember the type of this constraint node
-                vConstrType.push_back(it->Type);
             } break;
             case Group:
             case Text: {
@@ -2008,10 +2314,8 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                 lineSet->numVertices.set1Value(0, 5);  // A single polyline of 5 vertices
                 sep->addChild(lineSet);
 
-                vConstrType.push_back(it->Type);
             } break;
             case Coincident:  // no visual for coincident so far
-                vConstrType.push_back(Coincident);
                 break;
             case Parallel:
             case Perpendicular:
@@ -2031,8 +2335,6 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                 // #define CONSTRAINT_SEPARATOR_INDEX_SECOND_CONSTRAINTID 6
                 sep->addChild(new SoInfo());
 
-                // remember the type of this constraint node
-                vConstrType.push_back(it->Type);
             } break;
             case PointOnObject:
             case Tangent:
@@ -2065,7 +2367,6 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                     }
                 }
 
-                vConstrType.push_back(it->Type);
             } break;
             case Symmetric: {
                 auto* arrows = new SoDatumLabel();
@@ -2083,20 +2384,15 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                 // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_CONSTRAINTID 3
                 sep->addChild(new SoInfo());
 
-                vConstrType.push_back(it->Type);
             } break;
             case InternalAlignment: {
-                vConstrType.push_back(it->Type);
             } break;
             default:
-                vConstrType.push_back(it->Type);
+                break;
         }
 
-        editModeScenegraphNodes.constrGroup->addChild(sep);
-        // decrement ref counter again
-        sep->unref();
-        mat->unref();
-    }
+    mat->unref();
+    return sep;
 }
 
 QString EditModeConstraintCoinManager::getPresentationString(
@@ -2566,6 +2862,35 @@ void EditModeConstraintCoinManager::drawConstraintIcons(const GeoListFacade& geo
 
         iconQueue.push_back(thisIcon);
     }
+
+    // Skip the (expensive) icon rendering when nothing an icon depends on has
+    // changed since the last pass: positions, labels, visibility, rotation,
+    // node targets and the resolved color (which encodes selection /
+    // preselection / active / driving state).
+    std::size_t queueHash = 14695981039346656037ULL;
+    hashDouble(queueHash, ViewProviderSketchCoinAttorney::getScaleFactor(viewProvider));
+    for (const auto& icon : iconQueue) {
+        const QByteArray type = icon.type.toUtf8();
+        hashCombine(queueHash, type.constData(), type.size());
+        hashInt(queueHash, icon.constraintId);
+        hashDouble(queueHash, icon.position[0]);
+        hashDouble(queueHash, icon.position[1]);
+        hashDouble(queueHash, icon.position[2]);
+        const SoImage* dest = icon.destination;
+        hashCombine(queueHash, &dest, sizeof(dest));
+        hashInt(queueHash, icon.visible ? 1 : 0);
+        hashDouble(queueHash, icon.iconRotation);
+        const QByteArray label = icon.label.toUtf8();
+        hashCombine(queueHash, label.constData(), label.size());
+        hashInt(queueHash, static_cast<long long>(constrColor(icon.constraintId).rgba()));
+    }
+    if (queueHash == 0) {
+        queueHash = 1;
+    }
+    if (queueHash == lastIconQueueHash) {
+        return;
+    }
+    lastIconQueueHash = queueHash;
 
     combineConstraintIcons(iconQueue);
 }

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -109,10 +109,9 @@ inline void hashVector(std::size_t& seed, const Base::Vector3d& v)
 }
 
 // Fingerprint of a geometry's defining data as the placement code sees it.
-// Lines hash their endpoints directly; other curves hash five points sampled
-// along the parameter range (deterministic, so identical geometry always
-// yields an identical hash; different same-type geometry through five common
-// points does not occur in practice).
+// Lines and B-splines hash their exact defining data; other (low-DOF) curves
+// hash their parameter range plus five sampled points, which uniquely determine
+// them (a circle/ellipse/arc has at most five degrees of freedom).
 std::size_t hashGeometry(const Part::Geometry* geo)
 {
     std::size_t seed = 14695981039346656037ULL;
@@ -128,6 +127,27 @@ std::size_t hashGeometry(const Part::Geometry* geo)
     }
     if (const auto* point = dynamic_cast<const Part::GeomPoint*>(geo)) {
         hashVector(seed, point->getPoint());
+        return seed;
+    }
+    if (const auto* bsp = dynamic_cast<const Part::GeomBSplineCurve*>(geo)) {
+        // A B-spline has more effective DOF than five sampled points can
+        // distinguish (two different B-splines can pass through the same five
+        // samples), so hash its full defining data. The pole positions also
+        // drive the placement centroid, which the sampled form would miss.
+        for (const auto& p : bsp->getPoles()) {
+            hashVector(seed, p);
+        }
+        for (double w : bsp->getWeights()) {
+            hashDouble(seed, w);
+        }
+        for (double k : bsp->getKnots()) {
+            hashDouble(seed, k);
+        }
+        for (int m : bsp->getMultiplicities()) {
+            hashInt(seed, m);
+        }
+        hashInt(seed, bsp->getDegree());
+        hashInt(seed, bsp->isPeriodic() ? 1 : 0);
         return seed;
     }
     if (const auto* curve = dynamic_cast<const Part::GeomCurve*>(geo)) {

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
@@ -172,6 +172,20 @@ public:
 private:
     void rebuildConstraintNodes(const GeoListFacade& geolistfacade);  // with specific geometry
 
+    // create the coin separator for one constraint (structure depends on type)
+    SoSeparator* createConstraintNode(
+        Sketcher::Constraint* it,
+        const GeoListFacade& geolistfacade,
+        SbVec3f norm
+    );
+
+    // incremental insert/remove of constraint separators on count change;
+    // returns false when a full rebuild is required
+    bool trySyncConstraintNodes(
+        const GeoListFacade& geolistfacade,
+        const std::vector<Sketcher::Constraint*>& constrlist
+    );
+
     void rebuildConstraintNodes(
         const GeoListFacade& geolistfacade,
         const std::vector<Sketcher::Constraint*> constrlist,
@@ -223,6 +237,23 @@ private:
 
     // helper data structures for the constraint rendering
     std::vector<Sketcher::ConstraintType> vConstrType;
+
+    // Per-constraint hash of every input the placement update reads
+    // (constraint fields + referenced geometry + global view factors).
+    // A matching hash means the coin nodes already hold the right values and
+    // the update-switch can be skipped. 0 = unknown, never skip.
+    std::vector<std::size_t> vConstrPlacementHash;
+
+    // Hash of the last rendered icon queue (positions, labels, colors, node
+    // targets); a match skips re-rendering all constraint icons. 0 = unknown.
+    std::size_t lastIconQueueHash = 0;
+
+    // Per-constraint resolved color state (selected/preselected/active/
+    // driving/expression bits) from the last updateConstraintColor pass; a
+    // match skips rewriting that constraint's colors.
+    static constexpr unsigned char staleColorState = 0xFF;
+    std::vector<unsigned char> vConstrColorState;
+    std::size_t lastColorPaletteHash = 0;
 
     // For each of the combined constraint icons drawn, also create a vector
     // of bounding boxes and associated constraint IDs, to go from the icon's

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1130,7 +1130,7 @@ void TaskSketcherConstraints::onSettingsExtendedInformationChanged(bool value)
         hGrp->SetBool("ExtendedConstraintInformation", value);
     }
 
-    slotConstraintsChanged();
+    updateConstraintsList();
 }
 
 void TaskSketcherConstraints::onSettingsHideInternalAligmentChanged(bool value)
@@ -1143,7 +1143,7 @@ void TaskSketcherConstraints::onSettingsHideInternalAligmentChanged(bool value)
         hGrp->SetBool("HideInternalAlignment", value);
     }
 
-    slotConstraintsChanged();
+    updateConstraintsList();
 }
 
 void TaskSketcherConstraints::onSettingsRestrictVisibilityChanged(bool value)
@@ -1309,7 +1309,7 @@ void TaskSketcherConstraints::onListWidgetConstraintsUpdateDrivingStatus(QListWi
 
     Gui::Application::Instance->commandManager().runCommandByName(
         "Sketcher_ToggleDrivingConstraint");
-    slotConstraintsChanged();
+    updateConstraintsList();
 }
 
 void TaskSketcherConstraints::onListWidgetConstraintsUpdateActiveStatus(QListWidgetItem* item,
@@ -1322,7 +1322,7 @@ void TaskSketcherConstraints::onListWidgetConstraintsUpdateActiveStatus(QListWid
 
     Gui::Application::Instance->commandManager().runCommandByName(
         "Sketcher_ToggleActiveConstraint");
-    slotConstraintsChanged();
+    updateConstraintsList();
 }
 
 void TaskSketcherConstraints::onListWidgetConstraintsItemActivated(QListWidgetItem* item)
@@ -1444,7 +1444,7 @@ void TaskSketcherConstraints::updateList()
         filterList->getMultiFilter();// moved here in case the filter is changed programmatically.
 
     // new constraints have to be added first
-    slotConstraintsChanged();
+    updateConstraintsList();
 
     // enforce constraint visibility
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
@@ -1698,7 +1698,7 @@ void TaskSketcherConstraints::change3DViewVisibilityToTrackFilter(bool filterEna
     }
 
     if (constrIdsToSetVisible.empty() && constrIdsToSetHidden.empty()) {
-        slotConstraintsChanged();
+        updateConstraintsList();
     }
 }
 
@@ -1872,6 +1872,21 @@ bool TaskSketcherConstraints::isConstraintFiltered(QListWidgetItem* item)
 }
 
 void TaskSketcherConstraints::slotConstraintsChanged()
+{
+    // The solver signal fires on every solve; one rebuild when the event loop
+    // spins covers the whole burst. Direct callers that need the list current
+    // immediately use updateConstraintsList() instead.
+    if (constraintsUpdatePending) {
+        return;
+    }
+    constraintsUpdatePending = true;
+    QTimer::singleShot(0, this, [this]() {
+        constraintsUpdatePending = false;
+        updateConstraintsList();
+    });
+}
+
+void TaskSketcherConstraints::updateConstraintsList()
 {
     assert(sketchView);
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
@@ -173,6 +173,7 @@ public:
 
 private:
     void slotConstraintsChanged();
+    void updateConstraintsList();
     bool isConstraintFiltered(QListWidgetItem* item);
     void change3DViewVisibilityToTrackFilter(bool filterEnabled);
     bool doSetVirtualSpace(const std::vector<int>& constrIds, bool isvirtualspace);
@@ -220,6 +221,7 @@ private:
     QWidget* proxy;
     bool inEditMode;
     bool updateListPending;
+    bool constraintsUpdatePending = false;
     std::unique_ptr<Ui_TaskSketcherConstraints> ui;
     ConstraintFilter::FilterValueBitset multiFilterStatus;  // Stores the filters to be aggregated
                                                             // to form the multifilter.

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -1368,7 +1368,7 @@ TaskSketcherElements::TaskSketcherElements(ViewProviderSketch* sketchView)
     ui->filterBox->setChecked(hGrp->GetBool("ElementFilterEnabled", true));
     ui->filterButton->setEnabled(ui->filterBox->isChecked());
 
-    slotElementsChanged();
+    updateElementsList();
 }
 
 TaskSketcherElements::~TaskSketcherElements()
@@ -1443,7 +1443,7 @@ void TaskSketcherElements::onFilterBoxStateChanged(int val)
     hGrp->SetBool("ElementFilterEnabled", ui->filterBox->checkState() == Qt::Checked);
 
     ui->filterButton->setEnabled(ui->filterBox->checkState() == Qt::Checked);
-    slotElementsChanged();
+    updateElementsList();
 }
 
 void TaskSketcherElements::onListMultiFilterItemChanged(QListWidgetItem* item)
@@ -1987,7 +1987,22 @@ void TaskSketcherElements::leaveEvent(QEvent* event)
 
 void TaskSketcherElements::slotElementsChanged()
 {
+    // The signal fires several times per solve (once per changed property);
+    // one rebuild when the event loop spins covers the whole burst.
+    if (elementsUpdatePending) {
+        return;
+    }
+    elementsUpdatePending = true;
+    QTimer::singleShot(0, this, [this]() {
+        elementsUpdatePending = false;
+        updateElementsList();
+    });
+}
+
+void TaskSketcherElements::updateElementsList()
+{
     assert(sketchView);
+
     // Build up ListView with the elements
     Sketcher::SketchObject* sketch = sketchView->getSketchObject();
 
@@ -2284,7 +2299,7 @@ void TaskSketcherElements::onSettingsExtendedInformationChanged()
         "User parameter:BaseApp/Preferences/Mod/Sketcher/Elements");
     hGrp->SetBool("ExtendedNaming", isNamingBoxChecked);
 
-    slotElementsChanged();
+    updateElementsList();
 }
 
 #include "TaskSketcherElements.moc"// For Delegate as it is QOBJECT

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.h
@@ -134,6 +134,7 @@ public:
 
 private:
     void slotElementsChanged();
+    void updateElementsList();
     void updateVisibility();
     void setItemVisibility(QListWidgetItem* item, const std::set<int>& groupedGeoIds);
     void clearWidget();
@@ -168,6 +169,7 @@ private:
     ElementFilterList* filterList;
 
     bool isNamingBoxChecked;
+    bool elementsUpdatePending = false;
 
     // Buffering to speed up large selections
     std::unordered_map<int, ElementItem*> elementMap;

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -712,6 +712,9 @@ void ViewProviderSketch::slotUndoDocument(const Gui::Document& /*doc*/)
     // stale geometry IDs, which would lead to a crash.
     if (!drag.Dragged.empty() || !drag.DragConstraintSet.empty()) {
         drag.reset();
+        // also clear the solver-side drag state: the next solve() must rebuild
+        // from the undone Geometry, not write back stale drag-era geometry
+        getSketchObject()->cancelTemporaryMove();
         setSketchMode(STATUS_NONE);
         resetPositionText();
     }
@@ -731,6 +734,8 @@ void ViewProviderSketch::slotRedoDocument(const Gui::Document& /*doc*/)
     // stale geometry IDs, which would lead to a crash.
     if (!drag.Dragged.empty() || !drag.DragConstraintSet.empty()) {
         drag.reset();
+        // also clear the solver-side drag state (see slotUndoDocument)
+        getSketchObject()->cancelTemporaryMove();
         setSketchMode(STATUS_NONE);
         resetPositionText();
     }

--- a/tests/src/Mod/Sketcher/App/SketchObjectChanges.cpp
+++ b/tests/src/Mod/Sketcher/App/SketchObjectChanges.cpp
@@ -1210,3 +1210,60 @@ TEST_F(SketchObjectTest, testJoinCurvesWhenTangent)
         = static_cast<const Part::GeomBSplineCurve*>(getObject()->getGeometry(0))->getMultiplicities();
     EXPECT_TRUE(std::all_of(mults.begin(), mults.end(), [](auto mult) { return mult >= 1; }));
 }
+
+// Regression guard for the diagnosis-cache topology fingerprint
+// (Sketch::setUpSketch). An in-place change to a constraint's equation-defining
+// field must be treated as a topology change so the cached diagnosis is not
+// reused for a structurally different system. Both cases go through
+// Constraints.setValues(), so Orientation is the only variable: the unchanged
+// case proves the cache does restore, and the changed case proves the
+// fingerprint catches the change (it would restore, wrongly, if Orientation
+// were omitted from the fingerprint).
+TEST_F(SketchObjectTest, diagnosisCacheDetectsConstraintOrientationChange)
+{
+    // Arrange: a line with one driving DistanceX -> a diagnosable, stable system.
+    Part::GeomLineSegment lineSeg;
+    setupLineSegment(lineSeg);
+    int geoId = getObject()->addGeometry(&lineSeg);
+
+    auto* c = new Sketcher::Constraint();  // ownership transferred to the sketch
+    c->Type = Sketcher::ConstraintType::DistanceX;
+    c->First = geoId;
+    c->FirstPos = Sketcher::PointPos::start;
+    c->Second = geoId;
+    c->SecondPos = Sketcher::PointPos::end;
+    c->setValue(1.0);
+    int cid = getObject()->addConstraint(c);
+
+    // Prime the diagnosis and the topology fingerprint.
+    getObject()->setUpSketch();
+
+    auto cloneConstraints = [this]() {
+        std::vector<Sketcher::Constraint*> out;
+        for (auto* orig : getObject()->Constraints.getValues()) {
+            out.push_back(orig->clone());
+        }
+        return out;
+    };
+
+    // Constraints.setValues() triggers exactly one solver rebuild through
+    // onChanged(), so the cache-restored flag is observed directly after it. Do
+    // NOT add another solve()/setUpSketch() before the assertion: that second
+    // rebuild would compare the new fingerprint against itself and trivially
+    // report a cache hit, masking what the first rebuild decided.
+
+    // Act 1: replace the constraints with identical clones (same topology) -> the
+    // cache must be reused.
+    getObject()->Constraints.setValues(cloneConstraints());
+    EXPECT_TRUE(getObject()->wasDiagnosisRestored())
+        << "an unchanged constraint list should reuse the cached diagnosis";
+
+    // Act 2: same replacement, but flip the constraint's Orientation. Type, the
+    // geo/pos wiring and the constraint count are unchanged, so only the
+    // fingerprint's coverage of Orientation can detect this.
+    auto changed = cloneConstraints();
+    changed[cid]->Orientation |= Sketcher::ConstraintOrientations::Clockwise;
+    getObject()->Constraints.setValues(std::move(changed));
+    EXPECT_FALSE(getObject()->wasDiagnosisRestored())
+        << "changing a constraint's Orientation must invalidate the diagnosis cache";
+}

--- a/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+
 #include "Mod/Sketcher/App/planegcs/GCS.h"
 
 class SystemTest: public GCS::System
@@ -49,4 +51,84 @@ TEST_F(GCSTest, clearConstraints)  // NOLINT
 
     // Assert
     EXPECT_EQ(0, System()->getNumberOfConstraints());
+}
+
+// Regression guard for the drag-Jacobian column bug. A permanent Equal
+// constraint lives in the priority subsystem (subsysA), whose Jacobian the
+// two-subsystem SQP drag solver assembles via calcJacobi(plistAB, ..) with a
+// params array (plistAB) that differs in size and order from the subsystem's
+// own plist. The previous Equal fast path cached its output column keyed to
+// plist, so during dragging the Equal gradient landed in the wrong column and
+// the constraint was not enforced. After the fix the two params stay equal
+// while the drag pulls them to the target.
+TEST(DragSolveTest, equalConstraintEnforcedDuringDrag)  // NOLINT
+{
+    GCS::System sys;
+    double x0 = 1.0, y0 = 1.0;
+    double x1 = 1.0, y1 = 0.0;
+
+    GCS::Point p0(&x0, &y0), p1(&x1, &y1);
+
+    // Permanent constraint (tag >= 0): x0 == x1. Routes to subSystems (subsysA).
+    sys.addConstraintEqual(&x0, &x1);
+
+    GCS::VEC_pD params = {&x0, &y0, &x1, &y1};
+    sys.declareUnknowns(params);
+    sys.initSolution();
+    ASSERT_EQ(sys.solve(true, GCS::DogLeg), GCS::Success);
+    sys.applySolution();
+
+    // Drag point (MoveParameters, external to the declared unknowns) coincident
+    // with p0, tag = -1 → subSystemsAux (subsysB). Its param set differs from
+    // subsysA's, so plistAB is a reordered superset of subsysA's plist.
+    double drag_x = x0, drag_y = y0;
+    GCS::Point dragP(&drag_x, &drag_y);
+    sys.addConstraintP2PCoincident(dragP, p0, GCS::DefaultTemporaryConstraint);
+    sys.initSolution();
+
+    // Move the drag target; the SQP solve must pull p0 toward it while keeping
+    // the permanent Equal (x0 == x1) satisfied.
+    drag_x = 7.0;
+    drag_y = 3.0;
+    ASSERT_EQ(sys.solve(true, GCS::DogLeg), GCS::Success);
+    sys.applySolution();
+
+    EXPECT_NEAR(x0, x1, 1e-6) << "Equal constraint (x0==x1) not enforced during drag "
+                              << "(x0=" << x0 << ", x1=" << x1 << ")";
+    EXPECT_NEAR(x0, 7.0, 1e-6) << "drag did not pull p0 to target x (x0=" << x0 << ")";
+    EXPECT_NEAR(y0, 3.0, 1e-6) << "drag did not pull p0 to target y (y0=" << y0 << ")";
+}
+
+// Regression guard for the sparse DogLeg's rank-deficiency handling. Redundant
+// (duplicate) constraints make the least-norm normal matrix J*J^T singular. Because
+// SimplicialLDLT::info() only reports EXACT zero pivots, a near-singular factorization
+// can slip through and produce a NaN/Inf step; the solver must detect the non-finite
+// step and fall back to a dense solve, still converging on the (consistent) system.
+TEST(SparseDogLegTest, redundantConstraintsDoNotProduceNaN)  // NOLINT
+{
+    GCS::System sys;
+    double x0 = 0.0, y0 = 0.0;
+    double x1 = 3.0, y1 = 0.0;
+    double d = 5.0;
+
+    GCS::Point p0(&x0, &y0), p1(&x1, &y1);
+
+    // Two identical distance constraints on the same point pair -> J has duplicate
+    // rows (rank 1), so with 4 free params (under-constrained) J*J^T (2x2) is singular.
+    sys.addConstraintP2PDistance(p0, p1, &d);
+    sys.addConstraintP2PDistance(p0, p1, &d);
+
+    GCS::VEC_pD params = {&x0, &y0, &x1, &y1};
+    sys.declareUnknowns(params);
+    sys.initSolution();
+
+    int res = sys.solve(true, GCS::DogLeg);
+    sys.applySolution();
+
+    // The result must be finite and satisfy the (consistent) distance constraint.
+    EXPECT_TRUE(std::isfinite(x0) && std::isfinite(y0) && std::isfinite(x1) && std::isfinite(y1))
+        << "solve produced a non-finite result on a rank-deficient system";
+    double dist = std::hypot(x1 - x0, y1 - y0);
+    EXPECT_NEAR(dist, 5.0, 1e-6)
+        << "distance constraint not satisfied (dist=" << dist << ", res=" << res << ")";
 }

--- a/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -125,6 +125,10 @@ TEST(SparseDogLegTest, redundantConstraintsDoNotProduceNaN)  // NOLINT
     int res = sys.solve(true, GCS::DogLeg);
     sys.applySolution();
 
+    // The solver must report success on this consistent (redundant) system, not
+    // merely leave finite coordinates behind.
+    EXPECT_EQ(res, GCS::Success) << "solver did not report Success on a consistent "
+                                    "rank-deficient system (res=" << res << ")";
     // The result must be finite and satisfy the (consistent) distance constraint.
     EXPECT_TRUE(std::isfinite(x0) && std::isfinite(y0) && std::isfinite(x1) && std::isfinite(y1))
         << "solve produced a non-finite result on a rank-deficient system";

--- a/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -129,6 +129,6 @@ TEST(SparseDogLegTest, redundantConstraintsDoNotProduceNaN)  // NOLINT
     EXPECT_TRUE(std::isfinite(x0) && std::isfinite(y0) && std::isfinite(x1) && std::isfinite(y1))
         << "solve produced a non-finite result on a rank-deficient system";
     double dist = std::hypot(x1 - x0, y1 - y0);
-    EXPECT_NEAR(dist, 5.0, 1e-6)
-        << "distance constraint not satisfied (dist=" << dist << ", res=" << res << ")";
+    EXPECT_NEAR(dist, 5.0, 1e-6) << "distance constraint not satisfied (dist=" << dist
+                                 << ", res=" << res << ")";
 }

--- a/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -128,7 +128,8 @@ TEST(SparseDogLegTest, redundantConstraintsDoNotProduceNaN)  // NOLINT
     // The solver must report success on this consistent (redundant) system, not
     // merely leave finite coordinates behind.
     EXPECT_EQ(res, GCS::Success) << "solver did not report Success on a consistent "
-                                    "rank-deficient system (res=" << res << ")";
+                                    "rank-deficient system (res="
+                                 << res << ")";
     // The result must be finite and satisfy the (consistent) distance constraint.
     EXPECT_TRUE(std::isfinite(x0) && std::isfinite(y0) && std::isfinite(x1) && std::isfinite(y1))
         << "solve produced a non-finite result on a rank-deficient system";


### PR DESCRIPTION
The goal is to make the sketcher more responsive. The compute cost is reduced at four layers — the constraint solver, the diagnosis cache, the OCC shape rebuild, and the edit-mode redraw — without changing solver results, diagnosis semantics, or shape output.

I dug into this code after my sketches started taking over a minute to resolve each little update. I am coming from Fusion 360, where large sketches are a normal part of my workflow. I realize there are workarounds, but I am trying to do my part to make this software as powerful as closed-source options. Below are the specific benchmarks I obtained, but most importantly, the sketch process feels much more responsive. There are still pauses when working with dense geometry, but they are no longer painfully long.

After the flaws of my first submission were pointed out I realized how important maintainers are for guarding against bad code. I have been pretty obsessed with improving the sketcher and have spent a lot of evenings slowly optimizing each bottleneck I encountered. The project feels complete, but I will do my best to address any feedback.

# AI disclosure
I realize this repository has reservations about AI contributions. While I used Ai to track down problems and draft solutions, this PR was not a casual vibe coding session. I have been working on it for over a month during my evenings and back tracked several times after the AI agents created a mess. This PR is the result of many hours or iteration, testing and thought. It would have taken far more time without AI to highlight problems and trace code, however I believe I have upheld the AI policy of keeping myself in the 'front row' while leveraging AI as a tool. 
During the process I worked with the following AI tools while testing their usefulness. I made the final edits with Claud Fable and Opus 4.8.
- Claude Opus 4.8
- Claude Fable
- Gemini 3.1 Pro
- Grok 4.5
- GLM 5.2
- Deepseek R1

The work is split into five self-contained commits so each layer can be reviewed (and, if you prefer, reverted or split into its own PR) independently:

1. `perf(Sketcher): sparse least-norm DogLeg linear solve` — the solver hot path
2. `perf(Sketcher): cache the diagnosis across topology-stable re-solves`
3. `perf(Sketcher): skip and island-local OCC shape rebuild`
4. `perf(Part): analytic line/line intersection in WireJoiner::splitEdges`
5. `perf(Sketcher): incremental edit-mode constraint redraw`

I'm happy to peel any of these off into a separate PR if that's easier to land.

The companion branch with all the benchmarking instrumentation still attached: https://github.com/dustinhartlyn/FreeCAD/tree/planegcs-solver-instrumented

## Relationship to PR #31351

An earlier version of this branch also partitioned `diagnose()` into independent connected components. #31351 implements the same optimization (I built mine independently before finding it), reusing the existing `initSolution()` connected-components machinery, so I have dropped that part from this PR to avoid duplicating the work: here `diagnose()` and all of its helpers are byte-for-byte identical to upstream, and this PR has no textual overlap with #31351. The two are complementary — this PR addresses the solve, rebuild, and redraw costs; #31351 addresses `diagnose()` cost on many-island sketches. The original superset branch is kept for reference at https://github.com/dustinhartlyn/FreeCAD/tree/feature/planegcs-solver-v2

Reference workload used throughout: "N rects" = an array of N fully-constrained rectangles (4 lines + 12 constraints each; N=300 is 1,200 edges and 3,600 constraints). Times in milliseconds.

## Benchmarks — this branch vs its base (current `main`)

Both binaries were built identically (the conda `windows-release` preset, `/O2`) on the same machine; medians of 5–10 runs. Base = upstream `main` at 6c06a41; branch = base + the five commits above. This is a like-for-like A/B, reproducible with the scripts below.

**End-to-end GUI actions** — the full user-visible cost (solve + shape rebuild + edit-mode redraw), driven through the running GUI with `Gui.updateGui()` after each action:

| Action | N=150 | N=300 |
|---|---|---|
| Edit a dimension value | 11,029 → 373 ms  (**30×**) | 81,250 → 945 ms  (**86×**) |
| Touch recompute | 9,942 → 228 ms  (**44×**) | 16,160 → 481 ms  (**34×**) |
| Enter edit mode | 12,567 → 2,534 ms  (5.0×) | 32,673 → 5,531 ms  (5.9×) |
| Add a dimension | 17,253 → 2,565 ms  (6.7×) | 40,357 → 16,383 ms  (2.5×) |

**Headless App/solver** — `FreeCADCmd`, isolating compute from GUI/redraw overhead:

| Operation | N=150 | N=300 |
|---|---|---|
| `sketch.solve()` | 1,083 → 16.8 ms  (**64×**) | 7,822 → 42.0 ms  (**186×**) |
| Edit-dimension recompute | 3,367 → 68 ms  (49×) | 23,880 → 155 ms  (154×) |
| Touch recompute | 2,287 → 33 ms  (69×) | 16,301 → 85 ms  (192×) |
| 12×20 islands, setDatum + solve | — | 1,095 → 30 ms  (37×) |

**Reading these:** the everyday actions — editing a dimension value, recompute — drop from tens of seconds to well under a second (**30–86×** in the GUI; higher headless once redraw overhead is excluded). "Enter edit mode" improves ~6× from the incremental constraint-node redraw. "Add a dimension" is the one modest row (**2.5–6.7×**): adding or removing a constraint is a topology change dominated by a full `diagnose()`, which this PR deliberately leaves to #31351 — stacking that PR on top brings this action into line with the others. (For reference, my base `main` measures noticeably slower than the 1.1 release for value edits, so the same optimizations are an even larger win against 1.1; I report against current `main` to keep the comparison exact.)

## Solver (planegcs: `GCS::System::solve_DL`, `SubSystem::calcJacobi`)

Upstream's DogLeg used a dense FullPivLU for the Gauss-Newton step on every iteration (O(n³)) — the dominant cost on dense sketches. A naive sparse replacement using the normal equations JᵀJ does not work: sketches being edited are usually under-constrained (many free DOFs), which makes JᵀJ singular. The fix instead takes the least-norm step through the smaller full-rank system: solve (J·Jᵀ)y = −f (csize × csize, banded, SPD) with sparse LDLT, then h = Jᵀy; the normal equations JᵀJ are used only when csize ≥ xsize. The Jacobian is assembled directly as an `Eigen::SparseMatrix` in O(nnz), and the sparsity pattern is analyzed once per solve (it is fixed while the topology is). A rank-deficient matrix can factorize "successfully" with ~1e-16 pivots (`SimplicialLDLT::info()` only flags exact zeros), so a non-finite step falls back to the dense pivoting solve; the steepest-descent step length is guarded against a zero denominator (gradient in the Jacobian nullspace). This is the dominant term in the `sketch.solve()` speedup in the table above (64–186×).

One solver bug found and fixed on the way:

- **Uninitialized step vector.** In the two-subsystem SQP solve, `h` is declared uninitialized; if `qp_eq()` fails on the first iteration the loop breaks before `h` is ever assigned, and the post-loop `h.norm()` convergence check then reads uninitialized memory (mis-reporting Converged vs Failed). It is now zero-initialized. Latent — requires a first-iteration `qp_eq()` failure.

## Constraint diagnosis cache (`Sketch::setUpSketch`)

`diagnose()` runs on every sketch rebuild, even when the rebuild is a pure value edit (e.g. `setDatum()` during a drag) that cannot change the diagnosis. `Sketch::setUpSketch()` now caches the diagnosis across rebuilds: a fingerprint of the constraint topology (type + geo/pos wiring of every effective constraint, plus the geometry type sequence including B-spline pole/knot/degree data) detects that a rebuild is a pure value edit, and restores the previous diagnosis instead of re-running the QR factorization. The restore is index-validated against the solver's constraint/parameter list sizes and aborts to a fresh `diagnose()` on any mismatch. Topology changes (adding/removing geometry or constraints) always take the full `diagnose()` path — speeding that path up on many-island sketches is #31351's territory.

## Shape rebuild (`SketchObject::buildShape`)

Three changes, strictly ordered from "provably identical" to "guarded by strict preconditions":

**1. Skip-cache.** The solved geometry the current Shape/InternalShape were built from is kept (as clones); when the next `execute()` produces content-identical geometry (`Geometry::isSame` within OCC modeling tolerance, same construction flags, same external geometry), the whole OCC rebuild (edges, wires, FaceMaker, WireJoiner) is skipped. A content compare is used instead of explicit invalidation so a stale cache can only cost a rebuild, never produce a wrong shape. This is what makes "touch recompute" nearly free (34–192× above).

**2. Island-local rebuild for value edits.** The sketch's edges partition into bounding-box-disjoint clusters that cannot interact in makeElementWires (needs coincident endpoints), FaceMaker (nesting needs bbox containment), or WireJoiner (splits only at intersections). When a value edit moves only some clusters, exactly those are rebuilt and spliced positionally into the previous compounds. Strict preconditions (single wire + single face per changed cluster, no open wires, no vertices, no external geometry, boxes stay pairwise disjoint) fall back to the full rebuild. Together with the diagnosis cache, this is what collapses "edit a dimension value."

**3. Island deletion splice.** Deletions that remove whole islands drop those islands' wires/faces from the compounds instead of a full rebuild (same preconditions; partial island deletions fall back).

## Edge intersection (`Part::WireJoiner::splitEdges`)

The generic per-pair intersection check builds an OCC wire, a face, and a ShapeAnalysis_Wire per edge pair, which dominates WireJoiner on dense line sketches. Line/line pairs are now intersected analytically (Extrema_ExtElC); non-line curves and near-parallel pairs (collinear overlap semantics) keep the generic path, and shared-corner suppression matches the generic path's behavior. This shrinks the full-rebuild cost that still occurs on the first recompute and on topology changes.

## Drag lifecycle (`SketchObject::solve` / `initTemporaryMove`)

While an interactive drag is in progress, an `isDragActive` flag lets the solver keep its live drag state across a `solve()` instead of rebuilding from the committed Geometry property (which is stale mid-drag). The rebuild from the committed property happens once the drag ends or is canceled.

## Edit-mode redraw (`ViewProviderSketch::draw`, `EditModeConstraintCoinManager`)

Writing an unchanged value to a Coin field still notifies and invalidates render caches, so the constraint pass now skips work whose inputs are unchanged:

- Constraint **placement** updates are skipped when a fingerprint of every input the update reads (constraint fields, referenced geometry content, view factors) is unchanged; any hash-evaluation failure forces the update (never skip on doubt).
- Constraint **icon** rendering is skipped when the icon queue (positions, labels, colors, node targets, scale) is unchanged.
- Constraint **color** updates are skipped per-constraint when the resolved color state (selected/preselected/active/driving/expression) is unchanged; a palette-preference change invalidates all cached states, and constraints that write into the shared point/curve material arrays are always re-applied.
- Constraint scene nodes are inserted/removed **incrementally** on count change instead of recreating all of them (3,600 at 300 rects); node structure is type-dependent, and the one type whose structure depends on referenced geometry (Tangent) forces the full rebuild.
- Task-panel (Elements/Constraints) list rebuilds are coalesced to one per event-loop pass; the solver signal fires 5–6× per recompute.

This layer is the main contributor to the "enter edit mode" speedup and, together with the App-side work, to the GUI end-to-end numbers being close to the headless ones rather than dominated by redraw.

## How it was measured

- The same script runs unmodified on both binaries (branch and its base), built identically with the `windows-release` preset; medians of 5–10 runs on one machine.
- **GUI end-to-end**: a macro run inside the FreeCAD executable enters sketch edit mode and times each action with `time.perf_counter()`, calling `Gui.updateGui()` after each action so the redraw is included (App-only timing understates the user-visible cost).
- **Headless** (`FreeCADCmd`) isolates App/OCC cost from GUI cost — useful because OCCT's progress indicator pumps the Qt event queue during long kernel calls, so headless ratios exclude redraw overhead and run higher.
- The proposed change ships without any instrumentation; the benchmark scripts are external and not part of the PR.

## Correctness

Every optimization was validated by differential testing on a companion instrumented branch, which carries env-gated check modes that run both the old and the new path at runtime and warn on any result mismatch, plus kill switches that restore prior behavior without a rebuild.

Both suites pass on current `main` with this branch rebased on top:

- `Sketcher_tests_run` (C++): 109/109 pass. Adds two solver regression tests: a guard that Equal constraints stay enforced when `calcJacobi` is called with the SQP solver's reordered parameter array (the drag-Jacobian column bug), and a NaN guard for rank-deficient systems in the sparse DogLeg step.
- `TestSketcherApp` (Python): 82 tests, 0 failures, 0 errors. On the instrumented branch, with every shape-cache hit and island splice compared against a full rebuild: 0 mismatches, including check-mode runs of the deletion and value-edit benchmarks.
- WireJoiner check (analytic vs generic intersection per edge pair): 0 mismatches across TestSketcherApp and a crossing-geometry probe (instrumented branch).

## Approaches tried and abandoned

Five optimization attempts didn't yield good enough results. Others in the future might have more luck with them, but they didn't work for me:

- A pebble-game (2D Laman) cluster decomposition of the solve — dense chains produce no rigid clusters (the decomposition fell back to the monolithic path on the target workloads), converging the pre-drag state on the clustered path biased the two-subsystem SQP drag solver toward a degenerate Y=0 minimum ("drag snaps to origin"), and after the sparse least-norm fix the monolithic solve is ~1–2 ms, leaving clustering nothing to win.
- Skipping WireJoiner when all wires report closed — 4 TestSketcherApp sketches have self-intersecting closed wires that still produce open wires.
- Analytic intersection without shared-corner suppression — the generic path excludes intersections at an endpoint shared by two edges.
- Splicing multi-wire (nested) faces — FaceMaker `postBuild()` shares element-naming state across faces; element maps diverged (35 vs 27) on a rectangle-in-rectangle sketch. The splice is limited to single-wire faces.
- SoSeparator render caching on constraint nodes — no gain (SoZoomTranslation makes the subtrees view-dependent, so Coin declines to cache them) and the first render after a delete regressed to 1.4 s.

## Test environment

- Ryzen 7 4800H (8C/16T), 64 GB, Windows 11.
- Both binaries built identically: MSVC 19.51, conda `windows-release` preset (`/O2`), Qt 6, OCCT 7.8, bundled Coin 4.
- A/B base: upstream `main` at 6c06a41; branch is that base plus the five commits above. (Correctness suites — below — pass on the latest `main` as well.)

- [ x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
None — performance enhancement, no tracker issue.
Related: #31351 (this PR defers the `diagnose()` partitioning to it; it does not close it).

## Before and After Images
N/A


