### PR TITLE
CAM: fix TOOL_RETURN firing after every tool change instead of once

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPostOutput.py
+++ b/src/Mod/CAM/CAMTests/TestPostOutput.py
@@ -2013,3 +2013,89 @@ class TestExport2Integration(unittest.TestCase):
                 "nc",
                 "Existing property should not be overwritten",
             )
+
+    def test_tool_return_fires_once_at_job_end_not_per_tool_change(self):
+        """
+        Regression test: TOOL_RETURN must fire once, at the true end of the
+        job, not after every individual tool change.
+
+        Before the fix, _expand_post_item() attached TOOL_RETURN to every
+        tool_controller postable item. A postprocessor whose tool_return
+        content stops the spindle or cancels the tool-length offset (e.g.
+        Centroid's default "M5\nM25\nG49 H0") would cancel the M3/G43 that
+        the same tool-change had just emitted, before any cutting motion.
+        TOOL_RETURN should instead behave like POSTAMBLE: once, at the end.
+
+        This builds its own two-tool-change job (the shared class fixture
+        only has one tool controller, which can't exercise the "not between
+        tool changes" half of this regression).
+        """
+        from Path.Tool.toolbit import ToolBit
+
+        doc = FreeCAD.newDocument("tool_return_timing_test")
+        try:
+            box = doc.addObject("Part::Box", "TRBox")
+            box.Length = 100
+            box.Width = 100
+            box.Height = 20
+
+            job = PathJob.Create("ToolReturnTimingJob", [box], None)
+            job.PostProcessorOutputFile = ""
+            job.SplitOutput = False
+            job.Fixtures = ["G54"]
+
+            tcs = []
+            for i, diameter in enumerate((6.0, 3.0), start=1):
+                tool_attrs = {
+                    "name": f"Tool{i}",
+                    "shape": "endmill.fcstd",
+                    "parameter": {"Diameter": diameter},
+                    "attribute": {},
+                }
+                toolbit = ToolBit.from_dict(tool_attrs)
+                tool = toolbit.attach_to_doc(doc=doc)
+                tool.Label = f"Tool{i}"
+                tc = PathToolController.Create(f"TC_Tool{i}", tool, i)
+                tc.Label = f"TC: Tool{i}"
+                job.Proxy.addToolController(tc)
+                tcs.append(tc)
+
+            for i, tc in enumerate(tcs, start=1):
+                op = doc.addObject("Path::FeaturePython", f"TROp{i}")
+                op.Label = f"TROp{i}"
+                op.addProperty("App::PropertyLink", "ToolController", "Path", "")
+                op.ToolController = tc
+                op.Path = Path.Path(
+                    [
+                        Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 5.0}),
+                        Path.Command("G1", {"X": 10.0, "Y": 0.0, "Z": -1.0, "F": 100.0}),
+                        Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 5.0}),
+                    ]
+                )
+                job.Operations.addObject(op)
+
+            doc.recompute()
+
+            machine = self._create_machine()
+            machine.postprocessor_properties["tool_return"] = "(SENTINEL_TOOL_RETURN)"
+
+            results = self._run_export2(machine, job)
+            gcode = self._get_first_section_gcode(results)
+
+            self.assertEqual(
+                gcode.count("M6"),
+                2,
+                "sanity check: job should have two tool changes",
+            )
+            self.assertEqual(
+                gcode.count("SENTINEL_TOOL_RETURN"),
+                1,
+                "TOOL_RETURN should appear exactly once for the whole job",
+            )
+            self.assertGreater(
+                gcode.index("SENTINEL_TOOL_RETURN"),
+                gcode.rindex("M6"),
+                "TOOL_RETURN must appear after the last tool change, not between tool changes",
+            )
+        finally:
+            FreeCAD.closeDocument(doc.Name)

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -1679,7 +1679,12 @@ class PostProcessor:
 
             # item -> 'str' Postable's
             if item.item_type == "tool_controller":
