### PR TITLE
Gui: Toggle Visible Space

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -1276,8 +1276,8 @@ StdCmdToggleObjects::StdCmdToggleObjects()
     : Command("Std_ToggleObjects")
 {
     sGroup = "Standard-View";
-    sMenuText = QT_TR_NOOP("To&ggle All Objects");
-    sToolTipText = QT_TR_NOOP("Toggles the visibility of all objects in the active document");
+    sMenuText = QT_TR_NOOP("Toggle Visible Space");
+    sToolTipText = QT_TR_NOOP("Switches between the normal and complementary visible spaces");
     sStatusTip = sToolTipText;
     sWhatsThis = "Std_ToggleObjects";
     sPixmap = "Std_ToggleObjects";
@@ -1287,31 +1287,7 @@ StdCmdToggleObjects::StdCmdToggleObjects()
 void StdCmdToggleObjects::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    // go through active document
-    Gui::Document* doc = Application::Instance->activeDocument();
-    App::Document* app = doc->getDocument();
-    const std::vector<App::DocumentObject*> obj = app->getObjectsOfType(
-        App::DocumentObject::getClassTypeId()
-    );
-
-    for (const auto& it : obj) {
-        if (doc->isShow(it->getNameInDocument())) {
-            doCommand(
-                Gui,
-                "Gui.getDocument(\"%s\").getObject(\"%s\").Visibility=False",
-                app->getName(),
-                it->getNameInDocument()
-            );
-        }
-        else {
-            doCommand(
-                Gui,
-                "Gui.getDocument(\"%s\").getObject(\"%s\").Visibility=True",
-                app->getName(),
-                it->getNameInDocument()
-            );
-        }
-    }
+    Application::Instance->activeDocument()->toggleVisibleSpace();
 }
 
 bool StdCmdToggleObjects::isActive()

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -1281,6 +1281,7 @@ StdCmdToggleObjects::StdCmdToggleObjects()
     sStatusTip = sToolTipText;
     sWhatsThis = "Std_ToggleObjects";
     sPixmap = "Std_ToggleObjects";
+    sAccel = "Shift+Space";
     eType = Alter3DView;
 }
 

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -32,6 +32,7 @@
 #include <mutex>
 #include <QApplication>
 #include <QCheckBox>
+#include <QColor>
 #include <QFileInfo>
 #include <QMessageBox>
 #include <QOpenGLWidget>
@@ -954,7 +955,9 @@ void Document::setHide(const char* name)
 void Document::toggleVisibleSpace()
 {
     if (d->_alternateVisibleSpaceActive) {
+        setVisibleSpaceBackground(false);
         restoreNormalVisibleSpace();
+        TreeWidget::updateVisibilityIcons();
         d->_visibleSpaceStates.clear();
         d->_alternateVisibleSpaceActive = false;
         return;
@@ -972,6 +975,17 @@ void Document::toggleVisibleSpace()
     }
     d->_alternateVisibleSpaceActive = true;
     showAlternateVisibleSpace();
+    setVisibleSpaceBackground(true);
+}
+
+void Document::setVisibleSpaceBackground(bool active)
+{
+    const QColor background = active ? QColor(95, 125, 150) : QColor();
+    for (auto* view : d->baseViews) {
+        if (auto* view3d = dynamic_cast<View3DInventor*>(view)) {
+            view3d->getViewer()->setTemporaryBackgroundColor(background);
+        }
+    }
 }
 
 void Document::restoreNormalVisibleSpace()
@@ -1058,6 +1072,7 @@ void Document::showAlternateVisibleSpace()
             state.viewProvider->setSceneVisible(true);
         }
     }
+    TreeWidget::updateVisibilityIcons();
 }
 
 bool Document::updateVisibleSpaceVisibility(ViewProviderDocumentObject* viewProvider)
