### PR TITLE
BIM: Fix double click activates in Views panel

### DIFF
--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -1194,7 +1194,8 @@ class ViewProviderBuildingPart:
     def activate(self, action=None):
         from bimcommands.BimViews import _toggle_active_container
 
-        _toggle_active_container(self.Object, action)
+        if self.Object.ViewObject.DoubleClickActivates:
+            _toggle_active_container(self.Object, action)
         FreeCADGui.Selection.clearSelection()
 
     def setWorkingPlane(self, restore=False):

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -809,7 +809,9 @@ def show(item, column=None):
                 vparam.SetBool("Simple", True)
                 vparam.SetBool("Gradient", False)
                 vparam.SetBool("RadialGradient", False)
-        elif Draft.getType(obj) in ("BuildingPart", "IfcBuilding", "IfcBuildingStorey"):
+        elif Draft.getType(obj) in ("BuildingPart", "IfcBuilding", "IfcBuildingStorey") and getattr(
+            obj.ViewObject, "DoubleClickActivates", True
+        ):
             BIM_Views.activate()
         else:
             # WP Proxy


### PR DESCRIPTION
BIM Views now honors ViewObject.DoubleClickActivates before activating Buildings or Levels.
No AI used.

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/31807