### PR TITLE
CAM: No-Engagement feed

### DIFF
--- a/src/Mod/CAM/Constants.py
+++ b/src/Mod/CAM/Constants.py
@@ -207,3 +207,6 @@ GCODE_NON_CONFORMING = (
 # i.e. allow any gcode
 # absence for false; any non-false presence for true: use "True"
 ANNOT_ALLOW_UNSUPPORTED = "allow_unsupported"
+
+# G0 moves which can be replaced by G1 with No-Engagement Feed
+ANNOT_NO_ENGAGEMENT_FEED = "NoEngagementFeed"

--- a/src/Mod/CAM/Gui/Resources/panels/ToolControllerEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/ToolControllerEdit.ui
@@ -193,14 +193,14 @@
        </widget>
       </item>
       <item row="5" column="0">
-       <widget class="QLabel" name="label_5">
+       <widget class="QLabel" name="label_noEngagementFeed">
         <property name="text">
-         <string>Horizontal rapid</string>
+         <string>No-Engagement feed</string>
         </property>
        </widget>
       </item>
       <item row="5" column="1">
-       <widget class="Gui::QuantitySpinBox" name="horizRapid">
+       <widget class="Gui::QuantitySpinBox" name="noEngagementFeed">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -219,13 +219,39 @@
        </widget>
       </item>
       <item row="6" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Horizontal rapid</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="Gui::QuantitySpinBox" name="horizRapid">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimum">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>9999999.000000000000000</double>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true">mm/s</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>Vertical rapid</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="7" column="1">
        <widget class="Gui::QuantitySpinBox" name="vertRapid">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">

--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -308,7 +308,11 @@ def GenerateGCode(op, obj, adaptiveResults):
                         if z != lz:
                             op.commandlist.append(Path.Command("G0", {"Z": z}))
 
-                        op.commandlist.append(Path.Command("G0", {"X": x, "Y": y}))
+                        if feed := getattr(obj.ToolController, "NoEngagementFeed", 0):
+                            parameters = {"X": x, "Y": y, "F": feed.Value}
+                            op.commandlist.append(Path.Command("G1", parameters))
+                        else:
+                            op.commandlist.append(Path.Command("G0", {"X": x, "Y": y}))
 
                     elif motionType == area.AdaptiveMotionType.LinkNotClear:
                         z = obj.ClearanceHeight.Value

--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -308,11 +308,9 @@ def GenerateGCode(op, obj, adaptiveResults):
                         if z != lz:
                             op.commandlist.append(Path.Command("G0", {"Z": z}))
 
-                        if feed := getattr(obj.ToolController, "NoEngagementFeed", 0):
-                            parameters = {"X": x, "Y": y, "F": feed.Value}
-                            op.commandlist.append(Path.Command("G1", parameters))
-                        else:
-                            op.commandlist.append(Path.Command("G0", {"X": x, "Y": y}))
+                        cmd = Path.Command("G0", {"X": x, "Y": y})
+                        cmd.Annotations = {Constants.ANNOT_NO_ENGAGEMENT_FEED: "True"}
+                        op.commandlist.append(cmd)
 
                     elif motionType == area.AdaptiveMotionType.LinkNotClear:
                         z = obj.ClearanceHeight.Value

--- a/src/Mod/CAM/Path/Tool/Controller.py
+++ b/src/Mod/CAM/Path/Tool/Controller.py
@@ -53,6 +53,7 @@ class ToolControllerTemplate:
     LeadOutFeed = "leadoutfeed"
     Name = "name"
     RampFeed = "rampfeed"
+    NoEngagementFeed = "noengagementfeed"
     SpindleDir = "dir"
     SpindleSpeed = "speed"
     ToolNumber = "nr"
@@ -191,6 +192,16 @@ class ToolController:
 
         obj.addProperty(
             "App::PropertySpeed",
+            "NoEngagementFeed",
+            "Feed",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Feed rate used when the tool is not engaged in material, but is also not retracted",
+            ),
+        )
+
+        obj.addProperty(
+            "App::PropertySpeed",
             "LeadInFeed",
             "Feed",
             QT_TRANSLATE_NOOP("App::Property", "Feed rate for lead-in moves"),
@@ -297,6 +308,17 @@ class ToolController:
             obj.setExpression("LeadOutFeed", "HorizFeed")
             needsRecompute = True
 
+        if not hasattr(obj, "NoEngagementFeed"):
+            obj.addProperty(
+                "App::PropertySpeed",
+                "NoEngagementFeed",
+                "Feed",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Feed rate used when the tool is not engaged in material, but is also not retracted",
+                ),
+            )
+
         if needsRecompute:
             obj.recompute()
 
@@ -331,6 +353,10 @@ class ToolController:
                     )
                 if template.get(ToolControllerTemplate.RampFeed):
                     obj.RampFeed = template.get(ToolControllerTemplate.RampFeed, obj.RampFeed)
