### PR TITLE
FEM: Parse Windows NaN values in CalculiX FRD results

### DIFF
--- a/src/Mod/Fem/feminout/importCcxFrdResults.py
+++ b/src/Mod/Fem/feminout/importCcxFrdResults.py
@@ -38,6 +38,14 @@ import FreeCAD
 from FreeCAD import Console
 from builtins import open as pyopen
 
+
+def _sanitize_frd_line(line):
+    """Normalize non-standard NaN values without changing FRD fixed-width columns."""
+    for nan_value in ("NAN(IND)", "-1.#IND0E+00"):
+        line = line.replace(nan_value, "NAN".rjust(len(nan_value)))
+    return line
+
+
 # ********* generic FreeCAD import and export methods *********
 
 
@@ -382,9 +390,9 @@ def read_frd_result(frd_input):
 
     for line in frd_file:
 
-        # depending on c runtime lib and possibly locale calculix may format NAN differently so we
-        # need to sanitize the file
-        line = line.replace("NAN(IND)", "NAN")
+        # Depending on the C runtime library and possibly locale, CalculiX may
+        # format NaN differently, so normalize it before parsing fixed-width fields.
+        line = _sanitize_frd_line(line)
         # Check if we found nodes section
         if line[4:6] == "2C":
             nodes_found = True

--- a/src/Mod/Fem/femtest/app/test_femimport.py
+++ b/src/Mod/Fem/femtest/app/test_femimport.py
@@ -25,9 +25,12 @@ __title__ = "Import FEM unit tests"
 __author__ = "Bernd Hahnebach"
 __url__ = "https://www.freecad.org"
 
+import math
 import unittest
 
 import FreeCAD
+
+from feminout import importCcxFrdResults
 
 from .support_utils import fcc_print
 
@@ -69,6 +72,16 @@ class TestFemImport(unittest.TestCase):
                 # to get an error message what was going wrong
                 __import__(f"{mod}")
             self.assertTrue(im, f"Problem importing {mod}")
+
+    def test_frd_nan_sanitization(self):
+        for nan_value in ("NAN(IND)", "-1.#IND0E+00"):
+            with self.subTest(nan_value=nan_value):
+                line = f"prefix{nan_value}suffix"
+                sanitized_line = importCcxFrdResults._sanitize_frd_line(line)
+                sanitized_value = sanitized_line[6:-6]
+
+                self.assertEqual(len(sanitized_line), len(line))
+                self.assertTrue(math.isnan(float(sanitized_value)))
 
 
 # ************************************************************************************************


### PR DESCRIPTION
- [ ] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Summary

- Normalize CalculiX NaN spellings emitted by Windows runtimes before parsing FRD fixed-width fields.
- Preserve field widths so later columns remain correctly aligned.
- Add regression coverage for `NAN(IND)` and `-1.#IND0E+00`.

## Root cause

CalculiX can emit `-1.#IND0E+00` for an indeterminate floating-point value on Windows. Python's `float()` does not accept that spelling, so importing 1D fluid results fails. The existing normalization only handled `NAN(IND)` and shortened the line, which could disturb fixed-width columns.

## Validation

- Python compilation passed for both changed modules.
- Isolated sanitizer regression checks passed for both NaN spellings.
- `git diff --check` passed.

Full FreeCAD FEM tests were not run locally because a FreeCAD build is not available in this environment.

The implementation was assisted by OpenAI Codex (GPT-5). This PR remains a draft for the account owner to review before it is marked ready.

Fixes #18368