### PR TITLE
Gui: add icon to "Close Document" menu action

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -3919,6 +3919,7 @@ void TreeWidget::setupText()
 
     this->closeDocAction->setText(tr("Close Document"));
     this->closeDocAction->setStatusTip(tr("Closes the document"));
+    this->closeDocAction->setIcon(BitmapFactory().iconFromTheme("Std_CloseActiveWindow"));
 
 #ifdef Q_OS_MAC
     this->openFileLocationAction->setText(tr("Reveal in Finder"));


### PR DESCRIPTION
Bugged me to no end I couldn't quickly locate the option in the menu with the same visual cue you *do* get in the File menu.

- [x] AI? For this? Come on.

## Issues

None to my knowledge.

## Before and After Images

<img width="356" height="299" alt="Screenshot_20260723_235118-fs8" src="https://github.com/user-attachments/assets/0cb4b154-614f-43ce-b6ea-bbfcafab9a04" />
→
<img width="356" height="299" alt="Screenshot_20260723_235140-fs8" src="https://github.com/user-attachments/assets/b64ad85c-fc15-4987-a321-6c90141e849a" />