### PR TITLE
Fem: Improve glyph filter - fixes #21354

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/TaskPostGlyph.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/TaskPostGlyph.ui
@@ -165,7 +165,7 @@
       <item row="2" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
-         <widget class="QDoubleSpinBox" name="ScaleFactorBox">
+         <widget class="Gui::DoubleSpinBox" name="ScaleFactorBox">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -370,6 +370,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::DoubleSpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/SpinBox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/Mod/Fem/femobjects/post_glyphfilter.py
+++ b/src/Mod/Fem/femobjects/post_glyphfilter.py
@@ -142,10 +142,10 @@ class PostGlyphFilter(base_fempythonobject.BaseFemPythonObject):
 
     def __setupGlyphFilter(self, obj, glyph):
 
+        glyph.ScalingOn()
         # scaling
         if obj.ScaleData != "None":
 
-            glyph.ScalingOn()
             if obj.ScaleData in obj.getInputVectorFields():
 
                 # make sure the vector mode is set correctly
@@ -168,7 +168,7 @@ class PostGlyphFilter(base_fempythonobject.BaseFemPythonObject):
                 glyph.SetInputArrayToProcess(2, 0, 0, 0, obj.ScaleData)
                 glyph.SetScaleModeToScaleByScalar()
         else:
-            glyph.ScalingOff()
+            glyph.SetScaleModeToDataScalingOff()
 
         glyph.SetScaleFactor(obj.ScaleFactor)
 

--- a/src/Mod/Fem/femtaskpanels/task_post_glyphfilter.py
+++ b/src/Mod/Fem/femtaskpanels/task_post_glyphfilter.py
@@ -68,6 +68,7 @@ class _TaskPanel(base_fempostpanel._BasePostTaskPanel):
         self._enumPropertyToCombobox(self.obj, "VectorScaleMode", self.widget.VectorModeComboBox)
         self._enumPropertyToCombobox(self.obj, "MaskMode", self.widget.MaskModeComboBox)
 
+        FreeCADGui.ExpressionBinding(self.widget.ScaleFactorBox).bind(self.obj, "ScaleFactor")
         self.widget.ScaleFactorBox.setValue(self.obj.ScaleFactor)
         self.__slide_min = self.obj.ScaleFactor * 0.5
         self.__slide_max = self.obj.ScaleFactor * 1.5
@@ -91,8 +92,6 @@ class _TaskPanel(base_fempostpanel._BasePostTaskPanel):
     def __update_scaling_ui(self):
         enabled = self.widget.ScaleComboBox.currentIndex() != 0
         self.widget.VectorModeComboBox.setEnabled(enabled)
-        self.widget.ScaleFactorBox.setEnabled(enabled)
-        self.widget.ScaleSlider.setEnabled(enabled)
 
     def __update_masking_ui(self):
         enabled = self.widget.MaskModeComboBox.currentIndex() != 0
@@ -125,7 +124,13 @@ class _TaskPanel(base_fempostpanel._BasePostTaskPanel):
         # set slider
         self.__slide_min = value * 0.5
         self.__slide_max = value * 1.5
-        slider_value = (value - self.__slide_min) / (self.__slide_max - self.__slide_min) * 100.0
+        try:
+            slider_value = (
+                (value - self.__slide_min) / (self.__slide_max - self.__slide_min) * 100.0
+            )
+        except ZeroDivisionError:
+            slider_value = 0
+
         self.widget.ScaleSlider.blockSignals(True)
         self.widget.ScaleSlider.setValue(slider_value)
         self.widget.ScaleSlider.blockSignals(False)


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Now the scale factor can be used for uniform scaling (`ScaleData = None`), which is useful for viewing glyphs if the fields decay rapidly with distance (e.g., electromagnetic fields).

While I added the use of expressions, the number of decimals should also reflect the global preference. Currently, it remains at two digits. This is a general issue with the DoubleSpinBox (those without units) in FreeCAD and needs to be fixed in core GUI.

@FEA-eng 
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
 fixes #21354
## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
