### PR TITLE
TechDraw: Leader line upgrade

### DIFF
--- a/src/Mod/TechDraw/App/DrawLeaderLine.cpp
+++ b/src/Mod/TechDraw/App/DrawLeaderLine.cpp
@@ -78,6 +78,7 @@ DrawLeaderLine::DrawLeaderLine()
 
     constexpr long int FilledArrow{0l};
     constexpr long int NoEnd{7l};
+    constexpr long int NormalType{0l};
 
     ADD_PROPERTY_TYPE(LeaderParent, (nullptr), group, (App::PropertyType)(App::Prop_None),
                       "View to which this leader is attached");
@@ -90,6 +91,11 @@ DrawLeaderLine::DrawLeaderLine()
 
     EndSymbol.setEnums(ArrowPropEnum::ArrowTypeEnums);
     ADD_PROPERTY(EndSymbol, (NoEnd));                //no symbol
+
+    static const char* TypeEnums[] = {"Normal", "Straight", "Complex", "Complex with kink",  nullptr};
+    Type.setEnums(TypeEnums);
+    ADD_PROPERTY_TYPE(Type, (NormalType), group, App::Prop_None,
+                      "Normal, Straight, Complex (multiple waypoints) leader line");
 
     ADD_PROPERTY_TYPE(Scalable ,(false), group, App::Prop_None, "Scale line with LeaderParent");
     ADD_PROPERTY_TYPE(AutoHorizontal ,(getDefAuto()), group, App::Prop_None, "Forces last line segment to be horizontal");
@@ -105,7 +111,6 @@ DrawLeaderLine::DrawLeaderLine()
     Rotation.setStatus(App::Property::Hidden, true);
     Caption.setStatus(App::Property::Hidden, true);
 
-    LockPosition.setValue(true);
     LockPosition.setStatus(App::Property::Hidden, true);
 }
 

--- a/src/Mod/TechDraw/App/DrawLeaderLine.h
+++ b/src/Mod/TechDraw/App/DrawLeaderLine.h
@@ -46,6 +46,7 @@ public:
     App::PropertyVectorList   WayPoints;
     App::PropertyEnumeration  StartSymbol;
     App::PropertyEnumeration  EndSymbol;
+    App::PropertyEnumeration  Type;
 
     App::PropertyBool         Scalable;
     App::PropertyBool         AutoHorizontal;

--- a/src/Mod/TechDraw/App/DrawRichAnno.cpp
+++ b/src/Mod/TechDraw/App/DrawRichAnno.cpp
@@ -45,6 +45,7 @@ DrawRichAnno::DrawRichAnno()
     // Necessary to support legacy files made before #24624.
     ADD_PROPERTY_TYPE(OriginCentered, (false), group, App::Prop_None, "Center the annotation on it's origin.");
     ADD_PROPERTY_TYPE(MaxWidth, (-1.0), group, App::Prop_None, "Width limit before auto wrap");
+    ADD_PROPERTY_TYPE(LeaderLine, (nullptr), group, App::Prop_None, "Leader line to this annotation");
     Caption.setStatus(App::Property::Hidden, true);
     Scale.setStatus(App::Property::Hidden, true);
     ScaleType.setStatus(App::Property::Hidden, true);

--- a/src/Mod/TechDraw/App/DrawRichAnno.h
+++ b/src/Mod/TechDraw/App/DrawRichAnno.h
@@ -45,6 +45,7 @@ public:
     App::PropertyBool         ShowFrame;
     App::PropertyFloat        MaxWidth;
     App::PropertyBool         OriginCentered;
+    App::PropertyLink         LeaderLine;
 
     void Restore(Base::XMLReader& reader) override;
     short mustExecute() const override;

--- a/src/Mod/TechDraw/Gui/CMakeLists.txt
+++ b/src/Mod/TechDraw/Gui/CMakeLists.txt
@@ -213,6 +213,8 @@ SET(TechDrawGui_SRCS
     TaskCosmeticCircle.ui
     TechDrawHandler.cpp
     TechDrawHandler.h
+    TechDrawLeaderLineHandler.cpp
+    TechDrawLeaderLineHandler.h
     Widgets/CompassDialWidget.cpp
     Widgets/CompassDialWidget.h
     Widgets/CompassWidget.cpp

--- a/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
@@ -107,23 +107,7 @@ void CmdTechDrawLeaderLine::activated(int iMsg)
         return;
     }
 
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
-    TechDraw::DrawView* baseFeat = nullptr;
-    if (!selection.empty()) {
-        baseFeat =  dynamic_cast<TechDraw::DrawView *>(selection[0].getObject());
-        if (!baseFeat) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                 QObject::tr("Cannot attach leader. No base view selected."));
-            return;
-        }
-    } else {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                 QObject::tr("You must select a base view for the line"));
-            return;
-    }
-
-    Gui::Control().showDialog(new TechDrawGui::TaskDlgLeaderLine(baseFeat,
-                                                                 page));
+    Gui::Control().showDialog(new TechDrawGui::TaskDlgLeaderLine(page));
     updateActive();
     Gui::Selection().clearSelection();
 }
@@ -1420,18 +1404,15 @@ void CmdTechDrawWeldSymbol::activated(int iMsg)
                                          getObjectsOfType(TechDraw::DrawWeldSymbol::getClassTypeId());
     TechDraw::DrawLeaderLine* leadFeat = nullptr;
     TechDraw::DrawWeldSymbol* weldFeat = nullptr;
-    if ( (leaders.size() != 1) &&
-         (welds.size() != 1) ) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select exactly one leader line or one weld symbol"));
-        return;
-    }
+
     if (!leaders.empty()) {
         leadFeat = static_cast<TechDraw::DrawLeaderLine*> (leaders.front());
         Gui::Control().showDialog(new TaskDlgWeldingSymbol(leadFeat));
     } else if (!welds.empty()) {
         weldFeat = static_cast<TechDraw::DrawWeldSymbol*> (welds.front());
         Gui::Control().showDialog(new TaskDlgWeldingSymbol(weldFeat));
+    } else {
+        Gui::Control().showDialog(new TaskDlgWeldingSymbol(page));
     }
     updateActive();
     Gui::Selection().clearSelection();

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
@@ -137,15 +137,162 @@ QVariant QGILeaderLine::itemChange(GraphicsItemChange change, const QVariant& va
     return QGIView::itemChange(change, value);
 }
 
-//QGILL isn't draggable so skip QGIV::mousePress have event
 void QGILeaderLine::mousePressEvent(QGraphicsSceneMouseEvent* event)
 {
+    m_dragActive = true;
+    m_dragPointIndex = -1;
+
+    // Length from mouse to feature where dragging is considered to be "on" the feature
+    // 5 seems to be a good value for this 
+    int dragLength = Rez::guiX(5.0);
+    
+    int pointNum = 0;
+    for (auto point : m_pathPoints) {
+        if (QVector2D(point - event->pos()).length() < dragLength) {
+            m_dragDelta = event->pos() - point;
+            m_dragPointIndex = pointNum;
+            break;
+        }
+        pointNum++;
+    }
+
+    auto featLeader = getLeaderFeature();
+    if (featLeader && m_dragPointIndex < 0) {
+        // Normal, and complex with kink
+        if(featLeader->Type.getValue() == 0 || featLeader->Type.getValue() == 3) {
+            // Length formula for distance from point to line segment
+            QPointF kinkStart = m_pathPoints[m_pathPoints.size() - 2];
+            QPointF kinkEnd = m_pathPoints[m_pathPoints.size() - 1];
+            QPointF mousePoint = event->pos();
+
+            QVector2D kinkVector(kinkEnd - kinkStart);
+            float t = QVector2D::dotProduct(QVector2D(mousePoint - kinkStart), kinkVector) / kinkVector.lengthSquared();
+            t = qBound(0.0f, t, 1.0f);
+
+            QPointF closestPoint = kinkStart + t * (kinkEnd - kinkStart);
+            double distanceToSegment = QVector2D(mousePoint - closestPoint).length();
+
+            // If the user is dragging the kink segment, then set the drag point to the start of the kink
+            if (distanceToSegment < dragLength) {
+                m_dragDelta = event->pos() - kinkStart;
+                m_dragPointIndex = m_pathPoints.size() - 2;
+            }
+        }
+    }
+
     QGraphicsItem::mousePressEvent(event);
 }
 
-//QGILL isn't draggable so skip QGIV::Release
+void QGILeaderLine::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
+{
+    if (!m_dragActive || m_dragPointIndex < 1) {
+        QGraphicsItem::mouseMoveEvent(event);
+        return;
+    }
+
+    auto featLeader = getLeaderFeature();
+    if (featLeader) {
+        long leaderType = featLeader->Type.getValue();
+        switch (leaderType) {
+            // Normal
+            case 0: {
+                QPointF oldPosition = m_pathPoints[m_dragPointIndex];
+                int otherPointIndex = (m_dragPointIndex == 1) ? 2 : 1;
+                
+                m_pathPoints[m_dragPointIndex] = event->pos() - m_dragDelta;
+                QPointF delta = m_pathPoints[m_dragPointIndex] - oldPosition;
+                m_pathPoints[otherPointIndex] += delta;
+
+                QPointF referencePoint = m_pathPoints.front();
+                QPointF firstPoint = m_pathPoints[1];
+                QPointF secondPoint = m_pathPoints[2];
+
+                double distA = std::hypot(firstPoint.x() - referencePoint.x(), firstPoint.y() - referencePoint.y());
+                double distB = std::hypot(secondPoint.x() - referencePoint.x(), secondPoint.y() - referencePoint.y());
+
+                if (distB < distA) {
+                    std::swap(m_pathPoints[1], m_pathPoints[2]);
+                }
+
+                m_line->setPath(makeLeaderPath(m_pathPoints));
+                setArrows(m_pathPoints);
+                update(boundingRect());
+                break;
+            }
+            // Straight
+            case 1: {
+                m_pathPoints[m_dragPointIndex] = event->pos() - m_dragDelta;
+                m_line->setPath(makeLeaderPath(m_pathPoints));
+                setArrows(m_pathPoints);
+                update(boundingRect());
+                break;
+            }
+            // Complex
+            case 2: {
+                m_pathPoints[m_dragPointIndex] = event->pos() - m_dragDelta;
+                m_line->setPath(makeLeaderPath(m_pathPoints));
+                setArrows(m_pathPoints);
+                update(boundingRect());
+                break;
+            }
+            // Complex with kink
+            case 3: {
+                // If dragging a random point
+                if (m_dragPointIndex != m_pathPoints.size() - 2 && m_dragPointIndex != m_pathPoints.size() - 1) {
+                    m_pathPoints[m_dragPointIndex] = event->pos() - m_dragDelta;
+                }
+                // Dragging the kink
+                else {
+                    int kinkStartIndex = m_pathPoints.size() - 2;
+                    int kinkEndIndex = m_pathPoints.size() - 1;
+
+                    QPointF oldPosition = m_pathPoints[m_dragPointIndex];
+                    int otherPointIndex = (m_dragPointIndex == kinkStartIndex) ? kinkEndIndex : kinkStartIndex;
+                    
+                    m_pathPoints[m_dragPointIndex] = event->pos() - m_dragDelta;
+                    QPointF delta = m_pathPoints[m_dragPointIndex] - oldPosition;
+                    m_pathPoints[otherPointIndex] += delta;
+
+                    QPointF referencePoint = m_pathPoints[m_pathPoints.size() - 3];
+                    QPointF firstPoint = m_pathPoints[kinkStartIndex];
+                    QPointF secondPoint = m_pathPoints[kinkEndIndex];
+
+                    double distA = std::hypot(firstPoint.x() - referencePoint.x(), firstPoint.y() - referencePoint.y());
+                    double distB = std::hypot(secondPoint.x() - referencePoint.x(), secondPoint.y() - referencePoint.y());
+
+                    if (distB < distA) {
+                        std::swap(m_pathPoints[kinkStartIndex], m_pathPoints[kinkEndIndex]);
+                    }
+                }
+
+                m_line->setPath(makeLeaderPath(m_pathPoints));
+                setArrows(m_pathPoints);
+                update(boundingRect());
+                break;
+            }
+            
+            default:
+                break;
+        }
+    }
+
+    QGraphicsItem::mouseMoveEvent(event);
+}
+
 void QGILeaderLine::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 {
+    if (!m_dragActive) {
+        return;
+    }
+    m_dragActive = false;
+
+    if (m_dragPointIndex >= 0) {
+        QPointF tipDisplace(0.0, 0.0);
+        onLineEditFinished(tipDisplace, m_pathPoints);
+    }
+
+    m_dragPointIndex = -1;
+    m_dragDelta = QPointF(0.0, 0.0);
     QGraphicsItem::mouseReleaseEvent(event);
 }
 
@@ -363,13 +510,7 @@ void QGILeaderLine::draw()
         return;
     }
 
-    //********
-    if (featLeader->isLocked()) {
-        setFlag(QGraphicsItem::ItemIsMovable, false);
-    }
-    else {
-        setFlag(QGraphicsItem::ItemIsMovable, true);
-    }
+    setFlag(QGraphicsItem::ItemIsMovable, false);
 
     // set the leader's Qt position from feature's X,Y and scale.
     // the feature's x,y is unscaled, unrotated and conventional Y
@@ -395,6 +536,7 @@ void QGILeaderLine::draw()
     setNormalColorAll();
     m_line->setPath(makeLeaderPath(qPoints));
     setArrows(qPoints);
+    m_pathPoints = qPoints;
 
     if (isSelected()) {
         setPrettySel();

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.h
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.h
@@ -72,7 +72,6 @@ public:
     void drawBorder() override;
     void updateView(bool update = false) override;
 
-    // leaders are not draggable
     void dragFinished() override { };
 
     virtual TechDraw::DrawLeaderLine* getLeaderFeature();
@@ -86,6 +85,7 @@ public:
     double getLineWidth();
 
     void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
+    void mouseMoveEvent(QGraphicsSceneMouseEvent* event) override;
     void mouseReleaseEvent(QGraphicsSceneMouseEvent* event) override;
     void mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event) override;
     void hoverEnterEvent(QGraphicsSceneHoverEvent* event) override;
