### PR TITLE
PD: Support Pad and Pocket starts from a surface

### DIFF
--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -891,9 +891,19 @@ double FeatureExtrude::getStartReferenceOffset(
     }
 
     TopoShape referenceShape;
+    const auto& subValues = reference.getSubValues();
     if (reference.getValue()->isDerivedFrom<Part::Part2DObject>()) {
-        referenceShape
-            = getTopoShapeVerifiedFace(false, false, reference.getValue(), reference.getSubValues());
+        if (!subValues.empty()) {
+            referenceShape = Part::Feature::getTopoShape(
+                reference.getValue(),
+                Part::ShapeOption::NeedSubElement | Part::ShapeOption::ResolveLink
+                    | Part::ShapeOption::Transform,
+                subValues.front().c_str()
+            );
+        }
+        if (!referenceShape.hasSubShape(TopAbs_FACE)) {
+            referenceShape = getTopoShapeVerifiedFace(false, false, reference.getValue(), subValues);
+        }
     }
     else {
         getUpToFaceFromLinkSub(referenceShape, reference);

--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -322,9 +322,10 @@ void FeatureExtrude::updateProperties()
     UpToShape2.setReadOnly(!isUpToShape2Enabled);
     Offset2.setReadOnly(!isOffset2Enabled);
 
-    const bool isStartOffsetEnabled = std::strcmp(StartType.getValueAsString(), "Profile plane") != 0;
+    const char* startType = StartType.getValueAsString();
+    const bool isStartOffsetEnabled = std::strcmp(startType, "Profile plane") != 0;
     StartOffset.setReadOnly(!isStartOffsetEnabled);
-    StartReference.setReadOnly(std::strcmp(StartType.getValueAsString(), "Reference") != 0);
+    StartReference.setReadOnly(std::strcmp(startType, "Reference") != 0);
 
     AlongSketchNormal.setReadOnly(!currentAlongSketchNormalEnabled);
 }
@@ -348,7 +349,6 @@ double FeatureExtrude::getStartOffset() const
     if (std::strcmp(startType, "Offset") == 0) {
         return StartOffset.getValue();
     }
-
     TopLoc_Location identity;
     return getStartReferenceOffset(
         getTopoShapeVerifiedFace(),
@@ -521,30 +521,146 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
         sketchshape.move(invObjLoc);
 
         const char* startType = StartType.getValueAsString();
-        const double startOffset = std::strcmp(startType, "Profile plane") == 0 ? 0.0
-            : std::strcmp(startType, "Offset") == 0
-            ? StartOffset.getValue()
-            : getStartReferenceOffset(sketchshape, StartReference, dir, StartOffset.getValue(), invObjLoc);
+        bool fromSurface = false;
+        if (std::strcmp(startType, "Reference") == 0 && StartReference.getValue()) {
+            TopoShape referenceShape;
+            if (StartReference.getValue()->isDerivedFrom<Part::Part2DObject>()) {
+                referenceShape = getTopoShapeVerifiedFace(
+                    false,
+                    false,
+                    StartReference.getValue(),
+                    StartReference.getSubValues()
+                );
+            }
+            else {
+                getUpToFaceFromLinkSub(referenceShape, StartReference);
+            }
+            referenceShape.move(invObjLoc);
+            if (referenceShape.shapeType(true) != TopAbs_FACE) {
+                referenceShape = referenceShape.getSubTopoShape(TopAbs_FACE, 1);
+            }
+            BRepAdaptor_Surface surface(TopoDS::Face(referenceShape.getShape()));
+            fromSurface = surface.GetType() != GeomAbs_Plane;
+        }
+        if (fromSurface && Sidemethod != "One side") {
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+                "Exception",
+                "A non-planar start reference is only supported for one-sided extrusions"
+            ));
+        }
+        if (fromSurface && (method == "Length" || method == "ThroughAll")
+            && std::fabs(TaperAngle.getValue()) > Base::toRadians(Precision::Angular())) {
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+                "Exception",
+                "A non-planar start reference does not support taper angles"
+            ));
+        }
+
+        double startOffset = 0.0;
+        if (std::strcmp(startType, "Offset") == 0) {
+            startOffset = StartOffset.getValue();
+        }
+        else if (std::strcmp(startType, "Reference") == 0 && !fromSurface) {
+            startOffset = getStartReferenceOffset(
+                sketchshape,
+                StartReference,
+                dir,
+                StartOffset.getValue(),
+                invObjLoc
+            );
+        }
         TopoShape startSketch = moveProfileToStart(sketchshape, dir, startOffset);
