### PR TITLE
CAM: rewrite filter_inefficient_moves for path safety

### DIFF
--- a/src/Mod/CAM/CAMTests/TestDrillCycleExpander.py
+++ b/src/Mod/CAM/CAMTests/TestDrillCycleExpander.py
@@ -27,6 +27,7 @@ Test suite for DrillCycleExpander class.
 import unittest
 import Path
 from Path.Post.DrillCycleExpander import DrillCycleExpander
+from Path.Post.GcodeProcessingUtils import NO_COLLAPSE_ANNOTATION
 from Path.Base.MachineState import MachineState
 
 
@@ -390,3 +391,29 @@ class TestDrillCycleExpander(unittest.TestCase):
             self.assertEqual(
                 res.Parameters, exp.Parameters, f"Command {i} {exp}: parameters mismatch"
             )
+
+    def test_12_no_collapse_annotation(self):
+        """In-cycle rapids carry the no-collapse annotation; the preliminary
+        positioning rapids and pass-through commands do not."""
+        machine_state = MachineState({"ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
+
+        input_cmds = [
+            Path.Command("G0", {"X": 0, "Y": 0, "Z": 1.0, "F": 1000}),
+            Path.Command("G83", {"X": 1.0, "Y": 1.0, "Z": -0.6, "R": 0.1, "Q": 0.2, "F": 10.0}),
+            Path.Command("G80", {}),
+        ]
+        result = expander.expand_commands(input_cmds)
+
+        first_feed = next(i for i, c in enumerate(result) if c.Name == "G1")
+        for i, cmd in enumerate(result):
+            if cmd.Name == "G0" and i > first_feed:
+                self.assertTrue(
+                    cmd.Annotations.get(NO_COLLAPSE_ANNOTATION),
+                    f"Command {i}: in-cycle rapid unmarked",
+                )
+            else:
+                self.assertNotIn(
+                    NO_COLLAPSE_ANNOTATION, cmd.Annotations, f"Command {i}: unexpected annotation"
+                )
+            self.assertNotIn("NOCOLLAPSE", cmd.Parameters, f"Command {i}: parameter pollution")

--- a/src/Mod/CAM/CAMTests/TestGcodeProcessingUtils.py
+++ b/src/Mod/CAM/CAMTests/TestGcodeProcessingUtils.py
@@ -29,6 +29,7 @@ from Path.Post.GcodeProcessingUtils import (
     filter_inefficient_moves,
     deduplicate_repeated_commands,
     NumberGenerator,
+    NO_COLLAPSE_MARKER,
 )
 
 
@@ -248,17 +249,32 @@ class TestFilterInefficientMoves(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_optimize_single_axis_collapse(self):
-        """Test collapsing rapid chain with single-axis changes."""
+        """Test collapsing a same-direction rapid chain on one axis."""
+        gcode = ["G1 X0.0 F100", "G0 X10.0", "G0 X20.0", "G0 X30.0"]
+        result = filter_inefficient_moves(gcode)
+        expected = ["G1 X0.0 F100", "G0 X30.0"]  # Only last position kept
+        self.assertEqual(result, expected)
+
+    def test_unknown_start_prevents_collapse(self):
+        """Test no collapse when the starting position is unknown.
+
+        Without a known start, a direction reversal (e.g. an initial
+        retract to safe height) cannot be ruled out.
+        """
         gcode = ["G0 X10.0", "G0 X20.0", "G0 X30.0"]
         result = filter_inefficient_moves(gcode)
-        expected = ["G0 X30.0"]  # Only last position kept
+        expected = ["G0 X10.0", "G0 X20.0", "G0 X30.0"]
         self.assertEqual(result, expected)
 
     def test_optimize_multi_axis_no_collapse(self):
-        """Test that multi-axis rapid chains within linear group DO collapse."""
+        """Test that multi-axis rapid chains do NOT collapse.
+
+        Collapsing them would replace two path segments with a single direct
+        move through different territory.
+        """
         gcode = ["G0 X10.0 Y10.0", "G0 X20.0 Y20.0"]
         result = filter_inefficient_moves(gcode)
-        expected = ["G0 X20.0 Y20.0"]  # Collapsed to final position (both X,Y in linear group)
+        expected = ["G0 X10.0 Y10.0", "G0 X20.0 Y20.0"]
         self.assertEqual(result, expected)
 
     def test_optimize_with_side_effects(self):
@@ -306,6 +322,7 @@ class TestFilterInefficientMoves(unittest.TestCase):
     def test_optimize_mixed_sequence(self):
         """Test mixed sequence with rapid and side effect commands."""
         gcode = [
+            "G1 X0.0 F100",
             "G0 X10.0",
             "G0 X20.0",
             "M3 S1000",  # Spindle on, side effect
@@ -313,30 +330,162 @@ class TestFilterInefficientMoves(unittest.TestCase):
         ]
         result = filter_inefficient_moves(gcode)
         expected = [
+            "G1 X0.0 F100",
             "G0 X20.0",  # First chain collapses to last position
             "M3 S1000",  # Side effect
             "G0 X30.0",  # New move after side effect
         ]
         self.assertEqual(result, expected)
 
-    def test_optimize_linear_group_collapse(self):
-        """Test collapsing rapid moves within linear axis group (X,Y,Z)."""
+    def test_optimize_linear_group_no_collapse(self):
+        """Test that rapids changing several linear axes are preserved."""
         gcode = [
             "G0 X10.0 Y10.0 Z10.0",
             "G0 X20.0 Y20.0 Z20.0",  # All linear axes change
         ]
         result = filter_inefficient_moves(gcode)
-        expected = ["G0 X20.0 Y20.0 Z20.0"]  # Collapsed to final position
+        expected = ["G0 X10.0 Y10.0 Z10.0", "G0 X20.0 Y20.0 Z20.0"]
         self.assertEqual(result, expected)
 
-    def test_optimize_rotary_group_collapse(self):
-        """Test collapsing rapid moves within rotary axis group (A,B,C)."""
+    def test_optimize_rotary_group_no_collapse(self):
+        """Test that rapids changing several rotary axes are preserved."""
         gcode = [
             "G0 A10.0 B10.0 C10.0",
             "G0 A20.0 B20.0 C20.0",  # All rotary axes change
         ]
         result = filter_inefficient_moves(gcode)
-        expected = ["G0 A20.0 B20.0 C20.0"]  # Collapsed to final position
+        expected = ["G0 A10.0 B10.0 C10.0", "G0 A20.0 B20.0 C20.0"]
+        self.assertEqual(result, expected)
+
+    def test_retract_then_traverse_preserved(self):
+        """Test that a retract rapid followed by a traverse rapid is preserved.
+
+        This is the standard between-operations pattern; dropping the Z
+        retract would drag the tool through the stock at cutting depth.
+        """
+        gcode = [
+            "G1 X50.0 Y50.0 Z-2.0 F500",
+            "G0 Z15.0",  # retract
+            "G0 X0.0 Y0.0",  # traverse at safe height
+        ]
+        result = filter_inefficient_moves(gcode)
+        self.assertEqual(result, gcode)
+
+    def test_single_axis_runs_collapse_independently(self):
+        """Test that a chain splits into single-axis runs, each collapsed."""
+        gcode = [
+            "G1 X0.0 Y0.0 Z0.0 F100",
+            "G0 X10.0",
+            "G0 X20.0",
+            "G0 Y5.0",
+            "G0 Y15.0",
+        ]
+        result = filter_inefficient_moves(gcode)
+        expected = ["G1 X0.0 Y0.0 Z0.0 F100", "G0 X20.0", "G0 Y15.0"]
+        self.assertEqual(result, expected)
+
+    def test_direction_reversal_preserved(self):
+        """Test that a single-axis direction reversal is never collapsed.
+
+        An excursion is intentional motion; its purpose is the excursion
+        itself, not its endpoint.
+        """
+        gcode = ["G1 X0.0 F100", "G0 X10.0", "G0 X30.0", "G0 X20.0"]
+        result = filter_inefficient_moves(gcode)
+        expected = ["G1 X0.0 F100", "G0 X10.0", "G0 X30.0", "G0 X20.0"]
+        self.assertEqual(result, expected)
+
+    def test_peck_drill_retracts_preserved(self):
+        """Test that expanded peck-drilling rapids are preserved.
+
+        The drill cycle expander converts G83 into feed and rapid moves;
+        the rapid out of the hole clears chips and the rapid back in
+        resumes the peck. Both reverse direction on Z and must survive.
+        """
+        gcode = [
+            "G0 X10.0 Y10.0",
+            "G0 Z2.0",
+            "G1 Z-5.0 F100",  # first peck
+            "G0 Z2.0",  # rapid out to clear chips
+            "G0 Z-4.5",  # rapid back to just above the bottom
+            "G1 Z-10.0 F100",  # second peck
+            "G0 Z2.0",  # final retract
+        ]
+        result = filter_inefficient_moves(gcode)
+        self.assertEqual(result, gcode)
+
+    def test_endpoint_word_required_on_survivor(self):
+        """Test no collapse when the last line lacks the changing axis word."""
+        gcode = [
+            "G1 X0.0 Y0.0 F100",
+            "G0 X10.0",
+            "G0 Y0.0",  # redundant Y word; X endpoint not stated here
+        ]
+        result = filter_inefficient_moves(gcode)
+        expected = ["G1 X0.0 Y0.0 F100", "G0 X10.0", "G0 Y0.0"]
+        self.assertEqual(result, expected)
+
+    def test_unknown_baseline_prevents_collapse(self):
+        """Test that axes with unknown starting position count as changing."""
+        gcode = ["G0 X10.0 Y5.0", "G0 X20.0"]  # Y start unknown
+        result = filter_inefficient_moves(gcode)
+        expected = ["G0 X10.0 Y5.0", "G0 X20.0"]
+        self.assertEqual(result, expected)
+
+    def test_incremental_mode_disables_collapsing(self):
+        """Test that G91 suspends collapsing; repeated words are real motion."""
+        gcode = ["G91", "G0 X10.0", "G0 X10.0"]
+        result = filter_inefficient_moves(gcode)
+        expected = ["G91", "G0 X10.0", "G0 X10.0"]
+        self.assertEqual(result, expected)
+
+    def test_modal_rapid_chain_collapses_with_motion_word(self):
+        """Test that bare modal rapids collapse and keep a G0 word."""
+        gcode = ["G1 X0.0 F100", "G0 X10.0", "X20.0", "X30.0"]
+        result = filter_inefficient_moves(gcode)
+        expected = ["G1 X0.0 F100", "G0 X30.0"]
+        self.assertEqual(result, expected)
+
+    def test_no_op_rapids_keep_only_last(self):
+        """Test that rapids to the current known position collapse to one."""
+        gcode = [
+            "G1 X10.0 Y10.0 F100",
+            "G0 X10.0 Y10.0",
+            "G0 X10.0 Y10.0",
+        ]
+        result = filter_inefficient_moves(gcode)
+        expected = ["G1 X10.0 Y10.0 F100", "G0 X10.0 Y10.0"]
+        self.assertEqual(result, expected)
+
+    def test_no_collapse_annotation_blocks_collapse(self):
+        """Test that an annotated rapid is never collapsed, even when the
+        run is monotonic, and that the marker is stripped from output."""
+        gcode = [
+            "G1 X0.0 F100",
+            f"G0 X10.0 {NO_COLLAPSE_MARKER}",
+            "G0 X20.0",
+            "G0 X30.0",
+        ]
+        result = filter_inefficient_moves(gcode)
+        expected = [
+            "G1 X0.0 F100",
+            "G0 X10.0",  # protected, marker stripped
+            "G0 X30.0",  # remaining unprotected run still collapses
+        ]
+        self.assertEqual(result, expected)
+
+    def test_no_collapse_marker_stripped_everywhere(self):
+        """Test that the marker is stripped even outside of chains."""
+        gcode = [f"G0 Z2.0 {NO_COLLAPSE_MARKER}", f"G1 Z-5.0 F100 {NO_COLLAPSE_MARKER}"]
+        result = filter_inefficient_moves(gcode)
+        expected = ["G0 Z2.0", "G1 Z-5.0 F100"]
+        self.assertEqual(result, expected)
+
+    def test_blockdelete_flushes_chain(self):
+        """Test that block-deleted lines are passed through and end a chain."""
+        gcode = ["G0 X10.0", "/G0 X20.0", "G0 X30.0"]
+        result = filter_inefficient_moves(gcode)
+        expected = ["G0 X10.0", "/G0 X20.0", "G0 X30.0"]
         self.assertEqual(result, expected)
 
     def test_optimize_mixed_axes_no_collapse(self):

--- a/src/Mod/CAM/CAMTests/TestPostOutput.py
+++ b/src/Mod/CAM/CAMTests/TestPostOutput.py
@@ -38,6 +38,7 @@ import Path.Tool.Controller as PathToolController
 from Machine.models.machine import Machine, OutputUnits, Toolhead, ToolheadType
 
 from .FilePathTestUtils import assertFilePathsEqual
+from Path.Post.GcodeProcessingUtils import NO_COLLAPSE_MARKER
 
 PathCommand.LOG_MODULE = Path.Log.thisModule()
 Path.Log.setLevel(Path.Log.Level.INFO, PathCommand.LOG_MODULE)
@@ -2013,3 +2014,42 @@ class TestExport2Integration(unittest.TestCase):
                 "nc",
                 "Existing property should not be overwritten",
             )
+
+    def test_drill_cycle_rapids_survive_move_filtering(self):
+        """Expanded drill-cycle rapids must survive filter_inefficient_moves.
+
+        The G98 final-retract pair (rapid to R, then rapid to initial Z) is
+        a monotonic single-axis chain that would collapse without the
+        no-collapse annotation reaching the formatted line. The marker
+        itself must never appear in the output.
+        """
+        machine = self._create_machine()
+        machine.processing.translate_drill_cycles = True
+        machine.processing.filter_inefficient_moves = True
+
+        commands = [
+            Path.Command("G0", {"X": 10.0, "Y": 10.0, "Z": 5.0, "F": 3000.0}),
+            Path.Command("G98", {}),
+            Path.Command("G83", {"X": 10.0, "Y": 10.0, "Z": -6.0, "R": 2.0, "Q": 2.0, "F": 100.0}),
+            Path.Command("G80", {}),
+        ]
+        with self._modify_operation_path(commands):
+            results = self._run_export2(machine=machine)
+        gcode = self._get_first_section_gcode(results)
+
+        self.assertNotIn(NO_COLLAPSE_MARKER, gcode, "marker leaked into output")
+
+        lines = [line.strip() for line in gcode.splitlines()]
+        last_feed = max(
+            i for i, line in enumerate(lines) if line.startswith("G1") and "Z-6." in line
+        )
+        moves_after = [line for line in lines[last_feed + 1 :] if line.startswith(("G0", "G1"))]
+        self.assertGreaterEqual(len(moves_after), 2, f"final retracts missing: {moves_after}")
+        self.assertTrue(
+            moves_after[0].startswith("G0") and "Z2." in moves_after[0],
+            f"retract to R was collapsed away: {moves_after}",
+        )
+        self.assertTrue(
+            moves_after[1].startswith("G0") and "Z5." in moves_after[1],
+            f"final retract to initial Z missing: {moves_after}",
+        )

--- a/src/Mod/CAM/Path/Post/DrillCycleExpander.py
+++ b/src/Mod/CAM/Path/Post/DrillCycleExpander.py
@@ -30,6 +30,7 @@ from typing import List, Optional
 
 import Path
 from Path.Base.MachineState import MachineState
+from Path.Post.GcodeProcessingUtils import NO_COLLAPSE_ANNOTATION
 
 EXPANDABLE_DRILL_CYCLES = {"G81", "G82", "G83", "G73"}
 
@@ -221,7 +222,8 @@ class DrillCycleExpander:
         if cmd_name == "G82" and "P" in params:
             expanded.append(Path.Command("G4", {"P": params["P"]}))
 
-        # Retract
+        # Retract. The retract is functional motion; annotate it so
+        # move filtering never collapses it away.
         cmd = Path.Command(
             "G0",
             {
@@ -231,6 +233,7 @@ class DrillCycleExpander:
                 "F": self.machine_state.G0F,
             },
         )
+        cmd.Annotations = {NO_COLLAPSE_ANNOTATION: True}
         expanded.append(cmd)
         self.machine_state.addCommand(cmd)
 
@@ -245,7 +248,12 @@ class DrillCycleExpander:
         final_retract: float,
         feedrate: Optional[float],
     ) -> List[Path.Command]:
-        """Expand G73 (chip breaking) or G83 (peck drilling)."""
+        """Expand G73 (chip breaking) or G83 (peck drilling).
+
+        Every rapid in the cycle body is functional motion (chip clearing,
+        re-entry, retract), so all are annotated with NO_COLLAPSE_ANNOTATION
+        to protect them from move filtering.
+        """
         expanded = []
 
         peck_depth = params.get("Q", abs(drill_z - retract_z))
@@ -268,6 +276,7 @@ class DrillCycleExpander:
                         "F": self.machine_state.G0F,
                     },
                 )
