### PR TITLE
Sketcher: Use existing geometry to migrate to signed constraints

### DIFF
--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -64,6 +64,71 @@ using namespace Sketcher;
 using namespace Base;
 using namespace Part;
 
+namespace
+{
+
+/**
+ * @brief Distance from a point to a line, signed by the side the point is on.
+ *
+ * @param[in] line The line, read in its current solver state. Its direction runs from @c p1
+ *                 to @c p2.
+ * @param[in] pointX The x coordinate of the point.
+ * @param[in] pointY The y coordinate of the point.
+ * @return A positive value when the point lies counter-clockwise from the line direction, a
+ *         negative value when it lies clockwise, and zero for a degenerate line.
+ */
+double signedDistanceToLine(const GCS::Line& line, double pointX, double pointY)
+{
+    const double startX = *line.p1.x;
+    const double startY = *line.p1.y;
+    const double deltaX = *line.p2.x - startX;
+    const double deltaY = *line.p2.y - startY;
+    const double length = std::hypot(deltaX, deltaY);
+
+    if (length < Precision::Confusion()) {
+        return 0.0;
+    }
+
+    return (deltaX * (pointY - startY) - deltaY * (pointX - startX)) / length;
+}
+
+/**
+ * @brief Whether a constraint records which side of a line its subject sits on.
+ *
+ * Constraints restored from documents written before signed constraints existed carry
+ * ConstraintOrientations::None, and so do constraints whose migration could not resolve the
+ * geometry they reference. Reading that as Clockwise would silently mirror the sketch, so
+ * callers must derive the side from the geometry itself instead.
+ *
+ * @param[in] orientation The orientation flags of the constraint.
+ * @return @c true if the flags name a side, @c false if the side is unknown.
+ */
+bool hasKnownSide(ConstraintOrientation orientation)
+{
+    return orientation.testFlag(ConstraintOrientations::CounterClockwise)
+        || orientation.testFlag(ConstraintOrientations::Clockwise);
+}
+
+/**
+ * @brief The side of a line a tangent circle has to stay on.
+ *
+ * @param[in] orientation The orientation flags of the tangency constraint.
+ * @param[in] line The line, read in its current solver state.
+ * @param[in] circle The circle or arc, read in its current solver state.
+ * @return @c true to keep the circle counter-clockwise from the line direction, taken from
+ *         @p orientation when it names a side and from the current geometry otherwise.
+ */
+bool tangentSide(ConstraintOrientation orientation, const GCS::Line& line, const GCS::Circle& circle)
+{
+    if (hasKnownSide(orientation)) {
+        return orientation.testFlag(ConstraintOrientations::CounterClockwise);
+    }
+
+    return signedDistanceToLine(line, *circle.center.x, *circle.center.y) > 0.0;
+}
+
+}  // namespace
+
 TYPESYSTEM_SOURCE(Sketcher::Sketch, Base::Persistence)
 
 Sketch::Sketch()
