### PR TITLE
PD: Add Hole start controls

### DIFF
--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -57,7 +57,6 @@ FC_LOG_LEVEL_INIT("PartDesign", true, true)
 using namespace PartDesign;
 
 const char* FeatureExtrude::SideTypesEnums[] = {"One side", "Two sides", "Symmetric", nullptr};
-const char* FeatureExtrude::StartTypesEnums[] = {"Profile plane", "Offset", "Reference", nullptr};
 
 PROPERTY_SOURCE(PartDesign::FeatureExtrude, PartDesign::ProfileBased)
 
@@ -877,80 +876,6 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
     catch (Base::Exception& e) {
         return new App::DocumentObjectExecReturn(e.what());
     }
-}
-
-double FeatureExtrude::getStartReferenceOffset(
-    const TopoShape& sketchShape,
-    const App::PropertyLinkSub& reference,
-    const gp_Dir& dir,
-    double offset,
-    const TopLoc_Location& invObjLoc
-) const
-{
-    if (!reference.getValue()) {
-        return 0.0;
-    }
-
-    TopoShape referenceShape;
-    if (reference.getValue()->isDerivedFrom<Part::Part2DObject>()) {
-        referenceShape
-            = getTopoShapeVerifiedFace(false, false, reference.getValue(), reference.getSubValues());
-    }
-    else {
-        getUpToFaceFromLinkSub(referenceShape, reference);
-    }
-    referenceShape.move(invObjLoc);
-
-    TopoShape referenceFace = referenceShape;
-    if (referenceFace.shapeType(true) != TopAbs_FACE) {
-        referenceFace = referenceFace.getSubTopoShape(TopAbs_FACE, 1);
-    }
-    BRepAdaptor_Surface surface(TopoDS::Face(referenceFace.getShape()));
-    if (surface.GetType() == GeomAbs_Plane) {
-        // A planar start reference defines its underlying plane, independent of its trimming.
-        GProp_GProps properties;
-        BRepGProp::SurfaceProperties(sketchShape.getShape(), properties);
-        const gp_Pnt profileCenter = properties.CentreOfMass();
-        const gp_Dir normal = surface.Plane().Axis().Direction();
-        const double denominator = gp_Vec(dir).Dot(gp_Vec(normal));
-        if (std::fabs(denominator) > Precision::Confusion()) {
-            const double distance
-                = gp_Vec(profileCenter, surface.Plane().Location()).Dot(gp_Vec(normal)) / denominator;
-            return distance + offset;
-        }
-    }
-
-    auto faces = Part::findAllFacesCutBy(referenceShape, sketchShape, dir);
-    double direction = 1.0;
-    if (faces.empty()) {
-        gp_Dir oppositeDirection = dir;
-        oppositeDirection.Reverse();
-        faces = Part::findAllFacesCutBy(referenceShape, sketchShape, oppositeDirection);
-        direction = -1.0;
-    }
-
-    if (faces.empty()) {
-        throw Base::ValueError("Extrude: Start reference does not intersect the profile direction");
-    }
-
-    const auto nearest
-        = std::min_element(faces.begin(), faces.end(), [](const auto& first, const auto& second) {
-              return first.distsq < second.distsq;
-          });
-    return direction * std::sqrt(nearest->distsq) + offset;
-}
-
-TopoShape FeatureExtrude::moveProfileToStart(const TopoShape& sketchShape, const gp_Dir& dir, double offset)
-{
-    if (std::fabs(offset) < Precision::Confusion()) {
-        return sketchShape;
-    }
-
-    TopoShape result = sketchShape.makeElementCopy();
-    gp_Trsf transform;
-    transform.SetTranslation(gp_Vec(dir) * offset);
-    result.move(transform);
-    return result;
 }
 
 TopoShape FeatureExtrude::generateSingleExtrusionSide(

--- a/src/Mod/PartDesign/App/FeatureExtrude.h
+++ b/src/Mod/PartDesign/App/FeatureExtrude.h
@@ -79,7 +79,6 @@ public:
     //@}
 
     static const char* SideTypesEnums[];
-    static const char* StartTypesEnums[];
 
 protected:
     void onDocumentRestored() override;
@@ -126,15 +125,6 @@ protected:
         const TopoShape& base,      // The base shape for context (global CS)
         TopLoc_Location& invObjLoc  // MUST be passed. Cannot be re-accessed, see #26677
     );
-
-    double getStartReferenceOffset(
-        const TopoShape& sketchShape,
-        const App::PropertyLinkSub& reference,
-        const gp_Dir& dir,
-        double offset,
-        const TopLoc_Location& invObjLoc
-    ) const;
-    static TopoShape moveProfileToStart(const TopoShape& sketchShape, const gp_Dir& dir, double offset);
 };
 
 }  // namespace PartDesign

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 
+#include <cstring>
 #include <limits>
 #include <gp_Circ.hxx>
 #include <gp_Dir.hxx>
