### PR TITLE
Issue 20203 and 27000 part project on surface operation fails on curved surfaces

### DIFF
--- a/src/Mod/Part/App/FeatureProjectOnSurface.cpp
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.cpp
@@ -292,9 +292,15 @@ TopoDS_Face ProjectOnSurface::createFaceFromParametricWire(
             }
         }
     }
-    // auto doneFlag = faceMaker.IsDone();
-    // auto error = faceMaker.Error();
-    return faceMaker.Face();
+    // check validity of make face result
+    if (!faceMaker.IsDone()) {
+        return {};
+    }
+    TopoDS_Face result = faceMaker.Face();
+    if (result.IsNull() || !BRepCheck_Analyzer(result).IsValid()) {
+        return {};
+    }
+    return result;
 }
 
 std::vector<TopoDS_Wire> ProjectOnSurface::createWiresFromWires(

--- a/src/Mod/Part/App/FeatureProjectOnSurface.cpp
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.cpp
@@ -23,7 +23,7 @@
  **************************************************************************/
 
 #include <BRep_Tool.hxx>
-#include <BRepAlgoAPI_Common.hxx>
+#include <Mod/Part/App/FCBRepAlgoAPI_Common.h>
 #include <BRepBndLib.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
@@ -386,7 +386,7 @@ TopoDS_Face ProjectOnSurface::createFaceByClippingSource(
     }
 
     // boolean common operation to get trimmed face
-    BRepAlgoAPI_Common common(supportFace, prismMaker.Shape());
+    FCBRepAlgoAPI_Common common(supportFace, prismMaker.Shape());
     common.Build();
     if (!common.IsDone()) {
         return {};

--- a/src/Mod/Part/App/FeatureProjectOnSurface.cpp
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.cpp
@@ -338,6 +338,67 @@ std::vector<TopoDS_Wire> ProjectOnSurface::createWiresFromWires(
     return wiresInParametricSpace;
 }
 
+TopoDS_Face ProjectOnSurface::createFaceByClippingSource(
+    const TopoDS_Face& sourceFace,
+    const TopoDS_Face& supportFace,
+    const gp_Dir& direction
+) const
+{
+    // creates an extrusion, prism and then boolean common operation
+    // to create the projected face
+    if (sourceFace.IsNull()) {
+        return {};
+    }
+
+    // find the combined bounding box of source and target
+    Bnd_Box bounds;
+    BRepBndLib::Add(sourceFace, bounds);
+    BRepBndLib::Add(supportFace, bounds);
+    if (bounds.IsVoid()) {
+        return {};
+    }
+
+    // extrude the source face towards the target
+    const auto length = 2.0 * Max(Sqrt(bounds.SquareExtent()), 1.0);
+    gp_Vec extrusion(direction);
+    extrusion.Multiply(length);
+
+    // and make prism for boolean common op to trim
+    BRepPrimAPI_MakePrism prismMaker(sourceFace, extrusion);
+    if (!prismMaker.IsDone()) {
+        return {};
+    }
+
+    // boolean common operation to get trimmed face
+    BRepAlgoAPI_Common common(supportFace, prismMaker.Shape());
+    common.Build();
+    if (!common.IsDone()) {
+        return {};
+    }
+
+    // we only want the first intersection in case of curved target that may have multiple hits
+    auto nearestDistance = Precision::Infinite();
+    TopoDS_Face nearestFace;
+    // traverse faces to find the nearest intersection
+    for (TopExp_Explorer explorer(common.Shape(), TopAbs_FACE); explorer.More(); explorer.Next()) {
+        const auto candidate = TopoDS::Face(explorer.Current());
+        if (!BRepCheck_Analyzer(candidate).IsValid()) {
+            continue;
+        }
+
+        BRepExtrema_DistShapeShape distance(candidate, sourceFace);
+        distance.Perform();
+        if (!distance.IsDone() || distance.Value() >= nearestDistance) {
+            continue;
+        }
+
+        nearestDistance = distance.Value();
+        nearestFace = candidate;
+    }
+
+    return nearestFace;
+}
+
 TopoDS_Shape ProjectOnSurface::createSolidIfHeight(const TopoDS_Face& face) const
 {
     if (face.IsNull()) {

--- a/src/Mod/Part/App/FeatureProjectOnSurface.cpp
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.cpp
@@ -23,6 +23,8 @@
  **************************************************************************/
 
 #include <BRep_Tool.hxx>
+#include <BRepAlgoAPI_Common.hxx>
+#include <BRepBndLib.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepBuilderAPI_Transform.hxx>
@@ -30,6 +32,7 @@
 #include <BRepExtrema_DistShapeShape.hxx>
 #include <BRepPrimAPI_MakePrism.hxx>
 #include <BRepProj_Projection.hxx>
+#include <Bnd_Box.hxx>
 #include <Precision.hxx>
 #include <ShapeAnalysis.hxx>
 #include <ShapeAnalysis_FreeBounds.hxx>
@@ -37,11 +40,11 @@
 #include <ShapeFix_Wire.hxx>
 #include <ShapeFix_Wireframe.hxx>
 #include <Standard_Failure.hxx>
+#include <Standard_Real.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopTools_HSequenceOfShape.hxx>
 #include <TopoDS.hxx>
 #include <TopoDS_Builder.hxx>
-#include <sstream>
 
 
 #include "FeatureProjectOnSurface.h"

--- a/src/Mod/Part/App/FeatureProjectOnSurface.cpp
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.cpp
@@ -216,8 +216,15 @@ std::vector<TopoDS_Shape> ProjectOnSurface::createProjectedWire(
         return {};
     }
     if (shape.ShapeType() == TopAbs_FACE) {
-        auto wires = projectFace(TopoDS::Face(shape), supportFace, dir);
-        auto face = createFaceFromWire(wires, supportFace);
+        const auto sourceFace = TopoDS::Face(shape);
+        auto wires = projectFace(sourceFace, supportFace, dir);
+
+        // trim target with boolean common operation to create face
+        auto face = createFaceByClippingSource(sourceFace, supportFace, dir);
+        if (face.IsNull()) {
+            // fallback to original
+            face = createFaceFromWire(wires, supportFace);
+        }
         auto face_or_solid = createSolidIfHeight(face);
         if (!face_or_solid.IsNull()) {
             return {face_or_solid};

--- a/src/Mod/Part/App/FeatureProjectOnSurface.cpp
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.cpp
@@ -293,9 +293,15 @@ TopoDS_Face ProjectOnSurface::createFaceFromParametricWire(
             }
         }
     }
-    // auto doneFlag = faceMaker.IsDone();
-    // auto error = faceMaker.Error();
-    return faceMaker.Face();
+    // check validity of make face result
+    if (!faceMaker.IsDone()) {
+        return {};
+    }
+    TopoDS_Face result = faceMaker.Face();
+    if (result.IsNull() || !BRepCheck_Analyzer(result).IsValid()) {
+        return {};
+    }
+    return result;
 }
 
 std::vector<TopoDS_Wire> ProjectOnSurface::createWiresFromWires(

--- a/src/Mod/Part/App/FeatureProjectOnSurface.cpp
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.cpp
@@ -23,7 +23,7 @@
  **************************************************************************/
 
 #include <BRep_Tool.hxx>
-#include <BRepAlgoAPI_Common.hxx>
+#include <Mod/Part/App/FCBRepAlgoAPI_Common.h>
 #include <BRepBndLib.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
@@ -387,7 +387,7 @@ TopoDS_Face ProjectOnSurface::createFaceByClippingSource(
     }
 
     // boolean common operation to get trimmed face
-    BRepAlgoAPI_Common common(supportFace, prismMaker.Shape());
+    FCBRepAlgoAPI_Common common(supportFace, prismMaker.Shape());
     common.Build();
     if (!common.IsDone()) {
         return {};

--- a/src/Mod/Part/App/FeatureProjectOnSurface.cpp
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.cpp
@@ -380,7 +380,6 @@ TopoDS_Face ProjectOnSurface::createFaceByClippingSource(
     }
 
 
-
     // extrude the source face towards the target
     const auto length = 2.0 * Max(Sqrt(bounds.SquareExtent()), 1.0);
     gp_Vec extrusion(direction);

--- a/src/Mod/Part/App/FeatureProjectOnSurface.cpp
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.cpp
@@ -339,6 +339,67 @@ std::vector<TopoDS_Wire> ProjectOnSurface::createWiresFromWires(
     return wiresInParametricSpace;
 }
 
+TopoDS_Face ProjectOnSurface::createFaceByClippingSource(
+    const TopoDS_Face& sourceFace,
+    const TopoDS_Face& supportFace,
+    const gp_Dir& direction
+) const
+{
+    // creates an extrusion, prism and then boolean common operation
+    // to create the projected face
+    if (sourceFace.IsNull()) {
+        return {};
+    }
+
+    // find the combined bounding box of source and target
+    Bnd_Box bounds;
+    BRepBndLib::Add(sourceFace, bounds);
+    BRepBndLib::Add(supportFace, bounds);
+    if (bounds.IsVoid()) {
+        return {};
+    }
+
+    // extrude the source face towards the target
+    const auto length = 2.0 * Max(Sqrt(bounds.SquareExtent()), 1.0);
+    gp_Vec extrusion(direction);
+    extrusion.Multiply(length);
+
+    // and make prism for boolean common op to trim
+    BRepPrimAPI_MakePrism prismMaker(sourceFace, extrusion);
+    if (!prismMaker.IsDone()) {
+        return {};
+    }
+
+    // boolean common operation to get trimmed face
+    BRepAlgoAPI_Common common(supportFace, prismMaker.Shape());
+    common.Build();
+    if (!common.IsDone()) {
+        return {};
+    }
+
+    // we only want the first intersection in case of curved target that may have multiple hits
+    auto nearestDistance = Precision::Infinite();
+    TopoDS_Face nearestFace;
+    // traverse faces to find the nearest intersection
+    for (TopExp_Explorer explorer(common.Shape(), TopAbs_FACE); explorer.More(); explorer.Next()) {
+        const auto candidate = TopoDS::Face(explorer.Current());
+        if (!BRepCheck_Analyzer(candidate).IsValid()) {
+            continue;
+        }
+
+        BRepExtrema_DistShapeShape distance(candidate, sourceFace);
+        distance.Perform();
+        if (!distance.IsDone() || distance.Value() >= nearestDistance) {
+            continue;
+        }
+
+        nearestDistance = distance.Value();
+        nearestFace = candidate;
+    }
+
+    return nearestFace;
+}
+
 TopoDS_Shape ProjectOnSurface::createSolidIfHeight(const TopoDS_Face& face) const
 {
     if (face.IsNull()) {

--- a/src/Mod/Part/App/FeatureProjectOnSurface.cpp
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.cpp
@@ -39,13 +39,15 @@
 #include <ShapeFix_Face.hxx>
 #include <ShapeFix_Wire.hxx>
 #include <ShapeFix_Wireframe.hxx>
+#include <ShapeUpgrade_UnifySameDomain.hxx>
 #include <Standard_Failure.hxx>
 #include <Standard_Real.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopTools_HSequenceOfShape.hxx>
 #include <TopoDS.hxx>
 #include <TopoDS_Builder.hxx>
-
+#include <BOPTools_AlgoTools.hxx>
+#include <TopTools_ListOfShape.hxx>
 
 #include "FeatureProjectOnSurface.h"
 #include "ShapeAnalysis_FreeBoundsFix.h"
@@ -133,6 +135,7 @@ TopoDS_Face ProjectOnSurface::getSupportFace() const
 
 std::vector<TopoDS_Shape> ProjectOnSurface::getProjectionShapes() const
 {
+
     std::vector<TopoDS_Shape> shapes;
     auto objects = Projection.getValues();
     auto subvalues = Projection.getSubValues();
@@ -367,39 +370,53 @@ TopoDS_Face ProjectOnSurface::createFaceByClippingSource(
         return {};
     }
 
-    // find the combined bounding box of source and target
-    Bnd_Box bounds;
-    BRepBndLib::Add(sourceFace, bounds);
-    BRepBndLib::Add(supportFace, bounds);
-    if (bounds.IsVoid()) {
-        return {};
-    }
 
-    // extrude the source face towards the target
-    const auto length = 2.0 * Max(Sqrt(bounds.SquareExtent()), 1.0);
-    gp_Vec extrusion(direction);
-    extrusion.Multiply(length);
+    TopoShape prism;
+    prism.makeElementPrismUntil(
+        TopoShape(),                 // no base
+        TopoShape(sourceFace),       // profile
+        TopoShape(),                 // don't need support
+        TopoShape(supportFace),      // target
+        direction,
+        TopoShape::PrismMode::None,
+        false                        // needs to be false to avoid filling holes/ or failing partial overlaps
+    );
 
-    // and make prism for boolean common op to trim
-    BRepPrimAPI_MakePrism prismMaker(sourceFace, extrusion);
-    if (!prismMaker.IsDone()) {
-        return {};
-    }
-
-    // boolean common operation to get trimmed face
-    FCBRepAlgoAPI_Common common(supportFace, prismMaker.Shape());
+    // get trimmed face
+    FCBRepAlgoAPI_Common common(supportFace, prism.getShape());
     common.Build();
     if (!common.IsDone()) {
         return {};
     }
 
-    // we only want the first intersection in case of curved target that may have multiple hits
+    // connect faces across seams
+    // for example, when projecting onto a cylinder with a seam that splits the prjected face
+    // it would only return a face on one side of the seam, so we conenct patches then find the nearest
+    TopTools_ListOfShape patches;
+    BOPTools_AlgoTools::MakeConnexityBlocks(common.Shape(), TopAbs_EDGE, TopAbs_FACE, patches);
+
+
+   // find the closest face to the proejction source
     auto nearestDistance = Precision::Infinite();
     TopoDS_Face nearestFace;
-    // traverse faces to find the nearest intersection
-    for (TopExp_Explorer explorer(common.Shape(), TopAbs_FACE); explorer.More(); explorer.Next()) {
-        const auto candidate = TopoDS::Face(explorer.Current());
-        if (!BRepCheck_Analyzer(candidate).IsValid()) {
+    for (const auto& patch : patches) {
+        // Note: we use unifysamedomain instead of removesplitter here b/c
+        // it succeeds in unifying edges (of projection) across cylinderical seam
+        ShapeUpgrade_UnifySameDomain unify(patch, true, true, false);
+        unify.Build();
+
+        TopExp_Explorer faces(unify.Shape(), TopAbs_FACE);
+
+        if (!faces.More()) {
+            continue;
+        }
+
+        const auto candidate = TopoDS::Face(faces.Current());
+
+        faces.Next();
+
+        // filter out multi-face results
+        if (faces.More() || !BRepCheck_Analyzer(candidate).IsValid()) {
             continue;
         }
 

--- a/src/Mod/Part/App/FeatureProjectOnSurface.cpp
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.cpp
@@ -358,6 +358,7 @@ std::vector<TopoDS_Wire> ProjectOnSurface::createWiresFromWires(
     return wiresInParametricSpace;
 }
 
+
 TopoDS_Face ProjectOnSurface::createFaceByClippingSource(
     const TopoDS_Face& sourceFace,
     const TopoDS_Face& supportFace,
@@ -370,20 +371,31 @@ TopoDS_Face ProjectOnSurface::createFaceByClippingSource(
         return {};
     }
 
+    // find the combined bounding box of source and target
+    Bnd_Box bounds;
+    BRepBndLib::Add(sourceFace, bounds);
+    BRepBndLib::Add(supportFace, bounds);
+    if (bounds.IsVoid()) {
+        return {};
+    }
 
-    TopoShape prism;
-    prism.makeElementPrismUntil(
-        TopoShape(),             // no base
-        TopoShape(sourceFace),   // profile
-        TopoShape(),             // don't need support
-        TopoShape(supportFace),  // target
-        direction,
-        TopoShape::PrismMode::None,
-        false  // needs to be false to avoid filling holes/ or failing partial overlaps
-    );
+
+
+    // extrude the source face towards the target
+    const auto length = 2.0 * Max(Sqrt(bounds.SquareExtent()), 1.0);
+    gp_Vec extrusion(direction);
+    extrusion.Multiply(length);
+
+
+    // and make prism for boolean common op to trim
+    BRepPrimAPI_MakePrism prismMaker(sourceFace, extrusion);
+    if (!prismMaker.IsDone()) {
+        return {};
+    }
+
 
     // get trimmed face
-    FCBRepAlgoAPI_Common common(supportFace, prism.getShape());
+    FCBRepAlgoAPI_Common common(supportFace, prismMaker.Shape());
     common.Build();
     if (!common.IsDone()) {
         return {};

--- a/src/Mod/Part/App/FeatureProjectOnSurface.cpp
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.cpp
@@ -373,13 +373,13 @@ TopoDS_Face ProjectOnSurface::createFaceByClippingSource(
 
     TopoShape prism;
     prism.makeElementPrismUntil(
-        TopoShape(),                 // no base
-        TopoShape(sourceFace),       // profile
-        TopoShape(),                 // don't need support
-        TopoShape(supportFace),      // target
+        TopoShape(),             // no base
+        TopoShape(sourceFace),   // profile
+        TopoShape(),             // don't need support
+        TopoShape(supportFace),  // target
         direction,
         TopoShape::PrismMode::None,
-        false                        // needs to be false to avoid filling holes/ or failing partial overlaps
+        false  // needs to be false to avoid filling holes/ or failing partial overlaps
     );
 
     // get trimmed face
@@ -396,7 +396,7 @@ TopoDS_Face ProjectOnSurface::createFaceByClippingSource(
     BOPTools_AlgoTools::MakeConnexityBlocks(common.Shape(), TopAbs_EDGE, TopAbs_FACE, patches);
 
 
-   // find the closest face to the proejction source
+    // find the closest face to the proejction source
     auto nearestDistance = Precision::Infinite();
     TopoDS_Face nearestFace;
     for (const auto& patch : patches) {

--- a/src/Mod/Part/App/FeatureProjectOnSurface.cpp
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.cpp
@@ -217,8 +217,15 @@ std::vector<TopoDS_Shape> ProjectOnSurface::createProjectedWire(
         return {};
     }
     if (shape.ShapeType() == TopAbs_FACE) {
-        auto wires = projectFace(TopoDS::Face(shape), supportFace, dir);
-        auto face = createFaceFromWire(wires, supportFace);
+        const auto sourceFace = TopoDS::Face(shape);
+        auto wires = projectFace(sourceFace, supportFace, dir);
+
+        // trim target with boolean common operation to create face
+        auto face = createFaceByClippingSource(sourceFace, supportFace, dir);
+        if (face.IsNull()) {
+            // fallback to original
+            face = createFaceFromWire(wires, supportFace);
+        }
         auto face_or_solid = createSolidIfHeight(face);
         if (!face_or_solid.IsNull()) {
             return {face_or_solid};

--- a/src/Mod/Part/App/FeatureProjectOnSurface.h
+++ b/src/Mod/Part/App/FeatureProjectOnSurface.h
@@ -75,6 +75,11 @@ private:
         const std::vector<TopoDS_Wire>& wires,
         const TopoDS_Face& supportFace
     ) const;
+    TopoDS_Face createFaceByClippingSource(
+        const TopoDS_Face& sourceFace,
+        const TopoDS_Face& supportFace,
+        const gp_Dir& direction
+    ) const;
     TopoDS_Shape createSolidIfHeight(const TopoDS_Face& face) const;
     std::vector<TopoDS_Wire> createWiresFromWires(
         const std::vector<TopoDS_Shape>& wires,

--- a/src/Mod/Part/CMakeLists.txt
+++ b/src/Mod/Part/CMakeLists.txt
@@ -81,6 +81,7 @@ set(Part_tests
     parttests/TopoShapeTest.py
     parttests/TestTangentMode3-0.21.FCStd
     parttests/TestPartMirror.py
+    parttests/TestProjectOnSurface.py
     parttests/TestFaceMakerUnifiedPlanar.py
     parttests/TestFaceMakerUnifiedNonPlanar.py
 )

--- a/src/Mod/Part/CMakeLists.txt
+++ b/src/Mod/Part/CMakeLists.txt
@@ -85,6 +85,7 @@ set(Part_tests
     parttests/TestTangentMode3-0.21.FCStd
     parttests/TestLinkArrayCircular.py
     parttests/TestPartMirror.py
+    parttests/TestProjectOnSurface.py
     parttests/TestFaceMakerUnifiedPlanar.py
     parttests/TestFaceMakerUnifiedNonPlanar.py
 )

--- a/src/Mod/Part/TestPartApp.py
+++ b/src/Mod/Part/TestPartApp.py
@@ -37,6 +37,7 @@ from parttests.regression_tests import RegressionTests
 from parttests.TopoShapeListTest import TopoShapeListTest
 from parttests.TopoShapeTest import TopoShapeTest
 from parttests.TestPartMirror import TestPartMirroringRegression
+from parttests.TestProjectOnSurface import TestProjectOnSurface
 from parttests.TestFaceMakerUnifiedPlanar import *
 from parttests.TestFaceMakerUnifiedNonPlanar import *
 

--- a/src/Mod/Part/TestPartApp.py
+++ b/src/Mod/Part/TestPartApp.py
@@ -38,6 +38,7 @@ from parttests.TopoShapeListTest import TopoShapeListTest
 from parttests.TopoShapeTest import TopoShapeTest
 from parttests.TestLinkArrayCircular import TestLinkArrayCircular
 from parttests.TestPartMirror import TestPartMirroringRegression
+from parttests.TestProjectOnSurface import TestProjectOnSurface
 from parttests.TestFaceMakerUnifiedPlanar import *
 from parttests.TestFaceMakerUnifiedNonPlanar import *
 

--- a/src/Mod/Part/parttests/TestProjectOnSurface.py
+++ b/src/Mod/Part/parttests/TestProjectOnSurface.py
@@ -7,6 +7,8 @@ import Part
 
 
 class TestProjectOnSurface(unittest.TestCase):
+    """
+    Regression test for github issues #27000 and #20203"""
     def setUp(self):
         self.doc = App.newDocument("PartProjectOnSurfaceTest")
 

--- a/src/Mod/Part/parttests/TestProjectOnSurface.py
+++ b/src/Mod/Part/parttests/TestProjectOnSurface.py
@@ -9,6 +9,7 @@ import Part
 class TestProjectOnSurface(unittest.TestCase):
     """
     Regression test for github issues #27000 and #20203"""
+
     def setUp(self):
         self.doc = App.newDocument("PartProjectOnSurfaceTest")
 

--- a/src/Mod/Part/parttests/TestProjectOnSurface.py
+++ b/src/Mod/Part/parttests/TestProjectOnSurface.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+import FreeCAD as App
+import Part
+
+
+class TestProjectOnSurface(unittest.TestCase):
+    def setUp(self):
+        self.doc = App.newDocument("PartProjectOnSurfaceTest")
+
+    def tearDown(self):
+        App.closeDocument(self.doc.Name)
+
+    def test_face_reconstruction_across_sphere_singularity(self):
+        # make sphere
+        source = self.doc.addObject("Part::Feature", "SourceFace")
+        source.Shape = Part.makePlane(4, 4, App.Vector(-2, -2, 10))
+
+        sphere = self.doc.addObject("Part::Sphere", "Sphere")
+        sphere.Radius = 5
+
+        projection = self.doc.addObject("Part::ProjectOnSurface", "Projection")
+        projection.Projection = [(source, ["Face1"])]
+        projection.SupportFace = (sphere, ["Face1"])
+        projection.Direction = App.Vector(0, 0, -1)
+        self.doc.recompute()
+
+        self.assertTrue(projection.isValid(), projection.getStatusString())
+        self.assertTrue(projection.Shape.isValid())
+        self.assertEqual(len(projection.Shape.Faces), 1)
+
+        # should be about 17 square units
+        self.assertGreater(projection.Shape.Area, 15)
+        self.assertLess(projection.Shape.Area, 20)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/Part/parttests/TestProjectOnSurface.py
+++ b/src/Mod/Part/parttests/TestProjectOnSurface.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import math
 import unittest
 
 import FreeCAD as App
@@ -7,8 +8,7 @@ import Part
 
 
 class TestProjectOnSurface(unittest.TestCase):
-    """
-    Regression test for github issues #27000 and #20203"""
+    """Face projection regressions, including GitHub issues #27000 and #20203."""
 
     def setUp(self):
         self.doc = App.newDocument("PartProjectOnSurfaceTest")
@@ -37,6 +37,91 @@ class TestProjectOnSurface(unittest.TestCase):
         # should be about 17 square units
         self.assertGreater(projection.Shape.Area, 15)
         self.assertLess(projection.Shape.Area, 20)
+
+    def _project_face(self, source_shape, target_shape, direction):
+        source = self.doc.addObject("Part::Feature", "SourceFace")
+        source.Shape = source_shape
+        target = self.doc.addObject("Part::Feature", "TargetFace")
+        target.Shape = target_shape
+        projection = self.doc.addObject("Part::ProjectOnSurface", "Projection")
+        projection.Projection = [(source, ["Face1"])]
+        projection.SupportFace = (target, ["Face1"])
+        projection.Direction = direction
+        self.doc.recompute()
+
+        self.assertTrue(projection.isValid(), projection.getStatusString())
+        self.assertFalse(projection.Shape.isNull())
+        self.assertTrue(projection.Shape.isValid())
+        self.assertEqual(len(projection.Shape.Faces), 1)
+        self.assertEqual(len(projection.Shape.Solids), 0)
+        return projection.Shape
+
+    def _assert_bounds(self, shape, expected):
+        bounds = shape.optimalBoundingBox(False)
+        for name, value in zip(("XMin", "XMax", "YMin", "YMax", "ZMin", "ZMax"), expected):
+            with self.subTest(bound=name):
+                self.assertAlmostEqual(getattr(bounds, name), value, delta=1e-5)
+
+    def _check_cylindrical_projection(self, seam_rotation):
+        source = Part.Face(
+            Part.makePolygon(
+                [
+                    App.Vector(10, -2, 2),
+                    App.Vector(10, 2, 2),
+                    App.Vector(10, 2, 6),
+                    App.Vector(10, -2, 6),
+                    App.Vector(10, -2, 2),
+                ]
+            )
+        )
+        cylinder = Part.makeCylinder(5, 8)
+        cylinder.rotate(App.Vector(0, 0, 0), App.Vector(0, 0, 1), seam_rotation)
+        target = next(face for face in cylinder.Faces if isinstance(face.Surface, Part.Cylinder))
+        shape = self._project_face(source, target, App.Vector(-1, 0, 0))
+
+        # Require the whole near-side patch, not one seam fragment or the far-side hit.
+        self.assertAlmostEqual(shape.Area, 40 * math.asin(2 / 5), delta=1e-5)
+        self._assert_bounds(shape, (math.sqrt(21), 5, -2, 2, 2, 6))
+
+    def test_face_projection_across_cylindrical_seam(self):
+        self._check_cylindrical_projection(0)
+
+    def test_face_projection_away_from_cylindrical_seam(self):
+        self._check_cylindrical_projection(90)
+
+    def test_source_face_hole_is_preserved(self):
+        outer = Part.makePlane(6, 6, App.Vector(-3, -3, 10))
+        inner = Part.makePlane(2, 2, App.Vector(-1, -1, 10))
+        source = outer.cut(inner).Faces[0]
+        target = Part.makePlane(10, 10, App.Vector(-5, -5, 0))
+        shape = self._project_face(source, target, App.Vector(0, 0, -1))
+
+        self.assertAlmostEqual(shape.Area, 32, delta=1e-5)
+        self.assertEqual(len(shape.Faces[0].Wires), 2)
+        self._assert_bounds(shape, (-3, 3, -3, 3, 0, 0))
+        hole = Part.makePlane(2, 2, App.Vector(-1, -1, 0))
+        self.assertAlmostEqual(shape.common(hole).Area, 0, delta=1e-5)
+
+    def test_target_face_hole_is_preserved(self):
+        source = Part.makePlane(6, 6, App.Vector(-3, -3, 10))
+        outer = Part.makePlane(10, 10, App.Vector(-5, -5, 0))
+        hole = Part.makePlane(2, 2, App.Vector(0, -1, 0))
+        target = outer.cut(hole).Faces[0]
+        shape = self._project_face(source, target, App.Vector(0, 0, -1))
+
+        self.assertAlmostEqual(shape.Area, 32, delta=1e-5)
+        self.assertEqual(len(shape.Faces[0].Wires), 2)
+        self._assert_bounds(shape, (-3, 3, -3, 3, 0, 0))
+        self.assertAlmostEqual(shape.common(hole).Area, 0, delta=1e-5)
+
+    def test_partial_overlap_with_bounded_target(self):
+        source = Part.makePlane(4, 4, App.Vector(0, 0, 10))
+        target = Part.makePlane(4, 4, App.Vector(2, 1, 0))
+        shape = self._project_face(source, target, App.Vector(0, 0, -1))
+
+        self.assertAlmostEqual(shape.Area, 6, delta=1e-5)
+        self.assertEqual(len(shape.Faces[0].Wires), 1)
+        self._assert_bounds(shape, (2, 4, 1, 4, 0, 0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added a method to Part::ProjectOnSurface that creates the projected face by extrusion->prism->boolean common operations and is more robust to projecting faces on curved surfaces, which could be a challenge for the previous method (edges would project fine, but faces would fail on certain types of curved surfaces). 

The original face formation method is unchanged and is called as a fallback.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues

#27000
#20203

## Before and After Images

Before: 
<img width="1840" height="1119" alt="before_20203" src="https://github.com/user-attachments/assets/38f891c7-342c-43df-b2ef-d345df1d0842" />
<img width="1840" height="1119" alt="before_27000" src="https://github.com/user-attachments/assets/43d4a66b-ff2b-4eb6-a90a-886f4d764289" />

After:
<img width="1840" height="1119" alt="issue_20203" src="https://github.com/user-attachments/assets/922eed63-f3c0-4d95-a13c-69fbbeaab7de" />
<img width="1840" height="1119" alt="issue_27000" src="https://github.com/user-attachments/assets/6c835dac-79ba-44a8-955b-7c71d0641b36" />
