### PR TITLE
CAM: Add 2d/3d Flute Operation

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathFlute.py
+++ b/src/Mod/CAM/CAMTests/TestPathFlute.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Billy Huddleston <billy@ivdc.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+import FreeCAD
+import Part
+import Path.Geom as PathGeom
+import Path.Op.Flute as PathFlute
+
+from CAMTests.PathTestUtils import PathTestBase
+
+
+class TestPathFlute(PathTestBase):
+    """Direct tests of Flute's 2D ramp-profile synthesis (_apply_2d_profile).
+
+    No Job/Document is needed for these -- they exercise the pure geometry
+    helpers directly, the same way TestPathHelixGenerator tests the helix
+    generator without a full operation.
+    """
+
+    def test00_ramp_full_linear_single_edge(self):
+        """A single straight edge, Ramp Full / Linear, ramps start_z -> floor_z
+        end to end and collapses back to just its two endpoints (still a
+        straight line in 3D once the Z ramp is applied)."""
+        edge = Part.makeLine(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(10, 0, 0))
+        tol = PathFlute._make_tolerances(None)
+
+        wire = PathFlute._apply_2d_profile(
+            [edge],
+            start_z=0.0,
+            floor_z=-5.0,
+            flute_type="Ramp Full",
+            ramp_type="Linear",
+            ramp_frac=1.0,
+            tol=tol,
+        )
+
+        self.assertIsNotNone(wire)
+        pts = PathGeom.edgesToPoints(wire.Edges, tol.arc_chord)
+        self.assertEqual(len(pts), 2)
+        self.assertCoincide(pts[0], FreeCAD.Vector(0, 0, 0))
+        self.assertCoincide(pts[-1], FreeCAD.Vector(10, 0, -5))
+
+    def test01_flip_reverses_which_end_is_deep(self):
+        """flip=True reverses the wire's travel direction before the ramp is
+        applied, so the deep end moves to the opposite physical point."""
+        edge = Part.makeLine(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(10, 0, 0))
+        tol = PathFlute._make_tolerances(None)
+
+        wire = PathFlute._apply_2d_profile(
+            [edge],
+            start_z=0.0,
+            floor_z=-5.0,
+            flute_type="Ramp Full",
+            ramp_type="Linear",
+            ramp_frac=1.0,
+            tol=tol,
+            flip=True,
+        )
+
+        self.assertIsNotNone(wire)
+        pts = PathGeom.edgesToPoints(wire.Edges, tol.arc_chord)
+        self.assertCoincide(pts[0], FreeCAD.Vector(10, 0, 0))
+        self.assertCoincide(pts[-1], FreeCAD.Vector(0, 0, -5))
+
+    def test02_chains_edges_regardless_of_input_order_and_orientation(self):
+        """Two connected edges, given out of order and with mismatched
+        orientation, still chain into one continuous ramp -- anchored on the
+        first edge's OWN drawn direction (edges[0] is never itself reversed,
+        only the edges that follow it are), matching CombineTangentSegments'
+        "respect drawn direction" contract."""
+        p0 = FreeCAD.Vector(0, 0, 0)
+        p1 = FreeCAD.Vector(10, 0, 0)
+        p2 = FreeCAD.Vector(10, 10, 0)
+
+        # edge2 is listed FIRST and drawn p2->p1 ("backwards" relative to the
+        # p0->p1->p2 path); edge1 is listed second, drawn p0->p1 (its natural
+        # direction happens to match the overall chain here).
+        edge2 = Part.makeLine(p2, p1)
+        edge1 = Part.makeLine(p0, p1)
+        tol = PathFlute._make_tolerances(None)
+
+        wire = PathFlute._apply_2d_profile(
+            [edge2, edge1],
+            start_z=0.0,
+            floor_z=-4.0,
+            flute_type="Ramp Full",
+            ramp_type="Linear",
+            ramp_frac=1.0,
+            tol=tol,
+        )
+
+        self.assertIsNotNone(wire)
+        pts = PathGeom.edgesToPoints(wire.Edges, tol.arc_chord)
+        # Chain follows edge2's own drawn direction (p2 -> p1), then
+        # continues on to p0 via edge1 (reversed to connect).
+        self.assertCoincide(pts[0], FreeCAD.Vector(10, 10, 0))
+        self.assertCoincide(pts[-1], FreeCAD.Vector(0, 0, -4))

--- a/src/Mod/CAM/CAMTests/TestPathFlute.py
+++ b/src/Mod/CAM/CAMTests/TestPathFlute.py
@@ -27,6 +27,42 @@ import Path.Op.Flute as PathFlute
 from CAMTests.PathTestUtils import PathTestBase
 
 
+class _StubFluteObj:
+    """Minimal stand-in for a Flute DocumentObject.
+
+    _emit2dPasses only reads a handful of properties, so a plain object is
+    enough -- no Document or Job required.
+    """
+
+    def __init__(self, reverse=False, blind=False, tool_diameter=6.0):
+        self.SafeHeight = FreeCAD.Units.Quantity(5.0, FreeCAD.Units.Length)
+        self.ReverseDirection = reverse
+        self.BlindEndCompensation = blind
+        self.MultiPassStrategy = "Constant Angle"
+        self.RampLengthType = "Length"
+        self.RampLength = FreeCAD.Units.Quantity(0.0, FreeCAD.Units.Length)
+        self.ToolController = _StubToolController(tool_diameter)
+
+
+class _StubToolController:
+    def __init__(self, diameter):
+        self.Tool = _StubTool(diameter)
+
+
+class _StubTool:
+    def __init__(self, diameter):
+        self.Diameter = FreeCAD.Units.Quantity(diameter, FreeCAD.Units.Length)
+
+
+class _StubOp:
+    """Collects the commands _emit2dPasses appends."""
+
+    def __init__(self):
+        self.commandlist = []
+        self.horizFeed = 100.0
+        self.vertFeed = 50.0
+
+
 class TestPathFlute(PathTestBase):
     """Direct tests of Flute's 2D ramp-profile synthesis (_apply_2d_profile).
 
@@ -113,3 +149,60 @@ class TestPathFlute(PathTestBase):
         # continues on to p0 via edge1 (reversed to connect).
         self.assertCoincide(pts[0], FreeCAD.Vector(10, 10, 0))
         self.assertCoincide(pts[-1], FreeCAD.Vector(0, 0, -4))
+
+    def test03_entry_move_targets_the_actual_first_cut_point(self):
+        """The linking move computed before the pass loop must target the same
+        point the cut actually starts at.
+
+        Both ReverseDirection and BlindEndCompensation change which XY the
+        first cutting move begins from, so the entry target has to account for
+        them.  If it doesn't, the tool rapids to one spot and the wire-follow
+        generator immediately rapids somewhere else -- wasted motion that is
+        never checked against the collision model.
+        """
+        edges = [Part.makeLine(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(50, 0, 0))]
+        tol = PathFlute._make_tolerances(None)
+
+        for blind in (False, True):
+            for reverse in (False, True):
+                with self.subTest(blind=blind, reverse=reverse):
+                    obj = _StubFluteObj(reverse=reverse, blind=blind)
+                    op = _StubOp()
+                    captured = {}
+
+                    real = PathFlute.linking.get_linking_moves
+
+                    def spy(**kwargs):
+                        captured["target"] = kwargs.get("target_position")
+                        return []
+
+                    PathFlute.linking.get_linking_moves = spy
+                    try:
+                        PathFlute.ObjectFlute._emit2dPasses(
+                            op,
+                            obj,
+                            edges,
+                            "Ramp Full",
+                            "Linear",
+                            1.0,
+                            False,
+                            0.0,
+                            -4.0,
+                            0.0,
+                            0.0,
+                            4.0,
+                            5.0,
+                            {"heights_clearance": [5.0, 10.0]},
+                            FreeCAD.Vector(-10, -10, 5.0),
+                            tol,
+                            "Edge1",
+                        )
+                    finally:
+                        PathFlute.linking.get_linking_moves = real
+
+                    first_rapid = next(
+                        c for c in op.commandlist if c.Name == "G0" and "X" in c.Parameters
+                    )
+                    self.assertIsNotNone(captured.get("target"))
+                    self.assertRoughly(captured["target"].x, first_rapid.Parameters["X"])
+                    self.assertRoughly(captured["target"].y, first_rapid.Parameters["Y"])

--- a/src/Mod/CAM/CAMTests/TestPathFollowWireGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathFollowWireGenerator.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Billy Huddleston <billy@ivdc.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+import FreeCAD
+import Part
+import Path
+import Path.Base.Generator.follow_wire as generator
+
+import CAMTests.PathTestUtils as PathTestUtils
+
+
+class TestPathFollowWireGenerator(PathTestUtils.PathTestBase):
+    """Tests for the wire-follow generator.
+
+    The generator is deliberately dumb: it takes a wire that already
+    represents exactly one pass at the correct depth and turns it into
+    commands.  All depth scaling and pass logic belongs to the caller.
+    """
+
+    def test00(self):
+        """Test basic wire follow generator return"""
+        wire = Part.Wire([Part.makeLine(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(10, 0, -5))])
+
+        result = generator.generate(wire, retract_z=5, horiz_feed=100, vert_feed=50, arc_chord=0.1)
+
+        self.assertIsInstance(result, list)
+        self.assertIsInstance(result[0], Path.Command)
+
+        # G0 to entry XY, G1 plunge, G1 cut, G0 retract
+        self.assertEqual(len(result), 4)
+
+        self.assertEqual(result[0].Name, "G0")
+        self.assertRoughly(result[0].Parameters["X"], 0)
+        self.assertRoughly(result[0].Parameters["Y"], 0)
+        # the entry rapid must not command Z -- the caller positions above
+        # the work, and adding Z here would plunge at rapid speed
+        self.assertNotIn("Z", result[0].Parameters)
+
+        self.assertEqual(result[1].Name, "G1")
+        self.assertRoughly(result[1].Parameters["Z"], 0)
+        self.assertEqual(result[1].Parameters["F"], 50)
+
+        self.assertEqual(result[2].Name, "G1")
+        self.assertRoughly(result[2].Parameters["X"], 10)
+        self.assertRoughly(result[2].Parameters["Z"], -5)
+        self.assertEqual(result[2].Parameters["F"], 100)
+
+        self.assertEqual(result[3].Name, "G0")
+        self.assertEqual(result[3].Parameters["Z"], 5)
+
+    def test10(self):
+        """Test that the first point of the wire is the entry point"""
+        # same segment drawn the other way round
+        wire = Part.Wire([Part.makeLine(FreeCAD.Vector(10, 0, -5), FreeCAD.Vector(0, 0, 0))])
+
+        result = generator.generate(wire, retract_z=5, horiz_feed=100, vert_feed=50, arc_chord=0.1)
+
+        # entry follows the wire's own direction, no reordering
+        self.assertRoughly(result[0].Parameters["X"], 10)
+        self.assertRoughly(result[1].Parameters["Z"], -5)
+        self.assertRoughly(result[2].Parameters["X"], 0)
+        self.assertRoughly(result[2].Parameters["Z"], 0)
+
+    def test20(self):
+        """Test multi-edge wire produces one cutting move per waypoint"""
+        v0 = FreeCAD.Vector(0, 0, 0)
+        v1 = FreeCAD.Vector(10, 0, -2)
+        v2 = FreeCAD.Vector(10, 10, -4)
+        wire = Part.Wire([Part.makeLine(v0, v1), Part.makeLine(v1, v2)])
+
+        result = generator.generate(wire, retract_z=5, horiz_feed=100, vert_feed=50, arc_chord=0.1)
+
+        # G0, plunge, 2 cutting moves, retract
+        self.assertEqual(len(result), 5)
+        self.assertRoughly(result[2].Parameters["X"], 10)
+        self.assertRoughly(result[2].Parameters["Y"], 0)
+        self.assertRoughly(result[3].Parameters["X"], 10)
+        self.assertRoughly(result[3].Parameters["Y"], 10)
+        self.assertRoughly(result[3].Parameters["Z"], -4)
+
+    def test30(self):
+        """Test arc_chord controls how finely curves are discretized"""
+        arc = Part.Edge(Part.Circle(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(0, 0, 1), 10), 0, 1.5)
+        wire = Part.Wire([arc])
+
+        coarse = generator.generate(wire, retract_z=5, horiz_feed=100, vert_feed=50, arc_chord=1.0)
+        fine = generator.generate(wire, retract_z=5, horiz_feed=100, vert_feed=50, arc_chord=0.05)
+
+        # a tighter chord tolerance means more G1 segments along the same arc
+        self.assertGreater(len(fine), len(coarse))

--- a/src/Mod/CAM/CAMTests/TestPathGeom.py
+++ b/src/Mod/CAM/CAMTests/TestPathGeom.py
@@ -862,3 +862,21 @@ class TestPathGeom(PathTestBase):
         # do some sanity checks
         self.assertTrue(w2.isValid())
         self.assertTrue(w2.isClosed())
+
+    def test77(self):
+        """Flip an elliptical arc"""
+        ellipse = Part.Ellipse(Vector(1, 3, 2), 5, 3)
+        edge = Part.Edge(ellipse, 0.3, 2.1)
+        self.assertEdgeShapesMatch(edge, Path.Geom.flipEdge(edge))
+
+        ellipse = Part.Ellipse(Vector(1, 3, 2), 5, 3)
+        ellipse.Axis = Vector(0, 0, -1)
+        edge = Part.Edge(ellipse, 1.0, 4.0)
+        self.assertEdgeShapesMatch(edge, Path.Geom.flipEdge(edge))
+
+    def test78(self):
+        """Flip a rotated elliptical arc"""
+        ellipse = Part.Ellipse(Vector(1, 3, 2), 5, 3)
+        edge = Part.Edge(ellipse, 0.3, 2.1)
+        edge.rotate(edge.Curve.Center, Vector(0, 0, 1), -40)
+        self.assertEdgeShapesMatch(edge, Path.Geom.flipEdge(edge))

--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -386,6 +386,7 @@ SET(PathPythonOp_SRCS
     Path/Op/Deburr.py
     Path/Op/Engrave.py
     Path/Op/EngraveBase.py
+    Path/Op/Flute.py
     Path/Op/FeatureExtension.py
     Path/Op/Drilling.py
     Path/Op/Helix.py
@@ -420,6 +421,7 @@ SET(PathPythonOpGui_SRCS
     Path/Op/Gui/Drilling.py
     Path/Op/Gui/Engrave.py
     Path/Op/Gui/FeatureExtension.py
+    Path/Op/Gui/Flute.py
     Path/Op/Gui/Helix.py
     Path/Op/Gui/MillFace.py
     Path/Op/Gui/MillFacing.py
@@ -479,6 +481,7 @@ SET(PathPythonBaseGenerator_SRCS
     Path/Base/Generator/surface_waterline.py
     Path/Base/Generator/surface_postprocess.py
     Path/Base/Generator/surface_zlevel.py
+    Path/Base/Generator/follow_wire.py
 )
 
 SET(PathPythonGui_SRCS

--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -591,6 +591,7 @@ SET(Tests_SRCS
     CAMTests/TestPathDrillable.py
     CAMTests/TestPathEngrave.py
     CAMTests/TestPathFacingGenerator.py
+    CAMTests/TestPathFlute.py
     CAMTests/TestPathGeneratorDogboneII.py
     CAMTests/TestPathGeom.py
     CAMTests/TestPathHelix.py

--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -592,6 +592,7 @@ SET(Tests_SRCS
     CAMTests/TestPathEngrave.py
     CAMTests/TestPathFacingGenerator.py
     CAMTests/TestPathFlute.py
+    CAMTests/TestPathFollowWireGenerator.py
     CAMTests/TestPathGeneratorDogboneII.py
     CAMTests/TestPathGeom.py
     CAMTests/TestPathHelix.py

--- a/src/Mod/CAM/Gui/Resources/Path.qrc
+++ b/src/Mod/CAM/Gui/Resources/Path.qrc
@@ -121,6 +121,7 @@
         <file>panels/PageOpMillFacingEdit.ui</file>
         <file>panels/PageOpProbeEdit.ui</file>
         <file>panels/PageOpProfileFullEdit.ui</file>
+        <file>panels/PageOpFluteEdit.ui</file>
         <file>panels/PageOpSlotEdit.ui</file>
         <file>panels/PageOpRotarySurfaceEdit.ui</file>
         <file>panels/PageOpSurfaceEdit.ui</file>

--- a/src/Mod/CAM/Gui/Resources/Path.qrc
+++ b/src/Mod/CAM/Gui/Resources/Path.qrc
@@ -86,6 +86,13 @@
         <file>icons/edge-join-miter.svg</file>
         <file>icons/edge-join-round-not.svg</file>
         <file>icons/edge-join-round.svg</file>
+        <file>icons/flute-ramp-linear.svg</file>
+        <file>icons/flute-ramp-s-curve.svg</file>
+        <file>icons/flute-ramp-smooth.svg</file>
+        <file>icons/flute-ramp-fillet.svg</file>
+        <file>icons/flute-fluting-ramp-full.svg</file>
+        <file>icons/flute-fluting-ramp-start.svg</file>
+        <file>icons/flute-fluting-ramp-start-end.svg</file>
         <file>icons/preferences-cam.svg</file>
         <file>panels/AxisMapEdit.ui</file>
         <file>panels/DlgJobCreate.ui</file>

--- a/src/Mod/CAM/Gui/Resources/icons/flute-fluting-ramp-full.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/flute-fluting-ramp-full.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- FlutingType dropdown icon: Ramp Full, ramps the entire path length.
+     viewBox height matches the combo's iconSize (16px) exactly so there is
+     no extra vertical scaling; the line occupies y=2..14, leaving a real
+     2px margin top and bottom. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 16" width="54" height="16">
+  <polyline fill="none" stroke="#3d85c6" stroke-width="2" stroke-linecap="round"
+    points="2,2 52,14"/>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/flute-fluting-ramp-start-end.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/flute-fluting-ramp-start-end.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- FlutingType dropdown icon: Ramp Start End, ramps down at entry, flat at
+     floor through the middle, ramps back up to the surface at exit.
+     viewBox height matches the combo's iconSize (16px) exactly so there is
+     no extra vertical scaling; the line occupies y=2..14, leaving a real
+     2px margin top and bottom. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 16" width="54" height="16">
+  <polyline fill="none" stroke="#3d85c6" stroke-width="2" stroke-linecap="round"
+    points="2,2 14.5,14 39.5,14 52,2"/>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/flute-fluting-ramp-start.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/flute-fluting-ramp-start.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- FlutingType dropdown icon: Ramp Start, ramps only the entry, then flat
+     at floor.  viewBox height matches the combo's iconSize (16px) exactly
+     so there is no extra vertical scaling; the line occupies y=2..14,
+     leaving a real 2px margin top and bottom. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 16" width="54" height="16">
+  <polyline fill="none" stroke="#3d85c6" stroke-width="2" stroke-linecap="round"
+    points="2,2 19.5,14 52,14"/>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/flute-ramp-fillet.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/flute-ramp-fillet.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- RampType dropdown icon: Fillet (quarter-ellipse, f = sqrt(1-(1-t)^2)).
+     Drawn as a true elliptical arc (not a sampled polyline, and not a
+     line+arc hybrid) since the curve's near-vertical entry slope doesn't
+     approximate cleanly with short line segments at icon size, and a
+     straight lead-in visually kinked at the seam (curvature jumped from
+     zero to nonzero there even though direction matched).  A single arc
+     keeps curvature varying continuously the whole way, matching the exact
+     real math with no seam.  viewBox height matches the combo's iconSize
+     (16px) exactly, no extra vertical scaling; content occupies y=2..14,
+     leaving a real 2px margin top and bottom.  Ellipse center (22,2),
+     radii (20,12). -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 16" width="24" height="16">
+  <path fill="none" stroke="#3d85c6" stroke-width="2" stroke-linecap="round"
+    d="M 2,2 A 20,12 0 0,0 22,14"/>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/flute-ramp-linear.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/flute-ramp-linear.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- RampType dropdown icon: Linear (f = t).  viewBox height matches the
+     combo's iconSize (16px) exactly so there is no extra vertical scaling;
+     the curve occupies y=2..14, leaving a real 2px margin top and bottom. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 16" width="24" height="16">
+  <polyline fill="none" stroke="#3d85c6" stroke-width="2" stroke-linecap="round"
+    points="2.0,2.0 3.2,2.8 4.5,3.5 5.8,4.2 7.0,5.0 8.2,5.8 9.5,6.5 10.8,7.2 12.0,8.0 13.2,8.8 14.5,9.5 15.8,10.2 17.0,11.0 18.2,11.8 19.5,12.5 20.8,13.2 22.0,14.0"/>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/flute-ramp-s-curve.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/flute-ramp-s-curve.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- RampType dropdown icon: S-Curve (smoothstep, f = t*t*(3-2t)).  viewBox
+     height matches the combo's iconSize (16px) exactly so there is no extra
+     vertical scaling; the curve occupies y=2..14, leaving a real 2px margin
+     top and bottom.  Widened slightly further than the others so the subtle
+     zero-slope lead-in/out reads clearly at icon size. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 16" width="24" height="16">
+  <polyline fill="none" stroke="#3d85c6" stroke-width="2" stroke-linecap="round"
+    points="2.0,2.0 3.2,2.1 4.5,2.5 5.8,3.1 7.0,3.9 8.2,4.8 9.5,5.8 10.8,6.9 12.0,8.0 13.2,9.1 14.5,10.2 15.8,11.2 17.0,12.1 18.2,12.9 19.5,13.5 20.8,13.9 22.0,14.0"/>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/icons/flute-ramp-smooth.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/flute-ramp-smooth.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- RampType dropdown icon: Smooth (quarter-sine, f = sin(t*pi/2)).  viewBox
+     height matches the combo's iconSize (16px) exactly so there is no extra
+     vertical scaling; the curve occupies y=2..14, leaving a real 2px margin
+     top and bottom. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 16" width="24" height="16">
+  <polyline fill="none" stroke="#3d85c6" stroke-width="2" stroke-linecap="round"
+    points="2.0,2.0 3.2,3.2 4.5,4.3 5.8,5.5 7.0,6.6 8.2,7.7 9.5,8.7 10.8,9.6 12.0,10.5 13.2,11.3 14.5,12.0 15.8,12.6 17.0,13.1 18.2,13.5 19.5,13.8 20.8,13.9 22.0,14.0"/>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpFluteEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpFluteEdit.ui
@@ -99,15 +99,26 @@
         </property>
        </widget>
       </item>
+      <!-- Combine tangent segments -->
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="combineTangentSegments">
+        <property name="toolTip">
+         <string>Merge connected edges that meet tangent-continuously (collinear lines or smoothly-joined curves) into a single flute path. Uncheck to keep every selected edge as its own independent flute path.</string>
+        </property>
+        <property name="text">
+         <string>Combine Tangent Segments</string>
+        </property>
+       </widget>
+      </item>
       <!-- Axial stock to leave -->
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="axialStockToLeave_label">
         <property name="text">
          <string>Axial Stock to Leave</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="Gui::QuantitySpinBox" name="axialStockToLeave">
         <property name="toolTip">
          <string>Stock to leave in the axial (depth) direction</string>
@@ -177,18 +188,33 @@
         </property>
        </widget>
       </item>
-      <!-- Ramp length -->
+      <!-- Ramp value mode: selects which of Ramp Length / Ramp % is used -->
       <item row="3" column="0">
+       <widget class="QLabel" name="rampLengthType_label">
+        <property name="text">
+         <string>Ramp Length Type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="rampLengthType">
+        <property name="toolTip">
+         <string>Whether Ramp Length or Ramp % defines the ramp size. They are independent — only the selected one is used, and it applies to every selected wire.</string>
+        </property>
+       </widget>
+      </item>
+      <!-- Ramp length -->
+      <item row="4" column="0">
        <widget class="QLabel" name="rampLength_label">
         <property name="text">
          <string>Ramp Length</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="Gui::QuantitySpinBox" name="rampLength">
         <property name="toolTip">
-         <string>Length of each ramp segment in mm. Syncs with Ramp % below. Set to 0 to drive from Ramp % only.</string>
+         <string>Length of each ramp segment in mm. Used when Ramp Length Type is set to Length.</string>
         </property>
         <property name="unit">
          <string>mm</string>
@@ -196,17 +222,17 @@
        </widget>
       </item>
       <!-- Ramp percent -->
-      <item row="4" column="0">
-       <widget class="QLabel" name="rampPercent_label">
+      <item row="5" column="0">
+       <widget class="QLabel" name="rampLengthPercent_label">
         <property name="text">
          <string>Ramp %</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
-       <widget class="QSpinBox" name="rampPercent">
+      <item row="5" column="1">
+       <widget class="QSpinBox" name="rampLengthPercent">
         <property name="toolTip">
-         <string>Percentage of the total path length occupied by each ramp segment. Syncs with Ramp Length above.</string>
+         <string>Ramp size as a percentage of each wire's own length. Used when Ramp Length Type is set to Percent; applied independently to every selected wire.</string>
         </property>
         <property name="minimum">
          <number>1</number>
@@ -220,7 +246,7 @@
        </widget>
       </item>
       <!-- Flip start -->
-      <item row="5" column="0" colspan="2">
+      <item row="6" column="0" colspan="2">
        <widget class="QCheckBox" name="flipStart2D">
         <property name="toolTip">
          <string>Reverse which end of the flat wire is the ramp entry point.</string>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpFluteEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpFluteEdit.ui
@@ -105,9 +105,6 @@
         <property name="text">
          <string>Axial Stock to Leave</string>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignVCenter</set>
-        </property>
        </widget>
       </item>
       <item row="2" column="1">
@@ -156,9 +153,6 @@
         <property name="text">
          <string>Fluting Type</string>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignVCenter</set>
-        </property>
        </widget>
       </item>
       <item row="1" column="1">
@@ -174,15 +168,12 @@
         <property name="text">
          <string>Ramp Type</string>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignVCenter</set>
-        </property>
        </widget>
       </item>
       <item row="2" column="1">
        <widget class="QComboBox" name="rampType">
         <property name="toolTip">
-         <string>Shape of the Z ramp: Linear is a constant-rate plunge; Smooth uses a smoothstep curve.</string>
+         <string>Shape of the Z ramp: Linear is a constant-rate plunge; Smooth uses a smoothstep curve; Arc uses a quarter-circle curve.</string>
         </property>
        </widget>
       </item>
@@ -192,15 +183,12 @@
         <property name="text">
          <string>Ramp Length</string>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignVCenter</set>
-        </property>
        </widget>
       </item>
       <item row="3" column="1">
        <widget class="Gui::QuantitySpinBox" name="rampLength">
         <property name="toolTip">
-         <string>Length of each ramp segment in mm. When greater than zero, overrides Ramp %. Set to 0 to use Ramp % instead.</string>
+         <string>Length of each ramp segment in mm. Syncs with Ramp % below. Set to 0 to drive from Ramp % only.</string>
         </property>
         <property name="unit">
          <string>mm</string>
@@ -213,15 +201,12 @@
         <property name="text">
          <string>Ramp %</string>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignVCenter</set>
-        </property>
        </widget>
       </item>
       <item row="4" column="1">
        <widget class="QSpinBox" name="rampPercent">
         <property name="toolTip">
-         <string>Percentage of the total path length occupied by each ramp segment. Ignored when Ramp Length is set.</string>
+         <string>Percentage of the total path length occupied by each ramp segment. Syncs with Ramp Length above.</string>
         </property>
         <property name="minimum">
          <number>1</number>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpFluteEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpFluteEdit.ui
@@ -173,7 +173,7 @@
       <item row="2" column="1">
        <widget class="QComboBox" name="rampType">
         <property name="toolTip">
-         <string>Shape of the Z ramp: Linear is a constant-rate plunge; Smooth uses a smoothstep curve; Arc uses a quarter-circle curve.</string>
+         <string>Shape of the Z ramp: Linear is a constant-rate plunge; S-Curve eases at both ends (smoothstep); Smooth is tangent to the floor with an angled entry; Fillet rolls tangentially into the floor for a rounded bottom.</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpFluteEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpFluteEdit.ui
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>350</width>
+    <height>310</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <!-- Tool controller frame -->
+   <item>
+    <widget class="QFrame" name="toolOptions">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_tool">
+      <property name="bottomMargin">
+       <number>3</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="toolController_label">
+        <property name="text">
+         <string>Tool controller</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="toolController">
+        <property name="toolTip">
+         <string>The tool and its settings to be used for this operation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="coolantController_label">
+        <property name="text">
+         <string>Coolant mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="coolantController"/>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="editToolController">
+        <property name="text">
+         <string>Edit Tool Controller</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <!-- Flute settings frame -->
+   <item>
+    <widget class="QFrame" name="fluteOptions">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_flute">
+      <property name="topMargin">
+       <number>3</number>
+      </property>
+      <property name="bottomMargin">
+       <number>3</number>
+      </property>
+      <!-- Reverse direction -->
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="reverseDirection">
+        <property name="toolTip">
+         <string>Reverse the cut direction (enters at the deep end)</string>
+        </property>
+        <property name="text">
+         <string>Reverse Direction</string>
+        </property>
+       </widget>
+      </item>
+      <!-- Blind end compensation -->
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="blindEndCompensation">
+        <property name="toolTip">
+         <string>Pull the path end back by the tool radius when the flute terminates at depth (blind end). Has no effect when the path ramps back up to stock surface.</string>
+        </property>
+        <property name="text">
+         <string>Blind End Compensation</string>
+        </property>
+       </widget>
+      </item>
+      <!-- Axial stock to leave -->
+      <item row="2" column="0">
+       <widget class="QLabel" name="axialStockToLeave_label">
+        <property name="text">
+         <string>Axial Stock to Leave</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::QuantitySpinBox" name="axialStockToLeave">
+        <property name="toolTip">
+         <string>Stock to leave in the axial (depth) direction</string>
+        </property>
+        <property name="unit">
+         <string>mm</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <!-- 2D fluting frame — shown only when a flat (no-Z) wire is selected -->
+   <item>
+    <widget class="QFrame" name="flute2DOptions">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2d">
+      <property name="topMargin">
+       <number>3</number>
+      </property>
+      <property name="bottomMargin">
+       <number>3</number>
+      </property>
+      <!-- Section header label -->
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="flute2DHeader">
+        <property name="text">
+         <string>2D Fluting (flat wire selected)</string>
+        </property>
+        <property name="styleSheet">
+         <string>font-weight: bold;</string>
+        </property>
+       </widget>
+      </item>
+      <!-- Fluting type -->
+      <item row="1" column="0">
+       <widget class="QLabel" name="flutingType_label">
+        <property name="text">
+         <string>Fluting Type</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="flutingType">
+        <property name="toolTip">
+         <string>Z profile for a flat (2D) wire: RampFull ramps the full length; RampStart ramps only the entry; RampStartEnd ramps entry and exit.</string>
+        </property>
+       </widget>
+      </item>
+      <!-- Ramp type -->
+      <item row="2" column="0">
+       <widget class="QLabel" name="rampType_label">
+        <property name="text">
+         <string>Ramp Type</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="rampType">
+        <property name="toolTip">
+         <string>Shape of the Z ramp: Linear is a constant-rate plunge; Smooth uses a smoothstep curve.</string>
+        </property>
+       </widget>
+      </item>
+      <!-- Ramp length -->
+      <item row="3" column="0">
+       <widget class="QLabel" name="rampLength_label">
+        <property name="text">
+         <string>Ramp Length</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::QuantitySpinBox" name="rampLength">
+        <property name="toolTip">
+         <string>Length of each ramp segment in mm. When greater than zero, overrides Ramp %. Set to 0 to use Ramp % instead.</string>
+        </property>
+        <property name="unit">
+         <string>mm</string>
+        </property>
+       </widget>
+      </item>
+      <!-- Ramp percent -->
+      <item row="4" column="0">
+       <widget class="QLabel" name="rampPercent_label">
+        <property name="text">
+         <string>Ramp %</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QSpinBox" name="rampPercent">
+        <property name="toolTip">
+         <string>Percentage of the total path length occupied by each ramp segment. Ignored when Ramp Length is set.</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="suffix">
+         <string> %</string>
+        </property>
+       </widget>
+      </item>
+      <!-- Flip start -->
+      <item row="5" column="0" colspan="2">
+       <widget class="QCheckBox" name="flipStart2D">
+        <property name="toolTip">
+         <string>Reverse which end of the flat wire is the ramp entry point.</string>
+        </property>
+        <property name="text">
+         <string>Flip Start</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QAbstractSpinBox</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpFluteEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpFluteEdit.ui
@@ -14,53 +14,6 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <!-- Tool controller frame -->
-   <item>
-    <widget class="QFrame" name="toolOptions">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_tool">
-      <property name="bottomMargin">
-       <number>3</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="toolController_label">
-        <property name="text">
-         <string>Tool controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="coolantController_label">
-        <property name="text">
-         <string>Coolant mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController"/>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="editToolController">
-        <property name="text">
-         <string>Edit Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <!-- Flute settings frame -->
    <item>
     <widget class="QFrame" name="fluteOptions">

--- a/src/Mod/CAM/InitGui.py
+++ b/src/Mod/CAM/InitGui.py
@@ -147,6 +147,7 @@ class CAMWorkbench(Workbench):
             "CAM_Helix",
             "CAM_Adaptive",
             "CAM_Slot",
+            "CAM_Flute",
         ]
         threedopcmdlist = ["CAM_Pocket3D"]
         engravecmdlist = ["CAM_Engrave", "CAM_Deburr", "CAM_Vcarve"]

--- a/src/Mod/CAM/InitGui.py
+++ b/src/Mod/CAM/InitGui.py
@@ -147,7 +147,6 @@ class CAMWorkbench(Workbench):
             "CAM_Helix",
             "CAM_Adaptive",
             "CAM_Slot",
-            "CAM_Flute",
         ]
         threedopcmdlist = ["CAM_Pocket3D"]
         engravecmdlist = ["CAM_Engrave", "CAM_Deburr", "CAM_Vcarve"]
@@ -219,7 +218,7 @@ class CAMWorkbench(Workbench):
         if Path.Preferences.experimentalFeaturesEnabled():
             prepcmdlist.append("CAM_PathShape")
             extracmdlist.extend(["CAM_Area", "CAM_Area_Workplane"])
-            twodopcmdlist.append("CAM_Slot")
+            engravecmdlist.append("CAM_Flute")
 
         if Path.Preferences.advancedOCLFeaturesEnabled():
             try:
@@ -294,6 +293,7 @@ class CAMWorkbench(Workbench):
             + ["Separator"]
             + twodopcmdlist
             + drillingcmdlist
+            + ["Separator"]
             + engravecmdlist
             + ["Separator"]
             + threedopcmdlist

--- a/src/Mod/CAM/Path/Base/Generator/follow_wire.py
+++ b/src/Mod/CAM/Path/Base/Generator/follow_wire.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Billy Huddleston <billy@ivdc.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+__title__ = "CAM Wire Follow Generator"
+__author__ = "Connor (Billy Huddleston <billy@ivdc.com>)"
+__url__ = "https://www.freecad.org"
+__doc__ = "Generate G-code for a single pass along any Part.Wire."
+
+import Path
+import Path.Geom as PathGeom
+
+
+def generate(wire, retract_z, horiz_feed, vert_feed, arc_chord):
+    """Generate G-code commands for a single pass along a wire.
+
+    This generator is intentionally simple — it knows nothing about step-down
+    passes, depth scaling, or operation strategy.  The caller is responsible
+    for supplying a wire that already represents exactly one pass at the
+    correct depth.
+
+    Args:
+        wire       - Part.Wire, the exact path to follow for this pass.
+                     Point 0 should be the entry (shallowest) end.
+        retract_z  - float, Z height for the rapid retract after the pass.
+        horiz_feed - float, feed rate for XY+Z cutting moves.
+        vert_feed  - float, feed rate for the initial Z plunge.
+        arc_chord  - float, max chord length (mm) used to discretize curved
+                     edges into G1 line segments.
+
+    Returns a list of Path.Command objects:
+        G0 X Y        — rapid to entry XY
+        G1 Z F        — plunge to entry depth
+        G1 X Y Z F    — cutting moves along the wire
+        G0 Z          — retract
+    """
+    pts = PathGeom.wireToPoints(wire, arc_chord)
+    if not pts:
+        return []
+
+    commands = []
+    first = pts[0]
+    commands.append(Path.Command("G0", {"X": first.x, "Y": first.y}))
+    commands.append(Path.Command("G1", {"Z": first.z, "F": vert_feed}))
+    for wp in pts[1:]:
+        commands.append(Path.Command("G1", {"X": wp.x, "Y": wp.y, "Z": wp.z, "F": horiz_feed}))
+    commands.append(Path.Command("G0", {"Z": retract_z}))
+
+    return commands

--- a/src/Mod/CAM/Path/Base/Generator/follow_wire.py
+++ b/src/Mod/CAM/Path/Base/Generator/follow_wire.py
@@ -51,7 +51,7 @@ def generate(wire, retract_z, horiz_feed, vert_feed, arc_chord):
         G1 X Y Z F    — cutting moves along the wire
         G0 Z          — retract
     """
