### PR TITLE
Gui: make automatic rotation centers object-relative

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1979,7 +1979,6 @@ void StdCmdPlacement::activated(int iMsg)
             plm->setPropertyName(QLatin1String("Placement"));
             plm->setSelection(selection);
             plm->bindObject();
-            plm->clearSelection();
         }
     }
     Gui::Control().showDialog(plm, getDocument());

--- a/src/Gui/Placement.cpp
+++ b/src/Gui/Placement.cpp
@@ -378,9 +378,9 @@ QString PlacementHandler::getSimplePlacement(const App::DocumentObject* obj, con
         );
 }
 
-Base::Vector3d PlacementHandler::computeCenterOfMass() const
+bool PlacementHandler::computeCenterOfMass(Base::Vector3d& centerOfMass) const
 {
-    Base::Vector3d centerOfMass;
+    centerOfMass = Base::Vector3d();
     std::vector<App::DocumentObject*> sel = Gui::Selection().getObjectsOfType(
         App::GeoFeature::getClassTypeId()
     );
@@ -390,11 +390,11 @@ Base::Vector3d PlacementHandler::computeCenterOfMass() const
                 = static_cast<App::GeoFeature*>(it)->getPropertyOfGeometry();
             const Data::ComplexGeoData* geodata = propgeo ? propgeo->getComplexData() : nullptr;
             if (geodata && geodata->getCenterOfGravity(centerOfMass)) {
-                break;
+                return true;
             }
         }
     }
