### PR TITLE
CAM: MillFacing - G1 for plunge moves

### DIFF
--- a/src/Mod/CAM/Constants.py
+++ b/src/Mod/CAM/Constants.py
@@ -239,3 +239,6 @@ ANNOT_AS_IS = "as-is"
 
 # This tlo g-code was added due to option `output_tool_length_offset`
 ANNOT_ADDED_TLO = "tool_length_offset"
+
+# Moves from linking generator
+ANNOT_LINKING = {"type": "linking"}

--- a/src/Mod/CAM/Constants.py
+++ b/src/Mod/CAM/Constants.py
@@ -207,3 +207,6 @@ GCODE_NON_CONFORMING = (
 # i.e. allow any gcode
 # absence for false; any non-false presence for true: use "True"
 ANNOT_ALLOW_UNSUPPORTED = "allow_unsupported"
+
+# Moves from linking generator
+ANNOT_LINKING = {"type": "linking"}

--- a/src/Mod/CAM/Path/Base/Generator/linking.py
+++ b/src/Mod/CAM/Path/Base/Generator/linking.py
@@ -22,6 +22,7 @@
 # *                                                                         *
 # ***************************************************************************
 
+import Constants
 import Part
 import Path
 from FreeCAD import Vector
@@ -102,6 +103,7 @@ def get_linking_moves(
     retract_height_offset: Optional[float] = None,
     skip_if_no_collision: bool = False,
     collision_clearance: float = 1,
+    split_plunge_height: Optional[float] = None,
 ) -> list:
     """
     Generate linking moves from start to target position.
@@ -150,7 +152,13 @@ def get_linking_moves(
 
     # Try each height
     for i in range(len(heights)):
-        wire = make_linking_wire(start_position, target_position, heights[: i + 1])
+        plunge_heights = heights[: i + 1]
+        if (
+            split_plunge_height is not None
+            and max(plunge_heights) > split_plunge_height > target_position.z
+        ):
+            plunge_heights = sorted(plunge_heights + [split_plunge_height])
+        wire = make_linking_wire(start_position, target_position, plunge_heights)
         if is_travel_collision_free(
             wire, collision_model, tool_shape, tool_diameter, collision_clearance
         ):
@@ -158,6 +166,7 @@ def get_linking_moves(
             for e in wire.Edges:
                 cmd = Path.Geom.cmdsForEdge(e)[0]
                 cmd.Name = "G0"
+                cmd.Annotations = Constants.ANNOT_LINKING
                 commands.append(cmd)
             return commands
 

--- a/src/Mod/CAM/Path/Op/MillFacing.py
+++ b/src/Mod/CAM/Path/Op/MillFacing.py
@@ -283,6 +283,7 @@ class ObjectMillFacing(PathOp.ObjectOp):
             "tool_shape": None,
             "tool_diameter": None,
             "collision_clearance": obj.CollisionClearance.Value,
+            "split_plunge_height": obj.SafeHeight.Value,
         }
         if obj.CollisionAvoidanceStrategy == "Clearance Height":
             linkingArgs["heights_clearance"] = obj.ClearanceHeight.Value
@@ -456,7 +457,7 @@ class ObjectMillFacing(PathOp.ObjectOp):
                             abs(pre3["Z"] - self.commandlist[-1].Parameters.get("Z", pre3["Z"] + 1))
                             > 1e-9
                         ):
-                            self.commandlist.append(Path.Command("G0", pre3))
+                            self.commandlist.append(Path.Command("G1", pre3))
 
                     # Now append the base commands, skipping the generator's initial positioning move
                     for i, cmd in enumerate(base_commands):
@@ -586,28 +587,12 @@ class ObjectMillFacing(PathOp.ObjectOp):
                         # Build target position at cutting depth
                         first_position = FreeCAD.Vector(target_xy[0], target_xy[1], depth)
 
-                        # Generate collision-aware linking moves up to safe/clearance and back down
+                        # Append collision-aware linking moves
                         linkingArgs["start_position"] = last_position
                         linkingArgs["target_position"] = first_position
                         link_commands = linking.get_linking_moves(**linkingArgs)
-
-                        # Append linking moves, ensuring full XYZ continuity
-                        current = last_position
-                        for lc in link_commands:
-                            params = lc.Parameters
-                            X = params["X"]
-                            Y = params["Y"]
-                            Z = params["Z"]
-                            # Skip zero-length moves
-                            if not (
-                                abs(X - current.x) <= 1e-9
-                                and abs(Y - current.y) <= 1e-9
-                                and abs(Z - current.z) <= 1e-9
-                            ):
-                                self.commandlist.append(
-                                    Path.Command(lc.Name, {"X": X, "Y": Y, "Z": Z})
-                                )
-                                current = FreeCAD.Vector(X, Y, Z)
+                        self.commandlist.extend(link_commands)
+                        self.commandlist[-1].Name = "G1"
 
                         # Remove the entire initial G0 bundle (up, XY, down) from the copy
                         del copy_commands[bundle_start:bundle_end]


### PR DESCRIPTION
Fixes #31981

Forum: [Re: MillFacing non-flat stock](https://forum.freecad.org/viewtopic.php?p=900520#p900520)

---

> In my case it was at the edge of the stock. I used "spiral" pattern, and the outermost path was centered exactly on the edge of the stock. I did not make any tweaks at all. There one-half the diameter of the tool crashed into the stock.
>
> In general it is pretty dangerous to use downward G0 Z-motion below the Clearance height.

Test project: [millfacing_spiral.zip](https://github.com/user-attachments/files/30707806/millfacing_spiral.zip)

Default spiral pattern plunges to material with rapid feed

<img width="876" height="413" alt="Screenshot_20260804_172051_hor_lossy" src="https://github.com/user-attachments/assets/6b308653-be6b-4a5a-a157-3b3a61ab02af" />

---

### Changes

- Used G1 for plunge moves
- Added annotation to `linking`, which simplify debugging
- Added optional argument `split_plunge_depth` to `linking` generator, which uses to get rapid and feed plunge moves
  This also will be used in #30402

<img width="597" height="395" alt="Screenshot_20260804_183525_lossy" src="https://github.com/user-attachments/assets/2956c743-4557-4dd1-b984-c4955e082f08" />