@@ -52,6 +53,7 @@
 
 #include <App/Application.h>
 #include <App/DocumentObject.h>
+#include <Base/Converter.h>
 #include <Base/Placement.h>
 #include <Base/Reader.h>
 #include <Base/Stream.h>
@@ -653,6 +655,39 @@ Hole::Hole()
         App::Prop_None,
         "Which profile feature to base the holes on"
     );
+    ADD_PROPERTY_TYPE(StartType, (0L), "Start", App::Prop_None, "How to define the start plane");
+    StartType.setEnums(StartTypesEnums);
+    ADD_PROPERTY_TYPE(StartOffset, (0.0), "Start", App::Prop_None, "Offset from the start plane");
+    ADD_PROPERTY_TYPE(
+        StartReference,
+        (nullptr),
+        "Start",
+        App::Prop_None,
+        "Face, plane or sketch used as the start reference"
+    );
+}
+
+double Hole::getStartOffset() const
+{
+    const char* startType = StartType.getValueAsString();
+    if (std::strcmp(startType, "Profile plane") == 0) {
+        return 0.0;
+    }
+    if (std::strcmp(startType, "Offset") == 0) {
+        return StartOffset.getValue();
+    }
+
+    TopoShape profileShape = getProfileShape(
+        Part::ShapeOption::NeedSubElement | Part::ShapeOption::ResolveLink
+        | Part::ShapeOption::Transform | Part::ShapeOption::DontSimplifyCompound
+    );
+    gp_Dir direction = Base::convertTo<gp_Dir>(guessNormalDirection(profileShape));
+    if (!Reversed.getValue()) {
+        direction.Reverse();
+    }
+
+    TopLoc_Location identity;
+    return getStartReferenceOffset(profileShape, StartReference, direction, StartOffset.getValue(), identity);
 }
 
 void Hole::updateHoleCutParams()
