### PR TITLE
FEM: normalize displacement for mode shapes of small objects

### DIFF
--- a/src/Mod/Fem/femsolver/calculix/calculixtools.py
+++ b/src/Mod/Fem/femsolver/calculix/calculixtools.py
@@ -195,33 +195,8 @@ class CalculiXTools(ObjectTools):
                 reader.Update()
                 multi_block = reader.GetOutput()
 
-                # normalize eigenvectors for frequency analysis. 
-                # CalculiX outputs mass-normalized eigenvectors
-                # scaled with 1/sqrt(mass) -> small objects overly distorted
                 if self.obj.AnalysisType == "frequency":
-                    nblocks = multi_block.GetNumberOfBlocks()
-                    span = None
-                    for i in range(nblocks):
-                        grid = multi_block.GetBlock(i)
-                        if grid is None:
-                            continue
-                        pd = grid.GetPointData()
-                        if (pd is None) or not pd.HasArray("DISP"):
-                            continue
-
-                        # only fetch the mesh the first time through
-                        if span is None:
-                            pos = vtk_np.vtk_to_numpy(grid.GetPoints().GetData())
-                            span = max(np.max(pos, axis=0) - np.min(pos, axis=0))
-
-                        # figure out how large the deformation should be relatively
-                        disp = vtk_np.vtk_to_numpy(pd.GetAbstractArray("DISP"))
-                        max_mag = float(np.max(np.linalg.norm(disp, axis=1)))
-                        if max_mag == 0.0:
-                            continue
-
-                        # scale referenced array values
-                        disp *= 0.01 * span / max_mag if span > 0.0 else 1.0 / max_mag
+                    multi_block = self._normalize_disp_mesh(multi_block)
 
                 multi_block = self._generate_derived_result(multi_block)
                 if self.obj.DisplaceMesh:
@@ -277,6 +252,42 @@ class CalculiXTools(ObjectTools):
                 return "Potential"
             case _:
                 return "None"
+
+    def _normalize_disp_mesh(self, mb):
+        # normalize eigenvectors for frequency analysis.
+        # CalculiX outputs mass-normalized eigenvectors
+        # scaled with 1/sqrt(mass) -> small objects overly distorted
+        try:
+            span = None
+            for i in range(mb.GetNumberOfBlocks()):
+                grid = mb.GetBlock(i)
+                if grid is None:
+                    continue
+                pd = grid.GetPointData()
+                if (pd is None) or not pd.HasArray("DISP"):
+                    continue
+
+                # normalize displacement
+                disp = vtk_np.vtk_to_numpy(pd.GetAbstractArray("DISP"))
+                max_mag = float(np.max(np.linalg.norm(disp, axis=1)))
+                if np.isclose(max_mag, 0.0):
+                    continue
+                disp *= 1.0 / max_mag
+
+                # scale displacement against bounding box
+                if span is None:
+                    span = grid.GetLength()
+                if span > 0.0:
+                    disp *= 0.01 * span
+
+            mb_out = vtkMultiBlockDataSet()
+            mb_out.DeepCopy(mb)
+
+            return mb_out
+
+        except Exception as e:
+            FreeCAD.Console.PrintWarning("Displacement mesh could not be normalized\n")
+            return mb
 
     def _generate_disp_mesh(self, mb):
         try:

--- a/src/Mod/Fem/femsolver/calculix/calculixtools.py
+++ b/src/Mod/Fem/femsolver/calculix/calculixtools.py
@@ -195,7 +195,7 @@ class CalculiXTools(ObjectTools):
                 reader.Update()
                 multi_block = reader.GetOutput()
 
-                # normalize eigenvectors for frequency analysis. 
+                # normalize eigenvectors for frequency analysis.
                 # CalculiX outputs mass-normalized eigenvectors
                 # scaled with 1/sqrt(mass) -> small objects overly distorted
                 if self.obj.AnalysisType == "frequency":

--- a/src/Mod/Fem/femsolver/calculix/calculixtools.py
+++ b/src/Mod/Fem/femsolver/calculix/calculixtools.py
@@ -194,6 +194,35 @@ class CalculiXTools(ObjectTools):
                 reader.SetFileName(vtm_file)
                 reader.Update()
                 multi_block = reader.GetOutput()
+
+                # normalize eigenvectors for frequency analysis. 
+                # CalculiX outputs mass-normalized eigenvectors
+                # scaled with 1/sqrt(mass) -> small objects overly distorted
+                if self.obj.AnalysisType == "frequency":
+                    nblocks = multi_block.GetNumberOfBlocks()
+                    span = None
+                    for i in range(nblocks):
+                        grid = multi_block.GetBlock(i)
+                        if grid is None:
+                            continue
+                        pd = grid.GetPointData()
+                        if (pd is None) or not pd.HasArray("DISP"):
+                            continue
+
+                        # only fetch the mesh the first time through
+                        if span is None:
+                            pos = vtk_np.vtk_to_numpy(grid.GetPoints().GetData())
+                            span = max(np.max(pos, axis=0) - np.min(pos, axis=0))
+
+                        # figure out how large the deformation should be relatively
+                        disp = vtk_np.vtk_to_numpy(pd.GetAbstractArray("DISP"))
+                        max_mag = float(np.max(np.linalg.norm(disp, axis=1)))
+                        if max_mag == 0.0:
+                            continue
+
+                        # scale referenced array values
+                        disp *= 0.01 * span / max_mag if span > 0.0 else 1.0 / max_mag
+
                 multi_block = self._generate_derived_result(multi_block)
                 if self.obj.DisplaceMesh:
                     multi_block = self._generate_disp_mesh(multi_block)


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

I am working with a lot of small objects 10-200um and recently started trying to use the FEM workbench. The calculations out of CalculiX (with respect to bending modes and frequencies) are sensible but it was difficult to visualize results due to extremely large displacements with modal analysis. For example, for a 200um cantilever beam, it was common to see displacements in UI of several kilometers!

This is a patch to normalize the values returned from CalculiX against the mesh so that typical scaling factors can be used for objects of all sizes.

I did not use AI to write the patch but I did use it to determine why the displacements were shown incorrectly.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
With a cantilever like this, about 240x40um:
<img width="1362" height="956" alt="image" src="https://github.com/user-attachments/assets/28d890fa-3a60-4062-9607-a3ebe8e38d0e" />
A typical modal analysis would give displacements that render like this: 
<img width="1813" height="1173" alt="image" src="https://github.com/user-attachments/assets/12d311a4-d23e-463a-b912-10eb667d51ed" />

with this patch now they render like this:
<img width="1876" height="922" alt="Screenshot From 2026-07-29 21-36-21" src="https://github.com/user-attachments/assets/eeeeb3ff-30e8-4019-bc6e-76d1450281ea" />

and behavior for large objects (this is 1m x 100mm) is not broken with these changes:
<img width="1876" height="922" alt="Screenshot From 2026-07-29 21-36-02" src="https://github.com/user-attachments/assets/065d3c9d-1875-4471-943a-609d0e3a8820" />

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
