### PR TITLE
PD: Add interactive Pad and Pocket start controls

### DIFF
--- a/src/Gui/Inventor/Draggers/Gizmo.cpp
+++ b/src/Gui/Inventor/Draggers/Gizmo.cpp
@@ -307,9 +307,7 @@ void LinearGizmo::draggingContinued()
         value = snapToStep(value, baseStep * getCoarseLinearSnapMultiplier());
     }
 
-    // TODO: Need to change the lower limit to sudoThis->property->minimum() once the
-    // two direction extrude work gets merged
-    value = std::clamp(value, dragger->translationIncrement.getValue(), property->maximum());
+    value = std::clamp(value, property->minimum(), property->maximum());
 
     property->setValue(value);
     setDragLength(value);

--- a/src/Gui/Inventor/Draggers/Gizmo.cpp
+++ b/src/Gui/Inventor/Draggers/Gizmo.cpp
@@ -24,6 +24,7 @@
 #include "Gizmo.h"
 
 #include <cmath>
+#include <utility>
 #include <QApplication>
 
 #include <Inventor/nodes/SoOrthographicCamera.h>
@@ -147,12 +148,16 @@ SoInteractionKit* LinearGizmo::initDragger()
 
     dragger->labelVisible = false;
 
-    dragger->instantiateBaseGeometry();
+    if (draggerStyle == LinearDraggerStyle::Sphere) {
+        dragger->setPart("arrow", new SoSphereGeometry);
+    }
+    else {
+        dragger->instantiateBaseGeometry();
 
-    // change the dragger dimensions
-    auto arrow = SO_GET_PART(dragger, "arrow", SoArrowGeometry);
-    arrow->cylinderHeight = 3.5;
-    arrow->cylinderRadius = 0.2;
+        auto arrow = SO_GET_PART(dragger, "arrow", SoArrowGeometry);
+        arrow->cylinderHeight = 3.5;
+        arrow->cylinderRadius = 0.2;
+    }
 
     updateColorTheme();
 
@@ -265,6 +270,16 @@ void LinearGizmo::setAddFactor(const double val)
     setDragLength(property->value().getValue());
 }
 
