### PR TITLE
TechDraw: Broken view rework.

### DIFF
--- a/src/Mod/TechDraw/App/DrawBrokenView.cpp
+++ b/src/Mod/TechDraw/App/DrawBrokenView.cpp
@@ -96,12 +96,15 @@ using SU = ShapeUtils;
 // DrawBrokenView
 //===========================================================================
 
+// Kept as a DrawBrokenView symbol for source and binary compatibility.
 // NOLINTNEXTLINE
-const char *DrawBrokenView::BreakTypeEnums[] = {
+const char* DrawBrokenView::BreakTypeEnums[] = {
     QT_TRANSLATE_NOOP("DrawBrokenView", "None"),
     QT_TRANSLATE_NOOP("DrawBrokenView", "ZigZag"),
     QT_TRANSLATE_NOOP("DrawBrokenView", "Simple"),
+    QT_TRANSLATE_NOOP("DrawBrokenView", "Sinusoid"),
     nullptr};
+
 PROPERTY_SOURCE(TechDraw::DrawBrokenView, TechDraw::DrawViewPart)
 
 DrawBrokenView::DrawBrokenView()
@@ -156,9 +159,13 @@ App::DocumentObjectExecReturn* DrawBrokenView::execute()
     BRepBuilderAPI_Copy BuilderCopy(shape);
     TopoDS_Shape safeShape = BuilderCopy.Shape();
     m_unbrokenCenter = SU::findCentroidVec(safeShape, getProjectionCS());
+    setBreakSourceCentroid(m_unbrokenCenter);
 
     TopoDS_Shape brokenShape = breakShape(safeShape);
     m_compressedShape = compressShape(brokenShape);
+    if (getBreakCount() > 0) {
+        m_compressedShape = applyViewBreaks(m_compressedShape);
+    }
 
     partExec(m_compressedShape);
 

--- a/src/Mod/TechDraw/App/DrawBrokenView.h
+++ b/src/Mod/TechDraw/App/DrawBrokenView.h
@@ -62,11 +62,7 @@ class TechDrawExport DrawBrokenView: public TechDraw::DrawViewPart
 // NOLINTEND
 
 public:
-    enum class BreakType : int {
-        NONE,
-        ZIGZAG,
-        SIMPLE
-    };
+    using BreakType = DrawViewPart::BreakType;
     static const char* BreakTypeEnums[];    // NOLINT
 
     DrawBrokenView();

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -35,7 +35,12 @@
 // actual drawing routines in Gui
 
 
+#include <algorithm>
+#include <limits>
+#include <vector>
+
 #include <BRepAlgo_NormalProjection.hxx>
+#include <BRepAlgoAPI_Cut.hxx>
 #include <BRepBndLib.hxx>
 #include <BRepBuilderAPI_Copy.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
@@ -44,6 +49,7 @@
 #include <BRepTools.hxx>
 #include <BRep_Builder.hxx>
 #include <BRep_Tool.hxx>
+#include <BRepPrimAPI_MakeHalfSpace.hxx>
 #include <Bnd_Box.hxx>
 #include <HLRAlgo_Projector.hxx>
 #include <QtConcurrentRun>
@@ -51,6 +57,7 @@
 #include <TopExp.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopoDS.hxx>
+#include <TopoDS_Compound.hxx>
 #include <TopoDS_Edge.hxx>
 #include <TopoDS_Face.hxx>
 #include <TopoDS_Shape.hxx>
@@ -96,6 +103,185 @@ using DU = DrawUtil;
 
 PROPERTY_SOURCE_WITH_EXTENSIONS(TechDraw::DrawViewPart, TechDraw::DrawView)
 
+const char* DrawViewPart::DisplayStyleEnums[] = {
+    "All Edges",
+    "Hidden Edges",
+    "Visible Edges",
+    "Shaded with Edges",
+    "Shaded",
+    nullptr
+};
+
+const char* DrawViewPart::BreakTypeEnums[] = {
+    QT_TRANSLATE_NOOP("DrawBrokenView", "None"),
+    QT_TRANSLATE_NOOP("DrawBrokenView", "ZigZag"),
+    QT_TRANSLATE_NOOP("DrawBrokenView", "Simple"),
+    QT_TRANSLATE_NOOP("DrawBrokenView", "Sinusoid"),
+    nullptr
+};
+
+namespace
+{
+
+constexpr double defaultBreakGap = 10.0;
+
+struct ViewBreakDefinition
+{
+    Base::Vector3d first;
+    Base::Vector3d second;
+    Base::Vector3d direction;
+    double low{0.0};
+    double high{0.0};
+    double gap{defaultBreakGap};
+    DrawViewPart::BreakType type{DrawViewPart::BreakType::ZIGZAG};
+};
+
+std::vector<ViewBreakDefinition> viewBreakDefinitions(const DrawViewPart& view)
+{
+    const auto& points = view.BreakPoints.getValues();
+    const auto& directions = view.BreakDirections.getValues();
+    const auto& gaps = view.BreakGaps.getValues();
+    const auto& types = view.BreakLineTypes.getValues();
+    const std::size_t count = points.size() / 2;
+
+    std::vector<ViewBreakDefinition> result;
+    result.reserve(count);
+    for (std::size_t index = 0; index < count; ++index) {
+        ViewBreakDefinition item;
+        item.first = points[index * 2];
+        item.second = points[index * 2 + 1];
+        item.direction = index < directions.size()
+            ? directions[index]
+            : item.second - item.first;
+        if (item.direction.Sqr() <= std::numeric_limits<double>::epsilon()) {
+            continue;
+        }
+        item.direction.Normalize();
+        const double firstLimit = item.first.Dot(item.direction);
+        const double secondLimit = item.second.Dot(item.direction);
+        item.low = std::min(firstLimit, secondLimit);
+        item.high = std::max(firstLimit, secondLimit);
+        if (item.high - item.low <= EWTOLERANCE) {
+            continue;
+        }
+        if (index < gaps.size()) {
+            item.gap = std::max(0.0, gaps[index]);
+        }
+        if (index < types.size()
+            && types[index] >= static_cast<long>(DrawViewPart::BreakType::NONE)
+            && types[index] <= static_cast<long>(DrawViewPart::BreakType::SINUSOID)) {
+            item.type = static_cast<DrawViewPart::BreakType>(types[index]);
+        }
+        result.push_back(item);
+    }
+    return result;
+}
+
+TopoDS_Shape makeHalfSpace(const Base::Vector3d& planePoint,
+                           const Base::Vector3d& planeNormal,
+                           const Base::Vector3d& pointInSpace)
+{
+    gp_Pln plane(Base::convertTo<gp_Pnt>(planePoint),
+                 Base::convertTo<gp_Dir>(planeNormal));
+    BRepBuilderAPI_MakeFace face(plane);
+    BRepPrimAPI_MakeHalfSpace halfSpace(
+        face.Face(), Base::convertTo<gp_Pnt>(pointInSpace));
+    return halfSpace.Solid();
+}
+
+TopoDS_Shape applyCut(const TopoDS_Shape& input,
+                      const ViewBreakDefinition& item)
+{
+    const Base::Vector3d lowPoint =
+        item.first.Dot(item.direction) <= item.second.Dot(item.direction)
+        ? item.first : item.second;
+    const Base::Vector3d highPoint =
+        item.first.Dot(item.direction) <= item.second.Dot(item.direction)
+        ? item.second : item.first;
+    const Base::Vector3d insideHigh =
+        lowPoint + item.direction * ((item.high - item.low) * 0.5);
+    const Base::Vector3d insideLow =
+        highPoint - item.direction * ((item.high - item.low) * 0.5);
+
+    BRepAlgoAPI_Cut lowCut(
+        input, makeHalfSpace(lowPoint, item.direction, insideHigh));
+    if (!lowCut.IsDone() || lowCut.Shape().IsNull()) {
+        return {};
+    }
+    BRepAlgoAPI_Cut highCut(
+        input, makeHalfSpace(highPoint, item.direction * -1.0, insideLow));
+    if (!highCut.IsDone() || highCut.Shape().IsNull()) {
+        return {};
+    }
+
+    BRep_Builder builder;
+    TopoDS_Compound result;
+    builder.MakeCompound(result);
+    builder.Add(result, lowCut.Shape());
+    builder.Add(result, highCut.Shape());
+    return result;
+}
+
+void appendPieces(const TopoDS_Shape& shape,
+                  TopAbs_ShapeEnum wanted,
+                  TopAbs_ShapeEnum avoid,
+                  std::vector<TopoDS_Shape>& result)
+{
+    TopExp_Explorer explorer(shape, wanted, avoid);
+    for (; explorer.More(); explorer.Next()) {
+        result.push_back(explorer.Current());
+    }
+}
+
+std::vector<TopoDS_Shape> breakPieces(const TopoDS_Shape& shape)
+{
+    std::vector<TopoDS_Shape> result;
+    appendPieces(shape, TopAbs_SOLID, TopAbs_SHAPE, result);
+    appendPieces(shape, TopAbs_SHELL, TopAbs_SOLID, result);
+    appendPieces(shape, TopAbs_FACE, TopAbs_SHELL, result);
+    appendPieces(shape, TopAbs_WIRE, TopAbs_FACE, result);
+    appendPieces(shape, TopAbs_EDGE, TopAbs_WIRE, result);
+    return result;
+}
+
+std::pair<double, double> limitsAlong(const TopoDS_Shape& shape,
+                                      const Base::Vector3d& direction)
+{
+    double low = std::numeric_limits<double>::max();
+    double high = std::numeric_limits<double>::lowest();
+    TopExp_Explorer vertices(shape, TopAbs_VERTEX);
+    for (; vertices.More(); vertices.Next()) {
+        const gp_Pnt point = BRep_Tool::Pnt(TopoDS::Vertex(vertices.Current()));
+        const double value =
+            Base::convertTo<Base::Vector3d>(point).Dot(direction);
+        low = std::min(low, value);
+        high = std::max(high, value);
+    }
+    return {low, high};
+}
+
+Base::Vector3d breakShift(const Base::Vector3d& point,
+                          const std::vector<ViewBreakDefinition>& breaks)
+{
+    Base::Vector3d result;
+    for (const auto& item : breaks) {
+        const double removed = item.high - item.low;
+        const double netRemoved = removed - item.gap;
+        const double coordinate = point.Dot(item.direction);
+        double factor = 0.0;
+        if (coordinate <= item.low) {
+            factor = 1.0;
+        }
+        else if (coordinate < item.high) {
+            factor = (item.high - coordinate) / removed;
+        }
+        result += item.direction * (netRemoved * factor);
+    }
+    return result;
+}
+
+} // namespace
+
 DrawViewPart::DrawViewPart()
     : geometryObject(nullptr),
       m_tempGeometryObject(nullptr),
@@ -106,6 +292,7 @@ DrawViewPart::DrawViewPart()
 {
     static const char* group = "Projection";
     static const char* sgroup = "HLR Parameters";
+    static const char* breakGroup = "Broken View";
 
     CosmeticExtension::initExtension(this);
 
@@ -147,6 +334,22 @@ DrawViewPart::DrawViewPart()
 
     ADD_PROPERTY_TYPE(ScrubCount, (Preferences::scrubCount()), sgroup, App::Prop_None,
                       "The number of times FreeCAD should try to clean the HLR result.");
+
+    ADD_PROPERTY_TYPE(BreakPoints, (Base::Vector3d()), breakGroup, App::Prop_None,
+                      "Pairs of 3D model points defining the two cut planes of each break.");
+    BreakPoints.setValues({});
+    ADD_PROPERTY_TYPE(BreakDirections, (Base::Vector3d()), breakGroup, App::Prop_None,
+                      "One 3D compression direction for each break.");
+    BreakDirections.setValues({});
+    ADD_PROPERTY_TYPE(BreakGaps, (defaultBreakGap), breakGroup, App::Prop_None,
+                      "One final gap size in millimetres for each break.");
+    BreakGaps.setValues({});
+    ADD_PROPERTY_TYPE(BreakLineTypes,
+                      (static_cast<long>(BreakType::ZIGZAG)),
+                      breakGroup,
+                      App::Prop_None,
+                      "One break-line style value for each break.");
+    BreakLineTypes.setValues({});
 
     //initialize bbox to non-garbage
     bbox = Base::BoundBox3d(Base::Vector3d(0.0, 0.0, 0.0), 0.0);
@@ -203,6 +406,184 @@ std::vector<App::DocumentObject*> DrawViewPart::getAllSources() const
     return result;
 }
 
+std::size_t DrawViewPart::getBreakCount() const
+{
+    return BreakPoints.getValues().size() / 2;
+}
+
+void DrawViewPart::addBreak(
+    const Base::Vector3d& firstPoint,
+    const Base::Vector3d& secondPoint,
+    const Base::Vector3d& direction,
+    double gap,
+    BreakType lineType
+)
+{
+    auto points = BreakPoints.getValues();
+    auto directions = BreakDirections.getValues();
+    auto gaps = BreakGaps.getValues();
+    auto types = BreakLineTypes.getValues();
+    points.push_back(firstPoint);
+    points.push_back(secondPoint);
+    directions.push_back(direction);
+    gaps.push_back(std::max(0.0, gap));
+    types.push_back(static_cast<long>(lineType));
+    BreakPoints.setValues(points);
+    BreakDirections.setValues(directions);
+    BreakGaps.setValues(gaps);
+    BreakLineTypes.setValues(types);
+}
+
+bool DrawViewPart::removeBreak(std::size_t index)
+{
+    auto points = BreakPoints.getValues();
+    if (index >= points.size() / 2) {
+        return false;
+    }
+    auto directions = BreakDirections.getValues();
+    auto gaps = BreakGaps.getValues();
+    auto types = BreakLineTypes.getValues();
+    points.erase(
+        points.begin() + static_cast<std::ptrdiff_t>(index * 2),
+        points.begin() + static_cast<std::ptrdiff_t>(index * 2 + 2)
+    );
+    if (index < directions.size()) {
+        directions.erase(directions.begin() + static_cast<std::ptrdiff_t>(index));
+    }
+    if (index < gaps.size()) {
+        gaps.erase(gaps.begin() + static_cast<std::ptrdiff_t>(index));
+    }
+    if (index < types.size()) {
+        types.erase(types.begin() + static_cast<std::ptrdiff_t>(index));
+    }
+    BreakPoints.setValues(points);
+    BreakDirections.setValues(directions);
+    BreakGaps.setValues(gaps);
+    BreakLineTypes.setValues(types);
+    return true;
+}
+
+DrawViewPart::BreakType DrawViewPart::getBreakType(std::size_t index) const
+{
+    const auto& values = BreakLineTypes.getValues();
+    if (index >= values.size() || values[index] < static_cast<long>(BreakType::NONE)
+        || values[index] > static_cast<long>(BreakType::SINUSOID)) {
+        return BreakType::ZIGZAG;
+    }
+    return static_cast<BreakType>(values[index]);
+}
+
+double DrawViewPart::getBreakGap(std::size_t index) const
+{
+    const auto& values = BreakGaps.getValues();
+    return index < values.size() ? std::max(0.0, values[index]) : defaultBreakGap;
+}
+
+void DrawViewPart::setBreakSourceCentroid(const Base::Vector3d& centroid)
+{
+    m_breakSourceCentroid = centroid;
+    m_breakResultCentroid = centroid;
+}
+
+TopoDS_Shape DrawViewPart::applyViewBreaks(const TopoDS_Shape& shape)
+{
+    const auto breaks = viewBreakDefinitions(*this);
+    if (breaks.empty()) {
+        m_breakResultCentroid = m_breakSourceCentroid;
+        return shape;
+    }
+
+    TopoDS_Shape cutShape = shape;
+    for (const auto& item : breaks) {
+        const TopoDS_Shape previous = cutShape;
+        cutShape = applyCut(cutShape, item);
+        if (cutShape.IsNull()) {
+            Base::Console().warning("%s: failed to apply an interactive break.\n", getNameInDocument());
+            cutShape = previous;
+        }
+    }
+
+    const auto pieces = breakPieces(cutShape);
+    if (pieces.empty()) {
+        return shape;
+    }
+
+    BRep_Builder builder;
+    TopoDS_Compound result;
+    builder.MakeCompound(result);
+    for (const auto& piece : pieces) {
+        Base::Vector3d shift;
+        for (const auto& item : breaks) {
+            const auto limits = limitsAlong(piece, item.direction);
+            if (limits.first != std::numeric_limits<double>::max()
+                && limits.second <= item.low + EWTOLERANCE) {
+                shift += item.direction * ((item.high - item.low) - item.gap);
+            }
+        }
+        builder.Add(result, ShapeUtils::moveShape(piece, shift));
+    }
+
+    m_breakResultCentroid = Base::convertTo<Base::Vector3d>(
+        ShapeUtils::findCentroid(result, getProjectionCS())
+    );
+    return result;
+}
+
+std::pair<Base::Vector3d, Base::Vector3d> DrawViewPart::getBreakLinePoints(std::size_t index) const
+{
+    const auto& points = BreakPoints.getValues();
+    const auto breaks = viewBreakDefinitions(*this);
+    if (index >= points.size() / 2 || index >= breaks.size()) {
+        return {Base::Vector3d(), Base::Vector3d()};
+    }
+    const gp_Ax2 axes = getRotatedCS(m_breakResultCentroid);
+    const Base::Vector3d xAxis = Base::convertTo<Base::Vector3d>(axes.XDirection());
+    const Base::Vector3d yAxis = Base::convertTo<Base::Vector3d>(axes.YDirection());
+    auto project = [&](const Base::Vector3d& point) {
+        const Base::Vector3d compressed = point + breakShift(point, breaks);
+        const Base::Vector3d relative = compressed - m_breakResultCentroid;
+        return Base::Vector3d(relative.Dot(xAxis) * getScale(), relative.Dot(yAxis) * getScale(), 0.0);
+    };
+    return {project(points[index * 2]), project(points[index * 2 + 1])};
+}
+
+Base::Vector3d DrawViewPart::getBreakLineDirection(std::size_t index) const
+{
+    const auto breaks = viewBreakDefinitions(*this);
+    if (index >= breaks.size()) {
+        return Base::Vector3d();
+    }
+    const gp_Ax2 axes = getRotatedCS(m_breakResultCentroid);
+    const Base::Vector3d xAxis = Base::convertTo<Base::Vector3d>(axes.XDirection());
+    const Base::Vector3d yAxis = Base::convertTo<Base::Vector3d>(axes.YDirection());
+    const double normalX = breaks[index].direction.Dot(xAxis);
+    const double normalY = breaks[index].direction.Dot(yAxis);
+    Base::Vector3d tangent(-normalY, normalX, 0.0);
+    if (tangent.Sqr() > std::numeric_limits<double>::epsilon()) {
+        tangent.Normalize();
+    }
+    return tangent;
+}
+
+Base::Vector3d DrawViewPart::mapPointFromBrokenView(const Base::Vector3d& point2d) const
+{
+    const gp_Ax2 axes = getRotatedCS(m_breakResultCentroid);
+    const Base::Vector3d xAxis = Base::convertTo<Base::Vector3d>(axes.XDirection());
+    const Base::Vector3d yAxis = Base::convertTo<Base::Vector3d>(axes.YDirection());
+    const Base::Vector3d compressed = m_breakResultCentroid + xAxis * point2d.x + yAxis * point2d.y;
+    const auto breaks = viewBreakDefinitions(*this);
+    Base::Vector3d candidate = compressed;
+    for (int iteration = 0; iteration < 64; ++iteration) {
+        const Base::Vector3d next = compressed - breakShift(candidate, breaks);
+        if ((next - candidate).Sqr() < 1.0e-18) {
+            candidate = next;
+            break;
+        }
+        candidate = next;
+    }
+    return candidate;
+}
+
 //! pick vertex objects out of the Source properties and
 //! add them directly to the geometry without going through HLR
 void DrawViewPart::addPoints()
@@ -249,6 +630,13 @@ App::DocumentObjectExecReturn* DrawViewPart::execute()
         XDirection.purgeTouched();//don't trigger updates!
     }
 
