### PR TITLE
(cp) MeshPart: Use netgen via Python or command line

### DIFF
--- a/src/Mod/MeshPart/App/AppMeshPartPy.cpp
+++ b/src/Mod/MeshPart/App/AppMeshPartPy.cpp
@@ -110,9 +110,6 @@ public:
             "\n"
             "Additionally, when FreeCAD is built with netgen, the following\n"
             "signatures are also available (they are "
-#ifndef HAVE_NETGEN
-            "NOT "
-#endif
             "currently):\n"
             "\n"
             "    meshFromShape(Shape, Fineness, SecondOrder=0,\n"
@@ -571,7 +568,6 @@ private:
         if (Base::Wrapped_ParseTupleAndKeywords(args.ptr(), kwds.ptr(), "O!i|iiidd", kwds_fineness,
                                                 &(Part::TopoShapePy::Type), &shape, &fineness,
                                                 &secondOrder, &optimize, &allowquad, &minLen, &maxLen)) {
-#if defined (HAVE_NETGEN)
             MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->getShape());
             mesher.setMethod(MeshPart::Mesher::Netgen);
             mesher.setFineness(fineness);
@@ -580,9 +576,6 @@ private:
             mesher.setQuadAllowed(allowquad != 0);
             mesher.setMinMaxLengths(minLen, maxLen);
             return runMesher(mesher);
-#else
-            throw Py::RuntimeError("SMESH was built without NETGEN support");
-#endif
         }
 
         static const std::array<const char *, 10> kwds_user{"Shape", "GrowthRate", "SegPerEdge", "SegPerRadius",
@@ -594,7 +587,6 @@ private:
                                                 &(Part::TopoShapePy::Type), &shape,
                                                 &growthRate, &nbSegPerEdge, &nbSegPerRadius,
                                                 &secondOrder, &optimize, &allowquad, &minLen, &maxLen)) {
-#if defined (HAVE_NETGEN)
             MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->getShape());
             mesher.setMethod(MeshPart::Mesher::Netgen);
             mesher.setGrowthRate(growthRate);
@@ -605,20 +597,12 @@ private:
             mesher.setQuadAllowed(allowquad != 0);
             mesher.setMinMaxLengths(minLen, maxLen);
             return runMesher(mesher);
-#else
-            throw Py::RuntimeError("SMESH was built without NETGEN support");
-#endif
         }
 
         PyErr_Clear();
         if (PyArg_ParseTuple(args.ptr(), "O!", &(Part::TopoShapePy::Type), &shape)) {
             MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->getShape());
-#if defined (HAVE_NETGEN)
-            mesher.setMethod(MeshPart::Mesher::Netgen);
-#else
-            mesher.setMethod(MeshPart::Mesher::Mefisto);
-            mesher.setRegular(true);
-#endif
+            mesher.setMethod(MeshPart::Mesher::Standard);
             return runMesher(mesher);
         }
 

--- a/src/Mod/MeshPart/App/CMakeLists.txt
+++ b/src/Mod/MeshPart/App/CMakeLists.txt
@@ -68,6 +68,7 @@ SET(MeshPart_SRCS
 
 set(MeshPart_Scripts
     ../Init.py
+    ../netgen_mesh.py
 )
 
 if(FREECAD_USE_PCH)

--- a/src/Mod/MeshPart/App/Mesher.cpp
+++ b/src/Mod/MeshPart/App/Mesher.cpp
@@ -30,10 +30,13 @@
 #include <TopoDS_Shape.hxx>
 
 #include <Base/Console.h>
+#include <Base/Interpreter.h>
 #include <Base/Tools.h>
 #include <Mod/Mesh/App/Mesh.h>
+#include <Mod/Mesh/App/MeshPy.h>
 #include <Mod/Part/App/BRepMesh.h>
 #include <Mod/Part/App/TopoShape.h>
+#include <CXX/Objects.hxx>
 
 #include "Mesher.h"
 
@@ -238,13 +241,166 @@ Mesh::MeshObject* Mesher::createStandard() const
     return brepmesh.create(domains);
 }
 
