### PR TITLE
Part: Add MidPlane Attachment

### DIFF
--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -77,6 +77,73 @@
 using namespace Part;
 using namespace Attacher;
 
+namespace
+{
+struct PlanarFaceInfo
+{
+    gp_Pln plane;
+    gp_Dir normal;
+    gp_Pnt center;
+};
+
+PlanarFaceInfo getPlanarFaceInfo(const TopoShape& shape, double precision)
+{
+    TopoDS_Face face;
+    gp_Pln plane;
+    bool reverse = false;
+
+    try {
+        face = TopoDS::Face(shape.getShape());
+    }
+    catch (...) {
+    }
+
+    if (face.IsNull()) {
+        if (!shape.findPlane(plane)) {
+            throw Base::ValueError("No planar face in AttachEngine3D::calculateAttachedPlacement()!");
+        }
+    }
+    else {
+        BRepAdaptor_Surface adapt(face);
+        if (adapt.GetType() == GeomAbs_Plane) {
+            plane = adapt.Plane();
+        }
+        else {
+            TopLoc_Location loc;
+            Handle(Geom_Surface) surface = BRep_Tool::Surface(face, loc);
+            GeomLib_IsPlanarSurface check(surface, precision);
+            if (!check.IsPlanar()) {
+                throw Base::ValueError(
+                    "No planar face in AttachEngine3D::calculateAttachedPlacement()!"
+                );
+            }
+            plane = check.Plan();
+        }
+
+        reverse = face.Orientation() == TopAbs_REVERSED;
+    }
+
+    if (!plane.Direct()) {
+        // Use a right-handed coordinate system before calculating the face normal.
+        plane.UReverse();
+        reverse = !reverse;
+    }
+
+    gp_Ax1 normal = plane.Axis();
+    if (reverse) {
+        normal.Reverse();
+    }
+
+    PlanarFaceInfo result {plane, normal.Direction(), plane.Location()};
+    if (!face.IsNull() && !face.Infinite()) {
+        GProp_GProps properties;
+        BRepGProp::SurfaceProperties(face, properties);
+        result.center = properties.CentreOfMass();
+    }
+    return result;
+}
+}  // namespace
+
 // These strings are for mode list enum property.
 const char* AttachEngine::eMapModeStrings[] = {
     "Deactivated",
@@ -141,6 +208,7 @@ const char* AttachEngine::eMapModeStrings[] = {
 
     "ParallelPlane",
     "MidPoint",
+    "MidPlane",
 
     nullptr
 };
@@ -1235,6 +1303,7 @@ AttachEngine3D::AttachEngine3D()
     modeRefTypes[mmInertialCS].push_back(cat(rtAnything, rtAnything, rtAnything, rtAnything));
 
     modeRefTypes[mmFlatFace].push_back(cat(rtFlatFace));
+    modeRefTypes[mmMidPlane].push_back(cat(rtFlatFace, rtFlatFace));
 
     modeRefTypes[mmTangentPlane].push_back(cat(rtFace, rtVertex));
     modeRefTypes[mmTangentPlane].push_back(cat(rtVertex, rtFace));
@@ -1531,61 +1600,37 @@ Base::Placement AttachEngine3D::_calculateAttachedPlacement(
                 );
             }
 
-            TopoDS_Face face;
-            gp_Pln plane;
-            bool Reverse = false;
-            try {
-                face = TopoDS::Face(shapes[0]->getShape());
-            }
-            catch (...) {
-            }
-            if (face.IsNull()) {
-                if (!TopoShape(*shapes[0]).findPlane(plane)) {
-                    throw Base::ValueError(
-                        "No planar face in AttachEngine3D::calculateAttachedPlacement()!"
-                    );
-                }
-            }
-            else {
-                BRepAdaptor_Surface adapt(face);
-                if (adapt.GetType() == GeomAbs_Plane) {
-                    plane = adapt.Plane();
-                }
-                else {
-                    TopLoc_Location loc;
-                    Handle(Geom_Surface) surf = BRep_Tool::Surface(face, loc);
-                    GeomLib_IsPlanarSurface check(surf, precision);
-                    if (check.IsPlanar()) {
-                        plane = check.Plan();
-                    }
-                    else {
-                        throw Base::ValueError(
-                            "No planar face in AttachEngine3D::calculateAttachedPlacement()!"
-                        );
-                    }
-                }
+            const PlanarFaceInfo faceInfo = getPlanarFaceInfo(*shapes[0], precision);
+            SketchNormal = faceInfo.normal;
 
-                if (face.Orientation() == TopAbs_REVERSED) {
-                    Reverse = true;
-                }
-            }
-
-            Standard_Boolean ok = plane.Direct();
-            if (!ok) {
-                // toggle if plane has a left-handed coordinate system
-                plane.UReverse();
-                Reverse = !Reverse;
-            }
-            gp_Ax1 Normal = plane.Axis();
-            if (Reverse) {
-                Normal.Reverse();
-            }
-            SketchNormal = Normal.Direction();
-
-            Handle(Geom_Plane) gPlane = new Geom_Plane(plane);
+            Handle(Geom_Plane) gPlane = new Geom_Plane(faceInfo.plane);
             GeomAPI_ProjectPointOnSurf projector(refOrg, gPlane);
             SketchBasePoint = projector.NearestPoint();
 