+                cmd.Annotations = {NO_COLLAPSE_ANNOTATION: True}
                 expanded.append(cmd)
                 self.machine_state.addCommand(cmd)
 
@@ -297,6 +306,7 @@ class DrillCycleExpander:
                             "F": self.machine_state.G0F,
                         },
                     )
+                    cmd.Annotations = {NO_COLLAPSE_ANNOTATION: True}
                     expanded.append(cmd)
                     self.machine_state.addCommand(cmd)
                 else:
@@ -311,6 +321,7 @@ class DrillCycleExpander:
                             "F": self.machine_state.G0F,
                         },
                     )
+                    cmd.Annotations = {NO_COLLAPSE_ANNOTATION: True}
                     expanded.append(cmd)
                     self.machine_state.addCommand(cmd)
             elif cmd_name == "G83":
@@ -324,6 +335,7 @@ class DrillCycleExpander:
                         "F": self.machine_state.G0F,
                     },
                 )
+                cmd.Annotations = {NO_COLLAPSE_ANNOTATION: True}
                 expanded.append(cmd)
                 self.machine_state.addCommand(cmd)
 
@@ -340,6 +352,7 @@ class DrillCycleExpander:
                     "F": self.machine_state.G0F,
                 },
             )
+            cmd.Annotations = {NO_COLLAPSE_ANNOTATION: True}
             expanded.append(cmd)
             self.machine_state.addCommand(cmd)
 

