### PR TITLE
CAM: fix rigid tap feed rate ignoring spindle speed

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathTapGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathTapGenerator.py
@@ -132,3 +132,40 @@ class TestPathTapGenerator(PathTestUtils.PathTestBase):
         self.assertRaises(ValueError, generator.generate, **args)
         args = {"edge": e, "retractheight": "1"}
         self.assertRaises(ValueError, generator.generate, **args)
+
+    def test50_rigid_tap_feed_locked_to_pitch_and_speed(self):
+        """G84 feed rate must be pitch * spindle_speed (mm/s), not pitch alone.
+
+        Regression test: F was previously set to the raw pitch value with
+        spindle_speed unused, silently ignoring the RPM entirely. Rigid tap
+        feed must stay mechanically locked to spindle speed: mm/min =
+        pitch(mm) * RPM. Values below match a real 10-32 tap (0.79248mm
+        pitch) at 128 RPM.
+        """
+        v1 = FreeCAD.Vector(0, 0, 10)
+        v2 = FreeCAD.Vector(0, 0, 0)
+        e = Part.makeLine(v1, v2)
+
+        pitch = 0.79248
+        spindle_speed = 128.0
+
+        result = generator.generate(e, pitch=pitch, spindle_speed=spindle_speed)
+        command = result[0]
+
+        expected_f = pitch * spindle_speed / 60.0
+        self.assertAlmostEqual(command.Parameters["F"], expected_f, places=6)
+        # F must not equal the raw pitch alone (the previous, buggy behavior)
+        self.assertNotAlmostEqual(command.Parameters["F"], pitch, places=3)
+        self.assertEqual(command.Parameters["S"], spindle_speed)
+
+    def test51_rigid_tap_feed_sanity_default_without_pitch_or_speed(self):
+        """Without pitch/spindle_speed, F should fall back to the sanity default."""
+        v1 = FreeCAD.Vector(0, 0, 10)
+        v2 = FreeCAD.Vector(0, 0, 0)
+        e = Part.makeLine(v1, v2)
+
+        result = generator.generate(e)
+        self.assertEqual(result[0].Parameters["F"], 100.0)
+
+        result = generator.generate(e, pitch=0.79248)
+        self.assertEqual(result[0].Parameters["F"], 100.0)

--- a/src/Mod/CAM/CAMTests/TestPathTapGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathTapGenerator.py
@@ -169,3 +169,31 @@ class TestPathTapGenerator(PathTestUtils.PathTestBase):
 
         result = generator.generate(e, pitch=0.79248)
         self.assertEqual(result[0].Parameters["F"], 100.0)
+
+    def test52_rigid_tap_feed_locked_to_zero_spindle_speed(self):
+        """An explicit spindle_speed=0.0 must not be treated as "unset".
+
+        F must stay locked to S (both 0.0) rather than silently falling back
+        to the sanity default, which would desync F from S.
+        """
+        v1 = FreeCAD.Vector(0, 0, 10)
+        v2 = FreeCAD.Vector(0, 0, 0)
+        e = Part.makeLine(v1, v2)
+
+        result = generator.generate(e, pitch=0.79248, spindle_speed=0.0)
+        command = result[0]
+
+        self.assertEqual(command.Parameters["F"], 0.0)
+        self.assertEqual(command.Parameters["S"], 0.0)
+
+    def test53_rigid_tap_speed_normalized_to_float(self):
+        """S must be normalized to float, matching F, for consistent types."""
+        v1 = FreeCAD.Vector(0, 0, 10)
+        v2 = FreeCAD.Vector(0, 0, 0)
+        e = Part.makeLine(v1, v2)
+
+        result = generator.generate(e, pitch=0.79248, spindle_speed=128)
+        command = result[0]
+
+        self.assertIsInstance(command.Parameters["S"], float)
+        self.assertIsInstance(command.Parameters["F"], float)

