### PR TITLE
CAM: Helix - fix linking

### DIFF
--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -747,6 +747,9 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                         linkingMoves = linking.get_linking_moves(**linkingArgs)
                         self.commandlist.extend(linkingMoves)
                         machinestate.addCommands(linkingMoves)
+                    else:
+                        cmd = Path.Command("G0", {"X": hole["x"], "Y": hole["y"]})
+                        self.commandlist.append(cmd)
                     drillStep = obj.HelixMaxPitch.Value or obj.StepDown.Value
                     drillSteps = math.ceil(round((centerTop.z - centerBottom.z) / drillStep, 6))
                     for iDrill in range(1, drillSteps + 1):


### PR DESCRIPTION
https://forum.freecad.org/viewtopic.php?p=899456#p899456

### Desription

Missed linking moves if helix entry replaced by peck drilling

Test project: [usinage par le centre.zip](https://github.com/user-attachments/files/30427642/usinage.par.le.centre.zip)

<img width="1136" height="583" alt="Screenshot_20260727_204551_hor_lossy" src="https://github.com/user-attachments/assets/0fd8b3d1-4934-4f9a-ac41-519b92a6932e" />
