### PR TITLE
PD: Allow Sketcher internal faces as offset reference

### DIFF
--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -813,9 +813,20 @@ double ProfileBased::getStartReferenceOffset(
     }
 
     TopoShape referenceShape;
+    const auto& subValues = reference.getSubValues();
     if (reference.getValue()->isDerivedFrom<Part::Part2DObject>()) {
-        referenceShape
-            = getTopoShapeVerifiedFace(false, false, reference.getValue(), reference.getSubValues());
+        if (!subValues.empty()) {
+            const Part::ShapeOptions options = Part::ShapeOption::NeedSubElement
+                | Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform;
+            referenceShape = Part::Feature::getTopoShape(
+                reference.getValue(),
+                options,
+                subValues.front().c_str()
+            );
+        }
+        if (!referenceShape.hasSubShape(TopAbs_FACE)) {
+            referenceShape = getTopoShapeVerifiedFace(false, false, reference.getValue(), subValues);
+        }
     }
     else {
         getUpToFaceFromLinkSub(referenceShape, reference);

--- a/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
+++ b/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
@@ -214,7 +214,7 @@ bool ReferenceSelection::allowPartFeature(App::DocumentObject* pObj, const char*
         }
     }
 
-    if (type.testFlag(AllowSelection::FACE) && subName.compare(0, 4, "Face") == 0) {
+    if (type.testFlag(AllowSelection::FACE)) {
         if (isFace(pObj, sSubName)) {
             return true;
         }
@@ -245,10 +245,13 @@ bool ReferenceSelection::isEdge(App::DocumentObject* pObj, const char* sSubName)
 
 bool ReferenceSelection::isFace(App::DocumentObject* pObj, const char* sSubName) const
 {
-    const Part::TopoShape& shape = static_cast<const Part::Feature*>(pObj)->Shape.getValue();
-    TopoDS_Shape sh = shape.getSubShape(sSubName);
-    const TopoDS_Face& face = TopoDS::Face(sh);
-    if (!face.IsNull()) {
+    const Part::TopoShape shape = Part::Feature::getTopoShape(
+        pObj,
+        Part::ShapeOption::NeedSubElement | Part::ShapeOption::ResolveLink,
+        sSubName
+    );
+    if (shape.shapeType(true) == TopAbs_FACE) {
+        const TopoDS_Face& face = TopoDS::Face(shape.getShape());
         if (type.testFlag(AllowSelection::PLANAR)) {
             BRepAdaptor_Surface adapt(face);
             if (adapt.GetType() == GeomAbs_Plane) {

--- a/src/Mod/PartDesign/PartDesignTests/TestPad.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestPad.py
@@ -103,6 +103,27 @@ class TestPad(unittest.TestCase):
         self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMin, 13.0)
         self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMax, 16.0)
 
+    def testStartReferenceInternalSketchFace(self):
+        self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "SketchPad")
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 0), (1, 1))
+        self.Doc.recompute()
+
+        reference = self.Doc.addObject("Sketcher::SketchObject", "Reference")
+        reference.MakeInternals = True
+        reference.Placement.Base = Base.Vector(0, 0, 10)
+        TestSketcherApp.CreateRectangleSketch(reference, (0, 0), (1, 1))
+        self.Doc.recompute()
+
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 3
+        self.Pad.StartReference = (reference, ["InternalFace1"])
+        self.Pad.StartType = "Reference"
+        self.Pad.StartOffset = 2
+        self.Doc.recompute()
+        self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMin, 12.0)
+        self.assertAlmostEqual(self.Pad.Shape.BoundBox.ZMax, 15.0)
+
     def testStartOffsetForTwoSidedAndSymmetricPad(self):
         self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "SketchPad")
         TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 0), (1, 1))


### PR DESCRIPTION
Allow Sketcher internal faces as offset reference
Assisted-by: GPT-5.6-Terra

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
<img width="1121" height="374" alt="Bildschirmfoto 2026-08-10 um 19 20 52" src="https://github.com/user-attachments/assets/a93e6ab6-cc67-4e5e-9221-bd98a3d9f621" />



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
