### PR TITLE
PD: Allow BaseFeatures from other App::Parts

### DIFF
--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -73,6 +73,12 @@ const PropertyComplexGeoData* GeoFeature::getPropertyOfGeometry() const
     return nullptr;
 }
 
+const PropertyComplexGeoData* GeoFeature::getPropertyOfGeometry(const DocumentObject* object)
+{
+    auto* geoFeature = freecad_cast<const GeoFeature*>(object);
+    return geoFeature ? geoFeature->getPropertyOfGeometry() : nullptr;
+}
+
 PyObject* GeoFeature::getPyObject()
 {
     if (PythonObject.is(Py::_None())) {

--- a/src/App/GeoFeature.h
+++ b/src/App/GeoFeature.h
@@ -76,6 +76,8 @@ public:
      * The default implementation returns null.
      */
     virtual const PropertyComplexGeoData* getPropertyOfGeometry() const;
+    /// Returns the geometry property of a GeoFeature object, or null for other object types.
+    static const PropertyComplexGeoData* getPropertyOfGeometry(const DocumentObject* object);
     /**
      * @brief getPyObject returns the Python binding object
      * @return the Python binding object

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -44,6 +44,7 @@ PROPERTY_SOURCE(PartDesign::Body, Part::BodyBase)
 
 Body::Body()
 {
+    BaseFeature.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(AllowCompound, (true), "Base", App::Prop_None, "Allow multiple solids in Body");
 
     _GroupTouched.setStatus(App::Property::Output, true);

--- a/src/Mod/PartDesign/App/FeatureBase.cpp
+++ b/src/Mod/PartDesign/App/FeatureBase.cpp
@@ -28,6 +28,8 @@
 
 #include <App/Application.h>
 #include <App/FeaturePythonPyImp.h>
+#include <App/GeoFeature.h>
+#include <Mod/Part/App/PropertyTopoShape.h>
 #include "Body.h"
 #include "FeatureBase.h"
 #include "FeaturePy.h"
@@ -35,6 +37,19 @@
 namespace PartDesign
 {
 
+namespace
+{
+
+Part::TopoShape getGeometryShape(const App::DocumentObject* object)
+{
+    auto* geoFeature = freecad_cast<const App::GeoFeature*>(object);
+    auto* shapeProperty = geoFeature
+        ? freecad_cast<const Part::PropertyPartShape*>(geoFeature->getPropertyOfGeometry())
+        : nullptr;
+    return shapeProperty ? shapeProperty->getShape() : Part::TopoShape();
+}
+
+}  // namespace
 
 PROPERTY_SOURCE(PartDesign::FeatureBase, PartDesign::Feature)
 
@@ -80,18 +95,15 @@ App::DocumentObjectExecReturn* FeatureBase::execute()
         );
     }
 
-    if (!BaseFeature.getValue()->isDerivedFrom<Part::Feature>()) {
-        return new App::DocumentObjectExecReturn(
-            QT_TRANSLATE_NOOP("Exception", "BaseFeature must be a Part::Feature")
-        );
-    }
-
     auto* base = BaseFeature.getValue();
     if (UseLegacyBaseFeaturePlacement.getValue()) {
         auto shape = Part::Feature::getTopoShape(
             base,
             Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform
         );
+        if (shape.isNull()) {
+            shape = getGeometryShape(base);
+        }
         if (shape.isNull()) {
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "BaseFeature has an empty shape")
@@ -109,6 +121,9 @@ App::DocumentObjectExecReturn* FeatureBase::execute()
     auto shape = isBodyLocalFeature
         ? static_cast<Part::Feature*>(base)->Shape.getShape()
         : Part::Feature::getTopoShape(base, Part::ShapeOption::ResolveLink);
+    if (shape.isNull()) {
+        shape = getGeometryShape(base);
+    }
     if (shape.isNull()) {
         return new App::DocumentObjectExecReturn(
             QT_TRANSLATE_NOOP("Exception", "BaseFeature has an empty shape")

--- a/src/Mod/PartDesign/App/FeatureBase.cpp
+++ b/src/Mod/PartDesign/App/FeatureBase.cpp
@@ -37,20 +37,6 @@
 namespace PartDesign
 {
 
-namespace
-{
-
-Part::TopoShape getGeometryShape(const App::DocumentObject* object)
-{
-    auto* geoFeature = freecad_cast<const App::GeoFeature*>(object);
-    auto* shapeProperty = geoFeature
-        ? freecad_cast<const Part::PropertyPartShape*>(geoFeature->getPropertyOfGeometry())
-        : nullptr;
-    return shapeProperty ? shapeProperty->getShape() : Part::TopoShape();
-}
-
-}  // namespace
-
 PROPERTY_SOURCE(PartDesign::FeatureBase, PartDesign::Feature)
 
 FeatureBase::FeatureBase()
@@ -102,7 +88,12 @@ App::DocumentObjectExecReturn* FeatureBase::execute()
             Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform
         );
         if (shape.isNull()) {
-            shape = getGeometryShape(base);
+            auto* shapeProperty = freecad_cast<const Part::PropertyPartShape*>(
+                App::GeoFeature::getPropertyOfGeometry(base)
+            );
+            if (shapeProperty) {
+                shape = shapeProperty->getShape();
+            }
         }
         if (shape.isNull()) {
             return new App::DocumentObjectExecReturn(
@@ -122,7 +113,12 @@ App::DocumentObjectExecReturn* FeatureBase::execute()
         ? static_cast<Part::Feature*>(base)->Shape.getShape()
         : Part::Feature::getTopoShape(base, Part::ShapeOption::ResolveLink);
     if (shape.isNull()) {
-        shape = getGeometryShape(base);
+        auto* shapeProperty = freecad_cast<const Part::PropertyPartShape*>(
+            App::GeoFeature::getPropertyOfGeometry(base)
+        );
+        if (shapeProperty) {
+            shape = shapeProperty->getShape();
+        }
     }
     if (shape.isNull()) {
         return new App::DocumentObjectExecReturn(

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -30,8 +30,8 @@
 
 #include <App/Datums.h>
 #include <App/Document.h>
-#include <App/GeoFeatureGroupExtension.h>
 #include <App/GeoFeature.h>
+#include <App/GeoFeatureGroupExtension.h>
 #include <App/Origin.h>
 #include <App/Part.h>
 #include <Base/Console.h>
@@ -65,10 +65,9 @@ static Part::TopoShape getBaseFeatureShape(const App::DocumentObject* object)
 {
     auto shape = Part::Feature::getTopoShape(object, Part::ShapeOption::ResolveLink);
     if (shape.isNull()) {
-        auto* geoFeature = freecad_cast<const App::GeoFeature*>(object);
-        auto* shapeProperty = geoFeature
-            ? freecad_cast<const Part::PropertyPartShape*>(geoFeature->getPropertyOfGeometry())
-            : nullptr;
+        auto* shapeProperty = freecad_cast<const Part::PropertyPartShape*>(
+            App::GeoFeature::getPropertyOfGeometry(object)
+        );
         if (shapeProperty) {
             shape = shapeProperty->getShape();
         }

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -31,6 +31,7 @@
 #include <App/Datums.h>
 #include <App/Document.h>
 #include <App/GeoFeatureGroupExtension.h>
+#include <App/GeoFeature.h>
 #include <App/Origin.h>
 #include <App/Part.h>
 #include <Base/Console.h>
@@ -41,6 +42,7 @@
 #include <Gui/Application.h>
 #include <Gui/MainWindow.h>
 #include <Gui/MDIView.h>
+#include <Mod/Part/App/PropertyTopoShape.h>
 #include <Mod/Sketcher/App/SketchObject.h>
 #include <Mod/PartDesign/App/Body.h>
 #include <Mod/PartDesign/App/FeatureBase.h>
@@ -58,6 +60,21 @@
 
 namespace PartDesignGui
 {
+
+static Part::TopoShape getBaseFeatureShape(const App::DocumentObject* object)
+{
+    auto shape = Part::Feature::getTopoShape(object, Part::ShapeOption::ResolveLink);
+    if (shape.isNull()) {
+        auto* geoFeature = freecad_cast<const App::GeoFeature*>(object);
+        auto* shapeProperty = geoFeature
+            ? freecad_cast<const Part::PropertyPartShape*>(geoFeature->getPropertyOfGeometry())
+            : nullptr;
+        if (shapeProperty) {
+            shape = shapeProperty->getShape();
+        }
+    }
+    return shape;
+}
 
 /// Returns active part, if there is no such, creates a new part, if it fails, shows a message
 App::Part* assertActivePart()
@@ -103,10 +120,9 @@ void CmdPartDesignBody::activated(int iMsg)
     Q_UNUSED(iMsg);
 
     App::Part* actPart = PartDesignGui::getActivePart();
-    App::Part* partOfBaseFeature = nullptr;
 
     std::vector<App::DocumentObject*> features = getSelection().getObjectsOfType(
-        Part::Feature::getClassTypeId()
+        App::DocumentObject::getClassTypeId()
     );
     App::DocumentObject* baseFeature = nullptr;
     bool addtogroup = false;
@@ -139,71 +155,60 @@ void CmdPartDesignBody::activated(int iMsg)
                 // Prevent creating bodies based on bodies (but don't pop-up a dialog)
                 baseFeature = nullptr;
             }
+            else if (baseFeature->isDerivedFrom<Sketcher::SketchObject>()) {
+                // Add sketcher to the body's group property
+                addtogroup = true;
+            }
             else {
-                partOfBaseFeature = App::Part::getPartOfObject(baseFeature);
-                if (partOfBaseFeature && partOfBaseFeature != actPart) {
-                    // prevent cross-part mess
+                Part::TopoShape baseShape = PartDesignGui::getBaseFeatureShape(baseFeature);
+                if (baseShape.isNull()) {
                     QMessageBox::warning(
                         Gui::getMainWindow(),
                         QObject::tr("Bad base feature"),
-                        QObject::tr("Base feature (%1) belongs to other part.")
+                        QObject::tr("Base feature (%1) has an empty shape.")
                             .arg(QString::fromUtf8(baseFeature->Label.getValue()))
                     );
                     baseFeature = nullptr;
                 }
-                else if (baseFeature->isDerivedFrom<Sketcher::SketchObject>()) {
-                    // Add sketcher to the body's group property
-                    addtogroup = true;
-                }
-                // if a standard Part feature (not a PartDesign feature) is selected then check
-                // the number of solids/shells
                 else if (!baseFeature->isDerivedFrom<PartDesign::Feature>()) {
-                    const TopoDS_Shape& shape
-                        = static_cast<Part::Feature*>(baseFeature)->Shape.getValue();
-                    if (!shape.IsNull()) {
-                        int numSolids = 0;
-                        int numShells = 0;
-                        for (TopExp_Explorer xp(shape, TopAbs_SOLID); xp.More(); xp.Next()) {
-                            numSolids++;
-                        }
-                        for (TopExp_Explorer xp(shape, TopAbs_SHELL, TopAbs_SOLID); xp.More();
-                             xp.Next()) {
-                            numShells++;
-                        }
+                    const TopoDS_Shape& shape = baseShape.getShape();
+                    int numSolids = 0;
+                    int numShells = 0;
+                    for (TopExp_Explorer xp(shape, TopAbs_SOLID); xp.More(); xp.Next()) {
+                        numSolids++;
+                    }
+                    for (TopExp_Explorer xp(shape, TopAbs_SHELL, TopAbs_SOLID); xp.More(); xp.Next()) {
+                        numShells++;
+                    }
 
-                        QString warning;
-                        if (numSolids > 1 && numShells == 0) {
-                            warning = QObject::tr(
-                                "The selected shape consists of multiple solids.\n"
-                                "This may lead to unexpected results."
-                            );
-                        }
-                        else if (numShells > 1 && numSolids == 0) {
-                            warning = QObject::tr(
-                                "The selected shape consists of multiple shells.\n"
-                                "This may lead to unexpected results."
-                            );
-                        }
-                        else if (numShells == 1 && numSolids == 0) {
-                            warning = QObject::tr(
-                                "The selected shape consists of only a shell.\n"
-                                "This may lead to unexpected results."
-                            );
-                        }
-                        else if (numSolids + numShells > 1) {
-                            warning = QObject::tr(
-                                "The selected shape consists of multiple solids or shells.\n"
-                                "This may lead to unexpected results."
-                            );
-                        }
+                    QString warning;
+                    if (numSolids > 1 && numShells == 0) {
+                        warning = QObject::tr(
+                            "The selected shape consists of multiple solids.\n"
+                            "This may lead to unexpected results."
+                        );
+                    }
+                    else if (numShells > 1 && numSolids == 0) {
+                        warning = QObject::tr(
+                            "The selected shape consists of multiple shells.\n"
+                            "This may lead to unexpected results."
+                        );
+                    }
+                    else if (numShells == 1 && numSolids == 0) {
+                        warning = QObject::tr(
+                            "The selected shape consists of only a shell.\n"
+                            "This may lead to unexpected results."
+                        );
+                    }
+                    else if (numSolids + numShells > 1) {
+                        warning = QObject::tr(
+                            "The selected shape consists of multiple solids or shells.\n"
+                            "This may lead to unexpected results."
+                        );
+                    }
 
-                        if (!warning.isEmpty()) {
-                            QMessageBox::warning(
-                                Gui::getMainWindow(),
-                                QObject::tr("Base feature"),
-                                warning
-                            );
-                        }
+                    if (!warning.isEmpty()) {
+                        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Base feature"), warning);
                     }
                 }
             }

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -62,10 +62,9 @@ bool hasBaseFeatureShape(const App::DocumentObject* object)
     if (!Part::Feature::getTopoShape(object, Part::ShapeOption::ResolveLink).isNull()) {
         return true;
     }
-    auto* geoFeature = freecad_cast<const App::GeoFeature*>(object);
-    auto* shapeProperty = geoFeature
-        ? freecad_cast<const Part::PropertyPartShape*>(geoFeature->getPropertyOfGeometry())
-        : nullptr;
+    auto* shapeProperty = freecad_cast<const Part::PropertyPartShape*>(
+        App::GeoFeature::getPropertyOfGeometry(object)
+    );
     if (shapeProperty) {
         return !shapeProperty->getShape().isNull();
     }

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -27,6 +27,7 @@
 #include <QMenu>
 
 #include <App/Document.h>
+#include <App/GeoFeature.h>
 #include <App/Origin.h>
 #include <App/Part.h>
 #include <App/VarSet.h>
@@ -37,6 +38,7 @@
 #include <Gui/Document.h>
 #include <Gui/MDIView.h>
 #include <Gui/ViewProviderDatum.h>
+#include <Mod/Part/App/PropertyTopoShape.h>
 #include <Mod/PartDesign/App/Body.h>
 #include <Mod/PartDesign/App/FeatureSketchBased.h>
 #include <Mod/PartDesign/App/FeatureBase.h>
@@ -51,6 +53,26 @@ using namespace PartDesignGui;
 namespace sp = std::placeholders;
 
 const char* PartDesignGui::ViewProviderBody::BodyModeEnum[] = {"Through", "Tip", nullptr};
+
+namespace
+{
+
+bool hasBaseFeatureShape(const App::DocumentObject* object)
+{
+    if (!Part::Feature::getTopoShape(object, Part::ShapeOption::ResolveLink).isNull()) {
+        return true;
+    }
+    auto* geoFeature = freecad_cast<const App::GeoFeature*>(object);
+    auto* shapeProperty = geoFeature
+        ? freecad_cast<const Part::PropertyPartShape*>(geoFeature->getPropertyOfGeometry())
+        : nullptr;
+    if (shapeProperty) {
+        return !shapeProperty->getShape().isNull();
+    }
+    return false;
+}
+
+}  // namespace
 
 PROPERTY_SOURCE_WITH_EXTENSIONS(PartDesignGui::ViewProviderBody, PartGui::ViewProviderPart)
 
@@ -527,19 +549,13 @@ bool ViewProviderBody::canDropObject(App::DocumentObject* obj) const
     else if (obj->isDerivedFrom<Part::Part2DObject>()) {
         return true;
     }
-    else if (!obj->isDerivedFrom<Part::Feature>()) {
+    else if (!hasBaseFeatureShape(obj)) {
         return false;
     }
     else if (PartDesign::Body::findBodyOf(obj)) {
         return false;
     }
     else if (obj->isDerivedFrom(Part::BodyBase::getClassTypeId())) {
-        return false;
-    }
-
-    App::Part* actPart = PartDesignGui::getActivePart();
-    App::Part* partOfBaseFeature = App::Part::getPartOfObject(obj);
-    if (partOfBaseFeature && partOfBaseFeature != actPart) {
         return false;
     }
 

--- a/src/Mod/PartDesign/PartDesignTests/TestBaseFeature.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestBaseFeature.py
@@ -80,6 +80,71 @@ class TestBaseFeature(unittest.TestCase):
         self.assertAlmostEqual(body.Shape.BoundBox.XMin, 25)
         self.assertAlmostEqual(body.Shape.BoundBox.XMax, 35)
 
+    def testBodyBaseFeaturePreservesPlacementAcrossParts(self):
+        source_part = self.Doc.addObject("App::Part", "SourcePart")
+        source_part.Placement.Base = App.Vector(100, 0, 0)
+        box = self.Doc.addObject("Part::Box", "Box")
+        box.Length = 10
+        box.Width = 10
+        box.Height = 10
+        source_part.addObject(box)
+        box.Placement.Base = App.Vector(25, 0, 0)
+
+        target_part = self.Doc.addObject("App::Part", "TargetPart")
+        target_part.Placement.Base = App.Vector(200, 0, 0)
+        body = self.Doc.addObject("PartDesign::Body", "Body")
+        target_part.addObject(body)
+        body.Placement.Base = App.Vector(20, 0, 0)
+        body.BaseFeature = box
+        self.Doc.recompute()
+
+        base = body.Group[0]
+        self.assertIs(body.BaseFeature, box)
+        self.assertAlmostEqual(base.Placement.Base.x, -95)
+        self.assertAlmostEqual(body.Shape.BoundBox.XMin, -75)
+        self.assertAlmostEqual(body.Shape.BoundBox.XMax, -65)
+
+    def testBodyBaseFeaturePreservesPlacementFromPartToDocumentRoot(self):
+        source_part = self.Doc.addObject("App::Part", "SourcePart")
+        source_part.Placement.Base = App.Vector(100, 0, 0)
+        box = self.Doc.addObject("Part::Box", "Box")
+        box.Length = 10
+        box.Width = 10
+        box.Height = 10
+        source_part.addObject(box)
+        box.Placement.Base = App.Vector(25, 0, 0)
+
+        body = self.Doc.addObject("PartDesign::Body", "Body")
+        body.Placement.Base = App.Vector(20, 0, 0)
+        body.BaseFeature = box
+        self.Doc.recompute()
+
+        base = body.Group[0]
+        self.assertIs(body.BaseFeature, box)
+        self.assertAlmostEqual(base.Placement.Base.x, 105)
+        self.assertAlmostEqual(body.Shape.BoundBox.XMin, 125)
+        self.assertAlmostEqual(body.Shape.BoundBox.XMax, 135)
+
+    def testBodyBaseFeatureAcceptsLinkedShape(self):
+        box = self.Doc.addObject("Part::Box", "Box")
+        box.Length = 10
+        box.Width = 10
+        box.Height = 10
+        link = self.Doc.addObject("App::Link", "Link")
+        link.LinkedObject = box
+
+        body = self.Doc.addObject("PartDesign::Body", "Body")
+        body.BaseFeature = link
+        self.Doc.recompute()
+
+        self.assertIs(body.BaseFeature, link)
+        self.assertAlmostEqual(body.Shape.BoundBox.XMin, 0)
+        self.assertAlmostEqual(body.Shape.BoundBox.XMax, 10)
+
+        box.Length = 20
+        self.Doc.recompute()
+        self.assertAlmostEqual(body.Shape.BoundBox.XMax, 20)
+
     def testFeatureBasePlacementControlsExternalBaseFeature(self):
         box = self.Doc.addObject("Part::Box", "Box")
         box.Length = 10


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
When you import a STEP file (which loads as nested solids inside Part containers) or try to create Bodies from other solids the new body needs to be a child in the same part object. This is especially worse in nested files and assemblies.
This PR removes the dated limitation.

(Largest change is tests + formatting)

- GUI no longer rejects BaseFeatures by App::Part ownership
- Body.BaseFeature and its internal FeatureBase link both use global scope


File to test: 
[AssemblyExample.zip](https://github.com/user-attachments/files/30754961/AssemblyExample.zip)
(The color change is because of #11210)

Assisted-by: GPT-5.6-Terra
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/e00f075c-b82d-4bbc-a9e8-581bd0e52ce0



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