-Mesh::MeshObject* Mesher::createMesh() const
+Mesh::MeshObject* Mesher::createNetgenPython() const
 {
-    // OCC standard mesher
-    if (method == Standard) {
-        return createStandard();
+    Mesh::MeshObject* mesh = new Mesh::MeshObject();  // NOLINT
+
+    Base::PyGILStateLocker lock;
+    Py::Module module(PyImport_ImportModule("netgen_mesh"), true);
+    if (module.isNull()) {
+        return mesh;
     }
 
+    Py::Tuple args(2);
+    Part::TopoShape topoShape(shape);
+    args.setItem(0, Py::asObject(topoShape.getPyObject()));
+
+    Py::Dict opts;
+    args.setItem(1, opts);
+
+    static std::map<int, std::string> mapFine {{
+        {0, "VeryCoarse"},
+        {1, "Coarse"},
+        {2, "Moderate"},
+        {3, "Fine"},
+        {4, "VeryFine"},
+    }};
+
+    auto it = mapFine.find(fineness);
+    if (it != mapFine.end()) {
+        opts.setItem("Fineness", Py::String(it->second));
+    }
+    else {
+        if (growthRate > 0) {
+            opts.setItem("GrowthRate", Py::Float(growthRate));
+        }
+        if (nbSegPerEdge > 0) {
+            opts.setItem("SegPerEdge", Py::Float(nbSegPerEdge));
+        }
+        if (nbSegPerRadius > 0) {
+            opts.setItem("SegPerRadius", Py::Float(nbSegPerRadius));
+        }
+    }
+
+    if (maxLen > 0) {
+        opts.setItem("MaxSize", Py::Float(maxLen));
+    }
+    if (minLen > 0) {
+        opts.setItem("MinSize", Py::Float(minLen));
+    }
+
+    opts.setItem("AllowQuad", Py::Boolean(allowquad));
+    opts.setItem("SecondOrder", Py::Boolean(secondOrder));
+
+    if (optimize) {
+        opts.setItem("Optimize", Py::Boolean(optimize));
+    }
+
+    try {
+        Py::Object py = module.callMemberFunction("shapeToMesh", args);
+        if (!PyObject_TypeCheck(py.ptr(), &Mesh::MeshPy::Type)) {
+            return mesh;
+        }
+
+        Mesh::MeshObject* pymesh = static_cast<Mesh::MeshPy*>(py.ptr())->getMeshObjectPtr();
+        mesh->swap(*pymesh);
+        return mesh;
+    }
+    catch (const Py::Exception&) {
+        Base::PyException e;
+        e.reportException();
+        return mesh;
+    }
+}
+
+#if defined(HAVE_NETGEN)
+Mesh::MeshObject* Mesher::createNetgenSMesh() const
+{
+# ifndef HAVE_SMESH
+    throw Base::RuntimeError("SMESH is not available on this platform");
+# else
+    std::list<SMESH_Hypothesis*> hypoth;
+
+    if (!Mesher::_mesh_gen) {
+        Mesher::_mesh_gen = new SMESH_Gen();
+    }
+    SMESH_Gen* meshgen = Mesher::_mesh_gen;
+
+    int hyp = 0;
+
+#  if SMESH_VERSION_MAJOR >= 9
+    SMESH_Mesh* mesh = meshgen->CreateMesh(true);
+    NETGENPlugin_Hypothesis_2D* hyp2d = new NETGENPlugin_Hypothesis_2D(hyp++, meshgen);
+    NETGENPlugin_NETGEN_2D* alg2d = new NETGENPlugin_NETGEN_2D(hyp++, meshgen);
+#  else
+    SMESH_Mesh* mesh = meshgen->CreateMesh(0, true);
+    NETGENPlugin_Hypothesis_2D* hyp2d = new NETGENPlugin_Hypothesis_2D(hyp++, 0, meshgen);
+    NETGENPlugin_NETGEN_2D* alg2d = new NETGENPlugin_NETGEN_2D(hyp++, 0, meshgen);
+#  endif
+
+    if (fineness >= 0 && fineness < 5) {
+        hyp2d->SetFineness(NETGENPlugin_Hypothesis_2D::Fineness(fineness));
+    }
+    // user defined values
+    else {
+        if (growthRate > 0) {
+            hyp2d->SetGrowthRate(growthRate);
+        }
+        if (nbSegPerEdge > 0) {
+            hyp2d->SetNbSegPerEdge(nbSegPerEdge);
+        }
+        if (nbSegPerRadius > 0) {
+            hyp2d->SetNbSegPerRadius(nbSegPerRadius);
+        }
+    }
+
+    if (maxLen > 0) {
+        hyp2d->SetMaxSize(maxLen);
+    }
+    if (minLen > 0) {
+        hyp2d->SetMinSize(minLen);
+    }
+
+    hyp2d->SetQuadAllowed(allowquad);
+    hyp2d->SetOptimize(optimize);
+    // apply bisecting to create four triangles out of one
+    hyp2d->SetSecondOrder(secondOrder);
+    hypoth.push_back(hyp2d);
+    hypoth.push_back(alg2d);
+
+    // Set new cout
+    MeshingOutput stdcout;
+    std::streambuf* oldcout = std::cout.rdbuf(&stdcout);
+
+    // Apply the hypothesis and create the mesh
+    mesh->ShapeToMesh(shape);
+    for (int i = 0; i < hyp; i++) {
+        mesh->AddHypothesis(shape, i);
+    }
+    meshgen->Compute(*mesh, mesh->GetShapeToMesh());
+
+    // Restore old cout
+    std::cout.rdbuf(oldcout);
+
+    // build up the mesh structure
+    Mesh::MeshObject* meshdata = createFrom(mesh);
+
+    // clean up
+    TopoDS_Shape aNull;
+    mesh->ShapeToMesh(aNull);
+    mesh->Clear();
+    delete mesh;
+    for (auto it : hypoth) {
+        delete it;
+    }
+
+    return meshdata;
+# endif
+}
+#endif
+
+Mesh::MeshObject* Mesher::createMefisto() const
+{
 #ifndef HAVE_SMESH
     throw Base::RuntimeError("SMESH is not available on this platform");
 #else
@@ -263,140 +419,90 @@ Mesh::MeshObject* Mesher::createMesh() const
 
     int hyp = 0;
 
-    switch (method) {
-# if defined(HAVE_NETGEN)
-        case Netgen: {
-#  if SMESH_VERSION_MAJOR >= 9
-            NETGENPlugin_Hypothesis_2D* hyp2d = new NETGENPlugin_Hypothesis_2D(hyp++, meshgen);
-#  else
-            NETGENPlugin_Hypothesis_2D* hyp2d = new NETGENPlugin_Hypothesis_2D(hyp++, 0, meshgen);
-#  endif
-
-            if (fineness >= 0 && fineness < 5) {
-                hyp2d->SetFineness(NETGENPlugin_Hypothesis_2D::Fineness(fineness));
-            }
-            // user defined values
-            else {
-                if (growthRate > 0) {
-                    hyp2d->SetGrowthRate(growthRate);
-                }
-                if (nbSegPerEdge > 0) {
-                    hyp2d->SetNbSegPerEdge(nbSegPerEdge);
-                }
-                if (nbSegPerRadius > 0) {
-                    hyp2d->SetNbSegPerRadius(nbSegPerRadius);
-                }
-            }
-
-            if (maxLen > 0) {
-                hyp2d->SetMaxSize(maxLen);
-            }
-            if (minLen > 0) {
-                hyp2d->SetMinSize(minLen);
-            }
-
-            hyp2d->SetQuadAllowed(allowquad);
-            hyp2d->SetOptimize(optimize);
-            hyp2d->SetSecondOrder(secondOrder);  // apply bisecting to create four triangles out of one
-            hypoth.push_back(hyp2d);
-
-#  if SMESH_VERSION_MAJOR >= 9
-            NETGENPlugin_NETGEN_2D* alg2d = new NETGENPlugin_NETGEN_2D(hyp++, meshgen);
-#  else
-            NETGENPlugin_NETGEN_2D* alg2d = new NETGENPlugin_NETGEN_2D(hyp++, 0, meshgen);
-#  endif
-            hypoth.push_back(alg2d);
-        } break;
-# endif
 # if SMESH_VERSION_MAJOR <= 9 && SMESH_VERSION_MINOR < 10
 #  if defined(HAVE_MEFISTO)
-        case Mefisto: {
-            if (maxLength > 0) {
+    if (maxLength > 0) {
 #   if SMESH_VERSION_MAJOR >= 9
-                StdMeshers_MaxLength* hyp1d = new StdMeshers_MaxLength(hyp++, meshgen);
+        StdMeshers_MaxLength* hyp1d = new StdMeshers_MaxLength(hyp++, meshgen);
 #   else
-                StdMeshers_MaxLength* hyp1d = new StdMeshers_MaxLength(hyp++, 0, meshgen);
+        StdMeshers_MaxLength* hyp1d = new StdMeshers_MaxLength(hyp++, 0, meshgen);
 #   endif
-                hyp1d->SetLength(maxLength);
-                hypoth.push_back(hyp1d);
-            }
-            else if (localLength > 0) {
+        hyp1d->SetLength(maxLength);
+        hypoth.push_back(hyp1d);
+    }
+    else if (localLength > 0) {
 #   if SMESH_VERSION_MAJOR >= 9
-                StdMeshers_LocalLength* hyp1d = new StdMeshers_LocalLength(hyp++, meshgen);
+        StdMeshers_LocalLength* hyp1d = new StdMeshers_LocalLength(hyp++, meshgen);
 #   else
-                StdMeshers_LocalLength* hyp1d = new StdMeshers_LocalLength(hyp++, 0, meshgen);
+        StdMeshers_LocalLength* hyp1d = new StdMeshers_LocalLength(hyp++, 0, meshgen);
 #   endif
-                hyp1d->SetLength(localLength);
-                hypoth.push_back(hyp1d);
-            }
-            else if (maxArea > 0) {
+        hyp1d->SetLength(localLength);
+        hypoth.push_back(hyp1d);
+    }
+    else if (maxArea > 0) {
 #   if SMESH_VERSION_MAJOR >= 9
-                StdMeshers_MaxElementArea* hyp2d = new StdMeshers_MaxElementArea(hyp++, meshgen);
+        StdMeshers_MaxElementArea* hyp2d = new StdMeshers_MaxElementArea(hyp++, meshgen);
 #   else
-                StdMeshers_MaxElementArea* hyp2d = new StdMeshers_MaxElementArea(hyp++, 0, meshgen);
+        StdMeshers_MaxElementArea* hyp2d = new StdMeshers_MaxElementArea(hyp++, 0, meshgen);
 #   endif
-                hyp2d->SetMaxArea(maxArea);
-                hypoth.push_back(hyp2d);
-            }
-            else if (deflection > 0) {
+        hyp2d->SetMaxArea(maxArea);
+        hypoth.push_back(hyp2d);
+    }
+    else if (deflection > 0) {
 #   if SMESH_VERSION_MAJOR >= 9
-                StdMeshers_Deflection1D* hyp1d = new StdMeshers_Deflection1D(hyp++, meshgen);
+        StdMeshers_Deflection1D* hyp1d = new StdMeshers_Deflection1D(hyp++, meshgen);
 #   else
-                StdMeshers_Deflection1D* hyp1d = new StdMeshers_Deflection1D(hyp++, 0, meshgen);
+        StdMeshers_Deflection1D* hyp1d = new StdMeshers_Deflection1D(hyp++, 0, meshgen);
 #   endif
-                hyp1d->SetDeflection(deflection);
-                hypoth.push_back(hyp1d);
-            }
-            else if (minLen > 0 && maxLen > 0) {
+        hyp1d->SetDeflection(deflection);
+        hypoth.push_back(hyp1d);
+    }
+    else if (minLen > 0 && maxLen > 0) {
 #   if SMESH_VERSION_MAJOR >= 9
-                StdMeshers_Arithmetic1D* hyp1d = new StdMeshers_Arithmetic1D(hyp++, meshgen);
+        StdMeshers_Arithmetic1D* hyp1d = new StdMeshers_Arithmetic1D(hyp++, meshgen);
 #   else
-                StdMeshers_Arithmetic1D* hyp1d = new StdMeshers_Arithmetic1D(hyp++, 0, meshgen);
+        StdMeshers_Arithmetic1D* hyp1d = new StdMeshers_Arithmetic1D(hyp++, 0, meshgen);
 #   endif
-                hyp1d->SetLength(minLen, false);
-                hyp1d->SetLength(maxLen, true);
-                hypoth.push_back(hyp1d);
-            }
-            else {
+        hyp1d->SetLength(minLen, false);
+        hyp1d->SetLength(maxLen, true);
+        hypoth.push_back(hyp1d);
+    }
+    else {
 #   if SMESH_VERSION_MAJOR >= 9
-                StdMeshers_AutomaticLength* hyp1d = new StdMeshers_AutomaticLength(hyp++, meshgen);
+        StdMeshers_AutomaticLength* hyp1d = new StdMeshers_AutomaticLength(hyp++, meshgen);
 #   else
-                StdMeshers_AutomaticLength* hyp1d = new StdMeshers_AutomaticLength(hyp++, 0, meshgen);
+        StdMeshers_AutomaticLength* hyp1d = new StdMeshers_AutomaticLength(hyp++, 0, meshgen);
 #   endif
-                hypoth.push_back(hyp1d);
-            }
+        hypoth.push_back(hyp1d);
+    }
 
-            {
+    {
 #   if SMESH_VERSION_MAJOR >= 9
-                StdMeshers_NumberOfSegments* hyp1d = new StdMeshers_NumberOfSegments(hyp++, meshgen);
+        StdMeshers_NumberOfSegments* hyp1d = new StdMeshers_NumberOfSegments(hyp++, meshgen);
 #   else
-                StdMeshers_NumberOfSegments* hyp1d = new StdMeshers_NumberOfSegments(hyp++, 0, meshgen);
+        StdMeshers_NumberOfSegments* hyp1d = new StdMeshers_NumberOfSegments(hyp++, 0, meshgen);
 #   endif
-                hyp1d->SetNumberOfSegments(1);
-                hypoth.push_back(hyp1d);
-            }
+        hyp1d->SetNumberOfSegments(1);
+        hypoth.push_back(hyp1d);
+    }
 
-            if (regular) {
+    if (regular) {
 #   if SMESH_VERSION_MAJOR >= 9
-                StdMeshers_Regular_1D* hyp1d = new StdMeshers_Regular_1D(hyp++, meshgen);
+        StdMeshers_Regular_1D* hyp1d = new StdMeshers_Regular_1D(hyp++, meshgen);
 #   else
-                StdMeshers_Regular_1D* hyp1d = new StdMeshers_Regular_1D(hyp++, 0, meshgen);
+        StdMeshers_Regular_1D* hyp1d = new StdMeshers_Regular_1D(hyp++, 0, meshgen);
 #   endif
-                hypoth.push_back(hyp1d);
-            }
+        hypoth.push_back(hyp1d);
+    }
 
 #   if SMESH_VERSION_MAJOR >= 9
-            StdMeshers_MEFISTO_2D* alg2d = new StdMeshers_MEFISTO_2D(hyp++, meshgen);
+    StdMeshers_MEFISTO_2D* alg2d = new StdMeshers_MEFISTO_2D(hyp++, meshgen);
 #   else
-            StdMeshers_MEFISTO_2D* alg2d = new StdMeshers_MEFISTO_2D(hyp++, 0, meshgen);
+    StdMeshers_MEFISTO_2D* alg2d = new StdMeshers_MEFISTO_2D(hyp++, 0, meshgen);
 #   endif
-            hypoth.push_back(alg2d);
-        } break;
+    hypoth.push_back(alg2d);
 #  endif
 # endif
-        default:
-            break;
-    }
 
     // Set new cout
     MeshingOutput stdcout;
@@ -426,6 +532,26 @@ Mesh::MeshObject* Mesher::createMesh() const
 
     return meshdata;
 #endif  // HAVE_SMESH
+}
+
+Mesh::MeshObject* Mesher::createMesh() const
+{
+    // OCC standard mesher
+    if (method == Standard) {
+        return createStandard();
+    }
+    if (method == Netgen) {
+#if defined(HAVE_NETGEN)
+        return createNetgenSMesh();
+#else
+        return createNetgenPython();
+#endif
+    }
+    if (method == Mefisto) {
+        return createMefisto();
+    }
+
+    return new Mesh::MeshObject();
 }
 
 Mesh::MeshObject* Mesher::createFrom(SMESH_Mesh* mesh) const

--- a/src/Mod/MeshPart/App/Mesher.h
+++ b/src/Mod/MeshPart/App/Mesher.h
@@ -50,9 +50,7 @@ public:
     {
         None = 0,
         Mefisto = 1,
-#if defined(HAVE_NETGEN)
         Netgen = 2,
-#endif
         Standard = 3
     };
 
@@ -150,7 +148,6 @@ public:
     }
     //@}
 
