### PR TITLE
Measurement: Add support for lcs

### DIFF
--- a/src/Mod/Measure/App/MeasureAngle.cpp
+++ b/src/Mod/Measure/App/MeasureAngle.cpp
@@ -45,7 +45,7 @@
 #include <Mod/Part/App/Geometry.h>
 #include <Mod/Part/App/PartFeature.h>
 #include <Mod/Part/App/Tools.h>
-#include <Mod/Part/App/Datums.h>
+#include <Mod/Part/App/TopoShape.h>
 #include <TopTools_IndexedMapOfShape.hxx>
 
 using namespace Measure;
@@ -279,7 +279,7 @@ bool MeasureAngle::computeOriginFaceFace(TopoDS_Shape& s1, TopoDS_Shape& s2)
         }
     }
 
-    if (!isMeasuringDatum() || !areLocationsEqual()) {
+    if (!isMeasuringInfinite() || !areLocationsEqual()) {
         _isImgOrigin = true;
     }
 
@@ -302,7 +302,7 @@ bool MeasureAngle::computeOriginFaceFace(TopoDS_Shape& s1, TopoDS_Shape& s2)
 
 bool MeasureAngle::computeOriginEdgeEdge(TopoDS_Shape& s1, TopoDS_Shape& s2)
 {
-    if (!isMeasuringDatum()) {
+    if (!isMeasuringInfinite()) {
         TopoDS_Edge e1 = TopoDS::Edge(s1);
         TopoDS_Edge e2 = TopoDS::Edge(s2);
         TopoDS_Vertex common;
@@ -348,7 +348,7 @@ bool MeasureAngle::computeOriginEdgeEdge(TopoDS_Shape& s1, TopoDS_Shape& s2)
 
 bool MeasureAngle::computeOriginFaceEdge(TopoDS_Shape& s1)
 {
-    if (!isMeasuringDatum() || !areLocationsEqual()) {
+    if (!isMeasuringInfinite() || !areLocationsEqual()) {
         _isImgOrigin = true;
     }
 
@@ -385,25 +385,26 @@ bool MeasureAngle::computeOriginFaceEdge(TopoDS_Shape& s1)
 
 namespace
 {
-bool isDatum(App::DocumentObject* ob, const std::vector<std::string>& subNames)
+bool isInfinite(App::DocumentObject* ob, const std::vector<std::string>& subNames)
 {
     if (!ob || !ob->isValid() || subNames.empty()) {
         return false;
     }
 
-    App::SubObjectT subject {ob, subNames.at(0).c_str()};
-    App::DocumentObject* subObject = subject.getSubObjectList().back();
-    if (!subObject || !subObject->isValid()) {
-        return false;
-    }
-    return Measure::isDatum(*subObject);
+    return Part::Feature::getTopoShape(
+               ob,
+               Part::ShapeOption::NeedSubElement | Part::ShapeOption::ResolveLink
+                   | Part::ShapeOption::Transform,
+               subNames.at(0).c_str()
+    )
+        .isInfinite();
 }
 }  // namespace
 
-bool Measure::MeasureAngle::isMeasuringDatum()
+bool Measure::MeasureAngle::isMeasuringInfinite()
 {
-    return ::isDatum(Element1.getValue(), Element1.getSubValues())
-        || ::isDatum(Element2.getValue(), Element2.getSubValues());
+    return ::isInfinite(Element1.getValue(), Element1.getSubValues())
+        || ::isInfinite(Element2.getValue(), Element2.getSubValues());
 }
 
 bool Measure::MeasureAngle::areLocationsEqual()

--- a/src/Mod/Measure/App/MeasureAngle.h
+++ b/src/Mod/Measure/App/MeasureAngle.h
@@ -122,7 +122,7 @@ private:
 
     bool setDirections(TopoDS_Shape& s1);  // not the actual normals adjusted for arc visualization
 
-    bool isMeasuringDatum();  // check if one of the selected elements is a datum plane/axis/point
+    bool isMeasuringInfinite();
     bool areLocationsEqual();
 
     void onChanged(const App::Property* prop) override;

--- a/src/Mod/Measure/App/MeasureBase.cpp
+++ b/src/Mod/Measure/App/MeasureBase.cpp
@@ -29,8 +29,6 @@
 #include <App/DocumentObjectPy.h>
 #include <Base/UnitsApi.h>
 #include <Base/Quantity.h>
-#include <App/Datums.h>
-#include <Mod/Part/App/DatumFeature.h>
 
 #include <fmt/format.h>
 
@@ -225,14 +223,6 @@ void MeasureBase::onDocumentRestored()
 {
     // Force recompute the measurement
     recompute();
-}
-
-bool Measure::isDatum(const App::DocumentObject& ob)
-{
-    if (!ob.isValid()) {
-        return false;
-    }
-    return ob.isDerivedFrom<App::DatumElement>() || ob.isDerivedFrom<Part::Datum>();
 }
 
 // Python Drawing feature ---------------------------------------------------------

--- a/src/Mod/Measure/App/MeasureBase.h
+++ b/src/Mod/Measure/App/MeasureBase.h
@@ -160,8 +160,4 @@ private:
     inline static HandlerMap _mGeometryHandlers = MeasureBaseExtendable<T>::HandlerMap();
 };
 
-// Datum types are infinite so they have to be handled more delicatly,
-// when comparing 2 datums simply finding extrema may never converge or the result may be infinite.
-bool isDatum(const App::DocumentObject& ob);
-
 }  // namespace Measure

--- a/src/Mod/Measure/App/MeasureDistance.cpp
+++ b/src/Mod/Measure/App/MeasureDistance.cpp
@@ -26,7 +26,7 @@
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/MeasureManager.h>
-#include <Mod/Part/App/Datums.h>
+#include <Mod/Part/App/TopoShape.h>
 #include <Base/Tools.h>
 #include <BRepAdaptor_Curve.hxx>
 #include <BRepAdaptor_CompCurve.hxx>
@@ -329,10 +329,11 @@ bool MeasureDistance::distanceInfiniteInfinite(
 )
 {
     App::SubObjectT subject1 = {&ob1, subs1.at(0).c_str()};
-    App::DocumentObject* subObject1 = subject1.getSubObjectList().back();
+    App::DocumentObject* subObject1 = subject1.getSubObject();
     App::SubObjectT subject2 = {&ob2, subs2.at(0).c_str()};
-    App::DocumentObject* subObject2 = subject2.getSubObjectList().back();
-    if (!subObject1 || !subObject2 || !isDatum(*subObject1) || !isDatum(*subObject2)) {
+    App::DocumentObject* subObject2 = subject2.getSubObject();
+    if (!subObject1 || !subObject2 || !Part::TopoShape(shape1).isInfinite()
+        || !Part::TopoShape(shape2).isInfinite()) {
         return false;
     }
 

--- a/src/Mod/Part/App/MeasureClient.cpp
+++ b/src/Mod/Part/App/MeasureClient.cpp
@@ -43,6 +43,8 @@
 #include <GProp_GProps.hxx>
 #include <ShapeAnalysis_Edge.hxx>
 #include <gp_Circ.hxx>
+#include <gp_Lin.hxx>
+#include <gp_Pln.hxx>
 #include <BRepBuilderAPI_Copy.hxx>
 #include <GeomLib_IsPlanarSurface.hxx>
 
@@ -186,8 +188,8 @@ App::MeasureElementType PartMeasureTypeCb(App::DocumentObject* ob, const char* s
 
             switch (curve.GetType()) {
                 case GeomAbs_Line: {
-                    return isDatum(subject) ? App::MeasureElementType::LINE
-                                            : App::MeasureElementType::LINESEGMENT;
+                    return TopoShape(shape).isInfinite() ? App::MeasureElementType::LINE
+                                                         : App::MeasureElementType::LINESEGMENT;
                 }
                 case GeomAbs_Circle: {
                     return App::MeasureElementType::CIRCLE;
@@ -479,10 +481,39 @@ MeasureAngleInfoPtr MeasureAngleHandler(const App::SubObjectT& subject)
     }
 
     TopAbs_ShapeEnum sType = shape.ShapeType();
-    if (isDatum(subject) && sType != TopAbs_VERTEX) {
+    if (TopoShape(shape).isInfinite() && sType != TopAbs_VERTEX) {
         Base::Placement placement = getPlacement(subject);
-        Base::Vector3d orientation = placement.getRotation().multVec(Base::Vector3d(0, 0, -1));
-        return std::make_shared<MeasureAngleInfo>(true, orientation, placement.getPosition());
+        if (isDatum(subject)) {
+            Base::Vector3d orientation = placement.getRotation().multVec(Base::Vector3d(0, 0, -1));
+            return std::make_shared<MeasureAngleInfo>(true, orientation, placement.getPosition());
+        }
+        if (sType == TopAbs_EDGE) {
+            BRepAdaptor_Curve curve(TopoDS::Edge(shape));
+            if (curve.GetType() == GeomAbs_Line) {
+                gp_Lin line = curve.Line();
+                return std::make_shared<MeasureAngleInfo>(
+                    true,
+                    Base::Vector3d(line.Direction().X(), line.Direction().Y(), line.Direction().Z()),
+                    Base::Vector3d(line.Location().X(), line.Location().Y(), line.Location().Z())
+                );
+            }
+        }
+        else if (sType == TopAbs_FACE) {
+            BRepAdaptor_Surface surface(TopoDS::Face(shape));
+            if (surface.GetType() == GeomAbs_Plane) {
+                gp_Pln plane = surface.Plane();
+                return std::make_shared<MeasureAngleInfo>(
+                    true,
+                    Base::Vector3d(
+                        plane.Axis().Direction().X(),
+                        plane.Axis().Direction().Y(),
+                        plane.Axis().Direction().Z()
+                    ),
+                    Base::Vector3d(plane.Location().X(), plane.Location().Y(), plane.Location().Z())
+                );
+            }
+        }
+        return std::make_shared<MeasureAngleInfo>();
     }
 
     gp_Pnt position;

--- a/src/Mod/Part/App/MeasureClient.cpp
+++ b/src/Mod/Part/App/MeasureClient.cpp
@@ -93,7 +93,7 @@ double getFaceArea(TopoDS_Shape& face)
 
 bool isDatum(const App::SubObjectT& subject)
 {
-    App::DocumentObject* obj = subject.getSubObjectList().back();
+    App::DocumentObject* obj = subject.getSubObject();
     if (!obj || !obj->isValid()) {
         return false;
     }
@@ -102,7 +102,7 @@ bool isDatum(const App::SubObjectT& subject)
 
 Base::Placement getPlacement(const App::SubObjectT& subject)
 {
-    App::DocumentObject* obj = subject.getSubObjectList().back();
+    App::DocumentObject* obj = subject.getSubObject();
     if (obj && obj->isValid()) {
         return App::GeoFeature::getGlobalPlacement(obj, subject.getObject(), subject.getSubName());
     }
@@ -113,7 +113,7 @@ Base::Placement getPlacement(const App::SubObjectT& subject)
 
 TopoDS_Shape getLocatedShape(const App::SubObjectT& subject)
 {
-    App::DocumentObject* obj = subject.getSubObjectList().back();
+    App::DocumentObject* obj = subject.getSubObject();
     if (!obj || !obj->getNameInDocument()) {
         return {};
     }
@@ -483,6 +483,10 @@ MeasureAngleInfoPtr MeasureAngleHandler(const App::SubObjectT& subject)
     TopAbs_ShapeEnum sType = shape.ShapeType();
     if (TopoShape(shape).isInfinite() && sType != TopAbs_VERTEX) {
         Base::Placement placement = getPlacement(subject);
+        if (auto* datum = dynamic_cast<App::DatumElement*>(subject.getSubObject())) {
+            Base::Vector3d orientation = placement.getRotation().multVec(datum->getBaseDirection());
+            return std::make_shared<MeasureAngleInfo>(true, orientation, placement.getPosition());
+        }
         if (isDatum(subject)) {
             Base::Vector3d orientation = placement.getRotation().multVec(Base::Vector3d(0, 0, -1));
             return std::make_shared<MeasureAngleInfo>(true, orientation, placement.getPosition());
@@ -572,6 +576,7 @@ MeasureDistanceInfoPtr MeasureDistanceHandler(const App::SubObjectT& subject)
 
 void Part::MeasureClient::initialize()
 {
+    App::MeasureManager::addMeasureHandler("App", PartMeasureTypeCb);
     App::MeasureManager::addMeasureHandler("Part", PartMeasureTypeCb);
 }
 
@@ -592,6 +597,7 @@ Part::CallbackRegistrationList Part::MeasureClient::reportPositionCB()
     callbacks.emplace_back("PartDesign", "Position", MeasurePositionHandler);
     callbacks.emplace_back("Sketcher", "Position", MeasurePositionHandler);
     callbacks.emplace_back("Surface", "Position", MeasurePositionHandler);
+    callbacks.emplace_back("App", "Position", MeasurePositionHandler);
     return callbacks;
 }
 
@@ -613,6 +619,7 @@ Part::CallbackRegistrationList Part::MeasureClient::reportAngleCB()
     callbacks.emplace_back("PartDesign", "Angle", MeasureAngleHandler);
     callbacks.emplace_back("Sketcher", "Angle", MeasureAngleHandler);
     callbacks.emplace_back("Surface", "Angle", MeasureAngleHandler);
+    callbacks.emplace_back("App", "Angle", MeasureAngleHandler);
     return callbacks;
 }
 
@@ -624,6 +631,7 @@ Part::CallbackRegistrationList Part::MeasureClient::reportDistanceCB()
     callbacks.emplace_back("PartDesign", "Distance", MeasureDistanceHandler);
     callbacks.emplace_back("Sketcher", "Distance", MeasureDistanceHandler);
     callbacks.emplace_back("Surface", "Distance", MeasureDistanceHandler);
+    callbacks.emplace_back("App", "Distance", MeasureDistanceHandler);
     return callbacks;
 }
 

--- a/tests/src/Mod/Measure/App/CMakeLists.txt
+++ b/tests/src/Mod/Measure/App/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 add_executable(Measure_tests_run
+        MeasureAngle.cpp
         MeasureDistance.cpp
         MeasurePosition.cpp
 )

--- a/tests/src/Mod/Measure/App/MeasureAngle.cpp
+++ b/tests/src/Mod/Measure/App/MeasureAngle.cpp
@@ -5,8 +5,12 @@
 #include <algorithm>
 #include <cmath>
 
+#include <App/Datums.h>
 #include <App/Document.h>
+#include <Base/Placement.h>
+#include <Base/Rotation.h>
 #include <Base/Tools.h>
+#include <Base/Vector3D.h>
 #include <Mod/Measure/App/MeasureAngle.h>
 #include <Mod/Part/App/Datums.h>
 #include <Mod/Part/App/PartFeature.h>
@@ -41,6 +45,39 @@ protected:
 private:
     App::Document* document {};
 };
+
+TEST_F(MeasureAngle, testAngleBetweenLcsAxes)
+{
+    App::Document* doc = getDocument();
+    auto lcs = doc->addObject<App::LocalCoordinateSystem>("LCS");
+    doc->recompute();
+
+    auto measure = doc->addObject<Measure::MeasureAngle>("Angle");
+    measure->Element1.setValue(lcs, {"X_Axis"});
+    measure->Element2.setValue(lcs, {"Y_Axis"});
+    doc->recompute();
+
+    EXPECT_NEAR(measure->Angle.getValue(), 90.0, Base::toDegrees(Precision::Angular()));
+}
+
+TEST_F(MeasureAngle, testLcsAxisMatchesPlaneNormal)
+{
+    App::Document* doc = getDocument();
+    auto lcs = doc->addObject<App::LocalCoordinateSystem>("LCS");
+    lcs->Placement.setValue(
+        Base::Placement(Base::Vector3d(3.0, 4.0, 5.0), Base::Rotation(Base::Vector3d(1.0, 2.0, 3.0), 0.7))
+    );
+    doc->recompute();
+
+    auto measure = doc->addObject<Measure::MeasureAngle>("Angle");
+    measure->Element1.setValue(lcs, {"XY_Plane"});
+    measure->Element2.setValue(lcs, {"Z_Axis"});
+    doc->recompute();
+
+    const double angle = measure->Angle.getValue();
+    const double deviation = std::min(std::abs(angle), std::abs(std::abs(angle) - 180.0));
+    EXPECT_NEAR(deviation, 0.0, Base::toDegrees(Precision::Angular()));
+}
 
 TEST_F(MeasureAngle, testDatumLineMatchesPlaneNormal)
 {

--- a/tests/src/Mod/Measure/App/MeasureAngle.cpp
+++ b/tests/src/Mod/Measure/App/MeasureAngle.cpp
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <src/App/InitApplication.h>
+
+#include <algorithm>
+#include <cmath>
+
+#include <App/Document.h>
+#include <Base/Tools.h>
+#include <Mod/Measure/App/MeasureAngle.h>
+#include <Mod/Part/App/Datums.h>
+#include <Mod/Part/App/PartFeature.h>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <Precision.hxx>
+#include <gp_Lin.hxx>
+#include <gtest/gtest.h>
+
+class MeasureAngle: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        document = App::GetApplication().newDocument("MeasureAngle");
+    }
+
+    void TearDown() override
+    {
+        App::GetApplication().closeDocument(document->getName());
+    }
+
+    App::Document* getDocument() const
+    {
+        return document;
+    }
+
+private:
+    App::Document* document {};
+};
+
+TEST_F(MeasureAngle, testDatumLineMatchesPlaneNormal)
+{
+    App::Document* doc = getDocument();
+    auto line = doc->addObject<Part::DatumLine>("DatumLine");
+    auto plane = doc->addObject<Part::DatumPlane>("DatumPlane");
+    doc->recompute();
+
+    auto measure = doc->addObject<Measure::MeasureAngle>("Angle");
+    measure->Element1.setValue(plane);
+    measure->Element2.setValue(line);
+    doc->recompute();
+
+    const double angle = measure->Angle.getValue();
+    const double deviation = std::min(std::abs(angle), std::abs(std::abs(angle) - 180.0));
+    EXPECT_NEAR(deviation, 0.0, Base::toDegrees(Precision::Angular()));
+}
+
+TEST_F(MeasureAngle, testNonDatumInfiniteLineUsesShapeDirection)
+{
+    App::Document* doc = getDocument();
+    auto xLine = doc->addObject<Part::Feature>("XLine");
+    TopoDS_Edge xEdge
+        = BRepBuilderAPI_MakeEdge(gp_Lin(gp_Pnt(1.0, 2.0, 3.0), gp_Dir(1.0, 0.0, 0.0))).Edge();
+    xEdge.Infinite(Standard_True);
+    xLine->Shape.setValue(xEdge);
+
+    auto yLine = doc->addObject<Part::Feature>("YLine");
+    TopoDS_Edge yEdge
+        = BRepBuilderAPI_MakeEdge(gp_Lin(gp_Pnt(1.0, 2.0, 3.0), gp_Dir(0.0, 1.0, 0.0))).Edge();
+    yEdge.Infinite(Standard_True);
+    yLine->Shape.setValue(yEdge);
+    doc->recompute();
+
+    auto measure = doc->addObject<Measure::MeasureAngle>("Angle");
+    measure->Element1.setValue(xLine, {"Edge1"});
+    measure->Element2.setValue(yLine, {"Edge1"});
+    doc->recompute();
+
+    EXPECT_NEAR(measure->Angle.getValue(), 90.0, Base::toDegrees(Precision::Angular()));
+}

--- a/tests/src/Mod/Measure/App/MeasureDistance.cpp
+++ b/tests/src/Mod/Measure/App/MeasureDistance.cpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <src/App/InitApplication.h>
+#include <App/Datums.h>
 #include <App/Document.h>
 #include <App/Part.h>
 #include <App/GeoFeatureGroupExtension.h>
 #include <App/MeasureManager.h>
 #include <Mod/Measure/App/MeasureDistance.h>
+#include <Mod/Part/App/MeasureClient.h>
 #include <Mod/Part/App/PartFeature.h>
 #include <Base/Placement.h>
 #include <Base/Rotation.h>
@@ -170,4 +172,60 @@ TEST_F(MeasureDistance, testTwoBoxesMovedByContainers)
     EXPECT_DOUBLE_EQ(md->DistanceY.getValue(), 0.0);
     EXPECT_DOUBLE_EQ(md->DistanceZ.getValue(), 0.0);
 }
+
+TEST_F(MeasureDistance, testLcsSubelementsAreValidSelections)
+{
+    App::Document* doc = getDocument();
+    auto lcs1 = doc->addObject<App::LocalCoordinateSystem>("LCS1");
+    auto lcs2 = doc->addObject<App::LocalCoordinateSystem>("LCS2");
+    doc->recompute();
+
+    App::MeasureSelectionItem origin {App::SubObjectT {lcs1, "Origin"}, Base::Vector3d {}};
+    App::MeasureSelectionItem axis {App::SubObjectT {lcs1, "X_Axis"}, Base::Vector3d {}};
+    App::MeasureSelectionItem plane {App::SubObjectT {lcs2, "XY_Plane"}, Base::Vector3d {}};
+
+    EXPECT_EQ(App::MeasureManager::getMeasureElementType(origin), App::MeasureElementType::POINT);
+    EXPECT_EQ(App::MeasureManager::getMeasureElementType(axis), App::MeasureElementType::LINE);
+    EXPECT_EQ(App::MeasureManager::getMeasureElementType(plane), App::MeasureElementType::PLANE);
+    EXPECT_TRUE(Measure::MeasureDistance::isValidSelection({axis, plane}));
+}
+
+TEST_F(MeasureDistance, testDistanceBetweenParallelLcsPlanes)
+{
+    App::Document* doc = getDocument();
+    auto lcs1 = doc->addObject<App::LocalCoordinateSystem>("LCS1");
+    auto lcs2 = doc->addObject<App::LocalCoordinateSystem>("LCS2");
+    lcs2->Placement.setValue(Base::Placement(Base::Vector3d(0.0, 0.0, 5.0), Base::Rotation()));
+    doc->recompute();
+
+    auto md = doc->addObject<Measure::MeasureDistance>("Distance");
+    md->Element1.setValue(lcs1, {"XY_Plane"});
+    md->Element2.setValue(lcs2, {"XY_Plane"});
+    doc->recompute();
+
+    EXPECT_DOUBLE_EQ(md->Distance.getValue(), 5.0);
+    EXPECT_DOUBLE_EQ(md->DistanceX.getValue(), 0.0);
+    EXPECT_DOUBLE_EQ(md->DistanceY.getValue(), 0.0);
+    EXPECT_DOUBLE_EQ(md->DistanceZ.getValue(), 5.0);
+}
+
+TEST_F(MeasureDistance, testDistanceBetweenParallelLcsAxes)
+{
+    App::Document* doc = getDocument();
+    auto lcs1 = doc->addObject<App::LocalCoordinateSystem>("LCS1");
+    auto lcs2 = doc->addObject<App::LocalCoordinateSystem>("LCS2");
+    lcs2->Placement.setValue(Base::Placement(Base::Vector3d(0.0, 5.0, 0.0), Base::Rotation()));
+    doc->recompute();
+
+    auto md = doc->addObject<Measure::MeasureDistance>("Distance");
+    md->Element1.setValue(lcs1, {"X_Axis"});
+    md->Element2.setValue(lcs2, {"X_Axis"});
+    doc->recompute();
+
+    EXPECT_DOUBLE_EQ(md->Distance.getValue(), 5.0);
+    EXPECT_DOUBLE_EQ(md->DistanceX.getValue(), 0.0);
+    EXPECT_DOUBLE_EQ(md->DistanceY.getValue(), 5.0);
+    EXPECT_DOUBLE_EQ(md->DistanceZ.getValue(), 0.0);
+}
+
 // NOLINTEND

--- a/tests/src/Mod/Measure/App/MeasurePosition.cpp
+++ b/tests/src/Mod/Measure/App/MeasurePosition.cpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <src/App/InitApplication.h>
+#include <App/Datums.h>
 #include <App/Document.h>
 #include <App/Part.h>
 #include <App/GeoFeatureGroupExtension.h>
 #include <App/MeasureManager.h>
 #include <Mod/Measure/App/MeasurePosition.h>
+#include <Mod/Part/App/MeasureClient.h>
 #include <Mod/Part/App/PartFeature.h>
 #include <Base/Placement.h>
 #include <Base/Rotation.h>
@@ -172,5 +174,19 @@ TEST_F(MeasurePosition, testVertexContainerAndLocalPlacementCombine)
     doc->recompute();
 
     EXPECT_EQ(mp->Position.getValue(), Base::Vector3d(11.0, 20.0, 31.0));
+}
+
+TEST_F(MeasurePosition, testLcsOriginUsesGlobalPlacement)
+{
+    App::Document* doc = getDocument();
+    auto lcs = doc->addObject<App::LocalCoordinateSystem>("LCS");
+    lcs->Placement.setValue(Base::Placement(Base::Vector3d(10.0, 20.0, 30.0), Base::Rotation()));
+    doc->recompute();
+
+    auto mp = doc->addObject<Measure::MeasurePosition>("Position");
+    mp->Element.setValue(lcs, {"Origin"});
+    doc->recompute();
+
+    EXPECT_EQ(mp->Position.getValue(), Base::Vector3d(10.0, 20.0, 30.0));
 }
 // NOLINTEND


### PR DESCRIPTION
Adds support for the lcs for the measuring tool.
Also removes the datum only infinite check for the shape.isInfinite check allowing all infinite shapes to be handled correctly.

Waiting for https://github.com/FreeCAD/FreeCAD/pull/31138 and https://github.com/FreeCAD/FreeCAD/pull/31769 to make sure that everything works when it is commited, i have confirmed that it works with these prs so should be good to go when they are merged.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: Open AI GPT 5.6

### issues:

Adds: https://github.com/FreeCAD/FreeCAD/issues/18447 and maybe this one to: https://github.com/FreeCAD/FreeCAD/issues/23784 if I understod the request.

<img width="1177" height="1036" alt="lcsMeasure" src="https://github.com/user-attachments/assets/de7a3a65-bc0d-4571-86e8-a6b24732c3bd" />

