### PR TITLE
Fix #31047: Debounce angular deflection property to prevent GUI freeze

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -50,6 +50,7 @@
 
 #include <QAction>
 #include <QMenu>
+#include <QTimer>
 #include <sstream>
 
 #include <Inventor/SoPickedPoint.h>
@@ -280,6 +281,7 @@ ViewProviderPartExt::ViewProviderPartExt()
 
 ViewProviderPartExt::~ViewProviderPartExt()
 {
+    delete angularDeflectionTimer;
     pcFaceBind->unref();
     pcLineBind->unref();
     pcPointBind->unref();
@@ -321,8 +323,21 @@ void ViewProviderPartExt::onChanged(const App::Property* prop)
     }
     if (prop == &AngularDeflection) {
         lastRenderedShape = {};
-        if (isUpdateForced() || Visibility.getValue()) {
+        if (isUpdateForced()) {
             updateVisual();
+        }
+        else if (Visibility.getValue()) {
+            // Debounce: delay retessellation so typing intermediate values
+            // in the property editor doesn't freeze the GUI (issue #31047).
+            if (!angularDeflectionTimer) {
+                angularDeflectionTimer = new QTimer();
+                angularDeflectionTimer->setSingleShot(true);
+                angularDeflectionTimer->setInterval(500);  // 500 ms delay
+                QObject::connect(angularDeflectionTimer, &QTimer::timeout, [this]() {
+                    updateVisual();
+                });
+            }
+            angularDeflectionTimer->start();
         }
         else {
             VisualTouched = true;

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -58,6 +58,8 @@ class SoNormalBinding;
 class SoMaterialBinding;
 class SoIndexedLineSet;
 
+class QTimer;
+
 namespace PartGui
 {
 
@@ -253,6 +255,10 @@ private:
 
     // shape that was last rendered so if it does not change we don't re-render it without need
     TopoDS_Shape lastRenderedShape;
+
+    // Debounce timer to avoid immediate retessellation while typing
+    // angular deflection values in the property editor (issue #31047)
+    QTimer* angularDeflectionTimer = nullptr;
 };
 
 }  // namespace PartGui


### PR DESCRIPTION
Fixes #31047.

The AngularDeflection property was being interpreted immediately on every keystroke in the property editor, causing expensive retessellation that could freeze the GUI on complex shapes.

This adds a 500ms debounce timer (using QTimer::singleShot pattern) so that updateVisual() is only called after the user stops typing, rather than on every intermediate value. If the user presses Enter or the field loses focus, the property value is committed normally and the timer fires after the final value is set.

Changes:
- Added a QTimer* member to ViewProviderPartExt for debouncing
- Modified onChanged() to use a debounced timer for AngularDeflection instead of calling updateVisual() immediately
- Timer is cleaned up in the destructor