### PR TITLE
SubShapeBinder Profile with AdditivePipe fixes: #30464

### DIFF
--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -125,30 +125,6 @@ App::DocumentObjectExecReturn* Pipe::execute()
         return App::DocumentObject::StdReturn;
     }
 
-    auto getSectionShape = [](App::DocumentObject* feature,
-                              const std::vector<std::string>& subs) -> Part::TopoShape {
-        if (!feature || !feature->isDerivedFrom<Part::Feature>()) {
-            throw Base::TypeError("Pipe: Invalid profile/section");
-        }
-
-        auto subName = subs.empty() ? "" : subs.front();
-
-        // only take the entire shape when we have a sketch selected, but
-        // not a point of the sketch
-        if (feature->isDerivedFrom<Part::Part2DObject>() && subName.compare(0, 6, "Vertex") != 0) {
-            return static_cast<Part::Part2DObject*>(feature)->Shape.getShape();
-        }
-        else {
-            if (subName.empty()) {
-                throw Base::ValueError("Pipe: No valid subelement linked in Part::Feature");
-            }
-            return static_cast<Part::Feature*>(feature)->Shape.getShape().getSubTopoShape(
-                subName.c_str()
-            );
-        }
-    };
-
-
     std::vector<std::vector<Part::TopoShape>> wiresections;
 
     auto addWiresToWireSections = [](TopoShape& section,
@@ -205,7 +181,7 @@ App::DocumentObjectExecReturn* Pipe::execute()
         }
 
         // setup the profile section
-        Part::TopoShape profileShape = getSectionShape(Profile.getValue(), Profile.getSubValues());
+        Part::TopoShape profileShape = getTopoShapeVerifiedFace(false, false);
         if (profileShape.isNull()) {
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "Pipe: Could not obtain profile shape")
@@ -284,7 +260,8 @@ App::DocumentObjectExecReturn* Pipe::execute()
                 }
 
                 // if the section is an object's face then take just the face
