### PR TITLE
PD: Add Offset start for Extrude features

### DIFF
--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -22,12 +22,18 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <algorithm>
+#include <cmath>
+#include <cstring>
 #include <limits>
 #include <Mod/Part/App/FCBRepAlgoAPI_Fuse.h>
 #include <BRep_Builder.hxx>
+#include <BRepAdaptor_Surface.hxx>
+#include <BRepGProp.hxx>
 #include <BRepFeat_MakePrism.hxx>
 #include <BRepPrimAPI_MakePrism.hxx>
 #include <gp_Dir.hxx>
+#include <TopoDS.hxx>
 #include <gp_Ax2.hxx>
 #include <Precision.hxx>
 #include <TopExp_Explorer.hxx>
@@ -37,8 +43,10 @@
 
 #include <App/Document.h>
 #include <App/ObjectIdentifier.h>
+#include <Base/Converter.h>
 #include <Base/Tools.h>
 #include <Mod/Part/App/ExtrusionHelper.h>
+#include <Mod/Part/App/Tools.h>
 #include "Mod/Part/App/TopoShapeOpCode.h"
 #include <Mod/Part/App/PartFeature.h>
 
@@ -49,6 +57,7 @@ FC_LOG_LEVEL_INIT("PartDesign", true, true)
 using namespace PartDesign;
 
 const char* FeatureExtrude::SideTypesEnums[] = {"One side", "Two sides", "Symmetric", nullptr};
+const char* FeatureExtrude::StartTypesEnums[] = {"Profile plane", "Offset", "Reference", nullptr};
 
 PROPERTY_SOURCE(PartDesign::FeatureExtrude, PartDesign::ProfileBased)
 
@@ -65,7 +74,8 @@ short FeatureExtrude::mustExecute() const
         || Length.isTouched() || Length2.isTouched() || TaperAngle.isTouched()
         || TaperAngle2.isTouched() || UseCustomVector.isTouched() || Direction.isTouched()
         || ReferenceAxis.isTouched() || AlongSketchNormal.isTouched() || Offset.isTouched()
-        || Offset2.isTouched() || UpToFace.isTouched() || UpToFace2.isTouched()
+        || Offset2.isTouched() || StartType.isTouched() || StartOffset.isTouched()
+        || StartReference.isTouched() || UpToFace.isTouched() || UpToFace2.isTouched()
         || UpToShape.isTouched() || UpToShape2.isTouched()) {
         return 1;
     }
@@ -312,12 +322,41 @@ void FeatureExtrude::updateProperties()
     UpToShape2.setReadOnly(!isUpToShape2Enabled);
     Offset2.setReadOnly(!isOffset2Enabled);
 
+    const bool isStartOffsetEnabled = std::strcmp(StartType.getValueAsString(), "Profile plane") != 0;
+    StartOffset.setReadOnly(!isStartOffsetEnabled);
+    StartReference.setReadOnly(std::strcmp(StartType.getValueAsString(), "Reference") != 0);
+
     AlongSketchNormal.setReadOnly(!currentAlongSketchNormalEnabled);
 }
 
 void FeatureExtrude::setupObject()
 {
     ProfileBased::setupObject();
+}
+
+double FeatureExtrude::getStartOffset() const
+{
+    const char* startType = StartType.getValueAsString();
+    if (std::strcmp(startType, "Profile plane") == 0) {
+        return 0.0;
+    }
+
+    gp_Dir dir = Base::convertTo<gp_Dir>(Direction.getValue());
+    if (Reversed.getValue()) {
+        dir.Reverse();
+    }
+    if (std::strcmp(startType, "Offset") == 0) {
+        return StartOffset.getValue();
+    }
+
+    TopLoc_Location identity;
+    return getStartReferenceOffset(
+        getTopoShapeVerifiedFace(),
+        StartReference,
+        dir,
+        StartOffset.getValue(),
+        identity
+    );
 }
 
 App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions options)
@@ -481,13 +520,20 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
         }
         sketchshape.move(invObjLoc);
 
