### PR TITLE
Fem: Support radiation heat flux in Elmer heat equation

### DIFF
--- a/src/Mod/Fem/App/FemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/App/FemConstraintHeatflux.cpp
@@ -56,6 +56,13 @@ ConstraintHeatflux::ConstraintHeatflux()
     ADD_PROPERTY_TYPE(CavityRadiation, (false), "ConstraintHeatflux", App::Prop_None, "Cavity radiation");
     ADD_PROPERTY_TYPE(CavityName, ("cav"), "ConstraintHeatflux", App::Prop_None, "Cavity name");
     ADD_PROPERTY_TYPE(
+        ClosedCavity,
+        (false),
+        "ConstraintHeatflux",
+        App::Prop_None,
+        "Use closed cavity radiation"
+    );
+    ADD_PROPERTY_TYPE(
         EnableAmplitude,
         (false),
         "ConstraintHeatflux",

--- a/src/Mod/Fem/App/FemConstraintHeatflux.h
+++ b/src/Mod/Fem/App/FemConstraintHeatflux.h
@@ -49,6 +49,7 @@ public:
     App::PropertyEnumeration ConstraintType;
     App::PropertyBool CavityRadiation;
     App::PropertyString CavityName;
+    App::PropertyBool ClosedCavity;
 
     /// recalculate the object
     App::DocumentObjectExecReturn* execute() override;

--- a/src/Mod/Fem/femexamples/ccx_cavity_radiation.py
+++ b/src/Mod/Fem/femexamples/ccx_cavity_radiation.py
@@ -40,9 +40,9 @@ def get_information():
         "meshtype": "face",
         "meshelement": "Tria3",
         "constraints": ["temperature", "heat flux", "initial temperature", "section print"],
-        "solvers": ["calculix"],
+        "solvers": ["calculix", "elmer"],
         "material": "solid",
-        "equations": ["mechanical"],
+        "equations": ["heat"],
     }
 
 def get_explanation(header=""):
@@ -60,7 +60,7 @@ Analytical solution - heat flux 6.9 W/m^2 = 6.9e-3 mW/mm^2
 
 Special approaches required:
 - long transient instead of steady-state analysis