@@ -3059,23 +3124,13 @@ int Sketch::addTangentConstraint(int geoId1, int geoId2, ConstraintOrientation o
         if (Geoms[geoId2].type == Arc) {
             GCS::Arc& a = Arcs[Geoms[geoId2].index];
             int tag = ++ConstraintsCounter;
-            GCSsys.addConstraintTangent(
-                l,
-                a,
-                orientation.testFlag(ConstraintOrientations::CounterClockwise),
-                tag
-            );
+            GCSsys.addConstraintTangent(l, a, tangentSide(orientation, l, a), tag);
             return ConstraintsCounter;
         }
         else if (Geoms[geoId2].type == Circle) {
             GCS::Circle& c = Circles[Geoms[geoId2].index];
             int tag = ++ConstraintsCounter;
-            GCSsys.addConstraintTangent(
-                l,
-                c,
-                orientation.testFlag(ConstraintOrientations::CounterClockwise),
-                tag
-            );
+            GCSsys.addConstraintTangent(l, c, tangentSide(orientation, l, c), tag);
             return ConstraintsCounter;
         }
         else if (Geoms[geoId2].type == Ellipse) {
@@ -3583,15 +3638,12 @@ int Sketch::addDistanceConstraint(
     if (Geoms[geoId2].type == Line) {
         GCS::Line& l2 = Lines[Geoms[geoId2].index];
 
+        const bool counterClockwise = hasKnownSide(orientation)
+            ? orientation.testFlag(ConstraintOrientations::CounterClockwise)
+            : signedDistanceToLine(l2, *p1.x, *p1.y) > 0.0;
+
         int tag = ++ConstraintsCounter;
-        GCSsys.addConstraintP2LDistance(
-            p1,
-            l2,
-            value,
-            orientation.testFlag(ConstraintOrientations::CounterClockwise),
-            tag,
-            driving
-        );
+        GCSsys.addConstraintP2LDistance(p1, l2, value, counterClockwise, tag, driving);
         return ConstraintsCounter;
     }
     else {
@@ -3664,16 +3716,17 @@ int Sketch::addDistanceConstraint(
         }
 
         GCS::Line* l = &Lines[Geoms[geoId2].index];
+
+        bool counterClockwise = orientation.testFlag(ConstraintOrientations::CounterClockwise);
+        bool internal = orientation.testFlag(ConstraintOrientations::Internal);
+        if (!hasKnownSide(orientation)) {
+            const double signedDistance = signedDistanceToLine(*l, *c1->center.x, *c1->center.y);
+            counterClockwise = signedDistance > 0.0;
+            internal = std::abs(signedDistance) < *c1->rad;
+        }
+
         int tag = ++ConstraintsCounter;
-        GCSsys.addConstraintC2LDistance(
-            *c1,
-            *l,
-            value,
-            orientation.testFlag(ConstraintOrientations::CounterClockwise),
-            orientation.testFlag(ConstraintOrientations::Internal),
-            tag,
-            driving
-        );
+        GCSsys.addConstraintC2LDistance(*c1, *l, value, counterClockwise, internal, tag, driving);
         return ConstraintsCounter;
     }
     else {

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1396,6 +1396,11 @@ void SketchObject::onSketchRestore()
         }else
             acceptGeometry();
 
+        // Must run after the external geometry above: the orientations are derived from the
+        // geometry the constraints reference, and projected external geometry does not exist
+        // before it is rebuilt or accepted.
+        migrateConstraintOrientations();
+
         synchroniseGeometryState();
         // this may happen when saving a sketch directly in edit mode
         // but never performed a recompute before
@@ -1433,6 +1438,19 @@ void SketchObject::onSketchRestore()
 }
 
 // clang-format on
+void SketchObject::migrateConstraintOrientations()
+{
+    // Migrate point-line and circle-line distance and tangency from unsigned to signed. Documents
+    // written before signed constraints existed carry no orientation at all, so the side each
+    // constraint was solved on has to be read back out of the geometry stored in the file.
+    auto constraints = Constraints.getValues();
+    for (auto& constr : constraints) {
+        setOrientation(constr, false);
+    }
+
+    Constraints.setValues(std::move(constraints));
+}
+
 void SketchObject::migrateSketch()
 {
     // Old documents lack _InternalFaceVersion; infer it from the saving version (still the
@@ -1499,16 +1517,6 @@ void SketchObject::migrateSketch()
 
             g->deleteExtension(Part::GeometryMigrationExtension::getClassTypeId());
         }
-    }
-
-    {
-        // Migrate point-line, circle-circle and circle-line distance from abs to signed
-        auto constraints = Constraints.getValues();
-        for (auto& constr : constraints) {
-            setOrientation(constr, false);
-        }
-
-        Constraints.setValues(std::move(constraints));
     }
 
     /* parabola axis as internal geometry */

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -1089,6 +1089,9 @@ protected:
 
     // migration functions
     void migrateSketch();
+    /// Derive the signed-constraint orientations of a legacy sketch from its stored geometry.
+    /// Must be called once the external geometry of the sketch is available.
+    void migrateConstraintOrientations();
 
     static void appendConstraintsMsg(
         const std::vector<int>& vector,
@@ -1154,8 +1157,14 @@ public:
     void changeConstraintAfterDeletingGeo(Constraint* constr, const int deletedGeoId) const;
 
 private:
+    /// As getGeometry, but warns instead of quietly returning nullptr when @p geoId cannot be
+    /// resolved, so that a constraint left without an orientation is traceable.
+    const Part::Geometry* getGeometryOrWarn(int geoId) const;
     void setOrientationDistance(Constraint* constr);
     void setOrientationTangent(Constraint* constr);
+    /// Re-derive the orientation of every signed constraint that references one of
+    /// @p reversedGeoIds, whose projection came back running the other way.
+    void reorientConstraintsOnReversedGeometry(const std::set<int>& reversedGeoIds);
 
     /// Internal helper method for exposeInternalGeometryForType
     /// Add geometry and constraints to `this`, then delete the geometry and constraints in the

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -1428,11 +1428,30 @@ std::optional<gp_Circ> getCircle(const Part::Geometry* geo)
     }
     return std::nullopt;
 }
