### PR TITLE
BIM: IFC export: include doors and windows in assembly

### DIFF
--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -387,7 +387,7 @@ def export(exportList, filename, colors=None, preferences=None):
         obj
         for obj in objectslist
         if Draft.getType(obj)
-        not in ["Dimension", "Material", "MaterialContainer", "WorkingPlaneProxy"]
+        not in ["Material", "MaterialContainer", "WorkingPlaneProxy"]
     ]
 
     # Note that the Draft.get_group_contents() function used later will also find children.
@@ -485,6 +485,8 @@ def export(exportList, filename, colors=None, preferences=None):
 
     # products
 
+    assemblyElementsTotal = []
+
     for obj in objectslist:
 
         if obj.Name in products:
@@ -511,11 +513,6 @@ def export(exportList, filename, colors=None, preferences=None):
 
         assemblyElements = []
         assemblyTypes = ["IfcApp::Part", "IfcPart::Compound", "IfcElementAssembly"]
-        is_nested_group = False
-        if preferences["GROUPS_AS_ASSEMBLIES"] and ifctype == "IfcGroup":
-            for p in obj.InListRecursive:
-                if not p.isDerivedFrom("App::DocumentObjectGroup"):
-                    is_nested_group = True
 
         if ifctype == "IfcArray":
             clonedeltas = []
@@ -561,7 +558,7 @@ def export(exportList, filename, colors=None, preferences=None):
                         preferences,
                     )
                     products[obj.Base.Name] = subproduct
-                    assemblyElements.append(subproduct)
+                    assemblyElements.append(obj.Base.Name)
                     exportIFCHelper.writeQuantities(
                         ifcfile,
                         obj.Base,
@@ -571,40 +568,18 @@ def export(exportList, filename, colors=None, preferences=None):
                         getIfcTypeFromObj(obj.Base),
                     )
 
-        elif ifctype in assemblyTypes or is_nested_group:
+        elif ifctype in assemblyTypes or ifctype == "IfcGroup":
             if hasattr(obj, "Group"):
-                group = obj.Group
+                group = []
+                for subobj in obj.Group:
+                    group.extend([subobj] + Draft.get_windows(subobj))
             elif hasattr(obj, "Links"):
                 group = obj.Links
             else:
                 group = [FreeCAD.ActiveDocument.getObject(n[:-1]) for n in obj.getSubObjects()]
-            for subobj in group:
-                if subobj.Name in products:
-                    subproduct = products[subobj.Name]
-                else:
-                    representation, placement, shapetype = getRepresentation(
-                        ifcfile,
-                        context,
-                        subobj,
-                        forcebrep=(getBrepFlag(subobj, preferences)),
-                        colors=colors,
-                        preferences=preferences,
-                    )
-                    subproduct = createProduct(
-                        ifcfile,
-                        subobj,
-                        getIfcTypeFromObj(subobj),
-                        getUID(subobj, preferences),
-                        history,
-                        getText("Name", subobj),
-                        getText("Description", subobj),
-                        placement,
-                        representation,
-                        preferences,
-                    )
-                    products[subobj.Name] = subproduct
-                assemblyElements.append(subproduct)
-            ifctype = "IfcElementAssembly"
+            assemblyElements.extend(subobj.Name for subobj in group)
+            if ifctype in assemblyTypes or preferences["GROUPS_AS_ASSEMBLIES"]:
+                ifctype = "IfcElementAssembly"
 
         # export grids
 
@@ -695,6 +670,12 @@ def export(exportList, filename, colors=None, preferences=None):
                     )
             continue
 
+        # gather total assembly subelements (before gather groups)
+
+        if assemblyElements:
+            assemblyExportType = "Assembly" if ifctype == "IfcElementAssembly" else "FreeCADGroup"
+            assemblyElementsTotal.append([obj.Name, assemblyExportType, assemblyElements])
+
         # gather groups
 
         if ifctype == "IfcGroup":
