### PR TITLE
Sketcher: Convert text elements to paths in SVG icons

### DIFF
--- a/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_CreateRegularPolygon.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_CreateRegularPolygon.svg
@@ -189,26 +189,14 @@
        id="g4587"
        transform="matrix(0.91581284,0,0,0.91581284,1.8514053,0.7742157)"
        style="stroke-width:1.09193">
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:26.6667px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#2e0000;fill-opacity:1;stroke:#2e0000;stroke-width:6.55156;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
-         x="0.33403441"
-         y="27.462246"
-         id="text4553"><tspan
-           id="tspan4551"
-           x="0.33403441"
-           y="27.462246"
-           style="font-size:32px;fill:#2e0000;fill-opacity:1;stroke:#2e0000;stroke-width:6.55156;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill">N</tspan></text>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:26.6667px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#cc0000;fill-opacity:1;stroke:#ef2929;stroke-width:2.18385;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
-         x="0.33403441"
-         y="27.462246"
-         id="text1"><tspan
-           id="tspan1"
-           x="0.33403441"
-           y="27.462246"
-           style="font-size:32px;fill:#cc0000;stroke:#ef2929;stroke-width:2.18385;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill">N</tspan></text>
+      <path
+         style="fill:#2e0000;stroke:#2e0000;stroke-width:6.55156;paint-order:stroke markers fill"
+         d="m 21.550034,27.462246 h -3.36 L 5.9660344,8.4862459 h -0.128 q 0.064,0.736 0.096,1.7600001 0.064,0.992 0.096,2.144 0.064,1.12 0.064,2.304 v 12.768 h -2.656 V 4.6142459 h 3.328 L 18.958034,23.526246 h 0.128 q -0.032,-0.512 -0.096,-1.536 -0.032,-1.024 -0.096,-2.24 -0.032,-1.216 -0.032,-2.24 V 4.6142459 h 2.688 z"
+         id="text4553" />
+      <path
+         style="fill:#cc0000;stroke:#ef2929;stroke-width:2.18385;paint-order:stroke markers fill"
+         d="m 21.550034,27.462246 h -3.36 L 5.9660344,8.4862459 h -0.128 q 0.064,0.736 0.096,1.7600001 0.064,0.992 0.096,2.144 0.064,1.12 0.064,2.304 v 12.768 h -2.656 V 4.6142459 h 3.328 L 18.958034,23.526246 h 0.128 q -0.032,-0.512 -0.096,-1.536 -0.032,-1.024 -0.096,-2.24 -0.032,-1.216 -0.032,-2.24 V 4.6142459 h 2.688 z"
+         id="text1" />
     </g>
     <g
        transform="matrix(0.77869459,0,0,0.77869445,47.548264,23.597628)"

--- a/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_CreateRegularPolygon_Constr.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_CreateRegularPolygon_Constr.svg
@@ -189,26 +189,14 @@
        id="g4587"
        transform="matrix(0.91581284,0,0,0.91581284,1.8514053,0.7742157)"
        style="stroke-width:1.09193">
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:26.6667px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#2e0000;fill-opacity:1;stroke:#2e0000;stroke-width:6.55156;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
-         x="0.33403441"
-         y="27.462246"
-         id="text4553"><tspan
-           id="tspan4551"
-           x="0.33403441"
-           y="27.462246"
-           style="font-size:32px;fill:#2e0000;fill-opacity:1;stroke:#2e0000;stroke-width:6.55156;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill">N</tspan></text>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:26.6667px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#cc0000;fill-opacity:1;stroke:#ef2929;stroke-width:2.18385;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
-         x="0.33403441"
-         y="27.462246"
-         id="text1"><tspan
-           id="tspan1"
-           x="0.33403441"
-           y="27.462246"
-           style="font-size:32px;fill:#cc0000;stroke:#ef2929;stroke-width:2.18385;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill">N</tspan></text>
+      <path
+         style="fill:#2e0000;stroke:#2e0000;stroke-width:6.55156;paint-order:stroke markers fill"
+         d="m 21.550034,27.462246 h -3.36 L 5.9660344,8.4862459 h -0.128 q 0.064,0.736 0.096,1.7600001 0.064,0.992 0.096,2.144 0.064,1.12 0.064,2.304 v 12.768 h -2.656 V 4.6142459 h 3.328 L 18.958034,23.526246 h 0.128 q -0.032,-0.512 -0.096,-1.536 -0.032,-1.024 -0.096,-2.24 -0.032,-1.216 -0.032,-2.24 V 4.6142459 h 2.688 z"
+         id="text4553" />
+      <path
+         style="fill:#cc0000;stroke:#ef2929;stroke-width:2.18385;paint-order:stroke markers fill"
+         d="m 21.550034,27.462246 h -3.36 L 5.9660344,8.4862459 h -0.128 q 0.064,0.736 0.096,1.7600001 0.064,0.992 0.096,2.144 0.064,1.12 0.064,2.304 v 12.768 h -2.656 V 4.6142459 h 3.328 L 18.958034,23.526246 h 0.128 q -0.032,-0.512 -0.096,-1.536 -0.032,-1.024 -0.096,-2.24 -0.032,-1.216 -0.032,-2.24 V 4.6142459 h 2.688 z"
+         id="text1" />
     </g>
     <g
        transform="matrix(0.77869459,0,0,0.77869445,47.548264,23.597628)"


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

The use of `<text />` elements in icon SVGs causes a few minor problems in FreeCAD.

If the font is not found, this warning message shows up:

> (qt.qpa.fonts) Populating font family aliases took 36 ms. Replace uses of missing font family "Sans" with one that exists to avoid this cost.

This is particularly irritating on MacOS because, unlike on Linux, Qt SVG doesn't handle generic font families like `serif` & `sans-serif` properly.

it doesn't stop FreeCAD from working, but it's somewhat distracting. One of the first things a new user sees when they try to use FreeCAD is a cryptic error message.

The other problem is that icons using `<text />` will appear differently on different operating systems, depending on the fonts installed.

I've baked the shape of the letter into the SVG by converting the `<text>` to a `<path>` in Inkscape. I used the Noto Sans font, because it uses the GPL-compatible [Open Font License](https://fonts.google.com/noto/specimen/Noto+Sans/license#preamble) and is [already included](https://github.com/FreeCAD/FreeCAD/tree/weekly-2026.08.05/tests/visual/fonts) in the FreeCAD repository.

I explored a few other approaches to making this warning go away, but I think this one is the simplest and cleanest. This PR only covers the Sketcher workbench because that's the one that I use the most. If you guys are fine with this approach, I'd be happy to tackle the rest of them.

---

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.