+void LinearGizmo::setDraggerStyle(LinearDraggerStyle style)
+{
+    draggerStyle = style;
+}
+
+void LinearGizmo::setClickCallback(ClickCallback callback)
+{
+    clickCallback = std::move(callback);
+}
+
 void LinearGizmo::setVisibility(bool visible)
 {
     this->visible = visible;
@@ -274,6 +289,7 @@ void LinearGizmo::setVisibility(bool visible)
 void LinearGizmo::draggingStarted()
 {
     initialValue = property->value().getValue();
+    hasDragged = false;
     dragger->translationIncrementCount.setValue(0);
 
     if (isDelayedUpdateEnabled()) {
@@ -288,12 +304,17 @@ void LinearGizmo::draggingFinished()
         property->valueChanged(property->value().getValue());
     }
 
+    if (!hasDragged && clickCallback) {
+        clickCallback();
+    }
+
     property->setFocus();
     property->selectAll();
 }
 
 void LinearGizmo::draggingContinued()
 {
+    hasDragged = true;
     double value = initialValue + getDragLength();
 
     auto fineModifier = GizmoContainer::getFineSnapModifier();

--- a/src/Gui/Inventor/Draggers/Gizmo.h
+++ b/src/Gui/Inventor/Draggers/Gizmo.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <functional>
 #include <initializer_list>
 #include <memory>
 #include <vector>
@@ -91,9 +92,17 @@ protected:
     bool visible = true;
 };
 
+enum class LinearDraggerStyle
+{
+    Arrow,
+    Sphere,
+};
+
 class GuiExport LinearGizmo: public Gizmo
 {
 public:
+    using ClickCallback = std::function<void()>;
+
     LinearGizmo(QuantitySpinBox* property);
     ~LinearGizmo() override = default;
 
@@ -114,6 +123,8 @@ public:
     void setProperty(QuantitySpinBox* property);
     void setMultFactor(const double val);
     void setAddFactor(const double val);
+    void setDraggerStyle(LinearDraggerStyle style);
+    void setClickCallback(ClickCallback callback);
     void setVisibility(bool visible);
 
 private:
@@ -121,6 +132,9 @@ private:
     SoLinearDraggerContainer* draggerContainer = nullptr;
     QMetaObject::Connection quantityChangedConnection;
     QMetaObject::Connection formulaDialogConnection;
+    LinearDraggerStyle draggerStyle = LinearDraggerStyle::Arrow;
+    bool hasDragged = false;
+    ClickCallback clickCallback;
 
     void draggingStarted();
     void draggingFinished();

--- a/src/Gui/Inventor/Draggers/SoLinearDraggerGeometry.cpp
+++ b/src/Gui/Inventor/Draggers/SoLinearDraggerGeometry.cpp
@@ -26,6 +26,7 @@
 #include <Inventor/nodes/SoCylinder.h>
 #include <Inventor/nodes/SoLightModel.h>
 #include <Inventor/nodes/SoPickStyle.h>
+#include <Inventor/nodes/SoSphere.h>
 #include <Inventor/nodes/SoTranslation.h>
 
 #include "SoLinearDraggerGeometry.h"
@@ -108,6 +109,37 @@ void SoArrowGeometry::notify(SoNotList* notList)
 
         tipPosition = {0, cylinderHeight.getValue() + 1.5f * coneHeight.getValue(), 0};
     }
+}
+
+SO_KIT_SOURCE(SoSphereGeometry)
+
+void SoSphereGeometry::initClass()
+{
+    SO_KIT_INIT_CLASS(SoSphereGeometry, SoLinearGeometryKit, "LinearGeometryKit");
+}
+
+SoSphereGeometry::SoSphereGeometry()
+{
+    SO_KIT_CONSTRUCTOR(SoSphereGeometry);
+    SO_KIT_ADD_CATALOG_ENTRY(separator, SoSeparator, false, this, "", false);
+    SO_KIT_ADD_CATALOG_ENTRY(lightModel, SoLightModel, false, separator, "", false);
+    SO_KIT_ADD_CATALOG_ENTRY(pickStyle, SoPickStyle, false, separator, "", false);
+    SO_KIT_ADD_CATALOG_ENTRY(sphere, SoSphere, false, separator, "", true);
+
+    SO_KIT_ADD_FIELD(radius, (0.7f));
+
+    SO_KIT_INIT_INSTANCE();
+
+    auto sphere = SO_GET_ANY_PART(this, "sphere", SoSphere);
+    sphere->radius.connectFrom(&radius);
+
+    auto lightModel = SO_GET_ANY_PART(this, "lightModel", SoLightModel);
+    lightModel->model = SoLightModel::BASE_COLOR;
+
+    auto pickStyle = SO_GET_ANY_PART(this, "pickStyle", SoPickStyle);
+    pickStyle->style = SoPickStyle::SHAPE_ON_TOP;
+
+    tipPosition = {0, 1, 0};
 }
 
 SO_KIT_SOURCE(SoLinearGeometryBaseKit)

--- a/src/Gui/Inventor/Draggers/SoLinearDraggerGeometry.h
+++ b/src/Gui/Inventor/Draggers/SoLinearDraggerGeometry.h
@@ -83,6 +83,27 @@ private:
     using inherited = SoLinearGeometryKit;
 };
 
+class GuiExport SoSphereGeometry: public SoLinearGeometryKit
+{
+    SO_KIT_HEADER(SoSphereGeometry);
+    SO_KIT_CATALOG_ENTRY_HEADER(separator);
+    SO_KIT_CATALOG_ENTRY_HEADER(lightModel);
+    SO_KIT_CATALOG_ENTRY_HEADER(pickStyle);
+    SO_KIT_CATALOG_ENTRY_HEADER(sphere);
+
+public:
+    static void initClass();
+    SoSphereGeometry();
+
+    SoSFFloat radius;
+
+protected:
+    ~SoSphereGeometry() override = default;
+
+private:
+    using inherited = SoLinearGeometryKit;
+};
+
 class GuiExport SoLinearGeometryBaseKit: public SoBaseKit
 {
     SO_KIT_HEADER(SoLinearGeometryBaseKit);

--- a/src/Gui/SoFCDB.cpp
+++ b/src/Gui/SoFCDB.cpp
@@ -152,6 +152,7 @@ void Gui::SoFCDB::init()
     SoTransformDragger ::initClass();
     SoLinearGeometryKit ::initClass();
     SoArrowGeometry ::initClass();
+    SoSphereGeometry ::initClass();
     SoLinearGeometryBaseKit ::initClass();
     SoArrowBase ::initClass();
     SoRotatorGeometryKit ::initClass();

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -1501,8 +1501,18 @@ void TaskExtrudeParameters::setupGizmos()
         return;
     }
 
