### PR TITLE
(cp) Gui: Allow to edit description in tree view

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -2119,6 +2119,12 @@ void TreeWidget::mouseDoubleClickEvent(QMouseEvent* event)
         return;
     }
 
+    QModelIndex index = indexAt(event->pos());
+    if (index.column() != 0) {
+        QTreeWidget::mouseDoubleClickEvent(event);
+        return;
+    }
+
     try {
         if (item->type() == TreeWidget::DocumentType) {
             Gui::Document* doc = static_cast<DocumentItem*>(item)->document();


### PR DESCRIPTION
Cherry-picked https://codeberg.org/xwzCAD/FreeCAD/pulls/289

If the description columns in the tree view is enabled then for many feature types a doubleclick on the second column doesn't allow it to change the text.

Fixes https://github.com/FreeCAD/FreeCAD/issues/31660