### PR TITLE
Ensure material resources are available

### DIFF
--- a/src/Mod/Material/App/MaterialManagerLocal.cpp
+++ b/src/Mod/Material/App/MaterialManagerLocal.cpp
@@ -29,6 +29,7 @@
 
 #include <App/Application.h>
 #include <App/Material.h>
+#include <Base/Console.h>
 
 #include "Exceptions.h"
 #include "MaterialConfigLoader.h"
@@ -41,6 +42,33 @@
 
 
 using namespace Materials;
+
+namespace
+{
+QString findBuiltInMaterialPath(const QString& resourcePath, const QString& sourcePath)
+{
+    QDir resourceRoot(QString::fromStdString(App::Application::getResourceDir()));
+    QString resolvedPath = resourceRoot.filePath(resourcePath);
+    if (QDir(resolvedPath).exists()) {
+        return resolvedPath;
+    }
+
+    QDir searchRoot(QString::fromStdString(App::Application::getHomePath()));
+    for (;;) {
+        QString candidate = searchRoot.filePath(sourcePath);
+        if (QDir(candidate).exists()) {
+            Base::Console().log("Falling back to source tree material resources '%s'\n",
+                                candidate.toStdString().c_str());
+            return candidate;
+        }
+        if (!searchRoot.cdUp()) {
+            break;
+        }
+    }
+
+    return resolvedPath;
+}
+}
 
 /* TRANSLATOR Material::Materials */
 
@@ -527,8 +555,9 @@ MaterialManagerLocal::getConfiguredLibraries()
     bool useMatFromCustomDir = param->GetBool("UseMaterialsFromCustomDir", true);
 
     if (useBuiltInMaterials) {
-        QString resourceDir = QString::fromStdString(App::Application::getResourceDir()
-                                                     + "/Mod/Material/Resources/Materials");
+        QString resourceDir = findBuiltInMaterialPath(
+            QStringLiteral("Mod/Material/Resources/Materials"),
+            QStringLiteral("src/Mod/Material/Resources/Materials"));
         auto libData =
             std::make_shared<MaterialLibraryLocal>(QStringLiteral("System"),
                                                    resourceDir,

--- a/src/Mod/Material/App/ModelLoader.cpp
+++ b/src/Mod/Material/App/ModelLoader.cpp
@@ -26,6 +26,7 @@
 #include <QString>
 
 #include <App/Application.h>
+#include <Base/Console.h>
 #include <Base/FileInfo.h>
 #include <Base/Interpreter.h>
 #include <Base/Stream.h>
@@ -37,6 +38,33 @@
 
 
 using namespace Materials;
+
+namespace
+{
+QString findBuiltInModelPath(const QString& resourcePath, const QString& sourcePath)
+{
+    QDir resourceRoot(QString::fromStdString(App::Application::getResourceDir()));
+    QString resolvedPath = resourceRoot.filePath(resourcePath);
+    if (QDir(resolvedPath).exists()) {
+        return resolvedPath;
+    }
+
+    QDir searchRoot(QString::fromStdString(App::Application::getHomePath()));
+    for (;;) {
+        QString candidate = searchRoot.filePath(sourcePath);
+        if (QDir(candidate).exists()) {
+            Base::Console().log("Falling back to source tree material models '%s'\n",
+                                candidate.toStdString().c_str());
+            return candidate;
+        }
+        if (!searchRoot.cdUp()) {
+            break;
+        }
+    }
+
+    return resolvedPath;
+}
+}
 
 ModelEntry::ModelEntry(const std::shared_ptr<ModelLibraryLocal>& library,
                        const QString& baseName,
@@ -368,8 +396,9 @@ void ModelLoader::getModelLibraries()
     bool useMatFromCustomDir = param->GetBool("UseMaterialsFromCustomDir", true);
 
     if (useBuiltInMaterials) {
-        QString resourceDir = QString::fromStdString(App::Application::getResourceDir()
-                                                     + "/Mod/Material/Resources/Models");
+        QString resourceDir = findBuiltInModelPath(
+            QStringLiteral("Mod/Material/Resources/Models"),
+            QStringLiteral("src/Mod/Material/Resources/Models"));
         auto libData = std::make_shared<ModelLibraryLocal>(QStringLiteral("System"),
                                                       resourceDir,
                                                       QStringLiteral(":/icons/freecad.svg"));

--- a/src/Mod/Material/CMakeLists.txt
+++ b/src/Mod/Material/CMakeLists.txt
@@ -425,6 +425,23 @@ fc_target_copy_resource(MaterialModelLib
     ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/Material/
     ${MaterialModel_Files})
 
+if(TARGET Materials)
+    add_dependencies(Materials
+        MaterialsAPILib
+        MaterialScripts
+        MaterialToolsLib
+        MaterialLib
+        FluidMaterialLib
+        AppearanceLib
+        PatternLib
+        MachiningLib
+        MaterialTest
+        MaterialTestLib
+        MaterialPythonTestData
+        MaterialModelLib
+    )
+endif()
+
 INSTALL(
     FILES ${MaterialTest_Files}
     DESTINATION Mod/Material/materialtests


### PR DESCRIPTION
## Summary
- makes the Materials module wait for bundled material/model resource copy targets
- includes the Material Python test resources when building the Materials target directly
- lets local material/model resource loading fall back to the source tree in developer builds when build-tree resources are missing

## Validation
- `cmake --preset debug`
- `cmake --build build/debug --target Materials -j$(nproc)`
- `cmake --build build/debug --target FreeCADMainCmd -j$(nproc)`
- `cmake --build build/debug --target pivy pivy_stubs MaterialTestLib MaterialTestData MaterialPythonTestData -j$(nproc)`
- `./build/debug/bin/FreeCADCmd -t TestMaterialsApp`

## AI assistance disclosure
This draft was prepared with assistance from OpenAI Codex. It is not intended as unverified AI output: the contributor should review, understand, and manually validate before marking ready for review.