@@ -751,19 +732,6 @@ def export(exportList, filename, colors=None, preferences=None):
 
         if structobj:
             exportIFCStructuralTools.associates(ifcfile, product, structobj)
-
-        # gather assembly subelements
-
-        if assemblyElements:
-            if is_nested_group:
-                aname = "FreeCADGroup"
-            else:
-                aname = "Assembly"
-            ifcfile.createIfcRelAggregates(
-                ifcopenshell.guid.new(), history, aname, "", products[obj.Name], assemblyElements
-            )
-            if preferences["DEBUG"]:
-                print("      aggregating", len(assemblyElements), "object(s)")
 
         # additions
 
@@ -1505,14 +1473,13 @@ def export(exportList, filename, colors=None, preferences=None):
                 elif o in annos:
                     children.append(annos[o])
                     swallowed.append(annos[o])
-            if children:
-                name = FreeCAD.ActiveDocument.getObject(g[0]).Label
-                grp = ifcfile.createIfcGroup(ifcopenshell.guid.new(), history, name, "", None)
-                products[g[0]] = grp
-                spatialelements[g[0]] = grp
-                ass = ifcfile.createIfcRelAssignsToGroup(
-                    ifcopenshell.guid.new(), history, "GroupLink", "", children, None, grp
-                )
+            name = FreeCAD.ActiveDocument.getObject(g[0]).Label
+            grp = ifcfile.createIfcGroup(ifcopenshell.guid.new(), history, name, "", None)
+            products[g[0]] = grp
+            spatialelements[g[0]] = grp
+            ass = ifcfile.createIfcRelAssignsToGroup(
+                ifcopenshell.guid.new(), history, "GroupLink", "", children, None, grp
+            )
 
     # stack groups inside containers
 
@@ -1637,6 +1604,16 @@ def export(exportList, filename, colors=None, preferences=None):
                 ifcfile.createIfcRelAggregates(
                     ifcopenshell.guid.new(), history, "ProjectLink", "", project, remaining
                 )
+
+    # assembly relations
+
+    for objName, assemblyExportType, assemblyElements in assemblyElementsTotal:
+        assemblyElements = [products[name] for name in assemblyElements]
+        ifcfile.createIfcRelAggregates(
+            ifcopenshell.guid.new(), history, assemblyExportType, "", products[objName], assemblyElements
+        )
+        if preferences["DEBUG"]:
+            print("      aggregating", len(assemblyElements), "object(s)")
 
     if not existing_file:
         if preferences["DEBUG"]:

--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -386,8 +386,7 @@ def export(exportList, filename, colors=None, preferences=None):
     objectslist = [
         obj
         for obj in objectslist
-        if Draft.getType(obj)
-        not in ["Material", "MaterialContainer", "WorkingPlaneProxy"]
+        if Draft.getType(obj) not in ["Material", "MaterialContainer", "WorkingPlaneProxy"]
     ]
 
     # Note that the Draft.get_group_contents() function used later will also find children.
@@ -1610,7 +1609,12 @@ def export(exportList, filename, colors=None, preferences=None):
     for objName, assemblyExportType, assemblyElements in assemblyElementsTotal:
         assemblyElements = [products[name] for name in assemblyElements]
         ifcfile.createIfcRelAggregates(
-            ifcopenshell.guid.new(), history, assemblyExportType, "", products[objName], assemblyElements
+            ifcopenshell.guid.new(),
+            history,
+            assemblyExportType,
+            "",
+            products[objName],
+            assemblyElements,
         )
         if preferences["DEBUG"]:
             print("      aggregating", len(assemblyElements), "object(s)")

--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -386,7 +386,8 @@ def export(exportList, filename, colors=None, preferences=None):
     objectslist = [
         obj
         for obj in objectslist
-        if Draft.getType(obj) not in ["Material", "MaterialContainer", "WorkingPlaneProxy"]
+        if Draft.getType(obj)
+        not in ["Material", "MaterialContainer", "WorkingPlaneProxy"]
     ]
 
     # Note that the Draft.get_group_contents() function used later will also find children.
