### PR TITLE
CAM: Custom - Allow any string

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathCustom.py
+++ b/src/Mod/CAM/CAMTests/TestPathCustom.py
@@ -25,61 +25,64 @@ These tests deliberately avoid loading documents from disk and avoid building
 a full Job/Stock/ToolController graph. The operation is small
 """
 
-from types import SimpleNamespace
-from unittest.mock import Mock
-
+import FreeCAD
 import Path
+import Path.Main.Job as PathJob
 from Path.Op import Custom
 from Path.Base.MachineState import MachineState
 from Path.Post.Processor import PostProcessor
 from Path.Post.PostList import Postable
 from Machine.models.machine import Machine, OutputUnits
 from CAMTests import PathTestUtils
-from CAMTests.PostTestMocks import MockJob, MockStock
 
 Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
-
-
-def _make_job(xmin=0.0, ymin=0.0, zmin=0.0, xmax=10.0, ymax=10.0, zmax=4.0):
-    """A shared MockJob whose stock spans the requested bounding box."""
-    job = MockJob()
-    job.Stock = MockStock(xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax, zmin=zmin, zmax=zmax)
-    return job
 
 
 class TestPathCustomConverted(PathTestUtils.PathTestBase):
     """Test Custom through Processor.py's _convert_item_commands()"""
 
     @classmethod
-    def _make_op(cls, gcode):
+    def _make_op(cls, gcode, process=True):
         """make the op and postable from lines of gcode or ["gcode",...] or [Path.Command...]"""
-        op = Custom.Create(name="dumy", obj=Mock(), parentJob=cls.job).Proxy
+        if not cls.job.Operations.Group:
+            op = Custom.Create(name="Custom", parentJob=cls.job)
+        else:
+            op = cls.job.Operations.Group[0]
         op.Active = True
-        op.commandlist = []
         if isinstance(gcode, str):
             gcode = gcode.rstrip().split("\n")
         if isinstance(gcode, (list, tuple)):
             gcode = [(s if isinstance(s, str) else s.toGCode()) for s in gcode]
-        custom_gcode = SimpleNamespace(Source="Text", Gcode=gcode)
-        op.opExecute(custom_gcode)
+        op.Source = "Text"
+        op.Gcode = gcode
+        op.PostProcessOutput = process
+        op.recompute()
 
         postable = Postable(
             label="test custom",
             item_type="operation",
             data={},
-            path=Path.Path(op.commandlist),
+            path=op.Path,
             source=None,
         )
         return op, postable
 
     @classmethod
     def setUpClass(cls):
-
-        cls.job = _make_job()
+        cls.doc = FreeCAD.newDocument("test")
+        box = cls.doc.addObject("Part::Box", "TestBox")
+        cls.job = PathJob.Create("Job", [box])
+        cls.job.Machine = "TestMachine"
         cls.pp = PostProcessor(cls.job, "tooltip", "args", units="G21")
+
+    @classmethod
+    def tearDownClass(cls):
+        FreeCAD.closeDocument(cls.doc.Name)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     def setUp(self):
         self.pp._machine = Machine()
+        self.pp._machine.name = "TestMachine"
         self.pp._machine.output.units = OutputUnits.METRIC
         self.pp._merge_machine_config()
         self.pp.machine_state = MachineState()
@@ -92,7 +95,8 @@ class TestPathCustomConverted(PathTestUtils.PathTestBase):
         self.pp._convert_item_commands(postable, output)
         self.assertEqual(
             "\n".join(output),
-            """(Begin Custom)
+            """(Custom)
+(Begin Custom)
 G1 X1.000
 (End Custom)""",
         )
@@ -105,7 +109,37 @@ G1 X1.000
         self.pp._convert_item_commands(postable, output)
         self.assertEqual(
             "\n".join(output),
-            """(Begin Custom)
+            """(Custom)
+(Begin Custom)
 G666 X1.000
+(End Custom)""",
+        )
+
+    def test_as_is_one_line(self):
+        """Processor allows add lines without processing"""
+        _, postable = self._make_op("! G68 R#100 X#150 Y#151")
+
+        output = []
+        self.pp._convert_item_commands(postable, output)
+        self.assertEqual(
+            "\n".join(output),
+            """(Custom)
+(Begin Custom)
+ G68 R#100 X#150 Y#151
+(End Custom)""",
+        )
+
+    def test_as_is_all_line(self):
+        """Processor allows add lines without processing"""
+        _, postable = self._make_op(" ;EX1: REFERENCE LEFT 0\n  G68 R#100 X#150 Y#151", False)
+
+        output = []
+        self.pp._convert_item_commands(postable, output)
+        self.assertEqual(
+            "\n".join(output),
+            """(Custom)
+(Begin Custom)
+ ;EX1: REFERENCE LEFT 0
+  G68 R#100 X#150 Y#151
 (End Custom)""",
         )

