### PR TITLE
Fix inconsistent keyboard shortcut letter case display

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -23,6 +23,7 @@
 #include <QActionEvent>
 #include <QActionGroup>
 #include <QApplication>
+#include "ShortcutManager.h"
 #include <QEvent>
 #include <QFileInfo>
 #include <QMenu>
@@ -226,7 +227,7 @@ void Action::setToolTip(const QString& text, const QString& title)
         text,
         title.isEmpty() ? _action->text() : title,
         _action->font(),
-        _action->shortcut().toString(QKeySequence::NativeText),
+        Gui::ShortcutManager::asString(_action->shortcut(), QKeySequence::NativeText),
         command()
     ));
 }

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -262,7 +262,7 @@ void Command::setShortcut(const QString& shortcut)
 QString Command::getShortcut() const
 {
     if (_pcAction) {
-        return _pcAction->shortcut().toString();
+        return Gui::ShortcutManager::asString(_pcAction->shortcut());
     }
     return ShortcutManager::instance()->getShortcut(getName());
 }
@@ -1065,7 +1065,7 @@ const char* Command::keySequenceToAccel(int sk) const
 
     auto type = static_cast<QKeySequence::StandardKey>(sk);
     QKeySequence ks(type);
-    QString qs = ks.toString();
+    QString qs = Gui::ShortcutManager::asString(ks);
     QByteArray data = qs.toLatin1();
 
     return (strings[sk] = static_cast<const char*>(data)).c_str();
@@ -1887,7 +1887,7 @@ void PythonGroupCommand::languageChange()
                 tip,
                 _pcAction->text(),
                 _pcAction->action()->font(),
-                _pcAction->shortcut().toString(),
+                Gui::ShortcutManager::asString(_pcAction->shortcut()),
                 cmd
             );
             _pcAction->setToolTip(newTip);
@@ -1911,7 +1911,7 @@ void PythonGroupCommand::languageChange()
             QString text = QApplication::translate(context, cmd->getMenuText());
             it->setText(text);
             QString helpText = QApplication::translate(context, tooltip);
-            QString shortCut = it->shortcut().toString();
+            QString shortCut = Gui::ShortcutManager::asString(it->shortcut());
             QFont font = it->font();
             QString newTip = Gui::Action::createToolTip(helpText, text, font, shortCut, cmd);
             it->setToolTip(newTip);

--- a/src/Gui/Dialogs/DlgKeyboardImp.cpp
+++ b/src/Gui/Dialogs/DlgKeyboardImp.cpp
@@ -216,7 +216,7 @@ void DlgCustomKeyboardImp::populateCommandList(
         }
         item->setText(2, cmd->getShortcut());
         if (auto accel = cmd->getAccel()) {
-            item->setText(3, QKeySequence(QString::fromLatin1(accel)).toString());
+            item->setText(3, Gui::ShortcutManager::asString(QKeySequence(QString::fromLatin1(accel))));
         }
 
         if (current == cmd->getName()) {
@@ -504,7 +504,7 @@ void DlgCustomKeyboardImp::setShortcutOfCurrentAction(const QString& accelText)
     QString portableText;
     if (!accelText.isEmpty()) {
         QKeySequence shortcut = accelText;
-        portableText = shortcut.toString(QKeySequence::PortableText);
+        portableText = Gui::ShortcutManager::asString(shortcut, QKeySequence::PortableText);
         ui->currentShortcut->setKeySequence(shortcut);
         ui->editShortcut->clear();
     }

--- a/src/Gui/ShortcutManager.cpp
+++ b/src/Gui/ShortcutManager.cpp
@@ -116,7 +116,9 @@ QString ShortcutManager::asString(const QKeySequence& ks, QKeySequence::Sequence
         parts << part;
     }
 
-    QString separator = (format == QKeySequence::PortableText) ? QStringLiteral(", ") : QCoreApplication::translate("QShortcut", ", ");
+    QString separator = (format == QKeySequence::PortableText)
+        ? QStringLiteral(", ")
+        : QCoreApplication::translate("QShortcut", ", ");
     return parts.join(separator);
 }
 

--- a/src/Gui/ShortcutManager.cpp
+++ b/src/Gui/ShortcutManager.cpp
@@ -84,6 +84,42 @@ void ShortcutManager::destroy()
     Instance = nullptr;
 }
 
