### PR TITLE
Gui: Fix rubber-band selection rendering regression

### DIFF
--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -898,6 +898,7 @@ SET(View3D_CPP_SRCS
     Flag.cpp
     GLBuffer.cpp
     GLPainter.cpp
+    RubberbandOverlay.cpp
     Multisample.cpp
     MouseSelection.cpp
     SplitView3DInventor.cpp
@@ -917,6 +918,7 @@ SET(View3D_SRCS
     Camera.h
     Flag.h
     GLBuffer.h
+    RubberbandOverlay.h
     GLPainter.h
     Multisample.h
     MouseSelection.h

--- a/src/Gui/MouseSelection.cpp
+++ b/src/Gui/MouseSelection.cpp
@@ -20,7 +20,6 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QOpenGLFramebufferObject>
 #include <QPixmap>
 #include <QMenu>
 #include <Inventor/SbBox.h>
@@ -32,6 +31,7 @@
 #include <FCConfig.h>
 
 #include "MouseSelection.h"
+#include "RubberbandOverlay.h"
 #include "Selection/BoxSelection.h"
 #include "Selection/SelectionColors.h"
 #include "View3DInventorViewer.h"
@@ -562,24 +562,24 @@ int FreehandSelection::locationEvent(const SoLocation2Event* const e, const QPoi
 RubberbandSelection::RubberbandSelection()
 {
     const SbColor color = SelectionColors::defaultSelectionColor();
-    rubberband.setColor(color[0], color[1], color[2], 0.5);
+    rubberbandColor = QColor::fromRgbF(color[0], color[1], color[2], 0.5F);
 }
 
 RubberbandSelection::~RubberbandSelection() = default;
 
 void RubberbandSelection::setColor(float r, float g, float b, float a)
 {
-    rubberband.setColor(r, g, b, a);
+    rubberbandColor = QColor::fromRgbF(r, g, b, a);
+    if (_pcView3D) {
+        _pcView3D->rubberbandOverlay().setBorderColor(rubberbandColor);
+    }
 }
 
 void RubberbandSelection::initialize()
 {
-    rubberband.setViewer(_pcView3D);
-    rubberband.setWorking(false);
-    _pcView3D->addGraphicsItem(&rubberband);
-    if (QOpenGLFramebufferObject::hasOpenGLFramebufferObjects()) {
-        _pcView3D->setRenderType(View3DInventorViewer::Image);
-    }
+    auto& overlay = _pcView3D->rubberbandOverlay();
+    overlay.setBorderColor(rubberbandColor);
+    overlay.setVisible(false);
     _pcView3D->redraw();
 }
 
@@ -587,11 +587,30 @@ void RubberbandSelection::terminate(bool abort)
 {
     Q_UNUSED(abort)
 
-    _pcView3D->removeGraphicsItem(&rubberband);
-    if (QOpenGLFramebufferObject::hasOpenGLFramebufferObjects()) {
-        _pcView3D->setRenderType(View3DInventorViewer::Native);
+    if (_pcView3D) {
+        _pcView3D->rubberbandOverlay().setVisible(false);
+        _pcView3D->redraw();
     }
-    _pcView3D->redraw();
+}
+
+void RubberbandSelection::updateOverlayPosition()
+{
+    if (!_pcView3D) {
+        return;
+    }
+
+    const qreal dpr = _pcView3D->devicePixelRatio();
+    const qreal scale = dpr > 0.0 ? dpr : 1.0;
+    _pcView3D->rubberbandOverlay().setRectangle(
+        QRectF(QPointF(m_iXold / scale, m_iYold / scale), QPointF(m_iXnew / scale, m_iYnew / scale))
+    );
+}
+
+void RubberbandSelection::setOverlayVisible(bool visible)
+{
+    if (_pcView3D) {
+        _pcView3D->rubberbandOverlay().setVisible(visible);
+    }
 }
 
 void RubberbandSelection::draw()
@@ -609,9 +628,10 @@ int RubberbandSelection::mouseButtonEvent(const SoMouseButtonEvent* const e, con
     if (press) {
         switch (button) {
             case SoMouseButtonEvent::BUTTON1: {
-                rubberband.setWorking(true);
                 m_iXold = m_iXnew = pos.x();
                 m_iYold = m_iYnew = pos.y();
+                setOverlayVisible(true);
+                updateOverlayPosition();
             } break;
 
             default: {
@@ -621,7 +641,7 @@ int RubberbandSelection::mouseButtonEvent(const SoMouseButtonEvent* const e, con
     else {
         switch (button) {
             case SoMouseButtonEvent::BUTTON1: {
-                rubberband.setWorking(false);
+                setOverlayVisible(false);
                 releaseMouseModel();
                 _clPoly.push_back(e->getPosition());
                 ret = Finish;
@@ -639,7 +659,7 @@ int RubberbandSelection::locationEvent(const SoLocation2Event* const, const QPoi
 {
     m_iXnew = pos.x();
     m_iYnew = pos.y();
-    rubberband.setCoords(m_iXold, m_iYold, m_iXnew, m_iYnew);
+    updateOverlayPosition();
     draw();
     return Continue;
 }
@@ -654,7 +674,7 @@ int RubberbandSelection::keyboardEvent(const SoKeyboardEvent* const)
 RectangleSelection::RectangleSelection()
     : RubberbandSelection()
 {
-    rubberband.setColor(0.0, 0.0, 1.0, 1.0);
+    rubberbandColor = QColor(0, 0, 255);
 }
 
 RectangleSelection::~RectangleSelection() = default;
@@ -706,14 +726,14 @@ void BoxSelectSelection::initialize()
     selectionEnabled = _pcView3D->isSelectionEnabled();
     _pcView3D->setSelectionEnabled(false);
 
-    rubberband.setWorking(true);
     const QPoint start = toWidgetPoint(startPosition);
     const QPoint current = toWidgetPoint(currentPosition);
     m_iXold = start.x();
     m_iYold = start.y();
     m_iXnew = current.x();
     m_iYnew = current.y();
-    rubberband.setCoords(m_iXold, m_iYold, m_iXnew, m_iYnew);
+    setOverlayVisible(true);
+    updateOverlayPosition();
     draw();
 }
 
@@ -739,7 +759,7 @@ int BoxSelectSelection::mouseButtonEvent(const SoMouseButtonEvent* const e, cons
     _clPoly.clear();
     _clPoly.push_back(startPosition);
     _clPoly.push_back(currentPosition);
-    rubberband.setWorking(false);
+    setOverlayVisible(false);
     releaseMouseModel();
     return FinishAndConsume;
 }
@@ -750,7 +770,7 @@ int BoxSelectSelection::locationEvent(const SoLocation2Event* const e, const QPo
     currentPosition = e->getPosition();
     m_iXnew = pos.x();
     m_iYnew = pos.y();
-    rubberband.setCoords(m_iXold, m_iYold, m_iXnew, m_iYnew);
+    updateOverlayPosition();
     draw();
     return Continue;
 }
@@ -758,7 +778,7 @@ int BoxSelectSelection::locationEvent(const SoLocation2Event* const e, const QPo
 int BoxSelectSelection::keyboardEvent(const SoKeyboardEvent* const e)
 {
     if (e->getKey() == SoKeyboardEvent::ESCAPE && e->getState() == SoButtonEvent::UP) {
-        rubberband.setWorking(false);
+        setOverlayVisible(false);
         releaseMouseModel(true);
         return Cancel;
     }

--- a/src/Gui/MouseSelection.h
+++ b/src/Gui/MouseSelection.h
@@ -24,6 +24,8 @@
 
 #include <bitset>
 #include <vector>
+
+#include <QColor>
 #include <QCursor>
 #include <Gui/GLPainter.h>
 #include <Gui/Namespace.h>
@@ -237,7 +239,10 @@ protected:
     void draw() override;
 
 protected:
-    Gui::Rubberband rubberband;
+    QColor rubberbandColor;
+
+    void updateOverlayPosition();
+    void setOverlayVisible(bool visible);
 };
 
 // -----------------------------------------------------------------------------------

--- a/src/Gui/RubberbandOverlay.cpp
+++ b/src/Gui/RubberbandOverlay.cpp
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 FreeCAD contributors
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                     *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "RubberbandOverlay.h"
+
+#include <algorithm>
+
+#include <Inventor/SbViewportRegion.h>
+
+#include <Inventor/nodes/SoDrawStyle.h>
+#include <Inventor/nodes/SoFaceSet.h>
+#include <Inventor/nodes/SoLineSet.h>
+#include <Inventor/nodes/SoMaterial.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoSwitch.h>
+#include <Inventor/nodes/SoVertexProperty.h>
+
+#include "Inventor/SoFCScreenSpaceGroup.h"
+
+namespace Gui
+{
+
+void RubberbandOverlay::setMaterialColor(SoMaterial* material, const QColor& color)
+{
+    material->diffuseColor.setValue(
+        static_cast<float>(color.redF()),
+        static_cast<float>(color.greenF()),
+        static_cast<float>(color.blueF())
+    );
+    material->transparency.setValue(1.0F - static_cast<float>(color.alphaF()));
+}
+
+void RubberbandOverlay::updateGeometry(const QRectF& viewportRect, qreal scale)
+{
+    const QRectF logical = logicalRectangle.normalized();
+    const float width = static_cast<float>(viewportRect.width());
+    const float height = static_cast<float>(viewportRect.height());
+
+    const float left = std::clamp(static_cast<float>(logical.left() * scale), 0.0F, width);
+    const float right = std::clamp(static_cast<float>(logical.right() * scale), 0.0F, width);
+    const float top = std::clamp(static_cast<float>(logical.top() * scale), 0.0F, height);
+    const float bottom = std::clamp(static_cast<float>(logical.bottom() * scale), 0.0F, height);
+    const float lower = height - bottom;
+    const float upper = height - top;
+
+    fillVertices->vertex.set1Value(0, SbVec3f(left, lower, 0.0F));
+    fillVertices->vertex.set1Value(1, SbVec3f(left, upper, 0.0F));
+    fillVertices->vertex.set1Value(2, SbVec3f(right, upper, 0.0F));
+    fillVertices->vertex.set1Value(3, SbVec3f(right, lower, 0.0F));
+
+    borderVertices->vertex.set1Value(0, SbVec3f(left, lower, 0.0F));
+    borderVertices->vertex.set1Value(1, SbVec3f(left, upper, 0.0F));
+    borderVertices->vertex.set1Value(2, SbVec3f(right, upper, 0.0F));
+    borderVertices->vertex.set1Value(3, SbVec3f(right, lower, 0.0F));
+    borderVertices->vertex.set1Value(4, SbVec3f(left, lower, 0.0F));
+}
+
+RubberbandOverlay::RubberbandOverlay()
+{
+    root = new Inventor::SoFCScreenSpaceGroup;
+    root->ref();
+    root->setCoordinateSpace(Inventor::SoFCScreenSpaceGroup::CoordinateSpace::ViewportPixels);
+    root->setBaseColorLightModel(true);
+    root->setTexturesEnabled(false);
+    root->setMultiTexturesEnabled(false);
+    root->setDepthBuffer(false, false);
+
+    visibilitySwitch = new SoSwitch;
+    visibilitySwitch->whichChild = SO_SWITCH_NONE;
+
+    auto* fill = new SoSeparator;
+    fillMaterial = new SoMaterial;
+    fillVertices = new SoVertexProperty;
+    auto* fillFaces = new SoFaceSet;
+    fillFaces->vertexProperty.setValue(fillVertices);
+    fillFaces->numVertices.setValue(4);
+    fill->addChild(fillMaterial);
+    fill->addChild(fillFaces);
+    visibilitySwitch->addChild(fill);
+
+    auto* border = new SoSeparator;
+    borderMaterial = new SoMaterial;
+    borderStyle = new SoDrawStyle;
+    borderVertices = new SoVertexProperty;
+    auto* borderLines = new SoLineSet;
+    borderLines->vertexProperty.setValue(borderVertices);
+    borderLines->numVertices.setValue(5);
+    border->addChild(borderMaterial);
+    border->addChild(borderStyle);
+    border->addChild(borderLines);
+    visibilitySwitch->addChild(border);
+
+    setMaterialColor(fillMaterial, QColor(255, 255, 255, 128));
+    setMaterialColor(borderMaterial, Qt::white);
+    borderStyle->lineWidth.setValue(4.0F);
+    borderStyle->linePatternScaleFactor.setValue(3);
+    borderStyle->linePattern.setValue(0xAAAA);
+    root->addChild(visibilitySwitch);
+}
+
+RubberbandOverlay::~RubberbandOverlay()
+{
+    root->unref();
+}
+
+void RubberbandOverlay::setRectangle(const QRectF& rectangle)
+{
+    logicalRectangle = rectangle;
+}
+
+void RubberbandOverlay::setBorderColor(const QColor& color)
+{
+    setMaterialColor(borderMaterial, color);
+}
+
+void RubberbandOverlay::setVisible(bool visible)
+{
+    visibilitySwitch->whichChild = visible ? SO_SWITCH_ALL : SO_SWITCH_NONE;
+}
+
+void RubberbandOverlay::prepareGeometry(const SbViewportRegion& viewport, qreal devicePixelRatio)
+{
+    if (devicePixelRatio <= 0.0) {
+        return;
+    }
+
+    const SbVec2s size = viewport.getViewportSizePixels();
+    if (size[0] <= 0 || size[1] <= 0) {
+        return;
+    }
+
+    const QRectF viewportRect(0.0, 0.0, size[0], size[1]);
+    updateGeometry(viewportRect, devicePixelRatio);
+}
+
+SoNode* RubberbandOverlay::sceneRoot() const
+{
+    return root;
+}
+
+}  // namespace Gui

--- a/src/Gui/RubberbandOverlay.h
+++ b/src/Gui/RubberbandOverlay.h
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 FreeCAD contributors
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                     *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+#include <QColor>
+#include <QRectF>
+
+class SbViewportRegion;
+class SoDrawStyle;
+class SoMaterial;
+class SoNode;
+class SoSwitch;
+class SoVertexProperty;
+
+namespace Gui
+{
+
+namespace Inventor
+{
+class SoFCScreenSpaceGroup;
+}
+
+/**
+ * Retained rubber-band overlay owned by a 3D viewer.
+ *
+ * Rectangle geometry is stored in logical widget coordinates. The viewer
+ * prepares it for the current physical viewport and owns traversal of the
+ * retained scene root.
+ */
+class RubberbandOverlay
+{
+public:
+    explicit RubberbandOverlay();
+    ~RubberbandOverlay();
+
+    RubberbandOverlay(const RubberbandOverlay&) = delete;
+    RubberbandOverlay& operator=(const RubberbandOverlay&) = delete;
+
+    /** Store the rectangle in logical widget coordinates. */
+    void setRectangle(const QRectF& rectangle);
+
+    /** Set the retained rubber-band border color. */
+    void setBorderColor(const QColor& color);
+
+    /** Show or hide the retained rubber-band rectangle. */
+    void setVisible(bool visible);
+
+    /**
+     * Convert retained geometry to the supplied physical viewport.
+     *
+     * This prepares the scene root for traversal but does not render it.
+     */
+    void prepareGeometry(const SbViewportRegion& viewport, qreal devicePixelRatio);
+
+    /** Return the retained scene root owned by this overlay. */
+    SoNode* sceneRoot() const;
+
+private:
+    void updateGeometry(const QRectF& viewportRect, qreal scale);
+    static void setMaterialColor(SoMaterial* material, const QColor& color);
+
+    QRectF logicalRectangle;
+    Inventor::SoFCScreenSpaceGroup* root {nullptr};
+    SoSwitch* visibilitySwitch {nullptr};
+    SoMaterial* fillMaterial {nullptr};
+    SoMaterial* borderMaterial {nullptr};
+    SoDrawStyle* borderStyle {nullptr};
+    SoVertexProperty* fillVertices {nullptr};
+    SoVertexProperty* borderVertices {nullptr};
+};
+
+}  // namespace Gui

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -128,6 +128,7 @@
 #include "Command.h"
 #include "Document.h"
 #include "GLPainter.h"
+#include "RubberbandOverlay.h"
 #include "Inventor/SoAxisCrossKit.h"
 #include "Inventor/SoFCBackgroundGradient.h"
 #include "Inventor/SoFCBoundingBox.h"
@@ -1137,6 +1138,8 @@ void View3DInventorViewer::init()
     this->decorationroot->addChild(decorationBaseColor);
     this->decorationroot->addChild(naviCubeAnnotation);
 
+    rubberbandOverlayRenderer = std::unique_ptr<RubberbandOverlay>(new RubberbandOverlay);
+
     auto threePointLightingSeparator = new SoTransformSeparator;
     threePointLightingSeparator->addChild(lightRotation);
     threePointLightingSeparator->addChild(this->fillLight);
@@ -1320,6 +1323,8 @@ void View3DInventorViewer::init()
 
 View3DInventorViewer::~View3DInventorViewer()
 {
+    rubberbandOverlayRenderer.reset();
+
     // to prevent following OpenGL error message: "Texture is not valid in the current context.
     // Texture has not been destroyed"
     aboutToDestroyGLContext();
@@ -2890,6 +2895,11 @@ void View3DInventorViewer::clearGraphicsItems()
     this->graphicsItems.clear();
 }
 
+RubberbandOverlay& View3DInventorViewer::rubberbandOverlay()
+{
+    return *rubberbandOverlayRenderer;
+}
+
 int View3DInventorViewer::getNumSamples()
 {
     Gui::AntiAliasing msaa = Multisample::readMSAAFromSettings();
@@ -3400,6 +3410,7 @@ void View3DInventorViewer::renderScene()
         }
     }
 
+    renderRubberbandOverlay();
     // Workaround for inconsistent QT behavior related to handling custom OpenGL widgets that
     // leave non opaque alpha values in final output.
     // On wayland that can cause window to become transparent or blurry trail effect in the
@@ -3425,6 +3436,23 @@ void View3DInventorViewer::renderScene()
 
     glColorMask(colorMask[0], colorMask[1], colorMask[2], colorMask[3]);
     glClearColor(clearColor[0], clearColor[1], clearColor[2], clearColor[3]);
+}
+
+void View3DInventorViewer::renderRubberbandOverlay()
+{
+    if (currentRenderIntent() != RenderIntent::LiveInteractive || !rubberbandOverlayRenderer) {
+        return;
+    }
+
+    auto* manager = getSoRenderManager();
+    auto* action = manager ? manager->getGLRenderAction() : nullptr;
+    if (!action) {
+        return;
+    }
+
+    ZoneScopedN("Rubberband overlay");
+    rubberbandOverlayRenderer->prepareGeometry(manager->getViewportRegion(), devicePixelRatio());
+    action->apply(rubberbandOverlayRenderer->sceneRoot());
 }
 
 void View3DInventorViewer::setSeekMode(bool on)

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -106,6 +106,7 @@ class NavigationStyle;
 class SoFCUnifiedSelection;
 class Document;
 class GLGraphicsItem;
+class RubberbandOverlay;
 class SoShapeScale;
 class ViewerEventFilter;
 
@@ -258,6 +259,8 @@ public:
     std::list<GLGraphicsItem*> getGraphicsItems() const;
     std::list<GLGraphicsItem*> getGraphicsItemsOfType(const Base::Type&) const;
     void clearGraphicsItems();
+
+    RubberbandOverlay& rubberbandOverlay();
 
     /** @name Handling of view providers */
     //@{
@@ -591,6 +594,7 @@ Q_SIGNALS:
 protected:
     static GLenum getInternalTextureFormat();
     void renderScene();
+    void renderRubberbandOverlay();
     void renderFramebuffer();
     void renderGLImage();
     void animatedViewAll(const SbBox3f& bbox, int steps, int ms);
@@ -648,6 +652,7 @@ private:
     std::set<ViewProvider*> _ViewProviderSet;
     std::map<SoSeparator*, ViewProvider*> _ViewProviderMap;
     std::list<GLGraphicsItem*> graphicsItems;
+    std::unique_ptr<RubberbandOverlay> rubberbandOverlayRenderer;
     ViewProvider* editViewProvider;
     SoFCBackgroundGradient* pcBackGround;
     SoSeparator* backgroundroot;


### PR DESCRIPTION
Fixes #31495

## Summary

Replace the legacy image-based rubber-band rendering path with a viewer-owned retained rubber-band overlay.

Rubber-band selection now keeps the normal 3D scene and decorations rendering throughout the drag instead of switching the viewer to `RenderType::Image` and capturing the framebuffer.

## Problem

The previous rubber-band implementation captured the OpenGL framebuffer and displayed that image while the user dragged the selection rectangle.

That path could behave inconsistently across supported platforms and result in:

* The 3D geometry disappearing during selection.
* The NaviCube disappearing.
* A background-only viewport.
* Stale rubber-band pixels after repainting or resizing.
* Re-entrant rendering through `QOpenGLWidget::grabFramebuffer()`.

## Implementation

* Added a viewer-owned `RubberbandOverlay`.
* Build and retain the rubber-band Coin scene graph once.
* Store rectangle geometry in logical widget coordinates.
* Convert the rectangle to physical viewport coordinates using the current device-pixel ratio before rendering.
* Render the rectangle with `SoFCScreenSpaceGroup` in viewport-pixel space.
* Update retained vertex data during mouse movement instead of rebuilding temporary Coin scene graphs.
* Keep render-manager access and `SoGLRenderAction` traversal in `View3DInventorViewer`.
* Render the overlay only for `RenderIntent::LiveInteractive`.
* Remove framebuffer capture and `RenderType::Image` switching from rubber-band selection.
* Keep selection input handling and geometric selection behaviour unchanged.

The retained overlay is shared by the existing rubber-band interactions:

* Rectangle selection.
* Box zoom.
* Delayed drag-box selection.

## Visual behaviour

The new overlay preserves the previous rubber-band appearance:

* Translucent white fill.
* Configurable selection-colour border.
* Four-pixel line width.
* Stippled border pattern.

