### PR TITLE
Draft: guard unsupported subelement modifiers

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_move.py
+++ b/src/Mod/Draft/draftguitools/gui_move.py
@@ -207,6 +207,9 @@ class Move(gui_base_original.Modifier):
         for sel in selection:
             for sub in sel.SubElementNames if sel.SubElementNames else [""]:
                 if (not copy and "Vertex" in sub) or "Edge" in sub:
+                    obj = sel.Object.getSubObject(sub, 1)
+                    if utils.get_type(obj) != "Wire":
+                        continue
                     shape = Part.getShape(sel.Object, sub, needSubElement=True, retType=0)
                     ghosts.append(trackers.ghostTracker(shape))
         return ghosts

--- a/src/Mod/Draft/draftguitools/gui_rotate.py
+++ b/src/Mod/Draft/draftguitools/gui_rotate.py
@@ -260,6 +260,9 @@ class Rotate(gui_base_original.Modifier):
         for sel in selection:
             for sub in sel.SubElementNames if sel.SubElementNames else [""]:
                 if (not copy and "Vertex" in sub) or "Edge" in sub:
+                    obj = sel.Object.getSubObject(sub, 1)
+                    if utils.get_type(obj) != "Wire":
+                        continue
                     shape = Part.getShape(sel.Object, sub, needSubElement=True, retType=0)
                     ghosts.append(trackers.ghostTracker(shape))
         return ghosts

--- a/src/Mod/Draft/draftguitools/gui_scale.py
+++ b/src/Mod/Draft/draftguitools/gui_scale.py
@@ -138,6 +138,9 @@ class Scale(gui_base_original.Modifier):
         for sel in selection:
             for sub in sel.SubElementNames if sel.SubElementNames else [""]:
                 if (not copy and "Vertex" in sub) or "Edge" in sub:
+                    obj = sel.Object.getSubObject(sub, 1)
+                    if utils.get_type(obj) != "Wire":
+                        continue
                     shape = Part.getShape(sel.Object, sub, needSubElement=True, retType=0)
                     ghosts.append(trackers.ghostTracker(shape))
         return ghosts

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -40,6 +40,7 @@ import Draft
 from FreeCAD import Vector
 from drafttests import auxiliary as aux
 from drafttests import test_base
+from draftutils import utils
 from draftutils.messages import _msg
 
 
@@ -98,6 +99,37 @@ class DraftModification(test_base.DraftTestCaseDoc):
         Draft.rotate(obj, rot)
         self.doc.recompute()
         self.assertTrue(obj.Start.isEqual(c, 1e-6), "'{}' failed".format(operation))
+
+    def test_process_subselection_skips_objects_without_points(self):
+        """Subelement modifiers skip objects that do not expose Points."""
+
+        class SelectionObject:
+            def __init__(self, target, name):
+                self.target = target
+                self.Name = name
+
+            def getSubObject(self, sub, mode):
+                return self.target if mode == 1 else App.Placement()
+
+        class Selection:
+            def __init__(self, target, name, sub):
+                self.Object = SelectionObject(target, name)
+                self.SubElementNames = [sub]
+
+        unsupported = self.doc.addObject("Part::FeaturePython", "Unsupported")
+        supported = self.doc.addObject("Part::FeaturePython", "Supported")
+        supported.addProperty("App::PropertyVectorList", "Points")
+        supported.Points = [Vector(), Vector(1, 0, 0)]
+        selections = [
+            Selection(unsupported, unsupported.Name, "Edge1"),
+            Selection(supported, supported.Name, "Vertex1"),
+        ]
+
+        data_list, selection_info = utils._modifiers_process_subselection(selections, False)
+
+        self.assertEqual(len(data_list), 1)
+        self.assertIs(data_list[0][0], supported)
+        self.assertEqual(selection_info, [("", supported.Name, "Vertex1")])
 
     def test_offset_open(self):
         """Create an open wire, then produce an offset copy."""

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -100,8 +100,8 @@ class DraftModification(test_base.DraftTestCaseDoc):
         self.doc.recompute()
         self.assertTrue(obj.Start.isEqual(c, 1e-6), "'{}' failed".format(operation))
 
