### PR TITLE
Fix: removed unusable mode option from the thickness task panel - issue #6885

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
@@ -89,8 +89,6 @@ void TaskThicknessParameters::initControls()
 
     setupConnections();
 
-    int mode = static_cast<int>(thickness->Mode.getValue());
-    ui->modeComboBox->setCurrentIndex(mode);
 
     int join = static_cast<int>(thickness->Join.getValue());
     ui->joinComboBox->setCurrentIndex(join);
@@ -116,8 +114,6 @@ void TaskThicknessParameters::setupConnections()
             this, &TaskThicknessParameters::onIntersectionChanged);
     connect(ui->buttonRefSel, &QToolButton::toggled,
             this, &TaskThicknessParameters::onButtonRefSel);
-    connect(ui->modeComboBox, qOverload<int>(&QComboBox::currentIndexChanged),
-            this, &TaskThicknessParameters::onModeChanged);
     connect(ui->joinComboBox, qOverload<int>(&QComboBox::currentIndexChanged),
             this, &TaskThicknessParameters::onJoinTypeChanged);
 
@@ -189,13 +185,6 @@ void TaskThicknessParameters::onJoinTypeChanged(int join)
     }
 }
 
-void TaskThicknessParameters::onModeChanged(int mode)
-{
-    if (PartDesign::Thickness* thickness = onBeforeChange()) {
-        thickness->Mode.setValue(mode);
-        onAfterChange(thickness);
-    }
-}
 
 double TaskThicknessParameters::getValue() const
 {
@@ -236,11 +225,6 @@ int TaskThicknessParameters::getJoinType() const
     return ui->joinComboBox->currentIndex();
 }
 
-int TaskThicknessParameters::getMode() const
-{
-
-    return ui->modeComboBox->currentIndex();
-}
 
 TaskThicknessParameters::~TaskThicknessParameters()
 {
@@ -341,7 +325,6 @@ bool TaskDlgThicknessParameters::accept()
 
     FCMD_OBJ_CMD(obj, "Value = " << draftparameter->getValue());
     FCMD_OBJ_CMD(obj, "Reversed = " << draftparameter->getReversed());
-    FCMD_OBJ_CMD(obj, "Mode = " << draftparameter->getMode());
     FCMD_OBJ_CMD(obj, "Intersection = " << draftparameter->getIntersection());
     FCMD_OBJ_CMD(obj, "Join = " << draftparameter->getJoinType());
 

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.h
@@ -59,12 +59,10 @@ public:
     double getValue() const;
     bool getReversed() const;
     bool getIntersection() const;
-    int getMode() const;
     int getJoinType() const;
 
 private Q_SLOTS:
     void onValueChanged(double angle);
-    void onModeChanged(int mode);
     void onJoinTypeChanged(int join);
     void onReversedChanged(bool on);
     void onIntersectionChanged(bool on);

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.ui
@@ -70,39 +70,13 @@
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Mode</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="modeComboBox">
-       <item>
-        <property name="text">
-         <string>Skin</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Pipe</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Recto verso</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="2" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Join type</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="1" column="1">
       <widget class="QComboBox" name="joinComboBox">
        <item>
         <property name="text">
@@ -145,7 +119,6 @@
   <tabstop>buttonRefSel</tabstop>
   <tabstop>listWidgetReferences</tabstop>
   <tabstop>Value</tabstop>
-  <tabstop>modeComboBox</tabstop>
   <tabstop>joinComboBox</tabstop>
   <tabstop>checkIntersection</tabstop>
   <tabstop>checkReverse</tabstop>


### PR DESCRIPTION
The Part Design Thickness task panel has a _Mode_ combo that asks a user to choose between three options.  OCCT (7.8.1 and 8.0.1) only has one of these options ("Skin") implemented, and will run with that option regardless of what arguments are given.  

It is confusing to present the user with options that do nothing (it was to me!), and was highlighted in issue #6885 

This PR simply removes these from the UI; the thickness feature runs as normal. 

- [ x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.


## Issues

#6885 

## Before and After Images
Before:
<img width="510" height="605" alt="image" src="https://github.com/user-attachments/assets/9a23ca99-f174-4d92-97c3-a31742e21fa8" />


After:
<img width="451" height="568" alt="image" src="https://github.com/user-attachments/assets/0470a60b-ef80-4601-bf94-1bb7e08c655e" />

