### PR TITLE
Introduce unit test of PartDesign::AdditivePipe.  Relates to: #30464

### DIFF
--- a/tests/src/Mod/PartDesign/App/CMakeLists.txt
+++ b/tests/src/Mod/PartDesign/App/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(PartDesign_tests_run
         DatumPlane.cpp
         ShapeBinder.cpp
         Pad.cpp
+        Pipe.cpp
         GeoFeatureGroupExtension.cpp
 )
 

--- a/tests/src/Mod/PartDesign/App/Pipe.cpp
+++ b/tests/src/Mod/PartDesign/App/Pipe.cpp
@@ -5,14 +5,11 @@
 
 #include <App/Application.h>
 #include <App/Document.h>
-#include "Mod/Part/App/FeaturePartBox.h"
 #include "Mod/PartDesign/App/Body.h"
 #include "Mod/PartDesign/App/ShapeBinder.h"
 #include "Mod/PartDesign/App/FeaturePipe.h"
-#include "Mod/Sketcher/App/Sketch.h"
 #include "Mod/Sketcher/App/SketchObject.h"
 #include <BRepGProp.hxx>
-#include <filesystem>
 
 // NOLINTBEGIN(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 
@@ -84,7 +81,6 @@ protected:
             diameter.First = 0;
             diameter.setValue(1.0);
             sketch_circle_->addConstraint(&diameter);
-            // auto kind = diameter.typeToString();
         }
 
         auto obj = std::vector<std::pair<int, long>> {{0, 1}};
@@ -94,10 +90,9 @@ protected:
             sketch_circle_->solve();
         }
         catch (const Base::Exception& e) {
-            std::string break_on_me;
+            FAIL() << e.what();
         }
 
-        // sketch_circle_->setDatum(1, Base::Quantity(1.0, "mm"));
         doc_->recompute();
 
 #ifdef PIPE_SAVE_TEST_FCSTD
@@ -170,7 +165,7 @@ protected:
     // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
 
     App::Document* doc_ = nullptr;
-    std::string docName_ = "";
+    std::string docName_;
     Sketcher::SketchObject* sketch_circle_ = nullptr;
     Sketcher::SketchObject* sketch_line_ = nullptr;
     PartDesign::Body* body_ = nullptr;

--- a/tests/src/Mod/PartDesign/App/Pipe.cpp
+++ b/tests/src/Mod/PartDesign/App/Pipe.cpp
@@ -16,7 +16,7 @@
 // NOLINTBEGIN(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 
 // Uncomment the line below to save temporary test-generated documents
-//#define PIPE_SAVE_TEST_FCSTD 1
+// #define PIPE_SAVE_TEST_FCSTD 1
 
 // from tests/src/Mod/Part/App/TopoShapeExpansion.cpp
 double getVolume(const TopoDS_Shape& shape)
@@ -47,8 +47,10 @@ protected:
         body_->addObject(sketch_circle_);
         sketch_circle_->MapReversed.setValue(false);
         auto origin = body_->getObject("Origin");
-        sketch_circle_->AttachmentOffset.setValue(Base::Placement(Base::Vector3d(0,0,0), Base::Rotation()));
-        sketch_circle_->AttachmentSupport.setValue(origin, std::vector<std::string>{"XY_Plane."});
+        sketch_circle_->AttachmentOffset.setValue(
+            Base::Placement(Base::Vector3d(0, 0, 0), Base::Rotation())
+        );
+        sketch_circle_->AttachmentSupport.setValue(origin, std::vector<std::string> {"XY_Plane."});
         sketch_circle_->MapPathParameter.setValue(0.0);
         sketch_circle_->MapMode.setValue("FlatFace");
 
@@ -81,19 +83,20 @@ protected:
             diameter.First = 0;
             diameter.setValue(1.0);
             sketch_circle_->addConstraint(&diameter);
-            //auto kind = diameter.typeToString();
+            // auto kind = diameter.typeToString();
         }
 
-        auto obj = std::vector<std::pair<int,long>>{{0,1}};
+        auto obj = std::vector<std::pair<int, long>> {{0, 1}};
         sketch_circle_->setGeometryIds(obj);
 
         try {
             sketch_circle_->solve();
-        } catch (const Base::Exception &e) {
+        }
+        catch (const Base::Exception& e) {
             std::string break_on_me;
         }
 
