### PR TITLE
TechDraw: allow precise surface finish symbol placement

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewArch.h
+++ b/src/Mod/TechDraw/App/DrawViewArch.h
@@ -68,6 +68,8 @@ public:
 
     short mustExecute() const override;
 
+    bool snapsToPosition() const override { return true; }
+
 
 protected:
 /*    virtual void onChanged(const App::Property* prop) override;*/

--- a/src/Mod/TechDraw/App/DrawViewDraft.h
+++ b/src/Mod/TechDraw/App/DrawViewDraft.h
@@ -65,6 +65,8 @@ public:
 
     short mustExecute() const override;
 
+    bool snapsToPosition() const override { return true; }
+
 protected:
 /*    virtual void onChanged(const App::Property* prop) override;*/
     Base::BoundBox3d bbox;

--- a/src/Mod/TechDraw/App/DrawViewSymbol.h
+++ b/src/Mod/TechDraw/App/DrawViewSymbol.h
@@ -68,6 +68,8 @@ public:
     //return PyObject as DrawViewSymbolPy
     PyObject *getPyObject() override;
 
+    bool snapsToPosition() const override { return false; }
+
 protected:
     void onChanged(const App::Property* prop) override;
     Base::BoundBox3d bbox;

--- a/src/Mod/TechDraw/App/DrawWeldSymbol.h
+++ b/src/Mod/TechDraw/App/DrawWeldSymbol.h
@@ -63,6 +63,8 @@ public:
 
     App::PropertyLink *getOwnerProperty() override { return &Leader; }
 
+    bool snapsToPosition() const override { return false; }
+
 protected:
     void onChanged(const App::Property* prop) override;
 

--- a/src/Mod/TechDraw/Gui/TaskSurfaceFinishSymbols.cpp
+++ b/src/Mod/TechDraw/Gui/TaskSurfaceFinishSymbols.cpp
@@ -421,6 +421,7 @@ bool TaskSurfaceFinishSymbols::accept()
         page->addView(surfaceSymbol);
     }
 
+    surfaceSymbol->recomputeFeature();
     Gui::Command::commitCommand(tid);
     return true;
 }


### PR DESCRIPTION
This PR implements a fix for issue #31605.  Primary views (DrawViewPart, DrawViewSection, etc) snap to position when they are close to vertical/horizontal alignment with other primary views.  Some view types (ballons, leaders, etc) are positioned within a primary view and should not snap to vertical/horizontal alignment.  

Surface finish symbols (a type of view) must be positioned within a primary view and should not snap.  Unfortunately, surface finish symbols were not implemented as a specific view type, but use the base DrawViewSymbol which does snap.

This fix sets DrawViewSymbol to not snap, and adds override snapsToPosition methods to DrawViewArch (BIM) and DrawViewDraft which also derive from DrawViewSymbol, but should snap.


- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.