-    pts = PathGeom.wireToPoints(wire, arc_chord)
+    pts = PathGeom.edgesToPoints(wire.Edges, arc_chord)
     if not pts:
         return []
 

--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -559,19 +559,24 @@ def wiresForPath(path, startPoint=Vector(0, 0, 0)):
     return wires
 
 
-def wireToPoints(wire, chord):
-    """wireToPoints(wire, chord)
-    Extract an ordered list of Vector waypoints from a wire.
+def edgesToPoints(edges, chord, startPoint=None, error=Tolerance):
+    """edgesToPoints(edges, chord, [startPoint=None, error=Tolerance])
+    Extract an ordered list of Vector waypoints from a sequence of connected edges
+    (e.g. wire.Edges, or a hand-ordered edge list).
 
     Straight Line and LineSegment edges contribute only their two endpoints.
     All other curve types (arcs, splines, etc.) are discretized at the given
-    chord spacing (mm) so their shape is preserved.  Coincident consecutive
-    points are suppressed.
+    chord spacing (mm) so their shape is preserved.
+
+    Each edge's samples are oriented to continue from the previous point, so the
+    edges need not share a consistent parametric direction (they only need to
+    connect end-to-end).  startPoint, when given, orients the first edge so its
+    nearest end leads.  Consecutive points closer than error are suppressed.
 
     Returns a list of FreeCAD.Vector.
     """
     pts = []
-    for edge in wire.Edges:
+    for edge in edges:
         if isinstance(edge.Curve, (Part.Line, Part.LineSegment)):
             raw = [
                 edge.valueAt(edge.FirstParameter),
@@ -579,8 +584,15 @@ def wireToPoints(wire, chord):
             ]
         else:
             raw = edge.discretize(Distance=chord)
+        if not raw:
+            continue
+        # Orient this edge's samples to continue from the running end (or, for
+        # the first edge, from startPoint if supplied).
+        anchor = pts[-1] if pts else startPoint
+        if anchor is not None and anchor.distanceToPoint(raw[0]) > anchor.distanceToPoint(raw[-1]):
+            raw = list(reversed(raw))
         for p in raw:
-            if not pts or not pointsCoincide(pts[-1], p):
+            if not pts or not pointsCoincide(pts[-1], p, error):
                 pts.append(p)
     return pts
 

--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -559,6 +559,32 @@ def wiresForPath(path, startPoint=Vector(0, 0, 0)):
     return wires
 
 
+def wireToPoints(wire, chord):
+    """wireToPoints(wire, chord)
+    Extract an ordered list of Vector waypoints from a wire.
+
+    Straight Line and LineSegment edges contribute only their two endpoints.
+    All other curve types (arcs, splines, etc.) are discretized at the given
+    chord spacing (mm) so their shape is preserved.  Coincident consecutive
+    points are suppressed.
+
+    Returns a list of FreeCAD.Vector.
+    """
+    pts = []
+    for edge in wire.Edges:
+        if isinstance(edge.Curve, (Part.Line, Part.LineSegment)):
+            raw = [
+                edge.valueAt(edge.FirstParameter),
+                edge.valueAt(edge.LastParameter),
+            ]
+        else:
+            raw = edge.discretize(Distance=chord)
+        for p in raw:
+            if not pts or not pointsCoincide(pts[-1], p):
+                pts.append(p)
+    return pts
+
+
 def arcToHelix(edge, z0, z1):
     """arcToHelix(edge, z0, z1)
     Assuming edge is an arc it'll return a helix matching the arc starting at z0 and rising/falling to z1.

--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -742,7 +742,7 @@ def removeDuplicateEdges(wire):
 def flipEdge(edge):
     """flipEdge(edge)
     Flips given edge around so the new Vertexes[0] was the old Vertexes[-1] and vice versa, without changing the shape.
-    Currently only lines, line segments, circles and arcs are supported."""
+    Currently only lines, line segments, circles, arcs and ellipses are supported."""
 
     if isinstance(edge.Curve, Part.Line) and not edge.Vertexes:
         return Part.Edge(
@@ -765,6 +765,29 @@ def flipEdge(edge):
         )
         # Now the edge always starts at 0 and LastParameter is the value range
         arc = Part.Edge(circle, 0, edge.LastParameter - edge.FirstParameter)
+        return arc
+    elif isinstance(edge.Curve, Part.Ellipse):
+        # Ellipse has no (center, normal, radii) constructor to build the
+        # inverted curve directly the way Circle does above, so build it
+        # from explicit points instead: keep the same center and major-axis
+        # point (S1), but mirror the minor-axis reference point (S2) to the
+        # other side of the major axis. That flips the sign of the plane
+        # normal implied by (Center, S1, S2), which works out to
+        # newpoint(t) = point(-t) -- the same points, reverse direction,
+        # with parameter 0 still at the same physical point as before.
+        #
+        # Unlike a circle, an ellipse is NOT rotationally symmetric, so
+        # rotating it to shift the start point (the Circle branch's trick)
+        # would tilt it into a different ellipse entirely. Instead, trim to
+        # the mirrored parameter range [-LastParameter, -FirstParameter]:
+        # newpoint(-LastParameter) = point(LastParameter) (old end, now the
+        # new start) and newpoint(-FirstParameter) = point(FirstParameter)
+        # (old start, now the new end).
+        c = edge.Curve
+        s1 = c.Center + c.XAxis * c.MajorRadius
+        s2 = c.Center - c.YAxis * c.MinorRadius
+        ellipse = Part.Ellipse(s1, s2, c.Center)
+        arc = Part.Edge(ellipse, -edge.LastParameter, -edge.FirstParameter)
         return arc
     elif isinstance(edge.Curve, (Part.BSplineCurve, Part.BezierCurve)):
         if isinstance(edge.Curve, Part.BSplineCurve):

--- a/src/Mod/CAM/Path/GuiInit.py
+++ b/src/Mod/CAM/Path/GuiInit.py
@@ -75,6 +75,7 @@ def Startup():
         from Path.Op.Gui import Probe
         from Path.Op.Gui import Profile
         from Path.Op.Gui import SimpleCopy
+        from Path.Op.Gui import Flute
         from Path.Op.Gui import Slot
         from Path.Op.Gui import Stop
         from Path.Op.Gui import Tapping

--- a/src/Mod/CAM/Path/Op/Flute.py
+++ b/src/Mod/CAM/Path/Op/Flute.py
@@ -61,8 +61,16 @@ _VBIT_ANGLE_FRAC = 0.025  # 2.5% of groove half-angle — fuzzy margin for V-bit
 
 _Tol = collections.namedtuple(
     "_Tol",
-    ["edge", "chain2", "floor_snap", "axial_floor", "bb_overlap",
-     "section_overshoot", "pca_degenerate", "arc_chord"],
+    [
+        "edge",
+        "chain2",
+        "floor_snap",
+        "axial_floor",
+        "bb_overlap",
+        "section_overshoot",
+        "pca_degenerate",
+        "arc_chord",
+    ],
 )
 
 
@@ -72,14 +80,14 @@ def _make_tolerances(geom_tol):
     """
     t = geom_tol if geom_tol and geom_tol > 0 else 0.01
     return _Tol(
-        edge=t * 0.01,           # exact topological edge-coincidence
-        chain2=(t * 200.0) ** 2, # vertex snap distance while chaining (stored squared)
-        floor_snap=t * 50.0,     # floor-seam Z snapping
-        axial_floor=t * 50.0,    # axial-leave floor-point detection
-        bb_overlap=t * 100.0,    # face grouping by bounding-box touch
+        edge=t * 0.01,  # exact topological edge-coincidence
+        chain2=(t * 200.0) ** 2,  # vertex snap distance while chaining (stored squared)
+        floor_snap=t * 50.0,  # floor-seam Z snapping
+        axial_floor=t * 50.0,  # axial-leave floor-point detection
+        bb_overlap=t * 100.0,  # face grouping by bounding-box touch
         section_overshoot=t * 1000.0,  # section-plane / candidate-filter margin
         pca_degenerate=t * 5.0,  # centerline-coincides-with-edge test
-        arc_chord=t * 10.0,      # arc discretization chord (matches LeadInOut dressup)
+        arc_chord=t * 10.0,  # arc discretization chord (matches LeadInOut dressup)
     )
 
 
@@ -346,7 +354,6 @@ def _find_shared_edges(face_a, face_b, tol):
     return shared
 
 
-
 def _is_valley_edge(edge, face_a, face_b):
     """Return True if the shared edge sits below both adjacent face centroids.
 
@@ -486,7 +493,7 @@ def _centerline_from_valley_edge(edges, face_tuples, tol):
     for ft in face_tuples:
         try:
             n = ft[0].Surface.Axis
-            nlen = math.sqrt(n.x ** 2 + n.y ** 2 + n.z ** 2)
+            nlen = math.sqrt(n.x**2 + n.y**2 + n.z**2)
             if nlen > _PREC * 0.01:
                 groove_half_angle = math.degrees(math.asin(min(1.0, abs(n.z) / nlen)))
                 break
@@ -647,30 +654,6 @@ def _dist2(a, b):
     return (a.x - b.x) ** 2 + (a.y - b.y) ** 2 + (a.z - b.z) ** 2
 
 
-def _chain_to_waypoints(chain, tol):
-    """Convert an ordered chain of (seg_start, seg_end, edge) triples to a
-    deduplicated list of FreeCAD.Vector waypoints.
-
-    Straight Line edges contribute only their two endpoints.  Arcs, splines,
-    and other curves are discretized at tol.arc_chord spacing so their shape
-    is preserved.
-    """
-    pts = []
-    for seg_start, seg_end, edge in chain:
-        if edge.Curve.__class__.__name__ == "Line":
-            raw = [edge.valueAt(edge.FirstParameter), edge.valueAt(edge.LastParameter)]
-        else:
-            raw = edge.discretize(Distance=tol.arc_chord)
-        # Orient to match chain direction
-        if raw and _dist2(raw[0], seg_start) > _dist2(raw[-1], seg_start):
-            raw = list(reversed(raw))
-        for p in raw:
-            pv = FreeCAD.Vector(p)
-            if not pts or _dist2(pts[-1], pv) > (tol.arc_chord * 0.01) ** 2:
-                pts.append(pv)
-    return pts
-
-
 def _clip_and_scale(pts, f, stock_top_z):
     """Scale a full-depth point list to depth fraction f.
 
@@ -686,7 +669,7 @@ def _clip_and_scale(pts, f, stock_top_z):
         return []
 
     n = len(pts)
-    floor_z = min(p.z for p in pts)   # use actual deepest point, not pts[-1]
+    floor_z = min(p.z for p in pts)  # use actual deepest point, not pts[-1]
     pass_floor_z = stock_top_z - f * (stock_top_z - floor_z)
 
     if n == 1:
@@ -746,7 +729,7 @@ def _pts_to_wire(pts):
     edges = [
         Part.makeLine(pts[i], pts[i + 1])
         for i in range(len(pts) - 1)
-        if _dist2(pts[i], pts[i + 1]) > _PREC ** 2
+        if _dist2(pts[i], pts[i + 1]) > _PREC**2
     ]
     if not edges:
         return None
@@ -760,6 +743,76 @@ def _pts_to_wire(pts):
 # Centerline directly from a selected wire (edges) - bypasses face/solid
 # analysis entirely. The wire IS the centerline.
 # ---------------------------------------------------------------------------
+
+
+def _is_straight_line_edge(edge):
+    """True if the edge's underlying curve is a straight line."""
+    try:
+        cname = edge.Curve.__class__.__name__
+        if cname in ("Line", "LineSegment"):
+            return True
+        # Geometric fallback: arc length == chord length (works for any curve type name)
+        p0 = edge.Vertexes[0].Point
+        p1 = edge.Vertexes[-1].Point
+        chord = (p1 - p0).Length
+        return abs(edge.Length - chord) < max(1e-5, edge.Length * 1e-5)
+    except Exception:
+        return False
+
+
+def _edges_are_collinear(e1, e2, tol):
+    """True if two straight-line edges lie on the same infinite line."""
+    try:
+        d1 = e1.Vertexes[-1].Point - e1.Vertexes[0].Point
+        d2 = e2.Vertexes[-1].Point - e2.Vertexes[0].Point
+        l1 = d1.Length
+        l2 = d2.Length
+        if l1 < _PREC or l2 < _PREC:
+            return False
+        # Explicit unit vectors — avoids FreeCAD.Vector.normalize() in-place ambiguity
+        u1x, u1y, u1z = d1.x / l1, d1.y / l1, d1.z / l1
+        u2x, u2y, u2z = d2.x / l2, d2.y / l2, d2.z / l2
+        # Directions must be parallel (dot product of unit vectors ≈ ±1)
+        dot = u1x * u2x + u1y * u2y + u1z * u2z
+        if abs(abs(dot) - 1.0) > 1e-3:
+            return False
+        # Perpendicular distance from e2.Vertexes[0] to the infinite line through e1
+        p0 = e1.Vertexes[0].Point
+        p1 = e2.Vertexes[0].Point
+        dx, dy, dz = p1.x - p0.x, p1.y - p0.y, p1.z - p0.z
+        proj = dx * u1x + dy * u1y + dz * u1z
+        px = dx - u1x * proj
+        py = dy - u1y * proj
+        pz = dz - u1z * proj
+        perp_sq = px * px + py * py + pz * pz
+        return perp_sq < (tol.pca_degenerate**2)
+    except Exception:
+        return False
+
+
+def _split_2d_wire_groups(groups, tol):
+    """Post-process flat (2D) wire groups for independent flute paths.
+
+    A group of connected edges is kept as ONE path only when every edge is a
+    straight line AND all edges are collinear — i.e. they form a single
+    longer straight segment.  Any group that contains arcs, curves, or
+    non-collinear line segments is split into individual single-edge groups
+    so each edge becomes its own independent flute path.
+    """
+    result = []
+    for group in groups:
+        if len(group) == 1:
+            result.append(group)
+            continue
+        if all(_is_straight_line_edge(e) for e in group):
+            ref = group[0]
+            if all(_edges_are_collinear(ref, e, tol) for e in group[1:]):
+                result.append(group)
+                continue
+        # Non-collinear or contains curves: one group per edge
+        for edge in group:
+            result.append([edge])
+    return result
 
 
 def _split_into_wires(edges, tol):
@@ -852,7 +905,12 @@ def _wire_from_edges(edges, tol):
     if chain[0][0].z < chain[-1][1].z:
         chain = [(e, s, edge) for s, e, edge in reversed(chain)]
 
-    pts = _chain_to_waypoints(chain, tol)
+    pts = PathGeom.edgesToPoints(
+        [edge for _, _, edge in chain],
+        tol.arc_chord,
+        startPoint=chain[0][0],
+        error=tol.arc_chord * 0.01,
+    )
     if not pts:
         return None, None, None
 
@@ -917,9 +975,7 @@ def _detect_floor_wire(face, base_obj, info, tol, group_extent=None):
             Path.Log.debug("CAM_Flute: section returned no edges\n")
             return None, None, None
 
-        Path.Log.debug(
-            "CAM_Flute: section returned {} edge(s)\n".format(len(all_edges))
-        )
+        Path.Log.debug("CAM_Flute: section returned {} edge(s)\n".format(len(all_edges)))
 
         # --- filter candidates --------------------------------------------------
         def path_proj(v):
@@ -952,9 +1008,7 @@ def _detect_floor_wire(face, base_obj, info, tol, group_extent=None):
             Path.Log.debug("CAM_Flute: no floor edge candidates\n")
             return None, None, None
 
-        Path.Log.debug(
-            "CAM_Flute: {} candidate floor edge(s)\n".format(len(candidates))
-        )
+        Path.Log.debug("CAM_Flute: {} candidate floor edge(s)\n".format(len(candidates)))
 
         # --- chain from start ---------------------------------------------------
         def _orient(edge, toward_pt):
@@ -1006,7 +1060,12 @@ def _detect_floor_wire(face, base_obj, info, tol, group_extent=None):
         Path.Log.debug("CAM_Flute: chained {} edge(s)\n".format(len(chain)))
 
         # --- convert chain to wire ----------------------------------------------
-        pts = _chain_to_waypoints(chain, tol)
+        pts = PathGeom.edgesToPoints(
+            [edge for _, _, edge in chain],
+            tol.arc_chord,
+            startPoint=chain[0][0],
+            error=tol.arc_chord * 0.01,
+        )
         if not pts:
             return None, None, None
 
@@ -1015,8 +1074,11 @@ def _detect_floor_wire(face, base_obj, info, tol, group_extent=None):
         # sectioned (modeling seam); snapping removes any tiny Z step.
         floor_z = min(p.z for p in pts)
         pts = [
-            FreeCAD.Vector(p.x, p.y, floor_z) if abs(p.z - floor_z) < tol.floor_snap
-            else FreeCAD.Vector(p)
+            (
+                FreeCAD.Vector(p.x, p.y, floor_z)
+                if abs(p.z - floor_z) < tol.floor_snap
+                else FreeCAD.Vector(p)
+            )
             for p in pts
         ]
         top_z = max(p.z for p in pts)
@@ -1072,8 +1134,11 @@ def _apply_axial_leave_pts(pts, axial_leave, stock_top_z, tol):
 
     # Raise all floor-level points
     result = [
-        FreeCAD.Vector(p.x, p.y, new_floor_z) if abs(p.z - floor_z) < tol.axial_floor
-        else FreeCAD.Vector(p)
+        (
+            FreeCAD.Vector(p.x, p.y, new_floor_z)
+            if abs(p.z - floor_z) < tol.axial_floor
+            else FreeCAD.Vector(p)
+        )
         for p in pts
     ]
 
@@ -1136,9 +1201,59 @@ def _wire_is_flat(edges, tol):
     return (max(zs) - min(zs)) < tol.edge if zs else False
 
 
+def _apply_blind_end_compensation(pts, tool_radius, tol):
+    """Pull a path's floor-depth endpoint back by tool_radius along the approach
+    direction so the cutting edge — not the tool centre — reaches the groove end.
+
+    Only applies when the path terminates at depth (last point at the deepest Z);
+    a path that ramps back up to the surface is left unchanged.  Points within
+    tool_radius (XY) of the blind end are trimmed first, otherwise the
+    compensated endpoint would be appended after points already past it, making
+    the path overshoot then reverse.
+
+    Mutates and returns pts.
+    """
+    if len(pts) < 2 or tool_radius <= _PREC * 10:
+        return pts
+    floor_z = min(p.z for p in pts)
+    if abs(pts[-1].z - floor_z) >= tol.floor_snap:
+        return pts
+
+    blind_end = pts[-1]
+    tr2 = tool_radius * tool_radius
+    while len(pts) > 1:
+        dx = pts[-1].x - blind_end.x
+        dy = pts[-1].y - blind_end.y
+        if dx * dx + dy * dy >= tr2:
+            break
+        pts.pop()
+
+    dx = blind_end.x - pts[-1].x
+    dy = blind_end.y - pts[-1].y
+    seg_len = math.sqrt(dx * dx + dy * dy)
+    if seg_len > _PREC:
+        pts.append(
+            FreeCAD.Vector(
+                blind_end.x - (dx / seg_len) * tool_radius,
+                blind_end.y - (dy / seg_len) * tool_radius,
+                blind_end.z,
+            )
+        )
+    return pts
+
+
 def _apply_2d_profile(
-    edges, start_z, floor_z, flute_type, ramp_type, ramp_frac, tol, flip=False,
-    path_frac=1.0, path_offset=0.0, ramp_length_mm=0.0,
+    edges,
+    start_z,
+    floor_z,
+    flute_type,
+    ramp_type,
+    ramp_frac,
+    tol,
+    flip=False,
+    path_frac=1.0,
+    path_offset=0.0,
+    ramp_length_mm=0.0,
 ):
     """Synthesize a 3D wire from a flat (constant-Z) edge set by applying a Z ramp profile.
 
@@ -1339,16 +1454,6 @@ class ObjectFlute(PathOp.ObjectOp):
         )
         obj.RampType = ["Linear", "Smooth", "Arc"]
         obj.addProperty(
-            "App::PropertyPercent",
-            "RampPercent",
-            "Flute2D",
-            QtCore.QT_TRANSLATE_NOOP(
-                "App::Property",
-                "Percentage of the total path length occupied by each ramp "
-                "segment (2D wires only).",
-            ),
-        )
-        obj.addProperty(
             "App::PropertyBool",
             "FlipStart2D",
             "Flute2D",
@@ -1391,7 +1496,6 @@ class ObjectFlute(PathOp.ObjectOp):
         obj.BlindEndCompensation = False
         obj.FlutingType = "Ramp Full"
         obj.RampType = "Linear"
-        obj.RampPercent = 100
         obj.FlipStart2D = False
         obj.RampLength = 0.0
         obj.MultiPassStrategy = "Constant Angle"
@@ -1465,7 +1569,11 @@ class ObjectFlute(PathOp.ObjectOp):
             obj.FlutingType = "Ramp Full"
         else:
             # Migrate old enum values saved without spaces
-            _migrate = {"RampFull": "Ramp Full", "RampStart": "Ramp Start", "RampStartEnd": "Ramp Start End"}
+            _migrate = {
+                "RampFull": "Ramp Full",
+                "RampStart": "Ramp Start",
+                "RampStartEnd": "Ramp Start End",
+            }
             old_val = str(obj.FlutingType)
             if old_val in _migrate:
                 obj.FlutingType = ["Ramp Full", "Ramp Start", "Ramp Start End"]
@@ -1482,17 +1590,12 @@ class ObjectFlute(PathOp.ObjectOp):
             )
             obj.RampType = ["Linear", "Smooth", "Arc"]
             obj.RampType = "Linear"
-        if not hasattr(obj, "RampPercent"):
-            obj.addProperty(
-                "App::PropertyPercent",
-                "RampPercent",
-                "Flute2D",
-                QtCore.QT_TRANSLATE_NOOP(
-                    "App::Property",
-                    "Percentage of path length occupied by each ramp (2D wires only).",
-                ),
-            )
-            obj.RampPercent = 100
+        # Migrate: RampPercent was dropped in favour of RampLength (mm).
+        if hasattr(obj, "RampPercent"):
+            try:
+                obj.removeProperty("RampPercent")
+            except Exception:
+                pass
         if not hasattr(obj, "FlipStart2D"):
             obj.addProperty(
                 "App::PropertyBool",
@@ -1553,7 +1656,7 @@ class ObjectFlute(PathOp.ObjectOp):
         was appended to self.commandlist.
         """
         # --- remap Z from geometry to operation Depths tab -------------------
-        pts = PathGeom.wireToPoints(wire, tol.arc_chord)
+        pts = PathGeom.edgesToPoints(wire.Edges, tol.arc_chord)
         if not pts:
             return tool_pos, False
 
@@ -1565,41 +1668,12 @@ class ObjectFlute(PathOp.ObjectOp):
             pts = _apply_axial_leave_pts(pts, axial_leave, op_start_z, tol)
 
         # --- blind end compensation -----------------------------------------
-        # When the path terminates at depth (no exit ramp), pull the last
-        # point back by the tool radius so the cutting edge — not the centre —
-        # aligns with the groove end.  No effect when the path ramps back up.
-        if getattr(obj, "BlindEndCompensation", False) and len(pts) >= 2:
-            floor_z_pts = min(p.z for p in pts)
-            if abs(pts[-1].z - floor_z_pts) < tol.floor_snap:
-                try:
-                    tool_radius = obj.ToolController.Tool.Diameter.Value / 2.0
-                except Exception:
-                    tool_radius = 0.0
-                if tool_radius > _PREC * 10:
-                    blind_end = pts[-1]
-                    tr2 = tool_radius * tool_radius
-                    # Trim all points within tool_radius XY of the blind end.
-                    # Without this, the compensated endpoint would be appended
-                    # *after* points that are already past it, causing the path
-                    # to overshoot then reverse.
-                    while len(pts) > 1:
-                        dx = pts[-1].x - blind_end.x
-                        dy = pts[-1].y - blind_end.y
-                        if dx * dx + dy * dy >= tr2:
-                            break
-                        pts.pop()
-                    # Append the compensated endpoint: tool_radius back from
-                    # blind_end along the approach direction.
-                    if len(pts) >= 1:
-                        dx = blind_end.x - pts[-1].x
-                        dy = blind_end.y - pts[-1].y
-                        seg_len = math.sqrt(dx * dx + dy * dy)
-                        if seg_len > _PREC:
-                            pts.append(FreeCAD.Vector(
-                                blind_end.x - (dx / seg_len) * tool_radius,
-                                blind_end.y - (dy / seg_len) * tool_radius,
-                                blind_end.z,
-                            ))
+        if getattr(obj, "BlindEndCompensation", False):
+            try:
+                tool_radius = obj.ToolController.Tool.Diameter.Value / 2.0
+            except Exception:
+                tool_radius = 0.0
+            _apply_blind_end_compensation(pts, tool_radius, tol)
 
         # --- step-down pass loop --------------------------------------------
         floor_z = min(p.z for p in pts)
@@ -1618,8 +1692,7 @@ class ObjectFlute(PathOp.ObjectOp):
             depth = min(depth + step_down, rough_stop)
             f = depth / total_depth
             if multi_pass_strategy == "Variable Angle":