--- a/src/Mod/CAM/Path/Post/GcodeProcessingUtils.py
+++ b/src/Mod/CAM/Path/Post/GcodeProcessingUtils.py
@@ -30,6 +30,16 @@ operate on strings of pre-processed G-code.
 
 from typing import List
 
+# Annotation protecting functional rapid moves from filter_inefficient_moves.
+# Producers working on Path.Command objects (e.g. DrillCycleExpander) set
+# NO_COLLAPSE_ANNOTATION in the command's Annotations (by whole-dict
+# reassignment; item assignment does not persist). The formatting layers
+# (Processor._convert_move and UtilsParse) translate it into the
+# NO_COLLAPSE_MARKER word on the G-code line, which filter_inefficient_moves
+# honors and strips from the final output.
+NO_COLLAPSE_ANNOTATION = "no_collapse"
+NO_COLLAPSE_MARKER = "(no-collapse)"
+
 
 class NumberGenerator:
     """
@@ -226,10 +236,28 @@ def suppress_redundant_axes_words(gcode: List[str]) -> List[str]:
 
 
 def filter_inefficient_moves(gcode: List[str]) -> List[str]:
-    """Filter out inefficient or redundant moves from G-code.
+    """Collapse runs of consecutive rapid (G0) moves that travel along a
+    single axis, keeping only the final move of each run.
 
-    Removes unnecessary rapid (G0) moves by collapsing chains that only move
-    along single axes or within linear/rotary groups.
+    A run is collapsed only when the dropped moves are provably redundant
+    stutter: all motion is along one axis, in one direction, from a known
+    starting position, and the surviving line states the endpoint. Rapids
+    that change more than one axis are never collapsed, and neither is a
+    run containing a direction reversal — an excursion such as the
+    chip-clearing retract of an expanded peck-drilling cycle is intentional
+    motion whose purpose is the excursion itself, not its endpoint.
+
+    Producers can explicitly protect a rapid by annotating its line with the
+    NO_COLLAPSE_MARKER word (the formatting layer adds it for Path.Command
+    producers that set NO_COLLAPSE_ANNOTATION, e.g. the drill cycle
+    expander). Annotated lines never collapse and the marker is stripped
+    from the output.
+
+    Absolute positioning (G90) is assumed until a G91 is seen; collapsing is
+    suspended in incremental mode. Any command this function does not model
+    (tool changes, coordinate system changes, canned cycles, block delete,
+    unparsable words, ...) resets position tracking and passes through
+    unchanged.
 
     Args:
         gcode: List of G-code strings
@@ -238,168 +266,182 @@ def filter_inefficient_moves(gcode: List[str]) -> List[str]:
         List of G-code strings with inefficient moves filtered out
     """
     AXES = ("X", "Y", "Z", "A", "B", "C")
