### PR TITLE
[Backport releases/FreeCAD-1-1] Gui: ToolBarManager fixes backport of PR28674 and PR28998

### DIFF
--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -841,21 +841,8 @@ void ToolBarManager::onTimer()
 void ToolBarManager::saveState() const
 {
     auto ignoreSave = [](QAction* action) {
-        // If the toggle action is invisible then it's controlled by the application.
-        // In this case the current state is not saved.
-        if (!action->isVisible()) {
-            return true;
-        }
-
-        QVariant property = action->property("DefaultVisibility");
-        if (property.isNull()) {
-            return false;
-        }
-
-        // If DefaultVisibility is Unavailable then never save the state because it's
-        // always controlled by the client code.
-        auto value = static_cast<ToolBarItem::DefaultVisibility>(property.toInt());
-        return value == ToolBarItem::DefaultVisibility::Unavailable;
+        // Only save state for toolbars whose toggle action is user-visible.
+        return !action->isVisible();
     };
 
     QList<ToolBar*> toolbars = toolBars();

--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -703,6 +703,7 @@ void ToolBarManager::setup(ToolBarItem* toolBarItems)
             toolbar->setObjectName(name);
 
             getMainWindow()->addToolBar(toolbar);
+            setToolBarIconSize(toolbar);
 
             if (nameAsToolTip) {
                 auto tooltip = QChar::fromLatin1('[')


### PR DESCRIPTION
I've created one backport PR with a commit for each PR to be backported PR #28674 and PR #28998 as it's the same file and they are both small changes so should be easy enough to reference.