@@ -2568,6 +2583,9 @@ void Document::attachView(Gui::BaseView* pcView, bool bPassiv)
 {
     if (!bPassiv) {
         d->baseViews.push_back(pcView);
+        if (d->_alternateVisibleSpaceActive) {
+            setVisibleSpaceBackground(true);
+        }
     }
     else {
         d->passiveViews.push_back(pcView);

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -83,6 +83,12 @@ namespace Gui
 // Pimpl class
 struct DocumentP
 {
+    struct VisibleSpaceState
+    {
+        std::string objectName;
+        int normalSceneVisibilityState;
+    };
+
     Thumbnail thumb;
     int _iWinCount;
     int _iDocId;
@@ -117,6 +123,8 @@ struct DocumentP
     std::map<SoSeparator*, ViewProviderDocumentObject*> _CoinMap;
     std::map<std::string, ViewProvider*> _ViewProviderMapAnnotation;
     std::list<ViewProviderDocumentObject*> _redoViewProviders;
+    bool _alternateVisibleSpaceActive {false};
+    std::vector<VisibleSpaceState> _visibleSpaceStates;
 
     using Connection = fastsignals::connection;
     using AdvancedConnection = fastsignals::advanced_connection;
@@ -941,6 +949,152 @@ void Document::setHide(const char* name)
     if (pcProv && pcProv->isDerivedFrom<ViewProviderDocumentObject>()) {
         static_cast<ViewProviderDocumentObject*>(pcProv)->Visibility.setValue(false);
     }
+}
+
+void Document::toggleVisibleSpace()
+{
+    if (d->_alternateVisibleSpaceActive) {
+        restoreNormalVisibleSpace();
+        d->_visibleSpaceStates.clear();
+        d->_alternateVisibleSpaceActive = false;
+        return;
+    }
+
+    d->_visibleSpaceStates.reserve(d->_ViewProviderMap.size());
+    for (const auto& [object, viewProvider] : d->_ViewProviderMap) {
+        if (!viewProvider->canToggleVisibility() || !viewProvider->canAddToSceneGraph()) {
+            continue;
+        }
+        d->_visibleSpaceStates.push_back({
+            object->getNameInDocument(),
+            viewProvider->getSceneVisibilityState(),
+        });
+    }
+    d->_alternateVisibleSpaceActive = true;
+    showAlternateVisibleSpace();
+}
+
+void Document::restoreNormalVisibleSpace()
+{
+    for (const auto& state : d->_visibleSpaceStates) {
+        auto* object = d->_pcDocument->getObject(state.objectName.c_str());
+        auto* viewProvider = object ? getViewProvider(object) : nullptr;
+        if (auto* documentViewProvider = freecad_cast<ViewProviderDocumentObject*>(viewProvider)) {
+            documentViewProvider->setSceneVisibilityState(state.normalSceneVisibilityState);
+        }
+    }
+}
+
+void Document::showAlternateVisibleSpace()
+{
+    if (!d->_alternateVisibleSpaceActive) {
+        return;
+    }
+
+    // All decisions are made against the normal scene. This prevents a
+    // container's alternate state from becoming input to the next update.
+    restoreNormalVisibleSpace();
+
+    struct ObjectState
+    {
+        ViewProviderDocumentObject* viewProvider;
+        bool visible;
+        bool required;
+    };
+
+    std::vector<ObjectState> states;
+    std::map<const App::DocumentObject*, std::size_t> stateIndex;
+    states.reserve(d->_ViewProviderMap.size());
+    for (const auto& [object, viewProvider] : d->_ViewProviderMap) {
+        if (!viewProvider->canToggleVisibility() || !viewProvider->canAddToSceneGraph()) {
+            continue;
+        }
+
+        stateIndex.emplace(object, states.size());
+        states.push_back({viewProvider, viewProvider->isVisibleInScene(), false});
+    }
+
+    std::vector<std::vector<std::size_t>> parents(states.size());
+    for (std::size_t index = 0; index < states.size(); ++index) {
+        for (auto* child : states[index].viewProvider->claimChildren3D()) {
+            auto it = stateIndex.find(child);
+            if (it != stateIndex.end()) {
+                parents[it->second].push_back(index);
+            }
+        }
+    }
+
+    // Every object that was not effectively visible belongs to the alternate
+    // space. Its 3D parents must remain visible so the object can be reached.
+    for (std::size_t index = 0; index < states.size(); ++index) {
+        const auto mode = states[index].viewProvider->getVisibleSpaceMode();
+        const bool visible = mode == ViewProvider::VisibleSpaceMode::Show
+            || (mode == ViewProvider::VisibleSpaceMode::Complement && !states[index].visible);
+        if (!visible) {
+            continue;
+        }
+
+        std::vector<std::size_t> pending {index};
+        while (!pending.empty()) {
+            const std::size_t current = pending.back();
+            pending.pop_back();
+            if (states[current].required) {
+                continue;
+            }
+
+            states[current].required = true;
+            pending.insert(pending.end(), parents[current].begin(), parents[current].end());
+        }
+    }
+
+    // Make the transition deterministic: first hide every participant, then
+    // reveal only the alternate-space objects and the containers required to
+    // reach them.
+    for (const auto& state : states) {
+        state.viewProvider->setSceneVisible(false);
+    }
+    for (const auto& state : states) {
+        if (state.required) {
+            state.viewProvider->setSceneVisible(true);
+        }
+    }
+}
+
+bool Document::updateVisibleSpaceVisibility(ViewProviderDocumentObject* viewProvider)
+{
+    if (!d->_alternateVisibleSpaceActive || !viewProvider) {
+        return false;
+    }
+
+    if (auto* object = viewProvider->getObject()) {
+        bool found = false;
+        for (auto& visibleSpaceState : d->_visibleSpaceStates) {
+            if (visibleSpaceState.objectName == object->getNameInDocument()) {
+                visibleSpaceState.normalSceneVisibilityState = viewProvider->getSceneVisibilityState();
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            d->_visibleSpaceStates.push_back({
+                object->getNameInDocument(),
+                viewProvider->getSceneVisibilityState(),
+            });
+        }
+    }
+
+    showAlternateVisibleSpace();
+    return true;
+}
+
+bool Document::toggleVisibleSpaceVisibility(ViewProviderDocumentObject* viewProvider)
+{
+    if (!d->_alternateVisibleSpaceActive || !viewProvider) {
+        return false;
+    }
+
+    viewProvider->Visibility.setValue(viewProvider->isVisibleInScene());
+    return true;
 }
 
 /// set the feature in Noshow

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -274,6 +274,12 @@ public:
     void setShow(const char* name);
     /// set the feature in Noshow
     void setHide(const char* name);
+    /// Swap between the normal visible space and its temporary complement.
+    void toggleVisibleSpace();
+    /// Rebuilds the alternate visible space after an object visibility change.
+    bool updateVisibleSpaceVisibility(ViewProviderDocumentObject* viewProvider);
+    /// Toggles an object's membership in the alternate visible space.
+    bool toggleVisibleSpaceVisibility(ViewProviderDocumentObject* viewProvider);
     /// set the feature transformation (only viewing)
     void setPos(const char* name, const Base::Matrix4D& rclMtrx);
     std::vector<ViewProvider*> getViewProvidersOfType(const Base::Type& typeId) const;
@@ -353,6 +359,8 @@ protected:
     Gui::DocumentPy* _pcDocPy;
 
 private:
+    void restoreNormalVisibleSpace();
+    void showAlternateVisibleSpace();
     bool trySetEdit(Gui::ViewProvider* p, int ModNum, const char* subname);
     void resetIfEditing();
     // handles the scene graph nodes to correctly group child and parents

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -359,6 +359,7 @@ protected:
     Gui::DocumentPy* _pcDocPy;
 
 private:
+    void setVisibleSpaceBackground(bool active);
     void restoreNormalVisibleSpace();
     void showAlternateVisibleSpace();
     bool trySetEdit(Gui::ViewProvider* p, int ModNum, const char* subname);

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1433,6 +1433,7 @@ QMenu* NaviCubeImplementation::createNaviCubeMenu()
         menuCommands.emplace_back("Std_ViewFitAll");
         menuCommands.emplace_back("Std_ViewFitSelection");
         menuCommands.emplace_back("Std_AlignToSelection");
+        menuCommands.emplace_back("Std_ToggleObjects");
         menuCommands.emplace_back("Separator");
         menuCommands.emplace_back("NaviCubeDraggableCmd");
     }

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1095,6 +1095,8 @@ void View3DInventorViewer::init()
     // Background stuff
     pcBackGround = new SoFCBackgroundGradient;
     pcBackGround->ref();
+    temporaryBackground = new SoFCBackgroundGradient;
+    temporaryBackground->ref();
 
     // Set up foreground, overlaid scenegraph.
     this->foregroundroot = new SoSeparator;
@@ -1355,6 +1357,8 @@ View3DInventorViewer::~View3DInventorViewer()
     this->decorationroot = nullptr;
     this->pcBackGround->unref();
     this->pcBackGround = nullptr;
+    this->temporaryBackground->unref();
+    this->temporaryBackground = nullptr;
 
     setSceneGraph(nullptr);
     this->viewerSceneRoot->unref();
@@ -1575,7 +1579,13 @@ void View3DInventorViewer::addViewProvider(ViewProvider* pcProvider)
     }
 
     if (SoSeparator* back = pcProvider->getBackRoot()) {
-        backgroundroot->addChild(back);
+        const int overrideIndex = backgroundroot->findChild(temporaryBackground);
+        if (overrideIndex >= 0) {
+            backgroundroot->insertChild(back, overrideIndex);
+        }
+        else {
+            backgroundroot->addChild(back);
+        }
     }
 
     pcProvider->setOverrideMode(this->getOverrideMode());
@@ -2016,6 +2026,22 @@ void View3DInventorViewer::setGradientBackgroundColor(
 )
 {
     pcBackGround->setColorGradient(fromColor, toColor, midColor);
+}
+
+void View3DInventorViewer::setTemporaryBackgroundColor(const QColor& color)
+{
+    if (!color.isValid()) {
+        if (backgroundroot->findChild(temporaryBackground) != -1) {
+            backgroundroot->removeChild(temporaryBackground);
+        }
+        return;
+    }
+
+    const SbColor backgroundColor(color.redF(), color.greenF(), color.blueF());
+    temporaryBackground->setColorGradient(backgroundColor, backgroundColor);
+    if (backgroundroot->findChild(temporaryBackground) == -1) {
+        backgroundroot->addChild(temporaryBackground);
+    }
 }
 
 void View3DInventorViewer::setEnabledFPSCounter(bool on)

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include <QCursor>
+#include <QColor>
 #include <QImage>
 #include <QLabel>
 
@@ -553,6 +554,7 @@ public:
         const SbColor& toColor,
         const SbColor& midColor
     );