+        const char* startType = StartType.getValueAsString();
+        const double startOffset = std::strcmp(startType, "Profile plane") == 0 ? 0.0
+            : std::strcmp(startType, "Offset") == 0
+            ? StartOffset.getValue()
+            : getStartReferenceOffset(sketchshape, StartReference, dir, StartOffset.getValue(), invObjLoc);
+        TopoShape startSketch = moveProfileToStart(sketchshape, dir, startOffset);
+
         std::vector<TopoShape> prisms;  // Stores prisms, all in global CS
         double taper1 = TaperAngle.getValue();
         double offset1 = Offset.getValue();
 
         if (Sidemethod == "One side") {
             TopoShape prism1 = generateSingleExtrusionSide(
-                sketchshape,
+                startSketch,
                 method,
                 L,
                 taper1,
@@ -511,7 +557,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
                     // directions.
                     L /= 2.0;
                     TopoShape prism1 = generateSingleExtrusionSide(
-                        sketchshape.makeElementCopy(),
+                        startSketch.makeElementCopy(),
                         method,
                         L,
                         taper1,
@@ -530,7 +576,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
                     gp_Dir dir2 = dir;
                     dir2.Reverse();
                     TopoShape prism2 = generateSingleExtrusionSide(
-                        sketchshape.makeElementCopy(),
+                        startSketch.makeElementCopy(),
                         method,
                         L,
                         taper1,
@@ -553,7 +599,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
                     gp_Trsf start_transform;
                     start_transform.SetTranslation(gp_Vec(dir).Reversed() * (L / 2.0));
 
-                    TopoShape moved_sketch = sketchshape.makeElementCopy();
+                    TopoShape moved_sketch = startSketch.makeElementCopy();
                     moved_sketch.move(start_transform);
 
                     TopoShape prism1 = generateSingleExtrusionSide(
@@ -577,7 +623,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
             else {
                 // For "UpToFace", "UpToShape", etc., mirror the result.
                 TopoShape prism1 = generateSingleExtrusionSide(
-                    sketchshape,
+                    startSketch,
                     method,
                     L,
                     taper1,
@@ -596,7 +642,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
                 gp_Dir sketchNormalDir(SketchVector.x, SketchVector.y, SketchVector.z);
                 sketchNormalDir.Transform(invTrsf);  // Transform to global CS, like 'dir' was.
 
-                Base::Vector3d sketchCenter = sketchshape.getBoundBox().GetCenter();
+                Base::Vector3d sketchCenter = startSketch.getBoundBox().GetCenter();
                 gp_Ax2 mirrorPlane(
                     gp_Pnt(sketchCenter.x, sketchCenter.y, sketchCenter.z),
                     sketchNormalDir
@@ -614,8 +660,9 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
                 && std::fabs(taper2) < Precision::Angular();
             bool method1LengthBased = method == "Length" || method == "ThroughAll";
             bool method2LengthBased = method2 == "Length" || method2 == "ThroughAll";
+            bool hasStartOffset = std::fabs(startOffset) > Precision::Confusion();
 
-            if (method1LengthBased && method2 != "UpToFirst" && noTaper) {
+            if (!hasStartOffset && method1LengthBased && method2 != "UpToFirst" && noTaper) {
                 gp_Trsf start_transform;
                 start_transform.SetTranslation(gp_Vec(dir) * L);
 
@@ -638,7 +685,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
                     prisms.push_back(prism);
                 }
             }
-            else if (method2LengthBased && method != "UpToFirst" && noTaper) {
+            else if (!hasStartOffset && method2LengthBased && method != "UpToFirst" && noTaper) {
                 gp_Trsf start_transform;
                 start_transform.SetTranslation(gp_Vec(dir).Reversed() * L2);
 
@@ -663,7 +710,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
             }
             else {
                 TopoShape prism1 = generateSingleExtrusionSide(
-                    sketchshape.makeElementCopy(),
+                    startSketch.makeElementCopy(),
                     method,
                     L,
                     taper1,
@@ -681,7 +728,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
 
                 // Side 2
                 TopoShape prism2 = generateSingleExtrusionSide(
-                    sketchshape.makeElementCopy(),
+                    startSketch.makeElementCopy(),
                     method2,
                     L2,
                     taper2,
@@ -829,6 +876,80 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
     catch (Base::Exception& e) {
         return new App::DocumentObjectExecReturn(e.what());
     }
+}
+
+double FeatureExtrude::getStartReferenceOffset(
+    const TopoShape& sketchShape,
+    const App::PropertyLinkSub& reference,
+    const gp_Dir& dir,
+    double offset,
+    const TopLoc_Location& invObjLoc
+) const
+{
+    if (!reference.getValue()) {
+        return 0.0;
+    }
+
+    TopoShape referenceShape;
+    if (reference.getValue()->isDerivedFrom<Part::Part2DObject>()) {
+        referenceShape
+            = getTopoShapeVerifiedFace(false, false, reference.getValue(), reference.getSubValues());
+    }
+    else {
+        getUpToFaceFromLinkSub(referenceShape, reference);
+    }
+    referenceShape.move(invObjLoc);
+
+    TopoShape referenceFace = referenceShape;
+    if (referenceFace.shapeType(true) != TopAbs_FACE) {
+        referenceFace = referenceFace.getSubTopoShape(TopAbs_FACE, 1);
+    }
+    BRepAdaptor_Surface surface(TopoDS::Face(referenceFace.getShape()));
+    if (surface.GetType() == GeomAbs_Plane) {
+        // A planar start reference defines its underlying plane, independent of its trimming.
+        GProp_GProps properties;
+        BRepGProp::SurfaceProperties(sketchShape.getShape(), properties);
+        const gp_Pnt profileCenter = properties.CentreOfMass();
+        const gp_Dir normal = surface.Plane().Axis().Direction();
+        const double denominator = gp_Vec(dir).Dot(gp_Vec(normal));
+        if (std::fabs(denominator) > Precision::Confusion()) {
+            const double distance
+                = gp_Vec(profileCenter, surface.Plane().Location()).Dot(gp_Vec(normal)) / denominator;
+            return distance + offset;
+        }
+    }
+
+    auto faces = Part::findAllFacesCutBy(referenceShape, sketchShape, dir);
+    double direction = 1.0;
+    if (faces.empty()) {
+        gp_Dir oppositeDirection = dir;
+        oppositeDirection.Reverse();
+        faces = Part::findAllFacesCutBy(referenceShape, sketchShape, oppositeDirection);
+        direction = -1.0;
+    }
+
+    if (faces.empty()) {
+        throw Base::ValueError("Extrude: Start reference does not intersect the profile direction");
+    }
+
+    const auto nearest
+        = std::min_element(faces.begin(), faces.end(), [](const auto& first, const auto& second) {
+              return first.distsq < second.distsq;
+          });
+    return direction * std::sqrt(nearest->distsq) + offset;
+}
+
+TopoShape FeatureExtrude::moveProfileToStart(const TopoShape& sketchShape, const gp_Dir& dir, double offset)
+{
+    if (std::fabs(offset) < Precision::Confusion()) {
+        return sketchShape;
+    }
+
+    TopoShape result = sketchShape.makeElementCopy();
+    gp_Trsf transform;
+    transform.SetTranslation(gp_Vec(dir) * offset);
+    result.move(transform);
+    return result;
 }
 
 TopoShape FeatureExtrude::generateSingleExtrusionSide(

--- a/src/Mod/PartDesign/App/FeatureExtrude.h
+++ b/src/Mod/PartDesign/App/FeatureExtrude.h
@@ -54,6 +54,9 @@ public:
     App::PropertyBool UseCustomVector;
     App::PropertyVector Direction;
     App::PropertyBool AlongSketchNormal;
+    App::PropertyEnumeration StartType;
+    App::PropertyLength StartOffset;
+    App::PropertyLinkSub StartReference;
     App::PropertyLength Offset;
     App::PropertyLength Offset2;
     App::PropertyLinkSub ReferenceAxis;
@@ -61,6 +64,8 @@ public:
     static App::PropertyQuantityConstraint::Constraints signedLengthConstraint;
     static double maxAngle;
     static App::PropertyAngle::Constraints floatAngle;
+
+    double getStartOffset() const;
 
     /** @name methods override feature */
     //@{
@@ -74,6 +79,7 @@ public:
     //@}
 
     static const char* SideTypesEnums[];
+    static const char* StartTypesEnums[];
 
 protected:
     void onDocumentRestored() override;
@@ -120,6 +126,15 @@ protected:
         const TopoShape& base,      // The base shape for context (global CS)
         TopLoc_Location& invObjLoc  // MUST be passed. Cannot be re-accessed, see #26677
     );
+
+    double getStartReferenceOffset(
+        const TopoShape& sketchShape,
+        const App::PropertyLinkSub& reference,
+        const gp_Dir& dir,
+        double offset,
+        const TopLoc_Location& invObjLoc
+    ) const;
+    static TopoShape moveProfileToStart(const TopoShape& sketchShape, const gp_Dir& dir, double offset);
 };
 
 }  // namespace PartDesign

--- a/src/Mod/PartDesign/App/FeaturePad.cpp
+++ b/src/Mod/PartDesign/App/FeaturePad.cpp
@@ -75,6 +75,16 @@ Pad::Pad()
         App::Prop_None,
         "Measure pad length along the sketch normal direction"
     );
+    ADD_PROPERTY_TYPE(StartType, (0L), "Start", App::Prop_None, "How to define the start plane");
+    StartType.setEnums(StartTypesEnums);
+    ADD_PROPERTY_TYPE(StartOffset, (0.0), "Start", App::Prop_None, "Offset from the start plane");
+    ADD_PROPERTY_TYPE(
+        StartReference,
+        (nullptr),
+        "Start",
+        App::Prop_None,
+        "Face, plane or sketch used as the start reference"
+    );
     ADD_PROPERTY_TYPE(UpToFace, (nullptr), "Side1", App::Prop_None, "Face where pad will end");
     ADD_PROPERTY_TYPE(UpToShape, (nullptr), "Side1", App::Prop_None, "Faces or shape(s) where pad will end");
     ADD_PROPERTY_TYPE(UpToFace2, (nullptr), "Side2", App::Prop_None, "Face where pad will end on side2");
@@ -95,6 +105,7 @@ Pad::Pad()
     );
     Offset.setConstraints(&signedLengthConstraint);
     Offset2.setConstraints(&signedLengthConstraint);
+    StartOffset.setConstraints(&signedLengthConstraint);
     ADD_PROPERTY_TYPE(TaperAngle, (0.0), "Side1", App::Prop_None, "Taper angle");
     TaperAngle.setConstraints(&floatAngle);
     ADD_PROPERTY_TYPE(TaperAngle2, (0.0), "Side2", App::Prop_None, "Taper angle for 2nd direction");

--- a/src/Mod/PartDesign/App/FeaturePocket.cpp
+++ b/src/Mod/PartDesign/App/FeaturePocket.cpp
@@ -82,6 +82,16 @@ Pocket::Pocket()
         App::Prop_None,
         "Measure pocket length along the sketch normal direction"
     );
+    ADD_PROPERTY_TYPE(StartType, (0L), "Start", App::Prop_None, "How to define the start plane");
+    StartType.setEnums(StartTypesEnums);
+    ADD_PROPERTY_TYPE(StartOffset, (0.0), "Start", App::Prop_None, "Offset from the start plane");
+    ADD_PROPERTY_TYPE(
+        StartReference,
+        (nullptr),
+        "Start",
+        App::Prop_None,
+        "Face, plane or sketch used as the start reference"
+    );
     ADD_PROPERTY_TYPE(UpToFace, (nullptr), "Side1", App::Prop_None, "Face where pocket will end");
     ADD_PROPERTY_TYPE(
         UpToShape,
@@ -108,6 +118,7 @@ Pocket::Pocket()
     );
     Offset.setConstraints(&signedLengthConstraint);
     Offset2.setConstraints(&signedLengthConstraint);
+    StartOffset.setConstraints(&signedLengthConstraint);
     ADD_PROPERTY_TYPE(TaperAngle, (0.0), "Side1", App::Prop_None, "Taper angle");
     TaperAngle.setConstraints(&floatAngle);
     ADD_PROPERTY_TYPE(TaperAngle2, (0.0), "Side2", App::Prop_None, "Taper angle for 2nd direction");

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -22,8 +22,9 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QSignalBlocker>
 #include <QAction>
+#include <QAbstractButton>
+#include <QSignalBlocker>
 
 
 #include <App/Document.h>
@@ -63,6 +64,8 @@ TaskExtrudeParameters::TaskExtrudeParameters(
     ui->setupUi(proxy);
     handleLineFaceNameNo(ui->lineFaceName);
     handleLineFaceNameNo(ui->lineFaceName2);
+    ui->lineStartReference->setPlaceholderText(tr("No start reference selected"));
+    ui->startOffsetEdit->setToolTip(tr("Offset from the profile or selected start reference"));
 
     Gui::ButtonGroup* group = new Gui::ButtonGroup(this);
     group->addButton(ui->checkBoxReversed);
@@ -105,6 +108,12 @@ void TaskExtrudeParameters::setupDialog()
 
     ui->checkBoxReversed->setChecked(extrude->Reversed.getValue());
 
+    ui->startMode->setCurrentIndex(extrude->StartType.getValue());
+    ui->startOffsetEdit->setValue(extrude->StartOffset.getQuantityValue());
+    ui->startOffsetEdit->bind(extrude->StartOffset);
+
+    updateStartReferenceName();
+
     // --- Per-Side Setup using the Helper ---
     setupSideDialog(m_side1);
     setupSideDialog(m_side2);
@@ -115,6 +124,7 @@ void TaskExtrudeParameters::setupDialog()
     connectSlots();
 
     this->propReferenceAxis = &(extrude->ReferenceAxis);
+    updateStartUI();
     updateUI(Side::First);
 
     setupGizmos();
@@ -191,6 +201,47 @@ void TaskExtrudeParameters::setupSideDialog(SideController& side)
     side.listWidgetReferences->addAction(side.unselectShapeFaceAction);
     side.listWidgetReferences->setContextMenuPolicy(Qt::ActionsContextMenu);
     side.checkBoxAllFaces->setChecked(side.listWidgetReferences->count() == 0);
+}
+
+void TaskExtrudeParameters::updateStartUI()
+{
+    const int type = ui->startMode->currentIndex();
+    const bool hasOffset = type != 0;
+    const bool hasReference = type == 2;
+
+    ui->labelStartOffset->setVisible(hasOffset);
+    ui->startOffsetEdit->setVisible(hasOffset);
+    ui->labelStartReference->setVisible(hasReference);
+    ui->lineStartReference->setVisible(hasReference);
+    ui->buttonStartReference->setVisible(hasReference);
+}
+
+void TaskExtrudeParameters::updateStartReferenceName()
+{
+    auto extrude = getObject<PartDesign::FeatureExtrude>();
+    App::DocumentObject* reference = extrude->StartReference.getValue();
+    const auto subValues = extrude->StartReference.getSubValues();
+    const std::string subName = subValues.empty() ? "" : subValues.front();
+
+    if (!reference) {
+        ui->lineStartReference->clear();
+        ui->lineStartReference->setProperty("FeatureName", QVariant());
+        ui->lineStartReference->setProperty("FaceName", QVariant());
+        ui->lineStartReference->setPlaceholderText(tr("No start reference selected"));
+        return;
+    }
+
+    QString text = QString::fromUtf8(reference->Label.getValue());
+    if (subName.rfind("Face", 0) == 0) {
+        text += QStringLiteral(":%1%2").arg(tr("Face"), QString::fromStdString(subName.substr(4)));
+    }
+    else if (!subName.empty()) {
+        text += QStringLiteral(":%1").arg(QString::fromStdString(subName));
+    }
+
+    ui->lineStartReference->setText(text);
+    ui->lineStartReference->setProperty("FeatureName", QByteArray(reference->getNameInDocument()));
+    ui->lineStartReference->setProperty("FaceName", QByteArray(subName.c_str()));
 }
 
 void TaskExtrudeParameters::createSideControllers()
@@ -314,6 +365,19 @@ void TaskExtrudeParameters::connectSlots()
     connectSideSlots(m_side1, Side::First, &TaskExtrudeParameters::onModeChanged_Side1);
     connectSideSlots(m_side2, Side::Second, &TaskExtrudeParameters::onModeChanged_Side2);
 
+    connect(ui->startMode, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int type) {
+        onStartModeChanged(type);
+    });
+    connect(
+        ui->startOffsetEdit,
+        qOverload<double>(&Gui::PrefQuantitySpinBox::valueChanged),
+        this,
+        [this](double value) { onStartOffsetChanged(value); }
+    );
+    connect(ui->buttonStartReference, &QAbstractButton::toggled, this, [this](bool checked) {
+        onSelectStartReferenceToggle(checked);
+    });
+
     // clang-format off
     connect(ui->directionCB, qOverload<int>(&QComboBox::activated),
             this, &TaskExtrudeParameters::onDirectionCBChanged);
@@ -400,6 +464,7 @@ void TaskExtrudeParameters::setSelectionMode(SelectionMode mode, Side side)
     };
     updateCheckedForSide(Side::First, ui->buttonFace, ui->buttonShape, ui->buttonShapeFace);
     updateCheckedForSide(Side::Second, ui->buttonFace2, ui->buttonShape2, ui->buttonShapeFace2);
+    ui->buttonStartReference->setChecked(mode == SelectStartReference);
 
     selectionMode = mode;
     activeSelectionSide = side;
@@ -410,6 +475,7 @@ void TaskExtrudeParameters::setSelectionMode(SelectionMode mode, Side side)
             Gui::Selection().addSelectionGate(new SelectionFilterGate("SELECT Part::Feature COUNT 1"));
             break;
         case SelectFace:
+        case SelectStartReference:
             onSelectReference(AllowSelection::FACE);
             break;
         case SelectShapeFaces: {
@@ -455,6 +521,10 @@ void TaskExtrudeParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 
             case SelectFace:
                 selectedFace(msg, sideCtrl);
+                break;
+
+            case SelectStartReference:
+                selectedStartReference(msg);
                 break;
 
             case SelectReferenceAxis:
@@ -555,6 +625,16 @@ void PartDesignGui::TaskExtrudeParameters::selectedFace(
     setSelectionMode(None);
 }
 
+void PartDesignGui::TaskExtrudeParameters::selectedStartReference(const Gui::SelectionChanges& msg)
+{
+    auto extrude = getObject<PartDesign::FeatureExtrude>();
+    onAddSelection(msg, extrude->StartReference);
+    updateStartReferenceName();
+
+    setSelectionMode(None);
+    setGizmoPositions();
+}
+
 void PartDesignGui::TaskExtrudeParameters::selectedShape(
     const Gui::SelectionChanges& msg,
     SideController& side
@@ -638,6 +718,28 @@ void TaskExtrudeParameters::onLengthChanged(double len, Side side)
 {
     getSideController(side).Length->setValue(len);
     tryRecomputeFeature();
+}
+
+void TaskExtrudeParameters::onStartOffsetChanged(double len)
+{
+    getObject<PartDesign::FeatureExtrude>()->StartOffset.setValue(len);
+    tryRecomputeFeature();
+    setGizmoPositions();
+}
+
+void TaskExtrudeParameters::onStartModeChanged(int type)
+{
+    auto extrude = getObject<PartDesign::FeatureExtrude>();
+    extrude->StartType.setValue(type);
+    if (type == 2 && !extrude->StartReference.getValue()) {
+        ui->buttonStartReference->setChecked(true);
+    }
+    else if (type != 2) {
+        setSelectionMode(None);
+    }
+    updateStartUI();
+    tryRecomputeFeature();
+    setGizmoPositions();
 }
 
 void TaskExtrudeParameters::onOffsetChanged(double len, Side side)
@@ -770,6 +872,7 @@ void TaskExtrudeParameters::updateWholeUI(Type type, Side side)
     // --- Global UI visibility based on SidesMode ---
     const bool isSide2GroupVisible = (sidesMode == SidesMode::TwoSides);
     ui->side1Label->setVisible(isSide2GroupVisible);
+    ui->line1->setVisible(isSide2GroupVisible);
     ui->side2Label->setVisible(isSide2GroupVisible);
     ui->line2->setVisible(isSide2GroupVisible);
     ui->typeLabel2->setVisible(isSide2GroupVisible);
@@ -1081,6 +1184,19 @@ void TaskExtrudeParameters::onSelectFaceToggle(const bool checked, Side side)
     }
 }
 
+void TaskExtrudeParameters::onSelectStartReferenceToggle(const bool checked)
+{
+    if (checked) {
+        ui->buttonStartReference->setText(tr("Cancel"));
+        ui->lineStartReference->setPlaceholderText(tr("Select face, plane..."));
+        setSelectionMode(SelectStartReference);
+    }
+    else {
+        ui->buttonStartReference->setText(tr("Pick Reference"));
+        ui->lineStartReference->setPlaceholderText(tr("No start reference selected"));
+    }
+}
+
 void TaskExtrudeParameters::onSelectShapeToggle(bool checked, Side side)
 {
     auto& sideCtrl = getSideController(side);
@@ -1266,6 +1382,7 @@ void TaskExtrudeParameters::changeEvent(QEvent* e)
 
         translateFaceName(ui->lineFaceName);
         translateFaceName(ui->lineFaceName2);
+        updateStartReferenceName();
     }
 }
 
@@ -1305,6 +1422,7 @@ void TaskExtrudeParameters::applyParameters()
 
     ui->lengthEdit->apply();
     ui->lengthEdit2->apply();
+    ui->startOffsetEdit->apply();
     ui->taperEdit->apply();
     ui->taperEdit2->apply();
     FCMD_OBJ_CMD(obj, "UseCustomVector = " << (getCustom() ? 1 : 0));
@@ -1322,6 +1440,9 @@ void TaskExtrudeParameters::applyParameters()
     FCMD_OBJ_CMD(obj, "Reversed = " << (getReversed() ? 1 : 0));
     FCMD_OBJ_CMD(obj, "Offset = " << getOffset());
     FCMD_OBJ_CMD(obj, "Offset2 = " << getOffset2());
+    FCMD_OBJ_CMD(obj, "StartOffset = " << ui->startOffsetEdit->value().getValue());
+    FCMD_OBJ_CMD(obj, "StartType = " << ui->startMode->currentIndex());
+    FCMD_OBJ_CMD(obj, "StartReference = " << getFaceName(ui->lineStartReference).toUtf8().data());
 }
 
 void TaskExtrudeParameters::onSidesModeChanged(int index)
@@ -1418,11 +1539,22 @@ void TaskExtrudeParameters::setGizmoPositions()
     std::string extrudeType2 = std::string(extrude->Type2.getValueAsString());
     double dir = extrude->Reversed.getValue() ? -1 : 1;
 
-    lengthGizmo1->Gizmo::setDraggerPlacement(center, extrude->Direction.getValue() * dir);
+    Base::Vector3d direction = extrude->Direction.getValue() * dir;
+    Base::Vector3d center1 = center;
+    Base::Vector3d center2 = center;
+    try {
+        const Base::Vector3d start = direction.Normalized() * extrude->getStartOffset();
+        center1 += start;
+        center2 += start;
+    }
+    catch (const Base::Exception&) {
+    }
+
+    lengthGizmo1->Gizmo::setDraggerPlacement(center1, direction);
     lengthGizmo1->setVisibility(extrudeType == "Length");
     taperAngleGizmo1->placeOverLinearGizmo(lengthGizmo1);
     taperAngleGizmo1->setVisibility(extrudeType == "Length");
-    lengthGizmo2->Gizmo::setDraggerPlacement(center, -extrude->Direction.getValue() * dir);
+    lengthGizmo2->Gizmo::setDraggerPlacement(center2, -direction);
     lengthGizmo2->setVisibility(sideType == "Two sides" && extrudeType2 == "Length");
     taperAngleGizmo2->placeOverLinearGizmo(lengthGizmo2);
     taperAngleGizmo2->setVisibility(sideType == "Two sides" && extrudeType2 == "Length");

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.h
@@ -111,6 +111,7 @@ public:
     {
         None,
         SelectFace,
+        SelectStartReference,
         SelectShape,
         SelectShapeFaces,
         SelectReferenceAxis
@@ -193,9 +194,12 @@ private:
     void onModeChanged_Side1(int index);
     void onModeChanged_Side2(int index);
     void onLengthChanged(double len, Side side);
+    void onStartModeChanged(int type);
+    void onStartOffsetChanged(double len);
     void onOffsetChanged(double len, Side side);
     void onTaperChanged(double angle, Side side);
     void onSelectFaceToggle(bool checked, Side side);
+    void onSelectStartReferenceToggle(bool checked);
 
     void onFaceName(const QString& text, Side side);
     void onAllFacesToggled(bool checked, Side side);
@@ -245,6 +249,7 @@ private:
 
     void selectedReferenceAxis(const Gui::SelectionChanges& msg);
     void selectedFace(const Gui::SelectionChanges& msg, SideController& side);
+    void selectedStartReference(const Gui::SelectionChanges& msg);
     void selectedShape(const Gui::SelectionChanges& msg, SideController& side);
     void selectedShapeFace(const Gui::SelectionChanges& msg, SideController& side);
 
@@ -262,6 +267,8 @@ private:
     void changeFaceName(QLineEdit* lineEdit, const QString& text);
 
     void createSideControllers();
+    void updateStartUI();
+    void updateStartReferenceName();
 
     std::unique_ptr<Gui::GizmoContainer> gizmoContainer;
     Gui::LinearGizmo* lengthGizmo1 = nullptr;

--- a/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
@@ -17,17 +17,99 @@
    <item>
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
-      <widget class="QLabel" name="sidesLabel">
+      <widget class="QLabel" name="labelStart">
        <property name="text">
-        <string>Mode</string>
+        <string>Start</string>
        </property>
       </widget>
      </item>
      <item row="0" column="1">
+      <widget class="QComboBox" name="startMode">
+       <item>
+        <property name="text">
+         <string>Profile plane</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Offset</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Reference</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="1" column="0" rowspan="2">
+      <widget class="QLabel" name="labelStartReference">
+       <property name="text">
+        <string>Reference</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="lineStartReference">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QPushButton" name="buttonStartReference">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Pick Reference</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelStartOffset">
+       <property name="text">
+        <string>Offset</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="Gui::PrefQuantitySpinBox" name="startOffsetEdit" native="true">
+       <property name="keyboardTracking" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="sidesLabel">
+       <property name="text">
+        <string>Direction</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
       <widget class="QComboBox" name="sidesMode"/>
      </item>
-     <item row="1" column="0" colspan="2">
-      <layout class="QHBoxLayout" name="verticalLayout_220">
+     <item row="5" column="0" colspan="2">
+      <layout class="QHBoxLayout" name="side1Layout">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -62,14 +144,14 @@
        </item>
       </layout>
      </item>
-     <item row="2" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="textLabel1">
        <property name="text">
         <string>Type</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="6" column="1">
       <widget class="QComboBox" name="changeMode">
        <item>
         <property name="text">
@@ -78,14 +160,14 @@
        </item>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="7" column="0">
       <widget class="QLabel" name="labelLength">
        <property name="text">
         <string>Length</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="7" column="1">
       <widget class="Gui::PrefQuantitySpinBox" name="lengthEdit" native="true">
        <property name="keyboardTracking" stdset="0">
         <bool>false</bool>
@@ -95,14 +177,14 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="8" column="0">
       <widget class="QLabel" name="labelOffset">
        <property name="text">
         <string>Offset to face</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="8" column="1">
       <widget class="Gui::PrefQuantitySpinBox" name="offsetEdit" native="true">
        <property name="keyboardTracking" stdset="0">
         <bool>false</bool>
@@ -112,7 +194,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
+     <item row="9" column="0">
       <widget class="QLabel" name="labelTaperAngle">
        <property name="toolTip">
         <string>Angle to taper the extrusion</string>
@@ -122,7 +204,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="9" column="1">
       <widget class="Gui::PrefQuantitySpinBox" name="taperEdit" native="true">
        <property name="keyboardTracking" stdset="0">
         <bool>false</bool>
@@ -132,7 +214,7 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="0" colspan="2">
+     <item row="10" column="0" colspan="2">
       <widget class="QFrame" name="upToShapeList">
        <property name="frameShadow">
         <enum>QFrame::Plain</enum>
@@ -234,7 +316,7 @@
        </layout>
       </widget>
      </item>
-     <item row="7" column="0" colspan="2">
+     <item row="11" column="0" colspan="2">
       <layout class="QGridLayout" name="gridLayout_5">
        <item row="0" column="1">
         <widget class="QLineEdit" name="lineFaceName">
@@ -261,7 +343,7 @@
        </item>
       </layout>
      </item>
-     <item row="8" column="0" colspan="2">
+     <item row="12" column="0" colspan="2">
       <layout class="QHBoxLayout" name="verticalLayout_221">
        <property name="leftMargin">
         <number>0</number>
@@ -297,24 +379,24 @@
        </item>
       </layout>
      </item>
-     <item row="9" column="0">
+     <item row="13" column="0">
       <widget class="QLabel" name="typeLabel2">
        <property name="text">
         <string>Type</string>
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
+     <item row="13" column="1">
       <widget class="QComboBox" name="changeMode2"/>
      </item>
-     <item row="10" column="0">
+     <item row="14" column="0">
       <widget class="QLabel" name="labelLength2">
        <property name="text">
         <string>Length</string>
        </property>
       </widget>
      </item>
-     <item row="10" column="1">
+     <item row="14" column="1">
       <widget class="Gui::PrefQuantitySpinBox" name="lengthEdit2" native="true">
        <property name="keyboardTracking" stdset="0">
         <bool>false</bool>
@@ -324,14 +406,14 @@
        </property>
       </widget>
      </item>
-     <item row="11" column="0">
+     <item row="15" column="0">
       <widget class="QLabel" name="labelOffset2">
        <property name="text">
         <string>Offset to face</string>
        </property>
       </widget>
      </item>
-     <item row="11" column="1">
+     <item row="15" column="1">
       <widget class="Gui::PrefQuantitySpinBox" name="offsetEdit2" native="true">
        <property name="keyboardTracking" stdset="0">
         <bool>false</bool>
@@ -341,7 +423,7 @@
        </property>
       </widget>
      </item>
-     <item row="12" column="0">
+     <item row="16" column="0">
       <widget class="QLabel" name="labelTaperAngle2">
        <property name="toolTip">
         <string>Angle to taper the extrusion</string>
@@ -351,7 +433,7 @@
        </property>
       </widget>
      </item>
-     <item row="12" column="1">
+     <item row="16" column="1">
       <widget class="Gui::PrefQuantitySpinBox" name="taperEdit2" native="true">
        <property name="keyboardTracking" stdset="0">
         <bool>false</bool>
@@ -361,7 +443,7 @@
        </property>
       </widget>
      </item>
-     <item row="13" column="0" colspan="2">
+     <item row="17" column="0" colspan="2">
       <widget class="QFrame" name="upToShapeList2">
        <property name="frameShadow">
         <enum>QFrame::Plain</enum>
@@ -463,7 +545,7 @@
        </layout>
       </widget>
      </item>
-     <item row="14" column="0" colspan="2">
+     <item row="24" column="0" colspan="2">
       <layout class="QGridLayout" name="gridLayout_52">
        <item row="0" column="1">
         <widget class="QLineEdit" name="lineFaceName2">

--- a/src/Mod/PartDesign/PartDesignTests/TestPad.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestPad.py
@@ -24,6 +24,7 @@
 import unittest
 
 import FreeCAD
+import Part
 from FreeCAD import Base
 import TestSketcherApp
 
@@ -72,6 +73,57 @@ class TestPad(unittest.TestCase):
         self.Body.addObject(self.Pad)
         self.Doc.recompute()
         self.assertEqual(len(self.Pad.Shape.Faces), 6)
+
+    def testStartOffsetAndReference(self):
+        self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "SketchPad")
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 0), (1, 1))
+        self.Doc.recompute()
+
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Pad.Profile = self.PadSketch
+        self.Pad.StartType = "Offset"
+        self.Pad.StartOffset = 2
+        self.Pad.Length = 3
+        self.Doc.recompute()
+        self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMin, 2.0)
+        self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMax, 5.0)
+
+        reference = self.Doc.addObject("Part::Feature", "Reference")
+        outer = Part.makeCylinder(2, 1, Base.Vector(0, 0, 10))
+        inner = Part.makeCylinder(1, 1, Base.Vector(0, 0, 10))
+        reference.Shape = outer.cut(inner)
+        top_face = max(
+            range(1, len(reference.Shape.Faces) + 1),
+            key=lambda index: reference.Shape.Faces[index - 1].CenterOfMass.z,
+        )
+        self.Pad.StartReference = (reference, [f"Face{top_face}"])
+        self.Pad.StartType = "Reference"
+        self.Pad.StartOffset = 2
+        self.Doc.recompute()
+        self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMin, 13.0)
+        self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMax, 16.0)
+
+    def testStartOffsetForTwoSidedAndSymmetricPad(self):
+        self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "SketchPad")
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 0), (1, 1))
+        self.Doc.recompute()
+
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Pad.Profile = self.PadSketch
+        self.Pad.StartType = "Offset"
+        self.Pad.StartOffset = 2
+        self.Pad.SideType = "Two sides"
+        self.Pad.Length = 1
+        self.Pad.Length2 = 1
+        self.Doc.recompute()
+        self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMin, 1.0)
+        self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMax, 3.0)
+
+        self.Pad.SideType = "Symmetric"
+        self.Pad.Length = 4
+        self.Doc.recompute()
+        self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMin, 0.0)
+        self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMax, 4.0)
 
     def testPadToFirstCase(self):
         self.Body = self.Doc.addObject("PartDesign::Body", "Body")