+const Part::Geometry* SketchObject::getGeometryOrWarn(int geoId) const
+{
+    if (geoId == GeoEnum::GeoUndef) {
+        return nullptr;
+    }
+
+    const Part::Geometry* geo = getGeometry(geoId);
+    if (!geo) {
+        // Without the referenced geometry, the side a signed constraint has to be solved on can't
+        // be determined, and the constraint keeps ConstraintOrientations::None. Don't let this be
+        // invisible (which will look like everything worked, when it didn't). This is useful when
+        // debugging old files that didn't reload correctly.
+        FC_WARN("Cannot determine constraint orientation, geometry "
+                << geoId << " is unavailable in " << getFullName());
+    }
+    return geo;
+}
+
 void SketchObject::setOrientationDistance(Constraint* constr)
 {
     // Try to find the orientation of point-line distance
     if (constr->FirstPos != PointPos::none && constr->Second != GeoEnum::GeoUndef) {
-        auto* geo1AsLine = freecad_cast<const Part::GeomLineSegment*>(getGeometry(constr->Second));
+        auto* geo1AsLine =
+            freecad_cast<const Part::GeomLineSegment*>(getGeometryOrWarn(constr->Second));
         if (geo1AsLine) {
             constr->Orientation = ccw2d(geo1AsLine->getStartPoint(), geo1AsLine->getEndPoint(), getPoint(constr->First, constr->FirstPos));
         }
@@ -1441,8 +1460,8 @@ void SketchObject::setOrientationDistance(Constraint* constr)
 
     // Try to find the orientation of circle-circle distance or circle-line
     if (constr->FirstPos == PointPos::none && constr->SecondPos == PointPos::none && constr->Second != GeoEnum::GeoUndef) {
-        const Part::Geometry* firGeo = getGeometry(constr->First);
-        const Part::Geometry* secGeo = getGeometry(constr->Second);
+        const Part::Geometry* firGeo = getGeometryOrWarn(constr->First);
+        const Part::Geometry* secGeo = getGeometryOrWarn(constr->Second);
         auto geo1AsCirc = getCircle(firGeo);
         auto geo2AsCirc = getCircle(secGeo);
 
@@ -1476,8 +1495,8 @@ void SketchObject::setOrientationDistance(Constraint* constr)
 }
 void SketchObject::setOrientationTangent(Constraint* constr)
 {
-    const Part::Geometry* firGeo = getGeometry(constr->First);
-    const Part::Geometry* secGeo = getGeometry(constr->Second);
+    const Part::Geometry* firGeo = getGeometryOrWarn(constr->First);
+    const Part::Geometry* secGeo = getGeometryOrWarn(constr->Second);
 
     auto impl = [&](const Part::Geometry* firGeo, const Part::Geometry* secGeo) -> bool {
         auto geo1AsCirc = getCircle(firGeo);
@@ -1501,6 +1520,44 @@ void SketchObject::setOrientationTangent(Constraint* constr)
         return;
     }
 }
+void SketchObject::reorientConstraintsOnReversedGeometry(const std::set<int>& reversedGeoIds)
+{
+    if (reversedGeoIds.empty()) {
+        return;
+    }
+
+    auto constraints = Constraints.getValues();
+    bool changed = false;
+
+    for (auto& constr : constraints) {
+        if (constr->Type != Distance && constr->Type != Tangent) {
+            continue;
+        }
+
+        bool referencesReversed = false;
+        for (int index = 0; constr->hasElement(index); ++index) {
+            if (reversedGeoIds.count(constr->getElement(index).GeoId) > 0) {
+                referencesReversed = true;
+                break;
+            }
+        }
+
+        if (!referencesReversed) {
+            continue;
+        }
+
+        // The line turned around underneath the constraint, so the side it recorded no longer
+        // describes where the geometry actually is. Read the side back out of the geometry rather
+        // than inverting the flag, so that the sketch stays where the user left it.
+        setOrientation(constr, true);
+        changed = true;
+    }
+
+    if (changed) {
+        Constraints.setValues(std::move(constraints));
+    }
+}
+
 void SketchObject::setOrientation(Constraint* constr, bool reset)
 {
     if (!reset && !constr->Orientation.testFlag(ConstraintOrientations::None)) {

--- a/src/Mod/Sketcher/App/SketchObjectExternal.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectExternal.cpp
@@ -2300,6 +2300,17 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
 
     fixMissingAxisInExternalGeo();
 
+    // Remember which way the projected lines currently run. Signed constraints record which side
+    // of a line their subject sits on, and that side is expressed relative to the line direction,
+    // so a projection that comes back reversed would otherwise drag the sketch to the other side.
+    std::map<long, Base::Vector3d> previousLineDirections;
+    for (const auto& geo : ExternalGeo.getValues()) {
+        if (auto* line = freecad_cast<const Part::GeomLineSegment*>(geo)) {
+            previousLineDirections[GeometryFacade::getId(geo)] =
+                line->getEndPoint() - line->getStartPoint();
+        }
+    }
+
     // Analyze the state of existing external geometries to infer the desired state for new ones.
     // If any geometry from a source link is "defining", we'll treat the whole link as "defining".
     std::map<std::string, bool> linkIsDefiningMap;
@@ -2699,8 +2710,23 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
         }
     }
 
+    std::set<int> reversedGeoIds;
+    for (std::size_t index = 0; index < geoms.size(); ++index) {
+        auto* line = freecad_cast<const Part::GeomLineSegment*>(geoms[index]);
+        if (!line) {
+            continue;
+        }
+        auto previous = previousLineDirections.find(GeometryFacade::getId(geoms[index]));
+        if (previous != previousLineDirections.end()
+            && (line->getEndPoint() - line->getStartPoint()).Dot(previous->second) < 0.0) {
+            reversedGeoIds.insert(-static_cast<int>(index) - 1);
+        }
+    }
+
     ExternalGeo.setValues(std::move(geoms));
     rebuildVertexIndex();
+
+    reorientConstraintsOnReversedGeometry(reversedGeoIds);
 
     // clean up geometry reference
     if(refSet.size() != (size_t)ExternalGeometry.getSize()) {

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -1452,6 +1452,12 @@ int SketchObject::addSymmetric(
                     constNew->setValue(-constr->getValue());
                 }
 
+                // Signed constraints record which side of a line their subject sits on, and a
+                // symmetry about a *line* reverses that side while a symmetry about a *point* does
+                // not. For the new constraint, re-derive the sign from the updated geometry
+                // instead of trying to figure it out from the old one.
+                setOrientation(constNew, true);
+
                 newconstrVals.push_back(constNew);
                 continue;
             }

--- a/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
@@ -23,7 +23,7 @@
 # **************************************************************************
 
 
-import os, tempfile, unittest
+import os, re, tempfile, unittest, zipfile
 import FreeCAD, Part, Sketcher
 from Part import Precision
 
@@ -35,6 +35,53 @@ xy_normal = FreeCAD.Vector(0, 0, 1)
 def vec(x, y):
     """Shorthand to create a vector in the XY-plane"""
     return FreeCAD.Vector(x, y, 0)
+
+
+def signedDistanceToLine(line, point):
+    """Distance from point to line, positive when the point is counter-clockwise from the line"""
+    start = line.StartPoint
+    delta = line.EndPoint - start
+    return (delta.x * (point.y - start.y) - delta.y * (point.x - start.x)) / delta.Length
+
+
+def makeDocumentLookLegacy(path):
+    """Rewrite an FCStd in place so that its sketches look like they predate signed constraints.
+
+    Strips every constraint Orientation attribute and the whole ExternalGeo property, which is
+    exactly what a document saved by FreeCAD 0.21 and earlier looks like.
+    """
+    archive = zipfile.ZipFile(path)
+    members = {name: archive.read(name) for name in archive.namelist()}
+    archive.close()
+
+    document = members["Document.xml"].decode("utf-8")
+    document = re.sub(
+        r"<Constrain [^>]*/>",
+        lambda m: re.sub(r'\s*Orientation="\d+"', "", m.group(0)),
+        document,
+    )
+
+    def dropExternalGeo(match):
+        body, removed = re.subn(
+            r'[ \t]*<Property name="ExternalGeo" .*?</Property>\n',
+            "",
+            match.group("body"),
+            flags=re.DOTALL,
+        )
+        count = int(match.group("count")) - removed
+        return '<Properties Count="%d"%s>%s</Properties>' % (count, match.group("rest"), body)
+
+    document = re.sub(
+        r'<Properties Count="(?P<count>\d+)"(?P<rest>[^>]*)>(?P<body>.*?)</Properties>',
+        dropExternalGeo,
+        document,
+        flags=re.DOTALL,
+    )
+
+    members["Document.xml"] = document.encode("utf-8")
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as rewritten:
+        for name, data in members.items():
+            rewritten.writestr(name, data)
 
 
 def CreateRectangleSketch(SketchFeature, corner, lengths):
@@ -734,6 +781,134 @@ class TestSketcherSolver(unittest.TestCase):
         self.assertGreater(sketch.Geometry[circle_q4_idx].Location.x, 0)
         self.assertLess(sketch.Geometry[circle_q4_idx].Location.y, 0)
 
+    def buildSketchOnProjectedEdge(self):
+        """Attach a sketch to the top face of a box and dimension a circle against a borrowed edge.
+
+        Returns the sketch, the index of a borrowed edge that projects to a line segment, and the
+        index of the circle constrained against it. The circle sits on the counter-clockwise side
+        of that line, which is the side an unsigned constraint gets mirrored away from.
+
+        The borrowed edge is chosen to run through the sketch origin, so that reversing the sketch
+        plane turns the projection around without also displacing it. That keeps the circle's
+        stored position a valid solution afterwards, and therefore keeps "the sketch must not move"
+        a meaningful thing to assert.
+        """
+        box = self.Doc.addObject("Part::Box", "Box")
+        box.Length = 20
+        box.Width = 20
+        box.Height = 5
+        self.Doc.recompute()
+
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        sketch.AttachmentSupport = [(box, "Face6")]
+        sketch.MapMode = "FlatFace"
+        self.Doc.recompute()
+
+        # Edges perpendicular to the sketch plane project to points, so look for one that comes
+        # back as a line segment through the sketch origin.
+        external_index = None
+        for number in range(1, 13):
+            sketch.addExternal("Box", "Edge%d" % number)
+            self.Doc.recompute()
+            projected = sketch.ExternalGeo[-1]
+            if isinstance(projected, Part.LineSegment) and projected.StartPoint.Length < 1e-7:
+                external_index = len(sketch.ExternalGeo) - 1
+                break
+            sketch.delExternal(len(sketch.ExternalGeometry) - 1)
+            self.Doc.recompute()
+        self.assertIsNotNone(external_index, "no box edge projected to a line through the origin")
+        # Anything the two sketch axes already occupy would resolve without a rebuilt projection.
+        self.assertGreaterEqual(external_index, 2)
+
+        # Put the circle on the counter-clockwise side of the borrowed edge, whichever way round
+        # that edge happened to project. A constraint left unsigned defaults to the clockwise side,
+        # so a circle that started clockwise would be unaffected and prove nothing.
+        line = sketch.ExternalGeo[external_index]
+        direction = line.EndPoint - line.StartPoint
+        direction.normalize()
+        outward = FreeCAD.Vector(-direction.y, direction.x, 0)
+        centre = (line.StartPoint + line.EndPoint) * 0.5 + outward * 5.0
+
+        external_geo_id = -external_index - 1
+        circle = sketch.addGeometry(Part.Circle(centre, xy_normal, 2), False)
+        sketch.addConstraint(Sketcher.Constraint("Radius", circle, 2.0))
+        sketch.addConstraint(Sketcher.Constraint("Distance", circle, 3, external_geo_id, 5.0))
+        self.Doc.recompute()
+        self.assertSuccessfulSolve(sketch)
+
+        self.assertAlmostEqual(
+            signedDistanceToLine(
+                sketch.ExternalGeo[external_index], sketch.Geometry[circle].Center
+            ),
+            5.0,
+            delta=Precision.confusion(),
+            msg="the circle is meant to sit 5 mm counter-clockwise of the borrowed edge",
+        )
+
+        return sketch, external_index, circle
+
+    def testLegacyExternalGeometryOrientationMigration(self):
+        # A document written before signed constraints existed stores neither a constraint
+        # Orientation nor an ExternalGeo property. The orientation then has to be recovered from
+        # the geometry in the file, which is only possible once the projected external geometry
+        # has been rebuilt. Deriving it any earlier leaves the constraint unsigned, the solver
+        # reads that as clockwise, and every such sketch that sat on the counter-clockwise side is
+        # silently mirrored on load.
+        sketch, external_index, circle = self.buildSketchOnProjectedEdge()
+        expected = App.Vector(sketch.Geometry[circle].Center)
+
+        # Name the file after the document so that reopening it keeps the name tearDown expects.
+        path = os.path.join(tempfile.mkdtemp(), self.Doc.Name + ".FCStd")
+        self.Doc.saveAs(path)
+        FreeCAD.closeDocument(self.Doc.Name)
+        makeDocumentLookLegacy(path)
+
+        self.Doc = FreeCAD.openDocument(path)
+        self.Doc.recompute()
+        sketch = self.Doc.getObject("Sketch")
+        self.assertSuccessfulSolve(sketch)
+        self.assertVectorAlmostEqual(sketch.Geometry[circle].Center, expected)
+
+    def testSymmetricKeepsConstraintOnTheMirroredSide(self):
+        # Mirroring reverses handedness, so a copied signed constraint has to be re-derived from
+        # the mirrored geometry. Carrying the original side over pins the copy to the wrong side
+        # of the mirrored line.
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        line = sketch.addGeometry(Part.LineSegment(vec(3, -10), vec(3, 10)), False)
+        circle = sketch.addGeometry(Part.Circle(vec(-2, 0), xy_normal, 5), False)
+        sketch.addConstraint(Sketcher.Constraint("Distance", circle, 3, line, 5.0))
+        self.Doc.recompute()
+        self.assertSuccessfulSolve(sketch)
+
+        before = signedDistanceToLine(sketch.Geometry[line], sketch.Geometry[circle].Center)
+
+        # Mirror about the sketch vertical axis.
+        sketch.addSymmetric([line, circle], -2)
+        self.Doc.recompute()
+        self.assertSuccessfulSolve(sketch)
+
+        after = signedDistanceToLine(sketch.Geometry[2], sketch.Geometry[3].Center)
+        self.assertAlmostEqual(after, -before, delta=Precision.confusion())
+
+    def testReversedExternalGeometryLeavesSketchInPlace(self):
+        # A signed constraint records the side of a line relative to the line direction. Reversing
+        # the sketch plane reverses the direction the borrowed edge projects in, so the recorded
+        # side has to be re-derived or the geometry gets dragged across the line.
+        sketch, external_index, circle = self.buildSketchOnProjectedEdge()
+        expected = App.Vector(sketch.Geometry[circle].Center)
+        before = App.Vector(sketch.ExternalGeo[external_index].EndPoint)
+
+        sketch.AttachmentOffset = App.Placement(
+            App.Vector(0, 0, 0), App.Rotation(App.Vector(1, 0, 0), 180)
+        )
+        self.Doc.recompute()
+        self.assertSuccessfulSolve(sketch)
+
+        # The projection has to have turned around for this test to be exercising anything.
+        after = sketch.ExternalGeo[external_index].EndPoint
+        self.assertLess(after.dot(before), 0, "the borrowed edge did not reverse")
+        self.assertVectorAlmostEqual(sketch.Geometry[circle].Center, expected)
+
     def testRemovedExternalGeometryReference(self):
         if "BUILD_PARTDESIGN" in FreeCAD.__cmake__:
             body = self.Doc.addObject("PartDesign::Body", "Body")
@@ -959,6 +1134,15 @@ class TestSketcherSolver(unittest.TestCase):
         status = sketch.solve()
         # TODO: can we get the solver's messages somehow to improve the message?
         self.assertTrue(status == 0, msg=msg or "solver didn't converge")
+
+    def assertVectorAlmostEqual(self, actual, expected, msg=None):
+        for axis in ("x", "y", "z"):
+            self.assertAlmostEqual(
+                getattr(actual, axis),
+                getattr(expected, axis),
+                delta=Precision.confusion(),
+                msg=msg or "expected %s but got %s" % (expected, actual),
+            )
 
     def assertShapeDistance(self, shape1, shape2, expected_distance, msg=None):
         distance, _, _ = shape1.distToShape(shape2)


### PR DESCRIPTION
Fixes #30930. 

This is an alternative approach to the constraint-flipping problem addressed by #31649.

PR #26518 made point-line and circle-line `Distance` constraints signed, and #29015 did the same for line-circle `Tangent`. The side is stored as `Constraint::Orientation`, expressed relative to the line's start-to-end direction.

The migration for old files does **not** explicitly fail when it cannot determine that side. It leaves `Orientation` unset, and the solver reads "unset" as Clockwise, so every affected constraint that happened to sit on the counter-clockwise side ends up getting mirrored. Once a file with that case is opened and saved, both the flipped geometry and a now-derivable-but-wrong orientation are persisted, and the damage is no longer recoverable. That's what makes this bug a blocker: we must resolve this before releasing 26.3, and anyone using a currently dev build risks irrecoverably damaging their geometry.

#31649 resolves this by not migrating old constraints at all, leaving them on the unsigned solver permanently. That is a safe and conservative choice, at the cost of old files never benefiting from the flip-resistant algorithms.

This PR instead recovers the correct sign from the geometry **already stored in the file**, rather than assuming a default when it cannot be determined. It basically just assumes the user was happy with the geometry as they left it the last time they saved their file.

Three regressions are addressed by this PR:

1. The orientation migration ran before projected external geometry existed, so any constraint referencing a projected edge failed to migrate. Affects pre-26.3 files.
2. `addSymmetric` copied the stored side onto mirrored geometry. A reflection reverses handedness, so the copy ends up on the wrong side of the mirrored line.
3. A reversed external projection was not accounted for. Flipping the orientation of an existing sketch's attachment reverses the direction its borrowed edges project in and that has to be handled.

Note that 2 and 3 are not migration problems: they affect files created in current `main`, not just legacy ones.

Each regression has a test in `TestSketcherSolver.py`; all three fail without the corresponding fix. I've also tested to ensure that this PR fixes the flipping problem in every file in my integration test suite that exhibits it (35 total files), without causing any other regressions (among approximately 350 relevant files tested against).

Representative test cases:
* https://raw.githubusercontent.com/GliaX/Otoscope/9d0b6c9acd4a7f41bb2d1dfd94171ea832399ac9/Battery_box/source%20file/Battery%20Box%20V3.fcstd
* https://devel.lulzbot.com/TAZ/accessories/javelin/test_parts/source/40mm_fan_duct_v0.1.fcstd
* https://raw.githubusercontent.com/FreeCAD/FreeCAD-library/d8080924b1e9aa30dd2f57108efef42f3ecf6105/Logistics/Shipping%20Containers/20_Feet_ISO_Container/door-hinge.FCStd
* https://raw.githubusercontent.com/opulo-inc/lumenpnp/93f8124f24e04245a856cc3c9731e8de32d38726/pnp/cad/FDM/blade12.FCStd
* https://raw.githubusercontent.com/vidalperezbohoyo/g-arm/57f0e1f6390be03db02bc864f264f414d3683a2b/hardware/FreeCad/%235_MotorsBase.FCStd

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: Claude Opus 5
