### PR TITLE
BIM: fix site ReferenceError when creating project with default structure

### DIFF
--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -2102,7 +2102,11 @@ class _ViewProviderSite:
 
     def updateSunPosition(self, vobj):
         """Calculates sun position and updates the sphere, path arc, and ray object."""
-        if not hasattr(vobj, "ShowSunPosition"):
+        try:
+            vobj.ShowSunPosition
+        except (ReferenceError, AttributeError):
+            # ReferenceError: vobj no longer exists
+            # see https://github.com/FreeCAD/FreeCAD/issues/24543
             return
 
         import math


### PR DESCRIPTION
This PR fixes a problem identical to #24543. The `updateSunPosition` function is called via a `singleShot` construction and the referenced ViewObject can already be deleted in certain scenarios.

1. Start a new document.
2. Switch to the BIM WB.
3. Press the Strict IFC button in the Status Bar.
4. Confirm that you want to create a default structure.
5. Result: _ReferenceError: Cannot access attribute 'ShowSunPosition' of deleted object_

No AI was used.

```
OS: Ubuntu 22.04.5 LTS (ubuntu:GNOME/ubuntu/wayland)
Architecture: x86_64
Version: 26.3.0dev.20260728 (Git shallow) AppImage
Build date: 2026/07/28 21:59:12
Build type: Release
Branch: (HEAD detached at 63af5cb2f)
Hash: 63af5cb2f3dbb2b4c7333f6d220b03e05bf92f99
Python 3.11.14, Qt 6.8.3, Coin 4.0.10 (bundled), Pivy 0.6.11 (bundled), Vtk 9.3.1, boost 1_86, Eigen3 3.4.0, PySide 6.8.3
shiboken 6.8.3, xerces-c 3.3.0, Clipper2 , IfcOpenShell 0.8.0, OCC 7.8.1
Locale: Dutch/Netherlands (nl_NL)
Stylesheet/Theme/QtStyle: unset/FreeCAD Classic/
QPA/File dialog/Color dialog: xcb/non-native/via Qt
Navigation Style/Orbit Style/Rotation Mode: CAD/Trackball/Window center
Logical DPI/Physical DPI/Pixel Ratio: 96/86.1283/1
OpenGL version/vendor/renderer: 4.5 (Compatibility Profile) Mesa 23.2.1-1ubuntu3.1~22.04.4/AMD/KABINI (, LLVM 15.0.7, DRM 2.50, 6.8.0-136-generic)
Installed mods:
```