-#if defined(HAVE_NETGEN)
     /** @name Netgen settings */
     //@{
     void setFineness(int s)
@@ -210,12 +207,14 @@ public:
         return allowquad;
     }
     //@}
-#endif
 
     Mesh::MeshObject* createMesh() const;
 
 private:
     Mesh::MeshObject* createStandard() const;
+    Mesh::MeshObject* createMefisto() const;
+    Mesh::MeshObject* createNetgenSMesh() const;
+    Mesh::MeshObject* createNetgenPython() const;
     Mesh::MeshObject* createFrom(SMESH_Mesh*) const;
 
 private:
@@ -230,7 +229,6 @@ private:
     bool relative {false};
     bool regular {false};
     bool segments {false};
-#if defined(HAVE_NETGEN)
     int fineness {5};
     double growthRate {0};
     double nbSegPerEdge {0};
@@ -238,7 +236,6 @@ private:
     bool secondOrder {false};
     bool optimize {true};
     bool allowquad {false};
-#endif
     std::vector<uint32_t> colors;
 
     static SMESH_Gen* _mesh_gen;

--- a/src/Mod/MeshPart/CMakeLists.txt
+++ b/src/Mod/MeshPart/CMakeLists.txt
@@ -9,6 +9,7 @@ INSTALL(
     FILES
         Init.py
         InitGui.py
+        netgen_mesh.py
     DESTINATION
         Mod/MeshPart
 )

