### PR TITLE
Surface: fix boundary orientation flags

### DIFF
--- a/src/Mod/Surface/App/FeatureGeomFillSurface.cpp
+++ b/src/Mod/Surface/App/FeatureGeomFillSurface.cpp
@@ -135,6 +135,7 @@ GeomFillSurface::GeomFillSurface()
     ADD_PROPERTY(FillType, ((long)0));
     ADD_PROPERTY(BoundaryList, (nullptr, "Dummy"));
     ADD_PROPERTY(ReversedList, (false));
+    ReversedList.setSize(0);
     FillType.setEnums(FillTypeEnums);
     BoundaryList.setScope(App::LinkScope::Global);
 }
@@ -151,13 +152,14 @@ short GeomFillSurface::mustExecute() const
 
 void GeomFillSurface::onChanged(const App::Property* prop)
 {
-    if (isRestoring()) {
-        if (prop == &BoundaryList) {
-            // auto-adjusting size of this list
-            if (BoundaryList.getSize() != ReversedList.getSize()) {
-                ReversedList.setSize(BoundaryList.getSize());
-            }
+    if (isRestoring() && prop == &BoundaryList) {
+        // auto-adjusting size of this list
+        if (BoundaryList.getSize() != ReversedList.getSize()) {
+            ReversedList.setSize(BoundaryList.getSize());
         }
+    }
+    if (prop == &ReversedList && ReversedList.getSize() > BoundaryList.getSize()) {
+        ReversedList.setSize(BoundaryList.getSize());
     }
     Part::Spline::onChanged(prop);
 }

--- a/src/Mod/Surface/CMakeLists.txt
+++ b/src/Mod/Surface/CMakeLists.txt
@@ -13,6 +13,7 @@ set(Surface_Scripts
 set(Surface_TestScripts
     SurfaceTests/__init__.py
     SurfaceTests/TestBlendCurve.py
+    SurfaceTests/TestGeomFillSurface.py
 )
 
 if(BUILD_GUI)

--- a/src/Mod/Surface/SurfaceTests/TestGeomFillSurface.py
+++ b/src/Mod/Surface/SurfaceTests/TestGeomFillSurface.py
@@ -3,13 +3,13 @@
 import unittest
 
 import FreeCAD as App
-import Surface  # noqa: F401
+import Surface
 
 
 class TestGeomFillSurface(unittest.TestCase):
     def setUp(self):
         self.doc = App.newDocument("TestGeomFillSurface")
-        self.surface = self.doc.addObject("Surface::GeomFillSurface", "Surface")
+        self.surface = self.doc.addObject(f"{Surface.__name__}::GeomFillSurface", "Surface")
 
     def tearDown(self):
         App.closeDocument(self.doc.Name)

--- a/src/Mod/Surface/SurfaceTests/TestGeomFillSurface.py
+++ b/src/Mod/Surface/SurfaceTests/TestGeomFillSurface.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+import FreeCAD as App
+import Surface  # noqa: F401
+
+
+class TestGeomFillSurface(unittest.TestCase):
+    def setUp(self):
+        self.doc = App.newDocument("TestGeomFillSurface")
+        self.surface = self.doc.addObject("Surface::GeomFillSurface", "Surface")
+
+    def tearDown(self):
+        App.closeDocument(self.doc.Name)
+
+    def test_reversed_list_starts_empty(self):
+        self.assertEqual(tuple(self.surface.ReversedList), ())
+
+    def test_surplus_legacy_orientation_flag_is_removed(self):
+        edge1 = self.doc.addObject("PartDesign::Feature", "Edge1")
+        edge2 = self.doc.addObject("PartDesign::Feature", "Edge2")
+        self.surface.BoundaryList = [(edge1, ["Edge1"]), (edge2, ["Edge1"])]
+
+        self.surface.ReversedList = [True, False, True]
+
+        self.assertEqual(tuple(self.surface.ReversedList), (True, False))

--- a/src/Mod/Surface/TestSurfaceApp.py
+++ b/src/Mod/Surface/TestSurfaceApp.py
@@ -23,3 +23,4 @@
 
 # Unit test for the Surface module
 from SurfaceTests.TestBlendCurve import TestBlendCurve
+from SurfaceTests.TestGeomFillSurface import TestGeomFillSurface

--- a/src/Mod/Surface/TestSurfaceApp.py
+++ b/src/Mod/Surface/TestSurfaceApp.py
@@ -24,3 +24,5 @@
 # Unit test for the Surface module
 from SurfaceTests.TestBlendCurve import TestBlendCurve
 from SurfaceTests.TestGeomFillSurface import TestGeomFillSurface
+
+__all__ = ["TestBlendCurve", "TestGeomFillSurface"]


### PR DESCRIPTION
Initialize ReversedList as empty so the task panel maintains one flag per boundary. Trim the surplus tail when loading documents created with the old initialization.

Add regression coverage for new and legacy objects.

Description:
This PR fixes an issue where an extra flag in ReversedList caused boundary flipping to fail. The fix removes the redundant flag while maintaining compatibility with existing legacy documents. A test has been added to cover this case and prevent future regressions.

The implementation was assisted by GPT-5 (Codex), with all changes reviewed and verified by me.

Fixes #29874.

Assisted-by: GPT-5 (Codex)

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
