### PR TITLE
Material: Preserve imported per-face colors

### DIFF
--- a/src/Gui/Dialogs/DlgMaterialPropertiesImp.cpp
+++ b/src/Gui/Dialogs/DlgMaterialPropertiesImp.cpp
@@ -33,6 +33,21 @@
 
 using namespace Gui::Dialog;
 
+namespace
+{
+void setColor(Base::Color& materialColor, const Base::Color& originalColor, const QColor& buttonColor)
+{
+    // QColor is limited to the precision exposed by the color picker.  Retain the original
+    // material color when the picker restores its initial color after cancellation.
+    if (buttonColor == originalColor.asValue<QColor>()) {
+        materialColor = originalColor;
+    }
+    else {
+        materialColor.setValue(buttonColor);
+    }
+}
+}  // namespace
+
 
 /* TRANSLATOR Gui::Dialog::DlgMaterialPropertiesImp */
 
@@ -76,6 +91,7 @@ void DlgMaterialPropertiesImp::setupConnections()
 void DlgMaterialPropertiesImp::setCustomMaterial(const App::Material& mat)
 {
     customMaterial = mat;
+    originalMaterial = mat;
     setButtonColors(customMaterial);
 }
 
@@ -99,7 +115,7 @@ App::Material DlgMaterialPropertiesImp::getDefaultMaterial() const
  */
 void DlgMaterialPropertiesImp::onAmbientColorChanged()
 {
-    customMaterial.ambientColor.setValue(ui->ambientColor->color());
+    setColor(customMaterial.ambientColor, originalMaterial.ambientColor, ui->ambientColor->color());
 }
 
 /**
@@ -107,7 +123,7 @@ void DlgMaterialPropertiesImp::onAmbientColorChanged()
  */
 void DlgMaterialPropertiesImp::onDiffuseColorChanged()
 {
-    customMaterial.diffuseColor.setValue(ui->diffuseColor->color());
+    setColor(customMaterial.diffuseColor, originalMaterial.diffuseColor, ui->diffuseColor->color());
 }
 
 /**
@@ -115,7 +131,7 @@ void DlgMaterialPropertiesImp::onDiffuseColorChanged()
  */
 void DlgMaterialPropertiesImp::onEmissiveColorChanged()
 {
-    customMaterial.emissiveColor.setValue(ui->emissiveColor->color());
+    setColor(customMaterial.emissiveColor, originalMaterial.emissiveColor, ui->emissiveColor->color());
 }
 
 /**
@@ -123,7 +139,7 @@ void DlgMaterialPropertiesImp::onEmissiveColorChanged()
  */
 void DlgMaterialPropertiesImp::onSpecularColorChanged()
 {
-    customMaterial.specularColor.setValue(ui->specularColor->color());
+    setColor(customMaterial.specularColor, originalMaterial.specularColor, ui->specularColor->color());
 }
 
 /**

--- a/src/Gui/Dialogs/DlgMaterialPropertiesImp.h
+++ b/src/Gui/Dialogs/DlgMaterialPropertiesImp.h
@@ -75,6 +75,7 @@ private:
 private:
     std::unique_ptr<Ui_DlgMaterialProperties> ui;
     App::Material customMaterial;
+    App::Material originalMaterial;
     App::Material defaultMaterial;
 };
 

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -21,6 +21,8 @@
  ***************************************************************************/
 
 
+#include <vector>
+
 #include <Inventor/SoPickedPoint.h>
 #include <Inventor/actions/SoRayPickAction.h>
 #include <Inventor/actions/SoSearchAction.h>
@@ -75,6 +77,8 @@ ViewProviderGeometryObject::ViewProviderGeometryObject()
     Transparency.setConstraints(&intPercent);
 
     ADD_PROPERTY_TYPE(ShapeAppearance, (mat), osgroup, App::Prop_None, "Shape appearance");
+    ADD_PROPERTY_TYPE(BaseShapeAppearance, (mat), osgroup, App::Prop_Hidden, "Base shape appearance");
+    ADD_PROPERTY_TYPE(FaceAppearanceOverrides, (), osgroup, App::Prop_Hidden, "Face appearance overrides");
     ADD_PROPERTY_TYPE(BoundingBox, (false), dogroup, App::Prop_None, "Display object bounding box");
     ADD_PROPERTY_TYPE(
         Selectable,
@@ -154,6 +158,10 @@ void ViewProviderGeometryObject::onChanged(const App::Property* prop)
         if (ShapeAppearance.getSize() == 1) {
             const App::Material& Mat = ShapeAppearance[0];
             setCoinAppearance(Mat);
+            BaseShapeAppearance.setValue(Mat);
+            if (!FaceAppearanceOverrides.getValues().empty()) {
+                FaceAppearanceOverrides.setValues({});
+            }
         }
     }
     else if (prop == &BoundingBox) {
@@ -187,13 +195,45 @@ void ViewProviderGeometryObject::updateData(const App::Property* prop)
             if ((ShapeAppearance.getSize() == 1)
                 && (ShapeAppearance[0] == defaultMaterial || ShapeAppearance[0] == materialAppearance)
                 && (material != defaultMaterial)) {
-                ShapeAppearance.setValue(material);
+                setObjectAppearance(material, true);
                 materialAppearance = material;
             }
         }
     }
 
     ViewProviderDragger::updateData(prop);