+    setBreakSourceCentroid(Base::convertTo<Base::Vector3d>(
+        ShapeUtils::findCentroid(shape, getProjectionCS())));
+    if (getBreakCount() > 0) {
+        BRepBuilderAPI_Copy copy(shape);
+        shape = applyViewBreaks(copy.Shape());
+    }
+
     partExec(shape);
 
     return DrawView::execute();
@@ -265,7 +653,9 @@ short DrawViewPart::mustExecute() const
         || SmoothVisible.isTouched() || SeamVisible.isTouched() || IsoVisible.isTouched()
         || HardHidden.isTouched() || SmoothHidden.isTouched() || SeamHidden.isTouched()
         || IsoHidden.isTouched() || IsoCount.isTouched() || CoarseView.isTouched()
-        || CosmeticVertexes.isTouched() || CosmeticEdges.isTouched() || CenterLines.isTouched()) {
+        || CosmeticVertexes.isTouched() || CosmeticEdges.isTouched() || CenterLines.isTouched()
+        || BreakPoints.isTouched() || BreakDirections.isTouched()
+        || BreakGaps.isTouched() || BreakLineTypes.isTouched()) {
         return 1;
     }
 

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -32,7 +32,9 @@
 
 #include <App/DocumentObject.h>
 #include <App/FeaturePython.h>
+#include <App/PropertyGeo.h>
 #include <App/PropertyLinks.h>
+#include <App/PropertyStandard.h>
 #include <Base/BoundBox.h>
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
@@ -109,6 +111,13 @@ class TechDrawExport DrawViewPart: public DrawView, public CosmeticExtension
     PROPERTY_HEADER_WITH_EXTENSIONS(TechDraw::DrawViewPart);
 
 public:
+    enum class BreakType : int {
+        NONE,
+        ZIGZAG,
+        SIMPLE,
+        SINUSOID
+    };
+
     DrawViewPart();
     ~DrawViewPart() override;
 
