### PR TITLE
Build: Change release trigger from 'created' to 'published'

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,7 +1,7 @@
 name: Build Release
 on:
   release:
-    types: [created]
+    types: [published]
   schedule:
    - cron: "0 0 * * 3"
   workflow_dispatch:


### PR DESCRIPTION
I found out the hard way today that writing up a draft release, saving it, and then publishing it does **not** trigger a release build. The build was only being triggered on "created", which never happens when you save a draft first. If we switch to "published" we'll get builds on either a direct creation of a non-draft release, **or** the publication of a previously-draft release.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