--- a/src/Mod/MeshPart/Gui/CMakeLists.txt
+++ b/src/Mod/MeshPart/Gui/CMakeLists.txt
@@ -7,10 +7,6 @@ if (SMESH_FOUND)
     endif()
 endif(SMESH_FOUND)
 
-if(BUILD_FEM_NETGEN)
-    add_definitions(-DHAVE_NETGEN)
-endif(BUILD_FEM_NETGEN)
-
 set(MeshPartGui_LIBS
     MeshPart
     PartGui

--- a/src/Mod/MeshPart/Gui/Tessellation.cpp
+++ b/src/Mod/MeshPart/Gui/Tessellation.cpp
@@ -84,9 +84,6 @@ Tessellation::Tessellation(QWidget* parent)
 #if !defined(HAVE_MEFISTO)
     ui->stackedWidget->setTabEnabled(Mefisto, false);
 #endif
-#if !defined(HAVE_NETGEN)
-    ui->stackedWidget->setTabEnabled(Netgen, false);
-#endif
 
     Gui::Command::doCommand(Gui::Command::Doc, "import Mesh, Part, PartGui");
     try {

--- a/src/Mod/MeshPart/netgen_mesh.py
+++ b/src/Mod/MeshPart/netgen_mesh.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+
+__title__ = "netgenMesh"
+__author__ = "Werner Mayer"
+__license__ = "LGPL 2.1"
+__doc__ = "Use netgen mesher to create a mesh from a given shape"
+
+
+import Mesh
+import os
+import tempfile
+import uuid
+
+
+def shapeToMesh(occShape, options={}):
+
+    basename = str(uuid.uuid4())
+    shapeFile = tempfile.gettempdir() + os.sep + basename + ".brep"
+    occShape.exportBrep(shapeFile)
+
+    try:
+        meshFile = _fromPython(shapeFile, basename, options)
+    except ImportError:
+        meshFile = _fromProcess(shapeFile, basename, options)
+
+    mesh = Mesh.Mesh()
+    mesh.read(meshFile)
+
+    os.remove(shapeFile)
+    os.remove(meshFile)
+
+    return mesh
+
+
+def _fromPython(shapeFile, basename, options):
+    from netgen import occ
+
+    args = {}
+
+    # Fineness = (GrowthRate, SegPerEdge, SegPerRadius)
+    fineness = {
+        "VeryCoarse": (0.7, 0.3, 1.0),
+        "Coarse": (0.5, 0.5, 1.5),
+        "Moderate": (0.3, 1.0, 2.0),
+        "Fine": (0.2, 2.0, 3.0),
+        "VeryFine": (0.1, 3.0, 5.0),
+    }
+
+    # See NETGENPlugin_Mesher.cpp
+    # and netgen's meshtype.hpp
+    optsMap = {
+        "GrowthRate": "grading",
+        "SegPerEdge": "segmentsperedge",
+        "SegPerRadius": "curvaturesafety",
+        "AllowQuad": "quad_dominated",
+        "SecondOrder": "secondorder",
+        "MaxSize": "maxh",
+        "MinSize": "minh",
+        "SurfaceCurvature": "uselocalh",
+    }
+
+    # Add values for fineness mode
+    if "Fineness" in options:
+        mode = options["Fineness"]
+        if mode in fineness:
+            vals = fineness[mode]
+            args["grading"] = vals[0]
+            args["segmentsperedge"] = vals[1]
+            args["curvaturesafety"] = vals[2]
+
+    # Translate FreeCAD options to netgen options
+    for opt in optsMap:
+        if opt in options:
+            mapped = optsMap[opt]
+            args[mapped] = options[opt]
+
+    # Special handling of 'Optimize'
+    opt = "Optimize"
+    if opt in options:
+        args["perfstepsstart"] = 0
+        args["perfstepsend"] = 3
+        if options[opt]:
+            args["perfstepsend"] = 4
+
+    geo = occ.OCCGeometry(shapeFile)
+    mesh = geo.GenerateMesh(**args)
+
+    meshFile = tempfile.gettempdir() + os.sep + basename + ".stl"
+    mesh.Export(meshFile, "STL Format")
+
+    return meshFile
+
+
+def _fromProcess(shapeFile, basename, options):
+    import subprocess
+
+    fineness = {
+        "VeryCoarse": "-coarse",  # netgen doesn't offer the option -verycoarse
+        "Coarse": "-coarse",
+        "Moderate": "-moderate",
+        "Fine": "-fine",
+        "VeryFine": "-veryfine",
+    }
+
+    meshsize = "-moderate"
+    if "Fineness" in options:
+        mode = options["Fineness"]
+        if mode in fineness:
+            meshsize = fineness[mode]
+
+    meshFile = tempfile.gettempdir() + os.sep + basename + ".stl"
+
+    command_list = [
+        "netgen",
+        "-geofile={}".format(shapeFile),
+        meshsize,
+        "-meshfiletype=STL Format",
+        "-batchmode",
+        "-meshfile={}".format(meshFile),
+    ]
+
+    subprocess.run(command_list)
+
+    if not os.path.exists(meshFile):
+        raise RuntimeError("Failed to create mesh")
+
+    return meshFile


### PR DESCRIPTION
Cherry-picked https://codeberg.org/xwzCAD/FreeCAD/pulls/293

Since with newer netgen versions the plugin provided by SMESH doesn't work any more the direct use via C++ will be replaced with the use via Python. The module netgen_mesh.py tries to use netgen's Python API or if not available uses its executable.

Fixes https://github.com/FreeCAD/FreeCAD/issues/17216