--- a/src/Mod/CAM/CAMTests/TestPathCustom.py
+++ b/src/Mod/CAM/CAMTests/TestPathCustom.py
@@ -50,7 +50,7 @@ class TestPathCustomConverted(PathTestUtils.PathTestBase):
     """Test Custom through Processor.py's _convert_item_commands()"""
 
     @classmethod
-    def _make_op(cls, gcode):
+    def _make_op(cls, gcode, as_is=False):
         """make the op and postable from lines of gcode or ["gcode",...] or [Path.Command...]"""
         op = Custom.Create(name="dumy", obj=Mock(), parentJob=cls.job).Proxy
         op.Active = True
@@ -59,7 +59,7 @@ class TestPathCustomConverted(PathTestUtils.PathTestBase):
             gcode = gcode.rstrip().split("\n")
         if isinstance(gcode, (list, tuple)):
             gcode = [(s if isinstance(s, str) else s.toGCode()) for s in gcode]
-        custom_gcode = SimpleNamespace(Source="Text", Gcode=gcode)
+        custom_gcode = SimpleNamespace(Source="Text", Gcode=gcode, AddWithoutProcessing=as_is)
         op.opExecute(custom_gcode)
 
         postable = Postable(
@@ -105,5 +105,32 @@ G1 X1.000
             "\n".join(output),
             """(Begin Custom)
 G666 X1.000
+(End Custom)""",
+        )
+
+    def test_as_is_one_line(self):
+        """Processor allows add lines without processing"""
+        _, postable = self._make_op("!G68 R#100 X#150 Y#151")
+
+        output = []
+        self.pp._convert_item_commands(postable, output)
+        self.assertEqual(
+            "\n".join(output),
+            """(Begin Custom)
+G68 R#100 X#150 Y#151
+(End Custom)""",
+        )
+
+    def test_as_is_all_line(self):
+        """Processor allows add lines without processing"""
+        _, postable = self._make_op(";EX1: REFERENCE LEFT 0\nG68 R#100 X#150 Y#151", True)
+
+        output = []
+        self.pp._convert_item_commands(postable, output)
+        self.assertEqual(
+            "\n".join(output),
+            """(Begin Custom)
+;EX1: REFERENCE LEFT 0
+G68 R#100 X#150 Y#151
 (End Custom)""",
         )

--- a/src/Mod/CAM/Constants.py
+++ b/src/Mod/CAM/Constants.py
@@ -226,3 +226,6 @@ ANNOT_NO_ENGAGEMENT_FEED = "NoEngagementFeed"
 ANNOT_MODAL_BARRIER = "modal_barrier"
 # Don't optimize this G0 into next/previous ones, the motion is salient
 ANNOT_NO_COLLAPSE_G0 = "no_collapse_g0"
+
+# Pass through string in annotation as command without any changes
+ANNOT_AS_IS = "as-is"

