### PR TITLE
TechDraw: manual backport of PR #31635 Surface Finish

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewArch.h
+++ b/src/Mod/TechDraw/App/DrawViewArch.h
@@ -69,6 +69,8 @@ public:
 
     short mustExecute() const override;
 
+    bool snapsToPosition() const override { return true; }
+
 
 protected:
 /*    virtual void onChanged(const App::Property* prop) override;*/

--- a/src/Mod/TechDraw/App/DrawViewDraft.h
+++ b/src/Mod/TechDraw/App/DrawViewDraft.h
@@ -66,6 +66,8 @@ public:
 
     short mustExecute() const override;
 
+    bool snapsToPosition() const override { return true; }
+
 protected:
 /*    virtual void onChanged(const App::Property* prop) override;*/
     Base::BoundBox3d bbox;

--- a/src/Mod/TechDraw/App/DrawViewSymbol.h
+++ b/src/Mod/TechDraw/App/DrawViewSymbol.h
@@ -69,6 +69,8 @@ public:
     //return PyObject as DrawViewSymbolPy
     PyObject *getPyObject() override;
 
+    bool snapsToPosition() const override { return false; }
+
 protected:
     void onChanged(const App::Property* prop) override;
     Base::BoundBox3d bbox;

--- a/src/Mod/TechDraw/App/DrawWeldSymbol.h
+++ b/src/Mod/TechDraw/App/DrawWeldSymbol.h
@@ -64,6 +64,8 @@ public:
 
     App::PropertyLink *getOwnerProperty() override { return &Leader; }
 
+    bool snapsToPosition() const override { return false; }
+
 protected:
     void onChanged(const App::Property* prop) override;
 

--- a/src/Mod/TechDraw/Gui/TaskSurfaceFinishSymbols.cpp
+++ b/src/Mod/TechDraw/Gui/TaskSurfaceFinishSymbols.cpp
@@ -421,7 +421,9 @@ bool TaskSurfaceFinishSymbols::accept()
         page->addView(surfaceSymbol);
     }
 
+    surfaceSymbol->recomputeFeature();
     Gui::Command::commitCommand();
+
     return true;
 }
 


### PR DESCRIPTION
The automatic backport of PR #31635 failed due to a merge conflict.  This PR resolves the conflict.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

