### PR TITLE
(cp) Gui: Check for SuppressibleExtension of selection

### DIFF
--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -2178,11 +2178,15 @@ Command* CommandManager::getCommandByName(const char* sName) const
     return (it != _sCommands.end()) ? it->second : 0;
 }
 
-void CommandManager::runCommandByName(const char* sName) const
+bool CommandManager::isActive(const char* sName) const
 {
     Command* pCmd = getCommandByName(sName);
+    return pCmd && pCmd->isActive();
+}
 
-    if (pCmd) {
+void CommandManager::runCommandByName(const char* sName) const
+{
+    if (Command* pCmd = getCommandByName(sName)) {
         pCmd->invoke(0);
     }
 }

--- a/src/Gui/Command.h
+++ b/src/Gui/Command.h
@@ -1010,6 +1010,12 @@ public:
      */
     Command* getCommandByName(const char* sName) const;
 
+    /** Returns true if the command exists and is active.
+     *  If the command doesn't exist or is inactive false
+     *  is returned.
+     */
+    bool isActive(const char* sName) const;
+
     /**
      * Runs the command
      */

--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -254,11 +254,11 @@ void StdCmdToggleSuppress::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
 
-    std::vector<Gui::SelectionSingleton::SelObj> sels = Gui::Selection().getCompleteSelection();
+    auto sels = Gui::Selection().getCompleteSelection();
 
     Command::openCommand(QT_TRANSLATE_NOOP("Command", "Toggle suppress"));
-    for (Gui::SelectionSingleton::SelObj& sel : sels) {
-        if (App::DocumentObject* obj = sel.pObject) {
+    for (auto& sel : sels) {
+        if (auto* obj = sel.pObject) {
             if (auto ext = obj->getExtensionByType<App::SuppressibleExtension>(true)) {
                 if (ext && !ext->Suppressed.testStatus(App::Property::Hidden)) {
                     ext->Suppressed.setValue(!ext->Suppressed.getValue());
@@ -271,17 +271,16 @@ void StdCmdToggleSuppress::activated(int iMsg)
 
 bool StdCmdToggleSuppress::isActive()
 {
-    std::vector<Gui::SelectionSingleton::SelObj> sels = Gui::Selection().getCompleteSelection();
-    for (Gui::SelectionSingleton::SelObj& sel : sels) {
-        if (App::DocumentObject* obj = sel.pObject) {
-            if (auto ext = obj->getExtensionByType<App::SuppressibleExtension>(true)) {
-                if (ext && !ext->Suppressed.testStatus(App::Property::Hidden)) {
-                    return true;
-                }
-            }
+    auto sels = Gui::Selection().getCompleteSelection();
+    return std::any_of(sels.begin(), sels.end(), [](const auto& sel) {
+        auto* obj = sel.pObject;
+        if (!obj) {
+            return false;
         }
-    }
-    return false;
+
+        auto ext = obj->template getExtensionByType<App::SuppressibleExtension>(true);
+        return ext && !ext->Suppressed.testStatus(App::Property::Hidden);
+    });
 }
 
 

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -660,25 +660,15 @@ void StdWorkbench::setupContextMenu(const char* recipient, MenuItem* item) const
     }
     else if (strcmp(recipient, "Tree") == 0) {
         if (!sels.empty()) {
-            bool hasSuppressible
-                = std::any_of(sels.begin(), sels.end(), [](const SelectionSingleton::SelObj& sel) {
-                      App::DocumentObject* obj = sel.pObject;
-                      if (!obj) {
-                          return false;
-                      }
-                      auto ext = obj->getExtensionByType<App::SuppressibleExtension>(true);
-                      return ext && !ext->Suppressed.testStatus(App::Property::Hidden);
-                  });
-            if (hasSuppressible) {
+            const CommandManager& cmd = Application::Instance->commandManager();
+            if (cmd.isActive("Std_ToggleSuppress")) {
                 *item << "Std_ToggleSuppress";
             }
             *item << "Std_ToggleFreeze" << "Separator"
-                  << "Std_ToggleVisibility" << "Std_ShowSelection"
-                  << "Std_HideSelection"
+                  << "Std_ToggleVisibility" << "Std_ShowSelection" << "Std_HideSelection"
                   << "Std_ToggleSelectability" << "Std_TreeSelectAllInstances" << "Separator"
-                  << "Std_RandomColor" << "Std_ToggleTransparency" << "Separator"
-                  << "Std_Cut" << "Std_Copy" << "Std_Paste" << "Std_Delete"
-                  << "Std_SendToPythonConsole";
+                  << "Std_RandomColor" << "Std_ToggleTransparency" << "Separator" << "Std_Cut"
+                  << "Std_Copy" << "Std_Paste" << "Std_Delete" << "Std_SendToPythonConsole";
         }
     }
 


### PR DESCRIPTION
Cherry-picked from https://codeberg.org/xwzCAD/FreeCAD/pulls/285

In StdCmdToggleSuppress::isActive() check if one of the selected objects
has the SuppressibleExtension

Only add StdCmdToggleSuppress to the context menu if it's active

Example:

1. Create a Part box
2. In the context-menu the "Toggle suppressed" command is shown
3. But the Part box doesn't have the SuppressibleExtension.