--- a/src/Mod/CAM/Constants.py
+++ b/src/Mod/CAM/Constants.py
@@ -207,3 +207,6 @@ GCODE_NON_CONFORMING = (
 # i.e. allow any gcode
 # absence for false; any non-false presence for true: use "True"
 ANNOT_ALLOW_UNSUPPORTED = "allow_unsupported"
+
+# Pass through string in annotation as command without any changes
+ANNOT_AS_IS = "as-is"

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpCustomEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpCustomEdit.ui
@@ -14,6 +14,23 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QCheckBox" name="chkAsIs">
+     <property name="text">
+      <string>Post Process Output</string>
+     </property>
+     <property name="toolTip">
+      <string>Post processing can reformat G-code added in custom operations.
+This includes reordering parameters, stripping unsupported parameters,
+changing the number of decimals behind numbers
+and converting feed rate from an internal system to the current units.
+
+Post processing the commands is useful for freecad macros and using similar code on multiple machines.
+Use ! at the start of the line to individually disable post processing on a given line. Eg.
+!#101 = 2</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0">
     <widget class="QWidget" name="widget">
      <layout class="QGridLayout" name="gridLayout_2">

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpCustomEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpCustomEdit.ui
@@ -14,6 +14,13 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QCheckBox" name="chkAsIs">
+     <property name="text">
+      <string>Add without processing</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0">
     <widget class="QWidget" name="widget">
      <layout class="QGridLayout" name="gridLayout_2">

--- a/src/Mod/CAM/Path/Op/Custom.py
+++ b/src/Mod/CAM/Path/Op/Custom.py
@@ -1,25 +1,23 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2014 Yorik van Havre yorik@uncreated.net
+# SPDX-FileNotice: Part of the FreeCAD project.
 
-# ***************************************************************************
-# *   Copyright (c) 2014 Yorik van Havre <yorik@uncreated.net>              *
-# *                                                                         *
-# *   This program is free software; you can redistribute it and/or modify  *
-# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
-# *   as published by the Free Software Foundation; either version 2 of     *
-# *   the License, or (at your option) any later version.                   *
-# *   for detail see the LICENCE text file.                                 *
-# *                                                                         *
-# *   This program is distributed in the hope that it will be useful,       *
-# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-# *   GNU Library General Public License for more details.                  *
-# *                                                                         *
-# *   You should have received a copy of the GNU Library General Public     *
-# *   License along with this program; if not, write to the Free Software   *
-# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-# *   USA                                                                   *
-# *                                                                         *
-# ***************************************************************************
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
 
 import FreeCAD
 import re
@@ -27,6 +25,7 @@ import os
 import Path
 import Path.Op.Base as PathOp
 import Constants
+from PathScripts import PathUtils
 
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -70,7 +69,7 @@ class ObjectCustom(PathOp.ObjectOp):
         if dataType == "raw":
             return enums
 
-        data = list()
+        data = []
         idx = 0 if dataType == "translated" else 1
 
         Path.Log.debug(enums)
@@ -106,6 +105,14 @@ class ObjectCustom(PathOp.ObjectOp):
             QT_TRANSLATE_NOOP("App::Property", "The G-code to be inserted"),
         )
 
+        obj.addProperty(
+            "App::PropertyBool",
+            "PostProcessOutput",
+            "Path",
+            QT_TRANSLATE_NOOP("App::Property", "Pass Custom G-code through Post Processor"),
+        )
+        obj.PostProcessOutput = True
+
         # populate the property enumerations
         for n in self.propertyEnumerations():
             setattr(obj, n[0], n[1])
@@ -136,7 +143,14 @@ class ObjectCustom(PathOp.ObjectOp):
                 "Path",
                 "File containing gcode to be inserted",
             )
-
+        if not hasattr(obj, "PostProcessOutput"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "PostProcessOutput",
+                "Path",
+                QT_TRANSLATE_NOOP("App::Property", "Pass Custom G-code through Post Processor"),
+            )
+            obj.PostProcessOutput = True
         # populate the property enumerations
         for n in self.propertyEnumerations():
             setattr(obj, n[0], n[1])
@@ -179,65 +193,64 @@ class ObjectCustom(PathOp.ObjectOp):
             line = re.sub(pattern, str(value), line, count=1)
         return line
 
