### PR TITLE
CAM: Add spring passes to the Profile operation

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathProfile.py
+++ b/src/Mod/CAM/CAMTests/TestPathProfile.py
@@ -233,6 +233,133 @@ class TestPathProfile(PathTestBase):
             "expected_moves: {}\noperationMoves: {}".format(expected_moves, operationMoves),
         )
 
+    # Spring passes
+    def _springPassOp(self, name, base=("Face18",), **properties):
+        """_springPassOp(name, base, **properties) ... creates a recomputed Profile.
+
+        Pass base=None to profile the whole model as a contour, which is the only way
+        to get more than one depth layer out of the test geometry."""
+        profile = PathProfile.Create(name)
+        if base:
+            profile.Base = [(self.doc.Body, list(base))]
+        profile.Label = name
+        profile.UseComp = True
+        profile.Direction = "CW"
+        for prop, value in properties.items():
+            setattr(profile, prop, value)
+        _addViewProvider(profile)
+        self.doc.recompute()
+        return profile
+
+    @staticmethod
+    def _cutMovesByDepth(profile):
+        """_cutMovesByDepth(profile) ... returns {z: number of cutting moves at that z}."""
+        byDepth = {}
+        for move in getGcodeMoves(profile.Path.Commands, includeRapids=False):
+            z = float(move.rsplit("Z", 1)[1])
+            byDepth[z] = byDepth.get(z, 0) + 1
+        return byDepth
+
+    def testSpringPassPropertyDefaults(self):
+        """testSpringPassPropertyDefaults() Verify a Profile makes no spring passes unless asked."""
+        profile = self._springPassOp("ProfileSpringDefaults")
+
+        self.assertEqual(profile.SpringPasses, 0)
+        self.assertEqual(profile.SpringPassScope, "Final Depth")
+        self.assertEqual(
+            profile.getEnumerationsOfProperty("SpringPassScope"),
+            ["Final Depth", "Every Depth"],
+        )
+
+    def testSpringPassRepeatsFinalPass(self):
+        """testSpringPassRepeatsFinalPass() Verify a spring pass repeats the final pass exactly,
+        without retracting between the pass and its repeat."""
+        one = self._springPassOp("ProfileSpringOne", SpringPasses=1)
+        two = self._springPassOp("ProfileSpringTwo", SpringPasses=2)
+
+        cutsOne = getGcodeMoves(one.Path.Commands, includeRapids=False)
+        cutsTwo = getGcodeMoves(two.Path.Commands, includeRapids=False)
+
+        self.assertTrue(cutsOne, "Profile produced no cutting moves")
+        self.assertEqual(len(cutsOne) % 2, 0, "cutting moves: {}".format(cutsOne))
+
+        # One spring pass cuts the profile twice, two spring passes cut it three times.
+        loop = cutsOne[: len(cutsOne) // 2]
+        self.assertEqual(cutsOne, loop * 2, "cutting moves: {}".format(cutsOne))
+        self.assertEqual(cutsTwo, loop * 3, "cutting moves: {}".format(cutsTwo))
+
+        # A spring pass adds cutting moves and nothing else. If the repeat retracted and
+        # plunged back in it would leave a dwell mark on the wall it has just finished.
+        rapidsOne = getGcodeMoves(one.Path.Commands, includeLines=False, includeArcs=False)
+        rapidsTwo = getGcodeMoves(two.Path.Commands, includeLines=False, includeArcs=False)
+        self.assertEqual(
+            rapidsOne,
+            rapidsTwo,
+            "Spring passes added rapids.\nSpringPasses=1: {}\nSpringPasses=2: {}".format(
+                rapidsOne, rapidsTwo
+            ),
+        )
+
+    def testSpringPassRepeatsFinishingOffsetOnly(self):
+        """testSpringPassRepeatsFinishingOffsetOnly() Verify that on a multi-pass profile the
+        spring pass repeats the finishing offset rather than the whole offset ladder."""
+        plain = self._springPassOp("ProfileSpringMulti", NumPasses=3, Stepover=1.0)
+        sprung = self._springPassOp(
+            "ProfileSpringMultiSprung", NumPasses=3, Stepover=1.0, SpringPasses=1
+        )
+
+        cuts = getGcodeMoves(plain.Path.Commands, includeRapids=False)
+        sprungCuts = getGcodeMoves(sprung.Path.Commands, includeRapids=False)
+
+        self.assertTrue(cuts, "Multi-pass profile produced no cutting moves")
+        self.assertEqual(len(cuts) % 3, 0, "cutting moves: {}".format(cuts))
+
+        # The offsets run from the largest to the smallest, so the finishing offset is
+        # the last of the three, and it is the only one a spring pass may repeat.
+        finishing = cuts[2 * len(cuts) // 3 :]
+        self.assertEqual(
+            sprungCuts,
+            cuts + finishing,
+            "expected the finishing offset repeated once.\n"
+            "finishing offset: {}\nsprung: {}".format(finishing, sprungCuts),
+        )
+
+    def testSpringPassScopeEveryDepth(self):
+        """testSpringPassScopeEveryDepth() Verify spring passes land on the final depth alone
+        or on every depth layer, according to SpringPassScope."""
+        finalOnly = self._springPassOp("ProfileSpringFinalDepth", base=None, SpringPasses=1)
+        everyDepth = self._springPassOp(
+            "ProfileSpringEveryDepth",
+            base=None,
+            SpringPasses=1,
+            SpringPassScope="Every Depth",
+        )
+        for profile in (finalOnly, everyDepth):
+            profile.setExpression("StepDown", None)
+            profile.StepDown.Value = 5.0
+        self.doc.recompute()
+
+        finalCounts = self._cutMovesByDepth(finalOnly)
+        everyCounts = self._cutMovesByDepth(everyDepth)
+
+        depths = sorted(everyCounts)  # ascending, so depths[0] is the final depth
+        self.assertGreater(len(depths), 1, "Test needs more than one depth layer")
+        self.assertEqual(depths, sorted(finalCounts))
+
+        # The topmost layer is never repeated under 'Final Depth', so it sizes one loop.
+        loop = finalCounts[depths[-1]]
+        for z in depths:
+            self.assertEqual(
+                finalCounts[z],
+                2 * loop if z == depths[0] else loop,
+                "'Final Depth' scope, cutting moves per depth: {}".format(finalCounts),
+            )
+            self.assertEqual(
+                everyCounts[z],
+                2 * loop,
+                "'Every Depth' scope, cutting moves per depth: {}".format(everyCounts),
+            )
+
 
 class TestPathOpenProfile(PathTestBase):
     """Unit tests for profiling open edges (edges of geometry)."""
@@ -296,10 +423,12 @@ class TestPathOpenProfile(PathTestBase):
                     edges_at_origin.append(f"Edge{i+1}")
 
         # Save triangle geometry for test assertions
+        cls.job = job
         cls.triangle_part = triangle_part
         cls.triangle_edges = edges_at_origin
         cls.triangle_base = triangle_base
         cls.triangle_height = triangle_height
+        cls.extrude_height = extrude_height
 
         # Create profile operation for the two edges
         cls.profile = PathProfile.Create("TriangleProfile", parentJob=job)
@@ -413,6 +542,86 @@ class TestPathOpenProfile(PathTestBase):
             expected_arc_length,
             delta=expected_arc_length * 0.01,
             msg=f"Arc length ({arc_total:.2f}) should equal radius × angle ({expected_arc_length:.2f})",
+        )
+
+    def _openProfileOp(self, name, **properties):
+        """_openProfileOp(name, **properties) ... creates a recomputed open-edge Profile
+        with two depth layers."""
+        profile = PathProfile.Create(name, parentJob=self.job)
+        profile.Base = [(self.triangle_part, self.triangle_edges)]
+        profile.Label = name
+        profile.Direction = "CCW"
+        profile.Side = "Outside"
+        profile.setExpression("FinalDepth", None)
+        profile.setExpression("StartDepth", None)
+        profile.setExpression("StepDown", None)
+        profile.FinalDepth.Value = 0.0
+        profile.StartDepth.Value = self.extrude_height
+        profile.StepDown.Value = self.extrude_height / 2.0
+        for prop, value in properties.items():
+            setattr(profile, prop, value)
+        _addViewProvider(profile)
+        self.doc.recompute()
+        return profile
+
+    @staticmethod
+    def _cutMovesByDepth(profile):
+        """_cutMovesByDepth(profile) ... returns {z: number of cutting moves at that z}."""
+        byDepth = {}
+        for move in getGcodeMoves(profile.Path.Commands, includeRapids=False):
+            z = float(move.rsplit("Z", 1)[1])
+            byDepth[z] = byDepth.get(z, 0) + 1
+        return byDepth
+
+    def testSpringPassOnOpenEdges(self):
+        """testSpringPassOnOpenEdges() Verify spring passes repeat an open-edge profile at the
+        final depth alone, or at every depth, according to SpringPassScope."""
+        plain = self._openProfileOp("OpenProfileSpringOff")
+        finalOnly = self._openProfileOp("OpenProfileSpringFinal", SpringPasses=1)
+        everyDepth = self._openProfileOp(
+            "OpenProfileSpringEvery", SpringPasses=1, SpringPassScope="Every Depth"
+        )
+
+        plainCounts = self._cutMovesByDepth(plain)
+        finalCounts = self._cutMovesByDepth(finalOnly)
+        everyCounts = self._cutMovesByDepth(everyDepth)
+
+        depths = sorted(plainCounts)  # ascending, so depths[0] is the final depth
+        self.assertGreater(len(depths), 1, "Test needs more than one depth layer")
+
+        for z in depths:
+            self.assertEqual(
+                finalCounts[z],
+                2 * plainCounts[z] if z == depths[0] else plainCounts[z],
+                "'Final Depth' scope, cutting moves per depth: {}".format(finalCounts),
+            )
+            self.assertEqual(
+                everyCounts[z],
+                2 * plainCounts[z],
+                "'Every Depth' scope, cutting moves per depth: {}".format(everyCounts),
+            )
+
+    def testSpringPassOnOpenEdgesRepeatsFinishingOffsetOnly(self):
+        """testSpringPassOnOpenEdgesRepeatsFinishingOffsetOnly() Verify that on a multi-pass
+        open-edge profile the spring pass repeats the finishing offset only."""
+        plain = self._openProfileOp("OpenProfileMulti", NumPasses=3, Stepover=1.0)
+        sprung = self._openProfileOp(
+            "OpenProfileMultiSprung", NumPasses=3, Stepover=1.0, SpringPasses=1
+        )
+
+        cuts = getGcodeMoves(plain.Path.Commands, includeRapids=False)
+        sprungCuts = getGcodeMoves(sprung.Path.Commands, includeRapids=False)
+
+        # Each offset is emitted as its own wire, deepest layer last, so the finishing
+        # offset's final-depth moves are the tail of the path and the repeat follows them.
+        added = len(sprungCuts) - len(cuts)
+        self.assertGreater(added, 0, "Spring pass added no cutting moves")
+        self.assertEqual(sprungCuts[: len(cuts)], cuts, "Spring pass altered the preceding passes")
+        self.assertEqual(
+            sprungCuts[-added:],
+            cuts[-added:],
+            "expected the finishing offset repeated once.\n"
+            "finishing offset: {}\nrepeat: {}".format(cuts[-added:], sprungCuts[-added:]),
         )
 
 

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpProfileFullEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpProfileFullEdit.ui
@@ -112,6 +112,45 @@
         </property>
        </widget>
       </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="springPassesLabel">
+        <property name="text">
+         <string>Spring passes</string>
+        </property>
+       </widget>
+      </item>
+     <item row="5" column="1">
+       <widget class="QSpinBox" name="springPasses">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>10</number>
+        </property>
+        <property name="toolTip">
+         <string>The number of exact repetitions of the final cutting pass, at the same depth and offset, to recover tool deflection. Zero means no spring passes.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="springPassScopeLabel">
+        <property name="text">
+         <string>Spring pass scope</string>
+        </property>
+       </widget>
+      </item>
+     <item row="6" column="1">
+       <widget class="QComboBox" name="springPassScope">
+        <property name="toolTip">
+         <string>Whether spring passes are added only at the final depth or at every depth layer</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>PLACEHOLDER</string>
+         </property>
+        </item>
+       </widget>
+      </item>
       </layout>
     </widget>
    </item>

--- a/src/Mod/CAM/Path/Op/Area.py
+++ b/src/Mod/CAM/Path/Op/Area.py
@@ -211,6 +211,108 @@ class ObjectOp(PathOp.ObjectOp):
 
         return candidate.discretize(3)[1]
 
+    def _springPassLayers(self, obj, layerCount):
+        """_springPassLayers(obj, layerCount) ... returns (springPasses, layerIndexes).
+
+        A spring pass is an exact repetition of the immediately preceding cutting pass -
+        same depth, same offset, same feed - to recover the deflection of tool and
+        workpiece. Returns how many repetitions to make and the indexes of the depth
+        layers they apply to. Returns (0, []) if the operation makes no spring passes."""
+        springPasses = getattr(obj, "SpringPasses", 0)
+        if not springPasses or layerCount < 1:
+            return 0, []
+
+        if getattr(obj, "SpringPassScope", "Final Depth") == "Every Depth":
+            return springPasses, list(range(layerCount))
+
+        return springPasses, [layerCount - 1]
+
+    def _isOpenEdgeFinishOffset(self, obj, openWire):
+        """_isOpenEdgeFinishOffset(obj, openWire) ... returns True if the given open-edge
+        wire belongs to the finishing offset rather than to a roughing offset.
+
+        Operations that expand multiple offsets into separate open wires record all of
+        them in self.openEdgeWires and the finishing ones in self.openEdgeFinishWires. A
+        wire that is in neither - a compound assembled by 'Collectively' handling, for
+        instance - cannot be attributed to an offset and so is not repeated."""
+        if getattr(obj, "NumPasses", 1) <= 1:
+            # A single offset makes every open wire a finishing wire.
+            return True
+
+        if any(openWire is w for w in getattr(self, "openEdgeFinishWires", [])):
+            return True
+        if any(openWire is w for w in getattr(self, "openEdgeWires", [])):
+            return False
+
+        Path.Log.warning(
+            translate(
+                "PathAreaOp",
+                "Cannot identify the finishing offset of these open edges. Skipping spring passes.",
+            )
+        )
+        return False
+
+    def _finishOffsetShapes(self, obj, baseobject, isHole, heights, areaParams):
+        """_finishOffsetShapes(obj, baseobject, isHole, heights, areaParams) ... returns the
+        section shapes of the finishing offset alone - without the multi-pass offset
+        ladder - at the given heights."""
+        area = Path.Area()
+        area.setPlane(PathUtils.makeWorkplane(baseobject))
+        area.add(baseobject)
+
+        params = self.areaOpAreaParams(obj, isHole, finalPassOnly=True)
+        params["SectionTolerance"] = areaParams["SectionTolerance"]
+        area.setParams(**params)
+
+        sections = area.makeSections(mode=0, project=self.areaOpUseProjection(obj), heights=heights)
+        return [sec.getShape() for sec in sections]
+
+    def _addSpringPasses(self, obj, baseobject, isHole, shapelist, heights, areaParams):
+        """_addSpringPasses(obj, baseobject, isHole, shapelist, heights, areaParams) ...
+        returns shapelist with the spring passes inserted after the layers they repeat.
+
+        The repeats are added to the same shapelist rather than emitted as a separate
+        path so the tool carries on from where the previous pass ended, instead of
+        retracting and plunging back into the wall it has just finished."""
+        springPasses, layers = self._springPassLayers(obj, len(shapelist))
+        if not springPasses:
+            return shapelist
+
+        if len(shapelist) != len(heights):
+            Path.Log.warning(
+                translate(
+                    "PathAreaOp",
+                    "Depth layers do not match the requested depths. Skipping spring passes.",
+                )
+            )
+            return shapelist
+
+        if getattr(obj, "NumPasses", 1) > 1:
+            # A layer's section holds the whole multi-pass offset ladder, but a spring
+            # pass repeats only the finishing offset, so rebuild that offset on its own.
+            springShapes = self._finishOffsetShapes(
+                obj, baseobject, isHole, [heights[i] for i in layers], areaParams
+            )
+            if len(springShapes) != len(layers):
+                Path.Log.warning(
+                    translate(
+                        "PathAreaOp",
+                        "Unable to build the finishing offset. Skipping spring passes.",
+                    )
+                )
+                return shapelist
+            byLayer = dict(zip(layers, springShapes))
+        else:
+            byLayer = {i: shapelist[i] for i in layers}
+
+        withSprings = []
+        for i, shape in enumerate(shapelist):
+            withSprings.append(shape)
+            if i in byLayer:
+                withSprings.extend([byLayer[i]] * springPasses)
+
+        return withSprings
+
     def _buildPathArea(self, obj, baseobject, isHole, start, getsim):
         """_buildPathArea(obj, baseobject, isHole, start, getsim) ... internal function."""
         Path.Log.track()
@@ -246,6 +348,8 @@ class ObjectOp(PathOp.ObjectOp):
 
         shapelist = [sec.getShape() for sec in sections]
         Path.Log.debug("shapelist = %s" % shapelist)
+
+        shapelist = self._addSpringPasses(obj, baseobject, isHole, shapelist, heights, areaParams)
 
         pathParams = self.areaOpPathParams(obj, isHole)
         pathParams["shapes"] = shapelist
@@ -309,6 +413,13 @@ class ObjectOp(PathOp.ObjectOp):
         paths = []
         heights = [i for i in self.depthparams]
         Path.Log.debug("depths: {}".format(heights))
+
+        # Spring passes repeat the finishing offset only. Multi-pass profiles hand each
+        # offset to this method as its own wire, so the roughing wires make no repeats.
+        springPasses, springLayers = self._springPassLayers(obj, len(heights))
+        if springPasses and not self._isOpenEdgeFinishOffset(obj, openWire):
+            springPasses, springLayers = 0, []
+
         for i in range(0, len(heights)):
             openWire.translate(FreeCAD.Vector(0, 0, heights[i] - openWire.BoundBox.ZMin))
 
@@ -351,6 +462,12 @@ class ObjectOp(PathOp.ObjectOp):
             pp, end_vector = Path.fromShapes(**pathParams)
             paths.extend(pp.Commands)
             Path.Log.debug("pp: {}, end vector: {}".format(pp, end_vector))
+
+            # An open wire cannot be closed back onto itself, so a repetition is the
+            # same emission again: retract, return to the start vertex, cut once more.
+            if i in springLayers:
+                for _ in range(springPasses):
+                    paths.extend(Path.fromShapes(**pathParams)[0].Commands)
 
         self.endVector = end_vector
         simobj = None

--- a/src/Mod/CAM/Path/Op/Gui/Profile.py
+++ b/src/Mod/CAM/Path/Op/Gui/Profile.py
@@ -62,7 +62,11 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         """getForm() ... returns UI customized according to profileFeatures()"""
         form = FreeCADGui.PySideUic.loadUi(":/panels/PageOpProfileFullEdit.ui")
 
-        comboToPropertyMap = [("cutSide", "Side"), ("direction", "Direction")]
+        comboToPropertyMap = [
+            ("cutSide", "Side"),
+            ("direction", "Direction"),
+            ("springPassScope", "SpringPassScope"),
+        ]
         enumTups = PathProfile.ObjectProfile.areaOpPropertyEnumerations(dataType="raw")
 
         self.populateCombobox(form, enumTups, comboToPropertyMap)
@@ -77,6 +81,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         PathGuiUtil.updateInputField(obj, "OffsetExtra", self.form.extraOffset)
         obj.NumPasses = self.form.numPasses.value()
         PathGuiUtil.updateInputField(obj, "Stepover", self.form.stepover)
+        obj.SpringPasses = self.form.springPasses.value()
+        if obj.SpringPassScope != str(self.form.springPassScope.currentData()):
+            obj.SpringPassScope = str(self.form.springPassScope.currentData())
 
         if obj.UseComp != self.form.useCompensation.isChecked():
             obj.UseComp = self.form.useCompensation.isChecked()
@@ -97,6 +104,8 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.extraOffset.setProperty("rawValue", obj.OffsetExtra.Value)
         self.form.numPasses.setValue(obj.NumPasses)
         self.form.stepover.setProperty("rawValue", obj.Stepover.Value)
+        self.form.springPasses.setValue(obj.SpringPasses)
+        self.selectInComboBox(obj.SpringPassScope, self.form.springPassScope)
 
         self.form.useCompensation.setChecked(obj.UseComp)
         self.form.useStartPoint.setChecked(obj.UseStartPoint)
@@ -114,6 +123,8 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.extraOffset.editingFinished)
         signals.append(self.form.numPasses.editingFinished)
         signals.append(self.form.stepover.editingFinished)
