### PR TITLE
CAM: MillFacing - Fix for several top faces

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathFacingGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathFacingGenerator.py
@@ -675,6 +675,20 @@ class TestPathFacingGenerator(PathTestBase):
         # Should have 4 edges (rectangular)
         self.assertEqual(len(result.Edges), 4)
 
+    def test_get_angled_polygon_two_wires(self):
+        """Test get_angled_polygon with 0 degree rotation and two wires."""
+        result = facing_common.get_angled_polygon([self.square_wire, self.rectangle_wire], 0)
+
+        # Should get back a valid wire
+        self.assertTrue(result.isClosed())
+        # Bounding box should be a common for both wires
+        original_bb1 = self.square_wire.BoundBox
+        original_bb2 = self.rectangle_wire.BoundBox
+        common_bb = original_bb1.united(original_bb2)
+        result_bb = result.BoundBox
+        self.assertAlmostEqual(common_bb.XLength, result_bb.XLength, places=1)
+        self.assertAlmostEqual(common_bb.YLength, result_bb.YLength, places=1)
+
     def test_analyze_rectangle_axis_aligned(self):
         """Test polygon geometry extraction with axis-aligned rectangle."""
         result = facing_common.extract_polygon_geometry(self.rectangle_wire)

--- a/src/Mod/CAM/Path/Base/Generator/facing_common.py
+++ b/src/Mod/CAM/Path/Base/Generator/facing_common.py
@@ -219,7 +219,7 @@ def get_angled_polygon(wire, angle):
     3. Rotating the bounding box back to the desired angle
 
     Args:
-        wire (Part.Wire): A closed wire to create the rotated bounding box for
+        wire (Part.Wire): A closed wire or list of wires to create the rotated bounding box for
         angle (float): Rotation angle in degrees (positive = counterclockwise)
 
     Returns:
