### PR TITLE
CAM: Helix - Added properties to Task panel

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
@@ -18,13 +18,37 @@
     <widget class="QWidget" name="widget">
      <layout class="QFormLayout" name="formLayout">
       <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Side</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="side">
+        <property name="toolTip">
+         <string>Side of profile on which create Path</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Inside</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Outside</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
          <string>Start from</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="QComboBox" name="startAt">
         <property name="toolTip">
          <string>Specify if the helix operation should start at the inside and work its way outwards, or start at the outside and work its way to the center</string>
@@ -41,14 +65,14 @@
         </item>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>Cut mode</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QComboBox" name="cutMode">
         <property name="toolTip">
          <string>The direction of the circular cuts</string>
@@ -148,6 +172,95 @@
         </property>
         <property name="toolTip">
          <string>How much stock to leave on the outer wall for this operation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Radial stock to leave (inner)</string>
+        </property>
+        <property name="toolTip">
+         <string>How much stock to leave on the inner wall for this operation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="Gui::QuantitySpinBox" name="radialStockToLeaveInner">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Offset inner radius
+Default inner radius for Internal profile is Tool radius and can not be less than -ToolRadius
+Default inner radius for External profile - profile radius</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Cone angle</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="Gui::QuantitySpinBox" name="coneAngle">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Cone angle of the Helix</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0">
+       <widget class="QCheckBox" name="spiralMill">
+        <property name="toolTip">
+         <string>Create single helix and spiral mill</string>
+        </property>
+        <property name="text">
+         <string>Spiral mill</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1">
+       <widget class="QCheckBox" name="singleHelix">
+        <property name="toolTip">
+         <string>Create only one Helix</string>
+        </property>
+        <property name="text">
+         <string>Single helix</string>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="0">
+       <widget class="QCheckBox" name="overrideArcFeed">
+        <property name="toolTip">
+         <string>Override arcs feed rate to get constant tool cutting speed</string>
+        </property>
+        <property name="text">
+         <string>Override arc feed rate</string>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="1">
+       <widget class="QCheckBox" name="startBottom">
+        <property name="toolTip">
+         <string>Process cone helix from bottom to top</string>
+        </property>
+        <property name="text">
+         <string>Start from bottom</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="0">
+       <widget class="QCheckBox" name="retractFromWall">
+        <property name="toolTip">
+         <string>Move from wall while retract if there is free space</string>
+        </property>
+        <property name="text">
+         <string>Retract from wall</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Path/Op/Gui/Helix.py
+++ b/src/Mod/CAM/Path/Op/Gui/Helix.py
@@ -56,12 +56,18 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         self.radialStockToLeaveOuterSpinBox = PathGuiUtil.QuantitySpinBox(
             self.form.radialStockToLeaveOuter, obj, "RadialStockToLeaveOuter"
         )
+        self.radialStockToLeaveInnerSpinBox = PathGuiUtil.QuantitySpinBox(
+            self.form.radialStockToLeaveInner, obj, "RadialStockToLeaveInner"
+        )
+        self.coneAngleSpinBox = PathGuiUtil.QuantitySpinBox(
+            self.form.coneAngle, obj, "HelixConeAngle"
+        )
 
     def getForm(self):
         """getForm() ... return UI"""
         form = FreeCADGui.PySideUic.loadUi(":/panels/PageOpHelixEdit.ui")
 
-        comboToPropertyMap = [("startAt", "StartAt"), ("cutMode", "CutMode")]
+        comboToPropertyMap = [("side", "Side"), ("startAt", "StartAt"), ("cutMode", "CutMode")]
         enumTups = PathHelix.ObjectHelix.helixOpPropertyEnumerations(dataType="raw")
         self.populateCombobox(form, enumTups, comboToPropertyMap)
 
@@ -71,6 +77,8 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         self.helixMaxPitchSpinBox.updateWidget()
         self.helixMaxRampAngleSpinBox.updateWidget()
         self.radialStockToLeaveOuterSpinBox.updateWidget()
+        self.radialStockToLeaveInnerSpinBox.updateWidget()
+        self.coneAngleSpinBox.updateWidget()
 
     def getFields(self, obj):
         """getFields(obj) ... transfers values from UI to obj's properties"""
@@ -78,14 +86,29 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         self.helixMaxPitchSpinBox.updateProperty()
         self.helixMaxRampAngleSpinBox.updateProperty()
         self.radialStockToLeaveOuterSpinBox.updateProperty()
