### PR TITLE
(cp) Sketcher: Handle OCC exception in sketcher

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -283,6 +283,25 @@ struct DocumentP
 
     bool tryStartEditing(ViewProviderDocumentObject* svp, App::DocumentObject* sobj, int ModNum)
     {
+        try {
+            return startEditing(svp, sobj, ModNum);
+        }
+        catch (const Base::Exception& e) {
+            FC_ERR("startEditing:" << e.what());
+            return false;
+        }
+        catch (const std::exception& e) {
+            FC_ERR("startEditing:" << e.what());
+            return false;
+        }
+        catch (...) {
+            FC_ERR("startEditing: Unknown C++ exception");
+            return false;
+        }
+    }
+
+    bool startEditing(ViewProviderDocumentObject* svp, App::DocumentObject* sobj, int ModNum)
+    {
         _editingObject = sobj;
         _editMode = ModNum;
         _editViewProvider = svp;  // Used to resolve start editing (find the document in edit from
@@ -604,7 +623,15 @@ bool Document::setEdit(Gui::ViewProvider* p, int ModNum, const char* subname)
         return trySetEdit(p, ModNum, subname);
     }
     catch (const Base::Exception& e) {
-        FC_ERR("" << e.what());
+        FC_ERR("setEdit:" << e.what());
+        return false;
+    }
+    catch (const std::exception& e) {
+        FC_ERR("setEdit:" << e.what());
+        return false;
+    }
+    catch (...) {
+        FC_ERR("setEdit: Unknown C++ exception");
         return false;
     }
 }

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -264,6 +264,14 @@ struct DocumentP
         _editObjs.insert(sobjs.begin(), sobjs.end());
     }
 
+    void resetFailedEditing()
+    {
+        _editViewProvider = nullptr;
+        _editViewProviderParent = nullptr;
+        _editObjs.clear();
+        _editingObject = nullptr;
+    }
+
     bool tryStartEditing(
         ViewProviderDocumentObject* vp,
         App::DocumentObject* obj,
@@ -287,14 +295,17 @@ struct DocumentP
             return startEditing(svp, sobj, ModNum);
         }
         catch (const Base::Exception& e) {
+            resetFailedEditing();
             FC_ERR("startEditing:" << e.what());
             return false;
         }
         catch (const std::exception& e) {
+            resetFailedEditing();
             FC_ERR("startEditing:" << e.what());
             return false;
         }
         catch (...) {
+            resetFailedEditing();
             FC_ERR("startEditing: Unknown C++ exception");
             return false;
         }
@@ -308,9 +319,7 @@ struct DocumentP
                                   // within the viewprovider)
         _editViewProvider = svp->startEditing(ModNum);
         if (!_editViewProvider) {
-            _editViewProviderParent = nullptr;
-            _editObjs.clear();
-            _editingObject = nullptr;
+            resetFailedEditing();
             FC_LOG("object '" << sobj->getFullName() << "' refuse to edit");
             return false;
         }

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -4663,6 +4663,11 @@ bool Sketch::updateGeometry()
             Base::Console().error("Updating geometry: Error build geometry(%d): %s\n", i, e.what());
             return false;
         }
+        catch (const Standard_Failure& e) {
+            Base::Console()
+                .error("Updating geometry: Error build geometry(%d): %s\n", i, e.GetMessageString());
+            return false;
+        }
     }
     return true;
 }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -4301,11 +4301,19 @@ bool ViewProviderSketch::setEdit(int ModNum)
     // In order to have updated solver information, solve must take "true", this cause the Geometry
     // property to be updated with the solver information, including solver extensions, and triggers
     // a draw(true) via ViewProvider::UpdateData.
-    getSketchObject()->solve(true);
+    try {
+        getSketchObject()->solve(true);
 
-    // Enable solver initial solution update while dragging.
-    getSketchObject()->setRecalculateInitialSolutionWhileMovingPoint(
-        viewProviderParameters.recalculateInitialSolutionWhileDragging);
+        // Enable solver initial solution update while dragging.
+        getSketchObject()->setRecalculateInitialSolutionWhileMovingPoint(
+            viewProviderParameters.recalculateInitialSolutionWhileDragging);
+    }
+    catch (const Base::Exception& e) {
+        e.reportException();
+    }
+    catch (const Standard_Failure& e) {
+        Base::Console().error("ViewProviderSketch::setEdit: %s\n", e.GetMessageString());
+    }
 
     // intercept del key press from main app
     listener = std::make_unique<ShortcutListener>(this);


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Cherry-picked from https://codeberg.org/xwzCAD/FreeCAD/pulls/287

Avoid that when editing an object raises an exception it doesn't slip through GUIApplication::notify which may
crash the application and make sure that the document name is set to the opened task dialog.

Handle OCC exceptions in the sketcher when updating the geometry.

Fixes https://github.com/FreeCAD/FreeCAD/issues/30867