### PR TITLE
Fix Arch Space label rotation in rotated TechDraw views

### DIFF
--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -1008,7 +1008,7 @@ def get_svg(
             n = vobj.FontName
             a = 0
             if rotation != 0:
-                a = math.radians(rotation)
+                a = -math.radians(rotation) # negative to keep text horizontal
 
             t1 = vobj.Proxy.text1.string.getValues()
             t2 = vobj.Proxy.text2.string.getValues()

--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -1008,7 +1008,7 @@ def get_svg(
             n = vobj.FontName
             a = 0
             if rotation != 0:
-                a = -math.radians(rotation) # negative to keep text horizontal
+                a = -math.radians(rotation)  # negative to keep text horizontal
 
             t1 = vobj.Proxy.text1.string.getValues()
             t2 = vobj.Proxy.text2.string.getValues()


### PR DESCRIPTION
Fix the orientation of Arch Space labels when an Arch SectionPlane is
displayed in a rotated TechDraw view.

Previously the label rotation was applied in the same direction as the
TechDraw view rotation, causing room labels to rotate together with the
page. For example, a view rotation of 90° resulted in labels rotated by
180° relative to the page.

This change applies the inverse rotation so that room labels remain
upright regardless of the TechDraw view rotation.

**Before**

- View rotation 90° → room labels upside down
- Arbitrary view rotation θ → room labels rotated by 2θ

**After**

- Room labels remain readable for arbitrary TechDraw view rotations.

**Notes**

This change only affects Arch Space annotations. Other annotation types
and dimensions retain their existing behavior.