### PR TITLE
App: Correct missing default in FineGraindRecomputes

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -818,7 +818,7 @@ bool Application::isFineGrainedRecomputeEnabled()
     static const ParameterGrp::handle hGrp = GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/General"
     );
-    bool enableFineGrainedRecompute = hGrp->GetBool("FineGrainedRecompute");
+    bool enableFineGrainedRecompute = hGrp->GetBool("FineGrainedRecompute", true);
     return enableFineGrainedRecompute;
 }
 


### PR DESCRIPTION
With no default value provided, a boolean will default to false, and this one should be true.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.