### PR TITLE
(cp) App: Implement rich compare for MaterialPy

### DIFF
--- a/src/App/Material.pyi
+++ b/src/App/Material.pyi
@@ -10,6 +10,7 @@ from typing import Any, overload
 @export(
     Constructor=True,
     Delete=True,
+    RichCompare=True,
 )
 @class_declarations("""public:
     static Base::Color toColor(PyObject* value);

--- a/src/App/MaterialPyImp.cpp
+++ b/src/App/MaterialPyImp.cpp
@@ -181,6 +181,29 @@ std::string MaterialPy::representation() const
     return {"<Material object>"};
 }
 
+PyObject* MaterialPy::richCompare(PyObject* v, PyObject* w, int op)
+{
+    if (PyObject_TypeCheck(v, &(MaterialPy::Type)) && PyObject_TypeCheck(w, &(MaterialPy::Type))) {
+        const Material* m1 = static_cast<MaterialPy*>(v)->getMaterialPtr();
+        const Material* m2 = static_cast<MaterialPy*>(w)->getMaterialPtr();
+
+        PyObject* res = nullptr;
+        switch (op) {
+            case Py_NE:
+                res = (!(*m1 == *m2)) ? Py_True : Py_False;
+                Py_INCREF(res);
+                return res;
+            case Py_EQ:
+                res = (*m1 == *m2) ? Py_True : Py_False;
+                Py_INCREF(res);
+                return res;
+        }
+    }
+
+    Py_INCREF(Py_NotImplemented);
+    return Py_NotImplemented;
+}
+
 PyObject* MaterialPy::set(PyObject* args)
 {
     char* pstr {};

--- a/src/App/MaterialPyImp.cpp
+++ b/src/App/MaterialPyImp.cpp
@@ -181,27 +181,39 @@ std::string MaterialPy::representation() const
     return {"<Material object>"};
 }
 
+namespace
+{
+bool equalMaterialValues(const Material& lhs, const Material& rhs)
+{
+    return lhs.shininess == rhs.shininess
+        && lhs.transparency == rhs.transparency
+        && lhs.ambientColor == rhs.ambientColor
+        && lhs.diffuseColor == rhs.diffuseColor
+        && lhs.specularColor == rhs.specularColor
+        && lhs.emissiveColor == rhs.emissiveColor
+        && lhs.image == rhs.image
+        && lhs.imagePath == rhs.imagePath;
+}
+}  // namespace
+
 PyObject* MaterialPy::richCompare(PyObject* v, PyObject* w, int op)
 {
     if (PyObject_TypeCheck(v, &(MaterialPy::Type)) && PyObject_TypeCheck(w, &(MaterialPy::Type))) {
         const Material* m1 = static_cast<MaterialPy*>(v)->getMaterialPtr();
         const Material* m2 = static_cast<MaterialPy*>(w)->getMaterialPtr();
 
-        PyObject* res = nullptr;
+        const bool equal = equalMaterialValues(*m1, *m2);
         switch (op) {
             case Py_NE:
-                res = (!(*m1 == *m2)) ? Py_True : Py_False;
-                Py_INCREF(res);
-                return res;
+                return PyBool_FromLong(!equal);
             case Py_EQ:
-                res = (*m1 == *m2) ? Py_True : Py_False;
-                Py_INCREF(res);
-                return res;
+                return PyBool_FromLong(equal);
+            default:
+                break;
         }
     }
 
-    Py_INCREF(Py_NotImplemented);
-    return Py_NotImplemented;
+    Py_RETURN_NOTIMPLEMENTED;
 }
 
 PyObject* MaterialPy::set(PyObject* args)

--- a/src/Mod/Test/BaseTests.py
+++ b/src/Mod/Test/BaseTests.py
@@ -30,6 +30,20 @@ import FreeCAD
 from FreeCAD import Base
 
 
+class MaterialTestCase(unittest.TestCase):
+    def testComparison(self):
+        first = FreeCAD.Material()
+        second = FreeCAD.Material()
+
+        self.assertEqual(first, second)
+        self.assertFalse(first != second)
+
+        first.DiffuseColor = (1.0, 0.0, 0.0, 1.0)
+
+        self.assertNotEqual(first, second)
+        self.assertFalse(first == second)
+
+
 class ConsoleTestCase(unittest.TestCase):
     def setUp(self):
         self.count = 0


### PR DESCRIPTION
Cherry-picked from https://codeberg.org/xwzCAD/FreeCAD/pulls/278

This PR allows it to compare two Material objects in Python using the `==` and `!=` operators.

The default mechanism of equal/not equal in Python uses the object id but this is useless here because every time
the C++ property class returns the Python wrapper a new object is created.

Example:

1. Create a Part box
3. Running this code snippet: `Gui.ActiveDocument.ActiveObject.LineMaterial == Gui.ActiveDocument.ActiveObject.LineMaterial `always returns False
