### PR TITLE
Sketcher: fix angle label depth and disconnected distance witness lines

### DIFF
--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -214,6 +214,8 @@ SoDatumLabel::SoDatumLabel()
     SO_NODE_ADD_FIELD(string, (""));
     SO_NODE_ADD_FIELD(textColor, (SbVec3f(1.0F, 1.0F, 1.0F)));
     SO_NODE_ADD_FIELD(pnts, (SbVec3f(.0F, .0F, .0F)));
+    SO_NODE_ADD_FIELD(extensionLines, (SbVec3f(.0F, .0F, .0F)));
+    extensionLines.setNum(0);
     SO_NODE_ADD_FIELD(norm, (SbVec3f(.0F, .0F, 1.F)));
     SO_NODE_ADD_FIELD(strikethrough, (false));
 
@@ -428,6 +430,12 @@ public:
         }
         else if (label->datumtype.getValue() == SoDatumLabel::ARCLENGTH) {
             corners = computeArcLengthBBox();
+        }
+
+        const int extensionPointCount = label->extensionLines.getNum();
+        if (extensionPointCount > 0) {
+            const SbVec3f* extensionPoints = label->extensionLines.getValues(0);
+            corners.insert(corners.end(), extensionPoints, extensionPoints + extensionPointCount);
         }
 
         getBBox(corners, box, center);
@@ -1244,6 +1252,20 @@ void SoDatumLabel::generatePrimitives(SoAction* action)
             generateArcLengthPrimitives(action, p1, p2, p3);
         }
     }
+
+    const int extensionPointCount = extensionLines.getNum();
+    if (extensionPointCount > 0) {
+        const SbVec3f* extensionPoints = extensionLines.getValues(0);
+        const float selectionWidth = (imgHeight / 3.0F) * 0.8F;
+        for (int i = 0; i + 1 < extensionPointCount; i += 2) {
+            generateLineSelectionPrimitive(
+                action,
+                extensionPoints[i],
+                extensionPoints[i + 1],
+                selectionWidth
+            );
+        }
+    }
 }
 
 void SoDatumLabel::notify(SoNotList* l)
@@ -1506,6 +1528,14 @@ void SoDatumLabel::ensureCoinGeometry(const SbVec3f* points, int numPoints)
                 arrowWidth,
                 arrowLength
             );
+        }
+    }
+
+    const int extensionPointCount = extensionLines.getNum();
+    if (extensionPointCount > 0) {
+        const SbVec3f* extensionPoints = extensionLines.getValues(0);
+        for (int i = 0; i + 1 < extensionPointCount; i += 2) {
+            appendLine(lineVertices, lineCounts, extensionPoints[i], extensionPoints[i + 1]);
         }
     }
 

--- a/src/Gui/SoDatumLabel.h
+++ b/src/Gui/SoDatumLabel.h
@@ -99,6 +99,8 @@ public:
     SoSFFloat param7;
     SoSFFloat param8;
     SoMFVec3f pnts;
+    // Optional line pairs connecting dimension anchors to finite geometry.
+    SoMFVec3f extensionLines;
     SoSFVec3f norm;
     SoSFBool strikethrough;
     SoSFImage image;

--- a/src/Mod/Sketcher/CMakeLists.txt
+++ b/src/Mod/Sketcher/CMakeLists.txt
@@ -32,6 +32,7 @@ if(BUILD_GUI)
     )
     list (APPEND Sketcher_TestScripts
           SketcherTests/TestConstraintPreselectionGui.py
+          SketcherTests/TestDistanceLabelExtensionGui.py
           SketcherTests/GuiTestCase.py
           SketcherTests/TestPlacementUpdate.py
           SketcherTests/TestOnViewParameterGui.py

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -1455,6 +1455,7 @@ Restart:
                     asciiText->param4 = endLineLength1;
                     asciiText->param5 = endLineLength2;
 
+                    p0[2] = zConstrH;
                     asciiText->pnts.setNum(2);
                     SbVec3f* verts = asciiText->pnts.startEditing();
 

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -857,6 +857,9 @@ Restart:
                     double radius2 = 0.;
                     Base::Vector3d center1(0., 0., 0.);
                     Base::Vector3d center2(0., 0., 0.);
+                    Base::Vector3d lineHelperStart(0., 0., 0.);
+                    Base::Vector3d lineHelperEnd(0., 0., 0.);
+                    bool hasLineHelper = false;
 
                     int numPoints = 2;
 
@@ -878,11 +881,39 @@ Restart:
                             Base::Vector3d l2p1 = lineSeg->getStartPoint();
                             Base::Vector3d l2p2 = lineSeg->getEndPoint();
 
+                            const auto setLineHelper = [&](const Base::Vector3d& projection) {
+                                const Base::Vector3d lineDir = l2p2 - l2p1;
+                                const double lineLengthSquared = lineDir.Sqr();
+                                if (lineLengthSquared <= 0.) {
+                                    return;
+                                }
+
+                                const double projectionParameter = ((projection - l2p1) * lineDir)
+                                    / lineLengthSquared;
+                                constexpr double projectionTolerance = 64.
+                                    * std::numeric_limits<double>::epsilon();
+                                if (projectionParameter < -projectionTolerance) {
+                                    lineHelperStart = l2p1;
+                                    lineHelperEnd = projection;
+                                    hasLineHelper = true;
+                                }
+                                else if (projectionParameter > 1. + projectionTolerance) {
+                                    lineHelperStart = l2p2;
+                                    lineHelperEnd = projection;
+                                    hasLineHelper = true;
+                                }
+                            };
+
                             if (Constr->FirstPos != Sketcher::PointPos::none) {
                                 // point to line distance
                                 // calculate the projection of p1 onto lineSeg
                                 pnt2.ProjectToLine(pnt1 - l2p1, l2p2 - l2p1);
                                 pnt2 += pnt1;
+
+                                // Point-to-line distance uses the infinite support line. If its
+                                // projection is outside the finite segment, connect the segment
+                                // to that projection so the witness line has no visual gap.
+                                setLineHelper(pnt2);
                             }
                             else if (isCircleOrArc(*geo1)) {
                                 // circular to line distance
@@ -892,6 +923,7 @@ Restart:
                                 Base::Vector3d dir = pnt1;
                                 dir.Normalize();
                                 pnt1 += ct;
+                                setLineHelper(pnt1);
                                 pnt2 = ct + dir * radius;
                             }
                         }
