### PR TITLE
TechDraw: Block unnecessary HLR calls

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -346,6 +346,25 @@ TopoDS_Shape DrawViewPart::centerScaleRotate(const DrawViewPart *dvp, TopoDS_Sha
 TechDraw::GeometryObjectPtr DrawViewPart::buildGeometryObject(const TopoDS_Shape& shape,
                                                               const gp_Ax2& viewAxis)
 {
+    // Create a hash of the shape and view parameters to determine is something has changed
+    std::size_t newViewHash = std::hash<std::string>{}(DU::shapeToString(shape));
+    Base::hash_combine(newViewHash, DU::formatVector(viewAxis.Location()));
+    Base::hash_combine(newViewHash, DU::formatVector(viewAxis.Direction()));
+    Base::hash_combine(newViewHash, DU::formatVector(viewAxis.XDirection()));
+    Base::hash_combine(newViewHash, Rotation.getValue());
+    Base::hash_combine(newViewHash, getScale());
+    Base::hash_combine(newViewHash, Perspective.getValue());
+    Base::hash_combine(newViewHash, Focus.getValue());
+    Base::hash_combine(newViewHash, IsoCount.getValue());
+    Base::hash_combine(newViewHash, CoarseView.getValue());
+    Base::hash_combine(newViewHash, ScrubCount.getValue());
+
+    // If the object is not different we just return the existing geometryObject to skip HLR
+    if (newViewHash == m_viewHash && geometryObject) {
+        return geometryObject;
+    }
+
+    m_viewHash = newViewHash;
     TechDraw::GeometryObjectPtr go(
         std::make_shared<TechDraw::GeometryObject>(getNameInDocument(), this));
     go->setIsoCount(IsoCount.getValue());

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -358,9 +358,10 @@ TechDraw::GeometryObjectPtr DrawViewPart::buildGeometryObject(const TopoDS_Shape
     Base::hash_combine(newViewHash, IsoCount.getValue());
     Base::hash_combine(newViewHash, CoarseView.getValue());
     Base::hash_combine(newViewHash, ScrubCount.getValue());
+    m_hlrBlocked = false;
 
-    // If the object is not different we just return the existing geometryObject to skip HLR
     if (newViewHash == m_viewHash && geometryObject) {
+        m_hlrBlocked = true;
         return geometryObject;
     }
 
@@ -428,6 +429,10 @@ void DrawViewPart::onHlrFinished()
     waitingForHlr(false);
     QObject::disconnect(connectHlrWatcher);
     showProgressMessage(getNameInDocument(), "has finished finding hidden lines");
+
+    if (m_hlrBlocked) {
+        return;
+    }
 
     postHlrTasks();//application level tasks that depend on HLR/GO being complete
 

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include <QFuture>
 #include <QFutureWatcher>
 
@@ -275,6 +277,7 @@ protected:
 
     TopoDS_Shape m_saveShape;     //TODO: make this a Property.  Part::TopoShapeProperty??
     Base::Vector3d m_saveCentroid;//centroid before centering shape in origin
+    std::size_t m_viewHash{0}; // view hash to check if the view has changed
 
     std::vector<TechDraw::VertexPtr> m_referenceVerts;
 
@@ -289,7 +292,6 @@ private:
     QMetaObject::Connection connectFaceWatcher;
     QFutureWatcher<void> m_faceWatcher;
     QFuture<void> m_faceFuture;
-
 };
 
 using DrawViewPartPython = App::FeaturePythonT<DrawViewPart>;

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -278,6 +278,7 @@ protected:
     TopoDS_Shape m_saveShape;     //TODO: make this a Property.  Part::TopoShapeProperty??
     Base::Vector3d m_saveCentroid;//centroid before centering shape in origin
     std::size_t m_viewHash{0}; // view hash to check if the view has changed
+    bool m_hlrBlocked{false};
 
     std::vector<TechDraw::VertexPtr> m_referenceVerts;
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

TechDraw is currently very slow for large models. The HLR algorithm can for complex models be slow. But the main issue is that the HLR gets run on every recompute. So it updates when dimensions, balloons or any other kinds of annotations are deleted. In this PR I have added a small hash that keeps the shape and settings for the view, and if nothing in the view or shape has been updated it does not recompute the HLR. 

Work from PR #21427 might be needed after this PR. 

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Before and After Images
Before these changes the HLR runs every time annotations are deleted, and also happens when the "New View" command is closed even though a change to the view has not been done:

https://github.com/user-attachments/assets/efa639b4-41c7-4e33-bbbf-ef891d3e4a5a

After it only gets recomputed hwen the scale gets changed or when more views are added. Not when dimension or other annotations are deleted:

https://github.com/user-attachments/assets/f2c46562-9985-407f-9e8f-eca38563a99a

Note that the changes can be seen in a log I placed in the HLR code, so this can not be seen when testing this PR. Also the errors are not from this PR.