+        self.radialStockToLeaveInnerSpinBox.updateProperty()
+        self.coneAngleSpinBox.updateProperty()
 
         if obj.CutMode != str(self.form.cutMode.currentData()):
             obj.CutMode = str(self.form.cutMode.currentData())
         if obj.StartAt != str(self.form.startAt.currentData()):
             obj.StartAt = str(self.form.startAt.currentData())
+        if obj.Side != str(self.form.side.currentData()):
+            obj.Side = str(self.form.side.currentData())
 
         if obj.StepOver != self.form.stepOver.value():
             obj.StepOver = self.form.stepOver.value()
+
+        if obj.SpiralMill != self.form.spiralMill.isChecked():
+            obj.SpiralMill = self.form.spiralMill.isChecked()
+        if obj.SingleHelix != self.form.singleHelix.isChecked():
+            obj.SingleHelix = self.form.singleHelix.isChecked()
+        if obj.StartConeFromBottom != self.form.startBottom.isChecked():
+            obj.StartConeFromBottom = self.form.startBottom.isChecked()
+        if obj.RetractFromWall != self.form.retractFromWall.isChecked():
+            obj.RetractFromWall = self.form.retractFromWall.isChecked()
+        if obj.OverrideArcFeedRate != self.form.overrideArcFeed.isChecked():
+            obj.OverrideArcFeedRate = self.form.overrideArcFeed.isChecked()
 
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
@@ -96,6 +119,15 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
 
         self.selectInComboBox(obj.CutMode, self.form.cutMode)
         self.selectInComboBox(obj.StartAt, self.form.startAt)
+        self.selectInComboBox(obj.Side, self.form.side)
+
+        self.form.spiralMill.setChecked(obj.SpiralMill)
+        self.form.singleHelix.setChecked(obj.SingleHelix)
+        self.form.startBottom.setChecked(obj.StartConeFromBottom)
+        self.form.retractFromWall.setChecked(obj.RetractFromWall)
+        self.form.overrideArcFeed.setChecked(obj.OverrideArcFeedRate)
+
+        self.updateVisibility()
 
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
@@ -104,12 +136,36 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         signals.append(self.form.helixMaxPitch.editingFinished)
         signals.append(self.form.helixMaxRampAngle.editingFinished)
         signals.append(self.form.radialStockToLeaveOuter.editingFinished)
+        signals.append(self.form.radialStockToLeaveInner.editingFinished)
+        signals.append(self.form.coneAngle.editingFinished)
         signals.append(self.form.stepOver.editingFinished)
 
         signals.append(self.form.cutMode.currentIndexChanged)
         signals.append(self.form.startAt.currentIndexChanged)
+        signals.append(self.form.side.currentIndexChanged)
+
+        signals.append(self.form.spiralMill.checkStateChanged)
+        signals.append(self.form.singleHelix.checkStateChanged)
+        signals.append(self.form.startBottom.checkStateChanged)
+        signals.append(self.form.retractFromWall.checkStateChanged)
+        signals.append(self.form.overrideArcFeed.checkStateChanged)
 
         return signals
+
+    def updateVisibility(self):
+        if self.form.coneAngle.property("rawValue"):
+            self.form.startBottom.show()
+        else:
+            self.form.startBottom.hide()
+
+        if self.form.spiralMill.isChecked():
+            self.form.singleHelix.hide()
+        else:
+            self.form.singleHelix.show()
+
+    def registerSignalHandlers(self, obj):
+        self.form.coneAngle.editingFinished.connect(self.updateVisibility)
+        self.form.spiralMill.checkStateChanged.connect(self.updateVisibility)
 
 
 Command = PathOpGui.SetupOperation(


### PR DESCRIPTION
PR #21971 added a lot of new features to **Helix** op, but access to them possible only through `Property view`

### Changes

- Added new widgets to Task panel
  - Radial stock to leave (inner)
  - Cone angle
  - Starting angle
  - Single helix (only if spiral mill disabled)
  - Spiral mill
  - Start cone from bottom (only if cone angle not a zero)
  - Override arc feed rate
  - Retract from wall

- Added button to define cone angle
Allowed only if all base geometry is `Part.Cone` and all surfaces has identical angle

- Added new methods to class `Op.Gui.Base.TaskPanelPage` to set widget tool tip from property description
  We set tool tip in `ui` files and also set property description
  Some times this text is different and creates confusion
  Also this duplicates code and increase load for translators twice

- Removed tool tips from ui file
Used properties description to set tool tips

<img width="761" height="554" alt="1_lossy" src="https://github.com/user-attachments/assets/91ecf7b4-0fdc-4fc9-9f8b-bccecfd53d28" />