### PR TITLE
CI: fix run test actions not using pixi environment in pixi build workflow

### DIFF
--- a/.github/workflows/actions/runCPPTests/runAllTests/action.yml
+++ b/.github/workflows/actions/runCPPTests/runAllTests/action.yml
@@ -36,6 +36,10 @@ inputs:
   reportFile:
     description: "Path for report file"
     required: true
+  shellCmd:
+    description: "Shell command to use for action steps (e.g. 'pixi run bash -l {0}')"
+    default: "bash -l {0}"
+    required: false
 
 runs:
   using: "composite"
@@ -47,6 +51,7 @@ runs:
           testCommand: ${{ inputs.builddir }}/tests/Assembly_tests_run --gtest_output=json:${{ inputs.reportdir }}assembly_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}assembly_gtest_test_log.txt
           testName: Assembly
+          shellCmd: ${{ inputs.shellCmd }}
       - name: C++ app tests
         id: app
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
@@ -54,6 +59,7 @@ runs:
           testCommand: ${{ inputs.builddir }}/tests/App_tests_run --gtest_output=json:${{ inputs.reportdir }}app_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}app_gtest_test_log.txt
           testName: App
+          shellCmd: ${{ inputs.shellCmd }}
       - name: C++ base tests
         id: base
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
@@ -61,6 +67,7 @@ runs:
           testCommand: ${{ inputs.builddir }}/tests/Base_tests_run --gtest_output=json:${{ inputs.reportdir }}base_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}base_gtest_test_log.txt
           testName: Base
+          shellCmd: ${{ inputs.shellCmd }}
       - name: C++ Gui tests
         id: gui
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
@@ -68,12 +75,14 @@ runs:
           testCommand: ${{ inputs.builddir }}/tests/Gui_tests_run --gtest_output=json:${{ inputs.reportdir }}gui_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}gui_gtest_test_log.txt
           testName: Gui
+          shellCmd: ${{ inputs.shellCmd }}
       - name: C++ Qt tests
         id: qttests
         uses: ./.github/workflows/actions/runCPPTests/runQtTests
         with:
           builddir: ${{ inputs.builddir }}
           testLogFile: ${{ inputs.reportdir }}qt_ctest_log.txt
+          shellCmd: ${{ inputs.shellCmd }}
       - name: C++ Material tests
         id: material
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
@@ -81,6 +90,7 @@ runs:
           testCommand: ${{ inputs.builddir }}/tests/Material_tests_run --gtest_output=json:${{ inputs.reportdir }}material_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}material_gtest_test_log.txt
           testName: Material
+          shellCmd: ${{ inputs.shellCmd }}
       - name: C++ Measure tests
         id: measure
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
@@ -88,6 +98,7 @@ runs:
           testCommand: ${{ inputs.builddir }}/tests/Measure_tests_run --gtest_output=json:${{ inputs.reportdir }}measure_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}measure_gtest_test_log.txt
           testName: Measure
+          shellCmd: ${{ inputs.shellCmd }}
       - name: C++ Mesh tests
         id: mesh
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
@@ -95,6 +106,7 @@ runs:
           testCommand: ${{ inputs.builddir }}/tests/Mesh_tests_run --gtest_output=json:${{ inputs.reportdir }}mesh_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}mesh_gtest_test_log.txt
           testName: Mesh
+          shellCmd: ${{ inputs.shellCmd }}
       - name: C++ MeshPart tests
         id: meshpart
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
@@ -102,6 +114,7 @@ runs:
           testCommand: ${{ inputs.builddir }}/tests/MeshPart_tests_run --gtest_output=json:${{ inputs.reportdir }}meshpart_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}meshpart_gtest_test_log.txt
           testName: MeshPart
+          shellCmd: ${{ inputs.shellCmd }}
       - name: C++ Part tests
         id: part
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
@@ -109,6 +122,7 @@ runs:
           testCommand: ${{ inputs.builddir }}/tests/Part_tests_run --gtest_output=json:${{ inputs.reportdir }}part_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}Part_gtest_test_log.txt
           testName: Part
+          shellCmd: ${{ inputs.shellCmd }}
       - name: C++ PartDesign tests
         id: partdesign
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
@@ -116,6 +130,7 @@ runs:
           testCommand: ${{ inputs.builddir }}/tests/PartDesign_tests_run --gtest_output=json:${{ inputs.reportdir }}partdesign_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}PartDesign_gtest_test_log.txt
           testName: PartDesign
+          shellCmd: ${{ inputs.shellCmd }}
       - name: C++ Points tests
         id: points
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
@@ -123,6 +138,7 @@ runs:
           testCommand: ${{ inputs.builddir }}/tests/Points_tests_run --gtest_output=json:${{ inputs.reportdir }}points_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}points_gtest_test_log.txt
           testName: Points
