### PR TITLE
Build: Add more error-checking and handling to macOS code signing

### DIFF
--- a/package/scripts/macos_sign_and_notarize.zsh
+++ b/package/scripts/macos_sign_and_notarize.zsh
@@ -91,25 +91,34 @@ if ! command -v dmgbuild &> /dev/null; then
     exit 1
 fi
 
+# A failure here is fatal: catch it as early as possible to hopefully be able to provide some kind
+# of useful diagnostic information.
 function run_codesign {
     echo "Signing $1"
-    /usr/bin/codesign --options runtime -f -s ${SIGNING_KEY_ID} --timestamp --entitlements entitlements.plist "$1"
+    if ! /usr/bin/codesign --options runtime -f -s ${SIGNING_KEY_ID} --timestamp --entitlements entitlements.plist "$1"; then
+        print -r -- "❌ codesign failed for $1" >&2
+        exit 1
+    fi
 }
 
 function run_codesign_extension {
     local target="$1"
     local entitlements_file="$2"
     echo "Signing extension $target with entitlements $entitlements_file"
-    /usr/bin/codesign --options runtime -f -s ${SIGNING_KEY_ID} --timestamp --entitlements "$entitlements_file" "$target"
+    if ! /usr/bin/codesign --options runtime -f -s ${SIGNING_KEY_ID} --timestamp --entitlements "$entitlements_file" "$target"; then
+        print -r -- "❌ codesign failed for extension $target" >&2
+        exit 1
+    fi
 }
 
 IFS=$'\n'
 dylibs=($(/usr/bin/find "${CONTAINING_FOLDER}/${APP_NAME}" -name "*.dylib"))
 shared_objects=($(/usr/bin/find "${CONTAINING_FOLDER}/${APP_NAME}" -name "*.so"))
 bundles=($(/usr/bin/find "${CONTAINING_FOLDER}/${APP_NAME}" -name "*.bundle"))
-executables=($(/usr/bin/find "${CONTAINING_FOLDER}/${APP_NAME}" -type f -perm +111 -exec file {} + | grep "Mach-O 64-bit executable" | sed 's/:.*//g'))
+executables=($(/usr/bin/find "${CONTAINING_FOLDER}/${APP_NAME}" -type f -perm +111 -exec file {} + | grep "Mach-O 64-bit executable" | grep -v " (for architecture " | sed 's/:.*//g'))
 IFS=$' \t\n' # The default
 
+typeset -U signed_files
 signed_files=("${dylibs[@]}" "${shared_objects[@]}" "${bundles[@]}" "${executables[@]}")
 
 # This list of files is generated from:
@@ -164,6 +173,20 @@ dmgbuild -s ${DMG_SETTINGS} -Dcontaining_folder="${CONTAINING_FOLDER}" -Dapp_nam
 
 ID_FILE="${DMG_NAME}.notarization_id"
 
+# Total wall-clock budget for Apple to finish processing a submission. Individual "notarytool wait"
+# calls have their own shorter timeout and are retried until this budget is exhausted.
+NOTARIZATION_TIMEOUT_SECONDS="${NOTARIZATION_TIMEOUT_SECONDS:-3600}"
+
+# How long to keep retrying the staple *after* Apple has confirmed the submission was Accepted. A
+# ticket for an accepted submission is normally published within seconds, so a few minutes is
+# already generous, there's no benefit to keep hammering on this for hours.
+STAPLE_MAX_ATTEMPTS="${STAPLE_MAX_ATTEMPTS:-20}"
+
+# Set to 1 to ship a notarized-but-unstapled disk image instead of failing. An unstapled image still
+# passes Gatekeeper, but only if the user is online the first time they open it, so this is a
+# reasonable trade for weekly builds and a bad one for tagged releases.
+ALLOW_UNSTAPLED="${ALLOW_UNSTAPLED:-0}"
+
 # Submit it for notarization (requires that an App Store API Key has been set up in the notarytool)
 # This is a *very slow* process, and occasionally the GitHub runners lose the internet connection for a short time
 # during the run. So in order to be fault-tolerant, this script polls, instead of using --wait
@@ -189,46 +212,50 @@ submit_notarization_request() {
   print -r -- "$id"  # ID is a string here, not an integer, so I can't just return it
 }
 
