### PR TITLE
Measure: Seperated unbound and bounded plane type

### DIFF
--- a/src/App/MeasureManager.h
+++ b/src/App/MeasureManager.h
@@ -52,6 +52,7 @@ enum class MeasureElementType
     CURVE,  // Has a length but no radius or axis
     DISC,
     PLANE,
+    PLANESEGMENT,
     CYLINDER,
     VOLUME,
     SURFACE,

--- a/src/Mod/Measure/App/MeasureAngle.cpp
+++ b/src/Mod/Measure/App/MeasureAngle.cpp
@@ -97,6 +97,7 @@ bool MeasureAngle::isValidSelection(const App::MeasureSelection& selection)
 
         if (!(type == App::MeasureElementType::LINE || type == App::MeasureElementType::PLANE
               || type == App::MeasureElementType::LINESEGMENT
+              || type == App::MeasureElementType::PLANESEGMENT
               || type == App::MeasureElementType::DISC)) {
             return false;
         }

--- a/src/Mod/Measure/App/MeasureArea.cpp
+++ b/src/Mod/Measure/App/MeasureArea.cpp
@@ -54,7 +54,7 @@ MeasureArea::~MeasureArea() = default;
 bool MeasureArea::isSupported(App::MeasureElementType type)
 {
     // clang-format off
-    return (type == App::MeasureElementType::PLANE) ||
+    return (type == App::MeasureElementType::PLANESEGMENT) ||
            (type == App::MeasureElementType::CYLINDER) ||
            (type == App::MeasureElementType::SURFACE) ||
            (type == App::MeasureElementType::VOLUME) ||

--- a/src/Mod/Measure/App/MeasureDistance.cpp
+++ b/src/Mod/Measure/App/MeasureDistance.cpp
@@ -139,6 +139,7 @@ bool MeasureDistance::isValidSelection(const App::MeasureSelection& selection)
             && type != App::MeasureElementType::LINESEGMENT && type != App::MeasureElementType::CIRCLE
             && type != App::MeasureElementType::ARC && type != App::MeasureElementType::CURVE
             && type != App::MeasureElementType::PLANE && type != App::MeasureElementType::CYLINDER
+            && type != App::MeasureElementType::PLANESEGMENT
             && type != App::MeasureElementType::SPHERE && type != App::MeasureElementType::TORUS
             && type != App::MeasureElementType::SURFACE && type != App::MeasureElementType::DISC) {
             return false;

--- a/src/Mod/Part/App/MeasureClient.cpp
+++ b/src/Mod/Part/App/MeasureClient.cpp
@@ -227,19 +227,23 @@ App::MeasureElementType PartMeasureTypeCb(App::DocumentObject* ob, const char* s
                     return App::MeasureElementType::SPHERE;
                 }
                 case GeomAbs_Plane: {
+                    if (isDatum(subject)) {
+                        return App::MeasureElementType::PLANE;
+                    }
+
                     TopExp_Explorer edges(face, TopAbs_EDGE);
                     if (!edges.More()) {
-                        return App::MeasureElementType::PLANE;
+                        return App::MeasureElementType::PLANESEGMENT;
                     }
                     TopoDS_Edge edge = TopoDS::Edge(edges.Current());
                     edges.Next();
                     if (edges.More()) {
-                        return App::MeasureElementType::PLANE;
+                        return App::MeasureElementType::PLANESEGMENT;
                     }
 
                     BRepAdaptor_Curve adapt(edge);
                     if (adapt.GetType() != GeomAbs_Circle) {
-                        return App::MeasureElementType::PLANE;
+                        return App::MeasureElementType::PLANESEGMENT;
                     }
 
                     return App::MeasureElementType::DISC;
@@ -248,8 +252,11 @@ App::MeasureElementType PartMeasureTypeCb(App::DocumentObject* ob, const char* s
                     TopLoc_Location loc;
                     Handle(Geom_Surface) surf = BRep_Tool::Surface(face, loc);
                     GeomLib_IsPlanarSurface check(surf, AttachEnginePlane::planarPrecision());
-                    return check.IsPlanar() ? App::MeasureElementType::PLANE
-                                            : App::MeasureElementType::SURFACE;
+                    if (!check.IsPlanar()) {
+                        return App::MeasureElementType::SURFACE;
+                    }
+                    return isDatum(subject) ? App::MeasureElementType::PLANE
+                                            : App::MeasureElementType::PLANESEGMENT;
                 }
             }
         }
@@ -409,18 +416,6 @@ MeasureAreaInfoPtr MeasureAreaHandler(const App::SubObjectT& subject)
             subject.getElementName()
         );
         return std::make_shared<MeasureAreaInfo>(false, 0.0, Base::Matrix4D());
-    }
-
-    if (isDatum(subject)) {
-        return std::make_shared<MeasureAreaInfo>(
-            true,
-            0.0,
-            App::GeoFeature::getGlobalPlacement(
-                subject.getSubObjectList().back(),
-                subject.getObject(),
-                subject.getSubName()
-            )
-        );
     }
 
     TopAbs_ShapeEnum sType = shape.ShapeType();

--- a/tests/src/Mod/Measure/App/CMakeLists.txt
+++ b/tests/src/Mod/Measure/App/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 add_executable(Measure_tests_run
+        MeasureElementType.cpp
         MeasureDistance.cpp
         MeasurePosition.cpp
 )