+                if template.get(ToolControllerTemplate.NoEngagementFeed):
+                    obj.NoEngagementFeed = template.get(
+                        ToolControllerTemplate.NoEngagementFeed, obj.NoEngagementFeed
+                    )
                 if template.get(ToolControllerTemplate.VertRapid):
                     obj.VertRapid = template.get(ToolControllerTemplate.VertRapid)
                 if template.get(ToolControllerTemplate.HorizRapid):
@@ -388,6 +414,7 @@ class ToolController:
         attrs[ToolControllerTemplate.LeadInFeed] = "%s" % (obj.LeadInFeed)
         attrs[ToolControllerTemplate.LeadOutFeed] = "%s" % (obj.LeadOutFeed)
         attrs[ToolControllerTemplate.RampFeed] = "%s" % (obj.RampFeed)
+        attrs[ToolControllerTemplate.NoEngagementFeed] = "%s" % (obj.NoEngagementFeed)
         attrs[ToolControllerTemplate.VertRapid] = "%s" % (obj.VertRapid)
         attrs[ToolControllerTemplate.HorizRapid] = "%s" % (obj.HorizRapid)
         attrs[ToolControllerTemplate.SpindleSpeed] = obj.SpindleSpeed

--- a/src/Mod/CAM/Path/Tool/Gui/Controller.py
+++ b/src/Mod/CAM/Path/Tool/Gui/Controller.py
@@ -224,6 +224,9 @@ class ToolControllerEditor(object):
             self.controller.leadOutFeed, obj, "LeadOutFeed"
         )
         self.rampFeed = PathGuiUtil.QuantitySpinBox(self.controller.rampFeed, obj, "RampFeed")
+        self.noEngagementFeed = PathGuiUtil.QuantitySpinBox(
+            self.controller.noEngagementFeed, obj, "NoEngagementFeed"
+        )
         self.vertRapid = PathGuiUtil.QuantitySpinBox(self.controller.vertRapid, obj, "VertRapid")
         self.horizRapid = PathGuiUtil.QuantitySpinBox(self.controller.horizRapid, obj, "HorizRapid")
 
@@ -299,6 +302,7 @@ class ToolControllerEditor(object):
             self.leadInFeed.widget,
             self.leadOutFeed.widget,
             self.rampFeed.widget,
+            self.noEngagementFeed.widget,
             self.vertFeed.widget,
             self.vertRapid.widget,
             self.controller.spindleSpeed,
@@ -317,6 +321,7 @@ class ToolControllerEditor(object):
             self.leadInFeed.updateWidget()
             self.leadOutFeed.updateWidget()
             self.rampFeed.updateWidget()
+            self.noEngagementFeed.updateWidget()
             self.vertFeed.updateWidget()
             self.vertRapid.updateWidget()
             self.controller.spindleSpeed.setValue(tc.SpindleSpeed)
@@ -341,6 +346,7 @@ class ToolControllerEditor(object):
             self.leadInFeed.updateProperty()
             self.leadOutFeed.updateProperty()
             self.rampFeed.updateProperty()
+            self.noEngagementFeed.updateProperty()
             self.horizRapid.updateProperty()
             self.vertRapid.updateProperty()
             if tc.SpindleSpeed != self.controller.spindleSpeed.value():
@@ -381,6 +387,7 @@ class ToolControllerEditor(object):
         self.leadInFeed.widget.textChanged.connect(self.changed)
         self.leadOutFeed.widget.textChanged.connect(self.changed)
         self.rampFeed.widget.textChanged.connect(self.changed)
+        self.noEngagementFeed.widget.textChanged.connect(self.changed)
         self.vertRapid.widget.textChanged.connect(self.changed)
         self.horizRapid.widget.textChanged.connect(self.changed)
         self.controller.spindleSpeed.editingFinished.connect(self.changed)


### PR DESCRIPTION
Forum discussion: [Adaptive Rapid G0 Moves?](https://forum.freecad.org/viewtopic.php?t=67808)

**Adaptive** op uses rapid moves at working depth

- Some CNC don't like short G0 moves
  https://forum.freecad.org/viewtopic.php?p=586675#p586675

- Rapid moves at work depth get me nervous
  Depends from machine rapid moves can be very fast, which does not looks safely 

- Short rapid horizontal moves cause a frame shaking


Suggested to add new property `No Engagement Feed` to tool controller

Old behavior uses by default,
but if `No Engagement Feed` present and have non zero value, instead of G0 will be used G1

<img width="1522" height="559" alt="Screenshot_20260801_235259_hor_lossy" src="https://github.com/user-attachments/assets/f5717e91-9d9f-442c-bc82-4e280ce49813" />

<img width="379" height="418" alt="Screenshot_20260808_082405_lossy" src="https://github.com/user-attachments/assets/8401a16c-f5a8-42b2-a981-4f21a1ff2a21" />
