### PR TITLE
Fix #30203: Allow import of system fonts into Sketcher Text Module

### DIFF
--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -28,6 +28,7 @@
 #include <QDir>
 #include <QDirIterator>
 #include <QFileInfo>
+#include <QStandardPaths>
 
 #include <App/Application.h>
 #include <App/Transactions.h>
@@ -1026,12 +1027,20 @@ QMap<QString, QString> SketcherGui::findAvailableFontFiles()
 
 #if defined(Q_OS_WIN)
     fontPaths << QString::fromUtf8("C:/Windows/Fonts");
+    // Also scan per-user installed fonts (Windows 10 1803+)
+    QString localAppData = QDir::toNativeSeparators(
+        QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+    );
+    if (!localAppData.isEmpty()) {
+        fontPaths << localAppData + QString::fromUtf8("/Microsoft/Windows/Fonts");
+    }
 #elif defined(Q_OS_MACOS)
     fontPaths << QString::fromUtf8("/System/Library/Fonts") << QString::fromUtf8("/Library/Fonts")
               << QDir::homePath() + QString::fromUtf8("/Library/Fonts");
 #else  // Linux and other Unix-like systems
     fontPaths << QString::fromUtf8("/usr/share/fonts") << QString::fromUtf8("/usr/local/share/fonts")
-              << QDir::homePath() + QString::fromUtf8("/.fonts");
+              << QDir::homePath() + QString::fromUtf8("/.fonts")
+              << QDir::homePath() + QString::fromUtf8("/.local/share/fonts");
 #endif
 
     for (const QString& path : fontPaths) {


### PR DESCRIPTION
Fixes #30203.

Extends the font discovery in `findAvailableFontFiles()` to also scan:
- **Windows**: Per-user installed fonts at `%LOCALAPPDATA%/Microsoft/Windows/Fonts` (where Windows 10 1803+ installs fonts added via Settings > Personalization > Fonts)
- **Linux**: `~/.local/share/fonts` (XDG standard user font directory)

Previously, fonts installed per-user on Windows were invisible to the Sketcher Text Module because only `C:/Windows/Fonts` (system-wide) was scanned. This also covers the common Linux case where users install fonts to `~/.local/share/fonts` instead of the legacy `~/.fonts`.