### PR TITLE
Fem: Use `Joule Heat` keyword in Elmer magnetodynamic2d equation

### DIFF
--- a/src/Mod/Fem/CMakeLists.txt
+++ b/src/Mod/Fem/CMakeLists.txt
@@ -103,6 +103,7 @@ SET(FemExamples_SRCS
     femexamples/equation_magnetostatics_2D_elmer.py
     femexamples/equation_staticcurrent_elmer.py
     femexamples/frequency_beamsimple.py
+    femexamples/inductive_heating_axisymmetric.py
     femexamples/magnetic_shielding_2D.py
     femexamples/manager.py
     femexamples/material_multiple_bendingbeam_fiveboxes.py

--- a/src/Mod/Fem/femexamples/equation_magnetodynamics_2D_elmer.py
+++ b/src/Mod/Fem/femexamples/equation_magnetodynamics_2D_elmer.py
@@ -125,7 +125,7 @@ def setup(doc=None, solvertype="elmer"):
         solver_obj = ObjectsFem.makeSolverElmer(doc, "SolverElmer")
         solver_obj.CoordinateSystem = "Axi Symmetric"
         equation_magnetodynamic2D = ObjectsFem.makeEquationMagnetodynamic2D(doc, solver_obj)
-        equation_magnetodynamic2D.AngularFrequency = "50 kHz"
+        equation_magnetodynamic2D.Frequency = "50 kHz"
         equation_magnetodynamic2D.CalculateCurrentDensity = True
         equation_magnetodynamic2D.CalculateElectricField = True
         equation_magnetodynamic2D.CalculateJouleHeating = True

--- a/src/Mod/Fem/femexamples/equation_magnetodynamics_2D_elmer.py
+++ b/src/Mod/Fem/femexamples/equation_magnetodynamics_2D_elmer.py
@@ -187,6 +187,14 @@ def setup(doc=None, solvertype="elmer"):
     CurrentDensity.Mode = "Normal"
     analysis.addObject(CurrentDensity)
 
+    # constraint A potential vector
+    BoundaryPotential = ObjectsFem.makeConstraintElectromagnetic(doc, "BoundaryPotential")
+    BoundaryPotential.References = [(shell, "Edge6")]
+    BoundaryPotential.AV_re_3 = "0.0 Wb/m"
+    BoundaryPotential.AV_im_3 = "0.0 Wb/m"
+    BoundaryPotential.EnableAV_3 = True
+    analysis.addObject(BoundaryPotential)
+
     # mesh
     femmesh_obj = analysis.addObject(ObjectsFem.makeMeshGmsh(doc, get_meshname()))[0]
     femmesh_obj.Shape = shell

--- a/src/Mod/Fem/femexamples/equation_magnetodynamics_elmer.py
+++ b/src/Mod/Fem/femexamples/equation_magnetodynamics_elmer.py
@@ -110,7 +110,7 @@ def setup(doc=None, solvertype="elmer"):
     if solvertype == "elmer":
         solver_obj = ObjectsFem.makeSolverElmer(doc, "SolverElmer")
         eq_electrostatic = ObjectsFem.makeEquationMagnetodynamic(doc, solver_obj)
-        eq_electrostatic.AngularFrequency = "100 kHz"
+        eq_electrostatic.Frequency = "100 kHz"
         eq_electrostatic.BiCGstablDegree = 4
         eq_electrostatic.IsHarmonic = True
         eq_electrostatic.LinearIterativeMethod = "BiCGStabl"

--- a/src/Mod/Fem/femexamples/equation_magnetostatics_2D_elmer.py
+++ b/src/Mod/Fem/femexamples/equation_magnetostatics_2D_elmer.py
@@ -146,6 +146,7 @@ def setup(doc=None, solvertype="elmer"):
     sedges = Part.__sortEdges__(edges)
     Horseshoe_U = doc.addObject("Part::Feature", "Horseshoe_U")
     Horseshoe_U.Shape = Part.Face(Part.Wire(sedges))
+    Horseshoe_U.ViewObject.Visibility = False
 
     # a circle defining later the air volume
     Air_Circle = doc.addObject("Part::Feature", "Air_Circle")
@@ -179,16 +180,18 @@ def setup(doc=None, solvertype="elmer"):
     Cut.Base = Air_Circle
     Cut.Tool = Fusion
     Cut.ViewObject.Visibility = False
+    Cut.recompute(True)
 
-    # BooleanFregments object to combine cut with rod
-    BooleanFragments = SplitFeatures.makeBooleanFragments(name="BooleanFragments")
-    BooleanFragments.Objects = [Horseshoe_lower, Horseshoe_upper, Horseshoe_U, Cut]
+    # shell object to combine cut with rod
+    Shape = Part.makeShell(Horseshoe_lower.Shape.Faces + Horseshoe_U.Shape.Faces + Horseshoe_upper.Shape.Faces + Cut.Shape.Faces)
+    Shell = doc.addObject("Part::Feature", "Shell")
+    Shell.Shape = Shape
 
     # set view
     doc.recompute()
     if FreeCAD.GuiUp:
-        BooleanFragments.ViewObject.Document.activeView().viewTop()
-        BooleanFragments.ViewObject.Document.activeView().fitAll()
+        Shell.ViewObject.Document.activeView().viewTop()
+        Shell.ViewObject.Document.activeView().fitAll()
 
     # analysis
     analysis = ObjectsFem.makeAnalysis(doc, "Analysis")
@@ -225,7 +228,7 @@ def setup(doc=None, solvertype="elmer"):
     mat["RelativePermeability"] = "1.0"
     mat["RelativePermittivity"] = "1.00059"
     material_obj.Material = mat
-    material_obj.References = [(BooleanFragments, "Face4")]
+    material_obj.References = [(Shell, "Face4")]
     analysis.addObject(material_obj)
 
     # iron of the horse shoe
@@ -236,29 +239,35 @@ def setup(doc=None, solvertype="elmer"):
     mat["RelativePermeability"] = "5000.0"
     material_obj.Material = mat
     material_obj.References = [
-        (BooleanFragments, "Face1"),
-        (BooleanFragments, "Face2"),
-        (BooleanFragments, "Face3"),
+        (Shell, "Face1"),
+        (Shell, "Face2"),
+        (Shell, "Face3"),
     ]
     analysis.addObject(material_obj)
 
     # magnetization lower
     Magnetization_lower = ObjectsFem.makeConstraintMagnetization(doc, "Magnetization_Lower_End")
-    Magnetization_lower.References = [(BooleanFragments, "Face1")]
+    Magnetization_lower.References = [(Shell, "Face1")]
     Magnetization_lower.Magnetization_re_1 = "-7500.0 A/m"
     Magnetization_lower.EnableMagnetization_1 = True
     analysis.addObject(Magnetization_lower)
 
     # magnetization upper
     Magnetization_upper = ObjectsFem.makeConstraintMagnetization(doc, "Magnetization_Upper_End")
-    Magnetization_upper.References = [(BooleanFragments, "Face2")]
+    Magnetization_upper.References = [(Shell, "Face3")]
     Magnetization_upper.Magnetization_re_1 = "7500.0 A/m"
     Magnetization_upper.EnableMagnetization_1 = True
     analysis.addObject(Magnetization_upper)
 
+    # far field
+    FarField = ObjectsFem.makeConstraintElectromagnetic(doc, "FarField")
+    FarField.References = [(Shell, "Edge15")]
+    FarField.FarField = True
+    analysis.addObject(FarField)
+
     # mesh
     femmesh_obj = analysis.addObject(ObjectsFem.makeMeshGmsh(doc, get_meshname()))[0]
-    femmesh_obj.Shape = BooleanFragments
+    femmesh_obj.Shape = Shell
     femmesh_obj.CharacteristicLengthMax = "100.0 mm"
     femmesh_obj.ViewObject.Visibility = False
 
@@ -266,9 +275,9 @@ def setup(doc=None, solvertype="elmer"):
     mesh_region = ObjectsFem.makeMeshRegion(doc, femmesh_obj, name="MeshRegion")
     mesh_region.CharacteristicLength = "6.5 mm"
     mesh_region.References = [
-        (BooleanFragments, "Face1"),
-        (BooleanFragments, "Face2"),
-        (BooleanFragments, "Face3"),
+        (Shell, "Face1"),
+        (Shell, "Face2"),
+        (Shell, "Face3"),
     ]
     mesh_region.ViewObject.Visibility = False
 

--- a/src/Mod/Fem/femexamples/inductive_heating_axisymmetric.py
+++ b/src/Mod/Fem/femexamples/inductive_heating_axisymmetric.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *   Copyright (c) 2026 Mario Passaglia <mpassaglia[at]cbc.uba.ar>         *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+# to run the example use:
+"""
+from femexamples.inductive_heating_axisymmetric import setup
+setup()
+"""
+
+
+import FreeCAD
+from FreeCAD import Vector
+
+import ObjectsFem
+import Part
+
+from . import manager
+from .meshes import generate_mesh
+
+
+def get_information():
+    return {
+        "name": "Eddy currents heating",
+        "meshtype": "face",
+        "meshelement": "Tria3",
+        "constraints": ["electromagnetic", "temperature", "current density"],
+        "solvers": ["elmer"],
+        "material": "solid",
+        "equations": ["electromagnetic", "heat"],
+    }
+
+
+def get_explanation(header=""):
+    return (
+        header
+        + """
+
+To run the example from Python console use:
+from femexamples.inductive_heating_axisymmetric import setup
+setup()
+
+Magnetodynamic2d and heat equations - Elmer solver
+Magnetodynamic2d and heat equations coupled on axisymmetric system.
+Due to symmetry, only half of the geometry is considered.
+
+Boundary conditions:
+- outer temperature T = 300 K
+- outer vector potential A = 0 Wb/m
+- x-axis tangential B = 0 T (default)
+- coil current density J = 10 A/mm^2
+
+"""
+    )
+
+
+def setup(doc=None, solvertype="elmer"):
+
+    # init FreeCAD document
+    if doc is None:
+        doc = manager.init_doc()
+
+    # explanation object
+    manager.add_explanation_obj(doc, get_explanation(manager.get_header(get_information())))
+
+    # geometric objects
+
+    # rod
+    p1 = Vector(0, 0, 0)
+    p2 = Vector(0, -250, 0)
+    p3 = Vector(50, -250, 0)
+    p4 = Vector(50, 0, 0)
+    rod = Part.makePolygon([p1, p2, p3, p4, p1])
+
+    # coil
+    p5 = Vector(90, 0, 0)
+    p6 = Vector(90, -10, 0)
+    p7 = Vector(110, -10, 0)
+    p8 = Vector(110, 0, 0)
+    coil = Part.makePolygon([p5, p6, p7, p8, p5])
+
+    # air
+    air_circle = Part.makeCircle(500, Vector(0, 0, 0), Vector(0, 0, 1), -90, 0)
+    air_line_1 = Part.makeLine(p1, Vector(0, -500, 0))
+    air_line_2 = Part.makeLine(p1, Vector(500, 0, 0))
+    air_area = Part.makeFace(Part.Wire((air_circle, air_line_1, air_line_2)))
+    cut_area = Part.makeFace((coil, rod))
+    air_area = air_area.cut(cut_area)
+
+    shape = Part.makeShell(air_area.Faces + cut_area.Faces)
+    shell = doc.addObject("Part::Feature", "Shell")
+    shell.Shape = shape
+
+    if FreeCAD.GuiUp:
+        shell.ViewObject.Visibility = True
+        shell.ViewObject.Document.ActiveView.viewTop()
+        shell.ViewObject.Document.ActiveView.fitAll()
+
+    # analysis
+    analysis = ObjectsFem.makeAnalysis(doc, "Analysis")
+    if FreeCAD.GuiUp:
+        import FemGui
+
+        FemGui.setActiveAnalysis(analysis)
+
+    # solver
+    if solvertype == "elmer":
+        solver_obj = ObjectsFem.makeSolverElmer(doc, "SolverElmer")
+        solver_obj.SimulationType = "Steady State"
+        solver_obj.CoordinateSystem = "Axi Symmetric"
+        eq_mgdyn_2d = ObjectsFem.makeEquationMagnetodynamic2D(doc, solver_obj)
+        eq_mgdyn_2d.Frequency = "50 Hz"
+        eq_mgdyn_2d.IsHarmonic = True
+        eq_mgdyn_2d.CalculateElementalFields = True
+        eq_mgdyn_2d.CalculateJouleHeating = True
+        eq_mgdyn_2d.CalculateElectricField = True
+        eq_mgdyn_2d.CalculateCurrentDensity = True
+        eq_heat = ObjectsFem.makeEquationHeat(doc, solver_obj)
+        eq_heat.NonlinearIterations = 10
+    else:
+        FreeCAD.Console.PrintWarning(
+            "Unknown or unsupported solver type: {}. "
+            "No solver object was created.\n".format(solvertype)
+        )
+    analysis.addObject(solver_obj)
+
+
+    # materials
+    material_obj = ObjectsFem.makeMaterialSolid(doc, "Conductor")
+    mat = material_obj.Material
+    mat["Name"] = "Conductor"
+    mat["Density"] = "8960.0 kg/m^3"
+    mat["ThermalConductivity"] = "398.0 W/m/K"
+    mat["SpecificHeat"] = "385.0 J/kg/K" 
+    mat["ElectricalConductivity"] = "1.0e7 S/m"
+    mat["RelativePermeability"] = "1.0"
+    material_obj.Material = mat
+    material_obj.References = [(shell, "Face2")]
+    analysis.addObject(material_obj)
+
+    material_obj = ObjectsFem.makeMaterialFluid(doc, "Air")
+    mat = material_obj.Material
+    mat["Name"] = "Air"
+    mat["Density"] = "1.204 kg/m^3"
+    mat["ThermalConductivity"] = "0.0259 W/m/K"
+    mat["SpecificHeat"] = "1010.0 J/kg/K" 
+    mat["ElectricalConductivity"] = "1.0e3 S/m"
+    mat["RelativePermeability"] = "1.0"
+    material_obj.Material = mat
+    material_obj.References = [(shell, ("Face1", "Face3"))]
+    analysis.addObject(material_obj)
+
+    # boundary conditions and loads
+    # A potential vector
+    outer_A = ObjectsFem.makeConstraintElectromagnetic(doc, "OuterPotential")
+    outer_A.References = [(shell, "Edge9")]
+    outer_A.BoundaryCondition = "Dirichlet"
+    outer_A.PotentialEnabled = False
+    outer_A.EnableAV_3 = True
+    outer_A.AV_re_3 = "0 Wb/m"
+    outer_A.AV_im_3 = "0 Wb/m"
+    analysis.addObject(outer_A)
+
+    # temperature
+    outer_Temp = ObjectsFem.makeConstraintTemperature(doc, "OuterTemp")
+    outer_Temp.References = [(shell, "Edge9")]
+    outer_Temp.ConstraintType = "Temperature"
+    outer_Temp.Temperature = "300 K"
+    analysis.addObject(outer_Temp)
+
+    # current density
+    current = ObjectsFem.makeConstraintCurrentDensity(doc, "CurrentDensity")
+    current.References = [(shell, "Face3")]
+    current.NormalCurrentDensity_re = "10.000 A/mm^2"
+    current.Mode = "Normal"
+    analysis.addObject(current)
+
+    # mesh
+    femmesh_obj = analysis.addObject(ObjectsFem.makeMeshGmsh(doc, manager.get_meshname()))[0]
+    femmesh_obj.Shape = shell
+    femmesh_obj.ElementOrder = "1st"
+    femmesh_obj.CharacteristicLengthMax = "30 mm"
+    femmesh_obj.ViewObject.Visibility = False
+    # mesh_region
+    mesh_region = ObjectsFem.makeMeshRegion(doc, femmesh_obj, name="MeshRegion")
+    mesh_region.CharacteristicLength = "4 mm"
+    mesh_region.References = [(shell, ("Edge4", "Face2", "Face3"))]
+    mesh_region.ViewObject.Visibility = False
+
+    # generate the mesh
+    generate_mesh.mesh_from_mesher(femmesh_obj, "gmsh")
+
+    doc.recompute()
+    return doc

--- a/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic.py
@@ -28,6 +28,10 @@ __url__ = "https://www.freecad.org"
 ## \addtogroup FEM
 #  @{
 
+import math
+
+from FreeCAD import Base
+
 from femtools import femutils
 from . import nonlinear
 from ... import equationbase
@@ -53,7 +57,7 @@ class Proxy(nonlinear.Proxy, equationbase.MagnetodynamicProxy):
         )
         obj.addProperty(
             "App::PropertyFrequency",
-            "AngularFrequency",
+            "Frequency",
             "Magnetodynamic",
             "Frequency of the driving current",
             locked=True,
@@ -121,7 +125,7 @@ class Proxy(nonlinear.Proxy, equationbase.MagnetodynamicProxy):
         )
 
         obj.IsHarmonic = False
