### PR TITLE
CAM: MBPP and Job Dialog - Operations data

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/DlgPostProcess.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DlgPostProcess.ui
@@ -229,7 +229,35 @@
          </property>
          <column>
           <property name="text">
+           <string>#</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
            <string>Operation</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Tool</string>
+          </property>
+          <property name="textAlignment">
+           <set>AlignCenter</set>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Tool Controller</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Coolant</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Time</string>
           </property>
          </column>
         </widget>

--- a/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
@@ -1574,10 +1574,40 @@ If &lt;span style=&quot; font-style:italic;&quot;&gt;order by&lt;/span&gt; is se
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_4">
       <item>
-       <widget class="QListWidget" name="operationsList">
-        <property name="dragDropMode">
-         <enum>QAbstractItemView::InternalMove</enum>
-        </property>
+       <widget class="QTreeWidget" name="operationsList">
+        <column>
+         <property name="text">
+          <string>#</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Operation</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Tool</string>
+         </property>
+         <property name="textAlignment">
+          <set>AlignCenter</set>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Tool Controller</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Coolant</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Time</string>
+         </property>
+        </column>
        </widget>
       </item>
       <item>

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -976,8 +976,8 @@ class TaskPanel:
             self.obj.Label = str(self.form.jobLabel.text())
             self.obj.Description = str(self.form.jobDescription.toPlainText())
             self.obj.Operations.Group = [
-                self.form.operationsList.item(i).data(self.DataObject)
-                for i in range(self.form.operationsList.count())
+                self.form.operationsList.invisibleRootItem().child(i).data(self.DataObject, 0)
+                for i in range(self.form.operationsList.topLevelItemCount())
             ]
             try:
                 self.obj.SplitOutput = self.form.splitOutput.isChecked()
@@ -1112,11 +1112,43 @@ class TaskPanel:
         # self.obj.Proxy.onChanged(self.obj, "PostProcessor")
         self.updateTooltips()
 
