### PR TITLE
PD: Improve default binder outline contrast

### DIFF
--- a/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
@@ -62,6 +62,9 @@
               <FCUInt Name="DefaultTextColor" Value="4177132287"/>
             </FCParamGroup>
           </FCParamGroup>
+          <FCParamGroup Name="PartDesign">
+            <FCUInt Name="DefaultDatumLineColor" Value="4204138751"/>
+          </FCParamGroup>
           <FCParamGroup Name="Sketcher">
             <FCParamGroup Name="General">
               <FCUInt Name="GridDivLineColor" Value="1230002175"/>

--- a/src/Gui/PreferencePacks/FreeCAD Light/FreeCAD Light.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Light/FreeCAD Light.cfg
@@ -66,6 +66,9 @@
             <FCUInt Name="LineColor" Value="255"/>
             <FCUInt Name="MeshColor" Value="2914369023"/>
           </FCParamGroup>
+          <FCParamGroup Name="PartDesign">
+            <FCUInt Name="DefaultDatumLineColor" Value="4204138751"/>
+          </FCParamGroup>
           <FCParamGroup Name="Sketcher">
             <FCParamGroup Name="General">
               <FCUInt Name="GridDivLineColor" Value="3082800383"/>

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -65,19 +65,20 @@ ViewProviderShapeBinder::ViewProviderShapeBinder()
     PointSize.setStatus(App::Property::Hidden, true);
     DisplayMode.setStatus(App::Property::Hidden, true);
 
-    // get the datum coloring scheme
-    //  set default color for datums (golden yellow with 60% transparency)
+    // Set the default datum face color (golden yellow with 60% transparency).
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/PartDesign"
     );
     unsigned long shcol = hGrp->GetUnsigned("DefaultDatumColor", 0xFFD70099);
+    unsigned long lncol = hGrp->GetUnsigned("DefaultDatumLineColor", 0xFA9600FF);
     Base::Color col((uint32_t)shcol);
+    Base::Color lineCol((uint32_t)lncol);
 
     ShapeAppearance.setDiffuseColor(col);
-    LineColor.setValue(col);
-    PointColor.setValue(col);
+    LineColor.setValue(lineCol);
+    PointColor.setValue(lineCol);
     Transparency.setValue(60);
-    LineWidth.setValue(1);
+    LineWidth.setValue(Gui::ViewParams::instance()->getDefaultShapeLineWidth());
 }
 
 ViewProviderShapeBinder::~ViewProviderShapeBinder() = default;
@@ -261,16 +262,15 @@ void ViewProviderSubShapeBinder::onChanged(const App::Property* prop)
         Base::Color shapeColor, lineColor, pointColor;
         int transparency, linewidth;
         if (UseBinderStyle.getValue()) {
-            // get the datum coloring scheme
-            //  set default color for datums (golden yellow with 60% transparency)
+            // Set the default datum face color (golden yellow with 60% transparency).
             static ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
                 "User parameter:BaseApp/Preferences/Mod/PartDesign"
             );
             shapeColor.setPackedValue(hGrp->GetUnsigned("DefaultDatumColor", 0xFFD70099));
-            lineColor = shapeColor;
-            pointColor = shapeColor;
+            lineColor.setPackedValue(hGrp->GetUnsigned("DefaultDatumLineColor", 0xFA9600FF));
+            pointColor = lineColor;
             transparency = 60;
-            linewidth = 1;
+            linewidth = Gui::ViewParams::instance()->getDefaultShapeLineWidth();
         }
         else {
             shapeColor.setPackedValue(Gui::ViewParams::instance()->getDefaultShapeColor());


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Previously, binder outlines used the same RGB(255,215,0) color as their faces and a fixed 1 px width. This made edges and points not recognizable.

- This PR changes the default line and point color of ShapeBinders and SubShapeBinders to RGB(250,150,0), while retaining the golden-yellow face color.
- The binders also use the standard default-shape line width.

No AI used.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
<img width="595" height="506" alt="Bildschirmfoto 2026-08-12 um 15 41 56" src="https://github.com/user-attachments/assets/aaeb841a-4140-45fd-ae00-3e25d61ff6fc" />

<img width="540" height="542" alt="Bildschirmfoto 2026-08-12 um 15 42 02" src="https://github.com/user-attachments/assets/f9682c60-0055-4ecf-9f43-171e62d781d8" />

<img width="565" height="409" alt="Bildschirmfoto 2026-08-12 um 15 50 30" src="https://github.com/user-attachments/assets/e1984635-8654-4ba8-9316-9fedf0bbcd0b" />

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