-        //sketch_circle_->setDatum(1, Base::Quantity(1.0, "mm"));
+        // sketch_circle_->setDatum(1, Base::Quantity(1.0, "mm"));
         doc_->recompute();
 
 #ifdef PIPE_SAVE_TEST_FCSTD
@@ -111,7 +114,7 @@ protected:
         // Attach the sketch to body origin, reference: tests/src/Mod/Part/Attacher.cpp
         body_->addObject(sketch_line_);
         sketch_line_->MapReversed.setValue(false);
-        sketch_line_->AttachmentSupport.setValue(origin, std::vector<std::string>{"XZ_Plane."});
+        sketch_line_->AttachmentSupport.setValue(origin, std::vector<std::string> {"XZ_Plane."});
         sketch_line_->MapPathParameter.setValue(0.0);
         sketch_line_->MapMode.setValue("FlatFace");
 
@@ -170,7 +173,7 @@ protected:
     // Volume of a cylinder is
     // V = pi * r^2 * h
     // calculated for the values in this unit test
-    static constexpr double volume_expected_ = M_PI * 0.5*0.5 * 1;
+    static constexpr double volume_expected_ = M_PI * 0.5 * 0.5 * 1;
 
     // NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes)
 };

--- a/tests/src/Mod/PartDesign/App/Pipe.cpp
+++ b/tests/src/Mod/PartDesign/App/Pipe.cpp
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+#include "src/App/InitApplication.h"
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include "Mod/Part/App/FeaturePartBox.h"
+#include "Mod/PartDesign/App/Body.h"
+#include "Mod/PartDesign/App/ShapeBinder.h"
+#include "Mod/PartDesign/App/FeaturePipe.h"
+#include "Mod/Sketcher/App/Sketch.h"
+#include "Mod/Sketcher/App/SketchObject.h"
+#include <BRepGProp.hxx>
+
+// NOLINTBEGIN(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+
+// Uncomment the line below to save temporary test-generated documents
+//#define PIPE_SAVE_TEST_FCSTD 1
+
+// from tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+double getVolume(const TopoDS_Shape& shape)
+{
+    GProp_GProps prop;
+    BRepGProp::VolumeProperties(shape, prop);
+    return abs(prop.Mass());
+}
+
+class FeaturePipeTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        docName_ = App::GetApplication().getUniqueDocumentName("testname");
+        doc_ = App::GetApplication().newDocument(docName_.c_str(), "testlabel");
+        body_ = doc_->addObject<PartDesign::Body>();
+
+        sketch_circle_ = doc_->addObject<Sketcher::SketchObject>("circle");
+
+        // Attach the sketch to body origin
+        // reference: tests/src/Mod/Part/Attacher.cpp
+        body_->addObject(sketch_circle_);
+        sketch_circle_->MapReversed.setValue(false);
+        auto origin = body_->getObject("Origin");
+        sketch_circle_->AttachmentOffset.setValue(Base::Placement(Base::Vector3d(0,0,0), Base::Rotation()));
+        sketch_circle_->AttachmentSupport.setValue(origin, std::vector<std::string>{"XY_Plane."});
+        sketch_circle_->MapPathParameter.setValue(0.0);
+        sketch_circle_->MapMode.setValue("FlatFace");
+
+        //
+        // Create a fully constrained circle sketch
+
+        // first create the circle geometry
+        Part::GeomCircle circle;
+        Base::Vector3d coordsCenter(0.0, 0.0, 0.0);
+        double radius = 1.0;
+        circle.setCenter(coordsCenter);
+        circle.setRadius(radius);
+
+        // add circle geometry to sketch
+        sketch_circle_->addGeometry(&circle);
+
+        // New scope for constraints.  This allows to use the same
+        // temporary variable names as the line sketch below
+        {
+            auto coincident = Sketcher::Constraint();
+            coincident.Type = Sketcher::ConstraintType::Coincident;
+            coincident.First = 0;
+            coincident.FirstPos = Sketcher::PointPos::mid;
+            coincident.Second = -1;
+            coincident.SecondPos = Sketcher::PointPos::start;
+            sketch_circle_->addConstraint(&coincident);
+
+            auto diameter = Sketcher::Constraint();
+            diameter.Type = Sketcher::ConstraintType::Diameter;
+            diameter.First = 0;
+            diameter.setValue(1.0);
+            sketch_circle_->addConstraint(&diameter);
+            //auto kind = diameter.typeToString();
+        }
+
+        auto obj = std::vector<std::pair<int,long>>{{0,1}};
+        sketch_circle_->setGeometryIds(obj);
+
+        try {
+            sketch_circle_->solve();
+        } catch (const Base::Exception &e) {
+            std::string break_on_me;
+        }
+
+        //sketch_circle_->setDatum(1, Base::Quantity(1.0, "mm"));
+        doc_->recompute();
+
+#ifdef PIPE_SAVE_TEST_FCSTD
+        doc_->saveAs("/tmp/test-circle.FCStd");
+#endif
+        //
+        // Create fully constrained line sketch
+        // - define the sketch attachment
+        // - create the line geometry
+        // - add the line geometry to the sketch
+        // - add constraints to the sketch
+
+        sketch_line_ = doc_->addObject<Sketcher::SketchObject>("line");
+
+        // Attach the sketch to body origin, reference: tests/src/Mod/Part/Attacher.cpp
+        body_->addObject(sketch_line_);
+        sketch_line_->MapReversed.setValue(false);
+        sketch_line_->AttachmentSupport.setValue(origin, std::vector<std::string>{"XZ_Plane."});
+        sketch_line_->MapPathParameter.setValue(0.0);
+        sketch_line_->MapMode.setValue("FlatFace");
+
+        Part::GeomLineSegment line;
+        Base::Vector3d p1(0.0, 0.0, 0.0);
+        Base::Vector3d p2(0.0, 1.0, 0.0);
+        line.setPoints(p1, p2);
+        sketch_line_->addGeometry(&line);
+
+        {
+            auto distance = Sketcher::Constraint();
+            distance.Type = Sketcher::ConstraintType::Distance;
+            distance.First = 0;
+            distance.setValue(1);
+            sketch_line_->addConstraint(&distance);
+
+            auto vertical = Sketcher::Constraint();
+            vertical.Type = Sketcher::ConstraintType::Vertical;
+            vertical.First = 0;
+            sketch_line_->addConstraint(&vertical);
+
+            auto coincident = Sketcher::Constraint();
+            coincident.Type = Sketcher::ConstraintType::Coincident;
+            coincident.First = 0;
+            coincident.FirstPos = Sketcher::PointPos::start;
+            coincident.Second = -1;
+            coincident.SecondPos = Sketcher::PointPos::start;
+            sketch_line_->addConstraint(&coincident);
+        }
+        doc_->recompute();
+        sketch_line_->solve();
+
+#ifdef PIPE_SAVE_TEST_FCSTD
+        doc_->saveAs("/tmp/test-circle-line.FCStd");
+#endif
+
+        ASSERT_TRUE(sketch_circle_->FullyConstrained.getValue());
+        ASSERT_TRUE(sketch_line_->FullyConstrained.getValue());
+    }
+
+    void TearDown() override
+    {
+        App::GetApplication().closeDocument(docName_.c_str());
+    }
+
+    // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
+
+    App::Document* doc_ = nullptr;
+    std::string docName_ = "";
+    Sketcher::SketchObject* sketch_circle_ = nullptr;
+    Sketcher::SketchObject* sketch_line_ = nullptr;
+    PartDesign::Body* body_ = nullptr;
+    PartDesign::ShapeBinder* binder_circle_ = nullptr;
+    PartDesign::ShapeBinder* binder_line_ = nullptr;
+
+    // Volume of a cylinder is
+    // V = pi * r^2 * h
+    // calculated for the values in this unit test
+    static constexpr double volume_expected_ = M_PI * 0.5*0.5 * 1;
+
+    // NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes)
+};
+
+TEST_F(FeaturePipeTest, SketchProfileSketchSpine)
+{
+    auto pipe = doc_->addObject<PartDesign::AdditivePipe>("pipe");
+    body_->addObject(pipe);
+
+    pipe->Spine.setValue(sketch_line_);
+    pipe->Profile.setValue(sketch_circle_);
+    doc_->recompute();
+#ifdef PIPE_SAVE_TEST_FCSTD
+    doc_->saveAs("/tmp/test-additivepipe-sketchprofile-sketchspine.FCStd");
+#endif
+
+    auto shape = pipe->Shape.getShape().getShape();
+    auto volume_measured = getVolume(shape);
+    ASSERT_NEAR(volume_expected_, volume_measured, 0.001);
+}
+
+TEST_F(FeaturePipeTest, SketchProfileBinderSpine)
+{
+    auto binderspine = doc_->addObject<PartDesign::SubShapeBinder>("bind-spine");
+    binderspine->Shape.setValue(sketch_line_->Shape.getShape());
+    body_->addObject(binderspine);
+
+    auto pipe = doc_->addObject<PartDesign::AdditivePipe>("pipe");
+    body_->addObject(pipe);
+
+    pipe->Spine.setValue(binderspine);
+    pipe->Profile.setValue(sketch_circle_);
+    doc_->recompute();
+#ifdef PIPE_SAVE_TEST_FCSTD
+    doc_->saveAs("/tmp/test-additivepipe-sketchprofile-binderspine.FCStd");
+#endif
+
+    auto shape = pipe->Shape.getShape().getShape();
+    auto volume_measured = getVolume(shape);
+    ASSERT_NEAR(volume_expected_, volume_measured, 0.001);
+}
+
+// NOLINTEND(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)