+          shellCmd: ${{ inputs.shellCmd }}
       - name: C++ Sketcher tests
         id: sketcher
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
@@ -130,6 +146,7 @@ runs:
           testCommand: ${{ inputs.builddir }}/tests/Sketcher_tests_run --gtest_output=json:${{ inputs.reportdir }}sketcher_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}sketcher_gtest_test_log.txt
           testName: Sketcher
+          shellCmd: ${{ inputs.shellCmd }}
       - name: C++ Spreadsheet tests
         id: spreadsheet
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
@@ -137,6 +154,7 @@ runs:
           testCommand: ${{ inputs.builddir }}/tests/Spreadsheet_tests_run --gtest_output=json:${{ inputs.reportdir }}spreadsheet_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}spreadsheet_gtest_test_log.txt
           testName: Spreadsheet
+          shellCmd: ${{ inputs.shellCmd }}
       - name: C++ Start tests
         id: start
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
@@ -144,9 +162,10 @@ runs:
           testCommand: ${{ inputs.builddir }}/tests/Start_tests_run --gtest_output=json:${{ inputs.reportdir }}start_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}start_gtest_test_log.txt
           testName: Start
+          shellCmd: ${{ inputs.shellCmd }}
       - name: Compose summary report based on test results
         if: always()
-        shell: bash -l {0}
+        shell: ${{ inputs.shellCmd }}
         run: |
           # Print global result
           if [ ${{ job.status }} != "success" ]

--- a/.github/workflows/actions/runCPPTests/runQtTests/action.yml
+++ b/.github/workflows/actions/runCPPTests/runQtTests/action.yml
@@ -11,6 +11,10 @@ inputs:
   testLogFile:
     description: "Path for the command-line output of the tests"
     required: true
+  shellCmd:
+    description: "Shell command to use for action steps (e.g. 'pixi run bash -l {0}')"
+    default: "bash -l {0}"
+    required: false
 outputs:
   reportText:
     description: "Report text"
@@ -20,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Run Qt tests via CTest
-      shell: bash -l {0}
+      shell: ${{ inputs.shellCmd }}
       env:
         BUILD_DIR: ${{ inputs.builddir }}
         TEST_LOG_FILE: ${{ inputs.testLogFile }}
@@ -30,7 +34,7 @@ runs:
     - name: Parse test results
       if: always()
       id: report
-      shell: bash -l {0}
+      shell: ${{ inputs.shellCmd }}
       env:
         TEST_LOG_FILE: ${{ inputs.testLogFile }}
       run: |

--- a/.github/workflows/actions/runCPPTests/runSingleQtTest/action.yml
+++ b/.github/workflows/actions/runCPPTests/runSingleQtTest/action.yml
@@ -14,6 +14,10 @@ inputs:
   testName:
     description: "A descriptive name for the test suite"
     required: true
+  shellCmd:
+    description: "Shell command to use for action steps (e.g. 'pixi run bash -l {0}')"
+    default: "bash -l {0}"
+    required: false
 outputs:
   reportText:
     description: "Report text"
@@ -23,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - name: Run QtTest tests
-      shell: bash -l {0}
+      shell: ${{ inputs.shellCmd }}
       env:
         QT_QPA_PLATFORM: offscreen
         TEST_COMMAND: ${{ inputs.testCommand }}
@@ -34,7 +38,7 @@ runs:
     - name: Parse test results
       if: always()
       id: report
-      shell: bash -l {0}
+      shell: ${{ inputs.shellCmd }}
       env:
         TEST_LOG_FILE: ${{ inputs.testLogFile }}
         TEST_NAME: ${{ inputs.testName }}

--- a/.github/workflows/actions/runCPPTests/runSingleTest/action.yml
+++ b/.github/workflows/actions/runCPPTests/runSingleTest/action.yml
@@ -35,6 +35,10 @@ inputs:
   testName:
     description: "A descriptive name for the test suite"
     required: true
+  shellCmd:
+    description: "Shell command to use for action steps (e.g. 'pixi run bash -l {0}')"
+    default: "bash -l {0}"
+    required: false
 outputs:
   reportText:
     description: "Report text"
@@ -44,14 +48,14 @@ runs:
   using: "composite"
   steps:
     - name: Run C++ tests
-      shell: bash -l {0}
+      shell: ${{ inputs.shellCmd }}
       run: |
         set -o pipefail
         ${{ inputs.testCommand }} | tee -a ${{ inputs.testLogFile }}
     - name: Parse test results
       if: always()
       id: report
-      shell: bash -l {0}
+      shell: ${{ inputs.shellCmd }}
       run:  |
         result=$(sed -ne "/Global test environment tear-down/,/^$/{/^$/d;p}" ${{ inputs.testLogFile }})
         if grep -qF "[  FAILED  ]" <<< $result

--- a/.github/workflows/actions/runPythonTests/action.yml
+++ b/.github/workflows/actions/runPythonTests/action.yml
@@ -37,13 +37,17 @@ inputs:
   reportFile:
     description: "Path for report file"
     required: true