+        signals.append(self.form.springPasses.editingFinished)
+        signals.append(self.form.springPassScope.currentIndexChanged)
         if hasattr(self.form.useCompensation, "checkStateChanged"):  # Qt version >= 6.7.0
             signals.append(self.form.useCompensation.checkStateChanged)
             signals.append(self.form.useStartPoint.checkStateChanged)
@@ -153,6 +164,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             self.form.processPerimeter.hide()
 
         self.form.stepover.setEnabled(self.obj.NumPasses > 1)
+        self.form.springPassScope.setEnabled(self.obj.SpringPasses > 0)
 
     def registerSignalHandlers(self, obj):
         if hasattr(self.form.useCompensation, "checkStateChanged"):  # Qt version >= 6.7.0
@@ -160,6 +172,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         else:  # Qt version < 6.7.0
             self.form.useCompensation.stateChanged.connect(self.updateVisibility)
         self.form.numPasses.editingFinished.connect(self.updateVisibility)
+        self.form.springPasses.editingFinished.connect(self.updateVisibility)
 
         self.form.setStartPoint.clicked.connect(self.setStartPoint)
 

--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -195,6 +195,26 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                 ),
             ),
             (
+                "App::PropertyIntegerConstraint",
+                "SpringPasses",
+                "Profile",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Number of exact repetitions of the final cutting pass, at the same depth"
+                    " and offset, to recover tool deflection",
+                ),
+            ),
+            (
+                "App::PropertyEnumeration",
+                "SpringPassScope",
+                "Profile",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Whether spring passes are added only at the final depth"
+                    " or at every depth layer",
+                ),
+            ),
+            (
                 "App::PropertyBool",
                 "UseLongestEdge",
                 "Start Point",
@@ -261,6 +281,10 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                 (translate("PathProfile", "Automatic"), "Automatic"),
                 (translate("PathProfile", "Manual"), "Manual"),
             ],
