### PR TITLE
Part: preserve attachment when legacy support is empty

### DIFF
--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -522,7 +522,7 @@ bool AttachExtension::extensionHandleChangedPropertyName(
             tmp.setContainer(this->getExtendedContainer());
             tmp.Restore(reader);
             if (!tmp.getValues().empty()) {
-                AttachmentSupport.setValues(tmp.getValues(), tmp.getSubValues());
+                AttachmentSupport.Paste(tmp);
             }
             return true;
         }

--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -511,12 +511,19 @@ bool AttachExtension::extensionHandleChangedPropertyName(
         if (tmp.getTypeId().getName() == TypeName) {
             tmp.setContainer(this->getExtendedContainer());
             tmp.Restore(reader);
-            AttachmentSupport.setValue(tmp.getValue(), tmp.getSubValues());
-            this->MapMode.setValue(Attacher::mmFlatFace);
+            if (tmp.getValue()) {
+                AttachmentSupport.setValue(tmp.getValue(), tmp.getSubValues());
+                this->MapMode.setValue(Attacher::mmFlatFace);
+            }
             return true;
         }
         if (AttachmentSupport.getClassTypeId() == type) {
-            AttachmentSupport.Restore(reader);
+            App::PropertyLinkSubList tmp;
+            tmp.setContainer(this->getExtendedContainer());
+            tmp.Restore(reader);
+            if (!tmp.getValues().empty()) {
+                AttachmentSupport.setValues(tmp.getValues(), tmp.getSubValues());
+            }
             return true;
         }
     }

--- a/tests/src/Mod/Part/App/AttachExtension.cpp
+++ b/tests/src/Mod/Part/App/AttachExtension.cpp
@@ -4,11 +4,50 @@
 
 #include <cmath>
 #include <numbers>
+#include <sstream>
+#include <vector>
 
 #include <src/App/InitApplication.h>
+#include <Base/Reader.h>
+#include <Base/Writer.h>
 #include <App/Document.h>
+#include <App/PropertyLinks.h>
 #include <Mod/Part/App/FeaturePartBox.h>
 #include <Mod/Part/App/PrimitiveFeature.h>
+
+
+class TestablePlane: public Part::Plane
+{
+public:
+    bool restoreLegacySupport(Base::XMLReader& reader, const char* typeName)
+    {
+        return extensionHandleChangedPropertyName(reader, typeName, "Support");
+    }
+};
+
+
+template<typename PropertyT>
+void restoreLegacySupport(TestablePlane& plane, PropertyT& property)
+{
+    Base::StringWriter writer;
+    property.Save(writer);
+
+    std::stringstream data;
+    data << "<?xml version='1.0' encoding='utf-8'?>\n"
+         << "<Property name='Support' type='" << property.getTypeId().getName() << "'>\n"
+         << writer.getString() << "</Property>\n";
+    Base::XMLReader reader("Document.xml", data);
+
+    EXPECT_TRUE(plane.restoreLegacySupport(reader, property.getTypeId().getName()));
+}
+
+
+template<typename PropertyT>
+void restoreEmptyLegacySupport(TestablePlane& plane)
+{
+    PropertyT property;
+    restoreLegacySupport(plane, property);
+}
 
 
 class AttachExtensionTest: public ::testing::Test
@@ -33,6 +72,13 @@ protected:
     App::Document* getDocument() const
     {
         return _doc;
+    }
+
+    TestablePlane* createTestablePlane(const char* name)
+    {
+        auto plane = new TestablePlane();
+        getDocument()->addObject(plane, name);
+        return plane;
     }
 
 private:
@@ -201,4 +247,63 @@ TEST_F(AttachExtensionTest, testAttacherTypeEngine)
     plane->AttacherType.setValue("Attacher::AttachEngine3D");
     plane->onExtendedDocumentRestored();
     EXPECT_STREQ(plane->AttacherEngine.getValueAsString(), "Engine 3D");
