### PR TITLE
Inspection: Use annotation instead of flag

### DIFF
--- a/src/Mod/Inspection/Gui/ViewProviderInspection.cpp
+++ b/src/Mod/Inspection/Gui/ViewProviderInspection.cpp
@@ -23,9 +23,10 @@
  ***************************************************************************/
 
 
-#include <QApplication>
+#include <string>
+#include <vector>
+
 #include <QMenu>
-#include <QMessageBox>
 
 #include <Inventor/SoPickedPoint.h>
 #include <Inventor/actions/SoRayPickAction.h>
@@ -44,11 +45,14 @@
 #include <Inventor/nodes/SoNormal.h>
 #include <Inventor/nodes/SoPointSet.h>
 #include <Inventor/nodes/SoShapeHints.h>
+#include <Inventor/sensors/SoIdleSensor.h>
 
+#include <App/Annotation.h>
+#include <App/Document.h>
+#include <App/DocumentObjectGroup.h>
 #include <App/GeoFeature.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
-#include <Gui/Flag.h>
 #include <Gui/MainWindow.h>
 #include <Gui/SoFCColorBar.h>
 #include <Gui/SoFCColorBarNotifier.h>
@@ -491,63 +495,66 @@ void ViewProviderInspection::OnChange(Base::Subject<int>& /*rCaller*/, int /*rcR
 
 namespace InspectionGui
 {
-// Proxy class that receives an asynchronous custom event
-class ViewProviderProxyObject: public QObject
+class InspectionAnnotation
 {
 public:
-    explicit ViewProviderProxyObject(QWidget* w)
-        : QObject(nullptr)
-        , widget(w)
+    InspectionAnnotation(
+        Gui::ViewProviderDocumentObject* viewProvider,
+        const QString& text,
+        const SbVec3f& position,
+        const SbVec3f& normal
+    )
+        : viewProvider(viewProvider)
+        , text(text)
+        , position(position)
+        , normal(normal)
     {}
-    ~ViewProviderProxyObject() override = default;
-    void customEvent(QEvent*) override
-    {
-        if (!widget.isNull()) {
-            QList<Gui::Flag*> flags = widget->findChildren<Gui::Flag*>();
-            if (!flags.isEmpty()) {
-                int ret = QMessageBox::question(
-                    Gui::getMainWindow(),
-                    QObject::tr("Remove annotations"),
-                    QObject::tr("Do you want to remove all annotations?"),
-                    QMessageBox::Yes,
-                    QMessageBox::No
-                );
-                if (ret == QMessageBox::Yes) {
-                    for (auto it : flags) {
-                        it->deleteLater();
-                    }
-                }
-            }
-        }
 
-        this->deleteLater();
+    static void schedule(
+        Gui::ViewProviderDocumentObject* viewProvider,
+        const QString& text,
+        const SoPickedPoint* point
+    )
+    {
+        auto* annotation
+            = new InspectionAnnotation(viewProvider, text, point->getPoint(), point->getNormal());
+        auto* sensor = new SoIdleSensor(InspectionAnnotation::run, annotation);
+        sensor->schedule();
     }
 
-    static void addFlag(Gui::View3DInventorViewer* view, const QString& text, const SoPickedPoint* point)
+    static void run(void* data, SoSensor* sensor)
     {
-        Gui::Flag* flag = new Gui::Flag;
-        QPalette p;
-        p.setColor(QPalette::Window, QColor(85, 0, 127));
-        p.setColor(QPalette::Text, QColor(220, 220, 220));
-        flag->setPalette(p);
-        flag->setText(text);
-        flag->setOrigin(point->getPoint());
-        Gui::GLFlagWindow* flags = nullptr;
-        std::list<Gui::GLGraphicsItem*> glItems = view->getGraphicsItemsOfType(
-            Gui::GLFlagWindow::getClassTypeId()
-        );
-        if (glItems.empty()) {
-            flags = new Gui::GLFlagWindow(view);
-            view->addGraphicsItem(flags);
+        auto* annotation = static_cast<InspectionAnnotation*>(data);
+        annotation->show();
+        delete annotation;
+        delete sensor;
+    }
+
+    void show() const
+    {
+        auto* document = viewProvider->getObject()->getDocument();
+        auto* guiDocument = Gui::Application::Instance->getDocument(document);
+        guiDocument->openCommand(QT_TRANSLATE_NOOP("Command", "Create inspection annotation"));
+
+        auto* group = viewProvider->getObject()->getGroup();
+        auto* annotation = group ? group->addObject<App::AnnotationLabel>("InspectionAnnotation")
+                                 : document->addObject<App::AnnotationLabel>("InspectionAnnotation");
+        std::vector<std::string> labelText;
+        for (const auto& line : text.split(QLatin1Char('\n'))) {
+            labelText.emplace_back(line.toUtf8().constData());
         }
-        else {
-            flags = static_cast<Gui::GLFlagWindow*>(glItems.front());
-        }
-        flags->addFlag(flag, Gui::FlagLayout::BottomLeft);
+        annotation->LabelText.setValues(labelText);
+        annotation->Label.setValue("Inspection annotation");
+        annotation->BasePosition.setValue(position[0], position[1], position[2]);
+        annotation->TextPosition.setValue(normal[0], normal[1], normal[2]);
+        guiDocument->commitCommand();
     }
 
 private:
-    QPointer<QWidget> widget;
+    Gui::ViewProviderDocumentObject* viewProvider;
+    QString text;
+    SbVec3f position;
+    SbVec3f normal;
 };
 }  // namespace InspectionGui
 
@@ -575,12 +582,6 @@ void ViewProviderInspection::inspectCallback(void* ud, SoEventCallback* n)
                 addflag = fl->isChecked();
             }
             else if (cl == id) {
-                // post an event to a proxy object to make sure to avoid problems
-                // when opening a modal dialog
-                QApplication::postEvent(
-                    new ViewProviderProxyObject(view->getGLWidget()),
-                    new QEvent(QEvent::User)
-                );
                 view->setEditing(false);
                 view->getWidget()->setCursor(QCursor(Qt::ArrowCursor));
                 view->setRedirectToSceneGraph(false);
@@ -607,7 +608,7 @@ void ViewProviderInspection::inspectCallback(void* ud, SoEventCallback* n)
                 QString info = that->inspectDistance(point);
                 Gui::getMainWindow()->setPaneText(1, info);
                 if (addflag) {
-                    ViewProviderProxyObject::addFlag(view, info, point);
+                    InspectionAnnotation::schedule(that, info, point);
                 }
                 else {
                     Gui::ToolTip::showText(QCursor::pos(), info);
@@ -629,7 +630,7 @@ void ViewProviderInspection::inspectCallback(void* ud, SoEventCallback* n)
                         QString info = self->inspectDistance(point);
                         Gui::getMainWindow()->setPaneText(1, info);
                         if (addflag) {
-                            ViewProviderProxyObject::addFlag(view, info, point);
+                            InspectionAnnotation::schedule(self, info, point);
                         }
                         else {
                             Gui::ToolTip::showText(QCursor::pos(), info);


### PR DESCRIPTION
- Replaced Flag overlays with persistent AnnotationLabel
- Annotations now appear under an InspectionAnnotations document group, similar as measurements
- Removed obsolete flag cleanup/dialog logic that conflicted with persistent annotations

Assisted-by: GPT-5.6-Terra

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/14330

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
<img width="710" height="474" alt="Bildschirmfoto 2026-07-24 um 20 23 41" src="https://github.com/user-attachments/assets/3079427d-d252-4803-97b7-eb3703e17251" />



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
