### PR TITLE
FEM: Add Edges to geometries mentioned in the Contact task panel's tooltip

### DIFF
--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
@@ -144,12 +144,12 @@ TaskFemConstraintContact::TaskFemConstraintContact(
     }
 
     ui->lbl_info->setText(
-        tr("Select slave geometry of type: ") + QString::fromUtf8("<b>%1</b>; ").arg(tr("Edge, Face"))
-        + tr("click Add or Remove")
+        tr("Select slave geometry of type: ")
+        + QString::fromUtf8("<b>%1</b>; ").arg(tr("Edge, Face")) + tr("click Add or Remove")
     );
     ui->lbl_info_2->setText(
-        tr("Select master geometry of type: ") + QString::fromUtf8("<b>%1</b>; ").arg(tr("Edge, Face"))
-        + tr("click Add or Remove")
+        tr("Select master geometry of type: ")
+        + QString::fromUtf8("<b>%1</b>; ").arg(tr("Edge, Face")) + tr("click Add or Remove")
     );
 
     // Selection buttons

--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
@@ -144,11 +144,11 @@ TaskFemConstraintContact::TaskFemConstraintContact(
     }
 
     ui->lbl_info->setText(
-        tr("Select slave geometry of type: ") + QString::fromUtf8("<b>%1</b>; ").arg(tr("Face"))
+        tr("Select slave geometry of type: ") + QString::fromUtf8("<b>%1</b>; ").arg(tr("Edge, Face"))
         + tr("click Add or Remove")
     );
     ui->lbl_info_2->setText(
-        tr("Select master geometry of type: ") + QString::fromUtf8("<b>%1</b>; ").arg(tr("Face"))
+        tr("Select master geometry of type: ") + QString::fromUtf8("<b>%1</b>; ").arg(tr("Edge, Face"))
         + tr("click Add or Remove")
     );
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="lbl_info_2">
      <property name="text">
-      <string>Select master geometry of type: Face; click Add or Remove</string>
+      <string>Select master geometry of type: Edge, Face; click Add or Remove</string>
      </property>
     </widget>
    </item>
@@ -76,7 +76,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Select slave geometry of type: Face; click Add or Remove</string>
+      <string>Select slave geometry of type: Edge, Face; click Add or Remove</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Currently, the task panel for Contact mentions only Faces, even though it's also possible to select Edges for 2D models. This PR adds them to the tooltip.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

No AI was used for this PR

@marioalexis84 FYI

## Before:

<img width="439" height="218" alt="image" src="https://github.com/user-attachments/assets/94583c95-9ae0-457a-abb3-53277f866c48" />

## After:

<img width="490" height="219" alt="image" src="https://github.com/user-attachments/assets/2a51ae98-4596-412d-b895-21a2333fa463" />
