### PR TITLE
PartDesign: Preserve base feature appearance

### DIFF
--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -290,6 +290,11 @@ void CmdPartDesignBody::activated(int iMsg)
                 if (it->isDerivedFrom<PartDesign::FeatureBase>()) {
                     PartDesign::FeatureBase* base = static_cast<PartDesign::FeatureBase*>(it);
                     if (base && base->BaseFeature.getValue() == baseFeature) {
+                        copyVisual(base, "ShapeAppearance", baseFeature);
+                        copyVisual(base, "LineColor", baseFeature);
+                        copyVisual(base, "PointColor", baseFeature);
+                        copyVisual(base, "Transparency", baseFeature);
+                        copyVisual(base, "DisplayMode", baseFeature);
                         Gui::Application::Instance->hideViewProvider(baseFeature);
                         break;
                     }


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Preserve the selected source object’s appearance when creating a PartDesign body with a base feature.
Reuse the same visual-property transfer used by PartDesign Clone.

No AI used.

https://github.com/user-attachments/assets/893ab953-ebcd-4c43-ba7f-658ae626252f