+# Reports the submission status ("Accepted", "Invalid", "Rejected", "In Progress") on stdout, or
+# nothing at all if the query itself failed, which the caller treats as "ask again later".
+notarization_status() {
+  local id="$1" out
+  out=$(xcrun notarytool info "$id" --keychain-profile "${KEYCHAIN_PROFILE}" \
+          --output-format json 2>/dev/null) || return 1
+  print -r -- "$out" |
+    /usr/bin/python3 -c 'import sys, json; print(json.load(sys.stdin).get("status") or "")' 2>/dev/null
+}
+
+# The exit code of "notarytool wait" is NOT a success indicator: it returns 0 as soon as the
+# submission reaches *any* terminal state, and Invalid and Rejected are terminal states. So I guess
+# Apple thinks that's a success?! OK, so we manually check, because we don't have a choice.
 wait_for_notarization_result() {
-  local id="$1" attempt=0
+  local id="$1"
+  local deadline=$(( $(date +%s) + NOTARIZATION_TIMEOUT_SECONDS ))
+  local attempt=0
+  local submission_status
+
   while :; do
-    if xcrun notarytool wait "$id" --keychain-profile "${KEYCHAIN_PROFILE}" \
-          --timeout 10m --no-progress >/dev/null; then
-      return 0
-    fi
+    # Failure here isn't real failure: it means "timed out" or "the network is borked", etc.
+    # The status query below is what actually decides whether we are done.
+    xcrun notarytool wait "$id" --keychain-profile "${KEYCHAIN_PROFILE}" \
+      --timeout 10m --no-progress >/dev/null 2>&1
+
+    submission_status="$(notarization_status "$id")"
+    print -r -- "Notarization status: ${submission_status:-unavailable}"
+
+    case "${submission_status:l}" in
+      accepted)
+        return 0
+        ;;
+      invalid|rejected)
+        print -r -- "❌ Apple did not accept the submission (status: ${submission_status})." >&2
+        print -r -- "--- begin notarytool log ---" >&2
+        xcrun notarytool log "$id" --keychain-profile "${KEYCHAIN_PROFILE}" >&2
+        print -r -- "--- end notarytool log ---" >&2
+        return 3
+        ;;
+    esac
 
     (( attempt++ ))
-    # If the failure was transient (timeout/HTTP/connection) just retry, but make sure to check to see if the problem
-    # was actually that the signing failed before retrying.
-    local tmp_json
-    tmp_json=$(mktemp)
-    trap 'rm -f "$tmp_json"' EXIT INT TERM
-
-    xcrun notarytool info "$id" --keychain-profile "${KEYCHAIN_PROFILE}" --output-format json 2>/dev/null > "$tmp_json"
-    /usr/bin/python3 - "$tmp_json" <<'PY'
-import sys, json
-try:
-    with open(sys.argv[1]) as f:
-        s = (json.load(f).get("status") or "").lower()
-    if s in ("invalid", "rejected"):
-        sys.exit(2)
-    else:
-        sys.exit(0)
-except Exception:
-    sys.exit(1)
-PY
-    rc=$?
-
-    rm -f "$tmp_json"
-
-    if [[ $rc == 2 ]]; then
-      print -r -- "Notarization was not accepted by Apple:" >&2
-      xcrun notarytool log "$id" --keychain-profile "${KEYCHAIN_PROFILE}" >&2
-      return 3
-    fi
-
-    if [[ $attempt -gt 120 ]]; then
-      print -r -- "🏳️ Notarization is taking too long, bailing out. 🏳️" >&2
+    if (( $(date +%s) >= deadline )); then
+      print -r -- "🏳️ Notarization did not finish within ${NOTARIZATION_TIMEOUT_SECONDS}s, bailing out. 🏳️" >&2
       return 4
     fi
     sleep $(( (attempt<6?2**attempt:60) + RANDOM%5 ))  # Increasing timeout plus jitter for multi-run safety
@@ -251,10 +278,13 @@ print "Notarization submission ID: $id"
 # *Sometimes*, but not always, the staple action will emit failure text, but still return 0, so
 # we have to check for both the bad exit code, as well as a few different possible error strings.
 #