-    def opExecute(self, obj):
-        self.commandlist.append(Path.Command("(Begin Custom)"))
-        errorNumLines = []
-        errorLines = []
-
-        if obj.Source == "Text" and obj.Gcode:
-            for i, line in enumerate(obj.Gcode):
+    def processLines(self, obj, lines):
+        for i, line in enumerate(lines, 1):
+            if line.startswith("!"):
+                newcommand = Path.Command("", {}, {Constants.ANNOT_AS_IS: line[1:]})
+                self.commandlist.append(newcommand)
+            elif not obj.PostProcessOutput:
+                newcommand = Path.Command("", {}, {Constants.ANNOT_AS_IS: line})
+                self.commandlist.append(newcommand)
+            else:
+                line = line.strip()
                 line = self.parseExpressions(obj, line, i)
                 try:
-                    newcommand = Path.Command(
-                        str(line), {}, {Constants.ANNOT_ALLOW_UNSUPPORTED: "True"}
-                    )
+                    newcommand = Path.Command(line, {}, {Constants.ANNOT_ALLOW_UNSUPPORTED: "True"})
                     self.commandlist.append(newcommand)
                 except ValueError:
-                    errorNumLines.append(i)
-                    if len(errorLines) < 7:
-                        errorLines.append(f"{i}: {str(line).strip()}")
-            if errorLines:
-                # FIXME: should throw
-                Path.Log.warning(
-                    translate("PathCustom", "Total invalid lines in Custom Text G-code: %s")
-                    % len(errorNumLines)
+                    if len(self.errors) < 7:
+                        self.errors.append((i, line))
+                    else:
+                        self.errors.append((i, None))
+
+    def opExecute(self, obj):
+        self.errors = []
+        self.commandlist.append(Path.Command("(Begin Custom)"))
+
+        if not obj.PostProcessOutput and (job := PathUtils.findParentJob(obj)) and not job.Machine:
+            Path.Log.warning(
+                translate(
+                    "PathCustom",
+                    "Pass Custom G-code through Post Processor"
+                    " should be enabled for legacy post processor",
                 )
-
-        elif obj.Source == "File" and len(obj.GcodeFile) > 0:
+            )
+        if obj.Source == "Text" and obj.Gcode:
+            self.processLines(obj, obj.Gcode)
+        elif obj.Source == "File" and obj.GcodeFile:
             gcode_file = self.findGcodeFile(obj.GcodeFile)
-
-            # could not determine the path
-            if not gcode_file:
+            if not gcode_file:  # could not determine the path
                 Path.Log.error(
                     translate("PathCustom", "Custom file %s could not be found.") % obj.GcodeFile
                 )
-            else:
-                with open(gcode_file) as fd:
-                    for i, line in enumerate(fd.readlines()):
-                        line = line.strip()
-                        line = self.parseExpressions(obj, line, i)
-                        try:
-                            newcommand = Path.Command(str(line))
-                            self.commandlist.append(newcommand)
-                        except ValueError:
-                            errorNumLines.append(i)
-                            if len(errorLines) < 7:
-                                errorLines.append(f"{i}: {str(line).strip()}")
-                if errorLines:
-                    Path.Log.warning(gcode_file)
-                    Path.Log.warning(
-                        translate("PathCustom", "Total invalid lines in Custom File G-code: %s")
-                        % len(errorNumLines)
-                    )
+                obj.Path = Path.Path()
+                return
+            with open(gcode_file) as fd:
+                self.processLines(obj, fd.readlines())
 
-        if errorNumLines:
+        if self.errors:
             Path.Log.warning(
-                translate("PathCustom", "Check lines: %s") % ", ".join(map(str, errorNumLines))
+                translate("PathCustom", "Total invalid lines in Custom G-code: %s")
+                % len(self.errors)
             )
 
-            if len(errorLines) > 7:
-                errorLines.append("...")
-            Path.Log.warning("\n" + "\n".join(errorLines))
+            errorNums = ", ".join((str(i) for i, _ in self.errors))
+            Path.Log.warning(translate("PathCustom", "Check lines: %s") % errorNums)
+
+            errorLines = "\n" + "\n".join((f"{i} {line}" for i, line in self.errors[:7]))
+            if len(self.errors) > 7:
+                errorLines += "\n..."
+            Path.Log.warning(errorLines)
 
         self.commandlist.append(Path.Command("(End Custom)"))
 

--- a/src/Mod/CAM/Path/Op/Custom.py
+++ b/src/Mod/CAM/Path/Op/Custom.py
@@ -105,6 +105,12 @@ class ObjectCustom(PathOp.ObjectOp):
             "Path",
             QT_TRANSLATE_NOOP("App::Property", "The G-code to be inserted"),
         )
