### PR TITLE
Expose support face edges while sketching

### DIFF
--- a/src/Mod/Sketcher/App/ExternalGeometryExtension.h
+++ b/src/Mod/Sketcher/App/ExternalGeometryExtension.h
@@ -74,13 +74,13 @@ public:
     // <realthunder.dev@gmail.com>
     enum Flag
     {
-        Defining = 0,  // allow an external geometry to build shape
-        Frozen = 1,    // freeze an external geometry
-        Detached = 2,  // signal the intentions of detaching the geometry from external reference
-        Missing = 3,   // geometry with missing external reference
-        Sync = 4,      // signal the intention to synchronize a frozen geometry
+        Defining = 0,     // allow an external geometry to build shape
+        Frozen = 1,       // freeze an external geometry
+        Detached = 2,     // signal the intentions of detaching the geometry from external reference
+        Missing = 3,      // geometry with missing external reference
+        Sync = 4,         // signal the intention to synchronize a frozen geometry
         AutoSupport = 5,  // geometry auto-generated from the active attachment support face
-        NumFlags       // Must be the last type
+        NumFlags          // Must be the last type
     };
     // END_CREDIT_BLOCK: Credit under LGPL for this block to Zheng, Lei (realthunder)
     // <realthunder.dev@gmail.com>

--- a/src/Mod/Sketcher/App/ExternalGeometryExtension.h
+++ b/src/Mod/Sketcher/App/ExternalGeometryExtension.h
@@ -79,13 +79,14 @@ public:
         Detached = 2,  // signal the intentions of detaching the geometry from external reference
         Missing = 3,   // geometry with missing external reference
         Sync = 4,      // signal the intention to synchronize a frozen geometry
+        AutoSupport = 5,  // geometry auto-generated from the active attachment support face
         NumFlags       // Must be the last type
     };
     // END_CREDIT_BLOCK: Credit under LGPL for this block to Zheng, Lei (realthunder)
     // <realthunder.dev@gmail.com>
 
     constexpr static std::array<const char*, NumFlags> flag2str {
-        {"Defining", "Frozen", "Detached", "Missing", "Sync"}
+        {"Defining", "Frozen", "Detached", "Missing", "Sync", "AutoSupport"}
     };
 
 public:

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1292,13 +1292,6 @@ void SketchObject::onAttachmentSupportChanged()
     if (isRestoring()) {
         return;
     }
-
-    // if support face has changed then clear the external geometry
-    delConstraintsToExternal();
-    for (int i=0; i < getExternalGeometryCount(); i++) {
-        delExternal(0);
-    }
-    rebuildExternalGeometry();
 }
 
 void SketchObject::onUpdateElementReference(const App::Property *prop)

--- a/src/Mod/Sketcher/App/SketchObjectExternal.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectExternal.cpp
@@ -98,6 +98,39 @@
 using namespace Sketcher;
 using namespace Base;
 
+namespace
+{
+bool getAutoSupportFaceReference(const SketchObject& sketch,
+                                 App::DocumentObject*& object,
+                                 std::string& subName)
+{
+    const char* mapMode = sketch.MapMode.getValueAsString();
+    if (!mapMode || strcmp(mapMode, "FlatFace") != 0) {
+        return false;
+    }
+
+    const auto& refs = sketch.AttachmentSupport.getValues();
+    const auto& subs = sketch.AttachmentSupport.getSubValues();
+    if (refs.size() != 1 || subs.size() != 1) {
+        return false;
+    }
+
+    object = refs.front();
+    subName = subs.front();
+    return object && !subName.empty() && boost::starts_with(subName, "Face");
+}
+
+std::string makeExternalReferenceKey(const App::DocumentObject& object, const std::string& subName)
+{
+    std::string key = object.getNameInDocument();
+    key += '.';
+    if (!object.isDerivedFrom<Part::Datum>()) {
+        key += Data::newElementName(subName.c_str());
+    }
+    return key;
+}
+}
+
 FC_LOG_LEVEL_INIT("Sketch", true, true)
 
 void SketchObject::initExternalGeo() {
@@ -2311,18 +2344,54 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
         }
     }
 