--- a/tests/src/Mod/PartDesign/App/Pipe.cpp
+++ b/tests/src/Mod/PartDesign/App/Pipe.cpp
@@ -12,6 +12,7 @@
 #include "Mod/Sketcher/App/Sketch.h"
 #include "Mod/Sketcher/App/SketchObject.h"
 #include <BRepGProp.hxx>
+#include <filesystem>
 
 // NOLINTBEGIN(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 
@@ -100,7 +101,10 @@ protected:
         doc_->recompute();
 
 #ifdef PIPE_SAVE_TEST_FCSTD
-        doc_->saveAs("/tmp/test-circle.FCStd");
+        {
+            auto p = std::filesystem::temp_directory_path();
+            doc_->saveAs((p / "FeaturePipeTest-circle.FCStd").c_str());
+        }
 #endif
         //
         // Create fully constrained line sketch
@@ -148,7 +152,10 @@ protected:
         sketch_line_->solve();
 
 #ifdef PIPE_SAVE_TEST_FCSTD
-        doc_->saveAs("/tmp/test-circle-line.FCStd");
+        {
+            auto p = std::filesystem::temp_directory_path();
+            doc_->saveAs((p / "FeaturePipeTest-circle-line.FCStd").c_str());
+        }
 #endif
 
         ASSERT_TRUE(sketch_circle_->FullyConstrained.getValue());
