### PR TITLE
TechDraw: prevent unset colour attributes in exported Pdf

### DIFF
--- a/src/Mod/TechDraw/Gui/QGISectionLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.cpp
@@ -50,26 +50,26 @@ using namespace TechDrawGui;
 using namespace TechDraw;
 
 QGISectionLine::QGISectionLine() :
+    m_symbol(""),
+    m_line(new QGraphicsPathItem()),
+    m_extend(new QGraphicsPathItem()),
+    m_arrow1(new QGIArrow()),
+    m_arrow2(new QGIArrow()),
+    m_symbol1(new QGCustomText()),
+    m_symbol2(new QGCustomText()),
+    m_symSize(0.0),
+    m_arrowSize(QGIArrow::getPrefArrowSize()),
     m_pathMode(false),
     m_arrowMode()
 {
-    m_symbol = "";
-    m_symSize = 0.0;
-
     m_extLen = 1.5 * Rez::guiX(QGIArrow::getPrefArrowSize());   //is there a standard for this??
-    m_arrowSize = QGIArrow::getPrefArrowSize();
 
-    m_line = new QGraphicsPathItem();
     addToGroup(m_line);
-    m_extend = new QGraphicsPathItem();
     addToGroup(m_extend);
-    m_arrow1 = new QGIArrow();
     addToGroup(m_arrow1);
-    m_arrow2 = new QGIArrow();
     addToGroup(m_arrow2);
-    m_symbol1 = new QGCustomText();
+
     addToGroup(m_symbol1);
-    m_symbol2 = new QGCustomText();
     addToGroup(m_symbol2);
 
     setWidth(Rez::guiX(0.75));          //a default?
@@ -220,7 +220,7 @@ void QGISectionLine::makeSymbolsTrad()
 
     QRectF symRect = m_symbol1->boundingRect();
     double symHeight = symRect.height();
-    double gap = 0.5 * symHeight;  //symHeight as surrogate for char box
+    double gap = symHeight / 2;  //symHeight as surrogate for char box
 
     QPointF motion1(m_arrowDir1.x, -m_arrowDir1.y);    //move in same direction as arrow
     QPointF motion2(m_arrowDir2.x, -m_arrowDir2.y);     //Qt y coords!
@@ -231,10 +231,11 @@ void QGISectionLine::makeSymbolsTrad()
     m_symbol1->centerAt(symPos1);
     m_symbol2->centerAt(symPos2);
 
+    constexpr double DegreesInCircle{360.0};
     m_symbol1->setTransformOriginPoint(m_symbol1->mapFromParent(symPos1));
-    m_symbol1->setRotation(360.0 - rotation());         //to Qt angle
+    m_symbol1->setRotation(DegreesInCircle - rotation());         //to Qt angle
     m_symbol2->setTransformOriginPoint(m_symbol2->mapFromParent(symPos2));
-    m_symbol2->setRotation(360.0 - rotation());
+    m_symbol2->setRotation(DegreesInCircle - rotation());
 }
 
 //symbols go at ends of extensions
@@ -252,7 +253,7 @@ void QGISectionLine::makeSymbolsISO()
 
     QRectF symRect = m_symbol1->boundingRect();
     double symHeight = symRect.height();
-    double gap = 0.5 * symHeight;  //symHeight as surrogate for char box
+    double gap = symHeight / 2;  //symHeight as surrogate for char box
 
     QPointF motion1(-m_arrowDir1.x, m_arrowDir1.y);     //move away from extension end
     QPointF motion2(-m_arrowDir2.x, m_arrowDir2.y);     //Qt y coords!
@@ -263,10 +264,11 @@ void QGISectionLine::makeSymbolsISO()
     m_symbol1->centerAt(symPos1);
     m_symbol2->centerAt(symPos2);
 
+    constexpr double DegreesInCircle{360.0};
     m_symbol1->setTransformOriginPoint(m_symbol1->mapFromParent(symPos1));
-    m_symbol1->setRotation(360.0 - rotation());
+    m_symbol1->setRotation(DegreesInCircle - rotation());
     m_symbol2->setTransformOriginPoint(m_symbol2->mapFromParent(symPos2));
-    m_symbol2->setRotation(360.0 - rotation());
+    m_symbol2->setRotation(DegreesInCircle - rotation());
 }
 
 //extension lines are on the stock side of the section line