-                wps = [FreeCAD.Vector(p.x, p.y, op_start_z + (p.z - op_start_z) * f)
-                       for p in pts]
+                wps = [FreeCAD.Vector(p.x, p.y, op_start_z + (p.z - op_start_z) * f) for p in pts]
             else:
                 wps = _clip_and_scale(pts, f, op_start_z)
             if obj.ReverseDirection:
@@ -1730,18 +1803,34 @@ class ObjectFlute(PathOp.ObjectOp):
             if multi_pass_strategy == "Variable Angle":
                 # Full XY path every pass — angle steepens with each depth step.
                 w = _apply_2d_profile(
-                    wire_edges, op_start_z, pf, flute_type, ramp_type, ramp_frac, tol, flip,
+                    wire_edges,
+                    op_start_z,
+                    pf,
+                    flute_type,
+                    ramp_type,
+                    ramp_frac,
+                    tol,
+                    flip,
                     ramp_length_mm=ramp_length_mm,
                 )
             else:
                 # Constant Angle: fan from start — same slope every pass, path shortens.
                 if flute_type == "Ramp Start End":
-                    p_offset = (1.0 - f) / 2.0   # symmetric fan from centre
+                    p_offset = (1.0 - f) / 2.0  # symmetric fan from centre
                 else:
-                    p_offset = 1.0 - f            # fan from start (entry walks)
+                    p_offset = 1.0 - f  # fan from start (entry walks)
                 w = _apply_2d_profile(
-                    wire_edges, op_start_z, pf, flute_type, ramp_type, ramp_frac, tol, flip,
-                    path_frac=f, path_offset=p_offset, ramp_length_mm=ramp_length_mm,
+                    wire_edges,
+                    op_start_z,
+                    pf,
+                    flute_type,
+                    ramp_type,
+                    ramp_frac,
+                    tol,
+                    flip,
+                    path_frac=f,
+                    path_offset=p_offset,
+                    ramp_length_mm=ramp_length_mm,
                 )
             if w is not None:
                 pass_wires.append(w)
@@ -1749,7 +1838,7 @@ class ObjectFlute(PathOp.ObjectOp):
         if not pass_wires:
             return tool_pos, False
 
-        fp = PathGeom.wireToPoints(pass_wires[0], tol.arc_chord)
+        fp = PathGeom.edgesToPoints(pass_wires[0].Edges, tol.arc_chord)
         if not fp:
             return tool_pos, False
 
@@ -1775,31 +1864,12 @@ class ObjectFlute(PathOp.ObjectOp):
         emitted = False
         last_pts = fp
         for w in pass_wires:
-            pts = PathGeom.wireToPoints(w, tol.arc_chord)
+            pts = PathGeom.edgesToPoints(w.Edges, tol.arc_chord)
             if not pts:
                 continue
 
             if do_blind:
-                floor_z_pass = min(p.z for p in pts)
-                if abs(pts[-1].z - floor_z_pass) < tol.floor_snap:
-                    blind_end = pts[-1]
-                    tr2 = tool_radius * tool_radius
-                    while len(pts) > 1:
-                        dx = pts[-1].x - blind_end.x
-                        dy = pts[-1].y - blind_end.y
-                        if dx * dx + dy * dy >= tr2:
-                            break
-                        pts.pop()
-                    if pts:
-                        dx = blind_end.x - pts[-1].x
-                        dy = blind_end.y - pts[-1].y
-                        seg = math.sqrt(dx * dx + dy * dy)
-                        if seg > _PREC:
-                            pts.append(FreeCAD.Vector(
-                                blind_end.x - (dx / seg) * tool_radius,
-                                blind_end.y - (dy / seg) * tool_radius,
-                                blind_end.z,
-                            ))
+                _apply_blind_end_compensation(pts, tool_radius, tol)
 
             if obj.ReverseDirection:
                 pts = list(reversed(pts))
@@ -1809,7 +1879,10 @@ class ObjectFlute(PathOp.ObjectOp):
                 continue
 
             cmds = WireFollowGenerator.generate(
-                pass_wire, retract_z, self.horizFeed, self.vertFeed,
+                pass_wire,
+                retract_z,
+                self.horizFeed,
+                self.vertFeed,
                 arc_chord=tol.arc_chord,
             )
             if cmds:
@@ -1992,10 +2065,12 @@ class ObjectFlute(PathOp.ObjectOp):
             if wire is None:
                 # Fall back to a plain ramp wire using the centerline endpoints.
                 Path.Log.debug("CAM_Flute: falling back to plain ramp wire\n")
-                wire = _pts_to_wire([
-                    FreeCAD.Vector(section_info["start"]),
-                    FreeCAD.Vector(section_info["end"]),
-                ])
+                wire = _pts_to_wire(
+                    [
+                        FreeCAD.Vector(section_info["start"]),
+                        FreeCAD.Vector(section_info["end"]),
+                    ]
+                )
                 if wire is None:
                     continue
             else:
@@ -2031,9 +2106,7 @@ class ObjectFlute(PathOp.ObjectOp):
             edge_by_id = {id(e): sub for e, sub, _b in edge_tuples}
             wire_groups = _split_into_wires([e for e, _sub, _b in edge_tuples], tol)
             Path.Log.debug(
-                "CAM_Flute: {} edge(s) -> {} wire(s)\n".format(
-                    len(edge_tuples), len(wire_groups)
-                )
+                "CAM_Flute: {} edge(s) -> {} wire(s)\n".format(len(edge_tuples), len(wire_groups))
             )
 
             flat_groups = [wg for wg in wire_groups if _wire_is_flat(wg, tol)]
@@ -2044,45 +2117,65 @@ class ObjectFlute(PathOp.ObjectOp):
                     "Flute: mixed 2D (flat) and 3D wires in the same selection "
                     "are not supported. Use separate operations for each type.\n"
                 )
-            else:
-                for wire_edges in wire_groups:
+            elif flat_groups:
+                # 2D path: split connected groups into collinear sub-groups.
+                # Edges that are connected but NOT collinear (L-shapes, curves)
+                # each become their own independent flute path.
+                flute_type = getattr(obj, "FlutingType", "Ramp Full")
+                ramp_type = getattr(obj, "RampType", "Linear")
+                ramp_frac = 1.0  # full wire; overridden by RampLength if set
+                flip = getattr(obj, "FlipStart2D", False)
+                processed_groups = _split_2d_wire_groups(flat_groups, tol)
+                Path.Log.debug(
+                    "CAM_Flute: {} flat group(s) -> {} 2D flute path(s) after collinearity split\n".format(
+                        len(flat_groups), len(processed_groups)
+                    )
+                )
+                for wire_edges in processed_groups:
                     sub_names = [edge_by_id.get(id(e), "?") for e in wire_edges]
-
-                    if flat_groups:
-                        flute_type = getattr(obj, "FlutingType", "Ramp Full")
-                        ramp_type = getattr(obj, "RampType", "Linear")
-                        ramp_pct = getattr(obj, "RampPercent", 100.0)
-                        ramp_frac = max(0.0, min(1.0, ramp_pct / 100.0))
-                        flip = getattr(obj, "FlipStart2D", False)
-                        tool_pos, emitted = self._emit2dPasses(
-                            obj, wire_edges, flute_type, ramp_type, ramp_frac, flip,
-                            op_start_z, op_final_z, axial_leave, finish_d, step_down,
-                            retract_z, linking_kwargs, tool_pos, tol, sub_names,
-                        )
-                        any_path = any_path or emitted
-                    else:
-                        # 3D wire: edges carry Z information directly.
-                        wire, geo_top_z, geo_floor_z = _wire_from_edges(wire_edges, tol)
-                        if wire is None:
-                            continue
-
-                        tool_pos, emitted = self._emitFlutePath(
-                            obj,
-                            wire,
-                            geo_top_z,
-                            geo_floor_z,
-                            sub_names,
-                            op_start_z,
-                            op_final_z,
-                            axial_leave,
-                            finish_d,
-                            step_down,
-                            retract_z,
-                            linking_kwargs,
-                            tool_pos,
-                            tol,
-                        )
-                        any_path = any_path or emitted
+                    tool_pos, emitted = self._emit2dPasses(
+                        obj,
+                        wire_edges,
+                        flute_type,
+                        ramp_type,
+                        ramp_frac,
+                        flip,
+                        op_start_z,
+                        op_final_z,
+                        axial_leave,
+                        finish_d,
+                        step_down,
+                        retract_z,
+                        linking_kwargs,
+                        tool_pos,
+                        tol,
+                        sub_names,
+                    )
+                    any_path = any_path or emitted
+            else:
+                # 3D wires: edges carry Z information directly.
+                for wire_edges in solid_groups:
+                    sub_names = [edge_by_id.get(id(e), "?") for e in wire_edges]
+                    wire, geo_top_z, geo_floor_z = _wire_from_edges(wire_edges, tol)
+                    if wire is None:
+                        continue
+                    tool_pos, emitted = self._emitFlutePath(
+                        obj,
+                        wire,
+                        geo_top_z,
+                        geo_floor_z,
+                        sub_names,
+                        op_start_z,
+                        op_final_z,
+                        axial_leave,
+                        finish_d,
+                        step_down,
+                        retract_z,
+                        linking_kwargs,
+                        tool_pos,
+                        tol,
+                    )
+                    any_path = any_path or emitted
 
         if not any_path:
             self.commandlist.clear()
@@ -2108,7 +2201,6 @@ def SetupProperties():
         "FlutingType",
         "RampType",
         "RampLength",
-        "RampPercent",
         "FlipStart2D",
     ]
 

--- a/src/Mod/CAM/Path/Op/Flute.py
+++ b/src/Mod/CAM/Path/Op/Flute.py
@@ -58,6 +58,10 @@ _WALL_DS_MIN = _PREC * 10  # floating-point "is this exactly zero" epsilon
 # channel's edges converge there too and would give a false degenerate signal.
 _PCA_DEGENERATE_T_VALUES = (0.25, 0.5, 0.75)
 _VBIT_ANGLE_FRAC = 0.025  # 2.5% of groove half-angle — fuzzy margin for V-bit fit check