-- negative ambient temperature to specify that the cavity is closed
+- the cavity is closed
 """
     )
 
@@ -113,6 +113,17 @@ def setup(doc=None, solvertype="calculix"):
         solver_obj.TimeMinimumIncrement = 0
         solver_obj.TimePeriod = 5000000
         analysis.addObject(solver_obj)
+    elif solvertype == "elmer":
+        solver_obj = ObjectsFem.makeSolverElmer(doc, "SolverElmer")
+        eq_heat = ObjectsFem.makeEquationHeat(doc, solver_obj)
+        eq_flux = ObjectsFem.makeEquationFlux(doc, solver_obj)
+        solver_obj.SimulationType = "Transient"
+        solver_obj.TimestepIntervals = [20]
+        solver_obj.TimestepSizes = [250000]
+        eq_heat.LinearPreconditioning = "ILU4"
+        eq_heat.NonlinearIterations = 3
+        eq_flux.FluxVariable = "Temperature"
+        analysis.addObject(solver_obj)
     else:
         FreeCAD.Console.PrintWarning(
             "Unknown or unsupported solver type: {}. "
@@ -153,18 +164,18 @@ def setup(doc=None, solvertype="calculix"):
     con_hf1 = ObjectsFem.makeConstraintHeatflux(doc, "RadiationHot")
     con_hf1.References = [(compound_obj, "Edge3")]
     con_hf1.ConstraintType = "Radiation"
-    con_hf1.AmbientTemp = -300
     con_hf1.Emissivity = 0.02
     con_hf1.CavityRadiation = True
+    con_hf1.ClosedCavity = True
     con_hf1.CavityName = "cav"
     analysis.addObject(con_hf1)
     
     con_hf2 = ObjectsFem.makeConstraintHeatflux(doc, "RadiationCold")
     con_hf2.References = [(compound_obj, "Edge5")]
     con_hf2.ConstraintType = "Radiation"
-    con_hf2.AmbientTemp = -300
     con_hf2.Emissivity = 0.02
     con_hf2.CavityRadiation = True
+    con_hf2.ClosedCavity = True
     con_hf2.CavityName = "cav"
     analysis.addObject(con_hf2)
     

--- a/src/Mod/Fem/femexamples/ccx_radiation_benchmark.py
+++ b/src/Mod/Fem/femexamples/ccx_radiation_benchmark.py
@@ -37,9 +37,9 @@ def get_information():
         "meshtype": "solid",
         "meshelement": "Tet10",
         "constraints": ["temperature", "heat flux"],
-        "solvers": ["calculix"],
+        "solvers": ["calculix", "elmer"],
         "material": "solid",
-        "equations": ["mechanical"],
+        "equations": ["heat"],
     }
 
 
@@ -87,6 +87,10 @@ def setup(doc=None, solvertype="calculix"):
         solver_obj = ObjectsFem.makeSolverCalculiX(doc, "SolverCalculiX")
         solver_obj.AnalysisType = "thermomech"
         solver_obj.ThermoMechType = "pure heat transfer"
+    elif solvertype == "elmer":
+        solver_obj = ObjectsFem.makeSolverElmer(doc, "SolverElmer")
+        eq_heat = ObjectsFem.makeEquationHeat(doc, solver_obj)
+        eq_heat.NonlinearIterations = 5
     else:
         FreeCAD.Console.PrintWarning(
             "Unknown or unsupported solver type: {}. "

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_heatflux.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_heatflux.py
@@ -57,15 +57,17 @@ def write_meshdata_constraint(f, femobj, heatflux_obj, ccxwriter):
 
     elif heatflux_obj.ConstraintType == "Radiation":
         heatflux_facetype = "R"
+        amb_temp = heatflux_obj.AmbientTemp.getValueAs("K").Value
         if heatflux_obj.CavityRadiation:
             heatflux_key_word = f"RADIATE, CAVITY={heatflux_obj.CavityName}"
             heatflux_facesubtype = "CR"
+            # set negative temperature for closed cavity
+            if heatflux_obj.ClosedCavity:
+                amb_temp = -1.0
         else:
             heatflux_key_word = "RADIATE"
             heatflux_facesubtype = ""
-        heatflux_values = "{:.13G},{:.13G}".format(
-            heatflux_obj.AmbientTemp.getValueAs("K").Value, heatflux_obj.Emissivity
-        )
+        heatflux_values = "{:.13G},{:.13G}".format(amb_temp, heatflux_obj.Emissivity)
 
     elif heatflux_obj.ConstraintType == "Flux":
         heatflux_key_word = "DFLUX"

--- a/src/Mod/Fem/femsolver/elmer/equations/heat_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/heat_writer.py
@@ -130,6 +130,19 @@ class Heatwriter:
                         flux = obj.DistributedHeatFlux.getValueAs("W/m^2").Value
                         self.write.boundary(name, "Heat Flux BC", True)
                         self.write.boundary(name, "Heat Flux", flux)
+                    elif obj.ConstraintType == "Radiation":
+                        temp = obj.AmbientTemp.getValueAs("K").Value
+                        self.write.boundary(name, "Emissivity", obj.Emissivity)
+                        if obj.CavityRadiation:
+                            self.write.boundary(name, "Radiation", "Diffuse Gray")
+                            if obj.ClosedCavity:
+                                self.write.boundary(name, "Radiation Boundary Open", False)
+                            else:
+                                self.write.boundary(name, "Radiation Boundary Open", True)
+                                self.write.boundary(name, "External Temperature", temp)
+                        else:
+                            self.write.boundary(name, "Radiation", "Idealized")
+                            self.write.boundary(name, "External Temperature", temp)
                 self.write.handled(obj)
 
     def handleHeatInitial(self, bodies):


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Add support for radiation boundary condition for Elmer heat equation.
A new boolean property `ClosedCavity` is added to heat flux feature. (no need to set negative value for `AmbientTemp` in CalculiX).

Radiation examples are updated for elmer.

@FEA-eng 
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
