### PR TITLE
Core: Open, Save and help command groups

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -836,6 +836,7 @@ public:
         if (!updating && reason && strcmp(reason, "RecentFiles") == 0) {
             Base::StateLocker guard(updating);
             master->restore();
+            Q_EMIT master->recentFilesListModified();
         }
     }
 
@@ -866,11 +867,22 @@ public:
 
 /* TRANSLATOR Gui::RecentFilesAction */
 
-RecentFilesAction::RecentFilesAction(Command* pcCmd, QObject* parent)
+RecentFilesAction::RecentFilesAction(Command* pcCmd, QObject* parent, bool addOpen)
     : ActionGroup(pcCmd, parent)
     , visibleItems(4)
     , maximumItems(20)
 {
+    if (addOpen) {
+        QAction* openAction = groupAction()->addAction(QLatin1String(""));
+        openAction->setText(tr("Open..."));
+        openAction->setStatusTip(tr("Open a document or import files."));
+        openAction->setToolTip(tr("Open a document or import files."));
+        openAction->setIcon(Gui::BitmapFactory().iconFromTheme("document-open"));
+
+        QAction* openSeparator = groupAction()->addAction(QLatin1String(""));
+        openSeparator->setSeparator(true);
+    }
+
     _pimpl = std::make_unique<Private>(this, "User parameter:BaseApp/Preferences/RecentFiles");
     restore();
 
@@ -884,7 +896,7 @@ RecentFilesAction::RecentFilesAction(Command* pcCmd, QObject* parent)
     clearRecentFilesListAction.setToolTip({});
     this->groupAction()->addAction(&clearRecentFilesListAction);
 
-    auto clearFun = [this, hGrp = _pimpl->handle]() {
+    auto clearFun = [this]() {
         // prompt user before clearing the recent files list
         QMessageBox::StandardButton reply = QMessageBox::question(
             getMainWindow(),
@@ -898,23 +910,13 @@ RecentFilesAction::RecentFilesAction(Command* pcCmd, QObject* parent)
             return;
         }
 
-        const size_t recentFilesListSize = hGrp->GetASCIIs("MRU").size();
-        for (size_t i = 0; i < recentFilesListSize; i++) {
-            const QByteArray key = QStringLiteral("MRU%1").arg(i).toLocal8Bit();
-            hGrp->SetASCII(key.data(), "");
-        }
-        restore();
-        clearRecentFilesListAction.setEnabled(false);
+        setFiles({});
+        save();
+        _pimpl->trySaveUserParameter();
+        Q_EMIT recentFilesListModified();
     };
 
     connect(&clearRecentFilesListAction, &QAction::triggered, this, clearFun);
-
-    connect(
-        &clearRecentFilesListAction,
-        &QAction::triggered,
-        this,
-        &RecentFilesAction::recentFilesListModified
-    );
 }
 
 RecentFilesAction::~RecentFilesAction()
@@ -967,31 +969,29 @@ static QString numberToLabel(int number)
  */
 void RecentFilesAction::setFiles(const QStringList& files)
 {
-    QList<QAction*> recentFiles = groupAction()->actions();
-
-    int numRecentFiles = std::min<int>(recentFiles.count(), files.count());
+    int numRecentFiles = std::min<int>(recentFileActions.count(), files.count());
     for (int index = 0; index < numRecentFiles; index++) {
         QString numberLabel = numberToLabel(index + 1);
         QFileInfo fi(files[index]);
         QString fileName {fi.fileName()};
         fileName.replace(QLatin1Char('&'), QStringLiteral("&&"));
-        recentFiles[index]->setText(QStringLiteral("%1 %2").arg(numberLabel, fileName));
-        recentFiles[index]->setStatusTip(tr("Open file %1").arg(files[index]));
-        recentFiles[index]->setToolTip(files[index]);  // set the full name that we need later for saving
-        recentFiles[index]->setData(QVariant(index));
-        recentFiles[index]->setVisible(true);
+        recentFileActions[index]->setText(QStringLiteral("%1 %2").arg(numberLabel, fileName));
+        recentFileActions[index]->setStatusTip(tr("Open file %1").arg(files[index]));
+        recentFileActions[index]->setToolTip(files[index]);  // set the full name that we need later
+                                                             // for saving
+        recentFileActions[index]->setData(QVariant(index));
+        recentFileActions[index]->setVisible(true);
     }
 
     // if less file names than actions
     numRecentFiles = std::min<int>(numRecentFiles, this->visibleItems);
-    for (int index = numRecentFiles; index < recentFiles.count(); index++) {
-        if (recentFiles[index] == &sep || recentFiles[index] == &clearRecentFilesListAction) {
-            continue;
-        }
-        recentFiles[index]->setVisible(false);
-        recentFiles[index]->setText(QString());
-        recentFiles[index]->setToolTip(QString());
+    for (int index = numRecentFiles; index < recentFileActions.count(); index++) {
+        recentFileActions[index]->setVisible(false);
+        recentFileActions[index]->setText(QString());
+        recentFileActions[index]->setToolTip(QString());
     }
+
+    clearRecentFilesListAction.setEnabled(!files.isEmpty());
 }
 
 /**
@@ -1000,9 +1000,8 @@ void RecentFilesAction::setFiles(const QStringList& files)
 QStringList RecentFilesAction::files() const
 {
     QStringList files;
-    QList<QAction*> recentFiles = groupAction()->actions();
-    for (int index = 0; index < recentFiles.count(); index++) {
-        QString file = recentFiles[index]->toolTip();
+    for (QAction* action : recentFileActions) {
+        QString file = action->toolTip();
         if (file.isEmpty()) {
             break;
         }
@@ -1034,10 +1033,11 @@ void RecentFilesAction::activateFile(int id)
 void RecentFilesAction::resizeList(int size)
 {
     this->visibleItems = size;
-    int diff = this->visibleItems - this->maximumItems;
     // create new items if needed
-    for (int i = 0; i < diff; i++) {
-        groupAction()->addAction(QLatin1String(""))->setVisible(false);
+    while (recentFileActions.count() < this->visibleItems) {
+        QAction* action = groupAction()->addAction(QLatin1String(""));
+        action->setVisible(false);
+        recentFileActions.append(action);
     }
     setFiles(files());
 }
@@ -1051,8 +1051,10 @@ void RecentFilesAction::restore()
     this->visibleItems = hGrp->GetInt("RecentFiles", this->visibleItems);
 
     int count = std::max<int>(this->maximumItems, this->visibleItems);
-    for (int i = 0; i < count; i++) {
-        groupAction()->addAction(QLatin1String(""))->setVisible(false);
+    while (recentFileActions.count() < count) {
+        QAction* action = groupAction()->addAction(QLatin1String(""));
+        action->setVisible(false);
+        recentFileActions.append(action);
     }
     std::vector<std::string> MRU = hGrp->GetASCIIs("MRU");
     QStringList files;
@@ -1073,11 +1075,10 @@ void RecentFilesAction::save()
     hGrp->Clear();
 
     // count all set items
-    QList<QAction*> recentFiles = groupAction()->actions();
-    int num = std::min<int>(count, recentFiles.count());
+    int num = std::min<int>(count, recentFileActions.count());
     for (int index = 0; index < num; index++) {
         QString key = QStringLiteral("MRU%1").arg(index);
-        QString value = recentFiles[index]->toolTip();
+        QString value = recentFileActions[index]->toolTip();
         if (value.isEmpty()) {
             break;
         }

--- a/src/Gui/Action.h
+++ b/src/Gui/Action.h
@@ -243,7 +243,11 @@ class GuiExport RecentFilesAction: public ActionGroup
     Q_OBJECT
 
 public:
-    explicit RecentFilesAction(Command* pcCmd, QObject* parent = nullptr);
+    /**
+     * @param addOpen Whether to prepend an Open action and separator to the recent-files
+     * menu.
+     */
+    explicit RecentFilesAction(Command* pcCmd, QObject* parent = nullptr, bool addOpen = false);
     ~RecentFilesAction() override;
 
     void appendFile(const QString&);
@@ -264,6 +268,7 @@ private:
     int maximumItems; /**< Number of maximum items */
 
     QAction sep, clearRecentFilesListAction;
+    QList<QAction*> recentFileActions;
 
     class Private;
     friend class Private;

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -944,7 +944,7 @@ bool StdCmdSaveAll::isActive()
 //===========================================================================
 // Std_SaveGroup
 //===========================================================================
-class StdCmdSaveGroup : public Gui::GroupCommand
+class StdCmdSaveGroup: public Gui::GroupCommand
 {
 public:
     StdCmdSaveGroup()
@@ -964,11 +964,14 @@ public:
         addCommand("Std_SaveAs");
         addCommand("Std_SaveCopy");
         addCommand("Std_SaveAll");
-        addCommand(); //separator
+        addCommand();  // separator
         addCommand("Std_Export");
     }
 
-    const char* className() const override { return "StdCmdSaveGroup"; }
+    const char* className() const override
+    {
+        return "StdCmdSaveGroup";
+    }
 };
 
 //===========================================================================

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -942,6 +942,36 @@ bool StdCmdSaveAll::isActive()
 
 
 //===========================================================================
+// Std_SaveGroup
+//===========================================================================
+class StdCmdSaveGroup : public Gui::GroupCommand
+{
+public:
+    StdCmdSaveGroup()
+        : GroupCommand("Std_SaveGroup")
+    {
+        sGroup = "File";
+        sMenuText = QT_TR_NOOP("Save");
+        sToolTipText = QT_TR_NOOP("Saves the active document");
+        sWhatsThis = "Std_SaveGroup";
+        sPixmap = "document-save";
+        sStatusTip = sToolTipText;
+
+        setCheckable(false);
+        setRememberLast(false);
+
+        addCommand("Std_Save");
+        addCommand("Std_SaveAs");
+        addCommand("Std_SaveCopy");
+        addCommand("Std_SaveAll");
+        addCommand(); //separator
+        addCommand("Std_Export");
+    }
+
+    const char* className() const override { return "StdCmdSaveGroup"; }
+};
+
+//===========================================================================
 // Std_Revert
 //===========================================================================
 DEF_STD_CMD_A(StdCmdRevert)
@@ -2432,6 +2462,7 @@ void CreateDocCommands()
     rcCmdMgr.addCommand(new StdCmdSaveAs());
     rcCmdMgr.addCommand(new StdCmdSaveCopy());
     rcCmdMgr.addCommand(new StdCmdSaveAll());
+    rcCmdMgr.addCommand(new StdCmdSaveGroup());
     rcCmdMgr.addCommand(new StdCmdRevert());
     rcCmdMgr.addCommand(new StdCmdProjectInfo());
     rcCmdMgr.addCommand(new StdCmdProjectUtil());

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -73,6 +73,58 @@ FC_LOG_LEVEL_INIT("Command", false)
 
 using namespace Gui;
 
+DEF_STD_CMD_C(StdCmdOpenGroup)
+
+StdCmdOpenGroup::StdCmdOpenGroup()
+    : Command("Std_OpenGroup")
+{
+    sGroup = "File";
+    sMenuText = QT_TR_NOOP("&Open…");
+    sToolTipText = QT_TR_NOOP("Opens a document or imports files");
+    sWhatsThis = "Std_OpenGroup";
+    sStatusTip = sToolTipText;
+    sPixmap = "document-open";
+    eType = NoTransaction;
+}
+
+/**
+ * Opens the recent file at position \a iMsg in the menu.
+ * If the file does not exist or cannot be loaded this item is removed
+ * from the list.
+ */
+void StdCmdOpenGroup::activated(int iMsg)
+{
+    auto act = qobject_cast<RecentFilesAction*>(_pcAction);
+    if (act) {
+        if (iMsg == 0) {
+            CommandManager& rcCmdMgr = Application::Instance->commandManager();
+            rcCmdMgr.runCommandByName("Std_Open");
+        }
+        else if (iMsg == 1) {
+            return;  // should not happen it's the separator.
+        }
+        else {
+            act->activateFile(iMsg - 2);
+        }
+        _pcAction->setProperty("defaultAction", QVariant(0));
+        _pcAction->setToolTip(QString::fromLatin1(sToolTipText));
+        _pcAction->setStatusTip(QString::fromLatin1(sToolTipText));
+        _pcAction->setIcon(Gui::BitmapFactory().iconFromTheme(sPixmap));
+    }
+}
+
+/**
+ * Creates the QAction object containing the recent files.
+ */
+Action* StdCmdOpenGroup::createAction()
+{
+    auto pcAction = new RecentFilesAction(this, getMainWindow(), true);
+    pcAction->setObjectName(QLatin1String("openGroup"));
+    pcAction->setDropDownMenu(true);
+    pcAction->setIcon(Gui::BitmapFactory().iconFromTheme(sPixmap));
+    applyCommandData(this->className(), pcAction);
+    return pcAction;
+}
 
 //===========================================================================
 // Std_Open
@@ -2369,6 +2421,7 @@ void CreateDocCommands()
 
     rcCmdMgr.addCommand(new StdCmdNew());
     rcCmdMgr.addCommand(new StdCmdOpen());
+    rcCmdMgr.addCommand(new StdCmdOpenGroup());
     rcCmdMgr.addCommand(new StdCmdImport());
     rcCmdMgr.addCommand(new StdCmdExport());
     rcCmdMgr.addCommand(new StdCmdMergeProjects());

--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -310,6 +310,47 @@ void StdCmdAboutQt::activated(int iMsg)
 }
 
 //===========================================================================