+# Max deviation of the oriented tangent dot product from 1.0 for two connected
+# edges to count as one continuous flute (same idiom as the old collinearity
+# test).  1e-3 ≈ 2.6° kink; below it edges merge, above it a corner splits.
+_TANGENT_DOT_TOL = 1e-3
 
 _Tol = collections.namedtuple(
     "_Tol",
@@ -745,74 +749,81 @@ def _pts_to_wire(pts):
 # ---------------------------------------------------------------------------
 
 
-def _is_straight_line_edge(edge):
-    """True if the edge's underlying curve is a straight line."""
-    try:
-        cname = edge.Curve.__class__.__name__
-        if cname in ("Line", "LineSegment"):
-            return True
-        # Geometric fallback: arc length == chord length (works for any curve type name)
-        p0 = edge.Vertexes[0].Point
-        p1 = edge.Vertexes[-1].Point
-        chord = (p1 - p0).Length
-        return abs(edge.Length - chord) < max(1e-5, edge.Length * 1e-5)
-    except Exception:
-        return False
-
-
-def _edges_are_collinear(e1, e2, tol):
-    """True if two straight-line edges lie on the same infinite line."""
-    try:
-        d1 = e1.Vertexes[-1].Point - e1.Vertexes[0].Point
-        d2 = e2.Vertexes[-1].Point - e2.Vertexes[0].Point
-        l1 = d1.Length
-        l2 = d2.Length
-        if l1 < _PREC or l2 < _PREC:
-            return False
-        # Explicit unit vectors — avoids FreeCAD.Vector.normalize() in-place ambiguity
-        u1x, u1y, u1z = d1.x / l1, d1.y / l1, d1.z / l1
-        u2x, u2y, u2z = d2.x / l2, d2.y / l2, d2.z / l2
-        # Directions must be parallel (dot product of unit vectors ≈ ±1)
-        dot = u1x * u2x + u1y * u2y + u1z * u2z
-        if abs(abs(dot) - 1.0) > 1e-3:
-            return False
-        # Perpendicular distance from e2.Vertexes[0] to the infinite line through e1
-        p0 = e1.Vertexes[0].Point
-        p1 = e2.Vertexes[0].Point
-        dx, dy, dz = p1.x - p0.x, p1.y - p0.y, p1.z - p0.z
-        proj = dx * u1x + dy * u1y + dz * u1z
-        px = dx - u1x * proj
-        py = dy - u1y * proj
-        pz = dz - u1z * proj
-        perp_sq = px * px + py * py + pz * pz
-        return perp_sq < (tol.pca_degenerate**2)
-    except Exception:
-        return False
-
-
-def _split_2d_wire_groups(groups, tol):
-    """Post-process flat (2D) wire groups for independent flute paths.
-
-    A group of connected edges is kept as ONE path only when every edge is a
-    straight line AND all edges are collinear — i.e. they form a single
-    longer straight segment.  Any group that contains arcs, curves, or
-    non-collinear line segments is split into individual single-edge groups
-    so each edge becomes its own independent flute path.
+def _tangent_at_endpoint(edge, endpoint):
+    """Unit tangent of edge at whichever of its ends is nearest `endpoint`,
+    pointing in the direction of increasing parameter.  Returns None on failure.
     """
-    result = []
-    for group in groups:
-        if len(group) == 1:
-            result.append(group)
-            continue
-        if all(_is_straight_line_edge(e) for e in group):
-            ref = group[0]
-            if all(_edges_are_collinear(ref, e, tol) for e in group[1:]):
-                result.append(group)
-                continue
-        # Non-collinear or contains curves: one group per edge
-        for edge in group:
-            result.append([edge])
-    return result
+    try:
+        p_first = edge.valueAt(edge.FirstParameter)
+        p_last = edge.valueAt(edge.LastParameter)
+        if endpoint.distanceToPoint(p_first) <= endpoint.distanceToPoint(p_last):
+            param = edge.FirstParameter
+        else:
+            param = edge.LastParameter
+        t = edge.tangentAt(param)
+        length = t.Length
+        if length < _PREC:
+            return None
+        return FreeCAD.Vector(t.x / length, t.y / length, t.z / length)
+    except Exception:
+        return None
+
+
+def _tangent_continuous(prev_edge, cur_edge, junction, prev_start, cur_end):
+    """True if two connected edges meet smoothly (G1) at `junction`.
+
+    Compares the travel direction arriving along prev_edge (prev_start → junction)
+    with the travel direction departing along cur_edge (junction → cur_end).  A
+    collinear pair of straight lines and a pair of smoothly-joined arcs both pass;
+    a sharp corner (L-shape) fails.  tangentAt is orientation-agnostic, so each
+    tangent is flipped to match the actual direction of travel before comparison.
+    """
+    t1 = _tangent_at_endpoint(prev_edge, junction)
+    t2 = _tangent_at_endpoint(cur_edge, junction)
+    if t1 is None or t2 is None:
+        return False
+    # Sign of each tangent along its travel direction.
+    arrive = junction - prev_start
+    depart = cur_end - junction
+    d = t1.dot(t2)
+    if t1.dot(arrive) < 0:
+        d = -d
+    if t2.dot(depart) < 0:
+        d = -d
+    # d ≈ 1 when the travel directions align (smooth); deviation grows with kink.
+    return (1.0 - d) <= _TANGENT_DOT_TOL
+
+
+def _split_at_corners(edges, tol):
+    """Order a connected edge set and split it into tangent-continuous sub-chains.
+
+    Consecutive edges that meet smoothly (collinear straight lines or
+    smoothly-joined curves) stay in one sub-chain; a sharp corner starts a new
+    one, so each sub-chain becomes an independent flute path.  If the edges do
+    not form a single simple open chain (branching / not connected), each edge
+    is returned as its own sub-chain.
+
+    Returns a list of ordered edge lists.
+    """
+    if len(edges) == 1:
+        return [list(edges)]
+
+    chain = _chain_wire_edges(edges, tol)
+    if not chain:
+        return [[edge] for edge in edges]
+
+    subchains = []
+    current = [chain[0][2]]
+    for i in range(1, len(chain)):
+        prev_start, junction, prev_edge = chain[i - 1]
+        _cur_start, cur_end, cur_edge = chain[i]
+        if _tangent_continuous(prev_edge, cur_edge, junction, prev_start, cur_end):
+            current.append(cur_edge)
+        else:
+            subchains.append(current)
+            current = [cur_edge]
+    subchains.append(current)
+    return subchains
 
 
 def _split_into_wires(edges, tol):
@@ -1258,7 +1269,7 @@ def _apply_2d_profile(
     """Synthesize a 3D wire from a flat (constant-Z) edge set by applying a Z ramp profile.
 
     flute_type:     "Ramp Full" | "Ramp Start" | "Ramp Start End"
-    ramp_type:      "Linear" | "Smooth" | "Arc"
+    ramp_type:      "Linear" | "S-Curve" | "Smooth" | "Fillet"
     ramp_frac:      fraction of total path length occupied by ramp(s) (0–1).
                     Ignored when ramp_length_mm > 0.
     ramp_length_mm: if > 0, overrides ramp_frac with length/total_wire_length.
@@ -1352,10 +1363,21 @@ def _apply_2d_profile(
         else:
             f = t
 
-        if ramp_type == "Smooth":
-            f = f * f * (3.0 - 2.0 * f)  # smoothstep S-curve, zero slope at both ends
-        elif ramp_type == "Arc":
-            f = math.sin(f * math.pi / 2)  # quarter-circle arc, zero slope at floor end
+        # f is the normalized ramp position: 0 at the surface entry, 1 at the
+        # floor.  Each curve reshapes it into a depth fraction.
+        if ramp_type == "S-Curve":
+            # Smoothstep: zero slope at BOTH ends (eased entry and floor).
+            f = f * f * (3.0 - 2.0 * f)
+        elif ramp_type == "Smooth":
+            # Quarter-sine: tangent (zero slope) at the floor, angled entry.
+            # Length-driven; the tangent flattening compresses as the ramp
+            # length shrinks relative to depth.
+            f = math.sin(f * math.pi / 2)
+        elif ramp_type == "Fillet":
+            # Quarter-ellipse: the roundest tangent-to-floor blend that fits the
+            # ramp box, so the tool rolls tangentially into the floor for any
+            # ramp length/depth.  Steeper (near-vertical) at the entry.
+            f = math.sqrt(max(0.0, 1.0 - (1.0 - f) ** 2))
 
         return start_z - f * depth
 
@@ -1448,11 +1470,12 @@ class ObjectFlute(PathOp.ObjectOp):
             "Flute2D",
             QtCore.QT_TRANSLATE_NOOP(
                 "App::Property",
-                "Shape of the Z ramp on 2D wires: Linear is a straight "
-                "plunge; Smooth uses a smoothstep curve.",
+                "Shape of the Z ramp on 2D wires: Linear is a straight plunge; "
+                "S-Curve eases at both ends; Smooth is tangent to the floor "
+                "with an angled entry; Fillet rounds tangentially into the floor.",
             ),
         )
-        obj.RampType = ["Linear", "Smooth", "Arc"]
+        obj.RampType = ["Linear", "S-Curve", "Smooth", "Fillet"]
         obj.addProperty(
             "App::PropertyBool",
             "FlipStart2D",
@@ -1540,96 +1563,6 @@ class ObjectFlute(PathOp.ObjectOp):
     def onChanged(self, obj, prop):
         if prop == "Active" and obj.ViewObject:
             obj.ViewObject.signalChangeIcon()
-
-    def opOnDocumentRestored(self, obj):
-        if not hasattr(obj, "BlindEndCompensation"):
-            obj.addProperty(
-                "App::PropertyBool",
-                "BlindEndCompensation",
-                "Flute",
-                QtCore.QT_TRANSLATE_NOOP(
-                    "App::Property",
-                    "Pull the path end back by the tool radius when the flute "
-                    "terminates at depth (blind end). Has no effect when the "
-                    "path ramps back up to stock surface.",
-                ),
-            )
-            obj.BlindEndCompensation = False
-        if not hasattr(obj, "FlutingType"):
-            obj.addProperty(
-                "App::PropertyEnumeration",
-                "FlutingType",
-                "Flute2D",
-                QtCore.QT_TRANSLATE_NOOP(
-                    "App::Property",
-                    "Z profile applied when a flat (2D) wire is selected.",
-                ),
-            )
-            obj.FlutingType = ["Ramp Full", "Ramp Start", "Ramp Start End"]
-            obj.FlutingType = "Ramp Full"
-        else:
-            # Migrate old enum values saved without spaces
-            _migrate = {
-                "RampFull": "Ramp Full",
-                "RampStart": "Ramp Start",
-                "RampStartEnd": "Ramp Start End",
-            }
-            old_val = str(obj.FlutingType)
-            if old_val in _migrate:
-                obj.FlutingType = ["Ramp Full", "Ramp Start", "Ramp Start End"]
-                obj.FlutingType = _migrate[old_val]
-        if not hasattr(obj, "RampType"):
-            obj.addProperty(
-                "App::PropertyEnumeration",
-                "RampType",
-                "Flute2D",
-                QtCore.QT_TRANSLATE_NOOP(
-                    "App::Property",
-                    "Shape of the Z ramp on 2D wires.",
-                ),
-            )
-            obj.RampType = ["Linear", "Smooth", "Arc"]
-            obj.RampType = "Linear"
-        # Migrate: RampPercent was dropped in favour of RampLength (mm).
-        if hasattr(obj, "RampPercent"):
-            try:
-                obj.removeProperty("RampPercent")
-            except Exception:
-                pass
-        if not hasattr(obj, "FlipStart2D"):
-            obj.addProperty(
-                "App::PropertyBool",
-                "FlipStart2D",
-                "Flute2D",
-                QtCore.QT_TRANSLATE_NOOP(
-                    "App::Property",
-                    "Reverse which end of the flat wire is the ramp entry point.",
-                ),
-            )
-            obj.FlipStart2D = False
-        if not hasattr(obj, "RampLength"):
-            obj.addProperty(
-                "App::PropertyDistance",
-                "RampLength",
-                "Flute2D",
-                QtCore.QT_TRANSLATE_NOOP(
-                    "App::Property",
-                    "Length of each ramp segment in mm. When > 0, overrides Ramp %.",
-                ),
-            )
-            obj.RampLength = 0.0
-        if not hasattr(obj, "MultiPassStrategy"):
-            obj.addProperty(
-                "App::PropertyEnumeration",
-                "MultiPassStrategy",
-                "Flute",
-                QtCore.QT_TRANSLATE_NOOP(
-                    "App::Property",
-                    "How roughing passes are distributed across step-down depths.",
-                ),
-            )
-            obj.MultiPassStrategy = ["Constant Angle", "Variable Angle"]
-            obj.MultiPassStrategy = "Constant Angle"
 
     def _emitFlutePath(
         self,
@@ -2125,9 +2058,11 @@ class ObjectFlute(PathOp.ObjectOp):
                 ramp_type = getattr(obj, "RampType", "Linear")
                 ramp_frac = 1.0  # full wire; overridden by RampLength if set
                 flip = getattr(obj, "FlipStart2D", False)
-                processed_groups = _split_2d_wire_groups(flat_groups, tol)
+                processed_groups = []
+                for group in flat_groups:
+                    processed_groups.extend(_split_at_corners(group, tol))
                 Path.Log.debug(
-                    "CAM_Flute: {} flat group(s) -> {} 2D flute path(s) after collinearity split\n".format(
+                    "CAM_Flute: {} flat group(s) -> {} 2D flute path(s) after corner split\n".format(
                         len(flat_groups), len(processed_groups)
                     )
                 )
@@ -2153,8 +2088,13 @@ class ObjectFlute(PathOp.ObjectOp):
                     )
                     any_path = any_path or emitted
             else:
-                # 3D wires: edges carry Z information directly.
-                for wire_edges in solid_groups:
+                # 3D wires: edges carry Z information directly.  Split each
+                # connected component at sharp corners so a smooth run (straight
+                # or curved) is one flute and an L-corner becomes two.
+                solid_paths = []
+                for group in solid_groups:
+                    solid_paths.extend(_split_at_corners(group, tol))
+                for wire_edges in solid_paths:
                     sub_names = [edge_by_id.get(id(e), "?") for e in wire_edges]
                     wire, geo_top_z, geo_floor_z = _wire_from_edges(wire_edges, tol)
                     if wire is None:

--- a/src/Mod/CAM/Path/Op/Flute.py
+++ b/src/Mod/CAM/Path/Op/Flute.py
@@ -28,15 +28,15 @@ import collections
 import math
 
 import FreeCAD
+from lazy_loader.lazy_loader import LazyLoader
+from PathScripts import PathUtils
 from PySide import QtCore
+
 import Path
+import Path.Base.Generator.follow_wire as WireFollowGenerator
 import Path.Geom as PathGeom
 import Path.Op.Base as PathOp
-import Path.Base.Generator.follow_wire as WireFollowGenerator
-import Path.Base.Generator.linking as linking
-import PathScripts.PathUtils as PathUtils
-
-from lazy_loader.lazy_loader import LazyLoader
+from Path.Base.Generator import linking
 
 Part = LazyLoader("Part", globals(), "Part")
 
@@ -153,27 +153,10 @@ def _analyze_face_cylinder(face):
 
         Path.Log.debug(
             "CAM_Flute BoundBox:\n"
-            "  X: [{:.4f}, {:.4f}]  Y: [{:.4f}, {:.4f}]  Z: [{:.4f}, {:.4f}]\n"
-            "  axis=({:.4f},{:.4f},{:.4f})  radius={:.4f}\n"
+            f"  X: [{bb.XMin:.4f}, {bb.XMax:.4f}]  Y: [{bb.YMin:.4f}, {bb.YMax:.4f}]  Z: [{bb.ZMin:.4f}, {bb.ZMax:.4f}]\n"
+            f"  axis=({axis.x:.4f},{axis.y:.4f},{axis.z:.4f})  radius={radius:.4f}\n"
             "CAM_Flute centerline:\n"
-            "  start=({:.4f},{:.4f},{:.4f})  end=({:.4f},{:.4f},{:.4f})\n".format(
-                bb.XMin,
-                bb.XMax,
-                bb.YMin,
-                bb.YMax,
-                bb.ZMin,
-                bb.ZMax,
-                axis.x,
-                axis.y,
-                axis.z,
-                radius,
-                p_start.x,
-                p_start.y,
-                p_start.z,
-                p_end.x,
-                p_end.y,
-                p_end.z,
-            )
+            f"  start=({p_start.x:.4f},{p_start.y:.4f},{p_start.z:.4f})  end=({p_end.x:.4f},{p_end.y:.4f},{p_end.z:.4f})\n"
         )
 
         def _clean(v, tol=_PREC):
@@ -186,6 +169,8 @@ def _analyze_face_cylinder(face):
             "width": _clean(2.0 * radius),
         }
     except Exception:
+        # Null/invalid shape, or not a face at all - report "not a
+        # cylinder" so the caller falls back to PCA analysis.
         return None
 
 
@@ -204,6 +189,8 @@ def _line_coincides_with_an_edge(face, p_a, p_b, tol):
     try:
         edges = face.Edges
     except Exception:
+        # A face with no readable edge list can't be tested for
+        # coincidence; treat it as "does not coincide".
         return False
 
     for edge in edges:
@@ -217,6 +204,8 @@ def _line_coincides_with_an_edge(face, p_a, p_b, tol):
             try:
                 dist = edge.distToShape(Part.Vertex(p))[0]
             except Exception:
+                # Edge that won't accept a distance query - stop testing this
+                # edge and move on to the next one.
                 coincides = False
                 break
             if dist > tol.pca_degenerate:
@@ -241,6 +230,8 @@ def _analyze_face_pca(face, tol):
         for edge in face.Edges:
             pts.extend(edge.discretize(Number=100))
     except Exception:
+        # Degenerate/unsupported edge geometry - fall through with whatever
+        # points were collected; the length check below handles the rest.
         pass
 
     if len(pts) < 4:
@@ -371,6 +362,8 @@ def _is_valley_edge(edge, face_a, face_b):
         face_z = (face_a.CenterOfMass.z + face_b.CenterOfMass.z) / 2.0
         return edge_z < face_z - _PREC * 10
     except Exception:
+        # Edge or face with no computable centre of mass (degenerate
+        # geometry) - can't be confirmed as a valley edge.
         return False
 
 
@@ -502,6 +495,8 @@ def _centerline_from_valley_edge(edges, face_tuples, tol):
                 groove_half_angle = math.degrees(math.asin(min(1.0, abs(n.z) / nlen)))
                 break
         except Exception:
+            # Surface has no well-defined Axis (e.g. a plane) - try the next
+            # face; groove_half_angle keeps its default if none qualify.
             pass
 
     def _clean(val, tol=_PREC):
@@ -524,6 +519,8 @@ def _centerline_from_faces(face_tuples):
             for edge in face.OuterWire.Edges:
                 pts.extend(edge.discretize(Number=20))
         except Exception:
+            # Skip a face whose outer wire can't be discretized; the PCA
+            # below just runs on points from whichever faces succeeded.
             pass
 
     if len(pts) < 2:
@@ -608,6 +605,8 @@ def _check_tool_fit(info, tool):
         try:
             tool_ha = tool.CuttingEdgeAngle.Value / 2.0
         except Exception:
+            # Tool has no CuttingEdgeAngle (not a V-bit after all) - a zero
+            # half-angle disables the fit check below.
             tool_ha = 0.0
 
         groove_ha = info.get("groove_half_angle", 0.0)
@@ -619,9 +618,7 @@ def _check_tool_fit(info, tool):
                 groove_ha = math.degrees(math.atan2(width / 2.0, depth))
 
         Path.Log.debug(
-            "CAM_Flute: tool half-angle={:.2f}° groove half-angle={:.2f}°\n".format(
-                tool_ha, groove_ha
-            )
+            f"CAM_Flute: tool half-angle={tool_ha:.2f}° groove half-angle={groove_ha:.2f}°\n"
         )
         if tool_ha > 0.0 and groove_ha > 0.0 and tool_ha > groove_ha * (1.0 + _VBIT_ANGLE_FRAC):
             FreeCAD.Console.PrintWarning(
@@ -648,8 +645,8 @@ def _get_centerline(group, tol):
     else:
         # >2 faces with no detected valley edge: run PCA across all faces
         Path.Log.debug(
-            "Flute group has {} faces with no detected valley edge; "
-            "falling back to combined PCA.\n".format(len(face_tuples))
+            f"Flute group has {len(face_tuples)} faces with no detected valley edge; "
+            "falling back to combined PCA.\n"
         )
         return _centerline_from_faces(face_tuples)
 
@@ -684,7 +681,7 @@ def _clip_and_scale(pts, f, stock_top_z):
     for i in range(n - 2, -1, -1):
         dx = pts[i].x - pts[i + 1].x
         dy = pts[i].y - pts[i + 1].y
-        rev[i] = rev[i + 1] + math.sqrt(dx * dx + dy * dy)
+        rev[i] = rev[i + 1] + math.hypot(dx, dy)
 
     L_total = rev[0]
     if L_total < _PREC:
@@ -740,6 +737,8 @@ def _pts_to_wire(pts):
     try:
         return Part.Wire(edges)
     except Exception:
+        # OCC rejected the edge chain (self-intersecting or otherwise
+        # unbuildable) - the caller skips this path.
         return None
 
 
@@ -766,6 +765,8 @@ def _tangent_at_endpoint(edge, endpoint):
             return None
         return FreeCAD.Vector(t.x / length, t.y / length, t.z / length)
     except Exception:
+        # Edge that can't be evaluated or has no tangent at the endpoint
+        # - the caller treats "no tangent" as "not continuous".
         return None
 
 
@@ -985,7 +986,7 @@ def _detect_floor_wire(face, base_obj, info, tol, group_extent=None):
 
         dx = end_info.x - start.x
         dy = end_info.y - start.y
-        L = math.sqrt(dx * dx + dy * dy)
+        L = math.hypot(dx, dy)
         if L < _PREC:
             return None, None, None
 
@@ -1018,7 +1019,7 @@ def _detect_floor_wire(face, base_obj, info, tol, group_extent=None):
             Path.Log.debug("CAM_Flute: section returned no edges\n")
             return None, None, None
 
-        Path.Log.debug("CAM_Flute: section returned {} edge(s)\n".format(len(all_edges)))
+        Path.Log.debug(f"CAM_Flute: section returned {len(all_edges)} edge(s)\n")
 
         # --- filter candidates --------------------------------------------------
         def path_proj(v):
@@ -1051,7 +1052,7 @@ def _detect_floor_wire(face, base_obj, info, tol, group_extent=None):
             Path.Log.debug("CAM_Flute: no floor edge candidates\n")
             return None, None, None
 
-        Path.Log.debug("CAM_Flute: {} candidate floor edge(s)\n".format(len(candidates)))
+        Path.Log.debug(f"CAM_Flute: {len(candidates)} candidate floor edge(s)\n")
 
         # --- chain from start ---------------------------------------------------
         def _orient(edge, toward_pt):
@@ -1100,7 +1101,7 @@ def _detect_floor_wire(face, base_obj, info, tol, group_extent=None):
             chain.append((nxt_s, nxt_end, nxt_e))
             cur_e = nxt_end
 
-        Path.Log.debug("CAM_Flute: chained {} edge(s)\n".format(len(chain)))
+        Path.Log.debug(f"CAM_Flute: chained {len(chain)} edge(s)\n")
 
         # --- convert chain to wire ----------------------------------------------
         pts = PathGeom.edgesToPoints(
@@ -1131,17 +1132,18 @@ def _detect_floor_wire(face, base_obj, info, tol, group_extent=None):
             return None, None, None
 
         Path.Log.debug(
-            "CAM_Flute: floor wire {} pts, floor_z={:.3f}, top_z={:.3f}\n".format(
-                len(pts), floor_z, top_z
-            )
+            f"CAM_Flute: floor wire {len(pts)} pts, floor_z={floor_z:.3f}, top_z={top_z:.3f}\n"
         )
         return wire, floor_z, top_z
 
     except Exception as exc:
+        # Floor detection is best-effort: any failure here just means
+        # this face gets handled by the 2D/PCA path instead, so log the
+        # cause for debugging and report no waypoints.
         import traceback
 
         Path.Log.debug(
-            "CAM_Flute: _detect_floor_waypoints error: {}\n{}\n".format(exc, traceback.format_exc())
+            f"CAM_Flute: _detect_floor_waypoints error: {exc}\n{traceback.format_exc()}\n"
         )
         return None, None, None
 
@@ -1240,7 +1242,7 @@ def _apply_blind_end_compensation(pts, tool_radius, tol):
 
     dx = blind_end.x - pts[-1].x
     dy = blind_end.y - pts[-1].y
-    seg_len = math.sqrt(dx * dx + dy * dy)
+    seg_len = math.hypot(dx, dy)
     if seg_len > _PREC:
         pts.append(
             FreeCAD.Vector(
@@ -1310,7 +1312,7 @@ def _apply_2d_profile(
     for i in range(1, n):
         dx = raw[i].x - raw[i - 1].x
         dy = raw[i].y - raw[i - 1].y
-        arc_len[i] = arc_len[i - 1] + math.sqrt(dx * dx + dy * dy)
+        arc_len[i] = arc_len[i - 1] + math.hypot(dx, dy)
     total_full = arc_len[-1]
     if total_full < _PREC:
         return None
@@ -1745,6 +1747,8 @@ class ObjectFlute(PathOp.ObjectOp):
             try:
                 tool_radius = obj.ToolController.Tool.Diameter.Value / 2.0
             except Exception:
+                # No tool controller or tool assigned yet - a zero radius
+                # disables blind-end compensation rather than failing the op.
                 tool_radius = 0.0
             _apply_blind_end_compensation(pts, tool_radius, tol)
 
@@ -1921,15 +1925,11 @@ class ObjectFlute(PathOp.ObjectOp):
         if not fp:
             return tool_pos, False
 
-        entry_pos = FreeCAD.Vector(fp[0].x, fp[0].y, obj.SafeHeight.Value)
-        if tool_pos is not None:
-            linking_kwargs["start_position"] = tool_pos
-            linking_kwargs["target_position"] = entry_pos
-            self.commandlist.extend(linking.get_linking_moves(**linking_kwargs))
-
         try:
             tool_radius = obj.ToolController.Tool.Diameter.Value / 2.0
         except Exception:
+            # No tool controller or tool assigned yet - a zero radius
+            # disables blind-end compensation rather than failing the op.
             tool_radius = 0.0
 
         # Blind-end compensation only applies when the path ends at floor depth.
@@ -1939,6 +1939,19 @@ class ObjectFlute(PathOp.ObjectOp):
             and tool_radius > _PREC * 10
             and flute_type != "Ramp Start End"
         )
+
+        # fp must go through the same transforms the pass loop below applies,
+        # or the entry move targets a point the cut doesn't actually start at.
+        if do_blind:
+            _apply_blind_end_compensation(fp, tool_radius, tol)
+        if obj.ReverseDirection:
+            fp = list(reversed(fp))
+
+        entry_pos = FreeCAD.Vector(fp[0].x, fp[0].y, obj.SafeHeight.Value)
+        if tool_pos is not None:
+            linking_kwargs["start_position"] = tool_pos
+            linking_kwargs["target_position"] = entry_pos
+            self.commandlist.extend(linking.get_linking_moves(**linking_kwargs))
 
         emitted = False
         last_pts = fp
@@ -2013,7 +2026,7 @@ class ObjectFlute(PathOp.ObjectOp):
                 if elem.ShapeType == "Face":
                     face_tuples.append((elem, sub, base))
                 elif elem.ShapeType == "Edge":
-                    if "{}.{}".format(base.Name, sub) in flipped_keys:
+                    if f"{base.Name}.{sub}" in flipped_keys:
                         flipped = PathGeom.flipEdge(elem)
                         if flipped is not None:
                             elem = flipped
@@ -2028,14 +2041,12 @@ class ObjectFlute(PathOp.ObjectOp):
         groups = _group_flutes(face_tuples, tol) if face_tuples else []
 
         Path.Log.debug(
-            "CAM_Flute: {} face(s) -> {} group(s), {} edge(s)\n".format(
-                len(face_tuples), len(groups), len(edge_tuples)
-            )
+            f"CAM_Flute: {len(face_tuples)} face(s) -> {len(groups)} group(s), {len(edge_tuples)} edge(s)\n"
         )
 
         if obj.Comment:
-            self.commandlist.append(Path.Command("({})".format(obj.Comment)))
-        self.commandlist.append(Path.Command("({})".format(obj.Label)))
+            self.commandlist.append(Path.Command(f"({obj.Comment})"))
+        self.commandlist.append(Path.Command(f"({obj.Label})"))
         self.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeight.Value}))
 
         solids = []
@@ -2138,9 +2149,9 @@ class ObjectFlute(PathOp.ObjectOp):
             # Compute the XY span of ALL faces in the group so the section
             # plane covers ramp + flat + any exit ramp.
             bb_list = [ft[0].BoundBox for ft in group["faces"]]
-            group_xy_span = math.sqrt(
-                (max(b.XMax for b in bb_list) - min(b.XMin for b in bb_list)) ** 2
-                + (max(b.YMax for b in bb_list) - min(b.YMin for b in bb_list)) ** 2
+            group_xy_span = math.hypot(
+                max(b.XMax for b in bb_list) - min(b.XMin for b in bb_list),
+                max(b.YMax for b in bb_list) - min(b.YMin for b in bb_list),
             )
             wire, detected_floor_z, detected_top_z = _detect_floor_wire(
                 section_face, section_base, section_info, tol, group_extent=group_xy_span
@@ -2189,9 +2200,7 @@ class ObjectFlute(PathOp.ObjectOp):
         if edge_tuples:
             edge_by_id = {id(e): sub for e, sub, _b in edge_tuples}
             wire_groups = _split_into_wires([e for e, _sub, _b in edge_tuples], tol)
-            Path.Log.debug(
-                "CAM_Flute: {} edge(s) -> {} wire(s)\n".format(len(edge_tuples), len(wire_groups))
-            )
+            Path.Log.debug(f"CAM_Flute: {len(edge_tuples)} edge(s) -> {len(wire_groups)} wire(s)\n")
 
             flat_groups = [wg for wg in wire_groups if _wire_is_flat(wg, tol)]
             solid_groups = [wg for wg in wire_groups if not _wire_is_flat(wg, tol)]
@@ -2220,9 +2229,7 @@ class ObjectFlute(PathOp.ObjectOp):
                 for group in flat_groups:
                     processed_groups.extend(_split_at_corners(group, tol, combine=combine_tangent))
                 Path.Log.debug(
-                    "CAM_Flute: {} flat group(s) -> {} 2D flute path(s) after corner split\n".format(
-                        len(flat_groups), len(processed_groups)
-                    )
+                    f"CAM_Flute: {len(flat_groups)} flat group(s) -> {len(processed_groups)} 2D flute path(s) after corner split\n"
                 )
                 for wire_edges in processed_groups:
                     sub_names = [edge_by_id.get(id(e), "?") for e in wire_edges]

--- a/src/Mod/CAM/Path/Op/Flute.py
+++ b/src/Mod/CAM/Path/Op/Flute.py
@@ -1,0 +1,2120 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Billy Huddleston <billy@ivdc.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+__title__ = "CAM Flute Operation"
+__author__ = "Connor (Billy Huddleston <billy@ivdc.com>)"
+__url__ = "https://www.freecad.org"
+__doc__ = "Class and implementation of the Flute operation."
+
+import collections
+import math
+
+import FreeCAD
+from PySide import QtCore
+import Path
+import Path.Geom as PathGeom
+import Path.Op.Base as PathOp
+import Path.Base.Generator.follow_wire as WireFollowGenerator
+import Path.Base.Generator.linking as linking
+import PathScripts.PathUtils as PathUtils
+
+from lazy_loader.lazy_loader import LazyLoader
+
+Part = LazyLoader("Part", globals(), "Part")
+
+translate = FreeCAD.Qt.translate
+
+if False:
+    Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
+    Path.Log.trackModule(Path.Log.thisModule())
+else:
+    Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+
+_PREC = FreeCAD.Base.Precision.confusion()  # standard FreeCAD coincidence epsilon (1e-7)
+
+_SECTION_Z_TOL_FRAC = 0.05  # z_tol = max(1mm, depth * this fraction)
+_CHAIN_MAX_EDGES = 200  # guard against infinite loop (not a tolerance)
+_WALL_SLOPE_MAX = 5.0  # dz/ds above this → discard as a side wall
+_WALL_DS_MIN = _PREC * 10  # floating-point "is this exactly zero" epsilon
+# Middle-only sample points — endpoints excluded because a legitimately tapered
+# channel's edges converge there too and would give a false degenerate signal.
+_PCA_DEGENERATE_T_VALUES = (0.25, 0.5, 0.75)
+_VBIT_ANGLE_FRAC = 0.025  # 2.5% of groove half-angle — fuzzy margin for V-bit fit check
+
+_Tol = collections.namedtuple(
+    "_Tol",
+    ["edge", "chain2", "floor_snap", "axial_floor", "bb_overlap",
+     "section_overshoot", "pca_degenerate", "arc_chord"],
+)
+
+
+def _make_tolerances(geom_tol):
+    """Derive all absolute-distance tolerances from the job's GeometryTolerance.
+    Fallback of 0.01 mm matches the default used across other CAM operations.
+    """
+    t = geom_tol if geom_tol and geom_tol > 0 else 0.01
+    return _Tol(
+        edge=t * 0.01,           # exact topological edge-coincidence
+        chain2=(t * 200.0) ** 2, # vertex snap distance while chaining (stored squared)
+        floor_snap=t * 50.0,     # floor-seam Z snapping
+        axial_floor=t * 50.0,    # axial-leave floor-point detection
+        bb_overlap=t * 100.0,    # face grouping by bounding-box touch
+        section_overshoot=t * 1000.0,  # section-plane / candidate-filter margin
+        pca_degenerate=t * 5.0,  # centerline-coincides-with-edge test
+        arc_chord=t * 10.0,      # arc discretization chord (matches LeadInOut dressup)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Face analysis helpers
+# ---------------------------------------------------------------------------
+
+
+def _analyze_face_cylinder(face):
+    """Centerline from a Part.Cylinder face using the face BoundBox directly.
+
+    The BoundBox gives us everything we need:
+      - Groove center X (or Y): midpoint of the perpendicular extents
+      - Shallow end: the BoundBox extreme at ZMax (stock surface)
+      - Deep end:    the BoundBox extreme at ZMin (floor)
+      - Width:       2 * surface.Radius
+
+    The cylinder axis direction tells us which BoundBox dimension the groove
+    runs along, and the sign of that axis component tells us which extreme
+    is the shallow (entry) end.
+
+    Returns the same dict as _analyze_face_pca, or None if not a cylinder.
+    """
+    try:
+        surface = face.Surface
+        if not isinstance(surface, Part.Cylinder):
+            return None
+
+        axis = surface.Axis
+        radius = surface.Radius
+        bb = face.BoundBox
+
+        ax, ay, az = abs(axis.x), abs(axis.y), abs(axis.z)
+
+        if ay >= ax and ay >= az:
+            # Groove runs primarily in Y
+            cx = (bb.XMin + bb.XMax) / 2.0
+            if axis.y < 0:
+                # Moving along +axis → Y decreases → deep end = YMin
+                p_start = FreeCAD.Vector(cx, bb.YMax, bb.ZMax)
+                p_end = FreeCAD.Vector(cx, bb.YMin, bb.ZMin)
+            else:
+                # Moving along +axis → Y increases → deep end = YMax
+                p_start = FreeCAD.Vector(cx, bb.YMin, bb.ZMax)
+                p_end = FreeCAD.Vector(cx, bb.YMax, bb.ZMin)
+
+        elif ax >= ay and ax >= az:
+            # Groove runs primarily in X
+            cy = (bb.YMin + bb.YMax) / 2.0
+            if axis.x < 0:
+                p_start = FreeCAD.Vector(bb.XMax, cy, bb.ZMax)
+                p_end = FreeCAD.Vector(bb.XMin, cy, bb.ZMin)
+            else:
+                p_start = FreeCAD.Vector(bb.XMin, cy, bb.ZMax)
+                p_end = FreeCAD.Vector(bb.XMax, cy, bb.ZMin)
+
+        else:
+            return None  # Z-dominant - not a typical flute orientation
+
+        Path.Log.debug(
+            "CAM_Flute BoundBox:\n"
+            "  X: [{:.4f}, {:.4f}]  Y: [{:.4f}, {:.4f}]  Z: [{:.4f}, {:.4f}]\n"
+            "  axis=({:.4f},{:.4f},{:.4f})  radius={:.4f}\n"
+            "CAM_Flute centerline:\n"
+            "  start=({:.4f},{:.4f},{:.4f})  end=({:.4f},{:.4f},{:.4f})\n".format(
+                bb.XMin,
+                bb.XMax,
+                bb.YMin,
+                bb.YMax,
+                bb.ZMin,
+                bb.ZMax,
+                axis.x,
+                axis.y,
+                axis.z,
+                radius,
+                p_start.x,
+                p_start.y,
+                p_start.z,
+                p_end.x,
+                p_end.y,
+                p_end.z,
+            )
+        )
+
+        def _clean(v, tol=_PREC):
+            return 0.0 if abs(v) < tol else v
+
+        return {
+            "start": p_start,
+            "end": p_end,
+            "top_z": _clean(bb.ZMax),
+            "width": _clean(2.0 * radius),
+        }
+    except Exception:
+        return None
+
+
+def _line_coincides_with_an_edge(face, p_a, p_b, tol):
+    """True if the MIDDLE portion of the line p_a->p_b lies ON one of the
+    face's own boundary edges (within tol.pca_degenerate).
+
+    A real floor's centerline runs through the face's interior. A face that
+    legitimately tapers to a point at one end (e.g. a pointed channel) will
+    have its boundary edges genuinely converge near that end -- that's not
+    a sign of a missing partner face, so the endpoints are deliberately
+    excluded. Only the middle of the line is tested: a single wall of an
+    unselected V-groove pair has zero interior width along its ENTIRE
+    length, so it still coincides with the shared valley edge there too.
+    """
+    try:
+        edges = face.Edges
+    except Exception:
+        return False
+
+    for edge in edges:
+        coincides = True
+        for t in _PCA_DEGENERATE_T_VALUES:
+            p = FreeCAD.Vector(
+                p_a.x + t * (p_b.x - p_a.x),
+                p_a.y + t * (p_b.y - p_a.y),
+                p_a.z + t * (p_b.z - p_a.z),
+            )
+            try:
+                dist = edge.distToShape(Part.Vertex(p))[0]
+            except Exception:
+                coincides = False
+                break
+            if dist > tol.pca_degenerate:
+                coincides = False
+                break
+        if coincides:
+            return True
+    return False
+
+
+def _analyze_face_pca(face, tol):
+    """Centerline fallback via edge sampling + PCA for non-cylindrical faces.
+
+    Samples all face edges, uses PCA to split into two end-zones, then
+    finds the lowest-Z cluster in each zone.  Key insight: for any groove
+    profile the deepest cross-section point IS on the centreline.
+
+    Returns dict with keys start, end, top_z, width, or None on failure.
+    """
+    pts = []
+    try:
+        for edge in face.Edges:
+            pts.extend(edge.discretize(Number=100))
+    except Exception:
+        pass
+
+    if len(pts) < 4:
+        return None
+
+    mx = sum(p.x for p in pts) / len(pts)
+    my = sum(p.y for p in pts) / len(pts)
+
+    cxx = sum((p.x - mx) ** 2 for p in pts)
+    cyy = sum((p.y - my) ** 2 for p in pts)
+    cxy = sum((p.x - mx) * (p.y - my) for p in pts)
+
+    angle = 0.5 * math.atan2(2.0 * cxy, cxx - cyy)
+    ux, uy = math.cos(angle), math.sin(angle)
+    vx, vy = -uy, ux
+
+    s_vals = [(p.x - mx) * ux + (p.y - my) * uy for p in pts]
+    t_vals = [(p.x - mx) * vx + (p.y - my) * vy for p in pts]
+
+    s_min, s_max = min(s_vals), max(s_vals)
+    span = s_max - s_min
+    if span < _PREC:
+        return None
+
+    zone = span * 0.20
+    a_pts = [p for p, s in zip(pts, s_vals) if s <= s_min + zone]
+    b_pts = [p for p, s in zip(pts, s_vals) if s >= s_max - zone]
+
+    if not a_pts or not b_pts:
+        return None
+
+    def _lowest_z_center(zone_pts):
+        z_floor = min(p.z for p in zone_pts)
+        z_range = max(p.z for p in zone_pts) - z_floor
+        tol = max(0.01, z_range * 0.02)
+        near = [p for p in zone_pts if p.z <= z_floor + tol]
+        return FreeCAD.Vector(
+            sum(p.x for p in near) / len(near),
+            sum(p.y for p in near) / len(near),
+            sum(p.z for p in near) / len(near),
+        )
+
+    p_a = _lowest_z_center(a_pts)
+    p_b = _lowest_z_center(b_pts)
+    if p_a.z < p_b.z:
+        p_a, p_b = p_b, p_a
+
+    # Reject a degenerate result: if the computed centerline coincides with
+    # one of the face's own boundary edges, this face has no floor of its
+    # own -- it's most likely a single wall of an unselected V-groove pair.
+    if _line_coincides_with_an_edge(face, p_a, p_b, tol):
+        FreeCAD.Console.PrintWarning(
+            translate(
+                "CAM_Flute",
+                "Face appears to be a single wall of a V-groove (its "
+                "centerline coincides with a face edge). Select both walls "
+                "of the groove, or select the valley edge directly.\n",
+            )
+        )
+        return None
+
+    top_z = max(p.z for p in pts)
+
+    def _clean(v, tol=_PREC):
+        return 0.0 if abs(v) < tol else v
+
+    return {
+        "start": p_a,
+        "end": p_b,
+        "top_z": _clean(top_z),
+        "width": _clean(max(t_vals) - min(t_vals)),
+    }
+
+
+def _analyze_face(face, tol):
+    """Determine the centerline of a single groove face.
+
+    Tries exact cylinder-surface detection first; falls back to edge-
+    sampling PCA for BSpline or other surface types.
+    """
+    result = _analyze_face_cylinder(face)
+    if result is not None:
+        FreeCAD.Console.PrintLog("CAM_Flute: centerline via cylinder surface (exact)\n")
+        return result
+    FreeCAD.Console.PrintLog("CAM_Flute: centerline via edge-sampling PCA (fallback)\n")
+    return _analyze_face_pca(face, tol)
+
+
+# ---------------------------------------------------------------------------
+# V-bottom (multi-face) grouping helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_shared_edges(face_a, face_b, tol):
+    """Return edges that are geometrically coincident between two faces."""
+    shared = []
+    for ea in face_a.Edges:
+        com_a = ea.CenterOfMass
+        len_a = ea.Length
+        for eb in face_b.Edges:
+            if abs(len_a - eb.Length) > tol.edge:
+                continue
+            if com_a.distanceToPoint(eb.CenterOfMass) > tol.edge:
+                continue
+            # Verify endpoints match (in either order)
+            pa0 = ea.Vertexes[0].Point
+            pa1 = ea.Vertexes[-1].Point
+            pb0 = eb.Vertexes[0].Point
+            pb1 = eb.Vertexes[-1].Point
+            if (pa0.distanceToPoint(pb0) < tol.edge and pa1.distanceToPoint(pb1) < tol.edge) or (
+                pa0.distanceToPoint(pb1) < tol.edge and pa1.distanceToPoint(pb0) < tol.edge
+            ):
+                shared.append(ea)
+                break
+    return shared
+
+
+
+def _is_valley_edge(edge, face_a, face_b):
+    """Return True if the shared edge sits below both adjacent face centroids.
+
+    For any groove in a flute operation the valley edge is always the lowest
+    part of the two wall faces - its Z centroid is below the average face Z.
+    This is simpler and more reliable than a cross-product sign test, which
+    depends on the BRep edge orientation and can flip sign unexpectedly.
+    """
+    try:
+        edge_z = edge.CenterOfMass.z
+        face_z = (face_a.CenterOfMass.z + face_b.CenterOfMass.z) / 2.0
+        return edge_z < face_z - _PREC * 10
+    except Exception:
+        return False
+
+
+def _group_flutes(face_tuples, tol):
+    """Group (face, sub_name, base_obj) tuples into flute groups.
+
+    Primary grouping: faces whose XY bounding boxes overlap or touch (within
+    tol.bb_overlap) are treated as parts of the same groove.  This correctly
+    merges ramp + flat faces (which share an edge but are not a concave
+    V-bottom) as well as V-groove face pairs.
+
+    Within each resulting group, valley-edge detection is still run so that
+    two-face V-bottom groups can expose their shared concave edge for
+    centerline extraction.
+
+    Returns list of dicts:
+        {
+          'faces':       [(face, sub, base), ...],
+          'valley_edge': list[Part.Edge] or None,
+        }
+    """
+    n = len(face_tuples)
+    if n == 0:
+        return []
+
+    def _bb_overlaps_xy(bb_a, bb_b):
+        return (
+            bb_a.XMin <= bb_b.XMax + tol.bb_overlap
+            and bb_a.XMax >= bb_b.XMin - tol.bb_overlap
+            and bb_a.YMin <= bb_b.YMax + tol.bb_overlap
+            and bb_a.YMax >= bb_b.YMin - tol.bb_overlap
+        )
+
+    parent = list(range(n))
+
+    def _find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def _union(x, y):
+        rx, ry = _find(x), _find(y)
+        if rx != ry:
+            parent[rx] = ry
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            if _bb_overlaps_xy(face_tuples[i][0].BoundBox, face_tuples[j][0].BoundBox):
+                _union(i, j)
+
+    groups_map = {}
+    for i in range(n):
+        groups_map.setdefault(_find(i), []).append(i)
+
+    result = []
+    for indices in groups_map.values():
+        flute_faces = [face_tuples[k] for k in indices]
+
+        # Check for concave (valley) edges within the group - used only for
+        # V-bottom two-face centerline detection. The valley boundary between
+        # the two faces can be split into several B-Rep edge segments (e.g. a
+        # tapered V-groove with a seam partway along); collect ALL of them so
+        # the centerline isn't truncated at the first segment found.
+        valley_edges = []
+        if len(indices) == 2:
+            fa, fb = flute_faces[0][0], flute_faces[1][0]
+            shared = _find_shared_edges(fa, fb, tol)
+            for edge in shared:
+                if _is_valley_edge(edge, fa, fb):
+                    valley_edges.append(edge)
+
+        result.append({"faces": flute_faces, "valley_edge": valley_edges or None})
+
+    return result
+
+
+def _centerline_from_valley_edge(edges, face_tuples, tol):
+    """Get start/end/top_z from one or more V-bottom valley edges.
+
+    The valley boundary between two faces may consist of several colinear/
+    curved edge segments rather than a single edge. Chain them end-to-end
+    by matching coincident endpoints and use the two outer extremities of
+    the resulting chain as the cutting centerline. Start = shallower end.
+    top_z = highest Z across all face bounding boxes.
+    """
+    if not isinstance(edges, (list, tuple)):
+        edges = [edges]
+
+    if len(edges) == 1:
+        v0 = edges[0].Vertexes[0].Point
+        v1 = edges[0].Vertexes[-1].Point
+    else:
+        remaining = list(edges[1:])
+        chain = [edges[0].Vertexes[0].Point, edges[0].Vertexes[-1].Point]
+        changed = True
+        while remaining and changed:
+            changed = False
+            for e in list(remaining):
+                p0, p1 = e.Vertexes[0].Point, e.Vertexes[-1].Point
+                if chain[-1].distanceToPoint(p0) < tol.edge:
+                    chain.append(p1)
+                elif chain[-1].distanceToPoint(p1) < tol.edge:
+                    chain.append(p0)
+                elif chain[0].distanceToPoint(p0) < tol.edge:
+                    chain.insert(0, p1)
+                elif chain[0].distanceToPoint(p1) < tol.edge:
+                    chain.insert(0, p0)
+                else:
+                    continue
+                remaining.remove(e)
+                changed = True
+        v0, v1 = chain[0], chain[-1]
+
+    if v0.z < v1.z:
+        v0, v1 = v1, v0  # v0 = shallow, v1 = deep
+
+    top_z = max(ft[0].BoundBox.ZMax for ft in face_tuples)
+
+    # Groove half-angle from the first planar wall face normal.
+    # For a V-wall: normal points mostly horizontal (outward) with a Z
+    # component encoding the slope.  half_angle = arcsin(|n.z|).
+    groove_half_angle = 0.0
+    for ft in face_tuples:
+        try:
+            n = ft[0].Surface.Axis
+            nlen = math.sqrt(n.x ** 2 + n.y ** 2 + n.z ** 2)
+            if nlen > _PREC * 0.01:
+                groove_half_angle = math.degrees(math.asin(min(1.0, abs(n.z) / nlen)))
+                break
+        except Exception:
+            pass
+
+    def _clean(val, tol=_PREC):
+        return 0.0 if abs(val) < tol else val
+
+    return {
+        "start": FreeCAD.Vector(v0),
+        "end": FreeCAD.Vector(v1),
+        "top_z": _clean(top_z),
+        "width": 0.0,
+        "groove_half_angle": groove_half_angle,
+    }
+
+
+def _centerline_from_faces(face_tuples):
+    """Run PCA across all faces in a group (fallback for >2-face groups)."""
+    pts = []
+    for face, _sub, _base in face_tuples:
+        try:
+            for edge in face.OuterWire.Edges:
+                pts.extend(edge.discretize(Number=20))
+        except Exception:
+            pass
+
+    if len(pts) < 2:
+        return None
+
+    # Re-use the single-face PCA logic on the combined point cloud
+    mx = sum(p.x for p in pts) / len(pts)
+    my = sum(p.y for p in pts) / len(pts)
+    cxx = sum((p.x - mx) ** 2 for p in pts)
+    cyy = sum((p.y - my) ** 2 for p in pts)
+    cxy = sum((p.x - mx) * (p.y - my) for p in pts)
+
+    angle = 0.5 * math.atan2(2.0 * cxy, cxx - cyy)
+    ux, uy = math.cos(angle), math.sin(angle)
+    vx, vy = -uy, ux
+
+    proj = []
+    for p in pts:
+        dx, dy = p.x - mx, p.y - my
+        proj.append((p, dx * ux + dy * uy, dx * vx + dy * vy))
+
+    s_min = min(r[1] for r in proj)
+    s_max = max(r[1] for r in proj)
+    t_min = min(r[2] for r in proj)
+    t_max = max(r[2] for r in proj)
+    zone = (s_max - s_min) * 0.05
+
+    def _avg(points):
+        return FreeCAD.Vector(
+            sum(p.x for p in points) / len(points),
+            sum(p.y for p in points) / len(points),
+            sum(p.z for p in points) / len(points),
+        )
+
+    a_pts = [p for p, s, _t in proj if s <= s_min + zone]
+    b_pts = [p for p, s, _t in proj if s >= s_max - zone]
+    p_a, p_b = _avg(a_pts), _avg(b_pts)
+    if p_a.z < p_b.z:
+        p_a, p_b = p_b, p_a
+
+    top_z = max(p.z for p in pts)
+
+    def _clean(v, tol=_PREC):
+        return 0.0 if abs(v) < tol else v
+
+    return {
+        "start": p_a,
+        "end": p_b,
+        "top_z": _clean(top_z),
+        "width": _clean(t_max - t_min),
+    }
+
+
+def _check_tool_fit(info, tool):
+    """Warn if the tool appears too large for the detected groove geometry.
+
+    Checks two independent conditions from the centerline info dict:
+      - width > 0: rounded/flat channel - tool diameter vs groove width.
+      - groove_half_angle > 0: V-groove - V-bit half-angle vs groove half-angle.
+    Always returns None; caller continues regardless.
+    """
+    tool_dia = float(tool.Diameter)
+    is_vbit = hasattr(tool, "CuttingEdgeAngle")
+
+    # Width check only applies to flat/bull-nose tools - a V-bit's effective
+    # cutting width depends on depth, not diameter.
+    def _qty(mm):
+        return FreeCAD.Units.Quantity(mm, FreeCAD.Units.Length).UserString
+
+    if not is_vbit:
+        groove_width = info.get("width", 0.0)
+        if groove_width > 0.0 and tool_dia > groove_width:
+            FreeCAD.Console.PrintWarning(
+                translate(
+                    "CAM_Flute",
+                    "CAM_Flute: tool diameter ({}) exceeds groove width ({})"
+                    " - path may overcut.\n",
+                ).format(_qty(tool_dia), _qty(groove_width))
+            )
+
+    if is_vbit:
+        try:
+            tool_ha = tool.CuttingEdgeAngle.Value / 2.0
+        except Exception:
+            tool_ha = 0.0
+
+        groove_ha = info.get("groove_half_angle", 0.0)
+        if groove_ha == 0.0:
+            # Valley edge not detected - estimate from PCA width and depth.
+            width = info.get("width", 0.0)
+            depth = info["top_z"] - info["end"].z
+            if width > 0.0 and depth > 0.0:
+                groove_ha = math.degrees(math.atan2(width / 2.0, depth))
+
+        Path.Log.debug(
+            "CAM_Flute: tool half-angle={:.2f}° groove half-angle={:.2f}°\n".format(
+                tool_ha, groove_ha
+            )
+        )
+        if tool_ha > 0.0 and groove_ha > 0.0 and tool_ha > groove_ha * (1.0 + _VBIT_ANGLE_FRAC):
+            FreeCAD.Console.PrintWarning(
+                translate(
+                    "CAM_Flute",
+                    "CAM_Flute: V-bit half-angle ({:.1f}°) exceeds groove"
+                    " half-angle ({:.1f}°) - flanks may contact walls before"
+                    " reaching depth.\n",
+                ).format(tool_ha, groove_ha)
+            )
+
+
+def _get_centerline(group, tol):
+    """Return the centerline dict for a flute group (any size)."""
+    valley_edge = group.get("valley_edge")
+    face_tuples = group["faces"]
+
+    if valley_edge is not None:
+        # 2-face V-bottom: the valley edge IS the centerline
+        return _centerline_from_valley_edge(valley_edge, face_tuples, tol)
+    elif len(face_tuples) == 1:
+        # Single flat/bull-nose face: PCA
+        return _analyze_face(face_tuples[0][0], tol)
+    else:
+        # >2 faces with no detected valley edge: run PCA across all faces
+        Path.Log.debug(
+            "Flute group has {} faces with no detected valley edge; "
+            "falling back to combined PCA.\n".format(len(face_tuples))
+        )
+        return _centerline_from_faces(face_tuples)
+
+
+def _dist2(a, b):
+    return (a.x - b.x) ** 2 + (a.y - b.y) ** 2 + (a.z - b.z) ** 2
+
+
+def _chain_to_waypoints(chain, tol):
+    """Convert an ordered chain of (seg_start, seg_end, edge) triples to a
+    deduplicated list of FreeCAD.Vector waypoints.
+
+    Straight Line edges contribute only their two endpoints.  Arcs, splines,
+    and other curves are discretized at tol.arc_chord spacing so their shape
+    is preserved.
+    """
+    pts = []
+    for seg_start, seg_end, edge in chain:
+        if edge.Curve.__class__.__name__ == "Line":
+            raw = [edge.valueAt(edge.FirstParameter), edge.valueAt(edge.LastParameter)]
+        else:
+            raw = edge.discretize(Distance=tol.arc_chord)
+        # Orient to match chain direction
+        if raw and _dist2(raw[0], seg_start) > _dist2(raw[-1], seg_start):
+            raw = list(reversed(raw))
+        for p in raw:
+            pv = FreeCAD.Vector(p)
+            if not pts or _dist2(pts[-1], pv) > (tol.arc_chord * 0.01) ** 2:
+                pts.append(pv)
+    return pts
+
+
+def _clip_and_scale(pts, f, stock_top_z):
+    """Scale a full-depth point list to depth fraction f.
+
+    pts: ordered list of FreeCAD.Vector, shallow end first, deep end last.
+
+    At fraction f (0 < f <= 1):
+      - Include only the f * total_XY_length of path closest to the deep end.
+      - The new chain-start is forced to stock_top_z.
+      - pts[-1] is forced to pass_floor_z = stock_top_z - f*(stock_top_z - floor_z).
+      - Intermediate Z values scale: Z_i = stock_top_z - f*(stock_top_z - Z_i_full).
+    """
+    if not pts or f < _PREC:
+        return []
+
+    n = len(pts)
+    floor_z = min(p.z for p in pts)   # use actual deepest point, not pts[-1]
+    pass_floor_z = stock_top_z - f * (stock_top_z - floor_z)
+
+    if n == 1:
+        return [FreeCAD.Vector(pts[0].x, pts[0].y, pass_floor_z)]
+
+    # Cumulative XY arc lengths from the deep end toward pts[0].
+    rev = [0.0] * n
+    for i in range(n - 2, -1, -1):
+        dx = pts[i].x - pts[i + 1].x
+        dy = pts[i].y - pts[i + 1].y
+        rev[i] = rev[i + 1] + math.sqrt(dx * dx + dy * dy)
+
+    L_total = rev[0]
+    if L_total < _PREC:
+        return [FreeCAD.Vector(pts[-1].x, pts[-1].y, pass_floor_z)]
+
+    target = f * L_total
+
+    result_rev = []
+    for i in range(n - 1, -1, -1):
+        if rev[i] <= target + _PREC:
+            z_f = stock_top_z - f * (stock_top_z - pts[i].z)
+            result_rev.append(FreeCAD.Vector(pts[i].x, pts[i].y, z_f))
+        else:
+            if result_rev:
+                j = i + 1
+                seg_len = rev[i] - rev[j]
+                if seg_len > _PREC:
+                    t = (target - rev[j]) / seg_len
+                    px = pts[j].x + t * (pts[i].x - pts[j].x)
+                    py = pts[j].y + t * (pts[i].y - pts[j].y)
+                else:
+                    px, py = pts[j].x, pts[j].y
+            else:
+                px, py = pts[-1].x, pts[-1].y
+            result_rev.append(FreeCAD.Vector(px, py, stock_top_z))
+            break
+
+    if not result_rev:
+        return [FreeCAD.Vector(pts[-1].x, pts[-1].y, pass_floor_z)]
+
+    result_rev.reverse()
+    result_rev[0] = FreeCAD.Vector(result_rev[0].x, result_rev[0].y, stock_top_z)
+    # Snap the exit to pass_floor_z only when pts[-1] is at (or near) the floor.
+    # For Ramp Start End the path returns to stock_top_z at the exit — don't
+    # force that back down to pass_floor_z or the exit ramp is destroyed.
+    depth_range = stock_top_z - floor_z
+    if depth_range > _PREC and (pts[-1].z - floor_z) < 0.25 * depth_range:
+        result_rev[-1] = FreeCAD.Vector(result_rev[-1].x, result_rev[-1].y, pass_floor_z)
+    return result_rev
+
+
+def _pts_to_wire(pts):
+    """Build a polyline Part.Wire from an ordered list of FreeCAD.Vector.
+    Returns None if fewer than 2 distinct points.
+    """
+    edges = [
+        Part.makeLine(pts[i], pts[i + 1])
+        for i in range(len(pts) - 1)
+        if _dist2(pts[i], pts[i + 1]) > _PREC ** 2
+    ]
+    if not edges:
+        return None
+    try:
+        return Part.Wire(edges)
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Centerline directly from a selected wire (edges) - bypasses face/solid
+# analysis entirely. The wire IS the centerline.
+# ---------------------------------------------------------------------------
+
+
+def _split_into_wires(edges, tol):
+    """Split a flat list of edges into connected components (separate wires).
+
+    Each component becomes one independent flute (mirrors how separate face
+    groups become separate flutes).
+    """
+    remaining = list(edges)
+    wires = []
+    while remaining:
+        comp = [remaining.pop(0)]
+        changed = True
+        while changed:
+            changed = False
+            for e in list(remaining):
+                v0, v1 = e.Vertexes[0].Point, e.Vertexes[-1].Point
+                for c in comp:
+                    cv0, cv1 = c.Vertexes[0].Point, c.Vertexes[-1].Point
+                    if (
+                        _dist2(v0, cv0) < tol.chain2
+                        or _dist2(v0, cv1) < tol.chain2
+                        or _dist2(v1, cv0) < tol.chain2
+                        or _dist2(v1, cv1) < tol.chain2
+                    ):
+                        comp.append(e)
+                        remaining.remove(e)
+                        changed = True
+                        break
+        wires.append(comp)
+    return wires
+
+
+def _chain_wire_edges(edges, tol):
+    """Chain a connected set of edges into ordered (seg_start, seg_end, edge)
+    triples by matching coincident endpoints.
+
+    Assumes edges form a single simple open path (no branching).  Returns
+    None if they don't all connect into one chain.
+    """
+    if not edges:
+        return None
+
+    remaining = list(edges[1:])
+    e0 = edges[0]
+    chain = [(e0.Vertexes[0].Point, e0.Vertexes[-1].Point, e0)]
+
+    changed = True
+    while remaining and changed:
+        changed = False
+        cur_s, cur_e = chain[0][0], chain[-1][1]
+        for e in list(remaining):
+            v0, v1 = e.Vertexes[0].Point, e.Vertexes[-1].Point
+            if _dist2(cur_e, v0) < tol.chain2:
+                chain.append((v0, v1, e))
+            elif _dist2(cur_e, v1) < tol.chain2:
+                chain.append((v1, v0, e))
+            elif _dist2(cur_s, v0) < tol.chain2:
+                chain.insert(0, (v1, v0, e))
+            elif _dist2(cur_s, v1) < tol.chain2:
+                chain.insert(0, (v0, v1, e))
+            else:
+                continue
+            remaining.remove(e)
+            changed = True
+            break
+
+    if remaining:
+        return None  # could not connect all edges into a single chain
+
+    return chain
+
+
+def _wire_from_edges(edges, tol):
+    """Convert a connected set of selected edges directly into a Part.Wire.
+    The edges ARE the centerline — no face/solid analysis.
+
+    Orients so the shallower (higher Z) end is first.
+
+    Returns (Part.Wire, top_z, floor_z), or (None, None, None) on failure.
+    """
+    chain = _chain_wire_edges(edges, tol)
+    if not chain:
+        FreeCAD.Console.PrintWarning(
+            translate("CAM_Flute", "Selected edges do not form a single connected wire.\n")
+        )
+        return None, None, None
+
+    # Orient so the shallower (higher Z) free end is the start.
+    if chain[0][0].z < chain[-1][1].z:
+        chain = [(e, s, edge) for s, e, edge in reversed(chain)]
+
+    pts = _chain_to_waypoints(chain, tol)
+    if not pts:
+        return None, None, None
+
+    wire = _pts_to_wire(pts)
+    if wire is None:
+        return None, None, None
+
+    all_z = [p.z for p in pts]
+    return wire, max(all_z), min(all_z)
+
+
+# ---------------------------------------------------------------------------
+# Profile detection via solid section
+# ---------------------------------------------------------------------------
+
+
+def _detect_floor_wire(face, base_obj, info, tol, group_extent=None):
+    """Section base_obj.Shape with a vertical plane through the groove
+    centreline and return a Part.Wire representing the floor profile.
+
+    Returns (Part.Wire, floor_z, top_z), or (None, None, None) on any failure.
+    The caller falls back to a plain ramp line using the centerline endpoints.
+    """
+    try:
+        start = info["start"]
+        end_info = info["end"]
+        top_z = info["top_z"]
+        floor_z = end_info.z
+
+        dx = end_info.x - start.x
+        dy = end_info.y - start.y
+        L = math.sqrt(dx * dx + dy * dy)
+        if L < _PREC:
+            return None, None, None
+
+        path_dir = FreeCAD.Vector(dx / L, dy / L, 0.0)
+
+        # Plane normal is perpendicular to path_dir in XY (i.e. across the groove).
+        cx = (start.x + end_info.x) / 2.0
+        cy = (start.y + end_info.y) / 2.0
+        cz = (top_z + floor_z) / 2.0
+
+        # Use the full group XY span (all selected faces) when available so the
+        # plane covers ramp + flat + any exit ramp even though section_info only
+        # describes the ramp cylinder face.  Without this, the flat section that
+        # extends past the ramp end would fall outside the plane.
+        extent = group_extent if (group_extent is not None and group_extent > L) else L
+        depth = abs(top_z - floor_z)
+        half = max(extent, depth) + tol.section_overshoot
+        z_dir = FreeCAD.Vector(0.0, 0.0, 1.0)
+        ctr = FreeCAD.Vector(cx, cy, cz)
+
+        p1 = ctr - half * path_dir - half * z_dir
+        p2 = ctr + half * path_dir - half * z_dir
+        p3 = ctr + half * path_dir + half * z_dir
+        p4 = ctr - half * path_dir + half * z_dir
+        plane_face = Part.Face(Part.makePolygon([p1, p2, p3, p4, p1]))
+
+        section = base_obj.Shape.section(plane_face)
+        all_edges = section.Edges
+        if not all_edges:
+            Path.Log.debug("CAM_Flute: section returned no edges\n")
+            return None, None, None
+
+        Path.Log.debug(
+            "CAM_Flute: section returned {} edge(s)\n".format(len(all_edges))
+        )
+
+        # --- filter candidates --------------------------------------------------
+        def path_proj(v):
+            return (v.x - start.x) * path_dir.x + (v.y - start.y) * path_dir.y
+
+        z_tol = max(1.0, abs(top_z - floor_z) * _SECTION_Z_TOL_FRAC)
+        p_min = path_proj(start) - tol.section_overshoot
+        p_max = path_proj(start) + extent + tol.section_overshoot
+
+        candidates = []
+        for edge in all_edges:
+            bb = edge.BoundBox
+            if bb.ZMax < floor_z - z_tol or bb.ZMin > top_z + z_tol:
+                continue
+            mid = edge.CenterOfMass
+            if path_proj(mid) < p_min or path_proj(mid) > p_max:
+                continue
+            # Reject near-vertical edges (side walls).
+            v0 = edge.Vertexes[0].Point
+            v1 = edge.Vertexes[-1].Point
+            ds = abs(path_proj(v1) - path_proj(v0))
+            dz = abs(v1.z - v0.z)
+            if ds < _WALL_DS_MIN and dz > 0.5:
+                continue
+            if ds > _WALL_DS_MIN and dz / ds > _WALL_SLOPE_MAX:
+                continue
+            candidates.append(edge)
+
+        if not candidates:
+            Path.Log.debug("CAM_Flute: no floor edge candidates\n")
+            return None, None, None
+
+        Path.Log.debug(
+            "CAM_Flute: {} candidate floor edge(s)\n".format(len(candidates))
+        )
+
+        # --- chain from start ---------------------------------------------------
+        def _orient(edge, toward_pt):
+            v0 = edge.Vertexes[0].Point
+            v1 = edge.Vertexes[-1].Point
+            if _dist2(v0, toward_pt) <= _dist2(v1, toward_pt):
+                return v0, v1
+            return v1, v0
+
+        remaining = list(candidates)
+        best_d, best_e = 1e18, None
+        for e in remaining:
+            d = min(_dist2(e.Vertexes[0].Point, start), _dist2(e.Vertexes[-1].Point, start))
+            if d < best_d:
+                best_d, best_e = d, e
+
+        if best_e is None:
+            return None, None, None
+
+        remaining.remove(best_e)
+        cur_s, cur_e = _orient(best_e, start)
+        chain = [(cur_s, cur_e, best_e)]
+
+        for _ in range(_CHAIN_MAX_EDGES):
+            nxt_e = nxt_s = nxt_end = None
+            bd = tol.chain2
+            for e in remaining:
+                v0 = e.Vertexes[0].Point
+                v1 = e.Vertexes[-1].Point
+                d0 = _dist2(v0, cur_e)
+                d1 = _dist2(v1, cur_e)
+                if d0 < bd:
+                    bd, nxt_e, nxt_s, nxt_end = d0, e, v0, v1
+                elif d1 < bd:
+                    bd, nxt_e, nxt_s, nxt_end = d1, e, v1, v0
+            if nxt_e is None:
+                break
+            if nxt_end.z > top_z + z_tol:
+                break
+            if nxt_end.z < floor_z - z_tol:
+                # Deeper than the known groove floor: this is geometry outside
+                # the selected group (e.g. an adjacent groove or a step ledge
+                # past the tip), not a continuation of this flute's profile.
+                break
+            remaining.remove(nxt_e)
+            chain.append((nxt_s, nxt_end, nxt_e))
+            cur_e = nxt_end
+
+        Path.Log.debug("CAM_Flute: chained {} edge(s)\n".format(len(chain)))
+
+        # --- convert chain to wire ----------------------------------------------
+        pts = _chain_to_waypoints(chain, tol)
+        if not pts:
+            return None, None, None
+
+        # Snap floor-level points to the exact minimum Z found.  Two adjacent
+        # faces can produce slightly different Z values at their shared edge when
+        # sectioned (modeling seam); snapping removes any tiny Z step.
+        floor_z = min(p.z for p in pts)
+        pts = [
+            FreeCAD.Vector(p.x, p.y, floor_z) if abs(p.z - floor_z) < tol.floor_snap
+            else FreeCAD.Vector(p)
+            for p in pts
+        ]
+        top_z = max(p.z for p in pts)
+
+        wire = _pts_to_wire(pts)
+        if wire is None:
+            return None, None, None
+
+        Path.Log.debug(
+            "CAM_Flute: floor wire {} pts, floor_z={:.3f}, top_z={:.3f}\n".format(
+                len(pts), floor_z, top_z
+            )
+        )
+        return wire, floor_z, top_z
+
+    except Exception as exc:
+        import traceback
+
+        Path.Log.debug(
+            "CAM_Flute: _detect_floor_waypoints error: {}\n{}\n".format(exc, traceback.format_exc())
+        )
+        return None, None, None
+
+
+def _rescale_pts_z(pts, geo_top_z, geo_floor_z, op_start_z, op_final_z):
+    """Linearly remap waypoint Z values from [geo_floor_z, geo_top_z] to
+    [op_final_z, op_start_z].  Preserves profile shape while honouring the
+    Depths tab settings."""
+    if abs(geo_top_z - geo_floor_z) < _PREC:
+        return pts
+    z_range_src = geo_top_z - geo_floor_z
+    z_range_dst = op_start_z - op_final_z
+    result = []
+    for p in pts:
+        t = (p.z - geo_floor_z) / z_range_src  # 0 = floor, 1 = top
+        result.append(FreeCAD.Vector(p.x, p.y, op_final_z + t * z_range_dst))
+    return result
+
+
+def _apply_axial_leave_pts(pts, axial_leave, stock_top_z, tol):
+    """Raise the floor Z of all waypoints by axial_leave and trim the entry/exit
+    ends inward proportionally (same path angle, shallower depth)."""
+    if not pts or axial_leave <= _PREC:
+        return pts
+
+    floor_z = min(p.z for p in pts)
+    total_d = stock_top_z - floor_z
+    if total_d <= axial_leave + _PREC:
+        return pts
+
+    new_floor_z = floor_z + axial_leave
+    frac = axial_leave / total_d
+
+    # Raise all floor-level points
+    result = [
+        FreeCAD.Vector(p.x, p.y, new_floor_z) if abs(p.z - floor_z) < tol.axial_floor
+        else FreeCAD.Vector(p)
+        for p in pts
+    ]
+
+    # Trim entry: move first point inward if it starts at stock_top_z
+    if len(result) >= 2 and abs(result[0].z - stock_top_z) < tol.axial_floor:
+        sx = result[0].x + frac * (result[1].x - result[0].x)
+        sy = result[0].y + frac * (result[1].y - result[0].y)
+        result[0] = FreeCAD.Vector(sx, sy, stock_top_z)
+
+    # Trim exit: move last point inward if it ends at stock_top_z
+    if len(result) >= 2 and abs(result[-1].z - stock_top_z) < tol.axial_floor:
+        ex = result[-1].x + frac * (result[-2].x - result[-1].x)
+        ey = result[-1].y + frac * (result[-2].y - result[-1].y)
+        result[-1] = FreeCAD.Vector(ex, ey, stock_top_z)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 2D profile synthesis
+# ---------------------------------------------------------------------------
+
+
+def _simplify_collinear(pts, chord):
+    """Remove points that are collinear with their neighbours in 3D space.
+
+    Keeps only points whose perpendicular distance from the segment formed by
+    their predecessor and successor exceeds chord * 0.01.  Exactly collinear
+    points (e.g. intermediate samples on a straight edge with linear Z) are
+    removed; curved or smooth-Z segments are preserved.
+    """
+    if len(pts) < 3:
+        return list(pts)
+    tol_sq = (chord * 0.01) ** 2
+    result = [pts[0]]
+    for i in range(1, len(pts) - 1):
+        a, c = result[-1], pts[i + 1]
+        b = pts[i]
+        acx, acy, acz = c.x - a.x, c.y - a.y, c.z - a.z
+        ac2 = acx * acx + acy * acy + acz * acz
+        if ac2 < _PREC:
+            result.append(b)
+            continue
+        abx, aby, abz = b.x - a.x, b.y - a.y, b.z - a.z
+        t = (abx * acx + aby * acy + abz * acz) / ac2
+        px = a.x + t * acx
+        py = a.y + t * acy
+        pz = a.z + t * acz
+        dx, dy, dz = b.x - px, b.y - py, b.z - pz
+        if dx * dx + dy * dy + dz * dz < tol_sq:
+            continue
+        result.append(b)
+    result.append(pts[-1])
+    return result
+
+
+def _wire_is_flat(edges, tol):
+    """Return True if all edges lie at essentially the same Z (2D wire)."""
+    zs = [v.Point.z for e in edges for v in e.Vertexes]
+    return (max(zs) - min(zs)) < tol.edge if zs else False
+
+
+def _apply_2d_profile(
+    edges, start_z, floor_z, flute_type, ramp_type, ramp_frac, tol, flip=False,
+    path_frac=1.0, path_offset=0.0, ramp_length_mm=0.0,
+):
+    """Synthesize a 3D wire from a flat (constant-Z) edge set by applying a Z ramp profile.
+
+    flute_type:     "Ramp Full" | "Ramp Start" | "Ramp Start End"
+    ramp_type:      "Linear" | "Smooth" | "Arc"
+    ramp_frac:      fraction of total path length occupied by ramp(s) (0–1).
+                    Ignored when ramp_length_mm > 0.
+    ramp_length_mm: if > 0, overrides ramp_frac with length/total_wire_length.
+    flip:           if True, reverse the wire direction before applying the profile.
+    path_frac:      fraction of the (post-flip) wire to use; 1.0 = full length.
+    path_offset:    fractional start position (0–1) within the full wire.
+                    path_offset=1-path_frac → clip from exit end (Ramp Full fan).
+                    path_offset=(1-path_frac)/2 → symmetric centre clip (Ramp Start End fan).
+                    path_offset=0 → clip from entry end (Ramp Start fan).
+
+    Returns a Part.Wire with the profile Z applied, or None on failure.
+    """
+    chain = _chain_wire_edges(edges, tol)
+    if not chain:
+        return None
+
+    # Always discretize all edge types so intermediate arc-length positions
+    # exist for Z-profile sampling.  _simplify_collinear removes redundant
+    # collinear points afterward (e.g. straight edge + linear Z → 2 pts).
+    raw = []
+    for seg_s, seg_e, edge in chain:
+        disc = edge.discretize(Distance=tol.arc_chord)
+        if disc and _dist2(disc[0], seg_s) > _dist2(disc[-1], seg_s):
+            disc = list(reversed(disc))
+        for p in disc:
+            pv = FreeCAD.Vector(p.x, p.y, start_z)
+            if not raw or _dist2(raw[-1], pv) > (tol.arc_chord * 0.01) ** 2:
+                raw.append(pv)
+
+    if not raw:
+        return None
+
+    if flip:
+        raw = list(reversed(raw))
+
+    # Cumulative XY arc lengths
+    n = len(raw)
+    arc_len = [0.0] * n
+    for i in range(1, n):
+        dx = raw[i].x - raw[i - 1].x
+        dy = raw[i].y - raw[i - 1].y
+        arc_len[i] = arc_len[i - 1] + math.sqrt(dx * dx + dy * dy)
+    total_full = arc_len[-1]
+    if total_full < _PREC:
+        return None
+
+    # RampLength in mm overrides ramp_frac when set.
+    if ramp_length_mm > _PREC:
+        ramp_frac = min(1.0, ramp_length_mm / total_full)
+
+    # Sub-path clipping: keeps path_frac of the wire starting at path_offset.
+    # Used for progressive pass shortening — clips the XY path BEFORE applying
+    # the Z profile so ramp angles stay constant across all step-down passes.
+    if path_frac < 1.0 - _PREC or path_offset > _PREC:
+        t0 = path_offset * total_full
+        t1 = min((path_offset + path_frac) * total_full, total_full)
+        kept_raw = []
+        kept_arc = []
+        for i in range(n):
+            if t0 - _PREC <= arc_len[i] <= t1 + _PREC:
+                kept_raw.append(raw[i])
+                kept_arc.append(max(0.0, arc_len[i] - t0))
+        if not kept_raw:
+            return None
+        raw = kept_raw
+        arc_len = kept_arc
+        total = arc_len[-1]
+        if total < _PREC:
+            return None
+    else:
+        total = total_full
+
+    depth = start_z - floor_z
+
+    def _z_at(t):
+        """Return Z for parametric position t ∈ [0, 1] along the wire."""
+        if flute_type == "Ramp Full":
+            f = t
+        elif flute_type == "Ramp Start":
+            f = min(t / ramp_frac, 1.0) if ramp_frac > _PREC else 1.0
+        elif flute_type == "Ramp Start End":
+            half = ramp_frac / 2.0
+            if half < _PREC:
+                f = 1.0
+            elif t <= half:
+                f = t / half
+            elif t >= 1.0 - half:
+                f = (1.0 - t) / half
+            else:
+                f = 1.0
+        else:
+            f = t
+
+        if ramp_type == "Smooth":
+            f = f * f * (3.0 - 2.0 * f)  # smoothstep S-curve, zero slope at both ends
+        elif ramp_type == "Arc":
+            f = math.sin(f * math.pi / 2)  # quarter-circle arc, zero slope at floor end
+
+        return start_z - f * depth
+
+    pts = [FreeCAD.Vector(p.x, p.y, _z_at(arc_len[i] / total)) for i, p in enumerate(raw)]
+    pts = _simplify_collinear(pts, tol.arc_chord)
+    return _pts_to_wire(pts)
+
+
+# ---------------------------------------------------------------------------
+# Operation class
+# ---------------------------------------------------------------------------
+
+
+class ObjectFlute(PathOp.ObjectOp):
+    """Proxy object for the Flute operation.
+
+    A flute is a ramping slot cut – shallow at one end, deeper at the other.
+    The cutting path is derived from selected bottom faces:
+
+    - A single face (flat/bull-nose):  centerline found by PCA.
+    - Two faces sharing a concave edge (V-bottom):  the shared edge is the
+      centerline.
+    - Multiple groups (e.g. two V-flutes side-by-side with a ridge between
+      them):  the face adjacency graph is analysed so that faces connected
+      only by a convex (peak) edge are placed in separate flute groups.
+
+    Multiple passes step down incrementally.  Each intermediate pass starts
+    where the ramp first contacts uncut stock so that air-cut time is
+    minimised.
+    """
+
+    def opFeatures(self, obj):
+        return (
+            PathOp.FeatureTool
+            | PathOp.FeatureDepths
+            | PathOp.FeatureFinishDepth
+            | PathOp.FeatureHeights
+            | PathOp.FeatureStepDown
+            | PathOp.FeatureCoolant
+            | PathOp.FeatureBaseFaces
+            | PathOp.FeatureBaseEdges
+            | PathOp.FeatureLinking
+        )
+
+    def initOperation(self, obj):
+        obj.addProperty(
+            "App::PropertyBool",
+            "ReverseDirection",
+            "Flute",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Reverse the cut direction (enters at the deep end).",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyDistance",
+            "AxialStockToLeave",
+            "Flute",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Set the stock to leave in the axial (depth) direction.",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyBool",
+            "BlindEndCompensation",
+            "Flute",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Pull the path end back by the tool radius when the flute "
+                "terminates at depth (blind end). Has no effect when the "
+                "path ramps back up to stock surface.",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "FlutingType",
+            "Flute2D",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Z profile applied when a flat (2D) wire is selected: "
+                "RampFull ramps the full length; RampStart ramps only the "
+                "entry; RampStartEnd ramps both entry and exit.",
+            ),
+        )
+        obj.FlutingType = ["Ramp Full", "Ramp Start", "Ramp Start End"]
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "RampType",
+            "Flute2D",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Shape of the Z ramp on 2D wires: Linear is a straight "
+                "plunge; Smooth uses a smoothstep curve.",
+            ),
+        )
+        obj.RampType = ["Linear", "Smooth", "Arc"]
+        obj.addProperty(
+            "App::PropertyPercent",
+            "RampPercent",
+            "Flute2D",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Percentage of the total path length occupied by each ramp "
+                "segment (2D wires only).",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyBool",
+            "FlipStart2D",
+            "Flute2D",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Reverse which end of the flat wire is treated as the entry "
+                "point for the 2D ramp profile.",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyDistance",
+            "RampLength",
+            "Flute2D",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Length of each ramp segment in mm (2D wires only). "
+                "When greater than zero, overrides Ramp %. "
+                "The fraction is derived at compute time from this length "
+                "divided by the actual wire length.",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "MultiPassStrategy",
+            "Depth",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property",
+                "How roughing passes are distributed across step-down depths. "
+                "Constant Angle: same ramp slope every pass — entry point walks, "
+                "path shortens (lower peak chip load). "
+                "Variable Angle: full path length every pass — angle steepens "
+                "each depth (uniform XY engagement, longer cycle time).",
+            ),
+        )
+        obj.MultiPassStrategy = ["Constant Angle", "Variable Angle"]
+
+    def opSetDefaultValues(self, obj, job):
+        obj.ReverseDirection = False
+        obj.AxialStockToLeave = 0.0
+        obj.BlindEndCompensation = False
+        obj.FlutingType = "Ramp Full"
+        obj.RampType = "Linear"
+        obj.RampPercent = 100
+        obj.FlipStart2D = False
+        obj.RampLength = 0.0
+        obj.MultiPassStrategy = "Constant Angle"
+
+        d = None
+        if job and job.Stock:
+            d = PathUtils.guessDepths(job.Stock.Shape, None)
+
+        if d is not None:
+            obj.OpFinalDepth.Value = d.final_depth
+            obj.OpStartDepth.Value = d.start_depth
+        else:
+            obj.OpFinalDepth.Value = -10.0
+            obj.OpStartDepth.Value = 0.0
+
+    def opApplyPropertyLimits(self, obj):
+        # No property range clamping needed for this operation.
+        pass
+
+    def opUpdateDepths(self, obj):
+        """Auto-populate start/final depths from the face bounding boxes."""
+        if not hasattr(obj, "Base") or not obj.Base:
+            return
+
+        z_max = None
+        z_min = None
+
+        for base, sub_list in obj.Base:
+            for sub in sub_list:
+                try:
+                    bb = base.Shape.getElement(sub).BoundBox
+                    z_max = bb.ZMax if z_max is None else max(z_max, bb.ZMax)
+                    z_min = bb.ZMin if z_min is None else min(z_min, bb.ZMin)
+                except Part.OCCError as err:
+                    Path.Log.error(err)
+
+        if z_max is not None:
+            obj.OpStartDepth = z_max
+        if z_min is not None:
+            obj.OpFinalDepth = z_min
+
+    def onChanged(self, obj, prop):
+        if prop == "Active" and obj.ViewObject:
+            obj.ViewObject.signalChangeIcon()
+
+    def opOnDocumentRestored(self, obj):
+        if not hasattr(obj, "BlindEndCompensation"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "BlindEndCompensation",
+                "Flute",
+                QtCore.QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Pull the path end back by the tool radius when the flute "
+                    "terminates at depth (blind end). Has no effect when the "
+                    "path ramps back up to stock surface.",
+                ),
+            )
+            obj.BlindEndCompensation = False
+        if not hasattr(obj, "FlutingType"):
+            obj.addProperty(
+                "App::PropertyEnumeration",
+                "FlutingType",
+                "Flute2D",
+                QtCore.QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Z profile applied when a flat (2D) wire is selected.",
+                ),
+            )
+            obj.FlutingType = ["Ramp Full", "Ramp Start", "Ramp Start End"]
+            obj.FlutingType = "Ramp Full"
+        else:
+            # Migrate old enum values saved without spaces
+            _migrate = {"RampFull": "Ramp Full", "RampStart": "Ramp Start", "RampStartEnd": "Ramp Start End"}
+            old_val = str(obj.FlutingType)
+            if old_val in _migrate:
+                obj.FlutingType = ["Ramp Full", "Ramp Start", "Ramp Start End"]
+                obj.FlutingType = _migrate[old_val]
+        if not hasattr(obj, "RampType"):
+            obj.addProperty(
+                "App::PropertyEnumeration",
+                "RampType",
+                "Flute2D",
+                QtCore.QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Shape of the Z ramp on 2D wires.",
+                ),
+            )
+            obj.RampType = ["Linear", "Smooth", "Arc"]
+            obj.RampType = "Linear"
+        if not hasattr(obj, "RampPercent"):
+            obj.addProperty(
+                "App::PropertyPercent",
+                "RampPercent",
+                "Flute2D",
+                QtCore.QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Percentage of path length occupied by each ramp (2D wires only).",
+                ),
+            )
+            obj.RampPercent = 100
+        if not hasattr(obj, "FlipStart2D"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "FlipStart2D",
+                "Flute2D",
+                QtCore.QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Reverse which end of the flat wire is the ramp entry point.",
+                ),
+            )
+            obj.FlipStart2D = False
+        if not hasattr(obj, "RampLength"):
+            obj.addProperty(
+                "App::PropertyDistance",
+                "RampLength",
+                "Flute2D",
+                QtCore.QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Length of each ramp segment in mm. When > 0, overrides Ramp %.",
+                ),
+            )
+            obj.RampLength = 0.0
+        if not hasattr(obj, "MultiPassStrategy"):
+            obj.addProperty(
+                "App::PropertyEnumeration",
+                "MultiPassStrategy",
+                "Flute",
+                QtCore.QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "How roughing passes are distributed across step-down depths.",
+                ),
+            )
+            obj.MultiPassStrategy = ["Constant Angle", "Variable Angle"]
+            obj.MultiPassStrategy = "Constant Angle"
+
+    def _emitFlutePath(
+        self,
+        obj,
+        wire,
+        geo_top_z,
+        geo_floor_z,
+        sub_names,
+        op_start_z,
+        op_final_z,
+        axial_leave,
+        finish_d,
+        step_down,
+        retract_z,
+        linking_kwargs,
+        tool_pos,
+        tol,
+    ):
+        """Take a Part.Wire (from face analysis, edge selection, or 2D profile
+        synthesis) through Z remap, axial-leave, blind-end compensation, pass
+        generation, linking, and G-code emission.
+
+        Returns (new_tool_pos, emitted) where emitted is True if any G-code
+        was appended to self.commandlist.
+        """
+        # --- remap Z from geometry to operation Depths tab -------------------
+        pts = PathGeom.wireToPoints(wire, tol.arc_chord)
+        if not pts:
+            return tool_pos, False
+
+        if abs(geo_top_z - geo_floor_z) > _PREC:
+            pts = _rescale_pts_z(pts, geo_top_z, geo_floor_z, op_start_z, op_final_z)
+
+        # --- axial stock to leave -------------------------------------------
+        if axial_leave > _PREC:
+            pts = _apply_axial_leave_pts(pts, axial_leave, op_start_z, tol)
+
+        # --- blind end compensation -----------------------------------------
+        # When the path terminates at depth (no exit ramp), pull the last
+        # point back by the tool radius so the cutting edge — not the centre —
+        # aligns with the groove end.  No effect when the path ramps back up.
+        if getattr(obj, "BlindEndCompensation", False) and len(pts) >= 2:
+            floor_z_pts = min(p.z for p in pts)
+            if abs(pts[-1].z - floor_z_pts) < tol.floor_snap:
+                try:
+                    tool_radius = obj.ToolController.Tool.Diameter.Value / 2.0
+                except Exception:
+                    tool_radius = 0.0
+                if tool_radius > _PREC * 10:
+                    blind_end = pts[-1]
+                    tr2 = tool_radius * tool_radius
+                    # Trim all points within tool_radius XY of the blind end.
+                    # Without this, the compensated endpoint would be appended
+                    # *after* points that are already past it, causing the path
+                    # to overshoot then reverse.
+                    while len(pts) > 1:
+                        dx = pts[-1].x - blind_end.x
+                        dy = pts[-1].y - blind_end.y
+                        if dx * dx + dy * dy >= tr2:
+                            break
+                        pts.pop()
+                    # Append the compensated endpoint: tool_radius back from
+                    # blind_end along the approach direction.
+                    if len(pts) >= 1:
+                        dx = blind_end.x - pts[-1].x
+                        dy = blind_end.y - pts[-1].y
+                        seg_len = math.sqrt(dx * dx + dy * dy)
+                        if seg_len > _PREC:
+                            pts.append(FreeCAD.Vector(
+                                blind_end.x - (dx / seg_len) * tool_radius,
+                                blind_end.y - (dy / seg_len) * tool_radius,
+                                blind_end.z,
+                            ))
+
+        # --- step-down pass loop --------------------------------------------
+        floor_z = min(p.z for p in pts)
+        total_depth = op_start_z - floor_z
+        if total_depth <= _PREC:
+            FreeCAD.Console.PrintWarning(
+                translate("CAM_Flute", "No depth to cut for: {}\n").format(sub_names)
+            )
+            return tool_pos, False
+
+        multi_pass_strategy = getattr(obj, "MultiPassStrategy", "Constant Angle")
+        rough_stop = max(0.0, total_depth - max(0.0, finish_d))
+        pass_pts_list = []
+        depth = 0.0
+        while depth < rough_stop - _PREC:
+            depth = min(depth + step_down, rough_stop)
+            f = depth / total_depth
+            if multi_pass_strategy == "Variable Angle":
+                wps = [FreeCAD.Vector(p.x, p.y, op_start_z + (p.z - op_start_z) * f)
+                       for p in pts]
+            else:
+                wps = _clip_and_scale(pts, f, op_start_z)
+            if obj.ReverseDirection:
+                wps = list(reversed(wps))
+            pass_pts_list.append(wps)
+
+        if finish_d > _PREC and total_depth > rough_stop + _PREC:
+            if multi_pass_strategy == "Variable Angle":
+                wps = list(pts)  # f=1.0: original Z values unchanged
+            else:
+                wps = _clip_and_scale(pts, 1.0, op_start_z)
+            if obj.ReverseDirection:
+                wps = list(reversed(wps))
+            pass_pts_list.append(wps)
+
+        if not pass_pts_list:
+            FreeCAD.Console.PrintWarning(
+                translate("CAM_Flute", "No passes computed for: {}\n").format(sub_names)
+            )
+            return tool_pos, False
+
+        first_cut = pass_pts_list[0][0]
+        entry_pos = FreeCAD.Vector(first_cut.x, first_cut.y, obj.SafeHeight.Value)
+
+        if tool_pos is not None:
+            linking_kwargs["start_position"] = tool_pos
+            linking_kwargs["target_position"] = entry_pos
+            self.commandlist.extend(linking.get_linking_moves(**linking_kwargs))
+
+        for wps in pass_pts_list:
+            pass_wire = _pts_to_wire(wps)
+            if pass_wire is None:
+                continue
+            cmds = WireFollowGenerator.generate(
+                pass_wire,
+                retract_z,
+                self.horizFeed,
+                self.vertFeed,
+                arc_chord=tol.arc_chord,
+            )
+            self.commandlist.extend(cmds)
+
+        last_pt = pass_pts_list[-1][-1]
+        return FreeCAD.Vector(last_pt.x, last_pt.y, retract_z), True
+
+    def _emit2dPasses(
+        self,
+        obj,
+        wire_edges,
+        flute_type,
+        ramp_type,
+        ramp_frac,
+        flip,
+        op_start_z,
+        op_final_z,
+        axial_leave,
+        finish_d,
+        step_down,
+        retract_z,
+        linking_kwargs,
+        tool_pos,
+        tol,
+        sub_names,
+    ):
+        """Emit multi-pass G-code for Ramp Start / Ramp Start End 2D profiles.
+
+        Re-synthesises the Z profile at each step-down depth so every pass has
+        the correct geometric shape.  _clip_and_scale clips from pts[-1], which
+        gives wrong results for profiles where the floor is not at the exit:
+          - Ramp Start End: floor is in the middle; clipping from exit gives
+            only the exit-ramp half in early passes.
+          - Ramp Start:     floor IS at pts[-1] but clipping from there gives
+            flat-only passes until the very last pass adds the ramp.
+
+        Returns (new_tool_pos, emitted).
+        """
+        effective_final_z = op_final_z + max(0.0, axial_leave)
+        total_depth = op_start_z - effective_final_z
+        if total_depth <= _PREC:
+            FreeCAD.Console.PrintWarning(
+                translate("CAM_Flute", "No depth to cut for: {}\n").format(sub_names)
+            )
+            return tool_pos, False
+
+        rough_stop = max(0.0, total_depth - max(0.0, finish_d))
+        # Each pass stores (pass_floor_z, depth_fraction f).
+        # f drives path_frac / path_offset so all passes keep the same ramp angle:
+        #   Ramp Full:       path_offset = 1-f  (fan grows from exit toward entry)
+        #   Ramp Start:      path_offset = 0    (fan grows from entry toward exit)
+        #   Ramp Start End:  path_offset = (1-f)/2  (symmetric fan from centre)
+        passes = []
+        d = 0.0
+        while d < rough_stop - _PREC:
+            d = min(d + step_down, rough_stop)
+            passes.append((op_start_z - d, d / total_depth))
+        if finish_d > _PREC and total_depth > rough_stop + _PREC:
+            passes.append((effective_final_z, 1.0))
+
+        if not passes:
+            return tool_pos, False
+
+        multi_pass_strategy = getattr(obj, "MultiPassStrategy", "Constant Angle")
+        ramp_len_prop = getattr(obj, "RampLength", None)
+        ramp_length_mm = ramp_len_prop.Value if ramp_len_prop is not None else 0.0
+
+        pass_wires = []
+        for pf, f in passes:
+            if multi_pass_strategy == "Variable Angle":
+                # Full XY path every pass — angle steepens with each depth step.
+                w = _apply_2d_profile(
+                    wire_edges, op_start_z, pf, flute_type, ramp_type, ramp_frac, tol, flip,
+                    ramp_length_mm=ramp_length_mm,
+                )
+            else:
+                # Constant Angle: fan from start — same slope every pass, path shortens.
+                if flute_type == "Ramp Start End":
+                    p_offset = (1.0 - f) / 2.0   # symmetric fan from centre
+                else:
+                    p_offset = 1.0 - f            # fan from start (entry walks)
+                w = _apply_2d_profile(
+                    wire_edges, op_start_z, pf, flute_type, ramp_type, ramp_frac, tol, flip,
+                    path_frac=f, path_offset=p_offset, ramp_length_mm=ramp_length_mm,
+                )
+            if w is not None:
+                pass_wires.append(w)
+
+        if not pass_wires:
+            return tool_pos, False
+
+        fp = PathGeom.wireToPoints(pass_wires[0], tol.arc_chord)
+        if not fp:
+            return tool_pos, False
+
+        entry_pos = FreeCAD.Vector(fp[0].x, fp[0].y, obj.SafeHeight.Value)
+        if tool_pos is not None:
+            linking_kwargs["start_position"] = tool_pos
+            linking_kwargs["target_position"] = entry_pos
+            self.commandlist.extend(linking.get_linking_moves(**linking_kwargs))
+
+        try:
+            tool_radius = obj.ToolController.Tool.Diameter.Value / 2.0
+        except Exception:
+            tool_radius = 0.0
+
+        # Blind-end compensation only applies when the path ends at floor depth.
+        # Ramp Start End always exits back to surface — no blind end.
+        do_blind = (
+            getattr(obj, "BlindEndCompensation", False)
+            and tool_radius > _PREC * 10
+            and flute_type != "Ramp Start End"
+        )
+
+        emitted = False
+        last_pts = fp
+        for w in pass_wires:
+            pts = PathGeom.wireToPoints(w, tol.arc_chord)
+            if not pts:
+                continue
+
+            if do_blind:
+                floor_z_pass = min(p.z for p in pts)
+                if abs(pts[-1].z - floor_z_pass) < tol.floor_snap:
+                    blind_end = pts[-1]
+                    tr2 = tool_radius * tool_radius
+                    while len(pts) > 1:
+                        dx = pts[-1].x - blind_end.x
+                        dy = pts[-1].y - blind_end.y
+                        if dx * dx + dy * dy >= tr2:
+                            break
+                        pts.pop()
+                    if pts:
+                        dx = blind_end.x - pts[-1].x
+                        dy = blind_end.y - pts[-1].y
+                        seg = math.sqrt(dx * dx + dy * dy)
+                        if seg > _PREC:
+                            pts.append(FreeCAD.Vector(
+                                blind_end.x - (dx / seg) * tool_radius,
+                                blind_end.y - (dy / seg) * tool_radius,
+                                blind_end.z,
+                            ))
+
+            if obj.ReverseDirection:
+                pts = list(reversed(pts))
+
+            pass_wire = _pts_to_wire(pts)
+            if pass_wire is None:
+                continue
+
+            cmds = WireFollowGenerator.generate(
+                pass_wire, retract_z, self.horizFeed, self.vertFeed,
+                arc_chord=tol.arc_chord,
+            )
+            if cmds:
+                self.commandlist.extend(cmds)
+                emitted = True
+                last_pts = pts
+
+        if emitted and last_pts:
+            return FreeCAD.Vector(last_pts[-1].x, last_pts[-1].y, retract_z), True
+        return tool_pos, False
+
+    def opExecute(self, obj):
+        """Build the path for all selected flute faces and/or edges."""
+        Path.Log.track()
+
+        self.commandlist = []
+
+        if not hasattr(obj, "Base") or not obj.Base:
+            FreeCAD.Console.PrintError(
+                translate("CAM_Flute", "No base geometry selected for Flute operation.\n")
+            )
+            return False
+
+        step_down = obj.StepDown.Value
+        if step_down <= 0:
+            FreeCAD.Console.PrintError(
+                translate("CAM_Flute", "StepDown must be greater than zero.\n")
+            )
+            return False
+
+        # All absolute-distance tolerances used below scale with the Job's
+        # configured GeometryTolerance (same property Profile/Deburr/Engrave/
+        # Waterline/etc. already use), rather than being fixed mm values.
+        geom_tol = self.job.GeometryTolerance.Value if getattr(self, "job", None) else None
+        tol = _make_tolerances(geom_tol)
+
+        # Selected subelements can be faces (analysed via solid section) or
+        # edges (used directly as the centerline wire, no analysis needed).
+        face_tuples = []
+        edge_tuples = []
+        for base, sub_list in obj.Base:
+            for sub in sub_list:
+                try:
+                    elem = base.Shape.getElement(sub)
+                except Part.OCCError as err:
+                    Path.Log.error(err)
+                    continue
+                if elem.ShapeType == "Face":
+                    face_tuples.append((elem, sub, base))
+                elif elem.ShapeType == "Edge":
+                    edge_tuples.append((elem, sub, base))
+
+        if not face_tuples and not edge_tuples:
+            FreeCAD.Console.PrintError(
+                translate("CAM_Flute", "No valid faces or edges found in base geometry.\n")
+            )
+            return False
+
+        groups = _group_flutes(face_tuples, tol) if face_tuples else []
+
+        Path.Log.debug(
+            "CAM_Flute: {} face(s) -> {} group(s), {} edge(s)\n".format(
+                len(face_tuples), len(groups), len(edge_tuples)
+            )
+        )
+
+        if obj.Comment:
+            self.commandlist.append(Path.Command("({})".format(obj.Comment)))
+        self.commandlist.append(Path.Command("({})".format(obj.Label)))
+        self.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeight.Value}))
+
+        solids = []
+        if getattr(self, "job", None) and hasattr(self.job, "Model"):
+            solids = [b.Shape for b in self.job.Model.Group if hasattr(b, "Shape")]
+
+        linking_kwargs = {
+            "start_position": None,
+            "target_position": None,
+            "heights_clearance": (obj.SafeHeight.Value, obj.ClearanceHeight.Value),
+            "solids": None,
+            "tool_shape": None,
+            "tool_diameter": None,
+            "collision_clearance": obj.CollisionClearance.Value,
+        }
+        strategy = obj.CollisionAvoidanceStrategy
+        if strategy == "Clearance Height":
+            linking_kwargs["heights_clearance"] = obj.ClearanceHeight.Value
+        elif strategy == "Line of Sight":
+            linking_kwargs["solids"] = solids
+        elif strategy == "Tool Diameter":
+            linking_kwargs["solids"] = solids
+            linking_kwargs["tool_diameter"] = obj.ToolController.Tool.Diameter.Value
+        elif strategy == "Tool Shape":
+            linking_kwargs["solids"] = solids
+            linking_kwargs["tool_shape"] = obj.ToolController.Tool.BitBody.Shape
+
+        retract_z = (
+            obj.ClearanceHeight.Value if strategy == "Clearance Height" else obj.SafeHeight.Value
+        )
+
+        op_start_z = obj.StartDepth.Value
+        op_final_z = obj.FinalDepth.Value
+        axial_leave = getattr(obj, "AxialStockToLeave", None)
+        axial_leave = axial_leave.Value if axial_leave is not None else 0.0
+        finish_d = getattr(obj, "FinishDepth", None)
+        finish_d = finish_d.Value if finish_d is not None else 0.0
+
+        any_path = False
+        tool_pos = None
+
+        for group in groups:
+            sub_names = [ft[1] for ft in group["faces"]]
+
+            # --- centerline selection ---
+            # V-bottom groups (valley edge present) MUST use the valley-edge
+            # centerline - it bisects the two faces, unlike either face's own
+            # cylinder axis. Only fall back to per-face cylinder analysis for
+            # groups with no valley edge (e.g. ramp + flat merged by XY-overlap),
+            # where _get_centerline's PCA-on-combined-faces is less accurate
+            # than just analysing the ramp cylinder face directly.
+            section_info = None
+            section_face = None
+            section_base = None
+
+            if group.get("valley_edge") is not None:
+                section_info = _get_centerline(group, tol)
+                section_face = group["faces"][0][0]
+                section_base = group["faces"][0][2]
+            else:
+                for ft in group["faces"]:
+                    cyl_info = _analyze_face_cylinder(ft[0])
+                    if cyl_info is not None:
+                        section_info = cyl_info
+                        section_face = ft[0]
+                        section_base = ft[2]
+                        break
+
+                if section_info is None:
+                    section_info = _get_centerline(group, tol)
+                    section_face = group["faces"][0][0]
+                    section_base = group["faces"][0][2]
+
+            if section_info is None:
+                FreeCAD.Console.PrintWarning(
+                    translate("CAM_Flute", "Could not determine centerline for: {}\n").format(
+                        sub_names
+                    )
+                )
+                continue
+
+            _check_tool_fit(section_info, self.tool)
+
+            geo_top_z = section_info["top_z"]
+            geo_floor_z = section_info["end"].z
+
+            Path.Log.debug(
+                "CAM_Flute: centerline start=({:.3f},{:.3f},{:.3f}) "
+                "end=({:.3f},{:.3f},{:.3f})\n".format(
+                    section_info["start"].x,
+                    section_info["start"].y,
+                    section_info["start"].z,
+                    section_info["end"].x,
+                    section_info["end"].y,
+                    section_info["end"].z,
+                )
+            )
+
+            # --- profile detection via solid section ---
+            # Compute the XY span of ALL faces in the group so the section
+            # plane covers ramp + flat + any exit ramp.
+            bb_list = [ft[0].BoundBox for ft in group["faces"]]
+            group_xy_span = math.sqrt(
+                (max(b.XMax for b in bb_list) - min(b.XMin for b in bb_list)) ** 2
+                + (max(b.YMax for b in bb_list) - min(b.YMin for b in bb_list)) ** 2
+            )
+            wire, detected_floor_z, detected_top_z = _detect_floor_wire(
+                section_face, section_base, section_info, tol, group_extent=group_xy_span
+            )
+
+            if wire is None:
+                # Fall back to a plain ramp wire using the centerline endpoints.
+                Path.Log.debug("CAM_Flute: falling back to plain ramp wire\n")
+                wire = _pts_to_wire([
+                    FreeCAD.Vector(section_info["start"]),
+                    FreeCAD.Vector(section_info["end"]),
+                ])
+                if wire is None:
+                    continue
+            else:
+                # Re-derive Z range from the detected wire, not the centerline
+                # estimate.  PCA / cylinder analysis can disagree with the real
+                # sectioned floor depth.
+                geo_top_z = detected_top_z
+                geo_floor_z = detected_floor_z
+
+            tool_pos, emitted = self._emitFlutePath(
+                obj,
+                wire,
+                geo_top_z,
+                geo_floor_z,
+                sub_names,
+                op_start_z,
+                op_final_z,
+                axial_leave,
+                finish_d,
+                step_down,
+                retract_z,
+                linking_kwargs,
+                tool_pos,
+                tol,
+            )
+            any_path = any_path or emitted
+
+        # --- edges selected directly as the flute path ----------------------
+        # Each connected component of selected edges is one flute.
+        # Mixed selections (some flat, some carrying Z) are rejected — the
+        # user must create separate operations for 2D and 3D wires.
+        if edge_tuples:
+            edge_by_id = {id(e): sub for e, sub, _b in edge_tuples}
+            wire_groups = _split_into_wires([e for e, _sub, _b in edge_tuples], tol)
+            Path.Log.debug(
+                "CAM_Flute: {} edge(s) -> {} wire(s)\n".format(
+                    len(edge_tuples), len(wire_groups)
+                )
+            )
+
+            flat_groups = [wg for wg in wire_groups if _wire_is_flat(wg, tol)]
+            solid_groups = [wg for wg in wire_groups if not _wire_is_flat(wg, tol)]
+
+            if flat_groups and solid_groups:
+                Path.Log.warning(
+                    "Flute: mixed 2D (flat) and 3D wires in the same selection "
+                    "are not supported. Use separate operations for each type.\n"
+                )
+            else:
+                for wire_edges in wire_groups:
+                    sub_names = [edge_by_id.get(id(e), "?") for e in wire_edges]
+
+                    if flat_groups:
+                        flute_type = getattr(obj, "FlutingType", "Ramp Full")
+                        ramp_type = getattr(obj, "RampType", "Linear")
+                        ramp_pct = getattr(obj, "RampPercent", 100.0)
+                        ramp_frac = max(0.0, min(1.0, ramp_pct / 100.0))
+                        flip = getattr(obj, "FlipStart2D", False)
+                        tool_pos, emitted = self._emit2dPasses(
+                            obj, wire_edges, flute_type, ramp_type, ramp_frac, flip,
+                            op_start_z, op_final_z, axial_leave, finish_d, step_down,
+                            retract_z, linking_kwargs, tool_pos, tol, sub_names,
+                        )
+                        any_path = any_path or emitted
+                    else:
+                        # 3D wire: edges carry Z information directly.
+                        wire, geo_top_z, geo_floor_z = _wire_from_edges(wire_edges, tol)
+                        if wire is None:
+                            continue
+
+                        tool_pos, emitted = self._emitFlutePath(
+                            obj,
+                            wire,
+                            geo_top_z,
+                            geo_floor_z,
+                            sub_names,
+                            op_start_z,
+                            op_final_z,
+                            axial_leave,
+                            finish_d,
+                            step_down,
+                            retract_z,
+                            linking_kwargs,
+                            tool_pos,
+                            tol,
+                        )
+                        any_path = any_path or emitted
+
+        if not any_path:
+            self.commandlist.clear()
+            return False
+
+        self.commandlist.append(
+            Path.Command("G0", {"Z": obj.ClearanceHeight.Value, "F": self.vertRapid})
+        )
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Module-level API expected by PathOpGui.SetupOperation
+# ---------------------------------------------------------------------------
+
+
+def SetupProperties():
+    return [
+        "ReverseDirection",
+        "AxialStockToLeave",
+        "BlindEndCompensation",
+        "MultiPassStrategy",
+        "FlutingType",
+        "RampType",
+        "RampLength",
+        "RampPercent",
+        "FlipStart2D",
+    ]
+
+
+def Create(name, obj=None, parentJob=None):
+    if obj is None:
+        obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
+    obj.Proxy = ObjectFlute(obj, name, parentJob)
+    return obj