@@ -133,6 +142,34 @@ public:
     App::PropertyInteger IsoCount;
 
     App::PropertyInteger ScrubCount;
+
+    static const char* BreakTypeEnums[];
+
+    // BreakPoints contains two 3D model points per break. BreakDirections,
+    // BreakGaps, and BreakLineTypes contain one entry per break.
+    App::PropertyVectorList BreakPoints;
+    App::PropertyVectorList BreakDirections;
+    App::PropertyFloatList BreakGaps;
+    App::PropertyIntegerList BreakLineTypes;
+
+    ViewDisplayStyle getDisplayStyle() const;
+    bool hasShadedDisplay() const;
+    bool showsVisibleEdges() const;
+    bool hiddenEdgesAreSolid() const;
+
+    std::size_t getBreakCount() const;
+    void addBreak(const Base::Vector3d& firstPoint,
+                  const Base::Vector3d& secondPoint,
+                  const Base::Vector3d& direction,
+                  double gap,
+                  BreakType lineType);
+    bool removeBreak(std::size_t index);
+    BreakType getBreakType(std::size_t index) const;
+    double getBreakGap(std::size_t index) const;
+    std::pair<Base::Vector3d, Base::Vector3d>
+        getBreakLinePoints(std::size_t index) const;
+    Base::Vector3d getBreakLineDirection(std::size_t index) const;
+    Base::Vector3d mapPointFromBrokenView(const Base::Vector3d& point2d) const;
 
     short mustExecute() const override;
     App::DocumentObjectExecReturn* execute() override;
@@ -252,6 +289,9 @@ public Q_SLOTS:
 protected:
     bool checkXDirection() const;
 
+    TopoDS_Shape applyViewBreaks(const TopoDS_Shape& shape);
+    void setBreakSourceCentroid(const Base::Vector3d& centroid);
+
     TechDraw::GeometryObjectPtr geometryObject;
     TechDraw::GeometryObjectPtr m_tempGeometryObject;//holds the new GO until hlr is completed
     Base::BoundBox3d bbox;
@@ -275,6 +315,8 @@ protected:
 
     TopoDS_Shape m_saveShape;     //TODO: make this a Property.  Part::TopoShapeProperty??
     Base::Vector3d m_saveCentroid;//centroid before centering shape in origin
+    Base::Vector3d m_breakSourceCentroid;
+    Base::Vector3d m_breakResultCentroid;
 
     std::vector<TechDraw::VertexPtr> m_referenceVerts;
 

--- a/src/Mod/TechDraw/Gui/CMakeLists.txt
+++ b/src/Mod/TechDraw/Gui/CMakeLists.txt
@@ -58,6 +58,7 @@ set(TechDrawGui_UIC_SRCS
     TaskProjGroup.ui
     TaskRestoreLines.ui
     TaskRichAnno.ui
+    TaskBrokenView.ui
     TaskSectionView.ui
     TaskWeldingSymbol.ui
     TaskSurfaceFinishSymbols.ui
@@ -132,6 +133,9 @@ SET(TechDrawGui_SRCS
     DlgTemplateField.ui
     DlgTemplateField.cpp
     DlgTemplateField.h
+    TaskBrokenView.ui
+    TaskBrokenView.cpp
+    TaskBrokenView.h
     TaskSectionView.ui
     TaskSectionView.cpp
     TaskSectionView.h
@@ -413,6 +417,7 @@ SET(TechDrawGuiViewProvider_SRCS
 SET(TechDrawGuiTaskDlgs_SRCS
     TaskProjGroup.ui
     TaskLinkDim.ui
+    TaskBrokenView.ui
     TaskSectionView.ui
     TaskGeomHatch.ui
     TaskHatch.ui

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -69,6 +69,7 @@
 #include "QGSPage.h"
 #include "QGVPage.h"
 #include "Rez.h"
+#include "TaskBrokenView.h"
 #include "TaskActiveView.h"
 #include "TaskComplexSection.h"
 #include "TaskDetail.h"
@@ -552,7 +553,7 @@ CmdTechDrawBrokenView::CmdTechDrawBrokenView()
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Broken View");
-    sToolTipText    = QT_TR_NOOP("Inserts a new broken view for the selected objects or base view and break definition objects");
+    sToolTipText    = QT_TR_NOOP("Interactively adds breaks to drawing views");
     sWhatsThis      = "TechDraw_BrokenView";
     sStatusTip      = sToolTipText;
     sPixmap         = "actions/TechDraw_BrokenView";
@@ -561,132 +562,34 @@ CmdTechDrawBrokenView::CmdTechDrawBrokenView()
 void CmdTechDrawBrokenView::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+    if (Gui::Control().activeDialog()) {
+        QMessageBox::warning(Gui::getMainWindow(),
+                             QObject::tr("Task in progress"),
+                             QObject::tr("Close active task dialog and try again"));
+        return;
+    }
     TechDraw::DrawPage* page = DrawGuiUtil::findPage(this);
     if (!page) {
         return;
     }
-    std::string PageName = page->getNameInDocument();
-
-    // get shape objects from a base view
-    std::vector<App::DocumentObject*> shapesFromBase;
-    std::vector<App::DocumentObject*> xShapesFromBase;
-    std::vector<App::DocumentObject*> baseViews =
-        getSelection().getObjectsOfType(TechDraw::DrawViewPart::getClassTypeId());
-    TechDraw::DrawViewPart* dvp{nullptr};
-    if (!baseViews.empty()) {
-        dvp = static_cast<TechDraw::DrawViewPart*>(*baseViews.begin());
-        shapesFromBase = dvp->Source.getValues();
-        xShapesFromBase = dvp->XSource.getValues();
-    }
-
-    auto doc = getDocument();
-    if (dvp) {
-        doc = dvp->getDocument();
-    }
-
-    // get the shape objects from the selection
-    std::vector<App::DocumentObject*> shapes;
-    std::vector<App::DocumentObject*> xShapes;
-    App::DocumentObject* faceObj = nullptr;
-    std::string faceName;
-    getSelectedShapes(this, shapes, xShapes, faceObj, faceName);
-
-    // we need either a base view (dvp) or some shape objects in the selection
-    if (!dvp && (shapes.empty() && xShapes.empty())) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Empty Selection"),
-            QObject::tr("Select objects to break or a base view and break definition objects"));
+    auto* mdi = qobject_cast<MDIViewPage*>(
+        Gui::getMainWindow()->activeWindow());
+    QGVPage* graphicsView = mdi && mdi->getPage() == page
+        ? mdi->getViewProviderPage()->getQGVPage()
+        : nullptr;
+    if (!graphicsView) {
+        QMessageBox::warning(
+            Gui::getMainWindow(),
+            QObject::tr("No active drawing page"),
+            QObject::tr("Open the drawing page where breaks should be created."));
         return;
     }
-
-    shapes.insert(shapes.end(), shapesFromBase.begin(), shapesFromBase.end());
-    shapes.insert(xShapes.end(), xShapesFromBase.begin(), xShapesFromBase.end());
-
-
-    // pick the Break objects out of the selected pile
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx(
-        nullptr, App::DocumentObject::getClassTypeId(), Gui::ResolveMode::NoResolve);
-
-    std::vector<App::DocumentObject*> breakObjects;
-    for (auto& selObj : selection) {
-        auto temp = selObj.getObject();
-        // a sketch outside a body is returned as an independent object in the selection
-        if (selObj.getSubNames().empty()) {
-            if (DrawBrokenView::isBreakObject(*temp)) {
-                breakObjects.push_back(selObj.getObject());
-            }
-            continue;
-        }
-        // a sketch inside a body is returned as body + subelement, so we have to search through
-        // subnames to find it.  This may(?) apply to App::Part and Group also?
-        auto subname = selObj.getSubNames().front();
-        if (subname.back() == '.') {
-            subname = subname.substr(0, subname.length() - 1);
-            auto objects = doc->getObjects();
-            for (auto& obj : objects) {
-                std::string objname{obj->getNameInDocument()};
-                if (subname == objname  &&
-                    DrawBrokenView::isBreakObject(*obj)) {
-                    breakObjects.push_back(obj);
-                }
-            }
-        }
-    }
-    if (breakObjects.empty()) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("No break objects found in this selection"));
-        return;
-    }
-
-    // remove Break objects from shape pile
-    shapes = DrawBrokenView::removeBreakObjects(breakObjects, shapes);
-    xShapes = DrawBrokenView::removeBreakObjects(breakObjects, xShapes);
-    if (shapes.empty() &&
-        xShapes.empty()) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("No shapes, groups, or links in this selection"));
-        return;
-    }
-
-    Gui::WaitCursor wc;
-    openCommand(QT_TRANSLATE_NOOP("Command", "Create broken view"));
-    getDocument()->setStatus(App::Document::Status::SkipRecompute, true);
-    std::string FeatName = getUniqueObjectName("BrokenView");
-    doCommand(Doc, "App.activeDocument().addObject('TechDraw::DrawBrokenView','%s')", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.addView(App.activeDocument().%s)", PageName.c_str(), FeatName.c_str());
-
-    App::DocumentObject* docObj = getDocument()->getObject(FeatName.c_str());
-    TechDraw::DrawBrokenView* dbv = dynamic_cast<TechDraw::DrawBrokenView*>(docObj);
-    if (!dbv) {
-        throw Base::TypeError("CmdTechDrawBrokenView DBV not found\n");
-    }
-    dbv->Source.setValues(shapes);
-    dbv->XSource.setValues(xShapes);
-    dbv->Breaks.setValues(breakObjects);
-
-    //set projection direction from selected Face
-    std::pair<Base::Vector3d, Base::Vector3d> dirs;
-    if (faceName.size()) {
-        dirs = DrawGuiUtil::getProjDirFromFace(faceObj, faceName);
-    }
-    else {
-        dirs = DrawGuiUtil::get3DDirAndRot();
-    }
-
-    Base::Vector3d projDir = checkDirectionVsBasis(dirs.first);
-    doCommand(Doc, "App.activeDocument().%s.Direction = FreeCAD.Vector(%.6f,%.6f,%.6f)",
-              FeatName.c_str(), projDir.x, projDir.y, projDir.z);
-    doCommand(Doc, "App.activeDocument().%s.XDirection = FreeCAD.Vector(%.6f,%.6f,%.6f)",
-                  FeatName.c_str(), dirs.second.x, dirs.second.y, dirs.second.z);
-    getDocument()->setStatus(App::Document::Status::SkipRecompute, true);
-
-    commitCommand();
-
-    dbv->recomputeFeature();
+    Gui::Control().showDialog(new TaskDlgBrokenView(page, graphicsView));
 }
 
 bool CmdTechDrawBrokenView::isActive(void)
 {
-    return DrawGuiUtil::needPage(this);
+    return DrawGuiUtil::needPage(this) && !Gui::Control().activeDialog();
 }
 
 

--- a/src/Mod/TechDraw/Gui/QGIBreakLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGIBreakLine.cpp
@@ -23,10 +23,17 @@
  ***************************************************************************/
 
 # include <QGraphicsScene>