@@ -228,7 +228,10 @@ def get_angled_polygon(wire, angle):
     Raises:
         ValueError: If the input wire is not closed
     """
-    if not wire.isClosed():
+    if isinstance(wire, (list, tuple)):
+        wire = Part.Compound(wire)
+
+    if any(not w.isClosed() for w in wire.Wires):
         raise ValueError("Wire must be closed")
 
     # Get the center point of the original wire for all rotations

--- a/src/Mod/CAM/Path/Op/MillFacing.py
+++ b/src/Mod/CAM/Path/Op/MillFacing.py
@@ -299,8 +299,9 @@ class ObjectMillFacing(PathOp.ObjectOp):
 
         # Determine the step-downs
         finish_step = 0.0  # No finish step for facing
+        final_depth = obj.FinalDepth.Value + obj.AxialStockToLeave.Value
         Path.Log.debug(
-            f"Depth parameters: clearance={obj.ClearanceHeight.Value}, safe={obj.SafeHeight.Value}, start={obj.StartDepth.Value}, step={obj.StepDown.Value}, final={obj.FinalDepth.Value + obj.AxialStockToLeave.Value}"
+            f"Depth parameters: clearance={obj.ClearanceHeight.Value}, safe={obj.SafeHeight.Value}, start={obj.StartDepth.Value}, step={obj.StepDown.Value}, final={final_depth}"
         )
         depthparams = PathUtils.depth_params(
             clearance_height=obj.ClearanceHeight.Value,
@@ -308,7 +309,7 @@ class ObjectMillFacing(PathOp.ObjectOp):
             start_depth=obj.StartDepth.Value,
             step_down=obj.StepDown.Value,
             z_finish_step=finish_step,
-            final_depth=obj.FinalDepth.Value + obj.AxialStockToLeave.Value,
+            final_depth=final_depth,
             user_depths=None,
         )
         Path.Log.debug(f"Depth params object: {depthparams}")
@@ -317,45 +318,22 @@ class ObjectMillFacing(PathOp.ObjectOp):
         # when a 3+2 workplane is active.
         if self.stock and hasattr(self.stock, "Shape") and self.stock.Shape:
             Path.Log.debug(f"Stock: {self.stock.Label}")
-            stock_faces = self.stock.Shape.Faces
-            Path.Log.debug(f"Number of stock faces: {len(stock_faces)}")
-
-            # Find faces with normal pointing toward Z+ (upward)
-            z_up_faces = []
-            for face in stock_faces:
-                # Get face normal at center
-                u_mid = (face.ParameterRange[0] + face.ParameterRange[1]) / 2
-                v_mid = (face.ParameterRange[2] + face.ParameterRange[3]) / 2
-                normal = face.normalAt(u_mid, v_mid)
-                Path.Log.debug(f"Face normal: {normal}, Z component: {normal.z}")
-
-                # Check if normal points upward (Z+ direction) with some tolerance
-                if normal.z > 0.9:  # Allow for slight deviation from perfect vertical
-                    z_up_faces.append(face)
-                    Path.Log.debug(f"Found upward-facing face at Z={face.BoundBox.ZMax}")
-
-            if not z_up_faces:
-                Path.Log.error("No upward-facing faces found in stock")
-                raise ValueError("No upward-facing faces found in stock")
-
-            # From the upward-facing faces, select the highest one
-            top_face = max(z_up_faces, key=lambda f: f.BoundBox.ZMax)
-            Path.Log.debug(f"Selected top face ZMax: {top_face.BoundBox.ZMax}")
-            boundary_wire = top_face.OuterWire
-            Path.Log.debug(f"Wire vertices: {len(boundary_wire.Vertexes)}")
+            boundary_wires = self.stock.Shape.slice(FreeCAD.Vector(0, 0, 1), final_depth)
+            if not boundary_wires:
+                Path.Log.error("No shape found at final depth")
+                raise ValueError("No shape found at final depth")
         else:
             Path.Log.error("No stock found for facing operation")
             raise ValueError("No stock found for facing operation")
 
-        boundary_wire = boundary_wire.makeOffset2D(
-            obj.StockExtension.Value, 2
-        )  # offset with intersection joins
+        # offset with intersection joins
+        boundary_wires = [w.makeOffset2D(obj.StockExtension.Value, 2) for w in boundary_wires]
 
         # Convert boundary to a rectangular polygon aligned to the cut angle.
         # Stock faces may have curved edges (e.g. cylindrical stock) and all
         # facing strategies assume a rectangular boundary.
         cut_angle = getattr(obj.Angle, "Value", obj.Angle)
-        boundary_wire = facing_common.get_angled_polygon(boundary_wire, cut_angle)
+        boundary_wire = facing_common.get_angled_polygon(boundary_wires, cut_angle)
 
         # Determine milling direction
         milling_direction = "climb" if obj.CutMode == "Climb" else "conventional"


### PR DESCRIPTION
### Description

**MillFacing** op use one top face

https://github.com/FreeCAD/FreeCAD/blob/0475b124bef1705ad45a548fc0314ada56915d93/src/Mod/CAM/Path/Op/MillFacing.py#L342

This is correct if `Stock` is a simple cube
But `Stock` can be a complicated shape and have several faces upper than final model
Also this faces can be at different depths

E.g. heat sink used as a `Stock` to get specific shape

Test project: [31576_Stock.zip](https://github.com/user-attachments/files/30403714/31576_Stock.zip)

<img width="1218" height="440" alt="Screenshot_20260726_192411_hor" src="https://github.com/user-attachments/assets/e1fa1743-e99f-4ea6-97a8-5b0b01ce38f0" />

---

`Stock` can be a rod and not have a top flat face 
Forum: [MillFacing non-flat stock](https://forum.freecad.org/viewtopic.php?t=106774)
Test project: [MillFacing Example.zip](https://github.com/user-attachments/files/30645845/MillFacing.Example.zip)

<img width="1510" height="473" alt="Screenshot_20260803_070811_hor_lossy" src="https://github.com/user-attachments/assets/c7ec44e3-f768-4594-8f57-9270a77688a5" />

---

### Changes

- Take wires from slice at final depth
- Added test to `facing_common.get_angled_polygon()`

<img width="1073" height="440" alt="Screenshot_20260726_192433_hor" src="https://github.com/user-attachments/assets/6bfffe50-3e5b-43c2-a089-c21fdad8eb12" />