### PR TITLE
BIM: remove Building US unit system bug workaround

### DIFF
--- a/src/Mod/BIM/ArchMaterial.py
+++ b/src/Mod/BIM/ArchMaterial.py
@@ -1001,8 +1001,7 @@ class _ArchMultiMaterialTaskPanel:
         try:
             return float(text) * pref_factor
         except ValueError:
-            # Workaround for Building US unit system bug (Version 1.1, 2026):
-            return FreeCAD.Units.Quantity(text.replace("+", "--")).Value
+            return FreeCAD.Units.Quantity(text).Value
 
     def recalcThickness(self, item=None):
         prefix = translate("Arch", "Total thickness") + ": "

--- a/src/Mod/BIM/ArchRoof.py
+++ b/src/Mod/BIM/ArchRoof.py
@@ -1033,8 +1033,6 @@ class _RoofTaskPanel:
         self.updating = False
 
     def _update_value(self, row, prop, str_val):
-        # Workaround for Building US unit system bug (Version 1.1, 2025):
-        str_val = str_val.replace("+", "--")
         val_list = getattr(self.obj, prop)
         val_list[row] = Units.Quantity(str_val).Value
         setattr(self.obj, prop, val_list)


### PR DESCRIPTION
The workaround is not longer required after #30522.

No AI was used.