### PR TITLE
Build/macOS: Make sure to sign contents file before its container

### DIFF
--- a/package/scripts/macos_sign_and_notarize.zsh
+++ b/package/scripts/macos_sign_and_notarize.zsh
@@ -121,17 +121,19 @@ IFS=$' \t\n' # The default
 typeset -U signed_files
 signed_files=("${dylibs[@]}" "${shared_objects[@]}" "${bundles[@]}" "${executables[@]}")
 
+# Not caught by the searches above:
+run_codesign "${CONTAINING_FOLDER}/${APP_NAME}/Contents/packages.txt"
+
+MAIN_EXECUTABLE="${CONTAINING_FOLDER}/${APP_NAME}/Contents/MacOS/${APP_NAME:r}"
+
 # This list of files is generated from:
 # file `find . -type f -perm +111 -print` | grep "Mach-O 64-bit executable" | sed 's/:.*//g'
 for exe in ${signed_files}; do
     # Skip .appex executables as they will be signed separately with their bundles
-    if [[ "$exe" != */Contents/PlugIns/*.appex/* ]]; then
+    if [[ "$exe" != */Contents/PlugIns/*.appex/* && "$exe" != "$MAIN_EXECUTABLE" ]]; then
         run_codesign "${exe}"
     fi
 done
-
-# Two additional files that must be signed that aren't caught by the above searches:
-run_codesign "${CONTAINING_FOLDER}/${APP_NAME}/Contents/packages.txt"
 
 # Sign legacy QuickLook generator if present (not built for macOS 15.0+)
 if [ -f "${CONTAINING_FOLDER}/${APP_NAME}/Contents/Library/QuickLook/QuicklookFCStd.qlgenerator/Contents/MacOS/QuicklookFCStd" ]; then


### PR DESCRIPTION
The new error checking in the macOS notarization caught a pre-existing error in the signing script. This fixes it.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