@@ -1275,7 +1310,12 @@ void Hole::findClosestDesignation()
 
 void Hole::onChanged(const App::Property* prop)
 {
-    if (prop == &ThreadType) {
+    if (prop == &StartType) {
+        const bool hasOffset = std::strcmp(StartType.getValueAsString(), "Profile plane") != 0;
+        StartOffset.setReadOnly(!hasOffset);
+        StartReference.setReadOnly(std::strcmp(StartType.getValueAsString(), "Reference") != 0);
+    }
+    else if (prop == &ThreadType) {
         std::string type;
 
         if (ThreadType.isValid()) {
@@ -1679,7 +1719,8 @@ short Hole::mustExecute() const
         || Depth.isTouched() || DrillPoint.isTouched() || DrillPointAngle.isTouched()
         || Tapered.isTouched() || TaperedAngle.isTouched() || ModelThread.isTouched()
         || UseCustomThreadClearance.isTouched() || CustomThreadClearance.isTouched()
-        || ThreadDepthType.isTouched() || ThreadDepth.isTouched() || BaseProfileType.isTouched()) {
+        || ThreadDepthType.isTouched() || ThreadDepth.isTouched() || BaseProfileType.isTouched()
+        || StartType.isTouched() || StartOffset.isTouched() || StartReference.isTouched()) {
         return 1;
     }
     return ProfileBased::mustExecute();
@@ -1716,6 +1757,9 @@ void Hole::updateProps()
     onChanged(&ThreadDepthType);
     onChanged(&ThreadDepth);
     onChanged(&BaseProfileType);
+    onChanged(&StartType);
+    onChanged(&StartOffset);
+    onChanged(&StartReference);
 }
 
 static gp_Pnt toPnt(gp_Vec dir)
@@ -1774,6 +1818,20 @@ App::DocumentObjectExecReturn* Hole::execute()
         gp_Vec zDir(SketchVector.x, SketchVector.y, SketchVector.z);
         zDir.Transform(invObjLoc.Transformation());
         gp_Vec xDir = computePerpendicular(zDir);
+
+        gp_Dir holeDirection(zDir);
+        holeDirection.Reverse();
+        const char* startType = StartType.getValueAsString();
+        const double startOffset = std::strcmp(startType, "Profile plane") == 0 ? 0.0
+            : std::strcmp(startType, "Offset") == 0 ? StartOffset.getValue()
+                                                    : getStartReferenceOffset(
+                                                          profileshape,
+                                                          StartReference,
+                                                          holeDirection,
+                                                          StartOffset.getValue(),
+                                                          invObjLoc
+                                                      );
+        profileshape = moveProfileToStart(profileshape, holeDirection, startOffset);
 
         if (method == "Dimension") {
             length = Depth.getValue();

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -78,6 +78,9 @@ public:
     App::PropertyBool UseCustomThreadClearance;
     App::PropertyLength CustomThreadClearance;
     App::PropertyInteger BaseProfileType;
+    App::PropertyEnumeration StartType;
+    App::PropertyLength StartOffset;
+    App::PropertyLinkSub StartReference;
 
     enum BaseProfileTypeOptions
     {
@@ -131,6 +134,7 @@ public:
     bool isDynamicCounterbore(const std::string& thread, const std::string& holeCutType);
     bool isDynamicCountersink(const std::string& thread, const std::string& holeCutType);
     double getThreadPitch() const;
+    double getStartOffset() const;
 
     Base::Vector3d guessNormalDirection(const TopoShape& profileshape) const;
     TopoShape findHoles(

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -22,6 +22,10 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <algorithm>
+#include <cmath>
+#include <optional>
+#include <ranges>
 #include <Bnd_Box.hxx>
 #include <BRep_Builder.hxx>
 #include <BRep_Tool.hxx>
@@ -40,12 +44,14 @@
 #include <Extrema_POnCurv.hxx>
 #include <gp_Circ.hxx>
 #include <gp_Pln.hxx>
+#include <gp_Trsf.hxx>
 #include <GProp_GProps.hxx>
 #include <ShapeAnalysis.hxx>
 #include <Standard_Version.hxx>
 #include <TopExp.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopoDS_Face.hxx>
+#include <TopoDS.hxx>
 #include <TopoDS_Vertex.hxx>
 #include <TopoDS_Wire.hxx>
 #include <TopTools_IndexedDataMapOfShapeListOfShape.hxx>
@@ -54,8 +60,10 @@
 
 #include <App/Document.h>
 #include <App/Datums.h>
+#include <Base/Converter.h>
 #include <Base/Reader.h>
 #include <Mod/Part/App/FaceMakerCheese.h>
+#include <Mod/Part/App/Tools.h>
 
 #include "FeatureSketchBased.h"
 #include "DatumLine.h"
@@ -68,6 +76,8 @@ FC_LOG_LEVEL_INIT("PartDesign", true, true);
 using namespace PartDesign;
 
 PROPERTY_SOURCE(PartDesign::ProfileBased, PartDesign::FeatureAddSub)
+
+const char* ProfileBased::StartTypesEnums[] = {"Profile plane", "Offset", "Reference", nullptr};
 
 ProfileBased::ProfileBased()
 {
@@ -754,6 +764,100 @@ void ProfileBased::getUpToFaceFromLinkSub(TopoShape& upToFace, const App::Proper
     if (!upToFace.hasSubShape(TopAbs_FACE)) {
         throw Base::ValueError("SketchBased: Up to face: Failed to extract face");
     }
+}
+
+namespace
+{
+std::optional<double> getPlanarStartReferenceDistance(
+    const TopoShape& profileShape,
+    const TopoShape& referenceShape,
+    const gp_Dir& direction
+)
+{
+    TopoShape referenceFace = referenceShape;
+    if (referenceFace.shapeType(true) != TopAbs_FACE) {
+        referenceFace = referenceFace.getSubTopoShape(TopAbs_FACE, 1);
+    }
+
+    BRepAdaptor_Surface surface(TopoDS::Face(referenceFace.getShape()));
+    if (surface.GetType() != GeomAbs_Plane) {
+        return std::nullopt;
+    }
+
+    Base::Vector3d profileCenter;
+    if (!profileShape.getCenterOfGravity(profileCenter)) {
+        return std::nullopt;
+    }
+
+    const gp_Dir normal = surface.Plane().Axis().Direction();
+    const double denominator = gp_Vec(direction).Dot(gp_Vec(normal));
+    if (std::fabs(denominator) <= Precision::Confusion()) {
+        return std::nullopt;
+    }
+
+    const gp_Vec profileToReference(Base::convertTo<gp_Pnt>(profileCenter), surface.Plane().Location());
+    return profileToReference.Dot(gp_Vec(normal)) / denominator;
+}
+}  // namespace
+
+double ProfileBased::getStartReferenceOffset(
+    const TopoShape& profileShape,
+    const App::PropertyLinkSub& reference,
+    const gp_Dir& direction,
+    double offset,
+    const TopLoc_Location& invObjLoc
+) const
+{
+    if (!reference.getValue()) {
+        return 0.0;
+    }
+
+    TopoShape referenceShape;
+    if (reference.getValue()->isDerivedFrom<Part::Part2DObject>()) {
+        referenceShape
+            = getTopoShapeVerifiedFace(false, false, reference.getValue(), reference.getSubValues());
+    }
+    else {
+        getUpToFaceFromLinkSub(referenceShape, reference);
+    }
+    referenceShape.move(invObjLoc);
+
+    if (const auto distance = getPlanarStartReferenceDistance(profileShape, referenceShape, direction)) {
+        return *distance + offset;
+    }
+
+    auto faces = Part::findAllFacesCutBy(referenceShape, profileShape, direction);
+    double directionFactor = 1.0;
+    if (faces.empty()) {
+        gp_Dir oppositeDirection = direction;
+        oppositeDirection.Reverse();
+        faces = Part::findAllFacesCutBy(referenceShape, profileShape, oppositeDirection);
+        directionFactor = -1.0;
+    }
+
+    if (faces.empty()) {
+        throw Base::ValueError("SketchBased: Start reference does not intersect the profile direction");
+    }
+
+    const auto nearest = std::ranges::min_element(faces, {}, &Part::cutTopoShapeFaces::distsq);
+    return directionFactor * std::sqrt(nearest->distsq) + offset;
+}
+
+TopoShape ProfileBased::moveProfileToStart(
+    const TopoShape& profileShape,
+    const gp_Dir& direction,
+    double offset
+)
+{
+    if (std::fabs(offset) < Precision::Confusion()) {
+        return profileShape;
+    }
+
+    TopoShape result = profileShape.makeElementCopy();
+    gp_Trsf transform;
+    transform.SetTranslation(gp_Vec(direction) * offset);
+    result.move(transform);
+    return result;
 }
 
 int ProfileBased::getUpToShapeFromLinkSubList(

--- a/src/Mod/PartDesign/App/FeatureSketchBased.h
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.h
@@ -33,6 +33,7 @@ class gp_Lin;
 class TopoDS_Face;
 class TopoDS_Shape;
 class TopoDS_Wire;
+class TopLoc_Location;
 
 namespace PartDesign
 {
@@ -157,6 +158,8 @@ public:
     // calculate the through all length
     double getThroughAllLength() const;
 
+    static const char* StartTypesEnums[];
+
 protected:
     /// Set while onDocumentRestored() rewrites deprecated properties, so that the deprecation
     /// notices in onChanged() stay quiet for the migration's own writes.
@@ -170,6 +173,19 @@ protected:
 
     /// Extract a face from a given LinkSub
     static void getUpToFaceFromLinkSub(TopoShape& upToFace, const App::PropertyLinkSub& refFace);
+
+    double getStartReferenceOffset(
+        const TopoShape& profileShape,
+        const App::PropertyLinkSub& reference,
+        const gp_Dir& direction,
+        double offset,
+        const TopLoc_Location& invObjLoc
+    ) const;
+    static TopoShape moveProfileToStart(
+        const TopoShape& profileShape,
+        const gp_Dir& direction,
+        double offset
+    );
 
     /// Create a shape with shapes and faces from a given LinkSubList
     /// return the face count or 2 if a unique full shape is selected

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -205,9 +205,9 @@ void TaskExtrudeParameters::setupSideDialog(SideController& side)
 
 void TaskExtrudeParameters::updateStartUI()
 {
-    const int type = ui->startMode->currentIndex();
-    const bool hasOffset = type != 0;
-    const bool hasReference = type == 2;
+    const auto mode = static_cast<StartMode>(ui->startMode->currentIndex());
+    const bool hasOffset = mode != StartMode::ProfilePlane;
+    const bool hasReference = mode == StartMode::Reference;
 
     ui->labelStartOffset->setVisible(hasOffset);
     ui->startOffsetEdit->setVisible(hasOffset);
@@ -730,11 +730,12 @@ void TaskExtrudeParameters::onStartOffsetChanged(double len)
 void TaskExtrudeParameters::onStartModeChanged(int type)
 {
     auto extrude = getObject<PartDesign::FeatureExtrude>();
+    const auto mode = static_cast<StartMode>(type);
     extrude->StartType.setValue(type);
-    if (type == 2 && !extrude->StartReference.getValue()) {
+    if (mode == StartMode::Reference && !extrude->StartReference.getValue()) {
         ui->buttonStartReference->setChecked(true);
     }
-    else if (type != 2) {
+    else if (mode != StartMode::Reference) {
         setSelectionMode(None);
     }
     updateStartUI();

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.h
@@ -107,6 +107,13 @@ public:
         ToShape,
     };
 
+    enum class StartMode
+    {
+        ProfilePlane = 0,
+        Offset = 1,
+        Reference = 2,
+    };
+
     enum SelectionMode
     {
         None,

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -27,6 +27,8 @@
 #include <BRepAdaptor_Curve.hxx>
 #include <TopoDS.hxx>
 
+#include <cstring>
+
 #include <Base/Console.h>
 #include <Base/Converter.h>
 #include <Base/Tools.h>
@@ -194,6 +196,12 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
     ui->BaseProfileType->setCurrentIndex(
         PartDesign::Hole::baseProfileOption_bitmaskToIdx(pcHole->BaseProfileType.getValue())
     );
+    ui->StartType->setCurrentIndex(pcHole->StartType.getValue());
+    ui->StartOffset->setValue(pcHole->StartOffset.getValue());
+    ui->StartOffset->bind(pcHole->StartOffset);
+    ui->StartOffset->setToolTip(tr("Offset from the profile or selected start reference"));
+    updateStartReferenceName();
+    updateStartUI();
 
     setCutDiagram();
 
@@ -236,7 +244,7 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
             this, &TaskHoleParameters::drillForDepthChanged);
     connect(ui->Tapered, &QCheckBox::clicked,
             this, &TaskHoleParameters::taperedChanged);
-    connect(ui->Reversed, &QCheckBox::clicked,
+    connect(ui->Reversed, &QCheckBox::toggled,
             this, &TaskHoleParameters::reversedChanged);
     connect(ui->ModelThread, &QCheckBox::clicked,
             this, &TaskHoleParameters::modelThreadChanged);
@@ -254,6 +262,12 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
             this, &TaskHoleParameters::threadDepthChanged);
     connect(ui->BaseProfileType, qOverload<int>(&QComboBox::currentIndexChanged),
             this, &TaskHoleParameters::baseProfileTypeChanged);
+    connect(ui->StartType, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, &TaskHoleParameters::startTypeChanged);
+    connect(ui->StartOffset, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
+            this, &TaskHoleParameters::startOffsetChanged);
+    connect(ui->buttonStartReference, &QPushButton::toggled,
+            this, &TaskHoleParameters::selectStartReference);
     // clang-format on
 
     ui->Diameter->bind(pcHole->Diameter);
@@ -652,6 +666,51 @@ void TaskHoleParameters::reversedChanged()
     }
 }
 
+void TaskHoleParameters::startTypeChanged(int index)
+{
+    auto hole = getObject<PartDesign::Hole>();
+    if (!hole) {
+        return;
+    }
+
+    const auto type = static_cast<StartTypeIndex>(index);
+    hole->StartType.setValue(index);
+    if (type == Reference && !hole->StartReference.getValue()) {
+        ui->buttonStartReference->setChecked(true);
+    }
+    else if (type != Reference) {
+        exitSelectionMode();
+    }
+    updateStartUI();
+    recomputeFeature();
+    setGizmoPositions();
+}
+
+void TaskHoleParameters::startOffsetChanged(double value)
+{
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->StartOffset.setValue(value);
+        recomputeFeature();
+        setGizmoPositions();
+    }
+}
+
+void TaskHoleParameters::selectStartReference(bool checked)
+{
+    if (checked) {
+        ui->buttonStartReference->setText(tr("Cancel"));
+        ui->lineStartReference->setPlaceholderText(tr("Select face, plane..."));
+        selectingStartReference = true;
+        onSelectReference(AllowSelection::FACE);
+    }
+    else {
+        ui->buttonStartReference->setText(tr("Pick Reference"));
+        ui->lineStartReference->setPlaceholderText(tr("No start reference selected"));
+        selectingStartReference = false;
+        exitSelectionMode();
+    }
+}
+
 void TaskHoleParameters::taperedAngleChanged(double value)
 {
     if (auto hole = getObject<PartDesign::Hole>()) {
@@ -994,6 +1053,16 @@ void TaskHoleParameters::changedObject(const App::Document&, const App::Property
             PartDesign::Hole::baseProfileOption_bitmaskToIdx(hole->BaseProfileType.getValue())
         );
     }
+    else if (&Prop == &hole->StartType) {
+        updateComboBox(ui->StartType, hole->StartType.getValue());
+        updateStartUI();
+    }
+    else if (&Prop == &hole->StartOffset) {
+        updateSpinBox(ui->StartOffset, hole->StartOffset.getValue());
+    }
+    else if (&Prop == &hole->StartReference) {
+        updateStartReferenceName();
+    }
 }
 
 void TaskHoleParameters::updateHoleTypeCombo()
@@ -1020,7 +1089,75 @@ void TaskHoleParameters::updateHoleTypeCombo()
 
 void TaskHoleParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 {
-    Q_UNUSED(msg)
+    if (selectingStartReference && msg.Type == Gui::SelectionChanges::AddSelection) {
+        selectedStartReference(msg);
+    }
+}
+
+void TaskHoleParameters::selectedStartReference(const Gui::SelectionChanges& msg)
+{
+    auto hole = getObject<PartDesign::Hole>();
+    if (!hole) {
+        return;
+    }
+
+    onAddSelection(msg, hole->StartReference);
+    updateStartReferenceName();
+    ui->buttonStartReference->setChecked(false);
+    setGizmoPositions();
+}
+
+void TaskHoleParameters::updateStartUI()
+{
+    const auto type = static_cast<StartTypeIndex>(ui->StartType->currentIndex());
+    const bool hasOffset = type != ProfilePlane;
+    const bool hasReference = type == Reference;
+
+    ui->labelStartOffset->setVisible(hasOffset);
+    ui->StartOffset->setVisible(hasOffset);
+    ui->labelStartReference->setVisible(hasReference);
+    ui->lineStartReference->setVisible(hasReference);
+    ui->buttonStartReference->setVisible(hasReference);
+}
+
+void TaskHoleParameters::updateStartReferenceName()
+{
+    auto hole = getObject<PartDesign::Hole>();
+    App::DocumentObject* reference = hole->StartReference.getValue();
+    const auto subValues = hole->StartReference.getSubValues();
+    const std::string subName = subValues.empty() ? "" : subValues.front();
+
+    if (!reference) {
+        ui->lineStartReference->clear();
+        ui->lineStartReference->setProperty("FeatureName", QVariant());
+        ui->lineStartReference->setProperty("FaceName", QVariant());
+        ui->lineStartReference->setPlaceholderText(tr("No start reference selected"));
+        return;
+    }
+
+    QString text = QString::fromUtf8(reference->Label.getValue());
+    if (subName.rfind("Face", 0) == 0) {
+        text += QStringLiteral(":%1%2").arg(tr("Face"), QString::fromStdString(subName.substr(4)));
+    }
+    else if (!subName.empty()) {
+        text += QStringLiteral(":%1").arg(QString::fromStdString(subName));
+    }
+
+    ui->lineStartReference->setText(text);
+    ui->lineStartReference->setProperty("FeatureName", QByteArray(reference->getNameInDocument()));
+    ui->lineStartReference->setProperty("FaceName", QByteArray(subName.c_str()));
+}
+
+QString TaskHoleParameters::getStartReference() const
+{
+    QVariant featureName = ui->lineStartReference->property("FeatureName");
+    if (featureName.isValid()) {
+        return getFaceReference(
+            featureName.toString(),
+            ui->lineStartReference->property("FaceName").toString()
+        );
+    }
+    return QStringLiteral("None");
 }
 
 bool TaskHoleParameters::getThreaded() const
@@ -1184,6 +1321,7 @@ void TaskHoleParameters::apply()
     ui->Depth->apply();
     ui->DrillPointAngle->apply();
     ui->TaperedAngle->apply();
+    ui->StartOffset->apply();
 
     if (!hole->Threaded.isReadOnly()) {
         FCMD_OBJ_CMD(hole, "Threaded = " << (getThreaded() ? 1 : 0));
@@ -1242,6 +1380,9 @@ void TaskHoleParameters::apply()
     if (!hole->BaseProfileType.isReadOnly()) {
         FCMD_OBJ_CMD(hole, "BaseProfileType = " << getBaseProfileType());
     }
+    FCMD_OBJ_CMD(hole, "StartOffset = " << ui->StartOffset->value().getValue());
+    FCMD_OBJ_CMD(hole, "StartType = " << ui->StartType->currentIndex());
+    FCMD_OBJ_CMD(hole, "StartReference = " << getStartReference().toUtf8().data());
 }
 
 void TaskHoleParameters::updateHoleCutLimits(PartDesign::Hole* hole)
@@ -1258,8 +1399,15 @@ void TaskHoleParameters::setupGizmos(ViewProviderHole* vp)
     }
 
     holeDepthGizmo = new LinearGizmo(ui->Depth);
+    holeDepthGizmo->setClickCallback([this] {
+        if (ui->Reversed->isEnabled()) {
+            ui->Reversed->setChecked(!ui->Reversed->isChecked());
+        }
+    });
+    startOffsetGizmo = new LinearGizmo(ui->StartOffset);
+    startOffsetGizmo->setDraggerStyle(LinearDraggerStyle::Sphere);
 
-    gizmoContainer = GizmoContainer::create({holeDepthGizmo}, vp);
+    gizmoContainer = GizmoContainer::create({holeDepthGizmo, startOffsetGizmo}, vp);
 
     setGizmoPositions();
     showDraggerHints();
@@ -1330,6 +1478,7 @@ void TaskHoleParameters::setGizmoPositions()
     );
     Base::Vector3d dir = hole->guessNormalDirection(profileShape);
     dir *= hole->Reversed.getValue() ? -1 : 1;
+    Base::Vector3d holeDirection = -dir;
     std::vector<Base::Vector3d> holePositions
         = getHolePositionFromShape(profileShape, hole->BaseProfileType.getValue());
 
@@ -1338,6 +1487,19 @@ void TaskHoleParameters::setGizmoPositions()
         return;
     }
     gizmoContainer->visible = true;
+
+    const bool hasStartOffset = std::strcmp(hole->StartType.getValueAsString(), "Profile plane") != 0;
+    try {
+        const double effectiveStartOffset = hole->getStartOffset();
+        startOffsetGizmo->Gizmo::setDraggerPlacement(
+            holePositions[0] + holeDirection * (effectiveStartOffset - hole->StartOffset.getValue()),
+            holeDirection
+        );
+        holePositions[0] += holeDirection * effectiveStartOffset;
+    }
+    catch (const Base::Exception&) {
+    }
+    startOffsetGizmo->setVisibility(hasStartOffset);
 
     holeDepthGizmo->Gizmo::setDraggerPlacement(
         holePositions[0] - ui->HoleCutDepth->value().getValue() * dir,

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -117,6 +117,9 @@ private Q_SLOTS:
     void threadDepthTypeChanged(int index);
     void threadDepthChanged(double value);
     void baseProfileTypeChanged(int index);
+    void startTypeChanged(int index);
+    void startOffsetChanged(double value);
+    void selectStartReference(bool checked);
     void setCutDiagram();
 
 private:
@@ -136,6 +139,12 @@ private:
         TapDrill = 1,
         Threaded = 2
     };
+    enum StartTypeIndex : int
+    {
+        ProfilePlane = 0,
+        Offset = 1,
+        Reference = 2
+    };
 
 protected:
     void changeEvent(QEvent* e) override;
@@ -145,6 +154,10 @@ private:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
     void updateHoleCutLimits(PartDesign::Hole* hole);
     void updateHoleTypeCombo();
+    void updateStartUI();
+    void updateStartReferenceName();
+    void selectedStartReference(const Gui::SelectionChanges& msg);
+    QString getStartReference() const;
 
 private:
     using Connection = fastsignals::scoped_connection;
@@ -156,6 +169,8 @@ private:
 
     std::unique_ptr<Gui::GizmoContainer> gizmoContainer;
     Gui::LinearGizmo* holeDepthGizmo = nullptr;
+    Gui::LinearGizmo* startOffsetGizmo = nullptr;
+    bool selectingStartReference = false;
     void setupGizmos(ViewProviderHole* vp);
     void setGizmoPositions();
 };

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -33,89 +33,23 @@
     <number>6</number>
    </property>
    <item>
-    <layout class="QGridLayout" name="TopLayout" columnstretch="2,2">
+    <widget class="QGroupBox" name="ProfileAndPlacementGroupBox">
+     <property name="title">
+      <string>Profile and Placement</string>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="profileAndPlacementLayout">
+      <item>
+       <layout class="QGridLayout" name="TopLayout" columnstretch="2,2">
      <property name="topMargin">
       <number>10</number>
      </property>
-     <item row="2" column="0">
-      <widget class="Gui::ElideLabel" name="labelSize">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Size</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="Gui::ElideLabel" name="labelHeadType">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="layoutDirection">
-        <enum>Qt::LayoutDirection::RightToLeft</enum>
-       </property>
-       <property name="text">
-        <string>Head type</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="ThreadType">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="Gui::ElideLabel" name="labelThreadType">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Standard</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0">
       <widget class="Gui::ElideLabel" name="labelProfileType">
        <property name="text">
         <string>Base profile types</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QComboBox" name="ThreadSize">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QComboBox" name="HoleCutType">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>Cut type for screw heads</string>
        </property>
       </widget>
      </item>
@@ -138,48 +72,209 @@
        </item>
       </widget>
      </item>
-     <item row="4" column="0">
-      <widget class="Gui::ElideLabel" name="labelDepthType">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="layoutDirection">
-        <enum>Qt::LayoutDirection::LeftToRight</enum>
-       </property>
+     <item row="1" column="0">
+      <widget class="Gui::ElideLabel" name="labelStart">
        <property name="text">
-        <string>Depth type</string>
+        <string>Start</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="StartType">
+       <item>
+        <property name="text">
+         <string>Profile plane</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Offset</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Reference</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="2" column="0" rowspan="2">
+      <widget class="Gui::ElideLabel" name="labelStartReference">
+       <property name="text">
+        <string>Reference</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="lineStartReference">
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QPushButton" name="buttonStartReference">
+       <property name="text">
+        <string>Pick Reference</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="Gui::ElideLabel" name="labelStartOffset">
+       <property name="text">
+        <string>Offset</string>
        </property>
       </widget>
      </item>
      <item row="4" column="1">
-      <widget class="QComboBox" name="DepthType">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+      <widget class="Gui::PrefQuantitySpinBox" name="StartOffset">
+       <property name="keyboardTracking">
+        <bool>false</bool>
        </property>
-       <property name="layoutDirection">
-        <enum>Qt::LayoutDirection::LeftToRight</enum>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
        </property>
-       <item>
-        <property name="text">
-         <string>Dimension</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Through all</string>
-        </property>
-       </item>
       </widget>
      </item>
-    </layout>
+       </layout>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="HoleGroupBox">
+     <property name="title">
+      <string>Hole</string>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="holeLayout">
+      <item>
+       <layout class="QGridLayout" name="holeTopLayout" columnstretch="2,2">
+        <item row="0" column="0">
+         <widget class="Gui::ElideLabel" name="labelThreadType">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Standard</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="ThreadType">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="Gui::ElideLabel" name="labelSize">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Size</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="ThreadSize">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="Gui::ElideLabel" name="labelHeadType">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::LayoutDirection::RightToLeft</enum>
+          </property>
+          <property name="text">
+           <string>Head type</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QComboBox" name="HoleCutType">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Cut type for screw heads</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="Gui::ElideLabel" name="labelDepthType">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::LayoutDirection::LeftToRight</enum>
+          </property>
+          <property name="text">
+           <string>Depth type</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QComboBox" name="DepthType">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::LayoutDirection::LeftToRight</enum>
+          </property>
+          <item>
+           <property name="text">
+            <string>Dimension</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Through all</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
     <widget class="Gui::ElideCheckBox" name="HoleCutCustomValues">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1107,6 +1202,9 @@ Note that the calculation can take some time</string>
      </layout>
     </widget>
    </item>
+    </layout>
+   </widget>
+  </item>
   </layout>
  </widget>
  <customwidgets>

--- a/src/Mod/PartDesign/PartDesignTests/TestHole.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestHole.py
@@ -25,6 +25,7 @@ from math import pi
 import unittest
 
 import FreeCAD
+import Part
 import TestSketcherApp
 
 App = FreeCAD
@@ -67,6 +68,49 @@ class TestHole(unittest.TestCase):
         self.Hole.Tapered = 0  # On/off
         self.Doc.recompute()
         self.assertAlmostEqual(self.Hole.Shape.Volume, 10**3 - pi * 3**2 * 10)
+
+    def testStartOffset(self):
+        self.Hole.Diameter = 6
+        self.Hole.Depth = 5
+        self.Hole.DepthType = 0
+        self.Hole.DrillPoint = 0
+        self.Hole.StartType = "Offset"
+        self.Hole.StartOffset = 2
+        self.Doc.recompute()
+        self.assertAlmostEqual(self.Hole.Shape.Volume, 10**3 - pi * 3**2 * 5)
+        self.assertAlmostEqual(self.Hole.AddSubShape.BoundBox.ZMin, 2)
+        self.assertAlmostEqual(self.Hole.AddSubShape.BoundBox.ZMax, 7)
+
+        reference = self.Doc.addObject("Part::Feature", "StartReference")
+        reference.Shape = Part.makePlane(20, 20, App.Vector(-10, -10, 1))
+        self.Hole.StartType = "Reference"
+        self.Hole.StartReference = (reference, ["Face1"])
+        self.Doc.recompute()
+        self.assertAlmostEqual(self.Hole.Shape.Volume, 10**3 - pi * 3**2 * 5)
+        self.assertAlmostEqual(self.Hole.AddSubShape.BoundBox.ZMin, 3)
+        self.assertAlmostEqual(self.Hole.AddSubShape.BoundBox.ZMax, 8)
+
+    def testStartReferenceOffsetForPointProfile(self):
+        self.HoleSketch.deleteAllGeometry()
+        self.HoleSketch.AttachmentOffset.Base.z = 10
+        for point in ((2, 2), (8, 2), (2, 8), (8, 8)):
+            self.HoleSketch.addGeometry(Part.Point(App.Vector(*point)), False)
+
+        self.Hole.BaseProfileType = 1
+        self.Hole.Diameter = 2
+        self.Hole.Depth = 5
+        self.Hole.DepthType = 0
+        self.Hole.DrillPoint = 0
+
+        reference = self.Doc.addObject("Part::Feature", "StartReference")
+        reference.Shape = Part.makePlane(20, 20, App.Vector(-5, -5, 20))
+        self.Hole.StartType = "Reference"
+        self.Hole.StartReference = (reference, ["Face1"])
+        self.Hole.StartOffset = 2
+        self.Doc.recompute()
+
+        self.assertAlmostEqual(self.Hole.AddSubShape.BoundBox.ZMin, 22)
+        self.assertAlmostEqual(self.Hole.AddSubShape.BoundBox.ZMax, 27)
 
     def testTaperedHole(self):
         self.Hole.Diameter = 6


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Based upon https://github.com/FreeCAD/FreeCAD/pull/31839

- Added StartType, StartOffset, and StartReference properties with shared Pad/Pocket logic (moved code)
- Made task panel the same as Pad/Pocket for consistency
- Added offset dragger and depth-arrow click to reverse direction

Assisted-by: GPT-5.6-Terra
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/96970da8-883b-4bae-9684-f04504190313



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