-        obj.AngularFrequency = 0
+        obj.Frequency = 0
         obj.Priority = 10
 
         # the post processor options
@@ -151,6 +155,18 @@ class Proxy(nonlinear.Proxy, equationbase.MagnetodynamicProxy):
         obj.CalculateNodalForces = False
         obj.CalculateNodalHeating = False
         obj.DiscontinuousBodies = False
+
+    def onDocumentRestored(self, obj):
+        try:
+            # change AngularFrequency to Frequency
+            freq = obj.getPropertyByName("AngularFrequency")
+            obj.setPropertyStatus("AngularFrequency", "-LockDynamic")
+            obj.renameProperty("AngularFrequency", "Frequency")
+            obj.setPropertyStatus("Frequency", "LockDynamic")
+            obj.Frequency = freq / (2 * math.pi)
+        except Base.PropertyError:
+            # do nothing
+            pass
 
 
 class ViewProxy(nonlinear.ViewProxy, equationbase.MagnetodynamicViewProxy):

--- a/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic2D.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic2D.py
@@ -28,6 +28,10 @@ __url__ = "https://www.freecad.org"
 ## \addtogroup FEM
 #  @{
 
+import math
+
+from FreeCAD import Base
+
 from femtools import femutils
 from . import nonlinear
 from ... import equationbase
