### PR TITLE
(cp) Gui: Add method getTypeId() to MDIViewPy

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -76,6 +76,7 @@
 #include "CommandActionPy.h"
 #include "CommandPy.h"
 #include "Control.h"
+#include "Dialogs/DlgAbout.h"
 #include "PreferencePages/DlgSettingsCacheDirectory.h"
 #include "DocumentPy.h"
 #include "DocumentRecovery.h"
@@ -97,6 +98,7 @@
 #include "PythonConsolePy.h"
 #include "MainWindowPy.h"
 #include "MDIViewPy.h"
+#include "MDIViewPyWrap.h"
 #include "MDIViewWithCamera.h"
 #include "Placement.h"
 #include "SoFCDB.h"
@@ -2387,6 +2389,7 @@ void Application::initTypes()
     // views
     Gui::BaseView                               ::init();
     Gui::MDIView                                ::init();
+    Gui::MDIViewPyWrap                          ::init();
     Gui::MDIViewWithCamera						::init();
     Gui::View3DInventor                         ::init();
     Gui::AbstractSplitView                      ::init();
@@ -2396,6 +2399,7 @@ void Application::initTypes()
     Gui::PythonEditorView                       ::init();
     Gui::ImageView                              ::init();
     Gui::GraphvizView                           ::init();
+    Gui::Dialog::LicenseView                    ::init();
     // View Provider
     Gui::ViewProvider                           ::init();
     Gui::ViewProviderExtension                  ::init();

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -83,9 +83,11 @@
 #include "EditorView.h"
 #include "ExpressionBindingPy.h"
 #include "FileDialog.h"
+#include "GraphvizView.h"
 #include "GuiApplication.h"
 #include "GuiInitScript.h"
 #include "GuiTestScript.h"
+#include "ImageView.h"
 #include "InputHintPy.h"
 #include "LinkViewPy.h"
 #include "MainWindow.h"
@@ -2389,6 +2391,8 @@ void Application::initTypes()
     Gui::TextDocumentEditorView                 ::init();
     Gui::EditorView                             ::init();
     Gui::PythonEditorView                       ::init();
+    Gui::ImageView                              ::init();
+    Gui::GraphvizView                           ::init();
     // View Provider
     Gui::ViewProvider                           ::init();
     Gui::ViewProviderExtension                  ::init();

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -83,9 +83,11 @@
 #include "EditorView.h"
 #include "ExpressionBindingPy.h"
 #include "FileDialog.h"
+#include "GraphvizView.h"
 #include "GuiApplication.h"
 #include "GuiInitScript.h"
 #include "GuiTestScript.h"
+#include "ImageView.h"
 #include "InputHintPy.h"
 #include "LinkViewPy.h"
 #include "MainWindow.h"
@@ -2392,6 +2394,8 @@ void Application::initTypes()
     Gui::TextDocumentEditorView                 ::init();
     Gui::EditorView                             ::init();
     Gui::PythonEditorView                       ::init();
+    Gui::ImageView                              ::init();
+    Gui::GraphvizView                           ::init();
     // View Provider
     Gui::ViewProvider                           ::init();
     Gui::ViewProviderExtension                  ::init();

--- a/src/Gui/Dialogs/DlgAbout.cpp
+++ b/src/Gui/Dialogs/DlgAbout.cpp
@@ -61,6 +61,8 @@ using namespace Gui;
 using namespace Gui::Dialog;
 namespace fs = std::filesystem;
 
+TYPESYSTEM_SOURCE_ABSTRACT(Gui::Dialog::LicenseView, Gui::MDIView)  // NOLINT
+
 // ------------------------------------------------------------------------------
 
 AboutDialogFactory* AboutDialogFactory::factory = nullptr;

