### PR TITLE
BIM: make nudge values depend on unit system and fix tooltip

### DIFF
--- a/src/Mod/BIM/BimStatus.py
+++ b/src/Mod/BIM/BimStatus.py
@@ -36,32 +36,54 @@ translate = FreeCAD.Qt.translate
 # Status bar buttons
 
 
+def _get_nudge_tooltip():
+    "create nudge tooltip with correct shortcuts"
+
+    nudge_commands = [
+        "BIM_Nudge_Up",
+        "BIM_Nudge_Down",
+        "BIM_Nudge_Left",
+        "BIM_Nudge_Right",
+        "BIM_Nudge_RotateLeft",
+        "BIM_Nudge_RotateRight",
+        "BIM_Nudge_Extend",
+        "BIM_Nudge_Shrink",
+        "BIM_Nudge_Switch",
+    ]
+    shortcuts = {}
+    for nudge_command in nudge_commands:
+        shortcut = FreeCADGui.CommandAction(nudge_command).getCommand().getShortcut()
+        if not shortcut:
+            shortcut = "?"
+        shortcuts[nudge_command] = shortcut
+    return translate(
+        "BIM",
+        "The value of the nudge movement (rotation is always 45°)."
+        "\nNudge shortcuts:"
+        f"\n{shortcuts['BIM_Nudge_Up']} to move up, "
+        f"{shortcuts['BIM_Nudge_Down']} to move down."
+        f"\n{shortcuts['BIM_Nudge_Left']} to move left, "
+        f"{shortcuts['BIM_Nudge_Right']} to move right."
+        f"\n{shortcuts['BIM_Nudge_RotateLeft']} to rotate left, "
+        f"{shortcuts['BIM_Nudge_RotateRight']} to rotate right."
+        f"\n{shortcuts['BIM_Nudge_Extend']} to extend height, "
+        f"{shortcuts['BIM_Nudge_Shrink']} to shrink height."
+        f"\n{shortcuts['BIM_Nudge_Switch']} to switch between auto and manual mode.",
+    )
+
+
 def setStatusIcons(show=True):
     "shows or hides the BIM icons in the status bar"
 
     import FreeCADGui
     from PySide import QtCore, QtGui
+    from bimcommands import BimNudge
 
-    nudgeLabelsI = [
-        translate("BIM", "Custom…"),
-        '1/16"',
-        '1/8"',
-        '1/4"',
-        '1"',
-        '6"',
-        "1'",
-        translate("BIM", "Auto"),
-    ]
-    nudgeLabelsM = [
-        translate("BIM", "Custom…"),
-        "1 mm",
-        "5 mm",
-        "1 cm",
-        "5 cm",
-        "10 cm",
-        "50 cm",
-        translate("BIM", "Auto"),
-    ]
+    nudgeLabels = (
+        [translate("BIM", "Custom…")]
+        + BimNudge._NUDGE_DISTANCES_STRINGS
+        + [translate("BIM", "Auto")]
+    )
 
     def toggleBimViews(state):
         FreeCADGui.runCommand("BIM_Views")
@@ -71,7 +93,7 @@ def setStatusIcons(show=True):
 
     def setNudge(action):
         utext = action.text().replace("&", "")
-        if utext == nudgeLabelsM[0]:
+        if utext == nudgeLabels[0]:
             # load dialog
             form = FreeCADGui.PySideUic.loadUi(":/ui/dialogNudgeValue.ui")
             # center the dialog over FreeCAD window
@@ -150,31 +172,20 @@ def setStatusIcons(show=True):
                     ifc_status.set_status_widget(statuswidget)
 
                 # nudge button
-                nudge = QtGui.QPushButton(nudgeLabelsM[-1])
+                nudge = QtGui.QPushButton(nudgeLabels[-1])
                 nudge.setIcon(QtGui.QIcon(":/icons/BIM_Nudge.svg"))
                 nudge.setFlat(True)
