### PR TITLE
CAM: Make the adaptive finishing profile option hidden, default still true

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpAdaptiveEdit.ui
@@ -90,13 +90,6 @@ Larger values (further to the right) will calculate faster; smaller values (furt
         </property>
        </widget>
       </item>
-      <item row="24" column="0">
-       <widget class="QCheckBox" name="FinishingProfile">
-        <property name="text">
-         <string>Finishing profile</string>
-        </property>
-       </widget>
-      </item>
       <item row="20" column="1">
        <widget class="Gui::QuantitySpinBox" name="StockToLeave" native="true">
         <property name="toolTip">

--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -1627,6 +1627,7 @@ class PathAdaptive(PathOp.ObjectOp):
                 "To take a finishing profile path at the end",
             ),
         )
+        obj.setEditorMode("FinishingProfile", 2)  # hide this property
         obj.addProperty(
             "App::PropertyBool",
             "Stopped",

--- a/src/Mod/CAM/Path/Op/Gui/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Gui/Adaptive.py
@@ -84,12 +84,10 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.StockToLeave.valueChanged)
         if hasattr(self.form.ForceInsideOut, "checkStateChanged"):  # Qt version >= 6.7.0
             signals.append(self.form.ForceInsideOut.checkStateChanged)
-            signals.append(self.form.FinishingProfile.checkStateChanged)
             signals.append(self.form.useOutline.checkStateChanged)
             signals.append(self.form.useRestMachining.checkStateChanged)
         else:  # Qt version < 6.7.0
             signals.append(self.form.ForceInsideOut.stateChanged)
-            signals.append(self.form.FinishingProfile.stateChanged)
             signals.append(self.form.useOutline.stateChanged)
             signals.append(self.form.useRestMachining.stateChanged)
         signals.append(self.form.StopButton.toggled)
@@ -150,7 +148,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             self.form.StockToLeave.setProperty("rawValue", obj.StockToLeave.Value)
 
         self.form.ForceInsideOut.setChecked(obj.ForceInsideOut)
-        self.form.FinishingProfile.setChecked(obj.FinishingProfile)
         self.form.useOutline.setChecked(obj.UseOutline)
         self.form.useRestMachining.setChecked(obj.UseRestMachining)
         self.form.StopButton.setChecked(obj.Stopped)
@@ -188,7 +185,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             PathGuiUtil.updateInputField(obj, "StockToLeave", self.form.StockToLeave)
 
         obj.ForceInsideOut = self.form.ForceInsideOut.isChecked()
-        obj.FinishingProfile = self.form.FinishingProfile.isChecked()
         obj.UseOutline = self.form.useOutline.isChecked()
         obj.UseRestMachining = self.form.useRestMachining.isChecked()
         obj.Stopped = self.form.StopButton.isChecked()


### PR DESCRIPTION
@sliptonic here's your experiment, let's see if users care

FWIW we do have our adaptive tests mostly run without finishing passes, and if we decide to make this feature mandatory those tests will need to be updated (and might become a little more complicated, but we'll address that when we get there)

On the off chance there is a merge conflict, please merge https://github.com/FreeCAD/FreeCAD/pull/31053 first