### PR TITLE
Gui: Fix missing selection stack clear in selStackGoBack

### DIFF
--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -1414,6 +1414,7 @@ void SelectionSingleton::selStackGoBack(int count)
     }
     if (!_SelList.empty()) {
         selStackPush(false, true);
+        clearCompleteSelection();
     }
     else {
         --count;


### PR DESCRIPTION
PR #30588 accidentally broke the `Std_SelBack` command. This fixes it.

To verify the fix (and the bug):
1) Create a FreeCAD file with a few different objects in it
2) Ensure you have the "Record selection" option enabled in Preferences
3) **In the tree view** select one object after the other, one at a time.
4) In the Python console enter `Gui.runCommand("Std_SelBack")`

In current main, it will *add* the old selection to the new one. It should instead *go back* to the previous selection. Its missing this line.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
