### PR TITLE
Only use oriented constraint variant on new constraints

### DIFF
--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -3059,23 +3059,33 @@ int Sketch::addTangentConstraint(int geoId1, int geoId2, ConstraintOrientation o
         if (Geoms[geoId2].type == Arc) {
             GCS::Arc& a = Arcs[Geoms[geoId2].index];
             int tag = ++ConstraintsCounter;
-            GCSsys.addConstraintTangent(
-                l,
-                a,
-                orientation.testFlag(ConstraintOrientations::CounterClockwise),
-                tag
-            );
+            if (orientation.testFlag(ConstraintOrientations::None)) {
+                GCSsys.addConstraintTangent(l, a, tag);
+            }
+            else {
+                GCSsys.addConstraintTangentOriented(
+                    l,
+                    a,
+                    orientation.testFlag(ConstraintOrientations::CounterClockwise),
+                    tag
+                );
+            }
             return ConstraintsCounter;
         }
         else if (Geoms[geoId2].type == Circle) {
             GCS::Circle& c = Circles[Geoms[geoId2].index];
             int tag = ++ConstraintsCounter;
-            GCSsys.addConstraintTangent(
-                l,
-                c,
-                orientation.testFlag(ConstraintOrientations::CounterClockwise),
-                tag
-            );
+            if (orientation.testFlag(ConstraintOrientations::None)) {
+                GCSsys.addConstraintTangent(l, c, tag);
+            }
+            else {
+                GCSsys.addConstraintTangentOriented(
+                    l,
+                    c,
+                    orientation.testFlag(ConstraintOrientations::CounterClockwise),
+                    tag
+                );
+            }
             return ConstraintsCounter;
         }
         else if (Geoms[geoId2].type == Ellipse) {
@@ -3584,14 +3594,19 @@ int Sketch::addDistanceConstraint(
         GCS::Line& l2 = Lines[Geoms[geoId2].index];
 
         int tag = ++ConstraintsCounter;
-        GCSsys.addConstraintP2LDistance(
-            p1,
-            l2,
-            value,
-            orientation.testFlag(ConstraintOrientations::CounterClockwise),
-            tag,
-            driving
-        );
+        if (orientation.testFlag(ConstraintOrientations::None)) {
+            GCSsys.addConstraintP2LDistance(p1, l2, value, tag, driving);
+        }
+        else {
+            GCSsys.addConstraintP2LDistanceOriented(
+                p1,
+                l2,
+                value,
+                orientation.testFlag(ConstraintOrientations::CounterClockwise),
+                tag,
+                driving
+            );
+        }
         return ConstraintsCounter;
     }
     else {
@@ -3665,15 +3680,21 @@ int Sketch::addDistanceConstraint(
 
         GCS::Line* l = &Lines[Geoms[geoId2].index];
         int tag = ++ConstraintsCounter;
-        GCSsys.addConstraintC2LDistance(
-            *c1,
-            *l,
-            value,
-            orientation.testFlag(ConstraintOrientations::CounterClockwise),
-            orientation.testFlag(ConstraintOrientations::Internal),
-            tag,
-            driving
-        );
+        if (orientation.testFlag(ConstraintOrientations::None)) {
+            GCSsys.addConstraintC2LDistance(*c1, *l, value, tag, driving);
+        }
+        else {
+            GCSsys.addConstraintC2LDistanceOriented(
+                *c1,
+                *l,
+                value,
+                orientation.testFlag(ConstraintOrientations::CounterClockwise),
+                orientation.testFlag(ConstraintOrientations::Internal),
+                tag,
+                driving
+            );
+        }
+
         return ConstraintsCounter;
     }
     else {

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1462,16 +1462,6 @@ void SketchObject::migrateSketch()
         }
     }
 
-    {
-        // Migrate point-line, circle-circle and circle-line distance from abs to signed
-        auto constraints = Constraints.getValues();
-        for (auto& constr : constraints) {
-            setOrientation(constr, false);
-        }
-
-        Constraints.setValues(std::move(constraints));
-    }
-
     /* parabola axis as internal geometry */
     auto constraints = Constraints.getValues();
     auto geometries = getInternalGeometry();

--- a/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -860,8 +860,7 @@ void ConstraintP2PAngle::evaluate()
 
 // --------------------------------------------------------
 // P2LDistance
-ConstraintP2LDistance::ConstraintP2LDistance(Point& p, Line& l, double* d, bool ccw)
-    : ccw(ccw)
+ConstraintP2LDistance::ConstraintP2LDistance(Point& p, Line& l, double* d)
 {
     pvec.push_back(p.x);
     pvec.push_back(p.y);
@@ -895,9 +894,8 @@ double ConstraintP2LDistance::signed_value()
 }
 double ConstraintP2LDistance::error()
 {
-    double dist = ccw ? std::abs(*distance()) : -std::abs(*distance());
-
-    return scale * (signed_value() - dist);
+    double dist = *distance();
+    return scale * (value() - dist);
 }
 
 double ConstraintP2LDistance::grad(double* param)
@@ -932,9 +930,12 @@ double ConstraintP2LDistance::grad(double* param)
         if (param == p2y()) {
             deriv += ((x1 - x0) * d - (dy / d) * area) / d2;
         }
+        if (area < 0) {
+            deriv *= -1;
+        }
     }
     if (param == distance()) {
-        deriv += ccw ? -1 : +1;
+        deriv += -1;
     }
 
     return scale * deriv;
@@ -995,6 +996,57 @@ double ConstraintP2LDistance::maxStep(MAP_pD_D& dir, double lim)
 void ConstraintP2LDistance::evaluate()
 {
     *distance() = value();
+}
+
+ConstraintP2LDistanceOriented::ConstraintP2LDistanceOriented(Point& p, Line& l, double* d, bool ccw)
+    : ConstraintP2LDistance(p, l, d)
+    , ccw(ccw)
+{}
+
+double ConstraintP2LDistanceOriented::error()
+{
+    double dist = ccw ? std::abs(*distance()) : -std::abs(*distance());
+
+    return scale * (signed_value() - dist);
+}
+double ConstraintP2LDistanceOriented::grad(double* param)
+{
+    double deriv = 0.;
+
+    if (param == p0x() || param == p0y() || param == p1x() || param == p1y() || param == p2x()
+        || param == p2y()) {
+        double x0 = *p0x(), x1 = *p1x(), x2 = *p2x();
+        double y0 = *p0y(), y1 = *p1y(), y2 = *p2y();
+        double dx = x2 - x1;
+        double dy = y2 - y1;
+        double d2 = dx * dx + dy * dy;
+        double d = sqrt(d2);
+        double area = -x0 * dy + y0 * dx + x1 * y2 - x2 * y1;
+
+        if (param == p0x()) {
+            deriv += (y1 - y2) / d;
+        }
+        if (param == p0y()) {
+            deriv += (x2 - x1) / d;
+        }
+        if (param == p1x()) {
+            deriv += ((y2 - y0) * d + (dx / d) * area) / d2;
+        }
+        if (param == p1y()) {
+            deriv += ((x0 - x2) * d + (dy / d) * area) / d2;
+        }
+        if (param == p2x()) {
+            deriv += ((y0 - y1) * d - (dx / d) * area) / d2;
+        }
+        if (param == p2y()) {
+            deriv += ((x1 - x0) * d - (dy / d) * area) / d2;
+        }
+    }
+    if (param == distance()) {
+        deriv += ccw ? -1 : +1;
+    }
+
+    return scale * deriv;
 }
 
 
@@ -2998,11 +3050,9 @@ void ConstraintC2CDistance::evaluate()
 
 // --------------------------------------------------------
 // ConstraintC2LDistance
-ConstraintC2LDistance::ConstraintC2LDistance(Circle& c, Line& l, double* d, bool ccw, bool internal)
+ConstraintC2LDistance::ConstraintC2LDistance(Circle& c, Line& l, double* d)
     : circle(c)
     , line(l)
-    , ccw(ccw)
-    , internal(internal)
 {
     pvec.push_back(d);
     this->circle.PushOwnParams(pvec);
@@ -3058,6 +3108,60 @@ double ConstraintC2LDistance::signed_value(double& deriValue, double* param)
 void ConstraintC2LDistance::errorgrad(double* err, double* grad, double* param)
 {
     double h, dh;
+    h = std::abs(signed_value(dh, param));
+
+    if (err) {
+        double target;
+        if (h < *circle.rad) {
+            *err = *circle.rad - std::abs(*distance()) - h;
+        }
+        else {
+            *err = *circle.rad + std::abs(*distance()) - h;
+        }
+        target = ccw ? target : -target;  // Solve for one side of the line or the other
+        *err = target - h;
+    }
+    else if (grad) {
+        if (param == distance() || param == circle.rad) {
+            if (h < *circle.rad) {
+                *grad = -1.0;
+            }
+            else {
+                *grad = 1.0;
+            }
+        }
+        else {
+            *grad = -dh;
+        }
+    }
+}
+void ConstraintC2LDistance::evaluate()
+{
+    double h, dh;
+    h = std::abs(signed_value(dh, nullptr));
+
+    if (h < *circle.rad) {
+        *distance() = *circle.rad - h;
+    }
+    else {
+        *distance() = h - *circle.rad;
+    }
+}
+
+ConstraintC2LDistanceOriented::ConstraintC2LDistanceOriented(
+    Circle& c,
+    Line& l,
+    double* d,
+    bool ccw,
+    bool internal
+)
+    : ConstraintC2LDistance(c, l, d)
+    , ccw(ccw)
+    , internal(internal)
+{}
+void ConstraintC2LDistanceOriented::errorgrad(double* err, double* grad, double* param)
+{
+    double h, dh;
     h = signed_value(dh, param);
 
     if (err) {
@@ -3078,18 +3182,6 @@ void ConstraintC2LDistance::errorgrad(double* err, double* grad, double* param)
         else {
             *grad = -dh;
         }
-    }
-}
-void ConstraintC2LDistance::evaluate()
-{
-    double h, dh;
-    h = std::abs(signed_value(dh, nullptr));
-
-    if (h < *circle.rad) {
-        *distance() = *circle.rad - h;
-    }
-    else {
-        *distance() = h - *circle.rad;
     }
 }
 

--- a/src/Mod/Sketcher/App/planegcs/Constraints.h
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.h
@@ -503,9 +503,7 @@ public:
 // P2LDistance
 class ConstraintP2LDistance: public Constraint
 {
-private:
-    bool ccw;
-
+protected:
     double* p0x()
     {
         return pvec[0];
@@ -538,7 +536,7 @@ private:
     double signed_value();
 
 public:
-    ConstraintP2LDistance(Point& p, Line& l, double* d, bool ccw);
+    ConstraintP2LDistance(Point& p, Line& l, double* d);
 #ifdef _GCS_EXTRACT_SOLVER_SUBSYSTEM_
     ConstraintP2LDistance()
     {}
@@ -547,8 +545,19 @@ public:
     double error() override;
     double grad(double*) override;
     double maxStep(MAP_pD_D& dir, double lim = 1.) override;
-    double abs(double darea);
     void evaluate() override;
+};
+
+class ConstraintP2LDistanceOriented: public ConstraintP2LDistance
+{
+private:
+    bool ccw;
+
+public:
+    ConstraintP2LDistanceOriented(Point& p, Line& l, double* d, bool ccw);
+
+    double error() override;
+    double grad(double*) override;
 };
 
 // PointOnLine
@@ -1336,7 +1345,7 @@ public:
 // C2LDistance
 class ConstraintC2LDistance: public Constraint
 {
-private:
+protected:
     Circle circle;
     Line line;
     bool ccw;
@@ -1354,8 +1363,20 @@ private:
     void evaluate() override;
 
 public:
-    ConstraintC2LDistance(Circle& c, Line& l, double* d, bool ccw, bool internal);
+    ConstraintC2LDistance(Circle& c, Line& l, double* d);
     ConstraintType getTypeId() override;
+};
+
+class ConstraintC2LDistanceOriented: public ConstraintC2LDistance
+{
+protected:
+    bool ccw;
+    bool internal;
+
+    void errorgrad(double* err, double* grad, double* param) override;
+
+public:
+    ConstraintC2LDistanceOriented(Circle& c, Line& l, double* d, bool ccw, bool internal);
 };
 
 // P2CDistance

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -655,9 +655,24 @@ int System::addConstraintP2PAngle(Point& p1, Point& p2, double* angle, int /*tag
     return addConstraintP2PAngle(p1, p2, angle, 0., 0, driving);
 }
 
-int System::addConstraintP2LDistance(Point& p, Line& l, double* distance, bool ccw, int tagId, bool driving)
+int System::addConstraintP2LDistance(Point& p, Line& l, double* distance, int tagId, bool driving)
 {
-    Constraint* constr = new ConstraintP2LDistance(p, l, distance, ccw);
+    Constraint* constr = new ConstraintP2LDistance(p, l, distance);
+    constr->setTag(tagId);
+    constr->setDriving(driving);
+    return addConstraint(constr);
+}
+
+int System::addConstraintP2LDistanceOriented(
+    Point& p,
+    Line& l,
+    double* distance,
+    bool ccw,
+    int tagId,
+    bool driving
+)
+{
+    Constraint* constr = new ConstraintP2LDistanceOriented(p, l, distance, ccw);
     constr->setTag(tagId);
     constr->setDriving(driving);
     return addConstraint(constr);
@@ -884,7 +899,14 @@ int System::addConstraintC2CDistance(
     return addConstraint(constr);
 }
 
-int System::addConstraintC2LDistance(
+int System::addConstraintC2LDistance(Circle& c, Line& l, double* dist, int tagId, bool driving)
+{
+    Constraint* constr = new ConstraintC2LDistance(c, l, dist);
+    constr->setTag(tagId);
+    constr->setDriving(driving);
+    return addConstraint(constr);
+}
+int System::addConstraintC2LDistanceOriented(
     Circle& c,
     Line& l,
     double* dist,
@@ -894,7 +916,7 @@ int System::addConstraintC2LDistance(
     bool driving
 )
 {
-    Constraint* constr = new ConstraintC2LDistance(c, l, dist, ccw, internal);
+    Constraint* constr = new ConstraintC2LDistanceOriented(c, l, dist, ccw, internal);
     constr->setTag(tagId);
     constr->setDriving(driving);
     return addConstraint(constr);
@@ -1117,9 +1139,14 @@ int System::addConstraintPerpendicularArc2Arc(
     return addConstraintPerpendicular(a1.center, p1, a2.center, p2, tagId, driving);
 }
 
-int System::addConstraintTangent(Line& l, Circle& c, bool ccw, int tagId, bool driving)
+int System::addConstraintTangent(Line& l, Circle& c, int tagId, bool driving)
 {
-    return addConstraintP2LDistance(c.center, l, c.rad, ccw, tagId, driving);
+    return addConstraintP2LDistance(c.center, l, c.rad, tagId, driving);
+}
+
+int System::addConstraintTangentOriented(Line& l, Circle& c, bool ccw, int tagId, bool driving)
+{
+    return addConstraintP2LDistanceOriented(c.center, l, c.rad, ccw, tagId, driving);
 }
 
 int System::addConstraintTangent(Line& l, Ellipse& e, int tagId, bool driving)
@@ -1130,9 +1157,14 @@ int System::addConstraintTangent(Line& l, Ellipse& e, int tagId, bool driving)
     return addConstraint(constr);
 }
 
-int System::addConstraintTangent(Line& l, Arc& a, bool ccw, int tagId, bool driving)
+int System::addConstraintTangent(Line& l, Arc& a, int tagId, bool driving)
 {
-    return addConstraintP2LDistance(a.center, l, a.rad, ccw, tagId, driving);
+    return addConstraintP2LDistance(a.center, l, a.rad, tagId, driving);
+}
+
+int System::addConstraintTangentOriented(Line& l, Arc& a, bool ccw, int tagId, bool driving)
+{
+    return addConstraintP2LDistanceOriented(a.center, l, a.rad, ccw, tagId, driving);
 }
 
 int System::addConstraintTangent(Circle& c1, Circle& c2, int tagId, bool driving)

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -300,7 +300,8 @@ public:
         bool driving = true
     );
     int addConstraintP2PAngle(Point& p1, Point& p2, double* angle, int tagId = 0, bool driving = true);
-    int addConstraintP2LDistance(
+    int addConstraintP2LDistance(Point& p, Line& l, double* distance, int tagId = 0, bool driving = true);
+    int addConstraintP2LDistanceOriented(
         Point& p,
         Line& l,
         double* distance,
@@ -450,9 +451,11 @@ public:
         int tagId = 0,
         bool driving = true
     );
-    int addConstraintTangent(Line& l, Circle& c, bool ccw, int tagId = 0, bool driving = true);
+    int addConstraintTangent(Line& l, Circle& c, int tagId = 0, bool driving = true);
+    int addConstraintTangentOriented(Line& l, Circle& c, bool ccw, int tagId = 0, bool driving = true);
     int addConstraintTangent(Line& l, Ellipse& e, int tagId = 0, bool driving = true);
-    int addConstraintTangent(Line& l, Arc& a, bool ccw, int tagId = 0, bool driving = true);
+    int addConstraintTangent(Line& l, Arc& a, int tagId = 0, bool driving = true);
+    int addConstraintTangentOriented(Line& l, Arc& a, bool ccw, int tagId = 0, bool driving = true);
     int addConstraintTangent(Circle& c1, Circle& c2, int tagId = 0, bool driving = true);
     int addConstraintTangent(Arc& a1, Arc& a2, int tagId = 0, bool driving = true);
     int addConstraintTangent(Circle& c, Arc& a, int tagId = 0, bool driving = true);
@@ -491,7 +494,8 @@ public:
         int tagId,
         bool driving = true
     );
-    int addConstraintC2LDistance(
+    int addConstraintC2LDistance(Circle& c, Line& l, double* dist, int tagId, bool driving = true);
+    int addConstraintC2LDistanceOriented(
         Circle& c,
         Line& l,
         double* dist,


### PR DESCRIPTION


This PR is a replacement for #30950 and makes it so oriented constraints are only used for new constraints and we do not try to migrate old constraints. I think this is the best way forward because the migration process is just a recompute and it gets executed after sketch migrations are executed. Algorithm changes in the way projected geometry are computed would invert some edges on a recompute, *after the constraint orientations were computed* which would make constraint orientation fail in a way that would be hard (I don't know how I would do it) to manage.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues

Fix: https://github.com/FreeCAD/FreeCAD/issues/30930
Adress: https://github.com/FreeCAD/FreeCAD/pull/30950#issuecomment-4786186708
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
