### PR TITLE
[Spreadsheet] Replace setGeometry() with setGeometrySilently() in

### DIFF
--- a/src/Mod/Spreadsheet/Gui/LineEdit.cpp
+++ b/src/Mod/Spreadsheet/Gui/LineEdit.cpp
@@ -105,7 +105,7 @@ void LineEdit::setDocumentObject(const App::DocumentObject* currentDocObj, bool 
 
     auto updatePopupGeom = [getPopupPos, getPopupWidth, xpopup]() {
         const QPoint new_pos = getPopupPos();
-        xpopup->setGeometry(new_pos.x(), new_pos.y(), getPopupWidth(), xpopup->height());
+        xpopup->setGeometrySilently(new_pos.x(), new_pos.y(), getPopupWidth(), xpopup->height());
     };
 
     QObject::connect(xpopup, &XListView::geometryChanged, this, updatePopupGeom);
@@ -142,6 +142,7 @@ void LineEdit::keyPressEvent(QKeyEvent* event)
 
 XListView::XListView(LineEdit* parent)
     : QListView(parent)
+    , m_Silent{false}
 {
     setEditTriggers(QAbstractItemView::NoEditTriggers);
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -151,16 +152,28 @@ XListView::XListView(LineEdit* parent)
     setAttribute(Qt::WidgetAttribute::WA_ShowWithoutActivating);
 }
 
+void XListView::setGeometrySilently(int ax, int ay, int aw, int ah)
+{
+    m_Silent = true;
+    QListView::setGeometry(ax, ay, aw, ah);
+}
+
 void XListView::resizeEvent(QResizeEvent* event)
 {
-    Q_EMIT geometryChanged();
+    if(!m_Silent){
+        Q_EMIT geometryChanged();
+        m_Silent = false;
+    }
     QListView::resizeEvent(event);
 }
 
 void XListView::updateGeometries()
 {
     QListView::updateGeometries();
-    Q_EMIT geometryChanged();
+    if(!m_Silent){
+        Q_EMIT geometryChanged();
+        m_Silent = false;
+    }
 }
 
 #include "moc_LineEdit.cpp"

--- a/src/Mod/Spreadsheet/Gui/LineEdit.cpp
+++ b/src/Mod/Spreadsheet/Gui/LineEdit.cpp
@@ -142,7 +142,7 @@ void LineEdit::keyPressEvent(QKeyEvent* event)
 
 XListView::XListView(LineEdit* parent)
     : QListView(parent)
-    , m_Silent{false}
+    , m_Silent {false}
 {
     setEditTriggers(QAbstractItemView::NoEditTriggers);
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -160,7 +160,7 @@ void XListView::setGeometrySilently(int ax, int ay, int aw, int ah)
 
 void XListView::resizeEvent(QResizeEvent* event)
 {
-    if(!m_Silent){
+    if (!m_Silent) {
         Q_EMIT geometryChanged();
         m_Silent = false;
     }
@@ -170,7 +170,7 @@ void XListView::resizeEvent(QResizeEvent* event)
 void XListView::updateGeometries()
 {
     QListView::updateGeometries();
-    if(!m_Silent){
+    if (!m_Silent) {
         Q_EMIT geometryChanged();
         m_Silent = false;
     }

--- a/src/Mod/Spreadsheet/Gui/LineEdit.h
+++ b/src/Mod/Spreadsheet/Gui/LineEdit.h
@@ -59,12 +59,16 @@ class XListView: public QListView
 public:
     explicit XListView(LineEdit* parent);
 
+    void setGeometrySilently(int ax, int ay, int aw, int ah);
+
 Q_SIGNALS:
     void geometryChanged(void);
 
 protected:
     void resizeEvent(QResizeEvent* event) override;
     void updateGeometries(void) override;
+
+    bool m_Silent;
 };
 
 }  // namespace SpreadsheetGui


### PR DESCRIPTION
This commit is an attempt to fix #31348. Sadly, I don't have HiDPI multiscreen configuration with mixed scaling factors and building environment on Windows 11, therefore I can't reproduce the crash and test this fix.


The thing here is that the widget is created on a HiDPI screen with one scaling factor and subsequently used on a HiDPI screen with another, triggering recursive repaint in custom widget XListView.


This PR makes invocation of `setGeometry()` silent, possibly introducing misplacement of autocomplete popup in _Spreadsheet_ on HiDPI multiscreen configuration with mixed scaling factors.