### PR TITLE
[Core (GUI)] Simplify pop-up notification tooltip text

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsNotificationArea.ui
+++ b/src/Gui/PreferencePages/DlgSettingsNotificationArea.ui
@@ -29,9 +29,7 @@
       <item row="2" column="0">
        <widget class="QGroupBox" name="NonIntrusiveNotificationsEnabled">
         <property name="toolTip">
-         <string>Enables non-intrusive pop-up notifications above the status bar notification area. Pop-up notifications can be manually dismissed by clicking on them, and also automatically dismissed by specifying a maximum and minimum duration for them to be displayed.
-
-Additionally, pop-up notifications can be disabled. In this case the user can still use the notification area as a quick-access location to view notifications, without the distracton of an additional pop-up.</string>
+         <string>Enables non-intrusive pop-up notifications above the notification area. Pop-up notifications can be dismissed manually by clicking on them, or automatically after a set duration.</string>
         </property>
         <property name="title">
          <string>Enable Pop-Up Notifications</string>


### PR DESCRIPTION
This changes the wording of the tooltip for the Enable Pop-Up Notifications checkbox, which was previously unfocused and longer than it needed to be. 
Changes were made following [FEP-0007](https://github.com/FreeCAD/FreeCAD-Enhancement-Proposals/tree/master/FEPs/FEP-0007-consistent-language).

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
Follows discussion on #31408 

## Before and After Images
Before:
<img width="1761" height="718" alt="image" src="https://github.com/user-attachments/assets/5853d2d2-b25d-4738-9bef-73cb8b854a7e" />

After:
<img width="1550" height="407" alt="image" src="https://github.com/user-attachments/assets/43ba5242-ddbf-4c9f-be7b-ce630e418f7d" />

Note: #31410 also touches this same line, adding <html> tags to trigger Qt rich-text auto wrapping. May need rebase/merge order coordination.