### PR TITLE
CI: test external Coin and Pivy on Ubuntu

### DIFF
--- a/.github/workflows/sub_buildUbuntu.yml
+++ b/.github/workflows/sub_buildUbuntu.yml
@@ -145,7 +145,7 @@ jobs:
       - name: CMake Configure
         uses: ./.github/workflows/actions/linux/configure
         with:
-          extraParameters: -G Ninja --preset ${{ env.config }} -DFREECAD_USE_EXTERNAL_PYCXX=ON -DFREECAD_USE_EXTERNAL_JSON=ON
+          extraParameters: -G Ninja --preset ${{ env.config }} -DFREECAD_USE_EXTERNAL_COIN_PIVY=ON -DFREECAD_USE_EXTERNAL_PYCXX=ON -DFREECAD_USE_EXTERNAL_JSON=ON
           builddir: ${{ env.builddir }}
           logFile: ${{ env.logdir }}Cmake.log
           errorFile: ${{ env.logdir }}CmakeErrors.log

--- a/package/ubuntu/install-apt-packages.sh
+++ b/package/ubuntu/install-apt-packages.sh
@@ -33,6 +33,7 @@ packages=(
   libboost-regex-dev
   libboost-serialization-dev
   libboost-thread-dev
+  libcoin-dev
   libeigen3-dev
   libexpat1-dev
   libgtest-dev
@@ -73,6 +74,7 @@ packages=(
   python3-pip
   python3-ply
   python3-pybind11
+  python3-pivy
   python3-pyside6.qtcore
   python3-pyside6.qtgui
   python3-pyside6.qtnetwork


### PR DESCRIPTION
Closes #31958

- Enable external Coin/Pivy and the gated packages in Ubuntu CI only.
