### PR TITLE
[Gui] fix TinkerCAD nav style to consistently show the context menu …

### DIFF
--- a/src/Gui/Navigation/TinkerCADNavigationStyle.cpp
+++ b/src/Gui/Navigation/TinkerCADNavigationStyle.cpp
@@ -136,7 +136,7 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent* const ev)
                 this->button2down = press;
 
                 // About to start rotating
-                if (press && (curmode == NavigationStyle::IDLE)) {
+                if (!viewer->isEditing() && press && (curmode == NavigationStyle::IDLE)) {
                     // Use this variable to spot move events
                     saveCursorPosition(ev);
                     this->centerTime = ev->getTime();


### PR DESCRIPTION
…after repeated select/unselect routines in the same Sketcher editing session while still maintaining the same behaviour in the main 3D viewport. It would be good to have a regular TinkerCAD user compile the PR but my testing has been quite thorough.

FYI @Rexbas 


- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
fixes #31572 