+}
+
+void ViewProviderGeometryObject::setObjectAppearance(
+    const App::Material& material,
+    bool replaceFaceAppearances
+)
+{
+    BaseShapeAppearance.setValue(material);
+
+    const auto& appearances = ShapeAppearance.getValues();
+    const auto& overrides = FaceAppearanceOverrides.getValues();
+    if (replaceFaceAppearances || appearances.size() == 1) {
+        ShapeAppearance.setValue(material);
+        if (!FaceAppearanceOverrides.getValues().empty()) {
+            FaceAppearanceOverrides.setValues({});
+        }
+        return;
+    }
+
+    // Older documents do not record which face colors were explicitly assigned. Preserve every
+    // existing face appearance rather than risk overwriting imported or user-assigned colors.
+    if (appearances.size() != overrides.size()) {
+        return;
+    }
+
+    std::vector<App::Material> updatedAppearances = appearances;
+    for (std::size_t i = 0; i < updatedAppearances.size(); ++i) {
+        if (!overrides[i]) {
+            updatedAppearances[i] = material;
+        }
+    }
+    ShapeAppearance.setValues(updatedAppearances);
 }
 
 void ViewProviderGeometryObject::updateBoundingBox()

--- a/src/Gui/ViewProviderGeometryObject.h
+++ b/src/Gui/ViewProviderGeometryObject.h
@@ -62,8 +62,16 @@ public:
     // Display properties
     App::PropertyPercent Transparency;
     App::PropertyMaterialList ShapeAppearance;  // May be different from material
+    App::PropertyMaterial BaseShapeAppearance;
+    App::PropertyBoolList FaceAppearanceOverrides;
     App::PropertyBool BoundingBox;
     App::PropertyBool Selectable;