--- a/src/Mod/CAM/Path/Op/Flute.py
+++ b/src/Mod/CAM/Path/Op/Flute.py
@@ -794,36 +794,89 @@ def _tangent_continuous(prev_edge, cur_edge, junction, prev_start, cur_end):
     return (1.0 - d) <= _TANGENT_DOT_TOL
 
 
-def _split_at_corners(edges, tol):
-    """Order a connected edge set and split it into tangent-continuous sub-chains.
+def _split_at_corners(edges, tol, combine=True):
+    """Partition a connected edge set into tangent-continuous groups.
 
-    Consecutive edges that meet smoothly (collinear straight lines or
-    smoothly-joined curves) stay in one sub-chain; a sharp corner starts a new
-    one, so each sub-chain becomes an independent flute path.  If the edges do
-    not form a single simple open chain (branching / not connected), each edge
-    is returned as its own sub-chain.
+    Two edges sharing an endpoint stay in the same group only when they meet
+    tangent-continuously (G1) there — collinear straight lines or
+    smoothly-joined curves both qualify.  A sharp corner is a group boundary.
 
-    Returns a list of ordered edge lists.
+    Every PAIR of edges meeting at a shared node is tested independently, not
+    just when exactly two edges meet there.  This matters for a hub where
+    several distinct flute paths happen to cross at one coincident point
+    (e.g. many spokes through a common center): each genuinely collinear pair
+    is still detected and merged, while unrelated edges at the same point
+    correctly stay separate — the tangent test itself disambiguates, so an
+    edge count higher than two at a node is not, by itself, a reason to
+    refuse merging.
+
+    Groups are found via union-find directly on the edge-adjacency graph, so a
+    branch elsewhere in a larger connected selection cannot prevent an
+    unrelated tangent pair from merging (unlike walking one linear chain,
+    which fails outright on any branching).  Groups are not internally
+    ordered — callers (_wire_from_edges / _apply_2d_profile) re-chain each
+    group's edges via _chain_wire_edges before use.
+
+    combine: if False, tangent-continuity is ignored entirely and every edge
+    is returned as its own independent group (the CombineTangentSegments
+    operator override).
+
+    Returns a list of edge lists (each list = one flute path's edges).
     """
-    if len(edges) == 1:
-        return [list(edges)]
-
-    chain = _chain_wire_edges(edges, tol)
-    if not chain:
+    if not combine or len(edges) <= 1:
         return [[edge] for edge in edges]
 
-    subchains = []
-    current = [chain[0][2]]
-    for i in range(1, len(chain)):
-        prev_start, junction, prev_edge = chain[i - 1]
-        _cur_start, cur_end, cur_edge = chain[i]
-        if _tangent_continuous(prev_edge, cur_edge, junction, prev_start, cur_end):
-            current.append(cur_edge)
-        else:
-            subchains.append(current)
-            current = [cur_edge]
-    subchains.append(current)
-    return subchains
+    nodes = []  # representative Vector per snapped node
+
+    def _node(p):
+        for i, np_ in enumerate(nodes):
+            if _dist2(np_, p) < tol.chain2:
+                return i
+        nodes.append(p)
+        return len(nodes) - 1
+
+    edge_nodes = []  # (nodeA, nodeB) per edge, aligned with `edges`
+    at_node = {}  # node id -> [edge indices touching it]
+    for idx, e in enumerate(edges):
+        a = _node(e.Vertexes[0].Point)
+        b = _node(e.Vertexes[-1].Point)
+        edge_nodes.append((a, b))
+        at_node.setdefault(a, []).append(idx)
+        at_node.setdefault(b, []).append(idx)
+
+    parent = list(range(len(edges)))
+
+    def _find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def _union(x, y):
+        rx, ry = _find(x), _find(y)
+        if rx != ry:
+            parent[rx] = ry
+
+    for node, idxs in at_node.items():
+        if len(idxs) < 2:
+            continue  # dangling end: nothing to pair up
+        junction = nodes[node]
+        for a in range(len(idxs)):
+            for b in range(a + 1, len(idxs)):
+                i1, i2 = idxs[a], idxs[b]
+                a1, b1 = edge_nodes[i1]
+                other1 = b1 if a1 == node else a1
+                a2, b2 = edge_nodes[i2]
+                other2 = b2 if a2 == node else a2
+                if _tangent_continuous(
+                    edges[i1], edges[i2], junction, nodes[other1], nodes[other2]
+                ):
+                    _union(i1, i2)
+
+    groups = {}
+    for idx in range(len(edges)):
+        groups.setdefault(_find(idx), []).append(edges[idx])
+    return list(groups.values())
 
 
 def _split_into_wires(edges, tol):
@@ -863,38 +916,22 @@ def _chain_wire_edges(edges, tol):
 
     Assumes edges form a single simple open path (no branching).  Returns
     None if they don't all connect into one chain.
+
+    Connectivity/ordering is delegated to OCC's Part.sortEdges, which anchors
+    on edges[0]'s own drawn direction (never reversing it) and grows the
+    chain in either direction from there, reversing only the edges that
+    follow to keep it connected -- the same contract this function had when
+    hand-rolled, and the same pattern used ~25+ places elsewhere in the Path
+    codebase (Part.Wire(Part.__sortEdges__(edges))).
     """
     if not edges:
         return None
 
-    remaining = list(edges[1:])
-    e0 = edges[0]
-    chain = [(e0.Vertexes[0].Point, e0.Vertexes[-1].Point, e0)]
+    chains = Part.sortEdges(list(edges), math.sqrt(tol.chain2))
+    if len(chains) != 1 or len(chains[0]) != len(edges):
+        return None  # branching, a gap, or edges outside chaining tolerance
 
-    changed = True
-    while remaining and changed:
-        changed = False
-        cur_s, cur_e = chain[0][0], chain[-1][1]
-        for e in list(remaining):
-            v0, v1 = e.Vertexes[0].Point, e.Vertexes[-1].Point
-            if _dist2(cur_e, v0) < tol.chain2:
-                chain.append((v0, v1, e))
-            elif _dist2(cur_e, v1) < tol.chain2:
-                chain.append((v1, v0, e))
-            elif _dist2(cur_s, v0) < tol.chain2:
-                chain.insert(0, (v1, v0, e))
-            elif _dist2(cur_s, v1) < tol.chain2:
-                chain.insert(0, (v0, v1, e))
-            else:
-                continue
-            remaining.remove(e)
-            changed = True
-            break
-
-    if remaining:
-        return None  # could not connect all edges into a single chain
-
-    return chain
+    return [(e.Vertexes[0].Point, e.Vertexes[-1].Point, e) for e in chains[0]]
 
 
 def _wire_from_edges(edges, tol):
@@ -912,25 +949,20 @@ def _wire_from_edges(edges, tol):
         )
         return None, None, None
 