--- a/tests/src/Mod/Measure/App/MeasureElementType.cpp
+++ b/tests/src/Mod/Measure/App/MeasureElementType.cpp
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <Geom_BezierSurface.hxx>
+#include <Precision.hxx>
+#include <TColgp_Array2OfPnt.hxx>
+#include <gp_Circ.hxx>
+#include <gp_Pln.hxx>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/MeasureManager.h>
+#include <Mod/Measure/App/MeasureAngle.h>
+#include <Mod/Measure/App/MeasureArea.h>
+#include <Mod/Measure/App/MeasureDistance.h>
+#include <Mod/Part/App/Datums.h>
+#include <Mod/Part/App/PartFeature.h>
+#include <src/App/InitApplication.h>
+
+class MeasureElementType: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        document = App::GetApplication().newDocument("MeasureElementType");
+    }
+
+    void TearDown() override
+    {
+        App::GetApplication().closeDocument(document->getName());
+    }
+
+    App::Document* document {};
+};
+
+TEST_F(MeasureElementType, testBoundedPlaneIsPlaneSegment)
+{
+    auto box = document->addObject<Part::Feature>("Box");
+    box->Shape.setValue(BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Solid());
+    document->recompute();
+
+    App::MeasureSelectionItem face {App::SubObjectT {box, "Face1"}, Base::Vector3d {}};
+
+    EXPECT_EQ(App::MeasureManager::getMeasureElementType(face), App::MeasureElementType::PLANESEGMENT);
+}
+
+TEST_F(MeasureElementType, testUnboundedPlaneIsPlane)
+{
+    auto plane = document->addObject<Part::DatumPlane>("Plane");
+    document->recompute();
+
+    App::MeasureSelectionItem datum {App::SubObjectT {plane, ""}, Base::Vector3d {}};
+
+    EXPECT_EQ(App::MeasureManager::getMeasureElementType(datum), App::MeasureElementType::PLANE);
+}
+
+TEST_F(MeasureElementType, testBoundedPlanarBezierFaceIsPlaneSegment)
+{
+    TColgp_Array2OfPnt poles(1, 2, 1, 2);
+    poles.SetValue(1, 1, gp_Pnt(0.0, 0.0, 0.0));
+    poles.SetValue(1, 2, gp_Pnt(0.0, 10.0, 0.0));
+    poles.SetValue(2, 1, gp_Pnt(10.0, 0.0, 0.0));
+    poles.SetValue(2, 2, gp_Pnt(10.0, 10.0, 0.0));
+
+    auto plane = document->addObject<Part::Feature>("BezierPlane");
+    Handle(Geom_BezierSurface) surface = new Geom_BezierSurface(poles);
+    plane->Shape.setValue(BRepBuilderAPI_MakeFace(surface, Precision::Confusion()).Face());
+    document->recompute();
+
+    App::MeasureSelectionItem face {App::SubObjectT {plane, "Face1"}, Base::Vector3d {}};
+
+    EXPECT_EQ(App::MeasureManager::getMeasureElementType(face), App::MeasureElementType::PLANESEGMENT);
+}
+
+TEST_F(MeasureElementType, testDiscRemainsDisc)
+{
+    auto disc = document->addObject<Part::Feature>("Disc");
+    TopoDS_Edge circle = BRepBuilderAPI_MakeEdge(gp_Circ(gp::XOY(), 5.0)).Edge();
+    TopoDS_Wire wire = BRepBuilderAPI_MakeWire(circle).Wire();
+    disc->Shape.setValue(BRepBuilderAPI_MakeFace(wire).Face());
+    document->recompute();
+
+    App::MeasureSelectionItem face {App::SubObjectT {disc, "Face1"}, Base::Vector3d {}};
+
+    EXPECT_EQ(App::MeasureManager::getMeasureElementType(face), App::MeasureElementType::DISC);
+}
+
+TEST_F(MeasureElementType, testPlaneSegmentMeasurementSupport)
+{
+    auto box = document->addObject<Part::Feature>("Box");
+    box->Shape.setValue(BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Solid());
+    document->recompute();
+
+    App::MeasureSelectionItem face1 {App::SubObjectT {box, "Face1"}, Base::Vector3d {}};
+    App::MeasureSelectionItem face2 {App::SubObjectT {box, "Face2"}, Base::Vector3d {}};
+
+    EXPECT_TRUE(Measure::MeasureArea::isValidSelection({face1}));
+    EXPECT_TRUE(Measure::MeasureAngle::isValidSelection({face1, face2}));
+    EXPECT_TRUE(Measure::MeasureDistance::isValidSelection({face1, face2}));
+}
+
+TEST_F(MeasureElementType, testPlaneMeasurementSupport)
+{
+    auto plane1 = document->addObject<Part::DatumPlane>("Plane1");
+    auto plane2 = document->addObject<Part::DatumPlane>("Plane2");
+    document->recompute();
+
+    App::MeasureSelectionItem datum1 {App::SubObjectT {plane1, ""}, Base::Vector3d {}};
+    App::MeasureSelectionItem datum2 {App::SubObjectT {plane2, ""}, Base::Vector3d {}};
+
+    EXPECT_FALSE(Measure::MeasureArea::isValidSelection({datum1}));
+    EXPECT_TRUE(Measure::MeasureAngle::isValidSelection({datum1, datum2}));
+    EXPECT_TRUE(Measure::MeasureDistance::isValidSelection({datum1, datum2}));
+}


### PR DESCRIPTION
Now unbounded planes are not valid for area measurement, just like lines.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by Open AI GPT-5.6 sol

## Before:

<img width="684" height="287" alt="before" src="https://github.com/user-attachments/assets/cc2b587d-0f12-4bef-a663-6f5fbc5701ab" />

## After 

<img width="709" height="354" alt="after" src="https://github.com/user-attachments/assets/98e38149-9b76-48d5-b4cc-b022f69a4403" />

## Tests
Added tests to prevent regression for planes, plane segments, disc, and planar beziers.
