### PR TITLE
CAM: RetractThreshold in Task panels

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
@@ -23,7 +23,7 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="9" column="0" colspan="2">
+      <item row="9" column="0" colspan="3">
        <widget class="QFrame" name="frame_3">
         <property name="frameShape">
          <enum>QFrame::StyledPanel</enum>
@@ -69,10 +69,10 @@ Larger values (further to the right) will calculate faster; smaller values (furt
         </layout>
        </widget>
       </item>
-      <item row="23" column="0">
-       <widget class="QCheckBox" name="ForceInsideOut">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
         <property name="text">
-         <string>Force clearing inside-out</string>
+         <string>Cut region</string>
         </property>
        </widget>
       </item>
@@ -83,6 +83,13 @@ Larger values (further to the right) will calculate faster; smaller values (furt
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Operation type</string>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="1">
        <widget class="QComboBox" name="OperationType">
         <property name="toolTip">
@@ -90,20 +97,10 @@ Larger values (further to the right) will calculate faster; smaller values (furt
         </property>
        </widget>
       </item>
-      <item row="20" column="1">
-       <widget class="Gui::QuantitySpinBox" name="StockToLeave" native="true">
-        <property name="toolTip">
-         <string>How much stock to leave on the walls for this operation</string>
-        </property>
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
-      <item row="20" column="0">
-       <widget class="QLabel" name="label_12">
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Radial stock to leave</string>
+         <string>Step over (percent)</string>
         </property>
        </widget>
       </item>
@@ -132,10 +129,10 @@ Larger values (further to the right) will calculate faster; smaller values (furt
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_4">
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_stepOverDistance">
         <property name="text">
-         <string>Step over (percent)</string>
+         <string>Step over (distance)</string>
         </property>
        </widget>
       </item>
@@ -149,31 +146,10 @@ Larger values (further to the right) will calculate faster; smaller values (furt
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_stepOverDistance">
+      <item row="16" column="0">
+       <widget class="QLabel" name="label_10">
         <property name="text">
-         <string>Step over (distance)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="25" column="0">
-       <widget class="QCheckBox" name="useOutline">
-        <property name="text">
-         <string>Use outline</string>
-        </property>
-       </widget>
-      </item>
-      <item row="26" column="0">
-       <widget class="QCheckBox" name="useRestMachining">
-        <property name="text">
-         <string>Use rest machining</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Operation type</string>
+         <string>Lift distance</string>
         </property>
        </widget>
       </item>
@@ -190,21 +166,7 @@ Larger values (further to the right) will calculate faster; smaller values (furt
       <item row="18" column="0">
        <widget class="QLabel" name="label_11">
         <property name="text">
-         <string>Keep tool down ratio</string>
-        </property>
-       </widget>
-      </item>
-      <item row="16" column="0">
-       <widget class="QLabel" name="label_10">
-        <property name="text">
-         <string>Lift distance</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Cut region</string>
+         <string>Retract threshold</string>
         </property>
        </widget>
       </item>
@@ -215,6 +177,68 @@ Larger values (further to the right) will calculate faster; smaller values (furt
         </property>
         <property name="unit" stdset="0">
          <string notr="true"/>
+        </property>
+        <property name="minimum">
+         <double>0</double>
+        </property>
+       </widget>
+      </item>
+      <item row="18" column="2">
+       <widget class="QToolButton" name="KeepToolDownToggle">
+        <property name="toolTip">
+         <string>Toggle keep tool down ratio between 0 and tool diameter</string>
+        </property>
+        <property name="text">
+         <string notr="true">…</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/icons/button_sort.svg</normaloff>:/icons/button_sort.svg
+         </iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="20" column="1">
+       <widget class="Gui::QuantitySpinBox" name="StockToLeave" native="true">
+        <property name="toolTip">
+         <string>How much stock to leave on the walls for this operation</string>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true"/>
+        </property>
+       </widget>
+      </item>
+      <item row="20" column="0">
+       <widget class="QLabel" name="label_12">
+        <property name="text">
+         <string>Radial stock to leave</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="optionsWidget">
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="ForceInsideOut">
+        <property name="text">
+         <string>Force clearing inside-out</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="useOutline">
+        <property name="text">
+         <string>Use outline</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="useRestMachining">
+        <property name="text">
+         <string>Use rest machining</string>
         </property>
        </widget>
       </item>
@@ -245,7 +269,7 @@ Larger values (further to the right) will calculate faster; smaller values (furt
        </widget>
       </item>
       <item row="9" column="1">
-       <widget class="Gui::InputField" name="HelixMaxPitch">
+       <widget class="Gui::QuantitySpinBox" name="HelixMaxPitch">
         <property name="toolTip">
          <string>The maximum allowable descent in a single revolution of the helix. Set to zero to disable limitation by pitch.</string>
         </property>
@@ -379,11 +403,6 @@ Larger values (further to the right) will calculate faster; smaller values (furt
    <class>Gui::InputField</class>
    <extends>QLineEdit</extends>
    <header>Gui/InputField.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::QuantitySpinBox</class>
-   <extends>QWidget</extends>
-   <header>Gui/QuantitySpinBox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
@@ -23,7 +23,7 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="9" column="0" colspan="2">
+      <item row="9" column="0" colspan="3">
        <widget class="QFrame" name="frame_3">
         <property name="frameShape">
          <enum>QFrame::StyledPanel</enum>
@@ -69,10 +69,10 @@ Larger values (further to the right) will calculate faster; smaller values (furt
         </layout>
        </widget>
       </item>
-      <item row="23" column="0">
-       <widget class="QCheckBox" name="ForceInsideOut">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
         <property name="text">
-         <string>Force clearing inside-out</string>
+         <string>Cut region</string>
         </property>
        </widget>
       </item>
@@ -83,6 +83,13 @@ Larger values (further to the right) will calculate faster; smaller values (furt
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Operation type</string>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="1">
        <widget class="QComboBox" name="OperationType">
         <property name="toolTip">
@@ -90,27 +97,10 @@ Larger values (further to the right) will calculate faster; smaller values (furt
         </property>
        </widget>
       </item>
-      <item row="24" column="0">
-       <widget class="QCheckBox" name="FinishingProfile">
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Finishing profile</string>
-        </property>
-       </widget>
-      </item>
-      <item row="20" column="1">
-       <widget class="Gui::QuantitySpinBox" name="StockToLeave" native="true">
-        <property name="toolTip">
-         <string>How much stock to leave on the walls for this operation</string>
-        </property>
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
-      <item row="20" column="0">
-       <widget class="QLabel" name="label_12">
-        <property name="text">
-         <string>Radial stock to leave</string>
+         <string>Step over (percent)</string>
         </property>
        </widget>
       </item>
@@ -139,10 +129,10 @@ Larger values (further to the right) will calculate faster; smaller values (furt
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_4">
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_stepOverDistance">
         <property name="text">
-         <string>Step over (percent)</string>
+         <string>Step over (distance)</string>
         </property>
        </widget>
       </item>
@@ -156,31 +146,10 @@ Larger values (further to the right) will calculate faster; smaller values (furt
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_stepOverDistance">
+      <item row="16" column="0">
+       <widget class="QLabel" name="label_10">
         <property name="text">
-         <string>Step over (distance)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="25" column="0">
-       <widget class="QCheckBox" name="useOutline">
-        <property name="text">
-         <string>Use outline</string>
-        </property>
-       </widget>
-      </item>
-      <item row="26" column="0">
-       <widget class="QCheckBox" name="useRestMachining">
-        <property name="text">
-         <string>Use rest machining</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Operation type</string>
+         <string>Lift distance</string>
         </property>
        </widget>
       </item>
@@ -201,20 +170,6 @@ Larger values (further to the right) will calculate faster; smaller values (furt
         </property>
        </widget>
       </item>
-      <item row="16" column="0">
-       <widget class="QLabel" name="label_10">
-        <property name="text">
-         <string>Lift distance</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Cut region</string>
-        </property>
-       </widget>
-      </item>
       <item row="18" column="1">
        <widget class="Gui::QuantitySpinBox" name="KeepToolDownRatio" native="true">
         <property name="toolTip">
@@ -222,6 +177,75 @@ Larger values (further to the right) will calculate faster; smaller values (furt
         </property>
         <property name="unit" stdset="0">
          <string notr="true"/>
+        </property>
+        <property name="minimum">
+         <double>0</double>
+        </property>
+       </widget>
+      </item>
+      <item row="18" column="2">
+       <widget class="QToolButton" name="KeepToolDownToggle">
+        <property name="toolTip">
+         <string>Toggle keep tool down ratio between 0 and tool diameter</string>
+        </property>
+        <property name="text">
+         <string notr="true">…</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/icons/button_sort.svg</normaloff>:/icons/button_sort.svg
+         </iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="20" column="1">
+       <widget class="Gui::QuantitySpinBox" name="StockToLeave" native="true">
+        <property name="toolTip">
+         <string>How much stock to leave on the walls for this operation</string>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true"/>
+        </property>
+       </widget>
+      </item>
+      <item row="20" column="0">
+       <widget class="QLabel" name="label_12">
+        <property name="text">
+         <string>Radial stock to leave</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="optionsWidget">
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="ForceInsideOut">
+        <property name="text">
+         <string>Force clearing inside-out</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="FinishingProfile">
+        <property name="text">
+         <string>Finishing profile</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="useOutline">
+        <property name="text">
+         <string>Use outline</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="useRestMachining">
+        <property name="text">
+         <string>Use rest machining</string>
         </property>
        </widget>
       </item>
@@ -252,7 +276,7 @@ Larger values (further to the right) will calculate faster; smaller values (furt
        </widget>
       </item>
       <item row="9" column="1">
-       <widget class="Gui::InputField" name="HelixMaxPitch">
+       <widget class="Gui::QuantitySpinBox" name="HelixMaxPitch">
         <property name="toolTip">
          <string>The maximum allowable descent in a single revolution of the helix. Set to zero to disable limitation by pitch.</string>
         </property>
@@ -386,11 +410,6 @@ Larger values (further to the right) will calculate faster; smaller values (furt
    <class>Gui::InputField</class>
    <extends>QLineEdit</extends>
    <header>Gui/InputField.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::QuantitySpinBox</class>
-   <extends>QWidget</extends>
-   <header>Gui/QuantitySpinBox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpPocketFullEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpPocketFullEdit.ui
@@ -38,10 +38,7 @@ The latter can be used to face of the entire stock area to ensure uniform height
    </item>
    <item row="1" column="0">
     <widget class="QWidget" name="widget">
-     <layout class="QFormLayout" name="formLayout">
-      <property name="fieldGrowthPolicy">
-       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-      </property>
+     <layout class="QGridLayout" name="formLayout">
       <item row="0" column="0">
        <widget class="QLabel" name="cutMode_label">
         <property name="text">
@@ -126,9 +123,24 @@ The latter can be used to face of the entire stock area to ensure uniform height
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="Gui::InputField" name="angle">
+       <widget class="QDoubleSpinBox" name="angle">
         <property name="toolTip">
          <string>Angle in which the pattern is applied</string>
+        </property>
+        <property name="suffix">
+         <string>°</string>
+        </property>
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="minimum">
+         <double>-180.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>180.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>1.000000000000000</double>
         </property>
        </widget>
       </item>
@@ -164,14 +176,46 @@ The latter can be used to face of the entire stock area to ensure uniform height
       <item row="4" column="0">
        <widget class="QLabel" name="extraOffset_label">
         <property name="text">
-         <string>Material allowance</string>
+         <string>Radial stock to leave</string>
         </property>
        </widget>
       </item>
       <item row="4" column="1">
-       <widget class="Gui::InputField" name="extraOffset">
+       <widget class="Gui::QuantitySpinBox" name="extraOffset">
         <property name="toolTip">
          <string>The amount of material that should be left by this operation in relation to the target shape</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="threshold_label">
+        <property name="text">
+         <string>Retract threshold</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="Gui::QuantitySpinBox" name="threshold">
+        <property name="toolTip">
+         <string>Distance which will attempts to avoid unnecessary retractions</string>
+        </property>
+        <property name="minimum">
+         <double>0</double>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="2">
+       <widget class="QToolButton" name="thresholdToggle">
+        <property name="toolTip">
+         <string>Toggle retract threshold between 0 and tool diameter</string>
+        </property>
+        <property name="text">
+         <string notr="true">…</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/icons/button_sort.svg</normaloff>:/icons/button_sort.svg
+         </iconset>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpProfileFullEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpProfileFullEdit.ui
@@ -62,57 +62,80 @@
         </property>
        </widget>
       </item>
-     <item row="2" column="1">
+      <item row="2" column="1">
        <widget class="Gui::QuantitySpinBox" name="extraOffset">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
         <property name="toolTip">
          <string>How much stock to leave on the walls for this operation</string>
         </property>
        </widget>
       </item>
       <item row="3" column="0">
+       <widget class="QLabel" name="thresholdLabel">
+        <property name="text">
+         <string>Retract threshold</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::QuantitySpinBox" name="threshold">
+        <property name="toolTip">
+         <string>Distance which will attempts to avoid unnecessary retractions</string>
+        </property>
+        <property name="minimum">
+          <double>0</double>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QToolButton" name="thresholdToggle">
+        <property name="toolTip">
+         <string>Toggle retract threshold between 0 and tool diameter</string>
+        </property>
+        <property name="text">
+         <string notr="true">…</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/icons/button_sort.svg</normaloff>:/icons/button_sort.svg
+         </iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
        <widget class="QLabel" name="numPassesLabel">
         <property name="text">
          <string>Number of passes</string>
         </property>
        </widget>
       </item>
-     <item row="3" column="1">
-       <widget class="QSpinBox" name="numPasses">
-	    <property name="minimum">
-		 <number>1</number>
-        </property>
+      <item row="5" column="1">
+       <widget class="Gui::IntSpinBox" name="numPasses">
+         <property name="minimum">
+           <number>1</number>
+         </property>
+         <property name="maximum">
+           <number>999999</number>
+         </property>
         <property name="toolTip">
          <string>The number of passes to do. If more than one, requires a non-zero value for 'Pass stepover'.</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="6" column="0">
        <widget class="QLabel" name="stepoverLabel">
         <property name="text">
          <string>Pass stepover</string>
         </property>
        </widget>
       </item>
-     <item row="4" column="1">
+      <item row="6" column="1">
        <widget class="Gui::QuantitySpinBox" name="stepover">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
         <property name="toolTip">
          <string>If doing multiple passes, the extra offset of each additional pass</string>
         </property>
        </widget>
       </item>
-      </layout>
+     </layout>
     </widget>
    </item>
    <item row="1" column="0">

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpProfileFullEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpProfileFullEdit.ui
@@ -62,31 +62,59 @@
         </property>
        </widget>
       </item>
-     <item row="2" column="1">
+      <item row="2" column="1">
        <widget class="Gui::QuantitySpinBox" name="extraOffset">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
         <property name="toolTip">
          <string>How much stock to leave on the walls for this operation</string>
         </property>
        </widget>
       </item>
       <item row="3" column="0">
+       <widget class="QLabel" name="thresholdLabel">
+        <property name="text">
+         <string>Retract threshold</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::QuantitySpinBox" name="threshold">
+        <property name="toolTip">
+         <string>Distance which will attempts to avoid unnecessary retractions</string>
+        </property>
+        <property name="minimum">
+          <double>0</double>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QToolButton" name="thresholdToggle">
+        <property name="toolTip">
+         <string>Toggle retract threshold between 0 and tool diameter</string>
+        </property>
+        <property name="text">
+         <string notr="true">…</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/icons/button_sort.svg</normaloff>:/icons/button_sort.svg
+         </iconset>
+        </property>
+       </widget>
+      </item>
        <widget class="QLabel" name="numPassesLabel">
         <property name="text">
          <string>Number of passes</string>
         </property>
        </widget>
       </item>
-     <item row="3" column="1">
-       <widget class="QSpinBox" name="numPasses">
-	    <property name="minimum">
-		 <number>1</number>
-        </property>
+      <item row="5" column="1">
+       <widget class="Gui::IntSpinBox" name="numPasses">
+         <property name="minimum">
+           <number>1</number>
+         </property>
+         <property name="maximum">
+           <number>999999</number>
+         </property>
         <property name="toolTip">
          <string>The number of passes to do. If more than one, requires a non-zero value for 'Pass stepover'.</string>
         </property>
@@ -101,12 +129,6 @@
       </item>
      <item row="4" column="1">
        <widget class="Gui::QuantitySpinBox" name="stepover">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
         <property name="toolTip">
          <string>If doing multiple passes, the extra offset of each additional pass</string>
         </property>

--- a/src/Mod/CAM/Path/Base/Gui/Util.py
+++ b/src/Mod/CAM/Path/Base/Gui/Util.py
@@ -238,6 +238,16 @@ class QuantitySpinBox(QtCore.QObject):
                 return exp
         return None
 
+    def refresh_expression_icon(self, has_expression):
+        line_edit = self.widget.lineEdit()
+        icon_label = line_edit.findChild(QtGui.QLabel)
+        if icon_label is None:
+            return
+        icon_height = QtGui.QFontMetrics(line_edit.font()).height()
+        name = "bound-expression.svg" if has_expression else "bound-expression-unset.svg"
+        pixmap = FreeCADGui.getIcon(":/icons/" + name).pixmap(icon_height, icon_height)
+        icon_label.setPixmap(pixmap)
+
 
 class PropertyComboBox(QtCore.QObject):
     """Base controller class for properties represented as QComboBox."""

--- a/src/Mod/CAM/Path/Base/Gui/Util.py
+++ b/src/Mod/CAM/Path/Base/Gui/Util.py
@@ -248,6 +248,16 @@ class QuantitySpinBox(QtCore.QObject):
                 return exp
         return None
 
+    def refresh_expression_icon(self, has_expression):
+        line_edit = self.widget.lineEdit()
+        icon_label = line_edit.findChild(QtGui.QLabel)
+        if icon_label is None:
+            return
+        icon_height = QtGui.QFontMetrics(line_edit.font()).height()
+        name = "bound-expression.svg" if has_expression else "bound-expression-unset.svg"
+        pixmap = FreeCADGui.getIcon(":/icons/" + name).pixmap(icon_height, icon_height)
+        icon_label.setPixmap(pixmap)
+
 
 class PropertyComboBox(QtCore.QObject):
     """Base controller class for properties represented as QComboBox."""

--- a/src/Mod/CAM/Path/Op/Gui/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Gui/Adaptive.py
@@ -30,6 +30,7 @@ import Path.Op.Gui.FeatureExtension as PathFeatureExtensionsGui
 from PySide import QtCore
 
 import Path.Base.Gui.Util as PathGuiUtil
+from Path.Base.Gui.Util import QuantitySpinBox
 
 
 class TaskPanelOpPage(PathOpGui.TaskPanelPage):
@@ -45,11 +46,13 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         return form
 
     def initPage(self, obj):
-        self.form.HelixMaxPitch.setProperty("unit", obj.HelixMaxPitch.getUserPreferred()[2])
+        self.HelixMaxPitchSpinBox = QuantitySpinBox(self.form.HelixMaxPitch, obj, "HelixMaxPitch")
+        self.LiftDistanceSpinBox = QuantitySpinBox(self.form.LiftDistance, obj, "LiftDistance")
+        self.KeepToolDownRatioSpinBox = QuantitySpinBox(
+            self.form.KeepToolDownRatio, obj, "KeepToolDownRatio"
+        )
+        self.StockToLeaveSpinBox = QuantitySpinBox(self.form.StockToLeave, obj, "StockToLeave")
 
-        self.form.LiftDistance.setProperty("unit", obj.LiftDistance.getUserPreferred()[2])
-        self.form.KeepToolDownRatio.setProperty("unit", obj.KeepToolDownRatio.getUserPreferred()[2])
-        self.form.StockToLeave.setProperty("unit", obj.StockToLeave.getUserPreferred()[2])
         # Use user's preferred length unit
         self.form.stepOverDistance.setProperty(
             "unit", FreeCAD.Units.Quantity("1 mm").getUserPreferred()[2]
@@ -66,6 +69,12 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         (possibly new) tool diameter."""
         if prop == "ToolController":
             self.updateStepOverDistance(obj)
+
+    def updateQuantitySpinBoxes(self, index=None):
+        self.HelixMaxPitchSpinBox.updateWidget()
+        self.LiftDistanceSpinBox.updateWidget()
+        self.KeepToolDownRatioSpinBox.updateWidget()
+        self.StockToLeaveSpinBox.updateWidget()
 
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
@@ -118,6 +127,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
                 self.getFields(obj)
 
     def setFields(self, obj):
+        self.updateQuantitySpinBoxes()
         self.selectInComboBox(obj.Side, self.form.Side)
         self.selectInComboBox(obj.OperationType, self.form.OperationType)
         self.form.stepOver.setValue(obj.StepOverPercent)
@@ -129,23 +139,12 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             FreeCAD.Units.Quantity(obj.HelixMaxRampAngle, FreeCAD.Units.Angle).UserString
         )
 
-        self.form.HelixMaxPitch.setProperty("rawValue", obj.HelixMaxPitch.Value)
-
         self.form.HelixConeAngle.setText(
             FreeCAD.Units.Quantity(obj.HelixConeAngle, FreeCAD.Units.Angle).UserString
         )
 
         self.form.HelixMaxDiameterPercent.setValue(obj.HelixMaxDiameterPercent)
         self.form.HelixMinDiameterPercent.setValue(obj.HelixMinDiameterPercent)
-
-        self.form.LiftDistance.setProperty("rawValue", obj.LiftDistance.Value)
-
-        if hasattr(obj, "KeepToolDownRatio"):
-            self.form.KeepToolDownRatio.setProperty("rawValue", obj.KeepToolDownRatio.Value)
-            # self.form.KeepToolDownRatio.setValue(obj.KeepToolDownRatio)
-
-        if hasattr(obj, "StockToLeave"):
-            self.form.StockToLeave.setProperty("rawValue", obj.StockToLeave.Value)
 
         self.form.ForceInsideOut.setChecked(obj.ForceInsideOut)
         self.form.useOutline.setChecked(obj.UseOutline)
@@ -157,6 +156,11 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         obj.setEditorMode("Stopped", 2)  # hide this property
 
     def getFields(self, obj):
+        self.HelixMaxPitchSpinBox.updateProperty()
+        self.LiftDistanceSpinBox.updateProperty()
+        self.KeepToolDownRatioSpinBox.updateProperty()
+        self.StockToLeaveSpinBox.updateProperty()
+
         if obj.Side != str(self.form.Side.currentData()):
             obj.Side = str(self.form.Side.currentData())
 
@@ -174,15 +178,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
         obj.Tolerance = 1.0 * self.form.Tolerance.value() / 100.0
         PathGuiUtil.updateInputField(obj, "HelixMaxRampAngle", self.form.HelixMaxRampAngle)
-        PathGuiUtil.updateInputField(obj, "HelixMaxPitch", self.form.HelixMaxPitch)
         PathGuiUtil.updateInputField(obj, "HelixConeAngle", self.form.HelixConeAngle)
-        PathGuiUtil.updateInputField(obj, "LiftDistance", self.form.LiftDistance)
-
-        if hasattr(obj, "KeepToolDownRatio"):
-            PathGuiUtil.updateInputField(obj, "KeepToolDownRatio", self.form.KeepToolDownRatio)
-
-        if hasattr(obj, "StockToLeave"):
-            PathGuiUtil.updateInputField(obj, "StockToLeave", self.form.StockToLeave)
 
         obj.ForceInsideOut = self.form.ForceInsideOut.isChecked()
         obj.UseOutline = self.form.useOutline.isChecked()
@@ -201,6 +197,20 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         if not hasattr(self, "extensionsPanel"):
             self.extensionsPanel = PathFeatureExtensionsGui.TaskPanelExtensionPage(obj, features)
         return self.extensionsPanel
+
+    def registerSignalHandlers(self, obj):
+        self.form.KeepToolDownToggle.clicked.connect(self.keepToolDownRatioToggle)
+
+    def keepToolDownRatioToggle(self):
+        if self.obj.KeepToolDownRatio == 0:
+            self.obj.setExpression("KeepToolDownRatio", "OpToolDiameter")
+            self.KeepToolDownRatioSpinBox.refresh_expression_icon(True)
+        else:
+            self.obj.clearExpression("KeepToolDownRatio")
+            self.obj.KeepToolDownRatio = 0
+            self.KeepToolDownRatioSpinBox.refresh_expression_icon(False)
+        self.updateQuantitySpinBoxes()
+        self.setDirty()
 
 
 Command = PathOpGui.SetupOperation(

--- a/src/Mod/CAM/Path/Op/Gui/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Gui/Adaptive.py
@@ -30,6 +30,7 @@ import Path.Op.Gui.FeatureExtension as PathFeatureExtensionsGui
 from PySide import QtCore
 
 import Path.Base.Gui.Util as PathGuiUtil
+from Path.Base.Gui.Util import QuantitySpinBox
 
 
 class TaskPanelOpPage(PathOpGui.TaskPanelPage):
@@ -45,11 +46,13 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         return form
 
     def initPage(self, obj):
-        self.form.HelixMaxPitch.setProperty("unit", obj.HelixMaxPitch.getUserPreferred()[2])
+        self.HelixMaxPitchSpinBox = QuantitySpinBox(self.form.HelixMaxPitch, obj, "HelixMaxPitch")
+        self.LiftDistanceSpinBox = QuantitySpinBox(self.form.LiftDistance, obj, "LiftDistance")
+        self.KeepToolDownRatioSpinBox = QuantitySpinBox(
+            self.form.KeepToolDownRatio, obj, "KeepToolDownRatio"
+        )
+        self.StockToLeaveSpinBox = QuantitySpinBox(self.form.StockToLeave, obj, "StockToLeave")
 
-        self.form.LiftDistance.setProperty("unit", obj.LiftDistance.getUserPreferred()[2])
-        self.form.KeepToolDownRatio.setProperty("unit", obj.KeepToolDownRatio.getUserPreferred()[2])
-        self.form.StockToLeave.setProperty("unit", obj.StockToLeave.getUserPreferred()[2])
         # Use user's preferred length unit
         self.form.stepOverDistance.setProperty(
             "unit", FreeCAD.Units.Quantity("1 mm").getUserPreferred()[2]
@@ -66,6 +69,12 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         (possibly new) tool diameter."""
         if prop == "ToolController":
             self.updateStepOverDistance(obj)
+
+    def updateQuantitySpinBoxes(self, index=None):
+        self.HelixMaxPitchSpinBox.updateWidget()
+        self.LiftDistanceSpinBox.updateWidget()
+        self.KeepToolDownRatioSpinBox.updateWidget()
+        self.StockToLeaveSpinBox.updateWidget()
 
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
@@ -120,6 +129,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
                 self.getFields(obj)
 
     def setFields(self, obj):
+        self.updateQuantitySpinBoxes()
         self.selectInComboBox(obj.Side, self.form.Side)
         self.selectInComboBox(obj.OperationType, self.form.OperationType)
         self.form.stepOver.setValue(obj.StepOverPercent)
@@ -131,23 +141,12 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             FreeCAD.Units.Quantity(obj.HelixMaxRampAngle, FreeCAD.Units.Angle).UserString
         )
 
-        self.form.HelixMaxPitch.setProperty("rawValue", obj.HelixMaxPitch.Value)
-
         self.form.HelixConeAngle.setText(
             FreeCAD.Units.Quantity(obj.HelixConeAngle, FreeCAD.Units.Angle).UserString
         )
 
         self.form.HelixMaxDiameterPercent.setValue(obj.HelixMaxDiameterPercent)
         self.form.HelixMinDiameterPercent.setValue(obj.HelixMinDiameterPercent)
-
-        self.form.LiftDistance.setProperty("rawValue", obj.LiftDistance.Value)
-
-        if hasattr(obj, "KeepToolDownRatio"):
-            self.form.KeepToolDownRatio.setProperty("rawValue", obj.KeepToolDownRatio.Value)
-            # self.form.KeepToolDownRatio.setValue(obj.KeepToolDownRatio)
-
-        if hasattr(obj, "StockToLeave"):
-            self.form.StockToLeave.setProperty("rawValue", obj.StockToLeave.Value)
 
         self.form.ForceInsideOut.setChecked(obj.ForceInsideOut)
         self.form.FinishingProfile.setChecked(obj.FinishingProfile)
@@ -160,6 +159,11 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         obj.setEditorMode("Stopped", 2)  # hide this property
 
     def getFields(self, obj):
+        self.HelixMaxPitchSpinBox.updateProperty()
+        self.LiftDistanceSpinBox.updateProperty()
+        self.KeepToolDownRatioSpinBox.updateProperty()
+        self.StockToLeaveSpinBox.updateProperty()
+
         if obj.Side != str(self.form.Side.currentData()):
             obj.Side = str(self.form.Side.currentData())
 
@@ -177,15 +181,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
         obj.Tolerance = 1.0 * self.form.Tolerance.value() / 100.0
         PathGuiUtil.updateInputField(obj, "HelixMaxRampAngle", self.form.HelixMaxRampAngle)
-        PathGuiUtil.updateInputField(obj, "HelixMaxPitch", self.form.HelixMaxPitch)
         PathGuiUtil.updateInputField(obj, "HelixConeAngle", self.form.HelixConeAngle)
-        PathGuiUtil.updateInputField(obj, "LiftDistance", self.form.LiftDistance)
-
-        if hasattr(obj, "KeepToolDownRatio"):
-            PathGuiUtil.updateInputField(obj, "KeepToolDownRatio", self.form.KeepToolDownRatio)
-
-        if hasattr(obj, "StockToLeave"):
-            PathGuiUtil.updateInputField(obj, "StockToLeave", self.form.StockToLeave)
 
         obj.ForceInsideOut = self.form.ForceInsideOut.isChecked()
         obj.FinishingProfile = self.form.FinishingProfile.isChecked()
@@ -205,6 +201,20 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         if not hasattr(self, "extensionsPanel"):
             self.extensionsPanel = PathFeatureExtensionsGui.TaskPanelExtensionPage(obj, features)
         return self.extensionsPanel
+
+    def registerSignalHandlers(self, obj):
+        self.form.KeepToolDownToggle.clicked.connect(self.keepToolDownRatioToggle)
+
+    def keepToolDownRatioToggle(self):
+        if self.obj.KeepToolDownRatio == 0:
+            self.obj.setExpression("KeepToolDownRatio", "OpToolDiameter")
+            self.KeepToolDownRatioSpinBox.refresh_expression_icon(True)
+        else:
+            self.obj.clearExpression("KeepToolDownRatio")
+            self.obj.KeepToolDownRatio = 0
+            self.KeepToolDownRatioSpinBox.refresh_expression_icon(False)
+        self.updateQuantitySpinBoxes()
+        self.setDirty()
 
 
 Command = PathOpGui.SetupOperation(

--- a/src/Mod/CAM/Path/Op/Gui/PocketBase.py
+++ b/src/Mod/CAM/Path/Op/Gui/PocketBase.py
@@ -24,10 +24,9 @@
 import FreeCAD
 import FreeCADGui
 import Path
-import Path.Base.Gui.Util as PathGuiUtil
 import Path.Op.Gui.Base as PathOpGui
 import Path.Op.Pocket as PathPocket
-import PathGui
+from Path.Base.Gui.Util import QuantitySpinBox
 
 __title__ = "CAM Pocket Base Operation UI"
 __author__ = "sliptonic (Brad Collette)"
@@ -63,6 +62,10 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         Must be overwritten by subclasses"""
         pass
 
+    def initPage(self, obj):
+        self.extraOffsetSpinBox = QuantitySpinBox(self.form.extraOffset, obj, "ExtraOffset")
+        self.thresholdSpinBox = QuantitySpinBox(self.form.threshold, obj, "RetractThreshold")
+
     def getForm(self):
         """getForm() ... returns UI, adapted to the results from pocketFeatures()"""
         form = FreeCADGui.PySideUic.loadUi(":/panels/PageOpPocketFullEdit.ui")
@@ -75,18 +78,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
         self.populateCombobox(form, enumTups, comboToPropertyMap)
 
-        if not FeatureFacing & self.pocketFeatures():
+        if not (FeatureFacing & self.pocketFeatures()):
             form.facingWidget.hide()
             form.clearEdges.hide()
-
-        if FeaturePocket & self.pocketFeatures():
-            form.extraOffset_label.setText(translate("PathPocket", "Pass Extension"))
-            form.extraOffset.setToolTip(
-                translate(
-                    "PathPocket",
-                    "The distance the facing operation will extend beyond the boundary shape.",
-                )
-            )
 
         if not (FeatureOutline & self.pocketFeatures()):
             form.useOutline.hide()
@@ -100,14 +94,18 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         if setModel and obj.MinTravel != self.form.minTravel.isChecked():
             obj.MinTravel = self.form.minTravel.isChecked()
 
+    def updateQuantitySpinBoxes(self, index=None):
+        self.extraOffsetSpinBox.updateWidget()
+        self.thresholdSpinBox.updateWidget()
+
     def updateAngle(self, obj, setModel=True):
         if obj.ClearingPattern == "Offset":
             self.form.angle.setEnabled(False)
         else:
             self.form.angle.setEnabled(True)
 
-        if setModel:
-            PathGuiUtil.updateInputField(obj, "Angle", self.form.angle)
+        if setModel and getattr(obj.Angle, "Value", obj.Angle) != self.form.angle.value():
+            obj.Angle = self.form.angle.value()
 
     def getFields(self, obj):
         """getFields(obj) ... transfers values from UI to obj's properties"""
@@ -118,7 +116,8 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         if obj.ClearingPattern != str(self.form.clearingPattern.currentData()):
             obj.ClearingPattern = str(self.form.clearingPattern.currentData())
 
-        PathGuiUtil.updateInputField(obj, "ExtraOffset", self.form.extraOffset)
+        self.extraOffsetSpinBox.updateProperty()
+        self.thresholdSpinBox.updateProperty()
         self.updateAngle(obj)
 
         if obj.UseStartPoint != self.form.useStartPoint.isChecked():
@@ -144,16 +143,14 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
+        self.updateQuantitySpinBoxes()
         self.form.stepOver.setValue(obj.StepOver)
-        self.form.extraOffset.setText(
-            FreeCAD.Units.Quantity(obj.ExtraOffset.Value, FreeCAD.Units.Length).UserString
-        )
         self.form.useStartPoint.setChecked(obj.UseStartPoint)
         self.form.useRestMachining.setChecked(obj.UseRestMachining)
         if FeatureOutline & self.pocketFeatures():
             self.form.useOutline.setChecked(obj.UseOutline)
 
-        self.form.angle.setText(FreeCAD.Units.Quantity(obj.Angle, FreeCAD.Units.Angle).UserString)
+        self.form.angle.setValue(getattr(obj.Angle, "Value", obj.Angle))
         self.updateAngle(obj, False)
 
         self.form.minTravel.setChecked(obj.MinTravel)
@@ -175,6 +172,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.stepOver.editingFinished)
         signals.append(self.form.angle.editingFinished)
         signals.append(self.form.extraOffset.editingFinished)
+        signals.append(self.form.threshold.editingFinished)
         signals.append(self.form.useStartPoint.clicked)
         signals.append(self.form.useRestMachining.clicked)
         signals.append(self.form.useOutline.clicked)
@@ -188,6 +186,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def registerSignalHandlers(self, obj):
         self.form.setStartPoint.clicked.connect(self.setStartPoint)
+        self.form.thresholdToggle.clicked.connect(self.thresholdToggle)
 
     def setStartPoint(self):
         selEx = FreeCADGui.Selection.getSelectionEx()
@@ -199,3 +198,14 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
                 translate("CAM_Pocket", "Set start point: %s, %s")
                 % (round(point.x, 3), round(point.y, 3))
             )
+
+    def thresholdToggle(self):
+        if self.obj.RetractThreshold == 0:
+            self.obj.setExpression("RetractThreshold", "OpToolDiameter")
+            self.thresholdSpinBox.refresh_expression_icon(True)
+        else:
+            self.obj.clearExpression("RetractThreshold")
+            self.obj.RetractThreshold = 0
+            self.thresholdSpinBox.refresh_expression_icon(False)
+        self.updateQuantitySpinBoxes()
+        self.setDirty()

--- a/src/Mod/CAM/Path/Op/Gui/Profile.py
+++ b/src/Mod/CAM/Path/Op/Gui/Profile.py
@@ -23,10 +23,10 @@
 
 import FreeCAD
 import FreeCADGui
-import Path.Base.Gui.Util as PathGuiUtil
 import Path.Op.Gui.Base as PathOpGui
 import Path.Op.Profile as PathProfile
 import Path
+from Path.Base.Gui.Util import QuantitySpinBox
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 __title__ = "CAM Profile Operation UI"
@@ -47,8 +47,11 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     """
 
     def initPage(self, obj):
-        self.form.extraOffset.setProperty("unit", obj.OffsetExtra.getUserPreferred()[2])
-        self.form.stepover.setProperty("unit", obj.Stepover.getUserPreferred()[2])
+        self.extraOffsetSpinBox = QuantitySpinBox(self.form.extraOffset, obj, "OffsetExtra")
+        self.thresholdSpinBox = QuantitySpinBox(self.form.threshold, obj, "RetractThreshold")
+        self.stepoverSpinBox = QuantitySpinBox(self.form.stepover, obj, "Stepover")
+
+        FreeCADGui.ExpressionBinding(self.form.numPasses).bind(self.obj, "NumPasses")
 
     def profileFeatures(self):
         """profileFeatures() ... return which of the optional profile features are supported.
@@ -68,15 +71,23 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.populateCombobox(form, enumTups, comboToPropertyMap)
         return form
 
+    def updateQuantitySpinBoxes(self, index=None):
+        self.extraOffsetSpinBox.updateWidget()
+        self.thresholdSpinBox.updateWidget()
+        self.stepoverSpinBox.updateWidget()
+
     def getFields(self, obj):
         """getFields(obj) ... transfers values from UI to obj's properties"""
         if obj.Side != str(self.form.cutSide.currentData()):
             obj.Side = str(self.form.cutSide.currentData())
         if obj.Direction != str(self.form.direction.currentData()):
             obj.Direction = str(self.form.direction.currentData())
-        PathGuiUtil.updateInputField(obj, "OffsetExtra", self.form.extraOffset)
+
+        self.extraOffsetSpinBox.updateProperty()
+        self.thresholdSpinBox.updateProperty()
+        self.stepoverSpinBox.updateProperty()
+
         obj.NumPasses = self.form.numPasses.value()
-        PathGuiUtil.updateInputField(obj, "Stepover", self.form.stepover)
 
         if obj.UseComp != self.form.useCompensation.isChecked():
             obj.UseComp = self.form.useCompensation.isChecked()
@@ -92,12 +103,11 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
+        self.updateQuantitySpinBoxes()
+
         self.selectInComboBox(obj.Side, self.form.cutSide)
         self.selectInComboBox(obj.Direction, self.form.direction)
-        self.form.extraOffset.setProperty("rawValue", obj.OffsetExtra.Value)
         self.form.numPasses.setValue(obj.NumPasses)
-        self.form.stepover.setProperty("rawValue", obj.Stepover.Value)
-
         self.form.useCompensation.setChecked(obj.UseComp)
         self.form.useStartPoint.setChecked(obj.UseStartPoint)
         self.form.processHoles.setChecked(obj.processHoles)
@@ -112,6 +122,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.cutSide.currentIndexChanged)
         signals.append(self.form.direction.currentIndexChanged)
         signals.append(self.form.extraOffset.editingFinished)
+        signals.append(self.form.threshold.editingFinished)
         signals.append(self.form.numPasses.editingFinished)
         signals.append(self.form.stepover.editingFinished)
         if hasattr(self.form.useCompensation, "checkStateChanged"):  # Qt version >= 6.7.0
@@ -162,6 +173,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.numPasses.editingFinished.connect(self.updateVisibility)
 
         self.form.setStartPoint.clicked.connect(self.setStartPoint)
+        self.form.thresholdToggle.clicked.connect(self.thresholdToggle)
 
     def setStartPoint(self):
         selEx = FreeCADGui.Selection.getSelectionEx()
@@ -173,6 +185,17 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
                 translate("CAM_Profile", "Set start point: %s, %s")
                 % (round(point.x, 3), round(point.y, 3))
             )
+
+    def thresholdToggle(self):
+        if self.obj.RetractThreshold == 0:
+            self.obj.setExpression("RetractThreshold", "OpToolDiameter")
+            self.thresholdSpinBox.refresh_expression_icon(True)
+        else:
+            self.obj.clearExpression("RetractThreshold")
+            self.obj.RetractThreshold = 0
+            self.thresholdSpinBox.refresh_expression_icon(False)
+        self.updateQuantitySpinBoxes()
+        self.setDirty()
 
 
 # Eclass


### PR DESCRIPTION
### Description

Feature `KeepToolDown` was replaced by property `RetractThreshold`, which allows to adjust distance, but not so convenient to use


### Changes

- Added field `RetractThreshold` to Task panels of **Profile** and **Pocket_Shape** operations

- Replaced `Keep tool down ratio` by `Retract threshold` in **Adaptive** operation

- Added button which toggle `RetractThreshold` between `0` and `OpToolDiameter`
  This allows to get old behavior of `KeepToolDown` feature

- `Extra offset` label replaced by `Radial stock to leave`

- Added expression icons to some fields

<img width="1100" height="410" alt="1_hor_lossy" src="https://github.com/user-attachments/assets/a62b49e5-30e6-4d1b-b506-13431d56860f" />

https://github.com/user-attachments/assets/799b64a6-4db0-45a6-b9c6-3d3e6c0403aa