@@ -543,7 +544,7 @@ def export(exportList, filename, colors=None, preferences=None):
                     preferences,
                 )
                 i += 1
-                subname = obj_base_name + str(i)  # Unique name, does not end up in IFC.
+                subname = name + obj_base_name + str(i)  # Unique name, does not end up in IFC.
                 products[subname] = subproduct
                 assemblyElements.append(subname)
                 exportIFCHelper.writeQuantities(
@@ -1597,12 +1598,7 @@ def export(exportList, filename, colors=None, preferences=None):
     for objName, assemblyExportType, assemblyElements in assemblyElementsTotal:
         assemblyElements = [products[name] for name in assemblyElements]
         ifcfile.createIfcRelAggregates(
-            ifcopenshell.guid.new(),
-            history,
-            assemblyExportType,
-            "",
-            products[objName],
-            assemblyElements,
+            ifcopenshell.guid.new(), history, assemblyExportType, "", products[objName], assemblyElements
         )
         if preferences["DEBUG"]:
             print("      aggregating", len(assemblyElements), "object(s)")

--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -386,8 +386,7 @@ def export(exportList, filename, colors=None, preferences=None):
     objectslist = [
         obj
         for obj in objectslist
-        if Draft.getType(obj)
-        not in ["Material", "MaterialContainer", "WorkingPlaneProxy"]
+        if Draft.getType(obj) not in ["Material", "MaterialContainer", "WorkingPlaneProxy"]
     ]
 
     # Note that the Draft.get_group_contents() function used later will also find children.
@@ -1598,7 +1597,12 @@ def export(exportList, filename, colors=None, preferences=None):
     for objName, assemblyExportType, assemblyElements in assemblyElementsTotal:
         assemblyElements = [products[name] for name in assemblyElements]
         ifcfile.createIfcRelAggregates(
-            ifcopenshell.guid.new(), history, assemblyExportType, "", products[objName], assemblyElements
+            ifcopenshell.guid.new(),
+            history,
+            assemblyExportType,
+            "",
+            products[objName],
+            assemblyElements,
         )
         if preferences["DEBUG"]:
             print("      aggregating", len(assemblyElements), "object(s)")

--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -386,7 +386,8 @@ def export(exportList, filename, colors=None, preferences=None):
     objectslist = [
         obj
         for obj in objectslist
-        if Draft.getType(obj) not in ["Material", "MaterialContainer", "WorkingPlaneProxy"]
+        if Draft.getType(obj)
+        not in ["Material", "MaterialContainer", "WorkingPlaneProxy"]
     ]
 
     # Note that the Draft.get_group_contents() function used later will also find children.
@@ -513,59 +514,47 @@ def export(exportList, filename, colors=None, preferences=None):
         assemblyElements = []
         assemblyTypes = ["IfcApp::Part", "IfcPart::Compound", "IfcElementAssembly"]
 
-        if ifctype == "IfcArray":
-            clonedeltas = []
-            if obj.ArrayType == "ortho":
-                for i in range(obj.NumberX):
-                    clonedeltas.append(obj.Placement.Base + (i * obj.IntervalX))
-                    for j in range(obj.NumberY):
-                        if j > 0:
-                            clonedeltas.append(
-                                obj.Placement.Base + (i * obj.IntervalX) + (j * obj.IntervalY)
-                            )
-                        for k in range(obj.NumberZ):
-                            if k > 0:
-                                clonedeltas.append(
-                                    obj.Placement.Base
-                                    + (i * obj.IntervalX)
-                                    + (j * obj.IntervalY)
-                                    + (k * obj.IntervalZ)
-                                )
-            if clonedeltas:
-                ifctype = "IfcElementAssembly"
-                for delta in clonedeltas:
-                    # print("delta: {}".format(delta))
-                    representation, placement, shapetype = getRepresentation(
-                        ifcfile,
-                        context,
-                        obj.Base,
-                        forcebrep=(getBrepFlag(obj.Base, preferences)),
-                        colors=colors,
-                        preferences=preferences,
-                        forceclone=delta,
-                    )
-                    subproduct = createProduct(
-                        ifcfile,
-                        obj.Base,
-                        getIfcTypeFromObj(obj.Base),
-                        getUID(obj.Base, preferences),
-                        history,
-                        getText("Name", obj.Base),
-                        getText("Description", obj.Base),
-                        placement,
-                        representation,
-                        preferences,
-                    )
-                    products[obj.Base.Name] = subproduct
-                    assemblyElements.append(obj.Base.Name)
-                    exportIFCHelper.writeQuantities(
-                        ifcfile,
-                        obj.Base,
-                        subproduct,
-                        history,
-                        preferences["SCALE_FACTOR"],
-                        getIfcTypeFromObj(obj.Base),
-                    )
+        if ifctype == "IfcArray" and obj.ArrayType == "ortho":
+            ifctype = "IfcElementAssembly"
+            obj_pt = obj.Placement.Base
+            obj_base_name = obj.Base.Name
+            i = 0
+            for plc in obj.PlacementList:
+                pt = obj_pt + plc.Base
+                # print("pt: {}".format(pt))
+                representation, placement, shapetype = getRepresentation(
+                    ifcfile,
+                    context,
+                    obj.Base,
+                    forcebrep=(getBrepFlag(obj.Base, preferences)),
+                    colors=colors,
+                    preferences=preferences,
+                    forceclone=pt,
+                )
+                subproduct = createProduct(
+                    ifcfile,
+                    obj.Base,
+                    getIfcTypeFromObj(obj.Base),
+                    getUID(obj.Base, preferences),
+                    history,
+                    getText("Name", obj.Base),
+                    getText("Description", obj.Base),
+                    placement,
+                    representation,
+                    preferences,
+                )
+                i += 1
+                subname = obj_base_name + str(i)  # Unique name, does not end up in IFC.
+                products[subname] = subproduct
+                assemblyElements.append(subname)
+                exportIFCHelper.writeQuantities(
+                    ifcfile,
+                    obj.Base,
+                    subproduct,
+                    history,
+                    preferences["SCALE_FACTOR"],
+                    getIfcTypeFromObj(obj.Base),
+                )
 
         elif ifctype in assemblyTypes or ifctype == "IfcGroup":
             if hasattr(obj, "Group"):
@@ -1609,12 +1598,7 @@ def export(exportList, filename, colors=None, preferences=None):
     for objName, assemblyExportType, assemblyElements in assemblyElementsTotal:
         assemblyElements = [products[name] for name in assemblyElements]
         ifcfile.createIfcRelAggregates(
-            ifcopenshell.guid.new(),
-            history,
-            assemblyExportType,
-            "",
-            products[objName],
-            assemblyElements,
+            ifcopenshell.guid.new(), history, assemblyExportType, "", products[objName], assemblyElements
         )
         if preferences["DEBUG"]:
             print("      aggregating", len(assemblyElements), "object(s)")


### PR DESCRIPTION
Fixes #22054.

This PR implements the solution proposed by Yorik:
https://github.com/FreeCAD/FreeCAD/issues/22054#issuecomment-3069887539

Remarks:
* The `"GROUPS_AS_ASSEMBLIES"` preference is used for all groups, nested or unnested. I could not get an unnested group to export as a group with the old code and this preference set to `True`. If this is OK the text and tooltip in the preferences UI file  must be updated.
* Groups are always created even if the `children` list is empty. This is required to export groups with subgroups.
* Windows and rebars are added to the group content. `Draft.get_group_contents()` can't be used as that function is recursive.
* Removed `"Dimension"` on line 390 as objects of that type are already handled as `annotations`.
* This PR has to be updated once #31616 has been merged. So it is draft for now.

No AI was used.