-    # Orient so the shallower (higher Z) free end is the start.
+    wire = Part.Wire([edge for _, _, edge in chain])
+
+    # Orient so the shallower (higher Z) free end is the start. Every
+    # consumer of this wire (WireFollowGenerator.generate, _emitFlutePath)
+    # discretizes it themselves via PathGeom.edgesToPoints, so there is no
+    # need to sample points here just to rebuild a polyline wire from them.
     if chain[0][0].z < chain[-1][1].z:
-        chain = [(e, s, edge) for s, e, edge in reversed(chain)]
+        wire = PathGeom.flipWire(wire)
 
-    pts = PathGeom.edgesToPoints(
-        [edge for _, _, edge in chain],
-        tol.arc_chord,
-        startPoint=chain[0][0],
-        error=tol.arc_chord * 0.01,
-    )
-    if not pts:
-        return None, None, None
-
-    wire = _pts_to_wire(pts)
-    if wire is None:
-        return None, None, None
-
-    all_z = [p.z for p in pts]
-    return wire, max(all_z), min(all_z)
+    # BoundBox covers the true extent of curved edges too, not just their
+    # endpoints -- at least as accurate as sampling at the chord tolerance.
+    top_z = max(e.BoundBox.ZMax for e in wire.Edges)
+    floor_z = min(e.BoundBox.ZMin for e in wire.Edges)
+    return wire, top_z, floor_z
 
 
 # ---------------------------------------------------------------------------