+// Std_HelpGroup
+//===========================================================================
+class StdCmdHelpGroup: public Gui::GroupCommand
+{
+public:
+    StdCmdHelpGroup()
+        : GroupCommand("Std_HelpGroup")
+    {
+        sGroup = "File";
+        sMenuText = QT_TR_NOOP("Help");
+        sToolTipText = QT_TR_NOOP("Opens the documentation corresponding to the selection");
+        sWhatsThis = "Std_HelpGroup";
+        sStatusTip = sToolTipText;
+        sPixmap = "help-browser";
+
+        setCheckable(false);
+        setRememberLast(false);
+
+        addCommand("Std_WhatsThis");
+        addCommand("Std_OnlineHelp");
+        addCommand();  // separator
+        addCommand("Std_FreeCADUserHub");
+        addCommand("Std_FreeCADForum");
+        addCommand("Std_ReportBug");
+        addCommand();  // separator
+        addCommand("Std_RestartInSafeMode");
+        addCommand();  // separator
+        addCommand("Std_DevHandbook");
+        addCommand("Std_PythonHelp");
+        addCommand();  // separator
+        addCommand("Std_FreeCADWebsite");
+        addCommand("Std_FreeCADDonation");
+        addCommand("Std_About");
+    }
+
+    const char* className() const override
+    {
+        return "StdCmdHelpGroup";
+    }
+};
+//===========================================================================
 // Std_WhatsThis
 //===========================================================================
 DEF_STD_CMD(StdCmdWhatsThis)
