### PR TITLE
Sketcher: Fix arc of ellipse arc OVP flip

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -548,6 +548,9 @@ void DSHArcOfEllipseController::doEnforceControlParameters(Base::Vector2d& onSke
                 unsetOnViewParameter(arcAngleParam.get());
                 return;
             }
+            // Help it to not flip on changes over pi radians,
+            // since then the other direction is shorter and will be used instead
+            handler->arcAngle = arcAngle;
 
             double endAngle = handler->startAngle + arcAngle;
 


### PR DESCRIPTION
On changes over PI radians the ellipse arc goes the other way and is not the correct length do to it being the shortest path.
This PR helps the ellipse by setting the arc angle in `doEnforceControlParameters`. 

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Images
### Before: 

<img width="513" height="288" alt="before" src="https://github.com/user-attachments/assets/9edcc74d-4a47-44f7-ba9e-6c6ea29837fa" />

### After:

<img width="357" height="383" alt="after" src="https://github.com/user-attachments/assets/b94970bc-46f8-4d83-a17f-6b6a08c959ed" />

