### PR TITLE
Draft: fix format_object for Links

### DIFF
--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -572,9 +572,9 @@ def format_object(target, origin=None, ignore_construction=False):
             if obrep.getEditorMode(p):
                 continue
             val = getattr(matchrep, p)
-            if isinstance(val, tuple):
+            if isinstance(val, (list, tuple)):
                 if len(val) != len_faces:
-                    val = (val[0],)
+                    val = [val[0]]
             elif hasattr(val, "Value"):
                 val = val.Value
             try:
@@ -585,7 +585,15 @@ def format_object(target, origin=None, ignore_construction=False):
             obrep.DisplayMode = matchrep.DisplayMode
         if hasattr(obrep, "DiffuseColor"):
             difcol = get_diffuse_color(origin)
-            if difcol and len(difcol) == len_faces:
+            if difcol and (len(difcol) == len_faces or hasattr(origin, "ColoredElements")):
+                # Since v1.1, Links, Link arrays and LinkGroups have a ShapeAppearance property
+                # that replaces their former ShapeMaterial property. The property has a default
+                # hard-coded value and is only used if OverrideMaterial is set to True. Because
+                # of the new property name the ShapeAppearance property they used to inherit
+                # from their source object is effectively overridden in the PropertiesList. But
+                # (if OverrideMaterial is False) the ShapeAppearance of the source object is
+                # used. As a workaround we always apply the difcolor for those object types.
+                # Note that we currently completely ignore the OverrideMaterial property.
                 obrep.DiffuseColor = difcol
     elif "FontName" not in obprops:
         # Apply 2 Draft style preferences, other style preferences are applied by Core.


### PR DESCRIPTION
Fixes #31693.

The problem was caused by the renaming of the ShapeMaterial property to ShapeAppearance in v1.1. I have opted for a quick backportable fix. The whole code needs to be overhauled as it still relies on DiffuseColor, which is obsolete, although still supported.

No AI was used.