+
+    /**
+     * Sets the object appearance while retaining explicit face appearances unless requested
+     * otherwise.
+     */
+    void setObjectAppearance(const App::Material& material, bool replaceFaceAppearances);
 
     /**
      * Attaches the document object to this view provider.

--- a/src/Mod/Import/Gui/ImportOCAFGui.cpp
+++ b/src/Mod/Import/Gui/ImportOCAFGui.cpp
@@ -47,7 +47,10 @@ void ImportOCAFGui::applyFaceColors(Part::Feature* part, const std::vector<Base:
     }
 
     if (colors.size() == 1) {
-        vp->ShapeAppearance.setDiffuseColor(colors.front());
+        App::Material appearance = vp->ShapeAppearance[0];
+        appearance.diffuseColor = colors.front();
+        appearance.transparency = colors.front().transparency();
+        vp->setObjectAppearance(appearance, true);
         vp->Transparency.setValue(100 * colors.front().transparency());
     }
     else {
@@ -61,6 +64,10 @@ void ImportOCAFGui::applyFaceColors(Part::Feature* part, const std::vector<Base:
             [](const Base::Color& col) { return col.transparency(); }
         );
         vp->ShapeAppearance.setTransparencies(transp);
+
+        auto overrides = vp->FaceAppearanceOverrides.getValues();
+        overrides.resize(colors.size(), true);
+        vp->FaceAppearanceOverrides.setValues(overrides);
     }
 }
 

--- a/src/Mod/Import/TestImportGui.py
+++ b/src/Mod/Import/TestImportGui.py
@@ -25,8 +25,10 @@ import os
 import tempfile
 import unittest
 import FreeCAD as App
+import FreeCADGui
 import ImportGui
 from pivy import coin
+from PySide import QtCore, QtWidgets
 
 
 class ExportImportTest(unittest.TestCase):
@@ -38,22 +40,12 @@ class ExportImportTest(unittest.TestCase):
     def tearDown(self):
         App.closeDocument(self.doc.Name)
 
-    def testSaveLoadStepFile(self):
-        """
-        Create a STEP file with color per face
-        """
+    def createImportedColoredBox(self, colors):
         part = self.doc.addObject("App::Part", "Part")
         box = part.newObject("Part::Box", "Box")
         self.doc.recompute()
 
-        box.ViewObject.DiffuseColor = [
-            (1.0, 0.0, 0.0, 1.0),
-            (1.0, 0.0, 0.0, 1.0),
-            (1.0, 0.0, 0.0, 1.0),
-            (1.0, 0.0, 0.0, 1.0),
-            (1.0, 1.0, 0.0, 1.0),
-            (1.0, 1.0, 0.0, 1.0),
-        ]
+        box.ViewObject.DiffuseColor = colors
 
         ImportGui.export([part], self.fileName)
 
@@ -62,15 +54,25 @@ class ExportImportTest(unittest.TestCase):
 
         part_features = list(filter(lambda x: x.isDerivedFrom("Part::Feature"), self.doc.Objects))
         self.assertEqual(len(part_features), 1)
-        feature = part_features[0]
+        return part_features[0]
+
+    def testSaveLoadStepFile(self):
+        """
+        Create a STEP file with color per face
+        """
+        colors = [
+            (1.0, 0.0, 0.0, 1.0),
+            (1.0, 0.0, 0.0, 1.0),
+            (1.0, 0.0, 0.0, 1.0),
+            (1.0, 0.0, 0.0, 1.0),
+            (1.0, 1.0, 0.0, 1.0),
+            (1.0, 1.0, 0.0, 1.0),
+        ]
+        feature = self.createImportedColoredBox(colors)
 
         self.assertEqual(len(feature.ViewObject.DiffuseColor), 6)
-        self.assertEqual(feature.ViewObject.DiffuseColor[0], (1.0, 0.0, 0.0, 1.0))
-        self.assertEqual(feature.ViewObject.DiffuseColor[1], (1.0, 0.0, 0.0, 1.0))
-        self.assertEqual(feature.ViewObject.DiffuseColor[2], (1.0, 0.0, 0.0, 1.0))
-        self.assertEqual(feature.ViewObject.DiffuseColor[3], (1.0, 0.0, 0.0, 1.0))
-        self.assertEqual(feature.ViewObject.DiffuseColor[4], (1.0, 1.0, 0.0, 1.0))
-        self.assertEqual(feature.ViewObject.DiffuseColor[5], (1.0, 1.0, 0.0, 1.0))
+        self.assertEqual(feature.ViewObject.DiffuseColor, colors)
+        self.assertEqual(feature.ViewObject.FaceAppearanceOverrides, (True,) * 6)
 
         sa = coin.SoSearchAction()
         sa.setType(coin.SoMaterialBinding.getClassTypeId())
@@ -91,3 +93,111 @@ class ExportImportTest(unittest.TestCase):
 
         mat = paths.get(1).getTail()
         self.assertEqual(mat.diffuseColor.getNum(), 6)
+
+    def testAppearanceDialogPreservesFaceColors(self):
+        if not App.GuiUp:
+            self.skipTest("This test requires a graphical user interface (GUI).")
+
+        feature = self.createImportedColoredBox(
+            [
+                (0.123, 0.234, 0.345, 1.0),
+                (0.123, 0.234, 0.345, 1.0),
+                (0.123, 0.234, 0.345, 1.0),
+                (0.123, 0.234, 0.345, 1.0),
+                (0.567, 0.678, 0.789, 1.0),
+                (0.567, 0.678, 0.789, 1.0),
+            ]
+        )
+        colors = list(feature.ViewObject.DiffuseColor)
+
+        FreeCADGui.activateWorkbench("MaterialWorkbench")
+        self.addCleanup(FreeCADGui.Selection.clearSelection)
+        self.addCleanup(FreeCADGui.Control.closeDialog)
+        FreeCADGui.Selection.addSelection(feature)
+        FreeCADGui.runCommand("Std_SetAppearance")
+
+        main_window = FreeCADGui.getMainWindow()
+        appearance_button = main_window.findChild(QtWidgets.QPushButton, "buttonCustomAppearance")
+        self.assertIsNotNone(appearance_button)
+
+        dialog_state = {"color_dialog": False, "spinbox": False}
+
+        def change_shininess_after_canceling_color_picker():
+            dialog = QtWidgets.QApplication.activeModalWidget()
+            if dialog is None:
+                return
+
+            color_button = dialog.findChild(QtWidgets.QPushButton, "diffuseColor")
+            self.assertIsNotNone(color_button)
+
+            def reject_color_dialog():
+                color_dialog = QtWidgets.QApplication.activeModalWidget()
+                if isinstance(color_dialog, QtWidgets.QColorDialog):
+                    color_dialog.reject()
+                    dialog_state["color_dialog"] = True
+
+            QtCore.QTimer.singleShot(0, reject_color_dialog)
+            color_button.click()
+
+            spinbox = dialog.findChild(QtWidgets.QSpinBox, "shininess")
+            if spinbox is not None:
+                spinbox.setValue(50)
+                dialog_state["spinbox"] = True
+            dialog.reject()
+
+        QtCore.QTimer.singleShot(0, change_shininess_after_canceling_color_picker)
+        appearance_button.click()
+
+        self.assertEqual(feature.ViewObject.DiffuseColor, colors)
+        self.assertTrue(dialog_state["color_dialog"], "Color picker could not be found.")
+        self.assertTrue(dialog_state["spinbox"], "Shininess control could not be found.")
+        self.assertTrue(all(mat.Shininess == 0.5 for mat in feature.ViewObject.ShapeAppearance))
+
+    def testMaterialSelectionPreservesOrReplacesFaceColors(self):
+        if not App.GuiUp:
+            self.skipTest("This test requires a graphical user interface (GUI).")
+
+        feature = self.createImportedColoredBox(
+            [
+                (0.123, 0.234, 0.345, 1.0),
+                (0.123, 0.234, 0.345, 1.0),
+                (0.123, 0.234, 0.345, 1.0),
+                (0.123, 0.234, 0.345, 1.0),
+                (0.567, 0.678, 0.789, 1.0),
+                (0.567, 0.678, 0.789, 1.0),
+            ]
+        )
+        colors = list(feature.ViewObject.DiffuseColor)
+
+        FreeCADGui.activateWorkbench("MaterialWorkbench")
+        self.addCleanup(FreeCADGui.Selection.clearSelection)
+        self.addCleanup(FreeCADGui.Control.closeDialog)
+        FreeCADGui.Selection.addSelection(feature)
+        FreeCADGui.runCommand("Std_SetAppearance")
+
+        main_window = FreeCADGui.getMainWindow()
+        material_widget = main_window.findChild(QtWidgets.QWidget, "widgetMaterial")
+        replace_faces = main_window.findChild(QtWidgets.QCheckBox, "replaceFaceAppearances")
+        self.assertIsNotNone(material_widget)
+        self.assertIsNotNone(replace_faces)
+        self.assertFalse(replace_faces.isChecked())
+
+        import MatGui
+
+        material_tree = MatGui.MaterialTreeWidget(material_widget)
+        feature.ViewObject.FaceAppearanceOverrides = ()
+        material_tree.UUID = "d1f317f0-5ffa-4798-8ab3-af2ff0b5182c"
+        QtWidgets.QApplication.processEvents()
+        self.assertEqual(feature.ViewObject.DiffuseColor, colors)
+
+        feature.ViewObject.FaceAppearanceOverrides = (False, False, False, False, True, True)
+        material_tree.UUID = "4151e19c-fd6a-4ca4-83d4-d5e17d76cb9c"
+        QtWidgets.QApplication.processEvents()
+        updated_colors = list(feature.ViewObject.DiffuseColor)
+        self.assertNotEqual(updated_colors[:4], colors[:4])
+        self.assertEqual(updated_colors[4:], colors[4:])
+
+        replace_faces.setChecked(True)
+        material_tree.UUID = "cddfa21f-0715-49dd-b35b-951c076fa52c"
+        QtWidgets.QApplication.processEvents()
+        self.assertEqual(len(feature.ViewObject.ShapeAppearance), 1)

--- a/src/Mod/Import/TestImportGui.py
+++ b/src/Mod/Import/TestImportGui.py
@@ -25,8 +25,10 @@ import os
 import tempfile
 import unittest
 import FreeCAD as App
+import FreeCADGui
 import ImportGui
 from pivy import coin
+from PySide import QtCore, QtWidgets
 
 
 class ExportImportTest(unittest.TestCase):
@@ -38,22 +40,12 @@ class ExportImportTest(unittest.TestCase):
     def tearDown(self):
         App.closeDocument(self.doc.Name)
 
-    def testSaveLoadStepFile(self):
-        """
-        Create a STEP file with color per face
-        """
+    def createImportedColoredBox(self, colors):
         part = self.doc.addObject("App::Part", "Part")
         box = part.newObject("Part::Box", "Box")
         self.doc.recompute()
 
-        box.ViewObject.DiffuseColor = [
-            (1.0, 0.0, 0.0, 1.0),
-            (1.0, 0.0, 0.0, 1.0),
-            (1.0, 0.0, 0.0, 1.0),
-            (1.0, 0.0, 0.0, 1.0),
-            (1.0, 1.0, 0.0, 1.0),
-            (1.0, 1.0, 0.0, 1.0),
-        ]
+        box.ViewObject.DiffuseColor = colors
 
         ImportGui.export([part], self.fileName)
 
@@ -62,15 +54,24 @@ class ExportImportTest(unittest.TestCase):
 
         part_features = list(filter(lambda x: x.isDerivedFrom("Part::Feature"), self.doc.Objects))
         self.assertEqual(len(part_features), 1)
-        feature = part_features[0]
+        return part_features[0]
+
+    def testSaveLoadStepFile(self):
+        """
+        Create a STEP file with color per face
+        """
+        colors = [
+            (1.0, 0.0, 0.0, 1.0),
+            (1.0, 0.0, 0.0, 1.0),
+            (1.0, 0.0, 0.0, 1.0),
+            (1.0, 0.0, 0.0, 1.0),
+            (1.0, 1.0, 0.0, 1.0),
+            (1.0, 1.0, 0.0, 1.0),
+        ]
+        feature = self.createImportedColoredBox(colors)
 
         self.assertEqual(len(feature.ViewObject.DiffuseColor), 6)
-        self.assertEqual(feature.ViewObject.DiffuseColor[0], (1.0, 0.0, 0.0, 1.0))
-        self.assertEqual(feature.ViewObject.DiffuseColor[1], (1.0, 0.0, 0.0, 1.0))
-        self.assertEqual(feature.ViewObject.DiffuseColor[2], (1.0, 0.0, 0.0, 1.0))
-        self.assertEqual(feature.ViewObject.DiffuseColor[3], (1.0, 0.0, 0.0, 1.0))
-        self.assertEqual(feature.ViewObject.DiffuseColor[4], (1.0, 1.0, 0.0, 1.0))
-        self.assertEqual(feature.ViewObject.DiffuseColor[5], (1.0, 1.0, 0.0, 1.0))
+        self.assertEqual(feature.ViewObject.DiffuseColor, colors)
 
         sa = coin.SoSearchAction()
         sa.setType(coin.SoMaterialBinding.getClassTypeId())
@@ -91,3 +92,62 @@ class ExportImportTest(unittest.TestCase):
 
         mat = paths.get(1).getTail()
         self.assertEqual(mat.diffuseColor.getNum(), 6)
+
+    def testAppearanceDialogPreservesFaceColors(self):
+        if not App.GuiUp:
+            self.skipTest("This test requires a graphical user interface (GUI).")
+
+        feature = self.createImportedColoredBox(
+            [
+                (0.123, 0.234, 0.345, 1.0),
+                (0.123, 0.234, 0.345, 1.0),
+                (0.123, 0.234, 0.345, 1.0),
+                (0.123, 0.234, 0.345, 1.0),
+                (0.567, 0.678, 0.789, 1.0),
+                (0.567, 0.678, 0.789, 1.0),
+            ]
+        )
+        colors = list(feature.ViewObject.DiffuseColor)
+
+        FreeCADGui.activateWorkbench("MaterialWorkbench")
+        self.addCleanup(FreeCADGui.Selection.clearSelection)
+        self.addCleanup(FreeCADGui.Control.closeDialog)
+        FreeCADGui.Selection.addSelection(feature)
+        FreeCADGui.runCommand("Std_SetAppearance")
+
+        main_window = FreeCADGui.getMainWindow()
+        appearance_button = main_window.findChild(QtWidgets.QPushButton, "buttonCustomAppearance")
+        self.assertIsNotNone(appearance_button)
+
+        dialog_state = {"color_dialog": False, "spinbox": False}
+
+        def change_shininess_after_canceling_color_picker():
+            dialog = QtWidgets.QApplication.activeModalWidget()
+            if dialog is None:
+                return
+
+            color_button = dialog.findChild(QtWidgets.QPushButton, "diffuseColor")
+            self.assertIsNotNone(color_button)
+
+            def reject_color_dialog():
+                color_dialog = QtWidgets.QApplication.activeModalWidget()
+                if isinstance(color_dialog, QtWidgets.QColorDialog):
+                    color_dialog.reject()
+                    dialog_state["color_dialog"] = True
+
+            QtCore.QTimer.singleShot(0, reject_color_dialog)
+            color_button.click()
+
+            spinbox = dialog.findChild(QtWidgets.QSpinBox, "shininess")
+            if spinbox is not None:
+                spinbox.setValue(50)
+                dialog_state["spinbox"] = True
+            dialog.reject()
+
+        QtCore.QTimer.singleShot(0, change_shininess_after_canceling_color_picker)
+        appearance_button.click()
+
+        self.assertEqual(feature.ViewObject.DiffuseColor, colors)
+        self.assertTrue(dialog_state["color_dialog"], "Color picker could not be found.")
+        self.assertTrue(dialog_state["spinbox"], "Shininess control could not be found.")
+        self.assertTrue(all(mat.Shininess == 0.5 for mat in feature.ViewObject.ShapeAppearance))

--- a/src/Mod/Material/Gui/DlgDisplayProperties.ui
+++ b/src/Mod/Material/Gui/DlgDisplayProperties.ui
@@ -339,23 +339,14 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="1" column="0">
-       <layout class="QHBoxLayout">
-        <property name="spacing">
-         <number>6</number>
+       <widget class="QCheckBox" name="replaceFaceAppearances">
+        <property name="toolTip">
+         <string>When selecting a material, replace all face appearances instead of preserving explicit face appearances</string>
         </property>
-        <property name="leftMargin">
-         <number>0</number>
+        <property name="text">
+         <string>Replace face appearances</string>
         </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-       </layout>
+       </widget>
       </item>
       <item row="2" column="0">
        <layout class="QGridLayout" name="gridLayout">

--- a/src/Mod/Material/Gui/DlgDisplayPropertiesImp.cpp
+++ b/src/Mod/Material/Gui/DlgDisplayPropertiesImp.cpp
@@ -45,6 +45,71 @@ using namespace MatGui;
 using namespace std;
 namespace sp = std::placeholders;
 
+namespace
+{
+void applyCustomAppearance(App::PropertyMaterialList& appearance,
+                           const App::Material& original,
+                           const App::Material& custom)
+{
+    const bool ambientChanged = original.ambientColor != custom.ambientColor;
+    const bool diffuseChanged = original.diffuseColor != custom.diffuseColor;
+    const bool emissiveChanged = original.emissiveColor != custom.emissiveColor;
+    const bool specularChanged = original.specularColor != custom.specularColor;
+    const bool shininessChanged = original.shininess != custom.shininess;
+    const bool transparencyChanged = original.transparency != custom.transparency;
+
+    if (ambientChanged) {
+        appearance.setAmbientColor(custom.ambientColor);
+    }
+    if (diffuseChanged) {
+        appearance.setDiffuseColor(custom.diffuseColor);
+    }
+    if (emissiveChanged) {
+        appearance.setEmissiveColor(custom.emissiveColor);
+    }
+    if (specularChanged) {
+        appearance.setSpecularColor(custom.specularColor);
+    }
+    if (shininessChanged) {
+        appearance.setShininess(custom.shininess);
+    }
+    if (transparencyChanged) {
+        appearance.setTransparency(custom.transparency);
+    }
+}
+
+void applyCustomAppearance(App::Material& appearance,
+                           const App::Material& original,
+                           const App::Material& custom)
+{
+    const bool ambientChanged = original.ambientColor != custom.ambientColor;
+    const bool diffuseChanged = original.diffuseColor != custom.diffuseColor;
+    const bool emissiveChanged = original.emissiveColor != custom.emissiveColor;
+    const bool specularChanged = original.specularColor != custom.specularColor;
+    const bool shininessChanged = original.shininess != custom.shininess;
+    const bool transparencyChanged = original.transparency != custom.transparency;
+
+    if (ambientChanged) {
+        appearance.ambientColor = custom.ambientColor;
+    }
+    if (diffuseChanged) {
+        appearance.diffuseColor = custom.diffuseColor;
+    }
+    if (emissiveChanged) {
+        appearance.emissiveColor = custom.emissiveColor;
+    }
+    if (specularChanged) {
+        appearance.specularColor = custom.specularColor;
+    }
+    if (shininessChanged) {
+        appearance.shininess = custom.shininess;
+    }
+    if (transparencyChanged) {
+        appearance.transparency = custom.transparency;
+    }
+}
+}  // namespace
+
 
 /* TRANSLATOR Gui::Dialog::DlgDisplayPropertiesImp */
 
