### PR TITLE
BIM: fix several IFC import problems

### DIFF
--- a/src/Mod/BIM/nativeifc/ifc_psets.py
+++ b/src/Mod/BIM/nativeifc/ifc_psets.py
@@ -153,20 +153,20 @@ def show_psets(obj):
                 value = value.split("::")
             else:
                 ftype = "App::PropertyString"
-            # print("DEBUG: setting",pname, ptype, value)
-            if ftype:
-                if pname in obj.PropertiesList and obj.getGroupOfProperty(pname) == gname:
-                    if obj.getTypeOfProperty(pname) == ftype:
-                        pass
-                    if (
-                        ftype == "App::PropertyString"
-                        and obj.getTypeOfProperty(pname) == "App::PropertyStringList"
-                    ):
-                        value = [value]
-                else:
-                    print(pname, gname, obj.PropertiesList)
-                    obj.addProperty(ftype, pname, gname, ttip, locked=True)
+            # print("DEBUG: setting", pname, ptype, value)
+            if ftype is None:
+                continue
             if pname in obj.PropertiesList:
+                if (
+                    ftype == "App::PropertyString"
+                    and obj.getTypeOfProperty(pname) == "App::PropertyStringList"
+                ):
+                    ftype = "App::PropertyStringList"
+                    value = [value]
+            else:
+                # print(pname, gname, obj.PropertiesList)
+                obj.addProperty(ftype, pname, gname, ttip, locked=True)
+            if obj.getTypeOfProperty(pname) == ftype and obj.getGroupOfProperty(pname) == gname:
                 setattr(obj, pname, value)
 
 

--- a/src/Mod/BIM/nativeifc/ifc_types.py
+++ b/src/Mod/BIM/nativeifc/ifc_types.py
@@ -162,7 +162,7 @@ def edit_type(obj):
     typerel = getattr(element, "IsTypedBy", None)
     if obj.Type:
         # verify the type is compatible -ex IFcWall in IfcWallType
-        if obj.Type.Class != element.is_a() + "Type":
+        if obj.Type.Class != element.is_a().removesuffix("StandardCase") + "Type":
             t = translate("BIM", "Error: Incompatible type")
             FreeCAD.Console.PrintError(obj.Label + ": " + t + ": " + obj.Type.Class + "\n")
             obj.Type = None

--- a/src/Mod/BIM/nativeifc/ifc_viewproviders.py
+++ b/src/Mod/BIM/nativeifc/ifc_viewproviders.py
@@ -527,6 +527,12 @@ class ifc_vp_group:
             )
         return self.modicon
 
+    def __getstate__(self):
+        return None
+
+    def __setstate__(self, state):
+        return None
+
 
 class ifc_vp_material:
     """View provider for the IFC group object"""
@@ -622,6 +628,15 @@ class ifc_vp_buildingpart(ifc_vp_object, ArchBuildingPart.ViewProviderBuildingPa
 
     def attach(self, vobj):
         ArchBuildingPart.ViewProviderBuildingPart.attach(self, vobj)
+
+    def getDisplayModes(self, vobj):
+        return ["Default"]
+
+    def getDefaultDisplayMode(self):
+        return "Default"
+
+    def setDisplayMode(self, mode):
+        return mode
 
 
 def overlay(icon1, icon2):


### PR DESCRIPTION
Fixes: #31389.
Fixes: #32743.
Fixes: #32745.

Test file (attached to issue):
Ifc4_SampleHouse.copy.ifc

1. Properties that already existed could be added again which is not allowed.
2. There was a missing type check when setting properties.
3. A check for the correct property group did not have the most logical position.
4. IFC classes ending in `StandardCase` were not recognized.
5. There was a serialization problem when the file was saved. The `ifc_vp_group` class lacked its own `__getstate__` and `__setstate__` functions.
6. When the saved FCStd file was reopened BuildingParts were invisible. The `ifc_vp_buildingpart` class did not have correct DisplayMode handling.

As a result of these modifications the recursive recompute problem does not occur anymore.

No AI was used.