@@ -963,6 +995,14 @@ Restart:
 
                     int index = static_cast<int>(ConstraintNodePosition::DatumLabelIndex);
                     auto* asciiText = static_cast<SoDatumLabel*>(sep->getChild(index));  // NOLINT
+
+                    asciiText->extensionLines.setNum(hasLineHelper ? 2 : 0);
+                    if (hasLineHelper) {
+                        SbVec3f* extensionVerts = asciiText->extensionLines.startEditing();
+                        extensionVerts[0] = SbVec3f(lineHelperStart.x, lineHelperStart.y, zConstrH);
+                        extensionVerts[1] = SbVec3f(lineHelperEnd.x, lineHelperEnd.y, zConstrH);
+                        asciiText->extensionLines.finishEditing();
+                    }
 
                     // Get presentation string (w/o units if option is set)
                     asciiText->string = SbString(getPresentationString(Constr).toUtf8().constData());

--- a/src/Mod/Sketcher/SketcherTests/TestDistanceLabelExtensionGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestDistanceLabelExtensionGui.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import FreeCAD
+import Part
+import Sketcher
+from pivy import coin
+
+from SketcherTests.GuiTestCase import FreeCADGui, SketcherGuiTestCase
+
+
+class TestDistanceLabelExtensionGui(SketcherGuiTestCase):
+    def setUp(self):
+        super().setUp()
+        self.doc = FreeCAD.newDocument("TestDistanceLabelExtensionGui")
+        self.sketch = self.doc.addObject("Sketcher::SketchObject", "Sketch")
+
+    def extension_points(self):
+        self.doc.recompute()
+        FreeCADGui.ActiveDocument.setEdit(self.sketch.Name)
+        self.flush_gui(100)
+
+        render_manager = FreeCADGui.ActiveDocument.ActiveView.getViewer().getSoRenderManager()
+        scene_root = render_manager.getSceneGraph()
+        search = coin.SoSearchAction()
+        search.setType(coin.SoType.fromName("SoDatumLabel"))
+        search.setInterest(coin.SoSearchAction.ALL)
+        search.setSearchingAll(True)
+        search.apply(scene_root)
+
+        points = []
+        paths = search.getPaths()
+        for index in range(paths.getLength()):
+            field = paths[index].getTail().getField("extensionLines")
+            points.extend(tuple(value.getValue()) for value in field.getValues())
+        return points
+
+    def add_point_to_line_distance(self, line_start, line_end, point):
+        point_geometry = self.sketch.addGeometry(
+            Part.LineSegment(point, point + FreeCAD.Vector(1, 0, 0)),
+            False,
+        )
+        line_geometry = self.sketch.addGeometry(Part.LineSegment(line_start, line_end), False)
+        constraint = self.sketch.addConstraint(
+            Sketcher.Constraint("Distance", point_geometry, 1, line_geometry, 5.0)
+        )
+        self.sketch.setDriving(constraint, False)
+
+    def assert_extension_points(self, expected):
+        actual = self.extension_points()
+        self.assertEqual(len(actual), len(expected))
+        for actual_point, expected_point in zip(actual, expected):
+            for actual_coordinate, expected_coordinate in zip(actual_point, expected_point):
+                self.assertAlmostEqual(actual_coordinate, expected_coordinate, places=6)
+
+    def test_projection_inside_segment_has_no_extension(self):
+        self.add_point_to_line_distance(
+            FreeCAD.Vector(0, 0, 0),
+            FreeCAD.Vector(0, 10, 0),
+            FreeCAD.Vector(-5, 5, 0),
+        )
+        self.assert_extension_points([])
+
+    def test_projection_at_endpoint_with_roundoff_has_no_extension(self):
+        self.add_point_to_line_distance(
+            FreeCAD.Vector(0, 0, 0),
+            FreeCAD.Vector(0, 10, 0),
+            FreeCAD.Vector(-5, 10 + 1e-14, 0),
+        )
+        self.assert_extension_points([])
+
+    def test_projection_before_segment_connects_to_start(self):
+        self.add_point_to_line_distance(
+            FreeCAD.Vector(0, 0, 0),
+            FreeCAD.Vector(0, 10, 0),
+            FreeCAD.Vector(-5, -5, 0),
+        )
+        self.assert_extension_points([(0, 0), (0, -5)])
+
+    def test_projection_after_segment_connects_to_end(self):
+        self.add_point_to_line_distance(
+            FreeCAD.Vector(0, 0, 0),
+            FreeCAD.Vector(0, 10, 0),
+            FreeCAD.Vector(-5, 15, 0),
+        )
+        self.assert_extension_points([(0, 10), (0, 15)])
+
+    def test_reversed_segment_connects_to_nearest_endpoint(self):
+        self.add_point_to_line_distance(
+            FreeCAD.Vector(0, 10, 0),
+            FreeCAD.Vector(0, 0, 0),
+            FreeCAD.Vector(-5, 15, 0),
+        )
+        self.assert_extension_points([(0, 10), (0, 15)])
+
+    def test_circle_to_line_projection_gets_extension(self):
+        circle = self.sketch.addGeometry(
+            Part.Circle(FreeCAD.Vector(-5, 15, 0), FreeCAD.Vector(0, 0, 1), 1),
+            False,
+        )
+        line = self.sketch.addGeometry(
+            Part.LineSegment(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(0, 10, 0)),
+            False,
+        )
+        constraint = self.sketch.addConstraint(Sketcher.Constraint("Distance", circle, line, 4.0))
+        self.sketch.setDriving(constraint, False)
+
+        self.assert_extension_points([(0, 10), (0, 15)])