@@ -1173,39 +1205,6 @@ def _apply_axial_leave_pts(pts, axial_leave, stock_top_z, tol):
 # ---------------------------------------------------------------------------
 
 
-def _simplify_collinear(pts, chord):
-    """Remove points that are collinear with their neighbours in 3D space.
-
-    Keeps only points whose perpendicular distance from the segment formed by
-    their predecessor and successor exceeds chord * 0.01.  Exactly collinear
-    points (e.g. intermediate samples on a straight edge with linear Z) are
-    removed; curved or smooth-Z segments are preserved.
-    """
-    if len(pts) < 3:
-        return list(pts)
-    tol_sq = (chord * 0.01) ** 2
-    result = [pts[0]]
-    for i in range(1, len(pts) - 1):
-        a, c = result[-1], pts[i + 1]
-        b = pts[i]
-        acx, acy, acz = c.x - a.x, c.y - a.y, c.z - a.z
-        ac2 = acx * acx + acy * acy + acz * acz
-        if ac2 < _PREC:
-            result.append(b)
-            continue
-        abx, aby, abz = b.x - a.x, b.y - a.y, b.z - a.z
-        t = (abx * acx + aby * acy + abz * acz) / ac2
-        px = a.x + t * acx
-        py = a.y + t * acy
-        pz = a.z + t * acz
-        dx, dy, dz = b.x - px, b.y - py, b.z - pz
-        if dx * dx + dy * dy + dz * dz < tol_sq:
-            continue
-        result.append(b)
-    result.append(pts[-1])
-    return result
-
-
 def _wire_is_flat(edges, tol):
     """Return True if all edges lie at essentially the same Z (2D wire)."""
     zs = [v.Point.z for e in edges for v in e.Vertexes]
@@ -1287,7 +1286,7 @@ def _apply_2d_profile(
         return None
 
     # Always discretize all edge types so intermediate arc-length positions
-    # exist for Z-profile sampling.  _simplify_collinear removes redundant
+    # exist for Z-profile sampling.  PathUtils.simplify3dLine removes redundant
     # collinear points afterward (e.g. straight edge + linear Z → 2 pts).
     raw = []
     for seg_s, seg_e, edge in chain:
@@ -1351,7 +1350,11 @@ def _apply_2d_profile(
         elif flute_type == "Ramp Start":
             f = min(t / ramp_frac, 1.0) if ramp_frac > _PREC else 1.0
         elif flute_type == "Ramp Start End":
-            half = ramp_frac / 2.0
+            # ramp_frac is the size of EACH side's ramp independently (not a
+            # combined total split between them).  If it's more than half the
+            # path the two ramps would overlap, so clamp to 0.5 -- they then
+            # meet exactly at the midpoint with no flat section remaining.
+            half = min(ramp_frac, 0.5)
             if half < _PREC:
                 f = 1.0
             elif t <= half:
@@ -1382,7 +1385,7 @@ def _apply_2d_profile(
         return start_z - f * depth
 
     pts = [FreeCAD.Vector(p.x, p.y, _z_at(arc_len[i] / total)) for i, p in enumerate(raw)]
-    pts = _simplify_collinear(pts, tol.arc_chord)
+    pts = PathUtils.simplify3dLine(pts, tolerance=tol.arc_chord * 0.01)
     return _pts_to_wire(pts)
 
 
@@ -1453,6 +1456,31 @@ class ObjectFlute(PathOp.ObjectOp):
             ),
         )
         obj.addProperty(
+            "App::PropertyBool",
+            "CombineTangentSegments",
+            "Flute",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Merge connected edges that meet tangent-continuously "
+                "(collinear lines or smoothly-joined curves) into a single "
+                "flute path. When off, every selected edge is its own "
+                "independent flute path regardless of tangency.",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyStringList",
+            "FlippedSegments",
+            "Flute",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Base geometry entries (stored as 'ObjectName.SubName') whose "
+                "individual edge direction is force-reversed before path "
+                "generation, regardless of how it was drawn. Set from the "
+                "checkboxes on the Base Geometry list. Independent of "
+                "FlipStart2D, which reverses the whole result at the end.",
+            ),
+        )
+        obj.addProperty(
             "App::PropertyEnumeration",
             "FlutingType",
             "Flute2D",
@@ -1464,6 +1492,7 @@ class ObjectFlute(PathOp.ObjectOp):
             ),
         )
         obj.FlutingType = ["Ramp Full", "Ramp Start", "Ramp Start End"]
+        obj.FlutingType = "Ramp Full"
         obj.addProperty(
             "App::PropertyEnumeration",
             "RampType",
@@ -1487,21 +1516,46 @@ class ObjectFlute(PathOp.ObjectOp):
             ),
         )
         obj.addProperty(
+            "App::PropertyEnumeration",
+            "RampLengthType",
+            "Flute2D",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Whether Ramp Length or Ramp % defines the ramp size on 2D "
+                "wires. Only the selected one is used; they are independent "
+                "(not converted into each other).",
+            ),
+        )
+        obj.RampLengthType = ["Length", "Percent"]
+        obj.RampLengthType = "Length"
+        obj.addProperty(
             "App::PropertyDistance",
             "RampLength",
             "Flute2D",
             QtCore.QT_TRANSLATE_NOOP(
                 "App::Property",
                 "Length of each ramp segment in mm (2D wires only). "
-                "When greater than zero, overrides Ramp %. "
-                "The fraction is derived at compute time from this length "
-                "divided by the actual wire length.",
+                "Used when Ramp Length Type is Length.",
             ),
         )
         obj.addProperty(
+            "App::PropertyIntegerConstraint",
+            "RampLengthPercent",
+            "Flute2D",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Ramp size as a percentage of each wire's own length (2D "
+                "wires only). Used when Ramp Length Type is Percent; applied "
+                "independently to every selected wire. Capped at 50% for "
+                "Ramp Start End, since each side already ramps that fraction "
+                "independently -- beyond 50% the two ramps would overlap.",
+            ),
+        )
+        obj.RampLengthPercent = (100, 1, 100, 1)
+        obj.addProperty(
             "App::PropertyEnumeration",
             "MultiPassStrategy",
-            "Depth",
+            "Flute",
             QtCore.QT_TRANSLATE_NOOP(
                 "App::Property",
                 "How roughing passes are distributed across step-down depths. "
@@ -1513,14 +1567,21 @@ class ObjectFlute(PathOp.ObjectOp):
         )
         obj.MultiPassStrategy = ["Constant Angle", "Variable Angle"]
 
+        self.applyRampLengthTypeEditorMode(obj)
+        self.applyRampLengthPercentConstraint(obj)
+        self.applyBlindEndCompensationEditorMode(obj)
+
     def opSetDefaultValues(self, obj, job):
         obj.ReverseDirection = False
         obj.AxialStockToLeave = 0.0
         obj.BlindEndCompensation = False
+        obj.CombineTangentSegments = True
         obj.FlutingType = "Ramp Full"
         obj.RampType = "Linear"
         obj.FlipStart2D = False
+        obj.RampLengthType = "Length"
         obj.RampLength = 0.0
+        obj.RampLengthPercent = 100
         obj.MultiPassStrategy = "Constant Angle"
 
         d = None
@@ -1555,14 +1616,93 @@ class ObjectFlute(PathOp.ObjectOp):
                 except Part.OCCError as err:
                     Path.Log.error(err)
 
-        if z_max is not None:
-            obj.OpStartDepth = z_max
-        if z_min is not None:
+        if z_max is None or z_min is None:
+            return
+
+        # The wire's own Z is the ramp's starting surface, so it's always a
+        # valid StartDepth regardless of whether the selection is flat or 3D.
+        obj.OpStartDepth = z_max
+
+        if PathGeom.isRoughly(z_max, z_min):
+            # A flat (2D) wire has no Z range of its own -- z_min here just
+            # repeats the same single Z as z_max, which is NOT a meaningful
+            # final (deep) depth: it's the ramp's starting surface, not the
+            # cut's bottom. The base class's generic faceZmin heuristic
+            # (Path/Op/Base.py updateDepths) mistakes a flat wire for a top
+            # face and already set OpFinalDepth to that same Z before this
+            # override runs -- correct it back to the stock floor instead of
+            # collapsing FinalDepth to match StartDepth.
+            if hasattr(obj, "OpStockZMin"):
+                obj.OpFinalDepth = obj.OpStockZMin
+        else:
             obj.OpFinalDepth = z_min
 
     def onChanged(self, obj, prop):
         if prop == "Active" and obj.ViewObject:
             obj.ViewObject.signalChangeIcon()
+        if prop == "RampLengthType":
+            self.applyRampLengthTypeEditorMode(obj)
+        if prop == "FlutingType":
+            self.applyRampLengthPercentConstraint(obj)
+            self.applyRampLengthTypeEditorMode(obj)
+            self.applyBlindEndCompensationEditorMode(obj)
+
+    def applyBlindEndCompensationEditorMode(self, obj):
+        """Grey out (not hide) BlindEndCompensation when FlutingType is Ramp
+        Start End, since that profile always ramps back to the surface --
+        matching the same flute_type != "Ramp Start End" gate opExecute
+        already applies when computing whether to actually run the blind-end
+        logic.  Left fully editable (and thus usable) for a 3D wire
+        selection, where FlutingType has no bearing at all.
+
+        Runs from onChanged (works from any source) and once at creation.
+        """
+        if not hasattr(obj, "BlindEndCompensation"):
+            return
+        is_ramp_start_end = getattr(obj, "FlutingType", "Ramp Full") == "Ramp Start End"
+        obj.setEditorMode("BlindEndCompensation", 1 if is_ramp_start_end else 0)
+
+    def applyRampLengthPercentConstraint(self, obj):
+        """Cap Ramp % at 50 for Ramp Start End (each side already ramps that
+        fraction independently, so anything above 50% would just overlap and
+        clamp anyway -- capping the input directly avoids the false
+        impression of a bug).  Unclamps back to 100 for any other FlutingType.
+
+        Runs from onChanged (so it applies regardless of source: task panel,
+        Properties panel, or scripting) and once at creation for the initial
+        state.  Reassigning the constraint tuple also clamps the current
+        stored value down if it's now above the new maximum.
+        """
+        if not hasattr(obj, "RampLengthPercent"):
+            return
+        max_pct = 50 if getattr(obj, "FlutingType", "Ramp Full") == "Ramp Start End" else 100
+        current = min(obj.RampLengthPercent, max_pct)
+        obj.RampLengthPercent = (current, 1, max_pct, 1)
+
+    def applyRampLengthTypeEditorMode(self, obj):
+        """Show only the Ramp Length or Ramp % property matching RampLengthType
+        in the Properties panel, and grey out (not hide) the whole trio when
+        FlutingType is Ramp Full, since ramp_frac has no effect at all in that
+        mode.  Runs from onChanged on either RampLengthType or FlutingType (so
+        it stays correct regardless of source) and once at operation creation.
+
+        This method only ever chooses between mode 0 (editable) and mode 1
+        (read-only/greyed) -- never mode 2 (hidden).  Whether the trio is
+        visible at all (2D wire selected) is decided by the Gui task panel,
+        which knows the current wire-selection classification; layering a
+        hide/show decision in here too would risk the two fighting over the
+        same editor mode.
+        """
+        if not hasattr(obj, "RampLengthType"):
+            return
+        is_percent = obj.RampLengthType == "Percent"
+        ramp_full = getattr(obj, "FlutingType", "Ramp Full") == "Ramp Full"
+        greyed = 1 if ramp_full else 0
+        obj.setEditorMode("RampLengthType", greyed)
+        if hasattr(obj, "RampLength"):
+            obj.setEditorMode("RampLength", 2 if is_percent else greyed)
+        if hasattr(obj, "RampLengthPercent"):
+            obj.setEditorMode("RampLengthPercent", greyed if is_percent else 2)
 
     def _emitFlutePath(
         self,
@@ -1728,8 +1868,14 @@ class ObjectFlute(PathOp.ObjectOp):
             return tool_pos, False
 
         multi_pass_strategy = getattr(obj, "MultiPassStrategy", "Constant Angle")
-        ramp_len_prop = getattr(obj, "RampLength", None)
-        ramp_length_mm = ramp_len_prop.Value if ramp_len_prop is not None else 0.0
+        # Only Length mode overrides ramp_frac via an absolute length; in Percent
+        # mode ramp_frac (passed in from opExecute) is already the per-wire
+        # fraction, so no length override should apply.
+        if getattr(obj, "RampLengthType", "Length") == "Length":
+            ramp_len_prop = getattr(obj, "RampLength", None)
+            ramp_length_mm = ramp_len_prop.Value if ramp_len_prop is not None else 0.0
+        else:
+            ramp_length_mm = 0.0
 
         pass_wires = []
         for pf, f in passes:
@@ -1854,6 +2000,7 @@ class ObjectFlute(PathOp.ObjectOp):
 
         # Selected subelements can be faces (analysed via solid section) or
         # edges (used directly as the centerline wire, no analysis needed).
+        flipped_keys = set(getattr(obj, "FlippedSegments", None) or [])
         face_tuples = []
         edge_tuples = []
         for base, sub_list in obj.Base:
@@ -1866,6 +2013,10 @@ class ObjectFlute(PathOp.ObjectOp):
                 if elem.ShapeType == "Face":
                     face_tuples.append((elem, sub, base))
                 elif elem.ShapeType == "Edge":
+                    if "{}.{}".format(base.Name, sub) in flipped_keys:
+                        flipped = PathGeom.flipEdge(elem)
+                        if flipped is not None:
+                            elem = flipped
                     edge_tuples.append((elem, sub, base))
 
         if not face_tuples and not edge_tuples:
@@ -2056,11 +2207,18 @@ class ObjectFlute(PathOp.ObjectOp):
                 # each become their own independent flute path.
                 flute_type = getattr(obj, "FlutingType", "Ramp Full")
                 ramp_type = getattr(obj, "RampType", "Linear")
-                ramp_frac = 1.0  # full wire; overridden by RampLength if set
+                # Percent mode: ramp_frac is used directly, independently per wire.
+                # Length mode: ramp_frac defaults to full wire; _emit2dPasses
+                # overrides it per-wire from RampLength (see ramp_length_mm below).
+                ramp_length_type = getattr(obj, "RampLengthType", "Length")
+                ramp_frac = (
+                    (obj.RampLengthPercent / 100.0) if ramp_length_type == "Percent" else 1.0
+                )
                 flip = getattr(obj, "FlipStart2D", False)
+                combine_tangent = getattr(obj, "CombineTangentSegments", True)
                 processed_groups = []
                 for group in flat_groups:
-                    processed_groups.extend(_split_at_corners(group, tol))
+                    processed_groups.extend(_split_at_corners(group, tol, combine=combine_tangent))
                 Path.Log.debug(
                     "CAM_Flute: {} flat group(s) -> {} 2D flute path(s) after corner split\n".format(
                         len(flat_groups), len(processed_groups)
@@ -2091,9 +2249,10 @@ class ObjectFlute(PathOp.ObjectOp):
                 # 3D wires: edges carry Z information directly.  Split each
                 # connected component at sharp corners so a smooth run (straight
                 # or curved) is one flute and an L-corner becomes two.
+                combine_tangent = getattr(obj, "CombineTangentSegments", True)
                 solid_paths = []
                 for group in solid_groups:
-                    solid_paths.extend(_split_at_corners(group, tol))
+                    solid_paths.extend(_split_at_corners(group, tol, combine=combine_tangent))
                 for wire_edges in solid_paths:
                     sub_names = [edge_by_id.get(id(e), "?") for e in wire_edges]
                     wire, geo_top_z, geo_floor_z = _wire_from_edges(wire_edges, tol)
@@ -2137,10 +2296,14 @@ def SetupProperties():
         "ReverseDirection",
         "AxialStockToLeave",
         "BlindEndCompensation",
+        "CombineTangentSegments",
+        "FlippedSegments",
         "MultiPassStrategy",
         "FlutingType",
         "RampType",
+        "RampLengthType",
         "RampLength",
+        "RampLengthPercent",
         "FlipStart2D",
     ]
 

--- a/src/Mod/CAM/Path/Op/Gui/Flute.py
+++ b/src/Mod/CAM/Path/Op/Gui/Flute.py
@@ -107,7 +107,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         )
 
         self.form.flutingType.addItems(["Ramp Full", "Ramp Start", "Ramp Start End"])
-        self.form.rampType.addItems(["Linear", "Smooth", "Arc"])
+        self.form.rampType.addItems(["Linear", "S-Curve", "Smooth", "Fillet"])
 
         # Two-way sync between Ramp Length (stored) and Ramp % (derived display).
         # Mirrors Adaptive's stepOver ↔ stepOverDistance pattern.

--- a/src/Mod/CAM/Path/Op/Gui/Flute.py
+++ b/src/Mod/CAM/Path/Op/Gui/Flute.py
@@ -42,19 +42,11 @@ else:
     Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 
 # Z-variation threshold for flat-wire detection in the UI layer (mm).
-# Coarser than the tol.edge used at generate time — we only need to decide
-# whether to show the 2D controls, not whether to actually synthesize a profile.
 _FLAT_UI_TOL = 0.01
 
 
 def _classify_wire_selection(obj):
-    """Classify the edge selection as "flat", "3d", "mixed", or "none".
-
-    "flat"  — all selected edges lie at essentially constant Z
-    "3d"    — all selected edges carry Z variation
-    "mixed" — both types present (not allowed in one operation)
-    "none"  — no edges selected
-    """
+    """Classify the edge selection as "flat", "3d", "mixed", or "none"."""
     if not hasattr(obj, "Base") or not obj.Base:
         return "none"
     has_flat = False
@@ -84,11 +76,7 @@ def _classify_wire_selection(obj):
 
 
 def _get_selection_wire_length(obj):
-    """Return total arc length (mm) of all selected edges.
-
-    Used to convert between RampLength (mm) and RampPercent (%) in the UI.
-    Uses shape.Length (exact) rather than discretizing — close enough for display.
-    """
+    """Return total arc length (mm) of all selected edges (conversion factor for % ↔ mm)."""
     if not hasattr(obj, "Base") or not obj.Base:
         return 0.0
     total = 0.0
@@ -121,51 +109,37 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.flutingType.addItems(["Ramp Full", "Ramp Start", "Ramp Start End"])
         self.form.rampType.addItems(["Linear", "Smooth", "Arc"])
 
-        # Two-way sync: connect before FreeCAD registers getSignalsForUpdate so
-        # our slots fire first and the widget values are consistent when getFields
-        # reads them.  blockSignals() in each slot prevents infinite loops.
-        self.form.rampLength.editingFinished.connect(self._sync_pct_from_length)
-        self.form.rampPercent.valueChanged.connect(self._sync_length_from_pct)
+        # Two-way sync between Ramp Length (stored) and Ramp % (derived display).
+        # Mirrors Adaptive's stepOver ↔ stepOverDistance pattern.
+        # Connected here (before FreeCAD registers getSignalsForUpdate slots) so
+        # our slots fire first — the length widget is correct before getFields reads it.
+        self.form.rampLength.editingFinished.connect(lambda: self.updateRampPercent(obj))
+        self.form.rampPercent.valueChanged.connect(lambda: self.updateRampLength(obj))
 
-        # Stash obj so the sync slots can reach it.
-        self._flute_obj = obj
-
-    def _sync_pct_from_length(self):
-        """User finished editing Ramp Length — update Ramp % display."""
-        obj = getattr(self, "_flute_obj", None)
-        if obj is None:
-            return
+    def updateRampPercent(self, obj):
+        """Ramp Length changed — update Ramp % display."""
         wire_len = _get_selection_wire_length(obj)
         if wire_len <= 0:
             return
-        try:
-            length_mm = self.form.rampLength.value().Value
-        except Exception:
-            return
-        if length_mm <= 0:
-            return
-        pct = max(1, min(100, int(round(length_mm / wire_len * 100))))
-        self.form.rampPercent.blockSignals(True)
-        self.form.rampPercent.setValue(pct)
-        self.form.rampPercent.blockSignals(False)
+        length_mm = self.form.rampLength.property("rawValue")
+        if length_mm and length_mm > 0:
+            pct = max(1, min(100, int(round(length_mm / wire_len * 100))))
+            self.form.rampPercent.blockSignals(True)
+            self.form.rampPercent.setValue(pct)
+            self.form.rampPercent.blockSignals(False)
 
-    def _sync_length_from_pct(self, pct):
-        """User changed Ramp % — update Ramp Length display."""
-        obj = getattr(self, "_flute_obj", None)
-        if obj is None:
-            return
+    def updateRampLength(self, obj):
+        """Ramp % changed — update Ramp Length display so getFields reads the right value."""
         wire_len = _get_selection_wire_length(obj)
         if wire_len <= 0:
             return
+        pct = self.form.rampPercent.value()
         length_mm = wire_len * pct / 100.0
-        q = FreeCAD.Units.Quantity("{} mm".format(length_mm))
         self.form.rampLength.blockSignals(True)
-        self.form.rampLength.setValue(q)
+        self.form.rampLength.setProperty("rawValue", length_mm)
         self.form.rampLength.blockSignals(False)
 
     def setFields(self, obj):
-        self._flute_obj = obj
-
         self.setupToolController(obj, self.form.toolController)
         self.setupCoolant(obj, self.form.coolantController)
 
@@ -179,7 +153,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.axialStockToLeaveSpinBox.updateWidget()
 
         # 2D properties
-        flute_type = getattr(obj, "FlutingType", "RampFull")
+        flute_type = getattr(obj, "FlutingType", "Ramp Full")
         idx = self.form.flutingType.findText(flute_type)
         if idx >= 0:
             self.form.flutingType.setCurrentIndex(idx)
@@ -189,26 +163,21 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         if idx >= 0:
             self.form.rampType.setCurrentIndex(idx)
 
-        # Show RampLength widget first, then derive RampPercent from it.
-        # If RampLength is 0, fall back to the stored RampPercent.
+        # Load RampLength; then derive % from it.
+        # Load length; derive % from it. If length is 0, default % display to 100.
         self.rampLengthSpinBox.updateWidget()
-
         length_mm = getattr(obj, "RampLength", None)
         length_mm = length_mm.Value if length_mm is not None else 0.0
-        wire_len = _get_selection_wire_length(obj)
 
-        self.form.rampPercent.blockSignals(True)
-        if length_mm > 0 and wire_len > 0:
-            pct = max(1, min(100, int(round(length_mm / wire_len * 100))))
-            self.form.rampPercent.setValue(pct)
+        if length_mm > 0:
+            self.updateRampPercent(obj)
         else:
-            self.form.rampPercent.setValue(int(getattr(obj, "RampPercent", 100)))
-        self.form.rampPercent.blockSignals(False)
+            self.form.rampPercent.blockSignals(True)
+            self.form.rampPercent.setValue(100)
+            self.form.rampPercent.blockSignals(False)
 
         flip = getattr(obj, "FlipStart2D", False)
-        self.form.flipStart2D.setCheckState(
-            QtCore.Qt.Checked if flip else QtCore.Qt.Unchecked
-        )
+        self.form.flipStart2D.setCheckState(QtCore.Qt.Checked if flip else QtCore.Qt.Unchecked)
 
         self._update_2d_visibility(obj)
 
@@ -224,10 +193,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             obj.FlutingType = self.form.flutingType.currentText()
         if hasattr(obj, "RampType"):
             obj.RampType = self.form.rampType.currentText()
-        # RampLength is authoritative; RampPercent kept in sync for storage.
         self.rampLengthSpinBox.updateProperty()
-        if hasattr(obj, "RampPercent"):
-            obj.RampPercent = self.form.rampPercent.value()
         if hasattr(obj, "FlipStart2D"):
             obj.FlipStart2D = self.form.flipStart2D.isChecked()
 
@@ -243,6 +209,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
                 signals.append(checkbox.stateChanged)
 
         signals.append(self.form.axialStockToLeave.editingFinished)
+        # rampLength.editingFinished triggers recompute via FreeCAD machinery.
+        # rampPercent.valueChanged is also registered so changing % triggers recompute
+        # (our updateRampLength slot runs first to sync the length widget).
         signals.append(self.form.rampLength.editingFinished)
         signals.append(self.form.flutingType.currentIndexChanged)
         signals.append(self.form.rampType.currentIndexChanged)
@@ -267,10 +236,8 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
         self.form.flute2DOptions.setVisible(show_2d)
 
-        # Mirror visibility into the data panel properties so they don't clutter
-        # the tree when 2D mode isn't relevant.  2 = hidden, 0 = normal.
         mode = 0 if show_2d else 2
-        for prop in ("FlutingType", "RampType", "RampLength", "RampPercent", "FlipStart2D"):
+        for prop in ("FlutingType", "RampType", "RampLength", "FlipStart2D"):
             if hasattr(obj, prop):
                 obj.setEditorMode(prop, mode)
 

--- a/src/Mod/CAM/Path/Op/Gui/Flute.py
+++ b/src/Mod/CAM/Path/Op/Gui/Flute.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Billy Huddleston <billy@ivdc.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+__title__ = "CAM Flute Operation UI"
+__author__ = "Connor (Billy Huddleston <billy@ivdc.com>)"
+__url__ = "https://www.freecad.org"
+__doc__ = "Flute operation task panel controller and command implementation."
+
+import FreeCAD
+import FreeCADGui
+import Path
+import Path.Base.Gui.Util as PathGuiUtil
+import Path.Op.Flute as PathFlute
+import Path.Op.Gui.Base as PathOpGui
+
+from PySide import QtCore
+
+translate = FreeCAD.Qt.translate
+
+if False:
+    Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
+    Path.Log.trackModule(Path.Log.thisModule())
+else:
+    Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+
+# Z-variation threshold for flat-wire detection in the UI layer (mm).
+# Coarser than the tol.edge used at generate time — we only need to decide
+# whether to show the 2D controls, not whether to actually synthesize a profile.
+_FLAT_UI_TOL = 0.01
+
+
+def _classify_wire_selection(obj):
+    """Classify the edge selection as "flat", "3d", "mixed", or "none".
+
+    "flat"  — all selected edges lie at essentially constant Z
+    "3d"    — all selected edges carry Z variation
+    "mixed" — both types present (not allowed in one operation)
+    "none"  — no edges selected
+    """
+    if not hasattr(obj, "Base") or not obj.Base:
+        return "none"
+    has_flat = False
+    has_3d = False
+    for base, subs in obj.Base:
+        for sub in subs:
+            if not sub.startswith("Edge"):
+                continue
+            try:
+                shape = base.Shape.getElement(sub)
+                zs = [v.Point.z for v in shape.Vertexes]
+                if not zs:
+                    continue
+                if (max(zs) - min(zs)) < _FLAT_UI_TOL:
+                    has_flat = True
+                else:
+                    has_3d = True
+            except Exception:
+                pass
+    if has_flat and has_3d:
+        return "mixed"
+    if has_flat:
+        return "flat"
+    if has_3d:
+        return "3d"
+    return "none"
+
+
+def _get_selection_wire_length(obj):
+    """Return total arc length (mm) of all selected edges.
+
+    Used to convert between RampLength (mm) and RampPercent (%) in the UI.
+    Uses shape.Length (exact) rather than discretizing — close enough for display.
+    """
+    if not hasattr(obj, "Base") or not obj.Base:
+        return 0.0
+    total = 0.0
+    for base, subs in obj.Base:
+        for sub in subs:
+            if sub.startswith("Edge"):
+                try:
+                    total += base.Shape.getElement(sub).Length
+                except Exception:
+                    pass
+    return total
+
+
+class TaskPanelOpPage(PathOpGui.TaskPanelPage):
+    """Task panel page for the Flute operation."""
+
+    def getForm(self):
+        return FreeCADGui.PySideUic.loadUi(":/panels/PageOpFluteEdit.ui")
+
+    def initPage(self, obj):
+        self.setTitle("Flute - " + obj.Label)
+
+        self.axialStockToLeaveSpinBox = PathGuiUtil.QuantitySpinBox(
+            self.form.axialStockToLeave, obj, "AxialStockToLeave"
+        )
+        self.rampLengthSpinBox = PathGuiUtil.QuantitySpinBox(
+            self.form.rampLength, obj, "RampLength"
+        )
+
+        self.form.flutingType.addItems(["Ramp Full", "Ramp Start", "Ramp Start End"])
+        self.form.rampType.addItems(["Linear", "Smooth", "Arc"])
+
+        # Two-way sync: connect before FreeCAD registers getSignalsForUpdate so
+        # our slots fire first and the widget values are consistent when getFields
+        # reads them.  blockSignals() in each slot prevents infinite loops.
+        self.form.rampLength.editingFinished.connect(self._sync_pct_from_length)
+        self.form.rampPercent.valueChanged.connect(self._sync_length_from_pct)
+
+        # Stash obj so the sync slots can reach it.
+        self._flute_obj = obj
+
+    def _sync_pct_from_length(self):
+        """User finished editing Ramp Length — update Ramp % display."""
+        obj = getattr(self, "_flute_obj", None)
+        if obj is None:
+            return
+        wire_len = _get_selection_wire_length(obj)
+        if wire_len <= 0:
+            return
+        try:
+            length_mm = self.form.rampLength.value().Value
+        except Exception:
+            return
+        if length_mm <= 0:
+            return
+        pct = max(1, min(100, int(round(length_mm / wire_len * 100))))
+        self.form.rampPercent.blockSignals(True)
+        self.form.rampPercent.setValue(pct)
+        self.form.rampPercent.blockSignals(False)
+
+    def _sync_length_from_pct(self, pct):
+        """User changed Ramp % — update Ramp Length display."""
+        obj = getattr(self, "_flute_obj", None)
+        if obj is None:
+            return
+        wire_len = _get_selection_wire_length(obj)
+        if wire_len <= 0:
+            return
+        length_mm = wire_len * pct / 100.0
+        q = FreeCAD.Units.Quantity("{} mm".format(length_mm))
+        self.form.rampLength.blockSignals(True)
+        self.form.rampLength.setValue(q)
+        self.form.rampLength.blockSignals(False)
+
+    def setFields(self, obj):
+        self._flute_obj = obj
+
+        self.setupToolController(obj, self.form.toolController)
+        self.setupCoolant(obj, self.form.coolantController)
+
+        self.form.reverseDirection.setCheckState(
+            QtCore.Qt.Checked if obj.ReverseDirection else QtCore.Qt.Unchecked
+        )
+        self.form.blindEndCompensation.setCheckState(
+            QtCore.Qt.Checked if obj.BlindEndCompensation else QtCore.Qt.Unchecked
+        )
+
+        self.axialStockToLeaveSpinBox.updateWidget()
+
+        # 2D properties
+        flute_type = getattr(obj, "FlutingType", "RampFull")
+        idx = self.form.flutingType.findText(flute_type)
+        if idx >= 0:
+            self.form.flutingType.setCurrentIndex(idx)
+
+        ramp_type = getattr(obj, "RampType", "Linear")
+        idx = self.form.rampType.findText(ramp_type)
+        if idx >= 0:
+            self.form.rampType.setCurrentIndex(idx)
+
+        # Show RampLength widget first, then derive RampPercent from it.
+        # If RampLength is 0, fall back to the stored RampPercent.
+        self.rampLengthSpinBox.updateWidget()
+
+        length_mm = getattr(obj, "RampLength", None)
+        length_mm = length_mm.Value if length_mm is not None else 0.0
+        wire_len = _get_selection_wire_length(obj)
+
+        self.form.rampPercent.blockSignals(True)
+        if length_mm > 0 and wire_len > 0:
+            pct = max(1, min(100, int(round(length_mm / wire_len * 100))))
+            self.form.rampPercent.setValue(pct)
+        else:
+            self.form.rampPercent.setValue(int(getattr(obj, "RampPercent", 100)))
+        self.form.rampPercent.blockSignals(False)
+
+        flip = getattr(obj, "FlipStart2D", False)
+        self.form.flipStart2D.setCheckState(
+            QtCore.Qt.Checked if flip else QtCore.Qt.Unchecked
+        )
+
+        self._update_2d_visibility(obj)
+
+    def getFields(self, obj):
+        self.updateToolController(obj, self.form.toolController)
+        self.updateCoolant(obj, self.form.coolantController)
+
+        obj.ReverseDirection = self.form.reverseDirection.isChecked()
+        obj.BlindEndCompensation = self.form.blindEndCompensation.isChecked()
+        self.axialStockToLeaveSpinBox.updateProperty()
+
+        if hasattr(obj, "FlutingType"):
+            obj.FlutingType = self.form.flutingType.currentText()
+        if hasattr(obj, "RampType"):
+            obj.RampType = self.form.rampType.currentText()
+        # RampLength is authoritative; RampPercent kept in sync for storage.
+        self.rampLengthSpinBox.updateProperty()
+        if hasattr(obj, "RampPercent"):
+            obj.RampPercent = self.form.rampPercent.value()
+        if hasattr(obj, "FlipStart2D"):
+            obj.FlipStart2D = self.form.flipStart2D.isChecked()
+
+    def getSignalsForUpdate(self, obj):
+        signals = []
+        signals.append(self.form.toolController.currentIndexChanged)
+        signals.append(self.form.coolantController.currentIndexChanged)
+
+        for checkbox in (self.form.reverseDirection, self.form.blindEndCompensation):
+            if hasattr(checkbox, "checkStateChanged"):
+                signals.append(checkbox.checkStateChanged)
+            else:
+                signals.append(checkbox.stateChanged)
+
+        signals.append(self.form.axialStockToLeave.editingFinished)
+        signals.append(self.form.rampLength.editingFinished)
+        signals.append(self.form.flutingType.currentIndexChanged)
+        signals.append(self.form.rampType.currentIndexChanged)
+        signals.append(self.form.rampPercent.valueChanged)
+        if hasattr(self.form.flipStart2D, "checkStateChanged"):
+            signals.append(self.form.flipStart2D.checkStateChanged)
+        else:
+            signals.append(self.form.flipStart2D.stateChanged)
+
+        return signals
+
+    def _update_2d_visibility(self, obj):
+        """Show or hide 2D controls and property panel entries based on selection."""
+        kind = _classify_wire_selection(obj)
+        show_2d = kind == "flat"
+
+        if kind == "mixed":
+            Path.Log.warning(
+                "Flute: mixed 2D (flat) and 3D wires selected. "
+                "Use separate operations for each type.\n"
+            )
+
+        self.form.flute2DOptions.setVisible(show_2d)
+
+        # Mirror visibility into the data panel properties so they don't clutter
+        # the tree when 2D mode isn't relevant.  2 = hidden, 0 = normal.
+        mode = 0 if show_2d else 2
+        for prop in ("FlutingType", "RampType", "RampLength", "RampPercent", "FlipStart2D"):
+            if hasattr(obj, prop):
+                obj.setEditorMode(prop, mode)
+
+
+Command = PathOpGui.SetupOperation(
+    "Flute",
+    PathFlute.Create,
+    TaskPanelOpPage,
+    "CAM_Slot",  # placeholder icon until CAM_Flute.svg is created
+    QtCore.QT_TRANSLATE_NOOP("CAM_Flute", "Flute"),
+    QtCore.QT_TRANSLATE_NOOP(
+        "CAM_Flute",
+        "Create a ramping flute toolpath from a selected bottom face."
+        "\n\nThe path runs along the centerline of the face, stepping down"
+        "\nincrementally.  Supported tool types: flat, bull-nose, V-bit.",
+    ),
+    PathFlute.SetupProperties,
+)
+
+FreeCAD.Console.PrintLog("Loading PathFluteGui... done\n")

--- a/src/Mod/CAM/Path/Op/Gui/Flute.py
+++ b/src/Mod/CAM/Path/Op/Gui/Flute.py
@@ -31,7 +31,7 @@ import Path.Base.Gui.Util as PathGuiUtil
 import Path.Op.Flute as PathFlute
 import Path.Op.Gui.Base as PathOpGui
 
-from PySide import QtCore
+from PySide import QtCore, QtGui
 
 translate = FreeCAD.Qt.translate
 
@@ -75,23 +75,69 @@ def _classify_wire_selection(obj):
     return "none"
 
 
-def _get_selection_wire_length(obj):
-    """Return total arc length (mm) of all selected edges (conversion factor for % ↔ mm)."""
-    if not hasattr(obj, "Base") or not obj.Base:
-        return 0.0
-    total = 0.0
-    for base, subs in obj.Base:
-        for sub in subs:
-            if sub.startswith("Edge"):
-                try:
-                    total += base.Shape.getElement(sub).Length
-                except Exception:
-                    pass
-    return total
+class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
+    """Base Geometry page with an added per-edge "flip direction" checkbox.
+
+    Flipping is independent of FlipStart2D (which reverses the whole result
+    at the end) -- this overrides how one individual edge was drawn, before
+    the tangent-continuity chaining logic decides overall path direction.
+    """
+
+    def setFields(self, obj):
+        super(TaskPanelBaseGeometryPage, self).setFields(obj)
+        flipped_keys = set(getattr(obj, "FlippedSegments", None) or [])
+        show_flip = _classify_wire_selection(obj) == "flat"
+        self.form.baseList.blockSignals(True)
+        for i in range(self.form.baseList.count()):
+            item = self.form.baseList.item(i)
+            base = item.data(self.DataObject)
+            sub = item.data(self.DataObjectSub)
+            if show_flip and sub and str(sub).startswith("Edge"):
+                item.setFlags(item.flags() | QtCore.Qt.ItemIsUserCheckable)
+                item.setToolTip(
+                    translate(
+                        "CAM_Flute",
+                        "Force-reverse this segment's direction (2D wires only).",
+                    )
+                )
+                key = "{}.{}".format(base.Name, sub)
+                item.setCheckState(
+                    QtCore.Qt.Checked if key in flipped_keys else QtCore.Qt.Unchecked
+                )
+            else:
+                item.setFlags(item.flags() & ~QtCore.Qt.ItemIsUserCheckable)
+        self.form.baseList.blockSignals(False)
+
+    def registerSignalHandlers(self, obj):
+        super(TaskPanelBaseGeometryPage, self).registerSignalHandlers(obj)
+        self.form.baseList.itemChanged.connect(self.updateFlippedSegments)
+
+    def updateFlippedSegments(self, item=None):
+        flipped = []
+        for i in range(self.form.baseList.count()):
+            it = self.form.baseList.item(i)
+            if it.checkState() == QtCore.Qt.Checked:
+                base = it.data(self.DataObject)
+                sub = it.data(self.DataObjectSub)
+                if base and sub:
+                    flipped.append("{}.{}".format(base.Name, sub))
+        self.obj.FlippedSegments = flipped
+        self.setDirty()
+
+    def deleteBase(self):
+        super(TaskPanelBaseGeometryPage, self).deleteBase()
+        self.updateFlippedSegments()
+
+    def clearBase(self):
+        super(TaskPanelBaseGeometryPage, self).clearBase()
+        self.obj.FlippedSegments = []
 
 
 class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     """Task panel page for the Flute operation."""
+
+    def taskPanelBaseGeometryPage(self, obj, features):
+        return TaskPanelBaseGeometryPage(obj, features)
 
     def getForm(self):
         return FreeCADGui.PySideUic.loadUi(":/panels/PageOpFluteEdit.ui")
@@ -106,38 +152,55 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             self.form.rampLength, obj, "RampLength"
         )
 
-        self.form.flutingType.addItems(["Ramp Full", "Ramp Start", "Ramp Start End"])
-        self.form.rampType.addItems(["Linear", "S-Curve", "Smooth", "Fillet"])
+        # Icon shows WHERE along the path the ramp happens (flat vs ramping
+        # sections), distinct from RampType's icons which show the Z-profile
+        # curve SHAPE.
+        for text, icon_res in (
+            ("Ramp Full", ":/icons/flute-fluting-ramp-full.svg"),
+            ("Ramp Start", ":/icons/flute-fluting-ramp-start.svg"),
+            ("Ramp Start End", ":/icons/flute-fluting-ramp-start-end.svg"),
+        ):
+            self.form.flutingType.addItem(QtGui.QIcon(icon_res), text)
+        # QComboBox scales each item icon to fit within a single iconSize box
+        # shared by every item, preserving aspect ratio -- without an explicit
+        # wide iconSize here, these triple-width icons get squeezed down to
+        # whatever narrow default box the style uses, same as rampType's.
+        self.form.flutingType.setIconSize(QtCore.QSize(54, 16))
 
-        # Two-way sync between Ramp Length (stored) and Ramp % (derived display).
-        # Mirrors Adaptive's stepOver ↔ stepOverDistance pattern.
-        # Connected here (before FreeCAD registers getSignalsForUpdate slots) so
-        # our slots fire first — the length widget is correct before getFields reads it.
-        self.form.rampLength.editingFinished.connect(lambda: self.updateRampPercent(obj))
-        self.form.rampPercent.valueChanged.connect(lambda: self.updateRampLength(obj))
+        # Each dropdown item gets a small curve-shape icon (no text baked in --
+        # the item's own label already names it, and a bare colored line reads
+        # fine in both light and dark themes, unlike small embedded text).
+        for text, icon_res in (
+            ("Linear", ":/icons/flute-ramp-linear.svg"),
+            ("S-Curve", ":/icons/flute-ramp-s-curve.svg"),
+            ("Smooth", ":/icons/flute-ramp-smooth.svg"),
+            ("Fillet", ":/icons/flute-ramp-fillet.svg"),
+        ):
+            self.form.rampType.addItem(QtGui.QIcon(icon_res), text)
+        self.form.rampType.setIconSize(QtCore.QSize(24, 16))
+        self.form.rampLengthType.addItems(["Length", "Percent"])
 
-    def updateRampPercent(self, obj):
-        """Ramp Length changed — update Ramp % display."""
-        wire_len = _get_selection_wire_length(obj)
-        if wire_len <= 0:
-            return
-        length_mm = self.form.rampLength.property("rawValue")
-        if length_mm and length_mm > 0:
-            pct = max(1, min(100, int(round(length_mm / wire_len * 100))))
-            self.form.rampPercent.blockSignals(True)
-            self.form.rampPercent.setValue(pct)
-            self.form.rampPercent.blockSignals(False)
+        # Ramp Length and Ramp % are independent stored values (RampLength mm /
+        # RampLengthPercent), not converted into each other.  RampLengthType selects
+        # which one the backend actually uses; the other stays visible/hidden
+        # but its last-entered value is preserved for convenience if the user
+        # switches back.  The Properties-panel editor mode for RampLength /
+        # RampLengthPercent is owned by the model's onChanged (Path.Op.Flute), so it
+        # stays correct even when this task panel isn't open; here we only
+        # need to update the task-panel row visibility.
+        self.form.rampLengthType.currentIndexChanged.connect(
+            lambda: self._update_ramp_length_type(obj)
+        )
 
-    def updateRampLength(self, obj):
-        """Ramp % changed — update Ramp Length display so getFields reads the right value."""
-        wire_len = _get_selection_wire_length(obj)
-        if wire_len <= 0:
-            return
-        pct = self.form.rampPercent.value()
-        length_mm = wire_len * pct / 100.0
-        self.form.rampLength.blockSignals(True)
-        self.form.rampLength.setProperty("rawValue", length_mm)
-        self.form.rampLength.blockSignals(False)
+        # FlutingType drives three task-panel-only side effects: the Ramp %
+        # spinbox's own max (mirrors the model's Properties-panel cap), and
+        # graying out controls that have no effect for the current profile
+        # (Ramp Length Type/Length/% under Ramp Full; Blind End Compensation
+        # under Ramp Start End).  The model applies the equivalent
+        # Properties-panel editor modes independently via onChanged.
+        self.form.flutingType.currentIndexChanged.connect(
+            lambda: self._update_fluting_type_dependent_controls()
+        )
 
     def setFields(self, obj):
         self.setupToolController(obj, self.form.toolController)
@@ -149,6 +212,10 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.blindEndCompensation.setCheckState(
             QtCore.Qt.Checked if obj.BlindEndCompensation else QtCore.Qt.Unchecked
         )
+        combine_tangent = getattr(obj, "CombineTangentSegments", True)
+        self.form.combineTangentSegments.setCheckState(
+            QtCore.Qt.Checked if combine_tangent else QtCore.Qt.Unchecked
+        )
 
         self.axialStockToLeaveSpinBox.updateWidget()
 
@@ -157,24 +224,20 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         idx = self.form.flutingType.findText(flute_type)
         if idx >= 0:
             self.form.flutingType.setCurrentIndex(idx)
+        self._update_fluting_type_dependent_controls()
 
         ramp_type = getattr(obj, "RampType", "Linear")
         idx = self.form.rampType.findText(ramp_type)
         if idx >= 0:
             self.form.rampType.setCurrentIndex(idx)
 
-        # Load RampLength; then derive % from it.
-        # Load length; derive % from it. If length is 0, default % display to 100.
-        self.rampLengthSpinBox.updateWidget()
-        length_mm = getattr(obj, "RampLength", None)
-        length_mm = length_mm.Value if length_mm is not None else 0.0
+        ramp_length_type = getattr(obj, "RampLengthType", "Length")
+        idx = self.form.rampLengthType.findText(ramp_length_type)
+        if idx >= 0:
+            self.form.rampLengthType.setCurrentIndex(idx)
 
-        if length_mm > 0:
-            self.updateRampPercent(obj)
-        else:
-            self.form.rampPercent.blockSignals(True)
-            self.form.rampPercent.setValue(100)
-            self.form.rampPercent.blockSignals(False)
+        self.rampLengthSpinBox.updateWidget()
+        self.form.rampLengthPercent.setValue(int(getattr(obj, "RampLengthPercent", 100)))
 
         flip = getattr(obj, "FlipStart2D", False)
         self.form.flipStart2D.setCheckState(QtCore.Qt.Checked if flip else QtCore.Qt.Unchecked)
@@ -187,13 +250,19 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
         obj.ReverseDirection = self.form.reverseDirection.isChecked()
         obj.BlindEndCompensation = self.form.blindEndCompensation.isChecked()
+        if hasattr(obj, "CombineTangentSegments"):
+            obj.CombineTangentSegments = self.form.combineTangentSegments.isChecked()
         self.axialStockToLeaveSpinBox.updateProperty()
 
         if hasattr(obj, "FlutingType"):
             obj.FlutingType = self.form.flutingType.currentText()
         if hasattr(obj, "RampType"):
             obj.RampType = self.form.rampType.currentText()
+        if hasattr(obj, "RampLengthType"):
+            obj.RampLengthType = self.form.rampLengthType.currentText()
         self.rampLengthSpinBox.updateProperty()
+        if hasattr(obj, "RampLengthPercent"):
+            obj.RampLengthPercent = self.form.rampLengthPercent.value()
         if hasattr(obj, "FlipStart2D"):
             obj.FlipStart2D = self.form.flipStart2D.isChecked()
 
@@ -202,26 +271,80 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.coolantController.currentIndexChanged)
 
