### PR TITLE
CAM: fix rigid tap feed rate ignoring spindle speed

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathTapGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathTapGenerator.py
@@ -132,3 +132,40 @@ class TestPathTapGenerator(PathTestUtils.PathTestBase):
         self.assertRaises(ValueError, generator.generate, **args)
         args = {"edge": e, "retractheight": "1"}
         self.assertRaises(ValueError, generator.generate, **args)
+
+    def test50_rigid_tap_feed_locked_to_pitch_and_speed(self):
+        """G84 feed rate must be pitch * spindle_speed (mm/s), not pitch alone.
+
+        Regression test: F was previously set to the raw pitch value with
+        spindle_speed unused, silently ignoring the RPM entirely. Rigid tap
+        feed must stay mechanically locked to spindle speed: mm/min =
+        pitch(mm) * RPM. Values below match a real 10-32 tap (0.79248mm
+        pitch) at 128 RPM.
+        """
+        v1 = FreeCAD.Vector(0, 0, 10)
+        v2 = FreeCAD.Vector(0, 0, 0)
+        e = Part.makeLine(v1, v2)
+
+        pitch = 0.79248
+        spindle_speed = 128.0
+
+        result = generator.generate(e, pitch=pitch, spindle_speed=spindle_speed)
+        command = result[0]
+
+        expected_f = pitch * spindle_speed / 60.0
+        self.assertAlmostEqual(command.Parameters["F"], expected_f, places=6)
+        # F must not equal the raw pitch alone (the previous, buggy behavior)
+        self.assertNotAlmostEqual(command.Parameters["F"], pitch, places=3)
+        self.assertEqual(command.Parameters["S"], spindle_speed)
+
+    def test51_rigid_tap_feed_sanity_default_without_pitch_or_speed(self):
+        """Without pitch/spindle_speed, F should fall back to the sanity default."""
+        v1 = FreeCAD.Vector(0, 0, 10)
+        v2 = FreeCAD.Vector(0, 0, 0)
+        e = Part.makeLine(v1, v2)
+
+        result = generator.generate(e)
+        self.assertEqual(result[0].Parameters["F"], 100.0)
+
+        result = generator.generate(e, pitch=0.79248)
+        self.assertEqual(result[0].Parameters["F"], 100.0)

--- a/src/Mod/CAM/Path/Base/Generator/tapping.py
+++ b/src/Mod/CAM/Path/Base/Generator/tapping.py
@@ -100,7 +100,13 @@ def generate(
     cmdParams["Z"] = endPoint.z
     cmdParams["R"] = retractheight if retractheight is not None else startPoint.z
     cmdParams["S"] = spindle_speed if spindle_speed is not None else 1.0  # Sanity default
-    cmdParams["F"] = float(pitch) if pitch is not None else 100.0  # Sanity default
+    # Rigid tap feed must stay locked to spindle speed: mm/min = pitch(mm) * RPM.
+    # Divide by 60 for mm/s, matching the convention ToolController feed
+    # properties (and the rest of the post-processing pipeline) use.
+    if pitch is not None and spindle_speed:
+        cmdParams["F"] = float(pitch) * float(spindle_speed) / 60.0
+    else:
+        cmdParams["F"] = 100.0  # Sanity default
 
     if repeat < 1:
         raise ValueError("repeat must be 1 or greater")


### PR DESCRIPTION
**AI assistance disclosure:** This branch was developed with assistance from Claude (Anthropic), including investigation, the code fix, and the regression test. I have reviewed and tested it myself.

**Licensing:** This contribution is offered under LGPL-2.1-or-later, matching the existing SPDX-License-Identifier header on the modified files (`tapping.py`, `TestPathTapGenerator.py`). No third-party or non-compatible code is included.

## Observed bug
Rigid tapping (G84) feed rate was always wrong, and setting the Tool Controller's Vert Feed had no effect on it at all. For a 10-32 tap (0.79248mm pitch) running at S128, the expected pitch-locked feed rate is ~4.0 in/min, but the generated G-code always showed `F1.872`:
```
G84 X0.000 Y0.000 Z-0.500 F1.872 S128.0 R0.100 P0.010
```

## Root cause
`Path/Base/Generator/tapping.py`'s `generate()` sets `cmdParams["F"] = float(pitch)` — the raw tool pitch alone. `spindle_speed` is passed into the function and correctly used for the `S` parameter two lines above, but is never used for `F`. Rigid tap feed must stay mechanically locked to spindle speed (`mm/min = pitch(mm) * RPM`); using pitch alone made every G84 feed rate wrong by roughly a factor of RPM/60, and there was no way to correct it from the UI since the Tool Controller's feed settings are never consulted for tapping.

## Fix
`F` is now computed as `pitch * spindle_speed / 60` (mm/s, matching the convention the rest of the post-processing pipeline uses for feed rates — confirmed against the drilling operation's `G83` line in the same file, which correctly applies this same mm/s convention via `ToolController.VertFeed`).

## Test plan
- [x] Verified against a real `.FCStd` job (10-32 tap, 0.79248mm pitch, S128): `F` went from `1.872` to `3.994`, matching the pitch-locked ideal of ~4.0
- [x] Added `test50_rigid_tap_feed_locked_to_pitch_and_speed` and `test51_rigid_tap_feed_sanity_default_without_pitch_or_speed` (`TestPathTapGenerator.py`) — verified they fail against the pre-fix code and pass with the fix
- [x] Ran the Drilling/Tapping/CAM post-processor test sweep — no regressions
- [x] Both commits verified to compile/import cleanly on their own
- [x] Code style: `black`, trailing-whitespace, end-of-file-fixer, mixed-line-ending pre-commit hooks all pass on the changed files
- [ ] Only tested on Windows locally — CI will cover Ubuntu automatically; Windows/macOS/Pixi builds run once labeled

- [ ] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.