+# include <QGraphicsSceneMouseEvent>
+# include <QKeyEvent>
 # include <QPainter>
 # include <QPainterPath>
 # include <QStyleOptionGraphicsItem>
 
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+#include <utility>
+#include <vector>
 
 #include <App/Application.h>
 #include <Base/Console.h>
@@ -38,6 +45,7 @@
 
 #include "QGIBreakLine.h"
 #include "PreferencesGui.h"
+#include "Rez.h"
 
 using namespace TechDrawGui;
 using namespace TechDraw;
@@ -53,12 +61,15 @@ QGIBreakLine::QGIBreakLine()
     setFlag(QGraphicsItem::ItemIsMovable, false);
     setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
 
-    m_background = new QGraphicsRectItem();
+    m_background = new QGraphicsPathItem();
     addToGroup(m_background);
     m_line0 = new QGraphicsPathItem();
     addToGroup(m_line0);
     m_line1 = new QGraphicsPathItem();
     addToGroup(m_line1);
+    m_background->setAcceptedMouseButtons(Qt::NoButton);
+    m_line0->setAcceptedMouseButtons(Qt::NoButton);
+    m_line1->setAcceptedMouseButtons(Qt::NoButton);
 
 
     setColor(PreferencesGui::sectionLineQColor());
@@ -67,6 +78,12 @@ QGIBreakLine::QGIBreakLine()
 
 void QGIBreakLine::draw()
 {
+    if (m_genericGeometry) {
+        drawGenericLines();
+        update();
+        return;
+    }
+
     if (breakType() == DrawBrokenView::BreakType::NONE) {
         // none
         m_background->hide();
@@ -87,6 +104,28 @@ void QGIBreakLine::draw()
         m_background->hide();
         m_line0->show();
         m_line1->show();
+    }
+
+    if (breakType() == DrawBrokenView::BreakType::SINUSOID) {
+        const Base::Vector3d horizontal{1.0, 0.0, 0.0};
+        const QRectF bounds(
+            QPointF(m_left, m_bottom), QPointF(m_right, m_top));
+        if (DU::fpCompare(
+                std::fabs(m_direction.Dot(horizontal)), 1.0, EWTOLERANCE)) {
+            setLineGeometry(
+                QPointF(m_left, bounds.center().y()),
+                QPointF(m_right, bounds.center().y()),
+                QPointF(0.0, 1.0),
+                bounds);
+        }
+        else {
+            setLineGeometry(
+                QPointF(bounds.center().x(), m_bottom),
+                QPointF(bounds.center().x(), m_top),
+                QPointF(1.0, 0.0),
+                bounds);
+        }
+        drawGenericLines();
     }
 
     update();
@@ -121,7 +160,158 @@ void QGIBreakLine::drawLargeZigZag()
     QRectF backgroundRect(m_left - offset, m_bottom - offset,
                           std::fabs(m_right - m_left + zigzagWidth),
                           std::fabs(m_top - m_bottom + zigzagWidth));
-    m_background->setRect(backgroundRect);
+    QPainterPath background;
+    background.addRect(backgroundRect);
+    m_background->setPath(background);
+}
+
+void QGIBreakLine::setLineGeometry(const QPointF& first,
+                                   const QPointF& second,
+                                   const QPointF& tangent,
+                                   const QRectF& bounds)
+{
+    m_firstPoint = first;
+    m_secondPoint = second;
+    m_tangent = tangent;
+    const double length = std::hypot(m_tangent.x(), m_tangent.y());
+    if (length > 1.0e-12) {
+        m_tangent /= length;
+    }
+    m_clipBounds = bounds.normalized();
+    m_genericGeometry = true;
+}
+
+std::optional<std::pair<QPointF, QPointF>>
+QGIBreakLine::clippedLine(const QPointF& point, const QPointF& tangent) const
+{
+    constexpr double epsilon = 1.0e-9;
+    std::vector<std::pair<double, QPointF>> hits;
+    auto addHit = [&](double parameter) {
+        const QPointF hit = point + tangent * parameter;
+        if (hit.x() >= m_clipBounds.left() - epsilon
+            && hit.x() <= m_clipBounds.right() + epsilon
+            && hit.y() >= m_clipBounds.top() - epsilon
+            && hit.y() <= m_clipBounds.bottom() + epsilon) {
+            hits.emplace_back(parameter, hit);
+        }
+    };
+    if (std::abs(tangent.x()) > epsilon) {
+        addHit((m_clipBounds.left() - point.x()) / tangent.x());
+        addHit((m_clipBounds.right() - point.x()) / tangent.x());
+    }
+    if (std::abs(tangent.y()) > epsilon) {
+        addHit((m_clipBounds.top() - point.y()) / tangent.y());
+        addHit((m_clipBounds.bottom() - point.y()) / tangent.y());
+    }
+    if (hits.size() < 2) {
+        return std::nullopt;
+    }
+    std::sort(hits.begin(), hits.end(),
+              [](const auto& left, const auto& right) {
+                  return left.first < right.first;
+              });
+    if (std::hypot(hits.back().second.x() - hits.front().second.x(),
+                   hits.back().second.y() - hits.front().second.y())
+        <= epsilon) {
+        return std::nullopt;
+    }
+    return std::pair{hits.front().second, hits.back().second};
+}
+
+QPainterPath QGIBreakLine::makeStyledLine(const QPointF& start,
+                                          const QPointF& end,
+                                          double outwardSign) const
+{
+    QPainterPath path(start);
+    if (breakType() == BreakType::SIMPLE) {
+        path.lineTo(end);
+        return path;
+    }
+
+    QPointF tangent = end - start;
+    const double length = std::hypot(tangent.x(), tangent.y());
+    if (length <= 1.0e-9) {
+        return path;
+    }
+    tangent /= length;
+    const QPointF normal(-tangent.y(), tangent.x());
+    const double amplitude = Rez::guiX(1.5);
+    const int segments = breakType() == BreakType::SINUSOID ? 100 : 12;
+    for (int segment = 1; segment <= segments; ++segment) {
+        const double fraction =
+            static_cast<double>(segment) / static_cast<double>(segments);
+        double offset = 0.0;
+        if (breakType() == BreakType::SINUSOID) {
+            const double phase = fraction * 10.0 * std::numbers::pi;
+            offset = outwardSign == 0.0
+                ? amplitude * std::sin(phase)
+                : outwardSign * amplitude * 0.5 * (1.0 - std::cos(phase));
+        }
+        else if (segment < segments) {
+            offset = outwardSign == 0.0
+                ? (segment % 2 == 0 ? -amplitude : amplitude)
+                : (segment % 2 == 0 ? 0.0 : outwardSign * amplitude);
+        }
+        path.lineTo(start + tangent * (length * fraction) + normal * offset);
+    }
+    return path;
+}
+
+void QGIBreakLine::drawGenericLines()
+{
+    prepareGeometryChange();
+    if (breakType() == BreakType::NONE) {
+        m_background->hide();
+        m_line0->hide();
+        m_line1->hide();
+        return;
+    }
+
+    const auto firstLine = clippedLine(m_firstPoint, m_tangent);
+    const auto secondLine = clippedLine(m_secondPoint, m_tangent);
+    if (!firstLine || !secondLine) {
+        m_background->setPath({});
+        m_line0->setPath({});
+        m_line1->setPath({});
+        m_background->hide();
+        m_line0->hide();
+        m_line1->hide();
+        return;
+    }
+
+    const QPointF lineVector = firstLine->second - firstLine->first;
+    const double lineLength = std::hypot(lineVector.x(), lineVector.y());
+    const QPointF gapVector = m_secondPoint - m_firstPoint;
+    const double gapLength = std::hypot(gapVector.x(), gapVector.y());
+    double firstOutward = 0.0;
+    double secondOutward = 0.0;
+    if (lineLength > 1.0e-9 && gapLength > 1.0e-9) {
+        const QPointF lineNormal(-lineVector.y() / lineLength,
+                                 lineVector.x() / lineLength);
+        const QPointF gapNormal = gapVector / gapLength;
+        const double alignment =
+            QPointF::dotProduct(lineNormal, gapNormal);
+        firstOutward = alignment < 0.0 ? 1.0 : -1.0;
+        secondOutward = -firstOutward;
+    }
+
+    const QPainterPath firstPath =
+        makeStyledLine(firstLine->first, firstLine->second, firstOutward);
+    const QPainterPath secondPath =
+        makeStyledLine(secondLine->first, secondLine->second, secondOutward);
+    m_line0->setPath(firstPath);
+    m_line1->setPath(secondPath);
+
+    // The page-coloured mask must have the same boundary as the visible
+    // break lines.  A straight-sided mask leaves the HLR cut edge visible
+    // underneath zigzag and sinusoidal decorations.
+    QPainterPath background = firstPath;
+    background.connectPath(secondPath.toReversed());
+    background.closeSubpath();
+    m_background->setPath(background);
+    m_background->show();
+    m_line0->show();
+    m_line1->show();
 }
 
 // start needs to be Rez'd and +Y up
@@ -240,6 +430,12 @@ void QGIBreakLine::paint ( QPainter * painter, const QStyleOptionGraphicsItem * 
     myOption.state &= ~QStyle::State_Selected;
 
     setTools();
+    if (isSelected()) {
+        QPen selectedPen = m_pen;
+        selectedPen.setColor(prefSelectColor());
+        m_line0->setPen(selectedPen);
+        m_line1->setPen(selectedPen);
+    }
 
     // painter->setPen(Qt::blue);
     // painter->drawRect(boundingRect());          //good for debugging
@@ -260,9 +456,42 @@ void QGIBreakLine::setTools()
     m_background->setPen(Qt::NoPen);
 }
 
+void QGIBreakLine::setDeleteCallback(std::function<void()> callback)
+{
+    m_deleteCallback = std::move(callback);
+    const bool selectable = static_cast<bool>(m_deleteCallback);
+    setFlag(QGraphicsItem::ItemIsSelectable, selectable);
+    setFlag(QGraphicsItem::ItemIsFocusable, selectable);
+    setAcceptedMouseButtons(selectable ? Qt::LeftButton : Qt::NoButton);
+    setCursor(selectable ? Qt::PointingHandCursor : Qt::ArrowCursor);
+    if (selectable) {
+        setToolTip(QObject::tr("Select and press Delete to remove this break"));
+    }
+}
+
+void QGIBreakLine::mousePressEvent(QGraphicsSceneMouseEvent* event)
+{
+    QGIDecoration::mousePressEvent(event);
+    if (m_deleteCallback) {
+        setFocus();
+        event->accept();
+    }
+}
+
+void QGIBreakLine::keyPressEvent(QKeyEvent* event)
+{
+    if (m_deleteCallback
+        && (event->key() == Qt::Key_Delete
+            || event->key() == Qt::Key_Backspace)) {
+        m_deleteCallback();
+        event->accept();
+        return;
+    }
+    QGraphicsItemGroup::keyPressEvent(event);
+}
+
 
 void QGIBreakLine::setLinePen(QPen isoPen)
 {
     m_pen = isoPen;
 }
-