@@ -53,13 +57,13 @@ class Proxy(nonlinear.Proxy, equationbase.Magnetodynamic2DProxy):
         )
         obj.addProperty(
             "App::PropertyFrequency",
-            "AngularFrequency",
+            "Frequency",
             "Magnetodynamic2D",
             "Frequency of the driving current",
             locked=True,
         )
         obj.IsHarmonic = False
-        obj.AngularFrequency = 0
+        obj.Frequency = 0
         obj.Priority = 10
 
         # the post processor options
@@ -109,6 +113,18 @@ class Proxy(nonlinear.Proxy, equationbase.Magnetodynamic2DProxy):
         obj.CalculateNodalFields = True
         obj.CalculateNodalForces = False
         obj.CalculateNodalHeating = False
+
+    def onDocumentRestored(self, obj):
+        try:
+            # change AngularFrequency to Frequency
+            freq = obj.getPropertyByName("AngularFrequency")
+            obj.setPropertyStatus("AngularFrequency", "-LockDynamic")
+            obj.renameProperty("AngularFrequency", "Frequency")
+            obj.setPropertyStatus("Frequency", "LockDynamic")
+            obj.Frequency = freq / (2 * math.pi)
+        except Base.PropertyError:
+            # do nothing
+            pass
 
 
 class ViewProxy(nonlinear.ViewProxy, equationbase.Magnetodynamic2DViewProxy):

