### PR TITLE
CAM: Fix cam eval blacklist

### DIFF
--- a/src/Mod/CAM/Path/Preferences.py
+++ b/src/Mod/CAM/Path/Preferences.py
@@ -23,6 +23,7 @@
 
 import FreeCAD
 import Path
+import ast
 import glob
 import importlib.util
 import json
@@ -471,10 +472,22 @@ def setJobDefaults(jobTemplate, geometryTolerance, curveAccuracy):
 def postProcessorBlacklist():
     pref = preferences()
     blacklist = pref.GetString(PostProcessorBlacklist, "")
-    try:
-        return json.loads(blacklist)
-    except Exception:
+    if not blacklist:
         return []
+    try:
+        parsed = json.loads(blacklist)
+    except ValueError:
+        # Migrate the legacy format, which stored the list as a Python repr
+        # (for example "['GRBL', 'linuxcnc']") that json cannot parse. Use
+        # ast.literal_eval, which only evaluates literals and cannot execute
+        # arbitrary code, unlike the eval() that was previously used here.
+        try:
+            parsed = ast.literal_eval(blacklist)
+        except (ValueError, SyntaxError):
+            return []
+    if not isinstance(parsed, list):
+        return []
+    return [str(item) for item in parsed]
 
 
 def setPostProcessorDefaults(processor, args, blacklist):

--- a/src/Mod/CAM/Path/Preferences.py
+++ b/src/Mod/CAM/Path/Preferences.py
@@ -25,6 +25,7 @@ import FreeCAD
 import Path
 import glob
 import importlib.util
+import json
 import os
 import pathlib
 from collections import defaultdict
@@ -470,16 +471,17 @@ def setJobDefaults(jobTemplate, geometryTolerance, curveAccuracy):
 def postProcessorBlacklist():
     pref = preferences()
     blacklist = pref.GetString(PostProcessorBlacklist, "")
-    if not blacklist:
+    try:
+        return json.loads(blacklist)
+    except Exception:
         return []
-    return eval(blacklist)
 
 
 def setPostProcessorDefaults(processor, args, blacklist):
     pref = preferences()
     pref.SetString(PostProcessorDefault, processor)
     pref.SetString(PostProcessorDefaultArgs, args)
-    pref.SetString(PostProcessorBlacklist, "%s" % (blacklist))
+    pref.SetString(PostProcessorBlacklist, json.dumps(blacklist))
 
 
 def setOutputFileDefaults(fileName, policy):


### PR DESCRIPTION
Cherry-picks a security fix from @wwmayer's codeberg repo and adds a backwards-compatibility pathway so that existing blacklists aren't just reset.