### PR TITLE
Gui: Add a MaxFrameRate limiter

### DIFF
--- a/src/Gui/PreferencePages/DlgSettings3DView.ui
+++ b/src/Gui/PreferencePages/DlgSettings3DView.ui
@@ -539,6 +539,50 @@ bounding box size of the 3D object that is currently displayed.</string>
           </property>
          </widget>
         </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="maxFrameRateLabel">
+          <property name="text">
+           <string>Maximum frame rate</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="Gui::PrefSpinBox" name="SpinBox_MaxFrameRate">
+          <property name="minimumSize">
+           <size>
+            <width>120</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Upper limit on how often the 3D view is redrawn.
+'Automatic' follows the refresh rate of the display, since drawing
+faster than the display can show only wastes graphics card work.
+Set to 0 to redraw as fast as the graphics driver allows.</string>
+          </property>
+          <property name="specialValueText">
+           <string>Automatic</string>
+          </property>
+          <property name="suffix">
+           <string> FPS</string>
+          </property>
+          <property name="minimum">
+           <number>-1</number>
+          </property>
+          <property name="maximum">
+           <number>1000</number>
+          </property>
+          <property name="value">
+           <number>-1</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>MaxFrameRate</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>View</cstring>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>

--- a/src/Gui/PreferencePages/DlgSettings3DViewImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettings3DViewImp.cpp
@@ -68,6 +68,7 @@ void DlgSettings3DViewImp::saveSettings()
     ui->CheckBox_useVBO->onSave();
     ui->FloatSpinBox_EyeDistance->onSave();
     ui->FloatSpinBox_DatumScale->onSave();
+    ui->SpinBox_MaxFrameRate->onSave();
     ui->axisLetterColor->onSave();
     ui->radioPerspective->onSave();
     ui->radioOrthographic->onSave();
@@ -86,6 +87,7 @@ void DlgSettings3DViewImp::loadSettings()
     ui->CheckBox_useVBO->onRestore();
     ui->FloatSpinBox_EyeDistance->onRestore();
     ui->FloatSpinBox_DatumScale->onRestore();
+    ui->SpinBox_MaxFrameRate->onRestore();
     ui->axisLetterColor->onRestore();
     ui->radioPerspective->onRestore();
     ui->radioOrthographic->onRestore();

--- a/src/Gui/Quarter/QuarterWidget.cpp
+++ b/src/Gui/Quarter/QuarterWidget.cpp
@@ -888,6 +888,7 @@ void QuarterWidget::paintEvent(QPaintEvent* event)
     //glDrawBuffer(w->format().swapBehavior() == QSurfaceFormat::DoubleBuffer ? GL_BACK : GL_FRONT);
 
     w->makeCurrent();
+    PRIVATE(this)->timesincelastframe.restart();
     this->actualRedraw();
 
     QOpenGLFunctions* functions = w->context() ? w->context()->functions() : nullptr;
@@ -917,6 +918,11 @@ void QuarterWidget::paintEvent(QPaintEvent* event)
     // process the delay queue the next time we enter this function,
     // unless we get here after a call to redraw().
     PRIVATE(this)->processdelayqueue = true;
+
+    // Nothing above can have asked for another frame, so any request that is
+    // still outstanding has been satisfied by the render we just did. The
+    // frame is timed from before actualRedraw(), not from here.
+    PRIVATE(this)->frameRendered();
 }
 
 bool QuarterWidget::viewportEvent(QEvent* event)
