### PR TITLE
Start: Fix crash when closing the Start tab on startup

### DIFF
--- a/src/Mod/Start/Gui/PreCompiled.h
+++ b/src/Mod/Start/Gui/PreCompiled.h
@@ -54,6 +54,7 @@
 #include <QMessageBox>
 #include <QModelIndex>
 #include <QPainter>
+#include <QPointer>
 #include <QPushButton>
 #include <QResizeEvent>
 #include <QScrollArea>

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -30,6 +30,7 @@
 #include <QListView>
 #include <QMdiSubWindow>
 #include <QMessageBox>
+#include <QPointer>
 #include <QPushButton>
 #include <QScrollArea>
 #include <QTimer>
@@ -191,19 +192,65 @@ StartView::StartView(QWidget* parent)
     }
     configureRecentFilesListWidget(recentFilesListWidget, _recentFilesLabel);
 
-    QTimer::singleShot(2000, [this, recentFilesListWidget]() {
-        auto updateFun = [this, recentFilesListWidget]() {
-            configureRecentFilesListWidget(recentFilesListWidget, _recentFilesLabel);
-        };
-        auto recentFiles = Gui::getMainWindow()->findChild<Gui::RecentFilesAction*>();
-        if (recentFiles != nullptr) {
-            connect(recentFiles, &Gui::RecentFilesAction::recentFilesListModified, this, updateFun);
+    // RecentFilesAction is created asynchronously after StartView. A context-less
+    // QTimer::singleShot keeps running after this view is closed, and
+    // QObject::connect() then SIGSEGVs on the dangling context (issue #31927).
+    // Guard with QPointer and cancel the timer in the destructor instead of
+    // increasing the delay.
+    _recentFilesConnectTimer = gsl::owner<QTimer*>(new QTimer(this));
+    _recentFilesConnectTimer->setSingleShot(true);
+    QPointer<StartView> view(this);
+    QPointer<FileCardView> recentFilesView(recentFilesListWidget);
+    connect(_recentFilesConnectTimer, &QTimer::timeout, this, [view, recentFilesView]() {
+        if (!view || !recentFilesView) {
+            return;
         }
+        view->connectRecentFilesListModified(recentFilesView);
     });
+    _recentFilesConnectTimer->start(2000);
 
     isInitialized = true;
 
     retranslateUi();
+}
+
+StartView::~StartView()
+{
+    cancelPendingRecentFilesConnect();
+}
+
+void StartView::cancelPendingRecentFilesConnect()
+{
+    if (!_recentFilesConnectTimer) {
+        return;
+    }
+    _recentFilesConnectTimer->stop();
+    _recentFilesConnectTimer->disconnect();
+    _recentFilesConnectTimer = nullptr;
+}
+
+void StartView::connectRecentFilesListModified(QListView* recentFilesListWidget)
+{
+    QPointer<StartView> view(this);
+    QPointer<QListView> recentFilesView(recentFilesListWidget);
+    if (!view || !recentFilesView) {
+        return;
+    }
+
+    auto updateFun = [view, recentFilesView]() {
+        if (!view || !recentFilesView) {
+            return;
+        }
+        view->configureRecentFilesListWidget(recentFilesView, view->_recentFilesLabel);
+    };
+    auto* recentFiles = Gui::getMainWindow()->findChild<Gui::RecentFilesAction*>();
+    if (recentFiles != nullptr) {
+        StartView* context = view;
+        if (!context) {
+            return;
+        }
+        connect(recentFiles, &Gui::RecentFilesAction::recentFilesListModified, context, updateFun);
+    }
 }
 
 void StartView::configureNewFileButtons(QLayout* layout) const

--- a/src/Mod/Start/Gui/StartView.h
+++ b/src/Mod/Start/Gui/StartView.h
@@ -41,6 +41,7 @@ class QMdiSubWindow;
 class QScrollArea;
 class QStackedWidget;
 class QPushButton;
+class QTimer;
 
 namespace Gui
 {
@@ -58,6 +59,7 @@ class StartGuiExport StartView: public Gui::MDIView
 
 public:
     StartView(QWidget* parent);
+    ~StartView() override;
 
     const char* getName() const override
     {
@@ -106,6 +108,8 @@ private Q_SLOTS:
 private:
     void retranslateUi();
     void setListViewUpdatesEnabled(bool enabled);
+    void connectRecentFilesListModified(QListView* recentFilesListWidget);
+    void cancelPendingRecentFilesConnect();
 
     QStackedWidget* _contents = nullptr;
     Start::RecentFilesModel _recentFilesModel;
@@ -117,6 +121,7 @@ private:
     QLabel* _customFolderLabel;
     QPushButton* _openFirstStart;
     QCheckBox* _showOnStartupCheckBox;
+    QTimer* _recentFilesConnectTimer = nullptr;
 
     bool isInitialized = false;
 


### PR DESCRIPTION
Fixes #31927

Closing the Start tab immediately after launch (Ctrl+W or mouse) crashes in `QObject::connect` at `StartView.cpp`. Waiting a few seconds avoids it.

`RecentFilesAction` is created after `StartView`. The delayed connect used a context-less `QTimer::singleShot(2000, ...)`, so the lambda still ran after the view was destroyed and passed a dangling `this` into `QObject::connect`. Bisect pointed at d87b41181e (#22638). Increasing the delay is not a fix.

This owns the delay timer as a child of `StartView`, aborts with `QPointer<StartView>` if the view is gone, and stops/disconnects the timer in the destructor.

Start has App unit tests only (`FileUtilities`, `ThumbnailSource`), not Start GUI tests, so the lifetime guard is documented next to the connect.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.


Made with [Cursor](https://cursor.com)