### PR TITLE
BIM: fix IFC export of Part_Compound

### DIFF
--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -510,7 +510,7 @@ def export(exportList, filename, colors=None, preferences=None):
         # handle assemblies (arrays, app::parts, references, etc...)
 
         assemblyElements = []
-        assemblyTypes = ["IfcApp::Part", "IfcPart::Compound", "IfcElementAssembly"]
+        assemblyTypes = ["IfcApp::Part", "IfcElementAssembly"]
         is_nested_group = False
         if preferences["GROUPS_AS_ASSEMBLIES"] and ifctype == "IfcGroup":
             for p in obj.InListRecursive:

--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -574,8 +574,6 @@ def export(exportList, filename, colors=None, preferences=None):
         elif ifctype in assemblyTypes or is_nested_group:
             if hasattr(obj, "Group"):
                 group = obj.Group
-            elif hasattr(obj, "Links"):
-                group = obj.Links
             else:
                 group = [FreeCAD.ActiveDocument.getObject(n[:-1]) for n in obj.getSubObjects()]
             for subobj in group:
@@ -1756,7 +1754,7 @@ def getIfcTypeFromObj(obj):
         # https://forum.freecad.org/viewtopic.php?p=662934#p662927
     elif hasattr(obj, "IfcType"):
         ifctype = obj.IfcType.replace(" ", "")
-    elif dtype in ["App::Part", "Part::Compound"]:
+    elif dtype == "App::Part":
         ifctype = "IfcElementAssembly"
     elif dtype in ["App::DocumentObjectGroup"]:
         ifctype = "IfcGroup"

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -1441,7 +1441,7 @@ def get_ifctype(obj):
     if hasattr(obj, "IfcType") and obj.IfcType != "Undefined":
         return "Ifc" + obj.IfcType.replace(" ", "")
     dtype = Draft.getType(obj)
-    if dtype in ["App::Part", "Part::Compound", "Array"]:
+    if dtype in ["App::Part", "Array"]:
         return "IfcElementAssembly"
     if dtype in ["App::DocumentObjectGroup"]:
         return "IfcGroup"


### PR DESCRIPTION
Fixes #9324.

A Part_Compound was considered an `IfcElementAssembly`. This resulted in a placement issue when its nested objects were processed. The `getGlobalPlacement` method used in the IFC export code ignores the placement of the compound. With this PR a compound is exported as an `IfcBuildingElementProxy`, which is also used when exporting a Part_Box for example. This is a valid solution as a compound is really a shape type.

The ifc_tools.py file was also updated for consistency, but is not used when exporting.

No AI was used.