+        obj.addProperty(
+            "App::PropertyBool",
+            "AddWithoutProcessing",
+            "Path",
+            QT_TRANSLATE_NOOP("App::Property", "Add lines without processing"),
+        )
 
         # populate the property enumerations
         for n in self.propertyEnumerations():
@@ -135,6 +141,13 @@ class ObjectCustom(PathOp.ObjectOp):
                 "GcodeFile",
                 "Path",
                 "File containing gcode to be inserted",
+            )
+        if not hasattr(obj, "AddWithoutProcessing"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "AddWithoutProcessing",
+                "Path",
+                QT_TRANSLATE_NOOP("App::Property", "Add lines without processing"),
             )
 
         # populate the property enumerations
@@ -179,65 +192,56 @@ class ObjectCustom(PathOp.ObjectOp):
             line = re.sub(pattern, str(value), line, count=1)
         return line
 
-    def opExecute(self, obj):
-        self.commandlist.append(Path.Command("(Begin Custom)"))
-        errorNumLines = []
-        errorLines = []
-
-        if obj.Source == "Text" and obj.Gcode:
-            for i, line in enumerate(obj.Gcode):
+    def processLines(self, obj, lines):
+        for i, line in enumerate(lines, 1):
+            line = line.strip()
+            if obj.AddWithoutProcessing:
+                newcommand = Path.Command("", {}, {Constants.ANNOT_AS_IS: line})
+                self.commandlist.append(newcommand)
+            elif line.startswith("!"):
+                newcommand = Path.Command("", {}, {Constants.ANNOT_AS_IS: line[1:]})
+                self.commandlist.append(newcommand)
+            else:
                 line = self.parseExpressions(obj, line, i)
                 try:
-                    newcommand = Path.Command(
-                        str(line), {}, {Constants.ANNOT_ALLOW_UNSUPPORTED: "True"}
-                    )
+                    newcommand = Path.Command(line, {}, {Constants.ANNOT_ALLOW_UNSUPPORTED: "True"})
                     self.commandlist.append(newcommand)
                 except ValueError:
-                    errorNumLines.append(i)
-                    if len(errorLines) < 7:
-                        errorLines.append(f"{i}: {str(line).strip()}")
-            if errorLines:
-                # FIXME: should throw
-                Path.Log.warning(
-                    translate("PathCustom", "Total invalid lines in Custom Text G-code: %s")
-                    % len(errorNumLines)
-                )
+                    if len(self.errors) < 7:
+                        self.errors.append((i, line))
+                    else:
+                        self.errors.append((i, None))
 
-        elif obj.Source == "File" and len(obj.GcodeFile) > 0:
+    def opExecute(self, obj):
+        self.errors = []
+        self.commandlist.append(Path.Command("(Begin Custom)"))
+
+        if obj.Source == "Text" and obj.Gcode:
+            self.processLines(obj, obj.Gcode)
+        elif obj.Source == "File" and obj.GcodeFile:
             gcode_file = self.findGcodeFile(obj.GcodeFile)
-
-            # could not determine the path
-            if not gcode_file:
+            if not gcode_file:  # could not determine the path
                 Path.Log.error(
                     translate("PathCustom", "Custom file %s could not be found.") % obj.GcodeFile
                 )
