### PR TITLE
Gui: fix macOS trackpad navigation (pinch zoom, scroll pan, Shift orbit)

### DIFF
--- a/src/Gui/Inventor/SoMouseWheelEvent.h
+++ b/src/Gui/Inventor/SoMouseWheelEvent.h
@@ -27,6 +27,7 @@
 
 #include <Inventor/events/SoEvent.h>
 #include <Inventor/events/SoSubEvent.h>
+#include <Inventor/SbLinear.h>
 #include <FCGlobal.h>
 
 /**
@@ -59,8 +60,21 @@ public:  // methods
     {
         this->delta = delta;
     }
+    const SbVec2f& getPixelDelta() const
+    {
+        return pixelDelta;
+    }
+    void setPixelDelta(const SbVec2f& logicalDelta, float devicePixelRatio)
+    {
+        pixelDelta = SbVec2f(logicalDelta[0] * devicePixelRatio, -logicalDelta[1] * devicePixelRatio);
+    }
+    bool isPrecise() const
+    {
+        return pixelDelta != SbVec2f(0.0F, 0.0F);
+    }
     ~SoMouseWheelEvent() override = default;
 
 private:  // data
     int delta;
+    SbVec2f pixelDelta {0.0F, 0.0F};
 };

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -59,6 +59,7 @@
 #include "Command.h"
 #include "Action.h"
 #include "Inventor/SoMouseWheelEvent.h"
+#include "SoTouchEvents.h"
 #include "MenuManager.h"
 #include "MouseSelection.h"
 #include "Navigation/NavigationAnimator.h"
@@ -2280,6 +2281,10 @@ SbBool NavigationStyle::processSoEvent(const SoEvent* const ev)
         offeredtoViewerEventBase = true;
     }
 
+    if (!processed && ev->isOfType(SoGesturePinchEvent::getClassTypeId())) {
+        processed = processPinchEvent(static_cast<const SoGesturePinchEvent*>(ev));
+    }
+
     if (!processed && !offeredtoViewerEventBase) {
         processed = viewer->processSoEventBase(ev);
     }
@@ -2530,13 +2535,87 @@ void NavigationStyle::replayDeferredMouseDownEvent()
     clearDeferredMouseDownEvent();
 }
 
+namespace
+{
+bool touchpadScrollPans()
+{
+#ifdef Q_OS_MACOS
+    constexpr bool defaultValue = true;
+#else
+    constexpr bool defaultValue = false;
+#endif
+    return App::GetApplication()
+        .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
+        ->GetBool("TouchpadScrollPans", defaultValue);
+}
+}  // namespace
+
 SbBool NavigationStyle::processWheelEvent(const SoMouseWheelEvent* const event)
 {
     const SbVec2s pos(event->getPosition());
     const SbVec2f posn = normalizePixelPos(pos);
+    SoCamera* camera = viewer->getSoRenderManager()->getCamera();
+
+    if (event->isPrecise() && touchpadScrollPans()) {
+        if (!camera) {
+            return true;
+        }
+
+        if (event->wasShiftDown()) {
+            const SbVec2f center(0.5F, 0.5F);
+            spin_simplified(center + normalizePixelPos(event->getPixelDelta()), center);
+            return true;
+        }
+
+        if (!event->wasCtrlDown()) {
+            setupPanningPlane(camera);
+            const float ratio
+                = viewer->getSoRenderManager()->getViewportRegion().getViewportAspectRatio();
+            panCamera(
+                camera,
+                ratio,
+                this->panningplane,
+                normalizePixelPos(event->getPixelDelta()),
+                SbVec2f(0, 0)
+            );
+            return true;
+        }
+    }
 
     // handle mouse wheel zoom
-    doZoom(viewer->getSoRenderManager()->getCamera(), event->getDelta(), posn);
+    doZoom(camera, event->getDelta(), posn);
+    return true;
+}
+
+SbBool NavigationStyle::processPinchEvent(const SoGesturePinchEvent* const event)
+{
+    SoCamera* camera = viewer->getSoRenderManager()->getCamera();
+    if (!camera) {
+        return false;
+    }
+
+    if (event->state == SoGestureEvent::SbGSStart) {
+        setupPanningPlane(camera);
+        return true;
+    }
+
+    if (event->state == SoGestureEvent::SbGSEnd) {
+        return true;
+    }
+
+    const SbVec2f posn = normalizePixelPos(event->curCenter);
+
+    if (event->deltaZoom > 0.0) {
+        doZoom(camera, -logf(static_cast<float>(event->deltaZoom)), posn);
+    }
+
+    const bool enableTilt = !(App::GetApplication()
+                                  .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
+                                  ->GetBool("DisableTouchTilt", true));
+    if (event->deltaAngle != 0.0 && enableTilt) {
+        doRotate(camera, static_cast<float>(event->deltaAngle), posn);
+    }
+
     return true;
 }
 

--- a/src/Gui/Navigation/NavigationStyle.h
+++ b/src/Gui/Navigation/NavigationStyle.h
@@ -47,6 +47,7 @@
 // forward declarations
 class SoEvent;
 class SoMouseWheelEvent;
+class SoGesturePinchEvent;
 class SoMotion3Event;
 class SoQtViewer;
 class SoCamera;
@@ -244,6 +245,7 @@ public:
     virtual SbBool processKeyboardEvent(const SoKeyboardEvent* const event);
     virtual SbBool processClickEvent(const SoMouseButtonEvent* const event);
     virtual SbBool processWheelEvent(const SoMouseWheelEvent* const event);
+    virtual SbBool processPinchEvent(const SoGesturePinchEvent* const event);
 
     void setPopupMenuEnabled(const SbBool on);
     SbBool isPopupMenuEnabled() const;

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
@@ -61,6 +61,9 @@ DlgSettingsNavigation::DlgSettingsNavigation(QWidget* parent)
     ui->setupUi(this);
     ui->naviCubeBaseColor->setAllowTransparency(true);
     ui->rotationCenterColor->setAllowTransparency(true);
+#ifdef Q_OS_MACOS
+    ui->checkBoxTouchpadScrollPans->setChecked(true);
+#endif
     retranslate();
 #if !defined(_USE_3DCONNEXION_SDK) && !defined(SPNAV_FOUND)
     ui->legacySpaceMouseDevices->setDisabled(true);

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.ui
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.ui
@@ -734,6 +734,28 @@ Mouse tilting is not disabled by this setting.</string>
         </property>
        </widget>
       </item>
+      <item row="9" column="0">
+       <widget class="Gui::PrefCheckBox" name="checkBoxTouchpadScrollPans">
+        <property name="toolTip">
+         <string>Two-finger scroll on a touchpad pans the view,
+Shift + scroll orbits, and Ctrl + scroll (Cmd on macOS) zooms.
+Only affects devices that report pixel-precise scrolling.
+Mouse wheels always zoom.</string>
+        </property>
+        <property name="text">
+         <string>Touchpad scroll pans instead of zooming</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>TouchpadScrollPans</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/Gui/Quarter/Mouse.cpp
+++ b/src/Gui/Quarter/Mouse.cpp
@@ -191,6 +191,11 @@ MouseP::mouseWheelEvent(QWheelEvent * event)
   // can be a lot lower
   this->wheel->setDelta(event->angleDelta().y());
 
+  const QPoint pixels = event->pixelDelta();
+  this->wheel->setPixelDelta(SbVec2f(static_cast<float>(pixels.x()),
+                                     static_cast<float>(pixels.y())),
+                             static_cast<float>(publ->quarter->devicePixelRatio()));
+
   return this->wheel;
 }
 

--- a/src/Gui/SoTouchEvents.cpp
+++ b/src/Gui/SoTouchEvents.cpp
@@ -205,7 +205,7 @@ const SoEvent* GesturesDevice::translateEvent(QEvent* event)
         auto sg = static_cast<QSwipeGesture*>(gevent->gesture(Qt::SwipeGesture));
         if (sg) {
             gevent->setAccepted(Qt::SwipeGesture, true);
-            return new SoGesturePanEvent(pg, this->widget);
+            return new SoGestureSwipeEvent(sg, this->widget);
         }
     }
     return nullptr;

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -106,6 +106,7 @@
 #include <QSurfaceFormat>
 #include <QTimer>
 #include <QVariantAnimation>
+#include <QtMath>
 #include <QWheelEvent>
 
 #include <App/Document.h>
@@ -798,22 +799,82 @@ private:
     QPoint pressPosition;
     View3DInventorViewer* currentViewer = nullptr;
 
+    SbVec2f pinchBeginCenter {0.0F, 0.0F};
+
+    bool handleNativeGesture(QObject* obj, QEvent* event)
+    {
+        if (event->type() != QEvent::NativeGesture) {
+            return false;
+        }
+        auto* viewer = qobject_cast<View3DInventorViewer*>(obj);
+        if (!viewer) {
+            viewer = qobject_cast<View3DInventorViewer*>(obj->parent());
+        }
+        if (!viewer) {
+            return false;
+        }
+        auto* navigation = viewer->navigationStyle();
+        if (!navigation) {
+            return false;
+        }
+        auto* ev = static_cast<QNativeGestureEvent*>(event);
+
+        SoGesturePinchEvent pinch;
+        const QPoint local = viewer->mapFromGlobal(ev->globalPosition().toPoint());
+        const auto dpr = static_cast<double>(viewer->devicePixelRatio());
+        pinch.curCenter = SbVec2f(
+            static_cast<float>(local.x() * dpr),
+            static_cast<float>((viewer->height() - local.y()) * dpr)
+        );
+        pinch.setPosition(SbVec2s(pinch.curCenter));
+        pinch.setTime(SbTime::getTimeOfDay());
+
+        switch (ev->gestureType()) {
+            case Qt::BeginNativeGesture:
+                pinch.state = SoGestureEvent::SbGSStart;
+                pinchBeginCenter = pinch.curCenter;
+                break;
+            case Qt::EndNativeGesture:
+                pinch.state = SoGestureEvent::SbGSEnd;
+                break;
+            case Qt::ZoomNativeGesture:
+                pinch.state = SoGestureEvent::SbGSUpdate;
+                pinch.deltaZoom = 1.0 + ev->value();
+                break;
+            case Qt::RotateNativeGesture:
+                pinch.state = SoGestureEvent::SbGSUpdate;
+                pinch.deltaAngle = -qDegreesToRadians(ev->value());
+                break;
+            default:
+                return false;
+        }
+
+        pinch.startCenter = pinchBeginCenter;
+        navigation->processPinchEvent(&pinch);
+        event->accept();
+        return true;
+    }
+
 public:
     bool eventFilter(QObject* obj, QEvent* event) override
     {
+        if (handleNativeGesture(obj, event)) {
+            return true;
+        }
+
         // Bug #0000607: Some mice also support horizontal scrolling which however might
         // lead to some unwanted zooming when pressing the MMB for panning.
         // Thus, we filter out horizontal scrolling.
         if (event->type() == QEvent::Wheel) {
             auto we = static_cast<QWheelEvent*>(event);  // NOLINT
-            if (qAbs(we->angleDelta().x()) > qAbs(we->angleDelta().y())) {
+            if (we->pixelDelta().isNull() && qAbs(we->angleDelta().x()) > qAbs(we->angleDelta().y())) {
                 return true;
             }
         }
         else if (event->type() == QEvent::KeyPress) {
             auto ke = static_cast<QKeyEvent*>(event);  // NOLINT
-            if (ke->matches(QKeySequence::SelectAll)) {
-                auto* viewer3d = static_cast<View3DInventorViewer*>(obj);
+            auto* viewer3d = qobject_cast<View3DInventorViewer*>(obj);
+            if (viewer3d && ke->matches(QKeySequence::SelectAll)) {
                 auto* editingVP = viewer3d->getEditingViewProvider();
                 if (!editingVP || !editingVP->selectAll()) {
                     viewer3d->selectAll();
@@ -843,8 +904,9 @@ public:
 
         if (event->type() == QEvent::MouseButtonPress) {
             auto mouseEvent = static_cast<QMouseEvent*>(event);
-            if (mouseEvent->button() == Qt::LeftButton) {
-                currentViewer = static_cast<View3DInventorViewer*>(obj);
+            auto* pressViewer = qobject_cast<View3DInventorViewer*>(obj);
+            if (pressViewer && mouseEvent->button() == Qt::LeftButton) {
+                currentViewer = pressViewer;
                 pressPosition = mouseEvent->pos();
                 bool ctrlPressed = (mouseEvent->modifiers() & Qt::ControlModifier) != 0;
 
@@ -1028,6 +1090,14 @@ View3DInventorViewer::View3DInventorViewer(
     , _viewerPy(nullptr)
 {
     init();
+}
+
+void View3DInventorViewer::setupViewport(QWidget* widget)
+{
+    inherited::setupViewport(widget);
+    if (viewerEventFilter && widget) {
+        widget->installEventFilter(viewerEventFilter);
+    }
 }
 
 void View3DInventorViewer::init()
@@ -1282,6 +1352,7 @@ void View3DInventorViewer::init()
     // filter a few qt events
     viewerEventFilter = new ViewerEventFilter;
     installEventFilter(viewerEventFilter);
+    viewport()->installEventFilter(viewerEventFilter);
 #if defined(USE_3DCONNEXION_NAVLIB)
     if (SpaceMouseParameter::instance()->getLegacySpaceMouseDevices()) {
         getEventFilter()->registerInputDevice(new SpaceNavigatorDevice);
@@ -1292,8 +1363,10 @@ void View3DInventorViewer::init()
     getEventFilter()->registerInputDevice(new GesturesDevice(this));
 
     try {
+#ifndef Q_OS_MACOS
         this->grabGesture(Qt::PanGesture);
         this->grabGesture(Qt::PinchGesture);
+#endif
     }
     catch (Base::Exception& e) {
         Base::Console().warning("Failed to set up gestures. Error: %s\n", e.what());

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -592,6 +592,7 @@ Q_SIGNALS:
     void cameraChanged();
 
 protected:
+    void setupViewport(QWidget* widget) override;
     static GLenum getInternalTextureFormat();
     void renderScene();
     void renderRubberbandOverlay();

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(Gui_tests_run
         StyleParameters/YamlParameterSourceTest.cpp
         InputHintTest.cpp
         SelectionTest.cpp
+        SoMouseWheelEventTest.cpp
 )
 
 # Qt tests

--- a/tests/src/Gui/SoMouseWheelEventTest.cpp
+++ b/tests/src/Gui/SoMouseWheelEventTest.cpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+
+#include <Gui/Inventor/SoMouseWheelEvent.h>
+
+TEST(SoMouseWheelEvent, defaultConstructedIsNotPrecise)
+{
+    SoMouseWheelEvent event;
+
+    EXPECT_EQ(event.getDelta(), 0);
+    EXPECT_FALSE(event.isPrecise());
+}
+
+TEST(SoMouseWheelEvent, pixelDeltaIsScaledToDevicePixelsAndFlippedToGlOrientation)
+{
+    SoMouseWheelEvent event;
+
+    event.setPixelDelta(SbVec2f(3.0F, -10.0F), 2.0F);
+
+    EXPECT_EQ(event.getPixelDelta(), SbVec2f(6.0F, 20.0F));
+    EXPECT_TRUE(event.isPrecise());
+}
+
+TEST(SoMouseWheelEvent, nullPixelDeltaIsNotPreciseEvenWithWheelDelta)
+{
+    SoMouseWheelEvent event;
+
+    event.setDelta(120);
+    event.setPixelDelta(SbVec2f(0.0F, 0.0F), 2.0F);
+
+    EXPECT_EQ(event.getDelta(), 120);
+    EXPECT_FALSE(event.isPrecise());
+}


### PR DESCRIPTION
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues

Closes #5938. Related: #5640 (closed) and #29447. #29447 covers the pinch half of the same problem; see "Relationship to #29447" below.

## Problem

On macOS, three trackpad inputs do nothing in the 3D view. Pinch-to-zoom is ignored under the default CAD navigation style, two-finger rotate never works, and horizontal two-finger scroll is discarded.

## Root cause

macOS delivers trackpad pinch and rotate as `QNativeGestureEvent`s. Qt's `QWidgetWindow::handleGestureEvent` sends those to `QApplication::widgetAt(pos)`, the deepest widget under the cursor, and gesture events do not propagate to parents.

For the QGraphicsView-based 3D view, the deepest widget is the GL viewport. Every one of FreeCAD's 3D-view event filters is installed on the view widget instead, one level up. So the gestures have been arriving below every listener and dying there.

(Verified against the Qt 6.8 sources `qnsview_gestures.mm` and `qwidgetwindow.cpp`, and empirically with event tracing on Qt 6.8.3.)

## Changes

- Install `ViewerEventFilter` on the viewport as well, and translate native zoom/rotate gestures into `SoGesturePinchEvent`s.
- Handle pinch in the `NavigationStyle` base class (`processPinchEvent`), so every navigation style gets it instead of only the two gesture styles.
- Carry `QWheelEvent::pixelDelta()` through `SoMouseWheelEvent`. On devices that report pixel-precise deltas (touchpads), two-finger scroll pans, Shift+scroll orbits, and Ctrl+scroll (Cmd on macOS) zooms, matching Fusion 360 and Onshape. Wheel mice report no pixel delta and keep the current zoom behavior on every platform. The scheme sits behind a new preference (`View/TouchpadScrollPans`, checkbox in Preferences → Navigation) that defaults to on for macOS and off elsewhere.
- Stop grabbing Qt pan/pinch gestures on macOS. Qt's recognizer synthesizes a second pinch from the same touch stream, always with `rotationAngle == 0` because macOS never sends the native rotate stream Qt sources it from, and that second pinch would double the zoom.
- Restrict the horizontal-wheel filter (bug #0000607) to non-precise devices, so trackpads keep both scroll axes.
- Fix a null-pointer dereference in the swipe branch of `GesturesDevice::translateEvent`, which built a `SoGesturePanEvent` from a null `QPanGesture*`.

## Relationship to #29447

#29447 translates `QNativeGestureEvent` inside `GesturesDevice::translateEvent()` and also fixes the same swipe-branch null pointer. Two differences here:

1. As @chennes noted on that PR, only GestureNavigationStyle and MayaGestureNavigationStyle consume `SoGesturePinchEvent`, so translating the gesture is a partial fix: under the default CAD style the pinch is still dropped. This PR handles pinch in the `NavigationStyle` base class, so it reaches CAD, Blender, Touchpad and the rest too.
2. In my testing on Qt 6.8.3, `QNativeGestureEvent`s never reach the Quarter `EventFilter` at all. They are delivered to the GL viewport and stop there, which is why this PR hooks the viewport. I'd welcome the author of #29447 checking whether their branch still receives the events on current Qt.

Happy to coordinate so the swipe-branch fix lands only once.

## Behavioral note for touchpad users

On macOS this changes the default two-finger-scroll action on touchpads from zoom to pan, with pinch and Cmd+scroll doing the zooming, matching other CAD tools on that platform. On other platforms nothing changes by default: the same scheme is available behind the new preference, but the default stays zoom. The runtime gate is device capability plus the preference, wheel mice are never affected.

## Testing


https://github.com/user-attachments/assets/8ff2f959-3b2f-469e-a75a-a57621e914d4


https://github.com/user-attachments/assets/d4489917-837f-4706-be56-e23a731abbea


https://github.com/user-attachments/assets/6e8eeadf-f26d-412d-bdff-fe47c41c1c15


https://github.com/user-attachments/assets/69fc4a38-3431-4e38-8f82-2a50968bca63


https://github.com/user-attachments/assets/77d796a6-9b10-4b6b-88c9-3f50d1ffd211


macOS 15 (arm64), Qt 6.8.3, pixi/conda build:

- Manual: pinch zoom at cursor, two-finger pan (both axes), Shift-orbit, Cmd-zoom, under both CAD and Gesture navigation styles.
- Automated: synthesized pixel-precise scroll events via CGEventPost (with real modifier-key state) and asserted camera semantics through the Python API between batches. Pan moves the focal point purely laterally along the camera-up axis, with orientation and height untouched. Shift-orbit changes orientation, and camera elevation follows finger direction. Cmd-zoom changes only the view height. The assertions distinguish real motion from the orthographic focal-distance normalization that preserves the focal point.
- Screen recordings are embedded above.
- Unit tests: `tests/src/Gui/SoMouseWheelEventTest.cpp` covers the new `SoMouseWheelEvent` pixel-delta contract (`isPrecise()` semantics, including the horizontal-only case the old wheel filter used to discard). The navigation routing needs a live viewer with a GL context, so it is covered by the automated camera-semantics assertions above rather than unit tests.

Non-macOS platforms: no default behavior change. Wheel mice report no pixel delta so the existing zoom path runs, and the touchpad scheme is opt-in via the preference. The native gesture handler runs everywhere but only receives events where the platform produces them (macOS, Wayland). I could only test on macOS hardware, so testers on Linux and Windows touchpads are welcome.

## AI disclosure

Per the project's AI policy: this change was developed with AI assistance (Claude Opus 5, `claude-opus-5`, disclosed in the commit trailer). I directed the work, built and ran it locally, and tested the resulting behavior on my machine. I take responsibility for the contribution.