-                nudge.setToolTip(
-                    translate(
-                        "BIM",
-                        "The value of the nudge movement (rotation is always 45°)."
-                        "Alt+arrows to move\nAlt+, to rotate left"
-                        "Alt+. to rotate right\nAlt+PgUp to extend extrusion"
-                        "Alt+PgDown to shrink extrusion"
-                        "Alt+/ to switch between auto and manual mode",
-                    )
-                )
+                nudge.setToolTip(_get_nudge_tooltip())
                 statuswidget.addWidget(nudge)
                 statuswidget.nudge = nudge
                 menu = QtGui.QMenu(nudge)
                 gnudge = QtGui.QActionGroup(menu)
-                for u in nudgeLabelsM:
+                for u in nudgeLabels:
                     a = QtGui.QAction(gnudge)
                     a.setText(u)
                     menu.addAction(a)
                 nudge.setMenu(menu)
                 gnudge.triggered.connect(setNudge)
-                statuswidget.nudgeLabelsI = nudgeLabelsI
-                statuswidget.nudgeLabelsM = nudgeLabelsM
                 statuswidget.show()
 
         else:

--- a/src/Mod/BIM/BimStatus.py
+++ b/src/Mod/BIM/BimStatus.py
@@ -98,10 +98,11 @@ def setStatusIcons(show=True):
             # center the dialog over FreeCAD window
             mw = FreeCADGui.getMainWindow()
             form.move(mw.frameGeometry().topLeft() + mw.rect().center() - form.rect().center())
+            form.spinBox.setProperty("rawValue", BimNudge.BIM_Nudge().getNudgeValue("dist"))
             result = form.exec_()
             if not result:
                 return
-            utext = form.inputField.text()
+            utext = form.spinBox.text()
         action.parent().parent().parent().setText(utext)
 
     # main code

--- a/src/Mod/BIM/BimStatus.py
+++ b/src/Mod/BIM/BimStatus.py
@@ -50,26 +50,25 @@ def _get_nudge_tooltip():
         "BIM_Nudge_Shrink",
         "BIM_Nudge_Switch",
     ]
-    shortcuts = {}
+    shortcuts = []
     for nudge_command in nudge_commands:
         shortcut = FreeCADGui.CommandAction(nudge_command).getCommand().getShortcut()