+    App::DocumentObject* supportObject = nullptr;
+    std::string supportSubName;
+    const bool hasAutoSupport = getAutoSupportFaceReference(*this, supportObject, supportSubName);
+    const std::string autoSupportRef =
+        hasAutoSupport ? makeExternalReferenceKey(*supportObject, supportSubName) : std::string();
+
+    std::set<long> staleAutoSupportIds;
+    for (const auto& geo : ExternalGeo.getValues()) {
+        auto egf = ExternalGeometryFacade::getFacade(geo);
+        if (!egf->testFlag(ExternalGeometryExtension::AutoSupport) || egf->getRef().empty()) {
+            continue;
+        }
+        if (hasAutoSupport && egf->getRef() == autoSupportRef) {
+            continue;
+        }
+        auto refs = externalGeoRefMap.find(egf->getRef());
+        if (refs != externalGeoRefMap.end()) {
+            staleAutoSupportIds.insert(refs->second.begin(), refs->second.end());
+        }
+        else {
+            staleAutoSupportIds.insert(egf->getId());
+        }
+    }
+    if (!staleAutoSupportIds.empty()) {
+        delExternalPrivate(staleAutoSupportIds, true);
+        fixMissingAxisInExternalGeo();
+    }
+
     // Analyze the state of existing external geometries to infer the desired state for new ones.
     // If any geometry from a source link is "defining", we'll treat the whole link as "defining".
     std::map<std::string, bool> linkIsDefiningMap;
+    std::map<std::string, bool> linkIsAutoSupportMap;
     for (const auto& geo : ExternalGeo.getValues()) {
         auto egf = ExternalGeometryFacade::getFacade(geo);
         if (!egf->getRef().empty()) {
             bool isDefining = egf->testFlag(ExternalGeometryExtension::Defining);
+            bool isAutoSupport = egf->testFlag(ExternalGeometryExtension::AutoSupport);
             if (linkIsDefiningMap.find(egf->getRef()) == linkIsDefiningMap.end()) {
                 linkIsDefiningMap[egf->getRef()] = isDefining;
             }
             else {
                 linkIsDefiningMap[egf->getRef()] = linkIsDefiningMap[egf->getRef()] && isDefining;
+            }
+            if (linkIsAutoSupportMap.find(egf->getRef()) == linkIsAutoSupportMap.end()) {
+                linkIsAutoSupportMap[egf->getRef()] = isAutoSupport;
+            }
+            else {
+                linkIsAutoSupportMap[egf->getRef()] = linkIsAutoSupportMap[egf->getRef()] && isAutoSupport;
             }
         }
     }
@@ -2335,6 +2404,22 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
         throw Base::RuntimeError("Inconsistency with external geometries");
     }
     auto keys = externalGeoRef;
+
+    if (hasAutoSupport) {
+        bool alreadyLinked = false;
+        for (size_t i = 0; i < Objects.size(); ++i) {
+            if (Objects[i] == supportObject && SubElements[i] == supportSubName) {
+                alreadyLinked = true;
+                break;
+            }
+        }
+        if (!alreadyLinked) {
+            Objects.push_back(supportObject);
+            SubElements.push_back(supportSubName);
+            keys.push_back(autoSupportRef);
+            linkIsAutoSupportMap[autoSupportRef] = true;
+        }
+    }
 
     // re-check for any missing geometry element. The code here has a side
     // effect that the linked external geometry will continue to work even if
@@ -2675,6 +2760,9 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
         auto itKey = linkIsDefiningMap.find(key);
         bool hasLinkState = itKey != linkIsDefiningMap.end();
         bool isLinkDefining = hasLinkState ? itKey->second : false;
