### PR TITLE
Build: Add experimental LibPack-based Windows builds, including ARM

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -288,3 +288,38 @@ jobs:
       #   run: |
       #     security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
       #     rm ~/Library/MobileDevice/Provisioning\ Profiles/build_pp.mobileprovision
+
+  # Experimental Windows binaries built against the latest LibPack (OCCT 8, Qt 6, Python from the
+  # LibPack) for both Intel (x64) and ARM64. These are uploaded to the same release as the primary
+  # conda-based build, distinguished by an "experimental" file name. This path is non-blocking (the
+  # reusable workflow's Build job uses continue-on-error), so a failure here never fails the release.
+  windows_experimental:
+    needs: upload_src
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: windows-2022
+            cmakeArchitecture: ""
+            makeInstaller: "true"
+            libpackDownloadUrl: https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/3.5.3/LibPack-26.3.0-v3.5.3-x64-Release.7z
+            libpackName: LibPack-26.3.0-v3.5.3-x64-Release
+          - arch: arm64
+            runner: windows-11-arm
+            cmakeArchitecture: ARM64
+            makeInstaller: "false"
+            libpackDownloadUrl: https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/3.5.3/LibPack-26.3.0-v3.5.3-ARM64-Release.7z
+            libpackName: LibPack-26.3.0-v3.5.3-ARM64-Release
+    uses: ./.github/workflows/sub_releaseWindowsLibpack.yml
+    with:
+      build_tag: ${{ needs.upload_src.outputs.build_tag }}
+      arch: ${{ matrix.arch }}
+      runner: ${{ matrix.runner }}
+      cmakeArchitecture: ${{ matrix.cmakeArchitecture }}
+      libpackDownloadUrl: ${{ matrix.libpackDownloadUrl }}
+      libpackName: ${{ matrix.libpackName }}
+      makeInstaller: ${{ matrix.makeInstaller }}
+    secrets: inherit

