### PR TITLE
BIM: do not filter out furniture

### DIFF
--- a/src/Mod/BIM/nativeifc/ifc_generator.py
+++ b/src/Mod/BIM/nativeifc/ifc_generator.py
@@ -362,7 +362,6 @@ def filter_types(elements, obj_ids=[]):
     elements = [e for e in elements if not e.is_a("IfcFeatureElement")]
     elements = [e for e in elements if not e.is_a("IfcOpeningElement")]
     elements = [e for e in elements if not e.is_a("IfcSpace")]
-    elements = [e for e in elements if not e.is_a("IfcFurnishingElement")]
     elements = [e for e in elements if not e.id() in obj_ids]
     return elements
 

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -1055,8 +1055,6 @@ def filter_elements(elements, ifcfile, expand=True, spaces=False, assemblies=Tru
         elements = [e for e in elements if not e.is_a("IfcSpace")]
     # skip projects
     elements = [e for e in elements if not e.is_a("IfcProject")]
-    # skip furniture for now, they can be lazy loaded probably
-    elements = [e for e in elements if not e.is_a("IfcFurnishingElement")]
     return elements
 
 


### PR DESCRIPTION
Fixes #26157.

In 2 places furniture was filtered out in the Native IFC code. This resulted in some confusion for the user. Furniture was exported to IFC, but not imported from IFC. And dragging a furniture element into a Native IFC project did not work (#26157).

An IFC project may contain a lot of furniture and importing that may be problematic, but that consideration also applies to other elements (installations, construction, stairs, railings). So specifically filtering out furniture is not necessarily logical IMO. What if you are an interior designer for example?

No AI was used.