+    void setTemporaryBackgroundColor(const QColor& color);
     void setNavigationType(Base::Type);
 
     void setAxisLetterColor(const SbColor& color);
@@ -655,6 +657,7 @@ private:
     std::unique_ptr<RubberbandOverlay> rubberbandOverlayRenderer;
     ViewProvider* editViewProvider;
     SoFCBackgroundGradient* pcBackGround;
+    SoFCBackgroundGradient* temporaryBackground;
     SoSeparator* backgroundroot;
     SoSeparator* foregroundroot;
     // Dedicated root for viewer-owned HUD/decorations that should not be

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -28,6 +28,7 @@
 #include <QTimer>
 #include <Inventor/SoPickedPoint.h>
 #include <Inventor/actions/SoGetBoundingBoxAction.h>
+#include <Inventor/actions/SoSearchAction.h>
 #include <Inventor/details/SoDetail.h>
 #include <Inventor/events/SoKeyboardEvent.h>
 #include <Inventor/events/SoLocation2Event.h>
@@ -59,6 +60,7 @@
 #include "View3DInventorViewer.h"
 #include "ViewParams.h"
 #include "ViewProviderExtension.h"
+#include "ViewProviderDocumentObject.h"
 #include "ViewProviderLink.h"
 #include "ViewProviderPy.h"
 
