### PR TITLE
PartDesign: fix SubShapeBinder created inside not active Body

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -437,7 +437,7 @@ void CmdPartDesignSubShapeBinder::activated(int iMsg)
     }
 
     std::string FeatName;
-    PartDesign::Body* pcActiveBody = PartDesignGui::getBody(false, true, true, &parent, &parentSub);
+    PartDesign::Body* pcActiveBody = PartDesignGui::getBody(false, false, true, &parent, &parentSub);
     FeatName = getUniqueObjectName("Binder", pcActiveBody);
     if (parent) {
         decltype(values) links;


### PR DESCRIPTION
Fixes #30253. When a document contains only one Body, creating a SubShapeBinder will no longer automatically place it inside that Body if it's inactive.