### PR TITLE
BIM: stop creating deprecated CutDistance property

### DIFF
--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -1222,14 +1222,6 @@ class _ViewProviderSectionPlane:
                 locked=True,
             )
             vobj.LineWidth = 1
-        if not "CutDistance" in pl:
-            vobj.addProperty(
-                "App::PropertyLength",
-                "CutDistance",
-                "SectionPlane",
-                QT_TRANSLATE_NOOP("App::Property", "Show the cut in the 3D view"),
-                locked=True,
-            )
         if not "LineColor" in pl:
             vobj.addProperty(
                 "App::PropertyColor",

--- a/src/Mod/BIM/bimtests/TestArchSectionPlane.py
+++ b/src/Mod/BIM/bimtests/TestArchSectionPlane.py
@@ -52,6 +52,11 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         self.assertEqual(
             section_plane.Label, "TestSectionPlane", "Section plane label is incorrect."
         )
+        self.assertNotIn(
+            "CutDistance",
+            section_plane.ViewObject.PropertiesList,
+            "New section planes should not have the deprecated CutDistance property.",
+        )
 
     def testSectionPlaneFitUsesLocalAxesAfterRotateY(self):
         """Resize-to-fit dimensions follow the rotated section plane axes."""


### PR DESCRIPTION
Fixes #28909
使用了 Codex 协助，但我已经理解并审查全部修改。

1. 删除了新对象创建 CutDistance 的逻辑。
2. 增加了回归测试。
3. 旧文件中已有的属性不会被主动删除。
4. 已完成 Python 语法、差异检查和 FreeCAD weekly 方法级运行验证。
5. 容器内未运行完整 GUI 测试，上游 CI 仍需验证。

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.