--- a/src/Mod/TechDraw/Gui/QGIBreakLine.h
+++ b/src/Mod/TechDraw/Gui/QGIBreakLine.h
@@ -28,6 +28,8 @@
 #include <QFont>
 #include <QPainterPath>
 #include <QPointF>
+#include <functional>
+#include <optional>
 
 #include <Base/Vector3D.h>
 #include <Mod/TechDraw/App/DrawBrokenView.h>
@@ -54,8 +56,13 @@ public:
 
     void setBounds(double left, double top, double right, double bottom);
     void setBounds(Base::Vector3d topLeft, Base::Vector3d bottomRight);
+    void setLineGeometry(const QPointF& first,
+                         const QPointF& second,
+                         const QPointF& tangent,
+                         const QRectF& bounds);
     void setDirection(Base::Vector3d dir);      // horizontal(1,0,0) vertical(0,1,0);
     void draw() override;
+    void setDeleteCallback(std::function<void()> callback);
 
     void setLinePen(QPen isoPen);
     void setBreakColor(QColor c);
@@ -64,9 +71,17 @@ public:
     BreakType breakType() const { return m_breakType; }
 
 protected:
+    void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
 
 private:
     void drawLargeZigZag();
+    void drawGenericLines();
+    QPainterPath makeStyledLine(const QPointF& start,
+                                const QPointF& end,
+                                double outwardSign = 0.0) const;
+    std::optional<std::pair<QPointF, QPointF>>
+        clippedLine(const QPointF& point, const QPointF& tangent) const;
     QPainterPath makeHorizontalZigZag(Base::Vector3d start) const;
     QPainterPath makeVerticalZigZag(Base::Vector3d start) const;
     void drawSimpleLines();
@@ -76,7 +91,7 @@ private:
 
     QGraphicsPathItem* m_line0;
     QGraphicsPathItem* m_line1;
-    QGraphicsRectItem* m_background;
+    QGraphicsPathItem* m_background;
 
     Base::Vector3d     m_direction;
 
@@ -84,6 +99,12 @@ private:
     double             m_bottom;
     double             m_left;
     double             m_right;
+    QPointF m_firstPoint;
+    QPointF m_secondPoint;
+    QPointF m_tangent;
+    QRectF m_clipBounds;
+    bool m_genericGeometry{false};
+    std::function<void()> m_deleteCallback;
 
     BreakType m_breakType = BreakType::NONE;
 };

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -23,6 +23,10 @@
 #include <QPainterPath>
 #include <QKeyEvent>
 #include <QGraphicsTransform>
+#include <QImage>
+#include <QTimer>
+#include <algorithm>
+#include <cmath>
 #include <cstdio>
 #include <qmath.h>
 
@@ -78,6 +82,346 @@ using DU = DrawUtil;
 using FillMode = QGIFace::FillMode;
 
 const float lineScaleFactor = Rez::guiX(1.);// temp fiddle for devel