--- a/src/Mod/CAM/Path/Base/Generator/tapping.py
+++ b/src/Mod/CAM/Path/Base/Generator/tapping.py
@@ -100,7 +100,13 @@ def generate(
     cmdParams["Z"] = endPoint.z
     cmdParams["R"] = retractheight if retractheight is not None else startPoint.z
     cmdParams["S"] = spindle_speed if spindle_speed is not None else 1.0  # Sanity default
-    cmdParams["F"] = float(pitch) if pitch is not None else 100.0  # Sanity default
+    # Rigid tap feed must stay locked to spindle speed: mm/min = pitch(mm) * RPM.
+    # Divide by 60 for mm/s, matching the convention ToolController feed
+    # properties (and the rest of the post-processing pipeline) use.
+    if pitch is not None and spindle_speed:
+        cmdParams["F"] = float(pitch) * float(spindle_speed) / 60.0
+    else:
+        cmdParams["F"] = 100.0  # Sanity default
 
     if repeat < 1:
         raise ValueError("repeat must be 1 or greater")

--- a/src/Mod/CAM/Path/Base/Generator/tapping.py
+++ b/src/Mod/CAM/Path/Base/Generator/tapping.py
@@ -99,11 +99,14 @@ def generate(
     cmdParams["Y"] = startPoint.y
     cmdParams["Z"] = endPoint.z
     cmdParams["R"] = retractheight if retractheight is not None else startPoint.z
-    cmdParams["S"] = spindle_speed if spindle_speed is not None else 1.0  # Sanity default
+    cmdParams["S"] = float(spindle_speed) if spindle_speed is not None else 1.0  # Sanity default
     # Rigid tap feed must stay locked to spindle speed: mm/min = pitch(mm) * RPM.
     # Divide by 60 for mm/s, matching the convention ToolController feed
     # properties (and the rest of the post-processing pipeline) use.
-    if pitch is not None and spindle_speed:
+    # Check "is not None" (not truthiness) so an explicit spindle_speed=0.0
+    # still locks F to 0 instead of silently falling back to the sanity
+    # default, which would desync F from the S=0.0 already set above.
+    if pitch is not None and spindle_speed is not None:
         cmdParams["F"] = float(pitch) * float(spindle_speed) / 60.0
     else:
         cmdParams["F"] = 100.0  # Sanity default


### PR DESCRIPTION
**AI assistance disclosure:** This branch was developed with assistance from Claude (Anthropic), including investigation, the code fix, and the regression tests. I have reviewed and tested it myself.

**Licensing:** This contribution is offered under LGPL-2.1-or-later, matching the existing SPDX-License-Identifier header on the modified files (`tapping.py`, `TestPathTapGenerator.py`). No third-party or non-compatible code is included.

Clean, standalone rebase of #4 onto current upstream `main`, prepared for submission to `FreeCAD/FreeCAD`. Independent of the other two CAM fixes (#1/#31508, #5/#31553) — cherry-picked cleanly with no conflicts, since it only touches `Path/Base/Generator/tapping.py`.

## Observed bug
Rigid tapping (`G84`) feed rate in generated G-code was always wrong regardless of the Tool Controller's configured feed settings — `spindle_speed` was accepted as a parameter but never used to compute `F`, only the raw tap `pitch` was.

## Root cause
`tapping.generate()`'s `F` calculation used `float(pitch) if pitch is not None else 100.0`, silently ignoring `spindle_speed` entirely. Rigid tap feed must be mechanically locked to spindle speed (`mm/min = pitch(mm) * RPM`), not driven by pitch alone.

## Fix
`F` is now computed as `pitch * spindle_speed / 60.0` (mm/s, matching the ToolController feed-property convention).

A review comment (from Copilot) on the fork PR caught a follow-up edge case: the original fix's `spindle_speed` check used truthiness, so an explicit `spindle_speed=0.0` set `S=0.0` but silently fell back to `F=100.0` instead of locking to `0.0`. Fixed by checking `is not None` instead, and normalized `S` to `float` for type consistency with `F`.

## Test plan
- [x] Verified against real Tool Controller values from an actual 10-32 tap (0.79248mm pitch) at 128 RPM — matches expected `F` exactly
- [x] Added `test50_rigid_tap_feed_locked_to_pitch_and_speed`, `test51_rigid_tap_feed_sanity_default_without_pitch_or_speed`, `test52_rigid_tap_feed_locked_to_zero_spindle_speed`, `test53_rigid_tap_speed_normalized_to_float` (`TestPathTapGenerator.py`)
- [x] Full `CAMTests.TestPathTapGenerator` (10 tests) passes, no regressions
- [x] All three commits verified to compile/import cleanly on their own
- [x] Code style: `black`, trailing-whitespace, end-of-file-fixer, mixed-line-ending pre-commit hooks all pass on the changed files
- [x] Only tested on Windows locally — CI will cover Ubuntu automatically; Windows/macOS/Pixi builds run once labeled

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