--- a/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic2D_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic2D_writer.py
@@ -199,6 +199,10 @@ class MgDyn2Dwriter:
                     )
             self.write.handled(obj)
 
+        for name in bodies:
+            if equation.CalculateJouleHeating:
+                self.write.bodyForce(name, "Joule Heat", True)
+
     def handleMagnetodynamic2DBndConditions(self, equation):
         for obj in self.write.getMember("Fem::ConstraintElectromagnetic"):
             if obj.References:

--- a/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic2D_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic2D_writer.py
@@ -28,6 +28,8 @@ __url__ = "https://www.freecad.org"
 ## \addtogroup FEM
 #  @{
 
+import math
+
 from FreeCAD import Console
 from FreeCAD import Units
 
@@ -65,7 +67,8 @@ class MgDyn2Dwriter:
         s["Exec Solver"] = "Always"
         s["Procedure"] = sifio.FileAttr("MagnetoDynamics/MagnetoDynamicsCalcFields")
         if equation.IsHarmonic:
-            s["Angular Frequency"] = equation.AngularFrequency.getValueAs("Hz")
+            frequency = equation.Frequency.getValueAs("Hz")
+            s["Angular Frequency"] = frequency * 2 * math.pi
         s["Potential Variable"] = "Potential"
         if equation.CalculateCurrentDensity is True:
             s["Calculate Current Density"] = True