--- a/src/Mod/PartDesign/PartDesignTests/TestPocket.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestPocket.py
@@ -54,6 +54,32 @@ class TestPocket(unittest.TestCase):
         self.Doc.recompute()
         self.assertAlmostEqual(self.Pocket.Shape.Volume, 75.0)
 
+    def testStartOffset(self):
+        self.Body = self.Doc.addObject("PartDesign::Body", "Body")
+        self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "PadSketch")
+        self.Body.addObject(self.PadSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 0), (10, 10))
+        self.Doc.recompute()
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Body.addObject(self.Pad)
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 1
+        self.Pad.Reversed = 1
+        self.Doc.recompute()
+
+        self.PocketSketch = self.Doc.addObject("Sketcher::SketchObject", "PocketSketch")
+        self.Body.addObject(self.PocketSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PocketSketch, (2.5, 2.5), (5, 5))
+        self.Doc.recompute()
+        self.Pocket = self.Doc.addObject("PartDesign::Pocket", "Pocket")
+        self.Body.addObject(self.Pocket)
+        self.Pocket.Profile = self.PocketSketch
+        self.Pocket.StartType = "Offset"
+        self.Pocket.StartOffset = 0.5
+        self.Pocket.Length = 0.25
+        self.Doc.recompute()
+        self.assertAlmostEqual(self.Pocket.Shape.Volume, 93.75)
+
     def testPocketThroughAllCase(self):
         self.Body = self.Doc.addObject("PartDesign::Body", "Body")
         self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "PadSketch")


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Based on the DWG feedback it supersedes https://github.com/FreeCAD/FreeCAD/pull/30364

- Add optional start offset (offsets the profile) to Part Design Pad and Pocket
- Support direct dimensional offsets and reference-based offsets from faces, planes, and sketches
- Align length and taper draggers with the shifted feature start
- Keep existing documents unchanged: start offset defaults to profile position
- Tests added

No draggers for the offset for the initial implementation.
Assisted-by: GPT-5.6-Terra
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Closes https://github.com/FreeCAD/FreeCAD/pull/30364

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



https://github.com/user-attachments/assets/d399e597-ac85-401e-ad5b-891e42f72ba4



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