--- a/src/Mod/Sketcher/TestSketcherGui.py
+++ b/src/Mod/Sketcher/TestSketcherGui.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 from SketcherTests.TestConstraintPreselectionGui import SketcherGuiTestCases
+from SketcherTests.TestDistanceLabelExtensionGui import TestDistanceLabelExtensionGui
 from SketcherTests.TestOnViewParameterGui import TestOnViewParameterGui
 from SketcherTests.TestPlacementUpdate import TestSketchPlacementUpdate
 from SketcherTests.TestExternalFacePreselection import TestExternalFacePreselection
@@ -8,6 +9,7 @@ from SketcherTests.TestExternalFacePreselection import TestExternalFacePreselect
 (
     True
     if SketcherGuiTestCases
+    and TestDistanceLabelExtensionGui
     and TestSketchPlacementUpdate
     and TestOnViewParameterGui
     and TestExternalFacePreselection


### PR DESCRIPTION
Fix two Sketcher dimensional-constraint rendering problems:

- Keep angle constraint labels and helper geometry at the constraint rendering depth.
- Connect distance witness lines to finite line segments when the measured projection lies outside the segment.

## Problem

### Angle constraint depth

The angle datum anchor was left at `Z = 0`, allowing parts of the angle constraint label and helper geometry to render behind the model.

### Disconnected distance witness lines

Point-to-line distances are correctly measured against the line's infinite support. However, when the perpendicular projection falls outside the selected finite segment, the witness line previously started at that projected point.

This left a visible gap between the selected geometry and the dimension graphics, as demonstrated by #31917.

Clamping the projection to the segment endpoint would make the graphics inconsistent with the displayed perpendicular distance, so the measurement must continue using the infinite support line.

## Implementation

- Set the angle datum anchor Z coordinate to `zConstrH`, consistently with other dimensional constraints.
- Detect when a point-to-line or circle-to-line projection falls outside a finite line segment.
- Draw the missing collinear helper segment between the nearest segment endpoint and the projected anchor.
- Preserve the original infinite-line distance calculation.
- Include helper segments in:
  - rendering;
  - constraint selection;
  - bounding-box calculations.
- Apply numerical tolerance around segment endpoints to avoid microscopic helpers caused by floating-point noise.

## Testing

Added GUI regression coverage for:

- projection inside the segment;
- projection before the segment;
- projection after the segment;
- reversed segment direction;
- endpoint floating-point noise;
- circle-to-line projection.

Fixes #31917.
Addresses the angle-label rendering case from #27924.