@@ -519,6 +521,73 @@ void ViewProvider::show()
 bool ViewProvider::isShow() const
 {
     return pcModeSwitch->whichChild.getValue() != -1;
+}
+
+bool ViewProvider::isVisibleInScene() const
+{
+    if (!isShow()) {
+        return false;
+    }
+
+    const auto* viewer = getActiveViewer();
+    if (!viewer) {
+        return true;
+    }
+
+    SoSearchAction search;
+    search.setNode(getRoot());
+    search.setInterest(SoSearchAction::ALL);
+    search.apply(viewer->getSceneGraph());
+
+    const SoPathList& paths = search.getPaths();
+    for (int pathIndex = 0; pathIndex < paths.getLength(); ++pathIndex) {
+        const auto* path = paths[pathIndex];
+        bool visible = true;
+        for (int i = 0; i + 1 < path->getLength(); ++i) {
+            auto* switchNode = dynamic_cast<SoSwitch*>(path->getNode(i));
+            if (!switchNode) {
+                continue;
+            }
+
+            const int whichChild = switchNode->whichChild.getValue();
+            if (whichChild == SO_SWITCH_NONE
+                || (whichChild >= 0 && whichChild != path->getIndex(i + 1))) {
+                visible = false;
+                break;
+            }
+        }
+        if (visible) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void ViewProvider::setSceneVisible(bool visible)
+{
+    if (visible) {
+        setModeSwitch();
+    }
+    else {
+        pcModeSwitch->whichChild = SO_SWITCH_NONE;
+        for (auto ext : getExtensionsDerivedFromType<Gui::ViewProviderExtension>()) {
+            ext->extensionModeSwitchChange();
+        }
+    }
+}
+
+int ViewProvider::getSceneVisibilityState() const
+{
+    return pcModeSwitch->whichChild.getValue();
+}
+
+void ViewProvider::setSceneVisibilityState(int state)
+{
+    pcModeSwitch->whichChild = state;
+    for (auto ext : getExtensionsDerivedFromType<Gui::ViewProviderExtension>()) {
+        ext->extensionModeSwitchChange();
+    }
 }
 
 void ViewProvider::setVisible(bool s)
@@ -1136,6 +1205,14 @@ void ViewProvider::setRenderCacheMode(int mode)
 
 void ViewProvider::toggleVisibility()
 {
+    if (auto* viewProvider = freecad_cast<ViewProviderDocumentObject*>(this)) {
+        if (auto* document = viewProvider->getDocumentIfAttached()) {
+            if (document->toggleVisibleSpaceVisibility(viewProvider)) {
+                return;
+            }
+        }
+    }
+
     if (isShow()) {
         hide();
     }

--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -214,6 +214,17 @@ public:
         NoToggleVisibility = false
     };
 
+    /**
+     * Defines how an object participates in the alternate visible space.
+     * The mode is evaluated after the normal scene has been restored.
+     */
+    enum class VisibleSpaceMode
+    {
+        Complement,
+        Show,
+        Hide
+    };
+
     /// constructor.
     ViewProvider();
 
@@ -623,6 +634,27 @@ public:
     virtual void show();
     /// checks whether the view provider is visible or not
     virtual bool isShow() const;
+    /**
+     * Checks whether the view provider is visible in the active 3D scene.
+     *
+     * Unlike isShow(), this accounts for visibility switches owned by parent
+     * view providers and by the view provider's scene graph.
+     */
+    bool isVisibleInScene() const;
+    /// Returns this object's participation mode in the alternate visible space.
+    virtual VisibleSpaceMode getVisibleSpaceMode() const
+    {
+        return VisibleSpaceMode::Complement;
+    }
+    /**
+     * Sets visibility in the current scene without changing view object
+     * properties. This is intended for temporary GUI presentation states.
+     */
+    void setSceneVisible(bool visible);
+    /// Returns the raw scene visibility switch state.
+    int getSceneVisibilityState() const;
+    /// Sets a state obtained from getSceneVisibilityState().
+    void setSceneVisibilityState(int state);
     void setVisible(bool);
     bool isVisible() const;
     void setLinkVisible(bool);

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -248,6 +248,12 @@ void ViewProviderDocumentObject::onChanged(const App::Property* prop)
     }
 
     ViewProvider::onChanged(prop);
+
+    if (prop == &Visibility) {
+        if (auto* document = getDocumentIfAttached()) {
+            document->updateVisibleSpaceVisibility(this);
+        }
+    }
 }
 
 void ViewProviderDocumentObject::hide()
