### PR TITLE
CAM: MillFacing - Fixes

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PageOpMillFacingEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpMillFacingEdit.ui
@@ -112,7 +112,7 @@
          <string>%</string>
         </property>
         <property name="decimals">
-         <number>1</number>
+         <number>0</number>
         </property>
         <property name="minimum">
          <double>1.000000000000000</double>

--- a/src/Mod/CAM/Path/Base/Generator/bidirectional_facing.py
+++ b/src/Mod/CAM/Path/Base/Generator/bidirectional_facing.py
@@ -1,27 +1,23 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: LGPL-2.1-or-later
-# ***************************************************************************
-# *                                                                         *
-# *   Copyright (c) 2025 sliptonic sliptonic@freecad.org                    *
-# *                                                                         *
-# *   This file is part of FreeCAD.                                         *
-# *                                                                         *
-# *   FreeCAD is free software: you can redistribute it and/or modify it    *
-# *   under the terms of the GNU Lesser General Public License as           *
-# *   published by the Free Software Foundation, either version 2.1 of the  *
-# *   License, or (at your option) any later version.                       *
-# *                                                                         *
-# *   FreeCAD is distributed in the hope that it will be useful, but        *
-# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
-# *   Lesser General Public License for more details.                       *
-# *                                                                         *
-# *   You should have received a copy of the GNU Lesser General Public      *
-# *   License along with FreeCAD. If not, see                               *
-# *   <https://www.gnu.org/licenses/>.                                      *
-# *                                                                         *
-# ***************************************************************************
+# SPDX-FileCopyrightText: 2025 sliptonic sliptonic@freecad.org
+# SPDX-FileNotice: Part of the FreeCAD project.
 
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
 
 """
 Bidirectional facing toolpath generator.
@@ -83,75 +79,39 @@ def bidirectional(
     # Use the proven generate_t_values (with coverage fix) for full coverage
     # ------------------------------------------------------------------
     step_positions = facing_common.generate_t_values(
-        polygon, step_vec, tool_diameter, stepover_percent, origin
+        polygon, step_vec, tool_diameter, stepover_percent, origin, end_at_center=True
     )
 
     tool_radius = tool_diameter / 2.0
-    stepover_distance = tool_diameter * stepover_percent / 100.0
-
-    # Coverage guarantee at ≥100% stepover (exact same fix as zigzag/directional)
-    if stepover_percent >= 99.9 and step_positions:
-        min_covered = min(step_positions) - tool_radius
-        max_covered = max(step_positions) + tool_radius
-
-        added = False
-        if max_covered < max_t - 1e-4:
-            step_positions.append(step_positions[-1] + stepover_distance)
-            added = True
-        if min_covered > min_t + 1e-4:
-            step_positions.insert(0, step_positions[0] - stepover_distance)
-            added = True
-        if added:
-            Path.Log.info(
-                "Bidirectional facing: Added extra pass(es) for full coverage at ≥100% stepover"
-            )
-
     center = (min_t + max_t) / 2.0
-
-    # Split into bottom (≤ center) and top (> center)
-    bottom_positions = [t for t in step_positions if t <= center]  # ascending = outer → inner
-    top_positions = [t for t in step_positions if t > center][::-1]  # descending = outer → inner
-
-    # Interleave, starting with top if reverse=True
-    all_passes = []
-    max_passes = max(len(bottom_positions), len(top_positions))
-    for i in range(max_passes):
-        if reverse:
-            if i < len(top_positions):
-                all_passes.append(("top", top_positions[i]))
-            if i < len(bottom_positions):
-                all_passes.append(("bottom", bottom_positions[i]))
-        else:
-            if i < len(bottom_positions):
-                all_passes.append(("bottom", bottom_positions[i]))
-            if i < len(top_positions):
-                all_passes.append(("top", top_positions[i]))
-
-    Path.Log.debug(
-        f"Bidirectional: {len(all_passes)} passes ({len(bottom_positions)} bottom, {len(top_positions)} top)"
-    )
 
     commands = []
     tool_radius = tool_diameter / 2.0
-    engagement_offset = facing_common.calculate_engagement_offset(tool_diameter, stepover_percent)
-    total_extension = pass_extension + tool_radius + engagement_offset
-
+    total_extension = pass_extension + tool_radius
     start_s = min_s - total_extension
     end_s = max_s + total_extension
 
-    for side, t in all_passes:
-        # Same direction for all passes on the same side → short outside rapids
-        if side == "bottom":
-            if milling_direction == "climb":
-                p_start, p_end = end_s, start_s  # right → left
-            else:
-                p_start, p_end = start_s, end_s  # left → right
-        else:  # top
-            if milling_direction == "climb":
-                p_start, p_end = start_s, end_s  # left → right
-            else:
-                p_start, p_end = end_s, start_s  # right → left
+    s_mid = (min_s + max_s) / 2
+    if start_s > s_mid or end_s < s_mid:
+        step_positions = []
 
+    swap = reverse
+    while step_positions:
+        if swap:
+            index = -1
+            if milling_direction == "climb":
+                p_start, p_end = start_s, end_s  # left → right
+            else:
+                p_start, p_end = end_s, start_s  # right → left
+        else:
+            index = 0
+            if milling_direction == "climb":
+                p_start, p_end = end_s, start_s  # right → left
+            else:
+                p_start, p_end = start_s, end_s  # left → right
+
+        swap = not swap
+        t = step_positions.pop(index)
         start_point = origin + primary_vec * p_start + step_vec * t
         end_point = origin + primary_vec * p_end + step_vec * t
         start_point.z = z

--- a/src/Mod/CAM/Path/Base/Generator/directional_facing.py
+++ b/src/Mod/CAM/Path/Base/Generator/directional_facing.py
@@ -1,26 +1,24 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: LGPL-2.1-or-later
-# ***************************************************************************
-# *                                                                         *
-# *   Copyright (c) 2025 sliptonic sliptonic@freecad.org                    *
-# *                                                                         *
-# *   This file is part of FreeCAD.                                         *
-# *                                                                         *
-# *   FreeCAD is free software: you can redistribute it and/or modify it    *
-# *   under the terms of the GNU Lesser General Public License as           *
-# *   published by the Free Software Foundation, either version 2.1 of the  *
-# *   License, or (at your option) any later version.                       *
-# *                                                                         *
-# *   FreeCAD is distributed in the hope that it will be useful, but        *
-# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
-# *   Lesser General Public License for more details.                       *
-# *                                                                         *
-# *   You should have received a copy of the GNU Lesser General Public      *
-# *   License along with FreeCAD. If not, see                               *
-# *   <https://www.gnu.org/licenses/>.                                      *
-# *                                                                         *
-# ***************************************************************************
+# SPDX-FileCopyrightText: 2025 sliptonic sliptonic@freecad.org
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
 """
 Directional (unidirectional) facing toolpath generator.
 
