### PR TITLE
Core/UI/UX: Fix search reset in Selection View

### DIFF
--- a/src/Gui/Selection/SelectionView.cpp
+++ b/src/Gui/Selection/SelectionView.cpp
@@ -314,6 +314,11 @@ void SelectionView::search(const QString& text)
             countLabel->setText(QString::number(selectionView->count()));
         }
     }
+    else {
+        searchList.clear();
+        SelectionChanges Reason(SelectionChanges::SetSelection);
+        onSelectionChanged(Reason);
+    }
 }
 
 void SelectionView::validateSearch()


### PR DESCRIPTION
Fixes #30009. This connects the textChanged signal effectively by checking if text is empty, and then restoring the selection by firing a SelectionChanges event.