### PR TITLE
App: Finish relabel initialization for the first document

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -670,7 +670,14 @@ Document* Application::newDocument(const char * proposedName, const char * propo
     setActiveDocumentNoSignal(doc);
     signalNewDocument(*doc, CreateFlags.createView);
 
+    const bool labelIsUnchanged = doc->Label.getValue() == label;
     doc->Label.setValue(label);
+    if (labelIsUnchanged) {
+        // Property::setValue() does not emit when the value is unchanged.  The
+        // first default document starts with the same "Unnamed" label, so GUI
+        // observers would otherwise never finish their relabel initialization.
+        signalRelabelDocument(*doc);
+    }
 
     // set the old document active again if the new is temporary
     if (CreateFlags.temporary && oldActiveDoc) {

--- a/tests/src/App/Document.cpp
+++ b/tests/src/App/Document.cpp
@@ -94,4 +94,24 @@ TEST_F(DocumentTest, getStringHasherGivesExpectedHasher)
     EXPECT_EQ(hasher, foundHasher);
 }
 
+TEST_F(DocumentTest, newDocumentSignalsRelabelWhenDefaultLabelIsUnchanged)
+{
+    const App::Document* relabeledDocument {};
+    int relabelCount = 0;
+    auto connection = App::GetApplication().signalRelabelDocument.connect(
+        [&](const App::Document& document) {
+            relabeledDocument = &document;
+            ++relabelCount;
+        }
+    );
+
+    App::Document* defaultDocument = App::GetApplication().newDocument();
+    connection.disconnect();
+
+    EXPECT_EQ(relabeledDocument, defaultDocument);
+    EXPECT_EQ(relabelCount, 1);
+
+    App::GetApplication().closeDocument(defaultDocument);
+}
+
 // NOLINTEND(readability-magic-numbers)


### PR DESCRIPTION
## Summary

- notify relabel observers when a new document's requested label already matches the property default;
- let the first GUI document finish relabel initialization so later document-property edits mark it modified;
- add a regression test for the unchanged default-label path.

## Root cause

The first default document starts with the label `Unnamed` and is then assigned `Unnamed` again. `Property::setValue()` does not emit a change signal when the value is identical, so the GUI relabel handler never ran and its document-change connection stayed blocked. Later documents receive unique labels such as `Unnamed1`, so they did not exhibit the bug.

## Issues

Fixes #14862

## Verification

- `git diff --check` passes.
- Added `DocumentTest.newDocumentSignalsRelabelWhenDefaultLabelIsUnchanged`.
- A full FreeCAD build was not run locally because the native build dependencies are not available in this checkout.

## AI disclosure

This contribution was assisted by OpenAI Codex (GPT-5). The commit contains the required `Assisted-by` trailer. This PR remains a draft for human review before it is marked ready.