+    MOTION_GS = {0.0, 1.0, 2.0, 3.0}
+    # Words that neither move axes unpredictably nor change what tracked
+    # coordinates mean. Anything else invalidates tracked state.
+    TRACKED_LETTERS = {"G", "F", "S"} | set(AXES)
 
-    SIDE_EFFECT_KEYS = {
-        "tool",
-        "tool_change",
-        "spindle",
-        "spindle_on",
-        "spindle_off",
-        "coolant",
-        "dwell",
-        "feed",
-        "F",
-        "M",
-    }
-
-    def parse_gcode_line(line: str) -> dict:
-        """Parse a G-code line into command name and parameters."""
-        stripped = line.strip()
-        if not stripped or stripped.startswith("("):
-            return {"name": "COMMENT", "params": {}, "original": line}
-
-        # Check for blockdelete
-        has_blockdelete = stripped.startswith("/")
-        if has_blockdelete:
-            stripped = stripped[1:]
-
-        words = stripped.split()
-        if not words:
-            return {"name": "EMPTY", "params": {}, "original": line}
-
-        cmd_name = words[0]
-        params = {}
-
-        for word in words[1:]:
-            if len(word) > 1:
-                key = word[0]
-                try:
-                    value = float(word[1:])
-                    params[key] = value
-                except (ValueError, IndexError):
-                    params[word] = None  # Non-numeric parameter
-
-        return {
-            "name": cmd_name,
-            "params": params,
-            "original": line,
-            "blockdelete": has_blockdelete,
-        }
-
-    def is_rapid(parsed_cmd: dict) -> bool:
-        """Check if command is a rapid move (G0)."""
-        return parsed_cmd["name"] in ("G0", "G00")
-
-    def has_side_effects(parsed_cmd: dict) -> bool:
-        """Check if command has side effects that prevent optimization."""
-        # Check for side effect parameter keys
-        if any(k in parsed_cmd["params"] for k in SIDE_EFFECT_KEYS):
-            return True
-
-        # Check for M-codes and other side effect commands
-        cmd = parsed_cmd["name"]
-        if cmd.startswith("M") or cmd in (
-            "G28",
-            "G30",
-            "G53",
-            "G54",
-            "G55",
-            "G56",
-            "G57",
-            "G58",
-            "G59",
-            "G92",
-            "G10",
-            "T",  # Tool change
-            "G73",
-            "G74",
-            "G80",
-            "G81",
-            "G82",
-            "G83",
-            "G84",
-            "G85",
-            "G86",
-            "G87",
-            "G88",
-            "G89",  # Drill cycles
-            "G98",
-            "G99",
-        ):  # Retract modes
-            return True
-
-        return False
-
-    def full_position(parsed_cmd: dict, last_pos: dict) -> dict:
-        """Compute full position from command and last position."""
-        pos = {}
-        for ax in AXES:
-            if ax in parsed_cmd["params"] and parsed_cmd["params"][ax] is not None:
-                pos[ax] = parsed_cmd["params"][ax]
-            else:
-                pos[ax] = last_pos.get(ax)
-        return pos
-
-    def collapse_rapid_chain(chain):
-        """
-        Collapse a chain of rapid moves.
-        chain = list of dicts with 'parsed', 'pos', and 'original' keys.
-        """
-        if not chain:
-            return []
-
-        # Check which axes change across the chain
-        first = chain[0]["pos"]
-        axes_changed = {ax for ax in AXES if any(c["pos"][ax] != first[ax] for c in chain)}
-
-        # If only one axis changes → keep only the last command
-        if len(axes_changed) == 1:
-            return [chain[-1]["original"]]
-
-        # If changes are only within linear or rotary groups → keep only last
-        lin = {"X", "Y", "Z"}
-        rot = {"A", "B", "C"}
-
-        if axes_changed <= lin or axes_changed <= rot:
-            return [chain[-1]["original"]]
-
-        # Mixed changes → can't collapse, keep all
-        return [c["original"] for c in chain]
-
-    # Main optimization logic
     result = []