+            "SpringPassScope": [
+                (translate("PathProfile", "Final Depth"), "Final Depth"),
+                (translate("PathProfile", "Every Depth"), "Every Depth"),
+            ],
         }
 
         if dataType == "raw":
@@ -294,6 +318,8 @@ class ObjectProfile(PathAreaOp.ObjectOp):
             "processPerimeter": True,
             "Stepover": 0,
             "NumPasses": (1, 1, 99999, 1),
+            "SpringPasses": (0, 0, 10, 1),
+            "SpringPassScope": "Final Depth",
         }
 
     def areaOpApplyPropertyDefaults(self, obj, job, propList):
@@ -337,8 +363,10 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         )
         sortingMode = 0 if obj.HandleMultipleFeatures == "Individually" else 2
         multiPassMode = 0 if obj.NumPasses > 1 else 2
+        springPassMode = 0 if obj.SpringPasses > 0 else 2
 
         obj.setEditorMode("Stepover", multiPassMode)
+        obj.setEditorMode("SpringPassScope", springPassMode)
         obj.setEditorMode("JoinType", 2)
         obj.setEditorMode("MiterLimit", 2)  # ml
         obj.setEditorMode("Side", side)
@@ -368,8 +396,10 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         if hasattr(self, "propertiesReady") and self.propertiesReady:
             self.setOpEditorProperties(obj)
 
