### PR TITLE
BIM: Views panel fixes

### DIFF
--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -1173,7 +1173,7 @@ class ViewProviderBuildingPart:
 
         actionWriteCamera = QtGui.QAction(
             QtGui.QIcon(":/icons/Draft_SelectPlane.svg"),
-            translate("Arch", "Write Camera Position"),
+            translate("Arch", "Save Camera View"),
             menu,
         )
         QtCore.QObject.connect(actionWriteCamera, QtCore.SIGNAL("triggered()"), self.writeCamera)

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -157,7 +157,7 @@ class BIM_Views:
             self.dialog.buttonSaveView.triggered.connect(self.saveView)
             self.dialog.buttonSaveVisibility.triggered.connect(self.saveVisibility)
             self.dialog.buttonRename.triggered.connect(self.rename)
-            self.dialog.buttonActive.triggered.connect(lambda: BIM_Views.activate(self.dialog))
+            self.dialog.buttonActive.triggered.connect(self.activateContextItem)
             self.dialog.tree.itemClicked.connect(self.select)
             self.dialog.tree.itemDoubleClicked.connect(show)
             self.dialog.viewtree.itemDoubleClicked.connect(show)
@@ -533,6 +533,21 @@ class BIM_Views:
                     _toggle_active_container(obj, dialog=dialog)
                     FreeCADGui.Selection.clearSelection()
 
+    def activateContextItem(self):
+        """Activate the item under the context menu."""
+
+        import Draft
+
+        if not self.contextObject:
+            return
+        if Draft.getType(self.contextObject) == "WorkingPlaneProxy":
+            FreeCADGui.Selection.clearSelection()
+            FreeCADGui.Selection.addSelection(self.contextObject)
+            FreeCADGui.runCommand("Draft_SelectPlane")
+        elif hasattr(self.contextObject.ViewObject, "DoubleClickActivates"):
+            _toggle_active_container(self.contextObject, dialog=self.dialog)
+            FreeCADGui.Selection.clearSelection()
+
     def editObject(self, item, column):
         "renames or edits the elevation or height of the actual object"
 
@@ -679,15 +694,32 @@ class BIM_Views:
         import Draft
 
         self.dialog.buttonAddProxy.setEnabled(True)
-        selobj = self.dialog.tree.currentItem()
-        if selobj:
-            selobj = FreeCAD.ActiveDocument.getObject(selobj.toolTip(0))
-            if selobj:
-                if Draft.getType(selobj).startswith("Ifc"):
+        self.contextObject = None
+        self.dialog.buttonActive.setText(translate("BIM", "Active"))
+        self.dialog.buttonActive.setCheckable(True)
+        self.dialog.buttonActive.setChecked(False)
+        self.dialog.buttonActive.setToolTip(translate("BIM", "Activates the selected item"))
+        item = self.dialog.tree.itemAt(pos)
+        if item:
+            self.contextObject = FreeCAD.ActiveDocument.getObject(item.toolTip(0))
+            if self.contextObject:
+                if Draft.getType(self.contextObject).startswith("Ifc"):
                     self.dialog.buttonAddProxy.setEnabled(False)
-                if FreeCADGui.ActiveDocument.ActiveView.getActiveObject("NativeIFC") == selobj:
+                if Draft.getType(self.contextObject) == "WorkingPlaneProxy":
+                    self.dialog.buttonActive.setText(translate("BIM", "Set Working Plane"))
+                    self.dialog.buttonActive.setCheckable(False)
+                    self.dialog.buttonActive.setToolTip(
+                        translate("BIM", "Sets the selected item as the current working plane")
+                    )
+                elif (
+                    FreeCADGui.ActiveDocument.ActiveView.getActiveObject("NativeIFC")
+                    == self.contextObject
+                ):
                     self.dialog.buttonActive.setChecked(True)
-                elif FreeCADGui.ActiveDocument.ActiveView.getActiveObject("Arch") == selobj:
+                elif (
+                    FreeCADGui.ActiveDocument.ActiveView.getActiveObject("Arch")
+                    == self.contextObject
+                ):
                     self.dialog.buttonActive.setChecked(True)
                 else:
                     self.dialog.buttonActive.setChecked(False)

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -92,6 +92,7 @@ class BIM_Views:
                 ("Toggle", translate("BIM", "Toggle Visibility")),
                 ("Isolate", translate("BIM", "Isolate")),
                 ("SaveView", translate("BIM", "Save View Position")),
+                ("SaveVisibility", translate("BIM", "Save Visibility of Objects")),
                 ("Rename", translate("BIM", "Rename")),
             ]:
                 action = QtGui.QAction(button[1])
@@ -142,6 +143,7 @@ class BIM_Views:
             self.dialog.buttonToggle.triggered.connect(self.toggle)
             self.dialog.buttonIsolate.triggered.connect(self.isolate)
             self.dialog.buttonSaveView.triggered.connect(self.saveView)