-    rapid_chain = []
-    last_full_pos = {ax: None for ax in AXES}
+    pos = {ax: None for ax in AXES}  # tracked absolute position, None = unknown
+    absolute_mode = True
+    modal_motion = None  # last motion G word seen (0.0-3.0)
+    chain = []  # pending consecutive collapsible rapids
+    chain_base = None  # tracked position before the first move of the chain
+
+    def changed_axes(move_pos: dict, base: dict) -> set:
+        """Axes whose value differs from base; unknown baselines count as changed."""
+        changed = set()
+        for ax in AXES:
+            a, b = move_pos[ax], base[ax]
+            if a is None and b is None:
+                continue
+            if a is None or b is None or a != b:
+                changed.add(ax)
+        return changed
+
+    def is_monotonic(run: list, run_base: dict, ax: str) -> bool:
+        """True when the run's motion along ax never reverses direction,
+        starting from a known position."""
+        values = [run_base[ax]] + [m["pos"][ax] for m in run]
+        if any(v is None for v in values):
+            return False
+        deltas = [b - a for a, b in zip(values, values[1:])]
+        return all(d >= 0 for d in deltas) or all(d <= 0 for d in deltas)
+
+    def emit_run(run: list, run_changed: set, run_base: dict) -> list:
+        """Emit a run of rapids, keeping only the last move when that is safe."""
+        if len(run) > 1 and len(run_changed) <= 1:
+            last = run[-1]
+            # The surviving line must state the endpoint of the changing
+            # axis, and a reversal (e.g. the chip-clearing retract of an
+            # expanded peck cycle) must never be dropped.
+            safe = run_changed <= last["axis_letters"] and all(
+                is_monotonic(run, run_base, ax) for ax in run_changed
+            )
+            if safe:
+                if last["has_motion_word"]:
+                    return [last["line"]]
+                # Modal rapid: carry the G0 word forward from a dropped line
+                # so the surviving line cannot execute in a different mode.
+                g_word = next((m["g_word"] for m in run if m["g_word"]), None)
+                if g_word:
+                    return [f"{g_word} {last['line'].strip()}"]
+        return [m["line"] for m in run]
+
+    def collapse_chain(moves: list, base: dict) -> list:
+        """Split a chain into single-axis runs and emit each independently."""
+        out = []
+        run = []
+        run_changed = set()
+        run_base = base
+        for move in moves:
+            move_changed = changed_axes(move["pos"], run_base)
+            if run and len(run_changed | move_changed) > 1:
+                out.extend(emit_run(run, run_changed, run_base))
+                run_base = run[-1]["pos"]
+                run = []
+                run_changed = set()
+                move_changed = changed_axes(move["pos"], run_base)
+            run.append(move)
+            run_changed |= move_changed
+        out.extend(emit_run(run, run_changed, run_base))
+        return out
 
     def flush_chain():