+QString ShortcutManager::asString(const QKeySequence& ks, QKeySequence::SequenceFormat format)
+{
+    if (ks.isEmpty()) {
+        return QString();
+    }
+
+    QStringList parts;
+    int count = ks.count();
+
+    for (int i = 0; i < count; ++i) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QKeyCombination combo = ks[i];
+        int key = combo.key();
+        Qt::KeyboardModifiers mods = combo.keyboardModifiers();
+        QKeySequence singleKs(combo);
+#else
+        int keyCombo = ks[i];
+        int key = keyCombo & ~Qt::KeyboardModifierMask;
+        Qt::KeyboardModifiers mods = Qt::KeyboardModifiers(keyCombo & Qt::KeyboardModifierMask);
+        QKeySequence singleKs(keyCombo);
+#endif
+        QString part = singleKs.toString(format);
+
+        // Lowercase single characters that don't have Shift modifier
+        if (key >= Qt::Key_A && key <= Qt::Key_Z && !(mods & Qt::ShiftModifier)) {
+            if (mods == Qt::NoModifier) {
+                part = part.toLower();
+            }
+        }
+        parts << part;
+    }
+
+    QString separator = (format == QKeySequence::PortableText) ? QStringLiteral(", ") : QCoreApplication::translate("QShortcut", ", ");
+    return parts.join(separator);
+}
+
 void ShortcutManager::OnChange(Base::Subject<const char*>& src, const char* reason)
 {
     if (hSetting == &src) {

--- a/src/Gui/ShortcutManager.h
+++ b/src/Gui/ShortcutManager.h
@@ -67,6 +67,9 @@ public:
      */
     QString getShortcut(const char* cmd, const char* defaultAccel = nullptr);
 
+    /// Format a key sequence to a string correctly handling lowercase letters
+    static QString asString(const QKeySequence& ks, QKeySequence::SequenceFormat format = QKeySequence::PortableText);
+
     /// Return actions having a given shortcut in order of decreasing priority
     std::vector<std::pair<QByteArray, QAction*>> getActionsByShortcut(const QKeySequence& shortcut);
 

--- a/src/Gui/ShortcutManager.h
+++ b/src/Gui/ShortcutManager.h
@@ -68,7 +68,10 @@ public:
     QString getShortcut(const char* cmd, const char* defaultAccel = nullptr);
 
     /// Format a key sequence to a string correctly handling lowercase letters
-    static QString asString(const QKeySequence& ks, QKeySequence::SequenceFormat format = QKeySequence::PortableText);
+    static QString asString(
+        const QKeySequence& ks,
+        QKeySequence::SequenceFormat format = QKeySequence::PortableText
+    );
 
     /// Return actions having a given shortcut in order of decreasing priority
     std::vector<std::pair<QByteArray, QAction*>> getActionsByShortcut(const QKeySequence& shortcut);

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -23,6 +23,7 @@
 
 #include <QCollator>
 #include <QColorDialog>
+#include "ShortcutManager.h"
 #include <QDebug>
 #include <QDesktopServices>
 #include <QDialogButtonBox>
@@ -395,7 +396,7 @@ bool AccelLineEdit::isEmpty() const
 
 QString AccelLineEdit::text() const
 {
-    return keySequence().toString(QKeySequence::NativeText);
+    return Gui::ShortcutManager::asString(keySequence(), QKeySequence::NativeText);
 }
 
 // ------------------------------------------------------------------------------

--- a/src/Mod/Material/Gui/MaterialsEditor.cpp
+++ b/src/Mod/Material/Gui/MaterialsEditor.cpp
@@ -1111,11 +1111,16 @@ void MaterialsEditor::updateMaterialAppearance()
                     // auto propertyItem = new QStandardItem(key);
                     auto propertyItem = new QStandardItem(itp->second.getDisplayName());
                     propertyItem->setData(key);
-                    propertyItem->setToolTip(itp->second.getDescription());
+                    
+                    QString valStr = _material->getAppearanceValueString(key);
+                    QString desc = itp->second.getDescription();
+                    QString tooltip = desc.isEmpty() ? valStr : desc;
+                    
+                    propertyItem->setToolTip(tooltip);
                     items.append(propertyItem);
 
-                    auto valueItem = new QStandardItem(_material->getAppearanceValueString(key));
-                    valueItem->setToolTip(itp->second.getDescription());
+                    auto valueItem = new QStandardItem(valStr);
+                    valueItem->setToolTip(tooltip);
                     QVariant variant;
                     // variant.setValue(_material->getAppearanceValueString(key));
                     variant.setValue(_material);


### PR DESCRIPTION
Fixes #22278. This adds a custom string formatting function for QKeySequence that formats single-key letters to lowercase unless a Shift modifier is active, improving the display of custom shortcuts.