### PR TITLE
CAM: Base.Util.setProperty() - Convert int to float if needed and safely

### DIFF
--- a/src/Mod/CAM/Path/Base/Util.py
+++ b/src/Mod/CAM/Path/Base/Util.py
@@ -82,6 +82,8 @@ def setProperty(obj, prop, value):
             value = value.lower() in ["true", "1", "yes", "ok"]
         elif isinstance(attr, int):
             value = int(value, 0)
+    elif isinstance(attr, int) and isinstance(value, float) and value.is_integer():
+        value = int(value)
     if o and name:
         setattr(o, name, value)
 


### PR DESCRIPTION
### Description

`Base.Util.setProperty(obj, prop, value)` can convert
- `str` -> `bool`
- `str` -> `int`

Suggest add conversion `float` **value** to `int`,
if property expect `int` and `float` **value** can be safely converted to `int`
e.g. `5.0` -> `5`

This will allow to use `Gui::QuantitySpinBox` with property which expect `int`, e.g. `App::PropertyInteger`

Related to
- #31453
- #31497