-        for checkbox in (self.form.reverseDirection, self.form.blindEndCompensation):
+        for checkbox in (
+            self.form.reverseDirection,
+            self.form.blindEndCompensation,
+            self.form.combineTangentSegments,
+        ):
             if hasattr(checkbox, "checkStateChanged"):
                 signals.append(checkbox.checkStateChanged)
             else:
                 signals.append(checkbox.stateChanged)
 
         signals.append(self.form.axialStockToLeave.editingFinished)
-        # rampLength.editingFinished triggers recompute via FreeCAD machinery.
-        # rampPercent.valueChanged is also registered so changing % triggers recompute
-        # (our updateRampLength slot runs first to sync the length widget).
         signals.append(self.form.rampLength.editingFinished)
         signals.append(self.form.flutingType.currentIndexChanged)
         signals.append(self.form.rampType.currentIndexChanged)
-        signals.append(self.form.rampPercent.valueChanged)
+        signals.append(self.form.rampLengthType.currentIndexChanged)
+        signals.append(self.form.rampLengthPercent.valueChanged)
         if hasattr(self.form.flipStart2D, "checkStateChanged"):
             signals.append(self.form.flipStart2D.checkStateChanged)
         else:
             signals.append(self.form.flipStart2D.stateChanged)
 
         return signals
+
+    def _update_ramp_length_type(self, obj):
+        """RampLengthType changed — update which task-panel row is shown, and
+        let the model apply the Properties-panel editor mode (it reacts to
+        this property change directly via onChanged, from any source)."""
+        self._apply_ramp_length_type_row_visibility(_classify_wire_selection(obj) == "flat")
+
+    def _update_fluting_type_dependent_controls(self):
+        """Grey out task-panel controls that have no effect for the current
+        FlutingType, and keep the Ramp % spinbox's own range in sync with the
+        model's Properties-panel cap.  Mirrors the model's editor-mode logic
+        (Path.Op.Flute.applyRampLengthTypeEditorMode /
+        applyBlindEndCompensationEditorMode) so the task panel and Properties
+        panel never disagree about what's currently usable.
+        """
+        flute_type = self.form.flutingType.currentText()
+
+        # Ramp Start End ramps EACH side independently, so anything above 50%
+        # would just overlap and clamp anyway -- capping the spinbox directly
+        # avoids the false impression of a bug.
+        max_pct = 50 if flute_type == "Ramp Start End" else 100
+        self.form.rampLengthPercent.setMaximum(max_pct)
+        if self.form.rampLengthPercent.value() > max_pct:
+            self.form.rampLengthPercent.setValue(max_pct)
+
+        # Ramp Length Type / Length / % have no effect at all under Ramp Full
+        # (ramp_frac is never read in that profile).
+        ramp_full = flute_type == "Ramp Full"
+        for widget in (
+            self.form.rampLengthType_label,
+            self.form.rampLengthType,
+            self.form.rampLength_label,
+            self.form.rampLength,
+            self.form.rampLengthPercent_label,
+            self.form.rampLengthPercent,
+        ):
+            widget.setEnabled(not ramp_full)
+
+        # Blind End Compensation has no effect under Ramp Start End, which
+        # always ramps back to the surface (no blind end to compensate).
+        self.form.blindEndCompensation.setEnabled(flute_type != "Ramp Start End")
+
+    def _apply_ramp_length_type_row_visibility(self, show_2d):
+        """Show only the task-panel row matching the current RampLengthType.
+        Properties-panel visibility for RampLength/RampLengthPercent is owned by the
+        model's onChanged, not duplicated here.
+        """
+        is_percent = self.form.rampLengthType.currentText() == "Percent"
+        self.form.rampLength_label.setVisible(show_2d and not is_percent)
+        self.form.rampLength.setVisible(show_2d and not is_percent)
+        self.form.rampLengthPercent_label.setVisible(show_2d and is_percent)
+        self.form.rampLengthPercent.setVisible(show_2d and is_percent)
 
     def _update_2d_visibility(self, obj):
         """Show or hide 2D controls and property panel entries based on selection."""
@@ -237,9 +360,22 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.flute2DOptions.setVisible(show_2d)
 
         mode = 0 if show_2d else 2
-        for prop in ("FlutingType", "RampType", "RampLength", "FlipStart2D"):
+        for prop in ("FlutingType", "RampType", "RampLengthType", "FlipStart2D"):
             if hasattr(obj, prop):
                 obj.setEditorMode(prop, mode)
+
+        # RampLength/RampLengthPercent: hide both outright when not a 2D (flat) wire
+        # selection, regardless of RampLengthType.  When 2D, restore the
+        # correct split by re-applying the model's RampLengthType-driven mode
+        # (it may have been left at "both hidden" from a previous 3D state).
+        if not show_2d:
+            for prop in ("RampLength", "RampLengthPercent"):
+                if hasattr(obj, prop):
+                    obj.setEditorMode(prop, 2)
+        elif hasattr(obj, "Proxy") and hasattr(obj.Proxy, "applyRampLengthTypeEditorMode"):
+            obj.Proxy.applyRampLengthTypeEditorMode(obj)
+
+        self._apply_ramp_length_type_row_visibility(show_2d)
 
 
 Command = PathOpGui.SetupOperation(

--- a/src/Mod/CAM/Path/Op/Gui/Flute.py
+++ b/src/Mod/CAM/Path/Op/Gui/Flute.py
@@ -26,12 +26,12 @@ __doc__ = "Flute operation task panel controller and command implementation."
 
 import FreeCAD
 import FreeCADGui
+from PySide import QtCore, QtGui
+
 import Path
 import Path.Base.Gui.Util as PathGuiUtil
 import Path.Op.Flute as PathFlute
 import Path.Op.Gui.Base as PathOpGui
-
-from PySide import QtCore, QtGui
 
 translate = FreeCAD.Qt.translate
 
@@ -65,6 +65,8 @@ def _classify_wire_selection(obj):
                 else:
                     has_3d = True
             except Exception:
+                # Stale/invalid sub-element reference (e.g. geometry edited
+                # since selection) - just don't count this edge either way.
                 pass
     if has_flat and has_3d:
         return "mixed"
@@ -84,7 +86,7 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
     """
 
     def setFields(self, obj):
-        super(TaskPanelBaseGeometryPage, self).setFields(obj)
+        super().setFields(obj)
         flipped_keys = set(getattr(obj, "FlippedSegments", None) or [])
         show_flip = _classify_wire_selection(obj) == "flat"
         self.form.baseList.blockSignals(True)
@@ -100,7 +102,7 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
                         "Force-reverse this segment's direction (2D wires only).",
                     )
                 )
-                key = "{}.{}".format(base.Name, sub)
+                key = f"{base.Name}.{sub}"
                 item.setCheckState(
                     QtCore.Qt.Checked if key in flipped_keys else QtCore.Qt.Unchecked
                 )
@@ -109,7 +111,7 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
         self.form.baseList.blockSignals(False)
 
     def registerSignalHandlers(self, obj):
-        super(TaskPanelBaseGeometryPage, self).registerSignalHandlers(obj)
+        super().registerSignalHandlers(obj)
         self.form.baseList.itemChanged.connect(self.updateFlippedSegments)
 
     def updateFlippedSegments(self, item=None):
@@ -120,16 +122,16 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
                 base = it.data(self.DataObject)
                 sub = it.data(self.DataObjectSub)
                 if base and sub:
-                    flipped.append("{}.{}".format(base.Name, sub))
+                    flipped.append(f"{base.Name}.{sub}")
         self.obj.FlippedSegments = flipped
         self.setDirty()
 
     def deleteBase(self):
-        super(TaskPanelBaseGeometryPage, self).deleteBase()
+        super().deleteBase()
         self.updateFlippedSegments()
 
     def clearBase(self):
-        super(TaskPanelBaseGeometryPage, self).clearBase()
+        super().clearBase()
         self.obj.FlippedSegments = []
 
 
@@ -199,13 +201,10 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         # under Ramp Start End).  The model applies the equivalent
         # Properties-panel editor modes independently via onChanged.
         self.form.flutingType.currentIndexChanged.connect(
-            lambda: self._update_fluting_type_dependent_controls()
+            self._update_fluting_type_dependent_controls
         )
 
     def setFields(self, obj):
-        self.setupToolController(obj, self.form.toolController)
-        self.setupCoolant(obj, self.form.coolantController)
-
         self.form.reverseDirection.setCheckState(
             QtCore.Qt.Checked if obj.ReverseDirection else QtCore.Qt.Unchecked
         )
@@ -245,9 +244,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self._update_2d_visibility(obj)
 
     def getFields(self, obj):
-        self.updateToolController(obj, self.form.toolController)
-        self.updateCoolant(obj, self.form.coolantController)
-
         obj.ReverseDirection = self.form.reverseDirection.isChecked()
         obj.BlindEndCompensation = self.form.blindEndCompensation.isChecked()
         if hasattr(obj, "CombineTangentSegments"):
@@ -268,8 +264,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def getSignalsForUpdate(self, obj):
         signals = []
-        signals.append(self.form.toolController.currentIndexChanged)
-        signals.append(self.form.coolantController.currentIndexChanged)
 
         for checkbox in (
             self.form.reverseDirection,
@@ -382,13 +376,16 @@ Command = PathOpGui.SetupOperation(
     "Flute",
     PathFlute.Create,
     TaskPanelOpPage,
-    "CAM_Slot",  # placeholder icon until CAM_Flute.svg is created
+    "CAM_Engrave",  # placeholder icon until CAM_Flute.svg is created
     QtCore.QT_TRANSLATE_NOOP("CAM_Flute", "Flute"),
     QtCore.QT_TRANSLATE_NOOP(
         "CAM_Flute",
-        "Create a ramping flute toolpath from a selected bottom face."
-        "\n\nThe path runs along the centerline of the face, stepping down"
-        "\nincrementally.  Supported tool types: flat, bull-nose, V-bit.",
+        "Create a ramping flute toolpath from a selected bottom face or flat wire."
+        "\n\nFor a 3D face (or pair of faces forming a V-bottom), the path follows"
+        "\nthe face centerline.  For a flat (2D) wire, the path follows the wire"
+        "\nitself, with its Z ramp shaped by the Fluting/Ramp Type settings."
+        "\nBoth cases step down in multiple passes to final depth."
+        "\n\nSupported tool types: flat, bull-nose, V-bit.",
     ),
     PathFlute.SetupProperties,
 )

--- a/src/Mod/CAM/Path/Op/Gui/Selection.py
+++ b/src/Mod/CAM/Path/Op/Gui/Selection.py
@@ -171,6 +171,15 @@ class FACEGate(PathBaseGate):
         return isFace
 
 
+class FLUTEGate(PathBaseGate):
+    def allow(self, doc, obj, sub):
+        if sub and sub[0:4] == "Edge":
+            return True
+        if sub and sub[0:4] == "Face":
+            return True
+        return False
+
+
 class PROFILEGate(PathBaseGate):
     def allow(self, doc, obj, sub):
         try:
@@ -315,6 +324,12 @@ def adaptiveselect():
         FreeCAD.Console.PrintWarning("Adaptive Select Mode\n")
 
 
+def fluteselect():
+    FreeCADGui.Selection.addSelectionGate(FLUTEGate())
+    if not Path.Preferences.suppressSelectionModeWarning():
+        FreeCAD.Console.PrintWarning("Flute Select Mode\n")
+
+
 def slotselect():
     FreeCADGui.Selection.addSelectionGate(ALLGate())
     if not Path.Preferences.suppressSelectionModeWarning():
@@ -370,6 +385,7 @@ def select(op):
     opsel["Profile Edges"] = eselect  # deprecated
     opsel["Profile Faces"] = fselect  # deprecated
     opsel["Profile"] = profileselect
+    opsel["Flute"] = fluteselect
     opsel["Slot"] = slotselect
     opsel["RotarySurface"] = surfaceselect
     opsel["Surface"] = surfaceselect


### PR DESCRIPTION

[LineFluteTest.zip]
Adds a new **Flute** CAM operation: a ramping slot/groove cut that follows the centerline of a selected face (or a flat 2D wire), shallow at one end and deeper at the other. Supports flat, bull-nose, and V-bit tools.

- Works on 3D faces (single face or a V-bottom pair) and flat 2D wires, with adjustable ramp shape/length and multi-pass step-down.
- Grouped in the toolbar/menu alongside Engrave/Deburr/Vcarve.
- Hidden behind the "experimental features" preference for now.

Test File: (https://github.com/user-attachments/files/31317937/LineFluteTest.zip)

Screenshots below.
<img width="1012" height="657" alt="Screenshot from 2026-08-14 17-53-44" src="https://github.com/user-attachments/assets/b7736a86-3d38-4b9d-ac1b-39b8475f6385" />
<img width="1012" height="657" alt="Screenshot from 2026-08-14 17-53-36" src="https://github.com/user-attachments/assets/ac248e05-407e-4cb7-bb68-3c14619b532f" />
<img width="508" height="602" alt="Screenshot from 2026-08-14 17-53-07" src="https://github.com/user-attachments/assets/5b7d06bf-85c5-418a-a103-6ef2a91304f8" />
<img width="822" height="676" alt="Screenshot from 2026-08-14 17-52-54" src="https://github.com/user-attachments/assets/0f29741e-516f-4a0d-a0a3-05cb67301d0f" />
<img width="634" height="797" alt="Screenshot from 2026-08-14 17-52-41" src="https://github.com/user-attachments/assets/6d85200c-fb90-4e50-ae43-807f21cc1404" />

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