+        } break;
+        case mmMidPlane: {
+            if (shapes.size() != 2) {
+                throw Base::ValueError(
+                    "AttachEngine3D::calculateAttachedPlacement: need exactly two planar faces."
+                );
+            }
+
+            const PlanarFaceInfo firstFace = getPlanarFaceInfo(*shapes[0], precision);
+            const PlanarFaceInfo secondFace = getPlanarFaceInfo(*shapes[1], precision);
+
+            gp_Vec firstNormal(firstFace.normal);
+            gp_Vec secondNormal(secondFace.normal);
+            // A plane has no intrinsic normal direction. Align the second face to the first so
+            // that opposite-facing parallel faces produce the same midplane orientation.
+            if (firstNormal.Dot(secondNormal) < 0.0) {
+                secondNormal.Reverse();
+            }
+            SketchNormal = gp_Dir(firstNormal.Added(secondNormal));
+            SketchBasePoint = gp_Pnt(
+                (firstFace.center.X() + secondFace.center.X()) * 0.5,
+                (firstFace.center.Y() + secondFace.center.Y()) * 0.5,
+                (firstFace.center.Z() + secondFace.center.Z()) * 0.5
+            );
         } break;
         case mmTangentPlane: {
             if (shapes.size() < 2) {

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -142,6 +142,42 @@ PlanarFaceInfo getPlanarFaceInfo(const TopoShape& shape, double precision)
     }
     return result;
 }
+
+gp_Dir getMidPlaneNormal(const PlanarFaceInfo& firstFace, const PlanarFaceInfo& secondFace)
+{
+    const gp_Vec firstNormal(firstFace.normal);
+    const gp_Vec secondNormal(secondFace.normal);
+    const gp_Vec normalSum = firstNormal.Added(secondNormal);
+    const gp_Vec normalDifference = firstNormal.Subtracted(secondNormal);
+
+    // The sum and difference are the normals of the two dihedral bisector planes. Select the
+    // one that separates the face centers, so the plane lies between the selected faces.
+    const gp_Vec centerDirection(firstFace.center, secondFace.center);
+    const auto alignment = [&centerDirection](const gp_Vec& normal) {
+        const double dotProduct = centerDirection.Dot(normal);
+        return dotProduct * dotProduct / normal.SquareMagnitude();
+    };
+
+    if (normalSum.SquareMagnitude() < Precision::SquareConfusion()) {
+        return gp_Dir(normalDifference);
+    }
+    if (normalDifference.SquareMagnitude() < Precision::SquareConfusion()) {
+        return gp_Dir(normalSum);
+    }
+    const double sumAlignment = alignment(normalSum);
+    const double differenceAlignment = alignment(normalDifference);
+    if (sumAlignment > differenceAlignment) {
+        return gp_Dir(normalSum);
+    }
+    if (differenceAlignment > sumAlignment) {
+        return gp_Dir(normalDifference);
+    }
+
+    // The center direction does not distinguish the two planes. Keep the acute-angle bisector.
+    return gp_Dir(
+        normalSum.SquareMagnitude() >= normalDifference.SquareMagnitude() ? normalSum : normalDifference
+    );
+}
 }  // namespace
 
 // These strings are for mode list enum property.