--- a/src/Gui/Dialogs/DlgAbout.h
+++ b/src/Gui/Dialogs/DlgAbout.h
@@ -54,6 +54,7 @@ private:
 class GuiExport LicenseView: public Gui::MDIView
 {
     Q_OBJECT
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();  // NOLINT
 
 public:
     explicit LicenseView(QWidget* parent = nullptr);

--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -228,6 +228,8 @@ void GraphvizGraphicsView::mouseReleaseEvent(QMouseEvent* e)
 
 /* TRANSLATOR Gui::GraphvizView */
 
+TYPESYSTEM_SOURCE_ABSTRACT(Gui::GraphvizView, Gui::MDIView)  // NOLINT
+
 GraphvizView::GraphvizView(App::Document& _doc, QWidget* parent)
     : MDIView(nullptr, parent)
     , doc(_doc)

--- a/src/Gui/GraphvizView.h
+++ b/src/Gui/GraphvizView.h
@@ -40,6 +40,7 @@ class GraphvizWorker;
 class GuiExport GraphvizView: public MDIView
 {
     Q_OBJECT
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();  // NOLINT
 
 public:
     explicit GraphvizView(App::Document& _doc, QWidget* parent = nullptr);

--- a/src/Gui/ImageView.cpp
+++ b/src/Gui/ImageView.cpp
@@ -46,6 +46,8 @@
 
 using namespace Gui;
 
+TYPESYSTEM_SOURCE_ABSTRACT(Gui::ImageView, Gui::MDIView)  // NOLINT
+
 ImageView::ImageView(QWidget* parent)
     : MDIView(nullptr, parent)
     , imageLabel(new QLabel)

--- a/src/Gui/ImageView.h
+++ b/src/Gui/ImageView.h
@@ -37,6 +37,7 @@ namespace Gui
 class GuiExport ImageView: public MDIView
 {
     Q_OBJECT
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();  // NOLINT
 
 public:
     explicit ImageView(QWidget* parent);

--- a/src/Gui/MDIViewPy.cpp
+++ b/src/Gui/MDIViewPy.cpp
@@ -65,6 +65,7 @@ void MDIViewPy::init_type()
         "getActiveObject(name,resolve=True)\nreturns the active object for the given type"
     );
     add_varargs_method("cast_to_base", &MDIViewPy::cast_to_base, "cast_to_base() cast to MDIView class");
+    add_varargs_method("getTypeId", &MDIViewPy::getTypeId, "getTypeId() returns type id as string");
     behaviors().readyType();
 }
 
@@ -332,6 +333,20 @@ Py::Object MDIViewPy::getActiveObject(const Py::Tuple& args)
 
     return Py::TupleN(Py::None(), Py::None(), Py::String());
     // NOLINTEND(cppcoreguidelines-slicing)
+}
+
+Py::Object MDIViewPy::getTypeId(const Py::Tuple& args)
+{
+    if (!PyArg_ParseTuple(args.ptr(), "")) {
+        throw Py::Exception();
+    }
+
+    Base::Type type;
+    if (_view) {
+        type = _view->getTypeId();
+    }
+
+    return Base::toPyString(type.getName());
 }
 
 Py::Object MDIViewPy::cast_to_base(const Py::Tuple&)

--- a/src/Gui/MDIViewPy.cpp
+++ b/src/Gui/MDIViewPy.cpp
@@ -64,6 +64,7 @@ void MDIViewPy::init_type()
         "getActiveObject(name,resolve=True)\nreturns the active object for the given type"
     );
     add_varargs_method("cast_to_base", &MDIViewPy::cast_to_base, "cast_to_base() cast to MDIView class");
+    add_varargs_method("getTypeId", &MDIViewPy::getTypeId, "getTypeId() returns type id as string");
     behaviors().readyType();
 }
 
@@ -314,6 +315,20 @@ Py::Object MDIViewPy::getActiveObject(const Py::Tuple& args)
 
     return Py::TupleN(Py::None(), Py::None(), Py::String());
     // NOLINTEND(cppcoreguidelines-slicing)
+}
+
+Py::Object MDIViewPy::getTypeId(const Py::Tuple& args)
+{
+    if (!PyArg_ParseTuple(args.ptr(), "")) {
+        throw Py::Exception();
+    }
+
+    Base::Type type;
+    if (_view) {
+        type = _view->getTypeId();
+    }
+
+    return Base::toPyString(type.getName());
 }
 
 Py::Object MDIViewPy::cast_to_base(const Py::Tuple&)

--- a/src/Gui/MDIViewPy.h
+++ b/src/Gui/MDIViewPy.h
@@ -68,6 +68,7 @@ public:
     Py::Object setActiveObject(const Py::Tuple&);
     Py::Object getActiveObject(const Py::Tuple&);
     Py::Object cast_to_base(const Py::Tuple&);