@@ -113,7 +113,6 @@ protected:
     QPainterPath makeLeaderPath(std::vector<QPointF> qPoints);
     std::vector<QPointF> getWayPointsFromFeature();
     QPointF getAttachFromFeature();
-
     QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
 
     void saveState();
@@ -140,6 +139,10 @@ private:
     std::vector<Base::Vector3d> m_savePoints;
 
     bool m_blockDraw;//prevent redraws while updating.
+
+    bool m_dragActive = false;
+    QPointF m_dragDelta = QPointF(0.0, 0.0);
+    int m_dragPointIndex = -1;
 };
 
 }// namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGIRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/QGIRichAnno.cpp
@@ -44,6 +44,7 @@
 #include <Gui/Control.h>
 
 #include <App/AutoTransaction.h>
+#include <Mod/TechDraw/App/DrawLeaderLine.h>
 #include <Mod/TechDraw/App/DrawRichAnno.h>
 #include <Mod/TechDraw/App/DrawUtil.h>
 
@@ -52,7 +53,9 @@
 #include "PreferencesGui.h"
 #include "QGCustomRect.h"
 #include "QGCustomText.h"
+#include "QGILeaderLine.h"
 #include "Rez.h"
+#include "ViewProviderLeader.h"
 #include "ViewProviderRichAnno.h"
 #include "ZVALUE.h"
 #include "DrawGuiUtil.h"
@@ -104,6 +107,7 @@ QGIRichAnno::QGIRichAnno() :
             this,
             &QGIRichAnno::onContentsChanged);
     connect(m_text, &QGCustomText::selectionChanged, this, &QGIRichAnno::selectionChanged);
+    connect(this, &QGIRichAnno::positionChanged, this, &QGIRichAnno::updateAttachedLeaderLine);
 }
 
 void QGIRichAnno::updateView(bool update)
@@ -641,6 +645,61 @@ QVariant QGIRichAnno::itemChange(GraphicsItemChange change, const QVariant& valu
         Q_EMIT positionChanged();
     }
     return QGIView::itemChange(change, value);
+}
+
+void QGIRichAnno::updateAttachedLeaderLine()
+{
+    TechDraw::DrawRichAnno* annoFeat = getFeature();
+    if (!annoFeat) {
+        return;
+    }
+
+    auto leaderFeat = dynamic_cast<TechDraw::DrawLeaderLine*>(annoFeat->LeaderLine.getValue());
+    if (!leaderFeat) {
+        return;
+    }
+
+    auto leaderVP = dynamic_cast<ViewProviderLeader*>(getViewProvider(leaderFeat));
+    QGILeaderLine* leaderView =  dynamic_cast<QGILeaderLine*>(leaderVP->getQView());
+
+    QRectF annoRect = mapToScene(frameRect()).boundingRect();
+    QPointF attachScenePos = leaderView->mapToScene(QPointF(0.0, 0.0));
+    bool attachOnLeft = attachScenePos.x() < annoRect.center().x();
+
+    long leaderType = leaderFeat->Type.getValue();
+    std::vector<QPointF> richAnnoPoints;
+    
+    // Normal and Complex with kink
+    if (leaderType == 0 || leaderType == 3) {
+        QPointF kinkStart = attachOnLeft ? annoRect.bottomLeft() : annoRect.bottomRight();
+        QPointF kinkEnd = attachOnLeft ? annoRect.bottomRight() : annoRect.bottomLeft();
+        richAnnoPoints = {kinkStart, kinkEnd};
+    }
+    // Straight and Complex
+    else {
+        QPointF leftMid = annoRect.bottomLeft() + (annoRect.topLeft() - annoRect.bottomLeft()) / 2.0;
+        QPointF rightMid = annoRect.bottomRight() + (annoRect.topRight() - annoRect.bottomRight()) / 2.0;
+        richAnnoPoints = {attachOnLeft ? leftMid : rightMid};
+    }
+
+    std::vector<QPointF> localPoints;
+    for (auto& point : leaderFeat->getTransformedWayPoints()) {
+        localPoints.push_back(DU::toQPointF(Rez::guiX(point)));
+    }
+
+    // Turn the Rich Annotation points into local coordinates of the leader line
+    size_t startIndex = localPoints.size() - richAnnoPoints.size();
+    for (size_t i = 0; i < richAnnoPoints.size(); i++) {
+        localPoints[startIndex + i] = leaderView->mapFromScene(richAnnoPoints[i]);
+    }
+
+    std::vector<Base::Vector3d> wayPoints;
+    for (auto& point : localPoints) {
+        wayPoints.push_back(Rez::appX(DU::toVector3d(point - localPoints.front())));
+    }
+
+    leaderFeat->WayPoints.setValues(leaderFeat->makeCanonicalPointsInverted(wayPoints));
+    leaderFeat->recomputeFeature();
 }
 
 void QGIRichAnno::updateLayout()

--- a/src/Mod/TechDraw/Gui/QGIRichAnno.h
+++ b/src/Mod/TechDraw/Gui/QGIRichAnno.h
@@ -76,6 +76,7 @@ public:
                const QStyleOptionGraphicsItem* option,
                QWidget* widget = nullptr) override;
     QRectF boundingRect() const override;
+    using QGIView::frameRect;
 
     void updateView(bool update = false) override;
 
@@ -154,6 +155,7 @@ protected:
 
 private Q_SLOTS:
     void onContentsChanged();
+    void updateAttachedLeaderLine();
 };
 
 }

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -797,7 +797,8 @@ QRectF QGIView::frameRect() const
             child->type() != UserType::QGIVertex &&
             child->type() != UserType::QGICMark  &&
             child->type() != UserType::QGIViewDimension &&
-            child->type() != UserType::QGIViewBalloon) {
+            child->type() != UserType::QGIViewBalloon &&
+            child->type() != UserType::QGILeaderLine) {
             QRectF childRect = mapFromItem(child, child->boundingRect()).boundingRect();
             result = result.united(childRect);
         }

--- a/src/Mod/TechDraw/Gui/QGVPage.h
+++ b/src/Mod/TechDraw/Gui/QGVPage.h
@@ -124,6 +124,8 @@ public:
 
     void centerOnPage();
 
+    QPixmap prepareCursorPixmap(const char* iconName, QPoint& hotspot);
+
     TechDraw::DrawView* getBalloonParent() { return m_balloonParent; }
 
     void zoomIn();
@@ -150,8 +152,6 @@ protected:
     void contextMenuEvent(QContextMenuEvent* event) override;
 
     QColor getBackgroundColor();
-
-    QPixmap prepareCursorPixmap(const char* iconName, QPoint& hotspot);
 
     void drawForeground(QPainter* painter, const QRectF& rect) override;
 

--- a/src/Mod/TechDraw/Gui/Resources/TechDraw.qrc
+++ b/src/Mod/TechDraw/Gui/Resources/TechDraw.qrc
@@ -25,6 +25,7 @@
         <file>icons/actions/TechDraw_Hatch.svg</file>
         <file>icons/actions/TechDraw_Image.svg</file>
         <file>icons/actions/TechDraw_LeaderLine.svg</file>
+        <file>icons/actions/TechDraw_LeaderLine_Pointer.svg</file>
         <file>icons/actions/TechDraw_Line2Points.svg</file>
         <file>icons/actions/TechDraw_Midpoints.svg</file>
         <file>icons/actions/TechDraw_MoveView.svg</file>

--- a/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_LeaderLine_Pointer.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_LeaderLine_Pointer.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="58.703045"
+   height="58.790672"
+   id="svg5821"
+   version="1.1"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><defs
+     id="defs5823" /><metadata
+     id="metadata5826"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:creator><cc:Agent><dc:title>[WandererFan]</dc:title></cc:Agent></dc:creator><dc:date>2016-04-27</dc:date><dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation><dc:publisher><cc:Agent><dc:title>FreeCAD</dc:title></cc:Agent></dc:publisher><dc:identifier>FreeCAD/src/Mod/TechDraw/Gui/Resources/icons/TechDraw_Dimension_Diameter.svg</dc:identifier><dc:rights><cc:Agent><dc:title>FreeCAD LGPL2+</dc:title></cc:Agent></dc:rights><cc:license
+           rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html">https://www.gnu.org/copyleft/lesser.html</cc:license><dc:contributor><cc:Agent><dc:title>[agryson] Alexander Gryson</dc:title></cc:Agent></dc:contributor><dc:subject><rdf:Bag><rdf:li>double arrow</rdf:li><rdf:li>circle</rdf:li></rdf:Bag></dc:subject></cc:Work></rdf:RDF></metadata><g
+     id="layer1"
+     transform="translate(-0.1784387,-0.18587361)"><g
+       id="crosshair"
+       style="stroke:#ffffff;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:miter"
+       transform="translate(-0.8215613,-0.81412639)"><path
+         d="m 16,3 v 9 m 0,8 v 9 M 3,16 h 9 m 8,0 h 9"
+         id="path9"
+         style="stroke:#2e3436;stroke-width:4;stroke-dasharray:none" /><path
+         d="m 16,3 v 9 m 0,8 v 9 M 3,16 h 9 m 8,0 h 9"
+         id="path7"
+         style="stroke:#eeeeec;stroke-width:2;stroke-dasharray:none" /></g><g
+       id="g3"
+       transform="matrix(0.72539562,0,0,0.72245666,8.7605835,2.426107)"
+       style="stroke-width:0.999994"><path
+         style="fill:none;stroke:#0b1521;stroke-width:7.99996;stroke-dasharray:none"
+         d="M 9,63.796199 32.290565,40.68676 h 15.999952"
+         id="path2" /><path
+         style="display:inline;fill:#3465a4;stroke:#0b1521;stroke-width:1.99999;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 3.5811389,69.57704 5,56.796232 16,67.79618 Z"
+         id="path1" /><path
+         style="display:inline;fill:none;stroke:#0b1521;stroke-width:7.99996;stroke-linecap:round;stroke-dasharray:none"
+         d="m 58.290487,30.686844 -9.99997,9.999916 9.99997,9.999916"
+         id="path3" /><path
+         style="display:inline;fill:none;stroke:#3465a4;stroke-width:3.99997;stroke-linecap:round;stroke-dasharray:none"
+         d="M 9.1435549,63.768554 32,40.796309 h 16.290517"
+         id="path6" /><path
+         style="fill:none;stroke:#3465a4;stroke-width:3.99997;stroke-linecap:round;stroke-dasharray:none"
+         d="m 58.290487,30.686844 -9.999726,9.999916 9.999726,9.999916"
+         id="path7-9" /><path
+         style="fill:none;stroke:#729fcf;stroke-width:1.99999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 9.3644222,62.012639 30.999635,39.796771 h 16.290517"
+         id="path4" /><path
+         style="fill:none;stroke:#729fcf;stroke-width:1.99999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 57.290202,29.686856 -9.999726,9.999916 9.999726,9.999916"
+         id="path5" /></g></g></svg>

--- a/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
@@ -20,63 +20,45 @@
  *                                                                         *
  ***************************************************************************/
 
-# include <QStatusBar>
-
-
 #include <App/Document.h>
 #include <Base/Console.h>
-#include <Base/Tools.h>
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>
 #include <Gui/Document.h>
-#include <Gui/MainWindow.h>
+#include <Gui/Selection/Selection.h>
 #include <Gui/ViewProvider.h>
 #include <Mod/TechDraw/App/ArrowPropEnum.h>
 #include <Mod/TechDraw/App/DrawLeaderLine.h>
 #include <Mod/TechDraw/App/DrawPage.h>
 #include <Mod/TechDraw/App/DrawView.h>
 #include <Mod/TechDraw/App/LineGroup.h>
-#include <Mod/TechDraw/App/DrawUtil.h>
 
 #include "TaskLeaderLine.h"
 #include "ui_TaskLeaderLine.h"
 #include "DrawGuiUtil.h"
 #include "MDIViewPage.h"
 #include "PreferencesGui.h"
-#include "QGILeaderLine.h"
-#include "QGIView.h"
-#include "QGSPage.h"
-#include "QGTracker.h"
-#include "Rez.h"
+#include "QGVPage.h"
 #include "ViewProviderLeader.h"
 #include "ViewProviderPage.h"
+#include "TechDrawLeaderLineHandler.h"
 
 
 using namespace Gui;
 using namespace TechDraw;
 using namespace TechDrawGui;
-using DU = DrawUtil;
-using DGU = DrawGuiUtil;
-
-constexpr int MessageDisplayTime{3000};
 
 TaskLeaderLine::TaskLeaderLine(TechDrawGui::ViewProviderLeader* leadVP) :
     ui(new Ui_TaskLeaderLine),
-    m_tracker(nullptr),
     m_lineVP(leadVP),
     m_baseFeat(nullptr),
     m_basePage(nullptr),
     m_lineFeat(m_lineVP->getFeature()),
-    m_qgParent(nullptr),
     m_createMode(false),
-    m_trackerMode(QGTracker::TrackerMode::None),
     m_saveContextPolicy(Qt::DefaultContextMenu),
-    m_inProgressLock(false),
-    m_qgLeader(nullptr),
     m_btnOK(nullptr),
     m_btnCancel(nullptr),