-        nonlocal rapid_chain
-        if rapid_chain:
-            result.extend(collapse_rapid_chain(rapid_chain))
-            rapid_chain = []
+        nonlocal chain, chain_base
+        if chain:
+            result.extend(collapse_chain(chain, chain_base))
+            chain = []
+            chain_base = None
 
     for line in gcode:
-        parsed = parse_gcode_line(line)
+        # Honor and strip explicit no-collapse annotations from upstream
+        # producers (e.g. drill-cycle retracts marked by DrillCycleExpander).
+        blocked = NO_COLLAPSE_MARKER in line
+        if blocked:
+            line = line.replace(NO_COLLAPSE_MARKER, "").rstrip()
 
-        # Skip comments and empty lines
-        if parsed["name"] in ("COMMENT", "EMPTY"):
-            flush_chain()  # Flush any pending rapid chain
+        stripped = line.strip()
+
+        # Comments and empty lines pass through; they end any pending chain.
+        if not stripped or stripped.startswith("("):
+            flush_chain()
             result.append(line)
             continue
 
-        # Get full position for this command
-        pos = full_position(parsed, last_full_pos)
-        last_full_pos = pos
+        # Block-deleted lines may or may not execute on the machine, so any
+        # Block-deleted lines may or may not execute on the machine, so any
+        # axis they mention becomes unknown.
+        if stripped.startswith("/"):
+            flush_chain()
+            modal_motion = None
+            for word in stripped[1:].split():
+                letter = word[:1].upper()
+                if letter in pos:
+                    pos[letter] = None
+            result.append(line)
+            continue
+        words = []
+        parse_ok = True
+        for raw in stripped.split():
+            letter = raw[:1].upper()
+            try:
+                words.append((letter, float(raw[1:]), raw))
+            except ValueError:
+                parse_ok = False
+                break
 
