### PR TITLE
Gui: Set org name to fix QSettings

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2505,13 +2505,22 @@ void setAppNameAndIcon()
 {
     const std::map<std::string, std::string>& cfg = App::Application::Config();
 
-    // set application icon and window title
-    auto it = cfg.find("Application");
-    if (it != cfg.end()) {
-        QApplication::setApplicationName(QString::fromUtf8(it->second.c_str()));
+    // set application name and icon and organization name (used by QSettings)
+    auto app = cfg.find("Application");
+    if (app != cfg.end()) {
+        QApplication::setApplicationName(QString::fromUtf8(app->second.c_str()));
     }
     else {
         QApplication::setApplicationName(QString::fromStdString(App::Application::getExecutableName()));
+    }
+    auto vendor = cfg.find("ExeVendor");
+    if (vendor != cfg.end()) {
+        QApplication::setOrganizationName(QString::fromUtf8(vendor->second.c_str()));
+    }
+    else {
+        QApplication::setOrganizationName(
+            QString::fromStdString(App::Application::getExecutableName())
+        );
     }
 #ifndef Q_OS_MACOS
     QApplication::setWindowIcon(


### PR DESCRIPTION
While reviewing #30641 I found out that @Lokestrom had run across a very interesting bug with our use of `QSettings` -- if a settings object was created using its default constructor, it simply didn't work -- we never set the "organization" of our `QApplication`, and the default constructor absolutely requires it (at least on Windows). This corrects that oversight so that the few cases in our codebase that default-construct a `QSettings` object actually work.

As far as I can tell that's:
* TechDraw - `MRichTextEdit::insertImage()`, appears to use it as a default path for a file dialog
* Gui - `DownloadManager::load()` uses it for what appears to be some window sizing, a "removeDownloadsPolicy", and a "downloadsDirectory"
* Measure - `mAutoSave` and `mGreedySelection`

(note that I don't know why these are using `QSettings` and not our internal parameters system, I just note that they *are*)

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
