### PR TITLE
(cp) Sheet: Allow to format cells in edit mode

### DIFF
--- a/src/Gui/Command.h
+++ b/src/Gui/Command.h
@@ -707,6 +707,7 @@ private:
 protected:
     enum CmdType
     {
+        AlterNone = 0,      /**< Command change nothing */
         AlterDoc = 1,       /**< Command change the Document */
         Alter3DView = 2,    /**< Command change the Gui */
         AlterSelection = 4, /**< Command change the Selection */

--- a/src/Mod/Spreadsheet/Gui/Command.cpp
+++ b/src/Mod/Spreadsheet/Gui/Command.cpp
@@ -64,6 +64,7 @@ CmdSpreadsheetMergeCells::CmdSpreadsheetMergeCells()
     sWhatsThis = "Spreadsheet_MergeCells";
     sStatusTip = sToolTipText;
     sPixmap = "SpreadsheetMergeCells";
+    eType = AlterNone;
 }
 
 void CmdSpreadsheetMergeCells::activated(int iMsg)
@@ -125,6 +126,7 @@ CmdSpreadsheetSplitCell::CmdSpreadsheetSplitCell()
     sWhatsThis = "Spreadsheet_SplitCell";
     sStatusTip = sToolTipText;
     sPixmap = "SpreadsheetSplitCell";
+    eType = AlterNone;
 }
 
 void CmdSpreadsheetSplitCell::activated(int iMsg)
@@ -244,6 +246,7 @@ CmdSpreadsheetExport::CmdSpreadsheetExport()
     sWhatsThis = "Spreadsheet_Export";
     sStatusTip = sToolTipText;
     sPixmap = "SpreadsheetExport";
+    eType = AlterNone;
 }
 
 void CmdSpreadsheetExport::activated(int iMsg)
@@ -289,6 +292,7 @@ CmdSpreadsheetAlignLeft::CmdSpreadsheetAlignLeft()
     sWhatsThis = "Spreadsheet_AlignLeft";
     sStatusTip = sToolTipText;
     sPixmap = "SpreadsheetAlignLeft";
+    eType = AlterNone;
 }
 
 void CmdSpreadsheetAlignLeft::activated(int iMsg)
@@ -346,6 +350,7 @@ CmdSpreadsheetAlignCenter::CmdSpreadsheetAlignCenter()
     sWhatsThis = "Spreadsheet_AlignCenter";
     sStatusTip = sToolTipText;
     sPixmap = "SpreadsheetAlignCenter";
+    eType = AlterNone;
 }
 
 void CmdSpreadsheetAlignCenter::activated(int iMsg)
@@ -403,6 +408,7 @@ CmdSpreadsheetAlignRight::CmdSpreadsheetAlignRight()
     sWhatsThis = "Spreadsheet_AlignRight";
     sStatusTip = sToolTipText;
     sPixmap = "SpreadsheetAlignRight";
+    eType = AlterNone;
 }
 
 void CmdSpreadsheetAlignRight::activated(int iMsg)
@@ -460,6 +466,7 @@ CmdSpreadsheetAlignTop::CmdSpreadsheetAlignTop()
     sWhatsThis = "Spreadsheet_AlignTop";
     sStatusTip = sToolTipText;
     sPixmap = "SpreadsheetAlignTop";
+    eType = AlterNone;
 }
 
 void CmdSpreadsheetAlignTop::activated(int iMsg)
@@ -517,6 +524,7 @@ CmdSpreadsheetAlignBottom::CmdSpreadsheetAlignBottom()
     sWhatsThis = "Spreadsheet_AlignBottom";
     sStatusTip = sToolTipText;
     sPixmap = "SpreadsheetAlignBottom";
+    eType = AlterNone;
 }
 
 void CmdSpreadsheetAlignBottom::activated(int iMsg)
@@ -574,6 +582,7 @@ CmdSpreadsheetAlignVCenter::CmdSpreadsheetAlignVCenter()
     sWhatsThis = "Spreadsheet_AlignVCenter";
     sStatusTip = sToolTipText;
     sPixmap = "SpreadsheetAlignVCenter";
+    eType = AlterNone;
 }
 
 void CmdSpreadsheetAlignVCenter::activated(int iMsg)
@@ -632,6 +641,7 @@ CmdSpreadsheetStyleBold::CmdSpreadsheetStyleBold()
     sStatusTip = sToolTipText;
     sPixmap = "SpreadsheetStyleBold";
     sAccel = "Ctrl+B";
+    eType = AlterNone;
 }
 
 void CmdSpreadsheetStyleBold::activated(int iMsg)
@@ -717,6 +727,7 @@ CmdSpreadsheetStyleItalic::CmdSpreadsheetStyleItalic()
     sStatusTip = sToolTipText;
     sPixmap = "SpreadsheetStyleItalic";
     sAccel = "Ctrl+I";
+    eType = AlterNone;
 }
 
 void CmdSpreadsheetStyleItalic::activated(int iMsg)
@@ -802,6 +813,7 @@ CmdSpreadsheetStyleUnderline::CmdSpreadsheetStyleUnderline()
     sStatusTip = sToolTipText;
     sPixmap = "SpreadsheetStyleUnderline";
     sAccel = "Ctrl+U";
+    eType = AlterNone;
 }
 
 void CmdSpreadsheetStyleUnderline::activated(int iMsg)


### PR DESCRIPTION
Cherry-picked https://codeberg.org/xwzCAD/FreeCAD/pulls/290

If any unrelated object is in edit mode then still allow to format cells of a spreadsheet.

This fixes https://github.com/FreeCAD/FreeCAD/issues/31658
