### PR TITLE
CAM: Keep stock material dialog attached to main window

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathJobGui.py
+++ b/src/Mod/CAM/CAMTests/TestPathJobGui.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import FreeCADGui
+from PySide import QtWidgets
+
+import Path.Main.Gui.Job as PathJobGui
+
+
+class TestPathJobGui(unittest.TestCase):
+    def test_assign_material_dialog_has_main_window_parent(self):
+        panel = PathJobGui.TaskPanel.__new__(PathJobGui.TaskPanel)
+        panel._currentStockMaterial = MagicMock(return_value=(None, None))
+
+        dialog = MagicMock()
+        dialog.exec_.return_value = QtWidgets.QDialog.Rejected
+
+        with patch.object(PathJobGui, "MaterialDialog", return_value=dialog) as dialog_class:
+            panel.assignMaterial()
+
+        dialog_class.assert_called_once_with(parent=FreeCADGui.getMainWindow(), current_uuid=None)

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -890,7 +890,7 @@ class TaskPanel:
 
     def assignMaterial(self):
         current_uuid, _ = self._currentStockMaterial()
-        dialog = MaterialDialog(current_uuid=current_uuid)
+        dialog = MaterialDialog(parent=FreeCADGui.getMainWindow(), current_uuid=current_uuid)
         result = dialog.exec_()
 
         if result == QtWidgets.QDialog.Accepted and dialog.uuid is not None:

--- a/src/Mod/CAM/TestCAMGui.py
+++ b/src/Mod/CAM/TestCAMGui.py
@@ -21,6 +21,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+from CAMTests.TestPathJobGui import TestPathJobGui
 from CAMTests.TestPathToolBitPropertyEditorWidget import (
     TestBoolPropertyEditorWidget,
     TestEnumPropertyEditorWidget,


### PR DESCRIPTION
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Summary

Keep the **Assign Stock Material** dialog attached to the FreeCAD main window and add a GUI regression test for its parent.

## Root cause and impact

The dialog was created without a parent. After closing the nested Materials editor, window managers could lose the detached outer modal dialog while it continued to block the main window. Parenting it to the main window preserves the modal window hierarchy and returns focus to the outer dialog.

## Issues

Fixes #30281.

## Validation

- Added `TestPathJobGui.test_assign_material_dialog_has_main_window_parent` and registered it in `TestCAMGui`.
- Ran the regression test with FreeCAD weekly 26.3.0dev: 1 test passed.
- Exercised the actual Job task panel flow through the nested Materials editor; after closing the nested editor, the outer dialog remained visible and was the active modal window.
- Ran `git diff --check`.

## Before and After Images

Not included because the failure is a modal focus and window-ownership state rather than a visual layout change.

## AI assistance

OpenAI GPT-5 in Codex assisted with investigation and implementation. I reviewed, understood, and validated the final change and take responsibility for it.
