### PR TITLE
Measurement: Add translation to diameter label

### DIFF
--- a/src/Mod/Measure/App/AppMeasure.cpp
+++ b/src/Mod/Measure/App/AppMeasure.cpp
@@ -164,7 +164,7 @@ PyMOD_INIT_FUNC(Measure)
 
     App::MeasureManager::addMeasureType(
         "DIAMETER",
-        "Diameter",
+        QT_TRANSLATE_NOOP("TaskMeasure", "Diameter"),
         "Measure::MeasureDiameter",
         MeasureDiameter::isValidSelection,
         MeasureDiameter::isPrioritizedSelection


### PR DESCRIPTION
Adds QT_TRANSLATE_NOOP to the diameter label, just like the others.
The translation for the measurement labels is currently broken, but https://github.com/FreeCAD/FreeCAD/pull/30641 fixes it, and there is also no translation for this in the catalog yet.
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: Open AI GPT 5.6 sol, it found it when working on a different pr.