+}
+
+TEST_F(AttachExtensionTest, testEmptyLegacySupportDoesNotClearAttachmentSupport)
+{
+    auto object = createTestablePlane("Object");
+    auto support = getDocument()->addObject<Part::Plane>("Support");
+    ASSERT_TRUE(object);
+    ASSERT_TRUE(support);
+
+    object->AttachmentSupport.setValue(support, "Face1");
+    object->MapMode.setValue("Deactivated");
+
+    restoreEmptyLegacySupport<App::PropertyLinkSub>(*object);
+    restoreEmptyLegacySupport<App::PropertyLinkSubList>(*object);
+
+    ASSERT_EQ(object->AttachmentSupport.getValues().size(), 1);
+    EXPECT_EQ(object->AttachmentSupport.getValues().front(), support);
+    ASSERT_EQ(object->AttachmentSupport.getSubValues().size(), 1);
+    EXPECT_EQ(object->AttachmentSupport.getSubValues().front(), "Face1");
+    EXPECT_STREQ(object->MapMode.getValueAsString(), "Deactivated");
+}
+
+TEST_F(AttachExtensionTest, testNonEmptyLegacySupportReplacesAttachmentSupport)
+{
+    auto object = createTestablePlane("Object");
+    auto currentSupport = getDocument()->addObject<Part::Plane>("CurrentSupport");
+    auto legacySupport = getDocument()->addObject<Part::Plane>("LegacySupport");
+    ASSERT_TRUE(object);
+    ASSERT_TRUE(currentSupport);
+    ASSERT_TRUE(legacySupport);
+
+    object->AttachmentSupport.setValue(currentSupport, "Face1");
+    object->MapMode.setValue("Deactivated");
+
+    App::PropertyLinkSub oldLinkSub;
+    oldLinkSub.setContainer(object);
+    oldLinkSub.setValue(legacySupport, "Face2");
+    restoreLegacySupport(*object, oldLinkSub);
+
+    ASSERT_EQ(object->AttachmentSupport.getValues().size(), 1);
+    EXPECT_EQ(object->AttachmentSupport.getValues().front(), legacySupport);
+    EXPECT_STREQ(object->MapMode.getValueAsString(), "FlatFace");
+
+    object->AttachmentSupport.setValue(currentSupport, "Face1");
+    object->MapMode.setValue("Deactivated");
+
+    App::PropertyLinkSubList oldLinkSubList;
+    oldLinkSubList.setContainer(object);
+    oldLinkSubList.setValues(
+        std::vector<App::DocumentObject*> {legacySupport},
+        std::vector<std::string> {"Face2"}
+    );
+    restoreLegacySupport(*object, oldLinkSubList);
+
+    ASSERT_EQ(object->AttachmentSupport.getValues().size(), 1);
+    EXPECT_EQ(object->AttachmentSupport.getValues().front(), legacySupport);
+    ASSERT_EQ(object->AttachmentSupport.getSubValues().size(), 1);
+    EXPECT_EQ(object->AttachmentSupport.getSubValues().front(), "Face2");
+    EXPECT_STREQ(object->MapMode.getValueAsString(), "Deactivated");
 }

--- a/tests/src/Mod/Part/App/AttachExtension.cpp
+++ b/tests/src/Mod/Part/App/AttachExtension.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <numbers>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #include <src/App/InitApplication.h>
@@ -29,16 +30,17 @@ public:
 template<typename PropertyT>
 void restoreLegacySupport(TestablePlane& plane, PropertyT& property)
 {
+    const std::string typeName(property.getTypeId().getName());
     Base::StringWriter writer;
     property.Save(writer);
 
     std::stringstream data;
     data << "<?xml version='1.0' encoding='utf-8'?>\n"
-         << "<Property name='Support' type='" << property.getTypeId().getName() << "'>\n"
+         << "<Property name='Support' type='" << typeName << "'>\n"
          << writer.getString() << "</Property>\n";
     Base::XMLReader reader("Document.xml", data);
 
-    EXPECT_TRUE(plane.restoreLegacySupport(reader, property.getTypeId().getName()));
+    EXPECT_TRUE(plane.restoreLegacySupport(reader, typeName.c_str()));
 }
 
 
@@ -283,7 +285,7 @@ TEST_F(AttachExtensionTest, testNonEmptyLegacySupportReplacesAttachmentSupport)
 
     App::PropertyLinkSub oldLinkSub;
     oldLinkSub.setContainer(object);
-    oldLinkSub.setValue(legacySupport, "Face2");
+    oldLinkSub.setValue(legacySupport, std::vector<std::string> {"Face2"});
     restoreLegacySupport(*object, oldLinkSub);
 
     ASSERT_EQ(object->AttachmentSupport.getValues().size(), 1);


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

Description:
This PR fixes an issue where an empty Support field in legacy documents would overwrite a valid AttachmentSupport during migration. The fix ensures that attachment information is only migrated when the legacy Support is non-empty, preventing accidental data loss. Tests have been added to cover both empty PropertyLinkSub and PropertyLinkSubList cases, while also verifying that non-empty legacy data continues to migrate as expected. This resolves the problem where valid attachments were being cleared due to blank legacy support entries.

The initial implementation was assisted by GPT‑5, and the subsequent CI test fixes were assisted by GPT‑5.5. I have already fixed the Ubuntu compilation failure and pushed the changes; the new CI run will follow shortly.

Regarding the test file: an attachment already exists in the original issue and can be used to reproduce the problem, but the uploader has not explicitly provided an open-source license. I would like to ask the maintainers to decide whether to use the existing external file already available to them for testing, or wait for the uploader to confirm the licensing status of the attachment.

Assisted-by: GPT-5
Assisted-by: GPT-5.5 (Codex)

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

Fixes #18969.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
