### PR TITLE
CAM: Inspect - Tool visibility

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/Inspect.py
+++ b/src/Mod/CAM/Path/Main/Gui/Inspect.py
@@ -24,7 +24,8 @@ import FreeCAD
 import FreeCADGui
 import Path
 from PySide.QtCore import QT_TRANSLATE_NOOP
-import PathScripts.PathUtils as PathUtils
+from PathScripts import PathUtils
+from Path.Base.Util import toolControllerForOp
 from Path.Main.Gui.Editor import CodeEditor
 
 translate = FreeCAD.Qt.translate
@@ -33,14 +34,12 @@ translate = FreeCAD.Qt.translate
 class GCodeEditorDialog(QtGui.QDialog):
     tool = None
 
-    def __init__(self, PathObj, parent=FreeCADGui.getMainWindow()):
-        self.PathObj = PathObj
-        if hasattr(PathObj, "ToolController"):
-            self.tool = PathObj.ToolController.Tool
-        else:
-            self.tool = None
+    def __init__(self, PathObj, parent=None, readOnly=True, toolVisibility=None):
+        self.commands = PathUtils.getPathWithPlacement(PathObj).Commands
+        self.tool = getattr(toolControllerForOp(PathObj), "Tool", None)
+        self.toolInitVisibility = getattr(self.tool, "Visibility", False)  # keep tool visibility
 
-        QtGui.QDialog.__init__(self, parent)
+        QtGui.QDialog.__init__(self, parent or FreeCADGui.getMainWindow())
         self.setWindowTitle(translate("CAM", "CAM Inspect"))
         layout = QtGui.QVBoxLayout(self)
 
@@ -59,6 +58,11 @@ class GCodeEditorDialog(QtGui.QDialog):
         self.selectionobj.ViewObject.NormalColor = highlightcolor
 
         self.editor = CodeEditor()
+        if readOnly:
+            self.editor.setTextInteractionFlags(
+                QtGui.Qt.TextInteractionFlag.TextSelectableByMouse
+                | QtGui.Qt.TextInteractionFlag.TextSelectableByKeyboard
+            )  #  make a QPlainTextEdit read-only while keeping the text cursor visible
         layout.addWidget(self.editor)
 
         # Note
@@ -73,16 +77,37 @@ class GCodeEditorDialog(QtGui.QDialog):
         lab.setWordWrap(True)
         layout.addWidget(lab)
 
+        bottomFrame = QtGui.QFrame()
+        bottomFrame.setLayout(QtGui.QHBoxLayout())
+        layout.addWidget(bottomFrame)
+
+        self.chkTool = QtGui.QCheckBox("Show tool")
+        if self.tool is not None:
+            self.chkTool.setText(translate("CAM_Inspect", "Show tool: %s") % self.tool.Label)
+            self.chkTool.setToolTip(
+                translate(
+                    "CAM_Inspect",
+                    "Show tool shape\nG-code under the cursor defines tool shape placement",
+                )
+            )
+            if toolVisibility is not None:
+                self.chkTool.setChecked(toolVisibility)
+            else:
+                self.chkTool.setChecked(self.tool.Visibility)
+            bottomFrame.layout().addWidget(self.chkTool)
+
         self.buttons = QtGui.QDialogButtonBox(
             QtGui.QDialogButtonBox.Close,
             QtCore.Qt.Horizontal,
             self,
         )  # add Close button
-
-        layout.addWidget(self.buttons)
         self.buttons.rejected.connect(self.reject)
-        self.editor.selectionChanged.connect(self.highlightpath)
+        bottomFrame.layout().addWidget(self.buttons)
+
+        self.editor.cursorPositionChanged.connect(self.highlightpath)
+        self.editor.cursorPositionChanged.connect(self.toolPlacement)
         self.finished.connect(self.cleanup)
+        self.chkTool.checkStateChanged.connect(self.toolVisibility)
 
         prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/CAM")
         Xpos = int(prefs.GetString("inspecteditorX", "0"))
@@ -93,14 +118,18 @@ class GCodeEditorDialog(QtGui.QDialog):
         self.resize(width, height)
 
     def cleanup(self):
+        """Prepare for exit from Inspect"""
         prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/CAM")
         prefs.SetString("inspecteditorX", str(self.x()))
         prefs.SetString("inspecteditorY", str(self.y()))
         prefs.SetString("inspecteditorW", str(self.width()))
         prefs.SetString("inspecteditorH", str(self.height()))
         FreeCAD.ActiveDocument.removeObject(self.selectionobj.Name)