+        auto itAutoSupport = linkIsAutoSupportMap.find(key);
+        bool hasAutoSupportState = itAutoSupport != linkIsAutoSupportMap.end();
+        bool isAutoSupportLink = hasAutoSupportState ? itAutoSupport->second : false;
 
         for(auto &geo : geos) {
             auto it = externalGeoMap.find(GeometryFacade::getId(geo.get()));
@@ -2683,6 +2771,9 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
                 // Set its defining state based on the inferred state of its parent link.
                 if (hasLinkState) {
                     ExternalGeometryFacade::getFacade(geo.get())->setFlag(ExternalGeometryExtension::Defining, isLinkDefining);
+                }
+                if (hasAutoSupportState) {
+                    ExternalGeometryFacade::getFacade(geo.get())->setFlag(ExternalGeometryExtension::AutoSupport, isAutoSupportLink);
                 }
                 geoms.push_back(geo.release());
                 continue;

--- a/src/Mod/Sketcher/CMakeLists.txt
+++ b/src/Mod/Sketcher/CMakeLists.txt
@@ -14,6 +14,7 @@ set(Sketcher_Scripts
 
 set(Sketcher_TestScripts
     SketcherTests/__init__.py
+    SketcherTests/PrepareSupportFaceReview.py
     SketcherTests/TestSketchFillet.py
     SketcherTests/TestSketcherSolver.py
     SketcherTests/TestSketchExpression.py

--- a/src/Mod/Sketcher/SketcherTests/PrepareSupportFaceReview.py
+++ b/src/Mod/Sketcher/SketcherTests/PrepareSupportFaceReview.py
@@ -7,7 +7,6 @@ import tempfile
 
 import FreeCAD as App
 
-
 DEFAULT_BOX_LENGTH = 40.0
 DEFAULT_BOX_WIDTH = 40.0
 DEFAULT_BOX_HEIGHT = 20.0
@@ -40,15 +39,11 @@ def create_review_document(
 
     if len(sketch.ExternalGeometry) != 1:
         raise RuntimeError(
-            "Expected one automatic support reference, got {}".format(
-                len(sketch.ExternalGeometry)
-            )
+            "Expected one automatic support reference, got {}".format(len(sketch.ExternalGeometry))
         )
 
     if len(sketch.ExternalGeo) <= 2:
-        raise RuntimeError(
-            "Expected automatic support edges to be exposed in ExternalGeo"
-        )
+        raise RuntimeError("Expected automatic support edges to be exposed in ExternalGeo")
 
     return doc, box, sketch
 

--- a/src/Mod/Sketcher/SketcherTests/PrepareSupportFaceReview.py
+++ b/src/Mod/Sketcher/SketcherTests/PrepareSupportFaceReview.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import argparse
+import os
+import sys
+import tempfile
+
+import FreeCAD as App
+
+
+DEFAULT_BOX_LENGTH = 40.0
+DEFAULT_BOX_WIDTH = 40.0
+DEFAULT_BOX_HEIGHT = 20.0
+DEFAULT_SUPPORT_FACE = "Face6"
+
+
+def default_output_path():
+    return os.path.join(tempfile.gettempdir(), "SketcherSupportFaceReview.FCStd")
+
+
+def create_review_document(
+    box_length=DEFAULT_BOX_LENGTH,
+    box_width=DEFAULT_BOX_WIDTH,
+    box_height=DEFAULT_BOX_HEIGHT,
+    support_face=DEFAULT_SUPPORT_FACE,
+):
+    doc = App.newDocument("SketcherSupportFaceReview")
+
+    box = doc.addObject("Part::Box", "SupportBox")
+    box.Length = box_length
+    box.Width = box_width
+    box.Height = box_height
+
+    sketch = doc.addObject("Sketcher::SketchObject", "MappedSketch")
+    doc.recompute()
+
+    sketch.AttachmentSupport = (box, (support_face,))
+    sketch.MapMode = "FlatFace"
+    doc.recompute()
+
+    if len(sketch.ExternalGeometry) != 1:
+        raise RuntimeError(
+            "Expected one automatic support reference, got {}".format(
+                len(sketch.ExternalGeometry)
+            )
+        )
+
+    if len(sketch.ExternalGeo) <= 2:
+        raise RuntimeError(
+            "Expected automatic support edges to be exposed in ExternalGeo"
+        )
+
+    return doc, box, sketch
+
+
+def summarize_document(doc, box, sketch, output_path):
+    return {
+        "document": doc.Name,
+        "output_path": output_path,
+        "support_object": box.Name,
+        "support_face": tuple(sketch.AttachmentSupport[0][1])[0],
+        "external_geometry_count": len(sketch.ExternalGeometry),
+        "external_geo_entries": len(sketch.ExternalGeo),
+        "map_mode": sketch.MapMode,
+    }
+
+
+def format_summary(summary):
+    return "\n".join(
+        [
+            "Created Sketcher review scenario:",
+            "  document: {}".format(summary["document"]),
+            "  output: {}".format(summary["output_path"]),
+            "  support: {}.{}".format(summary["support_object"], summary["support_face"]),
+            "  map mode: {}".format(summary["map_mode"]),
+            "  external refs: {}".format(summary["external_geometry_count"]),
+            "  external geo entries: {}".format(summary["external_geo_entries"]),
+            "Next GUI checks:",
+            "  1. Open MappedSketch and start Sketcher_CreateLine.",
+            "  2. Snap directly to the support-face border without manual projection.",
+            "  3. Disable mapping or remove the support and verify cleanup.",
+        ]
+    )
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(
+        description="Create a review document for Sketcher automatic support-face borders."
+    )
+    parser.add_argument(
+        "--output",
+        default=default_output_path(),
+        help="FCStd path to create for manual GUI review.",
+    )
+    parser.add_argument(
+        "--support-face",
+        default=DEFAULT_SUPPORT_FACE,
+        help="Support face to map the sketch onto.",
+    )
+    parser.add_argument(
+        "--box-length",
+        type=float,
+        default=DEFAULT_BOX_LENGTH,
+        help="Length of the support box.",
+    )
+    parser.add_argument(
+        "--box-width",
+        type=float,
+        default=DEFAULT_BOX_WIDTH,
+        help="Width of the support box.",
+    )
+    parser.add_argument(
+        "--box-height",
+        type=float,
+        default=DEFAULT_BOX_HEIGHT,
+        help="Height of the support box.",
+    )
+    return parser
+
+
+def main(argv=None):
+    if argv is None and running_under_freecadcmd():
+        argv = sys.argv[2:]
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    output_dir = os.path.dirname(os.path.abspath(args.output))
+    if output_dir and not os.path.isdir(output_dir):
+        os.makedirs(output_dir, exist_ok=True)
+
+    doc, box, sketch = create_review_document(
+        box_length=args.box_length,
+        box_width=args.box_width,
+        box_height=args.box_height,
+        support_face=args.support_face,
+    )
+    doc.saveAs(args.output)
+
+    summary = summarize_document(doc, box, sketch, os.path.abspath(args.output))
+    print(format_summary(summary))
+    return summary
+
+
+def running_under_freecadcmd():
+    return (
+        __package__ == ""
+        and len(sys.argv) > 1
+        and os.path.abspath(sys.argv[1]) == os.path.abspath(__file__)
+    )
+
+
+if __name__ == "__main__" or running_under_freecadcmd():
+    main()

--- a/src/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py
+++ b/src/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py
@@ -126,8 +126,7 @@ class TestExternalFacePreselection(SketcherGuiTestCase):
         for point in points:
             screen_x, screen_y = view.getPointOnScreen(point)
             if not (
-                margin_x < screen_x < width - margin_x
-                and margin_y < screen_y < height - margin_y
+                margin_x < screen_x < width - margin_x and margin_y < screen_y < height - margin_y
             ):
                 return False
 

--- a/src/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py
+++ b/src/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py
@@ -114,6 +114,25 @@ class TestExternalFacePreselection(SketcherGuiTestCase):
 
         return FreeCADGui.Selection.getPreselection()
 
+    def points_are_framed(self, view, *points):
+        width, height = view.getSize()
+        if width <= 0 or height <= 0:
+            return False
+
+        view.fitAll()
+        margin_x = width * 0.1
+        margin_y = height * 0.1
+
+        for point in points:
+            screen_x, screen_y = view.getPointOnScreen(point)
+            if not (
+                margin_x < screen_x < width - margin_x
+                and margin_y < screen_y < height - margin_y
+            ):
+                return False
+
+        return True
+
     @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
     def testNoDepthBufferInEditRoot(self):
         """SoDepthBuffer nodes must not be direct children of
@@ -263,4 +282,74 @@ class TestExternalFacePreselection(SketcherGuiTestCase):
         self.assertTrue(
             any("Face" in s for s in sub_names),
             f"Expected a Face preselection but got " f"SubElementNames={sub_names}.",
+        )
+
+    @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
+    def testSupportEdgeSnapsDuringLineCreationWithoutManualProjection(self):
+        """Support-face borders must be immediately usable while drawing,
+        without requiring a manual External Geometry projection step."""
+
+        FreeCADGui.ActiveDocument.setEdit(self.testSketch.Name)
+        self.pump(300)
+
+        self.assertEqual(
+            len(self.testSketch.ExternalGeometry),
+            1,
+            "Expected support face auto-import to expose one support reference before drawing.",
+        )
+
+        view = FreeCADGui.ActiveDocument.ActiveView
+        view.viewTop()
+        view.fitAll()
+        self.pump(300)
+
+        support_vertex_3d = FreeCAD.Vector(20, -20, 20)
+        inner_point_3d = FreeCAD.Vector(5, -5, 20)
+
+        self.assertTrue(
+            self.wait_until(
+                lambda: self.points_are_framed(view, support_vertex_3d, inner_point_3d),
+                timeout_ms=5000,
+                step_ms=100,
+            ),
+            "Camera never framed the support edge points needed for the line-creation test.",
+        )
+
+        viewport = view.graphicsView().viewport()
+        support_vertex = self.viewport_to_qpoint(
+            view, viewport, view.getPointOnScreen(support_vertex_3d)
+        )
+        inner_point = self.viewport_to_qpoint(view, viewport, view.getPointOnScreen(inner_point_3d))
+
+        snapped_start = self.clamp_to_widget(
+            viewport,
+            QtCore.QPoint(support_vertex.x() + 3, support_vertex.y() + 3),
+        )
+        snapped_end = self.clamp_to_widget(viewport, inner_point)
+
+        FreeCADGui.runCommand("Sketcher_CreateLine", 0)
+        self.pump(300)
+
+        self.move(viewport, snapped_start)
+        self.click(viewport, snapped_start)
+        self.move(viewport, snapped_end)
+        self.click(viewport, snapped_end)
+
+        self.assertTrue(
+            self.wait_until(lambda: self.testSketch.GeometryCount == 1, timeout_ms=1500),
+            "Expected the line tool to create a segment while snapping to the support border.",
+        )
+
+        line = self.testSketch.Geometry[0]
+        self.assertAlmostEqual(
+            line.StartPoint.x,
+            20.0,
+            places=6,
+            msg="Expected the first line point to snap onto the support-face corner X coordinate.",
+        )
+        self.assertAlmostEqual(
+            line.StartPoint.y,
+            -20.0,
+            places=6,
+            msg="Expected the first line point to snap onto the support-face corner Y coordinate.",
         )

--- a/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
@@ -962,6 +962,103 @@ class TestSketcherSolver(unittest.TestCase):
             self.assertEqual(len(hole.Shape.Edges), 17)
             self.assertEqual(len(sketch2.ExternalGeometry), 0)
 
+    def testSupportFaceAutoExternalGeometry(self):
+        box = self.Doc.addObject("Part::Box", "Box")
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        self.Doc.recompute()
+
+        sketch.AttachmentSupport = (box, ("Face6",))
+        sketch.MapMode = "FlatFace"
+        self.Doc.recompute()
+
+        self.assertEqual(len(sketch.ExternalGeometry), 1)
+        self.assertEqual(sketch.ExternalGeometry[0][0], box)
+        self.assertEqual(tuple(sketch.ExternalGeometry[0][1]), ("Face6",))
+        self.assertGreater(len(sketch.ExternalGeo), 2)
+
+    def testDetachedFaceSupportDoesNotAutoExternalGeometry(self):
+        box = self.Doc.addObject("Part::Box", "Box")
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        self.Doc.recompute()
+
+        sketch.AttachmentSupport = (box, ("Face6",))
+        sketch.MapMode = "Deactivated"
+        self.Doc.recompute()
+
+        self.assertEqual(len(sketch.ExternalGeometry), 0)
+        self.assertEqual(len(sketch.ExternalGeo), 2)
+
+    def testSupportFaceAutoExternalGeometryTracksSupportChanges(self):
+        box = self.Doc.addObject("Part::Box", "Box")
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        self.Doc.recompute()
+
+        sketch.AttachmentSupport = (box, ("Face6",))
+        sketch.MapMode = "FlatFace"
+        self.Doc.recompute()
+
+        sketch.AttachmentSupport = (box, ("Face5",))
+        self.Doc.recompute()
+
+        self.assertEqual(len(sketch.ExternalGeometry), 1)
+        self.assertEqual(sketch.ExternalGeometry[0][0], box)
+        self.assertEqual(tuple(sketch.ExternalGeometry[0][1]), ("Face5",))
+        self.assertGreater(len(sketch.ExternalGeo), 2)
+
+    def testSupportFaceAutoExternalGeometryClearsWhenMapModeDisabled(self):
+        box = self.Doc.addObject("Part::Box", "Box")
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        self.Doc.recompute()
+
+        sketch.AttachmentSupport = (box, ("Face6",))
+        sketch.MapMode = "FlatFace"
+        self.Doc.recompute()
+
+        sketch.MapMode = "Deactivated"
+        self.Doc.recompute()
+
+        self.assertEqual(len(sketch.ExternalGeometry), 0)
+        self.assertEqual(len(sketch.ExternalGeo), 2)
+        self.assertEqual(tuple(sketch.AttachmentSupport[0][1]), ("Face6",))
+
+    def testSupportFaceAutoExternalGeometryClearsWhenSupportObjectDeleted(self):
+        box = self.Doc.addObject("Part::Box", "Box")
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        self.Doc.recompute()
+
+        sketch.AttachmentSupport = (box, ("Face6",))
+        sketch.MapMode = "FlatFace"
+        self.Doc.recompute()
+
+        self.Doc.removeObject("Box")
+        self.Doc.recompute()
+
+        self.assertEqual(len(sketch.ExternalGeometry), 0)
+        self.assertEqual(len(sketch.ExternalGeo), 2)
+        self.assertEqual(sketch.AttachmentSupport, [])
+
+    def testSaveLoadWithAutoSupportExternalGeometry(self):
+        box = self.Doc.addObject("Part::Box", "Box")
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        self.Doc.recompute()
+
+        sketch.AttachmentSupport = (box, ("Face6",))
+        sketch.MapMode = "FlatFace"
+        self.Doc.recompute()
+
+        filename = tempfile.gettempdir() + os.sep + self.Doc.Name + "_autosupport.FCStd"
+        self.Doc.saveAs(filename)
+        FreeCAD.closeDocument(self.Doc.Name)
+        self.Doc = FreeCAD.openDocument(filename)
+        box = self.Doc.getObject("Box")
+        sketch = self.Doc.getObject("Sketch")
+        self.Doc.recompute()
+
+        self.assertEqual(len(sketch.ExternalGeometry), 1)
+        self.assertEqual(sketch.ExternalGeometry[0][0], box)
+        self.assertEqual(tuple(sketch.ExternalGeometry[0][1]), ("Face6",))
+        self.assertGreater(len(sketch.ExternalGeo), 2)
+
     def testSaveLoadWithExternalGeometryReference(self):
         if "BUILD_PARTDESIGN" in FreeCAD.__cmake__:
             # Arrange
@@ -1125,6 +1222,9 @@ class TestSketcherSolver(unittest.TestCase):
             # first and only subobject name in second part of that first tuple and see that it moved
             # from the Face6 we set above.
             self.assertEqual(sketch1.AttachmentSupport[0][1][0], "Face9")
+            self.assertEqual(len(sketch1.ExternalGeometry), 1)
+            self.assertEqual(sketch1.ExternalGeometry[0][0], pad)
+            self.assertEqual(tuple(sketch1.ExternalGeometry[0][1]), ("Face9",))
             self.assertIn("Face6", pad.Shape.ElementReverseMap)  # different Face6 exists
 
     # TODO other tests:
@@ -1155,5 +1255,9 @@ class TestSketcherSolver(unittest.TestCase):
 
     def tearDown(self):
         # closing doc
-        FreeCAD.closeDocument("SketchSolverTest")
+        doc_name = getattr(getattr(self, "Doc", None), "Name", "SketchSolverTest")
+        if doc_name in FreeCAD.listDocuments():
+            FreeCAD.closeDocument(doc_name)
+        elif "SketchSolverTest" in FreeCAD.listDocuments():
+            FreeCAD.closeDocument("SketchSolverTest")
         # print ("omit closing document for debugging")

--- a/src/Mod/Sketcher/sketcher.dox
+++ b/src/Mod/Sketcher/sketcher.dox
@@ -1,4 +1,13 @@
 /** \defgroup SKETCHER Sketcher
  *  \ingroup CWORKBENCHES
  *  \brief Constrained 2D objects
+ *
+ *  When a sketch is mapped to a support face, the support-face border can be
+ *  exposed automatically while drawing so the user can snap directly to the
+ *  available face limits without first importing the border manually as
+ *  external geometry.
+ *
+ *  For manual regression review, `SketcherTests/PrepareSupportFaceReview.py`
+ *  creates a minimal `.FCStd` scenario with a mapped sketch whose support-face
+ *  edges are already exposed and ready for snap validation in the GUI.
  */


### PR DESCRIPTION
## Summary

Automatically exposes the borders of a mapped `FlatFace` support as auto-support external geometry for Sketcher.

This lets Sketcher drawing tools snap directly to the active support-face border without requiring the user to first use the manual External Geometry projection command.

## Motivation

When sketching on a face, the face boundary is usually part of the immediate design context. Professional CAD workflows generally make those support borders available during sketch creation. This change keeps the existing external-geometry pipeline, but marks support-generated geometry separately so it can be restored, updated, and cleaned up.

## What changed

- Adds an `AutoSupport` external-geometry flag.
- Detects mapped `FlatFace` support and injects the support face reference during external geometry rebuild.
- Removes stale auto-support geometry when the sketch support changes.
- Preserves the auto-support flag across external geometry rebuilds.
- Adds save/load and GUI regression coverage.
- Adds a small manual review helper script for creating a support-face scenario.

## Notes for reviewers

This is opened as a draft PR for human review and refinement before it is marked ready.

The touched C++ Sketcher files use CRLF line endings upstream. The local whitespace check was run with `cr-at-eol` enabled so Git does not report CRLF-only added lines as trailing whitespace.

## Validation

- Whitespace check with `cr-at-eol` enabled for CRLF C++ files
- `python3 -m py_compile` on the touched Sketcher test/helper files
- Equivalent local Sketcher build and targeted Sketcher tests passed before splitting this PR branch from the larger working tree

## AI assistance disclosure

This draft was prepared with AI assistance and includes an `Assisted-by:` trailer in the commit message. A human contributor should review, test, and take responsibility for the final PR before marking it ready for review.
