### PR TITLE
Sketcher: correct grid line width tooltips

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettingsGrid.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsGrid.ui
@@ -243,10 +243,7 @@ The grid spacing changes if it becomes smaller than the specified pixel size.</s
          <item row="1" column="1">
           <widget class="Gui::PrefSpinBox" name="gridLineWidth">
            <property name="toolTip">
-            <string>Distance between two subsequent grid lines</string>
-           </property>
-           <property name="unit" stdset="0">
-            <string notr="true">mm</string>
+            <string>Width of minor grid lines in pixels</string>
            </property>
            <property name="minimum">
             <number>1</number>
@@ -381,7 +378,7 @@ The grid spacing changes if it becomes smaller than the specified pixel size.</s
          <item row="2" column="1">
           <widget class="Gui::PrefSpinBox" name="gridDivLineWidth">
            <property name="toolTip">
-            <string>Distance between two subsequent division lines</string>
+            <string>Width of major grid lines in pixels</string>
            </property>
            <property name="minimum">
             <number>1</number>


### PR DESCRIPTION
## Summary
- Correct the Sketcher minor and major grid line-width tooltips to describe pixel widths.
- Remove the misleading `mm` unit metadata from the minor grid line-width control.

## Issues
Closes #31626

## Validation
- Parsed `SketcherSettingsGrid.ui` as XML.
- Asserted both corrected tooltip strings and the removed unit property.
- `git diff --check` passes.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

This change was developed with AI assistance, then manually reviewed and validated against the Sketcher rendering implementation (`SoDrawStyle::lineWidth`, which uses pixel units).