### PR TITLE
Fem: Fix Elmer mechanical equations for 2D cases

### DIFF
--- a/src/Mod/Fem/femexamples/ccx_axisymm_shaft.py
+++ b/src/Mod/Fem/femexamples/ccx_axisymm_shaft.py
@@ -39,7 +39,7 @@ def get_information():
         "meshtype": "face",
         "meshelement": "Tria6",
         "constraints": ["fixed", "pressure"],
-        "solvers": ["calculix"],
+        "solvers": ["calculix", "elmer"],
         "material": "solid",
         "equations": ["mechanical"],
     }
@@ -94,15 +94,19 @@ def setup(doc=None, solvertype="calculix"):
         solver_obj.AnalysisType = "static"
         solver_obj.ModelSpace = "axisymmetric"
         analysis.addObject(solver_obj)
+        # 2D element thickness
+        thickness_obj = ObjectsFem.makeElementGeometry2D(doc, 1.0, "ShellThickness")
+        analysis.addObject(thickness_obj)
+    elif solvertype == "elmer":
+        solver_obj = ObjectsFem.makeSolverElmer(doc, "SolverElmer")
+        solver_obj.CoordinateSystem = "Axi Symmetric"
+        ObjectsFem.makeEquationElasticity(doc, solver_obj)
+        analysis.addObject(solver_obj)
     else:
         FreeCAD.Console.PrintWarning(
             "Unknown or unsupported solver type: {}. "
             "No solver object was created.\n".format(solvertype)
         )
-
-    # 2D element thickness
-    thickness_obj = ObjectsFem.makeElementGeometry2D(doc, 1.0, "ShellThickness")
-    analysis.addObject(thickness_obj)
 
     # material
     material_obj = ObjectsFem.makeMaterialSolid(doc, "MechanicalMaterial")

--- a/src/Mod/Fem/femsolver/elmer/equations/deformation.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/deformation.py
@@ -107,14 +107,14 @@ class Proxy(nonlinear.Proxy, equationbase.DeformationProxy):
             "App::PropertyString",
             "Variable",
             "Deformation",
-            "Only for a 2D model change the '3' to '2'",
+            "Variable name",
             locked=True,
         )
 
         obj.Priority = 10
         obj.CalculatePrincipal = True
         obj.CalculateStresses = True
-        obj.Variable = "-dofs 3 Displacement"
+        obj.Variable = "Displacement"
 
 
 class ViewProxy(nonlinear.ViewProxy, equationbase.DeformationViewProxy):

--- a/src/Mod/Fem/femsolver/elmer/equations/deformation_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/deformation_writer.py
@@ -66,6 +66,7 @@ class DeformationWriter:
         s["Optimize Bandwidth"] = True
         s["Stabilize"] = equation.Stabilize
         s["Variable"] = equation.Variable
+        s["Variable DOFs"] = self.write.getCoordSystemDimension()
         return s
 
     def handleDeformationEquation(self, bodies, equation):
@@ -92,18 +93,20 @@ class DeformationWriter:
                 for name in obj.References[0][1]:
                     self.write.boundary(name, "Displacement 1", 0.0)
                     self.write.boundary(name, "Displacement 2", 0.0)
-                    self.write.boundary(name, "Displacement 3", 0.0)
+                    if self.write.getCoordSystemDimension() == 3:
+                        self.write.boundary(name, "Displacement 3", 0.0)
                 self.write.handled(obj)
         for obj in self.write.getMember("Fem::ConstraintForce"):
             if obj.References:
                 for name in obj.References[0][1]:
                     force = float(obj.Force.getValueAs("N"))
                     self.write.boundary(name, "Force 1", obj.DirectionVector.x * force)
-                    self.write.boundary(name, "Force 2", obj.DirectionVector.y * force)
-                    self.write.boundary(name, "Force 3", obj.DirectionVector.z * force)
                     self.write.boundary(name, "Force 1 Normalize by Area", True)
+                    self.write.boundary(name, "Force 2", obj.DirectionVector.y * force)
                     self.write.boundary(name, "Force 2 Normalize by Area", True)
-                    self.write.boundary(name, "Force 3 Normalize by Area", True)
+                    if self.write.getCoordSystemDimension() == 3:
+                        self.write.boundary(name, "Force 3", obj.DirectionVector.z * force)
+                        self.write.boundary(name, "Force 3 Normalize by Area", True)
                 self.write.handled(obj)
         for obj in self.write.getMember("Fem::ConstraintDisplacement"):
             if obj.References:
@@ -221,8 +224,6 @@ class DeformationWriter:
 
     def _getYoungsModulus(self, m):
         youngsModulus = self.write.convert(m["YoungsModulus"], "M/(L*T^2)")
-        if self.write.getMeshDimension() == 2:
-            youngsModulus *= 1e3
         return youngsModulus
 
 

--- a/src/Mod/Fem/femsolver/elmer/equations/elasticity_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/elasticity_writer.py
@@ -89,7 +89,7 @@ class ElasticityWriter:
         if equation.UpdateTransientSystem is True:
             s["Update Transient System"] = equation.UpdateTransientSystem
         s["Variable"] = equation.Variable
-        s["Variable DOFs"] = 3
+        s["Variable DOFs"] = self.write.getCoordSystemDimension()
         return s
 
     def handleElasticityEquation(self, bodies, equation):
@@ -323,18 +323,20 @@ class ElasticityWriter:
                 for name in obj.References[0][1]:
                     self.write.boundary(name, "Displacement 1", 0.0)
                     self.write.boundary(name, "Displacement 2", 0.0)
-                    self.write.boundary(name, "Displacement 3", 0.0)
+                    if self.write.getCoordSystemDimension() == 3:
+                        self.write.boundary(name, "Displacement 3", 0.0)
                 self.write.handled(obj)
         for obj in self.write.getMember("Fem::ConstraintForce"):
             if obj.References:
                 for name in obj.References[0][1]:
                     force = float(obj.Force.getValueAs("N"))
                     self.write.boundary(name, "Force 1", obj.DirectionVector.x * force)
-                    self.write.boundary(name, "Force 2", obj.DirectionVector.y * force)
-                    self.write.boundary(name, "Force 3", obj.DirectionVector.z * force)
                     self.write.boundary(name, "Force 1 Normalize by Area", True)
+                    self.write.boundary(name, "Force 2", obj.DirectionVector.y * force)
                     self.write.boundary(name, "Force 2 Normalize by Area", True)
-                    self.write.boundary(name, "Force 3 Normalize by Area", True)
+                    if self.write.getCoordSystemDimension() == 3:
+                        self.write.boundary(name, "Force 3", obj.DirectionVector.z * force)
+                        self.write.boundary(name, "Force 3 Normalize by Area", True)
                 self.write.handled(obj)
         for obj in self.write.getMember("Fem::ConstraintDisplacement"):
             if obj.References:
@@ -452,8 +454,6 @@ class ElasticityWriter:
 
     def _getYoungsModulus(self, m):
         youngsModulus = self.write.convert(m["YoungsModulus"], "M/(L*T^2)")
-        if self.write.getMeshDimension() == 2:
-            youngsModulus *= 1e3
         return youngsModulus
 
 

--- a/src/Mod/Fem/femsolver/elmer/writer.py
+++ b/src/Mod/Fem/femsolver/elmer/writer.py
@@ -666,6 +666,20 @@ class Writer:
     def getMesh(self):
         return membertools.get_mesh_to_solve(self.analysis)
 
+    def getCoordSystemDimension(self):
+        dim = 0
+        match self.solver.CoordinateSystem:
+            case "Cartesian":
+                # defined by the mesh
+                dim = self.getMeshDimension()
+            case "Cartesian 1D":
+                dim = 1
+            case "Cartesian 2D" | "Polar 2D" | "Cylindric Symmetric" | "Axi Symmetric":
+                dim = 2
+            case "Cartesian 3D" | "Polar 3D" | "Cylindric":
+                dim = 3
+        return dim
+
     def _addOutputSolver(self):
         s = sifio.createSection(sifio.SOLVER)
         # Since FreeCAD meshes are in mm we let Elmer scale it


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
For 2D cases, the dofs of the variable must be set to 2.

Note that for 2D planar cases, there is no thickness parameter; the system solves by considering the thickness as a unit of length (i.e., quantities must be considered per unit of length rather than per unit of area), so the user must be responsible for scaling the values.
The axisymmetric case is solved as expected.

The axisymmetric shaft example has also been updated for Elmer.



@FEA-eng 
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