-            else:
-                with open(gcode_file) as fd:
-                    for i, line in enumerate(fd.readlines()):
-                        line = line.strip()
-                        line = self.parseExpressions(obj, line, i)
-                        try:
-                            newcommand = Path.Command(str(line))
-                            self.commandlist.append(newcommand)
-                        except ValueError:
-                            errorNumLines.append(i)
-                            if len(errorLines) < 7:
-                                errorLines.append(f"{i}: {str(line).strip()}")
-                if errorLines:
-                    Path.Log.warning(gcode_file)
-                    Path.Log.warning(
-                        translate("PathCustom", "Total invalid lines in Custom File G-code: %s")
-                        % len(errorNumLines)
-                    )
+                obj.Path = Path.Path()
+                return
+            with open(gcode_file) as fd:
+                self.processLines(obj, fd.readlines())
 
-        if errorNumLines:
+        if self.errors:
             Path.Log.warning(
-                translate("PathCustom", "Check lines: %s") % ", ".join(map(str, errorNumLines))
+                translate("PathCustom", "Total invalid lines in Custom G-code: %s")
+                % len(self.errors)
             )
 
-            if len(errorLines) > 7:
-                errorLines.append("...")
-            Path.Log.warning("\n" + "\n".join(errorLines))
+            errorNums = ", ".join((str(i) for i, _ in self.errors))
+            Path.Log.warning(translate("PathCustom", "Check lines: %s") % errorNums)
+
+            errorLines = "\n" + "\n".join((f"{i} {line}" for i, line in self.errors[:7]))
+            if len(self.errors) > 7:
+                errorLines += "\n..."
+            Path.Log.warning(errorLines)
 
         self.commandlist.append(Path.Command("(End Custom)"))
 

--- a/src/Mod/CAM/Path/Op/Gui/Custom.py
+++ b/src/Mod/CAM/Path/Op/Gui/Custom.py
@@ -1,25 +1,23 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2017 sliptonic shopinthewoods@gmail.com
+# SPDX-FileNotice: Part of the FreeCAD project.
 
-# ***************************************************************************
-# *   Copyright (c) 2017 sliptonic <shopinthewoods@gmail.com>               *
-# *                                                                         *
-# *   This program is free software; you can redistribute it and/or modify  *
-# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
-# *   as published by the Free Software Foundation; either version 2 of     *
-# *   the License, or (at your option) any later version.                   *
-# *   for detail see the LICENCE text file.                                 *
-# *                                                                         *
-# *   This program is distributed in the hope that it will be useful,       *
-# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-# *   GNU Library General Public License for more details.                  *
-# *                                                                         *
-# *   You should have received a copy of the GNU Library General Public     *
-# *   License along with this program; if not, write to the Free Software   *
-# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-# *   USA                                                                   *
-# *                                                                         *
-# ***************************************************************************
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
 
 import FreeCAD
 import FreeCADGui
@@ -55,11 +53,20 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         # add editor with lines enumeration
         self.editor = CodeEditor()
         toolTip = (
-            "Form to enter G-code"
-            "\n\nTo add an expression, surround string with characters '{{expression}}'"
+            "Post processing can reformat G-code added in custom operations."
+            "\nThis includes reordering parameters, stripping unsupported parameters, "
+            "\nchanging the number of decimals behind numbers, "
+            "\nand converting feed rate from an internal system to the current units."
+            "\n\nPost processing the commands is useful for freecad macros "
+            "and using similar code on multiple machines."
+            "\n\nSurround expressing characters with {{expression}}"
             "\nExample:"
             "\nG0 Z{{VarSet.HeightZ.Value+5}}"
-            "\nG0 X{{Profile.Path.Commands[3].x}} Y{{Profile.Path.Commands[3].y}}"
+            "\nG0 X{{Profile.PathCommands[3].x}} Y{{Profile.Path.Commands[3].y}}"
+            "\n\nUse ! at the start of the line to individually disable post processing "
+            "on a given line when 'Post Process Output' is enabled"
+            "\nExample:"
+            "\n!#101 = 2"
         )
         self.editor.setToolTip(toolTip)
         form.txtGCodeBox.layout().removeWidget(form.txtGCode)
@@ -76,12 +83,15 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             obj.GcodeFile = str(self.form.fileName.text())
         if obj.Gcode != str(self.editor.toPlainText().split("\n")):
             obj.Gcode = self.editor.toPlainText().split("\n")
