### PR TITLE
Build: Move Windows-on-ARM code signing to x86 emulation layer

### DIFF
--- a/.github/workflows/sub_releaseWindowsLibpack.yml
+++ b/.github/workflows/sub_releaseWindowsLibpack.yml
@@ -119,16 +119,35 @@ jobs:
         run: |
           cmake --install "${{ env.builddir }}" --prefix "${{ env.stagingdir }}" --config Release
 
+      # The dotnet/sign tool only runs on Windows x64 (see its docs/signing-tool-spec.md), so the
+      # x64 SDK is requested on every runner and the signer runs under x64 emulation on ARM64.
+      # Authenticode does not care about the host architecture: an x64 signer signs ARM64 binaries.
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: '10.0.103'
+          architecture: 'x64'
 
       - name: Install sign tool
         run: |
+          # When the requested architecture is not the runner's native one, setup-dotnet installs
+          # into an architecture subdirectory but still points DOTNET_ROOT and PATH at the base
+          # directory, so on ARM64 the x64 host has to be selected here.
+          $dotnetRoot = $env:DOTNET_ROOT
+          if (Test-Path "$dotnetRoot\x64\dotnet.exe") {
+            $dotnetRoot = "$dotnetRoot\x64"
+            # GITHUB_ENV and GITHUB_PATH only take effect in later steps, so the running step needs
+            # the same values set directly for the tool install and the version check below.
+            $env:DOTNET_ROOT = $dotnetRoot
+            $env:PATH = "$dotnetRoot;$env:PATH"
+            "DOTNET_ROOT=$dotnetRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            $dotnetRoot | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          }
           # NOTE: The sign tool is ONLY available as a prerelease package, they never issue real releases.
-          dotnet tool install --global --prerelease sign
+          & "$dotnetRoot\dotnet.exe" tool install --global --prerelease sign
           echo "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          & "$dotnetRoot\dotnet.exe" --info
+          & "$env:USERPROFILE\.dotnet\tools\sign.exe" --version
 
       # The NSIS installer script uses advanced logging (LogSet), which requires a log-enabled NSIS
       # build. The stock choco/preinstalled NSIS lacks it, so use the same conda-forge log build the
@@ -172,6 +191,7 @@ jobs:
           LIBPACK_DIR: ${{ env.libpackdir }}
           MAKE_INSTALLER: ${{ inputs.makeInstaller }}
           UPLOAD_RELEASE: "true"
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           WINDOWS_AZURE_ENDPOINT: ${{ vars.AZURE_TRUSTED_SIGNING_ENDPOINT }}
           WINDOWS_AZURE_CERTIFICATE_PROFILE: ${{ vars.AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE }}
           WINDOWS_AZURE_SIGNING_ACCOUNT: ${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT }}
@@ -181,5 +201,12 @@ jobs:
             export WINDOWS_SIGN_RELEASE=1
           else
             export WINDOWS_SIGN_RELEASE=0
+          fi
+          # Where signing credentials exist the bundle must be signed or not published at all.
+          # Without them (a fork with no secrets) an unsigned bundle is still worth having.
+          if [[ -n "${AZURE_CLIENT_ID}" ]]; then
+            export WINDOWS_SIGNING_REQUIRED=1
+          else
+            export WINDOWS_SIGNING_REQUIRED=0
           fi
           bash package/libpack-windows/create_bundle.sh

--- a/package/libpack-windows/create_bundle.sh
+++ b/package/libpack-windows/create_bundle.sh
@@ -19,7 +19,11 @@
 #   MAKE_INSTALLER    "true" to also build the NSIS installer (x64 only for now)
 #   UPLOAD_RELEASE    "true" to upload artifacts to the release with "gh release upload"
 # Optional (code signing, all must be present to sign):
-#   WINDOWS_SIGN_RELEASE            "1" to attempt Azure Trusted Signing
+#   WINDOWS_SIGN_RELEASE            "1" to sign with Azure Trusted Signing. Signing is then
+#                                   mandatory: any failure aborts before an artifact is uploaded.
+#   WINDOWS_SIGNING_REQUIRED        "1" when signing credentials are configured for this build, so
+#                                   that an unsigned bundle is an error even if the Azure login
+#                                   itself failed and WINDOWS_SIGN_RELEASE ended up "0".
 #   WINDOWS_AZURE_ENDPOINT
 #   WINDOWS_AZURE_CERTIFICATE_PROFILE
 #   WINDOWS_AZURE_SIGNING_ACCOUNT
