### PR TITLE
Gui: fix polygon selection rendering and FEM callback lifetime crash

### DIFF
--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -900,6 +900,7 @@ SET(View3D_CPP_SRCS
     Flag.cpp
     GLBuffer.cpp
     GLPainter.cpp
+    PolygonOverlay.cpp
     RubberbandOverlay.cpp
     Multisample.cpp
     MouseSelection.cpp
@@ -920,6 +921,7 @@ SET(View3D_SRCS
     Camera.h
     Flag.h
     GLBuffer.h
+    PolygonOverlay.h
     RubberbandOverlay.h
     GLPainter.h
     Multisample.h

--- a/src/Gui/MouseSelection.cpp
+++ b/src/Gui/MouseSelection.cpp
@@ -31,6 +31,7 @@
 #include <FCConfig.h>
 
 #include "MouseSelection.h"
+#include "PolygonOverlay.h"
 #include "RubberbandOverlay.h"
 #include "Selection/BoxSelection.h"
 #include "Selection/SelectionColors.h"
@@ -165,12 +166,25 @@ PolyPickerSelection::PolyPickerSelection()
 
 void PolyPickerSelection::setColor(float r, float g, float b, float a)
 {
-    polyline.setColor(r, g, b, a);
+    polygonColor = QColor::fromRgbF(r, g, b, a);
+    if (polygonOverlay) {
+        polygonOverlay->setColor(polygonColor);
+    }
 }
 
 void PolyPickerSelection::setLineWidth(float l)
 {
-    polyline.setLineWidth(l);
+    polygonLineWidth = l;
+    if (polygonOverlay) {
+        polygonOverlay->setLineWidth(polygonLineWidth);
+    }
+}
+
+QPointF PolyPickerSelection::toLogicalPoint(const QPoint& point) const
+{
+    const qreal dpr = _pcView3D ? _pcView3D->devicePixelRatio() : 1.0;
+    const qreal scale = dpr > 0.0 ? dpr : 1.0;
+    return {point.x() / scale, point.y() / scale};
 }
 
 void PolyPickerSelection::initialize()
@@ -179,13 +193,16 @@ void PolyPickerSelection::initialize()
     QCursor cursor(p, 4, 4);
     _pcView3D->getWidget()->setCursor(cursor);
 
-    polyline.setViewer(_pcView3D);
-
-    _pcView3D->addGraphicsItem(&polyline);
-    _pcView3D->redraw();  // needed to get an up-to-date image
-    _pcView3D->setRenderType(View3DInventorViewer::Image);
+    polygonOverlay = &_pcView3D->polygonOverlay();
+    polygonOverlay->setColor(polygonColor);
+    polygonOverlay->setLineWidth(polygonLineWidth);
+    polygonOverlay->setClosed(polygonClosed);
+    polygonOverlay->setCloseStippled(polygonCloseStippled);
+    polygonOverlay->clearPoints();
+    polygonOverlay->setVisible(false);
     _pcView3D->redraw();
 
+    polygonWorking = false;
     lastConfirmed = false;
 }
 
@@ -193,8 +210,12 @@ void PolyPickerSelection::terminate(bool abort)
 {
     Q_UNUSED(abort)
 
-    _pcView3D->removeGraphicsItem(&polyline);
-    _pcView3D->setRenderType(View3DInventorViewer::Native);
+    if (polygonOverlay) {
+        polygonOverlay->setVisible(false);
+        polygonOverlay->clearPoints();
+        polygonOverlay = nullptr;
+    }
+    polygonWorking = false;
     _pcView3D->redraw();
 }
 
@@ -237,11 +258,12 @@ int PolyPickerSelection::mouseButtonEvent(const SoMouseButtonEvent* const e, con
     if (press) {
         switch (button) {
             case SoMouseButtonEvent::BUTTON1: {
-                if (!polyline.isWorking()) {
-                    polyline.setWorking(true);
-                    polyline.clear();
+                if (!polygonWorking) {
+                    polygonWorking = true;
+                    polygonOverlay->clearPoints();
+                    polygonOverlay->setVisible(true);
                 };
-                polyline.addNode(pos);
+                polygonOverlay->addPoint(toLogicalPoint(pos));
                 lastConfirmed = true;
                 m_iXnew = pos.x();
                 m_iYnew = pos.y();
@@ -250,7 +272,7 @@ int PolyPickerSelection::mouseButtonEvent(const SoMouseButtonEvent* const e, con
             } break;
 
             case SoMouseButtonEvent::BUTTON2: {
-                polyline.addNode(pos);
+                polygonOverlay->addPoint(toLogicalPoint(pos));
                 m_iXnew = pos.x();
                 m_iYnew = pos.y();
                 m_iXold = pos.x();
@@ -273,6 +295,10 @@ int PolyPickerSelection::mouseButtonEvent(const SoMouseButtonEvent* const e, con
                 // an inconsistent state.
                 int id = popupMenu();
 
+                polygonOverlay->setVisible(false);
+                polygonWorking = false;
+                _pcView3D->redraw();
+
                 if (id == Finish || id == Cancel) {
                     releaseMouseModel();
                 }
@@ -280,7 +306,6 @@ int PolyPickerSelection::mouseButtonEvent(const SoMouseButtonEvent* const e, con
                     _pcView3D->getWidget()->setCursor(cur);
                 }
 
-                polyline.setWorking(false);
                 return id;
             } break;
 
@@ -297,7 +322,7 @@ int PolyPickerSelection::locationEvent(const SoLocation2Event* const, const QPoi
     // do all the drawing stuff for us
     QPoint clPoint = pos;
 
-    if (polyline.isWorking()) {
+    if (polygonWorking) {
         // check the position
         qreal dpr = _pcView3D->getGLWidget()->devicePixelRatioF();
         QRect r = _pcView3D->getGLWidget()->rect();
@@ -330,9 +355,9 @@ int PolyPickerSelection::locationEvent(const SoLocation2Event* const, const QPoi
         }
 
         if (!lastConfirmed) {
-            polyline.popNode();
+            polygonOverlay->popPoint();
         }
-        polyline.addNode(clPoint);
+        polygonOverlay->addPoint(toLogicalPoint(clPoint));
         lastConfirmed = false;
 
         draw();
@@ -408,8 +433,12 @@ FreehandSelection::~FreehandSelection() = default;
 
 void FreehandSelection::setClosed(bool on)
 {
-    polyline.setClosed(on);
-    polyline.setCloseStippled(true);
+    polygonClosed = on;
+    polygonCloseStippled = true;
+    if (polygonOverlay) {
+        polygonOverlay->setClosed(polygonClosed);
+        polygonOverlay->setCloseStippled(polygonCloseStippled);
+    }
 }
 
 int FreehandSelection::popupMenu()
@@ -443,13 +472,13 @@ int FreehandSelection::mouseButtonEvent(const SoMouseButtonEvent* const e, const
     if (press) {
         switch (button) {
             case SoMouseButtonEvent::BUTTON1: {
-                if (!polyline.isWorking()) {
-                    polyline.setWorking(true);
-                    polyline.clear();
+                if (!polygonWorking) {
+                    polygonWorking = true;
+                    polygonOverlay->clearPoints();
+                    polygonOverlay->setVisible(true);
                 }
 
-                polyline.addNode(pos);
-                polyline.setCoords(pos.x(), pos.y());
+                polygonOverlay->addPoint(toLogicalPoint(pos));
                 m_iXnew = pos.x();
                 m_iYnew = pos.y();
                 m_iXold = pos.x();
@@ -457,7 +486,7 @@ int FreehandSelection::mouseButtonEvent(const SoMouseButtonEvent* const e, const
             } break;
 
             case SoMouseButtonEvent::BUTTON2: {
-                polyline.addNode(pos);
+                polygonOverlay->addPoint(toLogicalPoint(pos));
                 m_iXnew = pos.x();
                 m_iYnew = pos.y();
                 m_iXold = pos.x();
@@ -472,7 +501,9 @@ int FreehandSelection::mouseButtonEvent(const SoMouseButtonEvent* const e, const
     else {
         switch (button) {
             case SoMouseButtonEvent::BUTTON1:
-                if (polyline.isWorking()) {
+                if (polygonWorking) {
+                    polygonOverlay->setVisible(false);
+                    polygonWorking = false;
                     releaseMouseModel();
                     return Finish;
                 }
@@ -486,6 +517,10 @@ int FreehandSelection::mouseButtonEvent(const SoMouseButtonEvent* const e, const
                 // an inconsistent state.
                 int id = popupMenu();
 
+                polygonOverlay->setVisible(false);
+                polygonWorking = false;
+                _pcView3D->redraw();
+
                 if (id == Finish || id == Cancel) {
                     releaseMouseModel();
                 }
@@ -493,7 +528,6 @@ int FreehandSelection::mouseButtonEvent(const SoMouseButtonEvent* const e, const
                     _pcView3D->getWidget()->setCursor(cur);
                 }
 
-                polyline.setWorking(false);
                 return id;
             } break;
 
@@ -510,7 +544,7 @@ int FreehandSelection::locationEvent(const SoLocation2Event* const e, const QPoi
     // do all the drawing stuff for us
     QPoint clPoint = pos;
 
-    if (polyline.isWorking()) {
+    if (polygonWorking) {
         // check the position
         qreal dpr = _pcView3D->getGLWidget()->devicePixelRatioF();
         QRect r = _pcView3D->getGLWidget()->rect();
@@ -544,8 +578,7 @@ int FreehandSelection::locationEvent(const SoLocation2Event* const e, const QPoi
             _clPoly.push_back(curr);
         }
 
-        polyline.addNode(clPoint);
-        polyline.setCoords(clPoint.x(), clPoint.y());
+        polygonOverlay->addPoint(toLogicalPoint(clPoint));
     }
 
     m_iXnew = clPoint.x();

--- a/src/Gui/MouseSelection.h
+++ b/src/Gui/MouseSelection.h
@@ -27,7 +27,7 @@
 
 #include <QColor>
 #include <QCursor>
-#include <Gui/GLPainter.h>
+#include <QPointF>
 #include <Gui/Namespace.h>
 
 
@@ -47,6 +47,7 @@ class SoKeyboardEvent;
 namespace Gui
 {
 class View3DInventorViewer;
+class PolygonOverlay;
 
 /**
  * The mouse selection base class
@@ -159,7 +160,14 @@ protected:
     virtual int popupMenu();
 
 protected:
-    Gui::Polyline polyline;
+    QPointF toLogicalPoint(const QPoint& point) const;
+
+    PolygonOverlay* polygonOverlay {nullptr};
+    QColor polygonColor {Qt::white};
+    float polygonLineWidth {2.0F};
+    bool polygonClosed {true};
+    bool polygonCloseStippled {false};
+    bool polygonWorking {false};
     bool lastConfirmed;
 };
 

--- a/src/Gui/PolygonOverlay.cpp
+++ b/src/Gui/PolygonOverlay.cpp
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 FreeCAD contributors
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+#include "PolygonOverlay.h"
+
+#include <algorithm>
+
+#include <Inventor/SbViewportRegion.h>
+
+#include <Inventor/nodes/SoDrawStyle.h>
+#include <Inventor/nodes/SoLineSet.h>
+#include <Inventor/nodes/SoMaterial.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoSwitch.h>
+#include <Inventor/nodes/SoVertexProperty.h>
+
+#include "Inventor/SoFCScreenSpaceGroup.h"
+
+namespace Gui
+{
+
+void PolygonOverlay::setMaterialColor(SoMaterial* material, const QColor& color)
+{
+    material->diffuseColor.setValue(
+        static_cast<float>(color.redF()),
+        static_cast<float>(color.greenF()),
+        static_cast<float>(color.blueF())
+    );
+    material->transparency.setValue(1.0F - static_cast<float>(color.alphaF()));
+}
+
+void PolygonOverlay::updateGeometry(const SbViewportRegion& viewport, qreal scale)
+{
+    const SbVec2s size = viewport.getViewportSizePixels();
+    const float width = static_cast<float>(size[0]);
+    const float height = static_cast<float>(size[1]);
+    const int pointCount = static_cast<int>(logicalPoints.size());
+    const bool canClose = closed && pointCount > 1;
+    const bool separateClosingLine = canClose && closeStippled;
+    const int lineVertexCount = pointCount + (canClose && !separateClosingLine ? 1 : 0);
+
+    for (int i = 0; i < pointCount; ++i) {
+        const QPointF& point = logicalPoints[static_cast<size_t>(i)];
+        const float x = std::clamp(static_cast<float>(point.x() * scale), 0.0F, width);
+        const float y = std::clamp(static_cast<float>(point.y() * scale), 0.0F, height);
+        vertices->vertex.set1Value(i, SbVec3f(x, height - y, 0.0F));
+    }
+
+    if (canClose && !separateClosingLine) {
+        const QPointF& first = logicalPoints.front();
+        const float x = std::clamp(static_cast<float>(first.x() * scale), 0.0F, width);
+        const float y = std::clamp(static_cast<float>(first.y() * scale), 0.0F, height);
+        vertices->vertex.set1Value(pointCount, SbVec3f(x, height - y, 0.0F));
+    }
+    lineSet->numVertices.setValue(lineVertexCount);
+
+    if (separateClosingLine) {
+        const QPointF& first = logicalPoints.front();
+        const QPointF& last = logicalPoints.back();
+        const float firstX = std::clamp(static_cast<float>(first.x() * scale), 0.0F, width);
+        const float firstY = std::clamp(static_cast<float>(first.y() * scale), 0.0F, height);
+        const float lastX = std::clamp(static_cast<float>(last.x() * scale), 0.0F, width);
+        const float lastY = std::clamp(static_cast<float>(last.y() * scale), 0.0F, height);
+        closingLineVertices->vertex.set1Value(0, SbVec3f(lastX, height - lastY, 0.0F));
+        closingLineVertices->vertex.set1Value(1, SbVec3f(firstX, height - firstY, 0.0F));
+    }
+    closingLineSet->numVertices.setValue(separateClosingLine ? 2 : 0);
+    closingLineSwitch->whichChild = separateClosingLine ? SO_SWITCH_ALL : SO_SWITCH_NONE;
+}
+
+PolygonOverlay::PolygonOverlay()
+{
+    root = new Inventor::SoFCScreenSpaceGroup;
+    root->ref();
+    root->setCoordinateSpace(Inventor::SoFCScreenSpaceGroup::CoordinateSpace::ViewportPixels);
+    root->setBaseColorLightModel(true);
+    root->setTexturesEnabled(false);
+    root->setMultiTexturesEnabled(false);
+    root->setDepthBuffer(false, false);
+
+    visibilitySwitch = new SoSwitch;
+    visibilitySwitch->whichChild = SO_SWITCH_NONE;
+
+    auto* line = new SoSeparator;
+    material = new SoMaterial;
+    drawStyle = new SoDrawStyle;
+    vertices = new SoVertexProperty;
+    lineSet = new SoLineSet;
+    lineSet->vertexProperty.setValue(vertices);
+    lineSet->numVertices.setValue(0);
+    line->addChild(material);
+    line->addChild(drawStyle);
+    line->addChild(lineSet);
+    visibilitySwitch->addChild(line);
+
+    auto* closingLine = new SoSeparator;
+    closingLineMaterial = new SoMaterial;
+    closingLineStyle = new SoDrawStyle;
+    closingLineVertices = new SoVertexProperty;
+    closingLineSet = new SoLineSet;
+    closingLineSet->vertexProperty.setValue(closingLineVertices);
+    closingLineSet->numVertices.setValue(0);
+    closingLine->addChild(closingLineMaterial);
+    closingLine->addChild(closingLineStyle);
+    closingLine->addChild(closingLineSet);
+
+    closingLineSwitch = new SoSwitch;
+    closingLineSwitch->whichChild = SO_SWITCH_NONE;
+    closingLineSwitch->addChild(closingLine);
+    visibilitySwitch->addChild(closingLineSwitch);
+
+    setMaterialColor(material, lineColor);
+    setMaterialColor(closingLineMaterial, lineColor);
+    drawStyle->lineWidth.setValue(lineWidth);
+    closingLineStyle->lineWidth.setValue(lineWidth);
+    closingLineStyle->linePatternScaleFactor.setValue(2);
+    closingLineStyle->linePattern.setValue(0x3F3F);
+
+    root->addChild(visibilitySwitch);
+}
+
+PolygonOverlay::~PolygonOverlay()
+{
+    root->unref();
+}
+
+void PolygonOverlay::setPoints(const std::vector<QPointF>& points)
+{
+    logicalPoints = points;
+}
+
+void PolygonOverlay::clearPoints()
+{
+    logicalPoints.clear();
+}
+
+void PolygonOverlay::addPoint(const QPointF& point)
+{
+    logicalPoints.push_back(point);
+}
+
+void PolygonOverlay::popPoint()
+{
+    if (!logicalPoints.empty()) {
+        logicalPoints.pop_back();
+    }
+}
+
+void PolygonOverlay::setClosed(bool value)
+{
+    closed = value;
+}
+
+void PolygonOverlay::setCloseStippled(bool value)
+{
+    closeStippled = value;
+}
+
+void PolygonOverlay::setColor(const QColor& color)
+{
+    lineColor = color;
+    setMaterialColor(material, lineColor);
+    setMaterialColor(closingLineMaterial, lineColor);
+}
+
+void PolygonOverlay::setLineWidth(float width)
+{
+    lineWidth = width;
+    drawStyle->lineWidth.setValue(lineWidth);
+    closingLineStyle->lineWidth.setValue(lineWidth);
+}
+
+void PolygonOverlay::setVisible(bool visible)
+{
+    visibilitySwitch->whichChild = visible ? SO_SWITCH_ALL : SO_SWITCH_NONE;
+}
+
+void PolygonOverlay::prepareGeometry(const SbViewportRegion& viewport, qreal devicePixelRatio)
+{
+    if (devicePixelRatio <= 0.0) {
+        return;
+    }
+
+    const SbVec2s size = viewport.getViewportSizePixels();
+    if (size[0] <= 0 || size[1] <= 0) {
+        return;
+    }
+
+    updateGeometry(viewport, devicePixelRatio);
+}
+
+SoNode* PolygonOverlay::sceneRoot() const
+{
+    return root;
+}
+
+}  // namespace Gui

--- a/src/Gui/PolygonOverlay.h
+++ b/src/Gui/PolygonOverlay.h
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 FreeCAD contributors
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+#pragma once
+
+#include <QColor>
+#include <QPointF>
+
+#include <vector>
+
+class SbViewportRegion;
+class SoDrawStyle;
+class SoLineSet;
+class SoMaterial;
+class SoNode;
+class SoSwitch;
+class SoVertexProperty;
+
+namespace Gui
+{
+
+namespace Inventor
+{
+class SoFCScreenSpaceGroup;
+}
+
+/**
+ * Retained polygon overlay owned by a 3D viewer.
+ *
+ * Points are stored in logical widget coordinates. The viewer prepares the
+ * retained scene root for the current physical viewport before traversing it.
+ */
+class PolygonOverlay
+{
+public:
+    PolygonOverlay();
+    ~PolygonOverlay();
+
+    PolygonOverlay(const PolygonOverlay&) = delete;
+    PolygonOverlay& operator=(const PolygonOverlay&) = delete;
+
+    void setPoints(const std::vector<QPointF>& points);
+    void clearPoints();
+    void addPoint(const QPointF& point);
+    void popPoint();
+
+    void setClosed(bool closed);
+    void setCloseStippled(bool stippled);
+    void setColor(const QColor& color);
+    void setLineWidth(float width);
+    void setVisible(bool visible);
+
+    /** Prepare the retained geometry for traversal in the supplied viewport. */
+    void prepareGeometry(const SbViewportRegion& viewport, qreal devicePixelRatio);
+
+    /** Return the retained scene root owned by this overlay. */
+    SoNode* sceneRoot() const;
+
+private:
+    void updateGeometry(const SbViewportRegion& viewport, qreal scale);
+    static void setMaterialColor(SoMaterial* material, const QColor& color);
+
+    std::vector<QPointF> logicalPoints;
+    QColor lineColor {Qt::white};
+    float lineWidth {2.0F};
+    bool closed {true};
+    bool closeStippled {false};
+
+    Inventor::SoFCScreenSpaceGroup* root {nullptr};
+    SoSwitch* visibilitySwitch {nullptr};
+    SoSwitch* closingLineSwitch {nullptr};
+    SoMaterial* material {nullptr};
+    SoMaterial* closingLineMaterial {nullptr};
+    SoDrawStyle* drawStyle {nullptr};
+    SoDrawStyle* closingLineStyle {nullptr};
+    SoVertexProperty* vertices {nullptr};
+    SoVertexProperty* closingLineVertices {nullptr};
+    SoLineSet* lineSet {nullptr};
+    SoLineSet* closingLineSet {nullptr};
+};
+
+}  // namespace Gui

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -129,6 +129,7 @@
 #include "Document.h"
 #include "GLPainter.h"
 #include "RubberbandOverlay.h"
+#include "PolygonOverlay.h"
 #include "Inventor/SoAxisCrossKit.h"
 #include "Inventor/SoFCBackgroundGradient.h"
 #include "Inventor/SoFCBoundingBox.h"
@@ -1138,6 +1139,7 @@ void View3DInventorViewer::init()
     this->decorationroot->addChild(decorationBaseColor);
     this->decorationroot->addChild(naviCubeAnnotation);
 
+    polygonOverlayRenderer = std::unique_ptr<PolygonOverlay>(new PolygonOverlay);
     rubberbandOverlayRenderer = std::unique_ptr<RubberbandOverlay>(new RubberbandOverlay);
 
     auto threePointLightingSeparator = new SoTransformSeparator;
@@ -1323,6 +1325,7 @@ void View3DInventorViewer::init()
 
 View3DInventorViewer::~View3DInventorViewer()
 {
+    polygonOverlayRenderer.reset();
     rubberbandOverlayRenderer.reset();
 
     // to prevent following OpenGL error message: "Texture is not valid in the current context.
@@ -2900,6 +2903,11 @@ RubberbandOverlay& View3DInventorViewer::rubberbandOverlay()
     return *rubberbandOverlayRenderer;
 }
 
+PolygonOverlay& View3DInventorViewer::polygonOverlay()
+{
+    return *polygonOverlayRenderer;
+}
+
 int View3DInventorViewer::getNumSamples()
 {
     Gui::AntiAliasing msaa = Multisample::readMSAAFromSettings();
@@ -3410,6 +3418,7 @@ void View3DInventorViewer::renderScene()
         }
     }
 
+    renderPolygonOverlay();
     renderRubberbandOverlay();
     // Workaround for inconsistent QT behavior related to handling custom OpenGL widgets that
     // leave non opaque alpha values in final output.
@@ -3436,6 +3445,22 @@ void View3DInventorViewer::renderScene()
 
     glColorMask(colorMask[0], colorMask[1], colorMask[2], colorMask[3]);
     glClearColor(clearColor[0], clearColor[1], clearColor[2], clearColor[3]);
+}
+
+void View3DInventorViewer::renderPolygonOverlay()
+{
+    if (currentRenderIntent() != RenderIntent::LiveInteractive || !polygonOverlayRenderer) {
+        return;
+    }
+
+    auto* manager = getSoRenderManager();
+    auto* action = manager ? manager->getGLRenderAction() : nullptr;
+    if (!action) {
+        return;
+    }
+
+    polygonOverlayRenderer->prepareGeometry(manager->getViewportRegion(), devicePixelRatio());
+    action->apply(polygonOverlayRenderer->sceneRoot());
 }
 
 void View3DInventorViewer::renderRubberbandOverlay()

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -107,6 +107,7 @@ class SoFCUnifiedSelection;
 class Document;
 class GLGraphicsItem;
 class RubberbandOverlay;
+class PolygonOverlay;
 class SoShapeScale;
 class ViewerEventFilter;
 
@@ -261,6 +262,7 @@ public:
     void clearGraphicsItems();
 
     RubberbandOverlay& rubberbandOverlay();
+    PolygonOverlay& polygonOverlay();
 
     /** @name Handling of view providers */
     //@{
@@ -594,6 +596,7 @@ Q_SIGNALS:
 protected:
     static GLenum getInternalTextureFormat();
     void renderScene();
+    void renderPolygonOverlay();
     void renderRubberbandOverlay();
     void renderFramebuffer();
     void renderGLImage();
@@ -652,6 +655,7 @@ private:
     std::set<ViewProvider*> _ViewProviderSet;
     std::map<SoSeparator*, ViewProvider*> _ViewProviderMap;
     std::list<GLGraphicsItem*> graphicsItems;
+    std::unique_ptr<PolygonOverlay> polygonOverlayRenderer;
     std::unique_ptr<RubberbandOverlay> rubberbandOverlayRenderer;
     ViewProvider* editViewProvider;
     SoFCBackgroundGradient* pcBackGround;

--- a/src/Mod/Fem/Gui/TaskCreateElementSet.cpp
+++ b/src/Mod/Fem/Gui/TaskCreateElementSet.cpp
@@ -479,7 +479,9 @@ void writeToFile(
 
 TaskCreateElementSet::TaskCreateElementSet(Fem::FemSetElementNodesObject* pcObject, QWidget* parent)
     : TaskBox(Gui::BitmapFactory().pixmap("FEM_CreateElementsSet"), tr("Elements set"), true, parent)
+    , MeshViewProvider(nullptr)
     , pcObject(pcObject)
+    , selectionViewer(nullptr)
     , selectionMode(none)
 {
     proxy = new QWidget(this);
@@ -522,18 +524,68 @@ TaskCreateElementSet::TaskCreateElementSet(Fem::FemSetElementNodesObject* pcObje
 void TaskCreateElementSet::Poly(void)
 {
     Gui::Document* doc = Gui::Application::Instance->activeDocument();
+    if (!doc) {
+        return;
+    }
+
     Gui::MDIView* view = doc->getActiveView();
+    if (!view) {
+        return;
+    }
+
     if (view->isDerivedFrom<Gui::View3DInventor>()) {
         Gui::View3DInventorViewer* viewer = ((Gui::View3DInventor*)view)->getViewer();
+        cancelPolygonSelection();
+
+        if (viewer->isSelecting()) {
+            return;
+        }
+
         viewer->setEditing(true);
         viewer->startSelection(Gui::View3DInventorViewer::Clip);
+
+        if (!viewer->isSelecting()) {
+            viewer->setEditing(false);
+            return;
+        }
+
+        selectionViewer = viewer;
         viewer->addEventCallback(SoMouseButtonEvent::getClassTypeId(), DefineElementsCallback, this);
+    }
+}
+
+void TaskCreateElementSet::removePolygonSelectionCallback()
+{
+    if (selectionViewer) {
+        selectionViewer->removeEventCallback(
+            SoMouseButtonEvent::getClassTypeId(),
+            DefineElementsCallback,
+            this
+        );
+        selectionViewer = nullptr;
+    }
+}
+
+void TaskCreateElementSet::cancelPolygonSelection()
+{
+    Gui::View3DInventorViewer* viewer = selectionViewer.data();
+    removePolygonSelectionCallback();
+
+    if (viewer) {
+        viewer->setEditing(false);
+        if (viewer->isSelecting()) {
+            viewer->abortSelection();
+        }
     }
 }
 
 void TaskCreateElementSet::CopyResultsMesh(void)
 {
     std::vector<Gui::SelectionSingleton::SelObj> selection = Gui::Selection().getSelection();  // [0];
+    if (selection.empty()) {
+        return;
+    }
+
     highLightMesh = selection[0].FeatName;
     myCopyResultsMesh(highLightMesh, actualResultMesh);
     Gui::Command::doCommand(Gui::Command::Doc, "Gui.activeDocument().resetEdit()");
@@ -627,8 +679,12 @@ void TaskCreateElementSet::DefineElementsCallback(void* ud, SoEventCallback* n)
     TaskCreateElementSet* taskBox = static_cast<TaskCreateElementSet*>(ud);
     // When this callback function is invoked we must in either case leave the edit mode
     Gui::View3DInventorViewer* view = reinterpret_cast<Gui::View3DInventorViewer*>(n->getUserData());
+    if (!taskBox || !view) {
+        return;
+    }
+
     view->setEditing(false);
-    view->removeEventCallback(SoMouseButtonEvent::getClassTypeId(), DefineElementsCallback, ud);
+    taskBox->removePolygonSelectionCallback();
     n->setHandled();
 
     Gui::SelectionRole role;
@@ -657,13 +713,35 @@ void TaskCreateElementSet::DefineNodes(
     bool inner
 )
 {
-    const SMESHDS_Mesh* srcMeshDS
-        = const_cast<SMESH_Mesh*>(
-              pcObject->FemMesh.getValue<Fem::FemMeshObject*>()->FemMesh.getValue().getSMesh()
-        )
-              ->GetMeshDS();
+    if (!pcObject) {
+        Base::Console().warning("Cannot create element set: FEM object is no longer available.\n");
+        return;
+    }
+
+    Fem::FemMeshObject* femMeshObject = pcObject->FemMesh.getValue<Fem::FemMeshObject*>();
+    if (!femMeshObject) {
+        Base::Console().warning("Cannot create element set: no FEM mesh is linked.\n");
+        return;
+    }
+
+    const SMESH_Mesh* smesh = femMeshObject->FemMesh.getValue().getSMesh();
+    if (!smesh) {
+        Base::Console().warning("Cannot create element set: FEM mesh data is unavailable.\n");
+        return;
+    }
+
+    const SMESHDS_Mesh* srcMeshDS = const_cast<SMESH_Mesh*>(smesh)->GetMeshDS();
+    if (!srcMeshDS) {
+        Base::Console().warning("Cannot create element set: FEM mesh data is invalid.\n");
+        return;
+    }
 
     std::vector<Gui::SelectionSingleton::SelObj> selection = Gui::Selection().getSelection();  // [0];
+    if (selection.empty()) {
+        Base::Console().warning("Cannot create element set: no mesh is selected.\n");
+        return;
+    }
+
     highLightMesh = selection[0].FeatName;
 
     meshType = "NULL";
@@ -851,6 +929,8 @@ void TaskCreateElementSet::onSelectionChanged(const Gui::SelectionChanges& msg)
 
 TaskCreateElementSet::~TaskCreateElementSet()
 {
+    cancelPolygonSelection();
+
     // delete last elementsset
     if (strcmp(lastName.c_str(), "") != 0) {
         Gui::Command::doCommand(

--- a/src/Mod/Fem/Gui/TaskCreateElementSet.h
+++ b/src/Mod/Fem/Gui/TaskCreateElementSet.h
@@ -25,6 +25,7 @@
 #include <Gui/TaskView/TaskView.h>
 #include <Mod/Fem/App/FemSetElementNodesObject.h>
 #include <QMessageBox>
+#include <QPointer>
 
 
 class Ui_TaskCreateElementSet;
@@ -43,6 +44,7 @@ namespace Gui
 {
 class ViewProvider;
 class ViewVolumeProjection;
+class View3DInventorViewer;
 }  // namespace Gui
 
 namespace FemGui
@@ -72,6 +74,10 @@ protected:
     Fem::FemSetElementNodesObject* pcObject;
     static void DefineElementsCallback(void* ud, SoEventCallback* n);
     void DefineNodes(const Base::Polygon2d& polygon, const Gui::ViewVolumeProjection& proj, bool);
+    void removePolygonSelectionCallback();
+    void cancelPolygonSelection();
+
+    QPointer<Gui::View3DInventorViewer> selectionViewer;
 
 protected:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;


### PR DESCRIPTION
This PR fixes the polygon-selection rendering regression described in #31948.

The previous implementation drew the polygon through a `Gui::Polyline` graphics item and switched the viewer into framebuffer/image rendering mode. That approach depended on framebuffer capture and a separate graphics-item compositing path. With the current viewer rendering pipeline, it could produce flicker, stale visuals, incorrect scaling, and geometry misalignment, especially during interactive resizing or HiDPI rendering.

The fix introduces a viewer-owned retained Coin polygon overlay. Polygon and freehand selection now update retained geometry that is rendered as part of the normal live interactive 3D render pass. The overlay handles viewport scaling, logical widget coordinates, line styling, and stippled closing segments without changing the viewer’s render mode.

## Separate crash hardening

While testing the FEM element-set polygon workflow, I encountered a separate crash in the existing FEM selection callback path. The stack was:

```text
FemGui::TaskCreateElementSet::DefineElementsCallback
FemGui::TaskCreateElementSet::DefineNodes
```

The issue was that `TaskCreateElementSet` registered a raw Coin callback containing `this`, but did not unregister it when the task was destroyed or selection was cancelled. A later mouse event could therefore invoke a stale task object. The code also assumed that the FEM mesh and selection vector were always valid.

This PR hardens that path by:

- Tracking and unregistering the FEM callback during task teardown, cancellation, and selection restart.
- Removing the callback before processing the completed polygon.
- Aborting active selection after callback removal.
- Validating the FEM object, linked mesh, mesh data, and current selection.
- Avoiding unchecked access to empty selection vectors.