@@ -37,6 +35,7 @@ This strategy always maintains either climb or conventional milling direction.
 
 import FreeCAD
 import Path
+import math
 from . import facing_common
 
 if False:
@@ -56,11 +55,6 @@ def directional(
     reverse=False,
     angle_degrees=None,
 ):
-
-    import math
-    import Path
-    import FreeCAD
-    from . import facing_common
 
     if pass_extension is None:
         pass_extension = tool_diameter * 0.5
@@ -85,21 +79,6 @@ def directional(
     )
 
     tool_radius = tool_diameter / 2.0
-    stepover_distance = tool_diameter * (stepover_percent / 100.0)
-
-    if stepover_percent >= 99.9 and step_positions:
-        min_covered = min(step_positions) - tool_radius
-        max_covered = max(step_positions) + tool_radius
-
-        added = False
-        if max_covered < max_t - 1e-4:
-            step_positions.append(step_positions[-1] + stepover_distance)
-            added = True
-        if min_covered > min_t + 1e-4:
-            step_positions.insert(0, step_positions[0] - stepover_distance)
-            added = True
-        if added:
-            Path.Log.info("Directional: Added extra pass(es) for full coverage at high stepover")
 
     # Reverse = mirror positions around center (exactly like bidirectional) to preserve engagement offset on the starting side
     if reverse:
@@ -109,14 +88,13 @@ def directional(
     Path.Log.debug(f"Directional (fixed): {len(step_positions)} passes")
 
     # Use full-length passes exactly like bidirectional (no slice_wire_segments)
-    total_extension = (
-        pass_extension
-        + tool_radius
-        + facing_common.calculate_engagement_offset(tool_diameter, stepover_percent)
-    )
-
+    total_extension = pass_extension + tool_radius
     start_s = min_s - total_extension
     end_s = max_s + total_extension
+
+    s_mid = (min_s + max_s) / 2.0
+    if start_s > s_mid or end_s < s_mid:
+        step_positions = []
 
     commands = []
     kept_segments = 0
@@ -155,47 +133,5 @@ def directional(
         kept_segments += 1
 
     Path.Log.debug(f"Directional: generated {kept_segments} segments")
-    # Fallback: if nothing kept due to numeric guards, emit a single mid-line pass across bbox
-    if kept_segments == 0:
-        t_candidates = []
-        # mid, min, max t positions
-        t_candidates.append(0.5 * (min_t + max_t))
-        t_candidates.append(min_t)
-        t_candidates.append(max_t)
-        for t in t_candidates:
-            intervals = facing_common.slice_wire_segments(polygon, primary_vec, step_vec, t, origin)
-            if not intervals:
-                continue
-            s0, s1 = intervals[0]
-            start_s = max(s0 - pass_extension, min_s - s_margin)
-            end_s = min(s1 + pass_extension, max_s + s_margin)
-            if end_s <= start_s:
-                continue
-            if milling_direction == "climb":
-                p_start, p_end = start_s, end_s
-            else:
-                p_start, p_end = end_s, start_s
-            if reverse:
-                p_start, p_end = p_end, p_start
-            sp = (
-                FreeCAD.Vector(origin)
-                .add(FreeCAD.Vector(primary_vec).multiply(p_start))
-                .add(FreeCAD.Vector(step_vec).multiply(t))
-            )
-            ep = (
-                FreeCAD.Vector(origin)
-                .add(FreeCAD.Vector(primary_vec).multiply(p_end))
-                .add(FreeCAD.Vector(step_vec).multiply(t))
-            )
-            sp.z = z
-            ep.z = z
-            # Minimal preamble
-            if retract_height is not None:
-                commands.append(Path.Command("G0", {"Z": retract_height}))
-                commands.append(Path.Command("G0", {"X": sp.x, "Y": sp.y}))
-                commands.append(Path.Command("G0", {"Z": z}))
-            else:
-                commands.append(Path.Command("G1", {"X": sp.x, "Y": sp.y, "Z": z}))
-            commands.append(Path.Command("G1", {"X": ep.x, "Y": ep.y, "Z": z}))
-            break
+
     return commands

--- a/src/Mod/CAM/Path/Base/Generator/facing_common.py
+++ b/src/Mod/CAM/Path/Base/Generator/facing_common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # SPDX-FileCopyrightText: 2025 sliptonic sliptonic@freecad.org
 # SPDX-FileNotice: Part of the FreeCAD project.
@@ -266,15 +265,6 @@ def get_angled_polygon(wire, angle):
     return bounding_wire
 
 
-def calculate_engagement_offset(tool_diameter, stepover_percent):
-    """Calculate the engagement offset for proper tool engagement.
-
-    For 50% stepover, engagement should be 50% of tool diameter.
-    engagement_offset is how much of the tool is NOT engaged.
-    """
-    return tool_diameter * (1.0 - stepover_percent / 100.0)
-
-
 def validate_inputs(
     wire,
     tool_diameter,
@@ -405,12 +395,12 @@ def project_bounds(wire, vec, origin):
     return (min(ts), max(ts))
 
 
-def generate_t_values(wire, step_vec, tool_diameter, stepover_percent, origin):
+def generate_t_values(wire, step_vec, tool_diameter, stepover_percent, origin, end_at_center=False):
     """Generate step positions along step_vec with engagement offset and stepover.
 
-    The first pass engages (100 - stepover_percent)% of the tool diameter.
-    For 50% stepover, first pass engages 50% of tool diameter.
-    Tool center is positioned so the engaged portion touches the polygon edge.
+    end_at_center uses for bidirectinal pattern, passes starts at sides and ends near center
+
+    If only one pass created, place it at center
     """
     tool_radius = tool_diameter / 2.0
     stepover = tool_diameter * (stepover_percent / 100.0)
@@ -424,16 +414,38 @@ def generate_t_values(wire, step_vec, tool_diameter, stepover_percent, origin):
     # Start position: tool center positioned so engagement_amount reaches polygon edge
     # Tool center at: min_t - tool_radius + engagement_amount
     # This positions the engaged portion at the polygon edge
-    t = min_t - tool_radius + engagement_amount
     t_end = max_t + tool_radius - engagement_amount
 
-    values = []
     # Guard against zero/negative stepover
     if stepover <= 0:
-        return [t]
-    while t <= t_end + 1e-9:
-        values.append(t)
-        t += stepover
+        Path.Log.warning("Zero/negative stepover")
+        return []
+
+    if end_at_center:
+        t = t_end
+        values = [-t, +t]
+        while t - tool_radius > -t + tool_radius and not Path.Geom.isRoughly(
+            t - tool_radius, -t + tool_radius
+        ):
+            t -= stepover
+            values.append(-t)
+            values.append(+t)
+        if (
+            values[0] + tool_radius > max_t or Path.Geom.isRoughly(values[0] + tool_radius, max_t)
+        ) or (values[-2] + tool_radius > values[-1] - tool_radius + stepover):
+            # area cleared by previous pass and last pass can be removed
+            del values[-1]
+        values.sort()
+    else:
+        t = min_t - tool_radius + engagement_amount
+        values = [t]
+        while t + tool_radius < max_t and not Path.Geom.isRoughly(t + tool_radius, max_t):
+            t += stepover
+            values.append(t)
+
+    if len(values) == 1:  # single pass create at center
+        values = [0]
+
     return values
 
 
@@ -450,6 +462,7 @@ def slice_wire_segments(wire, primary_vec, step_vec, t, origin):
     bb = wire.BoundBox
     diag = math.hypot(bb.XLength, bb.YLength)
     s_debug_threshold = max(1.0, diag * 10.0)
+    Path.Log.debug(f"s_debug_threshold = {s_debug_threshold}")
 
     s_vals = []
     # Use scale-relative tolerance for near-parallel detection

--- a/src/Mod/CAM/Path/Base/Generator/spiral_facing.py
+++ b/src/Mod/CAM/Path/Base/Generator/spiral_facing.py
@@ -1,26 +1,24 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: LGPL-2.1-or-later
-# ***************************************************************************
-# *                                                                         *
-# *   Copyright (c) 2025 sliptonic sliptonic@freecad.org                    *
-# *                                                                         *
-# *   This file is part of FreeCAD.                                         *
-# *                                                                         *
-# *   FreeCAD is free software: you can redistribute it and/or modify it    *
-# *   under the terms of the GNU Lesser General Public License as           *
-# *   published by the Free Software Foundation, either version 2.1 of the  *
-# *   License, or (at your option) any later version.                       *
-# *                                                                         *
-# *   FreeCAD is distributed in the hope that it will be useful, but        *
-# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
-# *   Lesser General Public License for more details.                       *
-# *                                                                         *
-# *   You should have received a copy of the GNU Lesser General Public      *
-# *   License along with FreeCAD. If not, see                               *
-# *   <https://www.gnu.org/licenses/>.                                      *
-# *                                                                         *
-# ***************************************************************************
+# SPDX-FileCopyrightText: 2025 sliptonic sliptonic@freecad.org
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
 """
 Spiral facing toolpath generator.
 
@@ -30,7 +28,6 @@ including support for angled rectangles and proper tool engagement.
 
 import FreeCAD
 import Path
-from . import facing_common
 
 if False:
     Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
@@ -187,8 +184,6 @@ def spiral(
     in the limiting direction. This eliminates any uncleared areas in the center regardless of stepover% value.
     First engagement is preserved exactly at the requested percentage.
     """
-    import Path
-    import FreeCAD
     from . import facing_common
 
     theta = float(angle_degrees) if angle_degrees is not None else 0.0

--- a/src/Mod/CAM/Path/Base/Generator/zigzag_facing.py
+++ b/src/Mod/CAM/Path/Base/Generator/zigzag_facing.py
@@ -1,26 +1,24 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: LGPL-2.1-or-later
-# ***************************************************************************
-# *                                                                         *
-# *   Copyright (c) 2025 sliptonic sliptonic@freecad.org                    *
-# *                                                                         *
-# *   This file is part of FreeCAD.                                         *
-# *                                                                         *
-# *   FreeCAD is free software: you can redistribute it and/or modify it    *
-# *   under the terms of the GNU Lesser General Public License as           *
-# *   published by the Free Software Foundation, either version 2.1 of the  *
-# *   License, or (at your option) any later version.                       *
-# *                                                                         *
-# *   FreeCAD is distributed in the hope that it will be useful, but        *
-# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
-# *   Lesser General Public License for more details.                       *
-# *                                                                         *
-# *   You should have received a copy of the GNU Lesser General Public      *
-# *   License along with FreeCAD. If not, see                               *
-# *   <https://www.gnu.org/licenses/>.                                      *
-# *                                                                         *
-# ***************************************************************************
+# SPDX-FileCopyrightText: 2025 sliptonic sliptonic@freecad.org
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
 """
 Zigzag facing toolpath generator.
 
@@ -30,7 +28,7 @@ across the polygon in alternating directions, creating a continuous zigzag patte
 
 import FreeCAD
 import Path
-from . import facing_common
+import math
 
 if False:
     Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
@@ -58,7 +56,6 @@ def _create_link(
     Returns:
         List of Path.Command objects for the link
     """
-    import math
 
     P = prev_seg["end"]
     Q = next_seg["start"]
@@ -205,11 +202,10 @@ def zigzag(
     link_mode="arc",
     link_radius=None,
 ):
+    from . import facing_common
 
     if pass_extension is None:
         pass_extension = tool_diameter * 0.5
-
-    import math
 
     theta = float(angle_degrees) if angle_degrees is not None else 0.0
     primary_vec, step_vec = facing_common.unit_vectors_from_angle(theta)
@@ -239,21 +235,6 @@ def zigzag(
     tool_radius = tool_diameter / 2.0
     stepover_distance = tool_diameter * (stepover_percent / 100.0)
 
-    # Guarantee full coverage at high stepover – identical to bidirectional/directional
-    if stepover_percent >= 99.9 and step_positions:
-        min_covered = min(step_positions) - tool_radius
-        max_covered = max(step_positions) + tool_radius
-
-        added = False
-        if max_covered < max_t - 1e-4:
-            step_positions.append(step_positions[-1] + stepover_distance)
-            added = True
-        if min_covered > min_t + 1e-4:
-            step_positions.insert(0, step_positions[0] - stepover_distance)
-            added = True
-        if added:
-            Path.Log.info("Zigzag: Added extra pass(es) for full coverage at ≥100% stepover")
-
     # Reverse only reverses traversal order (same positions set as reverse=False, identical coverage)
     if reverse:
         step_positions = step_positions[::-1]
@@ -267,14 +248,13 @@ def zigzag(
         milling_direction == "climb"
     ) ^ reverse  # True → negative primary for first pass
 
-    total_extension = (
-        pass_extension
-        + tool_radius
-        + facing_common.calculate_engagement_offset(tool_diameter, stepover_percent)
-    )
+    total_extension = pass_extension + tool_radius
     start_s = min_s - total_extension
     end_s = max_s + total_extension
+
     s_mid = (min_s + max_s) / 2.0
+    if start_s > s_mid or end_s < s_mid:
+        step_positions = []
 
     segments = []
 

--- a/src/Mod/CAM/Path/Op/Gui/MillFacing.py
+++ b/src/Mod/CAM/Path/Op/Gui/MillFacing.py
@@ -1,26 +1,24 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: LGPL-2.1-or-later
-# ***************************************************************************
-# *                                                                         *
-# *   Copyright (c) 2025 sliptonic sliptonic@freecad.org                    *
-# *                                                                         *
-# *   This file is part of FreeCAD.                                         *
-# *                                                                         *
-# *   FreeCAD is free software: you can redistribute it and/or modify it    *
-# *   under the terms of the GNU Lesser General Public License as           *
-# *   published by the Free Software Foundation, either version 2.1 of the  *
-# *   License, or (at your option) any later version.                       *
-# *                                                                         *
-# *   FreeCAD is distributed in the hope that it will be useful, but        *
-# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
-# *   Lesser General Public License for more details.                       *
-# *                                                                         *
-# *   You should have received a copy of the GNU Lesser General Public      *
-# *   License along with FreeCAD. If not, see                               *
-# *   <https://www.gnu.org/licenses/>.                                      *
-# *                                                                         *
-# ***************************************************************************
+# SPDX-FileCopyrightText: 2025 sliptonic sliptonic@freecad.org
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
 
 from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD
@@ -122,6 +120,8 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         # Update QuantitySpinBox displays
         self.updateQuantitySpinBoxes()
 
+        self.updateVisibility()
+
     def updateQuantitySpinBoxes(self, index=None):
         """updateQuantitySpinBoxes() ... refresh QuantitySpinBox displays from properties"""
         self.axialStockToLeaveSpinBox.updateWidget()
@@ -149,6 +149,17 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.stepOver.editingFinished)
 
         return signals
+
+    def updateVisibility(self):
+        if self.obj.ClearingPattern == "Spiral":
+            self.form.passExtension.hide()
+            self.form.passExtension_label.hide()
+        else:
+            self.form.passExtension.show()
+            self.form.passExtension_label.show()
+
+    def registerSignalHandlers(self, obj):
+        self.form.clearingPattern.currentIndexChanged.connect(self.updateVisibility)
 
 
 Command = PathOpGui.SetupOperation(

--- a/src/Mod/CAM/Path/Op/MillFacing.py
+++ b/src/Mod/CAM/Path/Op/MillFacing.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # SPDX-FileCopyrightText: 2025 sliptonic sliptonic@freecad.org
 # SPDX-FileNotice: Part of the FreeCAD project.
@@ -28,18 +27,21 @@ __doc__ = "Class and implementation of Mill Facing operation."
 __contributors__ = ""
 
 import FreeCAD
-from PySide import QtCore
 import Path
 import Path.Op.Base as PathOp
 
-import Path.Base.Generator.spiral_facing as spiral_facing
-import Path.Base.Generator.facing_common as facing_common
-import Path.Base.Generator.zigzag_facing as zigzag_facing
-import Path.Base.Generator.directional_facing as directional_facing
-import Path.Base.Generator.bidirectional_facing as bidirectional_facing
-import Path.Base.Generator.linking as linking
-import PathScripts.PathUtils as PathUtils
-import Path.Base.FeedRate as FeedRate
+from Path.Base import FeedRate
+from Path.Base.Generator import (
+    bidirectional_facing,
+    directional_facing,
+    facing_common,
+    linking,
+    spiral_facing,
+    zigzag_facing,
+)
+
+from PathScripts import PathUtils
+from PySide import QtCore
 
 # lazily loaded modules
 from lazy_loader.lazy_loader import LazyLoader
@@ -84,7 +86,7 @@ class ObjectMillFacing(PathOp.ObjectOp):
     def initOpProperties(self, obj, warn=False):
         """initOpProperties(obj) ... create operation specific properties"""
         Path.Log.track()
-        self.addNewProps = list()
+        self.addNewProps = []
 
         for prtyp, nm, grp, tt in self.opPropertyDefinitions():
             if not hasattr(obj, nm):
@@ -108,14 +110,21 @@ class ObjectMillFacing(PathOp.ObjectOp):
     def onChanged(self, obj, prop):
         """onChanged(obj, prop) ... Called when a property changes"""
         if prop == "StepOver" and hasattr(obj, "StepOver"):
-            # Validate StepOver is between 0 and 100 percent
-            if obj.StepOver < 0:
-                obj.StepOver = 0
+            # Validate StepOver is between 1 and 100 percent
+            if obj.StepOver < 1:
+                obj.StepOver = 1
             elif obj.StepOver > 100:
                 obj.StepOver = 100
 
+        if prop == "ClearingPattern":
+            self.opUpdateEditorModes(obj)
+
         if prop == "Active" and obj.ViewObject:
             obj.ViewObject.signalChangeIcon()
+
+    def opUpdateEditorModes(self, obj):
+        mode = 2 if obj.ClearingPattern == "Spiral" else 0
+        obj.setEditorMode("PassExtension", mode)
 
     def opPropertyDefinitions(self):
         """opPropertyDefinitions(obj) ... Store operation specific properties"""
@@ -223,7 +232,7 @@ class ObjectMillFacing(PathOp.ObjectOp):
         if dataType == "raw":
             return enums
 
-        data = list()
+        data = []
         idx = 0 if dataType == "translated" else 1
 
         Path.Log.debug(enums)
@@ -327,14 +336,17 @@ class ObjectMillFacing(PathOp.ObjectOp):
             Path.Log.error("No stock found for facing operation")
             raise ValueError("No stock found for facing operation")
 
-        # offset with intersection joins
-        boundary_wires = [w.makeOffset2D(obj.StockExtension.Value, 2) for w in boundary_wires]
-
         # Convert boundary to a rectangular polygon aligned to the cut angle.
         # Stock faces may have curved edges (e.g. cylindrical stock) and all
         # facing strategies assume a rectangular boundary.
         cut_angle = getattr(obj.Angle, "Value", obj.Angle)
         boundary_wire = facing_common.get_angled_polygon(boundary_wires, cut_angle)
+
+        # offset with intersection joins
+        offsetVal = obj.StockExtension.Value
+        if offsetVal < 0:
+            offsetVal = max(offsetVal, -0.5 * min(e.Length for e in boundary_wire.Edges))
+        boundary_wire = boundary_wire.makeOffset2D(offsetVal, 2)
 
         # Determine milling direction
         milling_direction = "climb" if obj.CutMode == "Climb" else "conventional"
@@ -462,7 +474,7 @@ class ObjectMillFacing(PathOp.ObjectOp):
                     # Now append the base commands, skipping the generator's initial positioning move
                     for i, cmd in enumerate(base_commands):
                         # Skip the first move if it only positions at the start point
-                        if i == first_move_idx:
+                        if i <= first_move_idx:
                             # If this first move has only XY(Z) to the start point, skip it because we preambled it
                             pass
                         else:


### PR DESCRIPTION
Fixes #31834
Fixes #30760
- #31834
- #30760

---

### Changes
- Refactored imports, removed duplication, fixed some linter errors, SPDX
- Removed decimal in `StepOver` field in Task panel
- Fixed first move index usage in `MillFacing.py`
- Fixed `ZigZag` pattern, which not create single pass in some cases (picture 1)
- Fixed `Directional` pattern, which raise error while create single pass (picture 2)
- Fixed `Bidirectional` pattern, which give not cleared area in some cases (picture 3)
- Fixes for too big negative `StockExtension` ([Issue #30760](https://github.com/FreeCAD/FreeCAD/issues/30760))
- Removed `calculate_engagement_offset()` ([comment](https://github.com/FreeCAD/FreeCAD/pull/31840#issuecomment-5238430184))
- If single pass, place it at stock center
- Fixes for too big negative `PassExtension`, which creates cross-over passes (picture 4)
- Hide property `PassExtension` for `Spiral` clearing pattern in `Property View` and `Task panel`

---

Test project: [millfacing_31840.zip](https://github.com/user-attachments/files/30892625/millfacing_31840.zip)

---

<img width="750" height="628" alt="Screenshot_20260810_112822_hor_lossy" src="https://github.com/user-attachments/assets/738c63e3-e5d1-42a0-ab5c-b23024b94569" />

<img width="750" height="654" alt="Screenshot_20260810_113059_hor_lossy" src="https://github.com/user-attachments/assets/3c2d5866-7b39-46cf-a49d-04152f8aaf21" />

<img width="1259" height="654" alt="1_hor_lossy" src="https://github.com/user-attachments/assets/82e16113-9f13-40f5-9ca3-3ca156618a6b" />

<img width="1702" height="517" alt="Screenshot_20260811_101450_hor_lossy" src="https://github.com/user-attachments/assets/10927e56-0d13-48cf-a354-262d008b4157" />

