### PR TITLE
Collect theme foreground color from available sources for icon brush

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -38,9 +38,6 @@
 #include "ui_SketcherSettingsAppearance.h"
 #include "ui_SketcherSettingsDisplay.h"
 #include "ui_SketcherSettingsGrid.h"
-#include "StyleParameters.h"
-#include "Base/ServiceProvider.h"
-
 
 using namespace SketcherGui;
 
@@ -715,24 +712,12 @@ bool SketcherSettingsAppearance::event(QEvent* event)
         PreferencePage::event(event);
         const qreal dpr = devicePixelRatioF();
 
-        // Brush for pattern icon color - default to native palette value (always #fff)
-        QBrush brush = palette().windowText();
+        // Resolve color from qss source - see src/Gui/Application.cpp (2869)
+        QLabel dummyLabel;
+        dummyLabel.show();
 
-        auto* styleParameterManager = Base::provideService<Gui::StyleParameters::ParameterManager>();
-        if (styleParameterManager) {
-            // Override with yaml driven TextForegroundColor value (FreeCAD Dark/Light)
-            if (auto value = styleParameterManager->resolve("TextForegroundColor")) {
-                const Base::Color c = std::get<Base::Color>(*value);
-                brush = QBrush(QColor::fromRgbF(c.r, c.g, c.b, c.a));
-            }
-            else {
-                // Resolve color from qss source (OpenTheme) - see src/Gui/Application.cpp (2869)
-                QLabel l1;
-                l1.show();
-                QColor textColor = l1.palette().color(QPalette::Text);
-                brush = QBrush(textColor);
-            }
-        }
+        QColor textColor = dummyLabel.palette().color(QPalette::Text);
+        QBrush brush = QBrush(textColor);
 
         for (size_t i = 0; i < PenStyles.size(); ++i) {
             const QIcon icon = PenStyles[i].toIcon(LineIconSize, dpr, brush);

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -38,6 +38,8 @@
 #include "ui_SketcherSettingsAppearance.h"
 #include "ui_SketcherSettingsDisplay.h"
 #include "ui_SketcherSettingsGrid.h"
+#include "StyleParameters.h"
+#include "Base/ServiceProvider.h"
 
 
 using namespace SketcherGui;
@@ -688,7 +690,7 @@ SketcherSettingsAppearance::SketcherSettingsAppearance(QWidget* parent)
     ui->ExternalDefiningPattern->setItemDelegate(lineStyleDelegate);
     ui->InformationPattern->setIconSize(LineIconSize);
     ui->InformationPattern->setItemDelegate(lineStyleDelegate);
-    const QBrush brush = palette().windowText();
+
     for (auto style : PenStyles) {
         ui->EdgePattern->addItem(QString(), QVariant(style.pattern));
         ui->ConstructionPattern->addItem(QString(), QVariant(style.pattern));
@@ -712,7 +714,27 @@ bool SketcherSettingsAppearance::event(QEvent* event)
     if (event->type() == QEvent::StyleChange) {
         PreferencePage::event(event);
         const qreal dpr = devicePixelRatioF();
-        const QBrush brush = palette().windowText();
+
+        // Brush for pattern icon color - default to native palette value (always #fff)
+        QBrush brush = palette().windowText();
+
+        auto* styleParameterManager = Base::provideService<Gui::StyleParameters::ParameterManager>();
+        if (styleParameterManager) {
+            // Override with yaml driven TextForegroundColor value (FreeCAD Dark/Light)
+            if (auto value = styleParameterManager->resolve("TextForegroundColor")) {
+                const Base::Color c = std::get<Base::Color>(*value);
+                brush = QBrush(QColor::fromRgbF(c.r, c.g, c.b, c.a));
+            }
+            else
+            {
+                // Resolve color from qss source (OpenTheme) - see src/Gui/Application.cpp (2869)
+                QLabel l1;
+                l1.show();
+                QColor textColor = l1.palette().color(QPalette::Text);
+                brush = QBrush(textColor);
+            }
+        }
+
         for (size_t i = 0; i < PenStyles.size(); ++i) {
             const QIcon icon = PenStyles[i].toIcon(LineIconSize, dpr, brush);
             ui->EdgePattern->setItemIcon(i, icon);

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -725,8 +725,7 @@ bool SketcherSettingsAppearance::event(QEvent* event)
                 const Base::Color c = std::get<Base::Color>(*value);
                 brush = QBrush(QColor::fromRgbF(c.r, c.g, c.b, c.a));
             }
-            else
-            {
+            else {
                 // Resolve color from qss source (OpenTheme) - see src/Gui/Application.cpp (2869)
                 QLabel l1;
                 l1.show();


### PR DESCRIPTION
- Resolve TextForegroundColor style parameter
- Pull value from qss applied label color
- Assisted-by: Claude Sonnet 5

Works around issues related to `palette().windowText()` always resolving to `#ffffff`, allowing active theme foreground color to be rendered into generated `line-pattern` icons

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: Claude Sonnet 5

## Issues
#31584

## Before and After Images
| Before | After |
| ---- | ---- |
|<img width="400" alt="Image" src="https://github.com/user-attachments/assets/89fca8c1-fc07-400d-ad6a-933cdc0617d1" /> |<img width="400" alt="image" src="https://github.com/user-attachments/assets/1d4f4c67-e45f-46a1-b579-0090c4f73861" /> |

After
<img width="350" alt="image" src="https://github.com/user-attachments/assets/eb37df06-d795-41f0-84be-0b4a8b83c171" /> <br>
<img width="350" alt="image" src="https://github.com/user-attachments/assets/f0ea00b2-bde8-4251-901a-686b161ed038" /><img width="350" alt="image" src="https://github.com/user-attachments/assets/ba053e09-b7a5-42f9-819a-82ba8ab6624d" />

