### PR TITLE
Add missing tooltips to Part preferences

### DIFF
--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -424,7 +424,7 @@
          <string>Enable coarse snapping while dragging</string>
         </property>
         <property name="toolTip">
-         <string>Enables larger snapping increments while dragging objects</string>
+         <string>Enables larger snapping increments while  manipulating draggers</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -448,9 +448,9 @@
         </item>
         <item>
          <widget class="Gui::PrefComboBox" name="fineSnapModifier">
-         <property name="toolTip">
-          <string>Defines the modifier key used for fine snapping while dragging</string>
-         </property>
+          <property name="toolTip">
+           <string>Defines the modifier key used for fine snapping while dragging</string>
+          </property>
           <property name="prefEntry" stdset="0">
            <cstring>FineSnapModifier</cstring>
           </property>
@@ -512,7 +512,7 @@
            <number>5</number>
           </property>
           <property name="toolTip">
-           <string>Sets the multiplier for coarse linear movement while dragging</string>
+           <string>Multiplies the base movement increment when coarse snapping is active</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>CoarseLinearSnapMultiplier</cstring>
@@ -545,7 +545,7 @@
            <number>5</number>
           </property>
           <property name="toolTip">
-           <string>Sets the multiplier for coarse rotation steps while dragging</string>
+          <string>Sets the rotation step in degrees applied when coarse snapping is active</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>CoarseRotationSnapMultiplier</cstring>

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -423,6 +423,9 @@
         <property name="text">
          <string>Enable coarse snapping while dragging</string>
         </property>
+        <property name="toolTip">
+         <string>Enables larger snapping increments while dragging objects.</string>
+        </property>
         <property name="checked">
          <bool>true</bool>
         </property>
@@ -445,6 +448,9 @@
         </item>
         <item>
          <widget class="Gui::PrefComboBox" name="fineSnapModifier">
+         <property name="toolTip">
+          <string>Defines the modifier key used for fine snapping while dragging.</string>
+         </property>
           <property name="prefEntry" stdset="0">
            <cstring>FineSnapModifier</cstring>
           </property>
@@ -505,6 +511,9 @@
           <property name="value">
            <number>5</number>
           </property>
+          <property name="toolTip">
+           <string>Sets the multiplier for coarse linear movement while dragging.</string>
+          </property>
           <property name="prefEntry" stdset="0">
            <cstring>CoarseLinearSnapMultiplier</cstring>
           </property>
@@ -534,6 +543,9 @@
           </property>
           <property name="value">
            <number>5</number>
+          </property>
+          <property name="toolTip">
+           <string>Sets the multiplier for coarse rotation steps while dragging.</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>CoarseRotationSnapMultiplier</cstring>

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -424,7 +424,7 @@
          <string>Enable coarse snapping while dragging</string>
         </property>
         <property name="toolTip">
-         <string>Enables larger snapping increments while dragging objects.</string>
+         <string>Enables larger snapping increments while dragging objects</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -449,7 +449,7 @@
         <item>
          <widget class="Gui::PrefComboBox" name="fineSnapModifier">
          <property name="toolTip">
-          <string>Defines the modifier key used for fine snapping while dragging.</string>
+          <string>Defines the modifier key used for fine snapping while dragging</string>
          </property>
           <property name="prefEntry" stdset="0">
            <cstring>FineSnapModifier</cstring>
@@ -512,7 +512,7 @@
            <number>5</number>
           </property>
           <property name="toolTip">
-           <string>Sets the multiplier for coarse linear movement while dragging.</string>
+           <string>Sets the multiplier for coarse linear movement while dragging</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>CoarseLinearSnapMultiplier</cstring>
@@ -545,7 +545,7 @@
            <number>5</number>
           </property>
           <property name="toolTip">
-           <string>Sets the multiplier for coarse rotation steps while dragging.</string>
+           <string>Sets the multiplier for coarse rotation steps while dragging</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>CoarseRotationSnapMultiplier</cstring>


### PR DESCRIPTION
Added missing explanatory tooltips to widgets in the Part preferences General page.

This improves consistency with other FreeCAD preference pages and helps users understand the purpose of each setting.

Assisted-by: GPT-5.5-mini

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Before and After Images

Before:
(no tooltip shown)

After:
(tooltips are displayed when hovering over the settings)