@@ -967,10 +973,9 @@ bool QuarterWidget::viewportEvent(QEvent* event)
 void
 QuarterWidget::redraw()
 {
-  // we're triggering the next paintGL(). Set a flag to remember this
-  // to avoid that we process the delay queue in paintGL()
-  PRIVATE(this)->processdelayqueue = false;
-
+  // The request may be deferred to honor the frame rate limit, but it is
+  // never dropped, so every caller still gets its frame.
+  //
   // When stylesheet is used, there is recursive repaint warning caused by
   // repaint() here. It happens when switching active documents. Based on call
   // stacks, it happens like this, the repaint event first triggers a series
@@ -982,10 +987,35 @@ QuarterWidget::redraw()
   // back to the first QuarterWidget, at which time the "Recursive repaint
   // detected" Qt warning message will be printed.
   //
-  // Note that, the recursive repaint is not infinite due to setting
-  // 'processdelayqueue = false' above. However, it does cause annoying
-  // flickering, and actually crash on Windows.
-  this->viewport()->update();
+  // Note that the recursive repaint is not infinite due to setting
+  // 'processdelayqueue = false' in issueRedraw(). However, it does cause
+  // annoying flickering, and actually crash on Windows.
+  PRIVATE(this)->requestRedraw();
+}
+
+/*!
+  Returns the upper limit on how often the scene is rendered. A negative value
+  follows the refresh rate of the screen the widget is shown on, zero renders
+  as fast as the driver allows and a positive value is a limit in frames per
+  second.
+*/
+int
+QuarterWidget::maxFrameRate() const
+{
+  return PRIVATE(this)->maxframerate;
+}
+
+/*!
+  Sets the upper limit on how often the scene is rendered. Rendering faster
+  than the display can show only wastes GPU work, so the default is to follow
+  the refresh rate of the screen.
+
+  \sa maxFrameRate()
+*/
+void
+QuarterWidget::setMaxFrameRate(int fps)
+{
+  PRIVATE(this)->setMaxFrameRate(fps);
 }
 
 /*!

--- a/src/Gui/Quarter/QuarterWidget.h
+++ b/src/Gui/Quarter/QuarterWidget.h
@@ -107,6 +107,7 @@ public:
   Q_PROPERTY(TransparencyType transparencyType READ transparencyType WRITE setTransparencyType) // clazy:exclude=qproperty-without-notify
   Q_PROPERTY(RenderMode renderMode READ renderMode WRITE setRenderMode) // clazy:exclude=qproperty-without-notify
   Q_PROPERTY(StereoMode stereoMode READ stereoMode WRITE setStereoMode) // clazy:exclude=qproperty-without-notify
+  Q_PROPERTY(int maxFrameRate READ maxFrameRate WRITE setMaxFrameRate) // clazy:exclude=qproperty-without-notify
   Q_PROPERTY(qreal devicePixelRatio READ devicePixelRatio NOTIFY devicePixelRatioChanged)
 
   Q_ENUM(TransparencyType)
@@ -147,6 +148,9 @@ public:
 
   bool clearWindow() const;
   void setClearWindow(bool onoff);
+
+  int maxFrameRate() const;
+  void setMaxFrameRate(int fps);
 
   bool interactionModeEnabled() const;
   void setInteractionModeEnabled(bool onoff);

--- a/src/Gui/Quarter/QuarterWidgetP.cpp
+++ b/src/Gui/Quarter/QuarterWidgetP.cpp
@@ -38,12 +38,17 @@
 #include "QuarterWidget.h"
 #include "eventhandlers/EventFilter.h"
 
+#include <algorithm>
+#include <cmath>
+
 #include <QActionGroup>
 #include <QApplication>
 #include <QCursor>
 #include <QMenu>
 #include <QOpenGLContext>
 #include <QOpenGLWidget>
+#include <QScreen>
+#include <QTimer>
 
 #include <Inventor/SoEventManager.h>
 #include <Inventor/actions/SoSearchAction.h>
@@ -106,9 +111,116 @@ QuarterWidgetP::QuarterWidgetP(QuarterWidget * masterptr, const QOpenGLWidget * 
 
 QuarterWidgetP::~QuarterWidgetP()
 {
+  // The timer is a child of the master widget and would outlive this object,
+  // so make sure it can no longer fire into the callback below.
+  delete this->redrawtimer;
+  this->redrawtimer = nullptr;
+
   QOpenGLWidget* glMaster = static_cast<QOpenGLWidget*>(this->master->viewport());
   removeFromCacheContext(this->cachecontext, glMaster);
   delete this->contextmenu;
+}
+
+/*!
+  Returns how long to wait before the next frame may be rendered, or zero if it
+  may be rendered immediately.
+*/
+int
+QuarterWidgetP::millisecondsUntilNextFrame() const
+{
+  constexpr int fallbackframerate = 60;
+  int framerate = this->maxframerate;
+  if (framerate < 0) {
+    // Follow the screen the widget is currently shown on. Rendering faster
+    // than this produces frames the display can never show.
+    const QScreen * screen = this->master->screen();
+    const qreal refreshrate = screen ? screen->refreshRate() : 0.0;
+    // Screens seem to occasionally report a nonsensical rate? No idea. Fall back to a sane one.
+    framerate = (refreshrate >= 1.0) ? static_cast<int>(std::ceil(refreshrate)) : fallbackframerate;
+  }
+
+  if (framerate <= 0 || !this->timesincelastframe.isValid()) {
+    return 0;
+  }
+
+  constexpr qint64 nanosecondsPerSecond {1000000000};
+  constexpr qint64 nanosecondsPerMillisecond {1000000};
+
+  const qint64 interval = nanosecondsPerSecond / framerate;
+  const qint64 elapsed = std::max<qint64>(0, this->timesincelastframe.nsecsElapsed());
+  if (elapsed >= interval) {
+    return 0;
+  }
+  // Round down so that the limit is never enforced more strictly than asked
+  // for, but always wait at least one millisecond to make progress.
+  return std::max(1, static_cast<int>((interval - elapsed) / nanosecondsPerMillisecond));
+}
+
+void
+QuarterWidgetP::setMaxFrameRate(int fps)
+{
+  if (this->maxframerate == fps) {
+    return;
+  }
+  this->maxframerate = fps;
+
+  // Re-evaluate an outstanding request so a relaxed limit takes effect now instead of after the
+  // previously computed delay.
+  if (this->redrawdeferred) {
+    this->redrawtimer->stop();
+    this->redrawdeferred = false;
+    this->requestRedraw();
+  }
+}
+
+/*!
+  Asks for a new frame, deferring it if the frame rate limit has not elapsed yet. A deferred request
+  is not dropped -- it gets joined with any later request that arrives while it is being deferred.
+*/
+void
+QuarterWidgetP::requestRedraw()
+{
+  const int wait = this->millisecondsUntilNextFrame();
+  if (wait == 0) {
+    this->issueRedraw();
+    return;
+  }
+
+  if (this->redrawdeferred) {
+    // A frame is already pending and will pick up the current scene state.
+    return;
+  }
+
+  if (!this->redrawtimer) {
+    this->redrawtimer = new QTimer(this->master);
+    this->redrawtimer->setSingleShot(true);
+    this->redrawtimer->setTimerType(Qt::PreciseTimer);
+    QObject::connect(this->redrawtimer, &QTimer::timeout,
+                     this->master, [this] { this->issueRedraw(); });
+  }
+
+  this->redrawdeferred = true;
+  this->redrawtimer->start(wait);
+}
+
+void
+QuarterWidgetP::issueRedraw()
+{
+  this->redrawdeferred = false;
+  this->processdelayqueue = false;
+  this->master->viewport()->update();
+}
+
+/*!
+  Drops any redraw request that the frame just rendered has already satisfied.
+*/
+void
+QuarterWidgetP::frameRendered()
+{
+  if (this->redrawtimer) {
+    this->redrawtimer->stop();
+  }
+  this->redrawdeferred = false;
 }
 
 SoCamera *

