### PR TITLE
[Backport releases/FreeCAD-1-1] Gui: Replace..

### DIFF
--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -534,7 +534,11 @@ void NaviCubeImplementation::createCubeFaceTextures()
         if (m_LabelTextures[pickId].texture) {
             delete m_LabelTextures[pickId].texture;
         }
+#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
         m_LabelTextures[pickId].texture = new QOpenGLTexture(image.mirrored());
+#else
+        m_LabelTextures[pickId].texture = new QOpenGLTexture(image.flipped(Qt::Vertical));
+#endif
         m_LabelTextures[pickId].texture->setMaximumAnisotropy(4.0);
         m_LabelTextures[pickId].texture->setMinificationFilter(QOpenGLTexture::LinearMipMapLinear);
         m_LabelTextures[pickId].texture->setMagnificationFilter(QOpenGLTexture::Linear);

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1799,7 +1799,11 @@ void View3DInventorViewer::savePicture(int width, int height, int sample, const 
     if (useGrabFramebuffer) {
         auto self = const_cast<View3DInventorViewer*>(this);  // NOLINT
         img = self->grabFramebuffer();
+#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
         img = img.mirrored();
+#else
+        img = img.flipped(Qt::Vertical);
+#endif
         img = img.scaledToWidth(width);
         return;
     }

--- a/src/Gui/View3DViewerPy.cpp
+++ b/src/Gui/View3DViewerPy.cpp
@@ -693,7 +693,11 @@ Py::Object View3DInventorViewerPy::grabFramebuffer(const Py::Tuple& args)
 
     PythonWrapper wrap;
     wrap.loadGuiModule();
+#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
     return wrap.fromQImage(img.mirrored());
+#else
+    return wrap.fromQImage(img.flipped(Qt::Vertical));
+#endif
 }
 
 Py::Object View3DInventorViewerPy::setOverrideMode(const Py::Tuple& args)


### PR DESCRIPTION
...deprecated QImage::mirrored by QImage::flipped
QImage::mirrored was deprecated and will be deleted by Qt6.13

Manual backport of https://github.com/FreeCAD/FreeCAD/commit/5f89fd4e984f911445d3f1440d26ebe271478aee