+
+        TopoShape startSurfacePrism(0, getDocument()->getStringHasher());
+        double surfaceStartOffset = 0.0;
+        if (fromSurface) {
+            surfaceStartOffset = getStartReferenceOffset(
+                sketchshape,
+                StartReference,
+                dir,
+                StartOffset.getValue(),
+                invObjLoc
+            );
+            startSurfacePrism = generateSingleExtrusionSide(
+                sketchshape,
+                "UpToFace",
+                0.0,
+                0.0,
+                StartReference,
+                UpToShape,
+                dir,
+                StartOffset.getValue(),
+                makeface,
+                base,
+                invObjLoc
+            );
+        }
 
         std::vector<TopoShape> prisms;  // Stores prisms, all in global CS
         double taper1 = TaperAngle.getValue();
         double offset1 = Offset.getValue();
 
         if (Sidemethod == "One side") {
-            TopoShape prism1 = generateSingleExtrusionSide(
-                startSketch,
-                method,
-                L,
-                taper1,
-                UpToFace,
-                UpToShape,
-                dir,
-                offset1,
-                makeface,
-                base,
-                invObjLoc
-            );
+            TopoShape prism1;
+            if (fromSurface && method == "Length" && L < 0.0) {
+                TopoShape surfaceStartSketch = moveProfileToStart(sketchshape, dir, surfaceStartOffset);
+                prism1 = generateSingleExtrusionSide(
+                    surfaceStartSketch,
+                    method,
+                    L,
+                    taper1,
+                    UpToFace,
+                    UpToShape,
+                    dir,
+                    offset1,
+                    makeface,
+                    base,
+                    invObjLoc
+                );
+            }
+            else if (fromSurface && method == "Length") {
+                const double endOffset = getStartReferenceOffset(
+                    sketchshape,
+                    StartReference,
+                    dir,
+                    StartOffset.getValue() + L,
+                    invObjLoc
+                );
+                gp_Dir endDir = dir;
+                double surfaceOffset = StartOffset.getValue() + L;
+                if (endOffset < 0.0) {
+                    endDir.Reverse();
+                    surfaceOffset = -surfaceOffset;
+                }
+                prism1 = generateSingleExtrusionSide(
+                    sketchshape,
+                    "UpToFace",
+                    0.0,
+                    0.0,
+                    StartReference,
+                    UpToShape,
+                    endDir,
+                    surfaceOffset,
+                    makeface,
+                    base,
+                    invObjLoc
+                );
+            }
+            else {
+                prism1 = generateSingleExtrusionSide(
+                    startSketch,
+                    method,
+                    L,
+                    taper1,
+                    UpToFace,
+                    UpToShape,
+                    dir,
+                    offset1,
+                    makeface,
+                    base,
+                    invObjLoc
+                );
+            }
             prisms.push_back(prism1);
         }
         else if (Sidemethod == "Symmetric") {
@@ -776,6 +892,33 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "Resulting fused extrusion is null.")
             );
+        }
+
+        if (fromSurface) {
+            try {
+                if (method == "Length" && L < 0.0) {
+                    prism.makeElementFuse({prism, startSurfacePrism}, Part::OpCodes::Extrude);
+                }
+                else {
+                    prism.makeElementXor({prism, startSurfacePrism}, Part::OpCodes::Extrude);
+                }
+            }
+            catch (const Standard_Failure& e) {
+                return new App::DocumentObjectExecReturn(
+                    std::string("Failed to combine extrusion from surface (OCC): ")
+                    + e.GetMessageString()
+                );
+            }
+            catch (const Base::Exception& e) {
+                return new App::DocumentObjectExecReturn(
+                    std::string("Failed to combine extrusion from surface: ") + e.what()
+                );
+            }
+            if (prism.isNull()) {
+                return new App::DocumentObjectExecReturn(
+                    QT_TRANSLATE_NOOP("Exception", "Extrusion does not reach the start surface")
+                );
+            }
         }
 
         // store shape before refinement

--- a/src/Mod/PartDesign/App/FeaturePad.cpp
+++ b/src/Mod/PartDesign/App/FeaturePad.cpp
@@ -75,15 +75,15 @@ Pad::Pad()
         App::Prop_None,
         "Measure pad length along the sketch normal direction"
     );
-    ADD_PROPERTY_TYPE(StartType, (0L), "Start", App::Prop_None, "How to define the start plane");
+    ADD_PROPERTY_TYPE(StartType, (0L), "Start", App::Prop_None, "How to define the pad start");
     StartType.setEnums(StartTypesEnums);