-        if not shortcut:
-            shortcut = "?"
-        shortcuts[nudge_command] = shortcut
-    return translate(
+        shortcuts.append(shortcut if shortcut else "?")
+
+    #: BIM: tooltip for the status bar nudge widget, %1-%9 are keyboard shortcuts
+    tooltip = translate(
         "BIM",
-        "The value of the nudge movement (rotation is always 45°)."
-        "\nNudge shortcuts:"
-        f"\n{shortcuts['BIM_Nudge_Up']} to move up, "
-        f"{shortcuts['BIM_Nudge_Down']} to move down."
-        f"\n{shortcuts['BIM_Nudge_Left']} to move left, "
-        f"{shortcuts['BIM_Nudge_Right']} to move right."
-        f"\n{shortcuts['BIM_Nudge_RotateLeft']} to rotate left, "
-        f"{shortcuts['BIM_Nudge_RotateRight']} to rotate right."
-        f"\n{shortcuts['BIM_Nudge_Extend']} to extend height, "
-        f"{shortcuts['BIM_Nudge_Shrink']} to shrink height."
-        f"\n{shortcuts['BIM_Nudge_Switch']} to switch between auto and manual mode.",
+        "The value of the nudge movement (rotation is always 45°).\n"
+        "Nudge shortcuts:\n"
+        "%1 to move up, %2 to move down.\n"
+        "%3 to move left, %4 to move right.\n"
+        "%5 to rotate left, %6 to rotate right.\n"
+        "%7 to extend height, %8 to shrink height.\n"
+        "%9 to switch between auto and manual mode.",
     )
+    for index, shortcut in enumerate(shortcuts, start=1):
+        tooltip = tooltip.replace(f"%{index}", shortcut)
+    return tooltip
 
 
 def setStatusIcons(show=True):

--- a/src/Mod/BIM/BimStatus.py
+++ b/src/Mod/BIM/BimStatus.py
@@ -78,12 +78,6 @@ def setStatusIcons(show=True):
     from PySide import QtCore, QtGui
     from bimcommands import BimNudge
 
-    nudgeLabels = (
-        [translate("BIM", "Custom…")]
-        + BimNudge._NUDGE_DISTANCES_STRINGS
-        + [translate("BIM", "Auto")]
-    )
-
     def toggleBimViews(state):
         FreeCADGui.runCommand("BIM_Views")
 
@@ -92,7 +86,7 @@ def setStatusIcons(show=True):
 
     def setNudge(action):
         utext = action.text().replace("&", "")
-        if utext == nudgeLabels[0]:
+        if utext == translate("BIM", "Custom…"):
             # load dialog
             form = FreeCADGui.PySideUic.loadUi(":/ui/dialogNudgeValue.ui")
             # center the dialog over FreeCAD window
@@ -172,7 +166,7 @@ def setStatusIcons(show=True):
                     ifc_status.set_status_widget(statuswidget)
 
                 # nudge button
-                nudge = QtGui.QPushButton(nudgeLabels[-1])
+                nudge = QtGui.QPushButton(translate("BIM", "Auto"))
                 nudge.setIcon(QtGui.QIcon(":/icons/BIM_Nudge.svg"))
                 nudge.setFlat(True)
                 nudge.setToolTip(_get_nudge_tooltip())
@@ -180,10 +174,21 @@ def setStatusIcons(show=True):
                 statuswidget.nudge = nudge
                 menu = QtGui.QMenu(nudge)
                 gnudge = QtGui.QActionGroup(menu)
-                for u in nudgeLabels:
-                    a = QtGui.QAction(gnudge)
-                    a.setText(u)
-                    menu.addAction(a)
+
+                def updateNudgeMenu():
+                    menu.clear()
+                    labels = (
+                        [translate("BIM", "Custom…")]
+                        + [label for label, _quantity in BimNudge.get_nudge_presets()]
+                        + [translate("BIM", "Auto")]
+                    )
+                    for label in labels:
+                        action = QtGui.QAction(gnudge)
+                        action.setText(label)
+                        menu.addAction(action)
+
+                updateNudgeMenu()
+                menu.aboutToShow.connect(updateNudgeMenu)
                 nudge.setMenu(menu)
                 gnudge.triggered.connect(setNudge)
                 statuswidget.show()

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -269,6 +269,7 @@ SET(bimtests_SRCS
     bimtests/TestArchStairsGui.py
     bimtests/TestArchReport.py
     bimtests/TestArchReportGui.py
+    bimtests/TestBimNudgeGui.py
 )
 
 set(bimtests_FIXTURES

--- a/src/Mod/BIM/Resources/ui/dialogNudgeValue.ui
+++ b/src/Mod/BIM/Resources/ui/dialogNudgeValue.ui
@@ -23,9 +23,9 @@
    </item>
    <item>
     <widget class="Gui::QuantitySpinBox" name="spinBox">
-        <property name="unit" stdset="0">
-         <string notr="true">mm</string>
-        </property>
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
+     </property>
     </widget>
    </item>
    <item>

--- a/src/Mod/BIM/Resources/ui/dialogNudgeValue.ui
+++ b/src/Mod/BIM/Resources/ui/dialogNudgeValue.ui
@@ -22,10 +22,10 @@
     </widget>
    </item>
    <item>
-    <widget class="Gui::InputField" name="inputField">
-     <property name="unit" stdset="0">
-      <string notr="true"/>
-     </property>
+    <widget class="Gui::QuantitySpinBox" name="spinBox">
+        <property name="unit" stdset="0">
+         <string notr="true">mm</string>
+        </property>
     </widget>
    </item>
    <item>
@@ -40,13 +40,6 @@
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>Gui::InputField</class>
-   <extends>QLineEdit</extends>
-   <header>Gui/InputField.h</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/src/Mod/BIM/TestArchGui.py
+++ b/src/Mod/BIM/TestArchGui.py
@@ -27,6 +27,7 @@
 from bimtests.TestArchImportersGui import TestArchImportersGui
 from bimtests.TestArchAxisGui import TestArchAxisGui
 from bimtests.TestArchBuildingPartGui import TestArchBuildingPartGui
+from bimtests.TestBimTrimexGui import TestBimTrimexGui
 from bimtests.TestArchStairsGui import TestArchStairsGui
 from bimtests.TestArchReportGui import TestArchReportGui
 from bimtests.TestArchSiteGui import TestArchSiteGui
@@ -34,3 +35,4 @@ from bimtests.TestArchWallGui import TestArchWallGui
 from bimtests.TestArchWindowGui import TestArchWindowGui
 from bimtests.TestWebGLExportGui import TestWebGLExportGui
 from bimtests.TestArchCoveringGui import TestArchCoveringGui
+from bimtests.TestBimNudgeGui import TestBimNudgeGui

--- a/src/Mod/BIM/bimcommands/BimNudge.py
+++ b/src/Mod/BIM/bimcommands/BimNudge.py
@@ -31,6 +31,16 @@ QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
 translate = FreeCAD.Qt.translate
 
 
+if FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Units").GetInt(
+    "UserSchema", 0
+) in [2, 3, 5, 7]:
+    _NUDGE_DISTANCES = [1.5875, 3.175, 6.35, 25.4, 152.4, 304.8]
+    _NUDGE_DISTANCES_STRINGS = ['1/16"', '1/8"', '1/4"', '1"', '6"', "1'"]
+else:
+    _NUDGE_DISTANCES = [1, 5, 10, 50, 100, 500]
+    _NUDGE_DISTANCES_STRINGS = ["1 mm", "5 mm", "1 cm", "5 cm", "10 cm", "50 cm"]
+
+
 class BIM_Nudge:
     # base class for the different nudge commands
 
@@ -48,30 +58,23 @@ class BIM_Nudge:
                 nudgeValue = statuswidget.nudge.text().replace("&", "")
                 dist = 0
                 if "auto" in nudgeValue.lower():
-                    unit = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Units").GetInt(
-                        "UserSchema", 0
-                    )
-                    if unit in [2, 3, 5, 7]:
-                        scale = [1.5875, 3.175, 6.35, 25.4, 152.4, 304.8]
-                    else:
-                        scale = [1, 5, 10, 50, 100, 500]
                     viewsize = (
                         FreeCADGui.ActiveDocument.ActiveView.getCameraNode()
                         .getViewVolume()
                         .getWidth()
                     )
                     if viewsize < 250:
-                        dist = scale[0]
+                        dist = _NUDGE_DISTANCES[0]
                     elif viewsize < 750:
-                        dist = scale[1]
+                        dist = _NUDGE_DISTANCES[1]
                     elif viewsize < 4500:
-                        dist = scale[2]
+                        dist = _NUDGE_DISTANCES[2]
                     elif viewsize < 8000:
-                        dist = scale[3]
+                        dist = _NUDGE_DISTANCES[3]
                     elif viewsize < 25000:
-                        dist = scale[4]
+                        dist = _NUDGE_DISTANCES[4]
                     else:
-                        dist = scale[5]
+                        dist = _NUDGE_DISTANCES[5]
                     # u = FreeCAD.Units.Quantity(dist,FreeCAD.Units.Length).UserString
                     statuswidget.nudge.setText(translate("BIM", "Auto"))
                 else:

--- a/src/Mod/BIM/bimcommands/BimNudge.py
+++ b/src/Mod/BIM/bimcommands/BimNudge.py
@@ -31,9 +31,12 @@ QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
 translate = FreeCAD.Qt.translate
 
 
-if FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Units").GetInt(
-    "UserSchema", 0
-) in [2, 3, 5, 7]:
+if FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Units").GetInt("UserSchema", 0) in [
+    2,
+    3,
+    5,
+    7,
+]:
     _NUDGE_DISTANCES = [1.5875, 3.175, 6.35, 25.4, 152.4, 304.8]
     _NUDGE_DISTANCES_STRINGS = ['1/16"', '1/8"', '1/4"', '1"', '6"', "1'"]
 else:

--- a/src/Mod/BIM/bimcommands/BimNudge.py
+++ b/src/Mod/BIM/bimcommands/BimNudge.py
@@ -61,11 +61,14 @@ class BIM_Nudge:
                 nudgeValue = statuswidget.nudge.text().replace("&", "")
                 dist = 0
                 if "auto" in nudgeValue.lower():
-                    viewsize = (
-                        FreeCADGui.ActiveDocument.ActiveView.getCameraNode()
-                        .getViewVolume()
-                        .getWidth()
-                    )
+                    if hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph"):
+                        viewsize = (
+                            FreeCADGui.ActiveDocument.ActiveView.getCameraNode()
+                            .getViewVolume()
+                            .getWidth()
+                        )
+                    else:
+                        viewsize = 4000
                     if viewsize < 250:
                         dist = _NUDGE_DISTANCES[0]
                     elif viewsize < 750:

--- a/src/Mod/BIM/bimcommands/BimNudge.py
+++ b/src/Mod/BIM/bimcommands/BimNudge.py
@@ -35,19 +35,19 @@ _IMPERIAL_SCHEMAS = {2, 3, 5, 7}
 _METRIC_NUDGE_PRESETS = ("1 mm", "5 mm", "1 cm", "5 cm", "10 cm", "50 cm")
 _IMPERIAL_NUDGE_PRESETS = ('1/16"', '1/8"', '1/4"', '1"', '6"', "1'")
 
+
 def get_unit_schema():
     doc = FreeCAD.ActiveDocument
     if doc is None:
         return FreeCAD.Units.getSchema()
     return doc.getEnumerationsOfProperty("UnitSystem").index(doc.UnitSystem)
 
+
 def get_nudge_presets():
     """Return display labels and quantities for the active unit schema."""
 
     presets = (
-        _IMPERIAL_NUDGE_PRESETS
-        if get_unit_schema() in _IMPERIAL_SCHEMAS
-        else _METRIC_NUDGE_PRESETS
+        _IMPERIAL_NUDGE_PRESETS if get_unit_schema() in _IMPERIAL_SCHEMAS else _METRIC_NUDGE_PRESETS
     )
     return [(label, FreeCAD.Units.Quantity(label)) for label in presets]
 

--- a/src/Mod/BIM/bimcommands/BimNudge.py
+++ b/src/Mod/BIM/bimcommands/BimNudge.py
@@ -31,17 +31,25 @@ QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
 translate = FreeCAD.Qt.translate
 
 
-if FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Units").GetInt("UserSchema", 0) in [
-    2,
-    3,
-    5,
-    7,
-]:
-    _NUDGE_DISTANCES = [1.5875, 3.175, 6.35, 25.4, 152.4, 304.8]
-    _NUDGE_DISTANCES_STRINGS = ['1/16"', '1/8"', '1/4"', '1"', '6"', "1'"]
-else:
-    _NUDGE_DISTANCES = [1, 5, 10, 50, 100, 500]
-    _NUDGE_DISTANCES_STRINGS = ["1 mm", "5 mm", "1 cm", "5 cm", "10 cm", "50 cm"]
+_IMPERIAL_SCHEMAS = {2, 3, 5, 7}
+_METRIC_NUDGE_PRESETS = ("1 mm", "5 mm", "1 cm", "5 cm", "10 cm", "50 cm")
+_IMPERIAL_NUDGE_PRESETS = ('1/16"', '1/8"', '1/4"', '1"', '6"', "1'")
+
+def get_unit_schema():
+    doc = FreeCAD.ActiveDocument
+    if doc is None:
+        return FreeCAD.Units.getSchema()
+    return doc.getEnumerationsOfProperty("UnitSystem").index(doc.UnitSystem)
+
+def get_nudge_presets():
+    """Return display labels and quantities for the active unit schema."""
+
+    presets = (
+        _IMPERIAL_NUDGE_PRESETS
+        if get_unit_schema() in _IMPERIAL_SCHEMAS
+        else _METRIC_NUDGE_PRESETS
+    )
+    return [(label, FreeCAD.Units.Quantity(label)) for label in presets]
 
 
 class BIM_Nudge:
@@ -61,6 +69,7 @@ class BIM_Nudge:
                 nudgeValue = statuswidget.nudge.text().replace("&", "")
                 dist = 0
                 if "auto" in nudgeValue.lower():
+                    distances = [quantity for _label, quantity in get_nudge_presets()]
                     if hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph"):
                         viewsize = (
                             FreeCADGui.ActiveDocument.ActiveView.getCameraNode()
@@ -70,17 +79,17 @@ class BIM_Nudge:
                     else:
                         viewsize = 4000
                     if viewsize < 250:
-                        dist = _NUDGE_DISTANCES[0]
+                        dist = distances[0].Value
                     elif viewsize < 750:
-                        dist = _NUDGE_DISTANCES[1]
+                        dist = distances[1].Value
                     elif viewsize < 4500:
-                        dist = _NUDGE_DISTANCES[2]
+                        dist = distances[2].Value
                     elif viewsize < 8000:
-                        dist = _NUDGE_DISTANCES[3]
+                        dist = distances[3].Value
                     elif viewsize < 25000:
-                        dist = _NUDGE_DISTANCES[4]
+                        dist = distances[4].Value
                     else:
-                        dist = _NUDGE_DISTANCES[5]
+                        dist = distances[5].Value
                     # u = FreeCAD.Units.Quantity(dist,FreeCAD.Units.Length).UserString
                     statuswidget.nudge.setText(translate("BIM", "Auto"))
                 else:

--- a/src/Mod/BIM/bimtests/TestBimNudgeGui.py
+++ b/src/Mod/BIM/bimtests/TestBimNudgeGui.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import FreeCAD
+
+from bimcommands import BimNudge
+from bimtests.TestArchBaseGui import TestArchBaseGui
+
+
+class TestBimNudgeGui(TestArchBaseGui):
+
+    def test_presets_follow_active_schema(self):
+        self.document.UnitSystem = 0
+        metric = BimNudge.get_nudge_presets()
+
+        self.document.UnitSystem = 5
+        imperial = BimNudge.get_nudge_presets()
+
+        self.assertEqual(
+            [label for label, _quantity in metric],
+            [
+                "1 mm",
+                "5 mm",
+                "1 cm",
+                "5 cm",
+                "10 cm",
+                "50 cm",
+            ],
+        )
+        self.assertEqual(
+            [quantity.Value for _label, quantity in metric],
+            [
+                1.0,
+                5.0,
+                10.0,
+                50.0,
+                100.0,
+                500.0,
+            ],
+        )
+        self.assertEqual(
+            [label for label, _quantity in imperial],
+            [
+                '1/16"',
+                '1/8"',
+                '1/4"',
+                '1"',
+                '6"',
+                "1'",
+            ],
+        )
+        for actual, expected in zip(
+            [quantity.Value for _label, quantity in imperial],
+            [1.5875, 3.175, 6.35, 25.4, 152.4, 304.8],
+        ):
+            self.assertAlmostEqual(actual, expected)


### PR DESCRIPTION
Fixes #30401.

With this PR nudge values in the menu depend on the default unit system. The input for the custom value has been changed to a quantity spinbox that is prefilled with the current nudge value.

Additionally:
The tooltip of the statusbar widget was not updated when the shortcuts of the nudge commands were changed recently (#30776). To avoid this problem in the future the shortcuts are now read from the commands.

Limitations:
* <s>Both fixes do not dynamically follow changes to the preferences made during a FreeCAD session.</s>
* <s>The nudge values are not updated based on the document unit system. The assumption is that the document unit system and the default unit system match.</s>
* Nudge values are read as text values, this may result in inaccuracies (pre-existing problem).