### PR TITLE
Gui: avoid recompute on every keystroke in quantity spinbox

### DIFF
--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -1229,6 +1229,8 @@ QWidget* PropertyUnitItem::createEditor(
     auto infield = new Gui::QuantitySpinBox(parent);
     infield->setFrame(static_cast<bool>(frameOption));
     infield->setMinimumHeight(0);
+    // avoid triggering a recompute on every keystroke while typing
+    infield->setKeyboardTracking(false);
 
     // if we are bound to an expression we need to bind it to the input field
     if (isBound()) {


### PR DESCRIPTION
Typing a value in the property editor's quantity spinbox commits it on every keystroke, and every commit triggers a recompute. With expensive properties like `AngularDeflection` the whole shape gets retessellated while you're still typing — entering 45 first applies 4 degrees (see the video in the linked issue).

This disables keyboard tracking on the editor, so the value is only committed on Enter, focus loss or the spin buttons.

Tested with the sample file from the issue: typing "45" into Angular Deflection no longer recomputes per digit, the value is applied once on Enter or focus loss. Spin arrows and Esc behave as before.

Note: the sibling `Deviation` property has the same per-keystroke behavior. Left out of scope to keep this minimal, but the same one-line fix would work there.

## Issues

Fixes #31047
