### PR TITLE
Gui: Simplify and speed up Qt -> Coin3D image conversion

### DIFF
--- a/src/Gui/BitmapFactory.cpp
+++ b/src/Gui/BitmapFactory.cpp
@@ -559,94 +559,24 @@ QPixmap BitmapFactoryInst::empty(QSize size) const
 
 void BitmapFactoryInst::convert(const QImage& p, SoSFImage& img) const
 {
+    // Coin3D also supports grayscale, grayscale+alpha and RGB888 formats,
+    // but RGBA8888 is universal and is simple and fast to obtain.
+    QImage::Format targetFormat = QImage::Format_RGBA8888;
+    int numcomponents = 4;
+
+    QImage reformattedImage = p.convertedTo(targetFormat);
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
+    reformattedImage.mirror(/* horizontal= */ false, /* vertical= */ true);
+#else
+    reformattedImage.flip(Qt::Vertical);
+#endif
+
     SbVec2s size;
     size[0] = p.width();
     size[1] = p.height();
 
-    int buffersize = static_cast<int>(p.sizeInBytes());
-
-    int numcomponents = 0;
-    QVector<QRgb> table = p.colorTable();
-    if (!table.isEmpty()) {
-        if (p.hasAlphaChannel()) {
-            if (p.allGray()) {
-                numcomponents = 2;
-            }
-            else {
-                numcomponents = 4;
-            }
-        }
-        else {
-            if (p.allGray()) {
-                numcomponents = 1;
-            }
-            else {
-                numcomponents = 3;
-            }
-        }
-    }
-    else {
-        numcomponents = buffersize / (size[0] * size[1]);
-    }
-
-    int depth = numcomponents;
-
-    // Coin3D only supports up to 32-bit images
-    if (numcomponents == 8) {
-        numcomponents = 4;
-    }
-
-    // allocate image data
-    img.setValue(size, numcomponents, nullptr);
-
-    unsigned char* bytes = img.startEditing(size, numcomponents);
-
-    int width = (int)size[0];
-    int height = (int)size[1];
-
-    for (int y = 0; y < height; y++) {
-        unsigned char* line = &bytes[width * numcomponents * (height - (y + 1))];
-        for (int x = 0; x < width; x++) {
-            QColor col = p.pixelColor(x, y);
-            switch (depth) {
-                default:
-                    break;
-                case 1: {
-                    QRgb rgb = col.rgb();
-                    line[0] = qGray(rgb);
-                } break;
-                case 2: {
-                    QRgb rgb = col.rgba();
-                    line[0] = qGray(rgb);
-                    line[1] = qAlpha(rgb);
-                } break;
-                case 3: {
-                    QRgb rgb = col.rgb();
-                    line[0] = qRed(rgb);
-                    line[1] = qGreen(rgb);
-                    line[2] = qBlue(rgb);
-                } break;
-                case 4: {
-                    QRgb rgb = col.rgba();
-                    line[0] = qRed(rgb);
-                    line[1] = qGreen(rgb);
-                    line[2] = qBlue(rgb);
-                    line[3] = qAlpha(rgb);
-                } break;
-                case 8: {
-                    QRgba64 rgb = col.rgba64();
-                    line[0] = qRed(rgb);
-                    line[1] = qGreen(rgb);
-                    line[2] = qBlue(rgb);
-                    line[3] = qAlpha(rgb);
-                } break;
-            }
-
-            line += numcomponents;
-        }
-    }
-
-    img.finishEditing();
+    img.setValue(size, numcomponents, reformattedImage.constBits());
 }
 
 void BitmapFactoryInst::convert(const SoSFImage& p, QImage& img) const

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2978,14 +2978,7 @@ QString EditModeConstraintCoinManager::iconTypeFromConstraint(Constraint* constr
 
 void EditModeConstraintCoinManager::sendConstraintIconToCoin(const QImage& icon, SoImage* soImagePtr)
 {
-    SoSFImage icondata = SoSFImage();
-
-    Gui::BitmapFactory().convert(icon, icondata);
-
-    SbVec2s iconSize(icon.width(), icon.height());
-
-    int four = 4;
-    soImagePtr->image.setValue(iconSize, 4, icondata.getValue(iconSize, four));
+    Gui::BitmapFactory().convert(icon, soImagePtr->image);
 
     // Set Image Alignment to Center
     soImagePtr->vertAlignment = SoImage::HALF;


### PR DESCRIPTION
I found BitmapFactoryInst::convert() to be a bottleneck while profiling why zooming in/out in Sketcher is laggy. The issue is that QImage::pixelColor() is slow (and is called out as such in Qt docs).

The simplest way to solve that is to use Qt's native pixel format conversion. However, Qt does not support all formats that Coin3D supports (i.e. grayscale+alpha). I worked this around by always converting the images to the RGBA format. My (perhaps naive) thinking is that modern GPUs prefer RGBA8888 buffers anyway (at least over RGB888).

Assisted-by: gemini-3.5-flash

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