@@ -326,16 +328,10 @@ void QGISectionLine::extensionEndsISO()
 
 void QGISectionLine::makeChangePointMarks()
 {
-//    Base::Console().message("QGISL::makeChangePointMarks()\n");
-    double segmentLength = 0.50 * m_arrowSize;
+    double segmentLength = m_arrowSize / 2;
     QPen cPointPen;
-    //TODO: this should really be 2.0 * thickLineWidth, but we only have one
-    //width available (which should be 'thin', for the section line)
-    cPointPen.setWidthF(2.0 * getWidth());
-    cPointPen.setColor(getSectionColor());
-    cPointPen.setStyle(Qt::SolidLine);
     for (auto& cPoint : m_changePointData) {
-        QGraphicsPathItem* cPointItem = new QGraphicsPathItem();
+        auto* cPointItem = new QGraphicsPathItem();
         addToGroup(cPointItem);
 
         QPainterPath pPath;
@@ -347,7 +343,6 @@ void QGISectionLine::makeChangePointMarks()
         pPath.lineTo(Rez::guiPt(end));
 
         cPointItem->setPath(pPath);
-        cPointItem->setPen(cPointPen);
         cPointItem->setZValue(ZVALUE::SECTIONLINE + 1);
         cPointItem->setPos(0.0, 0.0);
 
@@ -371,7 +366,7 @@ void QGISectionLine::setBounds(double x1, double y1, double x2, double y2)
     m_end = QPointF(x2, y2);
 }
 
-void QGISectionLine::setSymbol(char* sym)
+void QGISectionLine::setSymbol(const char *sym)
 {
     m_symbol = sym;
 }
@@ -408,9 +403,10 @@ double QGISectionLine::getArrowRotation(Base::Vector3d arrowDir)
     arrowDir.Normalize();
     double angle = atan2f(arrowDir.y, arrowDir.x);
     if (angle < 0.0) {
-        angle = 2 * std::numbers::pi + angle;
+        angle = (2 * std::numbers::pi) + angle;
     }
-    double arrowRotation = 360.0 - Base::toDegrees(angle);   //convert to Qt rotation (clockwise degrees)
+    constexpr double DegreesInCircle{360.0};
+    double arrowRotation = DegreesInCircle - Base::toDegrees(angle);   //convert to Qt rotation (clockwise degrees)
     return arrowRotation;
 }
 
@@ -430,24 +426,24 @@ void QGISectionLine::setArrowSize(double arrowSize)
     m_arrowSize = arrowSize;
 }
 
-void QGISectionLine::setFont(QFont f)
+void QGISectionLine::setFont(const QFont &f)
 {
     m_symFont = f;
     m_symSize = -1.0;
 }
 
-void QGISectionLine::setFont(QFont f, double fsize)
+void QGISectionLine::setFont(const QFont &f, double fsize)
 {
     m_symFont = f;
     m_symSize = fsize;
 }
 
-void QGISectionLine::setPath(QPainterPath& path)
+void QGISectionLine::setPath(const QPainterPath &path)
 {
     m_line->setPath(path);
 }
 
-void QGISectionLine::setChangePoints(TechDraw::ChangePointVector changePointData)
+void QGISectionLine::setChangePoints(const TechDraw::ChangePointVector& changePointData)
 {
     m_changePointData = changePointData;
     clearChangePointMarks();
@@ -501,8 +497,9 @@ void QGISectionLine::paint ( QPainter * painter, const QStyleOptionGraphicsItem 
 void QGISectionLine::setTools()
 {
     m_line->setPen(m_pen);
-    QColor currentColor = m_pen.color();
+    m_extend->setPen(m_pen);
 
+    QColor currentColor = m_pen.color();
     m_arrow1->setNormalColor(currentColor);
     m_arrow1->setFillColor(currentColor);
     m_arrow1->setPrettyNormal();
@@ -512,6 +509,14 @@ void QGISectionLine::setTools()
 
     m_symbol1->setDefaultTextColor(currentColor);
     m_symbol2->setDefaultTextColor(currentColor);
+
+    QPen cPointPen{m_pen};
+    cPointPen.setWidthF(m_pen.widthF() * 2);
+    cPointPen.setStyle(Qt::SolidLine);
+
+    for(auto& mark : m_changePointMarks) {
+        mark->setPen(cPointPen);
+    }
 }
 
 

--- a/src/Mod/TechDraw/Gui/QGISectionLine.h
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.h
@@ -56,19 +56,19 @@ public:
 
     void setEnds(Base::Vector3d l1, Base::Vector3d l2);
     void setBounds(double x1, double y1, double x2, double y2);
-    void setPath(QPainterPath& path);
-    void setSymbol(char* sym);
+    void setPath(const QPainterPath& path);
+    void setSymbol(const char* sym);
     void setDirection(double xDir, double yDir);
     void setDirection(Base::Vector3d dir);
     void setArrowDirections(Base::Vector3d dir1, Base::Vector3d dir2);
     void setArrowSize(double arrowSize);
-    void setFont(QFont f);
-    void setFont(QFont f, double fsize);
+    void setFont(const QFont& f);
+    void setFont(const QFont& f, double fsize);
     void setSectionColor(QColor c);
     void setPathMode(bool mode) { m_pathMode = mode; }
     void setShowLine(bool state) { m_showLine = state; }
-    bool pathMode() { return m_pathMode; }
-    void setChangePoints(TechDraw::ChangePointVector changePoints);
+    bool pathMode() const { return m_pathMode; }
+    void setChangePoints(const TechDraw::ChangePointVector &changePoints);
     void clearChangePoints();
     void draw() override;
 


### PR DESCRIPTION
This PR implements a fix for issue #28688.  

Some Pdf viewers treat unset colours (SCN operator without parameters) as black, while others refuse to display the object containing the invalid SCN.  

Under certain conditions, a Section line object could  contain unset colours. This PR ensures that the section line components (cut line, extensions, arrows, etc) always have their colour attribute set. 

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.



