### PR TITLE
TechDraw: Remove Arc of Circle Centermarkings

### DIFF
--- a/src/Mod/TechDraw/App/GeometryObject.cpp
+++ b/src/Mod/TechDraw/App/GeometryObject.cpp
@@ -563,8 +563,9 @@ void GeometryObject::addGeomFromCompound(TopoDS_Shape edgeCompound, EdgeClass ca
         TechDraw::VertexPtr v1 = std::make_shared<TechDraw::Vertex>(lastAdded->getStartPoint());
         TechDraw::VertexPtr v2 = std::make_shared<TechDraw::Vertex>(lastAdded->getEndPoint());
         TechDraw::CirclePtr circle = std::dynamic_pointer_cast<TechDraw::Circle>(lastAdded);
+        TechDraw::AOCPtr arc = std::dynamic_pointer_cast<TechDraw::AOC>(lastAdded);
         TechDraw::VertexPtr c1;
-        if (circle) {
+        if (circle && !arc) {
             c1 = std::make_shared<TechDraw::Vertex>(circle->center);
             c1->isCenter(true);
             c1->setHlrVisible(hlrVisible);
@@ -578,7 +579,7 @@ void GeometryObject::addGeomFromCompound(TopoDS_Shape edgeCompound, EdgeClass ca
             if ((*itVertex)->isEqual(*v2, Precision::Confusion())) {
                 v2Add = false;
             }
-            if (circle) {
+            if (circle && !arc) {
                 if ((*itVertex)->isEqual(*c1, Precision::Confusion())) {
                     c1Add = false;
                 }
@@ -599,7 +600,7 @@ void GeometryObject::addGeomFromCompound(TopoDS_Shape edgeCompound, EdgeClass ca
             //    delete v2;
         }
 
-        if (circle) {
+        if (circle && !arc) {
             if (c1Add) {
                 vertexGeom.push_back(c1);
                 c1->setHlrVisible(hlrVisible);


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Currently centermarkings gets added to everything that is a circle. However Arc of Circle is also defined as a circle. This means that center markings are all over the place in complex models. 

I have added a check that makes sure it is not an arc before adding center markings. 

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.


## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
Before there was a lot of small + marks everywhere
<img width="385" height="417" alt="Center Markings Before" src="https://github.com/user-attachments/assets/d20cf305-7bdd-42aa-8865-ec4913d55a11" />

After:
<img width="251" height="422" alt="image" src="https://github.com/user-attachments/assets/96a29e19-8d09-4bc2-874c-4fa2f467c89f" />