-                Part::TopoShape shape = getSectionShape(subSet.first, subSet.second);
+                Part::TopoShape shape
+                    = getTopoShapeVerifiedFace(false, false, subSet.first, subSet.second);
                 if (shape.isNull()) {
                     return new App::DocumentObjectExecReturn(
                         QT_TRANSLATE_NOOP("Exception", "Pipe: Could not obtain section shape")

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -163,7 +163,7 @@ App::DocumentObjectExecReturn* Pipe::execute()
     Part::TopoShape profilePoint;
 
     // if the Base property has a valid shape, fuse the pipe into it
-	Part::TopoShape base;
+    Part::TopoShape base;
     try {
         base = getBaseTopoShape();
     }
@@ -261,7 +261,8 @@ App::DocumentObjectExecReturn* Pipe::execute()
                 }
 
                 // if the section is an object's face then take just the face
-                Part::TopoShape shape = getTopoShapeVerifiedFace(false, false, subSet.first, subSet.second);
+                Part::TopoShape shape
+                    = getTopoShapeVerifiedFace(false, false, subSet.first, subSet.second);
                 if (shape.isNull()) {
                     return new App::DocumentObjectExecReturn(
                         QT_TRANSLATE_NOOP("Exception", "Pipe: Could not obtain section shape")

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -119,35 +119,12 @@ short Pipe::mustExecute() const
     return ProfileBased::mustExecute();
 }
 
+
 App::DocumentObjectExecReturn* Pipe::execute()
 {
     if (onlyHaveRefined()) {
         return App::DocumentObject::StdReturn;
     }
-
-    auto getSectionShape = [](App::DocumentObject* feature,
-                              const std::vector<std::string>& subs) -> Part::TopoShape {
-        if (!feature || !feature->isDerivedFrom<Part::Feature>()) {
-            throw Base::TypeError("Pipe: Invalid profile/section");
-        }
-
-        auto subName = subs.empty() ? "" : subs.front();
-
-        // only take the entire shape when we have a sketch selected, but
-        // not a point of the sketch
-        if (feature->isDerivedFrom<Part::Part2DObject>() && subName.compare(0, 6, "Vertex") != 0) {
-            return static_cast<Part::Part2DObject*>(feature)->Shape.getShape();
-        }
-        else {
-            if (subName.empty()) {
-                throw Base::ValueError("Pipe: No valid subelement linked in Part::Feature");
-            }
-            return static_cast<Part::Feature*>(feature)->Shape.getShape().getSubTopoShape(
-                subName.c_str()
-            );
-        }
-    };
-
 
     std::vector<std::vector<Part::TopoShape>> wiresections;
 
@@ -186,7 +163,7 @@ App::DocumentObjectExecReturn* Pipe::execute()
     Part::TopoShape profilePoint;
 
     // if the Base property has a valid shape, fuse the pipe into it
-    Part::TopoShape base;
+	Part::TopoShape base;
     try {
         base = getBaseTopoShape();
     }
@@ -205,7 +182,7 @@ App::DocumentObjectExecReturn* Pipe::execute()
         }
 
         // setup the profile section
-        Part::TopoShape profileShape = getSectionShape(Profile.getValue(), Profile.getSubValues());
+        Part::TopoShape profileShape = getTopoShapeVerifiedFace(false, false);
         if (profileShape.isNull()) {
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "Pipe: Could not obtain profile shape")
@@ -284,7 +261,7 @@ App::DocumentObjectExecReturn* Pipe::execute()
                 }
 
                 // if the section is an object's face then take just the face
-                Part::TopoShape shape = getSectionShape(subSet.first, subSet.second);
+                Part::TopoShape shape = getTopoShapeVerifiedFace(false, false, subSet.first, subSet.second);
                 if (shape.isNull()) {
                     return new App::DocumentObjectExecReturn(
                         QT_TRANSLATE_NOOP("Exception", "Pipe: Could not obtain section shape")

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -159,9 +159,7 @@ TaskPipeParameters::TaskPipeParameters(ViewProviderPipe* PipeView, bool /*newObj
         auto* profileVP = doc->getViewProvider(pipe->Profile.getValue());
         profileShow = profileVP->isShow();
         profileVP->setVisible(true);
-        ui->profileBaseEdit->setText(
-            make2DLabel(pipe->Profile.getValue(), pipe->Profile.getSubValues())
-        );
+        ui->profileBaseEdit->setText(QString::fromUtf8(pipe->Profile.getValue()->Label.getValue()));
     }
     // the auxiliary spine
     if (pipe->AuxiliarySpine.getValue()) {

--- a/tests/src/Mod/PartDesign/App/Pipe.cpp
+++ b/tests/src/Mod/PartDesign/App/Pipe.cpp
@@ -224,4 +224,53 @@ TEST_F(FeaturePipeTest, SketchProfileBinderSpine)
     ASSERT_NEAR(volume_expected_, volume_measured, 0.001);
 }
 
+TEST_F(FeaturePipeTest, BinderProfileSketchSpine)
+{
+    auto binderprofile = doc_->addObject<PartDesign::SubShapeBinder>("bind-profile");
+    binderprofile->Shape.setValue(sketch_circle_->Shape.getShape());
+    body_->addObject(binderprofile);
+
+    auto pipe = doc_->addObject<PartDesign::AdditivePipe>("pipe");
+    body_->addObject(pipe);
+
+    pipe->Spine.setValue(sketch_line_);
+    pipe->Profile.setValue(binderprofile);
+    doc_->recompute();
+#ifdef PIPE_SAVE_TEST_FCSTD
+    {
+        auto p = std::filesystem::temp_directory_path();
+        doc_->saveAs((p / "FeaturePipeTest-BinderProfileSketchSpine.FCStd").c_str());
+    }
+#endif
+    auto shape = pipe->Shape.getShape().getShape();
+    auto volume_measured = getVolume(shape);
+    ASSERT_NEAR(volume_expected_, volume_measured, 0.001);
+}
+
+TEST_F(FeaturePipeTest, BinderProfileBinderSpine)
+{
+    auto binderprofile = doc_->addObject<PartDesign::SubShapeBinder>("bind-profile");
+    binderprofile->Shape.setValue(sketch_circle_->Shape.getShape());
+    body_->addObject(binderprofile);
+
+    auto binderspine = doc_->addObject<PartDesign::SubShapeBinder>("bind-spine");
+    binderspine->Shape.setValue(sketch_line_->Shape.getShape());
+    body_->addObject(binderspine);
+
+    auto pipe = doc_->addObject<PartDesign::AdditivePipe>("pipe");
+    body_->addObject(pipe);
+
+    pipe->Spine.setValue(binderspine);
+    pipe->Profile.setValue(binderprofile);
+    doc_->recompute();
+#ifdef PIPE_SAVE_TEST_FCSTD
+    {
+        auto p = std::filesystem::temp_directory_path();
+        doc_->saveAs((p / "FeaturePipeTest-BinderProfileBinderSpine.FCStd").c_str());
+    }
+#endif
+    auto shape = pipe->Shape.getShape().getShape();
+    auto volume_measured = getVolume(shape);
+    ASSERT_NEAR(volume_expected_, volume_measured, 0.001);
+}
 // NOLINTEND(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This PR:
- extends baseline unit tests from https://github.com/FreeCAD/FreeCAD/pull/31766
- permits SubShapeBinders to be used as Profile in FeaturePipe

Test permutations:

| profile type | spine type | unit test |
|-|-|-|
| Sketch | Sketch | implemented (baseline) |
| Sketch | SubShapeBinder | implemented (baseline) |
| SubShapeBinder | Sketch | implemented |
| SubShapeBinder | SubShapeBinder | implemented |

For discussion:

This change removes FeaturePipe::getSectionShape in favor of newer ProfileBased::getTopoShapeVerifiedFace.  Unit tests demonstrate correct behavior of circle profile moved along a straight-line path, with sketches and shapebinders.

If there are new failure modes introduced by this change, it may be helpful to address them with unit tests around the ProfileBased::getTopoShapeVerifiedFace method.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

https://github.com/FreeCAD/FreeCAD/issues/30464

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

### before

https://github.com/user-attachments/assets/384c690a-e685-4570-bc36-edc7a82a9a3c

### after

https://github.com/user-attachments/assets/8c1c8e54-a514-45f2-b82b-00af1cc377ff

Edit: [ad705af](https://github.com/FreeCAD/FreeCAD/commit/ad705af7990c7a464a81a25c205f51170bcaea79) contains an additional patch to make the gui task window profile label work "same as" the spine label
<img width="1920" height="1080" alt="gui-label" src="https://github.com/user-attachments/assets/eda2da44-c7ac-4691-8af9-2542a71e6ee1" />


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
