### PR TITLE
BIM: Fixes railings of Arch_Stairs created from multiple segments not respecting the visibility settings of the parent

### DIFF
--- a/src/Mod/BIM/ArchStairs.py
+++ b/src/Mod/BIM/ArchStairs.py
@@ -2466,10 +2466,16 @@ class _ViewProviderStairs(ArchComponent.ViewProviderComponent):
         if not obj:
             return
 
+        self._setRailingsVisibility(obj, vobj.Visibility)
+
+    def _setRailingsVisibility(self, obj, visible):
         for railing_name in ("RailingLeft", "RailingRight"):
             railing = getattr(obj, railing_name, None)
             if railing and hasattr(railing, "ViewObject"):
-                railing.ViewObject.Visibility = vobj.Visibility
+                railing.ViewObject.Visibility = visible
+        for child in getattr(obj, "Additions", []):
+            if Draft.getType(child) == "Stairs":
+                self._setRailingsVisibility(child, visible)
 
     def claimChildren(self):
         "Define which objects will appear as children in the tree view"

--- a/src/Mod/BIM/bimtests/TestArchStairsGui.py
+++ b/src/Mod/BIM/bimtests/TestArchStairsGui.py
@@ -75,7 +75,7 @@ class TestArchStairsGui(TestArchBaseGui):
         stairs = Arch.makeStairs(baseobj=[wire1, wire2], width=800, height=2500, steps=14)
         self.document.recompute()
 
-        Arch.makeRailing([stairs] + list(stairs.Additions))
+        Arch.makeRailing([stairs] + stairs.Additions)
         self.document.recompute()
 
         segment = stairs.Additions[-1]

--- a/src/Mod/BIM/bimtests/TestArchStairsGui.py
+++ b/src/Mod/BIM/bimtests/TestArchStairsGui.py
@@ -23,6 +23,8 @@
 # ***************************************************************************
 
 import Arch
+import Draft
+import FreeCAD
 
 from bimtests.TestArchBaseGui import TestArchBaseGui
 
@@ -66,3 +68,30 @@ class TestArchStairsGui(TestArchBaseGui):
         self.pump_gui_events()
         self.document.recompute()
         self._assert_visibility(stairs, True)
+
+    def test_stairs_multi_segment_railing_follow_parent_visibility(self):
+        wire1 = Draft.makeWire([FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(1000, 0, 0)])
+        wire2 = Draft.makeWire([FreeCAD.Vector(1000, 0, 0), FreeCAD.Vector(1000, 1000, 0)])
+        stairs = Arch.makeStairs(baseobj=[wire1, wire2], width=800, height=2500, steps=14)
+        self.document.recompute()
+
+        Arch.makeRailing([stairs] + list(stairs.Additions))
+        self.document.recompute()
+
+        segment = stairs.Additions[-1]
+        segment.RailingLeft.ViewObject.Visibility = True
+        segment.RailingRight.ViewObject.Visibility = True
+
+        stairs.ViewObject.Visibility = False
+        self.pump_gui_events()
+        self.document.recompute()
+
+        self.assertFalse(segment.RailingLeft.ViewObject.Visibility)
+        self.assertFalse(segment.RailingRight.ViewObject.Visibility)
+
+        stairs.ViewObject.Visibility = True
+        self.pump_gui_events()
+        self.document.recompute()
+
+        self.assertTrue(segment.RailingLeft.ViewObject.Visibility)
+        self.assertTrue(segment.RailingRight.ViewObject.Visibility)


### PR DESCRIPTION
Recursively set visibility of railings to respect visibility of parent in `_ViewProviderStairs.onChanged()` .
Added a unit test as well.


## Issues
Fixes #31715 

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
Before:
<img width="1279" height="475" alt="Screenshot 2026-08-05 at 1 16 30 AM" src="https://github.com/user-attachments/assets/32d99515-a9b5-4a84-88d6-fd60f326840d" />

After:
<img width="1279" height="475" alt="Screenshot 2026-08-05 at 1 14 27 AM" src="https://github.com/user-attachments/assets/a3f12997-321e-4132-a44e-b9422ce4730b" />
