### PR TITLE
Avoid visual studio slnx failing to load due to duplicate coin.vcxpro…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,5 +13,5 @@
 	branch = freecad-master
 [submodule "src/3rdParty/pivy"]
 	path = src/3rdParty/pivy
-	url = https://github.com/FreeCAD/pivy.git
-	branch = freecad-master
+	url = https://github.com/jacquesbeaurain/pivy.git
+	branch = jbfreecad-master

--- a/cMake/FreeCAD_Helpers/SetupCoin3D.cmake
+++ b/cMake/FreeCAD_Helpers/SetupCoin3D.cmake
@@ -150,7 +150,7 @@ macro(SetupBundledCoinPivy)
     set(PIVY_PACKAGE_OUTPUT_DIR "${PROJECT_BINARY_DIR}/Mod/pivy"
         CACHE PATH "Build-tree output directory for bundled Pivy" FORCE)
     add_subdirectory("${CMAKE_SOURCE_DIR}/src/3rdParty/pivy" "${CMAKE_BINARY_DIR}/src/3rdParty/pivy")
-    set_property(TARGET coin PROPERTY INSTALL_REMOVE_ENVIRONMENT_RPATH TRUE)
+    set_property(TARGET pivy_coin PROPERTY INSTALL_REMOVE_ENVIRONMENT_RPATH TRUE)
     if (NOT DEFINED PIVY_VERSION OR PIVY_VERSION STREQUAL "")
         message(FATAL_ERROR "Bundled Pivy did not define PIVY_VERSION")
     endif ()

--- a/cMake/FreeCAD_Helpers/SetupCoin3D.cmake
+++ b/cMake/FreeCAD_Helpers/SetupCoin3D.cmake
@@ -150,7 +150,7 @@ macro(SetupBundledCoinPivy)
     set(PIVY_PACKAGE_OUTPUT_DIR "${PROJECT_BINARY_DIR}/Mod/pivy"
         CACHE PATH "Build-tree output directory for bundled Pivy" FORCE)
     add_subdirectory("${CMAKE_SOURCE_DIR}/src/3rdParty/pivy" "${CMAKE_BINARY_DIR}/src/3rdParty/pivy")
-    set_property(TARGET coin PROPERTY INSTALL_REMOVE_ENVIRONMENT_RPATH TRUE)
+    set_property(TARGET coini PROPERTY INSTALL_REMOVE_ENVIRONMENT_RPATH TRUE)
     if (NOT DEFINED PIVY_VERSION OR PIVY_VERSION STREQUAL "")
         message(FATAL_ERROR "Bundled Pivy did not define PIVY_VERSION")
     endif ()


### PR DESCRIPTION
…j targets (issue FreeCAD/FreeCAD-LibPack#96)

When including pivy and coin from submodules (rather than external references e.g. LibPack) and using CMake to generate Visual Studio projects there are 2 targets named coin. This results in an invalid solution that fails to open with a silent failure in the IDE. Running a command-line build against the solution gave a better error pointing to the error. This PR addresses the issue  by renaming the coin interface target inside pivy to coini.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
Fixes FreeCAD/FreeCAD-LibPack#96