-    ADD_PROPERTY_TYPE(StartOffset, (0.0), "Start", App::Prop_None, "Offset from the start plane");
+    ADD_PROPERTY_TYPE(StartOffset, (0.0), "Start", App::Prop_None, "Offset from the pad start");
     ADD_PROPERTY_TYPE(
         StartReference,
         (nullptr),
         "Start",
         App::Prop_None,
-        "Face, plane or sketch used as the start reference"
+        "Face, plane or sketch used as the pad start reference"
     );
     ADD_PROPERTY_TYPE(UpToFace, (nullptr), "Side1", App::Prop_None, "Face where pad will end");
     ADD_PROPERTY_TYPE(UpToShape, (nullptr), "Side1", App::Prop_None, "Faces or shape(s) where pad will end");

--- a/src/Mod/PartDesign/App/FeaturePocket.cpp
+++ b/src/Mod/PartDesign/App/FeaturePocket.cpp
@@ -82,15 +82,15 @@ Pocket::Pocket()
         App::Prop_None,
         "Measure pocket length along the sketch normal direction"
     );
-    ADD_PROPERTY_TYPE(StartType, (0L), "Start", App::Prop_None, "How to define the start plane");
+    ADD_PROPERTY_TYPE(StartType, (0L), "Start", App::Prop_None, "How to define the pocket start");
     StartType.setEnums(StartTypesEnums);
-    ADD_PROPERTY_TYPE(StartOffset, (0.0), "Start", App::Prop_None, "Offset from the start plane");
+    ADD_PROPERTY_TYPE(StartOffset, (0.0), "Start", App::Prop_None, "Offset from the pocket start");
     ADD_PROPERTY_TYPE(
         StartReference,
         (nullptr),
         "Start",
         App::Prop_None,
-        "Face, plane or sketch used as the start reference"
+        "Face, plane or sketch used as the pocket start reference"
     );
     ADD_PROPERTY_TYPE(UpToFace, (nullptr), "Side1", App::Prop_None, "Face where pocket will end");
     ADD_PROPERTY_TYPE(

--- a/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
+++ b/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
@@ -214,7 +214,7 @@ bool ReferenceSelection::allowPartFeature(App::DocumentObject* pObj, const char*
         }
     }
 
-    if (type.testFlag(AllowSelection::FACE) && subName.compare(0, 4, "Face") == 0) {
+    if (type.testFlag(AllowSelection::FACE)) {
         if (isFace(pObj, sSubName)) {
             return true;
         }
@@ -245,10 +245,13 @@ bool ReferenceSelection::isEdge(App::DocumentObject* pObj, const char* sSubName)
 
 bool ReferenceSelection::isFace(App::DocumentObject* pObj, const char* sSubName) const
 {
-    const Part::TopoShape& shape = static_cast<const Part::Feature*>(pObj)->Shape.getValue();
-    TopoDS_Shape sh = shape.getSubShape(sSubName);
-    const TopoDS_Face& face = TopoDS::Face(sh);
-    if (!face.IsNull()) {
+    const Part::TopoShape shape = Part::Feature::getTopoShape(
+        pObj,
+        Part::ShapeOption::NeedSubElement | Part::ShapeOption::ResolveLink,
+        sSubName
+    );
+    if (shape.shapeType(true) == TopAbs_FACE) {
+        const TopoDS_Face& face = TopoDS::Face(shape.getShape());
         if (type.testFlag(AllowSelection::PLANAR)) {
             BRepAdaptor_Surface adapt(face);
             if (adapt.GetType() == GeomAbs_Plane) {

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -1383,6 +1383,7 @@ void TaskExtrudeParameters::changeEvent(QEvent* e)
         translateFaceName(ui->lineFaceName);
         translateFaceName(ui->lineFaceName2);
         updateStartReferenceName();
+        updateStartUI();
     }
 }
 

--- a/src/Mod/PartDesign/PartDesignTests/TestPad.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestPad.py
@@ -103,6 +103,27 @@ class TestPad(unittest.TestCase):
         self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMin, 13.0)
         self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMax, 16.0)
 
+    def testStartReferenceInternalSketchFace(self):
+        self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "SketchPad")
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 0), (1, 1))
+        self.Doc.recompute()
+
+        reference = self.Doc.addObject("Sketcher::SketchObject", "Reference")
+        reference.MakeInternals = True
+        reference.Placement.Base = Base.Vector(0, 0, 10)
+        TestSketcherApp.CreateRectangleSketch(reference, (0, 0), (1, 1))
+        self.Doc.recompute()
+
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 3
+        self.Pad.StartReference = (reference, ["InternalFace1"])
+        self.Pad.StartType = "Reference"
+        self.Pad.StartOffset = 2
+        self.Doc.recompute()
+        self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMin, 12.0)
+        self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMax, 15.0)
+
     def testStartOffsetForTwoSidedAndSymmetricPad(self):
         self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "SketchPad")
         TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 0), (1, 1))

