### PR TITLE
Force WildMagic4 to be a static library

### DIFF
--- a/src/3rdParty/WildMagic4/CMakeLists.txt
+++ b/src/3rdParty/WildMagic4/CMakeLists.txt
@@ -219,6 +219,6 @@ set(WildMagic4_SRCS
     Wm4Vector4.inl
 )
 
-add_library(WildMagic4 ${WildMagic4_SRCS})
+add_library(WildMagic4 STATIC ${WildMagic4_SRCS})
 target_include_directories(WildMagic4 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 set_target_properties(WildMagic4 PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Without an explicit qualifier, `-DBUILD_SHARED_LIBS=ON` could make it a shared lib, and would not be found at runtime because not in install tree.

Fixes up 0840a647 (#31090)

Fixes https://github.com/FreeCAD/FreeCAD/issues/31455

FYI @mr-miky @brettowe