@@ -310,8 +375,15 @@ void DlgDisplayPropertiesImp::slotChangedObject(const Gui::ViewProvider& obj,
                 d->ui.buttonPointColor->blockSignals(blocked);
             }
         }
+        else if (prop.is<App::PropertyMaterial>()) {
+            if (prop_name == "BaseShapeAppearance") {
+                const auto& material = static_cast<const App::PropertyMaterial&>(prop).getValue();
+                d->ui.widgetMaterial->setMaterial(QString::fromStdString(material.uuid));
+            }
+        }
         else if (prop.isDerivedFrom<App::PropertyMaterialList>()) {
-            if (prop_name == "ShapeAppearance") {
+            if (prop_name == "ShapeAppearance"
+                && !dynamic_cast<const Gui::ViewProviderGeometryObject*>(&obj)) {
                 auto& values = static_cast<const App::PropertyMaterialList&>(prop).getValues();
                 auto& material = values[0];
                 d->ui.widgetMaterial->setMaterial(QString::fromStdString(material.uuid));
@@ -364,18 +436,33 @@ void DlgDisplayPropertiesImp::onButtonCustomAppearanceClicked()
 {
     std::vector<Gui::ViewProvider*> Provider = getSelection();
     Gui::Dialog::DlgMaterialPropertiesImp dlg(this);
-    if (!Provider.empty()) {
-        if (auto vp = dynamic_cast<Gui::ViewProviderGeometryObject*>(Provider.front())) {
-            App::Material mat = vp->ShapeAppearance[0];
-            dlg.setCustomMaterial(mat);
-            dlg.setDefaultMaterial(mat);
+    App::Material original;
+    for (auto* vp : Provider) {
+        if (auto* geometry = dynamic_cast<Gui::ViewProviderGeometryObject*>(vp)) {
+            original = geometry->BaseShapeAppearance.getValue();
+            dlg.setCustomMaterial(original);
+            dlg.setDefaultMaterial(original);
+            break;
+        }
+        if (auto* appearance = dynamic_cast<App::PropertyMaterialList*>(
+                vp->getPropertyByName("ShapeAppearance"))) {
+            original = appearance->getValues()[0];
+            dlg.setCustomMaterial(original);
+            dlg.setDefaultMaterial(original);
+            break;
         }
     }
     dlg.exec();
-    App::Material mat = dlg.getCustomMaterial();
+    const App::Material custom = dlg.getCustomMaterial();
     for (auto vp : Provider) {
-        if (auto vpg = dynamic_cast<Gui::ViewProviderGeometryObject*>(vp)) {
-            vpg->ShapeAppearance.setValue(mat);
+        if (auto* appearance = dynamic_cast<App::PropertyMaterialList*>(
+                vp->getPropertyByName("ShapeAppearance"))) {
+            applyCustomAppearance(*appearance, original, custom);
+            if (auto* geometry = dynamic_cast<Gui::ViewProviderGeometryObject*>(vp)) {
+                App::Material baseAppearance = geometry->BaseShapeAppearance.getValue();
+                applyCustomAppearance(baseAppearance, original, custom);
+                geometry->BaseShapeAppearance.setValue(baseAppearance);
+            }
         }
     }
 }
@@ -567,6 +654,12 @@ void DlgDisplayPropertiesImp::setShapeAppearance(const std::vector<Gui::ViewProv
     bool material = false;
     App::Material mat = App::Material(App::Material::DEFAULT);
     for (auto view : views) {
+        if (auto* geometry = dynamic_cast<Gui::ViewProviderGeometryObject*>(view)) {
+            material = true;
+            mat = geometry->BaseShapeAppearance.getValue();
+            d->ui.widgetMaterial->setMaterial(QString::fromStdString(mat.uuid));
+            break;
+        }
         if (auto* prop =
                 dynamic_cast<App::PropertyMaterialList*>(view->getPropertyByName("ShapeAppearance"))) {
             material = true;
@@ -631,8 +724,12 @@ void DlgDisplayPropertiesImp::onMaterialSelected(
 {
     std::vector<Gui::ViewProvider*> Provider = getSelection();
     for (auto it : Provider) {
-        if (auto* prop = dynamic_cast<App::PropertyMaterialList*>(
-                it->getPropertyByName("ShapeAppearance"))) {
+        if (auto* geometry = dynamic_cast<Gui::ViewProviderGeometryObject*>(it)) {
+            geometry->setObjectAppearance(material->getMaterialAppearance(),
+                                          d->ui.replaceFaceAppearances->isChecked());
+        }
+        else if (auto* prop = dynamic_cast<App::PropertyMaterialList*>(
+                     it->getPropertyByName("ShapeAppearance"))) {
             prop->setValue(material->getMaterialAppearance());
         }
     }

--- a/src/Mod/Material/Gui/DlgDisplayPropertiesImp.cpp
+++ b/src/Mod/Material/Gui/DlgDisplayPropertiesImp.cpp
@@ -45,6 +45,40 @@ using namespace MatGui;
 using namespace std;
 namespace sp = std::placeholders;
 
+namespace
+{
+void applyCustomAppearance(App::PropertyMaterialList& appearance,
+                           const App::Material& original,
+                           const App::Material& custom)
+{
+    const bool ambientChanged = original.ambientColor != custom.ambientColor;
+    const bool diffuseChanged = original.diffuseColor != custom.diffuseColor;
+    const bool emissiveChanged = original.emissiveColor != custom.emissiveColor;
+    const bool specularChanged = original.specularColor != custom.specularColor;
+    const bool shininessChanged = original.shininess != custom.shininess;
+    const bool transparencyChanged = original.transparency != custom.transparency;
+
+    if (ambientChanged) {
+        appearance.setAmbientColor(custom.ambientColor);
+    }
+    if (diffuseChanged) {
+        appearance.setDiffuseColor(custom.diffuseColor);
+    }
+    if (emissiveChanged) {
+        appearance.setEmissiveColor(custom.emissiveColor);
+    }
+    if (specularChanged) {
+        appearance.setSpecularColor(custom.specularColor);
+    }
+    if (shininessChanged) {
+        appearance.setShininess(custom.shininess);
+    }
+    if (transparencyChanged) {
+        appearance.setTransparency(custom.transparency);
+    }
+}
+}  // namespace
+
 
 /* TRANSLATOR Gui::Dialog::DlgDisplayPropertiesImp */
 
@@ -364,18 +398,22 @@ void DlgDisplayPropertiesImp::onButtonCustomAppearanceClicked()
 {
     std::vector<Gui::ViewProvider*> Provider = getSelection();
     Gui::Dialog::DlgMaterialPropertiesImp dlg(this);
-    if (!Provider.empty()) {
-        if (auto vp = dynamic_cast<Gui::ViewProviderGeometryObject*>(Provider.front())) {
-            App::Material mat = vp->ShapeAppearance[0];
-            dlg.setCustomMaterial(mat);
-            dlg.setDefaultMaterial(mat);
+    App::Material original;
+    for (auto* vp : Provider) {
+        if (auto* appearance = dynamic_cast<App::PropertyMaterialList*>(
+                vp->getPropertyByName("ShapeAppearance"))) {
+            original = appearance->getValues()[0];
+            dlg.setCustomMaterial(original);
+            dlg.setDefaultMaterial(original);
+            break;
         }
     }
     dlg.exec();
-    App::Material mat = dlg.getCustomMaterial();
+    const App::Material custom = dlg.getCustomMaterial();
     for (auto vp : Provider) {
-        if (auto vpg = dynamic_cast<Gui::ViewProviderGeometryObject*>(vp)) {
-            vpg->ShapeAppearance.setValue(mat);
+        if (auto* appearance = dynamic_cast<App::PropertyMaterialList*>(
+                vp->getPropertyByName("ShapeAppearance"))) {
+            applyCustomAppearance(*appearance, original, custom);
         }
     }
 }

--- a/src/Mod/Part/Gui/TaskFaceAppearances.cpp
+++ b/src/Mod/Part/Gui/TaskFaceAppearances.cpp
@@ -24,6 +24,8 @@
 
 
 #include <sstream>
+#include <boost/dynamic_bitset.hpp>
+
 #include <QFontMetrics>
 #include <QPointer>
 #include <QSet>
@@ -368,8 +370,10 @@ void FaceAppearances::onBoxSelectionToggled(bool checked)
 
 void FaceAppearances::onDefaultButtonClicked()
 {
-    std::fill(d->perface.begin(), d->perface.end(), d->vp->ShapeAppearance[0]);
-    d->vp->ShapeAppearance.setValues(d->perface);
+    const App::Material& appearance = d->vp->BaseShapeAppearance.getValue();
+    std::fill(d->perface.begin(), d->perface.end(), appearance);
+    d->vp->ShapeAppearance.setValue(appearance);
+    d->vp->FaceAppearanceOverrides.setValues({});
 }
 
 void FaceAppearances::onMaterialSelected(const std::shared_ptr<Materials::Material>& material)
@@ -380,6 +384,7 @@ void FaceAppearances::onMaterialSelected(const std::shared_ptr<Materials::Materi
         for (int it : d->index) {
             d->perface[it] = appearance;
         }
+        markFaceAppearanceOverrides();
         d->vp->ShapeAppearance.setValues(d->perface);
         // new color has been applied, unselect so that users can see this
         onSelectionChanged(Gui::SelectionChanges::ClrSelection);
@@ -510,11 +515,30 @@ void FaceAppearances::onButtonCustomAppearanceClicked()
         for (int it : d->index) {
             d->perface[it] = dlg.getCustomMaterial();
         }
+        markFaceAppearanceOverrides();
         d->vp->ShapeAppearance.setValues(d->perface);
         // new color has been applied, unselect so that users can see this
         onSelectionChanged(Gui::SelectionChanges::ClrSelection);
         Gui::Selection().clearSelection();
     }
+}
+
+void FaceAppearances::markFaceAppearanceOverrides()
+{
+    const int faceCount = static_cast<int>(d->perface.size());
+    auto overrides = d->vp->FaceAppearanceOverrides.getValues();
+    if (d->vp->ShapeAppearance.getSize() == 1) {
+        d->vp->BaseShapeAppearance.setValue(d->vp->ShapeAppearance[0]);
+        overrides = boost::dynamic_bitset<>(faceCount);
+    }
+    else if (static_cast<int>(overrides.size()) != faceCount) {
+        overrides = boost::dynamic_bitset<>(faceCount, true);
+    }
+
+    for (int it : d->index) {
+        overrides.set(it);
+    }
+    d->vp->FaceAppearanceOverrides.setValues(overrides);
 }
 
 void FaceAppearances::open()

--- a/src/Mod/Part/Gui/TaskFaceAppearances.h
+++ b/src/Mod/Part/Gui/TaskFaceAppearances.h
@@ -72,6 +72,7 @@ protected:
     void updatePanel();
     void syncMaterialWidget();
     int getFirstIndex() const;
+    void markFaceAppearanceOverrides();
 
 private:
     class Private;

--- a/src/Mod/Part/parttests/TaskFaceAppearancesTest.py
+++ b/src/Mod/Part/parttests/TaskFaceAppearancesTest.py
@@ -79,3 +79,29 @@ class TaskFaceAppearancesGuiTest(unittest.TestCase):
 
         # 3. Close the Task Panel gracefully
         FreeCADGui.Control.closeDialog()
+
+    def test_face_material_marks_only_selected_faces_as_overrides(self):
+        if not FreeCAD.GuiUp:
+            self.skipTest("This test requires a graphical user interface (GUI).")
+
+        FreeCADGui.Selection.addSelection(self.doc.Name, "Box")
+        FreeCADGui.runCommand("Part_ColorPerFace")
+
+        main_window = FreeCADGui.getMainWindow()
+        widget_material = main_window.findChild(QtWidgets.QWidget, "widgetMaterial")
+        self.assertIsNotNone(widget_material, "Material widget not found in the UI.")
+
+        FreeCADGui.Selection.addSelection(self.doc.Name, "Box", "Face1")
+
+        import MatGui
+
+        material_tree = MatGui.MaterialTreeWidget(widget_material)
+        material_tree.UUID = "d1f317f0-5ffa-4798-8ab3-af2ff0b5182c"
+        QtWidgets.QApplication.processEvents()
+
+        self.assertEqual(
+            self.box.ViewObject.FaceAppearanceOverrides,
+            (True, False, False, False, False, False),
+        )
+
+        FreeCADGui.Control.closeDialog()


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
- Appearance edits now preserve imported per-face colors unless the diffuse color is explicitly changed
- Canceling a shape-color picker causes no appearance write, so it cannot reset colors
- Added a GUI regression test for preserving per-face colors while changing shininess

Assisted-by: GPT-5.6-Terra
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes #12415.



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