@@ -446,6 +452,17 @@ Gui::Document* ViewProviderDocumentObject::getDocument() const
         App::Document* pAppDoc = pcObject->getDocument();
         return Gui::Application::Instance->getDocument(pAppDoc);
     }
+}
+
+Gui::Document* ViewProviderDocumentObject::getDocumentIfAttached() const
+{
+    if (!pcObject || !isAttachedToDocument() || !pcObject->isAttachedToDocument()) {
+        return nullptr;
+    }
+    if (pcDocument) {
+        return pcDocument;
+    }
+    return Gui::Application::Instance->getDocument(pcObject->getDocument());
 }
 
 Gui::MDIView* ViewProviderDocumentObject::getActiveView() const

--- a/src/Gui/ViewProviderDocumentObject.h
+++ b/src/Gui/ViewProviderDocumentObject.h
@@ -114,6 +114,8 @@ public:
     }
     /// Get the GUI document to this ViewProvider object
     Gui::Document* getDocument() const;
+    /// Get the GUI document when this provider is fully attached, or nullptr.
+    Gui::Document* getDocumentIfAttached() const;
     /// Get the python wrapper for that ViewProvider
     PyObject* getPyObject() override;
 

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -653,10 +653,11 @@ void StdWorkbench::setupContextMenu(const char* recipient, MenuItem* item) const
 
         if (!sels.empty()) {
             *item << "Separator" << "Std_ToggleVisibility"
-                  << "Std_ToggleSelectability" << "Std_TreeSelection"
-                  << "Std_RandomColor" << "Std_ToggleTransparency" << "Separator" << "Std_Delete"
+                  << "Std_TreeSelection" << "Std_RandomColor" << "Std_ToggleTransparency"
+                  << "Separator" << "Std_Delete"
                   << "Std_SendToPythonConsole";
         }