+  shellCmd:
+    description: "Shell command to use for action steps (e.g. 'pixi run bash -l {0}')"
+    default: "bash -l {0}"
+    required: false
 
 runs:
   using: "composite"
   steps:
     - name: Run tests
       id: runTests
-      shell: bash -l {0}
+      shell: ${{ inputs.shellCmd }}
       run: |
         set -o pipefail
         mkdir -p "$(dirname "${{ inputs.logFile }}")"
@@ -51,7 +55,7 @@ runs:
           ${{ inputs.testCommand }}
         } 2>&1 | sed -Ee "/[[:blank:]]*\\([[:digit:]]{1,3} %\\)[[:blank:]]*/d" | tee -a "${{ inputs.logFile }}"
     - name: Write report
-      shell: bash -l {0}
+      shell: ${{ inputs.shellCmd }}
       if: always()
       run: |
         mkdir -p "$(dirname "${{ inputs.logFile }}")"

--- a/.github/workflows/sub_buildPixi.yml
+++ b/.github/workflows/sub_buildPixi.yml
@@ -75,6 +75,7 @@ jobs:
       logdir: ${{ github.workspace }}/logs/
       reportdir: ${{ github.workspace }}/report/
       reportfilename: ${{ inputs.artifactBasename }}-${{ matrix.os }}-report.md
+      shellCmd: "pixi run bash -l {0}"
     outputs:
       reportFile: ${{ steps.Init.outputs.reportFile }}
 
@@ -176,9 +177,10 @@ jobs:
       uses: ./.github/workflows/actions/runPythonTests
       with:
         testDescription: "CLI tests on build dir"
-        testCommand: pixi run ${{ env.builddir }}/bin/FreeCADCmd -t 0
+        testCommand: ${{ env.builddir }}/bin/FreeCADCmd -t 0
         logFile: ${{ env.logdir }}TestCLIBuild.log
         reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+        shellCmd: ${{ env.shellCmd }}
 
     - name: FreeCAD GUI tests on build dir
       if: runner.os == 'Linux' && inputs.testOnBuildDir && !inputs.skipBuild
@@ -186,9 +188,10 @@ jobs:
       uses: ./.github/workflows/actions/runPythonTests
       with:
         testDescription: "GUI tests on build dir"
-        testCommand: pixi run xvfb-run ${{ env.builddir }}/bin/FreeCAD -t 0
+        testCommand: xvfb-run ${{ env.builddir }}/bin/FreeCAD -t 0
         logFile: ${{ env.logdir }}TestGUIBuild.log
         reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+        shellCmd: ${{ env.shellCmd }}
 
     - name: Coin node snapshot visual tests on build dir
       if: runner.os == 'Linux' && inputs.testCoinNodeSnapshots && !inputs.skipBuild
@@ -198,10 +201,11 @@ jobs:
         testDescription: "Coin node snapshot visual tests on build dir"
         testCommand: |
           FC_VISUAL_OUT_DIR="/tmp/FreeCADTesting/CoinNodeSnapshots" \
-          pixi run xvfb-run -a -s "-screen 0 1024x768x24" \
+          xvfb-run -a -s "-screen 0 1024x768x24" \
             "${{ env.builddir }}/bin/FreeCAD" -t TestCoinNodeSnapshots
         logFile: ${{ env.logdir }}TestCoinNodeSnapshotsBuild.log
         reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+        shellCmd: ${{ env.shellCmd }}
 
     - name: Upload Coin node snapshot artifacts (on failure)
       if: failure() && runner.os == 'Linux' && inputs.testCoinNodeSnapshots && !inputs.skipBuild
@@ -222,6 +226,7 @@ jobs:
         reportdir: ${{ env.reportdir }}
         builddir: ${{ env.builddir }}
         reportFile: ${{ env.reportdir }}${{ env.reportfilename }}
+        shellCmd: ${{ env.shellCmd }}
 
     - name: CMake Install
       if: "!inputs.skipBuild"
@@ -234,9 +239,10 @@ jobs:
       uses: ./.github/workflows/actions/runPythonTests
       with:
         testDescription: "CLI tests on install"
-        testCommand: pixi run FreeCADCmd -t 0
+        testCommand: FreeCADCmd -t 0
         logFile: ${{ env.logdir }}TestCLIInstall.log
         reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+        shellCmd: ${{ env.shellCmd }}
 
     - name: FreeCAD GUI tests on install
       # if: runner.os == 'Linux' && !inputs.skipBuild
@@ -246,9 +252,10 @@ jobs:
       uses: ./.github/workflows/actions/runPythonTests
       with:
         testDescription: "GUI tests on install"
-        testCommand: pixi run xvfb-run FreeCAD -t 0
+        testCommand: xvfb-run FreeCAD -t 0
         logFile: ${{ env.logdir }}TestGUIInstall.log
         reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+        shellCmd: ${{ env.shellCmd }}
 
     - name: Save Compiler Cache
       id: cache-save


### PR DESCRIPTION
can result in error due to using system binaries instead of those from the pixi environment

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->

