### PR TITLE
CAM: Experimental features in Preferences

### DIFF
--- a/src/Mod/CAM/Gui/Resources/preferences/Advanced.ui
+++ b/src/Mod/CAM/Gui/Resources/preferences/Advanced.ui
@@ -77,44 +77,6 @@
         </property>
        </widget>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="title">
-      <string>OpenCAMLib</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>If OpenCAMLib is installed with Python bindings, it can be used by some additional 3D operations. NOTE: Enabling OpenCAMLib here requires a restart of FreeCAD to take effect.</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="EnableAdvancedOCLFeatures">
-        <property name="text">
-         <string>Enable OCL dependent features</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>EnableAdvancedOCLFeatures</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/CAM</cstring>
-        </property>
-       </widget>
-      </item>
       <item>
        <widget class="Gui::PrefCheckBox" name="WarningSuppressOpenCamLib">
         <property name="toolTip">
@@ -128,6 +90,60 @@
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>WarningSuppressOpenCamLib</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/CAM</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Experimental</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>NOTE: Requires a restart of FreeCAD to take effect</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="EnableExperimentalFeatures">
+        <property name="text">
+         <string>Enable experimental features</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>EnableExperimentalFeatures</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/CAM</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="EnableAdvancedOCLFeatures">
+        <property name="toolTip">
+         <string>OpenCAMLib can be used by some additional 3D operations</string>
+        </property>
+        <property name="text">
+         <string>Enable OCL dependent features</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>EnableAdvancedOCLFeatures</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/CAM</cstring>

--- a/src/Mod/CAM/InitGui.py
+++ b/src/Mod/CAM/InitGui.py
@@ -218,7 +218,6 @@ class CAMWorkbench(Workbench):
         if Path.Preferences.experimentalFeaturesEnabled():
             prepcmdlist.append("CAM_PathShapeTC")
             extracmdlist.extend(["CAM_Area", "CAM_Area_Workplane"])
-            twodopcmdlist.append("CAM_Slot")
 
         if Path.Preferences.advancedOCLFeaturesEnabled():
             try:

--- a/src/Mod/CAM/Path/Base/Gui/PreferencesAdvanced.py
+++ b/src/Mod/CAM/Path/Base/Gui/PreferencesAdvanced.py
@@ -42,11 +42,12 @@ class AdvancedPreferencesPage:
 
     def saveSettings(self):
         Path.Preferences.setPreferencesAdvanced(
-            self.form.EnableAdvancedOCLFeatures.isChecked(),
-            self.form.WarningSuppressAllSpeeds.isChecked(),
-            self.form.WarningSuppressRapidSpeeds.isChecked(),
-            self.form.WarningSuppressSelectionMode.isChecked(),
-            self.form.WarningSuppressOpenCamLib.isChecked(),
+            experimental=self.form.EnableExperimentalFeatures.isChecked(),
+            ocl=self.form.EnableAdvancedOCLFeatures.isChecked(),
+            warnSpeeds=self.form.WarningSuppressAllSpeeds.isChecked(),
+            warnRapids=self.form.WarningSuppressRapidSpeeds.isChecked(),
+            warnModes=self.form.WarningSuppressSelectionMode.isChecked(),
+            warnOCL=self.form.WarningSuppressOpenCamLib.isChecked(),
         )
 
     def loadSettings(self):
@@ -57,6 +58,9 @@ class AdvancedPreferencesPage:
         )
         self.form.WarningSuppressSelectionMode.setChecked(
             Path.Preferences.suppressSelectionModeWarning()
+        )
+        self.form.EnableExperimentalFeatures.setChecked(
+            Path.Preferences.experimentalFeaturesEnabled()
         )
         self.form.EnableAdvancedOCLFeatures.setChecked(
             Path.Preferences.advancedOCLFeaturesEnabled()

--- a/src/Mod/CAM/Path/Preferences.py
+++ b/src/Mod/CAM/Path/Preferences.py
@@ -575,7 +575,8 @@ def suppressOpenCamLibWarning():
     return preferences().GetBool(WarningSuppressOpenCamLib, True)
 
 
-def setPreferencesAdvanced(ocl, warnSpeeds, warnRapids, warnModes, warnOCL):
+def setPreferencesAdvanced(experimental, ocl, warnSpeeds, warnRapids, warnModes, warnOCL):
+    preferences().SetBool(EnableExperimentalFeatures, experimental)
     preferences().SetBool(EnableAdvancedOCLFeatures, ocl)
     preferences().SetBool(WarningSuppressAllSpeeds, warnSpeeds)
     preferences().SetBool(WarningSuppressRapidSpeeds, warnRapids)


### PR DESCRIPTION
### Changes
- Renamed group `OpenCAMLib` to `Experimental`

- Moved `Suppress openCAMlib warning` to group `Warnings`

- Added checkbox `Enable experimental features`

- Moved label `OpenCAMLib can be used by some additional 3D operations`
  to tool tip of `Enable OCL dependent features`

<img width="1290" height="357" alt="1" src="https://github.com/user-attachments/assets/545f961d-32fe-4123-8e47-e56762a48729" />
