### PR TITLE
STEP import: remove clutter "Show progress bar when importing" checkbox

### DIFF
--- a/src/Mod/Part/Gui/DlgImportStep.cpp
+++ b/src/Mod/Part/Gui/DlgImportStep.cpp
@@ -47,7 +47,6 @@ DlgImportStep::DlgImportStep(QWidget* parent)
     ui->checkBoxUseBaseName->setChecked(settings.getUseBaseName());
     ui->checkBoxReduceObjects->setChecked(settings.getReduceObjects());
     ui->checkBoxExpandCompound->setChecked(settings.getExpandCompound());
-    ui->checkBoxShowProgress->setChecked(settings.getShowProgress());
 #if OCC_VERSION_HEX >= 0x070800
     std::list<Part::OCAF::ImportExportSettings::CodePage> codepagelist;
     codepagelist = settings.getCodePageList();
@@ -78,7 +77,6 @@ void DlgImportStep::saveSettings()
     ui->checkBoxUseBaseName->onSave();
     ui->checkBoxReduceObjects->onSave();
     ui->checkBoxExpandCompound->onSave();
-    ui->checkBoxShowProgress->onSave();
     ui->comboBoxImportMode->onSave();
 }
 
@@ -94,7 +92,6 @@ void DlgImportStep::loadSettings()
     ui->checkBoxUseBaseName->onRestore();
     ui->checkBoxReduceObjects->onRestore();
     ui->checkBoxExpandCompound->onRestore();
-    ui->checkBoxShowProgress->onRestore();
     ui->comboBoxImportMode->onRestore();
 }
 
@@ -107,7 +104,6 @@ StepImportSettings DlgImportStep::getSettings() const
     set.useBaseName = settings.getUseBaseName();
     set.importHidden = settings.getImportHiddenObject();
     set.reduceObjects = settings.getReduceObjects();
-    set.showProgress = settings.getShowProgress();
     set.expandCompound = settings.getExpandCompound();
     set.mode = static_cast<int>(settings.getImportMode());
 #if OCC_VERSION_HEX >= 0x070800

--- a/src/Mod/Part/Gui/DlgImportStep.h
+++ b/src/Mod/Part/Gui/DlgImportStep.h
@@ -42,7 +42,8 @@ struct StepImportSettings
     bool useBaseName = true;
     bool importHidden = true;
     bool reduceObjects = false;
-    bool showProgress = false;
+    // Progress bar is always shown during import; no longer user-configurable (see #31162).
+    bool showProgress = true;
     bool expandCompound = false;
     int mode = 0;
     int codePage = -1;

--- a/src/Mod/Part/Gui/DlgImportStep.ui
+++ b/src/Mod/Part/Gui/DlgImportStep.ui
@@ -104,22 +104,6 @@
        </widget>
       </item>
       <item>
-       <widget class="Gui::PrefCheckBox" name="checkBoxShowProgress">
-        <property name="toolTip">
-         <string>Show progress bar when importing</string>
-        </property>
-        <property name="text">
-         <string>Show progress bar when importing</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ShowProgress</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Import</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="Gui::PrefCheckBox" name="checkBoxUseBaseName">
         <property name="toolTip">
          <string>Do not use instance names. Useful for some legacy STEP files with non-meaningful auto-generated instance names.</string>


### PR DESCRIPTION
## Summary

Closes #31162. Removes the "Show progress bar when importing" checkbox from the STEP import dialog — it doesn't change how objects are imported and isn't something a user would want to disable, per the issue and the community agreement in its comments ("Just remove the option and keep it enabled by default").

## What I found

The checkbox (`checkBoxShowProgress`, a `Gui::PrefCheckBox`, preference `ShowProgress` under `Mod/Import`) lives in `src/Mod/Part/Gui/DlgImportStep.ui`. That single `.ui` file is reused for both the pre-import options dialog (`TaskImportStep`) and the embedded page in Edit → Preferences → Part (`DlgSettingsGeneral.cpp`), so this change cleans up both.

The underlying `ShowProgress` preference genuinely gates real behavior — whether a `Part::ProgressIndicator`/`Base::SequencerLauncher` progress bar shows during STEP/IGES/glTF import and OCAF shape loading — and it's also read by the **headless, non-GUI** Python import path (`AppImportPy.cpp` → `ImportOCAFExt::customImportOptions()`). I intentionally left `ImportExportSettings` and the `ImportOCAF2` progress plumbing untouched — only the dialog's use of it changes.

## Changes (3 files)

- `DlgImportStep.ui`: removed the `checkBoxShowProgress` widget.
- `DlgImportStep.cpp`: removed the three `ui->checkBoxShowProgress->...` call sites (constructor, `onSave()`, `onRestore()`) and the corresponding line in `getSettings()`.
- `DlgImportStep.h`: changed `StepImportSettings::showProgress`'s default from `false` to `true`, so the interactive STEP-import path always shows the progress bar now — matching the accepted resolution in the issue thread — rather than silently flipping the default to `false` when the field was removed.

## How I tested this

I don't have a FreeCAD build environment set up, so I verified by:
- `xmllint --noout DlgImportStep.ui` — well-formed XML.
- `grep -rn "checkBoxShowProgress"` across `src/` — zero remaining references (won't fail to compile against the regenerated `Ui_DlgImportStep`).
- `grep -rn "ShowProgress"` across `src/` — confirmed only the intentionally-preserved shared preference/plumbing remains (`ImportExportSettings.{h,cpp}`, `ImportOCAF2.{h,cpp}`, `AppImportGuiPy.cpp`), now always receiving `true` from this dialog.
- Confirmed via `DlgSettingsGeneral.cpp` that the same dialog is reused for the Preferences page, so this addresses both entry points.

Given I couldn't compile, please treat this as needing a build-and-click-through check on review. Happy to adjust if CI or a maintainer spots something the grep-based review missed.

## Caveat

Users who'd previously unchecked this box keep their persisted `ShowProgress=false` preference (no UI to flip it back, though it remains editable via the raw parameter editor). Seemed like an acceptable, minor edge case given the issue's ask.