+        *item << "Separator" << "Std_ToggleObjects";
     }
     else if (strcmp(recipient, "Tree") == 0) {
         if (!sels.empty()) {

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -487,6 +487,12 @@ ViewProviderBody* ViewProvider::getBodyViewProvider()
 
 void ViewProvider::toggleVisibility()
 {
+    if (auto* document = getDocumentIfAttached()) {
+        if (document->toggleVisibleSpaceVisibility(this)) {
+            return;
+        }
+    }
+
     if (!PartDesign::Body::isSolidFeature(getObject())) {
         Gui::ViewProvider::toggleVisibility();
         return;
@@ -498,6 +504,45 @@ void ViewProvider::toggleVisibility()
         return;
     }
     Gui::ViewProvider::toggleVisibility();
+}
+
+Gui::ViewProvider::VisibleSpaceMode ViewProvider::getVisibleSpaceMode() const
+{
+    if (!getObject() || !PartDesign::Body::isSolidFeature(getObject())) {
+        return VisibleSpaceMode::Complement;
+    }
+
+    auto* document = getDocumentIfAttached();
+    if (!document) {
+        return VisibleSpaceMode::Complement;
+    }
+
+    auto* bodyViewProvider = const_cast<ViewProvider*>(this)->getBodyViewProvider();
+    auto* body = bodyViewProvider ? bodyViewProvider->getObject<PartDesign::Body>() : nullptr;
+    if (!body) {
+        return VisibleSpaceMode::Complement;
+    }
+
+    Gui::ViewProvider* lastFeatureViewProvider = nullptr;
+    bool hasVisibleFeature = false;
+    for (auto* feature : body->Group.getValues()) {
+        if (!PartDesign::Body::isSolidFeature(feature)) {
+            continue;
+        }
+
+        auto* featureViewProvider = document->getViewProvider(feature);
+        if (!featureViewProvider) {
+            continue;
+        }
+
+        lastFeatureViewProvider = featureViewProvider;
+        hasVisibleFeature = hasVisibleFeature || featureViewProvider->isVisibleInScene();
+    }
+
+    if (hasVisibleFeature) {
+        return VisibleSpaceMode::Hide;
+    }
+    return lastFeatureViewProvider == this ? VisibleSpaceMode::Show : VisibleSpaceMode::Hide;
 }
 
 namespace Gui

--- a/src/Mod/PartDesign/Gui/ViewProvider.h
+++ b/src/Mod/PartDesign/Gui/ViewProvider.h
@@ -83,6 +83,7 @@ public:
     ViewProviderBody* getBodyViewProvider();
 
     void toggleVisibility() override;
+    Gui::ViewProvider::VisibleSpaceMode getVisibleSpaceMode() const override;
 
     /// Provides preview shape
     Part::TopoShape getPreviewShape() const override;


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Fixes the broken toggle visible objects command to a "Toggle Visible Space" command.

- Switch between normal and hidden scene visibility without changing document visibility properties. Rebuild the hidden state from captured normal scene state so it works for nested objects.
- Objects can be toggled in hidden scene space to bring them back to the normal (visible) space
- For PD: keep inactive solid Body features out of the hidden space. When no solid feature is shown, expose the last feature while preserving generic handling for sketches and auxiliary objects
Assisted-by: GPT-5.6-Terra
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/11131

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/0f4db3c3-e1a4-4ccb-8f3f-f4b4de174bd4



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