-    return centerOfMass;
+    return false;
 }
 
 Base::Vector3d PlacementHandler::relativeCenter(
@@ -627,8 +627,10 @@ void Placement::onCenterOfMassToggled(bool on)
     ui->zCnt->setDisabled(on);
 
     if (on) {
-        Base::Vector3d pnt = handler.computeCenterOfMass();
-        pnt = PlacementHandler::relativeCenter(pnt, getPositionData());
+        Base::Vector3d pnt;
+        if (handler.computeCenterOfMass(pnt)) {
+            pnt = PlacementHandler::relativeCenter(pnt, getPositionData());
+        }
         handler.setCenterOfMass(pnt);
         ui->xCnt->setValue(pnt.x);
         ui->yCnt->setValue(pnt.y);
@@ -760,17 +762,14 @@ void Placement::onSelectedVertexClicked()
     ui->zCnt->setValue(center.z);
 
     if (!success) {
-        Base::Console().warning("Placement selection error.  Select either 1 or 2 points.\n");
+        Base::Console().warning("Placement selection error. Select 1, 2, or 3 points.\n");
         QMessageBox msgBox(this);
         msgBox.setText(
-            tr("Select 1, 2, or 3 points before clicking this button. A point may be on a vertex, \
-face, or edge.  If on a face or edge the point used will be the point at the mouse position along \
-face or edge.  If 1 point is selected it will be used as the center of rotation.  If 2 points are \
-selected the midpoint between them will be the center of rotation and a new custom axis will be \
-created, if needed.  If 3 points are selected the first point becomes the center of rotation and \
-lies on the vector that is normal to the plane defined by the 3 points.  Some distance and angle \
-information is provided in the report view, which can be useful when aligning objects.  For your \
-convenience when Shift + click is used the appropriate distance or angle is copied to the clipboard.")
+            tr("Select 1-3 points before clicking.\n\n"
+               "1 point: rotate around it.\n"
+               "2 points: rotate around their midpoint and create a custom rotation axis.\n"
+               "3 points: rotate around the first point about the normal to their plane.\n\n"
+               "Shift + click copies the distance or angle.")
         );
         msgBox.exec();
     }

--- a/src/Gui/Placement.cpp
+++ b/src/Gui/Placement.cpp
@@ -397,6 +397,14 @@ Base::Vector3d PlacementHandler::computeCenterOfMass() const
     return centerOfMass;
 }
 
+Base::Vector3d PlacementHandler::relativeCenter(
+    const Base::Vector3d& globalCenter,
+    const Base::Vector3d& objectPosition
+)
+{
+    return globalCenter - objectPosition;
+}
+
 void PlacementHandler::setCenterOfMass(const Base::Vector3d& pnt)
 {
     cntOfMass = pnt;
@@ -620,6 +628,7 @@ void Placement::onCenterOfMassToggled(bool on)
 
     if (on) {
         Base::Vector3d pnt = handler.computeCenterOfMass();
+        pnt = PlacementHandler::relativeCenter(pnt, getPositionData());
         handler.setCenterOfMass(pnt);
         ui->xCnt->setValue(pnt.x);
         ui->yCnt->setValue(pnt.y);
@@ -739,6 +748,10 @@ void Placement::onSelectedVertexClicked()
         ui->rotationInput->setCurrentIndex(0);  // use rotation with axis instead of euler
         ui->stackedWidget->setCurrentIndex(0);
         success = true;
+    }
+
+    if (success) {
+        center = PlacementHandler::relativeCenter(center, getPositionData());
     }
 
     handler.setCenterOfMass(center);

--- a/src/Gui/Placement.h
+++ b/src/Gui/Placement.h
@@ -66,6 +66,10 @@ public:
     void applyPlacement(const Base::Placement& p, bool incremental);
     void applyPlacement(const QString& p, bool incremental);
     Base::Vector3d computeCenterOfMass() const;
+    static Base::Vector3d relativeCenter(
+        const Base::Vector3d& globalCenter,
+        const Base::Vector3d& objectPosition
+    );
     void setCenterOfMass(const Base::Vector3d& pnt);
     Base::Vector3d getCenterOfMass() const;
     std::tuple<Base::Vector3d, std::vector<Base::Vector3d>> getSelectedPoints() const;

--- a/src/Gui/Placement.h
+++ b/src/Gui/Placement.h
@@ -65,7 +65,7 @@ public:
     const Base::Placement& getRefPlacement() const;
     void applyPlacement(const Base::Placement& p, bool incremental);
     void applyPlacement(const QString& p, bool incremental);
-    Base::Vector3d computeCenterOfMass() const;
+    bool computeCenterOfMass(Base::Vector3d& centerOfMass) const;
     static Base::Vector3d relativeCenter(
         const Base::Vector3d& globalCenter,
         const Base::Vector3d& objectPosition

--- a/tests/src/Gui/Dialogs/CMakeLists.txt
+++ b/tests/src/Gui/Dialogs/CMakeLists.txt
@@ -1,1 +1,2 @@
 setup_qt_test(DlgVersionMigrator)
+setup_qt_test(Placement)

--- a/tests/src/Gui/Dialogs/Placement.cpp
+++ b/tests/src/Gui/Dialogs/Placement.cpp
@@ -6,6 +6,7 @@
 #include <src/App/InitApplication.h>
 
 #include <Base/Vector3D.h>
+#include <Gui/Application.h>
 #include <Gui/Placement.h>
 
 
@@ -17,6 +18,9 @@ public:
     TestPlacement()
     {
         tests::initApplication();
+        if (!Gui::Application::Instance) {
+            new Gui::Application(false);
+        }
     }
 
 private Q_SLOTS:

--- a/tests/src/Gui/Dialogs/Placement.cpp
+++ b/tests/src/Gui/Dialogs/Placement.cpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+#include <QTest>
+
+#include <Base/Vector3D.h>
+#include <Gui/Dialogs/Placement.h>
+
+
+class TestPlacement final: public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void centerIsRelativeToTranslatedObject()
+    {
+        const Base::Vector3d globalCenter(5.0, 35.0, 5.0);
+        const Base::Vector3d objectPosition(0.0, 30.0, 0.0);
+
+        const auto center = Gui::Dialog::PlacementHandler::relativeCenter(globalCenter, objectPosition);
+
+        QVERIFY(center == Base::Vector3d(5.0, 5.0, 5.0));
+    }
+
+    void untranslatedObjectKeepsCenter()
+    {
+        const Base::Vector3d globalCenter(5.0, 5.0, 5.0);
+
+        const auto center
+            = Gui::Dialog::PlacementHandler::relativeCenter(globalCenter, Base::Vector3d());
+
+        QVERIFY(center == globalCenter);
+    }
+};
+
+
+QTEST_MAIN(TestPlacement)
+
+#include "Placement.moc"

--- a/tests/src/Gui/Dialogs/Placement.cpp
+++ b/tests/src/Gui/Dialogs/Placement.cpp
@@ -3,13 +3,21 @@
 
 #include <QTest>
 
+#include <src/App/InitApplication.h>
+
 #include <Base/Vector3D.h>
-#include <Gui/Dialogs/Placement.h>
+#include <Gui/Placement.h>
 
 
 class TestPlacement final: public QObject
 {
     Q_OBJECT
+
+public:
+    TestPlacement()
+    {
+        tests::initApplication();
+    }
 
 private Q_SLOTS:
     void centerIsRelativeToTranslatedObject()
@@ -30,6 +38,17 @@ private Q_SLOTS:
             = Gui::Dialog::PlacementHandler::relativeCenter(globalCenter, Base::Vector3d());
 
         QVERIFY(center == globalCenter);
+    }
+
+    void missingCenterOfMassDoesNotUseTranslatedFallback()
+    {
+        Gui::Dialog::PlacementHandler handler;
+        Base::Vector3d center(1.0, 2.0, 3.0);
+
+        const bool found = handler.computeCenterOfMass(center);
+
+        QVERIFY(!found);
+        QVERIFY(center == Base::Vector3d());
     }
 };
 


### PR DESCRIPTION
Center-of-mass and picked-point coordinates are reported in the parent coordinate system. Convert them to coordinates relative to the object position before constructing a centered Placement.

Description:
This PR converts both the mass center and selected point to coordinates relative to the object's position, fixing an incorrect rotation center issue for objects that have been translated. A Qt test has been added to validate the behavior and prevent future regressions.

The implementation was assisted by GPT-5 (Codex), with all changes reviewed and verified by me.

Fixes #6172.



Assisted-by: GPT-5 (Codex) 

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
