### PR TITLE
TechDraw: Sketch in techdraw page

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
@@ -22,6 +22,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <cmath>
 #include <limits>
 
 #include <Inventor/nodes/SoCamera.h>
@@ -188,6 +189,10 @@ void GridExtensionP::getClosestGridPoint(double& x, double& y) const
 bool GridExtensionP::checkCameraZoomChange(const Gui::View3DInventorViewer* viewer)
 {
     float newCamMaxDimension = viewer->getMaxDimension();
+    if (!std::isfinite(newCamMaxDimension)
+        || newCamMaxDimension <= std::numeric_limits<float>::epsilon()) {
+        return false;
+    }
     if (fabs(newCamMaxDimension - camMaxDimension) > 0) {  // ie if user zoomed.
         camMaxDimension = newCamMaxDimension;
         return true;
@@ -233,7 +238,8 @@ void GridExtensionP::computeGridSize(const Gui::View3DInventorViewer* viewer)
         return;
     }
 
-    int numberOfLines = static_cast<int>(std::max(pixelWidth, pixelHeight)) / GridSizePixelThreshold;
+    int numberOfLines
+        = std::max(1, static_cast<int>(std::max(pixelWidth, pixelHeight)) / GridSizePixelThreshold);
 
     // If number of subdivision is 1, grid auto spacing can't work as it uses it as a factor
     // In such case, we apply a default factor of 10
@@ -317,6 +323,21 @@ void GridExtensionP::createGridPart(
 {
     float gridZ = getViewOrientationFactor() * GRID_Z_OFFSET;
 
+    const float gridDimension = 1.5F * camMaxDimension;
+    const double verticalLineCount = gridDimension / computedGridValue;
+    if (!std::isfinite(gridDimension) || !std::isfinite(computedGridValue) || computedGridValue <= 0.0
+        || !std::isfinite(verticalLineCount) || verticalLineCount > 1000.0) {
+        if (!isTooManySegmentsNotified) {
+            Base::Console().warning(
+                "The grid dimensions are invalid or too dense, so the grid is being disabled. "
+                "Consider zooming in or changing the grid configuration\n"
+            );
+            isTooManySegmentsNotified = true;
+        }
+        Gui::coinRemoveAllChildren(GridRoot);
+        return;
+    }
+
     auto* parent = new Gui::SoSkipBoundingGroup();
     parent->mode = Gui::SoSkipBoundingGroup::EXCLUDE_BBOX;
 
@@ -341,9 +362,8 @@ void GridExtensionP::createGridPart(
     vts = new SoVertexProperty;
     grid->vertexProperty = vts;
 
-    float gridDimension = 1.5 * camMaxDimension;
-    int vlines = static_cast<int>(gridDimension / computedGridValue);  // total number of vertical lines
-    int nlines = 2 * vlines;                                           // total number of lines
+    int vlines = static_cast<int>(verticalLineCount);  // total number of vertical lines
+    int nlines = 2 * vlines;                           // total number of lines
 
     if (nlines > 2000) {
         if (!isTooManySegmentsNotified) {

--- a/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
@@ -238,10 +238,8 @@ void GridExtensionP::computeGridSize(const Gui::View3DInventorViewer* viewer)
         return;
     }
 
-    int numberOfLines = std::max(
-        1,
-        static_cast<int>(std::max(pixelWidth, pixelHeight)) / GridSizePixelThreshold
-    );
+    int numberOfLines
+        = std::max(1, static_cast<int>(std::max(pixelWidth, pixelHeight)) / GridSizePixelThreshold);
 
     // If number of subdivision is 1, grid auto spacing can't work as it uses it as a factor
     // In such case, we apply a default factor of 10
@@ -327,9 +325,8 @@ void GridExtensionP::createGridPart(
 
     const float gridDimension = 1.5F * camMaxDimension;
     const double verticalLineCount = gridDimension / computedGridValue;
-    if (!std::isfinite(gridDimension) || !std::isfinite(computedGridValue)
-        || computedGridValue <= 0.0 || !std::isfinite(verticalLineCount)
-        || verticalLineCount > 1000.0) {
+    if (!std::isfinite(gridDimension) || !std::isfinite(computedGridValue) || computedGridValue <= 0.0
+        || !std::isfinite(verticalLineCount) || verticalLineCount > 1000.0) {
         if (!isTooManySegmentsNotified) {
             Base::Console().warning(
                 "The grid dimensions are invalid or too dense, so the grid is being disabled. "
@@ -366,7 +363,7 @@ void GridExtensionP::createGridPart(
     grid->vertexProperty = vts;
 
     int vlines = static_cast<int>(verticalLineCount);  // total number of vertical lines
-    int nlines = 2 * vlines;                                           // total number of lines
+    int nlines = 2 * vlines;                           // total number of lines
 
     if (nlines > 2000) {
         if (!isTooManySegmentsNotified) {

--- a/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
@@ -22,6 +22,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <cmath>
 #include <limits>
 
 #include <Inventor/nodes/SoCamera.h>
@@ -188,6 +189,10 @@ void GridExtensionP::getClosestGridPoint(double& x, double& y) const
 bool GridExtensionP::checkCameraZoomChange(const Gui::View3DInventorViewer* viewer)
 {
     float newCamMaxDimension = viewer->getMaxDimension();
+    if (!std::isfinite(newCamMaxDimension)
+        || newCamMaxDimension <= std::numeric_limits<float>::epsilon()) {
+        return false;
+    }
     if (fabs(newCamMaxDimension - camMaxDimension) > 0) {  // ie if user zoomed.
         camMaxDimension = newCamMaxDimension;
         return true;
@@ -233,7 +238,10 @@ void GridExtensionP::computeGridSize(const Gui::View3DInventorViewer* viewer)
         return;
     }
 
-    int numberOfLines = static_cast<int>(std::max(pixelWidth, pixelHeight)) / GridSizePixelThreshold;
+    int numberOfLines = std::max(
+        1,
+        static_cast<int>(std::max(pixelWidth, pixelHeight)) / GridSizePixelThreshold
+    );
 
     // If number of subdivision is 1, grid auto spacing can't work as it uses it as a factor
     // In such case, we apply a default factor of 10
@@ -317,6 +325,22 @@ void GridExtensionP::createGridPart(
 {
     float gridZ = getViewOrientationFactor() * GRID_Z_OFFSET;
 
+    const float gridDimension = 1.5F * camMaxDimension;
+    const double verticalLineCount = gridDimension / computedGridValue;
+    if (!std::isfinite(gridDimension) || !std::isfinite(computedGridValue)
+        || computedGridValue <= 0.0 || !std::isfinite(verticalLineCount)
+        || verticalLineCount > 1000.0) {
+        if (!isTooManySegmentsNotified) {
+            Base::Console().warning(
+                "The grid dimensions are invalid or too dense, so the grid is being disabled. "
+                "Consider zooming in or changing the grid configuration\n"
+            );
+            isTooManySegmentsNotified = true;
+        }
+        Gui::coinRemoveAllChildren(GridRoot);
+        return;
+    }
+
     auto* parent = new Gui::SoSkipBoundingGroup();
     parent->mode = Gui::SoSkipBoundingGroup::EXCLUDE_BBOX;
 
@@ -341,8 +365,7 @@ void GridExtensionP::createGridPart(
     vts = new SoVertexProperty;
     grid->vertexProperty = vts;
 
-    float gridDimension = 1.5 * camMaxDimension;
-    int vlines = static_cast<int>(gridDimension / computedGridValue);  // total number of vertical lines
+    int vlines = static_cast<int>(verticalLineCount);  // total number of vertical lines
     int nlines = 2 * vlines;                                           // total number of lines
 
     if (nlines > 2000) {

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -250,6 +250,8 @@ public:
         bool defining = false,
         bool intersection = false
     );
+    /// add several projected external geometry references with a single rebuild
+    int addExternals(App::DocumentObject* Obj, const std::vector<std::string>& SubNames);
     /** delete external
      *  ExtGeoId >= 0 with 0 corresponding to the first user defined
      *  external geometry

--- a/src/Mod/Sketcher/App/SketchObjectExternal.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectExternal.cpp
@@ -747,6 +747,14 @@ int SketchObject::addExternal(App::DocumentObject* Obj, const char* SubName, boo
         Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform
     );
     auto shape = wholeShape.getSubTopoShape(SubName, /*silent*/ true);
+    if (shape.isNull()) {
+        shape = Part::Feature::getTopoShape(
+            Obj,
+            Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform
+                | Part::ShapeOption::NeedSubElement,
+            SubName
+        );
+    }
     TopAbs_ShapeEnum shapeType = TopAbs_SHAPE;
     if (shape.shapeType(/*silent*/ true) != TopAbs_FACE) {
         if (shape.hasSubShape(TopAbs_FACE)) {
@@ -865,6 +873,74 @@ int SketchObject::addExternal(App::DocumentObject* Obj, const char* SubName, boo
 
     solverNeedsUpdate = true;
     return ExternalGeometry.getValues().size() - 1;
+}
+
+int SketchObject::addExternals(App::DocumentObject* Obj, const std::vector<std::string>& SubNames)
+{
+    Base::StateLocker lock(managedoperation, true);
+
+    if (!Obj || !isExternalAllowed(Obj->getDocument(), Obj)) {
+        return -1;
+    }
+
+    std::vector<long> types = ExternalTypes.getValues();
+    std::vector<DocumentObject*> objects = ExternalGeometry.getValues();
+    std::vector<std::string> subElements = ExternalGeometry.getSubValues();
+    types.resize(objects.size(), static_cast<long>(ExtType::Projection));
+    if (objects.size() != subElements.size()) {
+        Base::Console().error(
+            "Internal error: counts of objects and subelements in external "
+            "geometry links do not match\n"
+        );
+        return -1;
+    }
+
+    const auto originalObjects = objects;
+    const auto originalSubElements = subElements;
+    const auto originalTypes = types;
+    int changed = 0;
+    for (const auto& subName : SubNames) {
+        bool alreadyLinked = false;
+        for (std::size_t index = 0; index < objects.size(); ++index) {
+            if (objects[index] != Obj || subElements[index] != subName) {
+                continue;
+            }
+            alreadyLinked = true;
+            if (types[index] == static_cast<long>(ExtType::Intersection)) {
+                types[index] = static_cast<long>(ExtType::Both);
+                ++changed;
+            }
+            break;
+        }
+        if (alreadyLinked) {
+            continue;
+        }
+
+        objects.push_back(Obj);
+        subElements.push_back(subName);
+        types.push_back(static_cast<long>(ExtType::Projection));
+        ++changed;
+    }
+
+    if (changed == 0) {
+        return 0;
+    }
+
+    ExternalGeometry.setValues(objects, subElements);
+    ExternalTypes.setValues(types);
+    try {
+        rebuildExternalGeometry();
+    }
+    catch (const Base::Exception& e) {
+        Base::Console().error("%s\n", e.what());
+        ExternalGeometry.setValues(originalObjects, originalSubElements);
+        ExternalTypes.setValues(originalTypes);
+        return -1;
+    }
+
+    acceptGeometry();
+    solverNeedsUpdate = true;
+    return changed;
 }
 // clang-format off
 
@@ -2526,8 +2602,18 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
                 refSubShape = v;
             }
             else {
-                throw Base::TypeError(
-                    "Datum feature type is not yet supported as external geometry for a sketch");
+                auto shape = Part::Feature::getTopoShape(
+                    resolvedObj,
+                    Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform
+                        | Part::ShapeOption::NeedSubElement,
+                    SubElement.c_str()
+                );
+                refSubShape = shape.getShape();
+                if (refSubShape.IsNull()) {
+                    throw Base::TypeError(
+                        "Object does not provide geometry usable as external sketch geometry"
+                    );
+                }
             }
 
             if (projection && !refSubShape.IsNull()) {

--- a/src/Mod/Sketcher/App/SketchObjectExternal.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectExternal.cpp
@@ -875,8 +875,7 @@ int SketchObject::addExternal(App::DocumentObject* Obj, const char* SubName, boo
     return ExternalGeometry.getValues().size() - 1;
 }
 
-int SketchObject::addExternals(App::DocumentObject* Obj,
-                               const std::vector<std::string>& SubNames)
+int SketchObject::addExternals(App::DocumentObject* Obj, const std::vector<std::string>& SubNames)
 {
     Base::StateLocker lock(managedoperation, true);
 

--- a/src/Mod/Sketcher/App/SketchObjectExternal.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectExternal.cpp
@@ -747,6 +747,14 @@ int SketchObject::addExternal(App::DocumentObject* Obj, const char* SubName, boo
         Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform
     );
     auto shape = wholeShape.getSubTopoShape(SubName, /*silent*/ true);
+    if (shape.isNull()) {
+        shape = Part::Feature::getTopoShape(
+            Obj,
+            Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform
+                | Part::ShapeOption::NeedSubElement,
+            SubName
+        );
+    }
     TopAbs_ShapeEnum shapeType = TopAbs_SHAPE;
     if (shape.shapeType(/*silent*/ true) != TopAbs_FACE) {
         if (shape.hasSubShape(TopAbs_FACE)) {
@@ -865,6 +873,75 @@ int SketchObject::addExternal(App::DocumentObject* Obj, const char* SubName, boo
 
     solverNeedsUpdate = true;
     return ExternalGeometry.getValues().size() - 1;
+}
+
+int SketchObject::addExternals(App::DocumentObject* Obj,
+                               const std::vector<std::string>& SubNames)
+{
+    Base::StateLocker lock(managedoperation, true);
+
+    if (!Obj || !isExternalAllowed(Obj->getDocument(), Obj)) {
+        return -1;
+    }
+
+    std::vector<long> types = ExternalTypes.getValues();
+    std::vector<DocumentObject*> objects = ExternalGeometry.getValues();
+    std::vector<std::string> subElements = ExternalGeometry.getSubValues();
+    types.resize(objects.size(), static_cast<long>(ExtType::Projection));
+    if (objects.size() != subElements.size()) {
+        Base::Console().error(
+            "Internal error: counts of objects and subelements in external "
+            "geometry links do not match\n"
+        );
+        return -1;
+    }
+
+    const auto originalObjects = objects;
+    const auto originalSubElements = subElements;
+    const auto originalTypes = types;
+    int changed = 0;
+    for (const auto& subName : SubNames) {
+        bool alreadyLinked = false;
+        for (std::size_t index = 0; index < objects.size(); ++index) {
+            if (objects[index] != Obj || subElements[index] != subName) {
+                continue;
+            }
+            alreadyLinked = true;
+            if (types[index] == static_cast<long>(ExtType::Intersection)) {
+                types[index] = static_cast<long>(ExtType::Both);
+                ++changed;
+            }
+            break;
+        }
+        if (alreadyLinked) {
+            continue;
+        }
+
+        objects.push_back(Obj);
+        subElements.push_back(subName);
+        types.push_back(static_cast<long>(ExtType::Projection));
+        ++changed;
+    }
+
+    if (changed == 0) {
+        return 0;
+    }
+
+    ExternalGeometry.setValues(objects, subElements);
+    ExternalTypes.setValues(types);
+    try {
+        rebuildExternalGeometry();
+    }
+    catch (const Base::Exception& e) {
+        Base::Console().error("%s\n", e.what());
+        ExternalGeometry.setValues(originalObjects, originalSubElements);
+        ExternalTypes.setValues(originalTypes);
+        return -1;
+    }
+
+    acceptGeometry();
+    solverNeedsUpdate = true;
+    return changed;
 }
 // clang-format off
 
@@ -2526,8 +2603,18 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
                 refSubShape = v;
             }
             else {
-                throw Base::TypeError(
-                    "Datum feature type is not yet supported as external geometry for a sketch");
+                auto shape = Part::Feature::getTopoShape(
+                    resolvedObj,
+                    Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform
+                        | Part::ShapeOption::NeedSubElement,
+                    SubElement.c_str()
+                );
+                refSubShape = shape.getShape();
+                if (refSubShape.IsNull()) {
+                    throw Base::TypeError(
+                        "Object does not provide geometry usable as external sketch geometry"
+                    );
+                }
             }
 
             if (projection && !refSubShape.IsNull()) {

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -76,6 +76,25 @@
 using namespace std;
 using namespace SketcherGui;
 
+namespace
+{
+
+bool isExternalGeometryCommandActive(Gui::Document* document)
+{
+    if (document) {
+        auto* activeView = document->getActiveView();
+        if (activeView) {
+            const QVariant capability = activeView->property("SketcherExternalGeometryEnabled");
+            if (capability.isValid() && !capability.toBool()) {
+                return false;
+            }
+        }
+    }
+    return isCommandActive(document);
+}
+
+}  // namespace
+
 #define CONSTRUCTION_UPDATE_ACTION(CLASS, ICON) \
     /* This macro creates an updateAction() function that will toggle between normal & \
      * construction icon */ \
@@ -1856,7 +1875,7 @@ public:
 
     bool isActive() override
     {
-        return isCommandActive(getActiveGuiDocument());
+        return isExternalGeometryCommandActive(getActiveGuiDocument());
     }
 };
 
@@ -1894,7 +1913,7 @@ void CmdSketcherProjection::activated(int iMsg)
 
 bool CmdSketcherProjection::isActive()
 {
-    return isCommandActive(getActiveGuiDocument());
+    return isExternalGeometryCommandActive(getActiveGuiDocument());
 }
 
 // Externals - Intersection ==================================================================
@@ -1931,7 +1950,7 @@ void CmdSketcherIntersection::activated(int iMsg)
 
 bool CmdSketcherIntersection::isActive()
 {
-    return isCommandActive(getActiveGuiDocument());
+    return isExternalGeometryCommandActive(getActiveGuiDocument());
 }
 
 // ======================================================================================

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -76,6 +76,26 @@
 using namespace std;
 using namespace SketcherGui;
 
+namespace
+{
+
+bool isExternalGeometryCommandActive(Gui::Document* document)
+{
+    if (document) {
+        auto* activeView = document->getActiveView();
+        if (activeView) {
+            const QVariant capability =
+                activeView->property("SketcherExternalGeometryEnabled");
+            if (capability.isValid() && !capability.toBool()) {
+                return false;
+            }
+        }
+    }
+    return isCommandActive(document);
+}
+
+}  // namespace
+
 #define CONSTRUCTION_UPDATE_ACTION(CLASS, ICON) \
     /* This macro creates an updateAction() function that will toggle between normal & \
      * construction icon */ \
@@ -1856,7 +1876,7 @@ public:
 
     bool isActive() override
     {
-        return isCommandActive(getActiveGuiDocument());
+        return isExternalGeometryCommandActive(getActiveGuiDocument());
     }
 };
 
@@ -1894,7 +1914,7 @@ void CmdSketcherProjection::activated(int iMsg)
 
 bool CmdSketcherProjection::isActive()
 {
-    return isCommandActive(getActiveGuiDocument());
+    return isExternalGeometryCommandActive(getActiveGuiDocument());
 }
 
 // Externals - Intersection ==================================================================
@@ -1931,7 +1951,7 @@ void CmdSketcherIntersection::activated(int iMsg)
 
 bool CmdSketcherIntersection::isActive()
 {
-    return isCommandActive(getActiveGuiDocument());
+    return isExternalGeometryCommandActive(getActiveGuiDocument());
 }
 
 // ======================================================================================

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -84,8 +84,7 @@ bool isExternalGeometryCommandActive(Gui::Document* document)
     if (document) {
         auto* activeView = document->getActiveView();
         if (activeView) {
-            const QVariant capability =
-                activeView->property("SketcherExternalGeometryEnabled");
+            const QVariant capability = activeView->property("SketcherExternalGeometryEnabled");
             if (capability.isValid() && !capability.toBool()) {
                 return false;
             }

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -982,6 +982,16 @@ EditModeCoinManager::~EditModeCoinManager()
     editModeScenegraphNodes.EditRoot->unref();
 }
 
+void EditModeCoinManager::useLightBackgroundColors()
+{
+    drawingParameters.CurveColor.setValue(0.12F, 0.12F, 0.12F);
+    drawingParameters.CurveDraftColor.setValue(0.10F, 0.30F, 0.70F);
+    drawingParameters.FullyConstrainedColor.setValue(0.00F, 0.45F, 0.10F);
+    drawingParameters.InformationColor.setValue(0.12F, 0.12F, 0.12F);
+    drawingParameters.CursorTextColor.setValue(0.12F, 0.12F, 0.12F);
+    updateInventorColors();
+}
+
 /***** Temporary edit curves and markers *****/
 
 void EditModeCoinManager::drawEditMarkers(

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -323,6 +323,9 @@ public:
 
     void updateElementSizeParameters();
 
+    /// Use colors with sufficient contrast when editing over a light drawing page.
+    void useLightBackgroundColors();
+
 private:
     PreselectionResult detectConstraintPreselection(
         const SoPickedPointList& points,

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -44,6 +44,8 @@
 #include <QListWidget>
 #include <QMenu>
 #include <QMessageBox>
+#include <QMetaObject>
+#include <QPointer>
 #include <QScreen>
 #include <QTextStream>
 #include <QToolTip>
@@ -3531,7 +3533,27 @@ bool ViewProviderSketch::selectAll()
 
 bool ViewProviderSketch::doubleClicked()
 {
-    Gui::Application::Instance->activeDocument()->setEdit(this);
+    Gui::Document* document = Gui::Application::Instance->activeDocument();
+    if (document) {
+        if (auto* activeView = document->getActiveView()) {
+            // TechDraw pages expose this optional hook. Check for it before invoking
+            // so ordinary 3D views do not produce a "No such method" warning.
+            if (activeView->metaObject()->indexOfMethod("editSketchByName(QString)") >= 0) {
+                bool handled = false;
+                const bool invoked = QMetaObject::invokeMethod(
+                    activeView,
+                    "editSketchByName",
+                    Qt::DirectConnection,
+                    Q_RETURN_ARG(bool, handled),
+                    Q_ARG(QString, QString::fromUtf8(getSketchObject()->getNameInDocument()))
+                );
+                if (invoked && handled) {
+                    return true;
+                }
+            }
+        }
+        document->setEdit(this);
+    }
     return true;
 }
 
@@ -4200,6 +4222,10 @@ bool ViewProviderSketch::setEdit(int ModNum)
     preselection.reset();
     selection.reset();
     editCoinManager = std::make_unique<EditModeCoinManager>(*this);
+    if (auto* activeView = getDocument()->getActiveView();
+        activeView && activeView->property("SketcherLightBackground").toBool()) {
+        editCoinManager->useLightBackgroundColors();
+    }
     snapManager = std::make_unique<SnapManager>(*this);
 
 
@@ -4746,7 +4772,27 @@ void ViewProviderSketch::onCameraChanged(SoCamera* cam)
         editCoinManager->updateAxesLength(vpBBox);
     }
 
-    drawGrid(true);
+    if (view && view->property("SketcherDeferredGridUpdate").toBool()) {
+        // Rebuilding the grid mutates its Coin scene graph. Do not do that
+        // re-entrantly from Coin's camera-sensor queue in the TechDraw editor.
+        // Using the view as the invocation context also cancels the callback if
+        // the temporary editor is destroyed before it runs.
+        const QPointer<Gui::View3DInventor> guardedView(view);
+        const std::weak_ptr<void> lifetime(deferredCallbackLifetime);
+        QMetaObject::invokeMethod(
+            view,
+            [this, guardedView, lifetime]() {
+                if (!lifetime.expired() && guardedView && isInEditMode()
+                    && getActiveView() == guardedView) {
+                    drawGrid(true);
+                }
+            },
+            Qt::QueuedConnection
+        );
+    }
+    else {
+        drawGrid(true);
+    }
 }
 
 int ViewProviderSketch::getPreselectPoint() const

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -1079,6 +1079,10 @@ private:
 
     std::unique_ptr<DrawSketchHandlerDragAutoConstraint> dragAutoConstraintHandler;
 
+    // Queued callbacks capture a weak reference to this token before accessing
+    // the view provider, so deleting the provider safely cancels them.
+    std::shared_ptr<void> deferredCallbackLifetime {std::make_shared<int>(0)};
+
     ViewProviderParameters viewProviderParameters;
 
     using Connection = fastsignals::connection;

--- a/src/Mod/TechDraw/App/DrawPage.cpp
+++ b/src/Mod/TechDraw/App/DrawPage.cpp
@@ -20,6 +20,7 @@
  *                                                                         *
  ***************************************************************************/
 
+# include <algorithm>
 # include <sstream>
 
 # include <Precision.hxx>
@@ -231,6 +232,19 @@ int DrawPage::getOrientation() const
 
 int DrawPage::addView(App::DocumentObject* docObj, bool setPosition)
 {
+    if (!docObj) {
+        return -1;
+    }
+
+    if (isSketch(docObj)) {
+        std::vector<App::DocumentObject*> pageItems(Views.getValues());
+        if (std::find(pageItems.begin(), pageItems.end(), docObj) == pageItems.end()) {
+            pageItems.push_back(docObj);
+            Views.setValues(pageItems);
+        }
+        return Views.getSize();
+    }
+
     if (!docObj->isDerivedFrom<DrawView>()
         && !docObj->isDerivedFrom<App::Link>()) {
         return -1;
@@ -280,7 +294,10 @@ int DrawPage::addView(App::DocumentObject* docObj, bool setPosition)
 //Note Views might be removed from document elsewhere so need to check if a View is still in Document here
 int DrawPage::removeView(App::DocumentObject* docObj)
 {
-    if (!docObj->isDerivedFrom<DrawView>() && !docObj->isDerivedFrom<App::Link>()) {
+    if (!docObj
+        || (!docObj->isDerivedFrom<DrawView>()
+            && !docObj->isDerivedFrom<App::Link>()
+            && !isSketch(docObj))) {
         return -1;
     }
 
@@ -391,6 +408,23 @@ std::vector<App::DocumentObject*> DrawPage::getViews() const
         }
     }
     return allViews;
+}
+
+bool DrawPage::isSketch(const App::DocumentObject* obj)
+{
+    return obj
+        && obj->isDerivedFrom(Base::Type::fromName("Sketcher::SketchObject"));
+}
+
+std::vector<App::DocumentObject*> DrawPage::getSketches() const
+{
+    std::vector<App::DocumentObject*> sketches;
+    for (auto* item : Views.getValues()) {
+        if (isSketch(item)) {
+            sketches.push_back(item);
+        }
+    }
+    return sketches;
 }
 
 std::vector<App::DocumentObject*> DrawPage::getAllViews() const

--- a/src/Mod/TechDraw/App/DrawPage.h
+++ b/src/Mod/TechDraw/App/DrawPage.h
@@ -90,6 +90,8 @@ public:
     int getOrientation() const;
     bool isUnsetting() { return nowUnsetting; }
     void requestPaint();
+    static bool isSketch(const App::DocumentObject* obj);
+    std::vector<App::DocumentObject*> getSketches() const;
     std::vector<App::DocumentObject*> getViews() const;
     std::vector<App::DocumentObject*> getAllViews() const;
 

--- a/src/Mod/TechDraw/App/DrawPagePyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawPagePyImp.cpp
@@ -22,6 +22,7 @@
 
 
 #include <App/DocumentObject.h>
+#include <App/DocumentObjectPy.h>
 #include <Base/Console.h>
 
 #include "DrawPage.h"
@@ -48,30 +49,26 @@ std::string DrawPagePy::representation() const
 
 PyObject* DrawPagePy::addView(PyObject* args)
 {
-    PyObject *pcDocObj;
-    if (!PyArg_ParseTuple(args, "O!", &(TechDraw::DrawViewPy::Type), &pcDocObj)) {
+    PyObject* objectPy;
+    if (!PyArg_ParseTuple(args, "O!", &App::DocumentObjectPy::Type, &objectPy)) {
         return nullptr;
     }
 
-    DrawPage* page = getDrawPagePtr();                         //get DrawPage for pyPage
-    DrawViewPy* pyView = static_cast<TechDraw::DrawViewPy*>(pcDocObj);
-    DrawView* view = pyView->getDrawViewPtr();                 //get DrawView for pyView
-    int rc = page->addView(view);
+    auto* object = static_cast<App::DocumentObjectPy*>(objectPy)->getDocumentObjectPtr();
+    int rc = getDrawPagePtr()->addView(object);
 
     return PyLong_FromLong(rc);
 }
 
 PyObject* DrawPagePy::removeView(PyObject* args)
 {
-    PyObject *pcDocObj;
-    if (!PyArg_ParseTuple(args, "O!", &(TechDraw::DrawViewPy::Type), &pcDocObj)) {
+    PyObject* objectPy;
+    if (!PyArg_ParseTuple(args, "O!", &App::DocumentObjectPy::Type, &objectPy)) {
         return nullptr;
     }
 
-    DrawPage* page = getDrawPagePtr();                         //get DrawPage for pyPage
-    DrawViewPy* pyView = static_cast<TechDraw::DrawViewPy*>(pcDocObj);
-    DrawView* view = pyView->getDrawViewPtr();                 //get DrawView for pyView
-    int rc = page->removeView(view);
+    auto* object = static_cast<App::DocumentObjectPy*>(objectPy)->getDocumentObjectPtr();
+    int rc = getDrawPagePtr()->removeView(object);
 
     return PyLong_FromLong(rc);
 }

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -103,8 +103,36 @@ DrawView::DrawView():
     Scale.setConstraints(&scaleRange);
 
     ADD_PROPERTY_TYPE(Caption, (""), group, App::Prop_Output, "Short text about the view");
+    ADD_PROPERTY_TYPE(Sketches, (nullptr), group, App::Prop_None,
+                      "Sketch geometry drawn relative to this view");
+    // Sketch membership is a presentation relationship. Keeping it out of
+    // the dependency DAG also permits a sketch to reference projected edges
+    // of its owning view without creating a cycle.
+    Sketches.setScope(App::LinkScope::Hidden);
 
     setScaleAttribute();
+}
+
+int DrawView::addSketch(App::DocumentObject* sketch)
+{
+    if (!DrawPage::isSketch(sketch)) {
+        return -1;
+    }
+
+    auto sketches = Sketches.getValues();
+    if (std::find(sketches.begin(), sketches.end(), sketch) == sketches.end()) {
+        sketches.push_back(sketch);
+        Sketches.setValues(sketches);
+    }
+    return Sketches.getSize();
+}
+
+int DrawView::removeSketch(App::DocumentObject* sketch)
+{
+    auto sketches = Sketches.getValues();
+    std::erase(sketches, sketch);
+    Sketches.setValues(sketches);
+    return Sketches.getSize();
 }
 
 

--- a/src/Mod/TechDraw/App/DrawView.h
+++ b/src/Mod/TechDraw/App/DrawView.h
@@ -28,6 +28,7 @@
 
 #include <App/DocumentObject.h>
 #include <App/FeaturePython.h>
+#include <App/PropertyLinks.h>
 #include <App/PropertyUnits.h>
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
@@ -61,6 +62,7 @@ public:
     App::PropertyEnumeration ScaleType;
     App::PropertyAngle Rotation;
     App::PropertyString Caption;
+    App::PropertyLinkList Sketches;
 
     /** @name methods override Feature */
     //@{
@@ -124,6 +126,9 @@ public:
     void translateLabel(std::string context, std::string baseName, std::string uniqueName);
 
     virtual App::PropertyLink *getOwnerProperty() { return nullptr; }
+
+    int addSketch(App::DocumentObject* sketch);
+    int removeSketch(App::DocumentObject* sketch);
 
     static bool isProjGroupItem(DrawViewPart* item);
 

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -61,6 +61,7 @@
 #include <gp_Pln.hxx>
 #include <gp_Pnt.hxx>
 #include <sstream>
+#include <cstring>
 
 
 #include <App/Document.h>
@@ -70,6 +71,8 @@
 #include <Base/Exception.h>
 #include <Base/Parameter.h>
 #include <Base/Tools.h>
+#include <Mod/Part/App/PartPyCXX.h>
+#include <Mod/Part/App/TopoShape.h>
 
 #include "Cosmetic.h"
 #include "CenterLine.h"
@@ -850,6 +853,50 @@ TechDraw::BaseGeomPtr DrawViewPart::getEdge(std::string edgeName) const
         return nullptr;
     }
     return geoms.at(iEdge);
+}
+
+App::DocumentObject* DrawViewPart::getSubObject(const char* subname,
+                                                PyObject** pyObj,
+                                                Base::Matrix4D* mat,
+                                                bool transform,
+                                                int depth) const
+{
+    while (subname && *subname == '.') {
+        ++subname;
+    }
+
+    if (!subname || std::strncmp(subname, "Edge", 4) != 0 || !subname[4]) {
+        return DrawView::getSubObject(subname, pyObj, mat, transform, depth);
+    }
+
+    try {
+        const auto edge = getEdge(subname);
+        if (!edge) {
+            return nullptr;
+        }
+        if (pyObj) {
+            // GeometryObject stores projected edges in the same inverted-Y
+            // coordinate system used by the Qt page. Sketcher uses a
+            // conventional right-handed XY plane, so convert the edge before
+            // removing the view's presentation rotation and scale.
+            TopoDS_Shape localEdge = ShapeUtils::fromQt(edge->getOCCEdge());
+            const gp_Ax2 localAxes;
+            if (!DrawUtil::fpCompare(Rotation.getValue(), 0.0)) {
+                localEdge =
+                    ShapeUtils::rotateShape(localEdge, localAxes, -Rotation.getValue());
+            }
+            const double viewScale = getScale();
+            if (!DrawUtil::fpCompare(viewScale, 1.0) && viewScale > Precision::Confusion()) {
+                localEdge = ShapeUtils::scaleShape(localEdge, 1.0 / viewScale);
+            }
+            Part::TopoShape shape(localEdge, getID(), getDocument()->getStringHasher());
+            *pyObj = Py::new_reference_to(Part::shape2pyshape(shape));
+        }
+        return const_cast<DrawViewPart*>(this);
+    }
+    catch (const Base::Exception&) {
+        return nullptr;
+    }
 }
 
 

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -138,6 +138,11 @@ public:
     App::DocumentObjectExecReturn* execute() override;
     const char* getViewProviderName() const override { return "TechDrawGui::ViewProviderViewPart"; }
     PyObject* getPyObject() override;
+    App::DocumentObject* getSubObject(const char* subname,
+                                      PyObject** pyObj = nullptr,
+                                      Base::Matrix4D* mat = nullptr,
+                                      bool transform = true,
+                                      int depth = 0) const override;
     void handleChangedPropertyType(
         Base::XMLReader &reader, const char * TypeName, App::Property * prop) override;
 

--- a/src/Mod/TechDraw/CMakeLists.txt
+++ b/src/Mod/TechDraw/CMakeLists.txt
@@ -177,6 +177,7 @@ endif(BUILD_GUI)
 SET(TDTest_SRCS
     TDTest/__init__.py
     TDTest/DrawHatchTest.py
+    TDTest/DrawPageSketchTest.py
     TDTest/DrawProjectionGroupTest.py
     TDTest/DrawViewAnnotationTest.py
     TDTest/DrawViewImageTest.py
@@ -212,4 +213,3 @@ fc_copy_sources(TDTestTarget "${CMAKE_BINARY_DIR}/Mod/TechDraw" ${TDAllTest})
 # install Python packages (for make install)
 INSTALL(FILES ${TDTest_SRCS} DESTINATION Mod/TechDraw/TDTest)
 INSTALL(FILES ${TDTestFile_SRCS} DESTINATION Mod/TechDraw/TDTest)
-

--- a/src/Mod/TechDraw/Gui/CMakeLists.txt
+++ b/src/Mod/TechDraw/Gui/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TechDrawGui_XML_SRCS
 
 set(TechDrawGui_LIBS
     TechDraw
+    Sketcher
     FreeCADGui
 )
 
@@ -190,6 +191,8 @@ SET(TechDrawGui_SRCS
     TaskActiveView.h
     Grabber3d.cpp
     Grabber3d.h
+    TaskNewSketch.cpp
+    TaskNewSketch.h
     TaskDetail.ui
     TaskDetail.cpp
     TaskDetail.h
@@ -226,6 +229,8 @@ SET(TechDrawGui_SRCS
 SET(TechDrawGuiView_SRCS
     MDIViewPage.cpp
     MDIViewPage.h
+    TechDrawSketchEditView.cpp
+    TechDrawSketchEditView.h
     PagePrinter.cpp
     PagePrinter.h
     QGVPage.cpp
@@ -300,6 +305,8 @@ SET(TechDrawGuiView_SRCS
     QGIDimLines.h
     QGISectionLine.cpp
     QGISectionLine.h
+    QGISketch.cpp
+    QGISketch.h
     QGIDecoration.cpp
     QGIDecoration.h
     QGICenterLine.cpp

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -73,6 +73,7 @@
 #include "TaskComplexSection.h"
 #include "TaskDetail.h"
 #include "TaskProjGroup.h"
+#include "TaskNewSketch.h"
 #include "TaskProjection.h"
 #include "TaskSectionView.h"
 #include "ViewProviderPage.h"
@@ -259,6 +260,42 @@ bool CmdTechDrawRedrawPage::isActive()
     bool havePage = DrawGuiUtil::needPage(this);
     bool haveView = DrawGuiUtil::needView(this, false);
     return (havePage && haveView);
+}
+
+//===========================================================================
+// TechDraw_NewSketch
+//===========================================================================
+
+DEF_STD_CMD_A(CmdTechDrawNewSketch)
+
+CmdTechDrawNewSketch::CmdTechDrawNewSketch()
+    : Command("TechDraw_NewSketch")
+{
+    sAppModule = "TechDraw";
+    sGroup = QT_TR_NOOP("TechDraw");
+    sMenuText = QT_TR_NOOP("New Sketch");
+    sToolTipText = QT_TR_NOOP("Creates a sketch on the current page or one of its views");
+    sWhatsThis = "TechDraw_NewSketch";
+    sStatusTip = sToolTipText;
+    sPixmap = "actions/TechDraw_NewSketch";
+}
+
+void CmdTechDrawNewSketch::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    if (Gui::Control().activeDialog()) {
+        return;
+    }
+
+    auto* page = DrawGuiUtil::findPage(this);
+    if (page) {
+        Gui::Control().showDialog(new TaskDlgNewSketch(page));
+    }
+}
+
+bool CmdTechDrawNewSketch::isActive()
+{
+    return hasActiveDocument() && DrawGuiUtil::needPage(this);
 }
 
 //===========================================================================
@@ -1962,6 +1999,7 @@ void CreateTechDrawCommands()
     rcCmdMgr.addCommand(new CmdTechDrawClipGroup());
     rcCmdMgr.addCommand(new CmdTechDrawClipGroupAdd());
     rcCmdMgr.addCommand(new CmdTechDrawClipGroupRemove());
+    rcCmdMgr.addCommand(new CmdTechDrawNewSketch());
     rcCmdMgr.addCommand(new CmdTechDrawSymbol());
     rcCmdMgr.addCommand(new CmdTechDrawExportPageSVG());
     rcCmdMgr.addCommand(new CmdTechDrawExportPageDXF());

--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
@@ -22,7 +22,9 @@
  ***************************************************************************/
 
 
-# include <sstream>
+#include <algorithm>
+#include <set>
+#include <sstream>
 
 #include <QBitmap>
 #include <QColor>
@@ -41,6 +43,7 @@
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
+#include <App/ElementNamingUtils.h>
 #include <App/PropertyPythonObject.h>
 #include <Base/Console.h>
 #include <Base/Exception.h>
@@ -59,6 +62,8 @@
 #include <Gui/PrefWidgets.h>
 #include <Inventor/SbVec3f.h>
 
+#include <Mod/Sketcher/App/ExternalGeometryFacade.h>
+#include <Mod/Sketcher/App/SketchObject.h>
 #include <Mod/TechDraw/App/ArrowPropEnum.h>
 #include <Mod/TechDraw/App/BalloonPropEnum.h>
 #include <Mod/TechDraw/App/LineNameEnum.h>
@@ -83,6 +88,72 @@
 using namespace TechDrawGui;
 using namespace TechDraw;
 using DU = DrawUtil;
+
+void DrawGuiUtil::detachSketchFromTechDraw(App::DocumentObject* sketch)
+{
+    if (!DrawPage::isSketch(sketch) || !sketch->getDocument()) {
+        return;
+    }
+
+    std::vector<DrawView*> owners;
+    std::vector<DrawPage*> pages;
+    for (auto* object : sketch->getDocument()->getObjects()) {
+        if (auto* view = freecad_cast<DrawView*>(object)) {
+            const auto sketches = view->Sketches.getValues();
+            if (std::find(sketches.begin(), sketches.end(), sketch) != sketches.end()) {
+                owners.push_back(view);
+            }
+        }
+        else if (auto* page = freecad_cast<DrawPage*>(object)) {
+            const auto pageObjects = page->Views.getValues();
+            if (std::find(pageObjects.begin(), pageObjects.end(), sketch) != pageObjects.end()) {
+                pages.push_back(page);
+            }
+        }
+    }
+
+    // External geometry generated for an owning view is meaningful only while
+    // the sketch remains attached to that view.
+    if (auto* sketchObject = freecad_cast<Sketcher::SketchObject*>(sketch)) {
+        const auto linkedObjects = sketchObject->ExternalGeometry.getValues();
+        const auto linkedSubElements = sketchObject->ExternalGeometry.getSubValues(false);
+        std::set<std::string> ownerReferences;
+        const std::size_t linkCount = std::min(linkedObjects.size(), linkedSubElements.size());
+        for (std::size_t index = 0; index < linkCount; ++index) {
+            auto* linkedObject = linkedObjects[index];
+            if (std::find(owners.begin(), owners.end(), linkedObject) == owners.end()) {
+                continue;
+            }
+            ownerReferences.insert(
+                std::string(linkedObject->getNameInDocument()) + '.'
+                + Data::newElementName(linkedSubElements[index].c_str())
+            );
+        }
+
+        std::vector<int> externalIds;
+        const auto& externalGeometry = sketchObject->getExternalGeometry();
+        // ExternalGeo slots 0 and 1 are the sketch axes. delExternal(0)
+        // addresses slot 2, and removes the complete expanded reference group.
+        for (std::size_t index = 2; index < externalGeometry.size(); ++index) {
+            const auto facade = Sketcher::ExternalGeometryFacade::getFacade(
+                externalGeometry[index]
+            );
+            if (facade && ownerReferences.erase(facade->getRef()) != 0) {
+                externalIds.push_back(static_cast<int>(index) - 2);
+            }
+        }
+        if (!externalIds.empty()) {
+            sketchObject->delExternal(externalIds);
+        }
+    }
+
+    for (auto* owner : owners) {
+        owner->removeSketch(sketch);
+    }
+    for (auto* page : pages) {
+        page->removeView(sketch);
+    }
+}
 
 void DrawGuiUtil::loadArrowBox(QComboBox* qcb)
 {

--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.h
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.h
@@ -95,6 +95,7 @@ class TechDrawGuiExport DrawGuiUtil {
     static Base::Vector3d fromSceneCoords(const Base::Vector3d& sceneCoord, bool invert = true);
     static Base::Vector3d toSceneCoords(const Base::Vector3d& pageCoord, bool invert = true);
     static Base::Vector3d toGuiPoint(TechDraw::DrawView* obj, const Base::Vector3d& toConvert);
+    static void detachSketchFromTechDraw(App::DocumentObject* sketch);
 
     static bool findObjectInSelection(const std::vector<Gui::SelectionObject>& selection,
                                       const App::DocumentObject& targetObject);

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -65,6 +65,7 @@
 #include "QGIDatumLabel.h"
 #include "QGIEdge.h"
 #include "QGIFace.h"
+#include "QGISketch.h"
 #include "QGIVertex.h"
 #include "QGIView.h"
 #include "QGIViewDimension.h"
@@ -74,6 +75,7 @@
 #include "ViewProviderPage.h"
 #include "PagePrinter.h"
 #include "PreferencesGui.h"
+#include "TechDrawSketchEditView.h"
 
 using namespace TechDrawGui;
 using namespace TechDraw;
@@ -140,6 +142,50 @@ void MDIViewPage::setScene(QGSPage* scene, QGVPage* viewWidget)
     m_scene = scene;
     setCentralWidget(viewWidget);//this makes viewWidget a Qt child of MDIViewPage
     QObject::connect(scene, &QGSPage::selectionChanged, this, &MDIViewPage::sceneSelectionChanged);
+}
+
+bool MDIViewPage::editSketch(App::DocumentObject* sketch, TechDraw::DrawView* owner)
+{
+    if (!sketch || !TechDraw::DrawPage::isSketch(sketch) || !getGuiDocument()) {
+        return false;
+    }
+
+    auto* editView = new TechDrawSketchEditView(getGuiDocument(), this, sketch, owner);
+    if (!editView->startSketchEdit()) {
+        if (auto* subWindow = qobject_cast<QMdiSubWindow*>(editView->parentWidget())) {
+            subWindow->close();
+        }
+        else {
+            editView->deleteLater();
+        }
+        return false;
+    }
+    return true;
+}
+
+bool MDIViewPage::editSketchByName(const QString& sketchName)
+{
+    if (!getAppDocument() || !m_scene) {
+        return false;
+    }
+
+    const QByteArray objectName = sketchName.toUtf8();
+    App::DocumentObject* sketch = getAppDocument()->getObject(objectName.constData());
+    if (!sketch || !m_scene->findSketchForDocObj(sketch)) {
+        return false;
+    }
+
+    return editSketch(sketch, m_scene->findSketchOwner(sketch));
+}
+
+bool MDIViewPage::containsViewProvider(const Gui::ViewProvider* viewProvider) const
+{
+    auto* documentViewProvider =
+        freecad_cast<const Gui::ViewProviderDocumentObject*>(viewProvider);
+    App::DocumentObject* object =
+        documentViewProvider ? documentViewProvider->getObject() : nullptr;
+    return viewProvider == m_vpPage
+        || (object && getPage() && getPage()->hasObject(object));
 }
 
 void MDIViewPage::setDocumentObject(const std::string& name)
@@ -730,6 +776,9 @@ void MDIViewPage::clearSceneSelection()
             item->updateView();
         }
     }
+    for (auto* sketch : m_scene->getSketches()) {
+        sketch->setGroupSelection(false);
+    }
 }
 
 //!Update QGIView's selection state based on Selection made outside Drawing Interface
@@ -740,6 +789,9 @@ void MDIViewPage::selectQGIView(App::DocumentObject *obj, bool isSelected,
     if (view) {
         view->setGroupSelection(isSelected, subNames);
         view->updateView();
+    }
+    else if (auto* sketch = m_scene->findSketchForDocObj(obj)) {
+        sketch->setGroupSelection(isSelected);
     }
 }
 
@@ -757,7 +809,8 @@ void MDIViewPage::onSelectionChanged(const Gui::SelectionChanges& msg)
             std::vector<Gui::SelectionObject> selObjs = Gui::Selection().getSelectionEx(msg.pDocName);
             for (auto &so : selObjs) {
                 App::DocumentObject *docObj = so.getObject();
-                if (docObj->isDerivedFrom<TechDraw::DrawView>()) {
+                if (docObj->isDerivedFrom<TechDraw::DrawView>()
+                    || TechDraw::DrawPage::isSketch(docObj)) {
                     selectQGIView(docObj, true, so.getSubNames());
                 }
             }
@@ -765,7 +818,8 @@ void MDIViewPage::onSelectionChanged(const Gui::SelectionChanges& msg)
     }
     else if (msg.Type == Gui::SelectionChanges::AddSelection || msg.Type == Gui::SelectionChanges::RmvSelection) {
         App::DocumentObject *docObj = msg.Object.getSubObject();
-        if (docObj->isDerivedFrom<TechDraw::DrawView>()) {
+        if (docObj->isDerivedFrom<TechDraw::DrawView>()
+            || TechDraw::DrawPage::isSketch(docObj)) {
             bool isSelected = msg.Type != Gui::SelectionChanges::RmvSelection;
             selectQGIView(docObj, isSelected, std::vector(1, std::string(msg.pSubName ? msg.pSubName : "")));
         }
@@ -869,6 +923,15 @@ void MDIViewPage::setTreeToSceneSelect()
     Gui::Selection().clearSelection();
 
     for (auto* scene : m_orderedSceneSelection) {
+        if (auto* sketchItem = dynamic_cast<QGISketch*>(scene)) {
+            auto* sketch = sketchItem->getSketchObject();
+            if (sketch && !sketch->isRemoving()) {
+                Gui::Selection().addSelection(sketch->getDocument()->getName(),
+                                              sketch->getNameInDocument());
+            }
+            continue;
+        }
+
         auto* itemView = dynamic_cast<QGIView*>(scene);
         if (!itemView) {
             auto* parent = dynamic_cast<QGIView*>(scene->parentItem());
@@ -938,6 +1001,16 @@ std::string MDIViewPage::getSceneSubName(QGraphicsItem* scene)
 // adds scene to core selection if it's not in already.
 void MDIViewPage::addSceneItemToTreeSel(QGraphicsItem* sn, [[maybe_unused]]std::vector<Gui::SelectionObject> treeSel)
 {
+    if (auto* sketchItem = dynamic_cast<QGISketch*>(sn)) {
+        auto* sketch = sketchItem->getSketchObject();
+        if (sketch && !sketch->isRemoving() && !Gui::Selection().isSelected(sketch)) {
+            Gui::Selection().addSelection(sketch->getDocument()->getName(),
+                                          sketch->getNameInDocument());
+            showStatusMsg(sketch->getDocument()->getName(), sketch->getNameInDocument(), "");
+        }
+        return;
+    }
+
     auto* itemView = dynamic_cast<QGIView*>(sn);
     if (!itemView) {
         auto* parent = dynamic_cast<QGIView*>(sn->parentItem());
@@ -997,6 +1070,16 @@ void MDIViewPage::removeUnselectedTreeSelection(QList<QGraphicsItem*> sceneSelec
     if (treeSelection.getSubNames().empty()) {
         bool matchFound{false};
         for (auto& sceneItem : sceneSelectedItems) {
+            if (auto* sketchItem = dynamic_cast<QGISketch*>(sceneItem)) {
+                auto* sketch = sketchItem->getSketchObject();
+                if (sketch && selDocName == sketch->getDocument()->getName()
+                    && selObj == sketch) {
+                    matchFound = true;
+                    break;
+                }
+                continue;
+            }
+
             auto* itemView = dynamic_cast<QGIView*>(sceneItem);
             if (!itemView) {
                 continue;

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -42,6 +42,7 @@ namespace TechDraw {
 class DrawPage;
 class DrawTemplate;
 class DrawView;
+class DrawViewPart;
 }
 
 namespace TechDrawGui
@@ -74,6 +75,7 @@ public:
 
     bool onMsg(const char* pMsg) override;
     bool onHasMsg(const char* pMsg) const override;
+    bool containsViewProvider(const Gui::ViewProvider* viewProvider) const override;
     void onRelabel(Gui::Document* pDoc) override;
 
     void print() override;
@@ -98,7 +100,7 @@ public:
     void setDocumentName(const std::string&);
 
     PyObject* getPyObject() override;
-    TechDraw::DrawPage * getPage() { return m_vpPage->getDrawPage(); }
+    TechDraw::DrawPage* getPage() const { return m_vpPage->getDrawPage(); }
     ViewProviderPage* getViewProviderPage() const {return m_vpPage;}
 
     void setTabText(std::string tabText);
@@ -108,6 +110,8 @@ public:
 
     void setScene(QGSPage* scene, QGVPage* view);
     void fixSceneDependencies();
+    bool editSketch(App::DocumentObject* sketch, TechDraw::DrawView* owner);
+    Q_INVOKABLE bool editSketchByName(const QString& sketchName);
 
     void setDimensionsSelectability(bool val);
     void enableContextualMenu(bool val) { isContextualMenuEnabled = val; }

--- a/src/Mod/TechDraw/Gui/QGISketch.cpp
+++ b/src/Mod/TechDraw/Gui/QGISketch.cpp
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2026 AstoCAD     <hello@astocad.com>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include <BRepAdaptor_Curve.hxx>
+#include <GCPnts_UniformDeflection.hxx>
+#include <TopAbs_ShapeEnum.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+
+#include <QGraphicsPathItem>
+#include <QPainterPath>
+
+#include <App/DocumentObject.h>
+#include <App/PropertyStandard.h>
+#include <Gui/Application.h>
+#include <Gui/ViewProvider.h>
+#include <Mod/Part/App/PartFeature.h>
+#include <Mod/TechDraw/App/DrawPage.h>
+#include <Mod/TechDraw/App/DrawView.h>
+
+#include "DrawGuiUtil.h"
+#include "PreferencesGui.h"
+#include "QGISketch.h"
+#include "Rez.h"
+#include "ZVALUE.h"
+
+using namespace TechDrawGui;
+
+namespace
+{
+QPointF toPagePoint(const gp_Pnt& point, TechDraw::DrawView* owner)
+{
+    if (owner) {
+        const Base::Vector3d sketchPoint(point.X(), point.Y(), 0.0);
+        const Base::Vector3d converted = DrawGuiUtil::toGuiPoint(owner, sketchPoint);
+        return {converted.x, converted.y};
+    }
+    return {Rez::guiX(point.X()), -Rez::guiX(point.Y())};
+}
+}
+
+QGISketch::QGISketch(App::DocumentObject* sketch, TechDraw::DrawView* owner)
+    : m_sketch(sketch),
+      m_owner(owner),
+      m_geometry(new QGraphicsPathItem(this)),
+      m_normalPen(PreferencesGui::normalQColor()),
+      m_selectedPen(PreferencesGui::selectQColor())
+{
+    setData(0, QStringLiteral("QGISketch"));
+    if (m_sketch && m_sketch->getNameInDocument()) {
+        setData(1, QString::fromUtf8(m_sketch->getNameInDocument()));
+    }
+
+    setFlag(QGraphicsItem::ItemIsSelectable, true);
+    setHandlesChildEvents(true);
+    setZValue(ZVALUE::EDGE);
+
+    m_geometry->setBrush(Qt::NoBrush);
+
+    updateView();
+}
+
+App::DocumentObject* QGISketch::getSketchObject() const
+{
+    return m_sketch;
+}
+
+TechDraw::DrawView* QGISketch::getOwnerView() const
+{
+    return m_owner;
+}
+
+void QGISketch::setOwnerView(TechDraw::DrawView* owner)
+{
+    m_owner = owner;
+    updateView();
+}
+
+void QGISketch::updateView()
+{
+    updatePens();
+
+    QPainterPath path;
+    auto* feature = dynamic_cast<Part::Feature*>(m_sketch);
+    if (!feature || !TechDraw::DrawPage::isSketch(feature)) {
+        m_geometry->setPath(path);
+        return;
+    }
+
+    const TopoDS_Shape shape = feature->Shape.getValue();
+    for (TopExp_Explorer explorer(shape, TopAbs_EDGE); explorer.More(); explorer.Next()) {
+        const TopoDS_Edge edge = TopoDS::Edge(explorer.Current());
+        BRepAdaptor_Curve curve(edge);
+
+        if (curve.GetType() == GeomAbs_Line) {
+            path.moveTo(toPagePoint(curve.Value(curve.FirstParameter()), m_owner));
+            path.lineTo(toPagePoint(curve.Value(curve.LastParameter()), m_owner));
+            continue;
+        }
+
+        GCPnts_UniformDeflection discretizer(curve, 0.05);
+        if (!discretizer.IsDone() || discretizer.NbPoints() == 0) {
+            continue;
+        }
+
+        for (int i = 1; i <= discretizer.NbPoints(); ++i) {
+            const QPointF point =
+                toPagePoint(curve.Value(discretizer.Parameter(i)), m_owner);
+            if (i == 1) {
+                path.moveTo(point);
+            }
+            else {
+                path.lineTo(point);
+            }
+        }
+    }
+
+    m_geometry->setPath(path);
+}
+
+void QGISketch::updatePens()
+{
+    QColor normalColor = PreferencesGui::normalQColor();
+    qreal width = 1.0;
+    Qt::PenStyle style = Qt::SolidLine;
+
+    Gui::ViewProvider* viewProvider = m_sketch
+        ? Gui::Application::Instance->getViewProvider(m_sketch)
+        : nullptr;
+
+    if (viewProvider) {
+        if (auto* lineWidth = dynamic_cast<App::PropertyFloat*>(
+                viewProvider->getPropertyByName("LineWidth"))) {
+            width = lineWidth->getValue();
+        }
+
+        if (auto* drawStyle = dynamic_cast<App::PropertyEnumeration*>(
+                viewProvider->getPropertyByName("DrawStyle"))) {
+            // ViewProviderPartExt uses the same order as Qt: solid, dash,
+            // dot and dash-dot, with Qt::SolidLine starting at 1.
+            const int qtStyle = drawStyle->getValue() + static_cast<int>(Qt::SolidLine);
+            if (qtStyle >= static_cast<int>(Qt::SolidLine)
+                && qtStyle <= static_cast<int>(Qt::DashDotLine)) {
+                style = static_cast<Qt::PenStyle>(qtStyle);
+            }
+        }
+
+        auto* autoColor = dynamic_cast<App::PropertyBool*>(
+            viewProvider->getPropertyByName("AutoColor"));
+        if ((!autoColor || !autoColor->getValue())) {
+            if (auto* lineColor = dynamic_cast<App::PropertyColor*>(
+                    viewProvider->getPropertyByName("LineColor"))) {
+                normalColor = lineColor->getValue().asValue<QColor>();
+            }
+        }
+    }
+
+    m_normalPen = QPen(normalColor, width, style);
+    m_normalPen.setCosmetic(true);
+    m_selectedPen = QPen(PreferencesGui::selectQColor(), width, style);
+    m_selectedPen.setCosmetic(true);
+    m_geometry->setPen(isSelected() ? m_selectedPen : m_normalPen);
+}
+
+void QGISketch::setGroupSelection(bool selected)
+{
+    setSelected(selected);
+}
+
+QVariant QGISketch::itemChange(GraphicsItemChange change, const QVariant& value)
+{
+    if (change == ItemSelectedHasChanged) {
+        m_geometry->setPen(value.toBool() ? m_selectedPen : m_normalPen);
+    }
+    return QGraphicsItemGroup::itemChange(change, value);
+}

--- a/src/Mod/TechDraw/Gui/QGISketch.cpp
+++ b/src/Mod/TechDraw/Gui/QGISketch.cpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2026 AstoCAD     <hello@astocad.com>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include <BRepAdaptor_Curve.hxx>
+#include <GCPnts_UniformDeflection.hxx>
+#include <TopAbs_ShapeEnum.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+
+#include <QGraphicsPathItem>
+#include <QPainterPath>
+
+#include <App/DocumentObject.h>
+#include <Mod/Part/App/PartFeature.h>
+#include <Mod/TechDraw/App/DrawPage.h>
+#include <Mod/TechDraw/App/DrawView.h>
+
+#include "DrawGuiUtil.h"
+#include "PreferencesGui.h"
+#include "QGISketch.h"
+#include "Rez.h"
+#include "ZVALUE.h"
+
+using namespace TechDrawGui;
+
+namespace
+{
+QPointF toPagePoint(const gp_Pnt& point, TechDraw::DrawView* owner)
+{
+    if (owner) {
+        const Base::Vector3d sketchPoint(point.X(), point.Y(), 0.0);
+        const Base::Vector3d converted = DrawGuiUtil::toGuiPoint(owner, sketchPoint);
+        return {converted.x, converted.y};
+    }
+    return {Rez::guiX(point.X()), -Rez::guiX(point.Y())};
+}
+}
+
+QGISketch::QGISketch(App::DocumentObject* sketch, TechDraw::DrawView* owner)
+    : m_sketch(sketch),
+      m_owner(owner),
+      m_geometry(new QGraphicsPathItem(this)),
+      m_normalPen(PreferencesGui::normalQColor()),
+      m_selectedPen(PreferencesGui::selectQColor())
+{
+    setData(0, QStringLiteral("QGISketch"));
+    if (m_sketch && m_sketch->getNameInDocument()) {
+        setData(1, QString::fromUtf8(m_sketch->getNameInDocument()));
+    }
+
+    setFlag(QGraphicsItem::ItemIsSelectable, true);
+    setHandlesChildEvents(true);
+    setZValue(ZVALUE::EDGE);
+
+    m_normalPen.setCosmetic(true);
+    m_normalPen.setWidth(0);
+    m_selectedPen.setCosmetic(true);
+    m_selectedPen.setWidth(0);
+    m_geometry->setPen(m_normalPen);
+    m_geometry->setBrush(Qt::NoBrush);
+
+    updateView();
+}
+
+App::DocumentObject* QGISketch::getSketchObject() const
+{
+    return m_sketch;
+}
+
+TechDraw::DrawView* QGISketch::getOwnerView() const
+{
+    return m_owner;
+}
+
+void QGISketch::setOwnerView(TechDraw::DrawView* owner)
+{
+    m_owner = owner;
+    updateView();
+}
+
+void QGISketch::updateView()
+{
+    QPainterPath path;
+    auto* feature = dynamic_cast<Part::Feature*>(m_sketch);
+    if (!feature || !TechDraw::DrawPage::isSketch(feature)) {
+        m_geometry->setPath(path);
+        return;
+    }
+
+    const TopoDS_Shape shape = feature->Shape.getValue();
+    for (TopExp_Explorer explorer(shape, TopAbs_EDGE); explorer.More(); explorer.Next()) {
+        const TopoDS_Edge edge = TopoDS::Edge(explorer.Current());
+        BRepAdaptor_Curve curve(edge);
+
+        if (curve.GetType() == GeomAbs_Line) {
+            path.moveTo(toPagePoint(curve.Value(curve.FirstParameter()), m_owner));
+            path.lineTo(toPagePoint(curve.Value(curve.LastParameter()), m_owner));
+            continue;
+        }
+
+        GCPnts_UniformDeflection discretizer(curve, 0.05);
+        if (!discretizer.IsDone() || discretizer.NbPoints() == 0) {
+            continue;
+        }
+
+        for (int i = 1; i <= discretizer.NbPoints(); ++i) {
+            const QPointF point =
+                toPagePoint(curve.Value(discretizer.Parameter(i)), m_owner);
+            if (i == 1) {
+                path.moveTo(point);
+            }
+            else {
+                path.lineTo(point);
+            }
+        }
+    }
+
+    m_geometry->setPath(path);
+}
+
+void QGISketch::setGroupSelection(bool selected)
+{
+    setSelected(selected);
+}
+
+QVariant QGISketch::itemChange(GraphicsItemChange change, const QVariant& value)
+{
+    if (change == ItemSelectedHasChanged) {
+        m_geometry->setPen(value.toBool() ? m_selectedPen : m_normalPen);
+    }
+    return QGraphicsItemGroup::itemChange(change, value);
+}

--- a/src/Mod/TechDraw/Gui/QGISketch.h
+++ b/src/Mod/TechDraw/Gui/QGISketch.h
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2026 AstoCAD     <hello@astocad.com>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <QGraphicsItemGroup>
+#include <QPen>
+
+#include <Mod/TechDraw/TechDrawGlobal.h>
+
+#include "QGIUserTypes.h"
+
+class QGraphicsPathItem;
+
+namespace App
+{
+class DocumentObject;
+}
+
+namespace TechDraw
+{
+class DrawView;
+}
+
+namespace TechDrawGui
+{
+
+class TechDrawGuiExport QGISketch: public QGraphicsItemGroup
+{
+public:
+    explicit QGISketch(App::DocumentObject* sketch, TechDraw::DrawView* owner = nullptr);
+    ~QGISketch() override = default;
+
+    enum {Type = UserType::QGISketch};
+    int type() const override { return Type; }
+
+    App::DocumentObject* getSketchObject() const;
+    TechDraw::DrawView* getOwnerView() const;
+    void setOwnerView(TechDraw::DrawView* owner);
+    void updateView();
+    void setGroupSelection(bool selected);
+
+protected:
+    QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
+
+private:
+    void updatePens();
+
+    App::DocumentObject* m_sketch;
+    TechDraw::DrawView* m_owner;
+    QGraphicsPathItem* m_geometry;
+    QPen m_normalPen;
+    QPen m_selectedPen;
+};
+
+}  // namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGISketch.h
+++ b/src/Mod/TechDraw/Gui/QGISketch.h
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2026 AstoCAD     <hello@astocad.com>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <QGraphicsItemGroup>
+#include <QPen>
+
+#include <Mod/TechDraw/TechDrawGlobal.h>
+
+#include "QGIUserTypes.h"
+
+class QGraphicsPathItem;
+
+namespace App
+{
+class DocumentObject;
+}
+
+namespace TechDraw
+{
+class DrawView;
+}
+
+namespace TechDrawGui
+{
+
+class TechDrawGuiExport QGISketch: public QGraphicsItemGroup
+{
+public:
+    explicit QGISketch(App::DocumentObject* sketch, TechDraw::DrawView* owner = nullptr);
+    ~QGISketch() override = default;
+
+    enum {Type = UserType::QGISketch};
+    int type() const override { return Type; }
+
+    App::DocumentObject* getSketchObject() const;
+    TechDraw::DrawView* getOwnerView() const;
+    void setOwnerView(TechDraw::DrawView* owner);
+    void updateView();
+    void setGroupSelection(bool selected);
+
+protected:
+    QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
+
+private:
+    App::DocumentObject* m_sketch;
+    TechDraw::DrawView* m_owner;
+    QGraphicsPathItem* m_geometry;
+    QPen m_normalPen;
+    QPen m_selectedPen;
+};
+
+}  // namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGIUserTypes.h
+++ b/src/Mod/TechDraw/Gui/QGIUserTypes.h
@@ -83,7 +83,8 @@ enum : int {
     QGMarker,
     QGMText,
     QGTracker,
-    TemplateTextField
+    TemplateTextField,
+    QGISketch
 };
 };
 }

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -20,6 +20,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <algorithm>
+
 #include <QApplication>
 #include <QDomDocument>
 #include <QFile>
@@ -64,6 +66,7 @@
 #include "QGILeaderLine.h"
 #include "QGIProjGroup.h"
 #include "QGIRichAnno.h"
+#include "QGISketch.h"
 #include "QGISVGTemplate.h"
 #include "QGITemplate.h"
 #include "QGIUserTypes.h"
@@ -79,6 +82,7 @@
 #include "QGIViewSymbol.h"
 #include "QGIWeldSymbol.h"
 #include "QGSPage.h"
+#include "MDIViewPage.h"
 #include "Rez.h"
 #include "ViewProviderDrawingView.h"
 #include "ViewProviderPage.h"
@@ -126,6 +130,28 @@ void QGSPage::mousePressEvent(QGraphicsSceneMouseEvent * event)
     }
 
     QGraphicsScene::mousePressEvent(event);
+}
+
+void QGSPage::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
+{
+    QGraphicsItem* item = itemAt(event->scenePos(), QTransform());
+    while (item) {
+        if (auto* sketchItem = dynamic_cast<QGISketch*>(item)) {
+            auto* pageView = m_vpPage ? m_vpPage->getMDIViewPage() : nullptr;
+            if (pageView
+                && pageView->editSketch(
+                    sketchItem->getSketchObject(),
+                    sketchItem->getOwnerView()
+                )) {
+                event->accept();
+                return;
+            }
+            break;
+        }
+        item = item->parentItem();
+    }
+
+    QGraphicsScene::mouseDoubleClickEvent(event);
 }
 
 
@@ -187,6 +213,9 @@ void QGSPage::addChildrenToPage()
                 attachView(childView);
             }
         }
+    }
+    for (auto* sketch : m_vpPage->getDrawPage()->getSketches()) {
+        attachSketch(sketch);
     }
     // when restoring, it is possible for an item (ex a Dimension) to be loaded before the ViewPart
     // it applies to therefore we need to make sure parentage of the graphics representation is set
@@ -303,6 +332,42 @@ std::vector<QGIView*> QGSPage::getViews() const
     return result;
 }
 
+std::vector<QGISketch*> QGSPage::getSketches() const
+{
+    std::vector<QGISketch*> result;
+    for (auto* item : items()) {
+        if (auto* sketch = dynamic_cast<QGISketch*>(item)) {
+            result.push_back(sketch);
+        }
+    }
+    return result;
+}
+
+QGISketch* QGSPage::findSketchForDocObj(App::DocumentObject* obj) const
+{
+    for (auto* sketch : getSketches()) {
+        if (sketch->getSketchObject() == obj) {
+            return sketch;
+        }
+    }
+    return nullptr;
+}
+
+TechDraw::DrawView* QGSPage::findSketchOwner(App::DocumentObject* obj) const
+{
+    for (auto* pageView : m_vpPage->getDrawPage()->getAllViews()) {
+        auto* view = freecad_cast<TechDraw::DrawView*>(pageView);
+        if (!view) {
+            continue;
+        }
+        const auto sketches = view->Sketches.getValues();
+        if (std::find(sketches.begin(), sketches.end(), obj) != sketches.end()) {
+            return view;
+        }
+    }
+    return nullptr;
+}
+
 int QGSPage::removeQView(QGIView* view)
 {
     if (view) {
@@ -357,6 +422,10 @@ bool QGSPage::addView(const App::DocumentObject* obj)
 
 bool QGSPage::attachView(App::DocumentObject* obj)
 {
+    if (TechDraw::DrawPage::isSketch(obj)) {
+        return attachSketch(obj);
+    }
+
     if (findQViewForDocObj(obj)) {
         return true;
     }
@@ -416,6 +485,57 @@ bool QGSPage::attachView(App::DocumentObject* obj)
     }
 
     return (qview != nullptr);
+}
+
+bool QGSPage::attachSketch(App::DocumentObject* obj)
+{
+    if (!TechDraw::DrawPage::isSketch(obj)) {
+        return false;
+    }
+    if (findSketchForDocObj(obj)) {
+        return true;
+    }
+
+    auto* owner = findSketchOwner(obj);
+    auto* sketchItem = new QGISketch(obj, owner);
+    if (owner) {
+        if (auto* parent = findQViewForDocObj(owner)) {
+            sketchItem->setParentItem(parent);
+            sketchItem->setPos(0.0, 0.0);
+        }
+        else {
+            addItem(sketchItem);
+        }
+    }
+    else {
+        addItem(sketchItem);
+    }
+    return true;
+}
+
+void QGSPage::updateSketch(App::DocumentObject* obj)
+{
+    if (auto* sketch = findSketchForDocObj(obj)) {
+        auto* owner = findSketchOwner(obj);
+        QGIView* desiredParent = owner ? findQViewForDocObj(owner) : nullptr;
+        if (sketch->getOwnerView() != owner || sketch->parentItem() != desiredParent) {
+            sketch->setParentItem(nullptr);
+            sketch->setPos(0.0, 0.0);
+            if (desiredParent) {
+                sketch->setParentItem(desiredParent);
+            }
+            sketch->setOwnerView(owner);
+        }
+        sketch->updateView();
+    }
+}
+
+void QGSPage::syncSketches()
+{
+    fixOrphans();
+    for (auto* sketch : m_vpPage->getDrawPage()->getSketches()) {
+        updateSketch(sketch);
+    }
 }
 
 
@@ -845,6 +965,9 @@ void QGSPage::refreshViews()
             itemView->updateView(true);
         }
     }
+    for (auto* sketch : getSketches()) {
+        sketch->updateView();
+    }
 }
 
 void QGSPage::findMissingViews(const std::vector<App::DocumentObject*>& list,
@@ -895,6 +1018,21 @@ void QGSPage::fixOrphans(bool force)
         if (!qv)
             attachView(dv);
     }
+
+    const std::vector<App::DocumentObject*> pageSketches = thisPage->getSketches();
+    for (auto* sketch : pageSketches) {
+        if (!sketch->isRemoving() && !findSketchForDocObj(sketch)) {
+            attachSketch(sketch);
+        }
+    }
+    for (auto* qSketch : getSketches()) {
+        if (std::find(pageSketches.begin(), pageSketches.end(), qSketch->getSketchObject())
+            == pageSketches.end()) {
+            removeItem(qSketch);
+            delete qSketch;
+        }
+    }
+
     // if qView doesn't have a Feature on this Page, delete it
     std::vector<QGIView*> qvss = getViews();
     // qvss may contain an item and its child item(s) and to avoid to access a deleted item a QPointer is needed

--- a/src/Mod/TechDraw/Gui/QGSPage.h
+++ b/src/Mod/TechDraw/Gui/QGSPage.h
@@ -67,6 +67,7 @@ class QGIViewBalloon;
 class QGITile;
 class QGILeaderLine;
 class QGIRichAnno;
+class QGISketch;
 
 class TechDrawGuiExport QGSPage: public QGraphicsScene
 {
@@ -78,6 +79,8 @@ public:
 
     bool addView(const App::DocumentObject* obj);
     bool attachView(App::DocumentObject* obj);
+    bool attachSketch(App::DocumentObject* obj);
+    void updateSketch(App::DocumentObject* obj);
     QGIView* addViewDimension(TechDraw::DrawViewDimension* dimFeat);
     QGIView* addViewBalloon(TechDraw::DrawViewBalloon* balloonFeat);
     QGIView* addProjectionGroup(TechDraw::DrawProjGroup* projGroupFeat);
@@ -118,6 +121,10 @@ public:
     void addItemToParent(QGIView* item, QGIView* parent);
 
     std::vector<QGIView*> getViews() const;
+    std::vector<QGISketch*> getSketches() const;
+    QGISketch* findSketchForDocObj(App::DocumentObject* obj) const;
+    TechDraw::DrawView* findSketchOwner(App::DocumentObject* obj) const;
+    void syncSketches();
 
     int removeQView(QGIView* view);
     int removeQViewByName(const char* name);
@@ -133,6 +140,10 @@ public:
 
     TechDraw::DrawPage* getDrawPage();
 
+protected:
+    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event) override;
+
+public:
     void setExportingSvg(bool enable);
     bool getExportingSvg() const { return m_exportingSvg; }
 

--- a/src/Mod/TechDraw/Gui/Resources/TechDraw.qrc
+++ b/src/Mod/TechDraw/Gui/Resources/TechDraw.qrc
@@ -33,6 +33,7 @@
         <file>icons/actions/TechDraw_FillTemplateFields.svg</file>
         <file>icons/actions/TechDraw_HoleShaftFit.svg</file>
         <file>icons/actions/TechDraw_Multiview.svg</file>
+        <file>icons/actions/TechDraw_NewSketch.svg</file>
         <file>icons/actions/TechDraw_PageDefault.svg</file>
         <file>icons/actions/TechDraw_PageTemplate.svg</file>
         <file>icons/actions/TechDraw_PrintAll.svg</file>

--- a/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_NewSketch.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_NewSketch.svg
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   width="64"
+   height="64"
+   id="svg4024"
+   sodipodi:docname="TechDraw_NewSketch.svg"
+   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#50505000"
+     bordercolor="#eeeeeeff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050ff"
+     inkscape:zoom="14.285767"
+     inkscape:cx="25.269907"
+     inkscape:cy="34.824872"
+     inkscape:window-width="3840"
+     inkscape:window-height="1511"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4024" />
+  <defs
+     id="defs4026">
+    <linearGradient
+       xlink:href="#linearGradient3775-1"
+       id="linearGradient3781-9"
+       x1="10"
+       y1="39.999996"
+       x2="53"
+       y2="25.999996"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-48)" />
+    <linearGradient
+       id="linearGradient3775-1">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="0"
+         id="stop3777-2" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop3779-7" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3776"
+       id="linearGradient3782"
+       x1="33.052631"
+       y1="73.676765"
+       x2="23.483253"
+       y2="19.131313"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.54609456,0,0,0.51735275,14.243846,8.2992762)" />
+    <linearGradient
+       id="linearGradient3776">
+      <stop
+         style="stop-color:#cc0000;stop-opacity:1"
+         offset="0"
+         id="stop3778" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3780" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3776"
+       id="linearGradient3774"
+       x1="1178.153"
+       y1="1453.8708"
+       x2="1105.0463"
+       y2="1059.0945"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0706949,0,0,0.07926421,-54.183624,-65.07586)" />
+  </defs>
+  <metadata
+     id="metadata4029">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer4"
+     style="display:inline"
+     transform="translate(0,16)">
+    <rect
+       style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect2987"
+       width="45.999996"
+       height="58.000004"
+       x="-38.999996"
+       y="3"
+       transform="rotate(-90)" />
+    <rect
+       style="fill:url(#linearGradient3781-9);fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect2987-1"
+       width="41.999996"
+       height="54.000004"
+       x="-36.999996"
+       y="5"
+       transform="rotate(-90)" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3894"
+       width="50"
+       height="38"
+       x="7"
+       y="-3" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4664"
+       width="23.999994"
+       height="12.000004"
+       x="33"
+       y="23" />
+    <path
+       style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 37,27 h 15.398794 v 0"
+       id="path4666" />
+    <path
+       style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 37,31 h 15.642526 v 0"
+       id="path4666-7" />
+  </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3774);stroke-width:2.94195;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect3860-3"
+     width="19.122612"
+     height="19.122665"
+     x="10.500043"
+     y="27.564558" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3782);stroke-width:2.94195;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path3862-6"
+     d="m 40.654965,25.513013 c 0,5.195019 -4.445362,9.406414 -9.928992,9.406414 -5.483632,0 -9.928993,-4.211395 -9.928993,-9.406414 0,-5.195019 4.445361,-9.406413 9.928993,-9.406413 5.48363,0 9.928992,4.211394 9.928992,9.406413 z" />
+</svg>

--- a/src/Mod/TechDraw/Gui/TaskNewSketch.cpp
+++ b/src/Mod/TechDraw/Gui/TaskNewSketch.cpp
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2026 AstoCAD     <hello@astocad.com>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include <algorithm>
+
+#include <QIcon>
+#include <QLabel>
+#include <QMetaObject>
+#include <QTreeWidget>
+#include <QVBoxLayout>
+
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <Base/Console.h>
+#include <Base/Exception.h>
+#include <Gui/Application.h>
+#include <Gui/BitmapFactory.h>
+#include <Gui/Command.h>
+#include <Gui/ViewProvider.h>
+#include <Mod/TechDraw/App/DrawPage.h>
+#include <Mod/TechDraw/App/DrawView.h>
+
+#include "MDIViewPage.h"
+#include "TaskNewSketch.h"
+#include "ViewProviderPage.h"
+
+using namespace TechDrawGui;
+
+namespace
+{
+QString objectLabel(const App::DocumentObject* object)
+{
+    if (!object) {
+        return {};
+    }
+    const char* label = object->Label.getValue();
+    return QString::fromUtf8(label && *label ? label : object->getNameInDocument());
+}
+}
+
+TaskNewSketch::TaskNewSketch(TechDraw::DrawPage* page, QWidget* parent)
+    : QWidget(parent)
+    , m_page(page)
+    , m_ownerTree(new QTreeWidget(this))
+{
+    auto* layout = new QVBoxLayout(this);
+    layout->addWidget(new QLabel(tr("Owner"), this));
+
+    m_ownerTree->setHeaderHidden(true);
+    m_ownerTree->setSelectionMode(QAbstractItemView::SingleSelection);
+    layout->addWidget(m_ownerTree);
+
+    if (!m_page) {
+        return;
+    }
+
+    auto* pageItem = new QTreeWidgetItem(m_ownerTree, {objectLabel(m_page)});
+    pageItem->setData(0, Qt::UserRole, QString());
+    pageItem->setIcon(0, QIcon(Gui::BitmapFactory().pixmap("actions/TechDraw_PageDefault")));
+    pageItem->setExpanded(true);
+    pageItem->setSelected(true);
+
+    for (auto* object : m_page->getAllViews()) {
+        auto* view = freecad_cast<TechDraw::DrawView*>(object);
+        if (view && std::find(m_views.begin(), m_views.end(), view) == m_views.end()) {
+            m_views.push_back(view);
+        }
+    }
+    addViewChildren(nullptr, pageItem);
+    m_ownerTree->setCurrentItem(pageItem);
+    m_ownerTree->expandAll();
+}
+
+void TaskNewSketch::addViewChildren(TechDraw::DrawView* owner, QTreeWidgetItem* parent)
+{
+    if (!parent) {
+        return;
+    }
+
+    for (auto* view : m_views) {
+        if (view->claimParent() != owner) {
+            continue;
+        }
+
+        auto* item = new QTreeWidgetItem(parent, {objectLabel(view)});
+        item->setData(0, Qt::UserRole, QString::fromUtf8(view->getNameInDocument()));
+        if (auto* viewProvider = Gui::Application::Instance->getViewProvider(view)) {
+            item->setIcon(0, viewProvider->getIcon());
+        }
+
+        addViewChildren(view, item);
+    }
+}
+
+TechDraw::DrawView* TaskNewSketch::selectedOwner() const
+{
+    QTreeWidgetItem* item = m_ownerTree->currentItem();
+    if (!item) {
+        return nullptr;
+    }
+    const QByteArray objectName = item->data(0, Qt::UserRole).toString().toUtf8();
+    if (objectName.isEmpty() || !m_page || !m_page->getDocument()) {
+        return nullptr;
+    }
+    return freecad_cast<TechDraw::DrawView*>(
+        m_page->getDocument()->getObject(objectName.constData())
+    );
+}
+
+bool TaskNewSketch::createSketch()
+{
+    if (!m_page || !m_page->isAttachedToDocument()) {
+        return false;
+    }
+
+    auto* document = m_page->getDocument();
+    auto* owner = selectedOwner();
+    if (owner && (!owner->isAttachedToDocument() || owner->getDocument() != document)) {
+        return false;
+    }
+
+    const int transactionId = Gui::Command::openActiveDocumentCommand(
+        QT_TRANSLATE_NOOP("Command", "Create a TechDraw sketch")
+    );
+    App::DocumentObject* sketch = nullptr;
+    try {
+        sketch = document->addObject("Sketcher::SketchObject", "Sketch");
+        if (!sketch) {
+            throw Base::RuntimeError("Could not create Sketcher::SketchObject");
+        }
+        sketch->Label.setValue("Sketch");
+        m_page->addView(sketch, false);
+        if (owner) {
+            owner->addSketch(sketch);
+        }
+        document->recompute();
+        Gui::Command::commitCommand(transactionId);
+    }
+    catch (const Base::Exception& error) {
+        Gui::Command::abortCommand(transactionId);
+        Base::Console().error("TechDraw new sketch: %s\n", error.what());
+        return false;
+    }
+
+    auto* pageProvider = freecad_cast<ViewProviderPage*>(
+        Gui::Application::Instance->getViewProvider(m_page)
+    );
+    if (!pageProvider) {
+        return true;
+    }
+    pageProvider->show();
+    auto* pageView = pageProvider->getMDIViewPage();
+    if (!pageView) {
+        return true;
+    }
+
+    // The owner chooser must close before Sketcher installs its own task box.
+    QMetaObject::invokeMethod(pageView, [pageView, sketch, owner]() {
+        pageView->editSketch(sketch, owner);
+    }, Qt::QueuedConnection);
+    return true;
+}
+
+TaskDlgNewSketch::TaskDlgNewSketch(TechDraw::DrawPage* page)
+    : m_widget(new TaskNewSketch(page))
+{
+    addTaskBox(Gui::BitmapFactory().pixmap("actions/TechDraw_NewSketch"), m_widget);
+}
+
+bool TaskDlgNewSketch::accept()
+{
+    return m_widget->createSketch();
+}
+
+bool TaskDlgNewSketch::reject()
+{
+    return true;
+}
+
+#include "moc_TaskNewSketch.cpp"

--- a/src/Mod/TechDraw/Gui/TaskNewSketch.h
+++ b/src/Mod/TechDraw/Gui/TaskNewSketch.h
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2026 AstoCAD     <hello@astocad.com>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <QDialogButtonBox>
+#include <QWidget>
+#include <vector>
+
+#include <Gui/TaskView/TaskDialog.h>
+#include <Mod/TechDraw/TechDrawGlobal.h>
+
+class QTreeWidget;
+class QTreeWidgetItem;
+
+namespace App
+{
+class DocumentObject;
+}
+
+namespace TechDraw
+{
+class DrawPage;
+class DrawView;
+}
+
+namespace TechDrawGui
+{
+
+class TechDrawGuiExport TaskNewSketch: public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit TaskNewSketch(TechDraw::DrawPage* page, QWidget* parent = nullptr);
+    bool createSketch();
+
+private:
+    void addViewChildren(TechDraw::DrawView* owner, QTreeWidgetItem* parent);
+    TechDraw::DrawView* selectedOwner() const;
+
+    TechDraw::DrawPage* m_page;
+    QTreeWidget* m_ownerTree;
+    std::vector<TechDraw::DrawView*> m_views;
+};
+
+class TechDrawGuiExport TaskDlgNewSketch: public Gui::TaskView::TaskDialog
+{
+    Q_OBJECT
+
+public:
+    explicit TaskDlgNewSketch(TechDraw::DrawPage* page);
+
+    bool accept() override;
+    bool reject() override;
+    QDialogButtonBox::StandardButtons getStandardButtons() const override
+    {
+        return QDialogButtonBox::Ok | QDialogButtonBox::Cancel;
+    }
+
+private:
+    TaskNewSketch* m_widget;
+};
+
+}  // namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/TechDrawSketchEditView.cpp
+++ b/src/Mod/TechDraw/Gui/TechDrawSketchEditView.cpp
@@ -1,0 +1,622 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2026 AstoCAD     <hello@astocad.com>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include <algorithm>
+#include <cmath>
+#include <set>
+
+#include <QCloseEvent>
+#include <QColor>
+#include <QImage>
+#include <QLayout>
+#include <QMetaObject>
+#include <QMdiSubWindow>
+#include <QPainter>
+
+#include <Inventor/nodes/SoCoordinate3.h>
+#include <Inventor/nodes/SoFaceSet.h>
+#include <Inventor/nodes/SoLightModel.h>
+#include <Inventor/nodes/SoMaterial.h>
+#include <Inventor/nodes/SoOrthographicCamera.h>
+#include <Inventor/nodes/SoPickStyle.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoTexture2.h>
+#include <Inventor/nodes/SoTextureCoordinate2.h>
+#include <Precision.hxx>
+
+#include <App/DocumentObject.h>
+#include <App/ElementNamingUtils.h>
+#include <Base/Color.h>
+#include <Base/Tools.h>
+#include <Gui/Application.h>
+#include <Gui/BitmapFactory.h>
+#include <Gui/Command.h>
+#include <Gui/Document.h>
+#include <Gui/MainWindow.h>
+#include <Gui/Navigation/NavigationStyle.h>
+#include <Gui/View3DInventorViewer.h>
+#include <Gui/ViewProvider.h>
+#include <Gui/ViewProviderDocumentObject.h>
+#include <Mod/Sketcher/App/ExternalGeometryFacade.h>
+#include <Mod/Sketcher/App/SketchObject.h>
+#include <Mod/TechDraw/App/DrawView.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
+#include <Mod/TechDraw/App/Geometry.h>
+#include <Mod/TechDraw/App/Preferences.h>
+
+#include "MDIViewPage.h"
+#include "QGISketch.h"
+#include "QGIView.h"
+#include "QGSPage.h"
+#include "QGVPage.h"
+#include "Rez.h"
+#include "TechDrawSketchEditView.h"
+
+using namespace TechDrawGui;
+
+namespace
+{
+QColor techDrawBackgroundColor()
+{
+    Base::Color color;
+    color.setPackedValue(
+        TechDraw::Preferences::getPreferenceGroup("Colors")
+            ->GetUnsigned("Background", 0x70707000)
+    );
+    return color.asValue<QColor>();
+}
+
+QPointF sceneToSketchPoint(const QPointF& scenePoint,
+                           TechDraw::DrawView* owner,
+                           QGISketch* sketchItem)
+{
+    // mapFromScene includes the effective projection-group position and every
+    // other QGraphicsItem parent transform. The resulting point is in the
+    // coordinate system in which QGISketch draws its geometry.
+    const QPointF localPoint =
+        sketchItem ? sketchItem->mapFromScene(scenePoint) : scenePoint;
+    const double transformedX = Rez::appX(localPoint.x());
+    const double transformedY = -Rez::appX(localPoint.y());
+    if (!owner) {
+        return {transformedX, transformedY};
+    }
+
+    const double angle = Base::toRadians(owner->Rotation.getValue());
+    const double cosine = std::cos(angle);
+    const double sine = std::sin(angle);
+    const double scale = owner->getScale();
+    if (scale <= Precision::Confusion()) {
+        return {transformedX, transformedY};
+    }
+
+    return {
+        (cosine * transformedX + sine * transformedY) / scale,
+        (-sine * transformedX + cosine * transformedY) / scale
+    };
+}
+}
+
+class TechDrawGui::PageBackgroundViewProvider final: public Gui::ViewProvider
+{
+public:
+    explicit PageBackgroundViewProvider(SoSeparator* background)
+        : m_background(background)
+    {
+        m_background->ref();
+    }
+
+    ~PageBackgroundViewProvider() override
+    {
+        m_background->unref();
+    }
+
+    SoSeparator* getRoot() const override
+    {
+        return m_background;
+    }
+
+    bool isPartOfPhysicalObject() const override
+    {
+        return false;
+    }
+
+private:
+    SoSeparator* m_background;
+};
+
+TechDrawSketchEditView::TechDrawSketchEditView(Gui::Document* document,
+                                               MDIViewPage* pageView,
+                                               App::DocumentObject* sketch,
+                                               TechDraw::DrawView* owner)
+    : Gui::View3DInventor(document, Gui::getMainWindow())
+    , m_pageView(pageView)
+    , m_sketch(sketch)
+    , m_owner(owner)
+{
+    setWindowTitle(pageView ? pageView->windowTitle() : tr("TechDraw Sketch"));
+    setWindowIcon(pageView ? pageView->windowIcon() : windowIcon());
+    setProperty("SketcherExternalGeometryEnabled", false);
+    setProperty("SketcherLightBackground", true);
+    setProperty("SketcherDeferredGridUpdate", true);
+}
+
+TechDrawSketchEditView::~TechDrawSketchEditView()
+{
+    m_resetEditConnection.disconnect();
+    removePageBackground();
+}
+
+const char* TechDrawSketchEditView::getName() const
+{
+    return "TechDrawSketchEditView";
+}
+
+bool TechDrawSketchEditView::startSketchEdit()
+{
+    if (!getGuiDocument() || !m_sketch) {
+        return false;
+    }
+
+    m_sketchViewProvider = Gui::Application::Instance->getViewProvider(m_sketch);
+    auto* documentViewProvider =
+        freecad_cast<Gui::ViewProviderDocumentObject*>(m_sketchViewProvider);
+    if (!documentViewProvider) {
+        return false;
+    }
+    m_previousWorkbench = Gui::Command::assureWorkbench("SketcherWorkbench");
+
+    if (!installOwnerExternalGeometry()) {
+        restoreWorkbench();
+        return false;
+    }
+
+    auto* mainWindow = Gui::getMainWindow();
+    if (!installEditingView()) {
+        restoreWorkbench();
+        return false;
+    }
+    mainWindow->setActiveWindow(this);
+
+    auto* viewer = getViewer();
+    viewer->setGradientBackground(Gui::View3DInventorViewer::Background::NoGradient);
+    viewer->setBackgroundColor(techDrawBackgroundColor());
+    // Configure the final camera before Sketcher enters edit mode. Sketcher
+    // attaches an SoNodeSensor to the current camera; replacing that camera
+    // afterward can leave its delete/reattach callback in Coin's delay queue.
+    viewer->setCameraType(SoOrthographicCamera::getClassTypeId());
+    viewer->setAxisCross(false);
+    // The normal animated viewAll() spins nested Qt event loops. Besides adding
+    // roughly 200 ms to startup, that can deliver deferred destruction events
+    // from the previous temporary edit view while this one is still being built.
+    viewer->setAnimationEnabled(false);
+
+    viewer->addViewProvider(m_sketchViewProvider);
+
+    // Supplying a non-empty self subname prevents edit-parent inference from
+    // redirecting a page-selected sketch to its TechDraw owner.
+    if (!getGuiDocument()->setEdit(documentViewProvider, 0, "TechDrawSketchEdit")) {
+        getViewer()->removeViewProvider(m_sketchViewProvider);
+        restorePage();
+        return false;
+    }
+
+    if (auto* mainLayout = mainWindow->layout()) {
+        mainLayout->activate();
+    }
+
+    if (!m_owner) {
+        alignCameraToPage();
+    }
+
+    if (auto* camera = getViewer()->getSoRenderManager()->getCamera()) {
+        // Owner geometry and the page background are expressed in the
+        // owner's unrotated local coordinate system. Roll the camera by the
+        // inverse presentation rotation so a rotated view (notably a section
+        // view whose Rotation is commonly 90 degrees) still appears on screen
+        // in the same horizontal orientation as the TechDraw page.
+        const double ownerRotation = m_owner ? m_owner->Rotation.getValue() : 0.0;
+        camera->orientation = SbRotation(
+            SbVec3f(0.0F, 0.0F, 1.0F),
+            static_cast<float>(-Base::toRadians(ownerRotation))
+        );
+    }
+    if (auto* navigation = viewer->navigationStyle()) {
+        navigation->setRotationEnabled(false);
+        navigation->setOrientationLocked(true);
+    }
+
+    installPageBackground();
+
+    m_resetEditConnection = getGuiDocument()->signalResetEdit.connect(
+        [this](const Gui::ViewProviderDocumentObject& viewProvider) {
+            if (viewProvider.getObject() != m_sketch) {
+                return;
+            }
+            const QPointer<TechDrawSketchEditView> guardedThis(this);
+            QMetaObject::invokeMethod(this, [guardedThis]() {
+                if (guardedThis) {
+                    guardedThis->restorePage();
+                }
+            }, Qt::QueuedConnection);
+        }
+    );
+    return true;
+}
+
+bool TechDrawSketchEditView::installOwnerExternalGeometry()
+{
+    auto* partOwner = freecad_cast<TechDraw::DrawViewPart*>(m_owner);
+    if (!partOwner) {
+        return true;
+    }
+
+    auto* sketch = freecad_cast<Sketcher::SketchObject*>(m_sketch);
+    if (!sketch) {
+        return false;
+    }
+
+    const auto projectedEdges = partOwner->getEdgeGeometry();
+    std::set<std::string> desiredEdges;
+    for (std::size_t edgeIndex = 0; edgeIndex < projectedEdges.size(); ++edgeIndex) {
+        const auto& edge = projectedEdges[edgeIndex];
+        if (edge && edge->getHlrVisible()) {
+            desiredEdges.insert("Edge" + std::to_string(edgeIndex));
+        }
+    }
+
+    const auto linkedObjects = sketch->ExternalGeometry.getValues();
+    const auto linkedSubElements = sketch->ExternalGeometry.getSubValues(false);
+    const auto& externalGeometry = sketch->getExternalGeometry();
+    std::set<std::string> linkedOwnerEdges;
+    std::vector<int> obsoleteExternalIds;
+    const std::size_t linkCount = std::min(linkedObjects.size(), linkedSubElements.size());
+    for (std::size_t linkIndex = 0; linkIndex < linkCount; ++linkIndex) {
+        if (linkedObjects[linkIndex] != partOwner) {
+            continue;
+        }
+
+        const auto& edgeName = linkedSubElements[linkIndex];
+        if (desiredEdges.find(edgeName) == desiredEdges.end()) {
+            // delExternal() addresses the expanded ExternalGeo array, not the
+            // LinkSub property row. Find an entity carrying this row's actual
+            // stable reference key; delExternal() will remove the complete
+            // expanded group. getRefIndex() cannot be used here because it is
+            // a migration field that Sketcher resets after resolving links.
+            const std::string expectedReference =
+                std::string(partOwner->getNameInDocument()) + '.'
+                + Data::newElementName(edgeName.c_str());
+            // ExternalGeo slots 0 and 1 are the horizontal and vertical
+            // sketch axes. delExternal(0) addresses slot 2.
+            for (std::size_t externalIndex = 2;
+                 externalIndex < externalGeometry.size();
+                 ++externalIndex) {
+                const auto facade = Sketcher::ExternalGeometryFacade::getFacade(
+                    externalGeometry[externalIndex]
+                );
+                if (facade && facade->getRef() == expectedReference) {
+                    obsoleteExternalIds.push_back(
+                        static_cast<int>(externalIndex) - 2
+                    );
+                    break;
+                }
+            }
+        }
+        else {
+            linkedOwnerEdges.insert(edgeName);
+        }
+    }
+
+    std::vector<std::string> missingEdges;
+    for (const auto& edgeName : desiredEdges) {
+        if (linkedOwnerEdges.find(edgeName) == linkedOwnerEdges.end()) {
+            missingEdges.push_back(edgeName);
+        }
+    }
+
+    if (obsoleteExternalIds.empty() && missingEdges.empty()) {
+        // Rebuild linked geometry so changes in the TechDraw-to-Sketcher
+        // coordinate conversion are also applied to existing sketches.
+        sketch->rebuildExternalGeometry();
+        return true;
+    }
+
+    const int transactionId = Gui::Command::openActiveDocumentCommand(
+        QT_TRANSLATE_NOOP("Command", "Update TechDraw external geometry")
+    );
+
+    bool success = true;
+    if (!obsoleteExternalIds.empty()) {
+        // Remove dead property links before anything asks Sketcher to rebuild
+        // them. This avoids one projection error and one missing-reference
+        // error for every edge that disappeared from the TechDraw view.
+        success = sketch->delExternal(obsoleteExternalIds) == 0;
+    }
+    if (success && !missingEdges.empty()) {
+        success = sketch->addExternals(partOwner, missingEdges) > 0;
+    }
+    else if (success) {
+        sketch->rebuildExternalGeometry();
+    }
+
+    if (success) {
+        Gui::Command::commitCommand(transactionId);
+    }
+    else {
+        Gui::Command::abortCommand(transactionId);
+    }
+    return success;
+}
+
+bool TechDrawSketchEditView::installEditingView()
+{
+    if (!m_pageView) {
+        return false;
+    }
+
+    m_pageSubWindow = qobject_cast<QMdiSubWindow*>(m_pageView->parentWidget());
+    if (!m_pageSubWindow) {
+        return false;
+    }
+
+    const QString pageTitle = m_pageView->windowTitle();
+    m_pageView->hide();
+    m_pageSubWindow->setWidget(this);
+    setWindowTitle(pageTitle);
+    m_pageSubWindow->setWindowTitle(pageTitle);
+    show();
+    return true;
+}
+
+void TechDrawSketchEditView::installPageBackground()
+{
+    if (!m_pageView || !getViewer()) {
+        return;
+    }
+
+    auto* pageGraphicsView = qobject_cast<QGVPage*>(m_pageView->centralWidget());
+    QGSPage* pageScene = pageGraphicsView ? pageGraphicsView->getScene() : nullptr;
+    if (!pageGraphicsView || !pageScene) {
+        return;
+    }
+
+    QGISketch* editedSketch =
+        pageScene->findSketchForDocObj(m_sketch);
+    const bool sketchWasVisible = editedSketch && editedSketch->isVisible();
+    if (editedSketch) {
+        editedSketch->setVisible(false);
+    }
+    // Part views are replaced by their projected external geometry while
+    // editing. A projection group has no direct geometry and stays visible.
+    auto* partOwner = freecad_cast<TechDraw::DrawViewPart*>(m_owner);
+    QGIView* ownerView = partOwner ? pageScene->findQViewForDocObj(partOwner) : nullptr;
+    const bool ownerWasVisible = ownerView && ownerView->isVisible();
+    if (ownerView) {
+        ownerView->setVisible(false);
+    }
+
+    QRectF sourceRect = pageScene->itemsBoundingRect();
+    if (sourceRect.isEmpty()) {
+        sourceRect = pageScene->sceneRect();
+    }
+    const double margin =
+        std::max(Rez::guiX(10.0), 0.02 * std::max(sourceRect.width(), sourceRect.height()));
+    sourceRect.adjust(-margin, -margin, margin, margin);
+
+    constexpr double preferredPixelsPerSceneUnit = 1.0;
+    constexpr double maximumImageDimension = 4096.0;
+    const double imageScale = std::min({
+        preferredPixelsPerSceneUnit,
+        maximumImageDimension / sourceRect.width(),
+        maximumImageDimension / sourceRect.height()
+    });
+    const QSize imageSize(
+        std::max(1, static_cast<int>(std::ceil(sourceRect.width() * imageScale))),
+        std::max(1, static_cast<int>(std::ceil(sourceRect.height() * imageScale)))
+    );
+    QImage pageImage(imageSize, QImage::Format_RGB32);
+    pageImage.fill(techDrawBackgroundColor());
+    {
+        QPainter painter(&pageImage);
+        painter.setRenderHints(
+            QPainter::Antialiasing | QPainter::TextAntialiasing
+                | QPainter::SmoothPixmapTransform
+        );
+        pageScene->render(
+            &painter,
+            QRectF(QPointF(0.0, 0.0), QSizeF(imageSize)),
+            sourceRect,
+            Qt::IgnoreAspectRatio
+        );
+    }
+    if (editedSketch) {
+        editedSketch->setVisible(sketchWasVisible);
+    }
+    if (ownerView) {
+        ownerView->setVisible(ownerWasVisible);
+    }
+    auto* background = new SoSeparator;
+    auto* pickStyle = new SoPickStyle;
+    pickStyle->style = SoPickStyle::UNPICKABLE;
+    background->addChild(pickStyle);
+
+    auto* lightModel = new SoLightModel;
+    lightModel->model = SoLightModel::BASE_COLOR;
+    background->addChild(lightModel);
+
+    // Coin's default diffuse material is 0.8 grey and would darken every
+    // texture pixel. White preserves the exact TechDraw scene RGB values.
+    auto* material = new SoMaterial;
+    material->diffuseColor.setValue(1.0F, 1.0F, 1.0F);
+    background->addChild(material);
+
+    auto* texture = new SoTexture2;
+    texture->wrapS = SoTexture2::CLAMP;
+    texture->wrapT = SoTexture2::CLAMP;
+    Gui::BitmapFactory().convert(pageImage, texture->image);
+    background->addChild(texture);
+
+    auto* textureCoordinates = new SoTextureCoordinate2;
+    textureCoordinates->point.set1Value(0, 0.0F, 0.0F);
+    textureCoordinates->point.set1Value(1, 1.0F, 0.0F);
+    textureCoordinates->point.set1Value(2, 1.0F, 1.0F);
+    textureCoordinates->point.set1Value(3, 0.0F, 1.0F);
+    background->addChild(textureCoordinates);
+
+    const QPointF bottomLeft =
+        sceneToSketchPoint({sourceRect.left(), sourceRect.bottom()}, m_owner, editedSketch);
+    const QPointF bottomRight =
+        sceneToSketchPoint({sourceRect.right(), sourceRect.bottom()}, m_owner, editedSketch);
+    const QPointF topRight =
+        sceneToSketchPoint({sourceRect.right(), sourceRect.top()}, m_owner, editedSketch);
+    const QPointF topLeft =
+        sceneToSketchPoint({sourceRect.left(), sourceRect.top()}, m_owner, editedSketch);
+
+    auto* coordinates = new SoCoordinate3;
+    coordinates->point.set1Value(
+        0,
+        static_cast<float>(bottomLeft.x()),
+        static_cast<float>(bottomLeft.y()),
+        -1.0F
+    );
+    coordinates->point.set1Value(
+        1,
+        static_cast<float>(bottomRight.x()),
+        static_cast<float>(bottomRight.y()),
+        -1.0F
+    );
+    coordinates->point.set1Value(
+        2,
+        static_cast<float>(topRight.x()),
+        static_cast<float>(topRight.y()),
+        -1.0F
+    );
+    coordinates->point.set1Value(
+        3,
+        static_cast<float>(topLeft.x()),
+        static_cast<float>(topLeft.y()),
+        -1.0F
+    );
+    background->addChild(coordinates);
+
+    auto* face = new SoFaceSet;
+    face->numVertices.set1Value(0, 4);
+    background->addChild(face);
+
+    m_pageBackgroundProvider = new PageBackgroundViewProvider(background);
+    getViewer()->addViewProvider(m_pageBackgroundProvider);
+}
+
+void TechDrawSketchEditView::removePageBackground()
+{
+    if (!m_pageBackgroundProvider) {
+        return;
+    }
+
+    if (getViewer()) {
+        getViewer()->removeViewProvider(m_pageBackgroundProvider);
+    }
+    delete m_pageBackgroundProvider;
+    m_pageBackgroundProvider = nullptr;
+}
+
+void TechDrawSketchEditView::restoreWorkbench()
+{
+    if (m_previousWorkbench.empty()) {
+        return;
+    }
+
+    Gui::Command::assureWorkbench(m_previousWorkbench.c_str());
+    m_previousWorkbench.clear();
+}
+
+void TechDrawSketchEditView::alignCameraToPage()
+{
+    if (!m_pageView) {
+        return;
+    }
+
+    auto* pageGraphicsView = qobject_cast<QGVPage*>(m_pageView->centralWidget());
+    auto* camera = dynamic_cast<SoOrthographicCamera*>(
+        getViewer()->getSoRenderManager()->getCamera()
+    );
+    if (!pageGraphicsView || !pageGraphicsView->viewport() || !camera) {
+        getViewer()->viewAll();
+        return;
+    }
+
+    const QRect viewportRect = pageGraphicsView->viewport()->rect();
+    const QPointF sceneCenter = pageGraphicsView->mapToScene(viewportRect.center());
+    const double pageScale = std::abs(pageGraphicsView->transform().m22());
+    const double sceneUnitsPerMillimetre = Rez::guiX(1.0);
+    if (pageScale <= 0.0 || sceneUnitsPerMillimetre <= 0.0) {
+        getViewer()->viewAll();
+        return;
+    }
+
+    const SbVec3f oldPosition = camera->position.getValue();
+    camera->position.setValue(
+        static_cast<float>(Rez::appX(sceneCenter.x())),
+        static_cast<float>(-Rez::appX(sceneCenter.y())),
+        oldPosition[2]
+    );
+    camera->height.setValue(
+        static_cast<float>(
+            viewportRect.height() / pageScale / sceneUnitsPerMillimetre
+        )
+    );
+}
+
+void TechDrawSketchEditView::restorePage()
+{
+    if (m_restoring) {
+        return;
+    }
+    m_restoring = true;
+    m_resetEditConnection.disconnect();
+
+    if (m_pageView && m_pageSubWindow) {
+        removePageBackground();
+        hide();
+        m_pageSubWindow->setWidget(m_pageView);
+        m_pageView->show();
+        m_pageSubWindow->setWindowTitle(m_pageView->windowTitle());
+        Gui::getMainWindow()->setActiveWindow(m_pageView);
+    }
+    restoreWorkbench();
+
+    m_pageSubWindow = nullptr;
+    setParent(Gui::getMainWindow());
+    close();
+}
+
+void TechDrawSketchEditView::closeEvent(QCloseEvent* event)
+{
+    if (!m_restoring && getGuiDocument()
+        && getGuiDocument()->getEditViewProvider() == m_sketchViewProvider) {
+        event->ignore();
+        getGuiDocument()->resetEdit();
+        return;
+    }
+
+    Gui::View3DInventor::closeEvent(event);
+}

--- a/src/Mod/TechDraw/Gui/TechDrawSketchEditView.h
+++ b/src/Mod/TechDraw/Gui/TechDrawSketchEditView.h
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2026 AstoCAD     <hello@astocad.com>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <string>
+
+#include <fastsignals/connection.h>
+#include <QPointer>
+
+#include <Gui/View3DInventor.h>
+#include <Mod/TechDraw/TechDrawGlobal.h>
+
+class QCloseEvent;
+class QMdiSubWindow;
+
+namespace App
+{
+class DocumentObject;
+}
+
+namespace Gui
+{
+class ViewProvider;
+}
+
+namespace TechDraw
+{
+class DrawView;
+}
+
+namespace TechDrawGui
+{
+
+class MDIViewPage;
+class PageBackgroundViewProvider;
+
+class TechDrawGuiExport TechDrawSketchEditView: public Gui::View3DInventor
+{
+public:
+    TechDrawSketchEditView(Gui::Document* document,
+                           MDIViewPage* pageView,
+                           App::DocumentObject* sketch,
+                           TechDraw::DrawView* owner);
+    ~TechDrawSketchEditView() override;
+
+    bool startSketchEdit();
+    const char* getName() const override;
+
+protected:
+    void closeEvent(QCloseEvent* event) override;
+
+private:
+    bool installEditingView();
+    bool installOwnerExternalGeometry();
+    void alignCameraToPage();
+    void installPageBackground();
+    void removePageBackground();
+    void restoreWorkbench();
+    void restorePage();
+
+    QPointer<MDIViewPage> m_pageView;
+    App::DocumentObject* m_sketch;
+    TechDraw::DrawView* m_owner;
+    Gui::ViewProvider* m_sketchViewProvider {nullptr};
+    PageBackgroundViewProvider* m_pageBackgroundProvider {nullptr};
+    QPointer<QMdiSubWindow> m_pageSubWindow;
+    fastsignals::connection m_resetEditConnection;
+    std::string m_previousWorkbench;
+    bool m_restoring {false};
+};
+
+}  // namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -43,6 +43,7 @@
 #include <Mod/TechDraw/App/DrawViewDimension.h>
 #include <Mod/TechDraw/App/Preferences.h>
 
+#include "DrawGuiUtil.h"
 #include "ViewProviderDrawingView.h"
 #include "ViewProviderDrawingViewExtension.h"
 #include "MDIViewPage.h"
@@ -224,8 +225,26 @@ bool ViewProviderDrawingView::isShow() const
     return Visibility.getValue();
 }
 
+bool ViewProviderDrawingView::canDropObject(App::DocumentObject* docObj) const
+{
+    return TechDraw::DrawPage::isSketch(docObj);
+}
+
 void ViewProviderDrawingView::dropObject(App::DocumentObject* docObj)
 {
+    if (TechDraw::DrawPage::isSketch(docObj)) {
+        auto* view = getViewObject();
+        auto* page = view ? view->findParentPage() : nullptr;
+        if (!page || docObj->getDocument() != view->getDocument()) {
+            return;
+        }
+
+        DrawGuiUtil::detachSketchFromTechDraw(docObj);
+        page->addView(docObj, false);
+        view->addSketch(docObj);
+        page->Views.touch();
+        return;
+    }
     getViewProviderPage()->dropObject(docObj);
 }
 
@@ -528,7 +547,7 @@ void ViewProviderDrawingView::fixSceneDependencies()
 
 std::vector<App::DocumentObject*> ViewProviderDrawingView::claimChildren() const
 {
-    std::vector<App::DocumentObject*> temp;
+    std::vector<App::DocumentObject*> temp = getViewObject()->Sketches.getValues();
     const std::vector<App::DocumentObject *> &potentialChildren = getViewObject()->getInList();
     try {
       for(auto& child : potentialChildren) {

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.h
@@ -66,6 +66,7 @@ public:
     void show() override;
     bool isShow() const override;
 
+    bool canDropObject(App::DocumentObject* docObj) const override;
     void dropObject(App::DocumentObject* docObj) override;
 
     void onChanged(const App::Property *prop) override;

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingViewExtension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingViewExtension.cpp
@@ -23,6 +23,7 @@
 
 #include <App/Document.h>
 
+#include "DrawGuiUtil.h"
 #include "ViewProviderDrawingViewExtension.h"
 #include "ViewProviderDrawingView.h"
 #include "ViewProviderPage.h"
@@ -49,9 +50,14 @@ bool ViewProviderDrawingViewExtension::extensionCanDragObject(App::DocumentObjec
     return true;
 }
 
-//the default drag will remove the object from the document until it is dropped and re-added, so we claim
-//to do the dragging.
-void ViewProviderDrawingViewExtension::extensionDragObject(App::DocumentObject* obj) { (void)obj; }
+// The default drag will remove the object from the document until it is
+// dropped and re-added, so TechDraw claims the operation. Sketches are the
+// exception: they must be detached from both their view and page before the
+// drop target claims them.
+void ViewProviderDrawingViewExtension::extensionDragObject(App::DocumentObject* obj)
+{
+    DrawGuiUtil::detachSketchFromTechDraw(obj);
+}
 
 //we don't support dropping of new children of Views (Dimensions, Balloons, Hatches, etc) now, but we don't want another
 //extension to try to drop on us and cause problems

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -21,6 +21,8 @@
  *                                                                         *
  ***************************************************************************/
 
+# include <algorithm>
+
 # include <QAction>
 # include <QList>
 # include <QMdiArea>
@@ -29,6 +31,8 @@
 # include <QMessageBox>
 # include <QPointer>
 # include <QTextStream>
+
+#include <Inventor/nodes/SoGroup.h>
 
 #include <fastsignals/signal.h>
 #include <fastsignals/connection.h>
@@ -49,6 +53,7 @@
 #include <Mod/TechDraw/App/DrawView.h>
 #include <Mod/TechDraw/App/DrawViewBalloon.h>
 #include <Mod/TechDraw/App/DrawViewDimension.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
 #include <Mod/TechDraw/App/DrawWeldSymbol.h>
 #include <Mod/TechDraw/App/Preferences.h>
 
@@ -75,8 +80,10 @@ PROPERTY_SOURCE(TechDrawGui::ViewProviderPage, Gui::ViewProviderDocumentObject)
 
 ViewProviderPage::ViewProviderPage()
     : m_mdiView(nullptr),  m_graphicsView(nullptr), m_graphicsScene(nullptr),
-      m_frameToggle(false)
+      m_frameToggle(false),
+      m_hiddenChildren(new SoGroup)
 {
+    m_hiddenChildren->ref();
     initExtension(this);
 
     sPixmap = "TechDraw_TreePage";
@@ -112,6 +119,8 @@ ViewProviderPage::~ViewProviderPage()
 {
     removeMDIView();//if the MDIViewPage is still in MainWindow, remove it.
     m_graphicsScene->deleteLater();
+    m_hiddenChildren->unref();
+    m_hiddenChildren = nullptr;
 }
 
 void ViewProviderPage::attach(App::DocumentObject* pcFeat)
@@ -124,6 +133,22 @@ void ViewProviderPage::attach(App::DocumentObject* pcFeat)
     auto* feature = dynamic_cast<TechDraw::DrawPage*>(pcFeat);
     if (feature) {
         connectGuiRepaint = feature->signalGuiPaint.connect(bnd);
+        if (auto* document = feature->getDocument()) {
+            connectChangedObject = document->signalChangedObject.connect(
+                [this](const App::DocumentObject& object, const App::Property&) {
+                    auto* page = getDrawPage();
+                    auto* changed = const_cast<App::DocumentObject*>(&object);
+                    if (page && page->hasObject(changed) && DrawPage::isSketch(changed)) {
+                        m_graphicsScene->updateSketch(changed);
+                    }
+                    else if (page && changed->isDerivedFrom<DrawViewPart>()) {
+                        const auto pageViews = page->getAllViews();
+                        if (std::find(pageViews.begin(), pageViews.end(), changed) != pageViews.end()) {
+                            m_graphicsScene->syncSketches();
+                        }
+                    }
+                });
+        }
         if (feature->isAttachedToDocument()) {
             // it could happen that feature is not completely in the document yet and getNameInDocument returns
             // nullptr, so we only update m_myName if we got a valid string.
@@ -419,6 +444,24 @@ std::vector<App::DocumentObject*> ViewProviderPage::claimChildren() const
             }
             auto* featView = dynamic_cast<TechDraw::DrawView*>(obj);
 
+            if (DrawPage::isSketch(obj)) {
+                bool attachedToView = false;
+                for (auto* viewObj : getDrawPage()->getAllViews()) {
+                    auto* view = freecad_cast<DrawView*>(viewObj);
+                    if (!view) {
+                        continue;
+                    }
+                    const auto sketches = view->Sketches.getValues();
+                    if (std::find(sketches.begin(), sketches.end(), obj) != sketches.end()) {
+                        attachedToView = true;
+                        break;
+                    }
+                }
+                if (attachedToView) {
+                    continue;
+                }
+            }
+
             // If the child view appoints a parent, skip it
             if (featView && featView->claimParent()) {
                 continue;
@@ -439,6 +482,17 @@ std::vector<App::DocumentObject*> ViewProviderPage::claimChildren() const
     catch (...) {
         return {};
     }
+}
+
+std::vector<App::DocumentObject*> ViewProviderPage::claimChildren3D() const
+{
+    auto* page = getDrawPage();
+    return page ? page->getSketches() : std::vector<App::DocumentObject*>{};
+}
+
+SoGroup* ViewProviderPage::getChildRoot() const
+{
+    return m_hiddenChildren;
 }
 
 bool ViewProviderPage::isShow() const { return Visibility.getValue(); }

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.h
@@ -34,6 +34,7 @@
 
 #include <ViewProviderPageExtension.h>
 
+class SoGroup;
 
 namespace TechDraw
 {
@@ -93,6 +94,8 @@ public:
 
     /// Claim all the views for the page
     std::vector<App::DocumentObject*> claimChildren() const override;
+    std::vector<App::DocumentObject*> claimChildren3D() const override;
+    SoGroup* getChildRoot() const override;
 
     /// Is called by the tree if the user double click on the object
     bool doubleClicked() override;
@@ -111,6 +114,7 @@ public:
 // NOLINTBEGIN
     using Connection = fastsignals::scoped_connection;
     Connection connectGuiRepaint;
+    Connection connectChangedObject;
 // NOLINTEND
 
     void unsetEdit(int ModNum) override;
@@ -157,6 +161,7 @@ private:
     QGSPage* m_graphicsScene;
 
     bool m_frameToggle{false};      // replacement for ShowFrame property to avoid marking document changed
+    SoGroup* m_hiddenChildren;
 };
 
 }// namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/ViewProviderPageExtension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPageExtension.cpp
@@ -26,7 +26,9 @@
 #include <Mod/TechDraw/App/DrawPage.h>
 #include <Mod/TechDraw/App/DrawProjGroupItem.h>
 #include <Mod/TechDraw/App/DrawTemplate.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
 
+#include "DrawGuiUtil.h"
 #include "ViewProviderPageExtension.h"
 #include "ViewProviderPage.h"
 
@@ -52,8 +54,13 @@ bool ViewProviderPageExtension::extensionCanDragObject(App::DocumentObject* docO
     return true;
 }
 
-//we don't take any action on drags.  everything is handling in drop
-void ViewProviderPageExtension::extensionDragObject(App::DocumentObject* obj) { (void)obj; }
+// Most TechDraw objects are handled entirely by their drop target. Sketches
+// are model objects, though, so dragging one out of a page must release the
+// TechDraw links before the new parent claims it.
+void ViewProviderPageExtension::extensionDragObject(App::DocumentObject* obj)
+{
+    DrawGuiUtil::detachSketchFromTechDraw(obj);
+}
 
 //we handle our own drops
 bool ViewProviderPageExtension::extensionCanDropObjects() const { return true; }
@@ -68,6 +75,9 @@ bool ViewProviderPageExtension::extensionCanDropObject(App::DocumentObject* obj)
 
     //only DrawView objects can live on pages (except special case Template)
     if (obj->isDerivedFrom<TechDraw::DrawView>()) {
+        return true;
+    }
+    if (TechDraw::DrawPage::isSketch(obj)) {
         return true;
     }
     if (obj->isDerivedFrom<TechDraw::DrawTemplate>()) {
@@ -96,6 +106,9 @@ bool ViewProviderPageExtension::extensionCanDropObjectEx(App::DocumentObject* ob
     if (obj->isDerivedFrom<TechDraw::DrawView>()) {
         return true;
     }
+    if (TechDraw::DrawPage::isSketch(obj)) {
+        return true;
+    }
     if (obj->isDerivedFrom<TechDraw::DrawTemplate>()) {
         //don't let another extension try to drop templates
         return true;
@@ -118,11 +131,22 @@ void ViewProviderPageExtension::extensionDropObject(App::DocumentObject* obj)
         dropObject(obj);
         return;
     }
+    if (TechDraw::DrawPage::isSketch(obj)) {
+        dropObject(obj);
+    }
 }
 
 //this code used to live in ViewProviderPage
 void ViewProviderPageExtension::dropObject(App::DocumentObject* obj)
 {
+    if (TechDraw::DrawPage::isSketch(obj)) {
+        DrawGuiUtil::detachSketchFromTechDraw(obj);
+        auto* page = getViewProviderPage()->getDrawPage();
+        page->addView(obj, false);
+        page->Views.touch();
+        return;
+    }
+
     auto dvp = freecad_cast<TechDraw::DrawViewPart*>(obj);
     if (dvp && DrawView::isProjGroupItem(dvp)) {
         //DPGI can not be dropped onto the Page if it belongs to DPG

--- a/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
@@ -183,7 +183,7 @@ std::vector<App::DocumentObject*> ViewProviderProjGroup::claimChildren() const
     //    - Balloons
     //    - Leaders
     //    - RichAnno
-    std::vector<App::DocumentObject*> temp;
+    std::vector<App::DocumentObject*> temp = getViewObject()->Sketches.getValues();
     const std::vector<App::DocumentObject*>& candidates = getViewObject()->getInList();
     // DPGI's do not point at the DPG, the DPG/DVC maintains links to the items
 

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -40,6 +40,7 @@
 #include <Mod/TechDraw/App/DrawGeomHatch.h>
 #include <Mod/TechDraw/App/DrawHatch.h>
 #include <Mod/TechDraw/App/DrawLeaderLine.h>
+#include <Mod/TechDraw/App/DrawPage.h>
 #include <Mod/TechDraw/App/DrawRichAnno.h>
 #include <Mod/TechDraw/App/DrawViewBalloon.h>
 #include <Mod/TechDraw/App/DrawViewDetail.h>
@@ -59,6 +60,7 @@
 #include "TaskDetail.h"
 #include "TaskProjGroup.h"
 #include "ViewProviderViewPart.h"
+#include "DrawGuiUtil.h"
 #include "ViewProviderPage.h"
 #include "QGIViewPart.h"
 #include "QGIViewDimension.h"
@@ -234,6 +236,8 @@ std::vector<App::DocumentObject*> ViewProviderViewPart::claimChildren() const
     //    - GeomHatches
     //    - any drawing views declaring this view as their parent
     std::vector<App::DocumentObject*> temp;
+    const auto sketches = getViewPart()->Sketches.getValues();
+    temp.insert(temp.end(), sketches.begin(), sketches.end());
     const std::vector<App::DocumentObject *> &views = getViewPart()->getInList();
     try {
       for(std::vector<App::DocumentObject *>::const_iterator it = views.begin(); it != views.end(); ++it) {
@@ -271,6 +275,30 @@ std::vector<App::DocumentObject*> ViewProviderViewPart::claimChildren() const
     } catch (...) {
         return {};
     }
+}
+
+bool ViewProviderViewPart::canDropObject(App::DocumentObject* obj) const
+{
+    return DrawPage::isSketch(obj);
+}
+
+void ViewProviderViewPart::dropObject(App::DocumentObject* obj)
+{
+    if (!DrawPage::isSketch(obj)) {
+        ViewProviderDrawingView::dropObject(obj);
+        return;
+    }
+
+    auto* view = getViewPart();
+    auto* page = view ? view->findParentPage() : nullptr;
+    if (!page || obj->getDocument() != view->getDocument()) {
+        return;
+    }
+
+    DrawGuiUtil::detachSketchFromTechDraw(obj);
+    page->addView(obj, false);
+    view->addSketch(obj);
+    page->Views.touch();
 }
 
 bool ViewProviderViewPart::setEdit(int ModNum)

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
@@ -79,6 +79,8 @@ public:
     int prefHighlightStyle();
 
     std::vector<App::DocumentObject*> claimChildren() const override;
+    bool canDropObject(App::DocumentObject* obj) const override;
+    void dropObject(App::DocumentObject* obj) override;
     void fixSceneDependencies() override;
 
     TechDraw::DrawViewPart* getViewObject() const override;

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -216,6 +216,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     *views << "TechDraw_DetailView";
     *views << "TechDraw_ProjectionGroup";
     *views << "TechDraw_ClipGroup";
+    *views << "TechDraw_NewSketch";
     *views << "Separator";
     *views << "TechDraw_Symbol";
     *views << "TechDraw_Image";
@@ -304,6 +305,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *views << "TechDraw_DetailView";
     *views << "TechDraw_DraftView";
     *views << "TechDraw_ClipGroup";
+    *views << "TechDraw_NewSketch";
 
     Gui::ToolBarItem* stacking = new Gui::ToolBarItem(root);
     stacking->setCommand("TechDraw Stacking");

--- a/src/Mod/TechDraw/TDTest/DrawPageSketchTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawPageSketchTest.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# /**************************************************************************
+#                                                                           *
+#    Copyright (c) 2026 AstoCAD <hello@astocad.com>                         *
+#                                                                           *
+#    This file is part of FreeCAD.                                          *
+#                                                                           *
+#    FreeCAD is free software: you can redistribute it and/or modify it     *
+#    under the terms of the GNU Lesser General Public License as            *
+#    published by the Free Software Foundation, either version 2.1 of the   *
+#    License, or (at your option) any later version.                        *
+#                                                                           *
+#    FreeCAD is distributed in the hope that it will be useful, but         *
+#    WITHOUT ANY WARRANTY; without even the implied warranty of             *
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+#    Lesser General Public License for more details.                        *
+#                                                                           *
+#    You should have received a copy of the GNU Lesser General Public       *
+#    License along with FreeCAD. If not, see                                *
+#    <https://www.gnu.org/licenses/>.                                       *
+#                                                                           *
+# **************************************************************************/
+
+import unittest
+
+import FreeCAD
+
+from .TechDrawTestUtilities import createPageWithSVGTemplate
+
+
+class DrawPageSketchTest(unittest.TestCase):
+    def setUp(self):
+        FreeCAD.newDocument("TDPageSketch")
+        self.document = FreeCAD.ActiveDocument
+        self.page = createPageWithSVGTemplate(self.document)
+        self.sketch = self.document.addObject("Sketcher::SketchObject", "Sketch")
+
+    def tearDown(self):
+        FreeCAD.closeDocument("TDPageSketch")
+
+    def testSketchCanBeAddedAndRemoved(self):
+        self.page.addView(self.sketch)
+
+        self.assertIn(self.sketch, self.page.Views)
+        self.assertNotIn(self.sketch, self.page.getViews())
+
+        self.page.removeView(self.sketch)
+        self.assertNotIn(self.sketch, self.page.Views)
+        self.assertIsNotNone(self.document.getObject("Sketch"))
+
+    def testSketchCanBelongToViewPart(self):
+        view = self.document.addObject("TechDraw::DrawViewPart", "View")
+        self.page.addView(view)
+        self.page.addView(self.sketch)
+
+        view.Sketches = [self.sketch]
+
+        self.assertIn(self.sketch, self.page.Views)
+        self.assertIn(self.sketch, view.Sketches)
+
+        view.Sketches = []
+        self.assertIn(self.sketch, self.page.Views)
+        self.assertNotIn(self.sketch, view.Sketches)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/TechDraw/TestTechDrawApp.py
+++ b/src/Mod/TechDraw/TestTechDrawApp.py
@@ -22,6 +22,7 @@
 
 #tests that do not require Gui
 from TDTest.DrawHatchTest import DrawHatchTest  # noqa: F401
+from TDTest.DrawPageSketchTest import DrawPageSketchTest  # noqa: F401
 from TDTest.DrawViewAnnotationTest import DrawViewAnnotationTest  # noqa: F401
 from TDTest.DrawViewBalloonTest import DrawViewBalloonTest  # noqa: F401
 from TDTest.DrawViewImageTest import DrawViewImageTest  # noqa: F401


### PR DESCRIPTION
- Add the capability to drag sketch from and to techdraw pages and techdraw views.
- Add a new sketch command to techdraw. This opens a task panel showing possible owner for selection.
- Double clicking a sketch that is in a techdraw page starts edit in a special mode such that it looks like the edition takes place in the techdraw page. What actually happens is that the sketch is edited in a 3dView, with a screenshot of the techdraw page at the back and the geometries of the owner view (if the sketch is in a view) are added as external.

Video : https://www.youtube.com/watch?v=zX42iMGNXDU