+        if obj.PostProcessOutput != self.form.chkAsIs.isChecked():
+            obj.PostProcessOutput = self.form.chkAsIs.isChecked()
 
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
         self.selectInComboBox(obj.Source, self.form.source)
         self.form.fileName.setText(obj.GcodeFile)
         self.editor.setText("\n".join(obj.Gcode))
+        self.form.chkAsIs.setChecked(obj.PostProcessOutput)
 
         self.updateVisibility()
 
@@ -91,6 +101,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.source.currentIndexChanged)
         signals.append(self.form.fileName.editingFinished)
         signals.append(self.editor.textChanged)
+        signals.append(self.form.chkAsIs.checkStateChanged)
 
         return signals
 

--- a/src/Mod/CAM/Path/Op/Gui/Custom.py
+++ b/src/Mod/CAM/Path/Op/Gui/Custom.py
@@ -60,6 +60,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             "\nExample:"
             "\nG0 Z{{VarSet.HeightZ.Value+5}}"
             "\nG0 X{{Profile.Path.Commands[3].x}} Y{{Profile.Path.Commands[3].y}}"
+            "\n\nLines which starts from '!' will be added without processing"
+            "\nExample:"
+            "\n!G666 X1"
         )
         self.editor.setToolTip(toolTip)
         form.txtGCodeBox.layout().removeWidget(form.txtGCode)
@@ -76,12 +79,15 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             obj.GcodeFile = str(self.form.fileName.text())
         if obj.Gcode != str(self.editor.toPlainText().split("\n")):
             obj.Gcode = self.editor.toPlainText().split("\n")
+        if obj.AddWithoutProcessing != self.form.chkAsIs.isChecked():
+            obj.AddWithoutProcessing = self.form.chkAsIs.isChecked()
 
     def setFields(self, obj):
         """setFields(obj) ... transfers obj's property values to UI"""
         self.selectInComboBox(obj.Source, self.form.source)
         self.form.fileName.setText(obj.GcodeFile)
         self.editor.setText("\n".join(obj.Gcode))
+        self.form.chkAsIs.setChecked(obj.AddWithoutProcessing)
 
         self.updateVisibility()
 
@@ -91,6 +97,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.source.currentIndexChanged)
         signals.append(self.form.fileName.editingFinished)
         signals.append(self.editor.textChanged)
+        signals.append(self.form.chkAsIs.checkStateChanged)
 
         return signals
 

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -2467,6 +2467,10 @@ class PostProcessor:
                 return super()._convert_drill_cycle(command)
         """
 
+        # Pass through G-code as-is
+        if "as-is" in command.Annotations:
+            return command.Annotations[Constants.ANNOT_AS_IS]
+
         # Validate command is supported
         supported = self.values.get(
             "SUPPORTED_COMMANDS",

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -2385,6 +2385,10 @@ class PostProcessor:
                 return super()._convert_drill_cycle(command)
         """
 
+        # Pass through G-code as-is
+        if "as-is" in command.Annotations:
+            return command.Annotations[Constants.ANNOT_AS_IS]
+
         # Validate command is supported
         supported = self.values.get(
             "SUPPORTED_COMMANDS",


### PR DESCRIPTION
### Description

Forum: [Unadulterated Custom G-Code?](https://forum.freecad.org/viewtopic.php?t=86649)

We can not foresee all cases
If user want to add some string specific for CNC, there is should be a convenient way to do this


### Changes
- Refactor to exclude code duplication in processing lines from **File** and **Text**

- Added `ANNOT_AS_IS`, string from which should be exported as-is without any changes

- Added property `Post Process Output` and field to Task panel

- Two ways to add lines without processing
   - Disable feature `Post Process Output`, which applies to all lines
   - Add symbol `!` in the begging of the specific lines

- Added tests

<img width="907" height="359" alt="Screenshot_20260821_222550_hor_lossy" src="https://github.com/user-attachments/assets/3e01bc75-5b00-4141-8cd4-0bf27f139ae3" />

<img width="1481" height="660" alt="1_hor" src="https://github.com/user-attachments/assets/8a5e34b4-93e7-4589-9067-28bac7a97607" />