+
+namespace {
+
+constexpr double ShadedPixelsPerMillimetre = 12.0;  // approximately 300 dpi
+constexpr int ShadedMaxImageDimension = 4096;
+constexpr double ShadedAngularDeflection = 0.20;
+constexpr double BreakLineClipInset = 2.0;
+
+QRectF breakLineClipBounds(const DrawViewPart* view)
+{
+    if (!view) {
+        return {};
+    }
+
+    const Base::BoundBox3d box = view->getBoundingBox();
+    if (!box.IsValid()) {
+        return {};
+    }
+
+    QRectF bounds(QPointF(Rez::guiX(box.MinX), Rez::guiX(-box.MaxY)),
+                  QPointF(Rez::guiX(box.MaxX), Rez::guiX(-box.MinY)));
+    bounds = bounds.normalized();
+
+    // Keep the break decoration, including its waveform and pen, inside the
+    // projected geometry.  In particular, never derive this extent from
+    // QGIViewPart::boundingRect(): it already contains previously drawn break
+    // lines and would make them grow on every redraw.
+    const double inset = std::min(
+        Rez::guiX(BreakLineClipInset),
+        0.25 * std::min(bounds.width(), bounds.height()));
+    bounds.adjust(inset, inset, -inset, -inset);
+    return bounds;
+}
+
+struct ShadedVertex
+{
+    QPointF point;
+    double depth;
+    gp_Vec normal;
+};
+
+struct ShadedTriangle
+{
+    ShadedVertex vertices[3];
+};
+
+struct ShadedImage
+{
+    QImage image;
+    QRectF rect;
+};
+
+class QGIShadedImage final : public QGIPrimPath
+{
+public:
+    explicit QGIShadedImage(ShadedImage shaded)
+        : m_image(std::move(shaded.image))
+        , m_rect(shaded.rect)
+    {
+        QPainterPath outline;
+        outline.addRect(m_rect);
+        setPath(outline);
+        setFlag(QGraphicsItem::ItemIsSelectable, false);
+        setFlag(QGraphicsItem::ItemIsFocusable, false);
+        setAcceptHoverEvents(false);
+    }
+
+    void paint(QPainter* painter,
+               const QStyleOptionGraphicsItem*,
+               QWidget*) override
+    {
+        painter->save();
+        painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
+        painter->drawImage(m_rect, m_image);
+        painter->restore();
+    }
+
+private:
+    QImage m_image;
+    QRectF m_rect;
+};
+
+double edgeFunction(const QPointF& a, const QPointF& b, double x, double y)
+{
+    return (x - a.x()) * (b.y() - a.y()) - (y - a.y()) * (b.x() - a.x());
+}
+
+QColor shadePixel(const QColor& base,
+                  gp_Vec normal,
+                  const gp_Vec& lightDirection,
+                  const gp_Vec& viewDirection,
+                  const gp_Vec& halfDirection)
+{
+    if (normal.SquareMagnitude() <= Precision::SquareConfusion()) {
+        return base;
+    }
+    normal.Normalize();
+
+    // TechDraw shades both sides of open shells. Make the normal face the camera
+    // before applying a camera-relative light.
+    if (normal.Dot(viewDirection) < 0.0) {
+        normal.Reverse();
+    }
+
+    const double diffuse = std::max(0.0, normal.Dot(lightDirection));
+    const double specular = std::pow(std::max(0.0, normal.Dot(halfDirection)), 24.0);
+    const double intensity = std::clamp(0.28 + 0.62 * diffuse + 0.18 * specular, 0.0, 1.15);
+
+    auto channel = [intensity](int value) {
+        return std::clamp(static_cast<int>(std::lround(value * intensity)), 0, 255);
+    };
+    return QColor(channel(base.red()), channel(base.green()), channel(base.blue()), base.alpha());
+}
+
+std::optional<ShadedImage> makeShadedImage(DrawViewPart* viewPart, QColor baseColor)
+{
+    TopoDS_Shape sourceShape = viewPart->getSourceShape();
+    if (sourceShape.IsNull()) {
+        return {};
+    }
+
+    // Work on a topology copy so tessellation never modifies the source object's mesh.
+    BRepBuilderAPI_Copy copier(sourceShape, false, false);
+    TopoDS_Shape displayShape = copier.Shape();
+    DrawViewPart::centerScaleRotate(
+        viewPart, displayShape, viewPart->getCurrentCentroid());
+
+    Bnd_Box shapeBox;
+    BRepBndLib::Add(displayShape, shapeBox);
+    if (shapeBox.IsVoid()) {
+        return {};
+    }
+
+    double xMin = 0.0;
+    double yMin = 0.0;
+    double zMin = 0.0;
+    double xMax = 0.0;
+    double yMax = 0.0;
+    double zMax = 0.0;
+    shapeBox.Get(xMin, yMin, zMin, xMax, yMax, zMax);
+    const double extent =
+        std::max({xMax - xMin, yMax - yMin, zMax - zMin});
+    const double deflection = std::max(Precision::Confusion(), extent / 500.0);
+    BRepMesh_IncrementalMesh mesher(
+        displayShape, deflection, false, ShadedAngularDeflection, true);
+    if (!mesher.IsDone()) {
+        return {};
+    }
+
+    const gp_Ax2 projection = viewPart->getProjectionCS();
+    const gp_Pnt origin = projection.Location();
+    const gp_Dir xDirection = projection.XDirection();
+    const gp_Dir yDirection = projection.YDirection();
+    const gp_Dir projectionDirection = projection.Direction();
+
+    gp_Vec lightDirection(projectionDirection);
+    lightDirection += gp_Vec(xDirection).Multiplied(-0.35);
+    lightDirection += gp_Vec(yDirection).Multiplied(-0.45);
+    lightDirection.Normalize();
+    gp_Vec viewDirection(projectionDirection);
+    gp_Vec halfDirection = lightDirection + viewDirection;
+    halfDirection.Normalize();
+
+    std::vector<ShadedTriangle> triangles;
+    double sceneMinX = std::numeric_limits<double>::infinity();
+    double sceneMinY = std::numeric_limits<double>::infinity();
+    double sceneMaxX = -std::numeric_limits<double>::infinity();
+    double sceneMaxY = -std::numeric_limits<double>::infinity();
+
+    for (TopExp_Explorer explorer(displayShape, TopAbs_FACE);
+         explorer.More();
+         explorer.Next()) {
+        const TopoDS_Face face = TopoDS::Face(explorer.Current());
+        TopLoc_Location location;
+        Handle(Poly_Triangulation) triangulation =
+            BRep_Tool::Triangulation(face, location);
+        if (triangulation.IsNull()) {
+            continue;
+        }
+
+        std::vector<gp_Vec> normals;
+        Part::Tools::getPointNormals(face, triangulation, normals);
+        Part::Tools::applyTransformationOnNormals(location, normals);
+
+#if OCC_VERSION_HEX < 0x070600
+        const TColgp_Array1OfPnt& nodes = triangulation->Nodes();
+        const Poly_Array1OfTriangle& meshTriangles = triangulation->Triangles();
+#endif
+        std::vector<ShadedVertex> vertices;
+        vertices.reserve(triangulation->NbNodes());
+        for (int nodeIndex = 1; nodeIndex <= triangulation->NbNodes(); ++nodeIndex) {
+#if OCC_VERSION_HEX < 0x070600
+            gp_Pnt point = nodes(nodeIndex);
+#else
+            gp_Pnt point = triangulation->Node(nodeIndex);
+#endif
+            if (!location.IsIdentity()) {
+                point.Transform(location.Transformation());
+            }
+
+            const gp_Vec relative(origin, point);
+            const QPointF projected(
+                Rez::guiX(relative.Dot(gp_Vec(xDirection))),
+                Rez::guiX(-relative.Dot(gp_Vec(yDirection))));
+            vertices.push_back(
+                {projected,
+                 relative.Dot(gp_Vec(projectionDirection)),
+                 normals.at(static_cast<size_t>(nodeIndex - 1))});
+
+            sceneMinX = std::min(sceneMinX, projected.x());
+            sceneMinY = std::min(sceneMinY, projected.y());
+            sceneMaxX = std::max(sceneMaxX, projected.x());
+            sceneMaxY = std::max(sceneMaxY, projected.y());
+        }
+
+        for (int triangleIndex = 1;
+             triangleIndex <= triangulation->NbTriangles();
+             ++triangleIndex) {
+            int indices[3];
+#if OCC_VERSION_HEX < 0x070600
+            meshTriangles(triangleIndex).Get(
+                indices[0], indices[1], indices[2]);
+#else
+            triangulation->Triangle(triangleIndex).Get(
+                indices[0], indices[1], indices[2]);
+#endif
+            ShadedTriangle triangle;
+            for (int vertexIndex = 0; vertexIndex < 3; ++vertexIndex) {
+                triangle.vertices[vertexIndex] =
+                    vertices.at(static_cast<size_t>(indices[vertexIndex] - 1));
+            }
+            triangles.push_back(std::move(triangle));
+        }
+    }
+
+    const QRectF sceneBoundsUnpadded(
+        QPointF(sceneMinX, sceneMinY),
+        QPointF(sceneMaxX, sceneMaxY));
+    if (triangles.empty() || sceneBoundsUnpadded.isEmpty()) {
+        return {};
+    }
+
+    QRectF sceneBounds = sceneBoundsUnpadded;
+    double pixelsPerSceneUnit = ShadedPixelsPerMillimetre / Rez::getRezFactor();
+    const double longestSceneSide = std::max(sceneBounds.width(), sceneBounds.height());
+    if (longestSceneSide * pixelsPerSceneUnit > ShadedMaxImageDimension) {
+        pixelsPerSceneUnit = ShadedMaxImageDimension / longestSceneSide;
+    }
+    pixelsPerSceneUnit = std::max(pixelsPerSceneUnit, 0.01);
+
+    const double margin = 1.0 / pixelsPerSceneUnit;
+    sceneBounds.adjust(-margin, -margin, margin, margin);
+    const int imageWidth =
+        std::max(2, static_cast<int>(std::ceil(sceneBounds.width() * pixelsPerSceneUnit)));
+    const int imageHeight =
+        std::max(2, static_cast<int>(std::ceil(sceneBounds.height() * pixelsPerSceneUnit)));
+
+    QImage image(imageWidth, imageHeight, QImage::Format_ARGB32);
+    image.fill(Qt::transparent);
+    std::vector<double> depthBuffer(
+        static_cast<size_t>(imageWidth) * static_cast<size_t>(imageHeight),
+        -std::numeric_limits<double>::infinity());
+
+    auto toImagePoint = [&sceneBounds, pixelsPerSceneUnit](const QPointF& point) {
+        return QPointF(
+            (point.x() - sceneBounds.left()) * pixelsPerSceneUnit,
+            (point.y() - sceneBounds.top()) * pixelsPerSceneUnit);
+    };
+
+    for (const auto& triangle : triangles) {
+        QPointF points[3] = {
+            toImagePoint(triangle.vertices[0].point),
+            toImagePoint(triangle.vertices[1].point),
+            toImagePoint(triangle.vertices[2].point)
+        };
+        const double area = edgeFunction(points[0], points[1], points[2].x(), points[2].y());
+        if (std::abs(area) <= std::numeric_limits<double>::epsilon()) {
+            continue;
+        }
+
+        const int left = std::max(
+            0, static_cast<int>(std::floor(std::min({points[0].x(), points[1].x(), points[2].x()}))));
+        const int right = std::min(
+            imageWidth - 1,
+            static_cast<int>(std::ceil(std::max({points[0].x(), points[1].x(), points[2].x()}))));
+        const int top = std::max(
+            0, static_cast<int>(std::floor(std::min({points[0].y(), points[1].y(), points[2].y()}))));
+        const int bottom = std::min(
+            imageHeight - 1,
+            static_cast<int>(std::ceil(std::max({points[0].y(), points[1].y(), points[2].y()}))));
+
+        for (int y = top; y <= bottom; ++y) {
+            auto* scanline = reinterpret_cast<QRgb*>(image.scanLine(y));
+            for (int x = left; x <= right; ++x) {
+                const double sampleX = x + 0.5;
+                const double sampleY = y + 0.5;
+                const double w0 =
+                    edgeFunction(points[1], points[2], sampleX, sampleY) / area;
+                const double w1 =
+                    edgeFunction(points[2], points[0], sampleX, sampleY) / area;
+                const double w2 = 1.0 - w0 - w1;
+                constexpr double edgeTolerance = -1.0e-8;
+                if (w0 < edgeTolerance || w1 < edgeTolerance || w2 < edgeTolerance) {
+                    continue;
+                }
+
+                const double depth =
+                    w0 * triangle.vertices[0].depth
+                    + w1 * triangle.vertices[1].depth
+                    + w2 * triangle.vertices[2].depth;
+                const size_t bufferIndex =
+                    static_cast<size_t>(y) * static_cast<size_t>(imageWidth)
+                    + static_cast<size_t>(x);
+                if (depth <= depthBuffer[bufferIndex]) {
+                    continue;
+                }
+
+                depthBuffer[bufferIndex] = depth;
+                const gp_Vec normal(
+                    w0 * triangle.vertices[0].normal.X()
+                        + w1 * triangle.vertices[1].normal.X()
+                        + w2 * triangle.vertices[2].normal.X(),
+                    w0 * triangle.vertices[0].normal.Y()
+                        + w1 * triangle.vertices[1].normal.Y()
+                        + w2 * triangle.vertices[2].normal.Y(),
+                    w0 * triangle.vertices[0].normal.Z()
+                        + w1 * triangle.vertices[1].normal.Z()
+                        + w2 * triangle.vertices[2].normal.Z());
+                const QColor shaded =
+                    shadePixel(baseColor, normal, lightDirection, viewDirection, halfDirection);
+                scanline[x] = qRgba(
+                    shaded.red(), shaded.green(), shaded.blue(), shaded.alpha());
+            }
+        }
+    }
+
+    return ShadedImage{std::move(image), sceneBounds};
+}
+
+}  // namespace
 
 QGIViewPart::QGIViewPart()
 {
@@ -1081,8 +1425,8 @@ void QGIViewPart::drawBreakLines()
 {
     // Base::Console().message("QGIVP::drawBreakLines()\n");
 
-    auto dbv = dynamic_cast<TechDraw::DrawBrokenView*>(getViewObject());
-    if (!dbv) {
+    auto* dvp = dynamic_cast<TechDraw::DrawViewPart*>(getViewObject());
+    if (!dvp) {
         return;
     }
 
@@ -1091,29 +1435,72 @@ void QGIViewPart::drawBreakLines()
         return;
     }
 
-    DrawBrokenView::BreakType breakType = static_cast<DrawBrokenView::BreakType>(vp->BreakLineType.getValue());
-    auto breaks = dbv->Breaks.getValues();
-    for (auto& breakObj : breaks) {
-        QGIBreakLine* breakLine = new QGIBreakLine();
-        addToGroupWithoutUpdate(breakLine);
+    auto dbv = dynamic_cast<TechDraw::DrawBrokenView*>(dvp);
+    if (dbv) {
+        DrawBrokenView::BreakType breakType =
+            static_cast<DrawBrokenView::BreakType>(vp->BreakLineType.getValue());
+        auto breaks = dbv->Breaks.getValues();
+        for (auto& breakObj : breaks) {
+            QGIBreakLine* breakLine = new QGIBreakLine();
+            addToGroupWithoutUpdate(breakLine);
 
-        Base::Vector3d direction = dbv->guiDirectionFromObj(*breakObj);
-        breakLine->setDirection(direction);
-        // the bounds describe two corners of the removed area in the view
-        std::pair<Base::Vector3d, Base::Vector3d> bounds = dbv->breakBoundsFromObj(*breakObj);
-        // the bounds are in 3d form, so we need to invert & rez them
-        Base::Vector3d topLeft     = Rez::guiX(DU::invertY(bounds.first));
-        Base::Vector3d bottomRight = Rez::guiX(DU::invertY(bounds.second));
-        breakLine->setBounds(topLeft, bottomRight);
+            Base::Vector3d direction = dbv->guiDirectionFromObj(*breakObj);
+            breakLine->setDirection(direction);
+            std::pair<Base::Vector3d, Base::Vector3d> bounds =
+                dbv->breakBoundsFromObj(*breakObj);
+            Base::Vector3d topLeft = Rez::guiX(DU::invertY(bounds.first));
+            Base::Vector3d bottomRight = Rez::guiX(DU::invertY(bounds.second));
+            breakLine->setBounds(topLeft, bottomRight);
+            breakLine->setPos(0.0, 0.0);
+            breakLine->setLinePen(m_dashedLineGenerator->getLinePen(
+                vp->BreakLineStyle.getValue(), vp->HiddenWidth.getValue()));
+            breakLine->setWidth(Rez::guiX(vp->HiddenWidth.getValue()));
+            breakLine->setBreakType(breakType);
+            breakLine->setZValue(ZVALUE::SECTIONLINE);
+            Base::Color color = prefBreaklineColor();
+            breakLine->setBreakColor(color.asValue<QColor>());
+            breakLine->setRotation(-dbv->Rotation.getValue());
+            breakLine->draw();
+        }
+    }
+
+    const QRectF clip = breakLineClipBounds(dvp);
+    for (std::size_t index = 0; index < dvp->getBreakCount(); ++index) {
+        const auto points = dvp->getBreakLinePoints(index);
+        const Base::Vector3d tangent = dvp->getBreakLineDirection(index);
+        const QPointF first(Rez::guiX(points.first.x),
+                            Rez::guiX(-points.first.y));
+        const QPointF second(Rez::guiX(points.second.x),
+                             Rez::guiX(-points.second.y));
+        const QPointF guiTangent(tangent.x, -tangent.y);
+
+        auto* breakLine = new QGIBreakLine();
+        addToGroupWithoutUpdate(breakLine);
+        breakLine->setLineGeometry(first, second, guiTangent, clip);
         breakLine->setPos(0.0, 0.0);
-        breakLine->setLinePen(
-            m_dashedLineGenerator->getLinePen(vp->BreakLineStyle.getValue(), vp->HiddenWidth.getValue()));
+        breakLine->setLinePen(m_dashedLineGenerator->getLinePen(
+            vp->BreakLineStyle.getValue(), vp->HiddenWidth.getValue()));
         breakLine->setWidth(Rez::guiX(vp->HiddenWidth.getValue()));
-        breakLine->setBreakType(breakType);
+        breakLine->setBreakType(dvp->getBreakType(index));
         breakLine->setZValue(ZVALUE::SECTIONLINE);
-        Base::Color color = prefBreaklineColor();
-        breakLine->setBreakColor(color.asValue<QColor>());
-        breakLine->setRotation(-dbv->Rotation.getValue());
+        breakLine->setBreakColor(prefBreaklineColor().asValue<QColor>());
+        breakLine->setDeleteCallback([dvp, index]() {
+            QTimer::singleShot(0, [dvp, index]() {
+                App::Document* document = dvp ? dvp->getDocument() : nullptr;
+                if (!document) {
+                    return;
+                }
+                document->openTransaction(
+                    QT_TRANSLATE_NOOP("Command", "Remove view break"));
+                if (!dvp->removeBreak(index)) {
+                    document->abortTransaction();
+                    return;
+                }
+                document->commitTransaction();
+                dvp->recomputeFeature();
+                dvp->requestPaint();
+            });
+        });
         breakLine->draw();
     }
 }

--- a/src/Mod/TechDraw/Gui/TaskBrokenView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskBrokenView.cpp
@@ -1,0 +1,490 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2026 AstoCAD     <hello@astocad.com>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include <QComboBox>
+#include <QDoubleSpinBox>
+#include <QGraphicsPathItem>
+#include <QGraphicsScene>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QPainterPath>
+#include <QPen>
+#include <QTimer>
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+#include <optional>
+#include <vector>
+
+#include <App/Document.h>
+#include <Base/Converter.h>
+#include <Base/Tools.h>
+#include <Gui/BitmapFactory.h>
+#include <Gui/Control.h>
+#include <Gui/InputHint.h>
+#include <Gui/MainWindow.h>
+#include <Gui/Selection/Selection.h>
+#include <Gui/TaskView/TaskView.h>
+#include <Mod/TechDraw/App/DrawPage.h>
+#include <Mod/TechDraw/App/DrawUtil.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
+
+#include "ui_TaskBrokenView.h"
+#include "QGIViewPart.h"
+#include "QGSPage.h"
+#include "QGVPage.h"
+#include "Rez.h"
+#include "TaskBrokenView.h"
+#include "TechDrawHandler.h"
+
+using namespace TechDraw;
+using namespace TechDrawGui;
+
+namespace
+{
+
+constexpr double BreakLineClipInset = 2.0;
+
+QRectF breakLineClipBounds(const DrawViewPart* view)
+{
+    if (!view) {
+        return {};
+    }
+
+    const Base::BoundBox3d box = view->getBoundingBox();
+    if (!box.IsValid()) {
+        return {};
+    }
+
+    QRectF bounds(QPointF(Rez::guiX(box.MinX), Rez::guiX(-box.MaxY)),
+                  QPointF(Rez::guiX(box.MaxX), Rez::guiX(-box.MinY)));
+    bounds = bounds.normalized();
+    const double inset = std::min(
+        Rez::guiX(BreakLineClipInset),
+        0.25 * std::min(bounds.width(), bounds.height()));
+    bounds.adjust(inset, inset, -inset, -inset);
+    return bounds;
+}
+
+QPainterPath styledBreakPath(const QPointF& start,
+                             const QPointF& end,
+                             DrawViewPart::BreakType type)
+{
+    QPainterPath path(start);
+    QPointF tangent = end - start;
+    const double length = std::hypot(tangent.x(), tangent.y());
+    if (length <= 1.0e-9 || type == DrawViewPart::BreakType::SIMPLE) {
+        path.lineTo(end);
+        return path;
+    }
+    tangent /= length;
+    const QPointF normal(-tangent.y(), tangent.x());
+    const double amplitude = Rez::guiX(1.5);
+    const int segments =
+        type == DrawViewPart::BreakType::SINUSOID ? 100 : 12;
+    for (int segment = 1; segment <= segments; ++segment) {
+        const double fraction =
+            static_cast<double>(segment) / static_cast<double>(segments);
+        double offset = 0.0;
+        if (type == DrawViewPart::BreakType::SINUSOID) {
+            offset =
+                amplitude * std::sin(fraction * 10.0 * std::numbers::pi);
+        }
+        else if (segment < segments) {
+            offset = segment % 2 == 0 ? -amplitude : amplitude;
+        }
+        path.lineTo(
+            start + tangent * (length * fraction) + normal * offset);
+    }
+    return path;
+}
+
+std::optional<std::pair<QPointF, QPointF>>
+clipLine(const QPointF& point,
+         const QPointF& tangent,
+         const QRectF& rectangle)
+{
+    constexpr double epsilon = 1.0e-9;
+    const QRectF bounds = rectangle.normalized();
+    std::vector<std::pair<double, QPointF>> hits;
+    auto add = [&](double parameter) {
+        const QPointF hit = point + tangent * parameter;
+        if (hit.x() >= bounds.left() - epsilon
+            && hit.x() <= bounds.right() + epsilon
+            && hit.y() >= bounds.top() - epsilon
+            && hit.y() <= bounds.bottom() + epsilon) {
+            hits.emplace_back(parameter, hit);
+        }
+    };
+    if (std::abs(tangent.x()) > epsilon) {
+        add((bounds.left() - point.x()) / tangent.x());
+        add((bounds.right() - point.x()) / tangent.x());
+    }
+    if (std::abs(tangent.y()) > epsilon) {
+        add((bounds.top() - point.y()) / tangent.y());
+        add((bounds.bottom() - point.y()) / tangent.y());
+    }
+    if (hits.size() < 2) {
+        return std::nullopt;
+    }
+    std::sort(hits.begin(), hits.end(),
+              [](const auto& left, const auto& right) {
+                  return left.first < right.first;
+              });
+    if (std::hypot(hits.back().second.x() - hits.front().second.x(),
+                   hits.back().second.y() - hits.front().second.y())
+        <= epsilon) {
+        return std::nullopt;
+    }
+    return std::pair{hits.front().second, hits.back().second};
+}
+
+class BrokenViewHandler final : public TechDrawHandler
+{
+public:
+    explicit BrokenViewHandler(TaskBrokenView* task) : m_task(task) {}
+
+    ~BrokenViewHandler() override
+    {
+        clearPreview(m_hoverPreview);
+        clearPreview(m_fixedPreview);
+    }
+
+    void mouseMoveEvent(QMouseEvent* event) override
+    {
+        if (!viewPage || !m_task) {
+            return;
+        }
+        QGIViewPart* hovered = findView(event->pos());
+        if (m_pending && hovered != m_baseItem) {
+            clearPreview(m_hoverPreview);
+            return;
+        }
+        if (!m_pending) {
+            m_baseItem = hovered;
+            m_base = hovered
+                ? dynamic_cast<DrawViewPart*>(hovered->getViewObject())
+                : nullptr;
+        }
+        if (!m_baseItem || !m_base) {
+            clearPreview(m_hoverPreview);
+            return;
+        }
+
+        const QPointF local = m_baseItem->mapFromScene(
+            viewPage->mapToScene(event->pos()));
+        updatePreview(m_hoverPreview,
+                      local,
+                      m_pending ? m_angle : m_task->angle(),
+                      m_pending ? m_type : m_task->breakType());
+        event->accept();
+    }
+
+    void mousePressEvent(QMouseEvent* event) override
+    {
+        if (event->button() != Qt::LeftButton || !m_baseItem || !m_base) {
+            return;
+        }
+        const QPointF local = m_baseItem->mapFromScene(
+            viewPage->mapToScene(event->pos()));
+        if (!m_pending) {
+            const double angle = m_task->angle();
+            const auto type = m_task->breakType();
+            if (!updatePreview(m_fixedPreview, local, angle, type)) {
+                event->accept();
+                return;
+            }
+            m_firstPoint = local;
+            m_angle = angle;
+            m_gap = m_task->gap();
+            m_type = type;
+            m_pending = true;
+            updateHint();
+        }
+        else {
+            const double radians = Base::toRadians(m_angle);
+            const QPointF tangent(std::cos(radians), -std::sin(radians));
+            if (!clipLine(
+                    local, tangent, breakLineClipBounds(m_base))) {
+                event->accept();
+                return;
+            }
+            createBreak(local);
+        }
+        event->accept();
+    }
+
+    void mouseReleaseEvent(QMouseEvent* event) override
+    {
+        if (event->button() == Qt::RightButton) {
+            if (m_pending) {
+                resetPending();
+            }
+            else {
+                QTimer::singleShot(
+                    0, Gui::getMainWindow(),
+                    []() { Gui::Control().closeDialog(); });
+            }
+            event->accept();
+            return;
+        }
+        if (event->button() == Qt::LeftButton) {
+            if (viewPage->getScene()) {
+                viewPage->getScene()->clearSelection();
+            }
+            Gui::Selection().clearSelection();
+            event->accept();
+            return;
+        }
+        TechDrawHandler::mouseReleaseEvent(event);
+    }
+
+    void keyPressEvent(QKeyEvent* event) override
+    {
+        Q_UNUSED(event);
+    }
+
+    void deactivate() override
+    {
+        clearPreview(m_hoverPreview);
+        clearPreview(m_fixedPreview);
+        TechDrawHandler::deactivate();
+    }
+
+private:
+    std::list<Gui::InputHint> getToolHints() const override
+    {
+        using enum Gui::InputHint::UserInput;
+
+        if (m_pending) {
+            return {
+                {QObject::tr("%1 place second break line"), {MouseLeft}},
+                {QObject::tr("%1 cancel pending break"), {MouseRight}},
+            };
+        }
+        return {
+            {QObject::tr("%1 place first break line"), {MouseLeft}},
+            {QObject::tr("%1 close broken view tool"), {MouseRight}},
+        };
+    }
+
+    QGIViewPart* findView(const QPoint& viewportPoint)
+    {
+        const QList<QGraphicsItem*> items = viewPage->items(viewportPoint);
+        for (QGraphicsItem* item : items) {
+            for (QGraphicsItem* parent = item; parent;
+                 parent = parent->parentItem()) {
+                auto* view = dynamic_cast<QGIViewPart*>(parent);
+                auto* object = view
+                    ? dynamic_cast<DrawViewPart*>(view->getViewObject())
+                    : nullptr;
+                if (view && view->isVisible() && object
+                    && object->findParentPage() == getPage()) {
+                    return view;
+                }
+            }
+        }
+        return nullptr;
+    }
+
+    bool updatePreview(QGraphicsPathItem*& preview,
+                       const QPointF& localPoint,
+                       double angle,
+                       DrawViewPart::BreakType type)
+    {
+        if (!preview) {
+            preview = new QGraphicsPathItem();
+            QPen pen(QColor(35, 95, 210), 1.5);
+            pen.setCosmetic(true);
+            preview->setPen(pen);
+            preview->setZValue(1005.0);
+            viewPage->getScene()->addItem(preview);
+        }
+        const double radians = Base::toRadians(angle);
+        const QPointF tangent(std::cos(radians), -std::sin(radians));
+        const auto ends =
+            clipLine(localPoint, tangent, breakLineClipBounds(m_base));
+        if (!ends) {
+            preview->hide();
+            return false;
+        }
+        const QPainterPath localPath =
+            styledBreakPath(ends->first, ends->second, type);
+        preview->setPath(m_baseItem->sceneTransform().map(localPath));
+        preview->show();
+        return true;
+    }
+
+    void clearPreview(QGraphicsPathItem*& preview)
+    {
+        delete preview;
+        preview = nullptr;
+    }
+
+    Base::Vector3d modelPoint(const QPointF& local) const
+    {
+        const double scale = m_base->getScale();
+        const Base::Vector3d displayed(
+            Rez::appX(local.x()) / scale,
+            -Rez::appX(local.y()) / scale,
+            0.0);
+        return m_base->mapPointFromBrokenView(displayed);
+    }
+
+    void createBreak(const QPointF& secondLocal)
+    {
+        Base::Vector3d first = modelPoint(m_firstPoint);
+        const Base::Vector3d second = modelPoint(secondLocal);
+        const double radians = Base::toRadians(m_angle);
+        const Base::Vector3d normal2d(
+            -std::sin(radians), std::cos(radians), 0.0);
+        const gp_Ax2 axes = m_base->getRotatedCS();
+        Base::Vector3d normal =
+            Base::convertTo<Base::Vector3d>(axes.XDirection()) * normal2d.x
+            + Base::convertTo<Base::Vector3d>(axes.YDirection()) * normal2d.y;
+        normal.Normalize();
+        const double separation = (second - first).Dot(normal);
+        if (std::abs(separation) <= EWTOLERANCE) {
+            return;
+        }
+        const Base::Vector3d alignedSecond = first + normal * separation;
+
+        App::Document* document = m_base->getDocument();
+        document->openTransaction(
+            QT_TRANSLATE_NOOP("Command", "Create view break"));
+        m_base->addBreak(first, alignedSecond, normal, m_gap, m_type);
+        document->commitTransaction();
+        m_base->recomputeFeature();
+        m_base->requestPaint();
+        resetPending();
+    }
+
+    void resetPending()
+    {
+        clearPreview(m_fixedPreview);
+        clearPreview(m_hoverPreview);
+        m_pending = false;
+        m_baseItem = nullptr;
+        m_base = nullptr;
+        m_firstPoint = {};
+        updateHint();
+    }
+
+    TaskBrokenView* m_task{nullptr};
+    QGIViewPart* m_baseItem{nullptr};
+    DrawViewPart* m_base{nullptr};
+    QGraphicsPathItem* m_hoverPreview{nullptr};
+    QGraphicsPathItem* m_fixedPreview{nullptr};
+    QPointF m_firstPoint;
+    double m_angle{0.0};
+    double m_gap{10.0};
+    DrawViewPart::BreakType m_type{DrawViewPart::BreakType::ZIGZAG};
+    bool m_pending{false};
+};
+
+} // namespace
+
+TaskBrokenView::TaskBrokenView(QWidget* parent)
+    : QWidget(parent)
+    , ui(new Ui_TaskBrokenView)
+{
+    ui->setupUi(this);
+    ui->styleCombo->setItemData(
+        0, static_cast<int>(DrawViewPart::BreakType::ZIGZAG));
+    ui->styleCombo->setItemData(
+        1, static_cast<int>(DrawViewPart::BreakType::SIMPLE));
+    ui->styleCombo->setItemData(
+        2, static_cast<int>(DrawViewPart::BreakType::SINUSOID));
+
+    connect(ui->orientationCombo,
+            qOverload<int>(&QComboBox::currentIndexChanged),
+            this,
+            [this](int index) {
+                const bool custom = index == 2;
+                ui->angleLabel->setVisible(custom);
+                ui->angleSpin->setVisible(custom);
+            });
+}
+
+TaskBrokenView::~TaskBrokenView() = default;
+
+DrawViewPart::BreakType TaskBrokenView::breakType() const
+{
+    return static_cast<DrawViewPart::BreakType>(
+        ui->styleCombo->currentData().toInt());
+}
+
+double TaskBrokenView::gap() const
+{
+    return ui->gapSpin->value();
+}
+
+double TaskBrokenView::angle() const
+{
+    if (ui->orientationCombo->currentIndex() == 0) {
+        return 0.0;
+    }
+    if (ui->orientationCombo->currentIndex() == 1) {
+        return 90.0;
+    }
+    return ui->angleSpin->value();
+}
+
+TaskDlgBrokenView::TaskDlgBrokenView(DrawPage* page, QGVPage* graphicsView) :
+    m_page(page),
+    m_graphicsView(graphicsView)
+{
+    m_widget = new TaskBrokenView();
+    m_taskBox = new Gui::TaskView::TaskBox(
+        Gui::BitmapFactory().pixmap("actions/TechDraw_BrokenView"),
+        m_widget->windowTitle(),
+        true,
+        nullptr);
+    m_taskBox->groupLayout()->addWidget(m_widget);
+    Content.push_back(m_taskBox);
+}
+
+TaskDlgBrokenView::~TaskDlgBrokenView()
+{
+    if (m_graphicsView && m_graphicsView->isHandlerActive()) {
+        m_graphicsView->deactivateHandler();
+    }
+}
+
+void TaskDlgBrokenView::open()
+{
+    if (m_graphicsView) {
+        m_graphicsView->activateHandler(new BrokenViewHandler(m_widget));
+    }
+}
+
+bool TaskDlgBrokenView::accept()
+{
+    return true;
+}
+
+bool TaskDlgBrokenView::reject()
+{
+    return true;
+}

--- a/src/Mod/TechDraw/Gui/TaskBrokenView.h
+++ b/src/Mod/TechDraw/Gui/TaskBrokenView.h
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2026 AstoCAD     <hello@astocad.com>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <QDialogButtonBox>
+#include <QWidget>
+
+#include <memory>
+
+#include <Gui/TaskView/TaskDialog.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
+#include <Mod/TechDraw/TechDrawGlobal.h>
+
+class Ui_TaskBrokenView;
+
+namespace TechDraw
+{
+class DrawPage;
+}
+
+namespace TechDrawGui
+{
+
+class QGVPage;
+
+class TechDrawGuiExport TaskBrokenView : public QWidget
+{
+public:
+    explicit TaskBrokenView(QWidget* parent = nullptr);
+    ~TaskBrokenView() override;
+
+    TechDraw::DrawViewPart::BreakType breakType() const;
+    double gap() const;
+    double angle() const;
+
+private:
+    std::unique_ptr<Ui_TaskBrokenView> ui;
+};
+
+class TechDrawGuiExport TaskDlgBrokenView : public Gui::TaskView::TaskDialog
+{
+public:
+    TaskDlgBrokenView(TechDraw::DrawPage* page, QGVPage* graphicsView);
+    ~TaskDlgBrokenView() override;
+
+    void open() override;
+    bool accept() override;
+    bool reject() override;
+
+    QDialogButtonBox::StandardButtons getStandardButtons() const override
+    {
+        return QDialogButtonBox::Close;
+    }
+    bool isAllowedAlterSelection() const override { return true; }
+    bool isAllowedAlterDocument() const override { return true; }
+
+private:
+    TechDraw::DrawPage* m_page{nullptr};
+    QGVPage* m_graphicsView{nullptr};
+    TaskBrokenView* m_widget{nullptr};
+    Gui::TaskView::TaskBox* m_taskBox{nullptr};
+};
+
+} // namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/TaskBrokenView.ui
+++ b/src/Mod/TechDraw/Gui/TaskBrokenView.ui
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TechDrawGui::TaskBrokenView</class>
+ <widget class="QWidget" name="TechDrawGui::TaskBrokenView">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>180</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Broken view</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="styleLabel">
+       <property name="text">
+        <string>Break line style</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="styleCombo">
+       <item>
+        <property name="text">
+         <string>Zig zag</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Straight</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Sinusoid</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="gapLabel">
+       <property name="text">
+        <string>Gap size</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QDoubleSpinBox" name="gapSpin">
+       <property name="suffix">
+        <string> mm</string>
+       </property>
+       <property name="decimals">
+        <number>2</number>
+       </property>
+       <property name="maximum">
+        <double>10000.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="orientationLabel">
+       <property name="text">
+        <string>Cut orientation</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="orientationCombo">
+       <item>
+        <property name="text">
+         <string>Horizontal</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Vertical</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Custom</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="angleLabel">
+       <property name="visible">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Angle</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QDoubleSpinBox" name="angleSpin">
+       <property name="visible">
+        <bool>false</bool>
+       </property>
+       <property name="suffix">
+        <string>°</string>
+       </property>
+       <property name="decimals">
+        <number>1</number>
+       </property>
+       <property name="minimum">
+        <double>-180.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>180.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/TechDraw/TDTest/DrawViewPartTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawViewPartTest.py
@@ -47,5 +47,56 @@ class DrawViewPartTest(unittest.TestCase):
         self.assertEqual(len(edges), 4, "DrawViewPart has wrong number of edges")
         self.assertTrue("Up-to-date" in view.State, "DrawViewPart is not Up-to-date")
 
+    def testDisplayStyleControlsHardHidden(self):
+        """DisplayStyle controls hard hidden edges without changing other HLR options."""
+        view = FreeCAD.ActiveDocument.addObject("TechDraw::DrawViewPart", "StyleView")
+
+        self.assertEqual(view.DisplayStyle, "Visible Edges")
+        self.assertFalse(view.HardHidden)
+        hard_hidden_status = view.getPropertyStatus("HardHidden")
+        self.assertIn(24, hard_hidden_status)  # App::Property::PropReadOnly
+        self.assertIn(26, hard_hidden_status)  # App::Property::PropHidden
+
+        view.DisplayStyle = "All Edges"
+        self.assertTrue(view.HardHidden)
+
+        view.DisplayStyle = "Hidden Edges"
+        self.assertTrue(view.HardHidden)
+
+        view.DisplayStyle = "Shaded with Edges"
+        self.assertFalse(view.HardHidden)
+
+        view.SmoothHidden = True
+        view.SeamHidden = True
+        view.DisplayStyle = "Shaded"
+        self.assertTrue(view.SmoothHidden)
+        self.assertTrue(view.SeamHidden)
+
+    def testBreakPropertiesOnDrawViewPart(self):
+        """Every DrawViewPart stores multiple breaks without helper sketches."""
+        view = FreeCAD.ActiveDocument.addObject("TechDraw::DrawViewPart", "BreakableView")
+        self.page.addView(view)
+        view.Source = [FreeCAD.ActiveDocument.Box]
+
+        self.assertEqual(view.BreakPoints, [])
+        self.assertEqual(view.BreakDirections, [])
+        self.assertEqual(view.BreakGaps, [])
+        self.assertEqual(view.BreakLineTypes, [])
+
+        view.BreakPoints = [
+            FreeCAD.Vector(3.0, 0.0, 0.0),
+            FreeCAD.Vector(7.0, 0.0, 0.0),
+        ]
+        view.BreakDirections = [FreeCAD.Vector(1.0, 0.0, 0.0)]
+        view.BreakGaps = [1.0]
+        view.BreakLineTypes = [1]
+        FreeCAD.ActiveDocument.recompute()
+
+        self.assertEqual(len(view.BreakPoints), 2)
+        self.assertEqual(len(view.BreakDirections), 1)
+        self.assertEqual(view.BreakGaps, [1.0])
+        self.assertEqual(view.BreakLineTypes, [1])
+        self.assertTrue(view.getVisibleEdges())
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add a proper UI to create broken views.

This PR change radically how broken views works. Instead of being a subclass of `DrawViewPart`, now any `DrawViewPart` can have breaks. This is much more convenient because you can add break to any views, including projection groups views, section views and so on.

Legacy `DrawViewPart `subclass is left alone for backward compatibility.

https://github.com/user-attachments/assets/2f942065-a0d8-40eb-b011-f981c00fbca7

