### PR TITLE
CAM: fix rigid tap feed rate ignoring spindle speed

### DIFF
--- a/src/Mod/CAM/Path/Base/Generator/tapping.py
+++ b/src/Mod/CAM/Path/Base/Generator/tapping.py
@@ -99,8 +99,11 @@ def generate(
     cmdParams["Y"] = startPoint.y
     cmdParams["Z"] = endPoint.z
     cmdParams["R"] = retractheight if retractheight is not None else startPoint.z
-    cmdParams["S"] = spindle_speed if spindle_speed is not None else 1.0  # Sanity default
-    cmdParams["F"] = float(pitch) if pitch is not None else 100.0  # Sanity default
+    cmdParams["S"] = float(spindle_speed) if spindle_speed is not None else 1.0  # Sanity default
+    if pitch is not None and spindle_speed is not None:
+        cmdParams["F"] = float(pitch) * float(spindle_speed) / 60.0
+    else:
+        cmdParams["F"] = 100.0  # Sanity default
 
     if repeat < 1:
         raise ValueError("repeat must be 1 or greater")


### PR DESCRIPTION
**AI assistance disclosure:** This branch was developed with assistance from Claude (Anthropic), including investigation and the code fix. I have reviewed and tested it myself.

 I'm trying to utilize the ridged tapping cycle in the, 1.2 dev branch, under the drill tool did not correctly calculate the Feed rate based on the RPM.

Example output:
`G84 X0.000 Y0.000 Z-1.000`**`F1.872`**`S128.0 R0.100`

Rigid tap feed must be mechanically locked to spindle speed (`(in/mm)/min = pitch(in/mm) * RPM`), not driven by pitch alone.

in the above case the pitch of a 10-32 UNF thread is 1/32 = .03125 which with a spindle speed of 128RPM should have a feed rate 4 IPM:
`G84 X0.000 Y0.000 Z-1.000`**`F4.000`**`S128.0 R0.100`

A consideration not covered by this PR:
In the case of my machine I don't have a resolver on the spindle, it just uses a resistance calculation sent from the VFD.  while pretty accurate it is not good enough for full ridged taping.  To get away with it the machine uses floating tap holders.    This adds forgiveness if the RPM and FEEDRATE are not perfectly in sync and I typically run a slightly (3-5%) slower Feed rate which allows the floating tap to pull down slightly as it taps and gives leeway on the extraction.  This can be done by fudging the pitch rate on the tool, in this case the .03125 can be set to .031 and give a feed rate of 3.968.

- [x] Only tested on Windows locally — CI will cover Ubuntu automatically; Windows/macOS/Pixi builds run once labeled

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