@@ -241,12 +244,12 @@ class MgDyn2Dwriter:
 
     def handleMagnetodynamic2DEquation(self, bodies, equation):
         for b in bodies:
-            if equation.IsHarmonic and (equation.AngularFrequency == 0):
+            if equation.IsHarmonic and (equation.Frequency == 0):
                 raise general_writer.WriteError("The angular frequency must not be zero.\n\n")
             self.write.equation(b, "Name", equation.Name)
             if equation.IsHarmonic:
-                frequency = equation.AngularFrequency.getValueAs("Hz")
-                self.write.equation(b, "Angular Frequency", frequency)
+                frequency = equation.Frequency.getValueAs("Hz")
+                self.write.equation(b, "Angular Frequency", frequency * 2 * math.pi)
 
 
 ##  @}

--- a/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic_writer.py
@@ -28,6 +28,8 @@ __url__ = "https://www.freecad.org"
 ## \addtogroup FEM
 #  @{
 
+import math
+
 from FreeCAD import Console
 from FreeCAD import Units
 
@@ -53,8 +55,8 @@ class MgDynwriter:
             s["Equation"] = "MgDynHarmonic"
             s["Procedure"] = sifio.FileAttr("MagnetoDynamics/WhitneyAVHarmonicSolver")
             s["Variable"] = "av[av re:1 av im:1]"
