### PR TITLE
Fix #30013: Make Clone body respect Active Part

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -545,6 +545,16 @@ void CmdPartDesignClone::activated(int iMsg)
             obj,
             std::stringstream() << "addObject('PartDesign::Body','" << bodyName << "')"
         );
+
+        App::Part* actPart = PartDesignGui::getActivePart();
+        if (actPart && actPart->getDocument() == obj->getDocument()) {
+            Gui::cmdAppDocument(
+                obj,
+                std::stringstream() << actPart->getNameInDocument() 
+                                    << ".addObject(App.getDocument('" << obj->getDocument()->getName() << "')." 
+                                    << bodyName << ")"
+            );
+        }
         Gui::cmdAppDocument(
             obj,
             std::stringstream() << "addObject('PartDesign::FeatureBase','" << cloneName << "')"

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -550,9 +550,8 @@ void CmdPartDesignClone::activated(int iMsg)
         if (actPart && actPart->getDocument() == obj->getDocument()) {
             Gui::cmdAppDocument(
                 obj,
-                std::stringstream() << actPart->getNameInDocument() 
-                                    << ".addObject(App.getDocument('" << obj->getDocument()->getName() << "')." 
-                                    << bodyName << ")"
+                std::stringstream() << actPart->getNameInDocument() << ".addObject(App.getDocument('"
+                                    << obj->getDocument()->getName() << "')." << bodyName << ")"
             );
         }
         Gui::cmdAppDocument(


### PR DESCRIPTION
This PR fixes issue #30013 by ensuring that a new body created for a clone respects the currently active part, and is added to it instead of the document root.