### PR TITLE
Measure: Fix quickmeasure disc distance regression

### DIFF
--- a/src/Mod/Measure/App/Measurement.cpp
+++ b/src/Mod/Measure/App/Measurement.cpp
@@ -253,16 +253,16 @@ MeasureType Measurement::findType()
             }
         }
         else {
-            if (planes == 1 && faces == 1) {
-                mode = MeasureType::Plane;
-            }
-            else if (planes == 2 && faces == 2) {
+            if ((planes + discs) == 2 && faces == 2) {
                 if (planesAreParallel()) {
-                    mode = MeasureType::TwoPlanes;
+                    mode = discs == 2 ? MeasureType::TwoDiscs : MeasureType::TwoPlanes;
                 }
                 else {
                     mode = MeasureType::Surfaces;
                 }
+            }
+            else if (planes == 1 && faces == 1) {
+                mode = MeasureType::Plane;
             }
             else if (cylinders == 1 && faces == 1) {
                 mode = MeasureType::Cylinder;
@@ -578,7 +578,8 @@ double Measurement::circleCenterDistance() const
 }
 double Measurement::planePlaneDistance() const
 {
-    if (measureType != MeasureType::TwoPlanes || References3D.getSize() != 2) {
+    if ((measureType != MeasureType::TwoPlanes && measureType != MeasureType::TwoDiscs)
+        || References3D.getSize() != 2) {
         return 0.0;
     }
 
@@ -610,6 +611,26 @@ double Measurement::planePlaneDistance() const
     double distance = Abs(vectorBetweenPlanes.Dot(normalToPlane1));
 
     return distance;
+}
+double Measurement::discAxisDistance() const
+{
+    if (measureType != MeasureType::TwoDiscs || References3D.getSize() != 2) {
+        return 0.0;
+    }
+
+    const auto& objects = References3D.getValues();
+    const auto& subElements = References3D.getSubValues();
+
+    const auto getDiscAxis = [](const TopoDS_Face& face) {
+        TopExp_Explorer edges(face, TopAbs_EDGE);
+        BRepAdaptor_Curve circle(TopoDS::Edge(edges.Current()));
+        return circle.Circle().Axis();
+    };
+
+    const TopoDS_Face face1 = TopoDS::Face(getShape(objects[0], subElements[0].c_str(), TopAbs_FACE));
+    const TopoDS_Face face2 = TopoDS::Face(getShape(objects[1], subElements[1].c_str(), TopAbs_FACE));
+
+    return gp_Lin(getDiscAxis(face1)).Distance(gp_Lin(getDiscAxis(face2)));
 }
 double Measurement::cylinderAxisDistance() const
 {

--- a/src/Mod/Measure/App/Measurement.h
+++ b/src/Mod/Measure/App/Measurement.h
@@ -58,9 +58,10 @@ enum class MeasureType
     Cone,       // One Cone
     Sphere,     // One Sphere
     Torus,      // One Torus
-    Plane,      // One Plane
-    TwoPlanes,  // One Plane
-    Disc,
+    Plane,      // One plane
+    TwoPlanes,  // Two parallel planar faces
+    Disc,       // One circular planar face
+    TwoDiscs,   // Two parallel circular planar faces
     Points,
     PointToPoint,  // Measure between TWO points
     PointToEdge,   // Measure between ONE point and ONE edge
@@ -102,6 +103,7 @@ public:
     double lineLineDistance() const;
     double circleCenterDistance() const;
     double planePlaneDistance() const;
+    double discAxisDistance() const;
     double cylinderAxisDistance() const;
 
     // Calculates the radius for an arc or circular edge

--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -222,6 +222,13 @@ void QuickMeasure::printResult()
     else if (mtype == MeasureType::TwoPlanes) {
         print(tr("Nominal distance: %1").arg(lengthStr(measurement->planePlaneDistance())));
     }
+    else if (mtype == MeasureType::TwoDiscs) {
+        print(tr("Nominal distance: %1, Axis distance: %2")
+                  .arg(
+                      lengthStr(measurement->planePlaneDistance()),
+                      lengthStr(measurement->discAxisDistance())
+                  ));
+    }
     else if (mtype == MeasureType::Cone || mtype == MeasureType::Plane) {
         print(tr("Area: %1").arg(areaStr(measurement->area())));
     }

--- a/tests/src/Mod/Measure/App/CMakeLists.txt
+++ b/tests/src/Mod/Measure/App/CMakeLists.txt
@@ -3,6 +3,7 @@
 add_executable(Measure_tests_run
         MeasureDistance.cpp
         MeasurePosition.cpp
+        QuickMeasure.cpp
 )
 
 target_include_directories(Measure_tests_run PUBLIC

--- a/tests/src/Mod/Measure/App/QuickMeasure.cpp
+++ b/tests/src/Mod/Measure/App/QuickMeasure.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <src/App/InitApplication.h>
+#include <App/Document.h>
+#include <Mod/Measure/App/Measurement.h>
+#include <Mod/Part/App/PartFeature.h>
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Circ.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pln.hxx>
+#include <gp_Pnt.hxx>
+#include <Precision.hxx>
+#include <gtest/gtest.h>
+
+class QuickMeasureTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        document = App::GetApplication().newDocument("QuickMeasure");
+    }
+
+    void TearDown() override
+    {
+        App::GetApplication().closeDocument(document->getName());
+    }
+
+    Part::Feature* makeDisc(const char* name, const gp_Pnt& center) const
+    {
+        gp_Circ circle(gp_Ax2(center, gp_Dir(0.0, 0.0, 1.0)), 5.0);
+        TopoDS_Edge edge = BRepBuilderAPI_MakeEdge(circle).Edge();
+        TopoDS_Wire wire = BRepBuilderAPI_MakeWire(edge).Wire();
+
+        auto feature = document->addObject<Part::Feature>(name);
+        feature->Shape.setValue(BRepBuilderAPI_MakeFace(wire).Face());
+        return feature;
+    }
+
+    Part::Feature* makePlane(const char* name, double z) const
+    {
+        gp_Pln plane(gp_Pnt(0.0, 0.0, z), gp_Dir(0.0, 0.0, 1.0));
+
+        auto feature = document->addObject<Part::Feature>(name);
+        feature->Shape.setValue(BRepBuilderAPI_MakeFace(plane, -5.0, 5.0, -5.0, 5.0).Face());
+        return feature;
+    }
+
+private:
+    App::Document* document {};
+};
+
+// NOLINTBEGIN(readability-magic-numbers)
+TEST_F(QuickMeasureTest, SingleDiscKeepsDiscType)
+{
+    Measure::Measurement measurement;
+    measurement.addReference3D(makeDisc("Disc", gp_Pnt(0.0, 0.0, 0.0)), "Face1");
+
+    EXPECT_EQ(measurement.getType(), Measure::MeasureType::Disc);
+}
+
+TEST_F(QuickMeasureTest, ParallelDiscsHaveNominalDistance)
+{
+    Measure::Measurement measurement;
+    measurement.addReference3D(makeDisc("Disc1", gp_Pnt(0.0, 0.0, 0.0)), "Face1");
+    measurement.addReference3D(makeDisc("Disc2", gp_Pnt(3.0, 0.0, 7.5)), "Face1");
+
+    EXPECT_EQ(measurement.getType(), Measure::MeasureType::TwoDiscs);
+    EXPECT_NEAR(measurement.planePlaneDistance(), 7.5, Precision::Confusion());
+    EXPECT_NEAR(measurement.discAxisDistance(), 3.0, Precision::Confusion());
+}
+
+TEST_F(QuickMeasureTest, ParallelDiscAndPlaneHaveNominalDistance)
+{
+    Measure::Measurement measurement;
+    measurement.addReference3D(makeDisc("Disc", gp_Pnt(0.0, 0.0, 2.0)), "Face1");
+    measurement.addReference3D(makePlane("Plane", 10.0), "Face1");
+
+    EXPECT_EQ(measurement.getType(), Measure::MeasureType::TwoPlanes);
+    EXPECT_NEAR(measurement.planePlaneDistance(), 8.0, Precision::Confusion());
+}
+// NOLINTEND(readability-magic-numbers)


### PR DESCRIPTION
Fixes a regression where 2 disc's or 1 disc and 1 plane that is parallel does not give the nominal distance but area. 
Also added test to prevent future regressions.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by OpenAI GPT 5.6 sol

## Before:

<img width="811" height="525" alt="before" src="https://github.com/user-attachments/assets/b3fc5716-7d9c-4c7b-a4a7-ac470f0d1c01" />

## After:

<img width="866" height="615" alt="after" src="https://github.com/user-attachments/assets/ce4162ed-6f2f-467e-b960-b4df9bd5dfb2" />