@@ -187,7 +194,10 @@ TEST_F(FeaturePipeTest, SketchProfileSketchSpine)
     pipe->Profile.setValue(sketch_circle_);
     doc_->recompute();
 #ifdef PIPE_SAVE_TEST_FCSTD
-    doc_->saveAs("/tmp/test-additivepipe-sketchprofile-sketchspine.FCStd");
+    {
+        auto p = std::filesystem::temp_directory_path();
+        doc_->saveAs((p / "FeaturePipeTest-SketchProfileSketchSpine.FCStd").c_str());
+    }
 #endif
 
     auto shape = pipe->Shape.getShape().getShape();
@@ -208,7 +218,10 @@ TEST_F(FeaturePipeTest, SketchProfileBinderSpine)
     pipe->Profile.setValue(sketch_circle_);
     doc_->recompute();
 #ifdef PIPE_SAVE_TEST_FCSTD
-    doc_->saveAs("/tmp/test-additivepipe-sketchprofile-binderspine.FCStd");
+    {
+        auto p = std::filesystem::temp_directory_path();
+        doc_->saveAs((p / "FeaturePipeTest-SketchProfileBinderSpine.FCStd").c_str());
+    }
 #endif
 
     auto shape = pipe->Shape.getShape().getShape();


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

Introduce a unit test for PartDesign::AdditivePipe. Relates to: #30464, which identifies shapebinders are non-functional as additive pipe profiles.

This unit test serves as a baseline level of performance.  See below table for permutations.  Support for shapebinder profiles will be addressed in a separate pull request.

| profile type | spine type | unit test |
|-|-|-|
| Sketch | Sketch | implemented |
| Sketch | SubShapeBinder | implemented |
| SubShapeBinder | Sketch | deferred |
| SubShapeBinder | SubShapeBinder | deferred |

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues

#30464
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
not applicable


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
