### PR TITLE
Part: Don't let `shapeType` throw when comp is null

### DIFF
--- a/src/Mod/Part/App/TopoShapeCompoundPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeCompoundPyImp.cpp
@@ -106,7 +106,7 @@ PyObject* TopoShapeCompoundPy::add(PyObject* args)
     std::vector<TopoShape> shapes;
 
     try {
-        if (comp.shapeType() == TopAbs_COMPOUND) {
+        if (comp.shapeType(/*silent = */ true) == TopAbs_COMPOUND) {
             for (const TopoShape& childShape : comp.getSubTopoShapes()) {
                 shapes.push_back(childShape);
             }


### PR DESCRIPTION
Fixes #31666 and un-breaks the unit tests added in #31700 (@maxwxyz).

PR #24632 lost the ability to add to an empty compound by using a bare call to `comp.shapeType()`, which throws an exception if the compound is null. Except that an empty compound default constructs null, so you then couldn't add to an empty default-constructed compound. Instead, call the version of `shapeType` that permits this call.

I should note that this is still not wonderful behavior, it might be better to make the default constructor make a legit non-null empty compound.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.