--- a/src/Mod/PartDesign/PartDesignTests/TestPad.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestPad.py
@@ -103,6 +103,45 @@ class TestPad(unittest.TestCase):
         self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMin, 13.0)
         self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMax, 16.0)
 
+    def testStartFromNonPlanarReference(self):
+        self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "SketchPad")
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (-0.5, -0.5), (0.5, 0.5))
+        self.Doc.recompute()
+
+        reference = self.Doc.addObject("Part::Feature", "Reference")
+        reference.Shape = Part.makeSphere(2, Base.Vector(0, 0, 3))
+
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 1
+        self.Pad.StartReference = (reference, ["Face1"])
+        self.Pad.StartType = "Reference"
+        self.Doc.recompute()
+
+        self.assertGreater(self.Pad.Shape.BoundBox.ZMin, 0.9)
+        self.assertGreater(self.Pad.Shape.BoundBox.ZMax, 2.1)
+
+        self.Pad.Length = -2
+        self.Doc.recompute()
+        self.assertLess(self.Pad.Shape.BoundBox.ZMin, -0.9)
+        self.assertGreater(self.Pad.Shape.BoundBox.ZMax, 1.1)
+
+    def testStartReferenceCylinderParallelToDirectionFails(self):
+        self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "SketchPad")
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (-0.5, -0.5), (0.5, 0.5))
+        self.Doc.recompute()
+
+        reference = self.Doc.addObject("Part::Feature", "Reference")
+        reference.Shape = Part.makeCylinder(2, 4, Base.Vector(0, 0, -2))
+
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Pad.Profile = self.PadSketch
+        self.Pad.StartReference = (reference, ["Face1"])
+        self.Pad.StartType = "Reference"
+        self.Doc.recompute()
+
+        self.assertIn("Invalid", self.Pad.State)
+
     def testStartReferenceInternalSketchFace(self):
         self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "SketchPad")
         TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 0), (1, 1))

--- a/src/Mod/PartDesign/PartDesignTests/TestPocket.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestPocket.py
@@ -24,6 +24,8 @@
 import unittest
 
 import FreeCAD
+import Part
+from FreeCAD import Base
 import TestSketcherApp
 
 
@@ -79,6 +81,29 @@ class TestPocket(unittest.TestCase):
         self.Pocket.Length = 0.25
         self.Doc.recompute()
         self.assertAlmostEqual(self.Pocket.Shape.Volume, 93.75)
+
+    def testStartFromNonPlanarReference(self):
+        self.PocketSketch = self.Doc.addObject("Sketcher::SketchObject", "PocketSketch")
+        TestSketcherApp.CreateRectangleSketch(self.PocketSketch, (-0.5, -0.5), (0.5, 0.5))
+        self.Doc.recompute()
+
+        reference = self.Doc.addObject("Part::Feature", "Reference")
+        reference.Shape = Part.makeSphere(2, Base.Vector(0, 0, -3))
+
+        self.Pocket = self.Doc.addObject("PartDesign::Pocket", "Pocket")
+        self.Pocket.Profile = self.PocketSketch
+        self.Pocket.Length = 1
+        self.Pocket.StartReference = (reference, ["Face1"])
+        self.Pocket.StartType = "Reference"
+        self.Doc.recompute()
+
+        self.assertLess(self.Pocket.Shape.BoundBox.ZMin, -2.1)
+        self.assertLess(self.Pocket.Shape.BoundBox.ZMax, -0.9)
+
+        self.Pocket.Length = -2
+        self.Doc.recompute()
+        self.assertLess(self.Pocket.Shape.BoundBox.ZMin, -1.1)
+        self.assertGreater(self.Pocket.Shape.BoundBox.ZMax, 0.9)
 
     def testPocketThroughAllCase(self):
         self.Body = self.Doc.addObject("PartDesign::Body", "Body")


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Adds a start offset mode for pad and pocket "From surface" similar as the end type "Up to face" works.

- Length extends from the selected surface, not from the sketch plane
- Curved faces retain their shape at the feature start
- Other end conditions are trimmed from the start surface
- Tests added

Assisted-by: GPT-5.6-Terra
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->



## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/c2cfab98-6248-4922-83bc-123244642993



https://github.com/user-attachments/assets/ea90a09a-6fed-4851-b703-04a336dd726f


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