@@ -134,27 +138,50 @@ fi
 sign_dir="${copy_dir}"
 sign_available=0
 if [[ "${WINDOWS_SIGN_RELEASE:-0}" == "1" ]]; then
-    tenant="$(az account show --query tenantId -o tsv)"
+    # Once signing is requested it is mandatory: an unusable signer aborts before anything is
+    # uploaded. Losing the artifact is deliberate, because a silently unsigned bundle published
+    # under a green job is far worse than a red job and no bundle at all.
+    if ! command -v sign >/dev/null 2>&1; then
+        echo "ERROR: signing was requested but the 'sign' tool was not found on PATH." >&2
+        exit 1
+    fi
+    if ! tenant="$(az account show --query tenantId -o tsv)"; then
+        echo "ERROR: signing was requested but the Azure tenant could not be determined." >&2
+        exit 1
+    fi
+
     export AZURE_IDENTITY_DISABLE_WORKLOAD_IDENTITY=true
     export AZURE_IDENTITY_DISABLE_MANAGED_IDENTITY=true
     unset AZURE_IDENTITY_LOGGING_ENABLED || true
 
-    if az account get-access-token --tenant "${tenant}" \
-           --scope "https://codesigning.azure.net/.default" >/dev/null 2>&1; then
-        sign_available=1
+    if ! az account get-access-token --tenant "${tenant}" \
+             --scope "https://codesigning.azure.net/.default" >/dev/null 2>&1; then
+        echo "ERROR: signing was requested but no Azure code signing token could be obtained." >&2
+        exit 1
     fi
+    sign_available=1
+elif [[ "${WINDOWS_SIGNING_REQUIRED:-0}" == "1" ]]; then
+    # Signing credentials are configured for this build, so the Azure login failing (its workflow
+    # step is continue-on-error) must not quietly downgrade a real release to an unsigned bundle.
+    echo "ERROR: signing credentials are configured but the Azure login did not succeed." >&2
+    exit 1
 fi
 
 sign_file() {
-    sign code artifact-signing \
+    # Output is captured rather than shown because Azure authentication is extremely noisy with
+    # misleading Managed Identity "failure" messages that do not affect the real signing result.
+    # It is printed when signing actually fails, so real errors are not swallowed.
+    local output
+    if ! output="$(sign code artifact-signing \
         --artifact-signing-endpoint "${WINDOWS_AZURE_ENDPOINT}" \
         --artifact-signing-certificate-profile "${WINDOWS_AZURE_CERTIFICATE_PROFILE}" \
         --artifact-signing-account "${WINDOWS_AZURE_SIGNING_ACCOUNT}" \
         --timestamp-url https://timestamp.acs.microsoft.com \
         --timestamp-digest sha256 \
-        "$1" >/dev/null 2>&1
-    # Output is silenced because Azure authentication is extremely noisy with misleading Managed
-    # Identity "failure" messages that do not affect the real signing result.
+        "$1" 2>&1)"; then
+        printf '%s\n' "${output}" >&2
+        return 1
+    fi
 }
 
 if [[ "${sign_available}" == "1" ]]; then
@@ -172,7 +199,10 @@ if [[ "${sign_available}" == "1" ]]; then
     for f in "${files[@]}"; do
         count=$((count + 1))
         echo "Signing [${count}/${total}]: ${f}"
-        sign_file "${f}"
+        if ! sign_file "${f}"; then
+            echo "Signing failed for ${f}"
+            exit 1
+        fi
     done
     signtool verify -pa "${sign_dir}/bin/FreeCAD.exe" || echo "signtool verify failed (continuing)"
     echo "Signing completed."


### PR DESCRIPTION
The Windows-on-ARM code signing failed in our first attempt at it because it turns out the `sign` tool actually only runs on x86. So install that, let it run on emulation, check the output, try to be more fault-tolerant, etc. Also add a code path that will block unsigned binaries from being uploaded if signing was requested. In the case where signing is requested, a failure there blocks upload. If no signing is requested, then an unsigned binary is allowed. This allows more testing in non-mainline repos.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: Claude Opus 5
