### PR TITLE
Sketcher: Delay auto-constraints while dragging

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.cpp
@@ -28,8 +28,10 @@
 #include <memory>
 #include <numbers>
 
+#include <QTimer>
 #include <QWidget>
 
+#include <App/Application.h>
 #include <Precision.hxx>
 #include <Base/Vector3D.h>
 #include <Mod/Part/App/Geometry.h>
@@ -46,7 +48,23 @@ using namespace Sketcher;
 namespace
 {
 constexpr double DragAutoConstraintSnapDistanceFactor = 0.25;
+constexpr int DefaultDragAutoConstraintDelay = 400;
+
+int getDragAutoConstraintDelay()
+{
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher/General"
+    );
+    const auto delay = hGrp->GetInt("DragAutoConstraintDelay", DefaultDragAutoConstraintDelay);
+    return static_cast<int>(std::clamp(delay, 0L, static_cast<long>(std::numeric_limits<int>::max())));
 }
+}  // namespace
+
+DrawSketchHandlerDragAutoConstraint::DrawSketchHandlerDragAutoConstraint()
+    : dwellTimerContext(std::make_unique<QObject>())
+{}
+
+DrawSketchHandlerDragAutoConstraint::~DrawSketchHandlerDragAutoConstraint() = default;
 
 bool DrawSketchHandlerDragAutoConstraint::canSuggestFor(const std::vector<GeoElementId>& dragged) const
 {
@@ -56,7 +74,7 @@ bool DrawSketchHandlerDragAutoConstraint::canSuggestFor(const std::vector<GeoEle
 
 void DrawSketchHandlerDragAutoConstraint::initDragging(const std::vector<GeoElementId>& dragged)
 {
-    suggestedConstraints.clear();
+    clear();
 
     if (QWidget* widget = getCursorWidget()) {
         oldCursor = widget->cursor();
@@ -82,7 +100,9 @@ void DrawSketchHandlerDragAutoConstraint::addAutoConstraint(ConstraintType type,
 
 void DrawSketchHandlerDragAutoConstraint::clear()
 {
+    ++dwellTimerGeneration;
     suggestedConstraints.clear();
+    draggedElements.clear();
     unsetCursor();
 }
 
@@ -197,6 +217,25 @@ void DrawSketchHandlerDragAutoConstraint::update(
     const std::vector<GeoElementId>& draggedElements,
     const Base::Vector2d& /*pos*/
 )
+{
+    const auto timerGeneration = ++dwellTimerGeneration;
+    suggestedConstraints.clear();
+    unsetCursor();
+
+    this->draggedElements = draggedElements;
+
+    if (!canSuggestFor(this->draggedElements)) {
+        return;
+    }
+
+    QTimer::singleShot(getDragAutoConstraintDelay(), dwellTimerContext.get(), [this, timerGeneration]() {
+        if (timerGeneration == dwellTimerGeneration) {
+            updateSuggestions();
+        }
+    });
+}
+
+void DrawSketchHandlerDragAutoConstraint::updateSuggestions()
 {
     suggestedConstraints.clear();
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.h
@@ -24,11 +24,15 @@
 
 #pragma once
 
+#include <cstddef>
+#include <memory>
 #include <vector>
 
 #include <Mod/Sketcher/App/GeoEnum.h>
 
 #include "DrawSketchHandler.h"
+
+class QObject;
 
 namespace Part
 {
@@ -41,6 +45,9 @@ namespace SketcherGui
 class DrawSketchHandlerDragAutoConstraint final: public DrawSketchHandler
 {
 public:
+    DrawSketchHandlerDragAutoConstraint();
+    ~DrawSketchHandlerDragAutoConstraint() override;
+
     void mouseMove(SnapManager::SnapHandle /*snapHandle*/) override
     {}
     bool pressButton(Base::Vector2d /*pos*/) override
@@ -81,10 +88,14 @@ private:
         const AutoConstraint& constraint
     ) const;
     void removeInvalidConstraints(const Sketcher::GeoElementId& dragged);
+    void updateSuggestions();
 
 private:
     std::vector<AutoConstraint> suggestedConstraints;
+    std::vector<Sketcher::GeoElementId> draggedElements;
     Base::Vector2d startPos {0.0, 0.0};
+    std::unique_ptr<QObject> dwellTimerContext;
+    std::size_t dwellTimerGeneration {0};
 };
 
 }  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -4490,6 +4490,10 @@ void ViewProviderSketch::unsetEdit(int ModNum)
         return PartGui::ViewProvider2DObject::unsetEdit(ModNum);
     }
 
+    if (dragAutoConstraintHandler) {
+        dragAutoConstraintHandler->clear();
+    }
+
     setGridEnabled(nullptr);
     auto gridnode = getGridNode();
     pcRoot->removeChild(gridnode);


### PR DESCRIPTION
Implement delay for drag auto-constraints shown after https://github.com/FreeCAD/FreeCAD/pull/29771

- Quick point drags no longer evaluate or commit auto-constraints
- Pausing the cursor for 400 ms evaluates and shows the proposal, then release commits it

Assisted-by: GPT-5.6-Terra

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/31499

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/511acee8-0124-4c80-8b17-8c3d62ee9e47



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