--- a/.github/workflows/sub_releaseWindowsLibpack.yml
+++ b/.github/workflows/sub_releaseWindowsLibpack.yml
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 The FreeCAD project association AISBL
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+# Experimental Windows release build using the FreeCAD LibPack (OCCT 8, Qt 6, Python from LibPack).
+# This produces experimental portable and (x64 only) installer artifacts and uploads them to an
+# existing release. It runs alongside the primary conda-based release build and is non-blocking:
+# a failure here must never fail the release, so the Build job uses continue-on-error.
+
+name: Release Windows (LibPack, experimental)
+on:
+  workflow_call:
+    inputs:
+      build_tag:
+        description: "Release tag to attach the experimental artifacts to"
+        required: true
+        type: string
+      arch:
+        description: "Target architecture name used in artifact file names (x86_64 or arm64)"
+        required: true
+        type: string
+      runner:
+        description: "Runner label to build on"
+        required: false
+        type: string
+        default: "windows-2022"
+      cmakeArchitecture:
+        description: "Value for cmake -A (empty for x64, ARM64 for arm)"
+        required: false
+        type: string
+        default: ""
+      libpackDownloadUrl:
+        required: false
+        type: string
+        default: "https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/3.5.3/LibPack-26.3.0-v3.5.3-x64-Release.7z"
+      libpackName:
+        required: false
+        type: string
+        default: "LibPack-26.3.0-v3.5.3-x64-Release"
+      makeInstaller:
+        description: "Whether to also build the NSIS installer (x64 only for now)"
+        required: false
+        type: string
+        default: "false"
+
+permissions:
+  contents: read
+
+jobs:
+  Build:
+    runs-on: ${{ inputs.runner }}
+    # Experimental platform: never block the release on a failure here.
+    continue-on-error: true
+    permissions:
+      contents: write
+    environment: weekly-build
+    env:
+      builddir: C:/FC/build/release/
+      stagingdir: C:/FC/install/
+      libpackdir: C:/FC/libpack/
+      config: release
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checking out source code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          fetch-tags: true
+          # Coin/Pivy are built from FreeCAD's own submodules (no longer supplied by the LibPack).
+          submodules: 'recursive'
+
+      - name: Make needed directories
+        run: |
+          mkdir ${{ env.libpackdir }}
+          mkdir ${{ env.builddir }}
+
+      - name: Get Libpack
+        uses: ./.github/workflows/actions/windows/getLibpack
+        with:
+          libpackdir: ${{ env.libpackdir }}
+          libpackdownloadurl: ${{ inputs.libpackDownloadUrl }}
+          libpackname: ${{ inputs.libpackName }}
+
+      - name: Install cmake
+        uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
+        with:
+          cmake-version: '3.31.6'
+
+      - name: Configuring CMake
+        run: >
+          cmake -B"${{ env.builddir }}" .
+          --preset ${{ env.config }}
+          ${{ inputs.cmakeArchitecture != '' && format('-A {0}', inputs.cmakeArchitecture) || '' }}
+          -DCMAKE_VS_NO_COMPILE_BATCHING=ON
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_INSTALL_PREFIX="${{ env.stagingdir }}"
+          -DFREECAD_USE_PCH=OFF
+          -DFREECAD_RELEASE_PDB=OFF
+          -DFREECAD_LIBPACK_DIR="${{ env.libpackdir }}"
+          -DFREECAD_COPY_DEPEND_DIRS_TO_BUILD=ON
+          -DFREECAD_COPY_LIBPACK_BIN_TO_BUILD=ON
+          -DFREECAD_COPY_PLUGINS_BIN_TO_BUILD=ON
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
+
+      - name: Compiling sources
+        run: |
+          cd $env:builddir
+          msbuild ALL_BUILD.vcxproj /m /p:Configuration=Release /p:TrackFileAccess=false
+
+      - name: Installing to staging tree
+        run: |
+          cmake --install "${{ env.builddir }}" --prefix "${{ env.stagingdir }}" --config Release
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: '10.0.103'
+
+      - name: Install sign tool
+        run: |
+          # NOTE: The sign tool is ONLY available as a prerelease package, they never issue real releases.
+          dotnet tool install --global --prerelease sign
+          echo "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      # The NSIS installer script uses advanced logging (LogSet), which requires a log-enabled NSIS
+      # build. The stock choco/preinstalled NSIS lacks it, so use the same conda-forge log build the
+      # primary conda release uses (package/rattler-build/pixi.toml: nsis build "*_log*").
+      - name: Setup pixi (for log-enabled NSIS)
+        if: inputs.makeInstaller == 'true'
+        uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
+        with:
+          pixi-version: v0.68.1
+          cache: false
+
+      - name: Install log-enabled NSIS
+        if: inputs.makeInstaller == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          pixi global install "nsis[build=*_log*]"
+          pixi_home="${PIXI_HOME:-${USERPROFILE:-$HOME}/.pixi}"
+          makensis="$(find "${pixi_home}" -iname makensis.exe 2>/dev/null | head -n 1)"
+          if [ -z "${makensis}" ]; then
+            echo "Could not locate the log-enabled makensis.exe under ${pixi_home}" >&2
+            exit 1
+          fi
+          echo "Using makensis: ${makensis}"
+          echo "MAKENSIS=${makensis}" >> "$GITHUB_ENV"
+
+      - name: Azure login for code signing
+        id: azure_login
+        continue-on-error: true
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+
+      - name: Bundle, sign, and upload experimental artifacts
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUILD_TAG: ${{ inputs.build_tag }}
+          TARGET_ARCH: ${{ inputs.arch }}
+          STAGING_DIR: ${{ env.stagingdir }}
+          LIBPACK_DIR: ${{ env.libpackdir }}
+          MAKE_INSTALLER: ${{ inputs.makeInstaller }}
+          UPLOAD_RELEASE: "true"
+          WINDOWS_AZURE_ENDPOINT: ${{ vars.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          WINDOWS_AZURE_CERTIFICATE_PROFILE: ${{ vars.AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE }}
+          WINDOWS_AZURE_SIGNING_ACCOUNT: ${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ steps.azure_login.outcome }}" == "success" ]]; then
+            export WINDOWS_SIGN_RELEASE=1
+          else
+            export WINDOWS_SIGN_RELEASE=0
+          fi
+          bash package/libpack-windows/create_bundle.sh

--- a/package/libpack-windows/create_bundle.sh
+++ b/package/libpack-windows/create_bundle.sh
@@ -1,0 +1,257 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 The FreeCAD project association AISBL
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+# Assemble an experimental Windows FreeCAD bundle from a LibPack-based build.
+#
+# Unlike package/rattler-build/windows/create_bundle.sh (which sources everything from a conda
+# environment), this script sources the redistributable tree from a "cmake --install" staging
+# prefix produced by a LibPack build. The LibPack supplies OCCT, Qt6 and Python; FreeCAD supplies
+# its own bundled Coin/Pivy. The resulting tree matches the layout the NSIS installer expects
+# (bin/ data/ doc/ Ext/ lib/ Mod/).
+#
+# Required environment:
+#   BUILD_TAG         Release tag to attach artifacts to (e.g. weekly-2026.07.22)
+#   TARGET_ARCH       "x86_64" or "arm64" (used in the artifact file name)
+#   STAGING_DIR       Path to the "cmake --install" prefix (contains bin/, data/, lib/, Mod/, ...)
+#   MAKE_INSTALLER    "true" to also build the NSIS installer (x64 only for now)
+#   UPLOAD_RELEASE    "true" to upload artifacts to the release with "gh release upload"
+# Optional (code signing, all must be present to sign):
+#   WINDOWS_SIGN_RELEASE            "1" to attempt Azure Trusted Signing
+#   WINDOWS_AZURE_ENDPOINT
+#   WINDOWS_AZURE_CERTIFICATE_PROFILE
+#   WINDOWS_AZURE_SIGNING_ACCOUNT
+
+set -euo pipefail
+
+: "${BUILD_TAG:?BUILD_TAG must be set}"
+: "${TARGET_ARCH:?TARGET_ARCH must be set}"
+: "${STAGING_DIR:?STAGING_DIR must be set}"
+MAKE_INSTALLER="${MAKE_INSTALLER:-false}"
+UPLOAD_RELEASE="${UPLOAD_RELEASE:-false}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+nsi_dir="${repo_root}/package/WindowsInstaller"
+
+version_name="FreeCAD_${BUILD_TAG}-Windows-${TARGET_ARCH}-experimental"
+copy_dir="${version_name}"
+
+echo "################"
+echo "version_name:  ${version_name}"
+echo "staging_dir:   ${STAGING_DIR}"
+echo "################"
+
+# The "cmake --install" prefix already holds the redistributable tree (bin/data/lib/Mod/Ext, plus
+# the LibPack runtime DLLs, Python and Qt plugins copied into bin/ by CopyLibpackDirectories.cmake).
+# Copy it wholesale, then prune what does not belong in a runtime bundle.
+rm -rf "${copy_dir}"
+cp -a "${STAGING_DIR}" "${copy_dir}"
+
+# Import libraries and development headers are not needed at runtime.
+find "${copy_dir}" -name \*.a -delete
+find "${copy_dir}" -name \*.lib -delete
+find "${copy_dir}" -name \*.exp -delete
+rm -rf "${copy_dir}/include"
+
+# Qt needs to find its plugins relative to the executable directory.
+if [ ! -f "${copy_dir}/bin/qt.conf" ]; then
+    printf '[Paths]\nPrefix = ..\n' > "${copy_dir}/bin/qt.conf"
+fi
+
+# The NSIS installer copies doc/*.* recursively, so the folder must exist and be non-empty.
+mkdir -p "${copy_dir}/doc"
+if [ -z "$(ls -A "${copy_dir}/doc" 2>/dev/null)" ]; then
+    for candidate in LICENSE COPYING LICENSE.txt; do
+        if [ -f "${repo_root}/${candidate}" ]; then
+            cp "${repo_root}/${candidate}" "${copy_dir}/doc/"
+        fi
+    done
+fi
+
+# Stage the MSVC runtime redistributables. A conda build gets these from the conda env; a LibPack
+# build does not bundle them, so gather them from the runner's Visual Studio redist directory. They
+# are needed at runtime in bin/ (portable bundle) and are passed to NSIS as FILES_DEPS.
+redist_arch="x64"
+if [ "${TARGET_ARCH}" = "arm64" ]; then
+    redist_arch="arm64"
+fi
+
+find_msvc_redist_dir() {
+    local vswhere="/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+    local vs_root=""
+    if [ -x "${vswhere}" ]; then
+        vs_root="$("${vswhere}" -latest -property installationPath 2>/dev/null | tr -d '\r')"
+    fi
+    local search_roots=()
+    if [ -n "${vs_root}" ]; then
+        search_roots+=("$(cygpath -u "${vs_root}")/VC/Redist/MSVC")
+    fi
+    search_roots+=("/c/Program Files/Microsoft Visual Studio/2022"*/*/VC/Redist/MSVC)
+    for root in "${search_roots[@]}"; do
+        [ -d "${root}" ] || continue
+        # Pick the newest CRT folder for the target architecture.
+        local crt
+        crt="$(ls -d "${root}"/*/"${redist_arch}"/Microsoft.VC*.CRT 2>/dev/null | sort -V | tail -n 1)"
+        if [ -n "${crt}" ] && [ -d "${crt}" ]; then
+            echo "${crt}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+msvc_redist_dir="MSVCRedist"
+rm -rf "${msvc_redist_dir}"
+mkdir -p "${msvc_redist_dir}"
+if crt_dir="$(find_msvc_redist_dir)"; then
+    echo "Using MSVC runtime from: ${crt_dir}"
+    for dll in vcruntime140.dll vcruntime140_1.dll concrt140.dll msvcp140.dll \
+               vcamp140.dll vccorlib140.dll vcomp140.dll; do
+        if [ -f "${crt_dir}/${dll}" ]; then
+            cp "${crt_dir}/${dll}" "${copy_dir}/bin/"
+            cp "${crt_dir}/${dll}" "${msvc_redist_dir}/"
+        fi
+    done
+else
+    echo "WARNING: could not locate the Visual Studio MSVC redistributable directory."
+    echo "         The bundle relies on the runtime DLLs already present in bin/."
+fi
+
+# Record what went into the bundle.
+{
+    echo "FreeCAD experimental LibPack build"
+    echo "Build tag:    ${BUILD_TAG}"
+    echo "Architecture: ${TARGET_ARCH}"
+    if [ -n "${LIBPACK_DIR:-}" ] && [ -f "${LIBPACK_DIR}/FREECAD_LIBPACK_VERSION" ]; then
+        echo "LibPack:      $(tr -d '\r' < "${LIBPACK_DIR}/FREECAD_LIBPACK_VERSION")"
+    fi
+} > "${copy_dir}/packages.txt"
+
+# --- Code signing (Azure Trusted Signing) -----------------------------------------------------
+sign_dir="${copy_dir}"
+sign_available=0
+if [[ "${WINDOWS_SIGN_RELEASE:-0}" == "1" ]]; then
+    tenant="$(az account show --query tenantId -o tsv)"
+    export AZURE_IDENTITY_DISABLE_WORKLOAD_IDENTITY=true
+    export AZURE_IDENTITY_DISABLE_MANAGED_IDENTITY=true
+    unset AZURE_IDENTITY_LOGGING_ENABLED || true
+
+    if az account get-access-token --tenant "${tenant}" \
+           --scope "https://codesigning.azure.net/.default" >/dev/null 2>&1; then
+        sign_available=1
+    fi
+fi
+
+sign_file() {
+    sign code artifact-signing \
+        --artifact-signing-endpoint "${WINDOWS_AZURE_ENDPOINT}" \
+        --artifact-signing-certificate-profile "${WINDOWS_AZURE_CERTIFICATE_PROFILE}" \
+        --artifact-signing-account "${WINDOWS_AZURE_SIGNING_ACCOUNT}" \
+        --timestamp-url https://timestamp.acs.microsoft.com \
+        --timestamp-digest sha256 \
+        "$1" >/dev/null 2>&1
+    # Output is silenced because Azure authentication is extremely noisy with misleading Managed
+    # Identity "failure" messages that do not affect the real signing result.
+}
+
+if [[ "${sign_available}" == "1" ]]; then
+    echo "Azure Artifact Signing access confirmed. Signing binaries..."
+    shopt -s nullglob
+    files=(
+        "${sign_dir}"/*.exe
+        "${sign_dir}"/bin/*.exe
+        "${sign_dir}"/bin/*.dll
+        "${sign_dir}"/bin/*.pyd
+    )
+    total=${#files[@]}
+    count=0
+    echo "Signing ${total} files"
+    for f in "${files[@]}"; do
+        count=$((count + 1))
+        echo "Signing [${count}/${total}]: ${f}"
+        sign_file "${f}"
+    done
+    signtool verify -pa "${sign_dir}/bin/FreeCAD.exe" || echo "signtool verify failed (continuing)"
+    echo "Signing completed."
+else
+    echo "No Azure Artifact Signing available -- skipping signing."
+fi
+
+# --- Smoke tests ------------------------------------------------------------------------------
+echo "Running FreeCAD command-line smoke test..."
+if ! "${copy_dir}/bin/freecadcmd.exe" --safe-mode --version; then
+    echo "FreeCAD command-line smoke test failed; the Windows bundle cannot start."
+    exit 1
+fi
+
+echo "Running FreeCAD bundled Pivy smoke test..."
+if ! "${copy_dir}/bin/freecadcmd.exe" --safe-mode --console \
+        "import pivy; from pivy import coin; print(pivy.__file__); print(coin.SoDB.getVersion())"; then
+    echo "FreeCAD bundled Pivy smoke test failed; the bundle cannot import the bundled Coin/Pivy runtime."
+    exit 1
+fi
+
+# --- Portable 7z archive ----------------------------------------------------------------------
+7z a -t7z -mx9 -mmt="${NUMBER_OF_PROCESSORS:-4}" "${version_name}.7z" "${version_name}" -bb
+sha256sum "${version_name}.7z" > "${version_name}.7z-SHA256.txt"
+
+# Upload the portable bundle right away so it is published even if a later step (e.g. the
+# installer) fails. The installer is a best-effort extra on top of the portable artifact.
+if [ "${UPLOAD_RELEASE}" == "true" ]; then
+    echo "Uploading portable bundle to release ${BUILD_TAG}..."
+    gh release upload --clobber "${BUILD_TAG}" \
+        "${version_name}.7z" "${version_name}.7z-SHA256.txt"
+fi
+
+# --- Installer (x64 only for now) -------------------------------------------------------------
+if [ "${MAKE_INSTALLER}" == "true" ]; then
+    # The installer uses NSIS advanced logging (LogSet), which requires a log-enabled NSIS build.
+    # The workflow provides one via ${MAKENSIS}; fall back to a makensis found on the system.
+    makensis_cmd="${MAKENSIS:-}"
+    if [ -z "${makensis_cmd}" ]; then
+        makensis_cmd="$(command -v makensis || true)"
+    fi
+    if [ -z "${makensis_cmd}" ]; then
+        for candidate in "/c/Program Files (x86)/NSIS/makensis.exe" "/c/Program Files/NSIS/makensis.exe"; do
+            if [ -x "${candidate}" ]; then
+                makensis_cmd="${candidate}"
+                break
+            fi
+        done
+    fi
+    if [ -z "${makensis_cmd}" ]; then
+        echo "makensis not found; cannot build the installer."
+        exit 1
+    fi
+
+    files_freecad="$(cygpath -w "$(pwd)")\\${version_name}"
+    files_deps="$(cygpath -w "$(pwd)")\\${msvc_redist_dir}"
+    "${makensis_cmd}" -V4 \
+        -D"ExeFile=${version_name}-installer.exe" \
+        -D"FILES_FREECAD=${files_freecad}" \
+        -D"FILES_DEPS=${files_deps}" \
+        -X'SetCompressor /FINAL lzma' \
+        "${nsi_dir}/FreeCAD-installer.nsi"
+    mv "${nsi_dir}/${version_name}-installer.exe" .
+    echo "Created installer ${version_name}-installer.exe"
+
+    if [[ "${sign_available}" == "1" ]]; then
+        echo "Signing the installer..."
+        sign_file "${version_name}-installer.exe" \
+            || { echo "Signing the installer failed!"; exit 1; }
+    else
+        echo "No code signing available, leaving the installer unsigned."
+    fi
+    sha256sum "${version_name}-installer.exe" > "${version_name}-installer.exe-SHA256.txt"
+
+    if [ "${UPLOAD_RELEASE}" == "true" ]; then
+        echo "Uploading installer to release ${BUILD_TAG}..."
+        gh release upload --clobber "${BUILD_TAG}" \
+            "${version_name}-installer.exe" "${version_name}-installer.exe-SHA256.txt"
+    fi
+fi
+
+echo "Done."


### PR DESCRIPTION
These workflows use the LibPack to build Windows-on-ARM weeklies (and ultimately releases, since it's the same workflow). WoA cannot currently be built via Pixi due to the large number of dependencies that don't work properly on ARM. Since the current LibPack is built against OCCT 8, I'm also including x64 builds here so that we can start to get more user testing of those new OCCT releases. Construction of an ARM installer is left as future work, this only builds the "portable" version of that release.

Most of the code is taken from the existing Release workflows, but I kept it independent and separable in the event that we eventually can/want to get rid of LibPack-based builds again.

Assisted-by: Claude 4.8 (Opus)

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
