### PR TITLE
OverlayManager: save space for navicube only for 3d views

### DIFF
--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -61,6 +61,7 @@
 #include "TaskView/TaskView.h"
 #include "Tree.h"
 #include "TreeParams.h"
+#include "View3DInventor.h"
 #include "View3DInventorViewer.h"
 
 FC_LOG_LEVEL_INIT("Dock", true, true);
@@ -653,11 +654,16 @@ public:
         }
 
         int naviCubeSize = NaviCube::getNaviCubeSize();
-        int naviCorner = OverlayParams::getDockOverlayCheckNaviCube()
-            ? App::GetApplication()
-                  .GetParameterGroupByPath("User parameter:BaseApp/Preferences/NaviCube")
-                  ->GetInt("CornerNaviCube", 1)
-            : -1;
+        int naviCorner = -1;
+        auto activeView = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
+        if (OverlayParams::getDockOverlayCheckNaviCube() && activeView
+            && activeView->getViewer()->isEnabledNaviCube()) {
+            naviCorner = App::GetApplication()
+                             .GetParameterGroupByPath(
+                                 "User parameter:BaseApp/Preferences/NaviCube"
+                             )
+                             ->GetInt("CornerNaviCube", 1);
+        }
 
         QRect rect;
         QRect rectBottom(0, 0, 0, 0);

--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -659,9 +659,7 @@ public:
         if (OverlayParams::getDockOverlayCheckNaviCube() && activeView
             && activeView->getViewer()->isEnabledNaviCube()) {
             naviCorner = App::GetApplication()
-                             .GetParameterGroupByPath(
-                                 "User parameter:BaseApp/Preferences/NaviCube"
-                             )
+                             .GetParameterGroupByPath("User parameter:BaseApp/Preferences/NaviCube")
                              ->GetInt("CornerNaviCube", 1);
         }
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/31777


https://github.com/user-attachments/assets/c0750691-0f40-4234-9706-39e690780756

