### PR TITLE
Sketcher: Fix grid line width preference tooltips

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettingsGrid.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsGrid.ui
@@ -243,7 +243,7 @@ The grid spacing changes if it becomes smaller than the specified pixel size.</s
          <item row="1" column="1">
           <widget class="Gui::PrefSpinBox" name="gridLineWidth">
            <property name="toolTip">
-            <string>Distance between two subsequent grid lines</string>
+            <string>Width of minor grid lines</string>
            </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
@@ -381,7 +381,7 @@ The grid spacing changes if it becomes smaller than the specified pixel size.</s
          <item row="2" column="1">
           <widget class="Gui::PrefSpinBox" name="gridDivLineWidth">
            <property name="toolTip">
-            <string>Distance between two subsequent division lines</string>
+            <string>Width of major grid lines</string>
            </property>
            <property name="minimum">
             <number>1</number>


### PR DESCRIPTION
Fixes FreeCAD/FreeCAD#31626.

The minor and major grid line width preference tooltips described grid spacing instead of line width. This updates the two tooltip strings so the hover text matches the controls:

- minor grid line width -> "Width of minor grid lines"
- major grid line width -> "Width of major grid lines"

Testing:
- `git diff --check`
- static string verification for the affected controls

Full GUI/build validation was not run.