+    const auto toggleReversed = [this] {
+        if (ui->checkBoxReversed->isEnabled()) {
+            ui->checkBoxReversed->setChecked(!ui->checkBoxReversed->isChecked());
+        }
+    };
+
     lengthGizmo1 = new Gui::LinearGizmo(ui->lengthEdit);
+    lengthGizmo1->setClickCallback(toggleReversed);
     lengthGizmo2 = new Gui::LinearGizmo(ui->lengthEdit2);
+    lengthGizmo2->setClickCallback(toggleReversed);
+    startOffsetGizmo = new Gui::LinearGizmo(ui->startOffsetEdit);
+    startOffsetGizmo->setDraggerStyle(Gui::LinearDraggerStyle::Sphere);
     taperAngleGizmo1 = new Gui::RotationGizmo(ui->taperEdit);
     taperAngleGizmo2 = new Gui::RotationGizmo(ui->taperEdit2);
 
@@ -1511,7 +1521,7 @@ void TaskExtrudeParameters::setupGizmos()
     });
 
     gizmoContainer = GizmoContainer::create(
-        {lengthGizmo1, lengthGizmo2, taperAngleGizmo1, taperAngleGizmo2},
+        {lengthGizmo1, lengthGizmo2, startOffsetGizmo, taperAngleGizmo1, taperAngleGizmo2},
         vp
     );
 
@@ -1542,13 +1552,23 @@ void TaskExtrudeParameters::setGizmoPositions()
     Base::Vector3d direction = extrude->Direction.getValue() * dir;
     Base::Vector3d center1 = center;
     Base::Vector3d center2 = center;
+    const bool hasStartOffset = std::strcmp(extrude->StartType.getValueAsString(), "Profile plane")
+        != 0;
     try {
-        const Base::Vector3d start = direction.Normalized() * extrude->getStartOffset();
+        const Base::Vector3d startDirection = direction.Normalized();
+        const double effectiveStartOffset = extrude->getStartOffset();
+        const Base::Vector3d start = startDirection * effectiveStartOffset;
         center1 += start;
         center2 += start;
+        startOffsetGizmo->Gizmo::setDraggerPlacement(
+            center + startDirection * (effectiveStartOffset - extrude->StartOffset.getValue()),
+            direction
+        );
     }
     catch (const Base::Exception&) {
     }
+
+    startOffsetGizmo->setVisibility(hasStartOffset);
 
     lengthGizmo1->Gizmo::setDraggerPlacement(center1, direction);
     lengthGizmo1->setVisibility(extrudeType == "Length");

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.h
@@ -271,6 +271,7 @@ private:
     void updateStartReferenceName();
 
     std::unique_ptr<Gui::GizmoContainer> gizmoContainer;
+    Gui::LinearGizmo* startOffsetGizmo = nullptr;
     Gui::LinearGizmo* lengthGizmo1 = nullptr;
     Gui::LinearGizmo* lengthGizmo2 = nullptr;
     Gui::RotationGizmo* taperAngleGizmo1 = nullptr;


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
After the start offset was merged this PR introduces a dragger for the offset:

- Added the small spherical start-offset handle (only shown when Start is Offset or Reference + Offset)
- Added click-to-reverse on both length handles
- Allow to drag length draggers to negative length

Assisted-by: GPT-5.6-Terra
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/23739

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

https://github.com/user-attachments/assets/ebda08fb-47a8-4801-b2f8-96387512d189



https://github.com/user-attachments/assets/79a5b56f-37f5-4fb0-855d-de50212f6f92



https://github.com/user-attachments/assets/ce6ad9ce-a9a3-4880-a705-bdd58cb338be



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
