### PR TITLE
Draft: remove Building US unit system bug workaround

### DIFF
--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -49,10 +49,7 @@ bool(Draft_rc.__name__)
 
 
 def _quantity(st):
-    # workaround for improper handling of plus sign
-    # in Building US unit system
-    # https://github.com/FreeCAD/FreeCAD/issues/11345
-    return U.Quantity(st.replace("+", "--")).Value
+    return U.Quantity(st).Value
 
 
 class TaskPanelCircularArray:

--- a/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
@@ -47,10 +47,7 @@ bool(Draft_rc.__name__)
 
 
 def _quantity(st):
-    # workaround for improper handling of plus sign
-    # in Building US unit system
-    # https://github.com/FreeCAD/FreeCAD/issues/11345
-    return U.Quantity(st.replace("+", "--")).Value
+    return U.Quantity(st).Value
 
 
 class TaskPanelOrthoArray:

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -49,10 +49,7 @@ bool(Draft_rc.__name__)
 
 
 def _quantity(st):
-    # workaround for improper handling of plus sign
-    # in Building US unit system
-    # https://github.com/FreeCAD/FreeCAD/issues/11345
-    return U.Quantity(st.replace("+", "--")).Value
+    return U.Quantity(st).Value
 
 
 class TaskPanelPolarArray:


### PR DESCRIPTION
The workaround is not longer required after #30522.

No AI was used.