### PR TITLE
Issue #31832 - Allow user to select the OCC variational smoothing solver option when creating lofts

### DIFF
--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -2228,7 +2228,7 @@ private:
             TopoShape().makeElementLoft(
                 getPyShapes(pcObj),
                 anIsSolid ? Part::IsSolid::solid : Part::IsSolid::notSolid,
-                anIsRuled ? Part::IsRuled::ruled : Part::IsRuled::notRuled,
+                anIsRuled ? Part::Smoothing::ruled : Part::Smoothing::bspline,
                 anIsClosed ? Part::IsClosed::closed : Part::IsClosed::notClosed,
                 degMax,
                 op

--- a/src/Mod/Part/App/PartFeatures.cpp
+++ b/src/Mod/Part/App/PartFeatures.cpp
@@ -234,11 +234,11 @@ App::DocumentObjectExecReturn* Loft::execute()
             }
         }
         IsSolid isSolid = Solid.getValue() ? IsSolid::solid : IsSolid::notSolid;
-        IsRuled isRuled = Ruled.getValue() ? IsRuled::ruled : IsRuled::notRuled;
+        Smoothing smoothing = Ruled.getValue() ? Smoothing::ruled : Smoothing::bspline;
         IsClosed isClosed = Closed.getValue() ? IsClosed::closed : IsClosed::notClosed;
         int degMax = MaxDegree.getValue();
         TopoShape result(0, getDocument()->getStringHasher());
-        result.makeElementLoft(shapes, isSolid, isRuled, isClosed, degMax);
+        result.makeElementLoft(shapes, isSolid, smoothing, isClosed, degMax);
         if (Linearize.getValue()) {
             result.linearize(LinearizeFace::linearizeFaces, LinearizeEdge::noEdges);
         }

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -1839,7 +1839,7 @@ public:
      * @param op: optional string to be encoded into topo naming for indicating
      *            the operation
      * @param parametrization: parametrization used by standard B-Spline approximation
-     * @param continuity: requested B-Spline continuity
+     * @param continuity: requested B-Spline continuity (C0, C1, C2)
      * @param checkCompatibility: whether to align profile origins, orientation, and edges
      *
      * @return The original content of this TopoShape is discarded and replaced

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -1840,6 +1840,7 @@ public:
      * @param parametrization: parametrization used by standard B-Spline approximation
      * @param continuity: requested B-Spline continuity (C0, C1, C2)
      * @param checkCompatibility: whether to align profile origins, orientation, and edges
+     * @param adaptive: retry failed selected settings with deterministic alternatives
      *
      * @return The original content of this TopoShape is discarded and replaced
      *         with the new shape. The function returns the TopoShape itself as
@@ -1855,7 +1856,8 @@ public:
         const char* op = nullptr,
         LoftParametrization parametrization = LoftParametrization::chordLength,
         LoftContinuity continuity = LoftContinuity::C2,
-        bool checkCompatibility = true
+        bool checkCompatibility = true,
+        bool adaptive = false
     );
 
     /** Make a ruled surface

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -161,6 +161,12 @@ enum class IsRuled
     ruled
 };
 
+enum class IsSmoothing
+{
+    noSmoothing,
+    smoothing
+};
+
 enum class IsClosed
 {
     notClosed,
@@ -1822,6 +1828,7 @@ public:
      * @param isClosed: If isClosed, then the first section is duplicated to close
      *                  the loft as the last section
      * @param maxDegree: define the maximal U degree of the result surface
+     * @param isSmoothing: whether to use variational smoothing algorithm
      * @param op: optional string to be encoded into topo naming for indicating
      *            the operation
      *

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -157,7 +157,6 @@ enum class IsSolid
 
 enum class Smoothing
 {
-    automatic,
     bspline,
     ruled,
     variational

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -155,16 +155,25 @@ enum class IsSolid
     solid
 };
 
-enum class IsRuled
+enum class Smoothing
 {
-    notRuled,
-    ruled
+    ruled,
+    bspline,
+    variational
 };
 
-enum class IsSmoothing
+enum class LoftParametrization
 {
-    noSmoothing,
-    smoothing
+    chordLength,
+    centripetal,
+    uniform
+};
+
+enum class LoftContinuity
+{
+    C0,
+    C1,
+    C2
 };
 
 enum class IsClosed
@@ -1822,15 +1831,15 @@ public:
      *                 type, but only wires are used. The first and last
      *                 section may be vertex.
      * @param isSolid: whether to make a solid
-     * @param isRuled: if isRuled then the faces generated between the edges of
-     *                 two consecutive section wires are ruled surfaces. If
-     *                 notRuled, then they are smoothed out by approximation
+     * @param smoothing: the loft surface generation algorithm
      * @param isClosed: If isClosed, then the first section is duplicated to close
      *                  the loft as the last section
      * @param maxDegree: define the maximal U degree of the result surface
-     * @param isSmoothing: whether to use variational smoothing algorithm
      * @param op: optional string to be encoded into topo naming for indicating
      *            the operation
+     * @param parametrization: parametrization used by standard B-Spline approximation
+     * @param continuity: requested B-Spline continuity
+     * @param checkCompatibility: whether to align profile origins, orientation, and edges
      *
      * @return The original content of this TopoShape is discarded and replaced
      *         with the new shape. The function returns the TopoShape itself as
@@ -1840,11 +1849,13 @@ public:
     TopoShape& makeElementLoft(
         const std::vector<TopoShape>& sources,
         IsSolid isSolid,
-        IsRuled isRuled,
+        Smoothing smoothing = Smoothing::bspline,
         IsClosed isClosed = IsClosed::notClosed,
         Standard_Integer maxDegree = 5,
         const char* op = nullptr,
-        IsSmoothing isSmoothing = IsSmoothing::noSmoothing
+        LoftParametrization parametrization = LoftParametrization::chordLength,
+        LoftContinuity continuity = LoftContinuity::C2,
+        bool checkCompatibility = true
     );
 
     /** Make a ruled surface

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -1836,7 +1836,8 @@ public:
         IsRuled isRuled,
         IsClosed isClosed = IsClosed::notClosed,
         Standard_Integer maxDegree = 5,
-        const char* op = nullptr
+        const char* op = nullptr,
+        IsSmoothing isSmoothing = IsSmoothing::noSmoothing
     );
 
     /** Make a ruled surface

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -157,8 +157,9 @@ enum class IsSolid
 
 enum class Smoothing
 {
-    ruled,
+    automatic,
     bspline,
+    ruled,
     variational
 };
 

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -41,6 +41,7 @@
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepCheck_Analyzer.hxx>
 #include <BRepFill.hxx>
+#include <BRepFill_ThruSectionErrorStatus.hxx>
 #include <BRepFill_Generator.hxx>
 #include <BRepTools.hxx>
 #include <BRep_Builder.hxx>
@@ -4460,6 +4461,45 @@ TopoShape& TopoShape::makeElementShape(
     return *this;
 }
 
+namespace
+{
+[[noreturn]] void throwThruSectionsError(BRepFill_ThruSectionErrorStatus status)
+{
+    switch (status) {
+        case BRepFill_ThruSectionErrorStatus_Done:
+            FC_THROWM(
+                Base::CADKernelError,
+                "Loft generation did not complete although OCCT reported success"
+            );
+        case BRepFill_ThruSectionErrorStatus_NotDone:
+            FC_THROWM(Base::CADKernelError, "OCCT did not complete the loft operation");
+        case BRepFill_ThruSectionErrorStatus_NotSameTopology:
+            FC_THROWM(
+                Base::CADKernelError,
+                "Loft profiles must be either all open or all closed"
+            );
+        case BRepFill_ThruSectionErrorStatus_ProfilesInconsistent:
+            FC_THROWM(
+                Base::CADKernelError,
+                "OCCT could not establish consistent edge correspondence between the loft profiles"
+            );
+        case BRepFill_ThruSectionErrorStatus_WrongUsage:
+            FC_THROWM(
+                Base::CADKernelError,
+                "Punctual loft profiles are only supported as the first or last profile"
+            );
+        case BRepFill_ThruSectionErrorStatus_Null3DCurve:
+            FC_THROWM(
+                Base::CADKernelError,
+                "A loft profile contains an edge without a 3D curve"
+            );
+        case BRepFill_ThruSectionErrorStatus_Failed:
+            FC_THROWM(Base::CADKernelError, "OCCT failed to construct the loft");
+    }
+    FC_THROWM(Base::CADKernelError, "OCCT returned an unknown loft error status");
+}
+}  // namespace
+
 
 TopoShape& TopoShape::makeElementLoft(
     const std::vector<TopoShape>& shapes,
@@ -4599,11 +4639,23 @@ TopoShape& TopoShape::makeElementLoft(
         }
     }
 
+    try {
 #if OCC_VERSION_HEX >= 0x070600
-    aGenerator.Build(std::make_unique<Part::ProgressIndicator>()->Start());
+        aGenerator.Build(std::make_unique<Part::ProgressIndicator>()->Start());
 #else
-    aGenerator.Build();
+        aGenerator.Build();
 #endif
+    }
+    catch (const Standard_Failure&) {
+        if (aGenerator.GetStatus() != BRepFill_ThruSectionErrorStatus_Done) {
+            throwThruSectionsError(aGenerator.GetStatus());
+        }
+        throw;
+    }
+    if (!aGenerator.IsDone()
+        || aGenerator.GetStatus() != BRepFill_ThruSectionErrorStatus_Done) {
+        throwThruSectionsError(aGenerator.GetStatus());
+    }
     return makeShapeWithElementMap(
         aGenerator.Shape(),
         MapperThruSections(aGenerator, profiles),

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4620,6 +4620,7 @@ void preflightLoftProfiles(const std::vector<TopoShape>& profiles, bool checkCom
     }
 }
 
+
 std::optional<BRepFill_ThruSectionErrorStatus> probeProfileCompatibility(
     const std::vector<TopoShape>& profiles,
     std::size_t profileCount,
@@ -4840,6 +4841,7 @@ LoftFailure diagnoseLoftFailure(
 
 [[noreturn]] void throwThruSectionsError(const LoftFailure& failure)
 {
+    // these are all of the possible OCCT BRepFill_ThruSectionErrorStatus values
     std::ostringstream message;
     switch (failure.status) {
         case BRepFill_ThruSectionErrorStatus_Done:
@@ -4865,6 +4867,8 @@ LoftFailure diagnoseLoftFailure(
             message << "OCCT failed to construct the loft";
             break;
     }
+    // the failure scope indicates which profiles were involved in the failure
+    // and attempts to provide a human-readable description of what went wrong
     switch (failure.scope) {
         case LoftFailureScope::none:
             break;
@@ -4877,16 +4881,20 @@ LoftFailure diagnoseLoftFailure(
                     << failure.secondProfile + 1;
             break;
         case LoftFailureScope::completeSequence:
-            message << "; the failure requires the complete sequence of "
-                    << failure.secondProfile + 1 << " profiles";
+            message << "; the failure occurs when trying the complete sequence of "
+                    << failure.secondProfile + 1 << " profiles (may succeed for subsets of profiles)";
             break;
     }
+    // a failure triggers "dry-runs" of the lofting algorithm
+    // with different parameterizations and the variational solver
+    // to determine if there is a combination that succeeds
+    // if so, that is communicated to the user
     if (failure.suggestedParametrization) {
         message << "; try " << loftParametrizationName(*failure.suggestedParametrization)
                 << " parameterization, which succeeds for these profiles";
     }
     else if (failure.suggestVariational) {
-        message << "; standard B-spline lofting failed with all parameterizations; try "
+        message << "; standard B-spline lofting failed with all available parameterizations; try "
                    "Variational B-Spline, whose variational solver succeeds for these profiles";
     }
     if (message.tellp() == 0) {
@@ -4909,6 +4917,7 @@ TopoShape& TopoShape::makeElementLoft(
     bool checkCompatibility
 )
 {
+    // Note: checkProfiles basically checks for coincident profiles, which are not allowed.
     auto checkProfiles = [](const TopoShape& sh1, const TopoShape& sh2) {
         // The same TShape is used but the locations might be different
         // even if they result into the same transformation matrix.
@@ -4965,13 +4974,17 @@ TopoShape& TopoShape::makeElementLoft(
         continuity,
         checkCompatibility,
     };
+
+    // ensure we have at least two profiles to loft
     auto profiles = prepareProfiles(shapes);
     if (shapes.size() < 2) {
         FC_THROWM(Base::CADKernelError, "Need at least two vertices, edges or wires to create loft face");
     }
+
+    // check that the profiles are compatible/valid
     preflightLoftProfiles(profiles, checkCompatibility);
 
-    // http://opencascade.blogspot.com/2010/01/surface-modeling-part5.html
+    // configure the loft generator
     BRepOffsetAPI_ThruSections aGenerator(
         isSolid == IsSolid::solid,
         smoothing == Smoothing::ruled
@@ -5022,7 +5035,7 @@ TopoShape& TopoShape::makeElementLoft(
         }
     }
 
-    // Diagnostics may suggest a valid alternative, but never replace the requested algorithm.
+    // Report loft failure and provide diagnostic information to the user
     auto reportLoftFailure = [&](BRepFill_ThruSectionErrorStatus status) -> void {
         throwThruSectionsError(diagnoseLoftFailure(status, profiles, options));
     };

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4467,7 +4467,8 @@ TopoShape& TopoShape::makeElementLoft(
     IsRuled isRuled,
     IsClosed isClosed,
     Standard_Integer maxDegree,
-    const char* op
+    const char* op,
+    IsSmoothing isSmoothing
 )
 {
     auto checkProfiles = [](const TopoShape& sh1, const TopoShape& sh2) {

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4496,10 +4496,19 @@ struct LoftOptions
     bool checkCompatibility;
 };
 
+// Configure the BRepOffsetAPI_ThruSections generator based on the loft options.
+// BRepOffsetAPI_ThruSections API: https://dev.opencascade.org/doc/refman/html/class_b_rep_offset_a_p_i___thru_sections.html
 void configureThruSections(BRepOffsetAPI_ThruSections& generator, const LoftOptions& options)
 {
+    // Max order of interpolation that OCCT will be allowed to use
     generator.SetMaxDegree(options.maxDegree);
+
+    // Set smoothing (solver) type: bspline (default), variational, or ruled
     generator.SetSmoothing(options.smoothing == Smoothing::variational);
+
+    // Set parametrization type: chord length, centripetal, or uniform
+    // This is a function of the profiles and the relative spacing between them
+    // Chord length is the default, centripedal when a high ratio of different spacings is present
     switch (options.parametrization) {
         case LoftParametrization::chordLength:
             generator.SetParType(Approx_ChordLength);
@@ -4522,9 +4531,14 @@ void configureThruSections(BRepOffsetAPI_ThruSections& generator, const LoftOpti
             generator.SetContinuity(GeomAbs_C2);
             break;
     }
+    // Sets/unsets the option to compute origin and orientation on wires
+    // to avoid twisted results and update wires to have same number of
+    // edges
     generator.CheckCompatibility(options.checkCompatibility);
 }
 
+// Test whether a shape is a punctual profile, i.e. it is a vertex or has no edges.
+// Punctual profiles can be used at the start or end of a loft.
 bool isPunctualProfile(const TopoDS_Shape& profile)
 {
     if (profile.ShapeType() == TopAbs_VERTEX) {
@@ -4542,17 +4556,15 @@ bool isPunctualProfile(const TopoDS_Shape& profile)
 
 bool isClosedProfile(const TopoDS_Wire& wire)
 {
-    if (wire.Closed()) {
-        return true;
-    }
-    TopoDS_Vertex first;
-    TopoDS_Vertex last;
-    TopExp::Vertices(wire, first, last);
-    return !first.IsNull() && first.IsSame(last);
+    return BRep_Tool::IsClosed(wire);
 }
 
+// Check the profiles for compatibility with the loft operation
+// and provide (actionable) user feedback if any issues are found
 void preflightLoftProfiles(const std::vector<TopoShape>& profiles, bool checkCompatibility)
 {
+    // Check punctual profiles, ensure they appear as first or last profile
+    // provide user feedback
     std::optional<std::pair<std::size_t, bool>> firstTopology;
     for (std::size_t profileIndex = 0; profileIndex < profiles.size(); ++profileIndex) {
         const auto& profile = profiles[profileIndex].getShape();
@@ -4565,6 +4577,7 @@ void preflightLoftProfiles(const std::vector<TopoShape>& profiles, bool checkCom
             FC_THROWM(Base::CADKernelError, message.str().c_str());
         }
 
+        // validate profile curves
         std::size_t edgeIndex = 0;
         for (TopExp_Explorer explorer(profile, TopAbs_EDGE); explorer.More(); explorer.Next()) {
             ++edgeIndex;
@@ -4582,15 +4595,18 @@ void preflightLoftProfiles(const std::vector<TopoShape>& profiles, bool checkCom
             }
         }
 
+        // ensure profile is a valid brep
         if (!BRepCheck_Analyzer(profile).IsValid()) {
             std::ostringstream message;
             message << "Loft profile " << profileIndex + 1 << " is not a valid BRep shape";
             FC_THROWM(Base::CADKernelError, message.str().c_str());
         }
 
+        // punctual profiles can be the first profile
         if (!checkCompatibility || punctual) {
             continue;
         }
+
         const bool closed = isClosedProfile(TopoDS::Wire(profile));
         if (!firstTopology) {
             firstTopology = std::pair {profileIndex, closed};
@@ -4631,6 +4647,7 @@ std::optional<BRepFill_ThruSectionErrorStatus> probeProfileCompatibility(
 }
 
 
+// Probe immutable profile copies so diagnosis cannot alter the requested loft inputs.
 BRepFill_ThruSectionErrorStatus probeLoftRange(
     const std::vector<TopoShape>& profiles,
     std::size_t profileCount,
@@ -4695,6 +4712,7 @@ void suggestLoftAlternative(
         return;
     }
 
+    // Test each standard parametrization in a stable order, then try the variational solver.
     constexpr std::array candidates {
         LoftParametrization::chordLength,
         LoftParametrization::centripetal,
@@ -4735,6 +4753,7 @@ const char* loftParametrizationName(LoftParametrization parametrization)
     return "Unknown";
 }
 
+// Probe pairs and prefixes to report the smallest profile range that reproduces the failure.
 LoftFailure diagnoseLoftFailure(
     BRepFill_ThruSectionErrorStatus status,
     const std::vector<TopoShape>& profiles,
@@ -4937,17 +4956,12 @@ TopoShape& TopoShape::makeElementLoft(
         op = Part::OpCodes::Loft;
     }
 
-    const bool automatic = smoothing == Smoothing::automatic;
-    const Smoothing initialSmoothing = automatic ? Smoothing::bspline : smoothing;
-    const LoftParametrization initialParametrization = automatic
-        ? LoftParametrization::chordLength
-        : parametrization;
     const LoftOptions options {
         isSolid,
-        initialSmoothing,
+        smoothing,
         isClosed,
         maxDegree,
-        initialParametrization,
+        parametrization,
         continuity,
         checkCompatibility,
     };
@@ -4960,12 +4974,9 @@ TopoShape& TopoShape::makeElementLoft(
     // http://opencascade.blogspot.com/2010/01/surface-modeling-part5.html
     BRepOffsetAPI_ThruSections aGenerator(
         isSolid == IsSolid::solid,
-        initialSmoothing == Smoothing::ruled
+        smoothing == Smoothing::ruled
     );
     configureThruSections(aGenerator, options);
-    if (automatic) {
-        aGenerator.SetMutableInput(false);
-    }
 
     int i = 0;
     for (auto& sh : profiles) {
@@ -5011,37 +5022,9 @@ TopoShape& TopoShape::makeElementLoft(
         }
     }
 
-    auto recoverAutomaticLoft = [&](BRepFill_ThruSectionErrorStatus status) -> TopoShape& {
-        const auto failure = diagnoseLoftFailure(status, profiles, options);
-        if (automatic) {
-            if (failure.suggestedParametrization) {
-                return makeElementLoft(
-                    shapes,
-                    isSolid,
-                    Smoothing::bspline,
-                    isClosed,
-                    maxDegree,
-                    op,
-                    *failure.suggestedParametrization,
-                    continuity,
-                    checkCompatibility
-                );
-            }
-            if (failure.suggestVariational) {
-                return makeElementLoft(
-                    shapes,
-                    isSolid,
-                    Smoothing::variational,
-                    isClosed,
-                    maxDegree,
-                    op,
-                    initialParametrization,
-                    continuity,
-                    checkCompatibility
-                );
-            }
-        }
-        throwThruSectionsError(failure);
+    // Diagnostics may suggest a valid alternative, but never replace the requested algorithm.
+    auto reportLoftFailure = [&](BRepFill_ThruSectionErrorStatus status) -> void {
+        throwThruSectionsError(diagnoseLoftFailure(status, profiles, options));
     };
 
     try {
@@ -5052,22 +5035,20 @@ TopoShape& TopoShape::makeElementLoft(
 #endif
     }
     catch (const Standard_Failure&) {
-        return recoverAutomaticLoft(aGenerator.GetStatus());
+        reportLoftFailure(aGenerator.GetStatus());
     }
     if (!aGenerator.IsDone()
         || aGenerator.GetStatus() != BRepFill_ThruSectionErrorStatus_Done) {
-        return recoverAutomaticLoft(aGenerator.GetStatus());
+        reportLoftFailure(aGenerator.GetStatus());
     }
-    if (automatic) {
-        try {
-            const auto& result = aGenerator.Shape();
-            if (result.IsNull() || !BRepCheck_Analyzer(result).IsValid()) {
-                return recoverAutomaticLoft(BRepFill_ThruSectionErrorStatus_Failed);
-            }
+    try {
+        const auto& result = aGenerator.Shape();
+        if (result.IsNull() || !BRepCheck_Analyzer(result).IsValid()) {
+            reportLoftFailure(BRepFill_ThruSectionErrorStatus_Failed);
         }
-        catch (const Standard_Failure&) {
-            return recoverAutomaticLoft(BRepFill_ThruSectionErrorStatus_Failed);
-        }
+    }
+    catch (const Standard_Failure&) {
+        reportLoftFailure(BRepFill_ThruSectionErrorStatus_Failed);
     }
     return makeShapeWithElementMap(
         aGenerator.Shape(),

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -22,8 +22,11 @@
  *                                                                          *
  ***************************************************************************/
 
+#include <array>
 #include <cmath>
+#include <iomanip>
 #include <limits>
+#include <optional>
 #include <sstream>
 
 #ifndef _Standard_Version_HeaderFile
@@ -41,6 +44,7 @@
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepCheck_Analyzer.hxx>
 #include <BRepFill.hxx>
+#include <BRepFill_CompatibleWires.hxx>
 #include <BRepFill_ThruSectionErrorStatus.hxx>
 #include <BRepFill_Generator.hxx>
 #include <BRepTools.hxx>
@@ -80,6 +84,8 @@
 #include <ShapeConstruct_Curve.hxx>
 #include <ShapeUpgrade_ShellSewing.hxx>
 #include <TopTools_HSequenceOfShape.hxx>
+#include <TopExp.hxx>
+#include <TopExp_Explorer.hxx>
 #include <ShapeFix_Shape.hxx>
 #include <ShapeFix_ShapeTolerance.hxx>
 #include <gp_Pln.hxx>
