### PR TITLE
Spreadsheet: Prevent paint from calling itself

### DIFF
--- a/src/Mod/Spreadsheet/Gui/LineEdit.cpp
+++ b/src/Mod/Spreadsheet/Gui/LineEdit.cpp
@@ -108,7 +108,11 @@ void LineEdit::setDocumentObject(const App::DocumentObject* currentDocObj, bool 
         xpopup->setGeometry(new_pos.x(), new_pos.y(), getPopupWidth(), xpopup->height());
     };
 
-    QObject::connect(xpopup, &XListView::geometryChanged, this, updatePopupGeom);
+    /* Queued: the signal comes from inside XListView's own paint, and moving a top-level window
+     * between screens of different scaling repaints synchronously, re-entering that paint.
+     * See #31348.
+     */
+    QObject::connect(xpopup, &XListView::geometryChanged, this, updatePopupGeom, Qt::QueuedConnection);
 }
 
 void LineEdit::focusOutEvent(QFocusEvent* event)


### PR DESCRIPTION
Use a queued connection to prevent repaint from calling itself if a window is dragged between monitors with different scaling. Fixes #31348 and replaces #31975.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
