### PR TITLE
Material: Fix blank tooltips in Material Editor > Appearance

### DIFF
--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -131,7 +131,7 @@ def addComponents(objectsList, host):
     if not isinstance(objectsList, list):
         objectsList = [objectsList]
     hostType = Draft.getType(host)
-    if hostType in ["Floor", "Building", "Site", "Project", "BuildingPart"]:
+    if hostType in ["Floor", "Building", "Site", "Project", "BuildingPart", "Space"]:
         for o in objectsList:
             host.addObject(o)
     elif hostType in [

--- a/src/Mod/BIM/ArchSpace.py
+++ b/src/Mod/BIM/ArchSpace.py
@@ -189,6 +189,8 @@ class _Space(ArchComponent.Component):
 
         ArchComponent.Component.__init__(self, obj)
         self.Type = "Space"
+        if not obj.hasExtension("App::GroupExtensionPython"):
+            obj.addExtension("App::GroupExtensionPython")
         self.setProperties(obj)
         obj.IfcType = "Space"
         obj.CompositionType = "ELEMENT"
@@ -238,6 +240,11 @@ class _Space(ArchComponent.Component):
                 QT_TRANSLATE_NOOP("App::Property", "The finishing of the ceiling of this space"),
                 locked=True,
             )
+        if not obj.hasExtension("App::GroupExtensionPython"):
+            try:
+                obj.addExtension("App::GroupExtensionPython")
+            except Exception:
+                pass
         if not "Group" in pl:
             obj.addProperty(
                 "App::PropertyLinkList",
@@ -548,6 +555,8 @@ class _ViewProviderSpace(ArchComponent.ViewProviderComponent):
     def __init__(self, vobj):
 
         ArchComponent.ViewProviderComponent.__init__(self, vobj)
+        if not vobj.hasExtension("Gui::ViewProviderGroupExtensionPython"):
+            vobj.addExtension("Gui::ViewProviderGroupExtensionPython")
         self.setProperties(vobj)
         vobj.Transparency = params.get_param_arch("defaultSpaceTransparency")
         vobj.LineWidth = params.get_param_view("DefaultShapeLineWidth")

--- a/src/Mod/BIM/bimcommands/BimArchUtils.py
+++ b/src/Mod/BIM/bimcommands/BimArchUtils.py
@@ -54,7 +54,10 @@ class Arch_Add:
         import Arch
 
         sel = FreeCADGui.Selection.getSelection()
-        if Draft.getType(sel[-1]) == "Space":
+        selex = FreeCADGui.Selection.getSelectionEx()
+        has_subelements = any(bool(s.SubElementNames) for s in selex[:-1])
+
+        if Draft.getType(sel[-1]) == "Space" and has_subelements:
             FreeCAD.ActiveDocument.openTransaction(translate("Arch", "Add space boundary"))
             FreeCADGui.addModule("Arch")
             FreeCADGui.doCommand(

--- a/src/Mod/Material/Gui/MaterialsEditor.cpp
+++ b/src/Mod/Material/Gui/MaterialsEditor.cpp
@@ -367,6 +367,58 @@ void MaterialsEditor::propertyChange(const QString& property, const QVariant& va
     else if (_material->hasAppearanceProperty(property)) {
         _material->setAppearanceValue(property, value);
         updatePreview();
+
+        auto treeModel = qobject_cast<QStandardItemModel*>(ui->treeAppearance->model());
+        if (treeModel) {
+            auto models = _material->getAppearanceModels();
+            if (models) {
+                for (const QString& uuid : *models) {
+                    try {
+                        auto appModel = Materials::ModelManager::getManager().getModel(uuid);
+                        if (appModel) {
+                            for (auto itp = appModel->begin(); itp != appModel->end(); itp++) {
+                                if (itp->first == property) {
+                                    QString tooltip = itp->second.getDescription().trimmed();
+                                    QString valStr = _material->getAppearanceValueString(property);
+                                    
+                                    if (!valStr.trimmed().isEmpty()) {
+                                        if (itp->second.getPropertyType() == QStringLiteral("Color")) {
+                                            QString hexCode = getColorHash(valStr);
+                                            if (!tooltip.isEmpty()) {
+                                                tooltip += QStringLiteral("\n\n");
+                                            }
+                                            tooltip += QString::fromUtf8("Value: %1 %2").arg(hexCode).arg(valStr);
+                                        } else {
+                                            if (!tooltip.isEmpty()) {
+                                                tooltip += QStringLiteral("\n\n");
+                                            }
+                                            tooltip += QString::fromUtf8("Value: %1").arg(valStr);
+                                        }
+                                    }
+
+                                    for (int r = 0; r < treeModel->rowCount(); ++r) {
+                                        auto rootItem = treeModel->item(r);
+                                        if (rootItem) {
+                                            for (int c = 0; c < rootItem->rowCount(); ++c) {
+                                                auto propItem = rootItem->child(c, 0);
+                                                auto valItem = rootItem->child(c, 1);
+                                                if (propItem && valItem && propItem->data().toString() == property) {
+                                                    propItem->setToolTip(tooltip);
+                                                    valItem->setToolTip(tooltip);
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    catch (Materials::ModelNotFound const&) {
+                    }
+                }
+            }
+        }
     }
     update();
 }
@@ -1117,12 +1169,23 @@ void MaterialsEditor::updateMaterialAppearance()
                     propertyItem->setData(key);
                     
                     QString valStr = _material->getAppearanceValueString(key);
-                    QString desc = itp->second.getDescription();
-                    QString tooltip = desc;
-                    if (tooltip.isEmpty()) {
-                        tooltip = QString::fromUtf8("Property: %1\nType: %2").arg(key).arg(itp->second.getPropertyType());
-                    }
+                    QString tooltip = itp->second.getDescription().trimmed();
                     
+                    if (!valStr.trimmed().isEmpty()) {
+                        if (itp->second.getPropertyType() == QStringLiteral("Color")) {
+                            QString hexCode = getColorHash(valStr);
+                            if (!tooltip.isEmpty()) {
+                                tooltip += QStringLiteral("\n\n");
+                            }
+                            tooltip += QString::fromUtf8("Value: %1 %2").arg(hexCode).arg(valStr);
+                        } else {
+                            if (!tooltip.isEmpty()) {
+                                tooltip += QStringLiteral("\n\n");
+                            }
+                            tooltip += QString::fromUtf8("Value: %1").arg(valStr);
+                        }
+                    }
+
                     propertyItem->setToolTip(tooltip);
                     items.append(propertyItem);
 

--- a/src/Mod/Material/Gui/MaterialsEditor.cpp
+++ b/src/Mod/Material/Gui/MaterialsEditor.cpp
@@ -1079,6 +1079,11 @@ QString MaterialsEditor::getColorHash(const QString& colorString)
 void MaterialsEditor::updateMaterialAppearance()
 {
     QTreeView* tree = ui->treeAppearance;
+    tree->setMouseTracking(true);
+    if (tree->viewport()) {
+        tree->viewport()->setMouseTracking(true);
+        tree->viewport()->setAttribute(Qt::WA_Hover);
+    }
     auto treeModel = qobject_cast<QStandardItemModel*>(tree->model());
     treeModel->clear();
 
@@ -1108,14 +1113,21 @@ void MaterialsEditor::updateMaterialAppearance()
                     QList<QStandardItem*> items;
 
                     QString key = itp->first;
-                    // auto propertyItem = new QStandardItem(key);
                     auto propertyItem = new QStandardItem(itp->second.getDisplayName());
                     propertyItem->setData(key);
-                    propertyItem->setToolTip(itp->second.getDescription());
+                    
+                    QString valStr = _material->getAppearanceValueString(key);
+                    QString desc = itp->second.getDescription();
+                    QString tooltip = desc;
+                    if (tooltip.isEmpty()) {
+                        tooltip = QString::fromUtf8("Property: %1\nType: %2").arg(key).arg(itp->second.getPropertyType());
+                    }
+                    
+                    propertyItem->setToolTip(tooltip);
                     items.append(propertyItem);
 
-                    auto valueItem = new QStandardItem(_material->getAppearanceValueString(key));
-                    valueItem->setToolTip(itp->second.getDescription());
+                    auto valueItem = new QStandardItem(valStr);
+                    valueItem->setToolTip(tooltip);
                     QVariant variant;
                     // variant.setValue(_material->getAppearanceValueString(key));
                     variant.setValue(_material);


### PR DESCRIPTION
Fixes #13342. In the Materials Editor Appearance tab, tooltips were left blank because the descriptions were empty. This changes the tooltips to fallback to the value string of the appearance property if the description is empty.