+    Py::Object getTypeId(const Py::Tuple&);
 
     MDIView* getMDIViewPtr()
     {

--- a/src/Gui/MDIViewPy.h
+++ b/src/Gui/MDIViewPy.h
@@ -67,6 +67,7 @@ public:
     Py::Object setActiveObject(const Py::Tuple&);
     Py::Object getActiveObject(const Py::Tuple&);
     Py::Object cast_to_base(const Py::Tuple&);
+    Py::Object getTypeId(const Py::Tuple&);
 
     MDIView* getMDIViewPtr()
     {

--- a/src/Mod/CAM/PathSimulator/AppGL/AppCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/AppCAMSimulator.cpp
@@ -28,6 +28,7 @@
 
 #include "CAMSim.h"
 #include "CAMSimPy.h"
+#include "ViewCAMSimulator.h"
 
 
 namespace CAMSimulator
@@ -81,6 +82,7 @@ PyMOD_INIT_FUNC(CAMSimulator)
     // call PyType_Ready, otherwise we run into a segmentation fault, later on.
     // This function is responsible for adding inherited slots from a type's base class.
     CAMSimulator::CAMSim::init();
+    CAMSimulator::ViewCAMSimulator::init();
 
     PyMOD_Return(mod);
 }

--- a/src/Mod/CAM/PathSimulator/AppGL/ViewCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/ViewCAMSimulator.cpp
@@ -53,6 +53,8 @@ using namespace Gui;
 namespace CAMSimulator
 {
 
+TYPESYSTEM_SOURCE_ABSTRACT(CAMSimulator::ViewCAMSimulator, Gui::MDIViewWithCamera)
+
 static QPointer<ViewCAMSimulator> viewCAMSimulator;
 
 ViewCAMSimulator::ViewCAMSimulator(Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wflags)

--- a/src/Mod/CAM/PathSimulator/AppGL/ViewCAMSimulator.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/ViewCAMSimulator.h
@@ -43,6 +43,8 @@ class CAMSettings;
 
 class ViewCAMSimulator: public Gui::MDIViewWithCamera
 {
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();
+
 public:
     ViewCAMSimulator(
         Gui::Document* pcDocument,

--- a/src/Mod/Start/Gui/AppStartGui.cpp
+++ b/src/Mod/Start/Gui/AppStartGui.cpp
@@ -133,6 +133,7 @@ PyMOD_INIT_FUNC(StartGui)
     auto manipulator = std::make_shared<StartGui::Manipulator>();
     Gui::WorkbenchManipulator::installManipulator(manipulator);
     loadStartResource();
+    StartGui::StartView::init();
     Base::Console().log("done\n");
 
     // register preferences pages

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -26,6 +26,7 @@ SET(Test_SRCS
     TestPerf.py
     TestTreeSelection.py
     TestGraphicsViewWrapping.py
+    TestMDIView.py
     TestRubberbandSelection.py
     TestCoinNodeSnapshots.py
     TestView3DFramebufferCapture.py

--- a/src/Mod/Test/InitGui.py
+++ b/src/Mod/Test/InitGui.py
@@ -99,6 +99,7 @@ FreeCAD.__unit_test__ += [
     "Menu.MenuCreateCases",
     "GuiDocument",
     "TestGraphicsViewWrapping",
+    "TestMDIView",
     "TestRubberbandSelection",
     "TestSelectionVisual",
     "TestCornerAxisCrossVisual",

--- a/src/Mod/Test/TestMDIView.py
+++ b/src/Mod/Test/TestMDIView.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 FreeCAD contributors
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+"""GUI regression tests for MDI view type IDs.
+
+To run tests:
+    FreeCAD -t TestMDIView.TestMDIView
+"""
+
+import unittest
+
+import FreeCAD
+import FreeCADGui
+from PySide6 import QtWidgets
+
+
+class PythonView:
+    def __init__(self):
+        self._widget = QtWidgets.QWidget()
+
+    def widget(self):
+        return self._widget
+
+
+class TestMDIView(unittest.TestCase):
+    def setUp(self):
+        self.doc = FreeCAD.newDocument("TestMDIView")
+        FreeCADGui.ActiveDocument = FreeCADGui.getDocument(self.doc.Name)
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.doc.Name)
+
+    def test_3d_view_type_id(self):
+        view = FreeCADGui.ActiveDocument.ActiveView
+
+        self.assertEqual(view.getTypeId(), "Gui::View3DInventor")
+
+    def test_python_view_type_id(self):
+        main_window = FreeCADGui.getMainWindow()
+        view = main_window.addWindow(PythonView())
+
+        try:
+            self.assertEqual(view.getTypeId(), "Gui::MDIViewPyWrap")
+        finally:
+            main_window.removeWindow(view)


### PR DESCRIPTION
Cherry-picked from https://codeberg.org/xwzCAD/FreeCAD/pulls/284

Add all MDI view classes to type system
This allows it in Python code check the type of e.g. the active MDI view.