@@ -4463,40 +4469,493 @@ TopoShape& TopoShape::makeElementShape(
 
 namespace
 {
-[[noreturn]] void throwThruSectionsError(BRepFill_ThruSectionErrorStatus status)
+enum class LoftFailureScope
 {
-    switch (status) {
-        case BRepFill_ThruSectionErrorStatus_Done:
-            FC_THROWM(
-                Base::CADKernelError,
-                "Loft generation did not complete although OCCT reported success"
-            );
-        case BRepFill_ThruSectionErrorStatus_NotDone:
-            FC_THROWM(Base::CADKernelError, "OCCT did not complete the loft operation");
-        case BRepFill_ThruSectionErrorStatus_NotSameTopology:
-            FC_THROWM(
-                Base::CADKernelError,
-                "Loft profiles must be either all open or all closed"
-            );
-        case BRepFill_ThruSectionErrorStatus_ProfilesInconsistent:
-            FC_THROWM(
-                Base::CADKernelError,
-                "OCCT could not establish consistent edge correspondence between the loft profiles"
-            );
-        case BRepFill_ThruSectionErrorStatus_WrongUsage:
-            FC_THROWM(
-                Base::CADKernelError,
-                "Punctual loft profiles are only supported as the first or last profile"
-            );
-        case BRepFill_ThruSectionErrorStatus_Null3DCurve:
-            FC_THROWM(
-                Base::CADKernelError,
-                "A loft profile contains an edge without a 3D curve"
-            );
-        case BRepFill_ThruSectionErrorStatus_Failed:
-            FC_THROWM(Base::CADKernelError, "OCCT failed to construct the loft");
+    none,
+    profilePair,
+    profilePrefix,
+    completeSequence,
+};
+
+struct LoftFailure
+{
+    BRepFill_ThruSectionErrorStatus status {BRepFill_ThruSectionErrorStatus_NotDone};
+    LoftFailureScope scope {LoftFailureScope::none};
+    std::size_t firstProfile {0};
+    std::size_t secondProfile {0};
+    std::optional<LoftParametrization> suggestedParametrization;
+    bool suggestVariational {false};
+    std::optional<double> spacingRatio;
+};
+
+struct LoftOptions
+{
+    IsSolid isSolid;
+    Smoothing smoothing;
+    IsClosed isClosed;
+    Standard_Integer maxDegree;
+    LoftParametrization parametrization;
+    LoftContinuity continuity;
+    bool checkCompatibility;
+};
+
+void configureThruSections(BRepOffsetAPI_ThruSections& generator, const LoftOptions& options)
+{
+    generator.SetMaxDegree(options.maxDegree);
+    generator.SetSmoothing(options.smoothing == Smoothing::variational);
+    switch (options.parametrization) {
+        case LoftParametrization::chordLength:
+            generator.SetParType(Approx_ChordLength);
+            break;
+        case LoftParametrization::centripetal:
+            generator.SetParType(Approx_Centripetal);
+            break;
+        case LoftParametrization::uniform:
+            generator.SetParType(Approx_IsoParametric);
+            break;
     }
-    FC_THROWM(Base::CADKernelError, "OCCT returned an unknown loft error status");
+    switch (options.continuity) {
+        case LoftContinuity::C0:
+            generator.SetContinuity(GeomAbs_C0);
+            break;
+        case LoftContinuity::C1:
+            generator.SetContinuity(GeomAbs_C1);
+            break;
+        case LoftContinuity::C2:
+            generator.SetContinuity(GeomAbs_C2);
+            break;
+    }
+    generator.CheckCompatibility(options.checkCompatibility);
+}
+
+bool isPunctualProfile(const TopoDS_Shape& profile)
+{
+    if (profile.ShapeType() == TopAbs_VERTEX) {
+        return true;
+    }
+    bool hasEdges = false;
+    for (TopExp_Explorer explorer(profile, TopAbs_EDGE); explorer.More(); explorer.Next()) {
+        hasEdges = true;
+        if (!BRep_Tool::Degenerated(TopoDS::Edge(explorer.Current()))) {
+            return false;
+        }
+    }
+    return hasEdges;
+}
+
+bool isClosedProfile(const TopoDS_Wire& wire)
+{
+    if (wire.Closed()) {
+        return true;
+    }
+    TopoDS_Vertex first;
+    TopoDS_Vertex last;
+    TopExp::Vertices(wire, first, last);
+    return !first.IsNull() && first.IsSame(last);
+}
+
+void preflightLoftProfiles(const std::vector<TopoShape>& profiles, bool checkCompatibility)
+{
+    std::optional<std::pair<std::size_t, bool>> firstTopology;
+    for (std::size_t profileIndex = 0; profileIndex < profiles.size(); ++profileIndex) {
+        const auto& profile = profiles[profileIndex].getShape();
+        const bool punctual = isPunctualProfile(profile);
+        if (punctual && profileIndex > 0 && profileIndex + 1 < profiles.size()) {
+            std::ostringstream message;
+            message << "Loft profile " << profileIndex + 1
+                    << " is punctual; punctual profiles are only supported as the first or last "
+                       "profile";
+            FC_THROWM(Base::CADKernelError, message.str().c_str());
+        }
+
+        std::size_t edgeIndex = 0;
+        for (TopExp_Explorer explorer(profile, TopAbs_EDGE); explorer.More(); explorer.Next()) {
+            ++edgeIndex;
+            const auto& edge = TopoDS::Edge(explorer.Current());
+            if (BRep_Tool::Degenerated(edge)) {
+                continue;
+            }
+            Standard_Real first = 0.0;
+            Standard_Real last = 0.0;
+            if (BRep_Tool::Curve(edge, first, last).IsNull()) {
+                std::ostringstream message;
+                message << "Loft profile " << profileIndex + 1 << ", edge " << edgeIndex
+                        << " has no 3D curve";
+                FC_THROWM(Base::CADKernelError, message.str().c_str());
+            }
+        }
+
+        if (!BRepCheck_Analyzer(profile).IsValid()) {
+            std::ostringstream message;
+            message << "Loft profile " << profileIndex + 1 << " is not a valid BRep shape";
+            FC_THROWM(Base::CADKernelError, message.str().c_str());
+        }
+
+        if (!checkCompatibility || punctual) {
+            continue;
+        }
+        const bool closed = isClosedProfile(TopoDS::Wire(profile));
+        if (!firstTopology) {
+            firstTopology = std::pair {profileIndex, closed};
+        }
+        else if (firstTopology->second != closed) {
+            std::ostringstream message;
+            message << "Loft profiles " << firstTopology->first + 1 << " and " << profileIndex + 1
+                    << " have different topology; profiles must be either all open or all closed";
+            FC_THROWM(Base::CADKernelError, message.str().c_str());
+        }
+    }
+}
+
+std::optional<BRepFill_ThruSectionErrorStatus> probeProfileCompatibility(
+    const std::vector<TopoShape>& profiles,
+    std::size_t profileCount,
+    std::size_t firstProfile = 0
+)
+{
+    NCollection_Sequence<TopoDS_Shape> sections;
+    for (std::size_t i = firstProfile; i < firstProfile + profileCount; ++i) {
+        const auto& profile = profiles[i].getShape();
+        if (profile.ShapeType() != TopAbs_WIRE) {
+            return std::nullopt;
+        }
+        sections.Append(profile);
+    }
+
+    try {
+        BRepFill_CompatibleWires compatibility(sections);
+        compatibility.Perform();
+        return compatibility.IsDone() ? BRepFill_ThruSectionErrorStatus_Done
+                                      : compatibility.GetStatus();
+    }
+    catch (const Standard_Failure&) {
+        return BRepFill_ThruSectionErrorStatus_NotDone;
+    }
+}
+
+std::optional<double> profileSpacingRatio(
+    const std::vector<TopoShape>& profiles,
+    IsClosed isClosed
+)
+{
+    NCollection_Sequence<TopoDS_Shape> sections;
+    for (const auto& profile : profiles) {
+        if (profile.getShape().ShapeType() != TopAbs_WIRE
+            || isPunctualProfile(profile.getShape())) {
+            return std::nullopt;
+        }
+        sections.Append(profile.getShape());
+    }
+
+    try {
+        BRepFill_CompatibleWires compatibility(sections);
+        compatibility.Perform();
+        if (!compatibility.IsDone()) {
+            return std::nullopt;
+        }
+
+        constexpr int sampleCount = 21;
+        double minimumSpacing = std::numeric_limits<double>::max();
+        double maximumSpacing = 0.0;
+        const auto& compatibleProfiles = compatibility.Shape();
+        const int pairCount = compatibleProfiles.Length() - 1
+            + (isClosed == IsClosed::closed ? 1 : 0);
+        for (int pairIndex = 1; pairIndex <= pairCount; ++pairIndex) {
+            const int nextIndex = pairIndex == compatibleProfiles.Length() ? 1 : pairIndex + 1;
+            BRepAdaptor_CompCurve first(
+                TopoDS::Wire(compatibleProfiles.Value(pairIndex)),
+                true
+            );
+            BRepAdaptor_CompCurve second(
+                TopoDS::Wire(compatibleProfiles.Value(nextIndex)),
+                true
+            );
+            double sumSquaredDistances = 0.0;
+            for (int sample = 0; sample < sampleCount; ++sample) {
+                const double fraction = static_cast<double>(sample) / (sampleCount - 1);
+                const double firstParameter = first.FirstParameter()
+                    + fraction * (first.LastParameter() - first.FirstParameter());
+                const double secondParameter = second.FirstParameter()
+                    + fraction * (second.LastParameter() - second.FirstParameter());
+                sumSquaredDistances += first.Value(firstParameter)
+                                           .SquareDistance(second.Value(secondParameter));
+            }
+            const double spacing = std::sqrt(sumSquaredDistances / sampleCount);
+            if (spacing <= Precision::Confusion()) {
+                return std::nullopt;
+            }
+            minimumSpacing = std::min(minimumSpacing, spacing);
+            maximumSpacing = std::max(maximumSpacing, spacing);
+        }
+        return maximumSpacing / minimumSpacing;
+    }
+    catch (const Standard_Failure&) {
+        return std::nullopt;
+    }
+}
+
+BRepFill_ThruSectionErrorStatus probeLoftRange(
+    const std::vector<TopoShape>& profiles,
+    std::size_t profileCount,
+    const LoftOptions& options,
+    std::size_t firstProfile = 0,
+    bool closeProfileSequence = false
+)
+{
+    BRepOffsetAPI_ThruSections generator(
+        options.isSolid == IsSolid::solid,
+        options.smoothing == Smoothing::ruled
+    );
+    configureThruSections(generator, options);
+    generator.SetMutableInput(false);
+    for (std::size_t i = firstProfile; i < firstProfile + profileCount; ++i) {
+        const auto& profile = profiles[i].getShape();
+        if (profile.ShapeType() == TopAbs_VERTEX) {
+            generator.AddVertex(TopoDS::Vertex(profile));
+        }
+        else {
+            generator.AddWire(TopoDS::Wire(profile));
+        }
+    }
+    if (closeProfileSequence && options.isClosed == IsClosed::closed
+        && profiles[firstProfile + profileCount - 1].getShape().ShapeType() != TopAbs_VERTEX) {
+        const auto& first = profiles[firstProfile].getShape();
+        if (first.ShapeType() == TopAbs_VERTEX) {
+            generator.AddVertex(TopoDS::Vertex(first));
+        }
+        else {
+            generator.AddWire(TopoDS::Wire(first));
+        }
+    }
+    try {
+        generator.Build();
+        if (!generator.IsDone()
+            || generator.GetStatus() != BRepFill_ThruSectionErrorStatus_Done) {
+            return generator.GetStatus() == BRepFill_ThruSectionErrorStatus_Done
+                ? BRepFill_ThruSectionErrorStatus_NotDone
+                : generator.GetStatus();
+        }
+        const auto& result = generator.Shape();
+        if (result.IsNull() || !BRepCheck_Analyzer(result).IsValid()) {
+            return BRepFill_ThruSectionErrorStatus_Failed;
+        }
+        return BRepFill_ThruSectionErrorStatus_Done;
+    }
+    catch (const Standard_Failure&) {
+        return generator.GetStatus() == BRepFill_ThruSectionErrorStatus_Done
+            ? BRepFill_ThruSectionErrorStatus_NotDone
+            : generator.GetStatus();
+    }
+}
+
+void suggestLoftAlternative(
+    LoftFailure& failure,
+    const std::vector<TopoShape>& profiles,
+    const LoftOptions& options
+)
+{
+    if (options.smoothing != Smoothing::bspline) {
+        return;
+    }
+
+    failure.spacingRatio = profileSpacingRatio(profiles, options.isClosed);
+    std::array<LoftParametrization, 3> candidates {
+        LoftParametrization::centripetal,
+        LoftParametrization::chordLength,
+        LoftParametrization::uniform,
+    };
+    if (failure.spacingRatio && *failure.spacingRatio >= 4.0) {
+        candidates = {
+            LoftParametrization::centripetal,
+            LoftParametrization::uniform,
+            LoftParametrization::chordLength,
+        };
+    }
+    else if (failure.spacingRatio && *failure.spacingRatio <= 1.5) {
+        candidates = {
+            LoftParametrization::chordLength,
+            LoftParametrization::centripetal,
+            LoftParametrization::uniform,
+        };
+    }
+
+    for (const auto candidate : candidates) {
+        if (candidate == options.parametrization) {
+            continue;
+        }
+        auto retryOptions = options;
+        retryOptions.parametrization = candidate;
+        if (probeLoftRange(profiles, profiles.size(), retryOptions, 0, true)
+            == BRepFill_ThruSectionErrorStatus_Done) {
+            failure.suggestedParametrization = candidate;
+            return;
+        }
+    }
+
+    auto retryOptions = options;
+    retryOptions.smoothing = Smoothing::variational;
+    if (probeLoftRange(profiles, profiles.size(), retryOptions, 0, true)
+        == BRepFill_ThruSectionErrorStatus_Done) {
+        failure.suggestVariational = true;
+    }
+}
+
+const char* loftParametrizationName(LoftParametrization parametrization)
+{
+    switch (parametrization) {
+        case LoftParametrization::chordLength:
+            return "Chord length";
+        case LoftParametrization::centripetal:
+            return "Centripetal";
+        case LoftParametrization::uniform:
+            return "Uniform";
+    }
+    return "Unknown";
+}
+
+LoftFailure diagnoseLoftFailure(
+    BRepFill_ThruSectionErrorStatus status,
+    const std::vector<TopoShape>& profiles,
+    const LoftOptions& options
+)
+{
+    LoftFailure failure;
+    failure.status = status;
+    if (profiles.size() < 2) {
+        return failure;
+    }
+
+    if (status == BRepFill_ThruSectionErrorStatus_ProfilesInconsistent
+        && options.checkCompatibility) {
+        for (std::size_t i = 0; i + 1 < profiles.size(); ++i) {
+            const auto pairStatus = probeProfileCompatibility(profiles, 2, i);
+            if (pairStatus && *pairStatus != BRepFill_ThruSectionErrorStatus_Done) {
+                failure.scope = LoftFailureScope::profilePair;
+                failure.firstProfile = i;
+                failure.secondProfile = i + 1;
+                return failure;
+            }
+        }
+        if (options.isClosed == IsClosed::closed) {
+            std::vector<TopoShape> closingPair {profiles.back(), profiles.front()};
+            const auto pairStatus = probeProfileCompatibility(closingPair, 2);
+            if (pairStatus && *pairStatus != BRepFill_ThruSectionErrorStatus_Done) {
+                failure.scope = LoftFailureScope::profilePair;
+                failure.firstProfile = profiles.size() - 1;
+                failure.secondProfile = 0;
+                return failure;
+            }
+        }
+        for (std::size_t count = 2; count < profiles.size(); ++count) {
+            const auto prefixStatus = probeProfileCompatibility(profiles, count);
+            if (prefixStatus && *prefixStatus != BRepFill_ThruSectionErrorStatus_Done) {
+                failure.scope = LoftFailureScope::profilePrefix;
+                failure.secondProfile = count - 1;
+                return failure;
+            }
+        }
+        failure.scope = LoftFailureScope::completeSequence;
+        failure.secondProfile = profiles.size() - 1;
+        return failure;
+    }
+
+    if (status == BRepFill_ThruSectionErrorStatus_Done
+        || status == BRepFill_ThruSectionErrorStatus_NotDone
+        || status == BRepFill_ThruSectionErrorStatus_Failed) {
+        suggestLoftAlternative(failure, profiles, options);
+        for (std::size_t i = 0; i + 1 < profiles.size(); ++i) {
+            if (probeLoftRange(profiles, 2, options, i)
+                != BRepFill_ThruSectionErrorStatus_Done) {
+                failure.scope = LoftFailureScope::profilePair;
+                failure.firstProfile = i;
+                failure.secondProfile = i + 1;
+                return failure;
+            }
+        }
+        if (options.isClosed == IsClosed::closed) {
+            std::vector<TopoShape> closingPair {profiles.back(), profiles.front()};
+            if (probeLoftRange(closingPair, 2, options) != BRepFill_ThruSectionErrorStatus_Done) {
+                failure.scope = LoftFailureScope::profilePair;
+                failure.firstProfile = profiles.size() - 1;
+                failure.secondProfile = 0;
+                return failure;
+            }
+        }
+        if (options.isClosed == IsClosed::notClosed) {
+            for (std::size_t count = 2; count < profiles.size(); ++count) {
+                if (probeLoftRange(profiles, count, options)
+                    != BRepFill_ThruSectionErrorStatus_Done) {
+                    failure.scope = LoftFailureScope::profilePrefix;
+                    failure.secondProfile = count - 1;
+                    return failure;
+                }
+            }
+        }
+        failure.scope = LoftFailureScope::completeSequence;
+        failure.secondProfile = profiles.size() - 1;
+    }
+    return failure;
+}
+
+[[noreturn]] void throwThruSectionsError(const LoftFailure& failure)
+{
+    std::ostringstream message;
+    switch (failure.status) {
+        case BRepFill_ThruSectionErrorStatus_Done:
+            message << "Loft generation did not complete although OCCT reported success";
+            break;
+        case BRepFill_ThruSectionErrorStatus_NotDone:
+            message << "OCCT did not complete the loft operation";
+            break;
+        case BRepFill_ThruSectionErrorStatus_NotSameTopology:
+            message << "Loft profiles must be either all open or all closed";
+            break;
+        case BRepFill_ThruSectionErrorStatus_ProfilesInconsistent:
+            message << "OCCT could not establish consistent edge correspondence between the loft "
+                       "profiles";
+            break;
+        case BRepFill_ThruSectionErrorStatus_WrongUsage:
+            message << "Punctual loft profiles are only supported as the first or last profile";
+            break;
+        case BRepFill_ThruSectionErrorStatus_Null3DCurve:
+            message << "A loft profile contains an edge without a 3D curve";
+            break;
+        case BRepFill_ThruSectionErrorStatus_Failed:
+            message << "OCCT failed to construct the loft";
+            break;
+    }
+    switch (failure.scope) {
+        case LoftFailureScope::none:
+            break;
+        case LoftFailureScope::profilePair:
+            message << " between profiles " << failure.firstProfile + 1 << " and "
+                    << failure.secondProfile + 1;
+            break;
+        case LoftFailureScope::profilePrefix:
+            message << "; the failure first appears in profiles 1 through "
+                    << failure.secondProfile + 1;
+            break;
+        case LoftFailureScope::completeSequence:
+            message << "; the failure requires the complete sequence of "
+                    << failure.secondProfile + 1 << " profiles";
+            break;
+    }
+    if (failure.suggestedParametrization) {
+        message << "; try " << loftParametrizationName(*failure.suggestedParametrization)
+                << " parameterization, which succeeds for these profiles";
+        if (failure.spacingRatio) {
+            message << " (adjacent profile spacing ratio " << std::fixed << std::setprecision(1)
+                    << *failure.spacingRatio << ')';
+        }
+    }
+    else if (failure.suggestVariational) {
+        message << "; standard B-spline lofting failed with all parameterizations; try Smoothed "
+                   "B-Spline, whose variational solver succeeds for these profiles";
+    }
+    if (message.tellp() == 0) {
+        message << "OCCT returned an unknown loft error status";
+    }
+    FC_THROWM(Base::CADKernelError, message.str().c_str());
 }
 }  // namespace
 
@@ -4560,40 +5019,27 @@ TopoShape& TopoShape::makeElementLoft(
         op = Part::OpCodes::Loft;
     }
 
+    const LoftOptions options {
+        isSolid,
+        smoothing,
+        isClosed,
+        maxDegree,
+        parametrization,
+        continuity,
+        checkCompatibility,
+    };
+    auto profiles = prepareProfiles(shapes);
+    if (shapes.size() < 2) {
+        FC_THROWM(Base::CADKernelError, "Need at least two vertices, edges or wires to create loft face");
+    }
+    preflightLoftProfiles(profiles, checkCompatibility);
+
     // http://opencascade.blogspot.com/2010/01/surface-modeling-part5.html
     BRepOffsetAPI_ThruSections aGenerator(
         isSolid == IsSolid::solid,
         smoothing == Smoothing::ruled
     );
-    aGenerator.SetMaxDegree(maxDegree);
-    aGenerator.SetSmoothing(smoothing == Smoothing::variational);
-    switch (parametrization) {
-        case LoftParametrization::chordLength:
-            aGenerator.SetParType(Approx_ChordLength);
-            break;
-        case LoftParametrization::centripetal:
-            aGenerator.SetParType(Approx_Centripetal);
-            break;
-        case LoftParametrization::uniform:
-            aGenerator.SetParType(Approx_IsoParametric);
-            break;
-    }
-    switch (continuity) {
-        case LoftContinuity::C0:
-            aGenerator.SetContinuity(GeomAbs_C0);
-            break;
-        case LoftContinuity::C1:
-            aGenerator.SetContinuity(GeomAbs_C1);
-            break;
-        case LoftContinuity::C2:
-            aGenerator.SetContinuity(GeomAbs_C2);
-            break;
-    }
-    aGenerator.CheckCompatibility(checkCompatibility);
-    auto profiles = prepareProfiles(shapes);
-    if (shapes.size() < 2) {
-        FC_THROWM(Base::CADKernelError, "Need at least two vertices, edges or wires to create loft face");
-    }
+    configureThruSections(aGenerator, options);
 
     int i = 0;
     for (auto& sh : profiles) {
@@ -4647,14 +5093,11 @@ TopoShape& TopoShape::makeElementLoft(
 #endif
     }
     catch (const Standard_Failure&) {
-        if (aGenerator.GetStatus() != BRepFill_ThruSectionErrorStatus_Done) {
-            throwThruSectionsError(aGenerator.GetStatus());
-        }
-        throw;
+        throwThruSectionsError(diagnoseLoftFailure(aGenerator.GetStatus(), profiles, options));
     }
     if (!aGenerator.IsDone()
         || aGenerator.GetStatus() != BRepFill_ThruSectionErrorStatus_Done) {
-        throwThruSectionsError(aGenerator.GetStatus());
+        throwThruSectionsError(diagnoseLoftFailure(aGenerator.GetStatus(), profiles, options));
     }
     return makeShapeWithElementMap(
         aGenerator.Shape(),

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -23,8 +23,6 @@
  ***************************************************************************/
 
 #include <array>
-#include <cmath>
-#include <iomanip>
 #include <limits>
 #include <optional>
 #include <sstream>
@@ -4485,7 +4483,6 @@ struct LoftFailure
     std::size_t secondProfile {0};
     std::optional<LoftParametrization> suggestedParametrization;
     bool suggestVariational {false};
-    std::optional<double> spacingRatio;
 };
 
 struct LoftOptions
@@ -4633,66 +4630,6 @@ std::optional<BRepFill_ThruSectionErrorStatus> probeProfileCompatibility(
     }
 }
 
-std::optional<double> profileSpacingRatio(
-    const std::vector<TopoShape>& profiles,
-    IsClosed isClosed
-)
-{
-    NCollection_Sequence<TopoDS_Shape> sections;
-    for (const auto& profile : profiles) {
-        if (profile.getShape().ShapeType() != TopAbs_WIRE
-            || isPunctualProfile(profile.getShape())) {
-            return std::nullopt;
-        }
-        sections.Append(profile.getShape());
-    }
-
-    try {
-        BRepFill_CompatibleWires compatibility(sections);
-        compatibility.Perform();
-        if (!compatibility.IsDone()) {
-            return std::nullopt;
-        }
-
-        constexpr int sampleCount = 21;
-        double minimumSpacing = std::numeric_limits<double>::max();
-        double maximumSpacing = 0.0;
-        const auto& compatibleProfiles = compatibility.Shape();
-        const int pairCount = compatibleProfiles.Length() - 1
-            + (isClosed == IsClosed::closed ? 1 : 0);
-        for (int pairIndex = 1; pairIndex <= pairCount; ++pairIndex) {
-            const int nextIndex = pairIndex == compatibleProfiles.Length() ? 1 : pairIndex + 1;
-            BRepAdaptor_CompCurve first(
-                TopoDS::Wire(compatibleProfiles.Value(pairIndex)),
-                true
-            );
-            BRepAdaptor_CompCurve second(
-                TopoDS::Wire(compatibleProfiles.Value(nextIndex)),
-                true
-            );
-            double sumSquaredDistances = 0.0;
-            for (int sample = 0; sample < sampleCount; ++sample) {
-                const double fraction = static_cast<double>(sample) / (sampleCount - 1);
-                const double firstParameter = first.FirstParameter()
-                    + fraction * (first.LastParameter() - first.FirstParameter());
-                const double secondParameter = second.FirstParameter()
-                    + fraction * (second.LastParameter() - second.FirstParameter());
-                sumSquaredDistances += first.Value(firstParameter)
-                                           .SquareDistance(second.Value(secondParameter));
-            }
-            const double spacing = std::sqrt(sumSquaredDistances / sampleCount);
-            if (spacing <= Precision::Confusion()) {
-                return std::nullopt;
-            }
-            minimumSpacing = std::min(minimumSpacing, spacing);
-            maximumSpacing = std::max(maximumSpacing, spacing);
-        }
-        return maximumSpacing / minimumSpacing;
-    }
-    catch (const Standard_Failure&) {
-        return std::nullopt;
-    }
-}
 
 BRepFill_ThruSectionErrorStatus probeLoftRange(
     const std::vector<TopoShape>& profiles,
@@ -4758,26 +4695,11 @@ void suggestLoftAlternative(
         return;
     }
 
-    failure.spacingRatio = profileSpacingRatio(profiles, options.isClosed);
-    std::array<LoftParametrization, 3> candidates {
-        LoftParametrization::centripetal,
+    constexpr std::array candidates {
         LoftParametrization::chordLength,
+        LoftParametrization::centripetal,
         LoftParametrization::uniform,
     };
-    if (failure.spacingRatio && *failure.spacingRatio >= 4.0) {
-        candidates = {
-            LoftParametrization::centripetal,
-            LoftParametrization::uniform,
-            LoftParametrization::chordLength,
-        };
-    }
-    else if (failure.spacingRatio && *failure.spacingRatio <= 1.5) {
-        candidates = {
-            LoftParametrization::chordLength,
-            LoftParametrization::centripetal,
-            LoftParametrization::uniform,
-        };
-    }
 
     for (const auto candidate : candidates) {
         if (candidate == options.parametrization) {
@@ -4943,10 +4865,6 @@ LoftFailure diagnoseLoftFailure(
     if (failure.suggestedParametrization) {
         message << "; try " << loftParametrizationName(*failure.suggestedParametrization)
                 << " parameterization, which succeeds for these profiles";
-        if (failure.spacingRatio) {
-            message << " (adjacent profile spacing ratio " << std::fixed << std::setprecision(1)
-                    << *failure.spacingRatio << ')';
-        }
     }
     else if (failure.suggestVariational) {
         message << "; standard B-spline lofting failed with all parameterizations; try "
@@ -5021,12 +4939,15 @@ TopoShape& TopoShape::makeElementLoft(
 
     const bool automatic = smoothing == Smoothing::automatic;
     const Smoothing initialSmoothing = automatic ? Smoothing::bspline : smoothing;
+    const LoftParametrization initialParametrization = automatic
+        ? LoftParametrization::chordLength
+        : parametrization;
     const LoftOptions options {
         isSolid,
         initialSmoothing,
         isClosed,
         maxDegree,
-        parametrization,
+        initialParametrization,
         continuity,
         checkCompatibility,
     };
@@ -5114,7 +5035,7 @@ TopoShape& TopoShape::makeElementLoft(
                     isClosed,
                     maxDegree,
                     op,
-                    parametrization,
+                    initialParametrization,
                     continuity,
                     checkCompatibility
                 );

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4473,7 +4473,8 @@ enum class LoftFailureScope
     none,              // The failing profile range could not be determined.
     profilePair,       // Two profiles fail when lofted together.
     profilePrefix,     // Where the failure first appears.
-    completeSequence,  // Only the complete profile sequence causes the failure (subsections may succeed).
+    completeSequence,  // Only the complete profile sequence causes the failure (subsections may
+                       // succeed).
 };
 
 // Captures an OCCT loft failure, its profile range, and any verified recovery suggestion.
@@ -4500,7 +4501,8 @@ struct LoftOptions
 };
 
 // Configure the BRepOffsetAPI_ThruSections generator based on the loft options.
-// BRepOffsetAPI_ThruSections API: https://dev.opencascade.org/doc/refman/html/class_b_rep_offset_a_p_i___thru_sections.html
+// BRepOffsetAPI_ThruSections API:
+// https://dev.opencascade.org/doc/refman/html/class_b_rep_offset_a_p_i___thru_sections.html
 void configureThruSections(BRepOffsetAPI_ThruSections& generator, const LoftOptions& options)
 {
     // Max order of interpolation that OCCT will be allowed to use
@@ -4692,8 +4694,7 @@ BRepFill_ThruSectionErrorStatus probeLoftRange(
     }
     try {
         generator.Build();
-        if (!generator.IsDone()
-            || generator.GetStatus() != BRepFill_ThruSectionErrorStatus_Done) {
+        if (!generator.IsDone() || generator.GetStatus() != BRepFill_ThruSectionErrorStatus_Done) {
             return generator.GetStatus() == BRepFill_ThruSectionErrorStatus_Done
                 ? BRepFill_ThruSectionErrorStatus_NotDone
                 : generator.GetStatus();
@@ -4777,8 +4778,7 @@ LoftFailure diagnoseLoftFailure(
         return failure;
     }
 
-    if (status == BRepFill_ThruSectionErrorStatus_ProfilesInconsistent
-        && options.checkCompatibility) {
+    if (status == BRepFill_ThruSectionErrorStatus_ProfilesInconsistent && options.checkCompatibility) {
         for (std::size_t i = 0; i + 1 < profiles.size(); ++i) {
             const auto pairStatus = probeProfileCompatibility(profiles, 2, i);
             if (pairStatus && *pairStatus != BRepFill_ThruSectionErrorStatus_Done) {
@@ -4816,8 +4816,7 @@ LoftFailure diagnoseLoftFailure(
         || status == BRepFill_ThruSectionErrorStatus_Failed) {
         suggestLoftAlternative(failure, profiles, options);
         for (std::size_t i = 0; i + 1 < profiles.size(); ++i) {
-            if (probeLoftRange(profiles, 2, options, i)
-                != BRepFill_ThruSectionErrorStatus_Done) {
+            if (probeLoftRange(profiles, 2, options, i) != BRepFill_ThruSectionErrorStatus_Done) {
                 failure.scope = LoftFailureScope::profilePair;
                 failure.firstProfile = i;
                 failure.secondProfile = i + 1;
@@ -4835,8 +4834,7 @@ LoftFailure diagnoseLoftFailure(
         }
         if (options.isClosed == IsClosed::notClosed) {
             for (std::size_t count = 2; count < profiles.size(); ++count) {
-                if (probeLoftRange(profiles, count, options)
-                    != BRepFill_ThruSectionErrorStatus_Done) {
+                if (probeLoftRange(profiles, count, options) != BRepFill_ThruSectionErrorStatus_Done) {
                     failure.scope = LoftFailureScope::profilePrefix;
                     failure.secondProfile = count - 1;
                     return failure;
@@ -4892,7 +4890,8 @@ LoftFailure diagnoseLoftFailure(
             break;
         case LoftFailureScope::completeSequence:
             message << "; the failure occurs when trying the complete sequence of "
-                    << failure.secondProfile + 1 << " profiles (may succeed for subsets of profiles)";
+                    << failure.secondProfile + 1
+                    << " profiles (may succeed for subsets of profiles)";
             break;
     }
     // a failure triggers "dry-runs" of the lofting algorithm
@@ -5003,8 +5002,7 @@ TopoShape& TopoShape::makeElementLoft(
 
     // For closed lofts, we can't create the closure with a vertex as the last profile
     bool closeProfileSequence = isClosed == IsClosed::closed;
-    if (closeProfileSequence
-        && profiles.back().getShape().ShapeType() == TopAbs_VERTEX) {
+    if (closeProfileSequence && profiles.back().getShape().ShapeType() == TopAbs_VERTEX) {
         Base::Console().message(
             "TopoShape::makeLoft: can't close Loft with Vertex as last "
             "profile. 'Closed' ignored.\n"
@@ -5054,8 +5052,7 @@ TopoShape& TopoShape::makeElementLoft(
 #else
             generator.Build();
 #endif
-            if (!generator.IsDone()
-                || generator.GetStatus() != BRepFill_ThruSectionErrorStatus_Done) {
+            if (!generator.IsDone() || generator.GetStatus() != BRepFill_ThruSectionErrorStatus_Done) {
                 return generator.GetStatus() == BRepFill_ThruSectionErrorStatus_Done
                     ? BRepFill_ThruSectionErrorStatus_NotDone
                     : generator.GetStatus();

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4521,6 +4521,8 @@ TopoShape& TopoShape::makeElementLoft(
     // http://opencascade.blogspot.com/2010/01/surface-modeling-part5.html
     BRepOffsetAPI_ThruSections aGenerator(isSolid == IsSolid::solid, isRuled == IsRuled::ruled);
     aGenerator.SetMaxDegree(maxDegree);
+    // https://dev.opencascade.org/doc/occt-7.8.0/refman/html/classBRepOffsetAPI__ThruSections.html
+    aGenerator.SetSmoothing(isSmoothing == IsSmoothing::smoothing);
 
     auto profiles = prepareProfiles(shapes);
     if (shapes.size() < 2) {

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4949,8 +4949,8 @@ LoftFailure diagnoseLoftFailure(
         }
     }
     else if (failure.suggestVariational) {
-        message << "; standard B-spline lofting failed with all parameterizations; try Smoothed "
-                   "B-Spline, whose variational solver succeeds for these profiles";
+        message << "; standard B-spline lofting failed with all parameterizations; try "
+                   "Variational B-Spline, whose variational solver succeeds for these profiles";
     }
     if (message.tellp() == 0) {
         message << "OCCT returned an unknown loft error status";
@@ -5019,9 +5019,11 @@ TopoShape& TopoShape::makeElementLoft(
         op = Part::OpCodes::Loft;
     }
 
+    const bool automatic = smoothing == Smoothing::automatic;
+    const Smoothing initialSmoothing = automatic ? Smoothing::bspline : smoothing;
     const LoftOptions options {
         isSolid,
-        smoothing,
+        initialSmoothing,
         isClosed,
         maxDegree,
         parametrization,
@@ -5037,9 +5039,12 @@ TopoShape& TopoShape::makeElementLoft(
     // http://opencascade.blogspot.com/2010/01/surface-modeling-part5.html
     BRepOffsetAPI_ThruSections aGenerator(
         isSolid == IsSolid::solid,
-        smoothing == Smoothing::ruled
+        initialSmoothing == Smoothing::ruled
     );
     configureThruSections(aGenerator, options);
+    if (automatic) {
+        aGenerator.SetMutableInput(false);
+    }
 
     int i = 0;
     for (auto& sh : profiles) {
@@ -5085,6 +5090,39 @@ TopoShape& TopoShape::makeElementLoft(
         }
     }
 
+    auto recoverAutomaticLoft = [&](BRepFill_ThruSectionErrorStatus status) -> TopoShape& {
+        const auto failure = diagnoseLoftFailure(status, profiles, options);
+        if (automatic) {
+            if (failure.suggestedParametrization) {
+                return makeElementLoft(
+                    shapes,
+                    isSolid,
+                    Smoothing::bspline,
+                    isClosed,
+                    maxDegree,
+                    op,
+                    *failure.suggestedParametrization,
+                    continuity,
+                    checkCompatibility
+                );
+            }
+            if (failure.suggestVariational) {
+                return makeElementLoft(
+                    shapes,
+                    isSolid,
+                    Smoothing::variational,
+                    isClosed,
+                    maxDegree,
+                    op,
+                    parametrization,
+                    continuity,
+                    checkCompatibility
+                );
+            }
+        }
+        throwThruSectionsError(failure);
+    };
+
     try {
 #if OCC_VERSION_HEX >= 0x070600
         aGenerator.Build(std::make_unique<Part::ProgressIndicator>()->Start());
@@ -5093,11 +5131,22 @@ TopoShape& TopoShape::makeElementLoft(
 #endif
     }
     catch (const Standard_Failure&) {
-        throwThruSectionsError(diagnoseLoftFailure(aGenerator.GetStatus(), profiles, options));
+        return recoverAutomaticLoft(aGenerator.GetStatus());
     }
     if (!aGenerator.IsDone()
         || aGenerator.GetStatus() != BRepFill_ThruSectionErrorStatus_Done) {
-        throwThruSectionsError(diagnoseLoftFailure(aGenerator.GetStatus(), profiles, options));
+        return recoverAutomaticLoft(aGenerator.GetStatus());
+    }
+    if (automatic) {
+        try {
+            const auto& result = aGenerator.Shape();
+            if (result.IsNull() || !BRepCheck_Analyzer(result).IsValid()) {
+                return recoverAutomaticLoft(BRepFill_ThruSectionErrorStatus_Failed);
+            }
+        }
+        catch (const Standard_Failure&) {
+            return recoverAutomaticLoft(BRepFill_ThruSectionErrorStatus_Failed);
+        }
     }
     return makeShapeWithElementMap(
         aGenerator.Shape(),

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4467,24 +4467,27 @@ TopoShape& TopoShape::makeElementShape(
 
 namespace
 {
+// Identifies the smallest range of profiles that reproduces a loft failure.
 enum class LoftFailureScope
 {
-    none,
-    profilePair,
-    profilePrefix,
-    completeSequence,
+    none,              // The failing profile range could not be determined.
+    profilePair,       // Two profiles fail when lofted together.
+    profilePrefix,     // Where the failure first appears.
+    completeSequence,  // Only the complete profile sequence causes the failure (subsections may succeed).
 };
 
+// Captures an OCCT loft failure, its profile range, and any verified recovery suggestion.
 struct LoftFailure
 {
     BRepFill_ThruSectionErrorStatus status {BRepFill_ThruSectionErrorStatus_NotDone};
     LoftFailureScope scope {LoftFailureScope::none};
-    std::size_t firstProfile {0};
-    std::size_t secondProfile {0};
+    std::size_t firstProfile {0};   // First profile in the failing range
+    std::size_t secondProfile {0};  // Last profile in the failing range
     std::optional<LoftParametrization> suggestedParametrization;
     bool suggestVariational {false};
 };
 
+// Groups the OCCT settings needed to build or probe a loft.
 struct LoftOptions
 {
     IsSolid isSolid;
@@ -4554,6 +4557,7 @@ bool isPunctualProfile(const TopoDS_Shape& profile)
     return hasEdges;
 }
 
+// Test whether a profile is closed
 bool isClosedProfile(const TopoDS_Wire& wire)
 {
     return BRep_Tool::IsClosed(wire);
@@ -4621,6 +4625,8 @@ void preflightLoftProfiles(const std::vector<TopoShape>& profiles, bool checkCom
 }
 
 
+// Tests whether OCCT can establish compatible edge correspondence for a profile range.
+// A null result means the range contains a punctual profile, which this wire-only check cannot test.
 std::optional<BRepFill_ThruSectionErrorStatus> probeProfileCompatibility(
     const std::vector<TopoShape>& profiles,
     std::size_t profileCount,
@@ -4636,6 +4642,7 @@ std::optional<BRepFill_ThruSectionErrorStatus> probeProfileCompatibility(
         sections.Append(profile);
     }
 
+    // Perform compatibility on a temporary sequence
     try {
         BRepFill_CompatibleWires compatibility(sections);
         compatibility.Perform();
@@ -4643,12 +4650,13 @@ std::optional<BRepFill_ThruSectionErrorStatus> probeProfileCompatibility(
                                       : compatibility.GetStatus();
     }
     catch (const Standard_Failure&) {
+        // OCCT may throw without setting a more specific status.
         return BRepFill_ThruSectionErrorStatus_NotDone;
     }
 }
 
 
-// Probe immutable profile copies so diagnosis cannot alter the requested loft inputs.
+// Probe/test a range of profiles to determine if they can be lofted together.
 BRepFill_ThruSectionErrorStatus probeLoftRange(
     const std::vector<TopoShape>& profiles,
     std::size_t profileCount,
@@ -4703,6 +4711,7 @@ BRepFill_ThruSectionErrorStatus probeLoftRange(
     }
 }
 
+// Suggest an alternative parametrization for a loft failure, if possible.
 void suggestLoftAlternative(
     LoftFailure& failure,
     const std::vector<TopoShape>& profiles,
@@ -4713,7 +4722,7 @@ void suggestLoftAlternative(
         return;
     }
 
-    // Test each standard parametrization in a stable order, then try the variational solver.
+    // Test each standard parametrization in order, then try the variational solver.
     constexpr std::array candidates {
         LoftParametrization::chordLength,
         LoftParametrization::centripetal,
@@ -4741,6 +4750,7 @@ void suggestLoftAlternative(
     }
 }
 
+// Convert a loft parametrization to a human-readable name.
 const char* loftParametrizationName(LoftParametrization parametrization)
 {
     switch (parametrization) {
@@ -4914,7 +4924,8 @@ TopoShape& TopoShape::makeElementLoft(
     const char* op,
     LoftParametrization parametrization,
     LoftContinuity continuity,
-    bool checkCompatibility
+    bool checkCompatibility,
+    bool adaptive
 )
 {
     // Note: checkProfiles basically checks for coincident profiles, which are not allowed.
@@ -4984,91 +4995,140 @@ TopoShape& TopoShape::makeElementLoft(
     // check that the profiles are compatible/valid
     preflightLoftProfiles(profiles, checkCompatibility);
 
-    // configure the loft generator
-    BRepOffsetAPI_ThruSections aGenerator(
-        isSolid == IsSolid::solid,
-        smoothing == Smoothing::ruled
-    );
-    configureThruSections(aGenerator, options);
+    for (std::size_t i = 1; i < profiles.size(); ++i) {
+        if (!checkProfiles(profiles[i], profiles[i - 1])) {
+            FC_THROWM(Base::CADKernelError, "Segments of a loft do not have sufficient separation");
+        }
+    }
 
-    int i = 0;
-    for (auto& sh : profiles) {
-        if (i > 0) {
-            if (!checkProfiles(sh, profiles[i - 1])) {
-                FC_THROWM(Base::CADKernelError, "Segments of a loft do not have sufficient separation");
+    // For closed lofts, we can't create the closure with a vertex as the last profile
+    bool closeProfileSequence = isClosed == IsClosed::closed;
+    if (closeProfileSequence
+        && profiles.back().getShape().ShapeType() == TopAbs_VERTEX) {
+        Base::Console().message(
+            "TopoShape::makeLoft: can't close Loft with Vertex as last "
+            "profile. 'Closed' ignored.\n"
+        );
+        closeProfileSequence = false;
+    }
+
+    // Creates OCCT generator for one selected or adaptive loft attempt.
+    auto makeGenerator = [&](const LoftOptions& attemptOptions) {
+        auto generator = std::make_unique<BRepOffsetAPI_ThruSections>(
+            attemptOptions.isSolid == IsSolid::solid,
+            attemptOptions.smoothing == Smoothing::ruled
+        );
+        configureThruSections(*generator, attemptOptions);
+
+        // Adaptive retries need to prevent modification of the input profile sequence.
+        if (adaptive) {
+            generator->SetMutableInput(false);
+        }
+
+        // OCCT accepts vertices only as punctual sections; all prepared curve profiles are wires.
+        for (const auto& profile : profiles) {
+            const auto& shape = profile.getShape();
+            if (shape.ShapeType() == TopAbs_VERTEX) {
+                generator->AddVertex(TopoDS::Vertex(shape));
+            }
+            else {
+                generator->AddWire(TopoDS::Wire(shape));
             }
         }
-        const auto& shape = sh.getShape();
-        if (shape.ShapeType() == TopAbs_VERTEX) {
-            aGenerator.AddVertex(TopoDS::Vertex(shape));
-        }
-        else {
-            aGenerator.AddWire(TopoDS::Wire(shape));
-        }
-        i++;
-    }
-    // close loft by duplicating initial profile as last profile.  not perfect.
-    if (isClosed == IsClosed::closed) {
-        /* can only close loft in certain combinations of Vertex/Wire(Edge):
-            - V1-W1-W2-W3-V2  ==> V1-W1-W2-W3-V2-V1  invalid closed
-            - V1-W1-W2-W3     ==> V1-W1-W2-W3-V1     valid closed
-            - W1-W2-W3-V1     ==> W1-W2-W3-V1-W1     invalid closed
-            - W1-W2-W3        ==> W1-W2-W3-W1        valid closed*/
-        if (profiles.back().getShape().ShapeType() == TopAbs_VERTEX) {
-            Base::Console().message(
-                "TopoShape::makeLoft: can't close Loft with Vertex as last "
-                "profile. 'Closed' ignored.\n"
-            );
-        }
-        else {
-            // repeat Add logic above for first profile
-            const TopoDS_Shape& firstProfile = profiles.front().getShape();
+        if (closeProfileSequence) {
+            const auto& firstProfile = profiles.front().getShape();
             if (firstProfile.ShapeType() == TopAbs_VERTEX) {
-                aGenerator.AddVertex(TopoDS::Vertex(firstProfile));
+                generator->AddVertex(TopoDS::Vertex(firstProfile));
             }
-            else if (firstProfile.ShapeType() == TopAbs_EDGE) {
-                aGenerator.AddWire(BRepBuilderAPI_MakeWire(TopoDS::Edge(firstProfile)).Wire());
-            }
-            else if (firstProfile.ShapeType() == TopAbs_WIRE) {
-                aGenerator.AddWire(TopoDS::Wire(firstProfile));
+            else {
+                generator->AddWire(TopoDS::Wire(firstProfile));
             }
         }
-    }
-
-    // Report loft failure and provide diagnostic information to the user
-    auto reportLoftFailure = [&](BRepFill_ThruSectionErrorStatus status) -> void {
-        throwThruSectionsError(diagnoseLoftFailure(status, profiles, options));
+        return generator;
     };
 
-    try {
+    auto buildGenerator = [](BRepOffsetAPI_ThruSections& generator) {
+        try {
 #if OCC_VERSION_HEX >= 0x070600
-        aGenerator.Build(std::make_unique<Part::ProgressIndicator>()->Start());
+            generator.Build(std::make_unique<Part::ProgressIndicator>()->Start());
 #else
-        aGenerator.Build();
+            generator.Build();
 #endif
-    }
-    catch (const Standard_Failure&) {
-        reportLoftFailure(aGenerator.GetStatus());
-    }
-    if (!aGenerator.IsDone()
-        || aGenerator.GetStatus() != BRepFill_ThruSectionErrorStatus_Done) {
-        reportLoftFailure(aGenerator.GetStatus());
-    }
-    try {
-        const auto& result = aGenerator.Shape();
-        if (result.IsNull() || !BRepCheck_Analyzer(result).IsValid()) {
-            reportLoftFailure(BRepFill_ThruSectionErrorStatus_Failed);
+            if (!generator.IsDone()
+                || generator.GetStatus() != BRepFill_ThruSectionErrorStatus_Done) {
+                return generator.GetStatus() == BRepFill_ThruSectionErrorStatus_Done
+                    ? BRepFill_ThruSectionErrorStatus_NotDone
+                    : generator.GetStatus();
+            }
+            const auto& result = generator.Shape();
+            return result.IsNull() || !BRepCheck_Analyzer(result).IsValid()
+                ? BRepFill_ThruSectionErrorStatus_Failed
+                : BRepFill_ThruSectionErrorStatus_Done;
         }
+        catch (const Standard_Failure&) {
+            return generator.GetStatus() == BRepFill_ThruSectionErrorStatus_Done
+                ? BRepFill_ThruSectionErrorStatus_NotDone
+                : generator.GetStatus();
+        }
+    };
+
+    std::vector<LoftOptions> attempts {options};
+    auto addAttempt = [&](Smoothing attemptSmoothing, LoftParametrization attemptParametrization) {
+        const auto duplicate = std::ranges::find_if(attempts, [&](const LoftOptions& attempt) {
+            return attempt.smoothing == attemptSmoothing
+                && attempt.parametrization == attemptParametrization;
+        });
+        if (duplicate == attempts.end()) {
+            auto attempt = options;
+            attempt.smoothing = attemptSmoothing;
+            attempt.parametrization = attemptParametrization;
+            attempts.push_back(attempt);
+        }
+    };
+
+    // the fallback options available for adaptive loft attempts
+    if (adaptive) {
+        addAttempt(Smoothing::bspline, LoftParametrization::chordLength);
+        addAttempt(Smoothing::bspline, LoftParametrization::centripetal);
+        addAttempt(Smoothing::bspline, LoftParametrization::uniform);
+        addAttempt(Smoothing::variational, LoftParametrization::chordLength);
     }
-    catch (const Standard_Failure&) {
-        reportLoftFailure(BRepFill_ThruSectionErrorStatus_Failed);
+
+    BRepFill_ThruSectionErrorStatus initialStatus = BRepFill_ThruSectionErrorStatus_NotDone;
+    for (std::size_t attemptIndex = 0; attemptIndex < attempts.size(); ++attemptIndex) {
+        const auto& attempt = attempts[attemptIndex];
+        auto generator = makeGenerator(attempt);
+        const auto status = buildGenerator(*generator);
+        if (attemptIndex == 0) {
+            initialStatus = status;
+        }
+        if (status != BRepFill_ThruSectionErrorStatus_Done) {
+            continue;
+        }
+
+        if (attemptIndex > 0) {
+            if (attempt.smoothing == Smoothing::variational) {
+                Base::Console().message(
+                    "Loft created using adaptive fallback: Variational B-Spline.\n"
+                );
+            }
+            else {
+                Base::Console().message(
+                    "Loft created using adaptive fallback: %s parameterization.\n",
+                    loftParametrizationName(attempt.parametrization)
+                );
+            }
+        }
+
+        return makeShapeWithElementMap(
+            generator->Shape(),
+            MapperThruSections(*generator, profiles),
+            shapes,
+            op
+        );
     }
-    return makeShapeWithElementMap(
-        aGenerator.Shape(),
-        MapperThruSections(aGenerator, profiles),
-        shapes,
-        op
-    );
+
+    throwThruSectionsError(diagnoseLoftFailure(initialStatus, profiles, options));
 }
 
 TopoShape& TopoShape::makeElementPrism(const TopoShape& base, const gp_Vec& vec, const char* op)

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4464,11 +4464,13 @@ TopoShape& TopoShape::makeElementShape(
 TopoShape& TopoShape::makeElementLoft(
     const std::vector<TopoShape>& shapes,
     IsSolid isSolid,
-    IsRuled isRuled,
+    Smoothing smoothing,
     IsClosed isClosed,
     Standard_Integer maxDegree,
     const char* op,
-    IsSmoothing isSmoothing
+    LoftParametrization parametrization,
+    LoftContinuity continuity,
+    bool checkCompatibility
 )
 {
     auto checkProfiles = [](const TopoShape& sh1, const TopoShape& sh2) {
@@ -4519,11 +4521,35 @@ TopoShape& TopoShape::makeElementLoft(
     }
 
     // http://opencascade.blogspot.com/2010/01/surface-modeling-part5.html
-    BRepOffsetAPI_ThruSections aGenerator(isSolid == IsSolid::solid, isRuled == IsRuled::ruled);
+    BRepOffsetAPI_ThruSections aGenerator(
+        isSolid == IsSolid::solid,
+        smoothing == Smoothing::ruled
+    );
     aGenerator.SetMaxDegree(maxDegree);
-    // https://dev.opencascade.org/doc/occt-7.8.0/refman/html/classBRepOffsetAPI__ThruSections.html
-    aGenerator.SetSmoothing(isSmoothing == IsSmoothing::smoothing);
-
+    aGenerator.SetSmoothing(smoothing == Smoothing::variational);
+    switch (parametrization) {
+        case LoftParametrization::chordLength:
+            aGenerator.SetParType(Approx_ChordLength);
+            break;
+        case LoftParametrization::centripetal:
+            aGenerator.SetParType(Approx_Centripetal);
+            break;
+        case LoftParametrization::uniform:
+            aGenerator.SetParType(Approx_IsoParametric);
+            break;
+    }
+    switch (continuity) {
+        case LoftContinuity::C0:
+            aGenerator.SetContinuity(GeomAbs_C0);
+            break;
+        case LoftContinuity::C1:
+            aGenerator.SetContinuity(GeomAbs_C1);
+            break;
+        case LoftContinuity::C2:
+            aGenerator.SetContinuity(GeomAbs_C2);
+            break;
+    }
+    aGenerator.CheckCompatibility(checkCompatibility);
     auto profiles = prepareProfiles(shapes);
     if (shapes.size() < 2) {
         FC_THROWM(Base::CADKernelError, "Need at least two vertices, edges or wires to create loft face");
@@ -4572,10 +4598,6 @@ TopoShape& TopoShape::makeElementLoft(
             }
         }
     }
-
-    Standard_Boolean anIsCheck = Standard_True;
-    aGenerator.CheckCompatibility(anIsCheck);  // use BRepFill_CompatibleWires on profiles. force
-                                               // #edges, orientation, "origin" to match.
 
 #if OCC_VERSION_HEX >= 0x070600
     aGenerator.Build(std::make_unique<Part::ProgressIndicator>()->Start());

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -31,6 +31,7 @@
 
 #include <boost/core/ignore_unused.hpp>
 
+#include <App/Application.h>
 #include <App/Document.h>
 #include <Base/Console.h>
 #include <Base/Exception.h>
@@ -110,6 +111,13 @@ Loft::Loft()
         App::Prop_None,
         "Align profile origins, orientations, and edge counts"
     );
+    ADD_PROPERTY_TYPE(
+        Adaptive,
+        (App::GetApplication().isRestoring() ? false : true),
+        "Loft",
+        App::Prop_None,
+        "Retry failed selected settings with deterministic loft alternatives"
+    );
     MaxDegree.setConstraints(&Degrees);
     LoftType.setEnums(LoftTypeEnums);
     Parametrization.setEnums(ParametrizationEnums);
@@ -122,8 +130,8 @@ void Loft::onChanged(const App::Property* prop)
     if (!isRestoring() && !synchronizingLoftType) {
         if (prop == &Ruled) {
             Base::Console().warning(
-                "The 'Ruled' property of PartDesign lofts is deprecated; use "
-                "LoftType = 'Ruled Surface' or 'Standard B-Spline' instead.\n"
+                "The 'Ruled' property of PartDesign lofts is deprecated; use LoftType = "
+                "'Standard B-Spline', 'Ruled Surface', or 'Variational B-Spline' instead.\n"
             );
             synchronizingLoftType = true;
             LoftType.setValue(Ruled.getValue() ? 1 : 0);
@@ -174,6 +182,9 @@ short Loft::mustExecute() const
         return 1;
     }
     if (CheckCompatibility.isTouched()) {
+        return 1;
+    }
+    if (Adaptive.isTouched()) {
         return 1;
     }
 
@@ -348,7 +359,8 @@ App::DocumentObjectExecReturn* Loft::execute()
                 nullptr,
                 static_cast<Part::LoftParametrization>(Parametrization.getValue()),
                 static_cast<Part::LoftContinuity>(Continuity.getValue()),
-                CheckCompatibility.getValue()
+                CheckCompatibility.getValue(),
+                Adaptive.getValue()
             ));
         }
 

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -62,17 +62,9 @@ Part::Smoothing loftSmoothing(long loftType)
 }
 }  // namespace
 
-App::PropertyIntegerConstraint::Constraints Loft::Degrees = {
-    2,
-    Geom_BSplineSurface::MaxDegree(),
-    1
-};
-const char* Loft::LoftTypeEnums[] = {
-    "Standard B-Spline",
-    "Ruled Surface",
-    "Variational B-Spline",
-    nullptr
-};
+App::PropertyIntegerConstraint::Constraints Loft::Degrees = {2, Geom_BSplineSurface::MaxDegree(), 1};
+const char* Loft::LoftTypeEnums[]
+    = {"Standard B-Spline", "Ruled Surface", "Variational B-Spline", nullptr};
 const char* Loft::ParametrizationEnums[] = {"Chord length", "Centripetal", "Uniform", nullptr};
 const char* Loft::ContinuityEnums[] = {"C0", "C1", "C2", nullptr};
 
@@ -80,29 +72,11 @@ Loft::Loft()
 {
     ADD_PROPERTY_TYPE(Sections, (nullptr), "Loft", App::Prop_None, "List of sections");
     Sections.setValue(nullptr);
-    ADD_PROPERTY_TYPE(
-        LoftType,
-        (long(0)),
-        "Loft",
-        App::Prop_None,
-        "Loft surface generation algorithm"
-    );
-    ADD_PROPERTY_TYPE(
-        Ruled,
-        (false),
-        "Compatibility",
-        App::Prop_Hidden,
-        "Deprecated: use LoftType instead"
-    );
+    ADD_PROPERTY_TYPE(LoftType, (long(0)), "Loft", App::Prop_None, "Loft surface generation algorithm");
+    ADD_PROPERTY_TYPE(Ruled, (false), "Compatibility", App::Prop_Hidden, "Deprecated: use LoftType instead");
     ADD_PROPERTY_TYPE(Closed, (false), "Loft", App::Prop_None, "Close Last to First Profile");
     ADD_PROPERTY_TYPE(MaxDegree, (5), "Loft", App::Prop_None, "Maximum B-Spline degree");
-    ADD_PROPERTY_TYPE(
-        Parametrization,
-        (long(0)),
-        "Loft",
-        App::Prop_None,
-        "B-Spline parametrization type"
-    );
+    ADD_PROPERTY_TYPE(Parametrization, (long(0)), "Loft", App::Prop_None, "B-Spline parametrization type");
     ADD_PROPERTY_TYPE(Continuity, (long(2)), "Loft", App::Prop_None, "B-Spline continuity");
     ADD_PROPERTY_TYPE(
         CheckCompatibility,

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -43,10 +43,36 @@ using namespace PartDesign;
 
 PROPERTY_SOURCE(PartDesign::Loft, PartDesign::ProfileBased)
 
+namespace
+{
+Part::Smoothing loftSmoothing(long loftType)
+{
+    switch (loftType) {
+        case 0:
+            return Part::Smoothing::automatic;
+        case 1:
+            return Part::Smoothing::bspline;
+        case 2:
+            return Part::Smoothing::ruled;
+        case 3:
+            return Part::Smoothing::variational;
+        default:
+            return Part::Smoothing::automatic;
+    }
+}
+}  // namespace
+
 App::PropertyIntegerConstraint::Constraints Loft::Degrees = {
     2,
     Geom_BSplineSurface::MaxDegree(),
     1
+};
+const char* Loft::LoftTypeEnums[] = {
+    "Auto",
+    "Standard B-Spline",
+    "Ruled Surface",
+    "Variational B-Spline",
+    nullptr
 };
 const char* Loft::ParametrizationEnums[] = {"Chord length", "Centripetal", "Uniform", nullptr};
 const char* Loft::ContinuityEnums[] = {"C0", "C1", "C2", nullptr};
@@ -55,8 +81,13 @@ Loft::Loft()
 {
     ADD_PROPERTY_TYPE(Sections, (nullptr), "Loft", App::Prop_None, "List of sections");
     Sections.setValue(nullptr);
-    ADD_PROPERTY_TYPE(Ruled, (false), "Loft", App::Prop_None, "Create ruled surface");
-    ADD_PROPERTY_TYPE(Smoothing, (false), "Loft", App::Prop_None, "Use variational smoothing");
+    ADD_PROPERTY_TYPE(
+        LoftType,
+        (long(0)),
+        "Loft",
+        App::Prop_None,
+        "Loft surface generation algorithm"
+    );
     ADD_PROPERTY_TYPE(Closed, (false), "Loft", App::Prop_None, "Close Last to First Profile");
     ADD_PROPERTY_TYPE(MaxDegree, (5), "Loft", App::Prop_None, "Maximum B-Spline degree");
     ADD_PROPERTY_TYPE(
@@ -75,6 +106,7 @@ Loft::Loft()
         "Align profile origins, orientations, and edge counts"
     );
     MaxDegree.setConstraints(&Degrees);
+    LoftType.setEnums(LoftTypeEnums);
     Parametrization.setEnums(ParametrizationEnums);
     Continuity.setEnums(ContinuityEnums);
 }
@@ -84,10 +116,7 @@ short Loft::mustExecute() const
     if (Sections.isTouched()) {
         return 1;
     }
-    if (Ruled.isTouched()) {
-        return 1;
-    }
-    if (Smoothing.isTouched()) {
+    if (LoftType.isTouched()) {
         return 1;
     }
     if (Closed.isTouched()) {
@@ -267,13 +296,7 @@ App::DocumentObjectExecReturn* Loft::execute()
             for (auto& wire : sectionWires) {
                 wire.move(invObjLoc);
             }
-            Part::Smoothing smoothing = Part::Smoothing::bspline;
-            if (Ruled.getValue()) {
-                smoothing = Part::Smoothing::ruled;
-            }
-            else if (Smoothing.getValue()) {
-                smoothing = Part::Smoothing::variational;
-            }
+            const auto smoothing = loftSmoothing(LoftType.getValue());
             shells.push_back(TopoShape(0, hasher).makeElementLoft(
                 sectionWires,
                 Part::IsSolid::notSolid,

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -47,6 +47,7 @@ Loft::Loft()
     ADD_PROPERTY_TYPE(Sections, (nullptr), "Loft", App::Prop_None, "List of sections");
     Sections.setValue(nullptr);
     ADD_PROPERTY_TYPE(Ruled, (false), "Loft", App::Prop_None, "Create ruled surface");
+    ADD_PROPERTY_TYPE(Smoothing, (false), "Loft", App::Prop_None, "Use variational smoothing");
     ADD_PROPERTY_TYPE(Closed, (false), "Loft", App::Prop_None, "Close Last to First Profile");
 }
 
@@ -56,6 +57,9 @@ short Loft::mustExecute() const
         return 1;
     }
     if (Ruled.isTouched()) {
+        return 1;
+    }
+    if (Smoothing.isTouched()) {
         return 1;
     }
     if (Closed.isTouched()) {
@@ -227,7 +231,10 @@ App::DocumentObjectExecReturn* Loft::execute()
                 sectionWires,
                 Part::IsSolid::notSolid,
                 Ruled.getValue() ? Part::IsRuled::ruled : Part::IsRuled::notRuled,
-                closed ? Part::IsClosed::closed : Part::IsClosed::notClosed
+                closed ? Part::IsClosed::closed : Part::IsClosed::notClosed,
+                5, // maxdegree Note: maybe add this as an option in the data tab at some point?
+                nullptr,
+                Smoothing.getValue() ? Part::IsSmoothing::smoothing : Part::IsSmoothing::noSmoothing
             ));
         }
 

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -68,7 +68,7 @@ App::PropertyIntegerConstraint::Constraints Loft::Degrees = {
     1
 };
 const char* Loft::LoftTypeEnums[] = {
-    "Auto",
+    "Automatic",
     "Standard B-Spline",
     "Ruled Surface",
     "Variational B-Spline",

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -32,6 +32,7 @@
 #include <boost/core/ignore_unused.hpp>
 
 #include <App/Document.h>
+#include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/Reader.h>
 #include <Mod/Part/App/FaceMakerCheese.h>
@@ -416,6 +417,7 @@ App::DocumentObjectExecReturn* Loft::execute()
                 ));
             }
             Shape.setValue(getSolid(result));
+            Base::Console().message("%s: Loft created successfully.\n", getNameInDocument());
             return App::DocumentObject::StdReturn;
         }
 
@@ -461,6 +463,7 @@ App::DocumentObjectExecReturn* Loft::execute()
         }
         boolOp = getSolid(boolOp);
         Shape.setValue(boolOp);
+        Base::Console().message("%s: Loft created successfully.\n", getNameInDocument());
         return App::DocumentObject::StdReturn;
     }
     catch (Standard_Failure& e) {

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -31,7 +31,6 @@
 
 #include <boost/core/ignore_unused.hpp>
 
-#include <App/Application.h>
 #include <App/Document.h>
 #include <Base/Console.h>
 #include <Base/Exception.h>
@@ -51,15 +50,13 @@ Part::Smoothing loftSmoothing(long loftType)
 {
     switch (loftType) {
         case 0:
-            return Part::Smoothing::automatic;
-        case 1:
             return Part::Smoothing::bspline;
-        case 2:
+        case 1:
             return Part::Smoothing::ruled;
-        case 3:
+        case 2:
             return Part::Smoothing::variational;
         default:
-            return Part::Smoothing::automatic;
+            return Part::Smoothing::bspline;
     }
 }
 }  // namespace
@@ -70,7 +67,6 @@ App::PropertyIntegerConstraint::Constraints Loft::Degrees = {
     1
 };
 const char* Loft::LoftTypeEnums[] = {
-    "Automatic",
     "Standard B-Spline",
     "Ruled Surface",
     "Variational B-Spline",
@@ -85,7 +81,7 @@ Loft::Loft()
     Sections.setValue(nullptr);
     ADD_PROPERTY_TYPE(
         LoftType,
-        (App::GetApplication().isRestoring() ? long(1) : long(0)),
+        (long(0)),
         "Loft",
         App::Prop_None,
         "Loft surface generation algorithm"
@@ -130,12 +126,12 @@ void Loft::onChanged(const App::Property* prop)
                 "LoftType = 'Ruled Surface' or 'Standard B-Spline' instead.\n"
             );
             synchronizingLoftType = true;
-            LoftType.setValue(Ruled.getValue() ? 2 : 1);
+            LoftType.setValue(Ruled.getValue() ? 1 : 0);
             synchronizingLoftType = false;
         }
         else if (prop == &LoftType) {
             synchronizingLoftType = true;
-            Ruled.setValue(LoftType.getValue() == 2);
+            Ruled.setValue(LoftType.getValue() == 1);
             synchronizingLoftType = false;
         }
     }
@@ -145,13 +141,13 @@ void Loft::onChanged(const App::Property* prop)
 
 void Loft::onDocumentRestored()
 {
-    // LoftType defaults to Standard B-Spline while restoring old documents that do not contain
-    // the new property. Preserve the old Ruled=true setting when present.
+    // Saved documents store only Ruled true/false
+    // This provides backwards compatability
     synchronizingLoftType = true;
     if (Ruled.getValue()) {
-        LoftType.setValue(2);
+        LoftType.setValue(1);
     }
-    Ruled.setValue(LoftType.getValue() == 2);
+    Ruled.setValue(LoftType.getValue() == 1);
     synchronizingLoftType = false;
 
     ProfileBased::onDocumentRestored();

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -31,6 +31,7 @@
 
 #include <boost/core/ignore_unused.hpp>
 
+#include <App/Application.h>
 #include <App/Document.h>
 #include <Base/Console.h>
 #include <Base/Exception.h>
@@ -84,10 +85,17 @@ Loft::Loft()
     Sections.setValue(nullptr);
     ADD_PROPERTY_TYPE(
         LoftType,
-        (long(0)),
+        (App::GetApplication().isRestoring() ? long(1) : long(0)),
         "Loft",
         App::Prop_None,
         "Loft surface generation algorithm"
+    );
+    ADD_PROPERTY_TYPE(
+        Ruled,
+        (false),
+        "Compatibility",
+        App::Prop_Hidden,
+        "Deprecated: use LoftType instead"
     );
     ADD_PROPERTY_TYPE(Closed, (false), "Loft", App::Prop_None, "Close Last to First Profile");
     ADD_PROPERTY_TYPE(MaxDegree, (5), "Loft", App::Prop_None, "Maximum B-Spline degree");
@@ -110,6 +118,43 @@ Loft::Loft()
     LoftType.setEnums(LoftTypeEnums);
     Parametrization.setEnums(ParametrizationEnums);
     Continuity.setEnums(ContinuityEnums);
+    synchronizingLoftType = false;
+}
+
+void Loft::onChanged(const App::Property* prop)
+{
+    if (!isRestoring() && !synchronizingLoftType) {
+        if (prop == &Ruled) {
+            Base::Console().warning(
+                "The 'Ruled' property of PartDesign lofts is deprecated; use "
+                "LoftType = 'Ruled Surface' or 'Standard B-Spline' instead.\n"
+            );
+            synchronizingLoftType = true;
+            LoftType.setValue(Ruled.getValue() ? 2 : 1);
+            synchronizingLoftType = false;
+        }
+        else if (prop == &LoftType) {
+            synchronizingLoftType = true;
+            Ruled.setValue(LoftType.getValue() == 2);
+            synchronizingLoftType = false;
+        }
+    }
+
+    ProfileBased::onChanged(prop);
+}
+
+void Loft::onDocumentRestored()
+{
+    // LoftType defaults to Standard B-Spline while restoring old documents that do not contain
+    // the new property. Preserve the old Ruled=true setting when present.
+    synchronizingLoftType = true;
+    if (Ruled.getValue()) {
+        LoftType.setValue(2);
+    }
+    Ruled.setValue(LoftType.getValue() == 2);
+    synchronizingLoftType = false;
+
+    ProfileBased::onDocumentRestored();
 }
 
 short Loft::mustExecute() const

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -24,6 +24,7 @@
 
 #include <BRepBuilderAPI_Sewing.hxx>
 #include <BRepClass3d_SolidClassifier.hxx>
+#include <Geom_BSplineSurface.hxx>
 #include <TopoDS.hxx>
 #include <Precision.hxx>
 
@@ -42,6 +43,14 @@ using namespace PartDesign;
 
 PROPERTY_SOURCE(PartDesign::Loft, PartDesign::ProfileBased)
 
+App::PropertyIntegerConstraint::Constraints Loft::Degrees = {
+    2,
+    Geom_BSplineSurface::MaxDegree(),
+    1
+};
+const char* Loft::ParametrizationEnums[] = {"Chord length", "Centripetal", "Uniform", nullptr};
+const char* Loft::ContinuityEnums[] = {"C0", "C1", "C2", nullptr};
+
 Loft::Loft()
 {
     ADD_PROPERTY_TYPE(Sections, (nullptr), "Loft", App::Prop_None, "List of sections");
@@ -49,6 +58,25 @@ Loft::Loft()
     ADD_PROPERTY_TYPE(Ruled, (false), "Loft", App::Prop_None, "Create ruled surface");
     ADD_PROPERTY_TYPE(Smoothing, (false), "Loft", App::Prop_None, "Use variational smoothing");
     ADD_PROPERTY_TYPE(Closed, (false), "Loft", App::Prop_None, "Close Last to First Profile");
+    ADD_PROPERTY_TYPE(MaxDegree, (5), "Loft", App::Prop_None, "Maximum B-Spline degree");
+    ADD_PROPERTY_TYPE(
+        Parametrization,
+        (long(0)),
+        "Loft",
+        App::Prop_None,
+        "B-Spline parametrization type"
+    );
+    ADD_PROPERTY_TYPE(Continuity, (long(2)), "Loft", App::Prop_None, "B-Spline continuity");
+    ADD_PROPERTY_TYPE(
+        CheckCompatibility,
+        (true),
+        "Loft",
+        App::Prop_None,
+        "Align profile origins, orientations, and edge counts"
+    );
+    MaxDegree.setConstraints(&Degrees);
+    Parametrization.setEnums(ParametrizationEnums);
+    Continuity.setEnums(ContinuityEnums);
 }
 
 short Loft::mustExecute() const
@@ -63,6 +91,18 @@ short Loft::mustExecute() const
         return 1;
     }
     if (Closed.isTouched()) {
+        return 1;
+    }
+    if (MaxDegree.isTouched()) {
+        return 1;
+    }
+    if (Parametrization.isTouched()) {
+        return 1;
+    }
+    if (Continuity.isTouched()) {
+        return 1;
+    }
+    if (CheckCompatibility.isTouched()) {
         return 1;
     }
 
@@ -227,14 +267,23 @@ App::DocumentObjectExecReturn* Loft::execute()
             for (auto& wire : sectionWires) {
                 wire.move(invObjLoc);
             }
+            Part::Smoothing smoothing = Part::Smoothing::bspline;
+            if (Ruled.getValue()) {
+                smoothing = Part::Smoothing::ruled;
+            }
+            else if (Smoothing.getValue()) {
+                smoothing = Part::Smoothing::variational;
+            }
             shells.push_back(TopoShape(0, hasher).makeElementLoft(
                 sectionWires,
                 Part::IsSolid::notSolid,
-                Ruled.getValue() ? Part::IsRuled::ruled : Part::IsRuled::notRuled,
+                smoothing,
                 closed ? Part::IsClosed::closed : Part::IsClosed::notClosed,
-                5, // maxdegree Note: maybe add this as an option in the data tab at some point?
+                MaxDegree.getValue(),
                 nullptr,
-                Smoothing.getValue() ? Part::IsSmoothing::smoothing : Part::IsSmoothing::noSmoothing
+                static_cast<Part::LoftParametrization>(Parametrization.getValue()),
+                static_cast<Part::LoftContinuity>(Continuity.getValue()),
+                CheckCompatibility.getValue()
             ));
         }
 

--- a/src/Mod/PartDesign/App/FeatureLoft.h
+++ b/src/Mod/PartDesign/App/FeatureLoft.h
@@ -36,7 +36,8 @@ class PartDesignExport Loft: public ProfileBased
 
 public:
     Loft();
-
+    // corresponds to OCCT BRepOffsetAPI_ThruSections API
+    // https://dev.opencascade.org/doc/refman/html/class_b_rep_offset_a_p_i___thru_sections.html#aefa57318229ddb92b2240eb5f85d9c18
     App::PropertyLinkSubList Sections;
     App::PropertyEnumeration LoftType;
     App::PropertyBool Closed;
@@ -44,6 +45,8 @@ public:
     App::PropertyEnumeration Parametrization;
     App::PropertyEnumeration Continuity;
     App::PropertyBool CheckCompatibility;
+    // Note: Add properties for variational solver (e.g., solver weights) for completeness
+
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/PartDesign/App/FeatureLoft.h
+++ b/src/Mod/PartDesign/App/FeatureLoft.h
@@ -37,6 +37,7 @@ class PartDesignExport Loft: public ProfileBased
 public:
     Loft();
     // Loft controls mirror the corresponding BRepOffsetAPI_ThruSections configuration.
+    // See: https://dev.opencascade.org/doc/refman/html/class_b_rep_offset_a_p_i___thru_sections.html
     App::PropertyLinkSubList Sections;
     App::PropertyEnumeration LoftType;
     App::PropertyBool Ruled;
@@ -45,6 +46,7 @@ public:
     App::PropertyEnumeration Parametrization;
     App::PropertyEnumeration Continuity;
     App::PropertyBool CheckCompatibility;
+    App::PropertyBool Adaptive;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/PartDesign/App/FeatureLoft.h
+++ b/src/Mod/PartDesign/App/FeatureLoft.h
@@ -40,6 +40,7 @@ public:
     // https://dev.opencascade.org/doc/refman/html/class_b_rep_offset_a_p_i___thru_sections.html#aefa57318229ddb92b2240eb5f85d9c18
     App::PropertyLinkSubList Sections;
     App::PropertyEnumeration LoftType;
+    App::PropertyBool Ruled;
     App::PropertyBool Closed;
     App::PropertyIntegerConstraint MaxDegree;
     App::PropertyEnumeration Parametrization;
@@ -67,6 +68,9 @@ public:
     );
 
 protected:
+    void onChanged(const App::Property* prop) override;
+    void onDocumentRestored() override;
+
     // handle changed property
     void handleChangedPropertyType(
         Base::XMLReader& reader,
@@ -79,6 +83,7 @@ private:
     static const char* LoftTypeEnums[];
     static const char* ParametrizationEnums[];
     static const char* ContinuityEnums[];
+    bool synchronizingLoftType = true;
 
     // static const char* TypeEnums[];
     // static const char* SideEnums[];

--- a/src/Mod/PartDesign/App/FeatureLoft.h
+++ b/src/Mod/PartDesign/App/FeatureLoft.h
@@ -39,6 +39,7 @@ public:
 
     App::PropertyLinkSubList Sections;
     App::PropertyBool Ruled;
+    App::PropertyBool Smoothing;
     App::PropertyBool Closed;
 
     /** @name methods override feature */

--- a/src/Mod/PartDesign/App/FeatureLoft.h
+++ b/src/Mod/PartDesign/App/FeatureLoft.h
@@ -41,6 +41,10 @@ public:
     App::PropertyBool Ruled;
     App::PropertyBool Smoothing;
     App::PropertyBool Closed;
+    App::PropertyIntegerConstraint MaxDegree;
+    App::PropertyEnumeration Parametrization;
+    App::PropertyEnumeration Continuity;
+    App::PropertyBool CheckCompatibility;
 
     /** @name methods override feature */
     //@{
@@ -69,6 +73,10 @@ protected:
     ) override;
 
 private:
+    static App::PropertyIntegerConstraint::Constraints Degrees;
+    static const char* ParametrizationEnums[];
+    static const char* ContinuityEnums[];
+
     // static const char* TypeEnums[];
     // static const char* SideEnums[];
 };

--- a/src/Mod/PartDesign/App/FeatureLoft.h
+++ b/src/Mod/PartDesign/App/FeatureLoft.h
@@ -36,8 +36,7 @@ class PartDesignExport Loft: public ProfileBased
 
 public:
     Loft();
-    // corresponds to OCCT BRepOffsetAPI_ThruSections API
-    // https://dev.opencascade.org/doc/refman/html/class_b_rep_offset_a_p_i___thru_sections.html#aefa57318229ddb92b2240eb5f85d9c18
+    // Loft controls mirror the corresponding BRepOffsetAPI_ThruSections configuration.
     App::PropertyLinkSubList Sections;
     App::PropertyEnumeration LoftType;
     App::PropertyBool Ruled;
@@ -46,8 +45,6 @@ public:
     App::PropertyEnumeration Parametrization;
     App::PropertyEnumeration Continuity;
     App::PropertyBool CheckCompatibility;
-    // Note: Add properties for variational solver (e.g., solver weights) for completeness
-
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/PartDesign/App/FeatureLoft.h
+++ b/src/Mod/PartDesign/App/FeatureLoft.h
@@ -38,8 +38,7 @@ public:
     Loft();
 
     App::PropertyLinkSubList Sections;
-    App::PropertyBool Ruled;
-    App::PropertyBool Smoothing;
+    App::PropertyEnumeration LoftType;
     App::PropertyBool Closed;
     App::PropertyIntegerConstraint MaxDegree;
     App::PropertyEnumeration Parametrization;
@@ -74,6 +73,7 @@ protected:
 
 private:
     static App::PropertyIntegerConstraint::Constraints Degrees;
+    static const char* LoftTypeEnums[];
     static const char* ParametrizationEnums[];
     static const char* ContinuityEnums[];
 

--- a/src/Mod/PartDesign/Gui/CMakeLists.txt
+++ b/src/Mod/PartDesign/Gui/CMakeLists.txt
@@ -49,6 +49,7 @@ set(PartDesignGui_UIC_SRCS
     TaskPipeOrientation.ui
     TaskPipeScaling.ui
     TaskLoftParameters.ui
+    TaskLoftAdvancedParameters.ui
     DlgReference.ui
     DlgActiveBody.ui
     TaskHelixParameters.ui
@@ -192,6 +193,7 @@ SET(PartDesignGuiTaskDlgs_SRCS
     TaskPipeParameters.h
     TaskPipeParameters.cpp
     TaskLoftParameters.ui
+    TaskLoftAdvancedParameters.ui
     TaskLoftParameters.h
     TaskLoftParameters.cpp
     TaskHelixParameters.ui

--- a/src/Mod/PartDesign/Gui/TaskLoftAdvancedParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLoftAdvancedParameters.ui
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PartDesignGui::TaskLoftAdvancedParameters</class>
+ <widget class="QWidget" name="PartDesignGui::TaskLoftAdvancedParameters">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>262</width>
+    <height>150</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayoutApproximation">
+   <item row="0" column="0">
+    <widget class="QLabel" name="labelMaxDegree">
+     <property name="text">
+      <string>Maximum degree</string>
+     </property>
+     <property name="buddy">
+      <cstring>spinBoxMaxDegree</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QSpinBox" name="spinBoxMaxDegree">
+     <property name="toolTip">
+      <string>Maximum polynomial degree of the generated B-Spline surface</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="labelParametrization">
+     <property name="text">
+      <string>Parametrization</string>
+     </property>
+     <property name="buddy">
+      <cstring>comboBoxParametrization</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="comboBoxParametrization">
+     <property name="toolTip">
+      <string>Distribution of parameters between loft profiles</string>
+     </property>
+     <item>
+      <property name="text">
+       <string>Chord length</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Centripetal</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Uniform</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="labelContinuity">
+     <property name="text">
+      <string>Continuity</string>
+     </property>
+     <property name="buddy">
+      <cstring>comboBoxContinuity</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="comboBoxContinuity">
+     <property name="toolTip">
+      <string>Requested continuity of the generated B-Spline surface</string>
+     </property>
+     <item>
+      <property name="text">
+       <string>C0</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>C1</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>C2</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QCheckBox" name="checkBoxCompatibility">
+     <property name="toolTip">
+      <string>Align profile origins, traversal directions, and edge counts before lofting</string>
+     </property>
+     <property name="text">
+      <string>Check profile compatibility</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>spinBoxMaxDegree</tabstop>
+  <tabstop>comboBoxParametrization</tabstop>
+  <tabstop>comboBoxContinuity</tabstop>
+  <tabstop>checkBoxCompatibility</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/PartDesign/Gui/TaskLoftAdvancedParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLoftAdvancedParameters.ui
@@ -16,6 +16,9 @@
   <layout class="QGridLayout" name="gridLayoutApproximation">
    <item row="0" column="0">
     <widget class="QLabel" name="labelMaxDegree">
+     <property name="toolTip">
+      <string>Maximum polynomial degree of the generated B-Spline surface</string>
+     </property>
      <property name="text">
       <string>Maximum degree</string>
      </property>
@@ -33,6 +36,9 @@
    </item>
    <item row="1" column="0">
     <widget class="QLabel" name="labelParametrization">
+     <property name="toolTip">
+      <string>Distribution of parameters between loft profiles</string>
+     </property>
      <property name="text">
       <string>Parametrization</string>
      </property>
@@ -44,7 +50,11 @@
    <item row="1" column="1">
     <widget class="QComboBox" name="comboBoxParametrization">
      <property name="toolTip">
-      <string>Distribution of parameters between loft profiles</string>
+      <string>Select a parametrization for the loft surface:
+            Chord Length: parameters of points proportionate to distances between them
+            Centripetal: parameters of points proportionate to square roots of distances between them
+            Uniform: parameters of points distributed uniformly
+      </string>
      </property>
      <item>
       <property name="text">
@@ -65,6 +75,9 @@
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="labelContinuity">
+     <property name="toolTip">
+      <string>Requested continuity of the generated B-Spline surface</string>
+     </property>
      <property name="text">
       <string>Continuity</string>
      </property>

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -38,6 +38,7 @@
 #include <Mod/PartDesign/App/FeatureLoft.h>
 
 #include "ui_TaskLoftParameters.h"
+#include "ui_TaskLoftAdvancedParameters.h"
 #include "TaskLoftParameters.h"
 #include "TaskSketchBasedParameters.h"
 
@@ -66,6 +67,13 @@ QString loftTaskTitle(ViewProviderLoft* view)
     return isSubtractiveLoft(view) ? TaskLoftParameters::tr("Subtractive Loft Parameters")
                                    : TaskLoftParameters::tr("Additive Loft Parameters");
 }
+
+QString loftAdvancedTaskTitle(ViewProviderLoft* view)
+{
+    return isSubtractiveLoft(view)
+        ? TaskLoftAdvancedParameters::tr("Subtractive Loft Advanced Parameters")
+        : TaskLoftAdvancedParameters::tr("Additive Loft Advanced Parameters");
+}
 }  // namespace
 
 TaskLoftParameters::TaskLoftParameters(ViewProviderLoft* LoftView, bool /*newObj*/, QWidget* parent)
@@ -86,18 +94,12 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft* LoftView, bool /*newObj
             this, &TaskLoftParameters::onRefButtonRemove);
     connect(ui->comboBoxMode, qOverload<int>(&QComboBox::currentIndexChanged),
             this, &TaskLoftParameters::onModeChanged);
-    connect(ui->spinBoxMaxDegree, qOverload<int>(&QSpinBox::valueChanged),
-            this, &TaskLoftParameters::onMaxDegreeChanged);
-    connect(ui->comboBoxParametrization, qOverload<int>(&QComboBox::currentIndexChanged),
-            this, &TaskLoftParameters::onParametrizationChanged);
-    connect(ui->comboBoxContinuity, qOverload<int>(&QComboBox::currentIndexChanged),
-            this, &TaskLoftParameters::onContinuityChanged);
-    connect(ui->checkBoxCompatibility, &QCheckBox::toggled,
-            this, &TaskLoftParameters::onCheckCompatibility);
     connect(ui->checkBoxClosed, &QCheckBox::toggled,
             this, &TaskLoftParameters::onClosed);
     connect(ui->checkBoxUpdateView, &QCheckBox::toggled,
             this, &TaskLoftParameters::onUpdateView);
+    connect(ui->checkBoxUpdateView, &QCheckBox::toggled,
+            this, &TaskLoftParameters::updateViewChanged);
     // clang-format on
 
     // Create context menu
@@ -150,17 +152,6 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft* LoftView, bool /*newObj
     // get options
     const int mode = loft->LoftType.getValue();
     ui->comboBoxMode->setCurrentIndex(mode);
-    const auto* degreeConstraints = loft->MaxDegree.getConstraints();
-    ui->spinBoxMaxDegree->setRange(
-        degreeConstraints->LowerBound,
-        degreeConstraints->UpperBound
-    );
-    ui->spinBoxMaxDegree->setSingleStep(degreeConstraints->StepSize);
-    ui->spinBoxMaxDegree->setValue(loft->MaxDegree.getValue());
-    ui->comboBoxParametrization->setCurrentIndex(loft->Parametrization.getValue());
-    ui->comboBoxContinuity->setCurrentIndex(loft->Continuity.getValue());
-    ui->checkBoxCompatibility->setChecked(loft->CheckCompatibility.getValue());
-    updateAlgorithmOptions(mode);
     ui->checkBoxClosed->setChecked(loft->Closed.getValue());
 
     // activate and de-activate dialog elements as appropriate
@@ -173,6 +164,64 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft* LoftView, bool /*newObj
 
 TaskLoftParameters::~TaskLoftParameters() = default;
 
+TaskLoftAdvancedParameters::TaskLoftAdvancedParameters(
+    ViewProviderLoft* LoftView,
+    bool /*newObj*/,
+    QWidget* parent
+)
+    : TaskSketchBasedParameters(
+        LoftView,
+        parent,
+        loftTaskIconName(LoftView),
+        loftAdvancedTaskTitle(LoftView)
+    )
+    , ui(new Ui_TaskLoftAdvancedParameters)
+{
+    proxy = new QWidget(this);
+    ui->setupUi(proxy);
+    QMetaObject::connectSlotsByName(this);
+
+    // clang-format off
+    connect(ui->spinBoxMaxDegree, qOverload<int>(&QSpinBox::valueChanged),
+            this, &TaskLoftAdvancedParameters::onMaxDegreeChanged);
+    connect(ui->comboBoxParametrization, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, &TaskLoftAdvancedParameters::onParametrizationChanged);
+    connect(ui->comboBoxContinuity, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, &TaskLoftAdvancedParameters::onContinuityChanged);
+    connect(ui->checkBoxCompatibility, &QCheckBox::toggled,
+            this, &TaskLoftAdvancedParameters::onCheckCompatibility);
+    // clang-format on
+
+    groupLayout()->addWidget(proxy);
+
+    const auto children = proxy->findChildren<QWidget*>();
+    for (QWidget* child : children) {
+        child->blockSignals(true);
+    }
+
+    auto* loft = LoftView->getObject<PartDesign::Loft>();
+    const auto* degreeConstraints = loft->MaxDegree.getConstraints();
+    ui->spinBoxMaxDegree->setRange(
+        degreeConstraints->LowerBound,
+        degreeConstraints->UpperBound
+    );
+    ui->spinBoxMaxDegree->setSingleStep(degreeConstraints->StepSize);
+    ui->spinBoxMaxDegree->setValue(loft->MaxDegree.getValue());
+    ui->comboBoxParametrization->setCurrentIndex(loft->Parametrization.getValue());
+    ui->comboBoxContinuity->setCurrentIndex(loft->Continuity.getValue());
+    ui->checkBoxCompatibility->setChecked(loft->CheckCompatibility.getValue());
+    updateAlgorithmOptions(loft->LoftType.getValue());
+
+    for (QWidget* child : children) {
+        child->blockSignals(false);
+    }
+}
+
+TaskLoftAdvancedParameters::~TaskLoftAdvancedParameters() = default;
+
+void TaskLoftAdvancedParameters::onSelectionChanged(const Gui::SelectionChanges&)
+{}
+
 void TaskLoftParameters::updateUI()
 {
     // we must assure the changed loft is kept visible on section changes,
@@ -184,7 +233,7 @@ void TaskLoftParameters::updateUI()
     }
 }
 
-void TaskLoftParameters::updateAlgorithmOptions(int mode)
+void TaskLoftAdvancedParameters::updateAlgorithmOptions(int mode)
 {
     const bool usesApproximation = mode != 2;
     const bool usesParametrization = mode <= 1;
@@ -194,6 +243,11 @@ void TaskLoftParameters::updateAlgorithmOptions(int mode)
     ui->labelContinuity->setEnabled(usesApproximation);
     ui->comboBoxParametrization->setEnabled(usesParametrization);
     ui->labelParametrization->setEnabled(usesParametrization);
+}
+
+void TaskLoftAdvancedParameters::setUpdateView(bool enabled)
+{
+    onUpdateView(enabled);
 }
 
 void TaskLoftParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
@@ -389,12 +443,12 @@ void TaskLoftParameters::onModeChanged(int index)
 {
     if (auto loft = getObject<PartDesign::Loft>()) {
         loft->LoftType.setValue(index);
-        updateAlgorithmOptions(index);
+        Q_EMIT algorithmChanged(index);
         recomputeFeature();
     }
 }
 
-void TaskLoftParameters::onMaxDegreeChanged(int value)
+void TaskLoftAdvancedParameters::onMaxDegreeChanged(int value)
 {
     if (auto loft = getObject<PartDesign::Loft>()) {
         loft->MaxDegree.setValue(value);
@@ -402,7 +456,7 @@ void TaskLoftParameters::onMaxDegreeChanged(int value)
     }
 }
 
-void TaskLoftParameters::onParametrizationChanged(int index)
+void TaskLoftAdvancedParameters::onParametrizationChanged(int index)
 {
     if (auto loft = getObject<PartDesign::Loft>()) {
         loft->Parametrization.setValue(index);
@@ -410,7 +464,7 @@ void TaskLoftParameters::onParametrizationChanged(int index)
     }
 }
 
-void TaskLoftParameters::onContinuityChanged(int index)
+void TaskLoftAdvancedParameters::onContinuityChanged(int index)
 {
     if (auto loft = getObject<PartDesign::Loft>()) {
         loft->Continuity.setValue(index);
@@ -418,7 +472,7 @@ void TaskLoftParameters::onContinuityChanged(int index)
     }
 }
 
-void TaskLoftParameters::onCheckCompatibility(bool enabled)
+void TaskLoftAdvancedParameters::onCheckCompatibility(bool enabled)
 {
     if (auto loft = getObject<PartDesign::Loft>()) {
         loft->CheckCompatibility.setValue(enabled);
@@ -469,8 +523,23 @@ TaskDlgLoftParameters::TaskDlgLoftParameters(ViewProviderLoft* LoftView, bool ne
 {
     assert(LoftView);
     parameter = new TaskLoftParameters(LoftView, newObj);
+    advanced = new TaskLoftAdvancedParameters(LoftView, newObj);
+
+    connect(
+        parameter,
+        &TaskLoftParameters::algorithmChanged,
+        advanced,
+        &TaskLoftAdvancedParameters::updateAlgorithmOptions
+    );
+    connect(
+        parameter,
+        &TaskLoftParameters::updateViewChanged,
+        advanced,
+        &TaskLoftAdvancedParameters::setUpdateView
+    );
 
     Content.push_back(parameter);
+    Content.push_back(advanced);
     Content.push_back(preview);
 }
 

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -148,13 +148,7 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft* LoftView, bool /*newObj
     }
 
     // get options
-    int mode = 0;
-    if (loft->Ruled.getValue()) {
-        mode = 1;
-    }
-    else if (loft->Smoothing.getValue()) {
-        mode = 2;
-    }
+    const int mode = loft->LoftType.getValue();
     ui->comboBoxMode->setCurrentIndex(mode);
     const auto* degreeConstraints = loft->MaxDegree.getConstraints();
     ui->spinBoxMaxDegree->setRange(
@@ -192,8 +186,8 @@ void TaskLoftParameters::updateUI()
 
 void TaskLoftParameters::updateAlgorithmOptions(int mode)
 {
-    const bool usesApproximation = mode != 1;
-    const bool usesParametrization = mode == 0;
+    const bool usesApproximation = mode != 2;
+    const bool usesParametrization = mode <= 1;
     ui->spinBoxMaxDegree->setEnabled(usesApproximation);
     ui->labelMaxDegree->setEnabled(usesApproximation);
     ui->comboBoxContinuity->setEnabled(usesApproximation);
@@ -394,8 +388,7 @@ void TaskLoftParameters::onClosed(bool val)
 void TaskLoftParameters::onModeChanged(int index)
 {
     if (auto loft = getObject<PartDesign::Loft>()) {
-        loft->Ruled.setValue(index == 1);
-        loft->Smoothing.setValue(index == 2);
+        loft->LoftType.setValue(index);
         updateAlgorithmOptions(index);
         recomputeFeature();
     }

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -235,9 +235,8 @@ void TaskLoftParameters::updateUI()
 
 void TaskLoftAdvancedParameters::updateAlgorithmOptions(int mode)
 {
-    // Auto chooses the solver and its parameters, so exposing editable values would imply that
-    // they constrain the automatic fallback sequence.  Explicit methods expose only the options
-    // that OCCT uses for that method (mode 1 is Standard B-Spline; mode 2 is Ruled Surface).
+    // Auto chooses the solver and its parameters starting with the default and progressively
+    // falling back to the next available option if the current one fails.
     const bool automatic = mode == 0;
     const bool usesApproximation = !automatic && mode != 2;
     const bool usesParametrization = mode == 1;

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -96,6 +96,8 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft* LoftView, bool /*newObj
             this, &TaskLoftParameters::onModeChanged);
     connect(ui->checkBoxClosed, &QCheckBox::toggled,
             this, &TaskLoftParameters::onClosed);
+    connect(ui->checkBoxAdaptive, &QCheckBox::toggled,
+            this, &TaskLoftParameters::onAdaptive);
     connect(ui->checkBoxUpdateView, &QCheckBox::toggled,
             this, &TaskLoftParameters::onUpdateView);
     connect(ui->checkBoxUpdateView, &QCheckBox::toggled,
@@ -153,6 +155,7 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft* LoftView, bool /*newObj
     const int mode = loft->LoftType.getValue();
     ui->comboBoxMode->setCurrentIndex(mode);
     ui->checkBoxClosed->setChecked(loft->Closed.getValue());
+    ui->checkBoxAdaptive->setChecked(loft->Adaptive.getValue());
 
     // activate and de-activate dialog elements as appropriate
     for (QWidget* child : childs) {
@@ -215,6 +218,10 @@ TaskLoftAdvancedParameters::TaskLoftAdvancedParameters(
     for (QWidget* child : children) {
         child->blockSignals(false);
     }
+
+    // if (!isSubtractiveLoft(LoftView)) {
+    hideGroupBox();
+     // }
 }
 
 TaskLoftAdvancedParameters::~TaskLoftAdvancedParameters() = default;
@@ -437,6 +444,14 @@ void TaskLoftParameters::onClosed(bool val)
 {
     if (auto loft = getObject<PartDesign::Loft>()) {
         loft->Closed.setValue(val);
+        recomputeFeature();
+    }
+}
+
+void TaskLoftParameters::onAdaptive(bool enabled)
+{
+    if (auto loft = getObject<PartDesign::Loft>()) {
+        loft->Adaptive.setValue(enabled);
         recomputeFeature();
     }
 }

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -84,6 +84,10 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft* LoftView, bool /*newObj
             this, &TaskLoftParameters::onRefButtonRemove);
     connect(ui->checkBoxRuled, &QCheckBox::toggled,
             this, &TaskLoftParameters::onRuled);
+    connect(ui->checkBoxRuled, &QCheckBox::toggled,
+            ui->checkBoxSmoothing, &QWidget::setDisabled);
+    connect(ui->checkBoxSmoothing, &QCheckBox::toggled,
+            this, &TaskLoftParameters::onSmoothing);
     connect(ui->checkBoxClosed, &QCheckBox::toggled,
             this, &TaskLoftParameters::onClosed);
     connect(ui->checkBoxUpdateView, &QCheckBox::toggled,
@@ -139,6 +143,8 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft* LoftView, bool /*newObj
 
     // get options
     ui->checkBoxRuled->setChecked(loft->Ruled.getValue());
+    ui->checkBoxSmoothing->setChecked(loft->Smoothing.getValue());
+    ui->checkBoxSmoothing->setEnabled(!loft->Ruled.getValue());
     ui->checkBoxClosed->setChecked(loft->Closed.getValue());
 
     // activate and de-activate dialog elements as appropriate
@@ -355,6 +361,14 @@ void TaskLoftParameters::onRuled(bool val)
 {
     if (auto loft = getObject<PartDesign::Loft>()) {
         loft->Ruled.setValue(val);
+        recomputeFeature();
+    }
+}
+
+void TaskLoftParameters::onSmoothing(bool val)
+{
+    if (auto loft = getObject<PartDesign::Loft>()) {
+        loft->Smoothing.setValue(val);
         recomputeFeature();
     }
 }

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -235,14 +235,34 @@ void TaskLoftParameters::updateUI()
 
 void TaskLoftAdvancedParameters::updateAlgorithmOptions(int mode)
 {
-    const bool usesApproximation = mode != 2;
-    const bool usesParametrization = mode <= 1;
+    // Auto chooses the solver and its parameters, so exposing editable values would imply that
+    // they constrain the automatic fallback sequence.  Explicit methods expose only the options
+    // that OCCT uses for that method (mode 1 is Standard B-Spline; mode 2 is Ruled Surface).
+    const bool automatic = mode == 0;
+    const bool usesApproximation = !automatic && mode != 2;
+    const bool usesParametrization = mode == 1;
     ui->spinBoxMaxDegree->setEnabled(usesApproximation);
     ui->labelMaxDegree->setEnabled(usesApproximation);
     ui->comboBoxContinuity->setEnabled(usesApproximation);
     ui->labelContinuity->setEnabled(usesApproximation);
     ui->comboBoxParametrization->setEnabled(usesParametrization);
     ui->labelParametrization->setEnabled(usesParametrization);
+    ui->checkBoxCompatibility->setEnabled(!automatic);
+
+    // Remember whether Auto performed the collapse.  This lets an explicit method restore the
+    // panel without overriding a collapse the user performed manually.
+    if (automatic) {
+        if (isGroupVisible()) {
+            hideGroupBox();
+            collapsedForAuto = true;
+        }
+    }
+    else {
+        if (collapsedForAuto && !isGroupVisible()) {
+            showHide();
+        }
+        collapsedForAuto = false;
+    }
 }
 
 void TaskLoftAdvancedParameters::setUpdateView(bool enabled)

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -235,33 +235,16 @@ void TaskLoftParameters::updateUI()
 
 void TaskLoftAdvancedParameters::updateAlgorithmOptions(int mode)
 {
-    // Show advanced parameters if the user chooses an option other than "automatic"
-    const bool automatic = mode == 0;
-    const bool usesApproximation = !automatic && mode != 2;
-    // some methods allow a paramaterization to be set (e.g., standard b-spline)
-    // other do not (e.g., variational solver), so these fields should not be editable
-    const bool usesParametrization = mode == 1;
+    // Ruled lofts bypass approximation; only the standard solver accepts parametrization.
+    const bool usesApproximation = mode != 1;
+    const bool usesParametrization = mode == 0;
     ui->spinBoxMaxDegree->setEnabled(usesApproximation);
     ui->labelMaxDegree->setEnabled(usesApproximation);
     ui->comboBoxContinuity->setEnabled(usesApproximation);
     ui->labelContinuity->setEnabled(usesApproximation);
     ui->comboBoxParametrization->setEnabled(usesParametrization);
     ui->labelParametrization->setEnabled(usesParametrization);
-    ui->checkBoxCompatibility->setEnabled(!automatic);
-
-    // If the user opens the advanced parameters, then keep it open until they close it manually
-    if (automatic) {
-        if (isGroupVisible()) {
-            hideGroupBox();
-            collapsedForAuto = true;
-        }
-    }
-    else {
-        if (collapsedForAuto && !isGroupVisible()) {
-            showHide();
-        }
-        collapsedForAuto = false;
-    }
+    ui->checkBoxCompatibility->setEnabled(true);
 }
 
 void TaskLoftAdvancedParameters::setUpdateView(bool enabled)

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -173,11 +173,11 @@ TaskLoftAdvancedParameters::TaskLoftAdvancedParameters(
     QWidget* parent
 )
     : TaskSketchBasedParameters(
-        LoftView,
-        parent,
-        loftTaskIconName(LoftView),
-        loftAdvancedTaskTitle(LoftView)
-    )
+          LoftView,
+          parent,
+          loftTaskIconName(LoftView),
+          loftAdvancedTaskTitle(LoftView)
+      )
     , ui(new Ui_TaskLoftAdvancedParameters)
 {
     proxy = new QWidget(this);
@@ -204,10 +204,7 @@ TaskLoftAdvancedParameters::TaskLoftAdvancedParameters(
 
     auto* loft = LoftView->getObject<PartDesign::Loft>();
     const auto* degreeConstraints = loft->MaxDegree.getConstraints();
-    ui->spinBoxMaxDegree->setRange(
-        degreeConstraints->LowerBound,
-        degreeConstraints->UpperBound
-    );
+    ui->spinBoxMaxDegree->setRange(degreeConstraints->LowerBound, degreeConstraints->UpperBound);
     ui->spinBoxMaxDegree->setSingleStep(degreeConstraints->StepSize);
     ui->spinBoxMaxDegree->setValue(loft->MaxDegree.getValue());
     ui->comboBoxParametrization->setCurrentIndex(loft->Parametrization.getValue());
@@ -221,7 +218,7 @@ TaskLoftAdvancedParameters::TaskLoftAdvancedParameters(
 
     // if (!isSubtractiveLoft(LoftView)) {
     hideGroupBox();
-     // }
+    // }
 }
 
 TaskLoftAdvancedParameters::~TaskLoftAdvancedParameters() = default;

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -25,6 +25,7 @@
 
 #include <QAction>
 #include <QComboBox>
+#include <QSpinBox>
 
 
 #include <App/Application.h>
@@ -85,6 +86,14 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft* LoftView, bool /*newObj
             this, &TaskLoftParameters::onRefButtonRemove);
     connect(ui->comboBoxMode, qOverload<int>(&QComboBox::currentIndexChanged),
             this, &TaskLoftParameters::onModeChanged);
+    connect(ui->spinBoxMaxDegree, qOverload<int>(&QSpinBox::valueChanged),
+            this, &TaskLoftParameters::onMaxDegreeChanged);
+    connect(ui->comboBoxParametrization, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, &TaskLoftParameters::onParametrizationChanged);
+    connect(ui->comboBoxContinuity, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, &TaskLoftParameters::onContinuityChanged);
+    connect(ui->checkBoxCompatibility, &QCheckBox::toggled,
+            this, &TaskLoftParameters::onCheckCompatibility);
     connect(ui->checkBoxClosed, &QCheckBox::toggled,
             this, &TaskLoftParameters::onClosed);
     connect(ui->checkBoxUpdateView, &QCheckBox::toggled,
@@ -147,6 +156,17 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft* LoftView, bool /*newObj
         mode = 2;
     }
     ui->comboBoxMode->setCurrentIndex(mode);
+    const auto* degreeConstraints = loft->MaxDegree.getConstraints();
+    ui->spinBoxMaxDegree->setRange(
+        degreeConstraints->LowerBound,
+        degreeConstraints->UpperBound
+    );
+    ui->spinBoxMaxDegree->setSingleStep(degreeConstraints->StepSize);
+    ui->spinBoxMaxDegree->setValue(loft->MaxDegree.getValue());
+    ui->comboBoxParametrization->setCurrentIndex(loft->Parametrization.getValue());
+    ui->comboBoxContinuity->setCurrentIndex(loft->Continuity.getValue());
+    ui->checkBoxCompatibility->setChecked(loft->CheckCompatibility.getValue());
+    updateAlgorithmOptions(mode);
     ui->checkBoxClosed->setChecked(loft->Closed.getValue());
 
     // activate and de-activate dialog elements as appropriate
@@ -168,6 +188,18 @@ void TaskLoftParameters::updateUI()
         auto view = getViewObject();
         view->makeTemporaryVisible(!loft->Sections.getValues().empty());
     }
+}
+
+void TaskLoftParameters::updateAlgorithmOptions(int mode)
+{
+    const bool usesApproximation = mode != 1;
+    const bool usesParametrization = mode == 0;
+    ui->spinBoxMaxDegree->setEnabled(usesApproximation);
+    ui->labelMaxDegree->setEnabled(usesApproximation);
+    ui->comboBoxContinuity->setEnabled(usesApproximation);
+    ui->labelContinuity->setEnabled(usesApproximation);
+    ui->comboBoxParametrization->setEnabled(usesParametrization);
+    ui->labelParametrization->setEnabled(usesParametrization);
 }
 
 void TaskLoftParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
@@ -364,6 +396,39 @@ void TaskLoftParameters::onModeChanged(int index)
     if (auto loft = getObject<PartDesign::Loft>()) {
         loft->Ruled.setValue(index == 1);
         loft->Smoothing.setValue(index == 2);
+        updateAlgorithmOptions(index);
+        recomputeFeature();
+    }
+}
+
+void TaskLoftParameters::onMaxDegreeChanged(int value)
+{
+    if (auto loft = getObject<PartDesign::Loft>()) {
+        loft->MaxDegree.setValue(value);
+        recomputeFeature();
+    }
+}
+
+void TaskLoftParameters::onParametrizationChanged(int index)
+{
+    if (auto loft = getObject<PartDesign::Loft>()) {
+        loft->Parametrization.setValue(index);
+        recomputeFeature();
+    }
+}
+
+void TaskLoftParameters::onContinuityChanged(int index)
+{
+    if (auto loft = getObject<PartDesign::Loft>()) {
+        loft->Continuity.setValue(index);
+        recomputeFeature();
+    }
+}
+
+void TaskLoftParameters::onCheckCompatibility(bool enabled)
+{
+    if (auto loft = getObject<PartDesign::Loft>()) {
+        loft->CheckCompatibility.setValue(enabled);
         recomputeFeature();
     }
 }

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -235,10 +235,11 @@ void TaskLoftParameters::updateUI()
 
 void TaskLoftAdvancedParameters::updateAlgorithmOptions(int mode)
 {
-    // Auto chooses the solver and its parameters starting with the default and progressively
-    // falling back to the next available option if the current one fails.
+    // Show advanced parameters if the user chooses an option other than "automatic"
     const bool automatic = mode == 0;
     const bool usesApproximation = !automatic && mode != 2;
+    // some methods allow a paramaterization to be set (e.g., standard b-spline)
+    // other do not (e.g., variational solver), so these fields should not be editable
     const bool usesParametrization = mode == 1;
     ui->spinBoxMaxDegree->setEnabled(usesApproximation);
     ui->labelMaxDegree->setEnabled(usesApproximation);
@@ -248,8 +249,7 @@ void TaskLoftAdvancedParameters::updateAlgorithmOptions(int mode)
     ui->labelParametrization->setEnabled(usesParametrization);
     ui->checkBoxCompatibility->setEnabled(!automatic);
 
-    // Remember whether Auto performed the collapse.  This lets an explicit method restore the
-    // panel without overriding a collapse the user performed manually.
+    // If the user opens the advanced parameters, then keep it open until they close it manually
     if (automatic) {
         if (isGroupVisible()) {
             hideGroupBox();

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -24,6 +24,7 @@
 
 
 #include <QAction>
+#include <QComboBox>
 
 
 #include <App/Application.h>
@@ -82,12 +83,8 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft* LoftView, bool /*newObj
             this, &TaskLoftParameters::onRefButtonAdd);
     connect(ui->buttonRefRemove, &QToolButton::toggled,
             this, &TaskLoftParameters::onRefButtonRemove);
-    connect(ui->checkBoxRuled, &QCheckBox::toggled,
-            this, &TaskLoftParameters::onRuled);
-    connect(ui->checkBoxRuled, &QCheckBox::toggled,
-            ui->checkBoxSmoothing, &QWidget::setDisabled);
-    connect(ui->checkBoxSmoothing, &QCheckBox::toggled,
-            this, &TaskLoftParameters::onSmoothing);
+    connect(ui->comboBoxMode, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, &TaskLoftParameters::onModeChanged);
     connect(ui->checkBoxClosed, &QCheckBox::toggled,
             this, &TaskLoftParameters::onClosed);
     connect(ui->checkBoxUpdateView, &QCheckBox::toggled,
@@ -142,9 +139,14 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft* LoftView, bool /*newObj
     }
 
     // get options
-    ui->checkBoxRuled->setChecked(loft->Ruled.getValue());
-    ui->checkBoxSmoothing->setChecked(loft->Smoothing.getValue());
-    ui->checkBoxSmoothing->setEnabled(!loft->Ruled.getValue());
+    int mode = 0;
+    if (loft->Ruled.getValue()) {
+        mode = 1;
+    }
+    else if (loft->Smoothing.getValue()) {
+        mode = 2;
+    }
+    ui->comboBoxMode->setCurrentIndex(mode);
     ui->checkBoxClosed->setChecked(loft->Closed.getValue());
 
     // activate and de-activate dialog elements as appropriate
@@ -357,18 +359,11 @@ void TaskLoftParameters::onClosed(bool val)
     }
 }
 
-void TaskLoftParameters::onRuled(bool val)
+void TaskLoftParameters::onModeChanged(int index)
 {
     if (auto loft = getObject<PartDesign::Loft>()) {
-        loft->Ruled.setValue(val);
-        recomputeFeature();
-    }
-}
-
-void TaskLoftParameters::onSmoothing(bool val)
-{
-    if (auto loft = getObject<PartDesign::Loft>()) {
-        loft->Smoothing.setValue(val);
+        loft->Ruled.setValue(index == 1);
+        loft->Smoothing.setValue(index == 2);
         recomputeFeature();
     }
 }

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.h
@@ -62,8 +62,7 @@ private Q_SLOTS:
     void onRefButtonAdd(bool);
     void onRefButtonRemove(bool);
     void onClosed(bool);
-    void onRuled(bool);
-    void onSmoothing(bool);
+    void onModeChanged(int);
     void onDeleteSection();
     void indexesMoved();
 

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.h
@@ -125,6 +125,8 @@ private:
 
     QWidget* proxy;
     std::unique_ptr<Ui_TaskLoftAdvancedParameters> ui;
+    // Distinguishes an Auto-initiated collapse from the user's task-panel preference.
+    bool collapsedForAuto = false;
 };
 
 /// simulation dialog for the TaskView

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.h
@@ -67,6 +67,7 @@ private Q_SLOTS:
     void onRefButtonAdd(bool);
     void onRefButtonRemove(bool);
     void onClosed(bool);
+    void onAdaptive(bool);
     void onModeChanged(int);
     void onDeleteSection();
     void indexesMoved();

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.h
@@ -29,6 +29,7 @@
 
 
 class Ui_TaskLoftParameters;
+class Ui_TaskLoftAdvancedParameters;
 class QListWidget;
 
 namespace App
@@ -57,16 +58,16 @@ public:
     );
     ~TaskLoftParameters() override;
 
+Q_SIGNALS:
+    void algorithmChanged(int);
+    void updateViewChanged(bool);
+
 private Q_SLOTS:
     void onProfileButton(bool);
     void onRefButtonAdd(bool);
     void onRefButtonRemove(bool);
     void onClosed(bool);
     void onModeChanged(int);
-    void onMaxDegreeChanged(int);
-    void onParametrizationChanged(int);
-    void onContinuityChanged(int);
-    void onCheckCompatibility(bool);
     void onDeleteSection();
     void indexesMoved();
 
@@ -84,7 +85,6 @@ protected:
 private:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
     void updateUI();
-    void updateAlgorithmOptions(int mode);
     bool referenceSelected(const Gui::SelectionChanges& msg) const;
     void removeFromListWidget(QListWidget* w, QString name);
     void clearButtons(const selectionModes notThis = none);
@@ -96,6 +96,35 @@ private:
     std::unique_ptr<Ui_TaskLoftParameters> ui;
 
     selectionModes selectionMode = none;
+};
+
+class TaskLoftAdvancedParameters: public TaskSketchBasedParameters
+{
+    Q_OBJECT
+
+public:
+    explicit TaskLoftAdvancedParameters(
+        ViewProviderLoft* LoftView,
+        bool newObj = false,
+        QWidget* parent = nullptr
+    );
+    ~TaskLoftAdvancedParameters() override;
+
+public Q_SLOTS:
+    void updateAlgorithmOptions(int mode);
+    void setUpdateView(bool enabled);
+
+private Q_SLOTS:
+    void onMaxDegreeChanged(int);
+    void onParametrizationChanged(int);
+    void onContinuityChanged(int);
+    void onCheckCompatibility(bool);
+
+private:
+    void onSelectionChanged(const Gui::SelectionChanges&) override;
+
+    QWidget* proxy;
+    std::unique_ptr<Ui_TaskLoftAdvancedParameters> ui;
 };
 
 /// simulation dialog for the TaskView
@@ -112,6 +141,7 @@ public:
 
 protected:
     TaskLoftParameters* parameter;
+    TaskLoftAdvancedParameters* advanced;
 };
 
 }  // namespace PartDesignGui

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.h
@@ -63,6 +63,10 @@ private Q_SLOTS:
     void onRefButtonRemove(bool);
     void onClosed(bool);
     void onModeChanged(int);
+    void onMaxDegreeChanged(int);
+    void onParametrizationChanged(int);
+    void onContinuityChanged(int);
+    void onCheckCompatibility(bool);
     void onDeleteSection();
     void indexesMoved();
 
@@ -80,6 +84,7 @@ protected:
 private:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
     void updateUI();
+    void updateAlgorithmOptions(int mode);
     bool referenceSelected(const Gui::SelectionChanges& msg) const;
     void removeFromListWidget(QListWidget* w, QString name);
     void clearButtons(const selectionModes notThis = none);

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.h
@@ -125,8 +125,6 @@ private:
 
     QWidget* proxy;
     std::unique_ptr<Ui_TaskLoftAdvancedParameters> ui;
-    // Distinguishes an Auto-initiated collapse from the user's task-panel preference.
-    bool collapsedForAuto = false;
 };
 
 /// simulation dialog for the TaskView

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.h
@@ -63,6 +63,7 @@ private Q_SLOTS:
     void onRefButtonRemove(bool);
     void onClosed(bool);
     void onRuled(bool);
+    void onSmoothing(bool);
     void onDeleteSection();
     void indexesMoved();
 

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>262</width>
-    <height>293</height>
+    <height>320</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -42,10 +42,20 @@
    <item>
     <widget class="QCheckBox" name="checkBoxClosed">
      <property name="toolTip">
-       <string>Attempt to close the loft surface by joining the start and end profiles.</string>
+      <string>Attempt to close the loft surface by joining the start and end profiles</string>
      </property>
      <property name="text">
       <string>Closed</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBoxAdaptive">
+     <property name="toolTip">
+      <string>Allow FreeCAD to try different settings to build the loft if the selected settings fail.</string>
+     </property>
+     <property name="text">
+      <string>Adaptive</string>
      </property>
     </widget>
    </item>
@@ -150,6 +160,7 @@
  <tabstops>
   <tabstop>comboBoxMode</tabstop>
   <tabstop>checkBoxClosed</tabstop>
+  <tabstop>checkBoxAdaptive</tabstop>
   <tabstop>buttonProfileBase</tabstop>
   <tabstop>profileBaseEdit</tabstop>
   <tabstop>buttonRefAdd</tabstop>

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
@@ -17,22 +17,11 @@
    <item>
     <widget class="QComboBox" name="comboBoxMode">
      <property name="toolTip">
-      <string>
-          Select the type of surface loft to generate:
-          - Automatic: Starts with the standard method and retries other parameterizations or the
-            variational solver if necessary.
-          - Standard B-Spline: The standard loft generation method is used to form the loft surface.
-          - Ruled Surface: A ruled surface is formed by joining the profiles along a straight line.
-          - Variational B-Spline: An alternative loft generation method is used to form the loft surface.
-            This method can be more robust than the standard B-Spline method for some geometries,
-            but may create slightly different loft surfaces.
-      </string>
+      <string>Select the loft surface algorithm:
+- Standard B-Spline approximates a smooth surface through the profiles.
+- Ruled Surface joins adjacent profiles with straight-line surfaces.
+- Variational B-Spline uses an alternative solver that can succeed for some profiles.</string>
      </property>
-     <item>
-      <property name="text">
-       <string>Automatic</string>
-      </property>
-     </item>
      <item>
       <property name="text">
        <string>Standard B-Spline</string>

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
@@ -18,8 +18,7 @@
     <widget class="QComboBox" name="comboBoxMode">
      <property name="toolTip">
       <string>
-          Select the type of surface loft to generate.
-
+          Select the type of surface loft to generate:
           - Automatic: Starts with the standard method and retries other parameterizations or the
             variational solver if necessary.
           - Standard B-Spline: The standard loft generation method is used to form the loft surface.
@@ -54,7 +53,7 @@
    <item>
     <widget class="QCheckBox" name="checkBoxClosed">
      <property name="toolTip">
-       <string>Attempt to close the loft surface by joining the start and end profiles</string>
+       <string>Attempt to close the loft surface by joining the start and end profiles.</string>
      </property>
      <property name="text">
       <string>Closed</string>

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
@@ -15,24 +15,40 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="QCheckBox" name="checkBoxRuled">
-     <property name="text">
-      <string>Ruled surface</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="checkBoxSmoothing">
+    <widget class="QComboBox" name="comboBoxMode">
      <property name="toolTip">
-      <string>Use variational smoothing algorithm</string>
+      <string>
+          Select the type of surface loft to generate.
+
+          - Standard B-Spline: The default loft generation method is used to form the loft surface.
+          - Ruled Surface: A ruled surface is formed by joining the profiles along a straight line.
+          - Smoothed B-Spline: An alternative loft generation method is used to form the loft surface.
+            This method can be more robust than the standard B-Spline method for some geometries,
+          but may create slightly different loft surfaces.
+      </string>
      </property>
-     <property name="text">
-      <string>Variational smoothing</string>
-     </property>
+     <item>
+      <property name="text">
+       <string>Standard B-Spline</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Ruled Surface</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Smoothed B-Spline</string>
+      </property>
+     </item>
     </widget>
    </item>
    <item>
     <widget class="QCheckBox" name="checkBoxClosed">
+     <property name="toolTip">
+       <string>Attempt to close the loft surface by joining the start and end profiles</string>
+     </property>
      <property name="text">
       <string>Closed</string>
      </property>
@@ -137,8 +153,7 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>checkBoxRuled</tabstop>
-  <tabstop>checkBoxSmoothing</tabstop>
+  <tabstop>comboBoxMode</tabstop>
   <tabstop>checkBoxClosed</tabstop>
   <tabstop>buttonProfileBase</tabstop>
   <tabstop>profileBaseEdit</tabstop>

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
@@ -52,106 +52,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBoxApproximation">
-     <property name="title">
-      <string>Advanced parameters</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayoutApproximation">
-      <item row="0" column="0">
-       <widget class="QLabel" name="labelMaxDegree">
-        <property name="text">
-         <string>Maximum degree</string>
-        </property>
-        <property name="buddy">
-         <cstring>spinBoxMaxDegree</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QSpinBox" name="spinBoxMaxDegree">
-        <property name="toolTip">
-         <string>Maximum polynomial degree of the generated B-Spline surface</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="labelParametrization">
-        <property name="text">
-         <string>Parametrization</string>
-        </property>
-        <property name="buddy">
-         <cstring>comboBoxParametrization</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="comboBoxParametrization">
-        <property name="toolTip">
-         <string>Distribution of parameters between loft profiles</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Chord length</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Centripetal</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Uniform</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="labelContinuity">
-        <property name="text">
-         <string>Continuity</string>
-        </property>
-        <property name="buddy">
-         <cstring>comboBoxContinuity</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QComboBox" name="comboBoxContinuity">
-        <property name="toolTip">
-         <string>Requested continuity of the generated B-Spline surface</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>C0</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>C1</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>C2</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QCheckBox" name="checkBoxCompatibility">
-        <property name="toolTip">
-         <string>Align profile origins, traversal directions, and edge counts before lofting</string>
-        </property>
-        <property name="text">
-         <string>Check profile compatibility</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <widget class="QCheckBox" name="checkBoxClosed">
      <property name="toolTip">
        <string>Attempt to close the loft surface by joining the start and end profiles</string>
@@ -261,10 +161,6 @@
  </widget>
  <tabstops>
   <tabstop>comboBoxMode</tabstop>
-  <tabstop>spinBoxMaxDegree</tabstop>
-  <tabstop>comboBoxParametrization</tabstop>
-  <tabstop>comboBoxContinuity</tabstop>
-  <tabstop>checkBoxCompatibility</tabstop>
   <tabstop>checkBoxClosed</tabstop>
   <tabstop>buttonProfileBase</tabstop>
   <tabstop>profileBaseEdit</tabstop>

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
@@ -22,6 +22,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="checkBoxSmoothing">
+     <property name="toolTip">
+      <string>Use variational smoothing algorithm</string>
+     </property>
+     <property name="text">
+      <string>Variational smoothing</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="checkBoxClosed">
      <property name="text">
       <string>Closed</string>
@@ -128,6 +138,7 @@
  </widget>
  <tabstops>
   <tabstop>checkBoxRuled</tabstop>
+  <tabstop>checkBoxSmoothing</tabstop>
   <tabstop>checkBoxClosed</tabstop>
   <tabstop>buttonProfileBase</tabstop>
   <tabstop>profileBaseEdit</tabstop>

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
@@ -20,13 +20,20 @@
       <string>
           Select the type of surface loft to generate.
 
-          - Standard B-Spline: The default loft generation method is used to form the loft surface.
+          - Auto: Starts with the standard method and retries other parameterizations or the
+            variational solver if necessary.
+          - Standard B-Spline: The standard loft generation method is used to form the loft surface.
           - Ruled Surface: A ruled surface is formed by joining the profiles along a straight line.
-          - Smoothed B-Spline: An alternative loft generation method is used to form the loft surface.
+          - Variational B-Spline: An alternative loft generation method is used to form the loft surface.
             This method can be more robust than the standard B-Spline method for some geometries,
-          but may create slightly different loft surfaces.
+            but may create slightly different loft surfaces.
       </string>
      </property>
+     <item>
+      <property name="text">
+       <string>Auto</string>
+      </property>
+     </item>
      <item>
       <property name="text">
        <string>Standard B-Spline</string>
@@ -39,7 +46,7 @@
      </item>
      <item>
       <property name="text">
-       <string>Smoothed B-Spline</string>
+       <string>Variational B-Spline</string>
       </property>
      </item>
     </widget>

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
@@ -20,7 +20,7 @@
       <string>
           Select the type of surface loft to generate.
 
-          - Auto: Starts with the standard method and retries other parameterizations or the
+          - Automatic: Starts with the standard method and retries other parameterizations or the
             variational solver if necessary.
           - Standard B-Spline: The standard loft generation method is used to form the loft surface.
           - Ruled Surface: A ruled surface is formed by joining the profiles along a straight line.
@@ -31,7 +31,7 @@
      </property>
      <item>
       <property name="text">
-       <string>Auto</string>
+       <string>Automatic</string>
       </property>
      </item>
      <item>

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
@@ -45,6 +45,106 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBoxApproximation">
+     <property name="title">
+      <string>Advanced parameters</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayoutApproximation">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelMaxDegree">
+        <property name="text">
+         <string>Maximum degree</string>
+        </property>
+        <property name="buddy">
+         <cstring>spinBoxMaxDegree</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="spinBoxMaxDegree">
+        <property name="toolTip">
+         <string>Maximum polynomial degree of the generated B-Spline surface</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelParametrization">
+        <property name="text">
+         <string>Parametrization</string>
+        </property>
+        <property name="buddy">
+         <cstring>comboBoxParametrization</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="comboBoxParametrization">
+        <property name="toolTip">
+         <string>Distribution of parameters between loft profiles</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Chord length</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Centripetal</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Uniform</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelContinuity">
+        <property name="text">
+         <string>Continuity</string>
+        </property>
+        <property name="buddy">
+         <cstring>comboBoxContinuity</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="comboBoxContinuity">
+        <property name="toolTip">
+         <string>Requested continuity of the generated B-Spline surface</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>C0</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>C1</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>C2</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="checkBoxCompatibility">
+        <property name="toolTip">
+         <string>Align profile origins, traversal directions, and edge counts before lofting</string>
+        </property>
+        <property name="text">
+         <string>Check profile compatibility</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="checkBoxClosed">
      <property name="toolTip">
        <string>Attempt to close the loft surface by joining the start and end profiles</string>
@@ -154,6 +254,10 @@
  </widget>
  <tabstops>
   <tabstop>comboBoxMode</tabstop>
+  <tabstop>spinBoxMaxDegree</tabstop>
+  <tabstop>comboBoxParametrization</tabstop>
+  <tabstop>comboBoxContinuity</tabstop>
+  <tabstop>checkBoxCompatibility</tabstop>
   <tabstop>checkBoxClosed</tabstop>
   <tabstop>buttonProfileBase</tabstop>
   <tabstop>profileBaseEdit</tabstop>

--- a/src/Mod/PartDesign/PartDesignTests/TestLoft.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestLoft.py
@@ -68,10 +68,12 @@ class TestLoft(unittest.TestCase):
         self.assertEqual(self.AdditiveLoft.Parametrization, "Chord length")
         self.assertEqual(self.AdditiveLoft.Continuity, "C2")
         self.assertTrue(self.AdditiveLoft.CheckCompatibility)
+        self.assertTrue(self.AdditiveLoft.Adaptive)
         self.AdditiveLoft.MaxDegree = 3
         self.AdditiveLoft.Parametrization = "Uniform"
         self.AdditiveLoft.Continuity = "C1"
         self.AdditiveLoft.CheckCompatibility = False
+        self.AdditiveLoft.Adaptive = False
         self.AdditiveLoft.Profile = self.ProfileSketch
         self.AdditiveLoft.Sections = [self.LoftSketch]
         self.Doc.recompute()
@@ -79,6 +81,7 @@ class TestLoft(unittest.TestCase):
         self.assertEqual(self.AdditiveLoft.Parametrization, "Uniform")
         self.assertEqual(self.AdditiveLoft.Continuity, "C1")
         self.assertFalse(self.AdditiveLoft.CheckCompatibility)
+        self.assertFalse(self.AdditiveLoft.Adaptive)
         self.assertAlmostEqual(self.AdditiveLoft.Shape.Volume, 1)
 
     def testSimpleSubtractiveLoftCase(self):

--- a/src/Mod/PartDesign/PartDesignTests/TestLoft.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestLoft.py
@@ -54,9 +54,21 @@ class TestLoft(unittest.TestCase):
         self.AdditiveLoft = self.Doc.addObject("PartDesign::AdditiveLoft", "AdditiveLoft")
         self.Body.addObject(self.AdditiveLoft)
         self.assertFalse(self.AdditiveLoft.Smoothing)
+        self.assertEqual(self.AdditiveLoft.MaxDegree, 5)
+        self.assertEqual(self.AdditiveLoft.Parametrization, "Chord length")
+        self.assertEqual(self.AdditiveLoft.Continuity, "C2")
+        self.assertTrue(self.AdditiveLoft.CheckCompatibility)
+        self.AdditiveLoft.MaxDegree = 3
+        self.AdditiveLoft.Parametrization = "Uniform"
+        self.AdditiveLoft.Continuity = "C1"
+        self.AdditiveLoft.CheckCompatibility = False
         self.AdditiveLoft.Profile = self.ProfileSketch
         self.AdditiveLoft.Sections = [self.LoftSketch]
         self.Doc.recompute()
+        self.assertEqual(self.AdditiveLoft.MaxDegree, 3)
+        self.assertEqual(self.AdditiveLoft.Parametrization, "Uniform")
+        self.assertEqual(self.AdditiveLoft.Continuity, "C1")
+        self.assertFalse(self.AdditiveLoft.CheckCompatibility)
         self.assertAlmostEqual(self.AdditiveLoft.Shape.Volume, 1)
 
     def testSimpleSubtractiveLoftCase(self):

--- a/src/Mod/PartDesign/PartDesignTests/TestLoft.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestLoft.py
@@ -53,6 +53,7 @@ class TestLoft(unittest.TestCase):
         self.Doc.recompute()
         self.AdditiveLoft = self.Doc.addObject("PartDesign::AdditiveLoft", "AdditiveLoft")
         self.Body.addObject(self.AdditiveLoft)
+        self.assertFalse(self.AdditiveLoft.Smoothing)
         self.AdditiveLoft.Profile = self.ProfileSketch
         self.AdditiveLoft.Sections = [self.LoftSketch]
         self.Doc.recompute()

--- a/src/Mod/PartDesign/PartDesignTests/TestLoft.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestLoft.py
@@ -53,7 +53,7 @@ class TestLoft(unittest.TestCase):
         self.Doc.recompute()
         self.AdditiveLoft = self.Doc.addObject("PartDesign::AdditiveLoft", "AdditiveLoft")
         self.Body.addObject(self.AdditiveLoft)
-        self.assertEqual(self.AdditiveLoft.LoftType, "Auto")
+        self.assertEqual(self.AdditiveLoft.LoftType, "Automatic")
         self.assertEqual(self.AdditiveLoft.MaxDegree, 5)
         self.assertEqual(self.AdditiveLoft.Parametrization, "Chord length")
         self.assertEqual(self.AdditiveLoft.Continuity, "C2")

--- a/src/Mod/PartDesign/PartDesignTests/TestLoft.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestLoft.py
@@ -54,6 +54,15 @@ class TestLoft(unittest.TestCase):
         self.AdditiveLoft = self.Doc.addObject("PartDesign::AdditiveLoft", "AdditiveLoft")
         self.Body.addObject(self.AdditiveLoft)
         self.assertEqual(self.AdditiveLoft.LoftType, "Automatic")
+        self.assertFalse(self.AdditiveLoft.Ruled)
+        self.AdditiveLoft.Ruled = True
+        self.assertEqual(self.AdditiveLoft.LoftType, "Ruled Surface")
+        self.AdditiveLoft.Ruled = False
+        self.assertEqual(self.AdditiveLoft.LoftType, "Standard B-Spline")
+        self.AdditiveLoft.LoftType = "Ruled Surface"
+        self.assertTrue(self.AdditiveLoft.Ruled)
+        self.AdditiveLoft.LoftType = "Automatic"
+        self.assertFalse(self.AdditiveLoft.Ruled)
         self.assertEqual(self.AdditiveLoft.MaxDegree, 5)
         self.assertEqual(self.AdditiveLoft.Parametrization, "Chord length")
         self.assertEqual(self.AdditiveLoft.Continuity, "C2")

--- a/src/Mod/PartDesign/PartDesignTests/TestLoft.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestLoft.py
@@ -53,7 +53,7 @@ class TestLoft(unittest.TestCase):
         self.Doc.recompute()
         self.AdditiveLoft = self.Doc.addObject("PartDesign::AdditiveLoft", "AdditiveLoft")
         self.Body.addObject(self.AdditiveLoft)
-        self.assertFalse(self.AdditiveLoft.Smoothing)
+        self.assertEqual(self.AdditiveLoft.LoftType, "Auto")
         self.assertEqual(self.AdditiveLoft.MaxDegree, 5)
         self.assertEqual(self.AdditiveLoft.Parametrization, "Chord length")
         self.assertEqual(self.AdditiveLoft.Continuity, "C2")

--- a/src/Mod/PartDesign/PartDesignTests/TestLoft.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestLoft.py
@@ -53,7 +53,7 @@ class TestLoft(unittest.TestCase):
         self.Doc.recompute()
         self.AdditiveLoft = self.Doc.addObject("PartDesign::AdditiveLoft", "AdditiveLoft")
         self.Body.addObject(self.AdditiveLoft)
-        self.assertEqual(self.AdditiveLoft.LoftType, "Automatic")
+        self.assertEqual(self.AdditiveLoft.LoftType, "Standard B-Spline")
         self.assertFalse(self.AdditiveLoft.Ruled)
         self.AdditiveLoft.Ruled = True
         self.assertEqual(self.AdditiveLoft.LoftType, "Ruled Surface")
@@ -61,8 +61,9 @@ class TestLoft(unittest.TestCase):
         self.assertEqual(self.AdditiveLoft.LoftType, "Standard B-Spline")
         self.AdditiveLoft.LoftType = "Ruled Surface"
         self.assertTrue(self.AdditiveLoft.Ruled)
-        self.AdditiveLoft.LoftType = "Automatic"
+        self.AdditiveLoft.LoftType = "Variational B-Spline"
         self.assertFalse(self.AdditiveLoft.Ruled)
+        self.AdditiveLoft.LoftType = "Standard B-Spline"
         self.assertEqual(self.AdditiveLoft.MaxDegree, 5)
         self.assertEqual(self.AdditiveLoft.Parametrization, "Chord length")
         self.assertEqual(self.AdditiveLoft.Continuity, "C2")

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -1796,18 +1796,11 @@ TEST_F(TopoShapeExpansionTest, makeElementLoft)
     auto& topoShape2 = (new TopoShape())->makeElementLoft(shapes, IsSolid::solid, Smoothing::bspline);
     auto& topoShape3 = (new TopoShape())->makeElementLoft(shapes, IsSolid::notSolid, Smoothing::ruled);
     auto& topoShape4 = (new TopoShape())->makeElementLoft(shapes, IsSolid::solid, Smoothing::ruled);
-    auto& topoShape5 = (new TopoShape())->makeElementLoft(
-        shapes,
-        IsSolid::notSolid,
-        Smoothing::variational
-    );
-    auto& topoShape6 = (new TopoShape())
-                          ->makeElementLoft(
-                              shapes,
-                              IsSolid::notSolid,
-                              Smoothing::bspline,
-                              IsClosed::closed
-                          );
+    auto& topoShape5
+        = (new TopoShape())->makeElementLoft(shapes, IsSolid::notSolid, Smoothing::variational);
+    auto& topoShape6
+        = (new TopoShape())
+              ->makeElementLoft(shapes, IsSolid::notSolid, Smoothing::bspline, IsClosed::closed);
     auto elements = elementMap((topoShape));
     // Assert that we haven't broken the basic Loft functionality
     EXPECT_EQ(topoShape.countSubElements("Wire"), 4);
@@ -1857,7 +1850,8 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftReportsMismatchedTopology)
     catch (const Base::CADKernelError& error) {
         EXPECT_STREQ(
             error.what(),
-            "Loft profiles 1 and 2 have different topology; profiles must be either all open or all "
+            "Loft profiles 1 and 2 have different topology; profiles must be either all open or "
+            "all "
             "closed"
         );
     }
@@ -1940,14 +1934,8 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
         TColStd_Array1OfInteger multiplicities(1, 2);
         multiplicities.SetValue(1, 3);
         multiplicities.SetValue(2, 3);
-        Handle(Geom_BSplineCurve) curve = new Geom_BSplineCurve(
-            poles,
-            weights,
-            knots,
-            multiplicities,
-            2,
-            false
-        );
+        Handle(Geom_BSplineCurve)
+            curve = new Geom_BSplineCurve(poles, weights, knots, multiplicities, 2, false);
 
         BRepBuilderAPI_MakeWire wire;
         wire.Add(BRepBuilderAPI_MakeEdge(curve).Edge());
@@ -1955,37 +1943,24 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
         wire.Add(BRepBuilderAPI_MakeEdge(corners[2], corners[3]).Edge());
         wire.Add(BRepBuilderAPI_MakeEdge(corners[3], corners[0]).Edge());
         gp_Trsf location;
-        location.SetValues(
-            0, 0, -1, planePosition,
-            -1, 0, 0, 0,
-            0, 1, 0, 0
-        );
+        location.SetValues(0, 0, -1, planePosition, -1, 0, 0, 0, 0, 1, 0, 0);
         return TopoShape(BRepBuilderAPI_Transform(wire.Wire(), location, true).Shape());
     };
 
     auto profileA = makeProfile(
-        {gp_Pnt(0, -1.57, 0),
-         gp_Pnt(2.13, -3.559, 0),
-         gp_Pnt(2.13, -8.929, 0),
-         gp_Pnt(0, -8.96, 0)},
+        {gp_Pnt(0, -1.57, 0), gp_Pnt(2.13, -3.559, 0), gp_Pnt(2.13, -8.929, 0), gp_Pnt(0, -8.96, 0)},
         gp_Pnt(2.13, -1.57, 0),
         1.0,
         50.0
     );
     auto profileD = makeProfile(
-        {gp_Pnt(0, 5.25, 0),
-         gp_Pnt(6.07, 2.79, 0),
-         gp_Pnt(6.07, 0.79, 0),
-         gp_Pnt(0, 1.1, 0)},
+        {gp_Pnt(0, 5.25, 0), gp_Pnt(6.07, 2.79, 0), gp_Pnt(6.07, 0.79, 0), gp_Pnt(0, 1.1, 0)},
         gp_Pnt(6.07, 5.25, 0),
         0.88560975361611738,
         13.0
     );
     auto profileE = makeProfile(
-        {gp_Pnt(9.65, 3.76, 0),
-         gp_Pnt(0, 6.87, 0),
-         gp_Pnt(0, 1.2, 0),
-         gp_Pnt(9.65, 1.2, 0)},
+        {gp_Pnt(9.65, 3.76, 0), gp_Pnt(0, 6.87, 0), gp_Pnt(0, 1.2, 0), gp_Pnt(9.65, 1.2, 0)},
         gp_Pnt(9.65, 6.87, 0),
         1.75,
         6.0
@@ -2137,11 +2112,9 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
     }
 
     TopoShape variationalResult;
-    EXPECT_NO_THROW(variationalResult.makeElementLoft(
-        variationalProfiles,
-        IsSolid::solid,
-        Smoothing::variational
-    ));
+    EXPECT_NO_THROW(
+        variationalResult.makeElementLoft(variationalProfiles, IsSolid::solid, Smoothing::variational)
+    );
     EXPECT_FALSE(variationalResult.isNull());
     EXPECT_TRUE(BRepCheck_Analyzer(variationalResult.getShape()).IsValid());
 
@@ -2176,14 +2149,8 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
         knots.SetValue(2, 1.0);
         multiplicities.SetValue(1, 3);
         multiplicities.SetValue(2, 3);
-        Handle(Geom_BSplineCurve) curve = new Geom_BSplineCurve(
-            poles,
-            weights,
-            knots,
-            multiplicities,
-            2,
-            false
-        );
+        Handle(Geom_BSplineCurve)
+            curve = new Geom_BSplineCurve(poles, weights, knots, multiplicities, 2, false);
         auto edge = BRepBuilderAPI_MakeEdge(curve).Edge();
         return reversed ? TopoDS::Edge(edge.Reversed()) : edge;
     };
@@ -2202,9 +2169,7 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
         makeIssueWire(
             {line(gp_Pnt(50, 0, -8.96), gp_Pnt(50, 0, -1.57)),
              makeIssueCurve(
-                 {gp_Pnt(50, 0, -1.57),
-                  gp_Pnt(50, -2.13, -1.57),
-                  gp_Pnt(50, -2.13, -3.559)},
+                 {gp_Pnt(50, 0, -1.57), gp_Pnt(50, -2.13, -1.57), gp_Pnt(50, -2.13, -3.559)},
                  {1, 1, 1}
              ),
              line(gp_Pnt(50, -2.13, -3.559), gp_Pnt(50, -2.13, -8.929)),
@@ -2213,9 +2178,7 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
         makeIssueWire(
             {line(gp_Pnt(43, 0, -6.75), gp_Pnt(43, 0, -1.38)),
              makeIssueCurve(
-                 {gp_Pnt(43, 0, -1.38),
-                  gp_Pnt(43, -2.43, -1.38),
-                  gp_Pnt(43, -2.43, -3.38)},
+                 {gp_Pnt(43, 0, -1.38), gp_Pnt(43, -2.43, -1.38), gp_Pnt(43, -2.43, -3.38)},
                  {1, 1, 1}
              ),
              line(gp_Pnt(43, -2.43, -3.38), gp_Pnt(43, -2.43, -6.75)),
@@ -2225,9 +2188,7 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
             {line(gp_Pnt(24, 0, -0.75), gp_Pnt(24, -3.43, -0.75)),
              line(gp_Pnt(24, -3.43, -0.75), gp_Pnt(24, -3.43, 0.6)),
              makeIssueCurve(
-                 {gp_Pnt(24, 0, 2.5),
-                  gp_Pnt(24, -3.43, 2.5),
-                  gp_Pnt(24, -3.43, 0.6)},
+                 {gp_Pnt(24, 0, 2.5), gp_Pnt(24, -3.43, 2.5), gp_Pnt(24, -3.43, 0.6)},
                  {1, 1.1376407018914187, 1},
                  true
              ),
@@ -2235,9 +2196,7 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
         ),
         makeIssueWire(
             {makeIssueCurve(
-                 {gp_Pnt(13, 0, 5.25),
-                  gp_Pnt(13, -6.07, 5.25),
-                  gp_Pnt(13, -6.07, 2.79)},
+                 {gp_Pnt(13, 0, 5.25), gp_Pnt(13, -6.07, 5.25), gp_Pnt(13, -6.07, 2.79)},
                  {1, 0.8856097536161174, 1}
              ),
              line(gp_Pnt(13, -6.07, 2.79), gp_Pnt(13, -6.07, 0.79)),
@@ -2246,9 +2205,7 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
         ),
         makeIssueWire(
             {makeIssueCurve(
-                 {gp_Pnt(6, -9.65, 3.76),
-                  gp_Pnt(6, -9.65, 6.87),
-                  gp_Pnt(6, 0, 6.87)},
+                 {gp_Pnt(6, -9.65, 3.76), gp_Pnt(6, -9.65, 6.87), gp_Pnt(6, 0, 6.87)},
                  {1, 1.75, 1}
              ),
              line(gp_Pnt(6, 0, 6.87), gp_Pnt(6, 0, 1.2)),
@@ -2258,11 +2215,9 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
     };
 
     TopoShape variationalIssueShell;
-    EXPECT_NO_THROW(variationalIssueShell.makeElementLoft(
-        issueProfiles,
-        IsSolid::notSolid,
-        Smoothing::variational
-    ));
+    EXPECT_NO_THROW(
+        variationalIssueShell.makeElementLoft(issueProfiles, IsSolid::notSolid, Smoothing::variational)
+    );
     EXPECT_FALSE(variationalIssueShell.isNull());
     EXPECT_TRUE(BRepCheck_Analyzer(variationalIssueShell.getShape()).IsValid());
 }

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -1787,13 +1787,22 @@ TEST_F(TopoShapeExpansionTest, makeElementLoft)
                                     // resulting name.
     std::vector<TopoShape> shapes = {wire1ts, wire2ts};
     // Act
-    auto& topoShape = (new TopoShape())->makeElementLoft(shapes, IsSolid::notSolid, IsRuled::notRuled);
-    auto& topoShape2 = (new TopoShape())->makeElementLoft(shapes, IsSolid::solid, IsRuled::notRuled);
-    auto& topoShape3 = (new TopoShape())->makeElementLoft(shapes, IsSolid::notSolid, IsRuled::ruled);
-    auto& topoShape4 = (new TopoShape())->makeElementLoft(shapes, IsSolid::solid, IsRuled::ruled);
-    auto& topoShape5
-        = (new TopoShape())
-              ->makeElementLoft(shapes, IsSolid::notSolid, IsRuled::notRuled, IsClosed::closed);
+    auto& topoShape = (new TopoShape())->makeElementLoft(shapes, IsSolid::notSolid, Smoothing::bspline);
+    auto& topoShape2 = (new TopoShape())->makeElementLoft(shapes, IsSolid::solid, Smoothing::bspline);
+    auto& topoShape3 = (new TopoShape())->makeElementLoft(shapes, IsSolid::notSolid, Smoothing::ruled);
+    auto& topoShape4 = (new TopoShape())->makeElementLoft(shapes, IsSolid::solid, Smoothing::ruled);
+    auto& topoShape5 = (new TopoShape())->makeElementLoft(
+        shapes,
+        IsSolid::notSolid,
+        Smoothing::variational
+    );
+    auto& topoShape6 = (new TopoShape())
+                          ->makeElementLoft(
+                              shapes,
+                              IsSolid::notSolid,
+                              Smoothing::bspline,
+                              IsClosed::closed
+                          );
     auto elements = elementMap((topoShape));
     // Assert that we haven't broken the basic Loft functionality
     EXPECT_EQ(topoShape.countSubElements("Wire"), 4);
@@ -1802,7 +1811,8 @@ TEST_F(TopoShapeExpansionTest, makeElementLoft)
     EXPECT_DOUBLE_EQ(getVolume(topoShape2.getShape()), 250);
     EXPECT_NEAR(getVolume(topoShape3.getShape()), 166.66667, 1e-5);
     EXPECT_DOUBLE_EQ(getVolume(topoShape4.getShape()), 250);
-    EXPECT_NEAR(getVolume(topoShape5.getShape()), 0, 1e-07);
+    EXPECT_FALSE(topoShape5.isNull());
+    EXPECT_NEAR(getVolume(topoShape6.getShape()), 0, 1e-07);
     // Assert that we're creating a correct element map
     EXPECT_TRUE(topoShape.getMappedChildElements().empty());
     EXPECT_EQ(elements.size(), 24);
@@ -1842,7 +1852,7 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftAllowsDistinctProfilesWithSameCent
 
     // Act: the previous code raised Base::CADKernelError here because the centers of gravity match.
     auto* loft = new TopoShape();
-    ASSERT_NO_THROW(loft->makeElementLoft(shapes, IsSolid::notSolid, IsRuled::ruled));  // NOLINT
+    ASSERT_NO_THROW(loft->makeElementLoft(shapes, IsSolid::notSolid, Smoothing::ruled));  // NOLINT
 
     // Assert: the result is the flat frame between the 5x5 and the 10x10 square.
     EXPECT_FALSE(loft->isNull());
@@ -1864,7 +1874,7 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftRejectsCoincidentProfiles)  // NOL
 
     // Act / Assert
     EXPECT_THROW(  // NOLINT
-        (new TopoShape())->makeElementLoft(shapes, IsSolid::notSolid, IsRuled::notRuled),
+        (new TopoShape())->makeElementLoft(shapes, IsSolid::notSolid, Smoothing::bspline),
         Base::CADKernelError
     );
 }

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -2010,8 +2010,7 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
         EXPECT_STREQ(
             error.what(),
             "OCCT failed to construct the loft; the failure requires the complete sequence of 3 "
-            "profiles; try Centripetal parameterization, which succeeds for these profiles "
-            "(adjacent profile spacing ratio 5.1)"
+            "profiles; try Centripetal parameterization, which succeeds for these profiles"
         );
     }
 

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -1801,11 +1801,6 @@ TEST_F(TopoShapeExpansionTest, makeElementLoft)
         IsSolid::notSolid,
         Smoothing::variational
     );
-    auto& automaticShape = (new TopoShape())->makeElementLoft(
-        shapes,
-        IsSolid::notSolid,
-        Smoothing::automatic
-    );
     auto& topoShape6 = (new TopoShape())
                           ->makeElementLoft(
                               shapes,
@@ -1822,7 +1817,6 @@ TEST_F(TopoShapeExpansionTest, makeElementLoft)
     EXPECT_NEAR(getVolume(topoShape3.getShape()), 166.66667, 1e-5);
     EXPECT_DOUBLE_EQ(getVolume(topoShape4.getShape()), 250);
     EXPECT_FALSE(topoShape5.isNull());
-    EXPECT_FALSE(automaticShape.isNull());
     EXPECT_NEAR(getVolume(topoShape6.getShape()), 0, 1e-07);
     // Assert that we're creating a correct element map
     EXPECT_TRUE(topoShape.getMappedChildElements().empty());
@@ -2026,15 +2020,6 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
     ));
     EXPECT_FALSE(suggestedResult.isNull());
 
-    TopoShape automaticParametrizationResult;
-    EXPECT_NO_THROW(automaticParametrizationResult.makeElementLoft(
-        {profileA, profileD, profileE},
-        IsSolid::solid,
-        Smoothing::automatic
-    ));
-    EXPECT_FALSE(automaticParametrizationResult.isNull());
-    EXPECT_TRUE(BRepCheck_Analyzer(automaticParametrizationResult.getShape()).IsValid());
-
     // This sequence fails with every standard B-spline parameterization, but the variational
     // solver constructs a valid solid.
     std::vector<TopoShape> variationalProfiles {
@@ -2111,24 +2096,6 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
     ));
     EXPECT_FALSE(variationalResult.isNull());
     EXPECT_TRUE(BRepCheck_Analyzer(variationalResult.getShape()).IsValid());
-
-    TopoShape automaticVariationalResult;
-    EXPECT_NO_THROW(automaticVariationalResult.makeElementLoft(
-        variationalProfiles,
-        IsSolid::solid,
-        Smoothing::automatic
-    ));
-    EXPECT_FALSE(automaticVariationalResult.isNull());
-    EXPECT_TRUE(BRepCheck_Analyzer(automaticVariationalResult.getShape()).IsValid());
-
-    TopoShape automaticVariationalShell;
-    EXPECT_NO_THROW(automaticVariationalShell.makeElementLoft(
-        variationalProfiles,
-        IsSolid::notSolid,
-        Smoothing::automatic
-    ));
-    EXPECT_FALSE(automaticVariationalShell.isNull());
-    EXPECT_TRUE(BRepCheck_Analyzer(automaticVariationalShell.getShape()).IsValid());
 
     auto makeIssueCurve = [](const std::array<gp_Pnt, 3>& curvePoles,
                              const std::array<double, 3>& curveWeights,
@@ -2226,14 +2193,14 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
         ),
     };
 
-    TopoShape automaticIssueShell;
-    EXPECT_NO_THROW(automaticIssueShell.makeElementLoft(
+    TopoShape variationalIssueShell;
+    EXPECT_NO_THROW(variationalIssueShell.makeElementLoft(
         issueProfiles,
         IsSolid::notSolid,
-        Smoothing::automatic
+        Smoothing::variational
     ));
-    EXPECT_FALSE(automaticIssueShell.isNull());
-    EXPECT_TRUE(BRepCheck_Analyzer(automaticIssueShell.getShape()).IsValid());
+    EXPECT_FALSE(variationalIssueShell.isNull());
+    EXPECT_TRUE(BRepCheck_Analyzer(variationalIssueShell.getShape()).IsValid());
 }
 
 TEST_F(TopoShapeExpansionTest, makeElementLoftAllowsDistinctProfilesWithSameCenter)  // NOLINT

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#include <array>
+
+#include <BRepCheck_Analyzer.hxx>
 #include <TColgp_Array2OfPnt.hxx>
+#include <TColStd_Array1OfInteger.hxx>
+#include <TColStd_Array1OfReal.hxx>
 #include <gtest/gtest.h>
 #include "src/App/InitApplication.h"
 #include <Mod/Part/App/TopoShape.h>
@@ -1850,7 +1855,11 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftReportsMismatchedTopology)
         FAIL() << "Expected mismatched loft topology to fail";
     }
     catch (const Base::CADKernelError& error) {
-        EXPECT_STREQ(error.what(), "Loft profiles must be either all open or all closed");
+        EXPECT_STREQ(
+            error.what(),
+            "Loft profiles 1 and 2 have different topology; profiles must be either all open or all "
+            "closed"
+        );
     }
 }
 
@@ -1878,9 +1887,216 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftReportsPunctualMiddleProfile)
     catch (const Base::CADKernelError& error) {
         EXPECT_STREQ(
             error.what(),
-            "Punctual loft profiles are only supported as the first or last profile"
+            "Loft profile 2 is punctual; punctual profiles are only supported as the first or last "
+            "profile"
         );
     }
+}
+
+TEST_F(TopoShapeExpansionTest, makeElementLoftReportsEdgeWithout3dCurve)
+{
+    auto [face, validWire, edge1, edge2, edge3, edge4] = CreateRectFace(5, 5);
+    boost::ignore_unused(face, edge1, edge2, edge3, edge4);
+    BRep_Builder builder;
+    TopoDS_Edge edgeWithoutCurve;
+    builder.MakeEdge(edgeWithoutCurve);
+    TopoDS_Wire invalidWire;
+    builder.MakeWire(invalidWire);
+    builder.Add(invalidWire, edgeWithoutCurve);
+
+    TopoShape result;
+    try {
+        result.makeElementLoft(
+            {TopoShape(validWire), TopoShape(invalidWire)},
+            IsSolid::notSolid,
+            Smoothing::bspline
+        );
+        FAIL() << "Expected an edge without a 3D curve to fail loft preflight";
+    }
+    catch (const Base::CADKernelError& error) {
+        EXPECT_STREQ(error.what(), "Loft profile 2, edge 1 has no 3D curve");
+    }
+}
+
+TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
+{
+    // Reduced construction of profiles A-D-E from lever2.FCStd. Each adjacent pair lofts, but
+    // OCCT cannot construct a standard B-spline loft through all three profiles.
+    auto makeProfile = [](const std::array<gp_Pnt, 4>& corners,
+                          const gp_Pnt& curvePole,
+                          double curvePoleWeight,
+                          double planePosition) {
+        TColgp_Array1OfPnt poles(1, 3);
+        poles.SetValue(1, corners[0]);
+        poles.SetValue(2, curvePole);
+        poles.SetValue(3, corners[1]);
+        TColStd_Array1OfReal weights(1, 3);
+        weights.SetValue(1, 1.0);
+        weights.SetValue(2, curvePoleWeight);
+        weights.SetValue(3, 1.0);
+        TColStd_Array1OfReal knots(1, 2);
+        knots.SetValue(1, 0.0);
+        knots.SetValue(2, 1.0);
+        TColStd_Array1OfInteger multiplicities(1, 2);
+        multiplicities.SetValue(1, 3);
+        multiplicities.SetValue(2, 3);
+        Handle(Geom_BSplineCurve) curve = new Geom_BSplineCurve(
+            poles,
+            weights,
+            knots,
+            multiplicities,
+            2,
+            false
+        );
+
+        BRepBuilderAPI_MakeWire wire;
+        wire.Add(BRepBuilderAPI_MakeEdge(curve).Edge());
+        wire.Add(BRepBuilderAPI_MakeEdge(corners[1], corners[2]).Edge());
+        wire.Add(BRepBuilderAPI_MakeEdge(corners[2], corners[3]).Edge());
+        wire.Add(BRepBuilderAPI_MakeEdge(corners[3], corners[0]).Edge());
+        gp_Trsf location;
+        location.SetValues(
+            0, 0, -1, planePosition,
+            -1, 0, 0, 0,
+            0, 1, 0, 0
+        );
+        return TopoShape(BRepBuilderAPI_Transform(wire.Wire(), location, true).Shape());
+    };
+
+    auto profileA = makeProfile(
+        {gp_Pnt(0, -1.57, 0),
+         gp_Pnt(2.13, -3.559, 0),
+         gp_Pnt(2.13, -8.929, 0),
+         gp_Pnt(0, -8.96, 0)},
+        gp_Pnt(2.13, -1.57, 0),
+        1.0,
+        50.0
+    );
+    auto profileD = makeProfile(
+        {gp_Pnt(0, 5.25, 0),
+         gp_Pnt(6.07, 2.79, 0),
+         gp_Pnt(6.07, 0.79, 0),
+         gp_Pnt(0, 1.1, 0)},
+        gp_Pnt(6.07, 5.25, 0),
+        0.88560975361611738,
+        13.0
+    );
+    auto profileE = makeProfile(
+        {gp_Pnt(9.65, 3.76, 0),
+         gp_Pnt(0, 6.87, 0),
+         gp_Pnt(0, 1.2, 0),
+         gp_Pnt(9.65, 1.2, 0)},
+        gp_Pnt(9.65, 6.87, 0),
+        1.75,
+        6.0
+    );
+
+    TopoShape result;
+    try {
+        result.makeElementLoft(
+            {profileA, profileD, profileE},
+            IsSolid::solid,
+            Smoothing::bspline
+        );
+        FAIL() << "Expected the complete A-D-E profile sequence to fail";
+    }
+    catch (const Base::CADKernelError& error) {
+        EXPECT_STREQ(
+            error.what(),
+            "OCCT failed to construct the loft; the failure requires the complete sequence of 3 "
+            "profiles; try Centripetal parameterization, which succeeds for these profiles "
+            "(adjacent profile spacing ratio 5.1)"
+        );
+    }
+
+    TopoShape suggestedResult;
+    EXPECT_NO_THROW(suggestedResult.makeElementLoft(
+        {profileA, profileD, profileE},
+        IsSolid::solid,
+        Smoothing::bspline,
+        IsClosed::notClosed,
+        5,
+        nullptr,
+        LoftParametrization::centripetal
+    ));
+    EXPECT_FALSE(suggestedResult.isNull());
+
+    // This sequence fails with every standard B-spline parameterization, but the variational
+    // solver constructs a valid solid.
+    std::vector<TopoShape> variationalProfiles {
+        makeProfile(
+            {gp_Pnt(0, 17.732158388647292, 0),
+             gp_Pnt(5.91256580453193, 10.368825818265051, 0),
+             gp_Pnt(5.91256580453193, 7.444724193179219, 0),
+             gp_Pnt(0, 7.444724193179219, 0)},
+            gp_Pnt(5.91256580453193, 17.732158388647292, 0),
+            3.3653696498054475,
+            60.0
+        ),
+        makeProfile(
+            {gp_Pnt(0, 1.2206759746700233, 0),
+             gp_Pnt(5.857175555046922, 0.9311818112458989, 0),
+             gp_Pnt(5.857175555046922, -1.9530022125581752, 0),
+             gp_Pnt(0, -1.9530022125581752, 0)},
+            gp_Pnt(5.857175555046922, 1.2206759746700233, 0),
+            3.7549019607843137,
+            45.23052567330434
+        ),
+        makeProfile(
+            {gp_Pnt(0, -4.107042038605325, 0),
+             gp_Pnt(5.688258182650492, 2.993713282978562, 0),
+             gp_Pnt(5.688258182650492, -5.818417639429312, 0),
+             gp_Pnt(0, -5.818417639429312, 0)},
+            gp_Pnt(5.688258182650492, -4.107042038605325, 0),
+            1.5047455558098726,
+            28.108873121232932
+        ),
+        makeProfile(
+            {gp_Pnt(0, 5.5303120469977864, 0),
+             gp_Pnt(8.89219501029984, 0.5561760891126877, 0),
+             gp_Pnt(8.89219501029984, -3.7218280308232243, 0),
+             gp_Pnt(0, -3.7218280308232243, 0)},
+            gp_Pnt(8.89219501029984, 5.5303120469977864, 0),
+            1.4196612497138934,
+            13.731555657282371
+        ),
+        makeProfile(
+            {gp_Pnt(0, 13.663736934462502, 0),
+             gp_Pnt(15.439688715953308, 13.618875410086213, 0),
+             gp_Pnt(15.439688715953308, 3.8289463645380337, 0),
+             gp_Pnt(0, 3.8289463645380337, 0)},
+            gp_Pnt(15.439688715953308, 13.663736934462502, 0),
+            0.36678873884184027,
+            -8.186007476920725
+        ),
+    };
+
+    try {
+        TopoShape standardResult;
+        standardResult.makeElementLoft(
+            variationalProfiles,
+            IsSolid::solid,
+            Smoothing::bspline
+        );
+        FAIL() << "Expected all standard B-spline parameterizations to fail";
+    }
+    catch (const Base::CADKernelError& error) {
+        EXPECT_STREQ(
+            error.what(),
+            "OCCT failed to construct the loft; the failure requires the complete sequence of 5 "
+            "profiles; standard B-spline lofting failed with all parameterizations; try Smoothed "
+            "B-Spline, whose variational solver succeeds for these profiles"
+        );
+    }
+
+    TopoShape variationalResult;
+    EXPECT_NO_THROW(variationalResult.makeElementLoft(
+        variationalProfiles,
+        IsSolid::solid,
+        Smoothing::variational
+    ));
+    EXPECT_FALSE(variationalResult.isNull());
+    EXPECT_TRUE(BRepCheck_Analyzer(variationalResult.getShape()).IsValid());
 }
 
 TEST_F(TopoShapeExpansionTest, makeElementLoftAllowsDistinctProfilesWithSameCenter)  // NOLINT

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -1831,6 +1831,58 @@ TEST_F(TopoShapeExpansionTest, makeElementLoft)
     ));
 }
 
+TEST_F(TopoShapeExpansionTest, makeElementLoftReportsMismatchedTopology)
+{
+    auto [face, closedWire, edge1, edge2, edge3, edge4] = CreateRectFace(5, 5);
+    boost::ignore_unused(face, edge1, edge2, edge3, edge4);
+    BRepBuilderAPI_MakePolygon openPolygon;
+    openPolygon.Add(gp_Pnt(0, 0, 10));
+    openPolygon.Add(gp_Pnt(5, 0, 10));
+    openPolygon.Add(gp_Pnt(5, 5, 10));
+
+    TopoShape result;
+    try {
+        result.makeElementLoft(
+            {TopoShape(closedWire), TopoShape(openPolygon.Wire())},
+            IsSolid::notSolid,
+            Smoothing::bspline
+        );
+        FAIL() << "Expected mismatched loft topology to fail";
+    }
+    catch (const Base::CADKernelError& error) {
+        EXPECT_STREQ(error.what(), "Loft profiles must be either all open or all closed");
+    }
+}
+
+TEST_F(TopoShapeExpansionTest, makeElementLoftReportsPunctualMiddleProfile)
+{
+    auto [face, firstWire, edge1, edge2, edge3, edge4] = CreateRectFace(5, 5);
+    boost::ignore_unused(face, edge1, edge2, edge3, edge4);
+    auto transform {gp_Trsf()};
+    transform.SetTranslation(gp_Vec(0, 0, 10));
+    auto lastWire = TopoDS::Wire(firstWire.Moved(TopLoc_Location(transform)));
+
+    TopoShape result;
+    try {
+        result.makeElementLoft(
+            {
+                TopoShape(firstWire),
+                TopoShape(BRepBuilderAPI_MakeVertex(gp_Pnt(2.5, 2.5, 5)).Vertex()),
+                TopoShape(lastWire),
+            },
+            IsSolid::notSolid,
+            Smoothing::bspline
+        );
+        FAIL() << "Expected a punctual middle loft profile to fail";
+    }
+    catch (const Base::CADKernelError& error) {
+        EXPECT_STREQ(
+            error.what(),
+            "Punctual loft profiles are only supported as the first or last profile"
+        );
+    }
+}
+
 TEST_F(TopoShapeExpansionTest, makeElementLoftAllowsDistinctProfilesWithSameCenter)  // NOLINT
 {
     // Regression test for PR #29982 / forum thread t=88234.  The fix for issue #5855 rejected any

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -1801,6 +1801,11 @@ TEST_F(TopoShapeExpansionTest, makeElementLoft)
         IsSolid::notSolid,
         Smoothing::variational
     );
+    auto& automaticShape = (new TopoShape())->makeElementLoft(
+        shapes,
+        IsSolid::notSolid,
+        Smoothing::automatic
+    );
     auto& topoShape6 = (new TopoShape())
                           ->makeElementLoft(
                               shapes,
@@ -1817,6 +1822,7 @@ TEST_F(TopoShapeExpansionTest, makeElementLoft)
     EXPECT_NEAR(getVolume(topoShape3.getShape()), 166.66667, 1e-5);
     EXPECT_DOUBLE_EQ(getVolume(topoShape4.getShape()), 250);
     EXPECT_FALSE(topoShape5.isNull());
+    EXPECT_FALSE(automaticShape.isNull());
     EXPECT_NEAR(getVolume(topoShape6.getShape()), 0, 1e-07);
     // Assert that we're creating a correct element map
     EXPECT_TRUE(topoShape.getMappedChildElements().empty());
@@ -2021,6 +2027,15 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
     ));
     EXPECT_FALSE(suggestedResult.isNull());
 
+    TopoShape automaticParametrizationResult;
+    EXPECT_NO_THROW(automaticParametrizationResult.makeElementLoft(
+        {profileA, profileD, profileE},
+        IsSolid::solid,
+        Smoothing::automatic
+    ));
+    EXPECT_FALSE(automaticParametrizationResult.isNull());
+    EXPECT_TRUE(BRepCheck_Analyzer(automaticParametrizationResult.getShape()).IsValid());
+
     // This sequence fails with every standard B-spline parameterization, but the variational
     // solver constructs a valid solid.
     std::vector<TopoShape> variationalProfiles {
@@ -2084,8 +2099,8 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
         EXPECT_STREQ(
             error.what(),
             "OCCT failed to construct the loft; the failure requires the complete sequence of 5 "
-            "profiles; standard B-spline lofting failed with all parameterizations; try Smoothed "
-            "B-Spline, whose variational solver succeeds for these profiles"
+            "profiles; standard B-spline lofting failed with all parameterizations; try "
+            "Variational B-Spline, whose variational solver succeeds for these profiles"
         );
     }
 
@@ -2097,6 +2112,129 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
     ));
     EXPECT_FALSE(variationalResult.isNull());
     EXPECT_TRUE(BRepCheck_Analyzer(variationalResult.getShape()).IsValid());
+
+    TopoShape automaticVariationalResult;
+    EXPECT_NO_THROW(automaticVariationalResult.makeElementLoft(
+        variationalProfiles,
+        IsSolid::solid,
+        Smoothing::automatic
+    ));
+    EXPECT_FALSE(automaticVariationalResult.isNull());
+    EXPECT_TRUE(BRepCheck_Analyzer(automaticVariationalResult.getShape()).IsValid());
+
+    TopoShape automaticVariationalShell;
+    EXPECT_NO_THROW(automaticVariationalShell.makeElementLoft(
+        variationalProfiles,
+        IsSolid::notSolid,
+        Smoothing::automatic
+    ));
+    EXPECT_FALSE(automaticVariationalShell.isNull());
+    EXPECT_TRUE(BRepCheck_Analyzer(automaticVariationalShell.getShape()).IsValid());
+
+    auto makeIssueCurve = [](const std::array<gp_Pnt, 3>& curvePoles,
+                             const std::array<double, 3>& curveWeights,
+                             bool reversed = false) {
+        TColgp_Array1OfPnt poles(1, 3);
+        TColStd_Array1OfReal weights(1, 3);
+        TColStd_Array1OfReal knots(1, 2);
+        TColStd_Array1OfInteger multiplicities(1, 2);
+        for (int i = 0; i < 3; ++i) {
+            poles.SetValue(i + 1, curvePoles[i]);
+            weights.SetValue(i + 1, curveWeights[i]);
+        }
+        knots.SetValue(1, 0.0);
+        knots.SetValue(2, 1.0);
+        multiplicities.SetValue(1, 3);
+        multiplicities.SetValue(2, 3);
+        Handle(Geom_BSplineCurve) curve = new Geom_BSplineCurve(
+            poles,
+            weights,
+            knots,
+            multiplicities,
+            2,
+            false
+        );
+        auto edge = BRepBuilderAPI_MakeEdge(curve).Edge();
+        return reversed ? TopoDS::Edge(edge.Reversed()) : edge;
+    };
+    auto makeIssueWire = [](const std::vector<TopoDS_Edge>& edges) {
+        BRepBuilderAPI_MakeWire wire;
+        for (const auto& edge : edges) {
+            wire.Add(edge);
+        }
+        return TopoShape(wire.Wire());
+    };
+    auto line = [](const gp_Pnt& first, const gp_Pnt& second) {
+        return BRepBuilderAPI_MakeEdge(first, second).Edge();
+    };
+
+    const std::vector<TopoShape> issueProfiles {
+        makeIssueWire(
+            {line(gp_Pnt(50, 0, -8.96), gp_Pnt(50, 0, -1.57)),
+             makeIssueCurve(
+                 {gp_Pnt(50, 0, -1.57),
+                  gp_Pnt(50, -2.13, -1.57),
+                  gp_Pnt(50, -2.13, -3.559)},
+                 {1, 1, 1}
+             ),
+             line(gp_Pnt(50, -2.13, -3.559), gp_Pnt(50, -2.13, -8.929)),
+             line(gp_Pnt(50, -2.13, -8.929), gp_Pnt(50, 0, -8.96))}
+        ),
+        makeIssueWire(
+            {line(gp_Pnt(43, 0, -6.75), gp_Pnt(43, 0, -1.38)),
+             makeIssueCurve(
+                 {gp_Pnt(43, 0, -1.38),
+                  gp_Pnt(43, -2.43, -1.38),
+                  gp_Pnt(43, -2.43, -3.38)},
+                 {1, 1, 1}
+             ),
+             line(gp_Pnt(43, -2.43, -3.38), gp_Pnt(43, -2.43, -6.75)),
+             line(gp_Pnt(43, -2.43, -6.75), gp_Pnt(43, 0, -6.75))}
+        ),
+        makeIssueWire(
+            {line(gp_Pnt(24, 0, -0.75), gp_Pnt(24, -3.43, -0.75)),
+             line(gp_Pnt(24, -3.43, -0.75), gp_Pnt(24, -3.43, 0.6)),
+             makeIssueCurve(
+                 {gp_Pnt(24, 0, 2.5),
+                  gp_Pnt(24, -3.43, 2.5),
+                  gp_Pnt(24, -3.43, 0.6)},
+                 {1, 1.1376407018914187, 1},
+                 true
+             ),
+             line(gp_Pnt(24, 0, 2.5), gp_Pnt(24, 0, -0.75))}
+        ),
+        makeIssueWire(
+            {makeIssueCurve(
+                 {gp_Pnt(13, 0, 5.25),
+                  gp_Pnt(13, -6.07, 5.25),
+                  gp_Pnt(13, -6.07, 2.79)},
+                 {1, 0.8856097536161174, 1}
+             ),
+             line(gp_Pnt(13, -6.07, 2.79), gp_Pnt(13, -6.07, 0.79)),
+             line(gp_Pnt(13, -6.07, 0.79), gp_Pnt(13, 0, 1.1)),
+             line(gp_Pnt(13, 0, 1.1), gp_Pnt(13, 0, 5.25))}
+        ),
+        makeIssueWire(
+            {makeIssueCurve(
+                 {gp_Pnt(6, -9.65, 3.76),
+                  gp_Pnt(6, -9.65, 6.87),
+                  gp_Pnt(6, 0, 6.87)},
+                 {1, 1.75, 1}
+             ),
+             line(gp_Pnt(6, 0, 6.87), gp_Pnt(6, 0, 1.2)),
+             line(gp_Pnt(6, 0, 1.2), gp_Pnt(6, -9.65, 1.2)),
+             line(gp_Pnt(6, -9.65, 1.2), gp_Pnt(6, -9.65, 3.76))}
+        ),
+    };
+
+    TopoShape automaticIssueShell;
+    EXPECT_NO_THROW(automaticIssueShell.makeElementLoft(
+        issueProfiles,
+        IsSolid::notSolid,
+        Smoothing::automatic
+    ));
+    EXPECT_FALSE(automaticIssueShell.isNull());
+    EXPECT_TRUE(BRepCheck_Analyzer(automaticIssueShell.getShape()).IsValid());
 }
 
 TEST_F(TopoShapeExpansionTest, makeElementLoftAllowsDistinctProfilesWithSameCenter)  // NOLINT

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -1996,15 +1996,23 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
         result.makeElementLoft(
             {profileA, profileD, profileE},
             IsSolid::solid,
-            Smoothing::bspline
+            Smoothing::bspline,
+            IsClosed::notClosed,
+            5,
+            nullptr,
+            LoftParametrization::chordLength,
+            LoftContinuity::C2,
+            true,
+            false
         );
         FAIL() << "Expected the complete A-D-E profile sequence to fail";
     }
     catch (const Base::CADKernelError& error) {
         EXPECT_STREQ(
             error.what(),
-            "OCCT failed to construct the loft; the failure requires the complete sequence of 3 "
-            "profiles; try Centripetal parameterization, which succeeds for these profiles"
+            "OCCT failed to construct the loft; the failure occurs when trying the complete "
+            "sequence of 3 profiles (may succeed for subsets of profiles); try Centripetal "
+            "parameterization, which succeeds for these profiles"
         );
     }
 
@@ -2019,6 +2027,38 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
         LoftParametrization::centripetal
     ));
     EXPECT_FALSE(suggestedResult.isNull());
+
+    TopoShape adaptiveParametrizationResult;
+    EXPECT_NO_THROW(adaptiveParametrizationResult.makeElementLoft(
+        {profileA, profileD, profileE},
+        IsSolid::solid,
+        Smoothing::bspline,
+        IsClosed::notClosed,
+        5,
+        nullptr,
+        LoftParametrization::chordLength,
+        LoftContinuity::C2,
+        true,
+        true
+    ));
+    EXPECT_FALSE(adaptiveParametrizationResult.isNull());
+    EXPECT_TRUE(BRepCheck_Analyzer(adaptiveParametrizationResult.getShape()).IsValid());
+
+    TopoShape adaptiveFromSelectedUniform;
+    EXPECT_NO_THROW(adaptiveFromSelectedUniform.makeElementLoft(
+        {profileA, profileD, profileE},
+        IsSolid::solid,
+        Smoothing::bspline,
+        IsClosed::notClosed,
+        5,
+        nullptr,
+        LoftParametrization::uniform,
+        LoftContinuity::C2,
+        true,
+        true
+    ));
+    EXPECT_FALSE(adaptiveFromSelectedUniform.isNull());
+    EXPECT_TRUE(BRepCheck_Analyzer(adaptiveFromSelectedUniform.getShape()).IsValid());
 
     // This sequence fails with every standard B-spline parameterization, but the variational
     // solver constructs a valid solid.
@@ -2075,16 +2115,24 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
         standardResult.makeElementLoft(
             variationalProfiles,
             IsSolid::solid,
-            Smoothing::bspline
+            Smoothing::bspline,
+            IsClosed::notClosed,
+            5,
+            nullptr,
+            LoftParametrization::chordLength,
+            LoftContinuity::C2,
+            true,
+            false
         );
         FAIL() << "Expected all standard B-spline parameterizations to fail";
     }
     catch (const Base::CADKernelError& error) {
         EXPECT_STREQ(
             error.what(),
-            "OCCT failed to construct the loft; the failure requires the complete sequence of 5 "
-            "profiles; standard B-spline lofting failed with all parameterizations; try "
-            "Variational B-Spline, whose variational solver succeeds for these profiles"
+            "OCCT failed to construct the loft; the failure occurs when trying the complete "
+            "sequence of 5 profiles (may succeed for subsets of profiles); standard B-spline "
+            "lofting failed with all available parameterizations; try Variational B-Spline, whose "
+            "variational solver succeeds for these profiles"
         );
     }
 
@@ -2096,6 +2144,22 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftSuggestsSuccessfulAlternatives)
     ));
     EXPECT_FALSE(variationalResult.isNull());
     EXPECT_TRUE(BRepCheck_Analyzer(variationalResult.getShape()).IsValid());
+
+    TopoShape adaptiveVariationalResult;
+    EXPECT_NO_THROW(adaptiveVariationalResult.makeElementLoft(
+        variationalProfiles,
+        IsSolid::solid,
+        Smoothing::bspline,
+        IsClosed::notClosed,
+        5,
+        nullptr,
+        LoftParametrization::chordLength,
+        LoftContinuity::C2,
+        true,
+        true
+    ));
+    EXPECT_FALSE(adaptiveVariationalResult.isNull());
+    EXPECT_TRUE(BRepCheck_Analyzer(adaptiveVariationalResult.getShape()).IsValid());
 
     auto makeIssueCurve = [](const std::array<gp_Pnt, 3>& curvePoles,
                              const std::array<double, 3>& curveWeights,


### PR DESCRIPTION
Addresses issue #31832, but likely provides a solution to many similar cases. 

This PR let's the user decide whether to use the _UseSmoothing_ option in OCCs loft builder. This tells OCC to use an alternative [algorithm](https://dev.opencascade.org/doc/refman/html/class_app_def___variational.html).  I think it should be a user-selectable option because it can give different results (though, from what I can tell - and I'm not an expert - the differences in most real cases would be indistinguishable). 

This was as close to a one line change as I could make it.  

A checkbox was added to the UI and an option (defaults to false) to enable OCC to use the variational smoothing option/solver was added to a couple of headers and implementation files. 

OCC documentation that was relevant to this: 
https://dev.opencascade.org/doc/occt-7.8.0/refman/html/classBRepOffsetAPI__ThruSections.html

Default solver that gets called in PartDesign Workbench with no options selected:
https://dev.opencascade.org/doc/refman/html/class_app_def___b_spline_compute.html

Solver used when "Variational Smoothing" option is selected:
https://dev.opencascade.org/doc/refman/html/class_app_def___variational.html


Note: I didn't update the Part workbench loft implementation with this change, but it would be trivial to do so, if desired. 


- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
 
Assisted-by: Qwen3.6-27b-mlx


## Issues
Issue #31832


## Before and After Images

Before: 
<img width="1706" height="990" alt="image" src="https://github.com/user-attachments/assets/c4b1cfe2-9f2d-46ec-b03c-8e0b7a38deb8" />


After (with variational smoothing option enabled and selected)
<img width="1840" height="1119" alt="image" src="https://github.com/user-attachments/assets/97925d68-e117-45c2-8b08-b2380ec2498f" />