-        # Check if this is a rapid move without side effects
-        if is_rapid(parsed) and not has_side_effects(parsed):
-            rapid_chain.append({"parsed": parsed, "pos": pos, "original": line})
+        g_values = {value for letter, value, raw in words if letter == "G"}
+        letters = {letter for letter, value, raw in words}
+        motion_words = g_values & MOTION_GS
+
+        # Distance mode words can share a line with other commands, so update
+        # the mode even when the line is otherwise passed through below.
+        if 91.0 in g_values:
+            absolute_mode = False
+        elif 90.0 in g_values:
+            absolute_mode = True
+
+        if (
+            not parse_ok
+            or letters - TRACKED_LETTERS
+            or g_values - MOTION_GS - {90.0, 91.0}
+            or len(motion_words) > 1
+        ):
+            flush_chain()
+            pos = {ax: None for ax in AXES}
+            modal_motion = None
+            result.append(line)
+            continue
+
+        if motion_words:
+            modal_motion = next(iter(motion_words))
+
+        pos_before = dict(pos)
+        axis_letters = set()
+        for letter, value, raw in words:
+            if letter in pos:
+                axis_letters.add(letter)
+                pos[letter] = value if absolute_mode else None
+
+        # A rapid is collapsible only when it is not annotated as functional
+        # and carries nothing but motion: no F/S words, no distance mode
+        # change riding along.
+        collapsible = (
+            not blocked
+            and absolute_mode
+            and modal_motion == 0.0
+            and g_values <= {0.0}
+            and letters <= {"G"} | set(AXES)
+        )
+
+        if collapsible:
+            if not chain:
+                chain_base = pos_before
+            chain.append(
+                {
+                    "line": line,
+                    "pos": dict(pos),
+                    "axis_letters": axis_letters,
+                    "g_word": next((raw for letter, _, raw in words if letter == "G"), None),
+                    "has_motion_word": bool(motion_words),
+                }
+            )
         else:
-            flush_chain()  # Flush any pending rapid chain before adding this command
+            flush_chain()
             result.append(line)
 
-    # Flush any remaining rapid chain
     flush_chain()
-
     return result
 
 

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -1912,14 +1912,16 @@ class PostProcessor:
         header_part = gcode_lines[:num_header_lines]
         body_part = gcode_lines[num_header_lines:]
 
+        if body_part and self.values["FILTER_INEFFICIENT_MOVES"]:
+            # Must run before the modal passes below strip command words,
+            # or rapid chains are no longer recognizable.
+            body_part = filter_inefficient_moves(body_part)
+
         if body_part:
             if not self.values["OUTPUT_DUPLICATE_COMMANDS"]:
                 body_part = deduplicate_repeated_commands(body_part)
             if not self.values["OUTPUT_DOUBLES"]:
                 body_part = suppress_redundant_axes_words(body_part)
