### PR TITLE
FEM: Change the definition of Tresca stress

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/ResultHints.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/ResultHints.ui
@@ -175,7 +175,7 @@
         <item row="4" column="1">
          <widget class="QLabel" name="user_def_head_19">
           <property name="text">
-           <string>maximum shear stress: MS</string>
+           <string>Tresca stress: TS</string>
           </property>
           <property name="textInteractionFlags">
            <set>Qt::TextSelectableByMouse</set>

--- a/src/Mod/Fem/Gui/Resources/ui/ResultShow.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/ResultShow.ui
@@ -120,7 +120,7 @@
         <item row="4" column="1">
          <widget class="QRadioButton" name="rb_max_shear_stress">
           <property name="text">
-           <string>Maximum shear stress (Tresca)</string>
+           <string>Tresca stress</string>
           </property>
          </widget>
         </item>

--- a/src/Mod/Fem/femobjects/result_mechanical.py
+++ b/src/Mod/Fem/femobjects/result_mechanical.py
@@ -167,7 +167,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "App::PropertyFloatList",
             "MaxShear",
             "NodeData",
-            "List of Maximum Shear stress values",
+            "List of Tresca stress values",
             True,
         )
         obj.setPropertyStatus("MaxShear", "LockDynamic")

--- a/src/Mod/Fem/femresult/resulttools.py
+++ b/src/Mod/Fem/femresult/resulttools.py
@@ -742,7 +742,7 @@ def calculate_principal_stress_std(stress_tensor):
     eigvals = list(np.linalg.eigvalsh(sigma))
     eigvals.sort()
     eigvals.reverse()
-    maxshear = (eigvals[0] - eigvals[2])
+    maxshear = eigvals[0] - eigvals[2]
     return (eigvals[0], eigvals[1], eigvals[2], maxshear)
 
 
@@ -785,7 +785,7 @@ def calculate_principal_stress_reinforced(stress_tensor):
     eigenvalues = eigenvalues[idx]
     eigenvectors = eigenvectors[:, idx]
 
-    maxshear = (eigenvalues[0] - eigenvalues[2])
+    maxshear = eigenvalues[0] - eigenvalues[2]
 
     return (
         eigenvalues[0],

--- a/src/Mod/Fem/femresult/resulttools.py
+++ b/src/Mod/Fem/femresult/resulttools.py
@@ -742,7 +742,7 @@ def calculate_principal_stress_std(stress_tensor):
     eigvals = list(np.linalg.eigvalsh(sigma))
     eigvals.sort()
     eigvals.reverse()
-    maxshear = (eigvals[0] - eigvals[2]) / 2.0
+    maxshear = (eigvals[0] - eigvals[2])
     return (eigvals[0], eigvals[1], eigvals[2], maxshear)
 
 
@@ -785,7 +785,7 @@ def calculate_principal_stress_reinforced(stress_tensor):
     eigenvalues = eigenvalues[idx]
     eigenvectors = eigenvectors[:, idx]
 
-    maxshear = (eigenvalues[0] - eigenvalues[2]) / 2.0
+    maxshear = (eigenvalues[0] - eigenvalues[2])
 
     return (
         eigenvalues[0],

--- a/src/Mod/Fem/femresult/resulttools.py
+++ b/src/Mod/Fem/femresult/resulttools.py
@@ -242,7 +242,7 @@ def get_stats(res_obj, result_type):
 #  - Prin1 - Principal stress 1
 #  - Prin2 - Principal stress 2
 #  - Prin3 - Principal stress 3
-#  - MaxSear - maximum shear stress
+#  - MaxSear - Tresca stress
 #  - Peeq - Equivalent plastic strain
 #  - Temp - Temperature
 #  - MFlow - MassFlowRate
@@ -256,7 +256,7 @@ def get_all_stats(res_obj):
     - MaxPrin - Principal stress 1
     - MidPrin - Principal stress 2
     - MinPrin - Principal stress 3
-    - MaxShear - maximum shear stress
+    - MaxShear - Tresca stress
     - Peeq - peeq strain
     - Temp - Temperature
     - MFlow - MassFlowRate

--- a/src/Mod/Fem/femsolver/calculix/calculixtools.py
+++ b/src/Mod/Fem/femsolver/calculix/calculixtools.py
@@ -332,8 +332,8 @@ class CalculiXTools(ObjectTools):
                 von_mises_vtk.SetName("von Mises Stress")
                 pd.AddArray(von_mises_vtk)
 
-                # max shear stress
-                max_shear = 1 / 2 * np.max(np.abs(sigma_diff), axis=0)
+                # tresca stress
+                max_shear = np.max(np.abs(sigma_diff), axis=0)
                 max_shear_vtk = vtk_np.numpy_to_vtk(max_shear)
                 max_shear_vtk.SetName("Tresca Stress")
                 pd.AddArray(max_shear_vtk)

--- a/src/Mod/Fem/femsolver/elmer/equations/deformation.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/deformation.py
@@ -69,7 +69,7 @@ class Proxy(nonlinear.Proxy, equationbase.DeformationProxy):
             "App::PropertyBool",
             "CalculateStresses",
             "Deformation",
-            "Compute stress tensor and vanMises",
+            "Compute stress tensor and von Mises stress",
             locked=True,
         )
         obj.addProperty(

--- a/src/Mod/Fem/femsolver/elmer/equations/elasticity.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/elasticity.py
@@ -79,7 +79,7 @@ class Proxy(linear.Proxy, equationbase.ElasticityProxy):
             "App::PropertyBool",
             "CalculateStresses",
             "Elasticity",
-            "Compute stress tensor and vanMises",
+            "Compute stress tensor and von Mises stress",
             locked=True,
         )
         obj.addProperty(

--- a/src/Mod/Fem/femtaskpanels/task_result_mechanical.py
+++ b/src/Mod/Fem/femtaskpanels/task_result_mechanical.py
@@ -371,7 +371,7 @@ class _TaskPanel:
                 "MaxShear",
                 self.result_obj.MaxShear,
                 "MPa",
-                translate("FEM", "Maximum shear stress (Tresca)"),
+                translate("FEM", "Tresca stress"),
             )
         else:
             self.result_widget.rb_none.setChecked(True)


### PR DESCRIPTION
https://forum.freecad.org/viewtopic.php?t=106550

The current definition of Tresca stress in FreeCAD FEM is `(σ_1-σ_3)/2`. This is the maximum shear stress, but the standard / most common definition of Tresca stress used e.g. in Abaqus, PrePoMax and SolidWorks Simulation is `σ_1-σ_3`. This PR changes the formula to account for that and also simply names this output "Tresca stress" everywhere in GUI. IMO the internal/variable names can stay as they are.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

No AI was used for this PR

@marioalexis84 FYI