### PR TITLE
Sketcher: Add hints for pattern tools

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -991,7 +991,7 @@ void DSHBSplineController::configureToolWidget()
 
         toolWidget->setParameterLabel(
             WParameter::First,
-            QApplication::translate("ToolWidgetManager_p4", "Degree (+'U'/ -'J')")
+            QApplication::translate("ToolWidgetManager_p4", "Degree")
         );
         toolWidget->configureParameterUnit(WParameter::First, Base::Unit());
         toolWidget->configureParameterMin(WParameter::First, 1.0);  // NOLINT

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
@@ -324,7 +324,7 @@ void DSHPolygonController::configureToolWidget()
 
     toolWidget->setParameterLabel(
         WParameter::First,
-        QApplication::translate("ToolWidgetManager_p4", "Sides (+'U'/ -'J')")
+        QApplication::translate("ToolWidgetManager_p4", "Sides")
     );
     toolWidget->setParameter(WParameter::First,
                              handler->numberOfCorners);  // unconditionally set

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
@@ -94,6 +94,11 @@ public:
     {
         using enum Gui::InputHint::UserInput;
 
+        const Gui::InputHint elementsHint {
+            tr("%1/%2 increase/decrease number of elements", "Sketcher Rotate: hint"),
+            {KeyU, KeyJ}
+        };
+
         return Gui::lookupHints<SelectMode>(
             state(),
             {
@@ -101,16 +106,19 @@ public:
                  .hints =
                      {
                          {tr("%1 pick center point", "Sketcher Rotate: hint"), {MouseLeft}},
+                         elementsHint,
                      }},
                 {.state = SelectMode::SeekSecond,
                  .hints =
                      {
                          {tr("%1 set start angle", "Sketcher Rotate: hint"), {MouseLeft}},
+                         elementsHint,
                      }},
                 {.state = SelectMode::SeekThird,
                  .hints =
                      {
                          {tr("%1 set rotation angle", "Sketcher Rotate: hint"), {MouseLeft}},
+                         elementsHint,
                      }},
             });
     }
@@ -589,7 +597,7 @@ void DSHRotateController::configureToolWidget()
 
     toolWidget->setParameterLabel(
         WParameter::First,
-        QApplication::translate("TaskSketcherTool_p4_rotate", "Elements (+'U'/ -'J')")
+        QApplication::translate("TaskSketcherTool_p4_rotate", "Elements")
     );
     toolWidget->setParameter(OnViewParameter::First, 1.0);
     toolWidget->configureParameterUnit(OnViewParameter::First, Base::Unit());

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
@@ -509,15 +509,38 @@ public:
     {
         using enum Gui::InputHint::UserInput;
 
+        const Gui::InputHint elementsHint {
+            tr("%1/%2 increase/decrease number of elements", "Sketcher Translate: hint"),
+            {KeyU, KeyJ}
+        };
+        const Gui::InputHint rowsHint {
+            tr("%1/%2 increase/decrease number of rows", "Sketcher Translate: hint"),
+            {KeyR, KeyF}
+        };
+
         return Gui::lookupHints<SelectMode>(
             state(),
-            {{.state = SelectMode::SeekFirst,
-              .hints = {{tr("%1 pick reference point", "Sketcher Translate: hint"), {MouseLeft}}}},
-             {.state = SelectMode::SeekSecond,
-              .hints = {{tr("%1 set translation vector", "Sketcher Translate: hint"), {MouseLeft}}}},
-             {.state = SelectMode::SeekThird,
-              .hints
-              = {{tr("%1 set second translation vector", "Sketcher Translate: hint"), {MouseLeft}}}}}
+            {
+                {.state = SelectMode::SeekFirst,
+                 .hints =
+                     {
+                         {tr("%1 pick reference point", "Sketcher Translate: hint"), {MouseLeft}},
+                     }},
+                {.state = SelectMode::SeekSecond,
+                 .hints =
+                     {
+                         {tr("%1 set translation vector", "Sketcher Translate: hint"), {MouseLeft}},
+                         elementsHint,
+                         rowsHint,
+                     }},
+                {.state = SelectMode::SeekThird,
+                 .hints =
+                     {
+                         {tr("%1 set second translation vector", "Sketcher Translate: hint"), {MouseLeft}},
+                         elementsHint,
+                         rowsHint,
+                     }},
+            }
         );
     }
 };
@@ -628,11 +651,11 @@ void DSHTranslateController::configureToolWidget()
 
     toolWidget->setParameterLabel(
         WParameter::First,
-        QApplication::translate("TaskSketcherTool_p3_translate", "Elements (+'U'/-'J')")
+        QApplication::translate("TaskSketcherTool_p3_translate", "Elements")
     );
     toolWidget->setParameterLabel(
         WParameter::Second,
-        QApplication::translate("TaskSketcherTool_p5_translate", "Rows (+'R'/-'F')")
+        QApplication::translate("TaskSketcherTool_p5_translate", "Rows")
     );
 
     toolWidget->setParameter(OnViewParameter::First, 1.0);


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Follow up from https://github.com/FreeCAD/FreeCAD/pull/30747#issuecomment-4923821176

- Rotate: U/J elements hint in every state
- Translate: U/J elements and R/F rows hints in every state
- Polygon and B-spline labels no longer repeat their existing U/J shortcuts, same in the pattern task dialog

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->



## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
<img width="1253" height="783" alt="Bildschirmfoto 2026-07-24 um 10 28 02" src="https://github.com/user-attachments/assets/8cc256f2-5f48-4c26-a9cd-21aeb9534d50" />
<img width="1171" height="812" alt="Bildschirmfoto 2026-07-24 um 10 28 22" src="https://github.com/user-attachments/assets/6abba73b-69a7-4582-a30d-c17bd7819c68" />
<img width="987" height="563" alt="Bildschirmfoto 2026-07-24 um 10 28 52" src="https://github.com/user-attachments/assets/561eb640-c404-42cd-8269-b64c05415e57" />



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
