### PR TITLE
CI: Update LibPack used to 3.5.3

### DIFF
--- a/.github/workflows/actions/windows/getLibpack/action.yml
+++ b/.github/workflows/actions/windows/getLibpack/action.yml
@@ -41,11 +41,11 @@ inputs:
   libpackdownloadurl:
     description: "URL where to download libpack"
     required: false
-    default: https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/3.1.1.3/LibPack-1.1.0-v3.1.1.3-Release.7z
+    default: https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/3.5.3/LibPack-26.3.0-v3.5.3-x64-Release.7z
   libpackname:
     description: "Libpack name (once downloaded)"
     required: false
-    default: LibPack-1.1.0-v3.1.1.3-Release
+    default: LibPack-26.3.0-v3.5.3-x64-Release
 
 runs:
   using: "composite"


### PR DESCRIPTION
Update the version of the Windows LibPack used in the CI to 3.5.3.