--- a/src/Gui/Quarter/QuarterWidgetP.h
+++ b/src/Gui/Quarter/QuarterWidgetP.h
@@ -33,10 +33,12 @@
 \**************************************************************************/
 
 #include <Inventor/SbBasic.h>
+#include <QElapsedTimer>
 #include <QList>
 #include <QUrl>
 
 class QOpenGLWidget;
+class QTimer;
 
 class SoNode;
 class SoCamera;
@@ -71,6 +73,12 @@ public:
   QList<QAction *> renderModeActions() const;
   QList<QAction *> stereoModeActions() const;
 
+  int millisecondsUntilNextFrame() const;
+  void setMaxFrameRate(int fps);
+  void requestRedraw();
+  void issueRedraw();
+  void frameRendered();
+
   QuarterWidget * const master;
   SoNode * scene;
   EventFilter * eventfilter;
@@ -89,6 +97,17 @@ public:
   bool addactions;
   bool processdelayqueue;
   QUrl navigationModeFile;
+
+  // Frame rate limiting:
+  //   * A negative value uses the refresh rate of the screen the widget is displayed on
+  //   * Zero renders as fast as the driver allows
+  //   * A positive value is an explicit limit in frames per second
+  int maxframerate {-1};
+
+  QTimer * redrawtimer {nullptr};
+  QElapsedTimer timesincelastframe;
+  bool redrawdeferred {false};
+
   SoScXMLStateMachine * currentStateMachine;
   qreal device_pixel_ratio;
 

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -95,6 +95,7 @@ void View3DSettings::applySettings()
     OnChange(*hGrp, "AxisZColor");
     OnChange(*hGrp, "UseVBO");
     OnChange(*hGrp, "RenderCache");
+    OnChange(*hGrp, "MaxFrameRate");
     OnChange(*hGrp, "Orthographic");
     OnChange(*hGrp, "NavigationStyle");
     OnChange(*hGrp, "OrbitStyle");
@@ -432,6 +433,11 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::
             for (auto _viewer : _viewers) {
                 _viewer->setRenderCache(rGrp.GetInt("RenderCache", 0));
             }
+        }
+    }
+    else if (strcmp(Reason, "MaxFrameRate") == 0) {
+        for (auto _viewer : _viewers) {
+            _viewer->setMaxFrameRate(static_cast<int>(rGrp.GetInt("MaxFrameRate", -1)));
         }
     }
     else if (strcmp(Reason, "Orthographic") == 0) {


### PR DESCRIPTION
While investigating #29376 I discovered that were generating frames way faster than they could be displayed, and that in the case I was looking at, 2/5 of our generated frames were simply being discarded. I don't know why VSync wasn't kicking in and stopping the behavior, but this PR adds a way to limit the frame rate from our end. It defaults to using the refresh rate of the display the widget is being rendered on, but can be overridden via the preferences if that isn't delivering good results for whatever reason (I ran into some cases where displays reported non-sensical refresh rates, so I both handle that case, but figure that users probably need control of this to handle other strange corner cases).

I don't have any reason to believe this will actually fix the above issue, but it's IMO it's a good idea for us to have anyway.

(Note that I matched the existing variable naming style here, so in the Quarter stuff the vars are all lowercase... happy to change it if you want :) ).

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.