### PR TITLE
CAM: fix postprocessor override priority

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPostCore.py
+++ b/src/Mod/CAM/CAMTests/TestPostCore.py
@@ -1187,3 +1187,55 @@ class TestJobPropertyOverrides(unittest.TestCase):
 
         finally:
             os.unlink(template_path)
+
+    def test_job_property_overrides_beat_merge_machine_config(self):
+        """
+        Regression test: job-level overrides must win even for properties
+        that _merge_machine_config() also sets directly from the live
+        machine model (e.g. f_for_rapid_moves, tool_change).
+
+        Before the fix, apply_configuration_bundle() only synced a bundle
+        key into self.values if _merge_machine_config() hadn't already set
+        it. Since _merge_machine_config() unconditionally sets these two
+        keys from machine.processing, a job override for either was
+        silently discarded in favor of the machine-level value.
+
+        Expected:
+            - self.values reflects the override, not the machine default.
+              (The other tests in this class check the internal bundle
+              dict, i.e. machine.postprocessor_properties; this checks the
+              actual self.values consumers read from, which is where the
+              bug lived.)
+        """
+        from Path.Post.Processor import PostProcessor
+        from Machine.models.machine import MachineFactory
+
+        self.job.PostProcessorPropertyOverrides = "{}"
+
+        machine = self._create_test_machine()
+        # Machine-level config: opposite of what we will override to.
+        machine.processing.f_for_rapid_moves = True
+        machine.processing.tool_change = True
+
+        original_get_machine = MachineFactory.get_machine
+        MachineFactory.get_machine = lambda name: machine
+
+        try:
+            self.job.PostProcessorPropertyOverrides = (
+                '{"f_for_rapid_moves": false, "tool_change": false}'
+            )
+            processor = PostProcessor(self.job, "", "", "mm")
+            processor._machine = machine
+            processor.export2()
+
+            self.assertFalse(
+                processor.values["F_FOR_RAPID_MOVES"],
+                "job override of f_for_rapid_moves must win over machine.processing",
+            )
+            self.assertFalse(
+                processor.values["TOOL_CHANGE"],
+                "job override of tool_change must win over machine.processing",
+            )
+
+        finally:
+            MachineFactory.get_machine = original_get_machine

--- a/src/Mod/CAM/CAMTests/TestPostCore.py
+++ b/src/Mod/CAM/CAMTests/TestPostCore.py
@@ -1193,19 +1193,6 @@ class TestJobPropertyOverrides(unittest.TestCase):
         Regression test: job-level overrides must win even for properties
         that _merge_machine_config() also sets directly from the live
         machine model (e.g. f_for_rapid_moves, tool_change).
-
-        Before the fix, apply_configuration_bundle() only synced a bundle
-        key into self.values if _merge_machine_config() hadn't already set
-        it. Since _merge_machine_config() unconditionally sets these two
-        keys from machine.processing, a job override for either was
-        silently discarded in favor of the machine-level value.
-
-        Expected:
-            - self.values reflects the override, not the machine default.
-              (The other tests in this class check the internal bundle
-              dict, i.e. machine.postprocessor_properties; this checks the
-              actual self.values consumers read from, which is where the
-              bug lived.)
         """
         from Path.Post.Processor import PostProcessor
         from Machine.models.machine import MachineFactory

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -950,6 +950,9 @@ class PostProcessor:
         """
         self.values = {}
 
+        if overrides is None:
+            overrides = self._read_job_overrides()
+
         bundle = self.build_configuration_bundle(overrides)
 
         # Write back to machine postprocessor_properties
@@ -963,6 +966,15 @@ class PostProcessor:
         # IF they weren't already set (by _merge_machine_config)
         for key, value in bundle.items():
             if key.upper() not in self.values:
+                self.values[key.upper()] = value
+
+        # Explicit overrides (job dialog / caller-supplied) are documented as
+        # highest priority, so they must win even over values already set by
+        # _merge_machine_config() straight from the live machine model —
+        # otherwise a per-job override of e.g. f_for_rapid_moves/tool_change
+        # is silently discarded in favor of the machine-level setting.
+        for key, value in overrides.items():
+            if key in bundle:
                 self.values[key.upper()] = value
 
         Path.Log.debug(f"Configuration bundle applied — " f"bundle: {bundle}")


### PR DESCRIPTION
**AI assistance disclosure:** This branch was developed with assistance from Claude (Anthropic), including investigation, the code fix, and the regression test. I have reviewed and tested it myself.

**Licensing:** This contribution is offered under LGPL-2.1-or-later, matching the existing SPDX-License-Identifier header on the modified files (`Processor.py`, `TestPostCore.py`). No third-party or non-compatible code is included.

## Observed bug
Post Process dialog / per-job postprocessor property overrides silently had no effect for some settings. A user could open the Post Process dialog (or set `Job.PostProcessorPropertyOverrides` directly), change a setting like "Output F parameter for G0 (rapid)" or "Tool Change" away from what the assigned Machine has configured, generate G-code, and the machine-level value would be used instead — with no error or warning that the override was ignored. For example, generated G-code kept including `F0.000` on rapid (`G0`) moves and `(Tool change suppressed: M6 T12)` comments even after the user explicitly configured the opposite in the dialog/job override.

## Root cause
`apply_configuration_bundle()` synced bundle keys into `self.values` only when not already set, but `_merge_machine_config()` unconditionally sets several of those same keys (e.g. `f_for_rapid_moves`, `tool_change`) straight from the live machine model, before that sync ever runs. So any override for one of those specific keys was discarded in favor of the machine-level value, even though overrides are documented as highest priority (`build_configuration_bundle()`'s own docstring: "Stage 4 — caller / dialog overrides (highest priority)").

## Fix
Explicit overrides (job-level or caller-supplied) are now applied last, after `_merge_machine_config()`, so they always win — while bundle values that aren't explicit overrides still respect the live machine-model read, avoiding stale-cache issues for code that mutates the `Machine` object directly.

## Test plan
- [x] Reproduced against real `Job`/`Machine` objects (not mocks) before fixing, confirmed fixed after
- [x] Added `test_job_property_overrides_beat_merge_machine_config` (`TestPostCore.py`) — verified it fails against the pre-fix code and passes with the fix
- [x] Ran the full CAM post-processor test sweep locally — no regressions
- [x] Both commits verified to compile/import cleanly on their own
- [x] Code style: `black`, trailing-whitespace, end-of-file-fixer, mixed-line-ending pre-commit hooks all pass on the changed files
- [x] Only tested on Windows locally — CI will cover Ubuntu automatically; Windows/macOS/Pixi builds run once labeled

A second, related fix (TOOL_RETURN firing after every tool change instead of once) found in the same investigation will follow as a separate PR based on this one, once this is reviewed.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.