@@ -1618,14 +1654,7 @@ Base::Placement AttachEngine3D::_calculateAttachedPlacement(
             const PlanarFaceInfo firstFace = getPlanarFaceInfo(*shapes[0], precision);
             const PlanarFaceInfo secondFace = getPlanarFaceInfo(*shapes[1], precision);
 
-            gp_Vec firstNormal(firstFace.normal);
-            gp_Vec secondNormal(secondFace.normal);
-            // A plane has no intrinsic normal direction. Align the second face to the first so
-            // that opposite-facing parallel faces produce the same midplane orientation.
-            if (firstNormal.Dot(secondNormal) < 0.0) {
-                secondNormal.Reverse();
-            }
-            SketchNormal = gp_Dir(firstNormal.Added(secondNormal));
+            SketchNormal = getMidPlaneNormal(firstFace, secondFace);
             SketchBasePoint = gp_Pnt(
                 (firstFace.center.X() + secondFace.center.X()) * 0.5,
                 (firstFace.center.Y() + secondFace.center.Y()) * 0.5,

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -114,6 +114,7 @@ enum eMapMode
 
     mmParallelPlane,
     mmMidpoint,
+    mmMidPlane,
 
     mmDummy_NumberOfModes  // a value useful to check the validity of mode value
 };  // see also eMapModeStrings[] definition in .cpp

--- a/src/Mod/Part/Gui/AttacherTexts.cpp
+++ b/src/Mod/Part/Gui/AttacherTexts.cpp
@@ -106,6 +106,16 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
                         "Attachment3D mode tooltip"
                     )
                 );
+            case mmMidPlane:
+                return TwoStrings(
+                    qApp->translate("Attacher3D", "Midplane between faces", "Attachment3D mode caption"),
+                    qApp->translate(
+                        "Attacher3D",
+                        "Plane origin is midway between the centers of two planar faces and its "
+                        "orientation equally bisects their angle.",
+                        "Attachment3D mode tooltip"
+                    )
+                );
             case mmFlatFace:
                 return TwoStrings(
                     qApp->translate("Attacher3D", "XY on plane", "Attachment3D mode caption"),
@@ -345,6 +355,16 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
                         "Attacher2D",
                         "X' Y' plane is parallel to the plane (object's XY) and passes through the "
                         "vertex",
+                        "AttachmentPlane mode tooltip"
+                    )
+                );
+            case mmMidPlane:
+                return TwoStrings(
+                    qApp->translate("Attacher2D", "Midplane between faces", "AttachmentPlane mode caption"),
+                    qApp->translate(
+                        "Attacher2D",
+                        "Plane origin is midway between the centers of two planar faces and its "
+                        "orientation equally bisects their angle.",
                         "AttachmentPlane mode tooltip"
                     )
                 );

--- a/tests/src/Mod/Part/App/AttachExtension.cpp
+++ b/tests/src/Mod/Part/App/AttachExtension.cpp
@@ -2,10 +2,12 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <numbers>
 
 #include <src/App/InitApplication.h>
 #include <App/Document.h>
+#include <Mod/Part/App/FeaturePartBox.h>
 #include <Mod/Part/App/PrimitiveFeature.h>
 
 
@@ -128,6 +130,35 @@ TEST_F(AttachExtensionTest, testMidPlaneBisectsFaceAngle)
     EXPECT_NEAR(normal.x, expectedNormal.x, 1e-7);
     EXPECT_NEAR(normal.y, expectedNormal.y, 1e-7);
     EXPECT_NEAR(normal.z, expectedNormal.z, 1e-7);
+}
+
+TEST_F(AttachExtensionTest, testMidPlaneBisectsConnectedFaces)
+{
+    auto box = getDocument()->addObject<Part::Box>("Box");
+    auto midPlane = getDocument()->addObject<Part::Plane>("MidPlane");
+
+    ASSERT_TRUE(box);
+    ASSERT_TRUE(midPlane);
+
+    box->Length.setValue(100.0);
+    box->Width.setValue(60.0);
+    box->Height.setValue(20.0);
+    midPlane->AttachmentSupport.setValues({box, box}, {"Face6", "Face4"});
+    midPlane->MapMode.setValue("MidPlane");
+
+    getDocument()->recompute();
+
+    const Base::Placement placement = midPlane->Placement.getValue();
+    const Base::Vector3d position = placement.getPosition();
+    EXPECT_NEAR(position.x, 50.0, 1e-7);
+    EXPECT_NEAR(position.y, 45.0, 1e-7);
+    EXPECT_NEAR(position.z, 15.0, 1e-7);
+
+    Base::Vector3d normal;
+    placement.getRotation().multVec(Base::Vector3d(0, 0, 1), normal);
+    EXPECT_NEAR(normal.x, 0.0, 1e-7);
+    EXPECT_NEAR(normal.y, -std::sqrt(0.5), 1e-7);
+    EXPECT_NEAR(normal.z, std::sqrt(0.5), 1e-7);
 }
 
 TEST_F(AttachExtensionTest, testAttacherEngineType)

