### PR TITLE
Gui: Let Project Utility choose its output file

### DIFF
--- a/src/Gui/Dialogs/DlgProjectUtility.cpp
+++ b/src/Gui/Dialogs/DlgProjectUtility.cpp
@@ -23,7 +23,6 @@
  ***************************************************************************/
 
 #include <sstream>
-#include <QDir>
 #include <QMessageBox>
 
 #include <App/Document.h>
@@ -47,6 +46,7 @@ DlgProjectUtility::DlgProjectUtility(QWidget* parent, Qt::WindowFlags fl)
     connect(ui->extractButton, &QPushButton::clicked, this, &DlgProjectUtility::extractButton);
     connect(ui->createButton, &QPushButton::clicked, this, &DlgProjectUtility::createButton);
     ui->extractSource->setFilter(QStringLiteral("%1 (*.FCStd)").arg(tr("Project file")));
+    ui->createDest->setFilter(QStringLiteral("%1 (*.FCStd)").arg(tr("Project file")));
 }
 
 /**
@@ -83,8 +83,6 @@ void DlgProjectUtility::createButton()
         QMessageBox::critical(this, tr("Empty Destination"), tr("No destination is defined."));
         return;
     }
-
-    dest = QDir(dest).absoluteFilePath(QStringLiteral("project.fcstd"));
 
     bool openFile = ui->checkLoadProject->isChecked();
     tryCreateArchive(source, dest, openFile);

--- a/src/Gui/Dialogs/DlgProjectUtility.ui
+++ b/src/Gui/Dialogs/DlgProjectUtility.ui
@@ -96,7 +96,10 @@
         <item row="1" column="1">
          <widget class="Gui::FileChooser" name="createDest">
           <property name="mode">
-           <enum>Gui::FileChooser::Directory</enum>
+           <enum>Gui::FileChooser::File</enum>
+          </property>
+          <property name="acceptMode">
+           <enum>Gui::FileChooser::AcceptSave</enum>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
## Summary
- change the Create Document destination from a directory picker to a save-file chooser
- keep the filename selected by the user instead of forcing `project.fcstd`
- use FreeCAD's canonical `.FCStd` filter for the output file

## Scope
This addresses the output-filename and extension parts of #9714. It does not close the broader dependency-discovery and automation items in that issue.

## Verification
- parsed `DlgProjectUtility.ui` as XML and verified `createDest` is `File` / `AcceptSave`
- verified the hard-coded `project.fcstd` path is absent
- `git diff --check` passed with the repository's CRLF convention
- a full native FreeCAD build was not run because the local checkout does not have the required build dependencies

## AI disclosure
This change was assisted by OpenAI Codex (GPT-5). The commit includes an `Assisted-by` trailer. This PR remains a draft for the account owner to review before it is marked ready.

## Issues
Refs #9714