### PR TITLE
Auto-flip dimension text to keep it readable in rotated TechDraw views

### DIFF
--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -376,7 +376,7 @@ def _svg_dimension(
                 linewidth,
                 angle + math.pi,
             )
-    
+
     # drawing text
     svg += svgtext.get_text(
         plane, techdraw, tstroke, fontsize, vobj.FontName, tangle, tbase, prx.string
@@ -1008,7 +1008,7 @@ def get_svg(
             n = vobj.FontName
             a = 0
             if rotation != 0:
-                a = -math.radians(rotation) # negative to keep text horizontal
+                a = -math.radians(rotation)  # negative to keep text horizontal
 
             t1 = vobj.Proxy.text1.string.getValues()
             t2 = vobj.Proxy.text2.string.getValues()

--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -1008,7 +1008,7 @@ def get_svg(
             n = vobj.FontName
             a = 0
             if rotation != 0:
-                a = math.radians(rotation)
+                a = -math.radians(rotation) # negative to keep text horizontal
 
             t1 = vobj.Proxy.text1.string.getValues()
             t2 = vobj.Proxy.text2.string.getValues()

--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -376,7 +376,7 @@ def _svg_dimension(
                 linewidth,
                 angle + math.pi,
             )
-
+    
     # drawing text
     svg += svgtext.get_text(
         plane, techdraw, tstroke, fontsize, vobj.FontName, tangle, tbase, prx.string


### PR DESCRIPTION
## Summary

Automatically flip Draft dimension text in TechDraw views whenever the
projected text would appear upside down.

Previously, users had to manually enable the `FlipText` property to
correct the text orientation. With this change, dimension text is
automatically kept readable on the drawing, regardless of the TechDraw
view rotation.

This only affects the displayed text orientation and preserves the
existing manual `FlipText` functionality.