-    def areaOpAreaParams(self, obj, isHole):
-        """areaOpAreaParams(obj, isHole) ... returns dictionary with area parameters.
+    def areaOpAreaParams(self, obj, isHole, finalPassOnly=False):
+        """areaOpAreaParams(obj, isHole, finalPassOnly=False) ... returns dictionary with area parameters.
+        With finalPassOnly=True only the finishing offset is returned, without the
+        multi-pass offset ladder. Used to rebuild the geometry a spring pass repeats.
         Do not overwrite."""
         params = {}
         params["Fill"] = 0
@@ -396,13 +426,20 @@ class ObjectProfile(PathAreaOp.ObjectOp):
             offset = 0 - offset
             stepover = -stepover
 
-        # Modify offset and stepover to do passes from most-offset to least
-        offset += stepover * (num_passes - 1)
-        stepover = -stepover
+        if finalPassOnly:
+            # The finishing offset is the least-offset pass, i.e. the value before
+            # the multi-pass ladder is stacked on top of it below.
+            params["Offset"] = offset
+            params["ExtraPass"] = 0
+            params["Stepover"] = 0
+        else:
+            # Modify offset and stepover to do passes from most-offset to least
+            offset += stepover * (num_passes - 1)
+            stepover = -stepover
 
-        params["Offset"] = offset
-        params["ExtraPass"] = num_passes - 1
-        params["Stepover"] = stepover
+            params["Offset"] = offset
+            params["ExtraPass"] = num_passes - 1
+            params["Stepover"] = stepover
 
         # Map JoinType string to AreaParams enum value
         jointype_map = {
@@ -446,8 +483,9 @@ class ObjectProfile(PathAreaOp.ObjectOp):
             else:
                 params["orientation"] = 0
 
-        if obj.NumPasses > 1:
-            # Disable path sorting to ensure that offsets appear in order, from farthest offset to closest, on all layers
+        if obj.NumPasses > 1 or obj.SpringPasses > 0:
+            # Disable path sorting to ensure that offsets appear in order, from farthest offset to
+            # closest, on all layers, and that spring passes stay adjacent to the pass they repeat
             params["sort_mode"] = 0
 
         return params
@@ -471,6 +509,11 @@ class ObjectProfile(PathAreaOp.ObjectOp):
             "The selected edge(s) are inaccessible. If multiple, re-ordering selection might work.",
         )
         self.offsetExtra = obj.OffsetExtra.Value
+        # Open-edge wires collected by _processWire(), and the subset of them belonging to
+        # the finishing offset. Consumed by PathAreaOp when deciding which wires a spring
+        # pass may repeat.
+        self.openEdgeWires = []
+        self.openEdgeFinishWires = []
 
         if self.isDebug:
             for grpNm in ("tmpDebugGrp", "tmpDebugGrp001"):
@@ -661,6 +704,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                 self._addDebugObject("FlatWire", flatWire)
 
                 openWires = []
+                finishWires = []
                 params = self.areaOpAreaParams(obj, False)
                 passOffsets = [
                     self.ofstRadius + i * abs(params["Stepover"])
@@ -676,8 +720,14 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                     if cutWireObjs:
                         for cW in cutWireObjs:
                             openWires.append(cW)
+                        # passOffsets runs from the largest offset to the smallest, so
+                        # the wires of the last successful iteration are the finishing
+                        # offset. Only those may be repeated by a spring pass.
+                        finishWires = list(cutWireObjs)
                     else:
                         Path.Log.error(self.inaccessibleMsg)
+                self.openEdgeWires.extend(openWires)
+                self.openEdgeFinishWires.extend(finishWires)
                 shapeTups.append((openWires[0], openWires, "OpenEdge"))
 
         return shapeTups

--- a/src/Mod/CAM/Roadmap/ADR/ADR-000.md
+++ b/src/Mod/CAM/Roadmap/ADR/ADR-000.md
@@ -83,7 +83,7 @@ A final cutting pass that follows a new toolpath offset from the roughing passes
 _Avoid_: conflating with **Spring Pass**.
 
 **Spring Pass**:
-An *exact repetition* of the immediately preceding cutting pass with no change in depth, offset, or feed. Its purpose is deflection recovery: the first pass leaves a thin witness of uncut material because tool and workpiece deflect under load; the repeat pass, seeing almost no load, springs back to true and cleans the witness. Not currently implemented as a first-class feature in the CAM workbench, but the concept is distinct from **Finish Pass**.
+An *exact repetition* of the immediately preceding cutting pass with no change in depth, offset, or feed. Its purpose is deflection recovery: the first pass leaves a thin witness of uncut material because tool and workpiece deflect under load; the repeat pass, seeing almost no load, springs back to true and cleans the witness. Implemented on **Profile** as the `SpringPasses` property (how many repetitions) and `SpringPassScope` (final depth only, or every depth layer). Where an operation makes multiple offset passes, a spring pass repeats the finishing offset alone, never the roughing ladder.
 _Avoid_: conflating with **Finish Pass**. A **Finish Pass** follows a *new* toolpath with a controlled allowance; a **Spring Pass** re-runs the *same* toolpath to recover deflection.
 
 **Operation catalog** (current operation types):


### PR DESCRIPTION
Fixes #29448 

A spring pass is an exact repetition of the immediately preceding cutting pass - same depth, same offset, same feed - to recover the deflection of tool and workpiece. ADR-000 already defined the term and recorded it as unimplemented; this makes it a first-class Profile feature.

Two new properties on Profile:

  SpringPasses     how many repetitions (0 = off, the default, so existing
                   documents are unaffected)
  SpringPassScope  'Final Depth' (the default) or 'Every Depth'

The repeats are appended to the same shapelist that Path.fromShapes() already receives, rather than emitted as a separate path. For a closed profile the repeat therefore starts where the previous pass ended and the tool carries straight on round the contour - a separate emission would retract and plunge back into the wall it has just finished.

Where NumPasses > 1 the section for a depth layer holds the entire offset ladder, so repeating it wholesale would re-run the roughing offsets in air. areaOpAreaParams() gained a finalPassOnly flag that yields the finishing offset alone, and that geometry is what a spring pass repeats.

Open edges take the other path through PathAreaOp, where each offset arrives as its own wire and depth layers are looped in Python. There the repeat is a second emission, since an open wire cannot close back onto itself. Profile records which wires belong to the finishing offset so the roughing wires are not repeated.

Enabling spring passes disables path sorting, as NumPasses > 1 already does, so the repeat stays adjacent to the pass it repeats.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by claude fable

