### PR TITLE
TechDraw: fix load fail for some documents

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -477,6 +477,7 @@ bool DrawViewDetail::debugDetail() const
 
 void DrawViewDetail::handleChangedPropertyType(Base::XMLReader &reader, const char * TypeName, App::Property * prop)
 {
+    DrawViewPart::handleChangedPropertyType(reader, TypeName, prop);
     if (prop == &AnchorPoint) {
         // AnchorPoint was PropertyVector, then briefly PropertyPosition, now back to PropertyVector
         App::PropertyPosition tmp;

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -1251,8 +1251,6 @@ void DrawViewSection::handleChangedPropertyType(Base::XMLReader &reader, const c
         }
         return;
     }
-
-    DrawViewPart::handleChangedPropertyType(reader, TypeName, prop);
 }
 
 // checks that SectionNormal and XDirection are perpendicular and that Direction is the same as


### PR DESCRIPTION
This PR corrects a situation which affects documents containing a section view whose Direction or XDirection properties were saved as App::PropertyDirection.  The property types changed to PropertyDirection approximately 2025-03-10 (PR#19941) and back to PropertyVector ~2025-08-11 (PR #22466).

Documents from before or after this range are not affected.  Documents that do not contain a section view are neveraffected.

Loading documents as described above encounters a problem in DrawViewSection::handleChangedPropertyType() when the ancestor's (DrawViewPart) handleChangedPropertyType() is called twice.  PR# 23101 and 22466 both corrected a missing
call to the ancestor - one at the top of the method and one at the bottom.

An example file is "base testa.FCStd" from issue #21864.

This PR
- eliminates 1 call in DrawViewSection::handleChangedPropertyType()
- adds a missing call in DrawViewDetail::handleChangedPropertyType()

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
