### PR TITLE
Sketcher: fix grid line width tooltips

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettingsGrid.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsGrid.ui
@@ -243,7 +243,7 @@ The grid spacing changes if it becomes smaller than the specified pixel size.</s
          <item row="1" column="1">
           <widget class="Gui::PrefSpinBox" name="gridLineWidth">
            <property name="toolTip">
-            <string>Distance between two subsequent grid lines</string>
+            <string>Width of minor grid lines in pixels</string>
            </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
@@ -381,7 +381,7 @@ The grid spacing changes if it becomes smaller than the specified pixel size.</s
          <item row="2" column="1">
           <widget class="Gui::PrefSpinBox" name="gridDivLineWidth">
            <property name="toolTip">
-            <string>Distance between two subsequent division lines</string>
+            <string>Width of major grid lines in pixels</string>
            </property>
            <property name="minimum">
             <number>1</number>


### PR DESCRIPTION
## Summary

我修正了 Sketcher 网格设置中的两个提示文字。原来的文字描述成了网格间距，但这两个选项实际控制的是次网格线和主网格线的宽度，单位为像素。

Fixes #31626

## Validation

我查看并理解了这两处修改，并使用 xmllint 检查了 UI 文件，XML 格式验证通过。

## AI assistance

OpenAI Codex（GPT-5）协助定位相关字符串并准备了初始修改。我本人检查了差异、理解修改内容并完成验证。

## Before and After

- Before: 提示文字错误地描述为网格线之间的距离。
- After: 提示文字明确说明次网格线和主网格线的宽度，单位为像素。

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.