### PR TITLE
Fix stale overlay pixels after splitter resize

### DIFF
--- a/src/Gui/OverlayWidgets.cpp
+++ b/src/Gui/OverlayWidgets.cpp
@@ -1996,6 +1996,11 @@ void OverlayTabWidget::onSplitterResize(int index)
     }
 
     saveTabs();
+    // A splitter resize can change the source pixmap used by the overlay
+    // graphics effect without causing a repaint of the affected dock widget.
+    // Schedule a refresh so a collapsed dock cannot leave stale pixels over
+    // the view when transparency is re-enabled.
+    scheduleRepaint();
 }
 
 void OverlayTabWidget::onCurrentChanged(int index)


### PR DESCRIPTION
## Summary

- Schedule the existing overlay repaint after a splitter resize.
- Prevent stale dock pixels from remaining over the model/tree view after a dock is collapsed and transparency is re-enabled.

## Issues

Fixes #30215

## Reproduction

1. Enable Clipping View in Part Design.
2. Toggle overlay twice to create the split Model/Clipping panel.
3. Shrink the Clipping panel until it contracts.
4. Move the pointer away to trigger transparency.

## Validation

- The change is limited to OverlayTabWidget::onSplitterResize() in src/Gui/OverlayWidgets.cpp.
- git -c core.whitespace=cr-at-eol diff --check passes locally.
- A focused secret/data scan of the diff is clean.
- A full FreeCAD GUI build and interactive reproduction were not available in this environment.

## AI assistance

This patch was prepared with assistance from OpenAI Codex (GPT-5). The published change is limited to the focused five-line repaint scheduling fix shown in the diff.