-    m_pbTrackerState(TrackerAction::EDIT),
     m_saveX(0.0),
     m_saveY(0.0)
 {
@@ -99,11 +81,6 @@ TaskLeaderLine::TaskLeaderLine(TechDrawGui::ViewProviderLeader* leadVP) :
     Gui::ViewProvider* vp = activeGui->getViewProvider(m_basePage);
     m_vpp = static_cast<ViewProviderPage*>(vp);
 
-    m_qgParent = nullptr;
-    if (m_baseFeat) {
-        m_qgParent = m_vpp->getQGSPage()->findQViewForDocObj(m_baseFeat);
-    }
-
     //TODO: when/if leaders are allowed to be parented to Page, check for m_baseFeat will be removed
     if (!m_baseFeat || !m_basePage) {
         Base::Console().error("TaskLeaderLine - bad parameters (2).  Cannot proceed.\n");
@@ -114,69 +91,65 @@ TaskLeaderLine::TaskLeaderLine(TechDrawGui::ViewProviderLeader* leadVP) :
 
     setUiEdit();
 
-    m_attachPoint = Rez::guiX(Base::Vector3d(m_lineFeat->X.getValue(),
-                                            -m_lineFeat->Y.getValue(),
-                                             0.0));
-
-    connect(ui->pbTracker, &QPushButton::clicked,
-            this, &TaskLeaderLine::onTrackerClicked);
-    connect(ui->pbCancelEdit, &QPushButton::clicked,
-            this, &TaskLeaderLine::onCancelEditClicked);
-    ui->pbCancelEdit->setEnabled(false);
-
     saveState();
 
-    m_trackerMode = QGTracker::TrackerMode::Line;
     if (m_vpp->getMDIViewPage()) {
         m_saveContextPolicy = m_vpp->getMDIViewPage()->contextMenuPolicy();
     }
 }
 
 //ctor for creation
-TaskLeaderLine::TaskLeaderLine(TechDraw::DrawView* baseFeat,
-                               TechDraw::DrawPage* page) :
+TaskLeaderLine::TaskLeaderLine(TechDraw::DrawPage* page) :
     ui(new Ui_TaskLeaderLine),
-    m_tracker(nullptr),
     m_lineVP(nullptr),
-    m_baseFeat(baseFeat),
+    m_baseFeat(nullptr),
     m_basePage(page),
     m_lineFeat(nullptr),
-    m_qgParent(nullptr),
     m_createMode(true),
-    m_trackerMode(QGTracker::TrackerMode::None),
     m_saveContextPolicy(Qt::DefaultContextMenu),
-    m_inProgressLock(false),
-    m_qgLeader(nullptr),
     m_btnOK(nullptr),
     m_btnCancel(nullptr),
-    m_pbTrackerState(TrackerAction::PICK),
     m_saveX(0.0),
-    m_saveY(0.0)
+    m_saveY(0.0),
+    m_vpp(nullptr),
+    m_viewPage(nullptr)
 {
-    //existence of basePage and baseFeat is checked in CmdTechDrawLeaderLine (CommandAnnotate.cpp)
+    //existence of page is guaranteed by caller (CmdTechDrawLeaderLine::activated)
+    if (!m_basePage) {
+        Base::Console().error("TaskLeaderLine - bad parameters (1).  Cannot proceed.\n");
+        return;
+    }
 
     Gui::Document* activeGui = Gui::Application::Instance->getDocument(m_basePage->getDocument());
     Gui::ViewProvider* vp = activeGui->getViewProvider(m_basePage);
     m_vpp = static_cast<ViewProviderPage*>(vp);
 
-    if (m_baseFeat) {
-        m_qgParent = m_vpp->getQGSPage()->findQViewForDocObj(baseFeat);
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
+    if (!selection.empty()) {
+        m_baseFeat = dynamic_cast<TechDraw::DrawView*>(selection.front().getObject());
     }
-
     ui->setupUi(this);
 
     setUiPrimary();
 
-    connect(ui->pbTracker, &QPushButton::clicked,
-            this, &TaskLeaderLine::onTrackerClicked);
-    connect(ui->pbCancelEdit, &QPushButton::clicked,
-            this, &TaskLeaderLine::onCancelEditClicked);
-    ui->pbCancelEdit->setEnabled(false);
+    connect(ui->cboxLeaderType, qOverload<int>(&QComboBox::currentIndexChanged),
+                this, &TaskLeaderLine::onLeaderTypeChanged);
 
-    m_trackerMode = QGTracker::TrackerMode::Line;
     if (m_vpp->getMDIViewPage()) {
         m_saveContextPolicy = m_vpp->getMDIViewPage()->contextMenuPolicy();
     }
+
+    m_viewPage = m_vpp->getQGVPage();
+
+    handler = new TechDrawLeaderLineHandler();
+    handler->color.setValue<QColor>(ui->cpLineColor->color());
+    handler->lineWidth = ui->dsbWeight->rawValue();
+    handler->lineStyle = ui->cboxStyle->currentIndex();
+    handler->startSymbol = ui->cboxStartSym->currentIndex();
+    handler->endSymbol = ui->cboxEndSym->currentIndex();
+    handler->kinkLength = ui->dsbKinkLength->rawValue();
+
+    m_viewPage->activateHandler(handler);
 }
 
 void TaskLeaderLine::saveState()
@@ -216,20 +189,6 @@ void TaskLeaderLine::setUiPrimary()
     enableVPUi(true);
     setWindowTitle(QObject::tr("New Leader Line"));
 
-    if (m_baseFeat) {
-        std::string baseName = m_baseFeat->getNameInDocument();
-        ui->tbBaseView->setText(QString::fromStdString(baseName));
-    }
-
-    ui->pbTracker->setText(tr("Pick Points"));
-    if (m_vpp->getMDIViewPage()) {
-        ui->pbTracker->setEnabled(true);
-        ui->pbCancelEdit->setEnabled(true);
-    } else {
-        ui->pbTracker->setEnabled(false);
-        ui->pbCancelEdit->setEnabled(false);
-    }
-
     DrawGuiUtil::loadArrowBox(ui->cboxStartSym);
     ArrowType aStyle = PreferencesGui::dimArrowStyle();
     ui->cboxStartSym->setCurrentIndex(static_cast<int>(aStyle));
@@ -242,6 +201,18 @@ void TaskLeaderLine::setUiPrimary()
     ui->dsbWeight->setValue(TechDraw::LineGroup::getDefaultWidth("Graphic"));
 
     ui->cpLineColor->setColor(PreferencesGui::leaderColor().asValue<QColor>());
+
+    ui->dsbKinkLength->setUnit(Base::Unit::Length);
+    ui->dsbKinkLength->setValue(5.0);
+
+    connect(ui->cpLineColor, &ColorButton::changed, this, &TaskLeaderLine::onColorChanged);
+    connect(ui->dsbWeight, qOverload<double>(&QuantitySpinBox::valueChanged), this, &TaskLeaderLine::onLineWidthChanged);
+    connect(ui->cboxStyle, qOverload<int>(&QComboBox::currentIndexChanged), this, &TaskLeaderLine::onLineStyleChanged);
+    connect(ui->cboxStartSym, qOverload<int>(&QComboBox::currentIndexChanged), this, &TaskLeaderLine::onStartSymbolChanged);
+    connect(ui->cboxEndSym, qOverload<int>(&QComboBox::currentIndexChanged), this, &TaskLeaderLine::onEndSymbolChanged);
+    connect(ui->dsbKinkLength, qOverload<double>(&QuantitySpinBox::valueChanged), this, &TaskLeaderLine::onKinkLengthChanged);
+
+    onLeaderTypeChanged(ui->cboxLeaderType->currentIndex());
 }
 
 //switch widgets related to ViewProvider on/off
@@ -258,10 +229,10 @@ void TaskLeaderLine::setUiEdit()
     enableVPUi(true);
     setWindowTitle(QObject::tr("Edit Leader Line"));
 
-    if (m_lineFeat) {
-        std::string baseName = m_lineFeat->LeaderParent.getValue()->getNameInDocument();
-        ui->tbBaseView->setText(QString::fromStdString(baseName));
+    ui->labelLeaderType->setVisible(false);
+    ui->cboxLeaderType->setVisible(false);
 
+    if (m_lineFeat) {
         DrawGuiUtil::loadArrowBox(ui->cboxStartSym);
         ui->cboxStartSym->setCurrentIndex(m_lineFeat->StartSymbol.getValue());
         connect(ui->cboxStartSym, qOverload<int>(&QComboBox::currentIndexChanged), this, &TaskLeaderLine::onStartSymbolChanged);
@@ -269,13 +240,17 @@ void TaskLeaderLine::setUiEdit()
         ui->cboxEndSym->setCurrentIndex(m_lineFeat->EndSymbol.getValue());
         connect(ui->cboxEndSym, qOverload<int>(&QComboBox::currentIndexChanged), this, &TaskLeaderLine::onEndSymbolChanged);
 
-        ui->pbTracker->setText(tr("Edit Points"));
-        if (m_vpp->getMDIViewPage()) {
-            ui->pbTracker->setEnabled(true);
-            ui->pbCancelEdit->setEnabled(true);
+        if (m_lineFeat->Type.getValue() == 0 || m_lineFeat->Type.getValue() == 3) {
+            ui->labelKinkLength->setVisible(true);
+            ui->dsbKinkLength->setVisible(true);
+            std::vector<Base::Vector3d> pts = m_lineFeat->WayPoints.getValues();
+            Base::Vector3d startPt = pts[pts.size() - 2];
+            Base::Vector3d endPt = pts[pts.size() - 1];
+            double kinkLength = std::hypot(startPt.x - endPt.x, startPt.y - endPt.y);
+            ui->dsbKinkLength->setValue(kinkLength);
         } else {
-            ui->pbTracker->setEnabled(false);
-            ui->pbCancelEdit->setEnabled(false);
+            ui->labelKinkLength->setVisible(false);
+            ui->dsbKinkLength->setVisible(false);
         }
     }
 
@@ -284,10 +259,14 @@ void TaskLeaderLine::setUiEdit()
         ui->dsbWeight->setValue(m_lineVP->LineWidth.getValue());
         ui->cboxStyle->setCurrentIndex(m_lineVP->LineStyle.getValue());
     }
+
     connect(ui->cpLineColor, &ColorButton::changed, this, &TaskLeaderLine::onColorChanged);
     ui->dsbWeight->setMinimum(0);
     connect(ui->dsbWeight, qOverload<double>(&QuantitySpinBox::valueChanged), this, &TaskLeaderLine::onLineWidthChanged);
     connect(ui->cboxStyle, qOverload<int>(&QComboBox::currentIndexChanged), this, &TaskLeaderLine::onLineStyleChanged);
+
+    ui->dsbKinkLength->setUnit(Base::Unit::Length);
+    connect(ui->dsbKinkLength, qOverload<double>(&QuantitySpinBox::valueChanged), this, &TaskLeaderLine::onKinkLengthChanged);
 }
 
 void TaskLeaderLine::recomputeFeature()
@@ -299,131 +278,115 @@ void TaskLeaderLine::recomputeFeature()
 
 void TaskLeaderLine::onStartSymbolChanged()
 {
-    m_lineFeat->StartSymbol.setValue(ui->cboxStartSym->currentIndex());
-    recomputeFeature();
+    if (handler) {
+        handler->startSymbol = ui->cboxStartSym->currentIndex();
+        handler->updateLeader();
+    }
+
+    if (m_lineFeat) {
+        m_lineFeat->StartSymbol.setValue(ui->cboxStartSym->currentIndex());
+        recomputeFeature();
+    }
 }
 
 void TaskLeaderLine::onEndSymbolChanged()
 {
-    m_lineFeat->EndSymbol.setValue(ui->cboxEndSym->currentIndex());
-    recomputeFeature();
+    if (handler) {
+        handler->endSymbol = ui->cboxEndSym->currentIndex();
+        handler->updateLeader();
+    }
+
+    if (m_lineFeat) {
+        m_lineFeat->EndSymbol.setValue(ui->cboxEndSym->currentIndex());
+        recomputeFeature();
+    }
 }
 
 void TaskLeaderLine::onColorChanged()
 {
     Base::Color ac;
     ac.setValue<QColor>(ui->cpLineColor->color());
-    m_lineVP->Color.setValue(ac);
-    recomputeFeature();
+    if (handler) {
+        handler->color = ac;
+        handler->updateLeader();
+    }
+
+    if (m_lineVP) {
+        m_lineVP->Color.setValue(ac);
+        recomputeFeature();
+    }
 }
 
 void TaskLeaderLine::onLineWidthChanged()
 {
-    m_lineVP->LineWidth.setValue(ui->dsbWeight->rawValue());
-    recomputeFeature();
+    if (handler) {
+        handler->lineWidth = ui->dsbWeight->rawValue();
+        handler->updateLeader();
+    }
+
+    if (m_lineVP) {
+        m_lineVP->LineWidth.setValue(ui->dsbWeight->rawValue());
+        recomputeFeature();
+    }
 }
 
 void TaskLeaderLine::onLineStyleChanged()
 {
-    m_lineVP->LineStyle.setValue(ui->cboxStyle->currentIndex());
-    recomputeFeature();
+    if (handler) {
+        handler->lineStyle = ui->cboxStyle->currentIndex();
+        handler->updateLeader();
+    }
+
+    if (m_lineVP) {
+        m_lineVP->LineStyle.setValue(ui->cboxStyle->currentIndex());
+        recomputeFeature();
+    }
 }
 
-
-//******************************************************************************
-//! sceneDeltas are vector from first picked scene point (0,0) to the ith point.
-//! sceneDeltas are in Qt scene coords (Rez and inverted Y).
-void TaskLeaderLine::createLeaderFeature(std::vector<Base::Vector3d> sceneDeltas)
+void TaskLeaderLine::onKinkLengthChanged()
 {
-    const std::string objectName{"LeaderLine"};
-    std::string m_leaderName = m_basePage->getDocument()->getUniqueObjectName(objectName.c_str());
-    m_leaderType = "TechDraw::DrawLeaderLine";
-
-    std::string PageName = m_basePage->getNameInDocument();
-
-    int tid = Gui::Command::openActiveDocumentCommand(QT_TRANSLATE_NOOP("Command", "Create Leader"));
-    Command::doCommand(Command::Doc, "App.activeDocument().addObject('%s', '%s')",
-                       m_leaderType.c_str(), m_leaderName.c_str());
-    Command::doCommand(Command::Doc, "App.activeDocument().%s.translateLabel('DrawLeaderLine', 'LeaderLine', '%s')",
-              m_leaderName.c_str(), m_leaderName.c_str());
-
-    Command::doCommand(Command::Doc, "App.activeDocument().%s.addView(App.activeDocument().%s)",
-                       PageName.c_str(), m_leaderName.c_str());
-
-    double baseRotation{0};
-    if (m_baseFeat) {
-        Command::doCommand(Command::Doc, "App.activeDocument().%s.LeaderParent = App.activeDocument().%s",
-                               m_leaderName.c_str(), m_baseFeat->getNameInDocument());
-        baseRotation = m_baseFeat->Rotation.getValue();
-    }
-
-    App::DocumentObject* obj = m_basePage->getDocument()->getObject(m_leaderName.c_str());
-    if (!obj) {
-        throw Base::RuntimeError("TaskLeaderLine - new markup object not found");
-    }
-
-    if (obj->isDerivedFrom<TechDraw::DrawLeaderLine>()) {
-        m_lineFeat = static_cast<TechDraw::DrawLeaderLine*>(obj);
-        auto forMath{m_attachPoint};
-        if (baseRotation != 0) {
-            forMath = DU::invertY(forMath);
-            forMath.RotateZ(-Base::toRadians(baseRotation));
-            forMath = DU::invertY(forMath);
-        }
-        m_attachPoint = forMath;
-        m_lineFeat->setPosition(Rez::appX(m_attachPoint.x), Rez::appX(- m_attachPoint.y), true);
-        if (!sceneDeltas.empty()) {
-            std::vector<Base::Vector3d> pageDeltas;
-            // convert deltas to mm. leader points are stored inverted, so we do not convert to conventional Y axis
-            for (auto& delta : sceneDeltas) {
-                Base::Vector3d deltaInPageCoords = Rez::appX(delta);
-                pageDeltas.push_back(deltaInPageCoords);
-            }
-
-            // already unrotated, now convert to unscaled, but inverted
-            bool doScale{true};
-            bool doRotate{false};
-            auto temp = m_lineFeat->makeCanonicalPointsInverted(pageDeltas, doScale, doRotate);
-            m_lineFeat->WayPoints.setValues(temp);
-        }
-        commonFeatureUpdate();
+    if (handler) {
+        handler->kinkLength = ui->dsbKinkLength->rawValue();
+        handler->updateLeader();
     }
 
     if (m_lineFeat) {
-        Gui::ViewProvider* vp = QGIView::getViewProvider(m_lineFeat);
-        auto leadVP = freecad_cast<ViewProviderLeader*>(vp);
-        if (leadVP) {
-            Base::Color ac;
-            ac.setValue<QColor>(ui->cpLineColor->color());
-            leadVP->Color.setValue(ac);
-            leadVP->LineWidth.setValue(ui->dsbWeight->rawValue());
-            leadVP->LineStyle.setValue(ui->cboxStyle->currentIndex());
+        std::vector<Base::Vector3d> pts = m_lineFeat->WayPoints.getValues();
+        if (pts.size() >= 3) {
+            Base::Vector3d& kinkStart = pts[pts.size() - 2];
+            Base::Vector3d& kinkEnd = pts[pts.size() - 1];
+
+            double kinkLength = ui->dsbKinkLength->rawValue();
+            Base::Vector3d mid = (kinkStart + kinkEnd) / 2.0;
+            double halfLength = (kinkEnd.x >= kinkStart.x) ? kinkLength / 2.0 : -kinkLength / 2.0;
+
+            kinkStart.x = mid.x - halfLength;
+            kinkEnd.x = mid.x + halfLength;
+            
+            m_lineFeat->WayPoints.setValues(pts);
+            recomputeFeature();
         }
     }
-
-    Gui::Command::updateActive();
-    Gui::Command::commitCommand(tid);
-
-    //trigger claimChildren in tree
-    if (m_baseFeat) {
-        m_baseFeat->touch();
-    }
-
-    m_basePage->touch();
-
-    if (m_lineFeat) {
-        m_lineFeat->requestPaint();
-    }
 }
 
-void TaskLeaderLine::dumpTrackerPoints(std::vector<Base::Vector3d>& tPoints) const
+void TaskLeaderLine::onLeaderTypeChanged(int index)
 {
-    Base::Console().message("TTL::dumpTrackerPoints(%d)\n", tPoints.size());
-    Base::Console().message("TTL::dumpTrackerPoints - attach point: %s\n", DU::formatVector(m_attachPoint).c_str());
-    for (auto& point : tPoints) {
-        Base::Console().message("TTL::dumpTrackerPoints - a point: %s\n", DU::formatVector(point).c_str());
+    if (index == 0 || index == 3) {
+        ui->labelKinkLength->setVisible(true);
+        ui->dsbKinkLength->setVisible(true);
+    } else {
+        ui->labelKinkLength->setVisible(false);
+        ui->dsbKinkLength->setVisible(false);
     }
+
+    if (!handler) {
+        return;
+    }
+
+    handler->currentLeaderType = static_cast<TechDrawLeaderLineHandler::LeaderType>(index);
+    handler->updateLeader();
 }
+
 
 void TaskLeaderLine::updateLeaderFeature()
 {
@@ -433,9 +396,6 @@ void TaskLeaderLine::updateLeaderFeature()
     commonFeatureUpdate();
     Base::Color ac;
     ac.setValue<QColor>(ui->cpLineColor->color());
-    m_lineVP->Color.setValue(ac);
-    m_lineVP->LineWidth.setValue(ui->dsbWeight->rawValue());
-    m_lineVP->LineStyle.setValue(ui->cboxStyle->currentIndex());
 
     Gui::Command::updateActive();
     Gui::Command::commitCommand(tid);
@@ -452,336 +412,6 @@ void TaskLeaderLine::commonFeatureUpdate()
     int end   = ui->cboxEndSym->currentIndex();
     m_lineFeat->StartSymbol.setValue(start);
     m_lineFeat->EndSymbol.setValue(end);
-}
-
-void TaskLeaderLine::removeFeature()
-{
-//    Base::Console().message("TTL::removeFeature()\n");
-    if (!m_lineFeat) {
-        return;
-    }
-
-    if (m_createMode) {
-        try {
-            std::string PageName = m_basePage->getNameInDocument();
-            Gui::Command::doCommand(Gui::Command::Gui, "App.activeDocument().%s.removeView(App.activeDocument().%s)",
-                                    PageName.c_str(), m_lineFeat->getNameInDocument());
-            Gui::Command::doCommand(Gui::Command::Gui, "App.activeDocument().removeObject('%s')",
-                                        m_lineFeat->getNameInDocument());
-        }
-        catch (...) {
-            Base::Console().message("TTL::removeFeature - failed to delete feature\n");
-            return;
-        }
-    } else {
-        if (Gui::Command::hasPendingCommand()) {
-            std::vector<std::string> undos = Gui::Application::Instance->activeDocument()->getUndoVector();
-            Gui::Application::Instance->activeDocument()->undo(1);
-        }
-    }
-}
-
-//********** Tracker routines *******************************************************************
-void TaskLeaderLine::onTrackerClicked(bool clicked)
-{
-    Q_UNUSED(clicked);
-    if (!m_vpp->getMDIViewPage()) {
-        Base::Console().message("TLL::onTrackerClicked - no MDI, no tracker!\n");
-        return;
-    }
-
-    if ( m_pbTrackerState == TrackerAction::SAVE &&
-         getCreateMode() ){
-        if (m_tracker) {
-            m_tracker->terminateDrawing();
-        }
-        m_pbTrackerState = TrackerAction::PICK;
-        ui->pbTracker->setText(tr("Pick Points"));
-        ui->pbCancelEdit->setEnabled(false);
-        enableTaskButtons(true);
-
-        setEditCursor(Qt::ArrowCursor);
-        return;
-    }
-
-    if ( m_pbTrackerState == TrackerAction::SAVE &&
-         !getCreateMode() ) {                //edit mode
-        if (m_qgLeader) {
-            m_qgLeader->closeEdit();
-        }
-        m_pbTrackerState = TrackerAction::PICK;
-        ui->pbTracker->setText(tr("Edit Points"));
-        ui->pbCancelEdit->setEnabled(false);
-        enableTaskButtons(true);
-
-        setEditCursor(Qt::ArrowCursor);
-        return;
-    }
-
-    //TrackerAction::PICK or TrackerAction::EDIT
-    if (getCreateMode()) {
-        m_inProgressLock = true;
-        m_saveContextPolicy = m_vpp->getMDIViewPage()->contextMenuPolicy();
-        m_vpp->getMDIViewPage()->setContextMenuPolicy(Qt::PreventContextMenu);
-        m_trackerMode = QGTracker::TrackerMode::Line;
-        setEditCursor(Qt::CrossCursor);
-        startTracker();
-
-        QString msg = tr("Pick a starting point for leader line");
-        getMainWindow()->statusBar()->show();
-        Gui::getMainWindow()->showMessage(msg, MessageDisplayTime);
-        ui->pbTracker->setText(tr("Save Points"));
-        ui->pbTracker->setEnabled(true);
-        ui->pbCancelEdit->setEnabled(true);
-        m_pbTrackerState = TrackerAction::SAVE;
-        enableTaskButtons(false);
-    } else {    //edit mode
-        // pageDeltas are in mm with conventional Y axis
-        auto pageDeltas =  m_lineFeat->getScaledAndRotatedPoints();
-
-        m_sceneDeltas.clear();
-        m_sceneDeltas.reserve(pageDeltas.size());
-        // now convert to sceneUnits and Qt Y axis
-        for (auto& entry : pageDeltas) {
-            m_sceneDeltas.push_back(DGU::toSceneCoords(entry, false));
-        }
-
-        if (!m_sceneDeltas.empty()) {    //regular edit session
-            m_inProgressLock = true;
-            m_saveContextPolicy = m_vpp->getMDIViewPage()->contextMenuPolicy();
-            m_vpp->getMDIViewPage()->setContextMenuPolicy(Qt::PreventContextMenu);
-            QGIView* qgiv = m_vpp->getQGSPage()->findQViewForDocObj(m_lineFeat);
-            auto qgLead = dynamic_cast<QGILeaderLine*>(qgiv);
-
-            if (!qgLead) {
-                //tarfu
-                Base::Console().error("TaskLeaderLine - cannot find leader graphic\n");
-                //now what? throw will generate "unknown unhandled exception"
-            } else {
-                m_qgLeader = qgLead;
-                connect(qgLead, &QGILeaderLine::editComplete,
-                        this, &TaskLeaderLine::onPointEditComplete);
-                qgLead->startPathEdit();
-                QString msg = tr("Click and drag markers to adjust leader line");
-                getMainWindow()->statusBar()->show();
-                Gui::getMainWindow()->showMessage(msg, MessageDisplayTime);
-                ui->pbTracker->setText(tr("Save Changes"));
-                ui->pbTracker->setEnabled(true);
-                ui->pbCancelEdit->setEnabled(true);
-                m_pbTrackerState = TrackerAction::SAVE;
-                enableTaskButtons(false);
-            }
-        } else { // need to recreate leaderline
-            m_inProgressLock = true;
-            m_saveContextPolicy = m_vpp->getMDIViewPage()->contextMenuPolicy();
-            m_vpp->getMDIViewPage()->setContextMenuPolicy(Qt::PreventContextMenu);
-            m_trackerMode = QGTracker::TrackerMode::Line;
-            setEditCursor(Qt::CrossCursor);
-            startTracker();
-
-            QString msg = tr("Pick a starting point for leader line");
-            getMainWindow()->statusBar()->show();
-            Gui::getMainWindow()->showMessage(msg, MessageDisplayTime);
-            ui->pbTracker->setText(tr("Save Changes"));
-            ui->pbTracker->setEnabled(true);
-            ui->pbCancelEdit->setEnabled(true);
-            m_pbTrackerState = TrackerAction::SAVE;
-            enableTaskButtons(false);
-        }
-    }
-}
-
-void TaskLeaderLine::startTracker()
-{
-//    Base::Console().message("TTL::startTracker()\n");
-    if (!m_vpp->getQGSPage()) {
-        return;
-    }
-
-    if (m_trackerMode == QGTracker::TrackerMode::None) {
-        return;
-    }
-
-    if (!m_tracker) {
-        m_tracker = new QGTracker(m_vpp->getQGSPage(), m_trackerMode);
-        QObject::connect(
-            m_tracker, &QGTracker::drawingFinished,
-            this     , &TaskLeaderLine::onTrackerFinished
-           );
-    } else {
-        //this is too harsh. but need to avoid restarting process
-        throw Base::RuntimeError("TechDrawNewLeader - tracker already active\n");
-    }
-    setEditCursor(Qt::CrossCursor);
-    QString msg = tr("Left click to set a point");
-    Gui::getMainWindow()->statusBar()->show();
-    Gui::getMainWindow()->showMessage(msg, MessageDisplayTime);
-}
-
-void TaskLeaderLine::onTrackerFinished(std::vector<QPointF> trackerScenePoints, QGIView* qgParent)
-{
-    //in this case, we already know who the parent is.  We don't need QGTracker to tell us.
-    (void) qgParent;
-    //    Base::Console().message("TTL::onTrackerFinished() - parent: %X\n", qgParent);
-    if (trackerScenePoints.empty()) {
-        Base::Console().error("TaskLeaderLine - no points available\n");
-        return;
-    }
-
-    if (m_qgParent) {
-        double scale = m_qgParent->getScale();
-        QPointF mapped = m_qgParent->mapFromScene(trackerScenePoints.front()) / scale;
-        m_attachPoint = Base::Vector3d(mapped.x(), mapped.y(), 0.0);
-        m_sceneDeltas = scenePointsToDeltas(trackerScenePoints);
-    } else {
-        Base::Console().message("TTL::onTrackerFinished - cannot find parent graphic!\n");
-        //blow up!?
-        throw Base::RuntimeError("TaskLeaderLine - cannot find parent graphic");
-    }
-
-    QString msg = tr("Press OK or Cancel to continue");
-    getMainWindow()->statusBar()->show();
-    Gui::getMainWindow()->showMessage(msg, MessageDisplayTime);
-    enableTaskButtons(true);
-
-            // ??? why does the tracker go to sleep when we are finished with it? why not removeTracker
-    m_tracker->sleep(true);
-    m_inProgressLock = false;
-
-            // can not pick points any more?
-    ui->pbTracker->setEnabled(false);
-    ui->pbCancelEdit->setEnabled(false);
-
-    // only option available to user is accept/reject?
-    enableTaskButtons(true);
-    setEditCursor(Qt::ArrowCursor);  // already done by m_tracker->sleep()?
-}
-
-
-// this is called at every possible exit path?
-void TaskLeaderLine::removeTracker()
-{
-//    Base::Console().message("TTL::removeTracker()\n");
-    if (!m_vpp->getQGSPage()) {
-        return;
-    }
-    if (m_tracker && m_tracker->scene()) {
-        m_vpp->getQGSPage()->removeItem(m_tracker);
-        delete m_tracker;
-        m_tracker = nullptr;
-    }
-}
-
-void TaskLeaderLine::onCancelEditClicked(bool clicked)
-{
-    Q_UNUSED(clicked);
-//    Base::Console().message("TTL::onCancelEditClicked() m_pbTrackerState: %d\n",
-//                            m_pbTrackerState);
-    abandonEditSession();
-    if (m_lineFeat) {
-        m_lineFeat->requestPaint();
-    }
-
-    m_pbTrackerState = TrackerAction::EDIT;
-    ui->pbTracker->setText(tr("Edit Points"));
-    ui->pbCancelEdit->setEnabled(false);
-    enableTaskButtons(true);
-
-    m_inProgressLock = false;
-    setEditCursor(Qt::ArrowCursor);
-}
-
-QGIView* TaskLeaderLine::findParentQGIV()
-{
-    if (!m_baseFeat) {
-        return nullptr;
-    }
-
-    Gui::ViewProvider* gvp = QGIView::getViewProvider(m_baseFeat);
-    ViewProviderDrawingView* vpdv = freecad_cast<ViewProviderDrawingView*>(gvp);
-    if (!vpdv) {
-        return nullptr;
-    }
-
-    return vpdv->getQView();;
-}
-
-void TaskLeaderLine::setEditCursor(const QCursor &cursor)
-{
-    if (!m_vpp->getQGSPage()) {
-        return;
-    }
-    if (m_baseFeat) {
-        QGIView* qgivBase = m_vpp->getQGSPage()->findQViewForDocObj(m_baseFeat);
-        qgivBase->setCursor(cursor);
-    }
-}
-
-// from scene QPointF to zero origin (delta from p0) Vector3d points
-std::vector<Base::Vector3d> TaskLeaderLine::scenePointsToDeltas(std::vector<QPointF> scenePoints)
-{
-    if (scenePoints.empty()) {
-        return {};
-    }
-
-    std::vector<Base::Vector3d> result;
-    auto frontPoint = DU::toVector3d(m_qgParent->mapFromScene(scenePoints.front()));
-    result.reserve(scenePoints.size());
-    for (auto& point: scenePoints) {
-        auto viewPoint = m_qgParent->mapFromScene(point);
-        auto vPoint = DU::toVector3d(viewPoint);
-        auto delta = vPoint - frontPoint;
-        auto rotationDeg = m_baseFeat->Rotation.getValue();
-        auto deltaUnrotated{delta};
-        if (rotationDeg != 0) {
-            deltaUnrotated = DU::invertY(deltaUnrotated);
-            deltaUnrotated.RotateZ(-Base::toRadians(rotationDeg));
-            deltaUnrotated = DU::invertY(deltaUnrotated);
-        }
-
-        result.push_back(deltaUnrotated);
-    }
-    return result;
-}
-
-//******************************************************************************
-//void TaskLeaderLine::onPointEditComplete(std::vector<QPointF> pts, QGIView* parent)
-
-//! point edit session completed.  reset ui to initial state.
-void TaskLeaderLine::onPointEditComplete()
-{
-//    Base::Console().message("TTL::onPointEditComplete()\n");
-    m_inProgressLock = false;
-
-    m_pbTrackerState = TrackerAction::EDIT;
-    ui->pbTracker->setText(tr("Edit Points"));
-    ui->pbTracker->setEnabled(true);
-    ui->pbCancelEdit->setEnabled(true);
-    enableTaskButtons(true);
-}
-
-
-//! give up on the current point editing session.  reset the ui so we are in a state to
-//! start editing points again.  leave the existing tracker instance in place.
-void TaskLeaderLine::abandonEditSession()
-{
-//    Base::Console().message("TTL::abandonEditSession()\n");
-    constexpr int MessageDuration{4000};
-    if (m_qgLeader) {
-        // tell the graphics item that we are giving up so it should do any clean up it needs.
-        m_qgLeader->abandonEdit();
-    }
-    QString msg = tr("In progress edit abandoned. Start over.");
-    getMainWindow()->statusBar()->show();
-    Gui::getMainWindow()->showMessage(msg, MessageDuration);
-
-    m_pbTrackerState = TrackerAction::EDIT;
-    ui->pbTracker->setText(tr("Edit Points"));
-    enableTaskButtons(true);
-    ui->pbTracker->setEnabled(true);
-    ui->pbCancelEdit->setEnabled(false);
-
-    setEditCursor(Qt::ArrowCursor);
 }
 
 void TaskLeaderLine::saveButtons(QPushButton* btnOK,
@@ -802,58 +432,33 @@ void TaskLeaderLine::enableTaskButtons(bool enable)
 bool TaskLeaderLine::accept()
 {
 //    Base::Console().message("TTL::accept()\n");
-    if (m_inProgressLock) {
-        //accept() button shouldn't be available if there is an edit in progress.
-        abandonEditSession();
-        removeTracker();
-        return true;
-    }
-
     Gui::Document* doc = Gui::Application::Instance->getDocument(m_basePage->getDocument());
     if (!doc)
         return false;
 
     if (!getCreateMode())  {
-//        removeTracker();
         updateLeaderFeature();
-    } else {
-//        removeTracker();
-        createLeaderFeature(m_sceneDeltas);
     }
-    m_trackerMode = QGTracker::TrackerMode::None;
-    removeTracker();
 
     Gui::Command::doCommand(Gui::Command::Gui, "Gui.ActiveDocument.resetEdit()");
 
     if (m_vpp->getMDIViewPage())
         m_vpp->getMDIViewPage()->setContextMenuPolicy(m_saveContextPolicy);
 
+    if (handler) {
+        m_viewPage->deactivateHandler();
+    }
+
     return true;
 }
 
 bool TaskLeaderLine::reject()
 {
-    if (m_inProgressLock) {
-//        Base::Console().message("TTL::reject - edit in progress!!\n");
-        //reject() button shouldn't be available if there is an edit in progress.
-        abandonEditSession();
-        removeTracker();
-        return false;
-    }
-
     Gui::Document* doc = Gui::Application::Instance->getDocument(m_basePage->getDocument());
     if (!doc)
         return false;
 
-    if (getCreateMode() && m_lineFeat)  {
-        removeFeature();
-    }
-    else  {
-        restoreState();
-    }
-
-    m_trackerMode = QGTracker::TrackerMode::None;
-    removeTracker();
+    restoreState();
 
     //make sure any dangling objects are cleaned up
     Gui::Command::doCommand(Gui::Command::Gui, "App.activeDocument().recompute()");
@@ -863,15 +468,20 @@ bool TaskLeaderLine::reject()
         m_vpp->getMDIViewPage()->setContextMenuPolicy(m_saveContextPolicy);
     }
 
+    if (handler) {
+        handler->deleteLeaderLine();
+        m_viewPage->deactivateHandler();
+    }
+    
+
     return false;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-TaskDlgLeaderLine::TaskDlgLeaderLine(TechDraw::DrawView* baseFeat,
-                                     TechDraw::DrawPage* page)
+TaskDlgLeaderLine::TaskDlgLeaderLine(TechDraw::DrawPage* page)
     : TaskDialog()
 {
-    widget  = new TaskLeaderLine(baseFeat, page);
+    widget  = new TaskLeaderLine(page);
     taskbox = new Gui::TaskView::TaskBox(Gui::BitmapFactory().pixmap("actions/TechDraw_LeaderLine"),
                                              widget->windowTitle(), true, nullptr);
     taskbox->groupLayout()->addWidget(widget);

--- a/src/Mod/TechDraw/Gui/TaskLeaderLine.h
+++ b/src/Mod/TechDraw/Gui/TaskLeaderLine.h
@@ -22,8 +22,8 @@
 
 #pragma once
 
-#include "QGTracker.h"
-
+#include "QGVPage.h"
+#include "TechDrawLeaderLineHandler.h"
 #include <Base/Vector3D.h>
 #include <Gui/TaskView/TaskDialog.h>
 #include <Gui/TaskView/TaskView.h>
@@ -39,12 +39,7 @@ class DrawLeaderLine;
 
 namespace TechDrawGui
 {
-class QGIView;
-class QGIPrimPath;
-class QGTracker;
-class QGEPath;
-class QGMText;
-class QGILeaderLine;
+class QGVPage;
 class ViewProviderPage;
 class ViewProviderLeader;
 class Ui_TaskLeaderLine;
@@ -54,8 +49,8 @@ class TaskLeaderLine : public QWidget
     Q_OBJECT
 
 public:
-    TaskLeaderLine(TechDraw::DrawView* baseFeat,
-                   TechDraw::DrawPage* page);
+    //ctor for creation
+    explicit TaskLeaderLine(TechDraw::DrawPage* page);
     //ctor for edit
     explicit TaskLeaderLine(TechDrawGui::ViewProviderLeader* leadVP);
     ~TaskLeaderLine() override = default;
@@ -70,68 +65,38 @@ public:
     void enableTaskButtons(bool enable);
     void recomputeFeature();
 
-public Q_SLOTS:
-    void onTrackerClicked(bool clicked);
-    void onCancelEditClicked(bool clicked);
-    void onTrackerFinished(std::vector<QPointF> pts, TechDrawGui::QGIView* qgParent);
-
 protected:
-    std::vector<Base::Vector3d> scenePointsToDeltas(std::vector<QPointF> pts);
     void changeEvent(QEvent *event) override;
-    void startTracker();
-    void removeTracker();
-    void abandonEditSession();
 
-    void createLeaderFeature(std::vector<Base::Vector3d> sceneDeltas);
     void updateLeaderFeature();
     void commonFeatureUpdate();
-    void removeFeature();
 
     void setUiPrimary();
     void setUiEdit();
     void enableVPUi(bool enable);
-    void setEditCursor(const QCursor& cursor);
 
-    QGIView* findParentQGIV();
-
-   void saveState();
-   void restoreState();
-
-   void dumpTrackerPoints(std::vector<Base::Vector3d>& tPoints) const;
-
-protected Q_SLOTS:
-    void onPointEditComplete();
+    void saveState();
+    void restoreState();
 
 private:
     std::unique_ptr<Ui_TaskLeaderLine> ui;
-    QGTracker* m_tracker;
     ViewProviderLeader* m_lineVP;
     TechDraw::DrawView* m_baseFeat;
     TechDraw::DrawPage* m_basePage;
     TechDraw::DrawLeaderLine* m_lineFeat;
-    QGIView* m_qgParent;
     bool m_createMode;
-    QGTracker::TrackerMode m_trackerMode;
     Qt::ContextMenuPolicy  m_saveContextPolicy;
-    bool m_inProgressLock;
-    QGILeaderLine* m_qgLeader;
 
     QPushButton* m_btnOK;
     QPushButton* m_btnCancel;
 
-    TrackerAction m_pbTrackerState;
-
     double m_saveX;
     double m_saveY;
 
+    TechDrawLeaderLineHandler* handler = nullptr;
+
     ViewProviderPage* m_vpp;
-    std::string m_leaderName;
-    std::string m_leaderType;
-    std::string m_qgParentName;
-
-    std::vector<Base::Vector3d> m_sceneDeltas;
-
-    Base::Vector3d m_attachPoint;
+    QGVPage* m_viewPage;
 
     std::vector<Base::Vector3d> m_savePoints;
 
@@ -141,6 +106,8 @@ private Q_SLOTS:
     void onColorChanged();
     void onLineWidthChanged();
     void onLineStyleChanged();
+    void onLeaderTypeChanged(int index);
+    void onKinkLengthChanged();
 };
 
 class TaskDlgLeaderLine : public Gui::TaskView::TaskDialog
@@ -148,8 +115,7 @@ class TaskDlgLeaderLine : public Gui::TaskView::TaskDialog
     Q_OBJECT
 
 public:
-    TaskDlgLeaderLine(TechDraw::DrawView* baseFeat,
-                      TechDraw::DrawPage* page);
+    explicit TaskDlgLeaderLine(TechDraw::DrawPage* page);
     explicit TaskDlgLeaderLine(TechDrawGui::ViewProviderLeader* leadVP);
     ~TaskDlgLeaderLine() override;
 

--- a/src/Mod/TechDraw/Gui/TaskLeaderLine.ui
+++ b/src/Mod/TechDraw/Gui/TaskLeaderLine.ui
@@ -31,65 +31,45 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,1">
-     <property name="verticalSpacing">
-      <number>12</number>
-     </property>
+    <layout class="QGridLayout" name="gridLayout_leaderType" columnstretch="1,1">
      <item row="0" column="0">
-      <widget class="QLabel" name="label_4">
+      <widget class="QLabel" name="labelLeaderType">
        <property name="text">
-        <string>Base view</string>
+        <string>Type</string>
        </property>
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QTextBrowser" name="tbBaseView">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
+      <widget class="QComboBox" name="cboxLeaderType">
+       <property name="minimumSize">
         <size>
-         <width>16777215</width>
+         <width>0</width>
          <height>22</height>
         </size>
        </property>
-       <property name="mouseTracking">
-        <bool>false</bool>
+       <property name="currentIndex">
+        <number>0</number>
        </property>
-       <property name="focusPolicy">
-        <enum>Qt::FocusPolicy::NoFocus</enum>
-       </property>
-       <property name="acceptDrops">
-        <bool>false</bool>
-       </property>
-       <property name="verticalScrollBarPolicy">
-        <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QPushButton" name="pbTracker">
-       <property name="toolTip">
-        <string>First pick the start point of the line,
-then at least one more point.
-You can pick further points to get line segments.</string>
-       </property>
-       <property name="text">
-        <string>Pick Points</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QPushButton" name="pbCancelEdit">
-       <property name="text">
-        <string>Discard Changes</string>
-       </property>
+       <item>
+        <property name="text">
+         <string>Normal</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Straight</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Complex</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Complex with kink</string>
+        </property>
+       </item>
       </widget>
      </item>
     </layout>
@@ -272,6 +252,26 @@ You can pick further points to get line segments.</string>
          <widget class="QLabel" name="label_5">
           <property name="text">
            <string>Width</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="labelKinkLength">
+          <property name="text">
+           <string>Kink length</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="Gui::QuantitySpinBox" name="dsbKinkLength" native="true">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Length of leader line kink</string>
           </property>
          </widget>
         </item>

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
@@ -50,6 +50,7 @@
 #include "QGVPage.h"
 #include "QGSPage.h"
 #include "Rez.h"
+#include "TechDrawLeaderLineHandler.h"
 #include "ViewProviderPage.h"
 #include "ViewProviderRichAnno.h"
 
@@ -255,6 +256,11 @@ void TaskRichAnno::finishSetup()
             qOverload<int>(&QComboBox::currentIndexChanged),
             this,
             &TaskRichAnno::onFrameStyleChanged);
+    connect(ui->gbLeader, &QGroupBox::toggled, this, &TaskRichAnno::onLeaderLineToggled);
+    connect(ui->cboxLeaderType,
+            qOverload<int>(&QComboBox::currentIndexChanged),
+            this,
+            &TaskRichAnno::onLeaderTypeChanged);
 
     // Panning is detected by scroll bar value changes.
     connect(graphicsView->horizontalScrollBar(),
@@ -422,6 +428,12 @@ void TaskRichAnno::setUiEdit()
         m_toolbar->setText(QString::fromUtf8(m_annoFeat->AnnoText.getValue()));
         ui->dsbMaxWidth->setValue(m_annoFeat->MaxWidth.getValue());
         ui->gbFrame->setChecked(m_annoFeat->ShowFrame.getValue());
+
+        auto leaderFeat = dynamic_cast<TechDraw::DrawLeaderLine*>(m_annoFeat->LeaderLine.getValue());
+        ui->gbLeader->setChecked(leaderFeat != nullptr);
+        if (leaderFeat) {
+            ui->cboxLeaderType->setCurrentIndex(leaderFeat->Type.getValue());
+        }
     }
 
     if (m_annoVP) {
@@ -493,6 +505,130 @@ void TaskRichAnno::onFrameStyleChanged(int index)
     if (m_annoFeat) m_annoFeat->requestPaint();
 }
 
+void TaskRichAnno::onLeaderLineToggled(bool checked)
+{
+    if (m_inProgressLock) return;
+
+    if (!checked) {
+        if (m_leaderHandler) {
+            stopLeaderLinePlacement();
+        }
+        else {
+            removeExistingLeaderLine();
+        }
+        return;
+    }
+
+    startLeaderLinePlacement();
+}
+
+void TaskRichAnno::startLeaderLinePlacement()
+{
+    createAnnoIfNotAlready();
+
+    m_leaderHandler = new TechDrawLeaderLineHandler();
+    m_leaderHandler->currentLeaderType =
+        static_cast<TechDrawLeaderLineHandler::LeaderType>(ui->cboxLeaderType->currentIndex());
+
+    m_leaderHandler->onFinished = [this]() {
+        if (m_annoFeat) {
+            m_annoFeat->LeaderLine.setValue(m_leaderHandler->getLeaderLine());
+        }
+        m_leaderHandler = nullptr;
+        if (m_qgiAnno) {
+            m_qgiAnno->positionChanged();
+        }
+    };
+
+    m_vpp->getQGVPage()->activateHandler(m_leaderHandler);
+    m_leaderHandler->createLeaderLineObject();
+    m_leaderHandler->attached = true;
+
+    updateLeaderPoints();
+}
+
+void TaskRichAnno::updateLeaderPoints() {
+    int type = static_cast<int>(m_leaderHandler->currentLeaderType);
+    
+    if (!m_qgiAnno) {
+        return;
+    }
+
+    // Normal or ComplexWithKink
+    if (type == 0 || type == 3) {
+        QRectF annoRect = m_qgiAnno->mapToScene(m_qgiAnno->frameRect()).boundingRect();
+        QPointF kinkPoint1 = annoRect.bottomLeft();
+        QPointF kinkPoint2 = annoRect.bottomRight();
+        m_leaderHandler->sceneClickPoints = std::vector<QPointF>{kinkPoint1, kinkPoint2};
+    }
+    // Straight or Complex
+    else if (type == 1 || type == 2) {
+        QRectF annoRect = m_qgiAnno->mapToScene(m_qgiAnno->frameRect()).boundingRect();
+        QPointF startPoint = annoRect.bottomLeft() + ((annoRect.topLeft() - annoRect.bottomLeft()) / 2.0);
+        m_leaderHandler->sceneClickPoints = std::vector<QPointF>{startPoint};
+    }
+    else {
+        m_leaderHandler->sceneClickPoints = std::vector<QPointF>{};
+    }
+}
+
+void TaskRichAnno::onLeaderTypeChanged(int index)
+{
+    if (m_leaderHandler) {
+        m_leaderHandler->currentLeaderType = static_cast<TechDrawLeaderLineHandler::LeaderType>(index);
+        m_leaderHandler->updateLeader();
+
+        if (!m_leaderHandler->getLeaderLine()) {
+            m_leaderHandler->createLeaderLineObject();
+        }
+
+        updateLeaderPoints();
+        return;
+    }
+
+    if (m_annoFeat && m_annoFeat->LeaderLine.getValue()) {
+        removeExistingLeaderLine();
+        startLeaderLinePlacement();
+    }
+}
+
+void TaskRichAnno::stopLeaderLinePlacement()
+{
+    if (!m_leaderHandler) return;
+
+    if (m_annoFeat) {
+        m_annoFeat->LeaderLine.setValue(m_leaderHandler->getLeaderLine());
+    }
+
+    m_vpp->getQGVPage()->deactivateHandler();
+
+    m_leaderHandler = nullptr;
+}
+
+void TaskRichAnno::removeExistingLeaderLine()
+{
+    if (!m_annoFeat) return;
+
+    auto* leaderFeat = dynamic_cast<TechDraw::DrawLeaderLine*>(m_annoFeat->LeaderLine.getValue());
+    
+    if (!leaderFeat) return;
+
+    TechDraw::DrawPage* page = leaderFeat->findParentPage();
+    std::string leaderName = leaderFeat->getNameInDocument();
+
+    m_annoFeat->LeaderLine.setValue(nullptr);
+
+
+    std::string pageName = page->getNameInDocument();
+    Gui::Command::doCommand(Gui::Command::Gui, "App.activeDocument().%s.removeView(App.activeDocument().%s)",
+                            pageName.c_str(), leaderName.c_str());
+    Gui::Command::doCommand(Gui::Command::Gui, "App.activeDocument().removeObject('%s')", leaderName.c_str());
+
+    if (m_qgiAnno) {
+        m_qgiAnno->positionChanged();
+    }
+}
+
 void TaskRichAnno::createAnnoIfNotAlready()
 {
     if (m_createMode && m_placementMode) {
@@ -555,6 +691,12 @@ bool TaskRichAnno::eventFilter(QObject* watched, QEvent* event)
                 auto mouseEvent = static_cast<QMouseEvent*>(event);
                 QPointF scenePos = graphicsView->mapToScene(mouseEvent->pos());
                 createAndSetupAnnotation(&scenePos);
+                return QWidget::eventFilter(watched, event);
+            }
+
+            if (m_leaderHandler) {
+                // A leader line is being placed. Let the handler see the click
+                // instead of treating it as "clicked outside the annotation".
                 return QWidget::eventFilter(watched, event);
             }
 

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.h
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.h
@@ -30,6 +30,7 @@
 #include "MDIViewPage.h"
 
 class Ui_TaskRichAnno;
+class TechDrawLeaderLineHandler;
 
 namespace TechDraw
 {
@@ -95,6 +96,8 @@ protected Q_SLOTS:
     void onFrameColorChanged();
     void onFrameWidthChanged(double value);
     void onFrameStyleChanged(int index);
+    void onLeaderLineToggled(bool checked);
+    void onLeaderTypeChanged(int index);
     void onViewTransformed();
     void refocusAnnotation();
 
@@ -106,6 +109,10 @@ private:
     void enterPlacementMode();
     void createAndSetupAnnotation(const QPointF* scenePos = nullptr);
     void createAnnoIfNotAlready();
+    void startLeaderLinePlacement();
+    void stopLeaderLinePlacement();
+    void removeExistingLeaderLine();
+    void updateLeaderPoints();
 
     std::unique_ptr<Ui_TaskRichAnno> ui;
 
@@ -133,6 +140,8 @@ private:
 
     QPointer<MRichTextEdit> m_toolbar {nullptr};
     QPointer<QWidget> m_viewport {nullptr};
+
+    TechDrawLeaderLineHandler* m_leaderHandler {nullptr};
 
     int m_tid {0};
 };

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.ui
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.ui
@@ -173,6 +173,67 @@
      </layout>
     </widget>
    </item>
+   <item row="5" column="0" colspan="2">
+    <widget class="QGroupBox" name="gbLeader">
+     <property name="title">
+      <string>Leader Line</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,1" columnminimumwidth="0,0">
+      <property name="verticalSpacing">
+       <number>12</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelLeaderType">
+        <property name="text">
+         <string>Type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="cboxLeaderType">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Leader line type</string>
+        </property>
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <item>
+         <property name="text">
+          <string>Normal</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Straight</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Complex</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Complex with kink</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
@@ -26,6 +26,7 @@
 #include <App/Document.h>
 #include <Base/Console.h>
 #include <Base/Tools.h>
+#include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>
 #include <Gui/Document.h>
@@ -36,9 +37,12 @@
 #include <Mod/TechDraw/App/DrawWeldSymbol.h>
 
 #include "TaskWeldingSymbol.h"
+#include "ViewProviderPage.h"
 #include "ui_TaskWeldingSymbol.h"
 #include "PreferencesGui.h"
+#include "QGVPage.h"
 #include "SymbolChooser.h"
+#include "ViewProviderPage.h"
 
 
 using namespace Gui;
@@ -62,6 +66,49 @@ TaskWeldingSymbol::TaskWeldingSymbol(TechDraw::DrawLeaderLine* leadFeat) :
     ui->setupUi(this);
 
     setUiPrimary();
+
+    connect(ui->pbArrowSymbol, &QPushButton::clicked,
+            this, &TaskWeldingSymbol::onArrowSymbolCreateClicked);
+    connect(ui->pbOtherSymbol, &QPushButton::clicked,
+            this, &TaskWeldingSymbol::onOtherSymbolCreateClicked);
+    connect(ui->pbOtherErase, &QPushButton::clicked,
+            this, &TaskWeldingSymbol::onOtherEraseCreateClicked);
+    connect(ui->pbFlipSides, &QPushButton::clicked,
+            this, &TaskWeldingSymbol::onFlipSidesCreateClicked);
+    connect(ui->fcSymbolDir, &FileChooser::fileNameSelected,
+            this, &TaskWeldingSymbol::onDirectorySelected);
+}
+//ctor for creating leader and welding symbol
+TaskWeldingSymbol::TaskWeldingSymbol(TechDraw::DrawPage* page) :
+    ui(new Ui_TaskWeldingSymbol),
+    m_leadFeat(nullptr),
+    m_weldFeat(nullptr),
+    m_arrowFeat(nullptr),
+    m_otherFeat(nullptr),
+    m_btnOK(nullptr),
+    m_btnCancel(nullptr),
+    m_createMode(true),
+    m_otherDirty(false)
+{
+
+    ui->setupUi(this);
+    setUiPrimary();
+
+    Gui::Document* activeGui = Gui::Application::Instance->getDocument(page->getDocument());
+    if (!activeGui) {
+        return;
+    }
+    auto* vpp = static_cast<ViewProviderPage*>(activeGui->getViewProvider(page));
+
+    m_leaderHandler = new TechDrawLeaderLineHandler();
+    m_leaderHandler->kinkLength = 20.0; // Good length for Welding Symbol Leader???
+    m_leaderHandler->onFinished = [this]() {
+        m_leadFeat = m_leaderHandler->getLeaderLine();
+        m_leaderHandler = nullptr;
+    };
+
+    vpp->getQGVPage()->activateHandler(m_leaderHandler);
+    m_leaderHandler->attached = true;
 
     connect(ui->pbArrowSymbol, &QPushButton::clicked,
             this, &TaskWeldingSymbol::onArrowSymbolCreateClicked);
@@ -141,6 +188,9 @@ TaskWeldingSymbol::TaskWeldingSymbol(TechDraw::DrawWeldSymbol* weld) :
 
 TaskWeldingSymbol::~TaskWeldingSymbol()
 {
+    if (m_leaderHandler) {
+        m_leaderHandler->onFinished = nullptr;
+    }
 }
 
 void TaskWeldingSymbol::updateTask()
@@ -607,6 +657,16 @@ TaskDlgWeldingSymbol::TaskDlgWeldingSymbol(TechDraw::DrawWeldSymbol* weld)
     : TaskDialog()
 {
     widget  = new TaskWeldingSymbol(weld);
+    taskbox = new Gui::TaskView::TaskBox(Gui::BitmapFactory().pixmap("actions/TechDraw_WeldSymbol"),
+                                             widget->windowTitle(), true, nullptr);
+    taskbox->groupLayout()->addWidget(widget);
+    Content.push_back(taskbox);
+}
+
+TaskDlgWeldingSymbol::TaskDlgWeldingSymbol(TechDraw::DrawPage* page)
+    : TaskDialog()
+{
+    widget  = new TaskWeldingSymbol(page);
     taskbox = new Gui::TaskView::TaskBox(Gui::BitmapFactory().pixmap("actions/TechDraw_WeldSymbol"),
                                              widget->windowTitle(), true, nullptr);
     taskbox->groupLayout()->addWidget(widget);

--- a/src/Mod/TechDraw/Gui/TaskWeldingSymbol.h
+++ b/src/Mod/TechDraw/Gui/TaskWeldingSymbol.h
@@ -26,6 +26,8 @@
 #include <Gui/TaskView/TaskView.h>
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
+#include "TechDrawLeaderLineHandler.h"
+
 
 class QPushButton;
 class Ui_TaskWeldingSymbol;
@@ -96,6 +98,7 @@ class TechDrawGuiExport TaskWeldingSymbol : public QWidget
 public:
     TaskWeldingSymbol(TechDraw::DrawLeaderLine* leadFeat);
     TaskWeldingSymbol(TechDraw::DrawWeldSymbol* weldFeat);
+    TaskWeldingSymbol(TechDraw::DrawPage* page);
     ~TaskWeldingSymbol() override;
 
     virtual bool accept();
@@ -160,6 +163,8 @@ private:
 
     bool m_createMode;
     bool m_otherDirty;
+
+    TechDrawLeaderLineHandler* m_leaderHandler {nullptr};
 };
 
 
@@ -170,6 +175,7 @@ class TaskDlgWeldingSymbol : public Gui::TaskView::TaskDialog
 public:
     explicit TaskDlgWeldingSymbol(TechDraw::DrawLeaderLine* leader);
     explicit TaskDlgWeldingSymbol(TechDraw::DrawWeldSymbol* weld);
+    explicit TaskDlgWeldingSymbol(TechDraw::DrawPage* page);
     ~TaskDlgWeldingSymbol() override;
 
     /// is called the TaskView when the dialog is opened

--- a/src/Mod/TechDraw/Gui/TechDrawHandler.h
+++ b/src/Mod/TechDraw/Gui/TechDrawHandler.h
@@ -22,7 +22,12 @@
 
 #pragma once
 
+#include <QKeyEvent>
+#include <QMouseEvent>
+
 #include <Gui/ToolHandler.h>
+
+#include <Mod/TechDraw/App/DrawPage.h>
 
 #include <Mod/TechDraw/TechDrawGlobal.h>
 

--- a/src/Mod/TechDraw/Gui/TechDrawLeaderLineHandler.cpp
+++ b/src/Mod/TechDraw/Gui/TechDrawLeaderLineHandler.cpp
@@ -1,0 +1,612 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Morten Vajhøj
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "TechDrawLeaderLineHandler.h"
+
+#include <QMouseEvent>
+#include <QKeyEvent>
+#include <QPointF>
+#include <QGraphicsItem>
+#include <vector>
+#include <string>
+#include <cmath>
+#include <algorithm>
+
+#include <App/Document.h>
+#include <Base/Tools.h>
+#include <Gui/Application.h>
+#include <Gui/Command.h>
+#include <Gui/MainWindow.h>
+#include <Gui/Selection/SelectionObject.h>
+#include <Gui/Selection/Selection.h>
+
+#include <Mod/TechDraw/App/DrawUtil.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
+#include <Mod/TechDraw/App/DrawLeaderLine.h>
+#include <Mod/TechDraw/App/DrawProjGroup.h>
+#include <Mod/TechDraw/App/Geometry.h>
+#include <Mod/TechDraw/App/Cosmetic.h>
+#include <Mod/TechDraw/App/Preferences.h>
+#include <Mod/TechDraw/App/CosmeticVertex.h>
+
+#include "QGIEdge.h"
+#include "QGIVertex.h"
+#include "QGIFace.h"
+#include "QGIView.h"
+#include "QGSPage.h"
+#include "QGVPage.h"
+#include "CommandHelpers.h"
+#include "MDIViewPage.h"
+#include "Rez.h"
+#include "ViewProviderLeader.h"
+
+
+using namespace TechDrawGui;
+using namespace TechDraw;
+
+void reorderClosestPoints(std::vector<QPointF>& points, const QPointF& referencePoint) {
+    if (points.size() < 2) {
+        return;
+    }
+
+    QPointF a = points[0];
+    QPointF b = points[1];
+
+    double distA = std::hypot(a.x() - referencePoint.x(), a.y() - referencePoint.y());
+    double distB = std::hypot(b.x() - referencePoint.x(), b.y() - referencePoint.y());
+
+    if (distB < distA) {
+        std::swap(points[0], points[1]);
+    }
+}
+
+void TechDrawLeaderLineHandler::addLeaderLine(TechDraw::DrawPage* basePage) {
+    const std::string objectName{"LeaderLine"};
+    std::string m_leaderName = basePage->getDocument()->getUniqueObjectName(objectName.c_str());
+    std::string m_leaderType = "TechDraw::DrawLeaderLine";
+
+    std::string PageName = basePage->getNameInDocument();
+
+    int tid = Gui::Command::openActiveDocumentCommand(QT_TRANSLATE_NOOP("Command", "Create Leader"));
+    Gui::Command::doCommand(Gui::Command::Doc, "App.activeDocument().addObject('%s', '%s')",
+                       m_leaderType.c_str(), m_leaderName.c_str());
+    Gui::Command::doCommand(Gui::Command::Doc, "App.activeDocument().%s.translateLabel('DrawLeaderLine', 'LeaderLine', '%s')",
+              m_leaderName.c_str(), m_leaderName.c_str());
+
+    Gui::Command::doCommand(Gui::Command::Doc, "App.activeDocument().%s.addView(App.activeDocument().%s)",
+                       PageName.c_str(), m_leaderName.c_str());
+
+    App::DocumentObject* obj = basePage->getDocument()->getObject(m_leaderName.c_str());
+
+    Gui::Command::updateActive();
+    Gui::Command::commitCommand(tid);
+    if (!obj->isDerivedFrom<TechDraw::DrawLeaderLine>()) {
+        return;
+    }
+
+    leaderLineObj = static_cast<TechDraw::DrawLeaderLine*>(obj);
+}
+
+void TechDrawLeaderLineHandler::createLeaderLineObject() {
+    
+    // Most likely it is getting placed by some annotation
+    if (!baseFeat) {
+        // Random view for now
+        auto items = viewPage->items();
+        for (auto item : items) {
+            if (auto view = dynamic_cast<QGIView*>(item)) {
+                baseFeatView = view;
+                baseFeat = view->getViewObject();
+                reverse = true;
+                break;
+            }
+        }
+    }
+
+    addLeaderLine(viewPage->getDrawPage());
+    if (!leaderLineObj) {
+        return;
+    }
+
+    oldLeaderType = currentLeaderType;
+    updateLeader();
+
+    switch (currentLeaderType) {
+        case LeaderType::Normal:
+            leaderLineObj->Type.setValue("Normal");
+            break;
+        case LeaderType::Straight:
+            leaderLineObj->Type.setValue("Straight");
+            break;
+        case LeaderType::Complex:
+            leaderLineObj->Type.setValue("Complex");
+            break;
+        case LeaderType::ComplexWithKink:
+            leaderLineObj->Type.setValue("Complex with kink");
+            break;
+        default:
+            leaderLineObj->Type.setValue("Normal");
+    }
+
+    leaderLineObj->LeaderParent.setValue(baseFeat);
+}
+
+void TechDrawLeaderLineHandler::deleteLeaderLine() {
+    if (!leaderLineObj) {
+        return;
+    }
+
+    TechDraw::DrawPage* page = leaderLineObj->findParentPage();
+    if (!page) {
+        return;
+    }
+
+    std::string PageName = page->getNameInDocument();
+    std::string LeaderName = leaderLineObj->getNameInDocument();
+
+    int tid = Gui::Command::openActiveDocumentCommand(QT_TRANSLATE_NOOP("Command", "Delete Leader"));
+    Gui::Command::doCommand(Gui::Command::Gui, "App.activeDocument().%s.removeView(App.activeDocument().%s)",
+                            PageName.c_str(), LeaderName.c_str());
+    Gui::Command::doCommand(Gui::Command::Gui, "App.activeDocument().removeObject('%s')",
+                            LeaderName.c_str());
+
+    Gui::Command::updateActive();
+    Gui::Command::commitCommand(tid);
+
+    leaderLineObj = nullptr;
+    sceneClickPoints.clear();
+    waypoints.clear();
+    baseFeat = nullptr;
+    baseFeatView = nullptr;
+    finished = false;
+    reverse = false;
+}
+
+void TechDrawLeaderLineHandler::activated()
+{
+    if (viewPage) {
+        QPoint hotspot(15, 15);
+        QPixmap pixmap = viewPage->prepareCursorPixmap("actions/TechDraw_LeaderLine_Pointer.svg", hotspot);
+        cursor = QCursor(pixmap, hotspot.x(), hotspot.y());
+        if (auto vp = viewPage->viewport()) {
+            vp->setCursor(cursor);
+        }
+    }
+
+}
+
+void TechDrawLeaderLineHandler::deactivated()
+{
+    if (viewPage) {
+        if (auto vp = viewPage->viewport()) {
+            vp->unsetCursor();
+        }
+    }
+}
+
+void TechDrawLeaderLineHandler::updateLeaderPoints(std::vector<QPointF> points) {
+    if (points.empty()) {
+        points = sceneClickPoints;
+    }
+
+    QPointF firstPoint = points.front();
+
+    std::vector<Base::Vector3d> pageDeltas;
+    pageDeltas.reserve(points.size());
+    for (auto& pt : points) {
+        QPointF distFromFirst = pt - firstPoint;
+        pageDeltas.push_back(Rez::appX(DrawUtil::toVector3d(distFromFirst)));
+    }
+    waypoints = leaderLineObj->makeCanonicalPointsInverted(pageDeltas);
+    leaderLineObj->WayPoints.setValues(waypoints);
+}
+
+void TechDrawLeaderLineHandler::mouseMoveEvent(QMouseEvent* event)
+{
+    if (auto vp = viewPage->viewport()) {
+        vp->setCursor(cursor);
+    }
+
+    if (finished) {
+        return;
+    }
+
+    if (sceneClickPoints.empty()) {
+        return;
+    }
+
+    if (reverse && sceneClickPoints.size() >= 2
+        && (currentLeaderType == LeaderType::Normal || currentLeaderType == LeaderType::ComplexWithKink)) {
+        sceneClickPoints = updateKinkLength(sceneClickPoints);
+    }
+
+    QPointF scenePos = viewPage->mapToScene(event->pos());
+    std::vector<QPointF> points;
+
+    if (reverse) {
+        if (currentLeaderType == LeaderType::Normal && sceneClickPoints.size() == 2) {
+            points.push_back(scenePos);
+            points.push_back(sceneClickPoints.front());
+            points.push_back(sceneClickPoints.back());
+        }
+        if (currentLeaderType == LeaderType::Straight && sceneClickPoints.size() == 1) {
+            points.push_back(scenePos);
+            points.push_back(sceneClickPoints.front());
+            leaderLineObj->AutoHorizontal.setValue(false);
+        }
+        if (currentLeaderType == LeaderType::Complex) {
+            points.insert(points.end(), sceneClickPoints.begin(), sceneClickPoints.end());
+            points.push_back(scenePos);
+            std::reverse(points.begin(), points.end());
+            leaderLineObj->AutoHorizontal.setValue(false);
+        }
+        if (currentLeaderType == LeaderType::ComplexWithKink) {
+            points.insert(points.end(), sceneClickPoints.begin(), sceneClickPoints.end());
+            points.push_back(scenePos);
+            std::reverse(points.begin(), points.end());
+        }
+
+        if (baseFeatView && baseFeat) {
+            QPointF localOffset = scenePos - baseFeatView->scenePos();
+            auto attachPoint = DrawUtil::toVector3d(localOffset);
+            double baseRotation = baseFeat->Rotation.getValue();
+            if (baseRotation != 0) {
+                attachPoint = DrawUtil::invertY(attachPoint);
+                attachPoint.RotateZ(-Base::toRadians(baseRotation));
+                attachPoint = DrawUtil::invertY(attachPoint);
+            }
+            Base::Vector3d attachDelta(Rez::appX(attachPoint.x), Rez::appX(-attachPoint.y), 0.0);
+            leaderLineObj->setPosition(attachDelta.x, attachDelta.y, true);
+        }
+    }
+    else {
+        if (currentLeaderType == LeaderType::Normal) {
+            points.push_back(sceneClickPoints.front());
+            QPointF kinkStart = scenePos;
+            kinkStart.setX(kinkStart.x() - Rez::guiX(kinkLength / 2.0));
+            QPointF kinkEnd = scenePos;
+            kinkEnd.setX(kinkEnd.x() + Rez::guiX(kinkLength / 2.0));
+
+            std::vector<QPointF> kinkPoints = {kinkStart, kinkEnd};
+            reorderClosestPoints(kinkPoints, sceneClickPoints.front());
+
+            points.push_back(kinkPoints[0]);
+            points.push_back(kinkPoints[1]);
+        }
+        else if (currentLeaderType == LeaderType::Straight) {
+            points.push_back(sceneClickPoints.front());
+            points.push_back(scenePos);
+            leaderLineObj->AutoHorizontal.setValue(false);
+        }
+    }
+
+    updateLeaderPoints(points);
+
+    leaderLineObj->recomputeFeature();
+}
+
+void TechDrawLeaderLineHandler::mouseReleaseEvent(QMouseEvent* event)
+{
+    if (finished) {
+        return;
+    }
+
+    if (event->button() == Qt::RightButton) {
+        deleteLeaderLine();
+        return;
+    }
+
+    QPointF scenePos = viewPage->mapToScene(event->pos());
+    QPainterPath circle;
+    circle.addEllipse(scenePos, 5.0, 5.0);
+    auto items = viewPage->scene()->items(circle);
+
+
+    if (!baseFeat || reverse) {
+        for (auto item : items) {
+            QGIView* qgiView = nullptr;
+            if (dynamic_cast<QGIEdge*>(item) || dynamic_cast<QGIVertex*>(item) || dynamic_cast<QGIFace*>(item)) {
+                qgiView = dynamic_cast<QGIView*>(item->parentItem());
+            }
+            if (qgiView) {
+                if (dynamic_cast<TechDraw::DrawLeaderLine*>(qgiView->getViewObject())) {
+                    continue;
+                }
+                if (dynamic_cast<TechDraw::DrawProjGroup*>(qgiView->getViewObject())) {
+                    continue;
+                }
+
+                baseFeat = qgiView->getViewObject();
+                baseFeatView = qgiView;
+
+                if (reverse) {
+                    if (leaderLineObj) {
+                        // Dot startsymbol
+                        if (dynamic_cast<QGIFace*>(item)) {
+                            leaderLineObj->StartSymbol.setValue(3L);
+                        }
+
+                        leaderLineObj->LeaderParent.setValue(baseFeat);
+
+                        QPointF localOffset = scenePos - baseFeatView->scenePos();
+                        Base::Vector3d attachPoint = DrawUtil::toVector3d(localOffset);
+                        double baseRotation = baseFeat->Rotation.getValue();
+                        if (baseRotation != 0) {
+                            attachPoint = DrawUtil::invertY(attachPoint);
+                            attachPoint.RotateZ(-Base::toRadians(baseRotation));
+                            attachPoint = DrawUtil::invertY(attachPoint);
+                        }
+                        Base::Vector3d attachDelta(Rez::appX(attachPoint.x), Rez::appX(-attachPoint.y), 0.0);
+                        leaderLineObj->setPosition(attachDelta.x, attachDelta.y, true);
+
+                        leaderLineObj->recomputeFeature();
+                        finished = true;
+                        if (attached) {
+                            Gui::Selection().clearSelection();
+                            if (onFinished) {
+                                onFinished();
+                            }
+                            viewPage->deactivateHandler();
+                            return;
+                        }
+                    }
+                }
+
+                break;
+            }
+        }
+        if (!baseFeat) {
+            auto items = viewPage->items();
+            for (auto item : items) {
+                if (auto view = dynamic_cast<QGIView*>(item)) {
+                    baseFeatView = view;
+                    baseFeat = view->getViewObject();
+                    reverse = true;
+                    break;
+                }
+            }
+        }
+        if (!baseFeat) {
+            return;
+        }
+    }
+    
+    Gui::Selection().clearSelection();
+
+    if (reverse) {
+        if (currentLeaderType == LeaderType::Normal && sceneClickPoints.empty()) {
+            QPointF kinkStart = scenePos;
+            kinkStart.setX(kinkStart.x() - Rez::guiX(kinkLength / 2.0));
+            QPointF kinkEnd = scenePos;
+            kinkEnd.setX(kinkEnd.x() + Rez::guiX(kinkLength / 2.0));
+
+            sceneClickPoints.push_back(kinkStart);
+            sceneClickPoints.push_back(kinkEnd);
+        }
+        if (currentLeaderType == LeaderType::Straight && sceneClickPoints.empty()) {
+            sceneClickPoints.push_back(scenePos);
+        }
+        if (currentLeaderType == LeaderType::Complex) {
+            sceneClickPoints.push_back(scenePos);
+        }
+        if (currentLeaderType == LeaderType::ComplexWithKink) {
+            if (sceneClickPoints.empty()) {
+                QPointF kinkStart = scenePos;
+                kinkStart.setX(kinkStart.x() + Rez::guiX(kinkLength / 2.0));
+                QPointF kinkEnd = scenePos;
+                kinkEnd.setX(kinkEnd.x() - Rez::guiX(kinkLength / 2.0));
+
+                sceneClickPoints.push_back(kinkStart);
+                sceneClickPoints.push_back(kinkEnd);
+            }
+            else {
+                sceneClickPoints.push_back(scenePos);
+            }
+        }
+    }
+    else {
+        sceneClickPoints.push_back(scenePos);
+    }
+
+    if (!leaderLineObj) {
+        createLeaderLineObject();
+
+        for (auto& item : items) {
+            if (dynamic_cast<QGIEdge*>(item) || dynamic_cast<QGIVertex*>(item)) {
+                break;
+            }
+            if (dynamic_cast<QGIFace*>(item)) {
+                leaderLineObj->StartSymbol.setValue(3L);
+                break;
+            }
+        }
+
+        QPointF localOffset = scenePos - baseFeatView->scenePos();
+        Base::Vector3d attachPoint = DrawUtil::toVector3d(localOffset);
+        double baseRotation = baseFeat->Rotation.getValue();
+        if (baseRotation != 0) {
+            attachPoint = DrawUtil::invertY(attachPoint);
+            attachPoint.RotateZ(-Base::toRadians(baseRotation));
+            attachPoint = DrawUtil::invertY(attachPoint);
+        }
+        Base::Vector3d attachDelta(Rez::appX(attachPoint.x), Rez::appX(-attachPoint.y), 0.0);
+        leaderLineObj->setPosition(attachDelta.x, attachDelta.y, true);
+    }
+
+
+    if ((currentLeaderType == LeaderType::Complex || currentLeaderType == LeaderType::ComplexWithKink) && !reverse) {
+        if (currentLeaderType == LeaderType::ComplexWithKink) {
+            if (sceneClickPoints.size() > 2) {
+                sceneClickPoints.erase(sceneClickPoints.end() - 2);
+            }
+            if (sceneClickPoints.size() > 1) {
+                QPointF kinkStart = sceneClickPoints.back();
+                const QPointF& prevPoint = sceneClickPoints[sceneClickPoints.size() - 2];
+
+                QPointF kinkEnd = kinkStart;
+                if (kinkStart.x() < prevPoint.x()) {
+                    kinkEnd.setX(kinkEnd.x() - Rez::guiX(kinkLength));
+                }
+                else {
+                    kinkEnd.setX(kinkEnd.x() + Rez::guiX(kinkLength));
+                }
+
+                sceneClickPoints.push_back(kinkEnd);
+            }
+        }
+
+        updateLeaderPoints();
+        leaderLineObj->AutoHorizontal.setValue(false);
+        leaderLineObj->recomputeFeature();
+    }
+    
+    if (currentLeaderType == LeaderType::Normal && sceneClickPoints.size() == 2 && !reverse) {
+        finished = true;
+        if (attached) {
+            if (onFinished) {
+                onFinished();
+            }
+            viewPage->deactivateHandler();
+            return;
+        }
+    }
+    if (currentLeaderType == LeaderType::Straight && sceneClickPoints.size() == 2 && !reverse) {
+        finished = true;
+        if (attached) {
+            if (onFinished) {
+                onFinished();
+            }
+            viewPage->deactivateHandler();
+            return;
+        }
+    }
+}
+
+void TechDrawLeaderLineHandler::mousePressEvent(QMouseEvent* event)
+{
+    Q_UNUSED(event);
+}
+
+void TechDrawLeaderLineHandler::keyPressEvent(QKeyEvent* event)
+{
+    if (event->key() == Qt::Key_Escape) {
+        event->accept();
+    }
+}
+
+void TechDrawLeaderLineHandler::updateLeader()
+{
+    if (!leaderLineObj) {
+        return;
+    }
+
+    if (oldLeaderType != currentLeaderType) {
+        deleteLeaderLine();
+        oldLeaderType = currentLeaderType;
+        baseFeat = nullptr;
+        baseFeatView = nullptr;
+        return;
+    }
+
+    auto* viewProvider =
+        Gui::Application::Instance->getViewProvider<TechDrawGui::ViewProviderLeader>(leaderLineObj);
+
+    if (viewProvider) {
+        viewProvider->Color.setValue(color);
+        viewProvider->LineStyle.setValue(lineStyle);
+        viewProvider->LineWidth.setValue(lineWidth);
+    }
+
+    leaderLineObj->StartSymbol.setValue(startSymbol);
+    leaderLineObj->EndSymbol.setValue(endSymbol);
+
+    std::vector<Base::Vector3d> updatedWaypoints = updateKinkLength(waypoints);
+    if (updatedWaypoints.size() >= 3) {
+        leaderLineObj->WayPoints.setValues(updatedWaypoints);
+    }
+
+    leaderLineObj->recomputeFeature();
+}
+
+std::vector<Base::Vector3d> TechDrawLeaderLineHandler::updateKinkLength(std::vector<Base::Vector3d> waypoints) {
+    if (attached) {
+        return waypoints;
+    }
+    if (currentLeaderType == LeaderType::Normal || currentLeaderType == LeaderType::ComplexWithKink) {
+        if (waypoints.size() >= 3) {
+            Base::Vector3d kinkStart, kinkEnd;
+            if (currentLeaderType == LeaderType::Normal) {
+                kinkStart = waypoints[1];
+                kinkEnd = waypoints[2];
+            }
+    
+            if (currentLeaderType == LeaderType::ComplexWithKink) {
+                kinkStart = waypoints[waypoints.size() - 2];
+                kinkEnd = waypoints[waypoints.size() - 1];
+            }
+    
+            double currentKinkLength = std::hypot(kinkEnd.x - kinkStart.x, kinkEnd.y - kinkStart.y);
+    
+            if (kinkLength != currentKinkLength) {
+                Base::Vector3d mid = (kinkStart + kinkEnd) / 2.0;
+                double halfLength = (kinkEnd.x >= kinkStart.x) ? kinkLength / 2.0 : -kinkLength / 2.0;
+    
+                kinkStart.x = mid.x - halfLength;
+                kinkEnd.x = mid.x + halfLength;
+            }
+    
+            if (currentLeaderType == LeaderType::Normal) {
+                waypoints[1] = kinkStart;
+                waypoints[2] = kinkEnd;
+            }
+            else if (currentLeaderType == LeaderType::ComplexWithKink) {
+                waypoints[waypoints.size() - 2] = kinkStart;
+                waypoints[waypoints.size() - 1] = kinkEnd;
+            }
+        }
+    }
+
+    return waypoints;
+}
+
+std::vector<QPointF> TechDrawLeaderLineHandler::updateKinkLength(std::vector<QPointF> scenePoints) {
+    if (attached) {
+        return scenePoints;
+    }
+    if ((currentLeaderType == LeaderType::Normal || currentLeaderType == LeaderType::ComplexWithKink)
+        && scenePoints.size() >= 2) {
+        QPointF& kinkStart = scenePoints[0];
+        QPointF& kinkEnd = scenePoints[1];
+
+        double currentKinkLength = std::hypot(kinkEnd.x() - kinkStart.x(), kinkEnd.y() - kinkStart.y());
+        double actualKinkLength = Rez::guiX(kinkLength);
+
+        if (actualKinkLength != currentKinkLength) {
+            QPointF mid = (kinkStart + kinkEnd) / 2.0;
+            double halfLength = (kinkEnd.x() >= kinkStart.x()) ? actualKinkLength / 2.0 : -actualKinkLength / 2.0;
+
+            kinkStart.setX(mid.x() - halfLength);
+            kinkEnd.setX(mid.x() + halfLength);
+        }
+    }
+
+    return scenePoints;
+}

--- a/src/Mod/TechDraw/Gui/TechDrawLeaderLineHandler.h
+++ b/src/Mod/TechDraw/Gui/TechDrawLeaderLineHandler.h
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Morten Vajhøj
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+#include <QPointF>
+#include <QCursor>
+#include <functional>
+#include <list>
+#include <string>
+
+#include <Gui/InputHint.h>
+#include <Mod/TechDraw/App/DrawView.h>
+#include <Mod/TechDraw/App/DrawLeaderLine.h>
+
+#include "TechDrawHandler.h"
+
+class QMouseEvent;
+class QKeyEvent;
+
+namespace TechDrawGui
+{
+class QGIView;
+}
+
+class TechDrawLeaderLineHandler : public TechDrawGui::TechDrawHandler
+{
+private:
+    QCursor cursor;
+    
+    TechDraw::DrawLeaderLine* leaderLineObj = nullptr;
+    
+    std::vector<Base::Vector3d> waypoints;
+    TechDraw::DrawView* baseFeat = nullptr;
+    TechDrawGui::QGIView* baseFeatView = nullptr;
+    bool finished = false;
+
+public:
+    enum class LeaderType {
+        Normal,
+        Straight,
+        Complex,
+        ComplexWithKink,
+    };
+    bool reverse = false;
+    bool attached = false;
+    std::function<void()> onFinished;
+    std::vector<QPointF> sceneClickPoints;
+    LeaderType currentLeaderType = LeaderType::Normal;
+    LeaderType oldLeaderType = LeaderType::Normal;
+
+    Base::Color color;
+    int lineStyle = 1;
+    double lineWidth = 0.5;
+    long startSymbol = 0;
+    long endSymbol = 7;
+    double kinkLength = 5.0;
+
+    void activated() override;
+    void deactivated() override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
+
+    void addLeaderLine(TechDraw::DrawPage* basePage);
+    void deleteLeaderLine();
+    void createLeaderLineObject();
+
+    TechDraw::DrawLeaderLine* getLeaderLine() { return leaderLineObj; }
+
+    void updateLeader();
+    void updateLeaderPoints(std::vector<QPointF> points = {});
+
+    std::vector<Base::Vector3d> updateKinkLength(std::vector<Base::Vector3d> waypoints);
+    std::vector<QPointF> updateKinkLength(std::vector<QPointF> scenePoints);
+};


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
This PR is a part of my GSoC project "TechDraw UX Overhaul"

This PR has a lot of changes for the current leaderline implementation.

The previous leader line only could only make unmoavable leader lines. This implementation has many upgrades including

4 Modes:
- Normal
- Straight
- Complex
- Complex with kink

The normal mode functions the same as the leader line on balloons.
Straight is just a straight line
Complex lets the user create a line with many different waypoints
Complex with kink is the same as complex but with a kink

Also did so that Rich text annotation can get a leader line by clicking in its own task panel. It uses the same handler to place the leader line. The same with weld where the user can now place a leader line instead of having to preselect it

It was planned to do the same with surface finish symbol, but it should probably be overhauled antoher time, since there are a lot of other issues with it



- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

https://github.com/user-attachments/assets/c3802f74-ff0d-4611-be23-658afa020fd8

