### PR TITLE
FEM: Avoid ZipSlip

### DIFF
--- a/src/Base/FileInfo.cpp
+++ b/src/Base/FileInfo.cpp
@@ -568,6 +568,44 @@ std::vector<Base::FileInfo> FileInfo::getDirectoryContent() const
     return list;
 }
 
+std::optional<std::string> FileInfo::safeArchiveEntryPath(const std::string& entryName)
+{
+    if (entryName.find(':') != std::string::npos) {
+        return std::nullopt;
+    }
+
+    std::string normalized = entryName;
+    std::ranges::replace(normalized, '\\', '/');
+
+    std::string result;
+    std::size_t start = 0;
+    while (start <= normalized.size()) {
+        std::size_t end = normalized.find('/', start);
+        if (end == std::string::npos) {
+            end = normalized.size();
+        }
+        std::string component = normalized.substr(start, end - start);
+        start = end + 1;
+
+        if (component == "..") {
+            return std::nullopt;
+        }
+        if (component.empty() || component == ".") {
+            continue;
+        }
+        if (!result.empty()) {
+            result += '/';
+        }
+        result += component;
+    }
+
+    if (result.empty()) {
+        return std::nullopt;
+    }
+
+    return result;
+}
+
 std::optional<std::string> FileInfo::getSymlinkTarget()
 {
     fs::path path = stringToPath(FileName);

--- a/src/Base/FileInfo.cpp
+++ b/src/Base/FileInfo.cpp
@@ -574,36 +574,32 @@ std::optional<std::string> FileInfo::safeArchiveEntryPath(const std::string& ent
         return std::nullopt;
     }
 
+    // A backslash is only a separator to fs::path on Windows, but setFile() converts it into a
+    // forward slash on every platform, so the separators must be unified before decomposition.
     std::string normalized = entryName;
     std::ranges::replace(normalized, '\\', '/');
 
-    std::string result;
-    std::size_t start = 0;
-    while (start <= normalized.size()) {
-        std::size_t end = normalized.find('/', start);
-        if (end == std::string::npos) {
-            end = normalized.size();
-        }
-        std::string component = normalized.substr(start, end - start);
-        start = end + 1;
+    // Leading separators are stripped rather than rejected: the FEM code this was written to
+    // address starts *every* path with a slash. They have to go before fs::path sees the
+    // name.
+    normalized.erase(0, normalized.find_first_not_of('/'));
 
+    fs::path result;
+    for (const fs::path& component : fs::path(normalized).relative_path()) {
         if (component == "..") {
             return std::nullopt;
         }
         if (component.empty() || component == ".") {
             continue;
         }
-        if (!result.empty()) {
-            result += '/';
-        }
-        result += component;
+        result /= component;
     }
 
     if (result.empty()) {
         return std::nullopt;
     }
 
-    return result;
+    return result.generic_string();
 }
 
 std::optional<std::string> FileInfo::getSymlinkTarget()

--- a/src/Base/FileInfo.h
+++ b/src/Base/FileInfo.h
@@ -171,6 +171,12 @@ public:
     static std::string pathToString(const std::filesystem::path& path);
     /// Convert from string to filesystem path
     static std::filesystem::path stringToPath(const std::string& str);
+    /** Reduce an archive entry name to a path that cannot escape the extraction directory.
+     *
+     * @param[in] entryName The raw entry name as stored in the archive.
+     * @return The normalized relative path, or @c std::nullopt if the entry must be skipped.
+     */
+    static std::optional<std::string> safeArchiveEntryPath(const std::string& entryName);
     //@}
 
 private:

--- a/src/Mod/Fem/App/PropertyPostDataObject.cpp
+++ b/src/Mod/Fem/App/PropertyPostDataObject.cpp
@@ -505,7 +505,21 @@ void PropertyPostDataObject::RestoreDocFile(Base::Reader& reader)
             try {
                 zipios::ConstEntryPointer entry = ZipReader.getNextEntry();
                 while (entry->isValid()) {
-                    Base::FileInfo entry_path(fo.filePath() + entry->getName());
+                    // The entry names come straight out of the stored file and are attacker
+                    // controlled, so they must never be joined to the extraction directory
+                    // unchecked.
+                    auto safeName = Base::FileInfo::safeArchiveEntryPath(entry->getName());
+                    if (!safeName) {
+                        Base::Console().error(
+                            "Skipped dataset entry '%s': the name escapes the extraction "
+                            "directory\n",
+                            entry->getName()
+                        );
+                        entry = ZipReader.getNextEntry();
+                        continue;
+                    }
+
+                    Base::FileInfo entry_path(fo.filePath() + "/" + *safeName);
                     if (entry->isDirectory()) {
                         // seems not to be called
                         entry_path.createDirectories();

--- a/src/Mod/Fem/CMakeLists.txt
+++ b/src/Mod/Fem/CMakeLists.txt
@@ -391,6 +391,7 @@ SET(FemTestsApp_SRCS
     femtest/app/test_object.py
     femtest/app/test_open.py
     femtest/app/test_result.py
+    femtest/app/test_security.py
     femtest/app/test_solver_elmer.py
     femtest/app/test_solver_mystran.py
     femtest/app/test_solver_z88.py

--- a/src/Mod/Fem/TestFemApp.py
+++ b/src/Mod/Fem/TestFemApp.py
@@ -39,6 +39,7 @@ from femtest.app.test_solver_elmer import TestSolverElmer as FemTest13
 from femtest.app.test_solver_z88 import TestSolverZ88 as FemTest14
 from femtest.app.test_gmsh import TestGMSHTransfinite as FemTest15
 from femtest.app.test_gmsh import TestGMSHRefinements as FemTest16
+from femtest.app.test_security import TestPostDataObjectSecurity as FemTest17
 
 # dummy usage to get flake8 and lgtm quiet
 False if FemTest01.__name__ else True
@@ -56,3 +57,4 @@ False if FemTest13.__name__ else True
 False if FemTest14.__name__ else True
 False if FemTest15.__name__ else True
 False if FemTest16.__name__ else True
+False if FemTest17.__name__ else True

--- a/src/Mod/Fem/femtest/app/test_security.py
+++ b/src/Mod/Fem/femtest/app/test_security.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 The FreeCAD project association AISBL
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+__title__ = "FEM App security unit tests"
+
+import io
+import os
+import shutil
+import tempfile
+import unittest
+import zipfile
+
+import FreeCAD
+
+from .support_utils import fcc_print
+
+# A document holding a single Fem::FemPostPipeline whose Data property points at an embedded
+# file called "payload.zip". Restoring Fem::PropertyPostDataObject selects its zip branch from
+# that name, which is what feeds the inner archive to the extraction loop. The FEM module is
+# loaded on demand by the type system when it meets the object type, so no workbench needs to
+# be active for this to run.
+MALICIOUS_DOCUMENT_XML = b"""<?xml version='1.0' encoding='utf-8'?>
+<Document SchemaVersion="4" ProgramVersion="1.1.3" FileVersion="1">
+    <Properties Count="1" TransientCount="0">
+        <Property name="Label" type="App::PropertyString">
+            <String value="zipslip"/>
+        </Property>
+    </Properties>
+    <Objects Count="1">
+        <Object type="Fem::FemPostPipeline" name="Pipeline" id="1" />
+    </Objects>
+    <ObjectData Count="1">
+        <Object name="Pipeline">
+            <Properties Count="1" TransientCount="0">
+                <Property name="Data" type="Fem::PropertyPostDataObject">
+                    <Data file="payload.zip"/>
+                </Property>
+            </Properties>
+        </Object>
+    </ObjectData>
+</Document>"""
+
+PAYLOAD = b"this file should never have been written\n"
+
+
+class TestPostDataObjectSecurity(unittest.TestCase):
+    """Regression tests for GHSA-9vjf-h8f4-c229.
+
+    Fem::PropertyPostDataObject stores multi block datasets as a zip inside the FCStd. The
+    names of the entries in that inner zip come straight out of an untrusted file, so joining
+    them to the extraction directory unchecked let a crafted document write anywhere the user
+    can write.
+    """
+
+    fcc_print("import TestPostDataObjectSecurity")
+
+    def setUp(self):
+        if "BUILD_FEM_VTK" not in FreeCAD.__cmake__:
+            self.skipTest("FEM was built without VTK, PropertyPostDataObject is not compiled")
+
+        self.working_dir = tempfile.mkdtemp(prefix="fem_post_security_")
+        self.document = None
+        self.escape_targets = []
+
+    def tearDown(self):
+        if self.document is not None:
+            FreeCAD.closeDocument(self.document.Name)
+            self.document = None
+        for target in self.escape_targets:
+            if os.path.exists(target):
+                os.remove(target)
+        shutil.rmtree(self.working_dir, ignore_errors=True)
+
+    def set_escape_target(self, name):
+        """Return the path a successful escape would land on in the tests below. Nothing is created
+        here, this is just the path we've crafted the test to land on if the escape is successful.
+        """
+        target = os.path.join(FreeCAD.getTempPath(), name)
+        self.assertFalse(os.path.exists(target), "stale file from an earlier run: " + str(target))
+        self.escape_targets.append(target)
+        return target
+
+    def write_malicious_document(self, entry_names):
+        """Build an FCStd whose embedded post-processing archive uses the given entry names."""
+        inner = io.BytesIO()
+        with zipfile.ZipFile(inner, "w", zipfile.ZIP_DEFLATED) as archive:
+            # The reader preloads the first entry, so a real file always has a leading dummy
+            archive.writestr("dummy", b"")
+            for name in entry_names:
+                # ZipInfo rewrites os.sep into "/" when it is built from a name, which would
+                # turn the backslash cases below into forward slash ones on Windows. Assigning
+                # the name afterwards stores the bytes an attacker would actually put there.
+                entry = zipfile.ZipInfo("entry")
+                entry.filename = name
+                entry.compress_type = zipfile.ZIP_DEFLATED
+                archive.writestr(entry, PAYLOAD)
+
+        path = os.path.join(self.working_dir, "malicious.FCStd")
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as outer:
+            outer.writestr("Document.xml", MALICIOUS_DOCUMENT_XML)
+            outer.writestr("payload.zip", inner.getvalue())
+        return path
+
+    def open_malicious_document(self, entry_names):
+        path = self.write_malicious_document(entry_names)
+        self.document = FreeCAD.openDocument(path)
+
+        # Guard against a vacuous pass: if the hand written Document.xml ever stops matching
+        # the schema, the object would silently not be restored and nothing would be extracted
+        # regardless of whether the entry names are checked.
+        self.assertEqual(len(self.document.Objects), 1)
+        self.assertEqual(self.document.Objects[0].TypeId, "Fem::FemPostPipeline")
+
+    def test_forward_slash_traversal_is_rejected(self):
+        target = self.set_escape_target("zipslip_forward_escape.txt")
+        self.open_malicious_document(["/../zipslip_forward_escape.txt"])
+        self.assertFalse(
+            os.path.exists(target),
+            "a zip entry name escaped the extraction directory: {}".format(target),
+        )
+
+    def test_backslash_traversal_is_rejected(self):
+        target = self.set_escape_target("zipslip_backslash_escape.txt")
+        self.open_malicious_document(["/..\\zipslip_backslash_escape.txt"])
+        self.assertFalse(
+            os.path.exists(target),
+            "a backslash zip entry name escaped the extraction directory: {}".format(target),
+        )
+
+    def test_deep_traversal_is_rejected(self):
+        target = self.set_escape_target("zipslip_deep_escape.txt")
+        deep = "/" + "../" * 30 + os.path.relpath(target, os.path.splitdrive(target)[0] + os.sep)
+        self.open_malicious_document([deep.replace(os.sep, "/")])
+        self.assertFalse(
+            os.path.exists(target),
+            "a deep zip entry name escaped the extraction directory: {}".format(target),
+        )
+
+    def test_mixed_entries_document_still_opens(self):
+        target = self.set_escape_target("zipslip_mixed_escape.txt")
+        self.open_malicious_document(["/../zipslip_mixed_escape.txt", "/datafile.vtm"])
+        self.assertFalse(os.path.exists(target))
+
+    def test_legitimate_dataset_survives_a_round_trip(self):
+        """The names FreeCAD itself writes start with a separator and must keep working. Make sure
+        that the separator-prefixed names that get generated aren't rejected by the sanitizer: if
+        they were, all old files would break.
+        """
+        if "BUILD_FEM_VTK_PYTHON" not in FreeCAD.__cmake__:
+            self.skipTest("FEM was built without the VTK Python bindings")
+        try:
+            from vtkmodules.vtkCommonCore import vtkPoints
+            from vtkmodules.vtkCommonDataModel import vtkMultiBlockDataSet, vtkUnstructuredGrid
+        except ImportError:
+            self.skipTest("the VTK Python modules are not importable")
+
+        points = vtkPoints()
+        points.InsertNextPoint(0.0, 0.0, 0.0)
+        points.InsertNextPoint(1.0, 0.0, 0.0)
+        points.InsertNextPoint(0.0, 1.0, 0.0)
+        grid = vtkUnstructuredGrid()
+        grid.SetPoints(points)
+        dataset = vtkMultiBlockDataSet()
+        dataset.SetNumberOfBlocks(1)
+        dataset.SetBlock(0, grid)
+
+        path = os.path.join(self.working_dir, "roundtrip.FCStd")
+        self.document = FreeCAD.newDocument("post_roundtrip")
+        pipeline = self.document.addObject("Fem::FemPostPipeline", "Pipeline")
+        pipeline.Data = dataset
+        self.document.saveAs(path)
+        # Drop the reference before reopening so tearDown never sees a closed document
+        name = self.document.Name
+        self.document = None
+        FreeCAD.closeDocument(name)
+
+        self.document = FreeCAD.openDocument(path)
+        restored = self.document.getObject("Pipeline").Data
+        self.assertEqual(restored.GetNumberOfBlocks(), 1)
+        self.assertEqual(restored.GetBlock(0).GetNumberOfPoints(), 3)

--- a/tests/src/Base/FileInfo.cpp
+++ b/tests/src/Base/FileInfo.cpp
@@ -281,6 +281,15 @@ TEST(FileInfoSafeArchiveEntryPathTest, RejectsParentDirectoryTraversal)
     EXPECT_FALSE(Base::FileInfo::safeArchiveEntryPath("//..//evil").has_value());
 }
 
+TEST(FileInfoSafeArchiveEntryPathTest, LeadingDoubleSeparatorDoesNotEatAComponent)
+{
+    // On Windows a name starting with two separators parses as a filesystem root name, so naive
+    // decomposition would drop "server" here (and, above, the ".." in "//..//evil"). The result
+    // has to be identical on every platform.
+    EXPECT_EQ(Base::FileInfo::safeArchiveEntryPath("//server/share/evil"), "server/share/evil");
+    EXPECT_EQ(Base::FileInfo::safeArchiveEntryPath("\\\\server\\share\\evil"), "server/share/evil");
+}
+
 TEST(FileInfoSafeArchiveEntryPathTest, RejectsBackslashTraversal)
 {
     // A backslash is an ordinary filename character on Linux and macOS, so these names look

--- a/tests/src/Base/FileInfo.cpp
+++ b/tests/src/Base/FileInfo.cpp
@@ -254,3 +254,152 @@ TEST_F(FileInfoPathConversionTest, NaivePathStringLosesNonAscii)
     EXPECT_NE(naive, safe);
 }
 #endif
+
+// Regression tests for GHSA-9vjf-h8f4-c229: a crafted archive entry name must not be able to
+// escape the directory it is being extracted into.
+
+TEST(FileInfoSafeArchiveEntryPathTest, AcceptsNamesWrittenByFreeCAD)
+{
+    // PropertyPostDataObject::SaveDocFile creates its names by removing the extraction directory
+    // name from the front of an absolute path, so *every* name it writes starts with a separator.
+    // Make sure we didn't break those, and they normalize to the expected separator-less name.
+    EXPECT_EQ(Base::FileInfo::safeArchiveEntryPath("/datafile.vtm"), "datafile.vtm");
+    EXPECT_EQ(
+        Base::FileInfo::safeArchiveEntryPath("/datafile/datafile_0_0.vtu"),
+        "datafile/datafile_0_0.vtu"
+    );
+    EXPECT_EQ(Base::FileInfo::safeArchiveEntryPath("dummy"), "dummy");
+}
+
+TEST(FileInfoSafeArchiveEntryPathTest, RejectsParentDirectoryTraversal)
+{
+    EXPECT_FALSE(Base::FileInfo::safeArchiveEntryPath("/../../../etc/passwd").has_value());
+    EXPECT_FALSE(Base::FileInfo::safeArchiveEntryPath("../evil").has_value());
+    EXPECT_FALSE(Base::FileInfo::safeArchiveEntryPath("datafile/../../evil").has_value());
+    EXPECT_FALSE(Base::FileInfo::safeArchiveEntryPath("..").has_value());
+    // Tricksy: starting with a separator shouldn't hide the traversal
+    EXPECT_FALSE(Base::FileInfo::safeArchiveEntryPath("//..//evil").has_value());
+}
+
+TEST(FileInfoSafeArchiveEntryPathTest, RejectsBackslashTraversal)
+{
+    // A backslash is an ordinary filename character on Linux and macOS, so these names look
+    // harmless there. They are *not*: every path ultimately goes through FileInfo, and
+    // setFile() rewrites '\' to '/'. So they *would* have been harmless, but are now real path seps
+    // when the file is opened. So on Windows this test isn't that useful, but on Linux and macOS it
+    // ensures that even though that happens, we still handle it as expected.
+    EXPECT_FALSE(Base::FileInfo::safeArchiveEntryPath("..\\..\\evil").has_value());
+    EXPECT_FALSE(Base::FileInfo::safeArchiveEntryPath("datafile\\..\\..\\evil").has_value());
+    EXPECT_EQ(Base::FileInfo::safeArchiveEntryPath("datafile\\sub.vtu"), "datafile/sub.vtu");
+}
+
+TEST(FileInfoSafeArchiveEntryPathTest, RejectsColonNames)
+{
+    // Drive-relative paths and NTFS alternate data streams both escape via a colon, so the
+    // sanitizer rejects colons wholesale -- any colon anywhere is treated as an invalid path.
+    EXPECT_FALSE(Base::FileInfo::safeArchiveEntryPath("C:/Windows/System32/evil.dll").has_value());
+    EXPECT_FALSE(Base::FileInfo::safeArchiveEntryPath("C:evil").has_value());
+    EXPECT_FALSE(Base::FileInfo::safeArchiveEntryPath("datafile.vtu:stream").has_value());
+}
+
+TEST(FileInfoSafeArchiveEntryPathTest, RejectsNamesThatNormalizeToNothing)
+{
+    EXPECT_FALSE(Base::FileInfo::safeArchiveEntryPath("").has_value());
+    EXPECT_FALSE(Base::FileInfo::safeArchiveEntryPath("/").has_value());
+    EXPECT_FALSE(Base::FileInfo::safeArchiveEntryPath(".").has_value());
+    EXPECT_FALSE(Base::FileInfo::safeArchiveEntryPath("./").has_value());
+}
+
+TEST(FileInfoSafeArchiveEntryPathTest, NormalizesRedundantComponents)
+{
+    // Not really security, but the method does do this cleanup
+    EXPECT_EQ(Base::FileInfo::safeArchiveEntryPath("./datafile.vtm"), "datafile.vtm");
+    EXPECT_EQ(Base::FileInfo::safeArchiveEntryPath("datafile//./sub.vtu"), "datafile/sub.vtu");
+}
+
+TEST(FileInfoSafeArchiveEntryPathTest, ContainedDotsAreAllowed)
+{
+    // A name that just *contains* dots is allowed, and must not get eaten
+    EXPECT_EQ(Base::FileInfo::safeArchiveEntryPath("/datafile..vtu"), "datafile..vtu");
+    EXPECT_EQ(Base::FileInfo::safeArchiveEntryPath("/a..b/c.vtu"), "a..b/c.vtu");
+}
+
+TEST(FileInfoSafeArchiveEntryPathTest, HostileNamesCannotEscapeWhenJoined)
+{
+    // Integration test for the above: **whatever** an archive holds, the path finally opened
+    // is inside the extraction directory.
+    const std::string extractionDir = "/tmp/FreeCAD_xxx/vtk_extract_datadir";
+    const std::filesystem::path extractionPath
+        = std::filesystem::path(extractionDir).lexically_normal();
+
+    std::vector<std::string> hostile = {
+        // Plain parent directory steps
+        "/../evil",
+        "../evil",
+        "../../../etc/passwd",
+        "a/../../evil",
+        "a/b/../../../../evil",
+        // Steps hidden behind redundant or empty components
+        "..//evil",
+        "//../evil",
+        "/./../evil",
+        ".././evil",
+        "a/./../../evil",
+        // Steps written with the separator FileInfo::setFile rewrites, including mixed forms
+        "..\\evil",
+        "a\\..\\..\\evil",
+        "\\..\\..\\evil",
+        "/..\\../evil",
+        // Names that are nothing but a step
+        "..",
+        "../",
+        "/..",
+        "..\\",
+        "./..",
+        // Absolute and rooted names that try to ignore the extraction directory entirely
+        "/etc/passwd",
+        "//server/share/evil",
+        "\\\\server\\share\\evil",
+        "C:/Windows/System32/evil.dll",
+        "C:evil",
+        "evil.vtu:stream",
+    };
+    // A run long enough to climb past the filesystem root, which clamps rather than wrapping
+    hostile.push_back("/" + [] {
+        std::string steps;
+        constexpr int soManySubdirs = 40;
+        for (int i = 0; i < soManySubdirs; ++i) {
+            steps += "../";
+        }
+        return steps;
+    }() + "evil");
+
+    std::size_t rejected = 0;
+    std::size_t contained = 0;
+    for (const auto& name : hostile) {
+        auto safe = Base::FileInfo::safeArchiveEntryPath(name);
+        if (!safe) {
+            ++rejected;
+            continue;
+        }
+
+        std::filesystem::path joined
+            = std::filesystem::path(extractionDir + "/" + *safe).lexically_normal();
+        std::filesystem::path relative = joined.lexically_relative(extractionPath);
+
+        // An empty relative path means the two are unrelated, and a leading ".." means the
+        // result climbed out. Either way the name escaped.
+        EXPECT_FALSE(relative.empty()) << name << " -> " << joined.string();
+        if (!relative.empty()) {
+            EXPECT_NE(*relative.begin(), std::filesystem::path(".."))
+                << name << " -> " << joined.string();
+        }
+        ++contained;
+    }
+
+    // Every single one of these should have tripped one test or the other, and both paths must
+    // have been taken: a sanitizer that gave up and rejected everything would otherwise satisfy
+    // the loop above without a single containment check ever running.
+    EXPECT_EQ(rejected + contained, hostile.size());
+    EXPECT_GT(contained, 0U);
+}


### PR DESCRIPTION
Address [ZipSlip](https://github.com/snyk/zip-slip-vulnerability) vulnerability reported in GHSA-9vjf-h8f4-c229: `Fem::PropertyPostDataObject` stores multi block datasets as a zip inside the FCStd. The names of the entries in that inner zip come straight out of an untrusted file, so joining them to the extraction directory unchecked let a crafted document write anywhere the user can write.

Mitigation is done in two steps: first, a general-purpose utility method is added to `Base::FileInfo` that takes an archive entry path and ensures that it does not escape from the archive itself. Second, a modification to the FEM workbench is made to use that new tool to prevent the reported escape.

Note that the actual fix itself is about 25 lines of code: the other 400 are an extensive set of tests in which I (and Claude) try to break out of the Zip.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: Claude Opus 5