-            frequency = equation.AngularFrequency.getValueAs("Hz")
-            s["Angular Frequency"] = frequency
+            frequency = equation.Frequency.getValueAs("Hz")
+            s["Angular Frequency"] = frequency * 2 * math.pi
         s["Exec Solver"] = "Always"
         s["Optimize Bandwidth"] = True
         s["Stabilize"] = equation.Stabilize
@@ -87,8 +89,8 @@ class MgDynwriter:
         s["Exec Solver"] = "Before Saving"
         s["Procedure"] = sifio.FileAttr("MagnetoDynamics/MagnetoDynamicsCalcFields")
         if equation.IsHarmonic:
-            frequency = equation.AngularFrequency.getValueAs("Hz")
-            s["Angular Frequency"] = frequency
+            frequency = equation.Frequency.getValueAs("Hz")
+            s["Angular Frequency"] = frequency * 2 * math.pi
         s["Potential Variable"] = "av"
         if equation.CalculateCurrentDensity is True:
             s["Calculate Current Density"] = True

--- a/src/Mod/Fem/femsolver/elmer/writer.py
+++ b/src/Mod/Fem/femsolver/elmer/writer.py
@@ -259,8 +259,8 @@ class Writer:
 
     def _handleDeformation(self):
         DEFW = DEF_writer.DeformationWriter(self, self.solver)
-        activeIn = []
         for equation in self.solver.Group:
+            activeIn = []
             if femutils.is_of_type(equation, "Fem::EquationElmerDeformation"):
                 if not self._haveMaterialSolid():
                     raise WriteError(
@@ -275,20 +275,20 @@ class Writer:
                     if not self.isBodyMaterialFluid(body):
                         self._addSolver(body, solverSection)
                         DEFW.handleDeformationEquation(activeIn, equation)
-        if activeIn:
-            DEFW.handleDeformationConstants()
-            DEFW.handleDeformationBndConditions()
-            DEFW.handleDeformationInitial(activeIn)
-            DEFW.handleDeformationBodyForces(activeIn)
-            DEFW.handleDeformationMaterial(activeIn)
+                if activeIn:
+                    DEFW.handleDeformationConstants()
+                    DEFW.handleDeformationBndConditions()
+                    DEFW.handleDeformationInitial(activeIn)
+                    DEFW.handleDeformationBodyForces(activeIn)
+                    DEFW.handleDeformationMaterial(activeIn)
 
     # -------------------------------------------------------------------------------------------
     # Elasticity
 
     def _handleElasticity(self):
         ELW = EL_writer.ElasticityWriter(self, self.solver)
-        activeIn = []
         for equation in self.solver.Group:
+            activeIn = []
             if femutils.is_of_type(equation, "Fem::EquationElmerElasticity"):
                 if not self._haveMaterialSolid():
                     raise WriteError(
@@ -306,20 +306,20 @@ class Writer:
                         ELW.handleElasticityEquation(activeIn, equation)
                         if solverEigenSection is not None:
                             self._addSolver(body, solverEigenSection)
-        if activeIn:
-            ELW.handleElasticityConstants()
-            ELW.handleElasticityBndConditions()
-            ELW.handleElasticityInitial(activeIn)
-            ELW.handleElasticityBodyForces(activeIn)
-            ELW.handleElasticityMaterial(activeIn)
+                if activeIn:
+                    ELW.handleElasticityConstants()
+                    ELW.handleElasticityBndConditions()
+                    ELW.handleElasticityInitial(activeIn)
+                    ELW.handleElasticityBodyForces(activeIn)
+                    ELW.handleElasticityMaterial(activeIn)
 
     # -------------------------------------------------------------------------------------------
     # Electrostatic
 
     def _handleElectrostatic(self):
         ESW = ES_writer.ESwriter(self, self.solver)
-        activeIn = []
         for equation in self.solver.Group:
+            activeIn = []
             if femutils.is_of_type(equation, "Fem::EquationElmerElectrostatic"):
                 if equation.References:
                     activeIn = equation.References[0][1]
@@ -328,19 +328,19 @@ class Writer:
                 solverSection = ESW.getElectrostaticSolver(equation)
                 for body in activeIn:
                     self._addSolver(body, solverSection)
-        if activeIn:
-            ESW.handleElectrostaticConstants()
-            ESW.handleElectrostaticBndConditions()
-            ESW.handleElectrostaticBodyForces()
-            ESW.handleElectrostaticMaterial(activeIn)
+                if activeIn:
+                    ESW.handleElectrostaticConstants()
+                    ESW.handleElectrostaticBndConditions()
+                    ESW.handleElectrostaticBodyForces()
+                    ESW.handleElectrostaticMaterial(activeIn)
 
     # -------------------------------------------------------------------------------------------
     # Electricforce
 
     def _handleElectricforce(self):
         EFW = EF_writer.EFwriter(self, self.solver)
-        activeIn = []
         for equation in self.solver.Group:
+            activeIn = []
             if femutils.is_of_type(equation, "Fem::EquationElmerElectricforce"):
                 if equation.References:
                     activeIn = equation.References[0][1]
@@ -355,8 +355,8 @@ class Writer:
 
     def _handleFlow(self):
         FlowW = flow_writer.Flowwriter(self, self.solver)
-        activeIn = []
         for equation in self.solver.Group:
+            activeIn = []
             if femutils.is_of_type(equation, "Fem::EquationElmerFlow"):
                 if not self._haveMaterialFluid():
                     raise WriteError(
@@ -371,20 +371,20 @@ class Writer:
                     if self.isBodyMaterialFluid(body):
                         self._addSolver(body, solverSection)
                         FlowW.handleFlowEquation(activeIn, equation)
-        if activeIn:
-            FlowW.handleFlowConstants()
-            FlowW.handleFlowBndConditions()
-            FlowW.handleFlowInitialPressure(activeIn)
-            FlowW.handleFlowInitialVelocity(activeIn)
-            FlowW.handleFlowMaterial(activeIn)
+                if activeIn:
+                    FlowW.handleFlowConstants()
+                    FlowW.handleFlowBndConditions()
+                    FlowW.handleFlowInitialPressure(activeIn)
+                    FlowW.handleFlowInitialVelocity(activeIn)
+                    FlowW.handleFlowMaterial(activeIn)
 
     # -------------------------------------------------------------------------------------------
     # Flux
 
     def _handleFlux(self):
         FluxW = flux_writer.Fluxwriter(self, self.solver)
-        activeIn = []
         for equation in self.solver.Group:
+            activeIn = []
             if femutils.is_of_type(equation, "Fem::EquationElmerFlux"):
                 if equation.References:
                     activeIn = equation.References[0][1]
@@ -399,8 +399,8 @@ class Writer:
 
     def _handleHeat(self):
         HeatW = heat_writer.Heatwriter(self, self.solver)
-        activeIn = []
         for equation in self.solver.Group:
+            activeIn = []
             if femutils.is_of_type(equation, "Fem::EquationElmerHeat"):
                 if equation.References:
                     activeIn = equation.References[0][1]
@@ -410,20 +410,20 @@ class Writer:
                 for body in activeIn:
                     self._addSolver(body, solverSection)
                 HeatW.handleHeatEquation(activeIn, equation)
-        if activeIn:
-            HeatW.handleHeatConstants()
-            HeatW.handleHeatBndConditions()
-            HeatW.handleHeatInitial(activeIn)
-            HeatW.handleHeatBodyForces(activeIn)
-            HeatW.handleHeatMaterial(activeIn)
+                if activeIn:
+                    HeatW.handleHeatConstants()
+                    HeatW.handleHeatBndConditions()
+                    HeatW.handleHeatInitial(activeIn)
+                    HeatW.handleHeatBodyForces(activeIn)
+                    HeatW.handleHeatMaterial(activeIn)
 
     # -------------------------------------------------------------------------------------------
     # Magnetodynamic
 
     def _handleMagnetodynamic(self):
         MgDyn = MgDyn_writer.MgDynwriter(self, self.solver)
-        activeIn = []
         for equation in self.solver.Group:
+            activeIn = []
             if femutils.is_of_type(equation, "Fem::EquationElmerMagnetodynamic"):
                 if equation.References:
                     activeIn = equation.References[0][1]
@@ -435,19 +435,19 @@ class Writer:
                 for body in activeIn:
                     self._addSolver(body, solverSection)
                     self._addSolver(body, solverPostSection)
-        if activeIn:
-            MgDyn.handleMagnetodynamicConstants()
-            MgDyn.handleMagnetodynamicBndConditions(equation)
-            MgDyn.handleMagnetodynamicBodyForces(activeIn, equation)
-            MgDyn.handleMagnetodynamicMaterial(activeIn)
+                if activeIn:
+                    MgDyn.handleMagnetodynamicConstants()
+                    MgDyn.handleMagnetodynamicBndConditions(equation)
+                    MgDyn.handleMagnetodynamicBodyForces(activeIn, equation)
+                    MgDyn.handleMagnetodynamicMaterial(activeIn)
 
     # -------------------------------------------------------------------------------------------
     # Magnetodynamic2D
 
     def _handleMagnetodynamic2D(self):
         MgDyn2D = MgDyn2D_writer.MgDyn2Dwriter(self, self.solver)
-        activeIn = []
         for equation in self.solver.Group:
+            activeIn = []
             if femutils.is_of_type(equation, "Fem::EquationElmerMagnetodynamic2D"):
                 if equation.References:
                     activeIn = equation.References[0][1]
@@ -469,19 +469,19 @@ class Writer:
                     self._addSolver(body, solverSection)
                     self._addSolver(body, solverPostSection)
                     MgDyn2D.handleMagnetodynamic2DEquation(activeIn, equation)
-        if activeIn:
-            MgDyn2D.handleMagnetodynamic2DConstants()
-            MgDyn2D.handleMagnetodynamic2DBndConditions(equation)
-            MgDyn2D.handleMagnetodynamic2DBodyForces(activeIn, equation)
-            MgDyn2D.handleMagnetodynamic2DMaterial(activeIn)
+                if activeIn:
+                    MgDyn2D.handleMagnetodynamic2DConstants()
+                    MgDyn2D.handleMagnetodynamic2DBndConditions(equation)
+                    MgDyn2D.handleMagnetodynamic2DBodyForces(activeIn, equation)
+                    MgDyn2D.handleMagnetodynamic2DMaterial(activeIn)
 
     # -------------------------------------------------------------------------------------------
     # StaticCurrent
 
     def _handleStaticCurrent(self):
         SCW = SC_writer.SCwriter(self, self.solver)
-        activeIn = []
         for equation in self.solver.Group:
+            activeIn = []
             if femutils.is_of_type(equation, "Fem::EquationElmerStaticCurrent"):
                 if equation.References:
                     activeIn = equation.References[0][1]
@@ -492,10 +492,10 @@ class Writer:
                     self._addSolver(body, solverSection)
                 SCW.handleStaticCurrentBodyForces(activeIn, equation)
 
-        if activeIn:
-            SCW.handleStaticCurrentConstants()
-            SCW.handleStaticCurrentBndConditions()
-            SCW.handleStaticCurrentMaterial(activeIn)
+                if activeIn:
+                    SCW.handleStaticCurrentConstants()
+                    SCW.handleStaticCurrentBndConditions()
+                    SCW.handleStaticCurrentMaterial(activeIn)
 
     # -------------------------------------------------------------------------------------------
     # Solver handling

--- a/src/Mod/Fem/femsolver/elmer/writer.py
+++ b/src/Mod/Fem/femsolver/elmer/writer.py
@@ -619,8 +619,6 @@ class Writer:
 
     def getDensity(self, m):
         density = self.convert(m["Density"], "M/L^3")
-        if self.getMeshDimension() == 2:
-            density *= 1e3
         return density
 
     def _hasExpression(self, equation):


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
If `CalculateJouleHeating` is `True`, add `Joule Heat` keyword to `Body Force` sections. This is needed to use in combination with the heat equation.

Add boundary conditions to magnetic 2D examples:
Use far field boundary condition in magnetostatic2d example and vector potential $A=0$ (magnetic insulation) in magnetodynamic2d example. Otherwise, Neumann BC is used by default.

@FEA-eng 
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