-        self.form.operationsList.clear()
-        for child in self.obj.Operations.Group:
-            item = QtGui.QListWidgetItem(child.Label)
-            item.setData(self.DataObject, child)
-            self.form.operationsList.addItem(item)
+        col_num = 0
+        col_op_label = 1
+        col_tool_number = 2
+        col_tc = 3
+        col_coolant = 4
+        col_time = 5
+
+        tree = self.form.operationsList
+        tree.blockSignals(True)
+        tree.setTextElideMode(QtCore.Qt.ElideMiddle)
+        tree.setWordWrap(False)
+        tree.clear()
+
+        for index, op in enumerate(self.obj.Operations.Group):
+            item = QtGui.QTreeWidgetItem(tree)
+            item.setData(self.DataObject, 0, op)
+            item.setText(col_num, str(index))
+            item.setText(col_op_label, op.Label)
+            if tc := PathUtil.toolControllerForOp(op):
+                tcLabel = tc.Label
+                toolNumber = str(tc.ToolNumber)
+            else:
+                tcLabel = "???"
+                toolNumber = ""
+            item.setText(col_tool_number, toolNumber)
+            item.setTextAlignment(col_tool_number, QtCore.Qt.AlignCenter)
+            item.setText(col_tc, tcLabel)
+            coolant = PathUtil.coolantModeForOp(op)
+            coolantString = coolant if coolant != "None" else ""
+            item.setText(col_coolant, coolantString)
+            item.setText(col_time, getattr(op, "CycleTime", ""))
+
+        for column in range(tree.columnCount()):
+            tree.resizeColumnToContents(column)
+
+        tree.resizeColumnToContents(0)
+        tree.blockSignals(False)
 
         self.form.jobModel.clear()
         for name, count in Counter(
@@ -1145,19 +1177,23 @@ class TaskPanel:
             self.setFields()
 
     def operationSelect(self):
-        if self.form.operationsList.selectedItems():
+        tree = self.form.operationsList
+        if tree.selectedItems():
             self.form.operationModify.setEnabled(True)
             self.form.operationMove.setEnabled(True)
-            row = self.form.operationsList.currentRow()
-            self.form.operationUp.setEnabled(row > 0)
-            self.form.operationDown.setEnabled(row < self.form.operationsList.count() - 1)
+            selected_item = tree.currentItem()
+            if selected_item:
+                row = tree.indexOfTopLevelItem(selected_item)
+                # row = tree.currentItem()
+                self.form.operationUp.setEnabled(row > 0)
+                self.form.operationDown.setEnabled(row < tree.topLevelItemCount() - 1)
         else:
             self.form.operationModify.setEnabled(False)
             self.form.operationMove.setEnabled(False)
 
     def objectDelete(self, widget):
         for item in widget.selectedItems():
-            obj = item.data(self.DataObject)
+            obj = item.data(self.DataObject, 0)
             if (
                 obj.ViewObject
                 and hasattr(obj.ViewObject, "Proxy")
@@ -1171,19 +1207,21 @@ class TaskPanel:
         self.objectDelete(self.form.operationsList)
 
     def operationMoveUp(self):
-        row = self.form.operationsList.currentRow()
+        selected_item = self.form.operationsList.currentItem()
+        row = self.form.operationsList.indexOfTopLevelItem(selected_item)
         if row > 0:
-            item = self.form.operationsList.takeItem(row)
-            self.form.operationsList.insertItem(row - 1, item)
-            self.form.operationsList.setCurrentRow(row - 1)
+            item = self.form.operationsList.takeTopLevelItem(row)
+            self.form.operationsList.insertTopLevelItem(row - 1, item)
+            self.form.operationsList.setCurrentItem(item)
             self.getFields()
 
     def operationMoveDown(self):
-        row = self.form.operationsList.currentRow()
-        if row < self.form.operationsList.count() - 1:
-            item = self.form.operationsList.takeItem(row)
-            self.form.operationsList.insertItem(row + 1, item)
-            self.form.operationsList.setCurrentRow(row + 1)
+        selected_item = self.form.operationsList.currentItem()
+        row = self.form.operationsList.indexOfTopLevelItem(selected_item)
+        if row < self.form.operationsList.topLevelItemCount() - 1:
+            item = self.form.operationsList.takeTopLevelItem(row)
+            self.form.operationsList.insertTopLevelItem(row + 1, item)
+            self.form.operationsList.setCurrentItem(item)
             self.getFields()
 
     def toolControllerSelect(self):
@@ -1723,7 +1761,7 @@ class TaskPanel:
 
         # Workplan
         self.form.operationsList.itemSelectionChanged.connect(self.operationSelect)
-        self.form.operationsList.indexesMoved.connect(self.getFields)
+        self.form.operationsList.itemChanged.connect(self.getFields)
         self.form.operationDelete.clicked.connect(self.operationDelete)
         self.form.operationUp.clicked.connect(self.operationMoveUp)
         self.form.operationDown.clicked.connect(self.operationMoveDown)

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -558,21 +558,48 @@ class PostProcessDialog:
         dlg.plainTextEditComment.setPlainText(getattr(self.job, "Description", "") or "")
 
     def _populate_operations(self):
+        from Path.Base.Util import toolControllerForOp, coolantModeForOp
+
+        col_num = 0
+        col_op_label = 1
+        col_tool_number = 2
+        col_tc = 3
+        col_coolant = 4
+        col_time = 5
         dlg = self.dialog
         tree = dlg.treeWidgetOperations
         tree.blockSignals(True)
+        tree.setTextElideMode(QtCore.Qt.ElideMiddle)
+        tree.setWordWrap(False)
         tree.clear()
-        tree.setHeaderHidden(True)
 
-        for op in self._get_active_operations():
+        for index, op in enumerate(self._get_active_operations(), 1):
             item = QtGui.QTreeWidgetItem(tree)
-            item.setText(0, op.Label)
             item.setCheckState(0, QtCore.Qt.CheckState.Checked)
             item.setFlags(
                 item.flags()
                 | QtCore.Qt.ItemFlag.ItemIsUserCheckable
                 | QtCore.Qt.ItemFlag.ItemIsEnabled
             )
+
+            item.setText(col_num, str(index))
+            item.setText(col_op_label, op.Label)
+            if tc := toolControllerForOp(op):
+                tcLabel = tc.Label
+                toolNumber = str(tc.ToolNumber)
+            else:
+                tcLabel = "???"
+                toolNumber = ""
+            item.setText(col_tool_number, toolNumber)
+            item.setTextAlignment(col_tool_number, QtCore.Qt.AlignCenter)
+            item.setText(col_tc, tcLabel)
+            coolant = coolantModeForOp(op)
+            coolantString = coolant if coolant != "None" else ""
+            item.setText(col_coolant, coolantString)
+            item.setText(col_time, getattr(op, "CycleTime", ""))
+
+        for column in range(tree.columnCount()):
+            tree.resizeColumnToContents(column)
 
         tree.resizeColumnToContents(0)
         tree.blockSignals(False)

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -565,15 +565,23 @@ class PostProcessDialog:
         dlg.plainTextEditComment.setPlainText(getattr(self.job, "Description", "") or "")
 
     def _populate_operations(self):
+        from Path.Base.Util import toolControllerForOp, coolantModeForOp
+
+        col_num = 0
+        col_op_label = 1
+        col_tool_number = 2
+        col_tc = 3
+        col_coolant = 4
+        col_time = 5
         dlg = self.dialog
         tree = dlg.treeWidgetOperations
         tree.blockSignals(True)
+        tree.setTextElideMode(QtCore.Qt.ElideMiddle)
+        tree.setWordWrap(False)
         tree.clear()
-        tree.setHeaderHidden(True)
 
-        for op in self._get_active_operations():
+        for index, op in enumerate(self._get_active_operations(), 1):
             item = QtGui.QTreeWidgetItem(tree)
-            item.setText(0, op.Label)
             if not self.operations or op in self.operations["operations"]:
                 item.setCheckState(0, QtCore.Qt.CheckState.Checked)
             else:
@@ -583,6 +591,25 @@ class PostProcessDialog:
                 | QtCore.Qt.ItemFlag.ItemIsUserCheckable
                 | QtCore.Qt.ItemFlag.ItemIsEnabled
             )
+
+            item.setText(col_num, str(index))
+            item.setText(col_op_label, op.Label)
+            if tc := toolControllerForOp(op):
+                tcLabel = tc.Label
+                toolNumber = str(tc.ToolNumber)
+            else:
+                tcLabel = "???"
+                toolNumber = ""
+            item.setText(col_tool_number, toolNumber)
+            item.setTextAlignment(col_tool_number, QtCore.Qt.AlignCenter)
+            item.setText(col_tc, tcLabel)
+            coolant = coolantModeForOp(op)
+            coolantString = coolant if coolant != "None" else ""
+            item.setText(col_coolant, coolantString)
+            item.setText(col_time, getattr(op, "CycleTime", ""))
+
+        for column in range(tree.columnCount()):
+            tree.resizeColumnToContents(column)
 
         tree.resizeColumnToContents(0)
         tree.blockSignals(False)


### PR DESCRIPTION
### Description
A lot of free space in tab **Operations** of MBPP dialog and **Workplan** of Job
Suggested to show some basic information about each operation

<img width="1034" height="398" alt="1_hor_lossy" src="https://github.com/user-attachments/assets/b7a8ed03-13ef-492f-a8f9-7b095b157941" />

<img width="974" height="612" alt="3_hor_lossy" src="https://github.com/user-attachments/assets/60a8d9db-3bde-4733-b67d-d2e1c847f304" />
