### PR TITLE
Clean up obsolete weekly build targets

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -116,7 +116,6 @@ jobs:
           - { target: linux-64, os: ubuntu-22.04 }
           - { target: linux-arm64, os: ubuntu-22.04-arm }
           - { target: osx-64, os: macos-15-intel, deploy_target: "10.13" }
-          - { target: osx-arm64, os: macos-latest, deploy_target: "11.0" }
           - { target: osx-arm64, os: macos-latest, deploy_target: "15.0" }
           - { target: win-64, os: windows-2022 }
       fail-fast: false

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -117,7 +117,6 @@ jobs:
           - { target: linux-64, os: ubuntu-22.04 }
           - { target: linux-arm64, os: ubuntu-22.04-arm }
           - { target: osx-64, os: macos-15-intel, deploy_target: "10.13" }
-          - { target: osx-arm64, os: macos-latest, deploy_target: "11.0" }
           - { target: osx-arm64, os: macos-latest, deploy_target: "15.0" }
           - { target: win-64, os: windows-2022 }
       fail-fast: false

--- a/package/rattler-build/build.sh
+++ b/package/rattler-build/build.sh
@@ -28,12 +28,11 @@ if [[ ${HOST} =~ .*darwin.* ]]; then
 
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 
-    # Use MACOS_DEPLOYMENT_TARGET from environment, default to 11.0 for backwards compat.
-    # Note that CI sets this per target: 10.13 (Intel), 11.0 (ARM legacy), 15.0 (ARM modern)
+    # Use MACOS_DEPLOYMENT_TARGET from environment, default to 15.0 for ARM builds.
+    # CI sets this per target: 10.13 (Intel) or 15.0 (ARM).
     # - macOS 10.13+ Intel: legacy QuickLook generator (.qlgenerator)
-    # - macOS 11-14 ARM: legacy QuickLook generator (.qlgenerator)
     # - macOS 15+ ARM: modern QuickLook App Extensions (.appex)
-    DEPLOY_TARGET="${MACOS_DEPLOYMENT_TARGET:-11.0}"
+    DEPLOY_TARGET="${MACOS_DEPLOYMENT_TARGET:-15.0}"
     CMAKE_PLATFORM_FLAGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=${DEPLOY_TARGET})
 
     # Patch Qt6's FindWrapOpenGL.cmake to not link AGL on macOS 10.15+

--- a/package/rattler-build/linux/create_bundle.sh
+++ b/package/rattler-build/linux/create_bundle.sh
@@ -72,10 +72,7 @@ chmod a+x appimagetool-$(uname -m).AppImage
 
 if [ "${UPLOAD_RELEASE}" == "true" ]; then
     case "${BUILD_TAG}" in
-        *weekly*)
-            GH_UPDATE_TAG="weeklies"
-            ;;
-        *rc*)
+        *weekly*|*rc*)
             GH_UPDATE_TAG="${BUILD_TAG}"
             ;;
         *)
@@ -100,12 +97,4 @@ sha256sum ${version_name}.AppImage > ${version_name}.AppImage-SHA256.txt
 
 if [ "${UPLOAD_RELEASE}" == "true" ]; then
     gh release upload --clobber ${BUILD_TAG} "${version_name}.AppImage" "${version_name}.AppImage.zsync" "${version_name}.AppImage-SHA256.txt"
-    if [ "${GH_UPDATE_TAG}" == "weeklies" ]; then
-        generic_name="FreeCAD_weekly-Linux-$(uname -m)"
-        mv "${version_name}.AppImage" "${generic_name}.AppImage"
-        mv "${version_name}.AppImage.zsync" "${generic_name}.AppImage.zsync"
-        mv "${version_name}.AppImage-SHA256.txt" "${generic_name}.AppImage-SHA256.txt"
-        gh release create weeklies --prerelease | true
-        gh release upload --clobber weeklies "${generic_name}.AppImage" "${generic_name}.AppImage.zsync" "${generic_name}.AppImage-SHA256.txt"
-    fi
 fi

--- a/package/rattler-build/osx/create_bundle.sh
+++ b/package/rattler-build/osx/create_bundle.sh
@@ -47,8 +47,8 @@ cmake --build build
 mkdir -p FreeCAD.app/Contents/MacOS
 cp build/FreeCAD FreeCAD.app/Contents/MacOS/FreeCAD
 
-# Add deployment target suffix to artifact name (e.g., "-macOS11" or "-macOS15")
-deploy_target="${MACOS_DEPLOYMENT_TARGET:-11.0}"
+# Add the deployment target suffix to the artifact name.
+deploy_target="${MACOS_DEPLOYMENT_TARGET:-15.0}"
 version_name="FreeCAD_${BUILD_TAG}-macOS${deploy_target%%.*}-$(uname -m)"
 application_menu_name="FreeCAD_${BUILD_TAG}"
 

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -17,7 +17,7 @@ build:
     # Without this, build.sh falls back to its default and the macOS 15 package
     # builds the legacy QuickLook generator instead of the modern .appex.
     env:
-      MACOS_DEPLOYMENT_TARGET: ${{ env.get("MACOS_DEPLOYMENT_TARGET", default="11.0") }}
+      MACOS_DEPLOYMENT_TARGET: ${{ env.get("MACOS_DEPLOYMENT_TARGET", default="15.0") }}
 
 requirements:
   build:


### PR DESCRIPTION
One commit per change:
- Remove the macOS 11 ARM target from weekly development builds
- Update macOS packaging defaults and documentation to use macOS 15 ARM, removing macOS 11 references
- Stop publishing duplicate weekly AppImages to the persistent weeklies release and instead upload to the dated weekly release



No AI used.