-    def test_process_subselection_skips_objects_without_points(self):
-        """Subelement modifiers skip objects that do not expose Points."""
+    def test_process_subselection_accepts_only_wires(self):
+        """Subelement modifiers process Draft wires and skip other objects."""
 
         class SelectionObject:
             def __init__(self, target, name):
@@ -116,10 +116,8 @@ class DraftModification(test_base.DraftTestCaseDoc):
                 self.Object = SelectionObject(target, name)
                 self.SubElementNames = [sub]
 
-        unsupported = self.doc.addObject("Part::FeaturePython", "Unsupported")
-        supported = self.doc.addObject("Part::FeaturePython", "Supported")
-        supported.addProperty("App::PropertyVectorList", "Points")
-        supported.Points = [Vector(), Vector(1, 0, 0)]
+        unsupported = Draft.make_rectangle(10, 10)
+        supported = Draft.make_wire([Vector(), Vector(1, 0, 0)])
         selections = [
             Selection(unsupported, unsupported.Name, "Edge1"),
             Selection(supported, supported.Name, "Vertex1"),

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -866,6 +866,7 @@ def get_rgba_tuple(color, typ=1.0):
 def _modifiers_process_subselection(sels, copy):
     data_list = []
     sel_info = []
+    unsupported_objects = set()
     for sel in sels:
         for sub in sel.SubElementNames if sel.SubElementNames else [""]:
             if not ("Vertex" in sub or "Edge" in sub):
@@ -873,6 +874,18 @@ def _modifiers_process_subselection(sels, copy):
             if copy and "Vertex" in sub:
                 continue
             obj = sel.Object.getSubObject(sub, 1)
+            if not hasattr(obj, "Points"):
+                object_id = id(obj)
+                if object_id not in unsupported_objects:
+                    _wrn(
+                        translate(
+                            "draft",
+                            "Cannot modify subelements of this object. "
+                            "Uncheck the 'Modify subelements' option to modify the whole object.",
+                        )
+                    )
+                    unsupported_objects.add(object_id)
+                continue
             pla = sel.Object.getSubObject(sub, 3)
             if "Vertex" in sub:
                 vert_idx = int(sub.rpartition("Vertex")[2]) - 1

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -866,7 +866,6 @@ def get_rgba_tuple(color, typ=1.0):
 def _modifiers_process_subselection(sels, copy):
     data_list = []
     sel_info = []
-    unsupported_objects = set()
     for sel in sels:
         for sub in sel.SubElementNames if sel.SubElementNames else [""]:
             if not ("Vertex" in sub or "Edge" in sub):
@@ -874,17 +873,7 @@ def _modifiers_process_subselection(sels, copy):
             if copy and "Vertex" in sub:
                 continue
             obj = sel.Object.getSubObject(sub, 1)
-            if not hasattr(obj, "Points"):
-                object_id = id(obj)
-                if object_id not in unsupported_objects:
-                    _wrn(
-                        translate(
-                            "draft",
-                            "Cannot modify subelements of this object. "
-                            "Uncheck the 'Modify subelements' option to modify the whole object.",
-                        )
-                    )
-                    unsupported_objects.add(object_id)
+            if get_type(obj) != "Wire":
                 continue
             pla = sel.Object.getSubObject(sub, 3)
             if "Vertex" in sub:


### PR DESCRIPTION
Skip selected objects that do not expose editable Points while retaining supported objects in mixed selections.

Description:
This PR ensures that objects without Points are properly skipped during processing, while objects with editable Points are still handled correctly even when they are part of a mixed selection. A regression test has been added to cover this scenario and prevent future regressions.

The implementation was assisted by GPT-5 (Codex), with all changes reviewed and verified by me.

Fixes #20661.
Assisted-by: GPT-5 (Codex)

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