+            self.dialog.buttonSaveVisibility.triggered.connect(self.saveVisibility)
             self.dialog.buttonRename.triggered.connect(self.rename)
             self.dialog.buttonActive.triggered.connect(lambda: BIM_Views.activate(self.dialog))
             self.dialog.tree.itemClicked.connect(self.select)
@@ -618,6 +620,17 @@ class BIM_Views:
                 if obj:
                     if hasattr(obj.ViewObject.Proxy, "writeCamera"):
                         obj.ViewObject.Proxy.writeCamera()
+        FreeCAD.ActiveDocument.recompute()
+
+    def saveVisibility(self):
+        "save the current visibility state to the selected item"
+
+        vm = findWidget()
+        if vm:
+            for item in vm.tree.selectedItems():
+                obj = FreeCAD.ActiveDocument.getObject(item.toolTip(0))
+                if obj and hasattr(obj.ViewObject.Proxy, "writeState"):
+                    obj.ViewObject.Proxy.writeState()
         FreeCAD.ActiveDocument.recompute()
 
     def onDockLocationChanged(self, area):

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -36,6 +36,17 @@ UPDATEINTERVAL = 2000  # number of milliseconds between BIM Views Manager update
 PARAMS = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM")
 
 
+if FreeCAD.GuiUp:
+    from PySide import QtCore, QtGui
+
+    class _HeightEditDelegate(QtGui.QStyledItemDelegate):
+        """Allow editing the Height column only for objects that provide it."""
+
+        def createEditor(self, parent, option, index):
+            if index.data(QtCore.Qt.UserRole):
+                return QtGui.QStyledItemDelegate.createEditor(self, parent, option, index)
+
+
 class BIM_Views:
 
     def GetResources(self):
@@ -81,6 +92,7 @@ class BIM_Views:
 
             # set context menu
             self.dialog.tree.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+            self.dialog.tree.setItemDelegateForColumn(2, _HeightEditDelegate(self.dialog.tree))
 
             # set button
             self.dialog.menu = QtGui.QMenu()
@@ -819,6 +831,7 @@ def getTreeViewItem(obj):
 
     it = QtGui.QTreeWidgetItem([obj.Label, elevStr, heightStr])
     it.setFlags(it.flags() | QtCore.Qt.ItemIsEditable)
+    it.setData(2, QtCore.Qt.UserRole, hasattr(obj, "Height"))
     it.setToolTip(0, obj.Name)
     if obj.ViewObject:
         if hasattr(obj.ViewObject, "Icon"):

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -103,7 +103,7 @@ class BIM_Views:
                 ("Delete", translate("BIM", "Delete")),
                 ("Toggle", translate("BIM", "Toggle Visibility")),
                 ("Isolate", translate("BIM", "Isolate")),
-                ("SaveView", translate("BIM", "Save View Position")),
+                ("SaveView", translate("BIM", "Save Camera View")),
                 ("SaveVisibility", translate("BIM", "Save Visibility of Objects")),
                 ("Rename", translate("BIM", "Rename")),
             ]:
@@ -143,7 +143,7 @@ class BIM_Views:
                 translate("BIM", "Turns all items off except the selected ones")
             )
             self.dialog.buttonSaveView.setToolTip(
-                translate("BIM", "Saves the current camera position to the selected items")
+                translate("BIM", "Saves the current camera view to the selected items")
             )
             self.dialog.buttonRename.setToolTip(translate("BIM", "Renames the selected item"))
             self.dialog.buttonActive.setToolTip(translate("BIM", "Activates the selected item"))

--- a/src/Mod/Draft/draftviewproviders/view_wpproxy.py
+++ b/src/Mod/Draft/draftviewproviders/view_wpproxy.py
@@ -39,6 +39,7 @@ import FreeCAD as App
 import FreeCADGui as Gui
 from draftutils import gui_utils
 from draftutils import params
+from draftutils.translate import translate
 
 
 class ViewProviderWorkingPlaneProxy:
@@ -90,7 +91,9 @@ class ViewProviderWorkingPlaneProxy:
 
     def setupContextMenu(self, vobj, menu):
         action1 = QtGui.QAction(
-            QtGui.QIcon(":/icons/Draft_SelectPlane.svg"), "Save Camera Position", menu
+            QtGui.QIcon(":/icons/Draft_SelectPlane.svg"),
+            translate("draft", "Save Camera View"),
+            menu,
         )
         QtCore.QObject.connect(action1, QtCore.SIGNAL("triggered()"), self.writeCamera)
         menu.addAction(action1)


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Fixes BIM Views issues (one commit per issue):

- Add Save Visibility of Objects to Views panel
- Prevent editing the Height field for WP proxies in Views panel
- Set WP proxies as the active working plane from Views panel
- Unify camera save action command names as Save Camera View

No AI used

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes #31782
Fixes #31781
Fixes #31780
Fixes #31783

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

<img width="300" height="111" alt="Bildschirmfoto 2026-08-07 um 07 24 40" src="https://github.com/user-attachments/assets/aa9e2ccc-b1f2-488f-bb36-9ed366b35d00" />


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