-# To handle significant network stability issues, we use a very long timeout and backoff.
+# This retries only for as long as a transient fault could last in real life. It is deliberately
+# NOT a multi-hour loop: this function is only ever reached once Apple has confirmed the submissio
+# was "Accepted", and a ticket for an accepted submission does not take hours to appear. A persistent
+# "Record not found" here means no ticket exists, so we should bail out, because it's never going to
+# appear.
 staple_with_retry() {
   local target="$1"
-  local max_attempts=120
   local attempt=0
   local out rc
   while :; do
@@ -267,7 +297,8 @@ staple_with_retry() {
     if [[ $rc -ne 0 ]]; then
       looks_failed=1
     elif print -r -- "$out" | grep -E -q -e 'The staple and validate action failed' \
-                                          -e 'Error 68' \
+                                          -e 'Error 6[0-9]' \
+                                          -e 'Record not found' \
                                           -e "CloudKit's response is inconsistent" \
                                           -e 'Could not validate ticket'; then
       looks_failed=1
@@ -280,26 +311,42 @@ staple_with_retry() {
       print -r -- "Staple appeared to succeed but stapler validate failed." >&2
     fi
 
-    if [[ $attempt -ge $max_attempts ]]; then
+    if (( attempt >= STAPLE_MAX_ATTEMPTS )); then
       print -r -- "Failed to staple after ${attempt} attempts" >&2
       return 1
     fi
 
     print -r -- "Staple attempt ${attempt} failed, retrying..."
-    sleep $(( (attempt<6?2**attempt:60) + RANDOM%5 ))  # Increasing timeout plus jitter for multi-run safety
+    sleep $(( (attempt<6?2**attempt:30) + RANDOM%5 ))  # Increasing timeout plus jitter for multi-run safety
   done
 }
 
-if wait_for_notarization_result "$id"; then
-  print "✅ Notarization succeeded. Stapling..."
-  if ! staple_with_retry "${DMG_NAME}"; then
-    print "❌ Failed to staple ${DMG_NAME}" >&2
-    exit 1
-  fi
-  print "Stapled: ${DMG_NAME}"
-  rm -f "${ID_FILE}"
-else
-  rc=$?
+wait_for_notarization_result "$id"
+rc=$?
+if (( rc != 0 )); then
   print "❌ Notarization failed (code $rc)." >&2
+  # Drop the cached id so that a re-run submits afresh instead of re-querying a dead submission.
+  rm -f "${ID_FILE}"
   exit "$rc"
 fi
+
+print "✅ Apple accepted the submission. Stapling..."
+if staple_with_retry "${DMG_NAME}"; then
+  print "Stapled: ${DMG_NAME}"
+  rm -f "${ID_FILE}"
+  exit 0
+fi
+
+# Reaching here means Apple accepted the submission but never published a ticket we can attach, which
+# is a fault on Apple's side rather than anything wrong with the disk image.
+print "❌ Failed to staple ${DMG_NAME} (submission ${id} was Accepted, but no ticket was issued)." >&2
+# The cached id describes the disk image built by *this* run. A re-run rebuilds the image from
+# scratch, and a ticket for the previous image can never be stapled to the new one, so the id has to
+# go or the retry is guaranteed to fail the same way.
+rm -f "${ID_FILE}"
+if [[ "${ALLOW_UNSTAPLED}" == "1" ]]; then
+  print "⚠️  Shipping an unstapled disk image. It is notarized, so Gatekeeper will accept it, but only" >&2
+  print "⚠️  for users who are online the first time they open it." >&2
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
We continue to see various types of failures during macOS code signing, so I continue to add more code to try to figure out what succeeded and what failed, and give some kind of useful error message for the failures. I am not sure that this change will actually fix the current Intel signing failure, but it should at least provide better diagnostics about what is going wrong, instead of just repeating the failing attempt for two hours.

I'm also adding the possibility of uploading a signed but unstapled binary. To run it a macOS user will have to be connected to the internet the first time they launch it, but that's not terrible for a weekly dev build, and is better than throwing away the multiple hour compilation result just because something is going wrong with the final staple. That said, I haven't actually *enabled* that yet, just coded it up for consideration.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: Claude Opus 5