@@ -1078,6 +1119,7 @@ void CreateStdCommands()
     rcCmdMgr.addCommand(new StdCmdUserEditMode());
     rcCmdMgr.addCommand(new StdCmdReloadStyleSheet());
     rcCmdMgr.addCommand(new StdCmdDevHandbook());
+    rcCmdMgr.addCommand(new StdCmdHelpGroup());
     // rcCmdMgr.addCommand(new StdCmdDownloadOnlineHelp());
     // rcCmdMgr.addCommand(new StdCmdDescription());
     rcCmdMgr.addCommand(new StdCmdAnnotationLabel());


### PR DESCRIPTION
This PR add 3 command groups : 
- Open, which show recent files.
<img width="340" height="230" alt="image" src="https://github.com/user-attachments/assets/c51e1d4f-d250-4b67-8abf-0adb51e7bd33" />

- Save

<img width="280" height="192" alt="image" src="https://github.com/user-attachments/assets/d56272ef-f1e4-4b7a-a422-2f2f13d9a1ab" />

- Help
<img width="407" height="357" alt="image" src="https://github.com/user-attachments/assets/59a7ca24-a6c4-452e-889a-86a54eea281c" />

They are not added to the toolbar by default because some people complained that the arrow increase the size of the toolbar.
So they can be used in a custom toolbar.
Personally I find them very useful. In particular the open with recent files and the save.