-                return 1, [pblock("POST_TOOL_CHANGE"), pblock("TOOL_RETURN")]
+                # NOTE: TOOL_RETURN is NOT emitted here. It fires once, at the
+                # true end of the job (see _expand_trailing_lines), not after
+                # every tool change: content like a spindle-stop/offset-cancel
+                # sequence would otherwise cancel the M3/G43 that this same
+                # tool-change item just emitted, before any cutting motion.
+                return 1, [pblock("POST_TOOL_CHANGE")]
             elif item.item_type == "fixture":
                 return 1, [pblock("POST_FIXTURE_CHANGE")]
             elif item.item_type == "operation":
@@ -1930,8 +1935,16 @@ class PostProcessor:
         return final_lines
 
     def _expand_trailing_lines(self, postables) -> None:
-        """Append post_job and postamble lines, to each section."""
+        """Append tool_return, post_job, and postamble lines, to each section.
+
+        TOOL_RETURN fires once here, at the true end of the job, matching
+        the legacy export_common() pipeline's output_tool_return() call
+        (once, before the trailing safety block/postamble) rather than
+        after every individual tool change.
+        """
         trailing = []
+        if (lines := self.values["TOOL_RETURN"]) is not None and lines != "":
+            trailing.append(self._make_postable("Post: tool_return", lines))
         if (lines := self.values["POST_JOB"]) is not None and lines != "":
             trailing.append(self._make_postable("Post: post_job", lines))
         if (lines := self.values["POSTAMBLE"]) is not None and lines != "":


### PR DESCRIPTION
**AI assistance disclosure:** This branch was developed with assistance from Claude (Anthropic), including investigation, the code fix, and the regression test. I have reviewed and tested it myself.

**Licensing:** This contribution is offered under LGPL-2.1-or-later, matching the existing SPDX-License-Identifier header on the modified files (`Processor.py`, `TestPostOutput.py`). No third-party or non-compatible code is included.

Clean, standalone rebase of #2 onto current upstream `main`, prepared for submission to `FreeCAD/FreeCAD`. Independent of the override-priority fix (#1/#31508) — cherry-picked cleanly with no conflicts, since it touches different functions in `Path/Post/Processor.py`.

## Observed bug
`TOOL_RETURN` content (spindle-stop/offset-cancel sequence, e.g. Centroid's default `M5\nM25\nG49 H0`) was being emitted after every tool change instead of once at job end. Any postprocessor whose tool_return content stops the spindle or cancels the tool-length offset killed the `M3`/`G43` that same tool-change had just emitted, before any cutting motion ran.

## Root cause
`TOOL_RETURN` was attached to every individual tool-change item via `_expand_post_item()`'s `tool_controller` branch, rather than only at the true end of the job. The legacy `export()`/`process_postables()` pipeline already calls `output_tool_return()` once, at the true end of the job, before the trailing safety block/postamble — `export2()`'s newer pipeline had drifted from that behavior.

## Fix
Removed `pblock("TOOL_RETURN")` from the per-tool-change expansion in `_expand_post_item()` and added it to `_expand_trailing_lines()`, so it fires exactly once, after the last tool change, at job end — matching the legacy pipeline's behavior.

## Test plan
- [x] Added `test_tool_return_fires_once_at_job_end_not_per_tool_change` (`TestPostOutput.py`) — a self-contained two-tool-change integration test (the shared fixture only has one tool controller, which can't exercise the "not between tool changes" half of the regression), verified to fail against pre-fix code and pass with the fix
- [x] Full `CAMTests.TestPostCore` (29 tests) and `CAMTests.TestPostOutput` (58 tests) pass, no regressions
- [x] Both commits verified to compile/import cleanly on their own
- [x] Only tested on Windows locally — CI will cover Ubuntu automatically; Windows/macOS/Pixi builds run once labeled

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
