### PR TITLE
[TD]fix section cut shape positioning (#2)

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -578,7 +578,11 @@ TopoDS_Shape DrawViewSection::prepareShape(const TopoDS_Shape& uncenteredCutShap
         Base::Vector3d centroid(inputCenter.X(), inputCenter.Y(), inputCenter.Z());
 
         m_cutShapeRaw = uncenteredCutShape;
-        preparedShape = ShapeUtils::moveShape(uncenteredCutShape, centroid * -1.0);
+        // move the cut shape to the origin.  Note this is slightly different than the move to
+        // origin in regular views. Here we move by the SectionOrigin instead of by the geo center
+        // (shape centroid).
+        Base::Vector3d moveToOrigin{SectionOrigin.getValue() * -1};
+        preparedShape = ShapeUtils::moveShape(uncenteredCutShape, moveToOrigin);
         m_cutShape = preparedShape;
         m_saveCentroid = centroid;
 


### PR DESCRIPTION
This PR implements a fix for issue #31072. The problem is due to moving the cut shape to align its centroid with the global origin. This effectively changes the SectionOrigin to the centroid.

This is how geometry is prepared in DrawViewPart. In DrawViewSection, the cut shape should be moved by the SectionOrigin instead.

This PR replaces closed PR #31146 with a simpler fix that does not impact Detail of a Section.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Misplaced Section:
<img width="480" height="745" alt="00_faulty_techdraw_section_before" src="https://github.com/user-attachments/assets/d35ae9f3-eb67-44c6-9d35-ecbf9c9d48db" />

Section with this PR:
<img width="609" height="581" alt="00_faulty_techdraw_section_fixed" src="https://github.com/user-attachments/assets/fe568ac8-d716-41cf-829e-9716e6a796bf" />

Detail of Section after this PR:
<img width="844" height="578" alt="DetailOfSection_fixed" src="https://github.com/user-attachments/assets/81d2d359-3bf0-4d9f-8c39-cba99ce196cc" />
