### PR TITLE
Core: Remove encoding detail from Label tooltips

### DIFF
--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -68,8 +68,8 @@ DocumentObject::DocumentObject()
     : ExpressionEngine()
 {
     // define Label of type 'Output' to avoid being marked as touched after relabeling
-    ADD_PROPERTY_TYPE(Label, ("Unnamed"), "Base", Prop_Output, "User name of the object (UTF8)");
-    ADD_PROPERTY_TYPE(Label2, (""), "Base", Prop_Hidden, "User description of the object (UTF8)");
+    ADD_PROPERTY_TYPE(Label, ("Unnamed"), "Base", Prop_Output, "User name of the object");
+    ADD_PROPERTY_TYPE(Label2, (""), "Base", Prop_Hidden, "User description of the object");
     Label2.setStatus(App::Property::Output, true);
     ADD_PROPERTY_TYPE(ExpressionEngine, (), "Base", Prop_Hidden, "Property expressions");
 


### PR DESCRIPTION
## Summary
This PR removes the redundant `UTF8` tag from tooltip/help text for `Label` and `Label2` metadata fields in `DocumentObject`.

## Details
- Change is limited to tooltip strings only, no logic or API behavior changes.
- Updated in:
  - `src/App/DocumentObject.cpp`
- New text:
  - `User name of the object`
  - `User description of the object`

## Checks
- Scope is intentionally small and limited to a string cleanup in property registration.
- `pre-commit` for `src/App/DocumentObject.cpp` is not fully executed because existing hook configuration skips this path.
- No runtime/build validation executed in this environment.

## Issues
- Fixes #30941

## Before and After Images
- No images are attached (tooltip text change only).

- [ ] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