-
-        if body_part and self.values["FILTER_INEFFICIENT_MOVES"]:
-            body_part = filter_inefficient_moves(body_part)
 
         if body_part and self.values["OUTPUT_LINE_NUMBERS"]:
             start = self.values["LINE_NUMBER_START"]
@@ -2608,6 +2610,7 @@ class PostProcessor:
         This method can be overridden by derived postprocessors to customize rapid move handling.
         """
         from Path.Post.UtilsParse import format_command_line
+        from Path.Post.GcodeProcessingUtils import NO_COLLAPSE_ANNOTATION, NO_COLLAPSE_MARKER
 
         # Extract command components
         command_name = command.Name
@@ -2656,6 +2659,12 @@ class PostProcessor:
         # A bare move (G0, G1, G2, G3) or dwell (G4) with no parameters is meaningless.
         if params and len(command_line) == 1:
             return None
+
+        # Moves annotated as functional motion get a marker word which
+        # filter_inefficient_moves honors and strips; only emit it when that
+        # filter will actually run.
+        if annotations.get(NO_COLLAPSE_ANNOTATION) and self.values.get("FILTER_INEFFICIENT_MOVES"):
+            command_line.append(NO_COLLAPSE_MARKER)
 
         # Format the command line
         formatted_line = format_command_line(self.values, command_line)

--- a/src/Mod/CAM/Path/Post/UtilsParse.py
+++ b/src/Mod/CAM/Path/Post/UtilsParse.py
@@ -40,6 +40,7 @@ import Path
 import Path.Post.Utils as PostUtils
 from Path.Base.MachineState import MachineState
 from Path.Post.DrillCycleExpander import DrillCycleExpander
+from Path.Post.GcodeProcessingUtils import NO_COLLAPSE_ANNOTATION, NO_COLLAPSE_MARKER
 
 # Define some types that are used throughout this file
 CommandLine = List[str]
@@ -481,6 +482,11 @@ def _format_expanded_command(values: Values, gcode: Gcode, cmd) -> None:
     if "P" in params:
         parts.append(f"P{params['P']}")
 
+    # Marked moves get a marker word which filter_inefficient_moves honors
+    # and strips; only emit it when that filter will actually run.
+    if values.get("FILTER_INEFFICIENT_MOVES") and cmd.Annotations.get(NO_COLLAPSE_ANNOTATION):
+        parts.append(NO_COLLAPSE_MARKER)
+
     gcode.append(f"{linenumber(values)}{format_command_line(values, parts)}")
 
 
@@ -787,6 +793,15 @@ def parse_a_path(values: Values, gcode: Gcode, pathobj) -> None:
             command_line = []
         if check_for_suppressed_commands(values, gcode, command, command_line):
             command_line = []
+
+        # Marked moves get a marker word which filter_inefficient_moves
+        # honors and strips; only emit it when that filter will actually run.
+        if (
+            command_line
+            and values.get("FILTER_INEFFICIENT_MOVES")
+            and c.Annotations.get(NO_COLLAPSE_ANNOTATION)
+        ):
+            command_line.append(NO_COLLAPSE_MARKER)
 
         if command_line:
             if command in ("M6", "M06") and swap_tool_change_order:


### PR DESCRIPTION
The previous rapid-move collapse could change the machined toolpath: it measured axis changes against the first chain move instead of the pre-chain position (dropping retracts before traverses), collapsed multi-axis chains within linear/rotary groups (replacing dog-leg clearance motion with direct moves), and could emit a surviving line that did not state the endpoint of dropped moves.

Rewrite the filter so a rapid run collapses only when it is provably redundant stutter: motion along a single axis, in one direction, from a known position, with the endpoint stated on the surviving line. Direction reversals are preserved because an excursion (e.g. the chip-clearing retract of an expanded peck cycle) is intentional motion. Collapsing is suspended in G91 and position tracking resets on any unmodeled command.

Add an explicit no-collapse annotation so producers can protect functional rapids regardless of geometry: DrillCycleExpander marks all in-cycle rapids via Command.Annotations, the formatting layers (Processor._convert_move and UtilsParse) translate the annotation into a (no-collapse) marker word when FILTER_INEFFICIENT_MOVES is active, and the filter honors and strips the marker. Without the marker the G98 final-retract pair (rapid to R, then to initial Z) is a monotonic single-axis chain the heuristic alone would collapse.

Run the filter before the modal deduplication passes in _optimize_gcode, since those strip the command words the filter needs to recognize rapids.

Assisted by Claude Fable 5 
