### PR TITLE
Fix: depreciation warning that throws an error on save. 

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -845,7 +845,7 @@ void StdCmdSave::activated(int iMsg)
         }
     }
 
-    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"Save\")");
+    doCommand(Command::Gui, "Gui.activeView().sendMessage(\"Save\")");
 }
 
 bool StdCmdSave::isActive()
@@ -874,7 +874,7 @@ StdCmdSaveAs::StdCmdSaveAs()
 void StdCmdSaveAs::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"SaveAs\")");
+    doCommand(Command::Gui, "Gui.activeView().sendMessage(\"SaveAs\")");
 }
 
 bool StdCmdSaveAs::isActive()
@@ -905,7 +905,7 @@ StdCmdSaveCopy::StdCmdSaveCopy()
 void StdCmdSaveCopy::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"SaveCopy\")");
+    doCommand(Command::Gui, "Gui.activeView().sendMessage(\"SaveCopy\")");
 }
 
 bool StdCmdSaveCopy::isActive()

--- a/src/Mod/Test/GuiDocument.py
+++ b/src/Mod/Test/GuiDocument.py
@@ -22,9 +22,11 @@
 ***************************************************************************/"""
 
 import os
+import tempfile
 import threading
 import time
 import unittest
+import warnings
 import zipfile
 
 import FreeCAD
@@ -190,6 +192,22 @@ class TestGuiDocument(unittest.TestCase):
 
         self.assertEqual(proxy.executed_thread_id, threading.get_ident())
         self.assertGreaterEqual(elapsed, 0.04)
+
+    def testSaveCommandDoesNotUseDeprecatedAPI(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.doc.saveAs(os.path.join(temp_dir, "TestDoc.FCStd"))
+            self.doc.addObject("App::FeaturePython", "ModifiedObject")
+
+            with warnings.catch_warnings(record=True) as caught_warnings:
+                warnings.simplefilter("always", DeprecationWarning)
+                FreeCADGui.runCommand("Std_Save", 0)
+
+            deprecations = [
+                warning
+                for warning in caught_warnings
+                if issubclass(warning.category, DeprecationWarning)
+            ]
+            self.assertEqual(deprecations, [])
 
     def testRecoverySnapshotIncludesGuiDocument(self):
         self.doc.addObject("App::FeaturePython", "RecoveryGuiObject")


### PR DESCRIPTION
Fix depreciation warning that throws an error on save. 

Changes the deprecated: 
`doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"Save\")");`

to:
`doCommand(Command::Gui, "Gui.activeView().sendMessage(\"Save\")");`


- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