--- a/tests/src/Mod/Part/App/AttachExtension.cpp
+++ b/tests/src/Mod/Part/App/AttachExtension.cpp
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include <numbers>
+
 #include <src/App/InitApplication.h>
 #include <App/Document.h>
 #include <Mod/Part/App/PrimitiveFeature.h>
@@ -53,6 +55,79 @@ TEST_F(AttachExtensionTest, testPlanePlane)
 
     getDocument()->recompute();
     EXPECT_TRUE(true);
+}
+
+TEST_F(AttachExtensionTest, testMidPlane)
+{
+    auto firstPlane = getDocument()->addObject<Part::Plane>("FirstPlane");
+    auto secondPlane = getDocument()->addObject<Part::Plane>("SecondPlane");
+    auto midPlane = getDocument()->addObject<Part::Plane>("MidPlane");
+
+    ASSERT_TRUE(firstPlane);
+    ASSERT_TRUE(secondPlane);
+    ASSERT_TRUE(midPlane);
+
+    secondPlane->Placement.setValue(
+        Base::Placement(
+            Base::Vector3d(0, 100, 20),
+            Base::Rotation(Base::Vector3d(1, 0, 0), std::numbers::pi)
+        )
+    );
+    midPlane->AttachmentSupport.setValues({firstPlane, secondPlane}, {"", ""});
+    midPlane->MapMode.setValue("MidPlane");
+    EXPECT_STREQ(midPlane->MapMode.getValueAsString(), "MidPlane");
+
+    getDocument()->recompute();
+
+    const Base::Placement placement = midPlane->Placement.getValue();
+    const Base::Vector3d position = placement.getPosition();
+    EXPECT_NEAR(position.x, 50.0, 1e-7);
+    EXPECT_NEAR(position.y, 50.0, 1e-7);
+    EXPECT_NEAR(position.z, 10.0, 1e-7);
+
+    Base::Vector3d normal;
+    placement.getRotation().multVec(Base::Vector3d(0, 0, 1), normal);
+    EXPECT_NEAR(normal.x, 0.0, 1e-7);
+    EXPECT_NEAR(normal.y, 0.0, 1e-7);
+    EXPECT_NEAR(normal.z, 1.0, 1e-7);
+}
+
+TEST_F(AttachExtensionTest, testMidPlaneBisectsFaceAngle)
+{
+    auto firstPlane = getDocument()->addObject<Part::Plane>("FirstPlane");
+    auto secondPlane = getDocument()->addObject<Part::Plane>("SecondPlane");
+    auto midPlane = getDocument()->addObject<Part::Plane>("MidPlane");
+
+    ASSERT_TRUE(firstPlane);
+    ASSERT_TRUE(secondPlane);
+    ASSERT_TRUE(midPlane);
+
+    const Base::Placement secondPlacement(
+        Base::Vector3d(0, 0, 10),
+        Base::Rotation(Base::Vector3d(1, 0, 0), std::numbers::pi / 2.0)
+    );
+    secondPlane->Placement.setValue(secondPlacement);
+    midPlane->AttachmentSupport.setValues({firstPlane, secondPlane}, {"", ""});
+    midPlane->MapMode.setValue("MidPlane");
+
+    getDocument()->recompute();
+
+    const Base::Vector3d position = midPlane->Placement.getValue().getPosition();
+    EXPECT_NEAR(position.x, 50.0, 1e-7);
+    EXPECT_NEAR(position.y, 25.0, 1e-7);
+    EXPECT_NEAR(position.z, 30.0, 1e-7);
+
+    Base::Vector3d secondNormal;
+    secondPlacement.getRotation().multVec(Base::Vector3d(0, 0, 1), secondNormal);
+    Base::Vector3d expectedNormal(0, 0, 1);
+    expectedNormal += secondNormal;
+    expectedNormal.Normalize();
+
+    Base::Vector3d normal;
+    midPlane->Placement.getValue().getRotation().multVec(Base::Vector3d(0, 0, 1), normal);
+    EXPECT_NEAR(normal.x, expectedNormal.x, 1e-7);
+    EXPECT_NEAR(normal.y, expectedNormal.y, 1e-7);
+    EXPECT_NEAR(normal.z, expectedNormal.z, 1e-7);
 }
 
 TEST_F(AttachExtensionTest, testAttacherEngineType)


### PR DESCRIPTION
- Adds a MidPlane attachment mode between two planar faces
- Places the attachment origin midway between the face centers
- For angled faces, chooses the angle-bisector plane that separates the two face centers
- Reuses planar-face extraction shared with FlatFace
- Tests added

Assisted-by: GPT-5.6-Terra

Fixes https://github.com/FreeCAD/FreeCAD/issues/24394

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.