+        if self.tool:
+            self.tool.Visibility = self.toolInitVisibility  # restore tool visibility
 
     def highlightpath(self):
+        """Set highlighted path"""
         cursor = self.editor.textCursor()
         sp = cursor.selectionStart()
         ep = cursor.selectionEnd()
@@ -109,43 +138,41 @@ class GCodeEditorDialog(QtGui.QDialog):
         cursor.setPosition(ep)
         endrow = cursor.blockNumber()
 
-        commands = PathUtils.getPathWithPlacement(self.PathObj).Commands
-
         # Derive the starting position for the first selected command
-        prevX = prevY = prevZ = None
-        prevcommands = commands[:startrow]
-        prevcommands.reverse()
-        for c in prevcommands:
-            if prevX is None:
-                if c.Parameters.get("X") is not None:
-                    prevX = c.Parameters.get("X")
-            if prevY is None:
-                if c.Parameters.get("Y") is not None:
-                    prevY = c.Parameters.get("Y")
-            if prevZ is None:
-                if c.Parameters.get("Z") is not None:
-                    prevZ = c.Parameters.get("Z")
-            if prevX is not None and prevY is not None and prevZ is not None:
-                break
-        if prevX is None:
-            prevX = 0.0
-        if prevY is None:
-            prevY = 0.0
-        if prevZ is None:
-            prevZ = 0.0
+        x, y, z = self.getPosition(self.commands[max(0, startrow - 1) :: -1])
+        firstrapid = Path.Command("G0", {"X": x, "Y": y, "Z": z})
+        selectionCommands = [firstrapid] + self.commands[startrow : endrow + 1]
+        self.selectionobj.Path = Path.Path()
+        if len(selectionCommands) > 1:
+            self.selectionobj.Path = Path.Path(selectionCommands)
+        self.selectionobj.ViewObject.StartIndex = 1  # hide first rapid move
 
-        # Build a new path with selection
-        p = Path.Path()
-        firstrapid = Path.Command("G0", {"X": prevX, "Y": prevY, "Z": prevZ})
+    def toolPlacement(self):
+        """Set tool placement"""
+        if self.tool is not None and self.tool.Visibility:
+            line_number = self.editor.textCursor().blockNumber()
+            self.tool.Placement.Base = self.getPosition(self.commands[line_number::-1])
 
-        selectionpath = [firstrapid] + commands[startrow : endrow + 1]
-        p.Commands = selectionpath
-        self.selectionobj.Path = p
-
+    def toolVisibility(self):
+        """Update tool visibility"""
         if self.tool is not None:
-            self.tool.Placement.Base.x = prevX
-            self.tool.Placement.Base.y = prevY
-            self.tool.Placement.Base.z = prevZ
+            self.tool.Visibility = self.chkTool.isChecked()
+
+    def getPosition(self, commands):
+        """Define position from commands list"""
+        x = y = z = None
+        for cmd in commands:
+            x = cmd.x if x is None and cmd.x is not None else x
+            y = cmd.y if y is None and cmd.y is not None else y
+            z = cmd.z if z is None and cmd.z is not None else z
+            if x is not None and y is not None and z is not None:
+                break
+
+        x = 0 if x is None else x
+        y = 0 if y is None else y
+        z = 0 if z is None else z
+
+        return x, y, z
 
 
 def show(obj):


### PR DESCRIPTION
### Description

Clicking on lines in **Inspect** window changes placement of the tool shape
It can be useful to see tool position in static
But toggle tool visibility not convenient

### Changes

- Text widget is read only now

- Get Path only once while init dialog, instead of every time while select lines

- Tool placement follows by cursor, instead of mouse clicking (selection)

- Added checkbox to toggle tool visibility, which also shows tool name
  <img width="670" height="314" alt="Screenshot_20260817_122124_lossy" src="https://github.com/user-attachments/assets/b536d774-76cb-4d08-ac5f-a568cacb654b" />

- Exclude rapid move from (0,0,0). Draw only selected moves
  <img width="1208" height="410" alt="Screenshot_20260812_202033_hor_lossy" src="https://github.com/user-attachments/assets/cfb63fb6-1938-4f45-b577-551c066888b1" />

---

Video includes also changes from PR #31938

https://github.com/user-attachments/assets/5bf53e4e-70fa-4039-9818-2e17bc8ad695

