### PR TITLE
Core: FIxes Std_Part not being touched for recomputation if visibility of nested shapes changes

### DIFF
--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -253,7 +253,9 @@ void GeoFeatureGroupExtension::extensionOnChanged(const Property* p)
             }
         }
 
-        // Skip handling in parent class GroupExtension
+        Base::ObjectStatusLocker<Property::Status, Property> connGuard(
+            Property::User3, &Group);
+        App::GroupExtension::extensionOnChanged(p);
         return;
     }
 

--- a/src/Mod/Test/Recompute.py
+++ b/src/Mod/Test/Recompute.py
@@ -392,6 +392,23 @@ class FineGrainedRecomputeCases(unittest.TestCase):
         self.Doc.removeObject(cube1.Name)
 
     @finegrained((True, False))
+    def testChildVisibilityTouchesPart(self):
+        part = self.Doc.addObject("App::Part", "Part")
+        cylinder = self.Doc.addObject("Part::Cylinder", "Cylinder")
+        part.addObject(cylinder)
+        self.Doc.recompute()
+
+        self.assertNotIn("Touched", part.State)
+        self.assertNotIn("Touched", cylinder.State)
+
+        cylinder.Visibility = False
+
+        self.assertIn("Touched", part.State)
+
+        self.Doc.removeObject(cylinder.Name)
+        self.Doc.removeObject(part.Name)
+
+    @finegrained((True, False))
     def testExpression(self):
         # arrange
         cube1 = self.Doc.addObject("Part::Box", "Cube1")


### PR DESCRIPTION
When a child is added to an `App::Part`, `GeoFeatureGroupExtension::extensionOnChanged` fires. It validates the geo-group rules, then returns early . This early return was meant to skip `GroupExtension`'s validation, But it also skipped `GroupExtension`'s  `_Conns`  setup.

Instead of returning early and skipping the parent entirely, we now call the parent (`GroupExtension::extensionOnChanged`) with `User3` status set on the Group property. The `User3` flag makes the parent skip its own validation (since `GeoFeatureGroupExtension` already did that), but still executes the signal connection setup.

Have added a regression test as well.

- [✅ ] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
fixes #31537 


