### PR TITLE
Gui: make native Python ownership shutdown-safe

### DIFF
--- a/.github/workflows/python314-shutdown.yml
+++ b/.github/workflows/python314-shutdown.yml
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+name: Python 3.14 shutdown regression
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/python314-shutdown.yml"
+      - "ci/pixi-python314/**"
+      - "src/App/**"
+      - "src/Base/**"
+      - "src/Gui/**"
+      - "tests/src/**"
+
+permissions:
+  contents: read
+
+jobs:
+  shutdown-tests:
+    name: Shutdown tests (Python 3.14)
+    runs-on: ubuntu-24.04
+    # This is deliberately non-blocking while the new toolchain is validated.
+    continue-on-error: true
+    timeout-minutes: 90
+    env:
+      PIXI_MANIFEST: ci/pixi-python314/pixi.toml
+      PYTHON314_ROOT: ${{ github.workspace }}/ci/pixi-python314/.pixi/envs/default
+      builddir: ${{ github.workspace }}/build/python314
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout source code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+
+      - name: Install FreeCAD C++ dependencies
+        run: ./package/ubuntu/install-apt-packages.sh
+
+      - name: Install Pixi
+        uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
+        with:
+          pixi-version: v0.70.2
+          cache: false
+
+      - name: Install Python 3.14 runtime
+        run: pixi install --manifest-path "$PIXI_MANIFEST" --frozen
+
+      - name: Configure CMake
+        run: |
+          pixi run --manifest-path "$PIXI_MANIFEST" cmake \
+            -S . \
+            -B "$builddir" \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_PREFIX_PATH="$PYTHON314_ROOT" \
+            -DPython3_ROOT_DIR="$PYTHON314_ROOT" \
+            -DPython3_EXECUTABLE="$PYTHON314_ROOT/bin/python" \
+            -DPython_EXECUTABLE="$PYTHON314_ROOT/bin/python" \
+            -DFREECAD_QT_VERSION=6 \
+            -DFREECAD_USE_EXTERNAL_PYCXX=ON \
+            -DFREECAD_USE_EXTERNAL_JSON=ON \
+            -DFREECAD_USE_EXTERNAL_COIN_PIVY=OFF \
+            -DFREECAD_CHECK_PIVY=OFF \
+            -DBUILD_GUI=ON \
+            -DBUILD_TEST=ON \
+            -DENABLE_DEVELOPER_TESTS=ON \
+            -DBUILD_ADDONMGR=OFF \
+            -DBUILD_ASSEMBLY=OFF \
+            -DBUILD_BIM=OFF \
+            -DBUILD_CAM=OFF \
+            -DBUILD_DRAFT=OFF \
+            -DBUILD_FEM=OFF \
+            -DBUILD_FLAT_MESH=OFF \
+            -DBUILD_HELP=OFF \
+            -DBUILD_IMPORT=OFF \
+            -DBUILD_INSPECTION=OFF \
+            -DBUILD_JTREADER=OFF \
+            -DBUILD_MATERIAL=OFF \
+            -DBUILD_MESH=OFF \
+            -DBUILD_MESH_PART=OFF \
+            -DBUILD_MEASURE=OFF \
+            -DBUILD_OPENSCAD=OFF \
+            -DBUILD_PART=OFF \
+            -DBUILD_PART_DESIGN=OFF \
+            -DBUILD_PLOT=OFF \
+            -DBUILD_POINTS=OFF \
+            -DBUILD_REVERSEENGINEERING=OFF \
+            -DBUILD_ROBOT=OFF \
+            -DBUILD_SHOW=OFF \
+            -DBUILD_SKETCHER=OFF \
+            -DBUILD_SPREADSHEET=OFF \
+            -DBUILD_START=OFF \
+            -DBUILD_SURFACE=OFF \
+            -DBUILD_TECHDRAW=OFF \
+            -DBUILD_TUX=OFF \
+            -DBUILD_WEB=OFF
+
+      - name: Build shutdown-test targets
+        run: |
+          pixi run --manifest-path "$PIXI_MANIFEST" cmake --build "$builddir" -j2 --target \
+            PythonReferenceShutdown \
+            PythonReferenceFinalizationRefusal \
+            TypePyLifetimeShutdown \
+            ParameterLifetimeShutdown \
+            ExtensionLifetimeShutdown \
+            FeaturePythonLifetimeShutdown \
+            ViewerLifetimeShutdown_Tests_run \
+            EditableDatumLabelLifetimeShutdown_Tests_run \
+            TaskDialogLifetimeShutdown_Tests_run \
+            MDIViewLifetimeShutdown_Tests_run \
+            PyResourceLifetimeShutdown \
+            GeneratedWrapperLifetimeShutdown
+
+      - name: Run shutdown tests
+        run: |
+          pixi run --manifest-path "$PIXI_MANIFEST" xvfb-run -a ctest \
+            --test-dir "$builddir" \
+            --output-on-failure \
+            -R 'PythonReferenceShutdown|PythonReferenceFinalizationRefusal|TypePyLifetimeShutdown|ParameterLifetimeShutdown|ExtensionLifetimeShutdown|FeaturePythonLifetimeShutdown|ViewerLifetimeShutdown_Tests_run|EditableDatumLabelLifetimeShutdown_Tests_run|TaskDialogLifetimeShutdown_Tests_run|MDIViewLifetimeShutdown_Tests_run|PyResourceLifetimeShutdown|GeneratedWrapperLifetimeShutdown'

--- a/ci/pixi-python314/pixi.lock
+++ b/ci/pixi-python314/pixi.lock
@@ -1,0 +1,1703 @@
+version: 7
+platforms:
+- name: linux-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h12ff6da_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.8-default_h96bbd2b_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-h45c3219_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.3.1-h23af247_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.8-hf7376ad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.6-h9d76c99_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.357.0-h0e34353_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-hb83e432_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.2-h51789e4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb03c661_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.2-py314h5d85b37_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.7-h399a421_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.2-pl5321h9df5c37_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-h1964d1d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-h7cc23a3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-h7cc23a3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.3-h7cc23a3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-h7cc23a3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-h280c20c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  build_number: 20
+  sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  md5: a9f577daf3de00bca7c3c76c0ecbd1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+  size: 28948
+  timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
+  sha256: cf93ca0f1f107e95a35969a4622684e08fcb8cf37f8cf4a1e9e424828386c921
+  md5: 8904e09bda369377b3dd07e2ac828c5d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  run_exports:
+    weak:
+    - alsa-lib >=1.2.16.1,<1.3.0a0
+  size: 592377
+  timestamp: 1781521980743
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+  sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+  md5: e675fabcf81499adc7edf58124fb1e01
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  run_exports:
+    weak:
+    - bzip2 >=1.0.8,<2.0a0
+  size: 257808
+  timestamp: 1785906269155
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+  sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
+  md5: bb6c4808bfa69d6f7f6b07e5846ced37
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - icu >=78.1,<79.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libglib >=2.86.3,<3.0a0
+  - libpng >=1.6.53,<1.7.0a0
+  - libstdcxx >=14
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.46.4,<1.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: LGPL-2.1-only or MPL-1.1
+  run_exports:
+    weak:
+    - cairo >=1.18.4,<2.0a0
+  size: 989514
+  timestamp: 1766415934926
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+  sha256: 7684da83306bb69686c0506fb09aa7074e1a55ade50c3a879e4e5df6eebb1009
+  md5: af491aae930edc096b58466c51c4126c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=13
+  - libntlm >=1.8,<2.0a0
+  - libstdcxx >=13
+  - libxcrypt >=4.4.36
+  - openssl >=3.5.5,<4.0a0
+  license: BSD-3-Clause-Attribution
+  license_family: BSD
+  run_exports:
+    weak:
+    - cyrus-sasl >=2.1.28,<3.0a0
+  size: 210103
+  timestamp: 1771943128249
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+  sha256: 8bb557af1b2b7983cf56292336a1a1853f26555d9c6cecf1e5b2b96838c9da87
+  md5: ce96f2f470d39bd96ce03945af92e280
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - libglib >=2.86.2,<3.0a0
+  - libexpat >=2.7.3,<3.0a0
+  license: AFL-2.1 OR GPL-2.0-or-later
+  run_exports:
+    weak:
+    - dbus >=1.16.2,<2.0a0
+  size: 447649
+  timestamp: 1764536047944
+- conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+  sha256: 40cdd1b048444d3235069d75f9c8e1f286db567f6278a93b4f024e5642cfaecc
+  md5: dbe3ec0f120af456b3477743ffd99b74
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - double-conversion >=3.4.0,<3.5.0a0
+  size: 71809
+  timestamp: 1765193127016
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+  sha256: 5a3eb10b18a97223ab06b3a7f0d7f56658db2f2800e2f2af95836fe3bf55ba63
+  md5: 922776b528a470ab5afa81fd42abfa1d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=15
+  - libuuid >=2.42.2,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - fontconfig >=2.18.3,<3.0a0
+    - fonts-conda-ecosystem
+  size: 296288
+  timestamp: 1786667377340
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+  sha256: 7fa3b6a9c081fa3e545573152a788d061a0a0ba57df7251cc0f4f75225fc93e7
+  md5: f9fe2984587fa8235a6af6004760cd18
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  run_exports:
+    weak:
+    - graphite2 >=1.3.15,<2.0a0
+  size: 102835
+  timestamp: 1786118485753
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+  sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+  md5: 72a381cbad04f24b1c2a43ef707f45b4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
+  size: 14459115
+  timestamp: 1786545741408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+  sha256: dd053c96dcb0dcfd59422aefea9d2fe937a190167f34fba7893ec1e10a7e8963
+  md5: ba55d1b89fd7775e67de8291029b4059
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - keyutils >=1.6.3,<2.0a0
+  size: 135295
+  timestamp: 1786739238128
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+  sha256: 2a5c38c85e63df84c4e69ee71439841ce570d259ae3060627bb9a49a938d66f4
+  md5: 53318d715316929a574f83591308b1f8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - keyutils >=1.6.3,<2.0a0
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - libgcc >=15
+  - libstdcxx >=15
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - krb5 >=1.22.2,<1.23.0a0
+  size: 1394333
+  timestamp: 1786762112514
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+  sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+  md5: 449500f2c089da11c40f5c21312e3e07
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.46.1
+  license: GPL-3.0-only
+  license_family: GPL
+  run_exports: {}
+  size: 745303
+  timestamp: 1784214507189
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+  sha256: bf9fdebf55d8bc99d83531cdffda00703f4dc5f93a1a956768c147362c72feda
+  md5: fb9d356b1a57d6d54768be7ebd5fce09
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - lerc >=4.2.0,<5.0a0
+  size: 271158
+  timestamp: 1785036167977
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_3.conda
+  sha256: e5864f257f839ffc27d681659bac95901f524f602b9121e5dcc5e2df18437f2d
+  md5: 7a2499a177753582fb7ae7e9dc4a908a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libbrotlicommon >=1.2.0,<1.3.0a0
+  size: 80265
+  timestamp: 1786622773969
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_3.conda
+  sha256: dad31b6d104973deb89710929a35651033aad692d4e7793cdb5b786a9bd54678
+  md5: 6ab3315dc56618d652c1da42a648a129
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.2.0 h39a168f_3
+  - libgcc >=15
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libbrotlidec >=1.2.0,<1.3.0a0
+  size: 34828
+  timestamp: 1786622783405
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_3.conda
+  sha256: d37124d0f51816e7d5e3a94bfc9ed3d6174d077f9b4f832d20c5a08b52bebf1f
+  md5: 2ac965638d4c6b2b38383bb1aebaf543
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.2.0 h39a168f_3
+  - libgcc >=15
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libbrotlienc >=1.2.0,<1.3.0a0
+  size: 298639
+  timestamp: 1786622792145
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h12ff6da_7.conda
+  sha256: 959d15215409cfcfb3254fe477f2f963d60a9e5d77db57ac61d3ffc9db28d0fe
+  md5: d9d3df7a5f6a2745823f9e0fdcf718a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=15
+  - libgcc >=15
+  - libzlib >=1.3.2,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - zstd >=1.5.7,<1.6.0a0
+  - libllvm22 >=22.1.8,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libclang-cpp22.1 >=22.1.8,<22.2.0a0
+  size: 24529835
+  timestamp: 1787227817225
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.8-default_h96bbd2b_7.conda
+  sha256: 177c74ce31a28f6dc16d2926166ba4fc3172e31d9b2d2841f13b115709612d25
+  md5: b4b888418917c0f4acad2bc63cd9a757
+  depends:
+  - libclang-cpp22.1 ==22.1.8 default_h12ff6da_7
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=15
+  - libgcc >=15
+  - libzlib >=1.3.2,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - zstd >=1.5.7,<1.6.0a0
+  - libllvm22 >=22.1.8,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libclang13 >=22.1.8
+  size: 14558479
+  timestamp: 1787227817225
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+  sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
+  md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - libcups >=2.3.3,<2.4.0a0
+  size: 4518030
+  timestamp: 1770902209173
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+  sha256: 82e134c8a08b1eed9a2ed8ab578b89aa1730dcde3dea8dd87645ed0637878e54
+  md5: 40f9b31aa9cf007789867df0decd0492
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libdeflate >=1.25,<1.26.0a0
+  size: 73710
+  timestamp: 1785908694612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
+  sha256: ea46b0ca0fa16af1f8b329b740e6cd8b4577c5378fa8717b28a885f70668633d
+  md5: 64cc91512b6278c315349dc13c53f680
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - libpciaccess >=0.19,<0.20.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libdrm >=2.4.129,<2.5.0a0
+  size: 313461
+  timestamp: 1786684701973
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+  sha256: 6473eb8caf2aae830f37caa93db9b26dddf7ac84b63229e8bf7fc0e5c3ab95b0
+  md5: 50708d3b951d0f8e2d7f2df5b5edc040
+  depends:
+  - ncurses
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ncurses >=6.6,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libedit >=3.1.20250104,<3.2.0a0
+  size: 135098
+  timestamp: 1786616658086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
+  sha256: 9a25ea93e8272785405a21d30f84e620befb1d545f6dfaae18f06103b5df0443
+  md5: 75e9f795be506c96dd43cb09c7c8d557
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 46500
+  timestamp: 1779728188901
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+  sha256: e4b46919c9bb65930bce238bd2736110ed7b8c30e5cd5394e4e1edb48de54843
+  md5: 5bc6d55503483aabe8a90c5e7f49a2a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libegl 1.7.0 ha4b6fd6_3
+  - libgl-devel 1.7.0 ha4b6fd6_3
+  - xorg-libx11
+  license: LicenseRef-libglvnd
+  run_exports:
+    weak:
+    - libegl >=1.7.0,<2.0a0
+  size: 31718
+  timestamp: 1779728222280
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+  md5: b24d3c612f71e7aa74158d92106318b2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 77856
+  timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+  sha256: ac38603008bf1e99b8ed379b1a656a67a70e2841f2b6a069c630cdf6316012d2
+  md5: 0abe40a9880086ca4d2e5daf09dceff9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libffi >=3.7.0,<3.8.0a0
+  size: 67576
+  timestamp: 1783520858222
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+  sha256: fb12ecb46c30d18d928c0e8fc346ab13b5f6fc8a9cacae4f2f4bb188782586f5
+  md5: f8054e759d0ddddaf34a5c8fedc900a1
+  depends:
+  - libfreetype6 >=2.14.3
+  license: GPL-2.0-only OR FTL
+  run_exports: {}
+  size: 8407
+  timestamp: 1786641007099
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+  sha256: ec607dd5445dd17ff6bf8b7fe6832e5504c226dd91d3aaea7ba83569808b0ce4
+  md5: b72a266a9317036fd0464cb98b027cd0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - libpng >=1.6.58,<1.7.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - freetype >=2.14.3
+  license: GPL-2.0-only OR FTL
+  run_exports: {}
+  size: 387671
+  timestamp: 1786641006460
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_2.conda
+  sha256: 4b733b68027a638fd24a38aaed1ebb05e055bef694970fab745b1c7678ca16f1
+  md5: b230041fd4acdd1127ef5870174310ef
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==16.1.0=*_2
+  - libgomp 16.1.0 he0feb66_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 1056637
+  timestamp: 1787165351282
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_2.conda
+  sha256: 23bfa3ade2de6e0b9af4a04cacd0d4d526c80a16686f264498475339f01d17d3
+  md5: be5ca38a4a2ddfda85ad7aae7d67238a
+  depends:
+  - libgcc 16.1.0 ha9f2e26_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports:
+    strong:
+    - libgcc
+  size: 28293
+  timestamp: 1787165356218
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
+  sha256: ec353b3076ed8e357ed961d0e9ff6997491cade0e603de5bd18a2e301ac78ebd
+  md5: f25206d7322c0e9648e8b83694d143ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  - libglx 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 133469
+  timestamp: 1779728207669
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
+  sha256: 41d7d864ad1f199bdb06ff6cc3931455c8af62f1d2071a08c6fa08affbcb678f
+  md5: 63e43d278ee5084813fe3c2edf4834ce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgl 1.7.0 ha4b6fd6_3
+  - libglx-devel 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  run_exports:
+    weak:
+    - libgl >=1.7.0,<2.0a0
+  size: 115664
+  timestamp: 1779728218325
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-h45c3219_1.conda
+  sha256: 4499458124bcf0bd45e8bd17576f9f007cb1373cb3b01659105443f522bab45c
+  md5: 533cb021c1bfeba9f720e669cd863fdf
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  constrains:
+  - glib >2.66
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - libglib >=2.88.3,<3.0a0
+  size: 4755172
+  timestamp: 1786457663614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
+  sha256: e019ebe4e3f5cdf23e2f5e58ddf7ade27988c53820115b17b98f218ebcc87748
+  md5: eb83f3f8cecc3e9bff9e250817fc69b6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 133586
+  timestamp: 1779728183422
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
+  sha256: 2f74713c9ca408ea84e88a30a9028153e7b553e8bb42e06139eac9a753c27da9
+  md5: ec3c4350aa0261bf7f87b8ca15c8e80e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 76586
+  timestamp: 1779728199059
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
+  sha256: a17ae2d4cb2de04a20882ae14ec3cc1958e868a4dec81e3d7eca30115ee50e94
+  md5: 16b6330783ce0d1ae8d22782173b32c9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglx 1.7.0 ha4b6fd6_3
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-xorgproto
+  license: LicenseRef-libglvnd
+  run_exports:
+    weak:
+    - libglx >=1.7.0,<2.0a0
+  size: 27363
+  timestamp: 1779728211402
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_2.conda
+  sha256: 7d4d1891d5fe5d75a73dd7268e8f2d7c11b7b637dea901a429f8056511960267
+  md5: 583bc8fce86ce542fa9a25c5b4d71e80
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+  size: 640468
+  timestamp: 1787165281830
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.3.1-h23af247_0.conda
+  sha256: a4eac5a21b84e0fc753b72de01781f634fc9ab70fd32a28d6a40a19700c9188a
+  md5: 29709e61096dd490fff9e833e4c869f6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.15,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=15
+  - libglib >=2.88.3,<3.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libstdcxx >=15
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 1353639
+  timestamp: 1786970872936
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+  sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+  md5: f92233bf33e24a25668bb2119e2c51f9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  license: LGPL-2.1-only
+  run_exports:
+    weak:
+    - libiconv >=1.18,<2.0a0
+  size: 789471
+  timestamp: 1787033836207
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+  sha256: bba8538e6538ed58a8479b332337b96986561f975d06cfa2039a016c2d246ee4
+  md5: 898d1c9793eaa52efc4727bd84d2e39a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  run_exports:
+    weak:
+    - libjpeg-turbo >=3.2.0,<4.0a0
+  size: 650434
+  timestamp: 1785896381946
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.8-hf7376ad_1.conda
+  sha256: e9b5f301d6b001a9b8ce782157f56b75c92c4fbc9eba95dc6345c1139251d13b
+  md5: 298bb2483fc7d15396147cf1c1465359
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports:
+    weak:
+    - libllvm22 >=22.1.8,<22.2.0a0
+  size: 44320272
+  timestamp: 1781788728739
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+  sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+  md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
+  size: 112995
+  timestamp: 1786348617826
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+  sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+  md5: fcfed1dc5053eb1901b66e7b1fc32588
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 92759
+  timestamp: 1786650399772
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+  sha256: 3b3f19ced060013c2dd99d9d46403be6d319d4601814c772a3472fe2955612b0
+  md5: 7c7927b404672409d9917d49bff5f2d6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - libntlm >=1.8,<2.0a0
+  size: 33418
+  timestamp: 1734670021371
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
+  sha256: 90777039b48529283df5f16383fc399866024257a8bd93de583f4730db1ab30a
+  md5: c2bd8055a2e2dce7a7f32cfd02101fb6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 51767
+  timestamp: 1779728204026
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+  sha256: addc80c69d362a9e6c40305c493139a8e9ee504b2f45a6687dbdaa9da3c6183c
+  md5: 35fa2b34bbced424e6976d30f5fde576
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libpciaccess >=0.19,<0.20.0a0
+  size: 30070
+  timestamp: 1785971678815
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+  sha256: c19eefb87d70d9b4b0629fa48414a155a47a1be4f04583ae71ed8c5a9a32fdcb
+  md5: fcf71c8d979148873f6f8ad4cfc73d86
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - libzlib >=1.3.2,<2.0a0
+  license: zlib-acknowledgement
+  run_exports:
+    weak:
+    - libpng >=1.6.58,<1.7.0a0
+  size: 316643
+  timestamp: 1786616563127
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.6-h9d76c99_0.conda
+  sha256: b1eb210c180fda9c445b11cba1286ec250ce2c2a85ccb0551a4ed5423df51e68
+  md5: 72e019c04ed02a179da38c56965802d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=15
+  - openldap >=2.6.13,<2.7.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: PostgreSQL
+  run_exports:
+    weak:
+    - libpq >=18.6,<19.0a0
+  size: 2719680
+  timestamp: 1786641133110
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+  sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+  md5: e72bbec309c2b0f37823ee7d4fabfcd3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=15
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 974348
+  timestamp: 1787051145557
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_2.conda
+  sha256: af96a5fcf1ce0659d257ababc1b8d0bbb698250e8140c6b8352f60d3be075392
+  md5: d4883ac53b4074ca17e5c567bb8008f1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 16.1.0 ha9f2e26_2
+  constrains:
+  - libstdcxx-ng ==16.1.0=*_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 6630263
+  timestamp: 1787165375778
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+  sha256: b31346e1c01ab40a170e91147092ee8fd92b1dee3c66ee47ef025571c879b159
+  md5: c1fcb4a88bc15a9f77ad8d27d7af1df9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.1.0,<5.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libstdcxx >=14
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  run_exports:
+    weak:
+    - libtiff >=4.7.2,<4.8.0a0
+  size: 452337
+  timestamp: 1783084902636
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+  sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+  md5: 01bb81d12c957de066ea7362007df642
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libuuid >=2.42.2,<3.0a0
+  size: 40017
+  timestamp: 1781625522462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.357.0-h0e34353_1.conda
+  sha256: 9ae82bfc37634f2d3ecf4c7cb43d43ec3d916de17ca9cfc393df457b043db8ed
+  md5: 8dcfd865081c198717384aec43fc4b98
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=15
+  - libgcc >=15
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-libxrandr >=1.5.5,<2.0a0
+  constrains:
+  - libvulkan-headers 1.4.357.0.*
+  license: Apache-2.0
+  run_exports:
+    weak:
+    - libvulkan-loader >=1.4.357.0,<2.0a0
+  size: 205064
+  timestamp: 1787260061523
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+  sha256: 8415001414f488c85b72b9d8cc2071dfb3981a47bc3c8eb56ef91a57d12eae7f
+  md5: 9332b53d0ea93c5d39e33be03a0c611a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libwebp-base >=1.6.0,<2.0a0
+  size: 428430
+  timestamp: 1785954557217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-hb83e432_1.conda
+  sha256: ce25a1efa85a78a3ce3b16721d9c36153814adbf2fb004a15f72ec69894b4cb1
+  md5: 64e856c420205b009da26471d3ac161d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - pthread-stubs
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libxcb >=1.17.0,<2.0a0
+  size: 397355
+  timestamp: 1787077466600
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+  sha256: f7e9292dd219a6435bbb1223da9586c3e70d66d169c5a92f08db3f2127df04e9
+  md5: f7a7ff5a6ab331e037abd34f379a631d
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - libxcrypt >=4.4.38
+  size: 101957
+  timestamp: 1785887123445
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.2-h51789e4_1.conda
+  sha256: d44878d396713ccf3b355df617f61c40a1442fffcf134392bc6ce0e6c2219369
+  md5: f888787e0eab7a8076a67d197e155ffc
+  depends:
+  - xkeyboard-config
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-libxau >=1.0.12,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: MIT AND MIT-open-group AND HPND AND HPND-sell-variant AND ISC
+  run_exports:
+    weak:
+    - libxkbcommon >=1.13.2,<2.0a0
+  size: 942571
+  timestamp: 1787178780572
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+  sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
+  md5: 20e4d67ec908f0405124f11612c48305
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - libxml2 2.15.3
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 559721
+  timestamp: 1787237579170
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+  sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
+  md5: 2d34cdb31014cbc8f1e9384c89ede0a5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libxml2-16 2.15.3 hca6bf5a_1
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libxml2
+    - libxml2-16 >=2.15.3
+  size: 46203
+  timestamp: 1787237584107
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
+  sha256: 0694760a3e62bdc659d90a14ae9c6e132b525a7900e59785b18a08bb52a5d7e5
+  md5: 87e6096ec6d542d1c1f8b33245fe8300
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libxslt >=1.1.43,<2.0a0
+  size: 245434
+  timestamp: 1757963724977
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+  sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+  md5: 0de0122d9570a8ab637c6b73db268389
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - zlib 1.3.2 *_3
+  license: Zlib
+  license_family: Other
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 63713
+  timestamp: 1785362952714
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+  sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+  md5: ee6c0cd80a60961a1f48aa3e0b91f986
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: X11 AND BSD-3-Clause
+  run_exports:
+    weak:
+    - ncurses >=6.6,<7.0a0
+  size: 911196
+  timestamp: 1786355078102
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+  sha256: 21c4f6c7f41dc9bec2ea2f9c80440d9a4d45a6f2ac13243e658f10dcf1044146
+  md5: 680608784722880fbfe1745067570b00
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cyrus-sasl >=2.1.28,<3.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.6,<4.0a0
+  license: OLDAP-2.8
+  license_family: BSD
+  run_exports:
+    weak:
+    - openldap >=2.6.13,<2.7.0a0
+  size: 786149
+  timestamp: 1775741359582
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+  sha256: 012096056b97abf1f68c46b7146bd2cbd68c1be762340b4f5dad4fbbe99177bc
+  md5: c5955c27917ff2234def47f075e71e02
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - openssl >=3.6.3,<4.0a0
+  size: 3182423
+  timestamp: 1785913583650
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+  sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
+  md5: 7a3bff861a6583f1889021facefc08b1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - pcre2 >=10.47,<10.48.0a0
+  size: 1222481
+  timestamp: 1763655398280
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+  sha256: 829d8288764282de5a9f7b9169acb75cc7dc0b6c3fe2535cfe87dea3436bbc5d
+  md5: 0ee5bb30034b081a1386c1e2c98ab0a7
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - pixman >=0.46.4,<1.0a0
+  size: 376704
+  timestamp: 1786106621354
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb03c661_1003.conda
+  sha256: afc3b27b2cbb0487c1d0e963f96e71181ecfb623a24fb393bb19ff974a6382a1
+  md5: df2c27f36bdb0dde779f55b5df76a352
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 9115
+  timestamp: 1786067714761
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.2-py314h5d85b37_0.conda
+  sha256: ac013bb9f32a448468fad4269659fc772cf9eac7e5c9143c46bbe4f4a5a8922d
+  md5: 78780ea7feb32f4b6e0c9aae536081dd
+  depends:
+  - python
+  - qt6-main 6.11.2.*
+  - libgcc >=15
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=15
+  - libgl >=1.7.0,<2.0a0
+  - libclang13 >=22.1.8
+  - qt6-main >=6.11.2,<7.0a0
+  - libxslt >=1.1.43,<2.0a0
+  - libvulkan-loader >=1.4.357.0,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  - python_abi 3.14.* *_cp314
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libopengl >=1.7.0,<2.0a0
+  license: LGPL-3.0-only
+  license_family: LGPL
+  run_exports: {}
+  size: 13950298
+  timestamp: 1787219457013
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.7-h399a421_100_cp314.conda
+  build_number: 100
+  sha256: ee59fa05898243b9a068476f4bed9461abef4487ebcdc094f569c4c47dc4a732
+  md5: a9d6f626c591a56d7b7b36d2465f646d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  - libgcc >=15
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libuuid >=2.42.2,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  run_exports:
+    weak:
+    - python_abi 3.14.* *_cp314
+    noarch:
+    - python
+  size: 37028007
+  timestamp: 1787154417160
+  python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.2-pl5321h9df5c37_0.conda
+  sha256: 00d9bc98d04aeeab6f698ca7fe9d666b157ab39b52cad1af0fa346522705668d
+  md5: 2ff98660281d1c6bfebda5bffa52cc89
+  depends:
+  - libxcb
+  - xcb-util
+  - xcb-util-wm
+  - xcb-util-keysyms
+  - xcb-util-image
+  - xcb-util-renderutil
+  - xcb-util-cursor
+  - libgl-devel
+  - libegl-devel
+  - libgcc >=15
+  - libstdcxx >=15
+  - __glibc >=2.17,<3.0.a0
+  - libglib >=2.88.3,<3.0a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libvulkan-loader >=1.4.357.0,<2.0a0
+  - wayland >=1.26.0,<2.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - libcups >=2.3.3,<2.4.0a0
+  - alsa-lib >=1.2.16.1,<1.3.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libtiff >=4.7.2,<4.8.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - dbus >=1.16.2,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libxxf86vm >=1.1.7,<2.0a0
+  - double-conversion >=3.4.0,<3.5.0a0
+  - icu >=78.3,<79.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - openssl >=3.5.7,<4.0a0
+  - xorg-libxcomposite >=0.4.7,<1.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libpq >=18.6,<19.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - libharfbuzz >=14.3.1
+  - fontconfig >=2.18.3,<3.0a0
+  - fonts-conda-ecosystem
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libxrandr >=1.5.5,<2.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - xcb-util-cursor >=0.1.6,<0.2.0a0
+  - libxkbcommon >=1.13.2,<2.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libdrm >=2.4.129,<2.5.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libxtst >=1.2.5,<2.0a0
+  constrains:
+  - qt ==6.11.2
+  license: LGPL-3.0-only
+  license_family: LGPL
+  run_exports:
+    weak:
+    - qt6-main >=6.11.2,<7.0a0
+  size: 60888449
+  timestamp: 1787048975419
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+  sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+  md5: 69c01c781e7c8190bbdaf79e3848c5ca
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - ncurses >=6.6,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
+  size: 348899
+  timestamp: 1787033801506
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+  build_number: 103
+  sha256: 43624eab22f5f29df7d6ffe914cf442f28fd559b55b290906255492826e636e8
+  md5: 48a1049e710857572fc2a832aa394d9f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: TCL
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
+  size: 3550916
+  timestamp: 1784229071544
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-h1964d1d_1.conda
+  sha256: a8f1333274382d23721d6f72483ece364631231f8ac3f74389951b1ff2820148
+  md5: 47e3c5d0b1e968ee49efc7c3fa8ebc0c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - wayland >=1.26.0,<2.0a0
+  size: 339462
+  timestamp: 1786151675802
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+  sha256: ad8cab7e07e2af268449c2ce855cbb51f43f4664936eff679b1f3862e6e4b01d
+  md5: fdc27cb255a7a2cc73b7919a968b48f0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libxcb >=1.17.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xcb-util >=0.4.1,<0.5.0a0
+  size: 20772
+  timestamp: 1750436796633
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+  sha256: c2be9cae786fdb2df7c2387d2db31b285cf90ab3bfabda8fa75a596c3d20fc67
+  md5: 4d1fc190b99912ed557a8236e958c559
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libxcb >=1.13
+  - libxcb >=1.17.0,<2.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xcb-util-cursor >=0.1.6,<0.2.0a0
+  size: 20829
+  timestamp: 1763366954390
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+  sha256: 94b12ff8b30260d9de4fd7a28cca12e028e572cbc504fd42aa2646ec4a5bded7
+  md5: a0901183f08b6c7107aab109733a3c91
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xcb-util-image >=0.4.0,<0.5.0a0
+  size: 24551
+  timestamp: 1718880534789
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+  sha256: 546e3ee01e95a4c884b6401284bb22da449a2f4daf508d038fdfa0712fe4cc69
+  md5: ad748ccca349aec3e91743e08b5e2b50
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  size: 14314
+  timestamp: 1718846569232
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+  sha256: 2d401dadc43855971ce008344a4b5bd804aca9487d8ebd83328592217daca3df
+  md5: 0e0cbe0564d03a99afd5fd7b362feecd
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  size: 16978
+  timestamp: 1718848865819
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+  sha256: 31d44f297ad87a1e6510895740325a635dd204556aa7e079194a0034cdd7e66a
+  md5: 608e0ef8256b81d04456e8d211eee3e8
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xcb-util-wm >=0.4.2,<0.5.0a0
+  size: 51689
+  timestamp: 1718844051451
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+  sha256: 3b04afd5d1a65d2d27ac2d49a63b01ab8bcd875776779ec63e337370ed38afdc
+  md5: b233b41be0bf210989d57160ed39b394
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 441670
+  timestamp: 1782027360439
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+  sha256: 49b532d1df875c6749d9078b56a76f3f5db49a5abe0ca620b593ed474ef0ebf1
+  md5: 85c9442aec283b4e464fa9ecc484a2f3
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libice >=1.1.2,<2.0a0
+  size: 62517
+  timestamp: 1786474410404
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+  sha256: ef907caee0665cf3b0f775602cc50e388e3bade8ce22ecade0873ff26604b2fd
+  md5: aa7459ed9ad086ba11dda843d764b33d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libice >=1.1.2,<2.0a0
+  - libuuid >=2.42.2,<3.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libsm >=1.2.6,<2.0a0
+  size: 30739
+  timestamp: 1786545374265
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_1.conda
+  sha256: 68053eebfa9f0d91666786c8fb5839d989aa9b869add92cb8815228bb2d7302c
+  md5: 8c282bbe4808a3cc80a5c98e9aec1cfc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libxcb >=1.17.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libx11 >=1.8.13,<2.0a0
+  size: 839578
+  timestamp: 1787087012372
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+  sha256: cbf891f6cc1a859347680af1c8562bc6b033bf182a2a3bb536016932be3206de
+  md5: f06ef439c280a5f90b8bf62355008dbc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxau >=1.0.12,<2.0a0
+  size: 16419
+  timestamp: 1786381001122
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+  sha256: 048c103000af9541c919deef03ae7c5e9c570ffb4024b42ecb58dbde402e373a
+  md5: f2ba4192d38b6cef2bb2c25029071d90
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxcomposite >=0.4.7,<1.0a0
+  size: 14415
+  timestamp: 1770044404696
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+  sha256: 832f538ade441b1eee863c8c91af9e69b356cd3e9e1350fff4fe36cc573fc91a
+  md5: 2ccd714aa2242315acaf0a67faea780b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxcursor >=1.2.3,<2.0a0
+  size: 32533
+  timestamp: 1730908305254
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+  sha256: 43b9772fd6582bf401846642c4635c47a9b0e36ca08116b3ec3df36ab96e0ec0
+  md5: b5fcc7172d22516e1f965490e65e33a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxdamage >=1.1.6,<2.0a0
+  size: 13217
+  timestamp: 1727891438799
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+  sha256: c50a16c05ccd7fe7dd6d6cfb539f4e9a491d50f9ed7a5c902fec638f7d0d27be
+  md5: 2e66c929f3d879708335b6ea4557c838
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxdmcp >=1.1.5,<2.0a0
+  size: 21120
+  timestamp: 1786381006369
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-h7cc23a3_1.conda
+  sha256: aa9bbe8b278aacc194e280ff5037f9f9a1f2c5b33ed97de8e7f01cfbe90dda43
+  md5: e5b6b28536b81b3f4cb20db4668a4642
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxext >=1.3.7,<2.0a0
+  size: 53124
+  timestamp: 1787100841900
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-h7cc23a3_1.conda
+  sha256: aec84f554fc897bf4085c7bc8b8f0740e4c224e13bca3cc51c93e7699d56f83a
+  md5: 09132e874fe0e1f5e4492b0b6b904b6e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxfixes >=6.0.2,<7.0a0
+  size: 21440
+  timestamp: 1787248059682
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.3-h7cc23a3_1.conda
+  sha256: a523d71344a2f640efe6fc42b88fc261d9cd389d4f9838a5d42dcdb120c2b0c8
+  md5: a1412b2b1184dacda45f8476fef2cc25
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxi >=1.8.3,<2.0a0
+  size: 49165
+  timestamp: 1787257060460
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-h7cc23a3_1.conda
+  sha256: 05a7f25d7f7f5cd32b27a019233ece97167fd8ade255bc13a0e49e53387f4c30
+  md5: 798a8c9d171859a022e1cb89e7d0eb10
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxrandr >=1.5.5,<2.0a0
+  size: 31106
+  timestamp: 1787246614086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb03c661_1.conda
+  sha256: 6901f91d398811e4ec89d7e20a69abac02a7bfebfaf073338b7ea3d1a99685b7
+  md5: e470d224a7a5be1b1d021bded7abb536
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxrender >=0.9.12,<0.10.0a0
+  size: 34645
+  timestamp: 1787100191192
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+  sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
+  md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxi >=1.7.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxtst >=1.2.5,<2.0a0
+  size: 32808
+  timestamp: 1727964811275
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+  sha256: 64db17baaf36fa03ed8fae105e2e671a7383e22df4077486646f7dbf12842c9f
+  md5: 665d152b9c6e78da404086088077c844
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxxf86vm >=1.1.7,<2.0a0
+  size: 18701
+  timestamp: 1769434732453
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-h280c20c_1.conda
+  sha256: 051c6088bf2381840fcf8764737b829cc6c5f793718d2417d097d6e3b153eba9
+  md5: 3b51576511038b50fdbd05245e22e4b1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 594844
+  timestamp: 1786114408394
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+  sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+  md5: aa459086047c0e5e27023ab19f8cb86a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - zstd >=1.5.7,<1.6.0a0
+  size: 601301
+  timestamp: 1786599621503
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  md5: 0f51e2391ade309db462a55611263e9c
+  depends:
+  - __unix
+  license: ISC
+  run_exports: {}
+  size: 131780
+  timestamp: 1784754889428
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  md5: 0c96522c6bdaed4b1566d11387caaf45
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 397370
+  timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  md5: 34893075a5c9e55cdafac56607368fc6
+  license: OFL-1.1
+  license_family: Other
+  run_exports: {}
+  size: 96530
+  timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  md5: 4d59c254e01d9cde7957100457e2d5fb
+  license: OFL-1.1
+  license_family: Other
+  run_exports: {}
+  size: 700814
+  timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+  sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+  md5: 49023d73832ef61042f6a237cb2687e7
+  license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+  license_family: Other
+  run_exports: {}
+  size: 1620504
+  timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  md5: fee5683a3f04bd15cbd8318b096a27ab
+  depends:
+  - fonts-conda-forge
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 3667
+  timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+  sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+  md5: a7970cd949a077b7cb9696379d338681
+  depends:
+  - font-ttf-ubuntu
+  - font-ttf-inconsolata
+  - font-ttf-dejavu-sans-mono
+  - font-ttf-source-code-pro
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 4059
+  timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  build_number: 8
+  sha256: ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
+  md5: 0539938c55b6b1a59b560e843ad864a4
+  constrains:
+  - python 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 6989
+  timestamp: 1752805904792
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  md5: fcb489df604d100968b737f2cb6076c6
+  license: LicenseRef-Public-Domain
+  run_exports: {}
+  size: 118849
+  timestamp: 1784250406640

--- a/ci/pixi-python314/pixi.toml
+++ b/ci/pixi-python314/pixi.toml
@@ -1,0 +1,11 @@
+[workspace]
+name = "freecad-python314"
+version = "0.1.0"
+description = "Python 3.14 runtime used by FreeCAD shutdown regression CI"
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+requires-pixi = ">=0.68"
+
+[dependencies]
+python = ">=3.14,<3.15"
+pyside6 = "*"

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -124,6 +124,7 @@
 #include "DocumentObjectGroup.h"
 #include "DocumentObjectGroupPy.h"
 #include "DocumentObserver.h"
+#include "DocumentObserverPython.h"
 #include "DocumentPy.h"
 #include "DocumentSettingsPy.h"
 #include "ExpressionParser.h"
@@ -137,6 +138,7 @@
 #include "LinkBaseExtensionPy.h"
 #include "VarSet.h"
 #include "MaterialObject.h"
+#include "MeasureManager.h"
 #include "MeasureManagerPy.h"
 #include "Origin.h"
 #include "Datums.h"
@@ -410,13 +412,28 @@ Application::Application(std::map<std::string,std::string> &mConfig)
 
 Application::~Application()
 {
-    // Signal the recompute worker thread to stop and join it.
+    prepareForShutdown();
+}
+
+void Application::prepareForShutdown()
+{
+    if (_preparedForShutdown) {
+        return;
+    }
+    _preparedForShutdown = true;
+
+    // Signal the recompute worker thread to stop and join it. This is kept as
+    // an explicit phase so all asynchronous native producers have stopped
+    // before native Python ownership reaches the finalization boundary.
     _stopRecomputeThread = true;
     _recomputeRequestAvailable.notify_all();
 
     if (_recomputeThread.joinable()) {
         _recomputeThread.join();
     }
+
+    DocumentObserverPython::clearObservers();
+    MeasureManager::destruct();
 }
 
 void Application::setupPythonTypes()
@@ -2044,6 +2061,7 @@ void Application::destruct()
 
     // not initialized or double destruct!
     assert(_pcSingleton);
+    _pcSingleton->prepareForShutdown();
     delete _pcSingleton;
 
     // We must detach from console and delete the observer to save our file

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -746,6 +746,9 @@ public:
     /// Destroy the application.
     static void destruct();
 
+    /// Stop asynchronous native producers before Python finalization begins.
+    void prepareForShutdown();
+
     /// Detach from the console.
     static void destructObserver();
 
@@ -1059,6 +1062,7 @@ private:
     // Separate from the mutex-protected queue state so shutdown can request a
     // worker stop and wake waiters without first taking _recomputeMutex.
     std::atomic<bool> _stopRecomputeThread{false};
+    bool _preparedForShutdown{false};
 
     // Worker thread function that processes _recomputeRequests
     void recomputeWorker();

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1070,12 +1070,11 @@ Document::~Document()
 
     d->clearDocument();
 
-    // Keep retained Python wrappers usable as invalidated objects, then release
-    // the native-owned reference while the interpreter is still running.
+    // Keep retained Python wrappers usable as invalidated objects without
+    // touching Python-owned attributes from this native destructor.
     if (d->DocumentPythonObject) {
-        Base::PyGILStateLocker lock;
         auto* doc = static_cast<Base::PyObjectBase*>(d->DocumentPythonObject.get());
-        doc->setInvalid();
+        doc->setInvalidWithoutPython();
     }
     d->DocumentPythonObject.reset();
 

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -957,7 +957,7 @@ Document::Document(const char* documentName)
     // have to care about ref counting any more.
     setAutoCreated(false);
     Base::PyGILStateLocker lock;
-    d->DocumentPythonObject = Py::Object(new DocumentPy(this), true);
+    d->DocumentPythonObject.reset(new DocumentPy(this));
 
 #ifdef FC_LOGUPDATECHAIN
     Console().log("+App::Document: %p\n", this);
@@ -1070,15 +1070,14 @@ Document::~Document()
 
     d->clearDocument();
 
-    // Remark: The API of Py::Object has been changed to set whether the wrapper owns the passed
-    // Python object or not. In the constructor we forced the wrapper to own the object so we need
-    // not to dec'ref the Python object any more.
-    // But we must still invalidate the Python object because it doesn't need to be
-    // destructed right now because the interpreter can own several references to it.
-    Base::PyGILStateLocker lock;
-    auto* doc = static_cast<Base::PyObjectBase*>(d->DocumentPythonObject.ptr());
-    // Call before decrementing the reference counter, otherwise a heap error can occur
-    doc->setInvalid();
+    // Keep retained Python wrappers usable as invalidated objects, then release
+    // the native-owned reference while the interpreter is still running.
+    if (d->DocumentPythonObject) {
+        Base::PyGILStateLocker lock;
+        auto* doc = static_cast<Base::PyObjectBase*>(d->DocumentPythonObject.get());
+        doc->setInvalid();
+    }
+    d->DocumentPythonObject.reset();
 
     // remove Transient directory
     try {
@@ -3992,7 +3991,8 @@ int Document::countObjectsOfType(const char* typeName) const
 
 PyObject* Document::getPyObject()
 {
-    return Py::new_reference_to(d->DocumentPythonObject);
+    Py_INCREF(d->DocumentPythonObject.get());
+    return d->DocumentPythonObject.get();
 }
 
 std::vector<DocumentObject*> Document::getRootObjects() const

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -86,15 +86,11 @@ DocumentObject::DocumentObject()
 DocumentObject::~DocumentObject()
 {
     if (!PythonObject.is(Py::_None())) {
-        Base::PyGILStateLocker lock;
-        // Remark: The API of Py::Object has been changed to set whether the wrapper owns the passed
-        // Python object or not. In the constructor we forced the wrapper to own the object so we
-        // need not to dec'ref the Python object any more. But we must still invalidate the Python
-        // object because it need not to be destructed right now because the interpreter can own
-        // several references to it.
+        // The wrapper may outlive this native object. Invalidate only the
+        // native twin state; Python-owned attributes are released later by
+        // the wrapper deallocator.
         Base::PyObjectBase* obj = static_cast<Base::PyObjectBase*>(PythonObject.ptr());
-        // Call before decrementing the reference counter, otherwise a heap error can occur
-        obj->setInvalid();
+        obj->setInvalidWithoutPython();
     }
 }
 

--- a/src/App/DocumentObserverPython.cpp
+++ b/src/App/DocumentObserverPython.cpp
@@ -30,6 +30,7 @@
 #include "DocumentObject.h"
 #include "DocumentObserverPython.h"
 #include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 
 
 using namespace App;
@@ -48,7 +49,7 @@ void DocumentObserverPython::removeObserver(const Py::Object& obj)
     for (std::vector<DocumentObserverPython*>::iterator it = _instances.begin();
          it != _instances.end();
          ++it) {
-        if ((*it)->inst == obj) {
+        if ((*it)->inst.get() == obj.ptr()) {
             obs = *it;
             _instances.erase(it);
             break;
@@ -59,12 +60,12 @@ void DocumentObserverPython::removeObserver(const Py::Object& obj)
 }
 
 DocumentObserverPython::DocumentObserverPython(const Py::Object& obj)
-    : inst(obj)
 {
+    inst.reset(obj);
 #define FC_PY_ELEMENT_ARG0(_name1, _name2)                                                         \
     do {                                                                                           \
-        FC_PY_GetCallable(obj.ptr(), "slot" #_name1, py##_name1.py);                               \
-        if (!py##_name1.py.isNone())                                                               \
+        Base::setNativePythonCallable(obj.ptr(), "slot" #_name1, py##_name1.py);                  \
+        if (py##_name1.py.get())                                                                   \
             py##_name1.slot = App::GetApplication().signal##_name2.connect(                        \
                 std::bind(&DocumentObserverPython::slot##_name1, this));                           \
     } while (0);
@@ -72,8 +73,8 @@ DocumentObserverPython::DocumentObserverPython(const Py::Object& obj)
 
 #define FC_PY_ELEMENT_ARG1(_name1, _name2)                                                         \
     do {                                                                                           \
-        FC_PY_GetCallable(obj.ptr(), "slot" #_name1, py##_name1.py);                               \
-        if (!py##_name1.py.isNone())                                                               \
+        Base::setNativePythonCallable(obj.ptr(), "slot" #_name1, py##_name1.py);                  \
+        if (py##_name1.py.get())                                                                   \
             py##_name1.slot = App::GetApplication().signal##_name2.connect(                        \
                 std::bind(&DocumentObserverPython::slot##_name1, this, sp::_1));                   \
     } while (0);
@@ -81,8 +82,8 @@ DocumentObserverPython::DocumentObserverPython(const Py::Object& obj)
     // NOLINTBEGIN
 #define FC_PY_ELEMENT_ARG2(_name1, _name2)                                                         \
     do {                                                                                           \
-        FC_PY_GetCallable(obj.ptr(), "slot" #_name1, py##_name1.py);                               \
-        if (!py##_name1.py.isNone())                                                               \
+        Base::setNativePythonCallable(obj.ptr(), "slot" #_name1, py##_name1.py);                  \
+        if (py##_name1.py.get())                                                                   \
             py##_name1.slot = App::GetApplication().signal##_name2.connect(                        \
                 std::bind(&DocumentObserverPython::slot##_name1, this, sp::_1, sp::_2));           \
     } while (0);
@@ -121,13 +122,21 @@ DocumentObserverPython::DocumentObserverPython(const Py::Object& obj)
 
 DocumentObserverPython::~DocumentObserverPython() = default;
 
+void DocumentObserverPython::clearObservers()
+{
+    for (auto* observer : _instances) {
+        delete observer;
+    }
+    _instances.clear();
+}
+
 void DocumentObserverPython::slotCreatedDocument(const App::Document& Doc)
 {
     Base::PyGILStateLocker lock;
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<App::Document&>(Doc).getPyObject()));
-        Base::pyCall(pyCreatedDocument.ptr(), args.ptr());
+        Base::pyCall(pyCreatedDocument.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -141,7 +150,7 @@ void DocumentObserverPython::slotDeletedDocument(const App::Document& Doc)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<App::Document&>(Doc).getPyObject()));
-        Base::pyCall(pyDeletedDocument.ptr(), args.ptr());
+        Base::pyCall(pyDeletedDocument.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -155,7 +164,7 @@ void DocumentObserverPython::slotRelabelDocument(const App::Document& Doc)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<App::Document&>(Doc).getPyObject()));
-        Base::pyCall(pyRelabelDocument.ptr(), args.ptr());
+        Base::pyCall(pyRelabelDocument.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -169,7 +178,7 @@ void DocumentObserverPython::slotActivateDocument(const App::Document& Doc)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<App::Document&>(Doc).getPyObject()));
-        Base::pyCall(pyActivateDocument.ptr(), args.ptr());
+        Base::pyCall(pyActivateDocument.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -183,7 +192,7 @@ void DocumentObserverPython::slotUndoDocument(const App::Document& Doc)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<App::Document&>(Doc).getPyObject()));
-        Base::pyCall(pyUndoDocument.ptr(), args.ptr());
+        Base::pyCall(pyUndoDocument.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -198,7 +207,7 @@ void DocumentObserverPython::slotRedoDocument(const App::Document& Doc)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<App::Document&>(Doc).getPyObject()));
-        Base::pyCall(pyRedoDocument.ptr(), args.ptr());
+        Base::pyCall(pyRedoDocument.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -210,7 +219,7 @@ void DocumentObserverPython::slotUndo()
 {
     Base::PyGILStateLocker lock;
     try {
-        Base::pyCall(pyUndo.ptr());
+        Base::pyCall(pyUndo.get());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -222,7 +231,7 @@ void DocumentObserverPython::slotRedo()
 {
     Base::PyGILStateLocker lock;
     try {
-        Base::pyCall(pyRedo.ptr());
+        Base::pyCall(pyRedo.get());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -236,7 +245,7 @@ void DocumentObserverPython::slotBeforeCloseTransaction(bool abort)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::Boolean(abort));
-        Base::pyCall(pyBeforeCloseTransaction.ptr(), args.ptr());
+        Base::pyCall(pyBeforeCloseTransaction.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -250,7 +259,7 @@ void DocumentObserverPython::slotCloseTransaction(bool abort)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::Boolean(abort));
-        Base::pyCall(pyCloseTransaction.ptr(), args.ptr());
+        Base::pyCall(pyCloseTransaction.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -270,7 +279,7 @@ void DocumentObserverPython::slotBeforeChangeDocument(const App::Document& Doc,
         const char* prop_name = Doc.getPropertyName(&Prop);
         if (prop_name) {
             args.setItem(1, Py::String(prop_name));
-            Base::pyCall(pyBeforeChangeDocument.ptr(), args.ptr());
+            Base::pyCall(pyBeforeChangeDocument.get(), args.ptr());
         }
     }
     catch (Py::Exception&) {
@@ -291,7 +300,7 @@ void DocumentObserverPython::slotChangedDocument(const App::Document& Doc,
         const char* prop_name = Doc.getPropertyName(&Prop);
         if (prop_name) {
             args.setItem(1, Py::String(prop_name));
-            Base::pyCall(pyChangedDocument.ptr(), args.ptr());
+            Base::pyCall(pyChangedDocument.get(), args.ptr());
         }
     }
     catch (Py::Exception&) {
@@ -306,7 +315,7 @@ void DocumentObserverPython::slotCreatedObject(const App::DocumentObject& Obj)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<App::DocumentObject&>(Obj).getPyObject()));
-        Base::pyCall(pyCreatedObject.ptr(), args.ptr());
+        Base::pyCall(pyCreatedObject.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -320,7 +329,7 @@ void DocumentObserverPython::slotDeletedObject(const App::DocumentObject& Obj)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<App::DocumentObject&>(Obj).getPyObject()));
-        Base::pyCall(pyDeletedObject.ptr(), args.ptr());
+        Base::pyCall(pyDeletedObject.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -340,7 +349,7 @@ void DocumentObserverPython::slotBeforeChangeObject(const App::DocumentObject& O
         const char* prop_name = Obj.getPropertyName(&Prop);
         if (prop_name) {
             args.setItem(1, Py::String(prop_name));
-            Base::pyCall(pyBeforeChangeObject.ptr(), args.ptr());
+            Base::pyCall(pyBeforeChangeObject.get(), args.ptr());
         }
     }
     catch (Py::Exception&) {
@@ -361,7 +370,7 @@ void DocumentObserverPython::slotChangedObject(const App::DocumentObject& Obj,
         const char* prop_name = Obj.getPropertyName(&Prop);
         if (prop_name) {
             args.setItem(1, Py::String(prop_name));
-            Base::pyCall(pyChangedObject.ptr(), args.ptr());
+            Base::pyCall(pyChangedObject.get(), args.ptr());
         }
     }
     catch (Py::Exception&) {
@@ -376,7 +385,7 @@ void DocumentObserverPython::slotRecomputedObject(const App::DocumentObject& Obj
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<App::DocumentObject&>(Obj).getPyObject()));
-        Base::pyCall(pyRecomputedObject.ptr(), args.ptr());
+        Base::pyCall(pyRecomputedObject.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -390,7 +399,7 @@ void DocumentObserverPython::slotRecomputedDocument(const App::Document& doc)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<App::Document&>(doc).getPyObject()));
-        Base::pyCall(pyRecomputedDocument.ptr(), args.ptr());
+        Base::pyCall(pyRecomputedDocument.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -404,7 +413,7 @@ void DocumentObserverPython::slotBeforeRecomputeDocument(const App::Document& do
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<App::Document&>(doc).getPyObject()));
-        Base::pyCall(pyBeforeRecomputeDocument.ptr(), args.ptr());
+        Base::pyCall(pyBeforeRecomputeDocument.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -419,7 +428,7 @@ void DocumentObserverPython::slotOpenTransaction(const App::Document& doc, std::
         Py::Tuple args(2);
         args.setItem(0, Py::asObject(const_cast<App::Document&>(doc).getPyObject()));
         args.setItem(1, Py::String(str));
-        Base::pyCall(pyOpenTransaction.ptr(), args.ptr());
+        Base::pyCall(pyOpenTransaction.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -433,7 +442,7 @@ void DocumentObserverPython::slotCommitTransaction(const App::Document& doc)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<App::Document&>(doc).getPyObject()));
-        Base::pyCall(pyCommitTransaction.ptr(), args.ptr());
+        Base::pyCall(pyCommitTransaction.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -447,7 +456,7 @@ void DocumentObserverPython::slotAbortTransaction(const App::Document& doc)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<App::Document&>(doc).getPyObject()));
-        Base::pyCall(pyAbortTransaction.ptr(), args.ptr());
+        Base::pyCall(pyAbortTransaction.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -467,7 +476,7 @@ void DocumentObserverPython::slotAppendDynamicProperty(const App::Property& Prop
         const char* prop_name = container->getPropertyName(&Prop);
         if (prop_name) {
             args.setItem(1, Py::String(prop_name));
-            Base::pyCall(pyAppendDynamicProperty.ptr(), args.ptr());
+            Base::pyCall(pyAppendDynamicProperty.get(), args.ptr());
         }
     }
     catch (Py::Exception&) {
@@ -488,7 +497,7 @@ void DocumentObserverPython::slotRemoveDynamicProperty(const App::Property& Prop
         const char* prop_name = container->getPropertyName(&Prop);
         if (prop_name) {
             args.setItem(1, Py::String(prop_name));
-            Base::pyCall(pyRemoveDynamicProperty.ptr(), args.ptr());
+            Base::pyCall(pyRemoveDynamicProperty.get(), args.ptr());
         }
     }
     catch (Py::Exception&) {
@@ -510,7 +519,7 @@ void DocumentObserverPython::slotChangePropertyEditor(const App::Document&,
         const char* prop_name = container->getPropertyName(&Prop);
         if (prop_name) {
             args.setItem(1, Py::String(prop_name));
-            Base::pyCall(pyChangePropertyEditor.ptr(), args.ptr());
+            Base::pyCall(pyChangePropertyEditor.get(), args.ptr());
         }
     }
     catch (Py::Exception&) {
@@ -527,7 +536,7 @@ void DocumentObserverPython::slotStartSaveDocument(const App::Document& doc,
         Py::Tuple args(2);
         args.setItem(0, Py::asObject(const_cast<App::Document&>(doc).getPyObject()));
         args.setItem(1, Py::String(file));
-        Base::pyCall(pyStartSaveDocument.ptr(), args.ptr());
+        Base::pyCall(pyStartSaveDocument.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -543,7 +552,7 @@ void DocumentObserverPython::slotFinishSaveDocument(const App::Document& doc,
         Py::Tuple args(2);
         args.setItem(0, Py::asObject(const_cast<App::Document&>(doc).getPyObject()));
         args.setItem(1, Py::String(file));
-        Base::pyCall(pyFinishSaveDocument.ptr(), args.ptr());
+        Base::pyCall(pyFinishSaveDocument.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -560,7 +569,7 @@ void DocumentObserverPython::slotBeforeAddingDynamicExtension(
         Py::Tuple args(2);
         args.setItem(0, Py::asObject(const_cast<App::ExtensionContainer&>(extcont).getPyObject()));
         args.setItem(1, Py::String(extension));
-        Base::pyCall(pyBeforeAddingDynamicExtension.ptr(), args.ptr());
+        Base::pyCall(pyBeforeAddingDynamicExtension.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -576,7 +585,7 @@ void DocumentObserverPython::slotAddedDynamicExtension(const App::ExtensionConta
         Py::Tuple args(2);
         args.setItem(0, Py::asObject(const_cast<App::ExtensionContainer&>(extcont).getPyObject()));
         args.setItem(1, Py::String(extension));
-        Base::pyCall(pyAddedDynamicExtension.ptr(), args.ptr());
+        Base::pyCall(pyAddedDynamicExtension.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text

--- a/src/App/DocumentObserverPython.h
+++ b/src/App/DocumentObserverPython.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <FCGlobal.h>
 #include <fastsignals/signal.h>
 #include <CXX/Objects.hxx>
@@ -56,6 +58,7 @@ public:
 
     static void addObserver(const Py::Object& obj);
     static void removeObserver(const Py::Object& obj);
+    static void clearObservers();
 
 private:
     /** Checks if a new document was created */
@@ -119,16 +122,16 @@ private:
 
 
 private:
-    Py::Object inst;
+    Base::NativePythonReference inst;
     static std::vector<DocumentObserverPython*> _instances;
 
     using Connection = struct PythonObject
     {
         fastsignals::scoped_connection slot;
-        Py::Object py;
-        PyObject* ptr()
+        Base::NativePythonReference py;
+        PyObject* get()
         {
-            return py.ptr();
+            return py.get();
         }
     };
 

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -382,26 +382,22 @@ struct PyObjectWrapper {
 public:
     using Pointer = std::shared_ptr<PyObjectWrapper>;
 
-    explicit PyObjectWrapper(PyObject *obj):pyobj(obj) {
-        Py::_XINCREF(pyobj);
+    explicit PyObjectWrapper(PyObject* obj)
+    {
+        pyobj.resetBorrowed(obj);
     }
-    ~PyObjectWrapper() {
-        if(pyobj) {
-            Base::PyGILStateLocker lock;
-            Py::_XDECREF(pyobj);
-        }
-    }
-    PyObjectWrapper(const PyObjectWrapper &) = delete;
-    PyObjectWrapper &operator=(const PyObjectWrapper &) = delete;
+    PyObjectWrapper(const PyObjectWrapper&) = delete;
+    PyObjectWrapper& operator=(const PyObjectWrapper&) = delete;
 
-    Py::Object get() const {
-        if(!pyobj)
+    Py::Object get() const
+    {
+        if (!pyobj)
             return Py::Object();
-        return Py::Object(const_cast<PyObject*>(pyobj));
+        return Py::Object(pyobj.get());
     }
 
 private:
-    PyObject *pyobj;
+    Base::NativePythonReference pyobj;
 };
 
 static inline PyObjectWrapper::Pointer pyObjectWrap(PyObject *obj) {
@@ -1241,31 +1237,18 @@ UnitExpression::UnitExpression(const DocumentObject *_owner, const Base::Quantit
 {
 }
 
-UnitExpression::~UnitExpression() {
-    if(cache) {
-        Base::PyGILStateLocker lock;
-        Py::_XDECREF(cache);
-    }
-}
+UnitExpression::~UnitExpression() = default;
 
 void UnitExpression::setQuantity(const Quantity &_quantity)
 {
     quantity = _quantity;
-    if(cache) {
-        Base::PyGILStateLocker lock;
-        Py::_XDECREF(cache);
-        cache = nullptr;
-    }
+    cache.reset();
 }
 
 void UnitExpression::setUnit(const Quantity &_quantity)
 {
     quantity = _quantity;
-    if(cache) {
-        Base::PyGILStateLocker lock;
-        Py::_XDECREF(cache);
-        cache = nullptr;
-    }
+    cache.reset();
 }
 
 ExpressionPtr UnitExpression::simplify() const
@@ -1284,9 +1267,9 @@ Expression *UnitExpression::_copy() const
 }
 
 Py::Object UnitExpression::_getPyValue() const {
-    if(!cache)
-        cache = Py::new_reference_to(pyFromQuantity(quantity));
-    return Py::Object(cache);
+    if (!cache)
+        cache.reset(pyFromQuantity(quantity));
+    return Py::Object(cache.get());
 }
 
 //
@@ -3103,47 +3086,42 @@ void VariableExpression::setPath(const ObjectIdentifier &path)
 
 TYPESYSTEM_SOURCE(App::PyObjectExpression, App::Expression)
 
-PyObjectExpression::~PyObjectExpression() {
-    if(pyObj) {
-        Base::PyGILStateLocker lock;
-        Py::_XDECREF(pyObj);
-    }
-}
+PyObjectExpression::~PyObjectExpression() = default;
 
 Py::Object PyObjectExpression::_getPyValue() const {
-    if(!pyObj)
+    if (!pyObj)
         return Py::Object();
-    return Py::Object(pyObj);
+    return Py::Object(pyObj.get());
 }
 
 void PyObjectExpression::setPyValue(Py::Object obj) {
-    Py::_XDECREF(pyObj);
-    pyObj = obj.ptr();
-    Py::_XINCREF(pyObj);
+    pyObj.reset(obj);
 }
 
 void PyObjectExpression::setPyValue(PyObject *obj, bool owned) {
-    if(pyObj == obj)
+    if (pyObj.get() == obj)
         return;
-    Py::_XDECREF(pyObj);
-    pyObj = obj;
-    if(!owned)
-        Py::_XINCREF(pyObj);
+    if (owned) {
+        pyObj.reset(obj);
+    }
+    else {
+        pyObj.resetBorrowed(obj);
+    }
 }
 
 void PyObjectExpression::_toString(std::ostream &ss, bool,int) const
 {
-    if(!pyObj)
+    if (!pyObj)
         ss << "None";
     else {
         Base::PyGILStateLocker lock;
-        ss << Py::Object(pyObj).as_string();
+        ss << Py::Object(pyObj.get()).as_string();
     }
 }
 
 Expression* PyObjectExpression::_copy() const
 {
-    return new PyObjectExpression(owner,pyObj,false);
+    return new PyObjectExpression(owner, pyObj.get(), false);
 }
 
 //
@@ -3158,12 +3136,7 @@ StringExpression::StringExpression(const DocumentObject *_owner, const std::stri
 {
 }
 
-StringExpression::~StringExpression() {
-    if(cache) {
-        Base::PyGILStateLocker lock;
-        Py::_XDECREF(cache);
-    }
-}
+StringExpression::~StringExpression() = default;
 
 ExpressionPtr StringExpression::simplify() const
 {
@@ -3299,17 +3272,17 @@ void ConstantExpression::_toString(std::ostream &ss, bool,int) const
 }
 
 Py::Object ConstantExpression::_getPyValue() const {
-    if(!cache) {
+    if (!cache) {
         if(strcmp(name,"None")==0)
-            cache = Py::new_reference_to(Py::None());
+            cache.reset(Py::None());
         else if(strcmp(name,"True")==0)
-            cache = Py::new_reference_to(Py::True());
+            cache.reset(Py::True());
         else if(strcmp(name, "False")==0)
-            cache = Py::new_reference_to(Py::False());
+            cache.reset(Py::False());
         else
             return NumberExpression::_getPyValue();
     }
-    return Py::Object(cache);
+    return Py::Object(cache.get());
 }
 
 bool ConstantExpression::isNumber() const {
@@ -3867,4 +3840,3 @@ bool ExpressionParser::isTokenAUnit(const std::string & str)
 #if defined(__clang__)
 # pragma clang diagnostic pop
 #endif
-

--- a/src/App/ExpressionParser.h
+++ b/src/App/ExpressionParser.h
@@ -28,6 +28,7 @@
 
 #include "Expression.h"
 #include <Base/Matrix.h>
+#include <Base/NativePythonReference.h>
 #include <Base/Quantity.h>
 #include <Base/Vector3D.h>
 
@@ -124,7 +125,7 @@ protected:
     Py::Object _getPyValue() const override;
 
 protected:
-    mutable PyObject* cache = nullptr;
+    mutable Base::NativePythonReference cache;
 
 private:
     Base::Quantity quantity;
@@ -552,7 +553,7 @@ protected:
     Py::Object _getPyValue() const override;
 
 protected:
-    PyObject* pyObj = nullptr;
+    Base::NativePythonReference pyObj;
 };
 
 /**
@@ -587,7 +588,7 @@ protected:
 
 private:
     std::string text; /**< Text string */
-    mutable PyObject* cache = nullptr;
+    mutable Base::NativePythonReference cache;
 };
 
 class AppExport RangeExpression: public App::Expression

--- a/src/App/Extension.cpp
+++ b/src/App/Extension.cpp
@@ -66,15 +66,11 @@ using namespace App;
 Extension::~Extension()
 {
     if (!ExtensionPythonObject.is(Py::_None())) {
-        Base::PyGILStateLocker lock;
-        // Remark: The API of Py::Object has been changed to set whether the wrapper owns the passed
-        // Python object or not. In the constructor we forced the wrapper to own the object so we
-        // need not to dec'ref the Python object any more. But we must still invalidate the Python
-        // object because it need not to be destructed right now because the interpreter can own
-        // several references to it.
+        // The wrapper may outlive this native extension.  Invalidate only the
+        // native twin state here; Python-owned attributes are released later
+        // by the wrapper deallocator.
         Base::PyObjectBase* obj = static_cast<Base::PyObjectBase*>(ExtensionPythonObject.ptr());
-        // Call before decrementing the reference counter, otherwise a heap error can occur
-        obj->setInvalid();
+        obj->setInvalidWithoutPython();
     }
 }
 

--- a/src/App/FeaturePython.cpp
+++ b/src/App/FeaturePython.cpp
@@ -40,19 +40,7 @@ FeaturePythonImp::FeaturePythonImp(App::DocumentObject* o)
     : object(o)
 {}
 
-FeaturePythonImp::~FeaturePythonImp()
-{
-    Base::PyGILStateLocker lock;
-#undef FC_PY_ELEMENT
-#define FC_PY_ELEMENT(_name) py_##_name = Py::None();
-
-    try {
-        FC_PY_FEATURE_PYTHON
-    }
-    catch (Py::Exception& e) {
-        e.clear();
-    }
-}
+FeaturePythonImp::~FeaturePythonImp() = default;
 
 void FeaturePythonImp::init(PyObject* pyobj)
 {
@@ -60,12 +48,14 @@ void FeaturePythonImp::init(PyObject* pyobj)
     has__object__ = !!PyObject_HasAttrString(pyobj, "__object__");
 
 #undef FC_PY_ELEMENT
-#define FC_PY_ELEMENT(_name) FC_PY_ELEMENT_INIT(_name)
+#define FC_PY_ELEMENT(_name) FC_PY_FEATURE_ELEMENT_INIT(_name)
 
     FC_PY_FEATURE_PYTHON
 }
 
-#define FC_PY_CALL_CHECK(_name) _FC_PY_CALL_CHECK(_name, return (false))
+#define FC_PY_CALL_CHECK(_name) _FC_PY_FEATURE_CALL_CHECK(_name, return (false))
+#undef _FC_PY_CALL_CHECK
+#define _FC_PY_CALL_CHECK(_name, _ret) _FC_PY_FEATURE_CALL_CHECK(_name, _ret)
 
 /*!
  Calls the execute() method of the Python feature class. If the Python feature class doesn't have an
@@ -77,7 +67,7 @@ bool FeaturePythonImp::execute()
     Base::PyGILStateLocker lock;
     try {
         if (has__object__) {
-            Py::Object res = Base::pyCall(py_execute.ptr());
+            Py::Object res = Base::pyCall(py_execute.get());
             if (res.isBoolean() && !res.isTrue()) {
                 return false;
             }
@@ -86,7 +76,7 @@ bool FeaturePythonImp::execute()
         else {
             Py::Tuple args(1);
             args.setItem(0, Py::Object(object->getPyObject(), true));
-            Py::Object res = Base::pyCall(py_execute.ptr(), args.ptr());
+            Py::Object res = Base::pyCall(py_execute.get(), args.ptr());
             if (res.isBoolean() && !res.isTrue()) {
                 return false;
             }
@@ -110,13 +100,13 @@ bool FeaturePythonImp::mustExecute() const
     Base::PyGILStateLocker lock;
     try {
         if (has__object__) {
-            Py::Object res(Base::pyCall(py_mustExecute.ptr()));
+            Py::Object res(Base::pyCall(py_mustExecute.get()));
             return res.isTrue();
         }
         else {
             Py::Tuple args(1);
             args.setItem(0, Py::Object(object->getPyObject(), true));
-            Py::Object res(Base::pyCall(py_mustExecute.ptr(), args.ptr()));
+            Py::Object res(Base::pyCall(py_mustExecute.get(), args.ptr()));
             return res.isTrue();
         }
     }
@@ -130,7 +120,7 @@ bool FeaturePythonImp::mustExecute() const
 
 void FeaturePythonImp::onBeforeChange(const Property* prop)
 {
-    if (py_onBeforeChange.isNone()) {
+    if (!py_onBeforeChange.get()) {
         return;
     }
 
@@ -144,13 +134,13 @@ void FeaturePythonImp::onBeforeChange(const Property* prop)
         if (has__object__) {
             Py::Tuple args(1);
             args.setItem(0, Py::String(prop_name));
-            Base::pyCall(py_onBeforeChange.ptr(), args.ptr());
+            Base::pyCall(py_onBeforeChange.get(), args.ptr());
         }
         else {
             Py::Tuple args(2);
             args.setItem(0, Py::Object(object->getPyObject(), true));
             args.setItem(1, Py::String(prop_name));
-            Base::pyCall(py_onBeforeChange.ptr(), args.ptr());
+            Base::pyCall(py_onBeforeChange.get(), args.ptr());
         }
     }
     catch (Py::Exception&) {
@@ -161,7 +151,7 @@ void FeaturePythonImp::onBeforeChange(const Property* prop)
 
 bool FeaturePythonImp::onBeforeChangeLabel(std::string& newLabel)
 {
-    if (py_onBeforeChangeLabel.isNone()) {
+    if (!py_onBeforeChangeLabel.get()) {
         return false;
     }
 
@@ -171,7 +161,7 @@ bool FeaturePythonImp::onBeforeChangeLabel(std::string& newLabel)
         Py::Tuple args(2);
         args.setItem(0, Py::Object(object->getPyObject(), true));
         args.setItem(1, Py::String(newLabel));
-        Py::Object ret(Base::pyCall(py_onBeforeChangeLabel.ptr(), args.ptr()));
+        Py::Object ret(Base::pyCall(py_onBeforeChangeLabel.get(), args.ptr()));
         if (!ret.isNone()) {
             if (!ret.isString()) {
                 throw Py::TypeError("onBeforeChangeLabel expects to return a string");
@@ -189,7 +179,7 @@ bool FeaturePythonImp::onBeforeChangeLabel(std::string& newLabel)
 
 void FeaturePythonImp::onChanged(const Property* prop)
 {
-    if (py_onChanged.isNone()) {
+    if (!py_onChanged.get()) {
         return;
     }
     // Run the execute method of the proxy object.
@@ -202,13 +192,13 @@ void FeaturePythonImp::onChanged(const Property* prop)
         if (has__object__) {
             Py::Tuple args(1);
             args.setItem(0, Py::String(prop_name));
-            Base::pyCall(py_onChanged.ptr(), args.ptr());
+            Base::pyCall(py_onChanged.get(), args.ptr());
         }
         else {
             Py::Tuple args(2);
             args.setItem(0, Py::Object(object->getPyObject(), true));
             args.setItem(1, Py::String(prop_name));
-            Base::pyCall(py_onChanged.ptr(), args.ptr());
+            Base::pyCall(py_onChanged.get(), args.ptr());
         }
     }
     catch (Py::Exception&) {
@@ -225,12 +215,12 @@ void FeaturePythonImp::onDocumentRestored()
     Base::PyGILStateLocker lock;
     try {
         if (has__object__) {
-            Base::pyCall(py_onDocumentRestored.ptr());
+            Base::pyCall(py_onDocumentRestored.get());
         }
         else {
             Py::Tuple args(1);
             args.setItem(0, Py::Object(object->getPyObject(), true));
-            Base::pyCall(py_onDocumentRestored.ptr(), args.ptr());
+            Base::pyCall(py_onDocumentRestored.get(), args.ptr());
         }
     }
     catch (Py::Exception&) {
@@ -247,12 +237,12 @@ void FeaturePythonImp::unsetupObject()
     Base::PyGILStateLocker lock;
     try {
         if (has__object__) {
-            Base::pyCall(py_unsetupObject.ptr());
+            Base::pyCall(py_unsetupObject.get());
         }
         else {
             Py::Tuple args(1);
             args.setItem(0, Py::Object(object->getPyObject(), true));
-            Base::pyCall(py_unsetupObject.ptr(), args.ptr());
+            Base::pyCall(py_unsetupObject.get(), args.ptr());
         }
     }
     catch (Py::Exception&) {
@@ -286,7 +276,7 @@ bool FeaturePythonImp::getSubObject(DocumentObject*& ret,
         args.setItem(4, Py::Boolean(transform));
         args.setItem(5, Py::Long(depth));
 
-        Py::Object res(Base::pyCall(py_getSubObject.ptr(), args.ptr()));
+        Py::Object res(Base::pyCall(py_getSubObject.get(), args.ptr()));
         if (res.isNone()) {
             ret = nullptr;
             return true;
@@ -343,7 +333,7 @@ bool FeaturePythonImp::getSubObjects(std::vector<std::string>& ret, int reason) 
         Py::Tuple args(2);
         args.setItem(0, Py::Object(object->getPyObject(), true));
         args.setItem(1, Py::Long(reason));
-        Py::Object res(Base::pyCall(py_getSubObjects.ptr(), args.ptr()));
+        Py::Object res(Base::pyCall(py_getSubObjects.get(), args.ptr()));
         if (!res.isTrue()) {
             return true;
         }
@@ -391,7 +381,7 @@ bool FeaturePythonImp::getLinkedObject(DocumentObject*& ret,
         args.setItem(3, Py::Boolean(transform));
         args.setItem(4, Py::Long(depth));
 
-        Py::Object res(Base::pyCall(py_getLinkedObject.ptr(), args.ptr()));
+        Py::Object res(Base::pyCall(py_getLinkedObject.get(), args.ptr()));
         if (!res.isTrue()) {
             ret = object;
             return true;
@@ -442,7 +432,7 @@ FeaturePythonImp::ValueT FeaturePythonImp::hasChildElement() const
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::Object(object->getPyObject(), true));
-        Py::Boolean ok(Base::pyCall(py_hasChildElement.ptr(), args.ptr()));
+        Py::Boolean ok(Base::pyCall(py_hasChildElement.get(), args.ptr()));
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -465,7 +455,7 @@ int FeaturePythonImp::isElementVisible(const char* element) const
         Py::Tuple args(2);
         args.setItem(0, Py::Object(object->getPyObject(), true));
         args.setItem(1, Py::String(element ? element : ""));
-        return Py::Long(Base::pyCall(py_isElementVisible.ptr(), args.ptr()));
+        return Py::Long(Base::pyCall(py_isElementVisible.get(), args.ptr()));
     }
     catch (Py::Exception&) {
         if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
@@ -487,7 +477,7 @@ int FeaturePythonImp::setElementVisible(const char* element, bool visible)
         args.setItem(0, Py::Object(object->getPyObject(), true));
         args.setItem(1, Py::String(element ? element : ""));
         args.setItem(2, Py::Boolean(visible));
-        return Py::Long(Base::pyCall(py_setElementVisible.ptr(), args.ptr()));
+        return Py::Long(Base::pyCall(py_setElementVisible.get(), args.ptr()));
     }
     catch (Py::Exception&) {
         if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
@@ -506,7 +496,7 @@ std::string FeaturePythonImp::getViewProviderName()
     Base::PyGILStateLocker lock;
     try {
         Py::TupleN args(Py::Object(object->getPyObject(), true));
-        Py::String ret(Base::pyCall(py_getViewProviderName.ptr(), args.ptr()));
+        Py::String ret(Base::pyCall(py_getViewProviderName.get(), args.ptr()));
         return ret.as_string();
     }
     catch (Py::Exception&) {
@@ -524,7 +514,7 @@ FeaturePythonImp::ValueT FeaturePythonImp::canLinkProperties() const
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::Object(object->getPyObject(), true));
-        Py::Boolean ok(Base::pyCall(py_canLinkProperties.ptr(), args.ptr()));
+        Py::Boolean ok(Base::pyCall(py_canLinkProperties.get(), args.ptr()));
         return ok ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -545,7 +535,7 @@ FeaturePythonImp::ValueT FeaturePythonImp::allowDuplicateLabel() const
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::Object(object->getPyObject(), true));
-        Py::Boolean ok(Base::pyCall(py_allowDuplicateLabel.ptr(), args.ptr()));
+        Py::Boolean ok(Base::pyCall(py_allowDuplicateLabel.get(), args.ptr()));
         return ok ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -567,7 +557,7 @@ int FeaturePythonImp::canLoadPartial() const
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::Object(object->getPyObject(), true));
-        Py::Long ret(Base::pyCall(py_canLoadPartial.ptr(), args.ptr()));
+        Py::Long ret(Base::pyCall(py_canLoadPartial.get(), args.ptr()));
         return ret;
     }
     catch (Py::Exception&) {
@@ -588,7 +578,7 @@ FeaturePythonImp::ValueT FeaturePythonImp::supportsAsyncRecompute() const
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::Object(object->getPyObject(), true));
-        Py::Boolean ok(Base::pyCall(py_supportsAsyncRecompute.ptr(), args.ptr()));
+        Py::Boolean ok(Base::pyCall(py_supportsAsyncRecompute.get(), args.ptr()));
         return ok ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -614,7 +604,7 @@ FeaturePythonImp::ValueT FeaturePythonImp::redirectSubName(std::ostringstream& s
         args.setItem(1, Py::String(ss.str()));
         args.setItem(2, topParent ? Py::Object(topParent->getPyObject(), true) : Py::Object());
         args.setItem(3, child ? Py::Object(child->getPyObject(), true) : Py::Object());
-        Py::Object ret(Base::pyCall(py_redirectSubName.ptr(), args.ptr()));
+        Py::Object ret(Base::pyCall(py_redirectSubName.get(), args.ptr()));
         if (ret.isNone()) {
             return Rejected;
         }
@@ -641,7 +631,7 @@ bool FeaturePythonImp::editProperty(const char* name)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::String(name));
-        Py::Object ret(Base::pyCall(py_editProperty.ptr(), args.ptr()));
+        Py::Object ret(Base::pyCall(py_editProperty.get(), args.ptr()));
         return ret.isTrue();
     }
     catch (Py::Exception&) {
@@ -663,7 +653,7 @@ FeaturePythonImp::ValueT FeaturePythonImp::isLink() const
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::Object(object->getPyObject(), true));
-        Py::Boolean ok(Base::pyCall(py_isLink.ptr(), args.ptr()));
+        Py::Boolean ok(Base::pyCall(py_isLink.get(), args.ptr()));
         return ok ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -685,7 +675,7 @@ FeaturePythonImp::ValueT FeaturePythonImp::isLinkGroup() const
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::Object(object->getPyObject(), true));
-        Py::Boolean ok(Base::pyCall(py_isLinkGroup.ptr(), args.ptr()));
+        Py::Boolean ok(Base::pyCall(py_isLinkGroup.get(), args.ptr()));
         return ok ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -726,7 +716,7 @@ bool FeaturePythonImp::getPlacementOf(
         }
 
         // Call the Python method
-        Py::Object res(Base::pyCall(py_getPlacementOf.ptr(), args.ptr()));
+        Py::Object res(Base::pyCall(py_getPlacementOf.get(), args.ptr()));
 
         // Check if Python returned None (implies "use base implementation")
         if (res.isNone()) {

--- a/src/App/FeaturePython.h
+++ b/src/App/FeaturePython.h
@@ -27,6 +27,7 @@
 
 #include <App/GeoFeature.h>
 #include <App/PropertyPythonObject.h>
+#include <Base/NativePythonReference.h>
 
 
 namespace App
@@ -128,6 +129,8 @@ private:
     FC_PY_ELEMENT(isLinkGroup)                                                                     \
     FC_PY_ELEMENT(getPlacementOf)
 
+// These macros are also used by the GUI FeaturePython implementation, which
+// shares the callback list infrastructure declared in this header.
 #define FC_PY_ELEMENT_DEFINE(_name) Py::Object py_##_name;
 
 #define FC_PY_ELEMENT_INIT(_name)                                                                  \
@@ -146,6 +149,24 @@ private:
 
 #define FC_PY_ELEMENT_FLAG(_name) FlagCalling_##_name, FlagAllowRecursive_##_name,
 
+#define FC_PY_FEATURE_ELEMENT_DEFINE(_name) Base::NativePythonReference py_##_name;
+
+#define FC_PY_FEATURE_ELEMENT_INIT(_name)                                                          \
+    Base::setNativePythonCallable(pyobj, #_name, py_##_name);                                      \
+    if (py_##_name.get()) {                                                                        \
+        PyObject* pyRecursive = PyObject_GetAttrString(pyobj, "__allow_recursive_" #_name);        \
+        if (!pyRecursive) {                                                                        \
+            PyErr_Clear();                                                                         \
+            _Flags.set(FlagAllowRecursive_##_name, false);                                         \
+        }                                                                                          \
+        else {                                                                                     \
+            _Flags.set(FlagAllowRecursive_##_name, PyObject_IsTrue(pyRecursive));                  \
+            Py_DECREF(pyRecursive);                                                                \
+        }                                                                                          \
+    }
+
+#define FC_PY_FEATURE_ELEMENT_FLAG(_name) FlagCalling_##_name, FlagAllowRecursive_##_name,
+
 #define _FC_PY_CALL_CHECK(_name, _ret)                                                             \
     if ((!_Flags.test(FlagAllowRecursive_##_name) && _Flags.test(FlagCalling_##_name))             \
         || py_##_name.isNone()) {                                                                  \
@@ -153,13 +174,20 @@ private:
     }                                                                                              \
     Base::BitsetLocker<Flags> guard(_Flags, FlagCalling_##_name);
 
+#define _FC_PY_FEATURE_CALL_CHECK(_name, _ret)                                                     \
+    if ((!_Flags.test(FlagAllowRecursive_##_name) && _Flags.test(FlagCalling_##_name))             \
+        || !py_##_name.get()) {                                                                    \
+        _ret;                                                                                      \
+    }                                                                                              \
+    Base::BitsetLocker<Flags> guard(_Flags, FlagCalling_##_name);
+
 #undef FC_PY_ELEMENT
-#define FC_PY_ELEMENT(_name) FC_PY_ELEMENT_DEFINE(_name)
+#define FC_PY_ELEMENT(_name) FC_PY_FEATURE_ELEMENT_DEFINE(_name)
 
     FC_PY_FEATURE_PYTHON
 
 #undef FC_PY_ELEMENT
-#define FC_PY_ELEMENT(_name) FC_PY_ELEMENT_FLAG(_name)
+#define FC_PY_ELEMENT(_name) FC_PY_FEATURE_ELEMENT_FLAG(_name)
 
     enum Flag
     {

--- a/src/App/FeaturePythonPyImp.h
+++ b/src/App/FeaturePythonPyImp.h
@@ -102,7 +102,7 @@ public:
     int _setattr(const char *attr, PyObject *value) override;
 
 protected:
-    PyObject * dict_methods;
+    PyObject* dict_methods = nullptr;
 
 private:
 };

--- a/src/App/FeaturePythonPyImp.inl
+++ b/src/App/FeaturePythonPyImp.inl
@@ -101,8 +101,9 @@ FeaturePythonPyT<FeaturePyT>::FeaturePythonPyT(Base::BaseClass *pcObject, PyType
 template<class FeaturePyT>
 FeaturePythonPyT<FeaturePyT>::~FeaturePythonPyT()
 {
-    Base::PyGILStateLocker lock;
-    Py_DECREF(dict_methods);
+    // This is a Python deallocator path. Python already owns the thread state,
+    // including during Py_Finalize(); do not reacquire the GIL here.
+    Py_XDECREF(dict_methods);
 }
 
 template<class FeaturePyT>

--- a/src/App/FeatureTest.cpp
+++ b/src/App/FeatureTest.cpp
@@ -348,28 +348,6 @@ FeatureTestAttribute::FeatureTestAttribute()
     ADD_PROPERTY(Attribute, ("Name"));
 }
 
-FeatureTestAttribute::~FeatureTestAttribute()
-{
-    Base::PyGILStateLocker lock;
-    try {
-        Object.getValue().getAttr("Name");
-#if PYCXX_VERSION_MAJOR >= 7
-        Py::ifPyErrorThrowCxxException();
-#else
-        if (PyErr_Occurred()) {
-            throw Py::RuntimeError();
-        }
-#endif
-    }
-    catch (Py::RuntimeError& e) {
-        e.clear();
-    }
-    catch (Py::Exception& e) {
-        e.clear();
-        Base::Console().error("Unexpected exception in ~FeatureTestRemoval()\n");
-    }
-}
-
 DocumentObjectExecReturn* FeatureTestAttribute::execute()
 {
     Base::PyGILStateLocker lock;

--- a/src/App/FeatureTest.h
+++ b/src/App/FeatureTest.h
@@ -214,7 +214,7 @@ class FeatureTestAttribute: public DocumentObject
 
 public:
     FeatureTestAttribute();
-    ~FeatureTestAttribute() override;
+    ~FeatureTestAttribute() override = default;
     DocumentObjectExecReturn* execute() override;
     bool canRecomputeOnWorker() const override { return false; }
 

--- a/src/App/MeasureManager.cpp
+++ b/src/App/MeasureManager.cpp
@@ -24,6 +24,7 @@
 
 #include <Base/Console.h>
 #include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <Base/VectorPy.h>
 #include <App/Document.h>
 #include <App/Link.h>
@@ -110,7 +111,13 @@ void MeasureManager::addMeasureType(std::string id,
                                     MeasurePrioritizeMethod prioritizeCb)
 {
     MeasureType* mType =
-        new MeasureType {id, label, measureObj, validatorCb, prioritizeCb, false, nullptr};
+        new MeasureType {id,
+                         label,
+                         measureObj,
+                         validatorCb,
+                         prioritizeCb,
+                         false,
+                         Base::NativePythonReference()};
     _mMeasureTypes.push_back(mType);
 }
 
@@ -125,6 +132,15 @@ void MeasureManager::addMeasureType(const char* id,
                    std::string(measureObj),
                    validatorCb,
                    prioritizeCb);
+}
+
+void MeasureManager::destruct()
+{
+    for (auto* measureType : _mMeasureTypes) {
+        delete measureType;
+    }
+    _mMeasureTypes.clear();
+    _mMeasureHandlers.clear();
 }
 
 const std::vector<MeasureType*> MeasureManager::getMeasureTypes()
@@ -177,7 +193,7 @@ std::vector<MeasureType*> MeasureManager::getValidMeasureTypes(App::MeasureSelec
 
         if (mType->isPython) {
             // Parse Python measure types
-            auto measurePyClass = Py::Object(mType->pythonClass);
+            auto measurePyClass = Py::Object(mType->pythonClass.get());
 
             Py::Tuple args(1);
             args.setItem(0, selectionPy);

--- a/src/App/MeasureManager.h
+++ b/src/App/MeasureManager.h
@@ -34,6 +34,7 @@
 #include <Base/Vector3D.h>
 #include <App/DocumentObserver.h>
 #include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 
 #include <FCGlobal.h>
 
@@ -87,7 +88,7 @@ struct MeasureType
     MeasurePrioritizeMethod prioritizeCb;
 
     bool isPython;
-    PyObject* pythonClass;
+    Base::NativePythonReference pythonClass;
 };
 
 struct MeasureHandler
@@ -118,6 +119,7 @@ public:
                                const char* measureObj,
                                MeasureValidateMethod validatorCb,
                                MeasurePrioritizeMethod prioritizeCb);
+    static void destruct();
     static const std::vector<MeasureType*> getMeasureTypes();
     static Py::Tuple getSelectionPy(const App::MeasureSelection& selection);
     static std::vector<MeasureType*> getValidMeasureTypes(App::MeasureSelection selection,

--- a/src/App/MeasureManagerPyImp.cpp
+++ b/src/App/MeasureManagerPyImp.cpp
@@ -24,6 +24,7 @@
 
 
 // inclusion of the generated files (generated out of MeasureManagerPy.xml)
+#include <Base/NativePythonReference.h>
 #include "MeasureManagerPy.h"
 #include "MeasureManagerPy.cpp"
 
@@ -57,8 +58,15 @@ PyObject* MeasureManagerPy::addMeasureType(PyObject* args)
         return nullptr;
     }
 
+    Py_INCREF(pyobj);
     MeasureManager::addMeasureType(
-        new App::MeasureType {id, label, "", nullptr, nullptr, true, pyobj});
+        new App::MeasureType {id,
+                              label,
+                              "",
+                              nullptr,
+                              nullptr,
+                              true,
+                              Base::NativePythonReference(pyobj)});
 
     Py_Return;
 }
@@ -71,7 +79,7 @@ PyObject* MeasureManagerPy::getMeasureTypes()
         Py::Tuple type(3);
         type.setItem(0, Py::String(it->identifier));
         type.setItem(1, Py::String(it->label));
-        type.setItem(2, Py::Object(it->pythonClass));
+        type.setItem(2, Py::Object(it->pythonClass.get()));
 
         types.append(type);
     }

--- a/src/App/PropertyPythonObject.cpp
+++ b/src/App/PropertyPythonObject.cpp
@@ -32,6 +32,7 @@
 #include <Base/Base64.h>
 #include <Base/Console.h>
 #include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <Base/Reader.h>
 #include <Base/Writer.h>
 
@@ -195,17 +196,30 @@ bool isAllowedModule(const std::string& moduleName)
 
 TYPESYSTEM_SOURCE(App::PropertyPythonObject, App::Property)
 
-PropertyPythonObject::PropertyPythonObject() = default;
-
-PropertyPythonObject::~PropertyPythonObject()
+PropertyPythonObject::PropertyPythonObject()
 {
-    // this is needed because the release of the pickled object may need the
-    // GIL. Thus, we grab the GIL and replace the pickled with an empty object
-    Base::PyGILStateLocker lock;
-    try {
-        this->object = Py::Object();
-    } catch (Py::TypeError &) {
-        Base::Console().warning("Py::TypeError Exception caught while destroying PropertyPythonObject\n");
+    object.resetBorrowed(Py::_None());
+}
+
+PropertyPythonObject::~PropertyPythonObject() = default;
+
+Py::Object PropertyPythonObject::getObject() const
+{
+    return Py::Object(object.get());
+}
+
+void PropertyPythonObject::setObject(const Py::Object& value)
+{
+    setObject(value.ptr());
+}
+
+void PropertyPythonObject::setObject(PyObject* value, bool owned)
+{
+    if (owned) {
+        object.reset(value);
+    }
+    else {
+        object.resetBorrowed(value);
     }
 }
 
@@ -213,25 +227,25 @@ void PropertyPythonObject::setValue(const Py::Object& py)
 {
     Base::PyGILStateLocker lock;
     aboutToSetValue();
-    this->object = py;
+    setObject(py);
     hasSetValue();
 }
 
 Py::Object PropertyPythonObject::getValue() const
 {
-    return object;
+    return getObject();
 }
 
 PyObject* PropertyPythonObject::getPyObject()
 {
-    return Py::new_reference_to(this->object);
+    return Py::new_reference_to(getObject());
 }
 
 void PropertyPythonObject::setPyObject(PyObject* obj)
 {
     Base::PyGILStateLocker lock;
     aboutToSetValue();
-    this->object = obj;
+    setObject(obj);
     hasSetValue();
 }
 
@@ -246,26 +260,27 @@ std::string PropertyPythonObject::toString() const
         }
         Py::Callable method(pickle.getAttr(std::string("dumps")));
         Py::Object dump;
-        if (this->object.hasAttr("dumps")) {
+        Py::Object object = getObject();
+        if (object.hasAttr("dumps")) {
             Py::Tuple args;
-            Py::Callable state(this->object.getAttr("dumps"));
+            Py::Callable state(object.getAttr("dumps"));
             dump = state.apply(args);
         }
         // support add-ons that use the old method names
-        else if (this->object.hasAttr("__getstate__")
+        else if (object.hasAttr("__getstate__")
 #if PY_VERSION_HEX >= 0x030b0000
-                 && this->object.getAttr("__getstate__").hasAttr("__func__")
+                 && object.getAttr("__getstate__").hasAttr("__func__")
 #endif
         ) {
             Py::Tuple args;
-            Py::Callable state(this->object.getAttr("__getstate__"));
+            Py::Callable state(object.getAttr("__getstate__"));
             dump = state.apply(args);
         }
-        else if (this->object.hasAttr("__dict__")) {
-            dump = this->object.getAttr("__dict__");
+        else if (object.hasAttr("__dict__")) {
+            dump = object.getAttr("__dict__");
         }
         else {
-            dump = this->object;
+            dump = object;
         }
 
         Py::Tuple args(1);
@@ -275,7 +290,7 @@ std::string PropertyPythonObject::toString() const
         repr = str.as_std_string("ascii");
     }
     catch (Py::Exception&) {
-        Py::String typestr(this->object.type().str());
+        Py::String typestr(getObject().type().str());
         Base::Console().error("PropertyPythonObject::toString(): failed for %s\n",
                               typestr.as_string().c_str());
         Base::PyException e;  // extract the Python error text
@@ -301,30 +316,31 @@ void PropertyPythonObject::fromString(const std::string& repr)
         args.setItem(0, Py::String(repr));
         Py::Object res = method.apply(args);
 
-        if (this->object.hasAttr("loads")) {
+        Py::Object object = getObject();
+        if (object.hasAttr("loads")) {
             Py::Tuple args(1);
             args.setItem(0, res);
-            Py::Callable state(this->object.getAttr("loads"));
+            Py::Callable state(object.getAttr("loads"));
             state.apply(args);
         }
         // support add-ons that use the old method names
-        else if (this->object.hasAttr("__setstate__")
+        else if (object.hasAttr("__setstate__")
 #if PY_VERSION_HEX >= 0x030b0000
-                 && this->object.getAttr("__setstate__").hasAttr("__func__")
+                 && object.getAttr("__setstate__").hasAttr("__func__")
 #endif
         ) {
             Py::Tuple args(1);
             args.setItem(0, res);
-            Py::Callable state(this->object.getAttr("__setstate__"));
+            Py::Callable state(object.getAttr("__setstate__"));
             state.apply(args);
         }
-        else if (this->object.hasAttr("__dict__")) {
+        else if (object.hasAttr("__dict__")) {
             if (!res.isNone()) {
-                this->object.setAttr("__dict__", res);
+                object.setAttr("__dict__", res);
             }
         }
         else {
-            this->object = res;
+            setObject(res);
         }
     }
     catch (Py::Exception&) {
@@ -385,12 +401,12 @@ void PropertyPythonObject::saveObject(Base::Writer& writer) const
     try {
         PropertyContainer* parent = this->getContainer();
         if (parent->isDerivedFrom(Base::Type::fromName("App::DocumentObject"))) {
-            if (this->object.hasAttr("__object__")) {
+            if (getObject().hasAttr("__object__")) {
                 writer.Stream() << " object=\"yes\"";
             }
         }
         if (parent->isDerivedFrom(Base::Type::fromName("Gui::ViewProvider"))) {
-            if (this->object.hasAttr("__vobject__")) {
+            if (getObject().hasAttr("__vobject__")) {
                 writer.Stream() << " vobject=\"yes\"";
             }
         }
@@ -408,13 +424,13 @@ void PropertyPythonObject::restoreObject(Base::XMLReader& reader)
         if (reader.hasAttribute("object")) {
             if (strcmp(reader.getAttribute<const char*>("object"), "yes") == 0) {
                 Py::Object obj = Py::asObject(parent->getPyObject());
-                this->object.setAttr("__object__", obj);
+                getObject().setAttr("__object__", obj);
             }
         }
         if (reader.hasAttribute("vobject")) {
             if (strcmp(reader.getAttribute<const char*>("vobject"), "yes") == 0) {
                 Py::Object obj = Py::asObject(parent->getPyObject());
-                this->object.setAttr("__vobject__", obj);
+                getObject().setAttr("__vobject__", obj);
             }
         }
     }
@@ -438,9 +454,10 @@ void PropertyPythonObject::Save(Base::Writer& writer) const
 
     Base::PyGILStateLocker lock;
     try {
-        if (this->object.hasAttr("__module__") && this->object.hasAttr("__class__")) {
-            Py::String mod(this->object.getAttr("__module__"));
-            Py::Object cls(this->object.getAttr("__class__"));
+        Py::Object object = getObject();
+        if (object.hasAttr("__module__") && object.hasAttr("__class__")) {
+            Py::String mod(object.getAttr("__module__"));
+            Py::Object cls(object.getAttr("__class__"));
             if (cls.hasAttr("__name__")) {
                 Py::String name(cls.getAttr("__name__"));
                 writer.Stream() << " module=\"" << (std::string)mod << "\""
@@ -502,7 +519,7 @@ void PropertyPythonObject::Restore(Base::XMLReader& reader)
                     throw Py::AttributeError(s.str());
                 }
                 if (PyType_Check(cls)) {
-                    this->object = PyType_GenericAlloc((PyTypeObject*)cls, 0);
+                    setObject(PyType_GenericAlloc((PyTypeObject*)cls, 0), true);
                 }
                 else {
                     throw Py::TypeError("neither class nor type object");
@@ -516,7 +533,7 @@ void PropertyPythonObject::Restore(Base::XMLReader& reader)
         catch (Py::Exception&) {
             Base::PyException e;  // extract the Python error text
             e.reportException();
-            this->object = Py::None();
+            setObject(Py::None());
             load_failed = true;
         }
 
@@ -556,14 +573,14 @@ void PropertyPythonObject::RestoreDocFile(Base::Reader& reader)
 
 unsigned int PropertyPythonObject::getMemSize() const
 {
-    return sizeof(Py::Object);
+    return sizeof(Base::NativePythonReference);
 }
 
 Property* PropertyPythonObject::Copy() const
 {
     PropertyPythonObject* p = new PropertyPythonObject();
     Base::PyGILStateLocker lock;
-    p->object = this->object;
+    p->setObject(this->getObject());
     return p;
 }
 
@@ -572,7 +589,7 @@ void PropertyPythonObject::Paste(const Property& from)
     if (from.is<PropertyPythonObject>()) {
         Base::PyGILStateLocker lock;
         aboutToSetValue();
-        this->object = static_cast<const PropertyPythonObject&>(from).object;
+        this->setObject(static_cast<const PropertyPythonObject&>(from).getObject());
         hasSetValue();
     }
 }

--- a/src/App/PropertyPythonObject.h
+++ b/src/App/PropertyPythonObject.h
@@ -28,6 +28,9 @@
 #include <string>
 #include <CXX/Objects.hxx>
 
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
+
 #include "Property.h"
 
 
@@ -77,7 +80,11 @@ private:
     void restoreObject(Base::XMLReader& reader);
     std::string encodeValue(const std::string& str) const;
     std::string decodeValue(const std::string& str) const;
-    Py::Object object;
+    Py::Object getObject() const;
+    void setObject(const Py::Object& value);
+    void setObject(PyObject* value, bool owned = false);
+
+    Base::NativePythonReference object;
 };
 
 

--- a/src/App/private/DocumentP.h
+++ b/src/App/private/DocumentP.h
@@ -45,6 +45,8 @@
 #include <App/DocumentObserver.h>
 #include <App/StringHasher.h>
 #include <App/ExportInfo.h>
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <Base/UniqueNameManager.h>
 
 // using VertexProperty = boost::property<boost::vertex_root_t, DocumentObject* >;
@@ -84,7 +86,7 @@ struct DocumentP
     DocumentObject* activeObject {nullptr};
     Transaction* activeUndoTransaction {nullptr};
     // pointer to the python class
-    Py::Object DocumentPythonObject;
+    Base::NativePythonReference DocumentPythonObject;
     int iTransactionMode {0};
     bool rollback {false};
     bool undoing {false};  ///< document in the middle of undo or redo

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -220,6 +220,7 @@ SET(FreeCADBase_CPP_SRCS
     Handle.cpp
     InputSource.cpp
     Interpreter.cpp
+    NativePythonReference.cpp
     Matrix.cpp
     MatrixPyImp.cpp
     Observer.cpp
@@ -295,6 +296,7 @@ SET(FreeCADBase_HPP_SRCS
     Handle.h
     InputSource.h
     Interpreter.h
+    NativePythonReference.h
     Matrix.h
     Observer.h
     Parameter.h

--- a/src/Base/Interpreter.cpp
+++ b/src/Base/Interpreter.cpp
@@ -30,6 +30,7 @@
 #include <FCConfig.h>
 
 #include "Interpreter.h"
+#include "NativePythonReference.h"
 #include "Console.h"
 #include "ExceptionFactory.h"
 #include "FileInfo.h"
@@ -646,6 +647,7 @@ std::string InterpreterSingleton::init(int argc, char* argv[])
         PySys_SetArgv(argc, _argv.data());
         PythonStdOutput::init_type();
         this->_global = PyEval_SaveThread();
+        NativePythonReference::markInterpreterRunning();
     }
 
     PyGILStateLocker lock;
@@ -699,6 +701,7 @@ std::string InterpreterSingleton::init(int argc, char* argv[])
             PythonStdOutput::init_type();
             this->_global = PyEval_SaveThread();
         }
+        NativePythonReference::markInterpreterRunning();
         return getPythonPath();
     }
     catch (const Exception& e) {
@@ -724,6 +727,13 @@ int InterpreterSingleton::cleanup(void (*func)())
 void InterpreterSingleton::finalize()
 {
     try {
+        if (!NativePythonReference::beginInterpreterFinalization()) {
+            Base::Console().error(
+                "Skipping Py_Finalize(): native Python ownership was not fully released\n"
+            );
+            return;
+        }
+
         PyEval_RestoreThread(this->_global);
         cleanupModules();
         Py_Finalize();

--- a/src/Base/Interpreter.h
+++ b/src/Base/Interpreter.h
@@ -45,8 +45,10 @@
 #endif
 
 #include <CXX/Extensions.hxx>
+#include <cstddef>
 #include <list>
 #include <string>
+#include <utility>
 #include "Exception.h"
 
 
@@ -201,23 +203,47 @@ private:
     long _exitCode;
 };
 
-/** If the application starts we release immediately the global interpreter lock
- * (GIL) once the Python interpreter is initialized, i.e. no thread -- including
- * the main thread doesn't hold the GIL. Thus, every thread must instantiate an
- * object of PyGILStateLocker if it needs to access protected areas in Python or
- * areas where the lock is needed. It's best to create the instance on the stack,
- * not on the heap.
+/** Acquire the Python thread state for the current scope.
+ *
+ * FreeCAD releases the interpreter's main thread state with PyEval_SaveThread()
+ * during normal execution. That thread still has a valid PyThreadState, but it
+ * does not hold the GIL. PyGILState_Ensure() must not be used for that case: it
+ * is only the right fallback for a thread which has no Python thread state yet.
+ * This follows CPython's GILState model and assumes FreeCAD's current
+ * single-interpreter architecture. Supporting subinterpreters would require
+ * associating the guard with an explicit PyInterpreterState.
  */
 class BaseExport PyGILStateLocker
 {
 public:
     PyGILStateLocker()
     {
+        if (PyGILState_Check()) {
+            return;
+        }
+
+        if (auto* threadState = PyGILState_GetThisThreadState()) {
+            PyEval_RestoreThread(threadState);  // NOLINT
+            mode = Mode::Restored;
+            return;
+        }
+
         gstate = PyGILState_Ensure();  // NOLINT
+        mode = Mode::Ensured;
     }
+
     ~PyGILStateLocker()
     {
-        PyGILState_Release(gstate);
+        switch (mode) {
+            case Mode::Held:
+                break;
+            case Mode::Restored:
+                PyEval_SaveThread();  // NOLINT
+                break;
+            case Mode::Ensured:
+                PyGILState_Release(gstate);
+                break;
+        }
     }
 
     PyGILStateLocker(const PyGILStateLocker&) = delete;
@@ -226,7 +252,15 @@ public:
     PyGILStateLocker& operator=(PyGILStateLocker&&) = delete;
 
 private:
-    PyGILState_STATE gstate;
+    enum class Mode
+    {
+        Held,
+        Restored,
+        Ensured,
+    };
+
+    Mode mode = Mode::Held;
+    PyGILState_STATE gstate = PyGILState_UNLOCKED;
 };
 
 /**

--- a/src/Base/NativePythonReference.cpp
+++ b/src/Base/NativePythonReference.cpp
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 FreeCAD Project                                    *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either version 2 *
+ *   of the License, or (at your option) any later version.                 *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <condition_variable>
+#include <mutex>
+#include <utility>
+
+#include "Interpreter.h"
+#include "NativePythonReference.h"
+#include "Console.h"
+
+namespace Base
+{
+namespace
+{
+
+enum class State
+{
+    Uninitialized,
+    Running,
+    Finalizing,
+};
+
+class NativePythonReferenceState
+{
+public:
+    void markRunning() noexcept
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        if (_state == State::Uninitialized) {
+            _state = State::Running;
+        }
+    }
+
+    bool acquire() noexcept
+    {
+        const char* error = nullptr;
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_state == State::Uninitialized) {
+                bool interpreterRunning = Py_IsInitialized();
+#if PY_VERSION_HEX >= 0x030d0000
+                interpreterRunning = interpreterRunning && !Py_IsFinalizing();
+#endif
+                if (interpreterRunning) {
+                    _state = State::Running;
+                }
+            }
+
+            if (_state != State::Running) {
+                error = "Native Python ownership acquired after the finalization barrier; "
+                        "the incoming reference was leaked";
+            }
+            else {
+                ++_nativeReferences;
+                return true;
+            }
+        }
+
+        Base::Console().error("%s\n", error);
+        return false;
+    }
+
+    void unregister() noexcept
+    {
+        bool violation = false;
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_nativeReferences == 0) {
+                violation = true;
+            }
+            else {
+                --_nativeReferences;
+            }
+        }
+
+        if (violation) {
+            Base::Console().error(
+                "Native Python ownership accounting underflow while transferring a reference\n"
+            );
+        }
+    }
+
+    void release(PyObject* object) noexcept
+    {
+        if (!object) {
+            return;
+        }
+
+        bool releaseReference = false;
+        bool leak = false;
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_nativeReferences == 0) {
+                leak = true;
+            }
+            else {
+                --_nativeReferences;
+            }
+
+            if (!leak && _state == State::Running) {
+#if PY_VERSION_HEX >= 0x030d0000
+                if (Py_IsFinalizing()) {
+                    leak = true;
+                }
+#endif
+                if (leak) {
+                    // The interpreter began finalization without going through
+                    // this lifecycle barrier. Do not attach to it.
+                }
+                else {
+                    // beginFinalization() cannot transition to Finalizing until
+                    // this active release completes, so acquiring the thread state outside
+                    // the mutex cannot race with interpreter finalization.
+                    ++_activeReleases;
+                    releaseReference = true;
+                }
+            }
+            else {
+                leak = true;
+            }
+        }
+
+        if (leak) {
+            Base::Console().error(
+                "Native Python reference released outside the running lifecycle; leaking one "
+                "reference\n"
+            );
+        }
+
+        if (!releaseReference) {
+            return;
+        }
+
+        {
+            PyGILStateLocker lock;
+            Py_DECREF(object);
+        }
+        finishRelease();
+    }
+
+    bool beginFinalization() noexcept
+    {
+        std::unique_lock<std::mutex> lock(_mutex);
+        if (_state != State::Running) {
+            return false;
+        }
+
+        _state = State::Finalizing;
+        const std::size_t remaining = _nativeReferences;
+        _condition.wait(lock, [this]() { return _activeReleases == 0; });
+        const bool noReferences = remaining == 0;
+        lock.unlock();
+        if (!noReferences) {
+            Base::Console().error(
+                "Cannot finalize Python: %zu native Python references remain\n",
+                remaining
+            );
+        }
+        return noReferences;
+    }
+
+private:
+    void finishRelease() noexcept
+    {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            --_activeReleases;
+        }
+        _condition.notify_all();
+    }
+
+    std::mutex _mutex;
+    std::condition_variable _condition;
+    State _state = State::Uninitialized;
+    unsigned int _activeReleases = 0;
+    std::size_t _nativeReferences = 0;
+};
+
+NativePythonReferenceState& nativePythonReferences()
+{
+    static NativePythonReferenceState state;
+    return state;
+}
+
+}  // namespace
+
+bool NativePythonReference::acquire(PyObject* object) noexcept
+{
+    return object ? nativePythonReferences().acquire() : true;
+}
+
+void NativePythonReference::releaseOwned(PyObject* object) noexcept
+{
+    nativePythonReferences().release(object);
+}
+
+void NativePythonReference::unregister(PyObject* object) noexcept
+{
+    if (object) {
+        nativePythonReferences().unregister();
+    }
+}
+
+void NativePythonReference::markInterpreterRunning() noexcept
+{
+    nativePythonReferences().markRunning();
+}
+
+bool NativePythonReference::beginInterpreterFinalization() noexcept
+{
+    return nativePythonReferences().beginFinalization();
+}
+
+NativePythonReference::NativePythonReference(PyObject* object) noexcept
+{
+    if (acquire(object)) {
+        _object = object;
+    }
+}
+
+NativePythonReference::NativePythonReference(const Py::Object& object) noexcept
+{
+    resetBorrowed(object.ptr());
+}
+
+void setNativePythonCallable(PyObject* object, const char* name, NativePythonReference& reference) noexcept
+{
+    reference.reset();
+    if (!object || !name || !PyObject_HasAttrString(object, name)) {
+        return;
+    }
+
+    PyObject* callable = PyObject_GetAttrString(object, name);
+    if (callable && PyCallable_Check(callable)) {
+        reference.reset(callable);
+    }
+    else {
+        Py_XDECREF(callable);
+    }
+}
+
+NativePythonReference::~NativePythonReference()
+{
+    reset();
+}
+
+void NativePythonReference::reset(PyObject* object) noexcept
+{
+    if (object && !acquire(object)) {
+        return;
+    }
+
+    PyObject* previous = std::exchange(_object, object);
+    releaseOwned(previous);
+}
+
+void NativePythonReference::reset(const Py::Object& object) noexcept
+{
+    resetBorrowed(object.ptr());
+}
+
+void NativePythonReference::resetBorrowed(PyObject* object) noexcept
+{
+    if (!object) {
+        reset();
+        return;
+    }
+
+    // Reserve native ownership before touching the Python reference count so
+    // the finalization barrier cannot miss this new owner.
+    if (!acquire(object)) {
+        return;
+    }
+
+    Py_INCREF(object);
+    PyObject* previous = std::exchange(_object, object);
+    releaseOwned(previous);
+}
+
+PyObject* NativePythonReference::release() noexcept
+{
+    PyObject* object = std::exchange(_object, nullptr);
+    unregister(object);
+    return object;
+}
+
+}  // namespace Base

--- a/src/Base/NativePythonReference.h
+++ b/src/Base/NativePythonReference.h
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 FreeCAD Project                                    *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either version 2 *
+ *   of the License, or (at your option) any later version.                 *
+ *                                                                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include <FCConfig.h>
+
+#include <CXX/Extensions.hxx>
+#include <utility>
+
+namespace Base
+{
+
+class InterpreterSingleton;
+
+/**
+ * RAII owner for one Python reference held by native C++ code.
+ *
+ * The constructor adopts an existing owned reference. While Python is
+ * running, destruction releases it synchronously, attaching the current
+ * thread when necessary. Native owners must be destroyed before the
+ * interpreter finalization boundary is crossed.
+ */
+class BaseExport NativePythonReference
+{
+public:
+    NativePythonReference() noexcept = default;
+    explicit NativePythonReference(PyObject* object) noexcept;
+    explicit NativePythonReference(const Py::Object& object) noexcept;
+    ~NativePythonReference();
+
+    NativePythonReference(const NativePythonReference&) = delete;
+    NativePythonReference& operator=(const NativePythonReference&) = delete;
+
+    NativePythonReference(NativePythonReference&& other) noexcept
+        : _object(std::exchange(other._object, nullptr))
+    {}
+    NativePythonReference& operator=(NativePythonReference&& other) noexcept
+    {
+        if (this != &other) {
+            PyObject* previous = std::exchange(_object, std::exchange(other._object, nullptr));
+            releaseOwned(previous);
+        }
+        return *this;
+    }
+
+    PyObject* get() const noexcept
+    {
+        return _object;
+    }
+
+    explicit operator bool() const noexcept
+    {
+        return _object != nullptr;
+    }
+
+    /** Replace the owned reference, adopting the new owned reference. */
+    void reset(PyObject* object = nullptr) noexcept;
+    /** Replace the owned reference, retaining a PyCXX object for native ownership. */
+    void reset(const Py::Object& object) noexcept;
+    /** Replace the owned reference by retaining a borrowed Python object. */
+    void resetBorrowed(PyObject* object) noexcept;
+
+    /** Release ownership without decrementing the Python reference count. */
+    PyObject* release() noexcept;
+
+private:
+    static bool acquire(PyObject* object) noexcept;
+    static void releaseOwned(PyObject* object) noexcept;
+    static void unregister(PyObject* object) noexcept;
+
+    // Interpreter lifecycle hooks. Only InterpreterSingleton may use these.
+    static void markInterpreterRunning() noexcept;
+    static bool beginInterpreterFinalization() noexcept;
+
+    friend class InterpreterSingleton;
+
+    PyObject* _object = nullptr;
+};
+
+/**
+ * Store a callable attribute in a native-owned reference.
+ *
+ * The attribute lookup is performed by the caller while Python is attached;
+ * the returned callable reference is adopted by reference.
+ */
+BaseExport void setNativePythonCallable(
+    PyObject* object,
+    const char* name,
+    NativePythonReference& reference
+) noexcept;
+
+}  // namespace Base

--- a/src/Base/ParameterPy.cpp
+++ b/src/Base/ParameterPy.cpp
@@ -60,7 +60,8 @@ public:
     {}
     ~ParameterGrpObserver() override
     {
-        Base::PyGILStateLocker lock;
+        // Destroyed from ParameterGrpPy's Python deallocator; do not reacquire
+        // the GIL here, including during Py_Finalize().
         inst = Py::None();
         callable = Py::None();
     }

--- a/src/Base/PyObjectBase.cpp
+++ b/src/Base/PyObjectBase.cpp
@@ -74,7 +74,9 @@ PyObjectBase::PyObjectBase(void* voidp, PyTypeObject *T)
 /// destructor
 PyObjectBase::~PyObjectBase()
 {
-    PyGILStateLocker lock;
+    // This destructor is reached from Python object deallocation. Python has
+    // already attached the current thread state, including during
+    // Py_Finalize(), so do not call PyGILState_Ensure() here.
 #ifdef FC_LOGPYOBJECTS
     Base::Console().log("PyO-: %s (%p)\n",Py_TYPE(this)->tp_name, this);
 #endif

--- a/src/Base/PyObjectBase.h
+++ b/src/Base/PyObjectBase.h
@@ -274,11 +274,22 @@ public:
         return ((PyObjectBase*) self)->PyInit(args, kwd);
     }
 
-    void setInvalid() {
+    /**
+     * Mark the wrapper invalid without touching any Python-owned attributes.
+     *
+     * Native destructors use this variant because they may run while Python is
+     * finalizing.  The wrapper remains allocated and its attributes are
+     * released later by Python's deallocator.
+     */
+    void setInvalidWithoutPython() noexcept {
         // first bit is not set, i.e. invalid
         StatusBits.reset(Valid);
-        clearAttributes();
         _pcTwinPointer = nullptr;
+    }
+
+    void setInvalid() {
+        setInvalidWithoutPython();
+        clearAttributes();
     }
 
     bool isValid() {

--- a/src/Base/SmartPtrPy.cpp
+++ b/src/Base/SmartPtrPy.cpp
@@ -32,38 +32,37 @@ namespace Py
 {
 void SmartPtr::set(PyObject* pyob, bool owned)
 {
-    release();
-    p = pyob;
-    if (!owned) {
-        Py::_XINCREF(p);
+    if (owned) {
+        p.reset(pyob);
+    }
+    else {
+        p.resetBorrowed(pyob);
     }
 }
 
 void SmartPtr::release()
 {
-    Base::PyGILStateLocker lock;
-    Py::_XDECREF(p);
-    p = nullptr;
+    p.reset();
 }
 
 SmartPtr::SmartPtr()
-    : p(Py::_None())
 {
-    Py::_XINCREF(p);
+    p.resetBorrowed(Py::_None());
 }
 
 SmartPtr::SmartPtr(PyObject* pyob, bool owned)
-    : p(pyob)
 {
-    if (!owned) {
-        Py::_XINCREF(p);
+    if (owned) {
+        p.reset(pyob);
+    }
+    else {
+        p.resetBorrowed(pyob);
     }
 }
 
 SmartPtr::SmartPtr(const SmartPtr& ob)
-    : p(ob.p)
 {
-    Py::_XINCREF(p);
+    p.resetBorrowed(ob.ptr());
 }
 
 SmartPtr& SmartPtr::operator=(const SmartPtr& rhs)
@@ -94,27 +93,27 @@ SmartPtr::~SmartPtr()
 
 PyObject* SmartPtr::operator*() const
 {
-    return p;
+    return p.get();
 }
 
 PyObject* SmartPtr::ptr() const
 {
-    return p;
+    return p.get();
 }
 
 bool SmartPtr::is(PyObject* pother) const
 {  // identity test
-    return p == pother;
+    return p.get() == pother;
 }
 
 bool SmartPtr::is(const SmartPtr& other) const
 {  // identity test
-    return p == other.p;
+    return p.get() == other.p.get();
 }
 
 bool SmartPtr::isNull() const
 {
-    return p == nullptr;
+    return p.get() == nullptr;
 }
 
 BaseExport PyObject* new_reference_to(const SmartPtr& ptr)

--- a/src/Base/SmartPtrPy.h
+++ b/src/Base/SmartPtrPy.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <FCGlobal.h>
+#include "NativePythonReference.h"
 
 // forward declarations
 using PyObject = struct _object;
@@ -45,7 +46,7 @@ class Object;
 class BaseExport SmartPtr  // NOLINT
 {
 private:
-    PyObject* p;
+    Base::NativePythonReference p;
 
 protected:
     void set(PyObject* pyob, bool owned = false);

--- a/src/Base/Stream.cpp
+++ b/src/Base/Stream.cpp
@@ -505,11 +505,11 @@ std::streambuf::pos_type BufferStreambuf::seekpos(pos_type pos, std::ios_base::o
 // http://www.mr-edd.co.uk/blog/beginners_guide_streambuf
 // http://www.icce.rug.nl/documents/cplusplus/cplusplus24.html
 PyStreambuf::PyStreambuf(PyObject* o, std::size_t buf_size, std::size_t put_back)
-    : inp(o)
-    , put_back(std::max(put_back, std::size_t(1)))
+    : put_back(std::max(put_back, std::size_t(1)))
     , buffer(std::max(buf_size, put_back) + put_back)
 {
-    Py_INCREF(inp);
+    Py_INCREF(o);
+    inp.reset(o);
     char* end = &buffer.front() + buffer.size();
     setg(end, end, end);
 #ifdef PYSTREAM_BUFFERED
@@ -521,7 +521,7 @@ PyStreambuf::PyStreambuf(PyObject* o, std::size_t buf_size, std::size_t put_back
 PyStreambuf::~PyStreambuf()
 {
     PyStreambuf::sync();
-    Py_DECREF(inp);
+    inp.reset();
 }
 
 PyStreambuf::int_type PyStreambuf::underflow()
@@ -542,7 +542,7 @@ PyStreambuf::int_type PyStreambuf::underflow()
     Py::Tuple arg(1);
     long len = static_cast<long>(buffer.size() - (start - base));
     arg.setItem(0, Py::Long(len));
-    Py::Callable meth(Py::Object(inp).getAttr("read"));
+    Py::Callable meth(Py::Object(inp.get()).getAttr("read"));
 
     try {
         std::string c;
@@ -621,7 +621,7 @@ bool PyStreambuf::writeStr(const char* str, std::streamsize num)
 {
     try {
         Py::Tuple arg(1);
-        Py::Callable meth(Py::Object(inp).getAttr("write"));
+        Py::Callable meth(Py::Object(inp.get()).getAttr("write"));
 
         if (type == StringIO) {
             arg.setItem(0, Py::String(str, num));
@@ -694,12 +694,12 @@ PyStreambuf::pos_type PyStreambuf::
         Py::Tuple arg(2);
         arg.setItem(0, Py::Long(static_cast<long>(offset)));
         arg.setItem(1, Py::Long(whence));
-        Py::Callable seek(Py::Object(inp).getAttr("seek"));
+        Py::Callable seek(Py::Object(inp.get()).getAttr("seek"));
         seek.apply(arg);
 
         // get current position
         Py::Tuple arg2;
-        Py::Callable tell(Py::Object(inp).getAttr("tell"));
+        Py::Callable tell(Py::Object(inp.get()).getAttr("tell"));
         Py::Long pos(tell.apply(arg2));
         long cur_pos = static_cast<long>(pos);
         return static_cast<pos_type>(cur_pos);

--- a/src/Base/Stream.h
+++ b/src/Base/Stream.h
@@ -37,6 +37,7 @@
 #include <vector>
 
 #include "FileInfo.h"
+#include "NativePythonReference.h"
 
 
 using PyObject = struct _object;
@@ -561,7 +562,7 @@ public:
     PyStreambuf& operator=(PyStreambuf&&) = delete;
 
 private:
-    PyObject* inp;
+    NativePythonReference inp;
     Type type {Unknown};
     const std::size_t put_back;
     std::vector<char> buffer;

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -78,6 +78,7 @@
 #include "Control.h"
 #include "PreferencePages/DlgSettingsCacheDirectory.h"
 #include "DocumentPy.h"
+#include "DocumentObserverPython.h"
 #include "DocumentRecovery.h"
 #include "EditableDatumLabelPy.h"
 #include "EditorView.h"
@@ -707,7 +708,7 @@ Application::Application(bool GUIenabled)
     Instance = this;
 
     // instantiate the workbench dictionary
-    _pcWorkbenchDictionary = PyDict_New();
+    _pcWorkbenchDictionary.reset(PyDict_New());
 
     if (GUIenabled) {
         createStandardOperations();
@@ -719,20 +720,33 @@ Application::Application(bool GUIenabled)
 Application::~Application()
 {
     Base::Console().log("Destruct Gui::Application\n");
+    prepareForShutdown();
+    delete d;
+    Instance = nullptr;
+}
+
+void Application::prepareForShutdown()
+{
+    if (_preparedForShutdown) {
+        return;
+    }
+    _preparedForShutdown = true;
+
+    shutdown();
+
 #ifdef USE_3DCONNEXION_NAVLIB
     if (pNavlibInterface) {
         delete pNavlibInterface;
+        pNavlibInterface = nullptr;
     }
 #endif
     WorkbenchManager::destruct();
     WorkbenchManipulator::removeAll();
+    DocumentObserverPython::clearObservers();
     SelectionSingleton::destruct();
     Translator::destruct();
     WidgetFactorySupplier::destruct();
     BitmapFactoryInst::destruct();
-
-    Base::PyGILStateLocker lock;
-    Py_DECREF(_pcWorkbenchDictionary);
 
     // save macros
     try {
@@ -742,8 +756,9 @@ Application::~Application()
         std::cerr << "Saving macros failed: " << e.what() << std::endl;
     }
 
-    delete d;
-    Instance = nullptr;
+    // This is a native-owned Python reference. It must be released while
+    // Python is still running, before the interpreter finalization boundary.
+    _pcWorkbenchDictionary.reset();
 }
 
 
@@ -1866,12 +1881,12 @@ bool Application::activateWorkbench(const char* name)
     // method, if available
     PyObject* pcOldWorkbench = nullptr;
     if (oldWb) {
-        pcOldWorkbench = PyDict_GetItemString(_pcWorkbenchDictionary, oldWb->name().c_str());
+        pcOldWorkbench = PyDict_GetItemString(_pcWorkbenchDictionary.get(), oldWb->name().c_str());
     }
 
     // get the python workbench object from the dictionary
     PyObject* pcWorkbench = nullptr;
-    pcWorkbench = PyDict_GetItemString(_pcWorkbenchDictionary, name);
+    pcWorkbench = PyDict_GetItemString(_pcWorkbenchDictionary.get(), name);
     // test if the workbench exists
     if (!pcWorkbench) {
         return false;
@@ -2008,7 +2023,7 @@ QPixmap Application::workbenchIcon(const QString& wb) const
 {
     Base::PyGILStateLocker lock;
     // get the python workbench object from the dictionary
-    PyObject* pcWorkbench = PyDict_GetItemString(_pcWorkbenchDictionary, wb.toLatin1());
+    PyObject* pcWorkbench = PyDict_GetItemString(_pcWorkbenchDictionary.get(), wb.toLatin1());
     // test if the workbench exists
     if (pcWorkbench) {
         // make a unique icon name
@@ -2085,7 +2100,7 @@ QString Application::workbenchToolTip(const QString& wb) const
 {
     // get the python workbench object from the dictionary
     Base::PyGILStateLocker lock;
-    PyObject* pcWorkbench = PyDict_GetItemString(_pcWorkbenchDictionary, wb.toLatin1());
+    PyObject* pcWorkbench = PyDict_GetItemString(_pcWorkbenchDictionary.get(), wb.toLatin1());
     // test if the workbench exists
     if (pcWorkbench) {
         // get its ToolTip member if possible
@@ -2109,7 +2124,7 @@ QString Application::workbenchMenuText(const QString& wb) const
 {
     // get the python workbench object from the dictionary
     Base::PyGILStateLocker lock;
-    PyObject* pcWorkbench = PyDict_GetItemString(_pcWorkbenchDictionary, wb.toLatin1());
+    PyObject* pcWorkbench = PyDict_GetItemString(_pcWorkbenchDictionary.get(), wb.toLatin1());
     // test if the workbench exists
     if (pcWorkbench) {
         // get its ToolTip member if possible
@@ -2160,7 +2175,7 @@ QStringList Application::workbenches() const
     Py_ssize_t pos = 0;
     QStringList wb;
     // insert all items
-    while (PyDict_Next(_pcWorkbenchDictionary, &pos, &key, &value)) {
+    while (PyDict_Next(_pcWorkbenchDictionary.get(), &pos, &key, &value)) {
         /* do something interesting with the values... */
         const char* wbName = PyUnicode_AsUTF8(key);
         // add only allowed workbenches
@@ -2195,7 +2210,7 @@ void Application::setupContextMenu(const char* recipient, MenuItem* items) const
             static_cast<PythonWorkbench*>(actWb)->clearContextMenu();
             Base::PyGILStateLocker lock;
             PyObject* pWorkbench = nullptr;
-            pWorkbench = PyDict_GetItemString(_pcWorkbenchDictionary, actWb->name().c_str());
+            pWorkbench = PyDict_GetItemString(_pcWorkbenchDictionary.get(), actWb->name().c_str());
 
             try {
                 // call its GetClassName method if possible
@@ -2661,7 +2676,7 @@ void Application::runApplication()
     mw.setProperty("QuitOnClosed", true);
 
     // Destroy deferred views while their GUI and Python owners are still alive.
-    auto shutdownGuard = qScopeGuard([&app]() { app.shutdown(); });
+    auto shutdownGuard = qScopeGuard([&app]() { app.prepareForShutdown(); });
 
     // https://forum.freecad.org/viewtopic.php?f=3&t=15540
     // Needs to be set after app is created to override platform defaults (qt commit a2aa1f81a81)
@@ -2691,6 +2706,8 @@ void Application::runApplication()
     runEventLoop(mainApp);
 
     Base::Console().log("Finish: Event loop left\n");
+    app.prepareForShutdown();
+    App::GetApplication().prepareForShutdown();
 }
 
 void Application::shutdown()

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -733,6 +733,9 @@ void Application::prepareForShutdown()
     _preparedForShutdown = true;
 
     shutdown();
+    // Python may retain _PyResource wrappers until Py_Finalize(). Release their
+    // QWidget and callback state while Qt and the GUI application are still alive.
+    PyResource::prepareForShutdown();
 
 #ifdef USE_3DCONNEXION_NAVLIB
     if (pNavlibInterface) {

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -28,6 +28,8 @@
 #include <string>
 
 #include <App/Application.h>
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 
 #include "StyleParameters/ParameterManager.h"
 
@@ -67,6 +69,10 @@ public:
     explicit Application(bool GUIenabled);
     /// destruction
     ~Application();
+
+    /// Close GUI-owned producers and native Python references before
+    /// interpreter finalization.
+    void prepareForShutdown();
 
     /// Initializes default configuration for Style Parameter Manager
     void initStyleParameterManager();
@@ -349,9 +355,10 @@ public:
 private:
     struct ApplicationP* d;
     /// workbench python dictionary
-    PyObject* _pcWorkbenchDictionary;
+    Base::NativePythonReference _pcWorkbenchDictionary;
     NavlibInterface* pNavlibInterface;
     void shutdown();
+    bool _preparedForShutdown {false};
     static void init3DMouse(MainWindow* mainWindow, QApplication* qtApp);
 
     friend class ApplicationPy;

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -1118,7 +1118,8 @@ PyObject* ApplicationPy::sActivateWorkbench(PyObject* /*self*/, PyObject* args)
     requirePythonMainThread("FreeCADGui.activateWorkbench");
 
     // search for workbench handler from the dictionary
-    PyObject* pcWorkbench = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary, psKey);
+    PyObject* pcWorkbench
+        = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary.get(), psKey);
     if (!pcWorkbench) {
         PyErr_Format(PyExc_KeyError, "No such workbench '%s'", psKey);
         return nullptr;
@@ -1200,13 +1201,17 @@ PyObject* ApplicationPy::sAddWorkbench(PyObject* /*self*/, PyObject* args)
 
         std::string item = name.as_std_string("ascii");
         PyObject* wb
-            = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary, item.c_str());
+            = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary.get(), item.c_str());
         if (wb) {
             PyErr_Format(PyExc_KeyError, "'%s' already exists.", item.c_str());
             return nullptr;
         }
 
-        PyDict_SetItemString(Application::Instance->_pcWorkbenchDictionary, item.c_str(), object.ptr());
+        PyDict_SetItemString(
+            Application::Instance->_pcWorkbenchDictionary.get(),
+            item.c_str(),
+            object.ptr()
+        );
         Application::Instance->signalRefreshWorkbenches();
     }
     catch (const Py::Exception&) {
@@ -1223,14 +1228,14 @@ PyObject* ApplicationPy::sRemoveWorkbench(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
-    PyObject* wb = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary, psKey);
+    PyObject* wb = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary.get(), psKey);
     if (!wb) {
         PyErr_Format(PyExc_KeyError, "No such workbench '%s'", psKey);
         return nullptr;
     }
 
     WorkbenchManager::instance()->removeWorkbench(psKey);
-    PyDict_DelItemString(Application::Instance->_pcWorkbenchDictionary, psKey);
+    PyDict_DelItemString(Application::Instance->_pcWorkbenchDictionary.get(), psKey);
     Application::Instance->signalRefreshWorkbenches();
 
     Py_Return;
@@ -1244,7 +1249,8 @@ PyObject* ApplicationPy::sGetWorkbench(PyObject* /*self*/, PyObject* args)
     }
 
     // get the python workbench object from the dictionary
-    PyObject* pcWorkbench = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary, psKey);
+    PyObject* pcWorkbench
+        = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary.get(), psKey);
     if (!pcWorkbench) {
         PyErr_Format(PyExc_KeyError, "No such workbench '%s'", psKey);
         return nullptr;
@@ -1260,8 +1266,8 @@ PyObject* ApplicationPy::sListWorkbenches(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
-    Py_INCREF(Application::Instance->_pcWorkbenchDictionary);
-    return Application::Instance->_pcWorkbenchDictionary;
+    Py_INCREF(Application::Instance->_pcWorkbenchDictionary.get());
+    return Application::Instance->_pcWorkbenchDictionary.get();
 }
 
 PyObject* ApplicationPy::sActiveWorkbench(PyObject* /*self*/, PyObject* args)
@@ -1279,7 +1285,7 @@ PyObject* ApplicationPy::sActiveWorkbench(PyObject* /*self*/, PyObject* args)
     // get the python workbench object from the dictionary
     std::string key = actWb->name();
     PyObject* pcWorkbench
-        = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary, key.c_str());
+        = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary.get(), key.c_str());
     if (!pcWorkbench) {
         PyErr_Format(PyExc_KeyError, "No such workbench '%s'", key.c_str());
         return nullptr;

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -1408,7 +1408,6 @@ void MacroCommand::save()
 
 PythonCommand::PythonCommand(const char* name, PyObject* pcPyCommand, const char* pActivationString)
     : Command(StringCache::New(name))
-    , _pcPyCommand(pcPyCommand)
 {
     if (pActivationString) {
         Activation = pActivationString;
@@ -1416,12 +1415,13 @@ PythonCommand::PythonCommand(const char* name, PyObject* pcPyCommand, const char
 
     sGroup = "Python";
 
-    Py_INCREF(_pcPyCommand);
+    Py_INCREF(pcPyCommand);
+    _pcPyCommand.reset(pcPyCommand);
 
     // call the method "GetResources()" of the command object
-    _pcPyResourceDict = Interpreter().runMethodObject(_pcPyCommand, "GetResources");
+    _pcPyResourceDict.reset(Interpreter().runMethodObject(_pcPyCommand.get(), "GetResources"));
     // check if the "GetResources()" method returns a Dict object
-    if (!PyDict_Check(_pcPyResourceDict)) {
+    if (!PyDict_Check(_pcPyResourceDict.get())) {
         throw Base::TypeError(
             "PythonCommand::PythonCommand(): Method GetResources() of the Python "
             "command object returns the wrong type (has to be dict)"
@@ -1457,8 +1457,7 @@ PythonCommand::PythonCommand(const char* name, PyObject* pcPyCommand, const char
 
 PythonCommand::~PythonCommand()
 {
-    Base::PyGILStateLocker lock;
-    Py_DECREF(_pcPyCommand);
+    _pcPyCommand.reset();
 }
 
 const char* PythonCommand::getResource(const char* sName) const
@@ -1467,7 +1466,7 @@ const char* PythonCommand::getResource(const char* sName) const
     PyObject* pcTemp;
 
     // get the "MenuText" resource string
-    pcTemp = PyDict_GetItemString(_pcPyResourceDict, sName);
+    pcTemp = PyDict_GetItemString(_pcPyResourceDict.get(), sName);
     if (!pcTemp) {
         return "";
     }
@@ -1485,10 +1484,10 @@ void PythonCommand::activated(int iMsg)
     if (Activation.empty()) {
         try {
             if (isCheckable()) {
-                Interpreter().runMethod(_pcPyCommand, "Activated", "", nullptr, "(i)", iMsg);
+                Interpreter().runMethod(_pcPyCommand.get(), "Activated", "", nullptr, "(i)", iMsg);
             }
             else {
-                Interpreter().runMethodVoid(_pcPyCommand, "Activated");
+                Interpreter().runMethodVoid(_pcPyCommand.get(), "Activated");
             }
         }
         catch (const Base::PyException& e) {
@@ -1508,7 +1507,7 @@ bool PythonCommand::isActive()
 {
     try {
         Base::PyGILStateLocker lock;
-        Py::Object cmd(_pcPyCommand);
+        Py::Object cmd(_pcPyCommand.get());
         if (cmd.hasAttr("IsActive")) {
             Py::Callable call(cmd.getAttr("IsActive"));
             Py::Tuple args;
@@ -1538,7 +1537,7 @@ void PythonCommand::languageChange()
 const char* PythonCommand::getHelpUrl() const
 {
     PyObject* pcTemp;
-    pcTemp = Interpreter().runMethodObject(_pcPyCommand, "CmdHelpURL");
+    pcTemp = Interpreter().runMethodObject(_pcPyCommand.get(), "CmdHelpURL");
     if (!pcTemp) {
         return "";
     }
@@ -1613,14 +1612,14 @@ const char* PythonCommand::getAccel() const
 bool PythonCommand::isCheckable() const
 {
     Base::PyGILStateLocker lock;
-    PyObject* item = PyDict_GetItemString(_pcPyResourceDict, "Checkable");
+    PyObject* item = PyDict_GetItemString(_pcPyResourceDict.get(), "Checkable");
     return item ? true : false;
 }
 
 bool PythonCommand::isChecked() const
 {
     Base::PyGILStateLocker lock;
-    PyObject* item = PyDict_GetItemString(_pcPyResourceDict, "Checkable");
+    PyObject* item = PyDict_GetItemString(_pcPyResourceDict.get(), "Checkable");
     if (!item) {
         throw Base::ValueError(
             "PythonCommand::isChecked(): Method GetResources() of the Python "
@@ -1643,7 +1642,7 @@ void PythonCommand::onActionInit()
 {
     try {
         Base::PyGILStateLocker lock;
-        Py::Object cmd(_pcPyCommand);
+        Py::Object cmd(_pcPyCommand.get());
         if (cmd.hasAttr("OnActionInit")) {
             Py::Callable call(cmd.getAttr("OnActionInit"));
             Py::Tuple args;
@@ -1664,16 +1663,16 @@ void PythonCommand::onActionInit()
 
 PythonGroupCommand::PythonGroupCommand(const char* name, PyObject* pcPyCommand)
     : Command(StringCache::New(name))
-    , _pcPyCommand(pcPyCommand)
 {
     sGroup = "Python";
 
-    Py_INCREF(_pcPyCommand);
+    Py_INCREF(pcPyCommand);
+    _pcPyCommand.reset(pcPyCommand);
 
     // call the method "GetResources()" of the command object
-    _pcPyResource = Interpreter().runMethodObject(_pcPyCommand, "GetResources");
+    _pcPyResource.reset(Interpreter().runMethodObject(_pcPyCommand.get(), "GetResources"));
     // check if the "GetResources()" method returns a Dict object
-    if (!PyDict_Check(_pcPyResource)) {
+    if (!PyDict_Check(_pcPyResource.get())) {
         throw Base::TypeError(
             "PythonGroupCommand::PythonGroupCommand(): Method GetResources() of the Python "
             "command object returns the wrong type (has to be dict)"
@@ -1706,8 +1705,7 @@ PythonGroupCommand::PythonGroupCommand(const char* name, PyObject* pcPyCommand)
 
 PythonGroupCommand::~PythonGroupCommand()
 {
-    Base::PyGILStateLocker lock;
-    Py_DECREF(_pcPyCommand);
+    _pcPyCommand.reset();
 }
 
 void PythonGroupCommand::activated(int iMsg)
@@ -1721,7 +1719,7 @@ void PythonGroupCommand::activated(int iMsg)
         setupCheckable(iMsg);
 
         Base::PyGILStateLocker lock;
-        Py::Object cmd(_pcPyCommand);
+        Py::Object cmd(_pcPyCommand.get());
         if (cmd.hasAttr("Activated")) {
             Py::Callable call(cmd.getAttr("Activated"));
             Py::Tuple args(1);
@@ -1750,7 +1748,7 @@ bool PythonGroupCommand::isActive()
 {
     try {
         Base::PyGILStateLocker lock;
-        Py::Object cmd(_pcPyCommand);
+        Py::Object cmd(_pcPyCommand.get());
 
         if (cmd.hasAttr("IsActive")) {
             Py::Callable call(cmd.getAttr("IsActive"));
@@ -1783,7 +1781,7 @@ Action* PythonGroupCommand::createAction()
 
     try {
         Base::PyGILStateLocker lock;
-        Py::Object cmd(_pcPyCommand);
+        Py::Object cmd(_pcPyCommand.get());
         Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
 
         Py::Callable call(cmd.getAttr("GetCommands"));
@@ -1931,7 +1929,7 @@ const char* PythonGroupCommand::getResource(const char* sName) const
     PyObject* pcTemp;
 
     // get the "MenuText" resource string
-    pcTemp = PyDict_GetItemString(_pcPyResource, sName);
+    pcTemp = PyDict_GetItemString(_pcPyResource.get(), sName);
     if (!pcTemp) {
         return "";
     }
@@ -1981,7 +1979,7 @@ const char* PythonGroupCommand::getAccel() const
 
 bool PythonGroupCommand::isExclusive() const
 {
-    PyObject* item = PyDict_GetItemString(_pcPyResource, "Exclusive");
+    PyObject* item = PyDict_GetItemString(_pcPyResource.get(), "Exclusive");
     if (!item) {
         return false;
     }
@@ -1999,7 +1997,7 @@ bool PythonGroupCommand::isExclusive() const
 
 bool PythonGroupCommand::hasDropDownMenu() const
 {
-    PyObject* item = PyDict_GetItemString(_pcPyResource, "DropDownMenu");
+    PyObject* item = PyDict_GetItemString(_pcPyResource.get(), "DropDownMenu");
     if (!item) {
         return true;
     }
@@ -2019,7 +2017,7 @@ void PythonGroupCommand::onActionInit()
 {
     try {
         Base::PyGILStateLocker lock;
-        Py::Object cmd(_pcPyCommand);
+        Py::Object cmd(_pcPyCommand.get());
         if (cmd.hasAttr("OnActionInit")) {
             Py::Callable call(cmd.getAttr("OnActionInit"));
             Py::Tuple args;

--- a/src/Gui/Command.h
+++ b/src/Gui/Command.h
@@ -30,6 +30,7 @@
 #include <fastsignals/signal.h>
 
 #include <Base/Type.h>
+#include <Base/NativePythonReference.h>
 #include <Gui/Application.h>
 
 /** @defgroup CommandMacros Helper macros for running commands through Python interpreter */
@@ -837,9 +838,9 @@ protected:
     /// Creates the used Action
     Action* createAction() override;
     /// a pointer to the Python command object
-    PyObject* _pcPyCommand;
+    Base::NativePythonReference _pcPyCommand;
     /// the command object resource dictionary
-    PyObject* _pcPyResourceDict;
+    Base::NativePythonReference _pcPyResourceDict;
     /// the activation sequence
     std::string Activation;
     //// set the parameters on action creation
@@ -896,9 +897,9 @@ protected:
     //// set the parameters on action creation
     void onActionInit();
     /// a pointer to the Python command object
-    PyObject* _pcPyCommand;
+    Base::NativePythonReference _pcPyCommand;
     /// the command object resources
-    PyObject* _pcPyResource;
+    Base::NativePythonReference _pcPyResource;
 
     fastsignals::connection connPyCmdInitialized;
 };

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -563,7 +563,7 @@ Document::Document(App::Document* pcDocument, Application* app)
     // NOTE: As this Python object doesn't get returned to the interpreter we
     // mustn't increment it (Werner Jan-12-2006)
     Base::PyGILStateLocker lock;
-    _pcDocPy = new Gui::DocumentPy(this);
+    _pcDocPy.reset(new Gui::DocumentPy(this));
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Document"
@@ -619,8 +619,8 @@ Document::~Document()
 
     // remove the reference from the object
     Base::PyGILStateLocker lock;
-    _pcDocPy->setInvalid();
-    _pcDocPy->DecRef();
+    static_cast<Base::PyObjectBase*>(_pcDocPy.get())->setInvalid();
+    _pcDocPy.reset();
     delete d;
 }
 
@@ -3048,8 +3048,8 @@ void Document::redo(int iSteps)
 
 PyObject* Document::getPyObject()
 {
-    _pcDocPy->IncRef();
-    return _pcDocPy;
+    Py_INCREF(_pcDocPy.get());
+    return _pcDocPy.get();
 }
 
 void Document::handleChildren3D(ViewProvider* viewProvider, bool deleting)

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -617,9 +617,9 @@ Document::~Document()
         delete va.second;
     }
 
-    // remove the reference from the object
-    Base::PyGILStateLocker lock;
-    static_cast<Base::PyObjectBase*>(_pcDocPy.get())->setInvalid();
+    // Invalidate the retained wrapper without touching Python-owned
+    // attributes from this native destructor.
+    static_cast<Base::PyObjectBase*>(_pcDocPy.get())->setInvalidWithoutPython();
     _pcDocPy.reset();
     delete d;
 }

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -29,6 +29,8 @@
 #include <QString>
 
 #include <Base/Persistence.h>
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <Gui/TreeItemMode.h>
 
 class SoNode;
@@ -350,7 +352,7 @@ public:
 
 protected:
     // pointer to the python class
-    Gui::DocumentPy* _pcDocPy;
+    Base::NativePythonReference _pcDocPy;
 
 private:
     bool trySetEdit(Gui::ViewProvider* p, int ModNum, const char* subname);

--- a/src/Gui/DocumentObserverPython.cpp
+++ b/src/Gui/DocumentObserverPython.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 
 #include "Application.h"
 #include "Document.h"
@@ -45,7 +46,7 @@ void DocumentObserverPython::removeObserver(const Py::Object& obj)
     for (std::vector<DocumentObserverPython*>::iterator it = _instances.begin();
          it != _instances.end();
          ++it) {
-        if ((*it)->inst == obj) {
+        if ((*it)->inst.get() == obj.ptr()) {
             obs = *it;
             _instances.erase(it);
             break;
@@ -56,13 +57,13 @@ void DocumentObserverPython::removeObserver(const Py::Object& obj)
 }
 
 DocumentObserverPython::DocumentObserverPython(const Py::Object& obj)
-    : inst(obj)
 {
+    inst.reset(obj);
     // NOLINTBEGIN
 #define FC_PY_ELEMENT_ARG1(_name1, _name2) \
     do { \
-        FC_PY_GetCallable(obj.ptr(), "slot" #_name1, py##_name1.py); \
-        if (!py##_name1.py.isNone()) \
+        Base::setNativePythonCallable(obj.ptr(), "slot" #_name1, py##_name1.py); \
+        if (py##_name1.py.get()) \
             py##_name1.slot = Application::Instance->signal##_name2.connect( \
                 std::bind(&DocumentObserverPython::slot##_name1, this, sp::_1) \
             ); \
@@ -70,8 +71,8 @@ DocumentObserverPython::DocumentObserverPython(const Py::Object& obj)
 
 #define FC_PY_ELEMENT_ARG2(_name1, _name2) \
     do { \
-        FC_PY_GetCallable(obj.ptr(), "slot" #_name1, py##_name1.py); \
-        if (!py##_name1.py.isNone()) \
+        Base::setNativePythonCallable(obj.ptr(), "slot" #_name1, py##_name1.py); \
+        if (py##_name1.py.get()) \
             py##_name1.slot = Application::Instance->signal##_name2.connect( \
                 std::bind(&DocumentObserverPython::slot##_name1, this, sp::_1, sp::_2) \
             ); \
@@ -93,13 +94,21 @@ DocumentObserverPython::DocumentObserverPython(const Py::Object& obj)
 
 DocumentObserverPython::~DocumentObserverPython() = default;
 
+void DocumentObserverPython::clearObservers()
+{
+    for (auto* observer : _instances) {
+        delete observer;
+    }
+    _instances.clear();
+}
+
 void DocumentObserverPython::slotCreatedDocument(const Gui::Document& Doc)
 {
     Base::PyGILStateLocker lock;
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<Gui::Document&>(Doc).getPyObject()));
-        Base::pyCall(pyCreatedDocument.ptr(), args.ptr());
+        Base::pyCall(pyCreatedDocument.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -113,7 +122,7 @@ void DocumentObserverPython::slotDeletedDocument(const Gui::Document& Doc)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<Gui::Document&>(Doc).getPyObject()));
-        Base::pyCall(pyDeletedDocument.ptr(), args.ptr());
+        Base::pyCall(pyDeletedDocument.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -127,7 +136,7 @@ void DocumentObserverPython::slotRelabelDocument(const Gui::Document& Doc)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<Gui::Document&>(Doc).getPyObject()));
-        Base::pyCall(pyRelabelDocument.ptr(), args.ptr());
+        Base::pyCall(pyRelabelDocument.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -141,7 +150,7 @@ void DocumentObserverPython::slotRenameDocument(const Gui::Document& Doc)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<Gui::Document&>(Doc).getPyObject()));
-        Base::pyCall(pyRenameDocument.ptr(), args.ptr());
+        Base::pyCall(pyRenameDocument.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -155,7 +164,7 @@ void DocumentObserverPython::slotActivateDocument(const Gui::Document& Doc)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<Gui::Document&>(Doc).getPyObject()));
-        Base::pyCall(pyActivateDocument.ptr(), args.ptr());
+        Base::pyCall(pyActivateDocument.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -169,7 +178,7 @@ void DocumentObserverPython::slotCreatedObject(const Gui::ViewProvider& Obj)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<Gui::ViewProvider&>(Obj).getPyObject()));
-        Base::pyCall(pyCreatedObject.ptr(), args.ptr());
+        Base::pyCall(pyCreatedObject.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -183,7 +192,7 @@ void DocumentObserverPython::slotDeletedObject(const Gui::ViewProvider& Obj)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<Gui::ViewProvider&>(Obj).getPyObject()));
-        Base::pyCall(pyDeletedObject.ptr(), args.ptr());
+        Base::pyCall(pyDeletedObject.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -205,7 +214,7 @@ void DocumentObserverPython::slotBeforeChangeObject(
         const char* prop_name = Obj.getPropertyName(&Prop);
         if (prop_name) {
             args.setItem(1, Py::String(prop_name));
-            Base::pyCall(pyBeforeChangeObject.ptr(), args.ptr());
+            Base::pyCall(pyBeforeChangeObject.get(), args.ptr());
         }
     }
     catch (Py::Exception&) {
@@ -225,7 +234,7 @@ void DocumentObserverPython::slotChangedObject(const Gui::ViewProvider& Obj, con
         const char* prop_name = Obj.getPropertyName(&Prop);
         if (prop_name) {
             args.setItem(1, Py::String(prop_name));
-            Base::pyCall(pyChangedObject.ptr(), args.ptr());
+            Base::pyCall(pyChangedObject.get(), args.ptr());
         }
     }
     catch (Py::Exception&) {
@@ -240,7 +249,7 @@ void DocumentObserverPython::slotInEdit(const Gui::ViewProviderDocumentObject& O
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<Gui::ViewProviderDocumentObject&>(Obj).getPyObject()));
-        Base::pyCall(pyInEdit.ptr(), args.ptr());
+        Base::pyCall(pyInEdit.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -254,7 +263,7 @@ void DocumentObserverPython::slotResetEdit(const Gui::ViewProviderDocumentObject
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(const_cast<Gui::ViewProviderDocumentObject&>(Obj).getPyObject()));
-        Base::pyCall(pyResetEdit.ptr(), args.ptr());
+        Base::pyCall(pyResetEdit.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text

--- a/src/Gui/DocumentObserverPython.h
+++ b/src/Gui/DocumentObserverPython.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <FCGlobal.h>
 #include <fastsignals/signal.h>
 #include <CXX/Objects.hxx>
@@ -57,6 +59,7 @@ public:
 
     static void addObserver(const Py::Object& obj);
     static void removeObserver(const Py::Object& obj);
+    static void clearObservers();
 
 private:
     /** Checks if a new document was created */
@@ -83,16 +86,16 @@ private:
     void slotResetEdit(const Gui::ViewProviderDocumentObject& Obj);
 
 private:
-    Py::Object inst;
+    Base::NativePythonReference inst;
     static std::vector<DocumentObserverPython*> _instances;
 
     using Connection = struct PythonObject
     {
         fastsignals::scoped_connection slot;
-        Py::Object py;
-        PyObject* ptr()
+        Base::NativePythonReference py;
+        PyObject* get()
         {
-            return py.ptr();
+            return py.get();
         }
     };
 

--- a/src/Gui/EditableDatumLabelPyImp.cpp
+++ b/src/Gui/EditableDatumLabelPyImp.cpp
@@ -326,14 +326,13 @@ int EditableDatumLabelPy::finalization()
         return 1;
     }
 
-    {
-        Base::PyGILStateLocker lock;
-        Py_XDECREF(callbackState->valueChangedCallback);
-        Py_XDECREF(callbackState->editingFinishedCallback);
-        Py_XDECREF(callbackState->editingCanceledCallback);
-        Py_XDECREF(callbackState->parameterUnsetCallback);
-        Py_XDECREF(callbackState->finishEditingCallback);
-    }
+    // Called from the generated Python deallocator; do not reacquire the GIL,
+    // including during Py_Finalize().
+    Py_XDECREF(callbackState->valueChangedCallback);
+    Py_XDECREF(callbackState->editingFinishedCallback);
+    Py_XDECREF(callbackState->editingCanceledCallback);
+    Py_XDECREF(callbackState->parameterUnsetCallback);
+    Py_XDECREF(callbackState->finishEditingCallback);
 
     delete callbackState;
     callbackState = nullptr;

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -57,7 +57,7 @@ TYPESYSTEM_SOURCE_ABSTRACT(Gui::MDIView, Gui::BaseView)
 MDIView::MDIView(Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wflags)
     : QMainWindow(parent, wflags)
     , BaseView(pcDocument)
-    , pythonObject(nullptr)
+    , pythonObject()
     , currentMode(Child)
     , wstate(Qt::WindowNoState)
     , ActiveObjects(pcDocument)
@@ -98,11 +98,7 @@ MDIView::~MDIView()
         connectDelObject.disconnect();
     }
 
-    if (pythonObject) {
-        Base::PyGILStateLocker lock;
-        Py_DECREF(pythonObject);
-        pythonObject = nullptr;
-    }
+    pythonObject.reset();
 }
 
 void MDIView::deleteSelf()
@@ -154,11 +150,11 @@ void MDIView::cloneFrom(const MDIView& from)
 PyObject* MDIView::getPyObject()
 {
     if (!pythonObject) {
-        pythonObject = new MDIViewPy(this);
+        pythonObject.reset(new MDIViewPy(this));
     }
 
-    Py_INCREF(pythonObject);
-    return pythonObject;
+    Py_INCREF(pythonObject.get());
+    return pythonObject.get();
 }
 
 void MDIView::setOverrideCursor(const QCursor& c)

--- a/src/Gui/MDIView.h
+++ b/src/Gui/MDIView.h
@@ -26,6 +26,8 @@
 #include <QMainWindow>
 #include <Gui/ActiveObjectList.h>
 #include <Gui/View.h>
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 
 
 QT_BEGIN_NAMESPACE
@@ -199,7 +201,7 @@ protected:
     void cloneFrom(const MDIView& from);
 
 protected:
-    PyObject* pythonObject;
+    Base::NativePythonReference pythonObject;
 
 private:
     ViewMode currentMode;

--- a/src/Gui/MDIViewPyWrap.cpp
+++ b/src/Gui/MDIViewPyWrap.cpp
@@ -26,6 +26,7 @@
 
 
 #include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <App/Document.h>
 
 #include "MDIViewPyWrap.h"
@@ -41,9 +42,9 @@ namespace Gui
 class MDIViewPyWrapImp
 {
 public:
-    MDIViewPyWrapImp(Py::Object pyobject)
-        : pyobject {pyobject}
+    MDIViewPyWrapImp(Py::Object object)
     {
+        pyobject.reset(object);
         Base::PyGILStateLocker lock;
         std::vector<std::string> methods = {
             "widget",
@@ -59,16 +60,15 @@ public:
         };
 
         for (const auto& it : methods) {
-            if (pyobject.hasAttr(it)) {
-                func[it] = pyobject.getAttr(it);
+            if (object.hasAttr(it)) {
+                func[it].reset(object.getAttr(it));
             }
         }
     }
 
     ~MDIViewPyWrapImp()
     {
-        Base::PyGILStateLocker lock;
-        pyobject = Py::None();
+        pyobject.reset();
         func.clear();
     }
 
@@ -80,7 +80,7 @@ public:
         if (!func.contains("widget")) {
             throw Py::AttributeError("Object has no attribute 'widget'");
         }
-        Py::Callable target(func.at("widget"));
+        Py::Callable target(function("widget"));
         Py::Object pywidget(target.apply(Py::Tuple()));
         return qobject_cast<QWidget*>(wrap.toQObject(pywidget));
     }
@@ -88,7 +88,7 @@ public:
     bool onMsg(const char* pMsg)
     {
         Base::PyGILStateLocker lock;
-        Py::Callable target(func.at("onMsg"));
+        Py::Callable target(function("onMsg"));
         Py::Boolean result(target.apply(Py::TupleN(Py::String(pMsg))));
         return static_cast<bool>(result);
     }
@@ -96,7 +96,7 @@ public:
     bool onHasMsg(const char* pMsg)
     {
         Base::PyGILStateLocker lock;
-        Py::Callable target(func.at("onHasMsg"));
+        Py::Callable target(function("onHasMsg"));
         Py::Boolean result(target.apply(Py::TupleN(Py::String(pMsg))));
         return static_cast<bool>(result);
     }
@@ -104,7 +104,7 @@ public:
     bool canClose()
     {
         Base::PyGILStateLocker lock;
-        Py::Callable target(func.at("canClose"));
+        Py::Callable target(function("canClose"));
         Py::Boolean result(target.apply(Py::Tuple()));
         return static_cast<bool>(result);
     }
@@ -115,35 +115,35 @@ public:
         PythonWrapper wrap;
         wrap.loadPrintSupportModule();
         Py::Object pyprint = wrap.fromQPrinter(printer);
-        Py::Callable target(func.at("printDocument"));
+        Py::Callable target(function("printDocument"));
         target.apply(Py::TupleN(pyprint));
     }
 
     void print()
     {
         Base::PyGILStateLocker lock;
-        Py::Callable target(func.at("print"));
+        Py::Callable target(function("print"));
         target.apply(Py::Tuple());
     }
 
     void printPdf()
     {
         Base::PyGILStateLocker lock;
-        Py::Callable target(func.at("printPdf"));
+        Py::Callable target(function("printPdf"));
         target.apply(Py::Tuple());
     }
 
     void printPreview()
     {
         Base::PyGILStateLocker lock;
-        Py::Callable target(func.at("printPreview"));
+        Py::Callable target(function("printPreview"));
         target.apply(Py::Tuple());
     }
 
     QStringList undoActions()
     {
         Base::PyGILStateLocker lock;
-        Py::Callable target(func.at("undoActions"));
+        Py::Callable target(function("undoActions"));
         Py::List list(target.apply(Py::Tuple()));
         QStringList actions;
         for (const auto& it : list) {
@@ -156,7 +156,7 @@ public:
     QStringList redoActions()
     {
         Base::PyGILStateLocker lock;
-        Py::Callable target(func.at("redoActions"));
+        Py::Callable target(function("redoActions"));
         Py::List list(target.apply(Py::Tuple()));
         QStringList actions;
         for (const auto& it : list) {
@@ -167,8 +167,13 @@ public:
     }
 
 private:
-    std::unordered_map<std::string, Py::Object> func;
-    Py::Object pyobject;
+    Py::Object function(const char* name) const
+    {
+        return Py::Object(func.at(name).get());
+    }
+
+    std::unordered_map<std::string, Base::NativePythonReference> func;
+    Base::NativePythonReference pyobject;
 };
 
 }  // namespace Gui

--- a/src/Gui/Macro.cpp
+++ b/src/Gui/Macro.cpp
@@ -30,6 +30,7 @@
 #include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 
 #include "Macro.h"
 #include "MainWindow.h"
@@ -361,7 +362,7 @@ public:
         if (out) {
             Base::PyGILStateLocker lock;
             old = PySys_GetObject(std_out);
-            PySys_SetObject(std_out, out);
+            PySys_SetObject(std_out, this->out.get());
         }
     }
     ~PythonRedirector()
@@ -369,13 +370,13 @@ public:
         if (out) {
             Base::PyGILStateLocker lock;
             PySys_SetObject(std_out, old);
-            Py_DECREF(out);
+            this->out.reset();
         }
     }
 
 private:
     const char* std_out;
-    PyObject* out;
+    Base::NativePythonReference out;
     PyObject* old {nullptr};
 };
 }  // namespace Gui

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -418,9 +418,10 @@ NavigationStyle::~NavigationStyle()
     delete this->animator;
 
     if (!pythonObject.is(nullptr)) {
-        Base::PyGILStateLocker lock;
         Base::PyObjectBase* obj = static_cast<Base::PyObjectBase*>(pythonObject.ptr());
-        obj->setInvalid();
+        // The wrapper may outlive this native style.  Do not touch its
+        // Python-owned attributes from a native destructor.
+        obj->setInvalidWithoutPython();
     }
 }
 

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -147,7 +147,6 @@ InteractiveInterpreter::InteractiveInterpreter()
 
 InteractiveInterpreter::~InteractiveInterpreter()
 {
-    Base::PyGILStateLocker lock;
     delete d;
 }
 
@@ -506,7 +505,6 @@ PythonConsole::PythonConsole(QWidget* parent)
 PythonConsole::~PythonConsole()
 {
     saveHistory();
-    Base::PyGILStateLocker lock;
     d->hGrpSettings->Detach(this);
     delete d->interpreter;
     delete d;

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -37,6 +37,7 @@
 
 #include <Base/Interpreter.h>
 #include <Base/Color.h>
+#include <Base/NativePythonReference.h>
 
 #include "PythonConsole.h"
 #include "PythonConsolePy.h"
@@ -95,7 +96,10 @@ struct PythonConsoleP
         Command
     };
     CopyType type;
-    PyObject *_stdoutPy = nullptr, *_stderrPy = nullptr, *_stdinPy = nullptr, *_stdin = nullptr;
+    Base::NativePythonReference _stdoutPy;
+    Base::NativePythonReference _stderrPy;
+    Base::NativePythonReference _stdinPy;
+    PyObject* _stdin = nullptr;
     InteractiveInterpreter* interpreter = nullptr;
     ConsoleHistory history;
     QString output, error, info, historyFile;
@@ -114,8 +118,8 @@ struct PythonConsoleP
 
 struct InteractiveInterpreterP
 {
-    PyObject* interpreter {nullptr};
-    PyObject* sysmodule {nullptr};
+    Base::NativePythonReference interpreter;
+    Base::NativePythonReference sysmodule;
     QStringList buffer;
     PythonTracing trace;
 };
@@ -133,7 +137,7 @@ InteractiveInterpreter::InteractiveInterpreter()
     PyObject* func = PyObject_GetAttrString(module, "InteractiveInterpreter");
     PyObject* args = Py_BuildValue("()");
     d = new InteractiveInterpreterP;
-    d->interpreter = PyObject_CallObject(func, args);
+    d->interpreter.reset(PyObject_CallObject(func, args));
     Py_DECREF(args);
     Py_DECREF(func);
     Py_DECREF(module);
@@ -144,8 +148,6 @@ InteractiveInterpreter::InteractiveInterpreter()
 InteractiveInterpreter::~InteractiveInterpreter()
 {
     Base::PyGILStateLocker lock;
-    Py_XDECREF(d->interpreter);
-    Py_XDECREF(d->sysmodule);
     delete d;
 }
 
@@ -156,12 +158,12 @@ void InteractiveInterpreter::setPrompt()
 {
     // import code.py and create an instance of InteractiveInterpreter
     Base::PyGILStateLocker lock;
-    d->sysmodule = PyImport_ImportModule("sys");
-    if (!PyObject_HasAttrString(d->sysmodule, "ps1")) {
-        PyObject_SetAttrString(d->sysmodule, "ps1", PyUnicode_FromString(">>> "));
+    d->sysmodule.reset(PyImport_ImportModule("sys"));
+    if (!PyObject_HasAttrString(d->sysmodule.get(), "ps1")) {
+        PyObject_SetAttrString(d->sysmodule.get(), "ps1", PyUnicode_FromString(">>> "));
     }
-    if (!PyObject_HasAttrString(d->sysmodule, "ps2")) {
-        PyObject_SetAttrString(d->sysmodule, "ps2", PyUnicode_FromString("... "));
+    if (!PyObject_HasAttrString(d->sysmodule.get(), "ps2")) {
+        PyObject_SetAttrString(d->sysmodule.get(), "ps2", PyUnicode_FromString("... "));
     }
 }
 
@@ -179,7 +181,7 @@ void InteractiveInterpreter::setPrompt()
 PyObject* InteractiveInterpreter::compile(const char* source) const
 {
     Base::PyGILStateLocker lock;
-    PyObject* func = PyObject_GetAttrString(d->interpreter, "compile");
+    PyObject* func = PyObject_GetAttrString(d->interpreter.get(), "compile");
     PyObject* args = Py_BuildValue("(s)", source);
     PyObject* eval = PyObject_CallObject(func, args);  // must decref later
 
@@ -212,7 +214,7 @@ PyObject* InteractiveInterpreter::compile(const char* source) const
 int InteractiveInterpreter::compileCommand(const char* source) const
 {
     Base::PyGILStateLocker lock;
-    PyObject* func = PyObject_GetAttrString(d->interpreter, "compile");
+    PyObject* func = PyObject_GetAttrString(d->interpreter.get(), "compile");
     PyObject* args = Py_BuildValue("(s)", source);
     PyObject* eval = PyObject_CallObject(func, args);  // must decref later
 
@@ -464,16 +466,16 @@ PythonConsole::PythonConsole(QWidget* parent)
 
     // try to override Python's stdout/err
     Base::PyGILStateLocker lock;
-    d->_stdoutPy = new PythonStdout(this);
-    d->_stderrPy = new PythonStderr(this);
-    d->_stdinPy = new PythonStdin(this);
+    d->_stdoutPy.reset(new PythonStdout(this));
+    d->_stderrPy.reset(new PythonStderr(this));
+    d->_stdinPy.reset(new PythonStdin(this));
     d->_stdin = PySys_GetObject("stdin");
 
     // Don't override stdin when running FreeCAD as Python module
     auto& cfg = App::Application::Config();
     auto overrideStdIn = cfg.find("DontOverrideStdIn");
     if (overrideStdIn == cfg.end()) {
-        PySys_SetObject("stdin", d->_stdinPy);
+        PySys_SetObject("stdin", d->_stdinPy.get());
     }
 
     const char* version = PyUnicode_AsUTF8(PySys_GetObject("version"));
@@ -506,9 +508,6 @@ PythonConsole::~PythonConsole()
     saveHistory();
     Base::PyGILStateLocker lock;
     d->hGrpSettings->Detach(this);
-    Py_XDECREF(d->_stdoutPy);
-    Py_XDECREF(d->_stderrPy);
-    Py_XDECREF(d->_stdinPy);
     delete d->interpreter;
     delete d;
 }
@@ -830,8 +829,8 @@ void PythonConsole::runSource(const QString& line)
     Base::PyGILStateLocker lock;
     PyObject* default_stdout = PySys_GetObject("stdout");
     PyObject* default_stderr = PySys_GetObject("stderr");
-    PySys_SetObject("stdout", d->_stdoutPy);
-    PySys_SetObject("stderr", d->_stderrPy);
+    PySys_SetObject("stdout", d->_stdoutPy.get());
+    PySys_SetObject("stderr", d->_stderrPy.get());
     d->interactive = true;
 
     try {

--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -31,6 +31,7 @@
 
 
 #include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <Base/Color.h>
 
 #include "ReportView.h"
@@ -378,40 +379,36 @@ public:
         if (!default_stdout) {
             Base::PyGILStateLocker lock;
             default_stdout = PySys_GetObject("stdout");
-            replace_stdout = new OutputStdout();
+            replace_stdout.reset(new OutputStdout());
             redirected_stdout = false;
         }
 
         if (!default_stderr) {
             Base::PyGILStateLocker lock;
             default_stderr = PySys_GetObject("stderr");
-            replace_stderr = new OutputStderr();
+            replace_stderr.reset(new OutputStderr());
             redirected_stderr = false;
         }
     }
     ~Data()
     {
         if (replace_stdout) {
-            Base::PyGILStateLocker lock;
-            Py_DECREF(replace_stdout);
-            replace_stdout = nullptr;
+            replace_stdout.reset();
         }
 
         if (replace_stderr) {
-            Base::PyGILStateLocker lock;
-            Py_DECREF(replace_stderr);
-            replace_stderr = nullptr;
+            replace_stderr.reset();
         }
     }
 
     // make them static because redirection should done only once
     static bool redirected_stdout;
     static PyObject* default_stdout;
-    static PyObject* replace_stdout;
+    static Base::NativePythonReference replace_stdout;
 
     static bool redirected_stderr;
     static PyObject* default_stderr;
-    static PyObject* replace_stderr;
+    static Base::NativePythonReference replace_stderr;
 #ifdef FC_DEBUG
     long logMessageSize = 0;
 #else
@@ -421,11 +418,11 @@ public:
 
 bool ReportOutput::Data::redirected_stdout = false;
 PyObject* ReportOutput::Data::default_stdout = nullptr;
-PyObject* ReportOutput::Data::replace_stdout = nullptr;
+Base::NativePythonReference ReportOutput::Data::replace_stdout;
 
 bool ReportOutput::Data::redirected_stderr = false;
 PyObject* ReportOutput::Data::default_stderr = nullptr;
-PyObject* ReportOutput::Data::replace_stderr = nullptr;
+Base::NativePythonReference ReportOutput::Data::replace_stderr;
 
 /* TRANSLATOR Gui::DockWnd::ReportOutput */
 
@@ -849,7 +846,7 @@ void ReportOutput::onToggleRedirectPythonStdout()
     else {
         d->redirected_stdout = true;
         Base::PyGILStateLocker lock;
-        PySys_SetObject("stdout", d->replace_stdout);
+        PySys_SetObject("stdout", d->replace_stdout.get());
     }
 
     getWindowParameter()->SetBool("RedirectPythonOutput", d->redirected_stdout);
@@ -865,7 +862,7 @@ void ReportOutput::onToggleRedirectPythonStderr()
     else {
         d->redirected_stderr = true;
         Base::PyGILStateLocker lock;
-        PySys_SetObject("stderr", d->replace_stderr);
+        PySys_SetObject("stderr", d->replace_stderr.get());
     }
 
     getWindowParameter()->SetBool("RedirectPythonErrors", d->redirected_stderr);

--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -2289,7 +2289,10 @@ SelectionSingleton::SelectionSingleton()
  * A destructor.
  * A more elaborate description of the destructor.
  */
-SelectionSingleton::~SelectionSingleton() = default;
+SelectionSingleton::~SelectionSingleton()
+{
+    rmvSelectionGate();
+}
 
 SelectionSingleton* SelectionSingleton::_pcSingleton = nullptr;
 
@@ -2303,6 +2306,7 @@ SelectionSingleton& SelectionSingleton::instance()
 
 void SelectionSingleton::destruct()
 {
+    SelectionObserverPython::clearObservers();
     if (_pcSingleton) {
         delete _pcSingleton;
     }

--- a/src/Gui/Selection/SelectionFilter.cpp
+++ b/src/Gui/Selection/SelectionFilter.cpp
@@ -105,8 +105,9 @@ std::unordered_set<std::string> SelectionFilterGate::getGatedTypes(
 // ----------------------------------------------------------------------------
 
 SelectionGatePython::SelectionGatePython(const Py::Object& obj)
-    : gate(obj)
-{}
+{
+    gate.reset(obj);
+}
 
 SelectionGatePython::~SelectionGatePython() = default;
 
@@ -114,8 +115,9 @@ bool SelectionGatePython::allow(App::Document* doc, App::DocumentObject* obj, co
 {
     Base::PyGILStateLocker lock;
     try {
-        if (this->gate.hasAttr(std::string("allow"))) {
-            Py::Callable method(this->gate.getAttr(std::string("allow")));
+        Py::Object gateObject(gate.get());
+        if (gateObject.hasAttr(std::string("allow"))) {
+            Py::Callable method(gateObject.getAttr(std::string("allow")));
             Py::Object pyDoc = Py::asObject(doc->getPyObject());
             Py::Object pyObj = Py::asObject(obj->getPyObject());
             Py::Object pySub = Py::None();
@@ -141,21 +143,17 @@ bool SelectionGatePython::allow(App::Document* doc, App::DocumentObject* obj, co
 // ----------------------------------------------------------------------------
 
 SelectionFilterGatePython::SelectionFilterGatePython(SelectionFilterPy* obj)
-    : filter(obj)
 {
     Base::PyGILStateLocker lock;
-    Py_INCREF(filter);
+    Py_INCREF(obj);
+    filter.reset(static_cast<PyObject*>(obj));
 }
 
-SelectionFilterGatePython::~SelectionFilterGatePython()
-{
-    Base::PyGILStateLocker lock;
-    Py_DECREF(filter);
-}
+SelectionFilterGatePython::~SelectionFilterGatePython() = default;
 
 bool SelectionFilterGatePython::allow(App::Document*, App::DocumentObject* obj, const char* sub)
 {
-    return filter->filter.test(obj, sub);
+    return SelectionFilterPy::cast(filter.get())->filter.test(obj, sub);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/Gui/Selection/SelectionFilter.h
+++ b/src/Gui/Selection/SelectionFilter.h
@@ -31,6 +31,8 @@
 #include <vector>
 
 #include <CXX/Extensions.hxx>
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include "Selection.h"
 
 namespace App
@@ -155,7 +157,7 @@ public:
     bool allow(App::Document*, App::DocumentObject*, const char*) override;
 
 private:
-    Py::Object gate;
+    Base::NativePythonReference gate;
 };
 
 /**
@@ -184,7 +186,7 @@ public:
     bool allow(App::Document*, App::DocumentObject*, const char*) override;
 
 private:
-    SelectionFilterPy* filter;
+    Base::NativePythonReference filter;
 };
 
 // === Abstract syntax tree (AST) ===========================================

--- a/src/Gui/Selection/SelectionObserverPython.cpp
+++ b/src/Gui/Selection/SelectionObserverPython.cpp
@@ -24,6 +24,7 @@
 
 #include "SelectionObserverPython.h"
 #include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 
 
 FC_LOG_LEVEL_INIT("Selection", false, true, true)
@@ -35,21 +36,8 @@ std::vector<SelectionObserverPython*> SelectionObserverPython::_instances;
 void SelectionObserverPythonHandler::init(PyObject* obj)
 {
 #undef FC_PY_ELEMENT
-#define FC_PY_ELEMENT(_name) FC_PY_GetCallable(obj, #_name, py_##_name);
+#define FC_PY_ELEMENT(_name) Base::setNativePythonCallable(obj, #_name, py_##_name);
     FC_PY_SEL_OBSERVER
-}
-
-SelectionObserverPythonHandler::~SelectionObserverPythonHandler()
-{
-#undef FC_PY_ELEMENT
-#define FC_PY_ELEMENT(_name) py_##_name = Py::None();
-
-    try {
-        FC_PY_SEL_OBSERVER
-    }
-    catch (Py::Exception& e) {
-        e.clear();
-    }
 }
 
 void SelectionObserverPythonHandler::handleSelectionChanged(const SelectionChanges& msg)
@@ -83,12 +71,12 @@ void SelectionObserverPythonHandler::handleSelectionChanged(const SelectionChang
 
 void SelectionObserverPythonHandler::pickedListChanged()
 {
-    if (py_pickedListChanged.isNone()) {
+    if (!py_pickedListChanged.get()) {
         return;
     }
     Base::PyGILStateLocker lock;
     try {
-        Py::Callable(py_pickedListChanged).apply(Py::Tuple());
+        Py::Callable(py_pickedListChanged.get()).apply(Py::Tuple());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -98,7 +86,7 @@ void SelectionObserverPythonHandler::pickedListChanged()
 
 void SelectionObserverPythonHandler::addSelection(const SelectionChanges& msg)
 {
-    if (py_addSelection.isNone()) {
+    if (!py_addSelection.get()) {
         return;
     }
     Base::PyGILStateLocker lock;
@@ -112,7 +100,7 @@ void SelectionObserverPythonHandler::addSelection(const SelectionChanges& msg)
         tuple[1] = Py::Float(msg.y);
         tuple[2] = Py::Float(msg.z);
         args.setItem(3, tuple);
-        Base::pyCall(py_addSelection.ptr(), args.ptr());
+        Base::pyCall(py_addSelection.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -122,7 +110,7 @@ void SelectionObserverPythonHandler::addSelection(const SelectionChanges& msg)
 
 void SelectionObserverPythonHandler::removeSelection(const SelectionChanges& msg)
 {
-    if (py_removeSelection.isNone()) {
+    if (!py_removeSelection.get()) {
         return;
     }
     Base::PyGILStateLocker lock;
@@ -131,7 +119,7 @@ void SelectionObserverPythonHandler::removeSelection(const SelectionChanges& msg
         args.setItem(0, Py::String(msg.pDocName ? msg.pDocName : ""));
         args.setItem(1, Py::String(msg.pObjectName ? msg.pObjectName : ""));
         args.setItem(2, Py::String(msg.pSubName ? msg.pSubName : ""));
-        Base::pyCall(py_removeSelection.ptr(), args.ptr());
+        Base::pyCall(py_removeSelection.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -141,14 +129,14 @@ void SelectionObserverPythonHandler::removeSelection(const SelectionChanges& msg
 
 void SelectionObserverPythonHandler::setSelection(const SelectionChanges& msg)
 {
-    if (py_setSelection.isNone()) {
+    if (!py_setSelection.get()) {
         return;
     }
     Base::PyGILStateLocker lock;
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::String(msg.pDocName ? msg.pDocName : ""));
-        Base::pyCall(py_setSelection.ptr(), args.ptr());
+        Base::pyCall(py_setSelection.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -158,14 +146,14 @@ void SelectionObserverPythonHandler::setSelection(const SelectionChanges& msg)
 
 void SelectionObserverPythonHandler::clearSelection(const SelectionChanges& msg)
 {
-    if (py_clearSelection.isNone()) {
+    if (!py_clearSelection.get()) {
         return;
     }
     Base::PyGILStateLocker lock;
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::String(msg.pDocName ? msg.pDocName : ""));
-        Base::pyCall(py_clearSelection.ptr(), args.ptr());
+        Base::pyCall(py_clearSelection.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -175,7 +163,7 @@ void SelectionObserverPythonHandler::clearSelection(const SelectionChanges& msg)
 
 void SelectionObserverPythonHandler::setPreselection(const SelectionChanges& msg)
 {
-    if (py_setPreselection.isNone()) {
+    if (!py_setPreselection.get()) {
         return;
     }
     Base::PyGILStateLocker lock;
@@ -184,7 +172,7 @@ void SelectionObserverPythonHandler::setPreselection(const SelectionChanges& msg
         args.setItem(0, Py::String(msg.pDocName ? msg.pDocName : ""));
         args.setItem(1, Py::String(msg.pObjectName ? msg.pObjectName : ""));
         args.setItem(2, Py::String(msg.pSubName ? msg.pSubName : ""));
-        Base::pyCall(py_setPreselection.ptr(), args.ptr());
+        Base::pyCall(py_setPreselection.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -194,7 +182,7 @@ void SelectionObserverPythonHandler::setPreselection(const SelectionChanges& msg
 
 void SelectionObserverPythonHandler::removePreselection(const SelectionChanges& msg)
 {
-    if (py_removePreselection.isNone()) {
+    if (!py_removePreselection.get()) {
         return;
     }
     Base::PyGILStateLocker lock;
@@ -203,7 +191,7 @@ void SelectionObserverPythonHandler::removePreselection(const SelectionChanges& 
         args.setItem(0, Py::String(msg.pDocName ? msg.pDocName : ""));
         args.setItem(1, Py::String(msg.pObjectName ? msg.pObjectName : ""));
         args.setItem(2, Py::String(msg.pSubName ? msg.pSubName : ""));
-        Base::pyCall(py_removePreselection.ptr(), args.ptr());
+        Base::pyCall(py_removePreselection.get(), args.ptr());
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
@@ -214,8 +202,8 @@ void SelectionObserverPythonHandler::removePreselection(const SelectionChanges& 
 
 SelectionObserverPython::SelectionObserverPython(const Py::Object& obj, ResolveMode resolve)
     : SelectionObserver(true, resolve)
-    , inst(obj)
 {
+    inst.reset(obj);
     this->init(obj.ptr());
 }
 
@@ -230,7 +218,7 @@ void SelectionObserverPython::removeObserver(const Py::Object& obj)
 {
     SelectionObserverPython* obs = nullptr;
     for (auto it = _instances.begin(); it != _instances.end(); ++it) {
-        if ((*it)->inst == obj) {
+        if ((*it)->inst.get() == obj.ptr()) {
             obs = *it;
             _instances.erase(it);
             break;
@@ -238,6 +226,14 @@ void SelectionObserverPython::removeObserver(const Py::Object& obj)
     }
 
     delete obs;
+}
+
+void SelectionObserverPython::clearObservers()
+{
+    for (auto* observer : _instances) {
+        delete observer;
+    }
+    _instances.clear();
 }
 
 void SelectionObserverPython::onSelectionChanged(const SelectionChanges& msg)

--- a/src/Gui/Selection/SelectionObserverPython.h
+++ b/src/Gui/Selection/SelectionObserverPython.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <CXX/Objects.hxx>
 #include "Selection.h"
 
@@ -36,7 +38,7 @@ class GuiExport SelectionObserverPythonHandler
 public:
     /// Constructor
     explicit SelectionObserverPythonHandler() = default;
-    virtual ~SelectionObserverPythonHandler();
+    virtual ~SelectionObserverPythonHandler() = default;
 
     void init(PyObject* obj);
     void handleSelectionChanged(const SelectionChanges& msg);
@@ -62,7 +64,7 @@ private:
     FC_PY_ELEMENT(pickedListChanged)
 
 #undef FC_PY_ELEMENT
-#define FC_PY_ELEMENT(_name) Py::Object py_##_name;
+#define FC_PY_ELEMENT(_name) Base::NativePythonReference py_##_name;
 
     FC_PY_SEL_OBSERVER
 };
@@ -88,11 +90,12 @@ public:
 
     static void addObserver(const Py::Object& obj, ResolveMode resolve = ResolveMode::OldStyleElement);
     static void removeObserver(const Py::Object& obj);
+    static void clearObservers();
 
 private:
     void onSelectionChanged(const SelectionChanges& msg) override;
 
-    Py::Object inst;
+    Base::NativePythonReference inst;
     static std::vector<SelectionObserverPython*> _instances;
 };
 

--- a/src/Gui/SplitView3DInventor.cpp
+++ b/src/Gui/SplitView3DInventor.cpp
@@ -49,7 +49,7 @@ TYPESYSTEM_SOURCE_ABSTRACT(Gui::AbstractSplitView, Gui::MDIView)
 AbstractSplitView::AbstractSplitView(Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wflags)
     : MDIView(pcDocument, parent, wflags)
 {
-    _viewerPy = nullptr;
+    _viewerPy.reset();
     // important for highlighting
     setMouseTracking(true);
 }
@@ -60,10 +60,7 @@ AbstractSplitView::~AbstractSplitView()
          ++it) {
         delete *it;
     }
-    if (_viewerPy) {
-        Base::PyGILStateLocker lock;
-        Py_DECREF(_viewerPy);
-    }
+    _viewerPy.reset();
 }
 
 void AbstractSplitView::deleteSelf()
@@ -274,10 +271,10 @@ void AbstractSplitView::setOverrideCursor(const QCursor& aCursor)
 PyObject* AbstractSplitView::getPyObject()
 {
     if (!_viewerPy) {
-        _viewerPy = new AbstractSplitViewPy(this);
+        _viewerPy.reset(new AbstractSplitViewPy(this));
     }
-    Py_INCREF(_viewerPy);
-    return _viewerPy;
+    Py_INCREF(_viewerPy.get());
+    return _viewerPy.get();
 }
 
 void AbstractSplitView::setPyObject(PyObject*)

--- a/src/Gui/SplitView3DInventor.h
+++ b/src/Gui/SplitView3DInventor.h
@@ -26,6 +26,8 @@
 #include "MDIViewPy.h"
 
 #include <Base/Parameter.h>
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <vector>
 
 
@@ -75,7 +77,7 @@ protected:
 
 protected:
     std::vector<View3DInventorViewer*> _viewer;
-    PyObject* _viewerPy;
+    Base::NativePythonReference _viewerPy;
     std::unique_ptr<View3DSettings> viewSettings;
 };
 

--- a/src/Gui/TaskView/TaskDialogPython.cpp
+++ b/src/Gui/TaskView/TaskDialogPython.cpp
@@ -308,26 +308,26 @@ Py::Object ControlPy::showModelView(const Py::Tuple& args)
 
 TaskWatcherPython::TaskWatcherPython(const Py::Object& o)
     : TaskWatcher(nullptr)
-    , watcher(o)
 {
+    watcher.reset(o);
     QString title;
-    if (watcher.hasAttr(std::string("title"))) {
-        Py::String name(watcher.getAttr(std::string("title")));
+    if (pythonObject().hasAttr(std::string("title"))) {
+        Py::String name(pythonObject().getAttr(std::string("title")));
         std::string s = static_cast<std::string>(name);
         title = QString::fromUtf8(s.c_str());
     }
 
     QPixmap icon;
-    if (watcher.hasAttr(std::string("icon"))) {
-        Py::String name(watcher.getAttr(std::string("icon")));
+    if (pythonObject().hasAttr(std::string("icon"))) {
+        Py::String name(pythonObject().getAttr(std::string("icon")));
         std::string s = static_cast<std::string>(name);
         icon = BitmapFactory().pixmap(s.c_str());
     }
 
     Gui::TaskView::TaskBox* tb = nullptr;
-    if (watcher.hasAttr(std::string("commands"))) {
+    if (pythonObject().hasAttr(std::string("commands"))) {
         tb = new Gui::TaskView::TaskBox(icon, title, true, nullptr);
-        Py::Sequence cmds(watcher.getAttr(std::string("commands")));
+        Py::Sequence cmds(pythonObject().getAttr(std::string("commands")));
         CommandManager& mgr = Gui::Application::Instance->commandManager();
         for (Py::Sequence::iterator it = cmds.begin(); it != cmds.end(); ++it) {
             Py::String name(*it);
@@ -339,11 +339,11 @@ TaskWatcherPython::TaskWatcherPython(const Py::Object& o)
         }
     }
 
-    if (watcher.hasAttr(std::string("widgets"))) {
+    if (pythonObject().hasAttr(std::string("widgets"))) {
         if (!tb && !title.isEmpty()) {
             tb = new Gui::TaskView::TaskBox(icon, title, true, nullptr);
         }
-        Py::Sequence list(watcher.getAttr(std::string("widgets")));
+        Py::Sequence list(pythonObject().getAttr(std::string("widgets")));
 
         Gui::PythonWrapper wrap;
         if (wrap.loadCoreModule()) {
@@ -368,8 +368,8 @@ TaskWatcherPython::TaskWatcherPython(const Py::Object& o)
         Content.push_back(tb);
     }
 
-    if (watcher.hasAttr(std::string("filter"))) {
-        Py::String name(watcher.getAttr(std::string("filter")));
+    if (pythonObject().hasAttr(std::string("filter"))) {
+        Py::String name(pythonObject().getAttr(std::string("filter")));
         std::string s = static_cast<std::string>(name);
         this->setFilter(s.c_str());
     }
@@ -380,8 +380,6 @@ TaskWatcherPython::~TaskWatcherPython()
     std::vector<QPointer<QWidget>> guarded;
     guarded.insert(guarded.begin(), Content.begin(), Content.end());
     Content.clear();
-    Base::PyGILStateLocker lock;
-    this->watcher = Py::None();
     Content.insert(Content.begin(), guarded.begin(), guarded.end());
 }
 
@@ -389,8 +387,8 @@ bool TaskWatcherPython::shouldShow()
 {
     Base::PyGILStateLocker lock;
     try {
-        if (watcher.hasAttr(std::string("shouldShow"))) {
-            Py::Callable method(watcher.getAttr(std::string("shouldShow")));
+        if (pythonObject().hasAttr(std::string("shouldShow"))) {
+            Py::Callable method(pythonObject().getAttr(std::string("shouldShow")));
             Py::Tuple args;
             Py::Boolean ret(method.apply(args));
             return (bool)ret;
@@ -742,10 +740,10 @@ TaskDialogPython::~TaskDialogPython()
 
 bool TaskDialogPython::tryLoadUiFile()
 {
-    if (dlg.hasAttr(std::string("ui"))) {
+    if (dialogObject().hasAttr(std::string("ui"))) {
         auto loader = UiLoader::newInstance();
         QString fn, icon;
-        Py::String ui(dlg.getAttr(std::string("ui")));
+        Py::String ui(dialogObject().getAttr(std::string("ui")));
         std::string path = static_cast<std::string>(ui);
         fn = QString::fromUtf8(path.c_str());
 
@@ -770,8 +768,8 @@ bool TaskDialogPython::tryLoadUiFile()
 
 bool TaskDialogPython::tryLoadForm()
 {
-    if (dlg.hasAttr(std::string("form"))) {
-        Py::Object f(dlg.getAttr(std::string("form")));
+    if (dialogObject().hasAttr(std::string("form"))) {
+        Py::Object f(dialogObject().getAttr(std::string("form")));
         Py::List widgets;
         if (f.isList()) {
             widgets = f;
@@ -814,10 +812,11 @@ void TaskDialogPython::clearForm()
         // The widgets stored in the 'form' attribute will be deleted.
         // Thus, set this attribute to None to make sure that when using
         // the same dialog instance for a task panel won't segfault.
-        if (this->dlg.hasAttr(std::string("form"))) {
-            this->dlg.setAttr(std::string("form"), Py::None());
+        auto dialog = dialogObject();
+        if (dialog.hasAttr(std::string("form"))) {
+            dialog.setAttr(std::string("form"), Py::None());
         }
-        this->dlg = Py::None();
+        dlg.reset();
     }
     catch (Py::AttributeError& e) {
         e.clear();
@@ -828,8 +827,8 @@ void TaskDialogPython::open()
 {
     Base::PyGILStateLocker lock;
     try {
-        if (dlg.hasAttr(std::string("open"))) {
-            Py::Callable method(dlg.getAttr(std::string("open")));
+        if (dialogObject().hasAttr(std::string("open"))) {
+            Py::Callable method(dialogObject().getAttr(std::string("open")));
             Py::Tuple args;
             method.apply(args);
         }
@@ -844,8 +843,8 @@ void TaskDialogPython::clicked(int i)
 {
     Base::PyGILStateLocker lock;
     try {
-        if (dlg.hasAttr(std::string("clicked"))) {
-            Py::Callable method(dlg.getAttr(std::string("clicked")));
+        if (dialogObject().hasAttr(std::string("clicked"))) {
+            Py::Callable method(dialogObject().getAttr(std::string("clicked")));
             PythonWrapper wrap;
             Py::Tuple args(1);
             args.setItem(0, wrap.toStandardButton(i));
@@ -862,8 +861,8 @@ bool TaskDialogPython::accept()
 {
     Base::PyGILStateLocker lock;
     try {
-        if (dlg.hasAttr(std::string("accept"))) {
-            Py::Callable method(dlg.getAttr(std::string("accept")));
+        if (dialogObject().hasAttr(std::string("accept"))) {
+            Py::Callable method(dialogObject().getAttr(std::string("accept")));
             Py::Tuple args;
             Py::Boolean ret(method.apply(args));
             return (bool)ret;
@@ -881,8 +880,8 @@ bool TaskDialogPython::reject()
 {
     Base::PyGILStateLocker lock;
     try {
-        if (dlg.hasAttr(std::string("reject"))) {
-            Py::Callable method(dlg.getAttr(std::string("reject")));
+        if (dialogObject().hasAttr(std::string("reject"))) {
+            Py::Callable method(dialogObject().getAttr(std::string("reject")));
             Py::Tuple args;
             Py::Boolean ret(method.apply(args));
             return (bool)ret;
@@ -900,8 +899,8 @@ void TaskDialogPython::helpRequested()
 {
     Base::PyGILStateLocker lock;
     try {
-        if (dlg.hasAttr(std::string("helpRequested"))) {
-            Py::Callable method(dlg.getAttr(std::string("helpRequested")));
+        if (dialogObject().hasAttr(std::string("helpRequested"))) {
+            Py::Callable method(dialogObject().getAttr(std::string("helpRequested")));
             Py::Tuple args;
             method.apply(args);
         }
@@ -917,8 +916,8 @@ bool TaskDialogPython::eventFilter(QObject* watched, QEvent* event)
     if (event->type() == QEvent::LanguageChange) {
         Base::PyGILStateLocker lock;
         try {
-            if (dlg.hasAttr(std::string("changeEvent"))) {
-                Py::Callable method(dlg.getAttr(std::string("changeEvent")));
+            if (dialogObject().hasAttr(std::string("changeEvent"))) {
+                Py::Callable method(dialogObject().getAttr(std::string("changeEvent")));
                 Py::Tuple args {1};
                 args.setItem(0, Py::Long(static_cast<int>(event->type())));
                 method.apply(args);
@@ -937,8 +936,8 @@ QDialogButtonBox::StandardButtons TaskDialogPython::getStandardButtons() const
 {
     Base::PyGILStateLocker lock;
     try {
-        if (dlg.hasAttr(std::string("getStandardButtons"))) {
-            Py::Callable method(dlg.getAttr(std::string("getStandardButtons")));
+        if (dialogObject().hasAttr(std::string("getStandardButtons"))) {
+            Py::Callable method(dialogObject().getAttr(std::string("getStandardButtons")));
             Py::Tuple args;
             Gui::PythonWrapper wrap;
             wrap.loadWidgetsModule();
@@ -958,11 +957,11 @@ void TaskDialogPython::modifyStandardButtons(QDialogButtonBox* buttonBox)
 {
     Base::PyGILStateLocker lock;
     try {
-        if (dlg.hasAttr(std::string("modifyStandardButtons"))) {
+        if (dialogObject().hasAttr(std::string("modifyStandardButtons"))) {
             Gui::PythonWrapper wrap;
             wrap.loadGuiModule();
             wrap.loadWidgetsModule();
-            Py::Callable method(dlg.getAttr(std::string("modifyStandardButtons")));
+            Py::Callable method(dialogObject().getAttr(std::string("modifyStandardButtons")));
             Py::Tuple args(1);
             args.setItem(0, wrap.fromQWidget(buttonBox, "QDialogButtonBox"));
             method.apply(args);
@@ -978,8 +977,8 @@ bool TaskDialogPython::isAllowedAlterDocument() const
 {
     Base::PyGILStateLocker lock;
     try {
-        if (dlg.hasAttr(std::string("isAllowedAlterDocument"))) {
-            Py::Callable method(dlg.getAttr(std::string("isAllowedAlterDocument")));
+        if (dialogObject().hasAttr(std::string("isAllowedAlterDocument"))) {
+            Py::Callable method(dialogObject().getAttr(std::string("isAllowedAlterDocument")));
             Py::Tuple args;
             Py::Boolean ret(method.apply(args));
             return (bool)ret;
@@ -997,8 +996,8 @@ bool TaskDialogPython::isAllowedAlterView() const
 {
     Base::PyGILStateLocker lock;
     try {
-        if (dlg.hasAttr(std::string("isAllowedAlterView"))) {
-            Py::Callable method(dlg.getAttr(std::string("isAllowedAlterView")));
+        if (dialogObject().hasAttr(std::string("isAllowedAlterView"))) {
+            Py::Callable method(dialogObject().getAttr(std::string("isAllowedAlterView")));
             Py::Tuple args;
             Py::Boolean ret(method.apply(args));
             return (bool)ret;
@@ -1016,8 +1015,8 @@ bool TaskDialogPython::isAllowedAlterSelection() const
 {
     Base::PyGILStateLocker lock;
     try {
-        if (dlg.hasAttr(std::string("isAllowedAlterSelection"))) {
-            Py::Callable method(dlg.getAttr(std::string("isAllowedAlterSelection")));
+        if (dialogObject().hasAttr(std::string("isAllowedAlterSelection"))) {
+            Py::Callable method(dialogObject().getAttr(std::string("isAllowedAlterSelection")));
             Py::Tuple args;
             Py::Boolean ret(method.apply(args));
             return (bool)ret;
@@ -1035,8 +1034,8 @@ bool TaskDialogPython::needsFullSpace() const
 {
     Base::PyGILStateLocker lock;
     try {
-        if (dlg.hasAttr(std::string("needsFullSpace"))) {
-            Py::Callable method(dlg.getAttr(std::string("needsFullSpace")));
+        if (dialogObject().hasAttr(std::string("needsFullSpace"))) {
+            Py::Callable method(dialogObject().getAttr(std::string("needsFullSpace")));
             Py::Tuple args;
             Py::Boolean ret(method.apply(args));
             return (bool)ret;
@@ -1054,8 +1053,8 @@ void TaskDialogPython::autoClosedOnTransactionChange()
 {
     Base::PyGILStateLocker lock;
     try {
-        if (dlg.hasAttr(std::string("autoClosedOnTransactionChange"))) {
-            Py::Callable method(dlg.getAttr(std::string("autoClosedOnTransactionChange")));
+        if (dialogObject().hasAttr(std::string("autoClosedOnTransactionChange"))) {
+            Py::Callable method(dialogObject().getAttr(std::string("autoClosedOnTransactionChange")));
             Py::Tuple args;
             method.apply(args);
         }
@@ -1070,8 +1069,8 @@ void TaskDialogPython::autoClosedOnResetEdit()
 {
     Base::PyGILStateLocker lock;
     try {
-        if (dlg.hasAttr(std::string("autoClosedOnResetEdit"))) {
-            Py::Callable method(dlg.getAttr(std::string("autoClosedOnResetEdit")));
+        if (dialogObject().hasAttr(std::string("autoClosedOnResetEdit"))) {
+            Py::Callable method(dialogObject().getAttr(std::string("autoClosedOnResetEdit")));
             Py::Tuple args;
             method.apply(args);
         }
@@ -1086,8 +1085,8 @@ void TaskDialogPython::autoClosedOnDeletedDocument()
 {
     Base::PyGILStateLocker lock;
     try {
-        if (dlg.hasAttr(std::string("autoClosedOnDeletedDocument"))) {
-            Py::Callable method(dlg.getAttr(std::string("autoClosedOnDeletedDocument")));
+        if (dialogObject().hasAttr(std::string("autoClosedOnDeletedDocument"))) {
+            Py::Callable method(dialogObject().getAttr(std::string("autoClosedOnDeletedDocument")));
             Py::Tuple args;
             method.apply(args);
         }

--- a/src/Gui/TaskView/TaskDialogPython.cpp
+++ b/src/Gui/TaskView/TaskDialogPython.cpp
@@ -729,13 +729,14 @@ TaskDialogPython::~TaskDialogPython()
     guarded.insert(guarded.begin(), Content.begin(), Content.end());
     Content.clear();
 
-    Base::PyGILStateLocker lock;
-    clearForm();
-
-    // Assigning None to 'dlg' may destroy some of the stored widgets.
-    // By guarding them with QPointer their pointers will be set to null
-    // so that the destructor of the base class can reliably call 'delete'.
+    // The Python dialog reference is released by NativePythonReference after
+    // this destructor returns. Do not access Python from this native destructor.
     Content.insert(Content.begin(), guarded.begin(), guarded.end());
+}
+
+void TaskDialogPython::closed()
+{
+    clearForm();
 }
 
 bool TaskDialogPython::tryLoadUiFile()

--- a/src/Gui/TaskView/TaskDialogPython.h
+++ b/src/Gui/TaskView/TaskDialogPython.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include "TaskDialog.h"
 #include "TaskWatcher.h"
 
@@ -67,7 +69,12 @@ public:
     bool shouldShow() override;
 
 private:
-    Py::Object watcher;
+    Py::Object pythonObject() const
+    {
+        return Py::Object(watcher.get());
+    }
+
+    Base::NativePythonReference watcher;
 };
 
 /**
@@ -191,9 +198,13 @@ private:
     bool tryLoadForm();
     void appendForm(QWidget* widget, const QPixmap& icon);
     void clearForm();
+    Py::Object dialogObject() const
+    {
+        return Py::Object(dlg.get());
+    }
 
 private:
-    Py::Object dlg;
+    Base::NativePythonReference dlg;
 };
 
 }  // namespace TaskView

--- a/src/Gui/TaskView/TaskDialogPython.h
+++ b/src/Gui/TaskView/TaskDialogPython.h
@@ -181,6 +181,8 @@ public:
 public:
     /// is called by the framework when the dialog is opened
     void open() override;
+    /// is called by the framework before the dialog is destroyed
+    void closed() override;
     /// is called by the framework if a button is clicked which has no accept or reject role
     void clicked(int) override;
     /// is called by the framework if the dialog is accepted (Ok)

--- a/src/Gui/UiLoader.cpp
+++ b/src/Gui/UiLoader.cpp
@@ -220,21 +220,18 @@ QUiLoader::QUiLoader(QObject* parent)
         Py::Tuple args(1);
         args[0] = wrap.fromQObject(parent);
         Py::Module mod(module, true);
-        uiloader = mod.callMemberFunction("QUiLoader", args);
+        Py::Object loader = mod.callMemberFunction("QUiLoader", args);
+        uiloader.reset(loader);
     }
 }
 
-QUiLoader::~QUiLoader()
-{
-    Base::PyGILStateLocker lock;
-    uiloader = Py::None();
-}
+QUiLoader::~QUiLoader() = default;
 
 QStringList QUiLoader::pluginPaths() const
 {
     Base::PyGILStateLocker lock;
     try {
-        Py::List list(uiloader.callMemberFunction("pluginPaths"));
+        Py::List list(pythonUiLoader().callMemberFunction("pluginPaths"));
         QStringList paths;
         for (const auto& it : list) {
             paths << QString::fromStdString(Py::String(it).as_std_string());
@@ -251,7 +248,7 @@ void QUiLoader::clearPluginPaths()
 {
     Base::PyGILStateLocker lock;
     try {
-        uiloader.callMemberFunction("clearPluginPaths");
+        pythonUiLoader().callMemberFunction("clearPluginPaths");
     }
     catch (Py::Exception& e) {
         e.clear();
@@ -264,7 +261,7 @@ void QUiLoader::addPluginPath(const QString& path)
     try {
         Py::Tuple args(1);
         args[0] = Py::String(path.toStdString());
-        uiloader.callMemberFunction("addPluginPath", args);
+        pythonUiLoader().callMemberFunction("addPluginPath", args);
     }
     catch (Py::Exception& e) {
         e.clear();
@@ -279,7 +276,7 @@ QWidget* QUiLoader::load(QIODevice* device, QWidget* parentWidget)
         Py::Tuple args(2);
         args[0] = wrap.fromQObject(device);
         args[1] = wrap.fromQObject(parentWidget);
-        Py::Object form(uiloader.callMemberFunction("load", args));
+        Py::Object form(pythonUiLoader().callMemberFunction("load", args));
         return qobject_cast<QWidget*>(wrap.toQObject(form));
     }
     catch (Py::Exception& e) {
@@ -292,7 +289,7 @@ QStringList QUiLoader::availableWidgets() const
 {
     Base::PyGILStateLocker lock;
     try {
-        Py::List list(uiloader.callMemberFunction("availableWidgets"));
+        Py::List list(pythonUiLoader().callMemberFunction("availableWidgets"));
         QStringList widgets;
         for (const auto& it : list) {
             widgets << QString::fromStdString(Py::String(it).as_std_string());
@@ -309,7 +306,7 @@ QStringList QUiLoader::availableLayouts() const
 {
     Base::PyGILStateLocker lock;
     try {
-        Py::List list(uiloader.callMemberFunction("availableLayouts"));
+        Py::List list(pythonUiLoader().callMemberFunction("availableLayouts"));
         QStringList layouts;
         for (const auto& it : list) {
             layouts << QString::fromStdString(Py::String(it).as_std_string());
@@ -331,7 +328,7 @@ QWidget* QUiLoader::createWidget(const QString& className, QWidget* parent, cons
         args[0] = Py::String(className.toStdString());
         args[1] = wrap.fromQObject(parent);
         args[2] = Py::String(name.toStdString());
-        Py::Object form(uiloader.callMemberFunction("createWidget", args));
+        Py::Object form(pythonUiLoader().callMemberFunction("createWidget", args));
         return qobject_cast<QWidget*>(wrap.toQObject(form));
     }
     catch (Py::Exception& e) {
@@ -349,7 +346,7 @@ QLayout* QUiLoader::createLayout(const QString& className, QObject* parent, cons
         args[0] = Py::String(className.toStdString());
         args[1] = wrap.fromQObject(parent);
         args[2] = Py::String(name.toStdString());
-        Py::Object form(uiloader.callMemberFunction("createLayout", args));
+        Py::Object form(pythonUiLoader().callMemberFunction("createLayout", args));
         return qobject_cast<QLayout*>(wrap.toQObject(form));
     }
     catch (Py::Exception& e) {
@@ -366,7 +363,7 @@ QActionGroup* QUiLoader::createActionGroup(QObject* parent, const QString& name)
         Py::Tuple args(2);
         args[0] = wrap.fromQObject(parent);
         args[1] = Py::String(name.toStdString());
-        Py::Object action(uiloader.callMemberFunction("createActionGroup", args));
+        Py::Object action(pythonUiLoader().callMemberFunction("createActionGroup", args));
         return qobject_cast<QActionGroup*>(wrap.toQObject(action));
     }
     catch (Py::Exception& e) {
@@ -383,7 +380,7 @@ QAction* QUiLoader::createAction(QObject* parent, const QString& name)
         Py::Tuple args(2);
         args[0] = wrap.fromQObject(parent);
         args[1] = Py::String(name.toStdString());
-        Py::Object action(uiloader.callMemberFunction("createAction", args));
+        Py::Object action(pythonUiLoader().callMemberFunction("createAction", args));
         return qobject_cast<QAction*>(wrap.toQObject(action));
     }
     catch (Py::Exception& e) {
@@ -399,7 +396,7 @@ void QUiLoader::setWorkingDirectory(const QDir& dir)
         PythonWrapper wrap;
         Py::Tuple args(1);
         args[0] = wrap.fromQDir(dir);
-        uiloader.callMemberFunction("setWorkingDirectory", args);
+        pythonUiLoader().callMemberFunction("setWorkingDirectory", args);
     }
     catch (Py::Exception& e) {
         e.clear();
@@ -411,7 +408,7 @@ QDir QUiLoader::workingDirectory() const
     Base::PyGILStateLocker lock;
     try {
         PythonWrapper wrap;
-        Py::Object dir((uiloader.callMemberFunction("workingDirectory")));
+        Py::Object dir((pythonUiLoader().callMemberFunction("workingDirectory")));
         QDir* d = wrap.toQDir(dir.ptr());
         if (d) {
             return *d;
@@ -430,7 +427,7 @@ void QUiLoader::setLanguageChangeEnabled(bool enabled)
     try {
         Py::Tuple args(1);
         args[0] = Py::Boolean(enabled);
-        uiloader.callMemberFunction("setLanguageChangeEnabled", args);
+        pythonUiLoader().callMemberFunction("setLanguageChangeEnabled", args);
     }
     catch (Py::Exception& e) {
         e.clear();
@@ -441,7 +438,7 @@ bool QUiLoader::isLanguageChangeEnabled() const
 {
     Base::PyGILStateLocker lock;
     try {
-        Py::Boolean ok((uiloader.callMemberFunction("isLanguageChangeEnabled")));
+        Py::Boolean ok((pythonUiLoader().callMemberFunction("isLanguageChangeEnabled")));
         return static_cast<bool>(ok);
     }
     catch (Py::Exception& e) {
@@ -456,7 +453,7 @@ void QUiLoader::setTranslationEnabled(bool enabled)
     try {
         Py::Tuple args(1);
         args[0] = Py::Boolean(enabled);
-        uiloader.callMemberFunction("setTranslationEnabled", args);
+        pythonUiLoader().callMemberFunction("setTranslationEnabled", args);
     }
     catch (Py::Exception& e) {
         e.clear();
@@ -467,7 +464,7 @@ bool QUiLoader::isTranslationEnabled() const
 {
     Base::PyGILStateLocker lock;
     try {
-        Py::Boolean ok((uiloader.callMemberFunction("isTranslationEnabled")));
+        Py::Boolean ok((pythonUiLoader().callMemberFunction("isTranslationEnabled")));
         return static_cast<bool>(ok);
     }
     catch (Py::Exception& e) {
@@ -480,7 +477,7 @@ QString QUiLoader::errorString() const
 {
     Base::PyGILStateLocker lock;
     try {
-        Py::String error((uiloader.callMemberFunction("errorString")));
+        Py::String error((pythonUiLoader().callMemberFunction("errorString")));
         return QString::fromStdString(error.as_std_string());
     }
     catch (Py::Exception& e) {

--- a/src/Gui/UiLoader.h
+++ b/src/Gui/UiLoader.h
@@ -32,6 +32,8 @@
 # include <QObject>
 #endif
 
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <CXX/Extensions.hxx>
 #include <memory>
 
@@ -87,7 +89,12 @@ public:
     QString errorString() const;
 
 private:
-    Py::Object uiloader;
+    Py::Object pythonUiLoader() const
+    {
+        return Py::Object(uiloader.get());
+    }
+
+    Base::NativePythonReference uiloader;
 };
 #endif
 

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -100,7 +100,7 @@ View3DInventor::View3DInventor(
     Qt::WindowFlags wflags
 )
     : MDIViewWithCamera(pcDocument, parent, wflags)
-    , _viewerPy(nullptr)
+    , _viewerPy()
 {
     stack = new QStackedWidget(this);
     // important for highlighting
@@ -182,8 +182,7 @@ View3DInventor::~View3DInventor()
     }
 
     if (_viewerPy) {
-        Base::PyGILStateLocker lock;
-        Py_DECREF(_viewerPy);
+        _viewerPy.reset();
     }
 
     // here is from time to time trouble!!!
@@ -221,11 +220,11 @@ View3DInventor* View3DInventor::clone()
 PyObject* View3DInventor::getPyObject()
 {
     if (!_viewerPy) {
-        _viewerPy = new View3DInventorPy(this);
+        _viewerPy.reset(new View3DInventorPy(this));
     }
 
-    Py_INCREF(_viewerPy);
-    return _viewerPy;
+    Py_INCREF(_viewerPy.get());
+    return _viewerPy.get();
 }
 
 void View3DInventor::applySettings()

--- a/src/Gui/View3DInventor.h
+++ b/src/Gui/View3DInventor.h
@@ -27,6 +27,7 @@
 #include <QImage>
 
 #include <Base/Parameter.h>
+#include <Base/NativePythonReference.h>
 
 #include "MDIViewWithCamera.h"
 
@@ -160,7 +161,7 @@ protected:
 
 private:
     View3DInventorViewer* _viewer;
-    PyObject* _viewerPy;
+    Base::NativePythonReference _viewerPy;
     QTimer* stopSpinTimer;
     QStackedWidget* stack;
     std::unique_ptr<View3DSettings> viewSettings;

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1001,7 +1001,6 @@ View3DInventorViewer::View3DInventorViewer(QWidget* parent, const QOpenGLWidget*
     , redirected(false)
     , allowredir(false)
     , overrideMode("As Is")
-    , _viewerPy(nullptr)
 {
     init();
 }
@@ -1025,7 +1024,6 @@ View3DInventorViewer::View3DInventorViewer(
     , redirected(false)
     , allowredir(false)
     , overrideMode("As Is")
-    , _viewerPy(nullptr)
 {
     init();
 }
@@ -1399,10 +1397,6 @@ View3DInventorViewer::~View3DInventorViewer()
 
     removeEventFilter(viewerEventFilter);
     delete viewerEventFilter;
-
-    if (_viewerPy) {
-        static_cast<View3DInventorViewerPy*>(_viewerPy)->_viewer = nullptr;
-    }
 
     // In the init() function we have overridden the default SoGLRenderAction with our
     // own instance of SoBoxSelectionRenderAction and SoRenderManager destroyed the default.
@@ -5579,11 +5573,11 @@ void View3DInventorViewer::turnDeltaDimensionsOff()
 PyObject* View3DInventorViewer::getPyObject()
 {
     if (!_viewerPy) {
-        _viewerPy = new View3DInventorViewerPy(this);
+        _viewerPy.reset(new View3DInventorViewerPy(this));
     }
 
-    Py_INCREF(_viewerPy);
-    return _viewerPy;
+    Py_INCREF(_viewerPy.get());
+    return _viewerPy.get();
 }
 
 /**

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -52,6 +52,8 @@
 #endif  // FC_OS_MACOSX
 
 #include <Base/BoundBox.h>
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <Base/Placement.h>
 
 #include "Namespace.h"
@@ -730,7 +732,7 @@ private:
 
     ViewerEventFilter* viewerEventFilter;
 
-    PyObject* _viewerPy;
+    Base::NativePythonReference _viewerPy;
 
     static unsigned char XPM_pixel_data[YPM_WIDTH * YPM_HEIGHT * YPM_BYTES_PER_PIXEL + 1];
     static unsigned char YPM_pixel_data[YPM_WIDTH * YPM_HEIGHT * YPM_BYTES_PER_PIXEL + 1];

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -367,7 +367,8 @@ View3DInventorPy::View3DInventorPy(View3DInventor* vi)
 
 View3DInventorPy::~View3DInventorPy()
 {
-    Base::PyGILStateLocker lock;
+    // Python invokes extension destructors with an attached thread state.
+    // This may run during Py_Finalize(), so never reacquire the GIL here.
     for (auto it : callbacks) {
         Py_DECREF(it);
     }

--- a/src/Gui/View3DViewerPy.cpp
+++ b/src/Gui/View3DViewerPy.cpp
@@ -35,6 +35,11 @@
 
 using namespace Gui;
 
+View3DInventorViewer* View3DInventorViewerPy::getView3DInventorViewerPtr() const
+{
+    return _viewer.data();
+}
+
 
 void View3DInventorViewerPy::init_type()
 {
@@ -208,9 +213,10 @@ View3DInventorViewerPy::View3DInventorViewerPy(View3DInventorViewer* vi)
 
 View3DInventorViewerPy::~View3DInventorViewerPy()
 {
-    Base::PyGILStateLocker lock;
-    for (auto it : callbacks) {
-        Py_DECREF(it);
+    // Python invokes extension destructors with an attached thread state.
+    // Do not use PyGILStateLocker here: this may run during Py_Finalize().
+    for (auto* callback : callbacks) {
+        Py_DECREF(callback);
     }
 }
 

--- a/src/Gui/View3DViewerPy.h
+++ b/src/Gui/View3DViewerPy.h
@@ -24,6 +24,7 @@
 
 #include <CXX/Extensions.hxx>
 #include <list>
+#include <QPointer>
 
 
 namespace Gui
@@ -86,10 +87,7 @@ public:
 
     Py::Object getNavigationStyle(const Py::Tuple&);
 
-    View3DInventorViewer* getView3DInventorViewerPtr() const
-    {
-        return _viewer;
-    }
+    View3DInventorViewer* getView3DInventorViewerPtr() const;
 
 private:
     using method_varargs_handler = PyObject* (*)(PyObject * _self, PyObject* _args);
@@ -104,7 +102,7 @@ private:
 private:
     friend class EditableDatumLabelPy;
     std::list<PyObject*> callbacks;
-    View3DInventorViewer* _viewer;
+    QPointer<View3DInventorViewer> _viewer;
     friend class View3DInventorViewer;
 };
 

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -134,7 +134,7 @@ ViewProvider::~ViewProvider()
 {
     if (pyViewObject) {
         auto* object = static_cast<Base::PyObjectBase*>(pyViewObject.get());
-        object->setInvalid();
+        object->setInvalidWithoutPython();
     }
     pyViewObject.reset();
 

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -133,10 +133,10 @@ ViewProvider::ViewProvider()
 ViewProvider::~ViewProvider()
 {
     if (pyViewObject) {
-        Base::PyGILStateLocker lock;
-        pyViewObject->setInvalid();
-        pyViewObject->DecRef();
+        auto* object = static_cast<Base::PyObjectBase*>(pyViewObject.get());
+        object->setInvalid();
     }
+    pyViewObject.reset();
 
     if (pcRoot && pcRoot->isOfType(SoFCSelectionRoot::getClassTypeId())) {
         static_cast<SoFCSelectionRoot*>(pcRoot)->setViewProvider(nullptr);
@@ -618,10 +618,11 @@ std::string ViewProvider::toString() const
 PyObject* ViewProvider::getPyObject()
 {
     if (!pyViewObject) {
-        pyViewObject = new ViewProviderPy(this);
+        auto* object = new ViewProviderPy(this);
+        pyViewObject.reset(static_cast<PyObject*>(object));
     }
-    pyViewObject->IncRef();
-    return pyViewObject;
+    Py_INCREF(pyViewObject.get());
+    return pyViewObject.get();
 }
 
 

--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -34,6 +34,8 @@
 #include <App/Material.h>
 #include <App/TransactionalObject.h>
 #include <Base/BoundBox.h>
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <Base/Vector3D.h>
 
 #include "TreeItemMode.h"
@@ -844,7 +846,7 @@ protected:
     SoSwitch* pcModeSwitch;
     /// The root separator for annotations
     SoSeparator* pcAnnotation {nullptr};
-    ViewProviderPy* pyViewObject {nullptr};
+    Base::NativePythonReference pyViewObject;
     bool autoCollapseOnDeactivation {true};
     std::string overrideMode;
     std::bitset<32> StatusBits;

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -571,10 +571,10 @@ PyObject* ViewProviderDocumentObject::getPyObject()
 {
     requireMainThread("Gui::ViewProviderDocumentObject::getPyObject");
     if (!pyViewObject) {
-        pyViewObject = new ViewProviderDocumentObjectPy(this);
+        pyViewObject.reset(new ViewProviderDocumentObjectPy(this));
     }
-    pyViewObject->IncRef();
-    return pyViewObject;
+    Py_INCREF(pyViewObject.get());
+    return pyViewObject.get();
 }
 
 bool ViewProviderDocumentObject::canDropObjectEx(

--- a/src/Gui/ViewProviderFeaturePython.cpp
+++ b/src/Gui/ViewProviderFeaturePython.cpp
@@ -63,21 +63,7 @@ ViewProviderFeaturePythonImp::ViewProviderFeaturePythonImp(
     , Proxy(proxy)
 {}
 
-ViewProviderFeaturePythonImp::~ViewProviderFeaturePythonImp()
-{
-    Base::PyGILStateLocker lock;
-#undef FC_PY_ELEMENT
-#define FC_PY_ELEMENT(_name) py_##_name = Py::None();
-
-    try {
-        FC_PY_VIEW_OBJECT
-    }
-    catch (Py::Exception& e) {
-        e.clear();
-    }
-
-    this->selectionObserver.~SelectionObserverPythonHandler();
-}
+ViewProviderFeaturePythonImp::~ViewProviderFeaturePythonImp() = default;
 
 void ViewProviderFeaturePythonImp::init(PyObject* pyobj)
 {
@@ -85,14 +71,16 @@ void ViewProviderFeaturePythonImp::init(PyObject* pyobj)
     has__object__ = !!PyObject_HasAttrString(pyobj, "__object__");
 
 #undef FC_PY_ELEMENT
-#define FC_PY_ELEMENT(_name) FC_PY_ELEMENT_INIT(_name)
+#define FC_PY_ELEMENT(_name) FC_PY_GUI_ELEMENT_INIT(_name)
 
     FC_PY_VIEW_OBJECT
 
     this->selectionObserver.init(pyobj);
 }
 
-#define FC_PY_CALL_CHECK(_name) _FC_PY_CALL_CHECK(_name, return (NotImplemented))
+#define FC_PY_CALL_CHECK(_name) _FC_PY_GUI_CALL_CHECK(_name, return (NotImplemented))
+#undef _FC_PY_CALL_CHECK
+#define _FC_PY_CALL_CHECK(_name, _ret) _FC_PY_GUI_CALL_CHECK(_name, _ret)
 
 QIcon ViewProviderFeaturePythonImp::getIcon() const
 {
@@ -101,7 +89,7 @@ QIcon ViewProviderFeaturePythonImp::getIcon() const
     // Run the getIcon method of the proxy object.
     Base::PyGILStateLocker lock;
     try {
-        Py::Object ret(Base::pyCall(py_getIcon.ptr()));
+        Py::Object ret(Base::pyCall(py_getIcon.get()));
         if (ret.isNone()) {
             return {};
         }
@@ -172,7 +160,7 @@ std::map<BitmapFactoryInst::Position, std::string> ViewProviderFeaturePythonImp:
 
     Base::PyGILStateLocker lock;
     try {
-        Py::Object ret(Base::pyCall(py_getOverlayIcons.ptr()));
+        Py::Object ret(Base::pyCall(py_getOverlayIcons.get()));
         if (ret.isNone()) {
             return overlays;
         }
@@ -228,7 +216,7 @@ bool ViewProviderFeaturePythonImp::claimChildren(std::vector<App::DocumentObject
 
     Base::PyGILStateLocker lock;
     try {
-        Py::Sequence list(Base::pyCall(py_claimChildren.ptr()));
+        Py::Sequence list(Base::pyCall(py_claimChildren.get()));
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             PyObject* item = (*it).ptr();
             if (PyObject_TypeCheck(item, &(App::DocumentObjectPy::Type))) {
@@ -257,7 +245,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::useNewSelecti
     // Run the useNewSelectionModel method of the proxy object.
     Base::PyGILStateLocker lock;
     try {
-        Py::Boolean ok(Py::Callable(py_useNewSelectionModel).apply(Py::Tuple()));
+        Py::Boolean ok(Py::Callable(py_useNewSelectionModel.get()).apply(Py::Tuple()));
         return ok ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -296,7 +284,7 @@ bool ViewProviderFeaturePythonImp::getElement(const SoDetail* det, std::string& 
         );
         Py::Tuple args(1);
         args.setItem(0, Py::Object(pivy, true));
-        Py::String name(Base::pyCall(py_getElement.ptr(), args.ptr()));
+        Py::String name(Base::pyCall(py_getElement.get(), args.ptr()));
         res = name;
         return true;
     }
@@ -333,7 +321,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::getElementPic
         );
         Py::Tuple args(1);
         args.setItem(0, Py::Object(pivy, true));
-        Py::Object ret(Base::pyCall(py_getElementPicked.ptr(), args.ptr()));
+        Py::Object ret(Base::pyCall(py_getElementPicked.get(), args.ptr()));
         if (!ret.isString()) {
             return Rejected;
         }
@@ -364,7 +352,7 @@ bool ViewProviderFeaturePythonImp::getDetail(const char* name, SoDetail*& det) c
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::String(name));
-        Py::Object pydet(Base::pyCall(py_getDetail.ptr(), args.ptr()));
+        Py::Object pydet(Base::pyCall(py_getDetail.get(), args.ptr()));
         void* ptr = nullptr;
         Base::Interpreter().convertSWIGPointerObj("pivy.coin", "SoDetail *", pydet.ptr(), &ptr, 0);
         auto detail = static_cast<SoDetail*>(ptr);
@@ -406,7 +394,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::getDetailPath
         args.setItem(0, Py::String(name));
         args.setItem(1, Py::Object(pivy, true));
         args.setItem(2, Py::Boolean(append));
-        Py::Object pyDet(Base::pyCall(py_getDetailPath.ptr(), args.ptr()));
+        Py::Object pyDet(Base::pyCall(py_getDetailPath.get(), args.ptr()));
         if (!pyDet.isTrue()) {
             return Rejected;
         }
@@ -452,7 +440,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::setEdit(int M
         if (has__object__) {
             Py::Tuple args(1);
             args.setItem(0, Py::Long(ModNum));
-            Py::Object ret(Base::pyCall(py_setEdit.ptr(), args.ptr()));
+            Py::Object ret(Base::pyCall(py_setEdit.get(), args.ptr()));
             if (ret.isNone()) {
                 return NotImplemented;
             }
@@ -464,7 +452,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::setEdit(int M
             Py::Tuple args(2);
             args.setItem(0, Py::Object(object->getPyObject(), true));
             args.setItem(1, Py::Long(ModNum));
-            Py::Object ret(Base::pyCall(py_setEdit.ptr(), args.ptr()));
+            Py::Object ret(Base::pyCall(py_setEdit.get(), args.ptr()));
             if (ret.isNone()) {
                 return NotImplemented;
             }
@@ -494,7 +482,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::unsetEdit(int
         if (has__object__) {
             Py::Tuple args(1);
             args.setItem(0, Py::Long(ModNum));
-            Py::Object ret(Base::pyCall(py_unsetEdit.ptr(), args.ptr()));
+            Py::Object ret(Base::pyCall(py_unsetEdit.get(), args.ptr()));
             if (ret.isNone()) {
                 return NotImplemented;
             }
@@ -506,7 +494,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::unsetEdit(int
             Py::Tuple args(2);
             args.setItem(0, Py::Object(object->getPyObject(), true));
             args.setItem(1, Py::Long(ModNum));
-            Py::Object ret(Base::pyCall(py_unsetEdit.ptr(), args.ptr()));
+            Py::Object ret(Base::pyCall(py_unsetEdit.get(), args.ptr()));
             if (ret.isNone()) {
                 return NotImplemented;
             }
@@ -540,7 +528,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::setEditViewer
         args.setItem(0, Py::Object(object->getPyObject(), true));
         args.setItem(1, Py::Object(viewer->getPyObject(), true));
         args.setItem(2, Py::Long(ModNum));
-        Py::Object ret(Base::pyCall(py_setEditViewer.ptr(), args.ptr()));
+        Py::Object ret(Base::pyCall(py_setEditViewer.get(), args.ptr()));
         return ret.isTrue() ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -566,7 +554,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::unsetEditView
         Py::Tuple args(2);
         args.setItem(0, Py::Object(object->getPyObject(), true));
         args.setItem(1, Py::Object(viewer->getPyObject(), true));
-        Py::Object ret(Base::pyCall(py_unsetEditViewer.ptr(), args.ptr()));
+        Py::Object ret(Base::pyCall(py_unsetEditViewer.get(), args.ptr()));
         return ret.isTrue() ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -588,14 +576,14 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::doubleClicked
     Base::PyGILStateLocker lock;
     try {
         if (has__object__) {
-            Py::Boolean ok(Base::pyCall(py_doubleClicked.ptr()));
+            Py::Boolean ok(Base::pyCall(py_doubleClicked.get()));
             bool value = (bool)ok;
             return value ? Accepted : Rejected;
         }
         else {
             Py::Tuple args(1);
             args.setItem(0, Py::Object(object->getPyObject(), true));
-            Py::Boolean ok(Base::pyCall(py_doubleClicked.ptr(), args.ptr()));
+            Py::Boolean ok(Base::pyCall(py_doubleClicked.get(), args.ptr()));
             bool value = (bool)ok;
             return value ? Accepted : Rejected;
         }
@@ -625,7 +613,7 @@ bool ViewProviderFeaturePythonImp::setupContextMenu(QMenu* menu)
             wrap.loadWidgetsModule();
             Py::Tuple args(1);
             args.setItem(0, wrap.fromQWidget(menu, "QMenu"));
-            return Base::pyCall(py_setupContextMenu.ptr(), args.ptr()).isTrue();
+            return Base::pyCall(py_setupContextMenu.get(), args.ptr()).isTrue();
         }
         else {
             PythonWrapper wrap;
@@ -634,7 +622,7 @@ bool ViewProviderFeaturePythonImp::setupContextMenu(QMenu* menu)
             Py::Tuple args(2);
             args.setItem(0, Py::Object(object->getPyObject(), true));
             args.setItem(1, wrap.fromQWidget(menu, "QMenu"));
-            return Base::pyCall(py_setupContextMenu.ptr(), args.ptr()).isTrue();
+            return Base::pyCall(py_setupContextMenu.get(), args.ptr()).isTrue();
         }
     }
     catch (Py::Exception&) {
@@ -656,12 +644,12 @@ void ViewProviderFeaturePythonImp::attach(App::DocumentObject* pcObject)
     Base::PyGILStateLocker lock;
     try {
         if (has__object__) {
-            Base::pyCall(py_attach.ptr());
+            Base::pyCall(py_attach.get());
         }
         else {
             Py::Tuple args(1);
             args.setItem(0, Py::Object(object->getPyObject(), true));
-            Base::pyCall(py_attach.ptr(), args.ptr());
+            Base::pyCall(py_attach.get(), args.ptr());
         }
 
         // #0000415: Now simulate a property change event to call
@@ -676,7 +664,7 @@ void ViewProviderFeaturePythonImp::attach(App::DocumentObject* pcObject)
 
 void ViewProviderFeaturePythonImp::updateData(const App::Property* prop)
 {
-    if (py_updateData.isNone()) {
+    if (!py_updateData.get()) {
         return;
     }
 
@@ -688,7 +676,7 @@ void ViewProviderFeaturePythonImp::updateData(const App::Property* prop)
             const char* prop_name = object->getObject()->getPropertyName(prop);
             if (prop_name) {
                 args.setItem(0, Py::String(prop_name));
-                Base::pyCall(py_updateData.ptr(), args.ptr());
+                Base::pyCall(py_updateData.get(), args.ptr());
             }
         }
         else {
@@ -697,7 +685,7 @@ void ViewProviderFeaturePythonImp::updateData(const App::Property* prop)
             const char* prop_name = object->getObject()->getPropertyName(prop);
             if (prop_name) {
                 args.setItem(1, Py::String(prop_name));
-                Base::pyCall(py_updateData.ptr(), args.ptr());
+                Base::pyCall(py_updateData.get(), args.ptr());
             }
         }
     }
@@ -709,7 +697,7 @@ void ViewProviderFeaturePythonImp::updateData(const App::Property* prop)
 
 void ViewProviderFeaturePythonImp::onChanged(const App::Property* prop)
 {
-    if (py_onChanged.isNone()) {
+    if (!py_onChanged.get()) {
         return;
     }
 
@@ -721,7 +709,7 @@ void ViewProviderFeaturePythonImp::onChanged(const App::Property* prop)
             const char* prop_name = object->getPropertyName(prop);
             if (prop_name) {
                 args.setItem(0, Py::String(prop_name));
-                Base::pyCall(py_onChanged.ptr(), args.ptr());
+                Base::pyCall(py_onChanged.get(), args.ptr());
             }
         }
         else {
@@ -730,7 +718,7 @@ void ViewProviderFeaturePythonImp::onChanged(const App::Property* prop)
             const char* prop_name = object->getPropertyName(prop);
             if (prop_name) {
                 args.setItem(1, Py::String(prop_name));
-                Base::pyCall(py_onChanged.ptr(), args.ptr());
+                Base::pyCall(py_onChanged.get(), args.ptr());
             }
         }
     }
@@ -742,7 +730,7 @@ void ViewProviderFeaturePythonImp::onChanged(const App::Property* prop)
 
 void ViewProviderFeaturePythonImp::onBeforeChange(const App::Property* prop)
 {
-    if (py_onBeforeChange.isNone()) {
+    if (!py_onBeforeChange.get()) {
         return;
     }
 
@@ -754,7 +742,7 @@ void ViewProviderFeaturePythonImp::onBeforeChange(const App::Property* prop)
             const char* prop_name = object->getPropertyName(prop);
             if (prop_name) {
                 args.setItem(0, Py::String(prop_name));
-                Base::pyCall(py_onBeforeChange.ptr(), args.ptr());
+                Base::pyCall(py_onBeforeChange.get(), args.ptr());
             }
         }
         else {
@@ -763,7 +751,7 @@ void ViewProviderFeaturePythonImp::onBeforeChange(const App::Property* prop)
             const char* prop_name = object->getPropertyName(prop);
             if (prop_name) {
                 args.setItem(1, Py::String(prop_name));
-                Base::pyCall(py_onBeforeChange.ptr(), args.ptr());
+                Base::pyCall(py_onBeforeChange.get(), args.ptr());
             }
         }
     }
@@ -787,7 +775,7 @@ void ViewProviderFeaturePythonImp::finishRestoring()
         }
         else {
             _FC_PY_CALL_CHECK(finishRestoring, return);
-            Base::pyCall(py_finishRestoring.ptr());
+            Base::pyCall(py_finishRestoring.get());
         }
     }
     catch (Py::Exception&) {
@@ -803,12 +791,12 @@ void ViewProviderFeaturePythonImp::beforeDelete()
     Base::PyGILStateLocker lock;
     try {
         if (has__object__) {
-            Base::pyCall(py_beforeDelete.ptr());
+            Base::pyCall(py_beforeDelete.get());
         }
         else {
             Py::Tuple args(1);
             args.setItem(0, Py::Object(object->getPyObject(), true));
-            Base::pyCall(py_beforeDelete.ptr(), args.ptr());
+            Base::pyCall(py_beforeDelete.get(), args.ptr());
         }
     }
     catch (Py::Exception&) {
@@ -839,14 +827,14 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::onDelete(
         if (has__object__) {
             Py::Tuple args(1);
             args.setItem(0, seq);
-            Py::Boolean ok(Base::pyCall(py_onDelete.ptr(), args.ptr()));
+            Py::Boolean ok(Base::pyCall(py_onDelete.get(), args.ptr()));
             return ok ? Accepted : Rejected;
         }
         else {
             Py::Tuple args(2);
             args.setItem(0, Py::Object(object->getPyObject(), true));
             args.setItem(1, seq);
-            Py::Boolean ok(Base::pyCall(py_onDelete.ptr(), args.ptr()));
+            Py::Boolean ok(Base::pyCall(py_onDelete.get(), args.ptr()));
             return ok ? Accepted : Rejected;
         }
     }
@@ -871,7 +859,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::canDelete(
     try {
         Py::Tuple args(1);
         args.setItem(0, obj ? Py::Object(obj->getPyObject(), true) : Py::Object());
-        return Py::Boolean(Base::pyCall(py_canDelete.ptr(), args.ptr())) ? Accepted : Rejected;
+        return Py::Boolean(Base::pyCall(py_canDelete.get(), args.ptr())) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
         if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
@@ -890,8 +878,8 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::canAddToScene
 
     Base::PyGILStateLocker lock;
     try {
-        return Py::Boolean(Py::Callable(py_canAddToSceneGraph).apply(Py::Tuple())) ? Accepted
-                                                                                   : Rejected;
+        return Py::Boolean(Py::Callable(py_canAddToSceneGraph.get()).apply(Py::Tuple())) ? Accepted
+                                                                                         : Rejected;
     }
     catch (Py::Exception&) {
         if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
@@ -911,7 +899,7 @@ bool ViewProviderFeaturePythonImp::getDefaultDisplayMode(std::string& mode) cons
     // Run the getDefaultDisplayMode method of the proxy object.
     Base::PyGILStateLocker lock;
     try {
-        Py::String str(Base::pyCall(py_getDefaultDisplayMode.ptr()));
+        Py::String str(Base::pyCall(py_getDefaultDisplayMode.get()));
         mode = str.as_std_string("ascii");
         return true;
     }
@@ -936,7 +924,7 @@ std::vector<std::string> ViewProviderFeaturePythonImp::getDisplayModes() const
     Base::PyGILStateLocker lock;
     try {
         if (has__object__) {
-            Py::Sequence list(Base::pyCall(py_getDisplayModes.ptr()));
+            Py::Sequence list(Base::pyCall(py_getDisplayModes.get()));
             for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
                 Py::String str(*it);
                 modes.push_back(str.as_std_string("ascii"));
@@ -945,7 +933,7 @@ std::vector<std::string> ViewProviderFeaturePythonImp::getDisplayModes() const
         else {
             Py::Tuple args(1);
             args.setItem(0, Py::Object(object->getPyObject(), true));
-            Py::Sequence list(Base::pyCall(py_getDisplayModes.ptr(), args.ptr()));
+            Py::Sequence list(Base::pyCall(py_getDisplayModes.get(), args.ptr()));
             for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
                 Py::String str(*it);
                 modes.push_back(str.as_std_string("ascii"));
@@ -974,7 +962,7 @@ std::string ViewProviderFeaturePythonImp::setDisplayMode(const char* ModeName)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::String(ModeName));
-        Py::String str(Base::pyCall(py_setDisplayMode.ptr(), args.ptr()));
+        Py::String str(Base::pyCall(py_setDisplayMode.get(), args.ptr()));
         return str.as_std_string("ascii");
     }
     catch (Py::Exception&) {
@@ -991,7 +979,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::canDragObject
 
     Base::PyGILStateLocker lock;
     try {
-        Py::Boolean ok(Base::pyCall(py_canDragObjects.ptr()));
+        Py::Boolean ok(Base::pyCall(py_canDragObjects.get()));
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -1016,7 +1004,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::canDragObject
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::Object(obj->getPyObject(), true));
-        Py::Boolean ok(Base::pyCall(py_canDragObject.ptr(), args.ptr()));
+        Py::Boolean ok(Base::pyCall(py_canDragObject.get(), args.ptr()));
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -1041,14 +1029,14 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::dragObject(Ap
         if (has__object__) {
             Py::Tuple args(1);
             args.setItem(0, Py::Object(obj->getPyObject(), true));
-            Base::pyCall(py_dragObject.ptr(), args.ptr());
+            Base::pyCall(py_dragObject.get(), args.ptr());
             return Accepted;
         }
         else {
             Py::Tuple args(2);
             args.setItem(0, Py::Object(object->getPyObject(), true));
             args.setItem(1, Py::Object(obj->getPyObject(), true));
-            Base::pyCall(py_dragObject.ptr(), args.ptr());
+            Base::pyCall(py_dragObject.get(), args.ptr());
             return Accepted;
         }
     }
@@ -1070,7 +1058,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::canDropObject
 
     Base::PyGILStateLocker lock;
     try {
-        Py::Boolean ok(Base::pyCall(py_canDropObjects.ptr()));
+        Py::Boolean ok(Base::pyCall(py_canDropObjects.get()));
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -1095,7 +1083,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::canDropObject
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::Object(obj->getPyObject(), true));
-        Py::Boolean ok(Base::pyCall(py_canDropObject.ptr(), args.ptr()));
+        Py::Boolean ok(Base::pyCall(py_canDropObject.get(), args.ptr()));
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -1119,14 +1107,14 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::dropObject(Ap
         if (has__object__) {
             Py::Tuple args(1);
             args.setItem(0, Py::Object(obj->getPyObject(), true));
-            Base::pyCall(py_dropObject.ptr(), args.ptr());
+            Base::pyCall(py_dropObject.get(), args.ptr());
             return Accepted;
         }
         else {
             Py::Tuple args(2);
             args.setItem(0, Py::Object(object->getPyObject(), true));
             args.setItem(1, Py::Object(obj->getPyObject(), true));
-            Base::pyCall(py_dropObject.ptr(), args.ptr());
+            Base::pyCall(py_dropObject.get(), args.ptr());
             return Accepted;
         }
     }
@@ -1150,7 +1138,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::canDragAndDro
     Base::PyGILStateLocker lock;
     try {
         Py::TupleN args(Py::Object(obj->getPyObject(), true));
-        Py::Boolean ok(Base::pyCall(py_canDragAndDropObject.ptr(), args.ptr()));
+        Py::Boolean ok(Base::pyCall(py_canDragAndDropObject.get(), args.ptr()));
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -1186,7 +1174,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::canDropObject
             tuple.setItem(i++, Py::String(element));
         }
         args.setItem(3, tuple);
-        Py::Boolean ok(Base::pyCall(py_canDropObjectEx.ptr(), args.ptr()));
+        Py::Boolean ok(Base::pyCall(py_canDropObjectEx.get(), args.ptr()));
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -1226,7 +1214,7 @@ bool ViewProviderFeaturePythonImp::dropObjectEx(
             Py::String(subname ? subname : ""),
             tuple
         );
-        res = Base::pyCall(py_dropObjectEx.ptr(), args.ptr());
+        res = Base::pyCall(py_dropObjectEx.get(), args.ptr());
         if (!res.isNone()) {
             ret = res.as_string();
         }
@@ -1248,7 +1236,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::isShow() cons
 
     Base::PyGILStateLocker lock;
     try {
-        Py::Boolean ok(Base::pyCall(py_isShow.ptr()));
+        Py::Boolean ok(Base::pyCall(py_isShow.get()));
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -1271,7 +1259,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::canRemoveChil
 
     Base::PyGILStateLocker lock;
     try {
-        Py::Boolean ok(Base::pyCall(py_canRemoveChildrenFromRoot.ptr()));
+        Py::Boolean ok(Base::pyCall(py_canRemoveChildrenFromRoot.get()));
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -1292,7 +1280,7 @@ bool ViewProviderFeaturePythonImp::getDropPrefix(std::string& prefix) const
 
     Base::PyGILStateLocker lock;
     try {
-        Py::Object ret(Base::pyCall(py_getDropPrefix.ptr()));
+        Py::Object ret(Base::pyCall(py_getDropPrefix.get()));
         if (ret.isNone()) {
             return false;
         }
@@ -1324,7 +1312,7 @@ ViewProviderFeaturePythonImp::ValueT ViewProviderFeaturePythonImp::replaceObject
     Base::PyGILStateLocker lock;
     try {
         Py::TupleN args(Py::asObject(oldObj->getPyObject()), Py::asObject(newObj->getPyObject()));
-        Py::Boolean ok(Base::pyCall(py_replaceObject.ptr(), args.ptr()));
+        Py::Boolean ok(Base::pyCall(py_replaceObject.get(), args.ptr()));
         return ok ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
@@ -1350,7 +1338,7 @@ bool ViewProviderFeaturePythonImp::getLinkedViewProvider(
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::Boolean(recursive));
-        Py::Object res(Base::pyCall(py_getLinkedViewProvider.ptr(), args.ptr()));
+        Py::Object res(Base::pyCall(py_getLinkedViewProvider.get(), args.ptr()));
         if (res.isNone()) {
             return true;
         }
@@ -1394,7 +1382,7 @@ bool ViewProviderFeaturePythonImp::editProperty(const char* name)
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::String(name));
-        Py::Object ret(Base::pyCall(py_editProperty.ptr(), args.ptr()));
+        Py::Object ret(Base::pyCall(py_editProperty.get(), args.ptr()));
         return ret.isTrue();
     }
     catch (Py::Exception&) {

--- a/src/Gui/ViewProviderFeaturePython.h
+++ b/src/Gui/ViewProviderFeaturePython.h
@@ -25,6 +25,7 @@
 #include <App/AutoTransaction.h>
 #include <App/PropertyPythonObject.h>
 #include <App/FeaturePython.h>
+#include <Base/NativePythonReference.h>
 #include <Gui/Selection/SelectionObserverPython.h>
 
 #include "ViewProviderGeometryObject.h"
@@ -194,13 +195,38 @@ private:
     FC_PY_ELEMENT(getLinkedViewProvider) \
     FC_PY_ELEMENT(editProperty)
 
+#define FC_PY_GUI_ELEMENT_DEFINE(_name) Base::NativePythonReference py_##_name;
+
+#define FC_PY_GUI_ELEMENT_INIT(_name) \
+    Base::setNativePythonCallable(pyobj, #_name, py_##_name); \
+    if (py_##_name.get()) { \
+        PyObject* pyRecursive = PyObject_GetAttrString(pyobj, "__allow_recursive_" #_name); \
+        if (!pyRecursive) { \
+            PyErr_Clear(); \
+            _Flags.set(FlagAllowRecursive_##_name, false); \
+        } \
+        else { \
+            _Flags.set(FlagAllowRecursive_##_name, PyObject_IsTrue(pyRecursive)); \
+            Py_DECREF(pyRecursive); \
+        } \
+    }
+
+#define FC_PY_GUI_ELEMENT_FLAG(_name) FlagCalling_##_name, FlagAllowRecursive_##_name,
+
+#define _FC_PY_GUI_CALL_CHECK(_name, _ret) \
+    if ((!_Flags.test(FlagAllowRecursive_##_name) && _Flags.test(FlagCalling_##_name)) \
+        || !py_##_name.get()) { \
+        _ret; \
+    } \
+    Base::BitsetLocker<Flags> guard(_Flags, FlagCalling_##_name);
+
 #undef FC_PY_ELEMENT
-#define FC_PY_ELEMENT(_name) FC_PY_ELEMENT_DEFINE(_name)
+#define FC_PY_ELEMENT(_name) FC_PY_GUI_ELEMENT_DEFINE(_name)
 
     FC_PY_VIEW_OBJECT
 
 #undef FC_PY_ELEMENT
-#define FC_PY_ELEMENT(_name) FC_PY_ELEMENT_FLAG(_name)
+#define FC_PY_ELEMENT(_name) FC_PY_GUI_ELEMENT_FLAG(_name)
 
     enum Flag
     {

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -419,10 +419,10 @@ void ViewProviderGeometryObject::setSelectable(bool selectable)
 PyObject* ViewProviderGeometryObject::getPyObject()
 {
     if (!pyViewObject) {
-        pyViewObject = new ViewProviderGeometryObjectPy(this);
+        pyViewObject.reset(new ViewProviderGeometryObjectPy(this));
     }
-    pyViewObject->IncRef();
-    return pyViewObject;
+    Py_INCREF(pyViewObject.get());
+    return pyViewObject.get();
 }
 
 void ViewProviderGeometryObject::handleChangedPropertyName(

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -1080,7 +1080,7 @@ void LinkView::setInvalid()
 {
     if (PythonObject) {
         auto obj = static_cast<Base::PyObjectBase*>(PythonObject.get());
-        obj->setInvalid();
+        obj->setInvalidWithoutPython();
         PythonObject.reset();
     }
     else {

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -1064,22 +1064,24 @@ LinkView::~LinkView()
 {
     unlink(linkInfo);
     unlink(linkOwner);
+    PythonObject.reset();
 }
 
 PyObject* LinkView::getPyObject()
 {
-    if (PythonObject.is(Py::_None())) {
-        PythonObject = Py::Object(new LinkViewPy(this), true);
+    if (!PythonObject) {
+        PythonObject.reset(new LinkViewPy(this));
     }
-    return Py::new_reference_to(PythonObject);
+    Py_INCREF(PythonObject.get());
+    return PythonObject.get();
 }
 
 void LinkView::setInvalid()
 {
-    if (!PythonObject.is(Py::_None())) {
-        auto obj = static_cast<Base::PyObjectBase*>(PythonObject.ptr());
+    if (PythonObject) {
+        auto obj = static_cast<Base::PyObjectBase*>(PythonObject.get());
         obj->setInvalid();
-        obj->DecRef();
+        PythonObject.reset();
     }
     else {
         delete this;
@@ -3521,10 +3523,10 @@ void ViewProviderLink::updateLinks(ViewProvider* vp)
 PyObject* ViewProviderLink::getPyObject()
 {
     if (!pyViewObject) {
-        pyViewObject = new ViewProviderLinkPy(this);
+        pyViewObject.reset(new ViewProviderLinkPy(this));
     }
-    pyViewObject->IncRef();
-    return pyViewObject;
+    Py_INCREF(pyViewObject.get());
+    return pyViewObject.get();
 }
 
 PyObject* ViewProviderLink::getPyLinkView()

--- a/src/Gui/ViewProviderLink.h
+++ b/src/Gui/ViewProviderLink.h
@@ -23,6 +23,8 @@
 #pragma once
 
 #include <App/Link.h>
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <unordered_map>
 #include <map>
 #include <string>
@@ -215,7 +217,7 @@ protected:
     std::vector<std::unique_ptr<Element>> nodeArray;
     std::unordered_map<SoNode*, int> nodeMap;
 
-    Py::Object PythonObject;
+    Base::NativePythonReference PythonObject;
 };
 
 class GuiExport ViewProviderLink: public ViewProviderDragger

--- a/src/Gui/WidgetFactory.cpp
+++ b/src/Gui/WidgetFactory.cpp
@@ -24,6 +24,9 @@
 #include <QApplication>
 #include <QVBoxLayout>
 
+#include <unordered_set>
+#include <utility>
+
 #include <FCConfig.h>
 
 #ifdef FC_OS_WIN32
@@ -47,6 +50,15 @@
 
 
 using namespace Gui;
+
+namespace
+{
+std::unordered_set<PyResource*>& pyResources()
+{
+    static std::unordered_set<PyResource*> resources;
+    return resources;
+}
+}  // namespace
 
 Gui::WidgetFactoryInst* Gui::WidgetFactoryInst::_pcSingleton = nullptr;
 
@@ -404,15 +416,31 @@ void PyResource::init_type()
 
 PyResource::PyResource()
     : myDlg(nullptr)
-{}
+{
+    pyResources().insert(this);
+}
 
 PyResource::~PyResource()
 {
-    delete myDlg;
+    pyResources().erase(this);
+    clearResources();
+}
+
+void PyResource::prepareForShutdown() noexcept
+{
+    for (auto* resource : pyResources()) {
+        resource->clearResources();
+    }
+}
+
+void PyResource::clearResources() noexcept
+{
+    delete std::exchange(myDlg, nullptr);
     for (auto it : mySignals) {
         SignalConnect* sc = it;
         delete sc;
     }
+    mySignals.clear();
 }
 
 /**

--- a/src/Gui/WidgetFactory.cpp
+++ b/src/Gui/WidgetFactory.cpp
@@ -229,29 +229,25 @@ void* PrefPageUiProducer::Produce() const
 // ----------------------------------------------------
 
 PrefPagePyProducer::PrefPagePyProducer(const Py::Object& p, const char* group)
-    : type(p)
 {
+    type.reset(p);
     std::string str;
     Base::PyGILStateLocker lock;
-    if (type.hasAttr("__name__")) {
-        str = static_cast<std::string>(Py::String(type.getAttr("__name__")));
+    if (pythonType().hasAttr("__name__")) {
+        str = static_cast<std::string>(Py::String(pythonType().getAttr("__name__")));
     }
 
     WidgetFactoryInst::instance().AddProducer(str.c_str(), this);
     Gui::Dialog::DlgPreferencesImp::addPage(str, group);
 }
 
-PrefPagePyProducer::~PrefPagePyProducer()
-{
-    Base::PyGILStateLocker lock;
-    type = Py::None();
-}
+PrefPagePyProducer::~PrefPagePyProducer() = default;
 
 void* PrefPagePyProducer::Produce() const
 {
     Base::PyGILStateLocker lock;
     try {
-        Py::Callable method(type);
+        Py::Callable method(pythonType());
         Py::Tuple args;
         Py::Object page = method.apply(args);
         QWidget* widget = new Gui::Dialog::PreferencePagePython(page);
@@ -273,8 +269,8 @@ using namespace Gui::Dialog;
 
 PreferencePagePython::PreferencePagePython(const Py::Object& p, QWidget* parent)
     : PreferencePage(parent)
-    , page(p)
 {
+    page.reset(p);
     Base::PyGILStateLocker lock;
     Gui::PythonWrapper wrap;
     if (wrap.loadCoreModule()) {
@@ -282,11 +278,11 @@ PreferencePagePython::PreferencePagePython(const Py::Object& p, QWidget* parent)
         // old style class must have a form attribute while
         // new style classes can be the widget itself
         Py::Object widget;
-        if (page.hasAttr(std::string("form"))) {
-            widget = page.getAttr(std::string("form"));
+        if (pythonPage().hasAttr(std::string("form"))) {
+            widget = pythonPage().getAttr(std::string("form"));
         }
         else {
-            widget = page;
+            widget = pythonPage();
         }
 
         QObject* object = wrap.toQObject(widget);
@@ -302,11 +298,7 @@ PreferencePagePython::PreferencePagePython(const Py::Object& p, QWidget* parent)
     }
 }
 
-PreferencePagePython::~PreferencePagePython()
-{
-    Base::PyGILStateLocker lock;
-    page = Py::None();
-}
+PreferencePagePython::~PreferencePagePython() = default;
 
 void PreferencePagePython::changeEvent(QEvent* e)
 {
@@ -317,8 +309,8 @@ void PreferencePagePython::loadSettings()
 {
     Base::PyGILStateLocker lock;
     try {
-        if (page.hasAttr(std::string("loadSettings"))) {
-            Py::Callable method(page.getAttr(std::string("loadSettings")));
+        if (pythonPage().hasAttr(std::string("loadSettings"))) {
+            Py::Callable method(pythonPage().getAttr(std::string("loadSettings")));
             Py::Tuple args;
             method.apply(args);
         }
@@ -333,8 +325,8 @@ void PreferencePagePython::saveSettings()
 {
     Base::PyGILStateLocker lock;
     try {
-        if (page.hasAttr(std::string("saveSettings"))) {
-            Py::Callable method(page.getAttr(std::string("saveSettings")));
+        if (pythonPage().hasAttr(std::string("saveSettings"))) {
+            Py::Callable method(pythonPage().getAttr(std::string("saveSettings")));
             Py::Tuple args;
             method.apply(args);
         }
@@ -735,13 +727,13 @@ Py::Object PyResource::connect(const Py::Tuple& args)
 
 SignalConnect::SignalConnect(PyObject* res, PyObject* cb)
     : myResource(res)
-    , myCallback(cb)
-{}
+{
+    myCallback.reset(cb);
+}
 
 SignalConnect::~SignalConnect()
 {
-    Base::PyGILStateLocker lock;
-    Py_XDECREF(myCallback); /* Dispose of callback */
+    myCallback.reset(); /* Dispose of callback */
 }
 
 /**
@@ -754,7 +746,7 @@ void SignalConnect::onExecute()
 
     /* Time to call the callback */
     arglist = Py_BuildValue("(O)", myResource);
-    result = PyObject_CallObject(myCallback, arglist);
+    result = PyObject_CallObject(myCallback.get(), arglist);
     Py_XDECREF(result);
     Py_DECREF(arglist);
 }

--- a/src/Gui/WidgetFactory.h
+++ b/src/Gui/WidgetFactory.h
@@ -30,6 +30,8 @@
 #include "Dialogs/DlgPreferencesImp.h"
 #include "PropertyPage.h"
 #include <CXX/Extensions.hxx>
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 
 QT_BEGIN_NAMESPACE
 class QDir;
@@ -183,7 +185,12 @@ public:
     void* Produce() const override;
 
 private:
-    Py::Object type;
+    Py::Object pythonType() const
+    {
+        return Py::Object(type.get());
+    }
+
+    Base::NativePythonReference type;
 };
 
 // --------------------------------------------------------------------
@@ -371,7 +378,7 @@ public Q_SLOTS:
 
 private:
     PyObject* myResource;
-    PyObject* myCallback;
+    Base::NativePythonReference myCallback;
 };
 
 // ----------------------------------------------------
@@ -396,7 +403,12 @@ protected:
     void changeEvent(QEvent* e) override;
 
 private:
-    Py::Object page;
+    Py::Object pythonPage() const
+    {
+        return Py::Object(page.get());
+    }
+
+    Base::NativePythonReference page;
 };
 
 }  // namespace Dialog

--- a/src/Gui/WidgetFactory.h
+++ b/src/Gui/WidgetFactory.h
@@ -340,6 +340,7 @@ class PyResource: public Py::PythonExtension<PyResource>
 {
 public:
     static void init_type();  // announce properties and methods
+    static void prepareForShutdown() noexcept;
 
     PyResource();
     ~PyResource() override;
@@ -355,6 +356,8 @@ public:
     Py::Object connect(const Py::Tuple&);
 
 private:
+    void clearResources() noexcept;
+
     std::vector<class SignalConnect*> mySignals;
     QDialog* myDlg;
 };

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -1126,22 +1126,23 @@ PythonBaseWorkbench::~PythonBaseWorkbench()
     delete _toolBar;
     delete _commandBar;
     if (_workbenchPy) {
-        Base::PyGILStateLocker lock;
-        _workbenchPy->setInvalid();
-        _workbenchPy->DecRef();
+        auto* object = static_cast<Base::PyObjectBase*>(_workbenchPy.get());
+        object->setInvalid();
     }
+    _workbenchPy.reset();
 }
 
 PyObject* PythonBaseWorkbench::getPyObject()
 {
     if (!_workbenchPy) {
-        _workbenchPy = new PythonWorkbenchPy(this);
+        auto* object = new PythonWorkbenchPy(this);
+        _workbenchPy.reset(static_cast<PyObject*>(object));
     }
 
     // Increment every time when this object is returned
-    _workbenchPy->IncRef();
+    Py_INCREF(_workbenchPy.get());
 
-    return _workbenchPy;
+    return _workbenchPy.get();
 }
 
 MenuItem* PythonBaseWorkbench::setupMenuBar() const

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -1127,7 +1127,7 @@ PythonBaseWorkbench::~PythonBaseWorkbench()
     delete _commandBar;
     if (_workbenchPy) {
         auto* object = static_cast<Base::PyObjectBase*>(_workbenchPy.get());
-        object->setInvalid();
+        object->setInvalidWithoutPython();
     }
     _workbenchPy.reset();
 }

--- a/src/Gui/Workbench.h
+++ b/src/Gui/Workbench.h
@@ -26,6 +26,8 @@
 #include <list>
 #include <string>
 #include <Base/BaseClass.h>
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <Base/Parameter.h>
 #include <Gui/TaskView/TaskWatcher.h>
 
@@ -297,7 +299,7 @@ protected:
     MenuItem* _contextMenu {nullptr};
     ToolBarItem* _toolBar {nullptr};
     ToolBarItem* _commandBar {nullptr};
-    Base::PyObjectBase* _workbenchPy {nullptr};
+    Base::NativePythonReference _workbenchPy;
 };
 
 class GuiExport PythonBlankWorkbench: public PythonBaseWorkbench

--- a/src/Gui/WorkbenchManipulatorPython.cpp
+++ b/src/Gui/WorkbenchManipulatorPython.cpp
@@ -43,7 +43,7 @@ void WorkbenchManipulatorPython::removeManipulator(const Py::Object& obj)
     auto manip = getManipulators();
     for (const auto& it : manip) {
         auto ptr = std::dynamic_pointer_cast<WorkbenchManipulatorPython>(it);
-        if (ptr && ptr->object == obj) {
+        if (ptr && ptr->object.get() == obj.ptr()) {
             WorkbenchManipulator::removeManipulator(ptr);
             break;
         }
@@ -51,14 +51,11 @@ void WorkbenchManipulatorPython::removeManipulator(const Py::Object& obj)
 }
 
 WorkbenchManipulatorPython::WorkbenchManipulatorPython(const Py::Object& obj)
-    : object(obj)
-{}
-
-WorkbenchManipulatorPython::~WorkbenchManipulatorPython()
 {
-    Base::PyGILStateLocker lock;
-    object = Py::None();
+    object.reset(obj);
 }
+
+WorkbenchManipulatorPython::~WorkbenchManipulatorPython() = default;
 
 /*!
  * \brief WorkbenchManipulatorPython::modifyMenuBar
@@ -93,8 +90,8 @@ void WorkbenchManipulatorPython::modifyMenuBar(MenuItem* menuBar)
 
 void WorkbenchManipulatorPython::tryModifyMenuBar(MenuItem* menuBar)
 {
-    if (object.hasAttr(std::string("modifyMenuBar"))) {
-        Py::Callable method(object.getAttr(std::string("modifyMenuBar")));
+    if (pythonObject().hasAttr(std::string("modifyMenuBar"))) {
+        Py::Callable method(pythonObject().getAttr(std::string("modifyMenuBar")));
         Py::Tuple args;
         Py::Object result = method.apply(args);
         if (result.isDict()) {
@@ -197,8 +194,8 @@ void WorkbenchManipulatorPython::modifyContextMenu(const char* recipient, MenuIt
 
 void WorkbenchManipulatorPython::tryModifyContextMenu(const char* recipient, MenuItem* menuBar)
 {
-    if (object.hasAttr(std::string("modifyContextMenu"))) {
-        Py::Callable method(object.getAttr(std::string("modifyContextMenu")));
+    if (pythonObject().hasAttr(std::string("modifyContextMenu"))) {
+        Py::Callable method(pythonObject().getAttr(std::string("modifyContextMenu")));
         Py::Tuple args(1);
         args.setItem(0, Py::String(recipient));
         Py::Object result = method.apply(args);
@@ -253,8 +250,8 @@ void WorkbenchManipulatorPython::modifyToolBars(ToolBarItem* toolBar)
  */
 void WorkbenchManipulatorPython::tryModifyToolBar(ToolBarItem* toolBar)
 {
-    if (object.hasAttr(std::string("modifyToolBars"))) {
-        Py::Callable method(object.getAttr(std::string("modifyToolBars")));
+    if (pythonObject().hasAttr(std::string("modifyToolBars"))) {
+        Py::Callable method(pythonObject().getAttr(std::string("modifyToolBars")));
         Py::Tuple args;
         Py::Object result = method.apply(args);
         if (result.isDict()) {
@@ -343,8 +340,8 @@ void WorkbenchManipulatorPython::modifyDockWindows(DockWindowItems* dockWindow)
 
 void WorkbenchManipulatorPython::tryModifyDockWindows(DockWindowItems* dockWindow)
 {
-    if (object.hasAttr(std::string("modifyDockWindows"))) {
-        Py::Callable method(object.getAttr(std::string("modifyDockWindows")));
+    if (pythonObject().hasAttr(std::string("modifyDockWindows"))) {
+        Py::Callable method(pythonObject().getAttr(std::string("modifyDockWindows")));
         Py::Tuple args;
         Py::Object result = method.apply(args);
         if (result.isDict()) {

--- a/src/Gui/WorkbenchManipulatorPython.h
+++ b/src/Gui/WorkbenchManipulatorPython.h
@@ -25,6 +25,8 @@
 #pragma once
 
 #include <Gui/WorkbenchManipulator.h>
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
 #include <CXX/Objects.hxx>
 
 namespace Gui
@@ -82,7 +84,12 @@ private:
     void tryModifyDockWindows(const Py::Dict& dict, DockWindowItems* dockWindow);
 
 private:
-    Py::Object object;
+    Py::Object pythonObject() const
+    {
+        return Py::Object(object.get());
+    }
+
+    Base::NativePythonReference object;
 };
 
 }  // namespace Gui

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -1413,10 +1413,10 @@ Gui::SoTransformDragger* ViewProviderAssembly::getDragger()
 PyObject* ViewProviderAssembly::getPyObject()
 {
     if (!pyViewObject) {
-        pyViewObject = new ViewProviderAssemblyPy(this);
+        pyViewObject.reset(new ViewProviderAssemblyPy(this));
     }
-    pyViewObject->IncRef();
-    return pyViewObject;
+    Py_INCREF(pyViewObject.get());
+    return pyViewObject.get();
 }
 
 void ViewProviderAssembly::applyIsolationRecursively(

--- a/src/Mod/Fem/Gui/TaskPostExtraction.cpp
+++ b/src/Mod/Fem/Gui/TaskPostExtraction.cpp
@@ -62,15 +62,16 @@ TaskPostExtraction::TaskPostExtraction(ViewProviderFemPostObject* view, QWidget*
         Py::Callable method(mod.getAttr(std::string("DataExtraction")));
         Py::Tuple args(1);
         args.setItem(0, Py::Object(view->getPyObject()));
-        m_panel = Py::Object(method.apply(args));
+        m_panel.reset(method.apply(args));
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
         e.reportException();
     }
 
-    if (m_panel.hasAttr(std::string("widget"))) {
-        Py::Object pywidget(m_panel.getAttr(std::string("widget")));
+    auto panel = panelObject();
+    if (panel.hasAttr(std::string("widget"))) {
+        Py::Object pywidget(panel.getAttr(std::string("widget")));
 
         Gui::PythonWrapper wrap;
         if (wrap.loadCoreModule()) {
@@ -94,10 +95,11 @@ TaskPostExtraction::~TaskPostExtraction()
 
     Base::PyGILStateLocker lock;
     try {
-        if (m_panel.hasAttr(std::string("widget"))) {
-            m_panel.setAttr(std::string("widget"), Py::None());
+        auto panel = panelObject();
+        if (panel.hasAttr(std::string("widget"))) {
+            panel.setAttr(std::string("widget"), Py::None());
         }
-        m_panel = Py::None();
+        m_panel.reset();
     }
     catch (Py::AttributeError& e) {
         e.clear();
@@ -108,8 +110,9 @@ void TaskPostExtraction::onPostDataChanged(Fem::FemPostObject* obj)
 {
     Base::PyGILStateLocker lock;
     try {
-        if (m_panel.hasAttr(std::string("onPostDataChanged"))) {
-            Py::Callable method(m_panel.getAttr(std::string("onPostDataChanged")));
+        auto panel = panelObject();
+        if (panel.hasAttr(std::string("onPostDataChanged"))) {
+            Py::Callable method(panel.getAttr(std::string("onPostDataChanged")));
             Py::Tuple args(1);
             args.setItem(0, Py::Object(obj->getPyObject()));
             method.apply(args);
@@ -125,8 +128,9 @@ bool TaskPostExtraction::isGuiTaskOnly()
 {
     Base::PyGILStateLocker lock;
     try {
-        if (m_panel.hasAttr(std::string("isGuiTaskOnly"))) {
-            Py::Callable method(m_panel.getAttr(std::string("isGuiTaskOnly")));
+        auto panel = panelObject();
+        if (panel.hasAttr(std::string("isGuiTaskOnly"))) {
+            Py::Callable method(panel.getAttr(std::string("isGuiTaskOnly")));
             auto result = Py::Boolean(method.apply());
             return result.as_bool();
         }
@@ -143,8 +147,9 @@ void TaskPostExtraction::apply()
 {
     Base::PyGILStateLocker lock;
     try {
-        if (m_panel.hasAttr(std::string("apply"))) {
-            Py::Callable method(m_panel.getAttr(std::string("apply")));
+        auto panel = panelObject();
+        if (panel.hasAttr(std::string("apply"))) {
+            Py::Callable method(panel.getAttr(std::string("apply")));
             method.apply();
         }
     }
@@ -158,8 +163,9 @@ bool TaskPostExtraction::initiallyCollapsed()
 {
     Base::PyGILStateLocker lock;
     try {
-        if (m_panel.hasAttr(std::string("initiallyCollapsed"))) {
-            Py::Callable method(m_panel.getAttr(std::string("initiallyCollapsed")));
+        auto panel = panelObject();
+        if (panel.hasAttr(std::string("initiallyCollapsed"))) {
+            Py::Callable method(panel.getAttr(std::string("initiallyCollapsed")));
             auto result = Py::Boolean(method.apply());
             return result.as_bool();
         }

--- a/src/Mod/Fem/Gui/TaskPostExtraction.cpp
+++ b/src/Mod/Fem/Gui/TaskPostExtraction.cpp
@@ -90,8 +90,13 @@ TaskPostExtraction::TaskPostExtraction(ViewProviderFemPostObject* view, QWidget*
     Base::Console().error("Unable to import data extraction widget\n");
 };
 
-TaskPostExtraction::~TaskPostExtraction()
+TaskPostExtraction::~TaskPostExtraction() = default;
+
+void TaskPostExtraction::clearPythonPanel() noexcept
 {
+    if (!m_panel) {
+        return;
+    }
 
     Base::PyGILStateLocker lock;
     try {
@@ -99,11 +104,12 @@ TaskPostExtraction::~TaskPostExtraction()
         if (panel.hasAttr(std::string("widget"))) {
             panel.setAttr(std::string("widget"), Py::None());
         }
-        m_panel.reset();
     }
-    catch (Py::AttributeError& e) {
+    catch (Py::Exception& e) {
         e.clear();
     }
+
+    m_panel.reset();
 }
 
 void TaskPostExtraction::onPostDataChanged(Fem::FemPostObject* obj)

--- a/src/Mod/Fem/Gui/TaskPostExtraction.h
+++ b/src/Mod/Fem/Gui/TaskPostExtraction.h
@@ -50,7 +50,10 @@ class TaskPostExtraction: public TaskPostWidget
 
 public:
     explicit TaskPostExtraction(ViewProviderFemPostObject* view, QWidget* parent = nullptr);
-    ~TaskPostExtraction();
+    ~TaskPostExtraction() override;
+
+    /// Clear the Python panel before the task widget is destroyed.
+    void clearPythonPanel() noexcept;
 
 protected:
     bool isGuiTaskOnly() override;

--- a/src/Mod/Fem/Gui/TaskPostExtraction.h
+++ b/src/Mod/Fem/Gui/TaskPostExtraction.h
@@ -26,6 +26,7 @@
 #include <Gui/TaskView/TaskDialog.h>
 #include <Gui/TaskView/TaskView.h>
 #include <Gui/ViewProviderDocumentObject.h>
+#include <Base/NativePythonReference.h>
 
 #include <QAbstractTableModel>
 
@@ -58,7 +59,12 @@ protected:
     bool initiallyCollapsed() override;
 
 private:
-    Py::Object m_panel;
+    Py::Object panelObject() const
+    {
+        return Py::Object(m_panel.get());
+    }
+
+    Base::NativePythonReference m_panel;
 };
 
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
@@ -305,10 +305,10 @@ void ViewProviderFemConstraint::unsetEdit(int ModNum)
 PyObject* ViewProviderFemConstraint::getPyObject()
 {
     if (!pyViewObject) {
-        pyViewObject = new ViewProviderFemConstraintPy(this);
+        pyViewObject.reset(new ViewProviderFemConstraintPy(this));
     }
-    pyViewObject->IncRef();
-    return pyViewObject;
+    Py_INCREF(pyViewObject.get());
+    return pyViewObject.get();
 }
 
 

--- a/src/Mod/Fem/Gui/ViewProviderFemMesh.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemMesh.cpp
@@ -595,10 +595,10 @@ void ViewProviderFemMesh::resetHighlightNodes()
 PyObject* ViewProviderFemMesh::getPyObject()
 {
     if (!pyViewObject) {
-        pyViewObject = new ViewProviderFemMeshPy(this);
+        pyViewObject.reset(new ViewProviderFemMeshPy(this));
     }
-    pyViewObject->IncRef();
-    return pyViewObject;
+    Py_INCREF(pyViewObject.get());
+    return pyViewObject.get();
 }
 
 void ViewProviderFemMesh::setDisplacementByNodeId(const std::map<long, Base::Vector3d>& NodeDispMap)

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFilter.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFilter.cpp
@@ -56,10 +56,10 @@ template<>
 PyObject* FemGui::ViewProviderPostFilterPython::getPyObject()
 {
     if (!pyViewObject) {
-        pyViewObject = new ViewProviderFemPostFilterPy(this);
+        pyViewObject.reset(new ViewProviderFemPostFilterPy(this));
     }
-    pyViewObject->IncRef();
-    return pyViewObject;
+    Py_INCREF(pyViewObject.get());
+    return pyViewObject.get();
 }
 
 // explicit template instantiation

--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -937,6 +937,9 @@ void ViewProviderFemPostObject::setupTaskDialog(TaskDlgPost* dlg)
 #ifdef FC_USE_VTK_PYTHON
     auto extrPanel = new TaskPostExtraction(this);
     dlg->addTaskBox(extrPanel->windowIcon().pixmap(32), extrPanel);
+    QObject::connect(dlg, &Gui::TaskView::TaskDialog::aboutToBeDestroyed, extrPanel, [extrPanel]() {
+        extrPanel->clearPythonPanel();
+    });
 #endif
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.cpp
@@ -263,8 +263,8 @@ bool ViewProviderFemPostPipeline::canDragObjectToTarget(
 PyObject* ViewProviderFemPostPipeline::getPyObject()
 {
     if (!pyViewObject) {
-        pyViewObject = new ViewProviderFemPostPipelinePy(this);
+        pyViewObject.reset(new ViewProviderFemPostPipelinePy(this));
     }
-    pyViewObject->IncRef();
-    return pyViewObject;
+    Py_INCREF(pyViewObject.get());
+    return pyViewObject.get();
 }

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -106,6 +106,15 @@ Part::Ellipse* createEllipsePrimitive(const TopoDS_Edge& edge, App::Document* do
 Part::Vertex* createVertexPrimitive(const TopoDS_Vertex& vertex, App::Document* doc, const char* name);
 Part::Feature* createGenericShapeFeature(const TopoDS_Shape& shape, App::Document* doc, const char* name);
 
+PyObject* layerViewObject(PyObject* drawingLayer)
+{
+    if (!drawingLayer) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+    return PyObject_GetAttrString(drawingLayer, "ViewObject");
+}
+
 }  // namespace
 
 namespace
@@ -1540,9 +1549,7 @@ ImpExpDxfRead::Layer::Layer(
     PyObject* drawingLayer
 )
     : CDxfRead::Layer(name, color, std::move(lineType))
-    , DraftLayerView(
-          drawingLayer == nullptr ? Py_None : PyObject_GetAttrString(drawingLayer, "ViewObject")
-      )
+    , DraftLayerView(layerViewObject(drawingLayer))
     , GroupContents(
           drawingLayer == nullptr ? nullptr
                                   : dynamic_cast<App::PropertyLinkListHidden*>(
@@ -1552,10 +1559,7 @@ ImpExpDxfRead::Layer::Layer(
                                     )
       )
 {}
-ImpExpDxfRead::Layer::~Layer()
-{
-    Py_XDECREF(DraftLayerView);
-}
+ImpExpDxfRead::Layer::~Layer() = default;
 
 void ImpExpDxfRead::Layer::FinishLayer() const
 {
@@ -1566,11 +1570,11 @@ void ImpExpDxfRead::Layer::FinishLayer() const
         // App::FeaturePython, and its Proxy is a draftobjects.layer.Layer
         GroupContents->setValue(Contents);
     }
-    if (DraftLayerView != Py_None && Hidden) {
+    if (DraftLayerView.get() != Py_None && Hidden) {
         // Hide the Hidden layers if possible (if GUI exists)
         // We do this now rather than when the layer is created so all objects
         // within the layers also become hidden.
-        PyObject_CallMethod(DraftLayerView, "hide", nullptr);
+        PyObject_CallMethod(DraftLayerView.get(), "hide", nullptr);
     }
 }
 
@@ -1608,12 +1612,16 @@ CDxfRead::Layer* ImpExpDxfRead::MakeLayer(const std::string& name, ColorIndex_t 
                 );
         }
         auto result = new Layer(name, color, std::move(lineType), layer);
-        if (result->DraftLayerView != Py_None) {
+        if (result->DraftLayerView.get() != Py_None) {
             // Get the correct boolean value based on the user's preference.
             PyObject* overrideValue = m_preserveColors ? Py_True : Py_False;
-            PyObject_SetAttrString(result->DraftLayerView, "OverrideLineColorChildren", overrideValue);
             PyObject_SetAttrString(
-                result->DraftLayerView,
+                result->DraftLayerView.get(),
+                "OverrideLineColorChildren",
+                overrideValue
+            );
+            PyObject_SetAttrString(
+                result->DraftLayerView.get(),
                 "OverrideShapeAppearanceChildren",
                 overrideValue
             );

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -33,6 +33,7 @@
 #include <Mod/Part/App/TopoShape.h>
 #include <Mod/Part/App/PartFeature.h>
 #include <Mod/Part/App/FeatureCompound.h>
+#include <Base/NativePythonReference.h>
 
 #include "dxf.h"
 
@@ -58,10 +59,7 @@ public:
     ImpExpDxfRead(ImpExpDxfRead&&) = delete;
     void operator=(const ImpExpDxfRead&) = delete;
     void operator=(ImpExpDxfRead&&) = delete;
-    ~ImpExpDxfRead() override
-    {
-        Py_XDECREF(DraftModule);
-    }
+    ~ImpExpDxfRead() override = default;
     static std::map<std::string, int> PreScan(const std::string& filepath);
     void StartImport() override;
 
@@ -176,7 +174,7 @@ private:
     // to the drawing. unref's all the shapes in the collection, possibly freeing them.
     void CombineShapes(std::list<TopoDS_Shape>& shapes, const char* nameBase) const;
     TopoDS_Shape CombineShapesToCompound(const std::list<TopoDS_Shape>& shapes) const;
-    PyObject* DraftModule = nullptr;
+    Base::NativePythonReference DraftModule;
     std::set<std::string> m_referencedBlocks;
     void ComposeBlocks();
     void ComposeParametricBlock(const std::string& blockName, std::set<std::string>& composed);
@@ -187,14 +185,14 @@ private:
 protected:
     PyObject* getDraftModule()
     {
-        if (DraftModule == nullptr) {
+        if (!DraftModule) {
             static int times = 0;
-            DraftModule = PyImport_ImportModule("Draft");
-            if (DraftModule == nullptr && times++ == 0) {
+            DraftModule.reset(PyImport_ImportModule("Draft"));
+            if (!DraftModule && times++ == 0) {
                 ImportError("Unable to locate \"Draft\" module");
             }
         }
-        return DraftModule;
+        return DraftModule.get();
     }
     CDxfRead::Layer* MakeLayer(const std::string& name, ColorIndex_t color, std::string&& lineType) override;
 
@@ -214,7 +212,7 @@ protected:
         void operator=(Layer&&) = delete;
         ~Layer() override;
         // The View object for the layer or Py_None (e.g. if no gui)
-        PyObject* const DraftLayerView;
+        Base::NativePythonReference DraftLayerView;
         std::vector<App::DocumentObject*> Contents;
         void FinishLayer() const;
         App::PropertyLinkListHidden* GroupContents;

--- a/src/Mod/Material/App/AppMaterial.cpp
+++ b/src/Mod/Material/App/AppMaterial.cpp
@@ -32,6 +32,7 @@
 #include "ModelManagerLocal.h"
 #include "PropertyMaterial.h"
 #if defined(BUILD_MATERIAL_EXTERNAL)
+#include "ExternalManager.h"
 #include "ModelManagerExternal.h"
 #include "MaterialManagerExternal.h"
 #endif
@@ -75,6 +76,9 @@ PyObject* initModule()
 
 PyMOD_INIT_FUNC(Materials)
 {
+#if defined(BUILD_MATERIAL_EXTERNAL)
+    App::CleanupProcess::registerCleanup([]() { Materials::ExternalManager::cleanup(); });
+#endif
 #ifdef FC_DEBUG
     App::CleanupProcess::registerCleanup([]() {
         Materials::MaterialManager::cleanup();

--- a/src/Mod/Material/App/ExternalManager.cpp
+++ b/src/Mod/Material/App/ExternalManager.cpp
@@ -115,8 +115,8 @@ void ExternalManager::instantiate()
         }
 
         Py::Callable managerClass(mod.getAttr(_className));
-        _managerObject = managerClass.apply();
-        if (!_managerObject.isNull() && _managerObject.hasAttr("APIVersion")) {
+        _managerObject.reset(managerClass.apply());
+        if (_managerObject && managerObject().hasAttr("APIVersion")) {
             _instantiated = true;
         }
 
@@ -158,6 +158,13 @@ ExternalManager* ExternalManager::getManager()
     initManager();
 
     return _manager;
+}
+
+void ExternalManager::cleanup()
+{
+    QMutexLocker locker(&_mutex);
+    delete _manager;
+    _manager = nullptr;
 }
 
 //=====
@@ -237,8 +244,8 @@ ExternalManager::libraries()
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("libraries")) {
-            Py::Callable libraries(_managerObject.getAttr("libraries"));
+        if (managerObject().hasAttr("libraries")) {
+            Py::Callable libraries(managerObject().getAttr("libraries"));
             Py::List list(libraries.apply());
             for (auto lib : list) {
                 auto library = libraryFromObject(Py::Object(lib));
@@ -267,8 +274,8 @@ std::shared_ptr<std::vector<std::shared_ptr<Library>>> ExternalManager::modelLib
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("modelLibraries")) {
-            Py::Callable libraries(_managerObject.getAttr("modelLibraries"));
+        if (managerObject().hasAttr("modelLibraries")) {
+            Py::Callable libraries(managerObject().getAttr("modelLibraries"));
             Py::List list(libraries.apply());
             for (auto lib : list) {
                 auto library = libraryFromObject(Py::Tuple(lib));
@@ -296,8 +303,8 @@ std::shared_ptr<std::vector<std::shared_ptr<Library>>> ExternalManager::material
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("materialLibraries")) {
-            Py::Callable libraries(_managerObject.getAttr("materialLibraries"));
+        if (managerObject().hasAttr("materialLibraries")) {
+            Py::Callable libraries(managerObject().getAttr("materialLibraries"));
             Py::List list(libraries.apply());
             for (auto lib : list) {
                 auto library = libraryFromObject(Py::Tuple(lib));
@@ -324,8 +331,8 @@ std::shared_ptr<Library> ExternalManager::getLibrary(const QString& name)
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("getLibrary")) {
-            Py::Callable libraries(_managerObject.getAttr("getLibrary"));
+        if (managerObject().hasAttr("getLibrary")) {
+            Py::Callable libraries(managerObject().getAttr("getLibrary"));
             Py::Tuple args(1);
             args.setItem(0, Py::String(name.toStdString()));
             Py::Object result(libraries.apply(args));
@@ -353,8 +360,8 @@ void ExternalManager::createLibrary(const QString& libraryName, const QByteArray
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("createLibrary")) {
-            Py::Callable libraries(_managerObject.getAttr("createLibrary"));
+        if (managerObject().hasAttr("createLibrary")) {
+            Py::Callable libraries(managerObject().getAttr("createLibrary"));
             Py::Tuple args(3);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::Bytes(icon.data(), icon.size()));
@@ -378,8 +385,8 @@ void ExternalManager::renameLibrary(const QString& libraryName, const QString& n
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("renameLibrary")) {
-            Py::Callable libraries(_managerObject.getAttr("renameLibrary"));
+        if (managerObject().hasAttr("renameLibrary")) {
+            Py::Callable libraries(managerObject().getAttr("renameLibrary"));
             Py::Tuple args(2);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(newName.toStdString()));
@@ -402,8 +409,8 @@ void ExternalManager::changeIcon(const QString& libraryName, const QByteArray& i
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("changeIcon")) {
-            Py::Callable libraries(_managerObject.getAttr("changeIcon"));
+        if (managerObject().hasAttr("changeIcon")) {
+            Py::Callable libraries(managerObject().getAttr("changeIcon"));
             Py::Tuple args(2);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::Bytes(icon.data(), icon.size()));
@@ -426,8 +433,8 @@ void ExternalManager::removeLibrary(const QString& libraryName)
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("removeLibrary")) {
-            Py::Callable libraries(_managerObject.getAttr("removeLibrary"));
+        if (managerObject().hasAttr("removeLibrary")) {
+            Py::Callable libraries(managerObject().getAttr("removeLibrary"));
             Py::Tuple args(1);
             args.setItem(0, Py::String(libraryName.toStdString()));
             libraries.apply(args);  // No return expected
@@ -452,8 +459,8 @@ ExternalManager::libraryModels(const QString& libraryName)
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("libraryModels")) {
-            Py::Callable libraries(_managerObject.getAttr("libraryModels"));
+        if (managerObject().hasAttr("libraryModels")) {
+            Py::Callable libraries(managerObject().getAttr("libraryModels"));
             Py::Tuple args(1);
             args.setItem(0, Py::String(libraryName.toStdString()));
             Py::List list(libraries.apply(args));
@@ -488,8 +495,8 @@ ExternalManager::libraryMaterials(const QString& libraryName)
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("libraryMaterials")) {
-            Py::Callable libraries(_managerObject.getAttr("libraryMaterials"));
+        if (managerObject().hasAttr("libraryMaterials")) {
+            Py::Callable libraries(managerObject().getAttr("libraryMaterials"));
             Py::Tuple args(1);
             args.setItem(0, Py::String(libraryName.toStdString()));
             Py::List list(libraries.apply(args));
@@ -526,8 +533,8 @@ ExternalManager::libraryMaterials(const QString& libraryName,
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("libraryMaterials")) {
-            Py::Callable libraries(_managerObject.getAttr("libraryMaterials"));
+        if (managerObject().hasAttr("libraryMaterials")) {
+            Py::Callable libraries(managerObject().getAttr("libraryMaterials"));
             Py::Tuple args(3);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::Object(new MaterialFilterPy(new MaterialFilter(filter)), true));
@@ -565,8 +572,8 @@ std::shared_ptr<std::vector<QString>> ExternalManager::libraryFolders(const QStr
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("libraryFolders")) {
-            Py::Callable folders(_managerObject.getAttr("libraryFolders"));
+        if (managerObject().hasAttr("libraryFolders")) {
+            Py::Callable folders(managerObject().getAttr("libraryFolders"));
             Py::Tuple args(1);
             args.setItem(0, Py::String(libraryName.toStdString()));
             Py::List list(folders.apply(args));
@@ -607,8 +614,8 @@ void ExternalManager::createFolder(const QString& libraryName, const QString& pa
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("createFolder")) {
-            Py::Callable libraries(_managerObject.getAttr("createFolder"));
+        if (managerObject().hasAttr("createFolder")) {
+            Py::Callable libraries(managerObject().getAttr("createFolder"));
             Py::Tuple args(2);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(path.toStdString()));
@@ -633,8 +640,8 @@ void ExternalManager::renameFolder(const QString& libraryName,
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("renameFolder")) {
-            Py::Callable libraries(_managerObject.getAttr("renameFolder"));
+        if (managerObject().hasAttr("renameFolder")) {
+            Py::Callable libraries(managerObject().getAttr("renameFolder"));
             Py::Tuple args(3);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(oldPath.toStdString()));
@@ -658,8 +665,8 @@ void ExternalManager::deleteRecursive(const QString& libraryName, const QString&
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("deleteRecursive")) {
-            Py::Callable libraries(_managerObject.getAttr("deleteRecursive"));
+        if (managerObject().hasAttr("deleteRecursive")) {
+            Py::Callable libraries(managerObject().getAttr("deleteRecursive"));
             Py::Tuple args(2);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(path.toStdString()));
@@ -719,8 +726,8 @@ std::shared_ptr<Model> ExternalManager::getModel(const QString& uuid)
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("getModel")) {
-            Py::Callable libraries(_managerObject.getAttr("getModel"));
+        if (managerObject().hasAttr("getModel")) {
+            Py::Callable libraries(managerObject().getAttr("getModel"));
             Py::Tuple args(1);
             args.setItem(0, Py::String(uuid.toStdString()));
             Py::Object result(libraries.apply(args));  // ignore return for now
@@ -748,8 +755,8 @@ void ExternalManager::addModel(const QString& libraryName,
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("addModel")) {
-            Py::Callable libraries(_managerObject.getAttr("addModel"));
+        if (managerObject().hasAttr("addModel")) {
+            Py::Callable libraries(managerObject().getAttr("addModel"));
             Py::Tuple args(3);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(path.toStdString()));
@@ -775,8 +782,8 @@ void ExternalManager::migrateModel(const QString& libraryName,
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("migrateModel")) {
-            Py::Callable libraries(_managerObject.getAttr("migrateModel"));
+        if (managerObject().hasAttr("migrateModel")) {
+            Py::Callable libraries(managerObject().getAttr("migrateModel"));
             Py::Tuple args(3);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(path.toStdString()));
@@ -802,8 +809,8 @@ void ExternalManager::updateModel(const QString& libraryName,
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("updateModel")) {
-            Py::Callable libraries(_managerObject.getAttr("updateModel"));
+        if (managerObject().hasAttr("updateModel")) {
+            Py::Callable libraries(managerObject().getAttr("updateModel"));
             Py::Tuple args(3);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(path.toStdString()));
@@ -829,8 +836,8 @@ void ExternalManager::setModelPath(const QString& libraryName,
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("setModelPath")) {
-            Py::Callable libraries(_managerObject.getAttr("setModelPath"));
+        if (managerObject().hasAttr("setModelPath")) {
+            Py::Callable libraries(managerObject().getAttr("setModelPath"));
             Py::Tuple args(3);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(path.toStdString()));
@@ -856,8 +863,8 @@ void ExternalManager::renameModel(const QString& libraryName,
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("renameModel")) {
-            Py::Callable libraries(_managerObject.getAttr("renameModel"));
+        if (managerObject().hasAttr("renameModel")) {
+            Py::Callable libraries(managerObject().getAttr("renameModel"));
             Py::Tuple args(3);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(name.toStdString()));
@@ -883,8 +890,8 @@ void ExternalManager::moveModel(const QString& libraryName,
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("moveModel")) {
-            Py::Callable libraries(_managerObject.getAttr("moveModel"));
+        if (managerObject().hasAttr("moveModel")) {
+            Py::Callable libraries(managerObject().getAttr("moveModel"));
             Py::Tuple args(3);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(path.toStdString()));
@@ -908,8 +915,8 @@ void ExternalManager::removeModel(const QString& uuid)
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("removeModel")) {
-            Py::Callable libraries(_managerObject.getAttr("removeModel"));
+        if (managerObject().hasAttr("removeModel")) {
+            Py::Callable libraries(managerObject().getAttr("removeModel"));
             Py::Tuple args(1);
             args.setItem(0, Py::String(uuid.toStdString()));
             libraries.apply(args);  // No return expected
@@ -968,8 +975,8 @@ std::shared_ptr<Material> ExternalManager::getMaterial(const QString& uuid)
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("getMaterial")) {
-            Py::Callable libraries(_managerObject.getAttr("getMaterial"));
+        if (managerObject().hasAttr("getMaterial")) {
+            Py::Callable libraries(managerObject().getAttr("getMaterial"));
             Py::Tuple args(1);
             args.setItem(0, Py::String(uuid.toStdString()));
             Py::Object result(libraries.apply(args));
@@ -997,8 +1004,8 @@ void ExternalManager::addMaterial(const QString& libraryName,
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("addMaterial")) {
-            Py::Callable libraries(_managerObject.getAttr("addMaterial"));
+        if (managerObject().hasAttr("addMaterial")) {
+            Py::Callable libraries(managerObject().getAttr("addMaterial"));
             Py::Tuple args(3);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(path.toStdString()));
@@ -1024,8 +1031,8 @@ void ExternalManager::migrateMaterial(const QString& libraryName,
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("migrateMaterial")) {
-            Py::Callable libraries(_managerObject.getAttr("migrateMaterial"));
+        if (managerObject().hasAttr("migrateMaterial")) {
+            Py::Callable libraries(managerObject().getAttr("migrateMaterial"));
             Py::Tuple args(3);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(path.toStdString()));
@@ -1052,8 +1059,8 @@ void ExternalManager::updateMaterial(const QString& libraryName,
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("updateMaterial")) {
-            Py::Callable libraries(_managerObject.getAttr("updateMaterial"));
+        if (managerObject().hasAttr("updateMaterial")) {
+            Py::Callable libraries(managerObject().getAttr("updateMaterial"));
             Py::Tuple args(3);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(path.toStdString()));
@@ -1079,8 +1086,8 @@ void ExternalManager::setMaterialPath(const QString& libraryName,
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("setMaterialPath")) {
-            Py::Callable libraries(_managerObject.getAttr("setMaterialPath"));
+        if (managerObject().hasAttr("setMaterialPath")) {
+            Py::Callable libraries(managerObject().getAttr("setMaterialPath"));
             Py::Tuple args(3);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(path.toStdString()));
@@ -1106,8 +1113,8 @@ void ExternalManager::renameMaterial(const QString& libraryName,
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("renameMaterial")) {
-            Py::Callable libraries(_managerObject.getAttr("renameMaterial"));
+        if (managerObject().hasAttr("renameMaterial")) {
+            Py::Callable libraries(managerObject().getAttr("renameMaterial"));
             Py::Tuple args(3);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(name.toStdString()));
@@ -1133,8 +1140,8 @@ void ExternalManager::moveMaterial(const QString& libraryName,
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("moveMaterial")) {
-            Py::Callable libraries(_managerObject.getAttr("moveMaterial"));
+        if (managerObject().hasAttr("moveMaterial")) {
+            Py::Callable libraries(managerObject().getAttr("moveMaterial"));
             Py::Tuple args(3);
             args.setItem(0, Py::String(libraryName.toStdString()));
             args.setItem(1, Py::String(path.toStdString()));
@@ -1158,8 +1165,8 @@ void ExternalManager::removeMaterial(const QString& uuid)
 
     Base::PyGILStateLocker lock;
     try {
-        if (_managerObject.hasAttr("removeMaterial")) {
-            Py::Callable libraries(_managerObject.getAttr("removeMaterial"));
+        if (managerObject().hasAttr("removeMaterial")) {
+            Py::Callable libraries(managerObject().getAttr("removeMaterial"));
             Py::Tuple args(1);
             args.setItem(0, Py::String(uuid.toStdString()));
             libraries.apply(args);  // No return expected

--- a/src/Mod/Material/App/ExternalManager.h
+++ b/src/Mod/Material/App/ExternalManager.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <Base/NativePythonReference.h>
 #include <Base/Parameter.h>
 #include <CXX/Objects.hxx>
 
@@ -47,6 +48,7 @@ class MaterialsExport ExternalManager: public ParameterGrp::ObserverType
 public:
 
     static ExternalManager* getManager();
+    static void cleanup();
 
     /// Observer message from the ParameterGrp
     void OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::MessageType Reason) override;
@@ -124,6 +126,11 @@ private:
     bool checkMaterialObjectType(const Py::Object& entry);
     std::shared_ptr<Material> materialFromObject(const Py::Object& entry, const QString& uuid);
 
+    Py::Object managerObject() const
+    {
+        return Py::Object(_managerObject.get());
+    }
+
     static ExternalManager* _manager;
     static QMutex _mutex;
 
@@ -133,7 +140,7 @@ private:
     std::string _className;
     bool _instantiated;
 
-    Py::Object _managerObject;
+    Base::NativePythonReference _managerObject;
 };
 
 }  // namespace Materials

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -314,7 +314,7 @@ void TaskMeasure::createObject(const App::MeasureType* measureType)
 
     if (measureType->isPython) {
         Base::PyGILStateLocker lock;
-        auto pyMeasureClass = measureType->pythonClass;
+        auto pyMeasureClass = Py::Object(measureType->pythonClass.get());
 
         // Create a MeasurePython instance
         // Note: writing addObject<Measure::MeasurePython>() is not yet supported because
@@ -327,7 +327,7 @@ void TaskMeasure::createObject(const App::MeasureType* measureType)
         // proxy
         Py::Tuple args(1);
         args.setItem(0, Py::asObject(_mMeasureObject->getPyObject()));
-        PyObject* result = PyObject_CallObject(pyMeasureClass, args.ptr());
+        PyObject* result = PyObject_CallObject(pyMeasureClass.ptr(), args.ptr());
         Py_XDECREF(result);
     }
     else {

--- a/src/Mod/Mesh/App/MeshProperties.cpp
+++ b/src/Mod/Mesh/App/MeshProperties.cpp
@@ -734,8 +734,7 @@ PropertyMeshKernel::~PropertyMeshKernel()
     if (meshPyObject) {
         // Note: Do not call setInvalid() of the Python binding
         // because the mesh should still be accessible afterwards.
-        meshPyObject->parentProperty = nullptr;
-        Py_DECREF(meshPyObject);
+        static_cast<MeshPy*>(meshPyObject.get())->parentProperty = nullptr;
     }
 }
 
@@ -846,15 +845,14 @@ Base::Matrix4D PropertyMeshKernel::getTransform() const
 PyObject* PropertyMeshKernel::getPyObject()
 {
     if (!meshPyObject) {
-        meshPyObject = new MeshPy(&*_meshObject);  // Lgtm[cpp/resource-not-released-in-destructor]
-                                                   // ** Not destroyed in this class because it is
-                                                   // reference-counted and destroyed elsewhere
-        meshPyObject->setConst();                  // set immutable
-        meshPyObject->parentProperty = this;
+        auto* object = new MeshPy(&*_meshObject);
+        object->setConst();  // set immutable
+        object->parentProperty = this;
+        meshPyObject.reset(object);
     }
 
-    Py_INCREF(meshPyObject);
-    return meshPyObject;
+    Py_INCREF(meshPyObject.get());
+    return meshPyObject.get();
 }
 
 void PropertyMeshKernel::setPyObject(PyObject* value)

--- a/src/Mod/Mesh/App/MeshProperties.h
+++ b/src/Mod/Mesh/App/MeshProperties.h
@@ -32,6 +32,7 @@
 
 #include <Base/Handle.h>
 #include <Base/Matrix.h>
+#include <Base/NativePythonReference.h>
 
 #include <Mod/Mesh/App/Core/MeshIO.h>
 #include <Mod/Mesh/App/Core/MeshKernel.h>
@@ -323,7 +324,7 @@ public:
 
 private:
     Base::Reference<MeshObject> _meshObject;
-    MeshPy* meshPyObject {nullptr};
+    Base::NativePythonReference meshPyObject;
 };
 
 }  // namespace Mesh

--- a/src/Mod/Mesh/Gui/ViewProvider.cpp
+++ b/src/Mod/Mesh/Gui/ViewProvider.cpp
@@ -2484,10 +2484,10 @@ bool ViewProviderMesh::canHighlightColors() const
 PyObject* ViewProviderMesh::getPyObject()
 {
     if (!pyViewObject) {
-        pyViewObject = new ViewProviderMeshPy(this);
+        pyViewObject.reset(new ViewProviderMeshPy(this));
     }
-    pyViewObject->IncRef();
-    return pyViewObject;
+    Py_INCREF(pyViewObject.get());
+    return pyViewObject.get();
 }
 
 // ------------------------------------------------------

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -299,10 +299,10 @@ ViewProviderPartExt::~ViewProviderPartExt()
 PyObject* ViewProviderPartExt::getPyObject()
 {
     if (!pyViewObject) {
-        pyViewObject = new ViewProviderPartExtPy(this);
+        pyViewObject.reset(new ViewProviderPartExtPy(this));
     }
-    pyViewObject->IncRef();
-    return pyViewObject;
+    Py_INCREF(pyViewObject.get());
+    return pyViewObject.get();
 }
 
 void ViewProviderPartExt::onChanged(const App::Property* prop)

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -464,10 +464,10 @@ void ViewProvider::makeTemporaryVisible(bool onoff)
 PyObject* ViewProvider::getPyObject()
 {
     if (!pyViewObject) {
-        pyViewObject = new ViewProviderPy(this);
+        pyViewObject.reset(new ViewProviderPy(this));
     }
-    pyViewObject->IncRef();
-    return pyViewObject;
+    Py_INCREF(pyViewObject.get());
+    return pyViewObject.get();
 }
 
 ViewProviderBody* ViewProvider::getBodyViewProvider()

--- a/src/Mod/Spreadsheet/App/PropertyColumnWidths.cpp
+++ b/src/Mod/Spreadsheet/App/PropertyColumnWidths.cpp
@@ -155,11 +155,11 @@ void PropertyColumnWidths::Restore(Base::XMLReader& reader)
 
 PyObject* PropertyColumnWidths::getPyObject()
 {
-    if (PythonObject.is(Py::_None())) {
-        // ref counter is set to 1
-        PythonObject = Py::Object(new PropertyColumnWidthsPy(this), true);
+    if (!PythonObject) {
+        PythonObject.reset(new PropertyColumnWidthsPy(this));
     }
-    return Py::new_reference_to(PythonObject);
+    Py_INCREF(PythonObject.get());
+    return PythonObject.get();
 }
 
 void PropertyColumnWidths::clear()

--- a/src/Mod/Spreadsheet/App/PropertyColumnWidths.h
+++ b/src/Mod/Spreadsheet/App/PropertyColumnWidths.h
@@ -26,6 +26,7 @@
 
 #include <App/Property.h>
 #include <CXX/Objects.hxx>
+#include <Base/NativePythonReference.h>
 #include <Mod/Spreadsheet/SpreadsheetGlobal.h>
 #include <map>
 
@@ -92,7 +93,7 @@ private:
 
     std::set<int> dirty;
 
-    Py::Object PythonObject;
+    Base::NativePythonReference PythonObject;
 };
 
 }  // namespace Spreadsheet

--- a/src/Mod/Spreadsheet/App/PropertyRowHeights.cpp
+++ b/src/Mod/Spreadsheet/App/PropertyRowHeights.cpp
@@ -149,11 +149,11 @@ void PropertyRowHeights::Restore(Base::XMLReader& reader)
 
 PyObject* PropertyRowHeights::getPyObject()
 {
-    if (PythonObject.is(Py::_None())) {
-        // ref counter is set to 1
-        PythonObject = Py::Object(new PropertyRowHeightsPy(this), true);
+    if (!PythonObject) {
+        PythonObject.reset(new PropertyRowHeightsPy(this));
     }
-    return Py::new_reference_to(PythonObject);
+    Py_INCREF(PythonObject.get());
+    return PythonObject.get();
 }
 
 void PropertyRowHeights::clear()

--- a/src/Mod/Spreadsheet/App/PropertyRowHeights.h
+++ b/src/Mod/Spreadsheet/App/PropertyRowHeights.h
@@ -26,6 +26,7 @@
 
 #include <App/Property.h>
 #include <CXX/Objects.hxx>
+#include <Base/NativePythonReference.h>
 #include <Mod/Spreadsheet/SpreadsheetGlobal.h>
 #include <map>
 
@@ -91,7 +92,7 @@ private:
 
     std::set<int> dirty;
 
-    Py::Object PythonObject;
+    Base::NativePythonReference PythonObject;
 };
 
 }  // namespace Spreadsheet

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -574,11 +574,11 @@ void SpreadsheetGui::SheetView::setCurrentIndex(App::CellAddress cell) const
 PyObject* SheetView::getPyObject()
 {
     if (!pythonObject) {
-        pythonObject = new SheetViewPy(this);
+        pythonObject.reset(new SheetViewPy(this));
     }
 
-    Py_INCREF(pythonObject);
-    return pythonObject;
+    Py_INCREF(pythonObject.get());
+    return pythonObject.get();
 }
 
 void SheetView::deleteSelf()

--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
@@ -180,10 +180,10 @@ void ViewProviderSheet::updateData(const App::Property* prop)
 PyObject* ViewProviderSheet::getPyObject()
 {
     if (!pyViewObject) {
-        pyViewObject = new ViewProviderSpreadsheetPy(this);
+        pyViewObject.reset(new ViewProviderSpreadsheetPy(this));
     }
-    pyViewObject->IncRef();
-    return pyViewObject;
+    Py_INCREF(pyViewObject.get());
+    return pyViewObject.get();
 }
 
 // Python feature -----------------------------------------------------------------------

--- a/src/Mod/TechDraw/App/CenterLine.cpp
+++ b/src/Mod/TechDraw/App/CenterLine.cpp
@@ -61,21 +61,41 @@ CenterLine::CenterLine()
     initialize();
 }
 
-CenterLine::CenterLine(const TechDraw::CenterLine* cl)
+CenterLine::CenterLine(const TechDraw::CenterLine& cl)
+    : CenterLine()
 {
-    m_start = cl->m_start;
-    m_end = cl->m_end;
-    m_mode = cl->m_mode;
-    m_hShift = cl->m_hShift;
-    m_vShift = cl->m_vShift;
-    m_rotate = cl->m_rotate;
-    m_extendBy = cl->m_extendBy;
-    m_type = cl->m_type;
-    m_flip2Line = cl->m_flip2Line;
+    *this = cl;
+}
 
-    m_geometry = cl->m_geometry;    //new BaseGeom(cl->m_geometry);??
+CenterLine::CenterLine(const TechDraw::CenterLine* cl)
+    : CenterLine(*cl)
+{}
 
-    initialize();
+CenterLine& CenterLine::operator=(const TechDraw::CenterLine& cl)
+{
+    if (this == &cl) {
+        return *this;
+    }
+
+    m_start = cl.m_start;
+    m_end = cl.m_end;
+    m_faces = cl.m_faces;
+    m_edges = cl.m_edges;
+    m_verts = cl.m_verts;
+    m_type = cl.m_type;
+    m_mode = cl.m_mode;
+    m_hShift = cl.m_hShift;
+    m_vShift = cl.m_vShift;
+    m_rotate = cl.m_rotate;
+    m_extendBy = cl.m_extendBy;
+    m_format = cl.m_format;
+    m_flip2Line = cl.m_flip2Line;
+    m_geometry = cl.m_geometry;
+    setTag(cl.getTag());
+
+    // PythonObject is a cache for this native instance and must not be shared
+    // with a copied CenterLine.
+    return *this;
 }
 
 CenterLine::CenterLine(const TechDraw::BaseGeomPtr& bg,
@@ -1062,11 +1082,11 @@ CenterLine *CenterLine::clone() const
 // To do: make const
 PyObject* CenterLine::getPyObject()
 {
-    if (PythonObject.is(Py::_None())) {
-        // ref counter is set to 1
-        PythonObject = Py::Object(new CenterLinePy(this), true);
+    if (!PythonObject) {
+        PythonObject.reset(new CenterLinePy(this));
     }
-    return Py::new_reference_to(PythonObject);
+    Py_INCREF(PythonObject.get());
+    return PythonObject.get();
 }
 
 
@@ -1115,4 +1135,3 @@ bool CenterLine::getFlip() const
 {
     return m_flip2Line;
 }
-

--- a/src/Mod/TechDraw/App/CenterLine.h
+++ b/src/Mod/TechDraw/App/CenterLine.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <App/FeaturePython.h>
+#include <Base/NativePythonReference.h>
 #include <Base/Persistence.h>
 #include <Base/Vector3D.h>
 #include <Mod/TechDraw/TechDrawGlobal.h>
@@ -68,7 +69,9 @@ public:
     }
 
     CenterLine();
+    CenterLine(const CenterLine& other);
     CenterLine(const CenterLine* cl);
+    CenterLine& operator=(const CenterLine& other);
     //set m_faces after using next 3 ctors
     CenterLine(const TechDraw::BaseGeomPtr& bg,
                const Mode m = Mode::VERTICAL,
@@ -178,7 +181,7 @@ public:
 protected:
     void initialize();
 
-    Py::Object PythonObject;
+    Base::NativePythonReference PythonObject;
 };
 
 }  // namespace TechDraw

--- a/src/Mod/TechDraw/App/Cosmetic.cpp
+++ b/src/Mod/TechDraw/App/Cosmetic.cpp
@@ -301,11 +301,11 @@ CosmeticEdge* CosmeticEdge::clone() const
 
 PyObject* CosmeticEdge::getPyObject()
 {
-    if (PythonObject.is(Py::_None())) {
-        // ref counter is set to 1
-        PythonObject = Py::Object(new CosmeticEdgePy(this), true);
+    if (!PythonObject) {
+        PythonObject.reset(new CosmeticEdgePy(this));
     }
-    return Py::new_reference_to(PythonObject);
+    Py_INCREF(PythonObject.get());
+    return PythonObject.get();
 }
 
 //------------------------------------------------------------------------------
@@ -442,15 +442,14 @@ GeomFormat* GeomFormat::copy() const
 
 PyObject* GeomFormat::getPyObject()
 {
-    if (PythonObject.is(Py::_None())) {
-        // ref counter is set to 1
-        PythonObject = Py::Object(new GeomFormatPy(this), true);
+    if (!PythonObject) {
+        PythonObject.reset(new GeomFormatPy(this));
     }
-    return Py::new_reference_to(PythonObject);
+    Py_INCREF(PythonObject.get());
+    return PythonObject.get();
 }
 
 bool CosmeticVertex::restoreCosmetic()
 {
     return Preferences::getPreferenceGroup("General")->GetBool("restoreCosmetic", true);
 }
-

--- a/src/Mod/TechDraw/App/Cosmetic.h
+++ b/src/Mod/TechDraw/App/Cosmetic.h
@@ -26,6 +26,7 @@
 
 #include <App/FeaturePython.h>
 #include <Base/Color.h>
+#include <Base/NativePythonReference.h>
 #include <Base/Persistence.h>
 #include <Base/Vector3D.h>
 
@@ -81,7 +82,7 @@ public:
     LineFormat m_format;
 
 protected:
-    Py::Object PythonObject;
+    Base::NativePythonReference PythonObject;
 };
 
 //********** GeomFormat ********************************************************
@@ -115,7 +116,7 @@ public:
     LineFormat m_format;
 
 protected:
-    Py::Object PythonObject;
+    Base::NativePythonReference PythonObject;
 };
 
 } //end namespace TechDraw

--- a/src/Mod/TechDraw/App/CosmeticVertex.cpp
+++ b/src/Mod/TechDraw/App/CosmeticVertex.cpp
@@ -230,11 +230,11 @@ CosmeticVertex* CosmeticVertex::clone() const
 
 PyObject* CosmeticVertex::getPyObject()
 {
-    if (PythonObject.is(Py::_None())) {
-        // ref counter is set to 1
-        PythonObject = Py::Object(new CosmeticVertexPy(this), true);
+    if (!PythonObject) {
+        PythonObject.reset(new CosmeticVertexPy(this));
     }
-    return Py::new_reference_to(PythonObject);
+    Py_INCREF(PythonObject.get());
+    return PythonObject.get();
 }
 
 // To do: make const

--- a/src/Mod/TechDraw/App/CosmeticVertex.h
+++ b/src/Mod/TechDraw/App/CosmeticVertex.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <App/FeaturePython.h>
+#include <Base/NativePythonReference.h>
 #include <Base/Persistence.h>
 #include <Base/Vector3D.h>
 
@@ -76,7 +77,7 @@ public:
     bool           visible{true};              //base class vertex also has visible property
 
 protected:
-    Py::Object PythonObject;
+    Base::NativePythonReference PythonObject;
 };
 
 } //end namespace TechDraw

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -457,11 +457,11 @@ void MDIViewPage::printAll(QPrinter* printer, App::Document* doc)
 PyObject* MDIViewPage::getPyObject()
 {
     if (!pythonObject) {
-        pythonObject = new MDIViewPagePy(this);
+        pythonObject.reset(new MDIViewPagePy(this));
     }
 
-    Py_INCREF(pythonObject);
-    return pythonObject;
+    Py_INCREF(pythonObject.get());
+    return pythonObject.get();
 }
 
 void MDIViewPage::contextMenuEvent(QContextMenuEvent* event)

--- a/src/Mod/Web/App/Server.cpp
+++ b/src/Mod/Web/App/Server.cpp
@@ -61,8 +61,9 @@ bool Firewall::filter(const QByteArray&) const
 }
 
 FirewallPython::FirewallPython(const Py::Object& o)
-    : obj(o)
-{}
+{
+    obj.reset(o);
+}
 
 FirewallPython::~FirewallPython() = default;
 
@@ -70,7 +71,8 @@ bool FirewallPython::filter(const QByteArray& msg) const
 {
     Base::PyGILStateLocker lock;
     try {
-        Py::Callable call(obj);
+        Py::Object firewallObject(obj.get());
+        Py::Callable call(firewallObject);
         Py::Tuple args(1);
         args.setItem(0, Py::String(msg.constData()));
         Py::Boolean ok(call.apply(args));
@@ -110,7 +112,7 @@ AppServer::AppServer(bool direct, QObject* parent)
 {
     PyObject* mod = PyImport_ImportModule("__main__");
     if (mod) {
-        module = mod;
+        module.reset(mod);
     }
     else {
         throw Py::RuntimeError("Cannot load __main__ module");
@@ -186,7 +188,8 @@ std::string AppServer::getRequest(const std::string& str) const
 {
     try {
         Base::PyGILStateLocker lock;
-        Py::Object attr = module.getAttr(std::string("GET"));
+        Py::Object mainModule(module.get());
+        Py::Object attr = mainModule.getAttr(std::string("GET"));
         return attr.as_string();
     }
     catch (Py::Exception& e) {

--- a/src/Mod/Web/App/Server.h
+++ b/src/Mod/Web/App/Server.h
@@ -30,6 +30,9 @@
 #include <QTcpServer>
 #include <QTcpSocket>
 
+#include <Base/Interpreter.h>
+#include <Base/NativePythonReference.h>
+
 
 namespace Web
 {
@@ -57,7 +60,7 @@ public:
     bool filter(const QByteArray&) const override;
 
 private:
-    Py::Object obj;
+    Base::NativePythonReference obj;
 };
 
 class ServerEvent: public QEvent
@@ -99,7 +102,7 @@ private Q_SLOTS:
 
 private:
     bool direct;
-    Py::Object module;
+    Base::NativePythonReference module;
 };
 
 }  // namespace Web

--- a/tests/src/App/CMakeLists.txt
+++ b/tests/src/App/CMakeLists.txt
@@ -37,3 +37,24 @@ target_link_libraries(App_tests_run PRIVATE
     ${Python3_LIBRARIES}
     FreeCADApp
 )
+
+add_executable(ExtensionLifetimeShutdown ExtensionLifetimeShutdown.cpp)
+target_link_libraries(ExtensionLifetimeShutdown PRIVATE
+    FreeCADApp
+    ${Python3_LIBRARIES}
+)
+add_test(NAME ExtensionLifetimeShutdown COMMAND ExtensionLifetimeShutdown)
+
+add_executable(FeaturePythonLifetimeShutdown FeaturePythonLifetimeShutdown.cpp)
+target_link_libraries(FeaturePythonLifetimeShutdown PRIVATE
+    FreeCADApp
+    ${Python3_LIBRARIES}
+)
+add_test(NAME FeaturePythonLifetimeShutdown COMMAND FeaturePythonLifetimeShutdown)
+
+add_executable(FeatureTestAttributeLifetimeShutdown FeatureTestAttributeLifetimeShutdown.cpp)
+target_link_libraries(FeatureTestAttributeLifetimeShutdown PRIVATE
+    FreeCADApp
+    ${Python3_LIBRARIES}
+)
+add_test(NAME FeatureTestAttributeLifetimeShutdown COMMAND FeatureTestAttributeLifetimeShutdown)

--- a/tests/src/App/ExtensionLifetimeShutdown.cpp
+++ b/tests/src/App/ExtensionLifetimeShutdown.cpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <Python.h>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <App/Extension.h>
+#include <Base/Interpreter.h>
+#include <Base/Type.h>
+
+#include <src/App/InitApplication.h>
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    tests::initApplication();
+
+    int result = 0;
+    PyGILState_STATE gilState = PyGILState_Ensure();
+    if (PyRun_SimpleString(
+            "import FreeCAD as App\n"
+            "_freecad_extension_lifetime_doc = App.newDocument(\"ExtensionLifetime\")\n"
+            "_freecad_extension_lifetime_object = "
+            "_freecad_extension_lifetime_doc.addObject(\"App::DocumentObject\", \"Object\")\n"
+            "_freecad_extension_lifetime_object.addExtension(\"App::GroupExtensionPython\")\n"
+        )
+        != 0) {
+        PyErr_Print();
+        result = 1;
+    }
+
+    if (result == 0) {
+        PyObject* mainModule = PyImport_AddModule("__main__");
+        PyObject* mainDict = PyModule_GetDict(mainModule);
+        auto* document = App::GetApplication().getDocument("ExtensionLifetime");
+        auto* object = document ? document->getObject("Object") : nullptr;
+        auto* extension = object
+            ? object->getExtension(Base::Type::fromName("App::GroupExtensionPython"), false, true)
+            : nullptr;
+
+        if (!extension) {
+            result = 2;
+        }
+        else {
+            PyObject* wrapper = extension->getExtensionPyObject();
+            if (PyDict_SetItemString(mainDict, "_freecad_extension_lifetime", wrapper) != 0) {
+                PyErr_Print();
+                result = 3;
+            }
+            Py_DECREF(wrapper);
+        }
+
+        // The wrapper remains reachable from Python, but the native extension
+        // must be destroyed while Python is still running.
+        if (document && !App::GetApplication().closeDocument(document)) {
+            result = 4;
+        }
+
+        if (result == 0) {
+            PyObject* retained = PyDict_GetItemString(mainDict, "_freecad_extension_lifetime");
+            PyObject* access = PyObject_CallMethod(retained, "getExtendedObject", nullptr);
+            if (access) {
+                Py_DECREF(access);
+                result = 5;
+            }
+            else if (!PyErr_ExceptionMatches(PyExc_ReferenceError)) {
+                PyErr_Print();
+                result = 6;
+            }
+            else {
+                PyErr_Clear();
+            }
+        }
+    }
+
+    App::GetApplication().prepareForShutdown();
+    PyGILState_Release(gilState);
+    Base::Interpreter().finalize();
+    if (Py_IsInitialized() != 0) {
+        result = 7;
+    }
+    return result;
+}

--- a/tests/src/App/FeaturePythonLifetimeShutdown.cpp
+++ b/tests/src/App/FeaturePythonLifetimeShutdown.cpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <Python.h>
+
+#include <App/Application.h>
+#include <Base/Interpreter.h>
+
+#include <src/App/InitApplication.h>
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    tests::initApplication();
+
+    int result = 0;
+    PyGILState_STATE gilState = PyGILState_Ensure();
+    if (PyRun_SimpleString(
+            "import FreeCAD as App\n"
+            "_freecad_feature_lifetime_doc = App.newDocument(\"FeaturePythonLifetime\")\n"
+            "_freecad_feature_lifetime_object = "
+            "_freecad_feature_lifetime_doc.addObject(\"App::FeaturePython\", \"Feature\")\n"
+            "_freecad_feature_lifetime_object.onChanged = lambda obj, prop: None\n"
+        )
+        != 0) {
+        PyErr_Print();
+        result = 1;
+    }
+
+    if (result == 0) {
+        auto* document = App::GetApplication().getDocument("FeaturePythonLifetime");
+        if (!document || !App::GetApplication().closeDocument(document)) {
+            result = 2;
+        }
+    }
+
+    // The FeaturePython wrapper remains reachable from __main__. Its native
+    // twin and callback dictionary must therefore be safe to destroy during
+    // Python finalization.
+    App::GetApplication().prepareForShutdown();
+    PyGILState_Release(gilState);
+    Base::Interpreter().finalize();
+    if (Py_IsInitialized() != 0) {
+        result = 3;
+    }
+    return result;
+}

--- a/tests/src/App/FeatureTestAttributeLifetimeShutdown.cpp
+++ b/tests/src/App/FeatureTestAttributeLifetimeShutdown.cpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <Python.h>
+
+#include <App/Application.h>
+#include <Base/Interpreter.h>
+
+#include <src/App/InitApplication.h>
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    tests::initApplication();
+
+    int result = 0;
+    PyGILState_STATE gilState = PyGILState_Ensure();
+    if (PyRun_SimpleString(
+            "import FreeCAD as App\n"
+            "_freecad_attribute_lifetime_doc = App.newDocument(\"FeatureTestAttributeLifetime\")\n"
+            "_freecad_attribute_lifetime_object = "
+            "_freecad_attribute_lifetime_doc.addObject(\"App::FeatureTestAttribute\", "
+            "\"Attribute\")\n"
+            "_freecad_attribute_lifetime_object.Object = _freecad_attribute_lifetime_object\n"
+        )
+        != 0) {
+        PyErr_Print();
+        result = 1;
+    }
+
+    if (result == 0) {
+        auto* document = App::GetApplication().getDocument("FeatureTestAttributeLifetime");
+        if (!document || !App::GetApplication().closeDocument(document)) {
+            result = 2;
+        }
+    }
+
+    // The Python wrapper and its PropertyPythonObject value remain reachable
+    // from __main__. Native property ownership must be released before the
+    // wrapper is destroyed by Py_Finalize().
+    App::GetApplication().prepareForShutdown();
+    PyGILState_Release(gilState);
+    Base::Interpreter().finalize();
+    if (Py_IsInitialized() != 0) {
+        result = 3;
+    }
+    return result;
+}

--- a/tests/src/Base/CMakeLists.txt
+++ b/tests/src/Base/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(Base_tests_run
         Placement.cpp
         Persistence.cpp
         PyException.cpp
+        PythonReference.cpp
         Quantity.cpp
         Reader.cpp
         Rotation.cpp
@@ -45,6 +46,34 @@ add_executable(Base_tests_run
         Writer.cpp
         XMLTools.cpp
 )
+
+add_executable(PythonReferenceShutdown PythonReferenceShutdown.cpp)
+target_link_libraries(PythonReferenceShutdown PRIVATE
+    FreeCADApp
+    ${Python3_LIBRARIES}
+)
+add_test(NAME PythonReferenceShutdown COMMAND PythonReferenceShutdown)
+
+add_executable(PythonReferenceFinalizationRefusal PythonReferenceFinalizationRefusal.cpp)
+target_link_libraries(PythonReferenceFinalizationRefusal PRIVATE
+    FreeCADApp
+    ${Python3_LIBRARIES}
+)
+add_test(NAME PythonReferenceFinalizationRefusal COMMAND PythonReferenceFinalizationRefusal)
+
+add_executable(TypePyLifetimeShutdown TypePyLifetimeShutdown.cpp)
+target_link_libraries(TypePyLifetimeShutdown PRIVATE
+    FreeCADApp
+    ${Python3_LIBRARIES}
+)
+add_test(NAME TypePyLifetimeShutdown COMMAND TypePyLifetimeShutdown)
+
+add_executable(ParameterLifetimeShutdown ParameterLifetimeShutdown.cpp)
+target_link_libraries(ParameterLifetimeShutdown PRIVATE
+    FreeCADApp
+    ${Python3_LIBRARIES}
+)
+add_test(NAME ParameterLifetimeShutdown COMMAND ParameterLifetimeShutdown)
 
 setup_qt_test(InventorBuilder)
 

--- a/tests/src/Base/ParameterLifetimeShutdown.cpp
+++ b/tests/src/Base/ParameterLifetimeShutdown.cpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <Python.h>
+
+#include <App/Application.h>
+#include <Base/Interpreter.h>
+
+#include <src/App/InitApplication.h>
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    tests::initApplication();
+
+    int result = 0;
+    PyGILState_STATE gilState = PyGILState_Ensure();
+    if (PyRun_SimpleString(
+            "import FreeCAD as App\n"
+            "class _ShutdownObserver:\n"
+            "    def onChange(self, *args):\n"
+            "        pass\n"
+            "_freecad_parameter_lifetime_observer = _ShutdownObserver()\n"
+            "_freecad_parameter_lifetime_group = App.ParamGet(\n"
+            "    'User parameter:BaseApp/Tests/PythonLifetime'\n"
+            ")\n"
+            "_freecad_parameter_lifetime_group.Attach(\n"
+            "    _freecad_parameter_lifetime_observer\n"
+            ")\n"
+        )
+        != 0) {
+        PyErr_Print();
+        result = 1;
+    }
+
+    App::GetApplication().prepareForShutdown();
+    PyGILState_Release(gilState);
+
+    Base::Interpreter().finalize();
+    if (Py_IsInitialized() != 0) {
+        result = 2;
+    }
+    return result;
+}

--- a/tests/src/Base/PythonReference.cpp
+++ b/tests/src/Base/PythonReference.cpp
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+
+#include <Python.h>
+
+#include <thread>
+
+#include "Base/Interpreter.h"
+#include "Base/NativePythonReference.h"
+#include "Base/SmartPtrPy.h"
+
+namespace
+{
+
+void ensurePython()
+{
+    if (!Py_IsInitialized()) {
+        Py_Initialize();
+    }
+}
+
+}  // namespace
+
+TEST(PythonReference, ReleasesWithAttachedThreadState)
+{
+    ensurePython();
+    PyGILState_STATE gilState = PyGILState_Ensure();
+
+    PyObject* object = PyList_New(0);
+    ASSERT_NE(object, nullptr);
+    Py_INCREF(object);
+
+    {
+        Base::NativePythonReference reference(object);
+    }
+
+    EXPECT_EQ(Py_REFCNT(object), 1);
+    Py_DECREF(object);
+    PyGILState_Release(gilState);
+}
+
+TEST(PythonReference, ResetAdoptsOwnedSamePointer)
+{
+    ensurePython();
+    PyGILState_STATE gilState = PyGILState_Ensure();
+
+    PyObject* object = PyList_New(0);
+    ASSERT_NE(object, nullptr);
+    Py_INCREF(object);
+
+    Base::NativePythonReference reference(object);
+    Py_INCREF(object);
+    reference.reset(object);
+    reference.reset();
+
+    EXPECT_EQ(Py_REFCNT(object), 1);
+    Py_DECREF(object);
+    PyGILState_Release(gilState);
+}
+
+TEST(PythonReference, ReleasesSynchronouslyFromDetachedThread)
+{
+    ensurePython();
+    PyGILState_STATE gilState = PyGILState_Ensure();
+
+    PyObject* object = PyList_New(0);
+    ASSERT_NE(object, nullptr);
+    Py_INCREF(object);
+
+    Base::NativePythonReference reference(object);
+    PyThreadState* threadState = PyEval_SaveThread();
+
+    std::thread worker([reference = std::move(reference)]() mutable { reference.reset(); });
+    worker.join();
+
+    PyEval_RestoreThread(threadState);
+    EXPECT_EQ(Py_REFCNT(object), 1);
+    Py_DECREF(object);
+    PyGILState_Release(gilState);
+}
+
+TEST(PythonReference, ReleasesFromDetachedMainThreadState)
+{
+    ensurePython();
+    PyGILState_STATE gilState = PyGILState_Ensure();
+
+    PyObject* object = PyList_New(0);
+    ASSERT_NE(object, nullptr);
+    Py_INCREF(object);
+
+    Base::NativePythonReference reference(object);
+    PyThreadState* threadState = PyEval_SaveThread();
+
+    reference.reset();
+
+    PyEval_RestoreThread(threadState);
+    EXPECT_EQ(Py_REFCNT(object), 1);
+    Py_DECREF(object);
+    PyGILState_Release(gilState);
+}
+
+TEST(PythonReference, LockerRestoresDetachedMainThreadState)
+{
+    ensurePython();
+    PyGILState_STATE gilState = PyGILState_Ensure();
+    PyThreadState* threadState = PyEval_SaveThread();
+
+    PyObject* object = nullptr;
+    {
+        Base::PyGILStateLocker lock;
+        object = PyList_New(0);
+    }
+
+    PyEval_RestoreThread(threadState);
+    ASSERT_NE(object, nullptr);
+    Py_DECREF(object);
+    PyGILState_Release(gilState);
+}
+
+TEST(PythonReference, SmartPtrRetainsBorrowedObject)
+{
+    ensurePython();
+    PyGILState_STATE gilState = PyGILState_Ensure();
+
+    PyObject* object = PyList_New(0);
+    ASSERT_NE(object, nullptr);
+
+    {
+        Py::SmartPtr reference(object);
+        EXPECT_EQ(Py_REFCNT(object), 2);
+    }
+
+    EXPECT_EQ(Py_REFCNT(object), 1);
+    Py_DECREF(object);
+    PyGILState_Release(gilState);
+}

--- a/tests/src/Base/PythonReferenceFinalizationRefusal.cpp
+++ b/tests/src/Base/PythonReferenceFinalizationRefusal.cpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <Python.h>
+
+#include "Base/Interpreter.h"
+#include "Base/NativePythonReference.h"
+
+int main(int argc, char** argv)
+{
+    Base::Interpreter().init(argc, argv);
+
+    PyGILState_STATE gilState = PyGILState_Ensure();
+    PyObject* object = PyList_New(0);
+    if (!object) {
+        PyGILState_Release(gilState);
+        Base::Interpreter().finalize();
+        return 1;
+    }
+
+    Base::NativePythonReference reference(object);
+    PyGILState_Release(gilState);
+
+    // A live native owner must prevent interpreter finalization. This is a
+    // deliberate invariant-failure subprocess, so leaving Python initialized
+    // at process exit is the expected safe outcome.
+    Base::Interpreter().finalize();
+    const bool refusedFinalization = Py_IsInitialized() != 0;
+
+    // Transfer the still-owned reference without DECREFing it. The process is
+    // intentionally exiting with Python alive after the finalization refusal.
+    reference.release();
+    return refusedFinalization ? 0 : 1;
+}

--- a/tests/src/Base/PythonReferenceShutdown.cpp
+++ b/tests/src/Base/PythonReferenceShutdown.cpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <Python.h>
+
+#include "Base/Interpreter.h"
+#include "Base/NativePythonReference.h"
+
+int main(int argc, char** argv)
+{
+    Base::Interpreter().init(argc, argv);
+
+    PyGILState_STATE gilState = PyGILState_Ensure();
+    PyObject* object = PyList_New(0);
+    if (!object) {
+        PyGILState_Release(gilState);
+        Base::Interpreter().finalize();
+        return 1;
+    }
+
+    {
+        Base::NativePythonReference reference(object);
+        reference.reset();
+    }
+
+    PyGILState_Release(gilState);
+    Base::Interpreter().finalize();
+    return Py_IsInitialized() == 0 ? 0 : 1;
+}

--- a/tests/src/Base/TypePyLifetimeShutdown.cpp
+++ b/tests/src/Base/TypePyLifetimeShutdown.cpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <Python.h>
+
+#include <Base/Interpreter.h>
+
+#include <src/App/InitApplication.h>
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    tests::initApplication();
+
+    int result = 0;
+    PyGILState_STATE gilState = PyGILState_Ensure();
+    if (PyRun_SimpleString(
+            "import FreeCAD as App\n"
+            "_freecad_typepy_lifetime = "
+            "App.Base.TypeId.fromName('App::StringHasher').createInstance()\n"
+        )
+        != 0) {
+        PyErr_Print();
+        result = 1;
+    }
+
+    App::GetApplication().prepareForShutdown();
+    PyGILState_Release(gilState);
+
+    // The Python wrapper deliberately remains reachable until Py_Finalize().
+    // Its generic tp_dealloc deletes the native twin, so this exercises native
+    // destruction from a Python-owned finalization path without retaining a
+    // native-owned wrapper reference that would intentionally refuse shutdown.
+    Base::Interpreter().finalize();
+    if (Py_IsInitialized() != 0) {
+        result = 2;
+    }
+    return result;
+}

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -20,6 +20,27 @@ add_executable(Gui_tests_run
 # Qt tests
 setup_qt_test(ObjectSelection)
 setup_qt_test(QuantitySpinBox)
+setup_qt_test(ViewerLifetime)
+setup_qt_test(ViewerLifetimeShutdown)
+setup_qt_test(EditableDatumLabelLifetimeShutdown)
+setup_qt_test(TaskDialogLifetimeShutdown)
+setup_qt_test(MDIViewLifetimeShutdown)
+
+add_executable(PyResourceLifetimeShutdown PyResourceLifetimeShutdown.cpp)
+target_link_libraries(PyResourceLifetimeShutdown PRIVATE
+    FreeCADApp
+    FreeCADGui
+    ${Python3_LIBRARIES}
+)
+add_test(NAME PyResourceLifetimeShutdown COMMAND PyResourceLifetimeShutdown)
+
+add_executable(GeneratedWrapperLifetimeShutdown GeneratedWrapperLifetimeShutdown.cpp)
+target_link_libraries(GeneratedWrapperLifetimeShutdown PRIVATE
+    FreeCADApp
+    FreeCADGui
+    ${Python3_LIBRARIES}
+)
+add_test(NAME GeneratedWrapperLifetimeShutdown COMMAND GeneratedWrapperLifetimeShutdown)
 
 target_link_libraries(Gui_tests_run PRIVATE
     GTest::gmock_main

--- a/tests/src/Gui/EditableDatumLabelLifetimeShutdown.cpp
+++ b/tests/src/Gui/EditableDatumLabelLifetimeShutdown.cpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <QApplication>
+
+#include <Python.h>
+
+#include <memory>
+
+#include <App/Application.h>
+#include <Base/Interpreter.h>
+#include <Gui/Application.h>
+#include <Gui/MainWindow.h>
+#include <Gui/View3DInventorViewer.h>
+
+#include <src/App/InitApplication.h>
+
+int main(int argc, char** argv)
+{
+    QApplication qtApplication(argc, argv);
+    tests::initApplication();
+    Gui::Application::initApplication();
+    Gui::Application::initOpenInventor();
+    App::GetApplication()
+        .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
+        ->SetBool("ShowNaviCube", false);
+
+    int result = 0;
+    {
+        auto guiApplication = std::make_unique<Gui::Application>(true);
+        auto mainWindow = std::make_unique<Gui::MainWindow>();
+        auto viewer = std::make_unique<Gui::View3DInventorViewer>(nullptr);
+
+        PyGILState_STATE gilState = PyGILState_Ensure();
+        PyObject* mainModule = PyImport_AddModule("__main__");
+        PyObject* mainDict = PyModule_GetDict(mainModule);
+        PyObject* viewerWrapper = viewer->getPyObject();
+        if (PyDict_SetItemString(mainDict, "_freecad_editable_label_lifetime_viewer", viewerWrapper)
+            != 0) {
+            PyErr_Print();
+            result = 1;
+        }
+        Py_DECREF(viewerWrapper);
+
+        if (result == 0
+            && PyRun_SimpleString(
+                   "import FreeCAD as App\n"
+                   "import FreeCADGui as Gui\n"
+                   "_freecad_editable_label_lifetime_label = Gui.EditableDatumLabel(\n"
+                   "    _freecad_editable_label_lifetime_viewer,\n"
+                   "    App.Placement()\n"
+                   ")\n"
+                   "_freecad_editable_label_lifetime_label.setValueChangedCallback(\n"
+                   "    lambda value: None\n"
+                   ")\n"
+               ) != 0) {
+            PyErr_Print();
+            result = 2;
+        }
+
+        viewer.reset();
+        guiApplication->prepareForShutdown();
+        App::GetApplication().prepareForShutdown();
+        PyGILState_Release(gilState);
+    }
+
+    Base::Interpreter().finalize();
+    if (Py_IsInitialized() != 0) {
+        result = 3;
+    }
+    return result;
+}

--- a/tests/src/Gui/GeneratedWrapperLifetimeShutdown.cpp
+++ b/tests/src/Gui/GeneratedWrapperLifetimeShutdown.cpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <QApplication>
+
+#include <Python.h>
+
+#include <memory>
+
+#include <Base/Interpreter.h>
+#include <Gui/Application.h>
+
+#include <src/App/InitApplication.h>
+
+int main(int argc, char** argv)
+{
+    QApplication qtApplication(argc, argv);
+    tests::initApplication();
+    Gui::Application::initApplication();
+    Gui::Application::initOpenInventor();
+
+    int result = 0;
+    {
+        auto guiApplication = std::make_unique<Gui::Application>(true);
+        PyGILState_STATE gilState = PyGILState_Ensure();
+        if (PyRun_SimpleString(
+                "import FreeCADGui as Gui\n"
+                "_freecad_axis_origin_lifetime = Gui.AxisOrigin()\n"
+                "_freecad_link_view_lifetime = Gui.LinkView()\n"
+            )
+            != 0) {
+            PyErr_Print();
+            result = 1;
+        }
+        guiApplication->prepareForShutdown();
+        App::GetApplication().prepareForShutdown();
+        PyGILState_Release(gilState);
+    }
+
+    // These generated Delete=True wrappers intentionally remain Python-owned
+    // until Py_Finalize(); their native twins must be safe to delete there.
+    Base::Interpreter().finalize();
+    if (Py_IsInitialized() != 0) {
+        result = 2;
+    }
+    return result;
+}

--- a/tests/src/Gui/MDIViewLifetimeShutdown.cpp
+++ b/tests/src/Gui/MDIViewLifetimeShutdown.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <QApplication>
+
+#include <Python.h>
+
+#include <memory>
+
+#include <App/Application.h>
+#include <Base/Interpreter.h>
+#include <Gui/Application.h>
+#include <Gui/MDIView.h>
+
+#include <src/App/InitApplication.h>
+
+int main(int argc, char** argv)
+{
+    QApplication qtApplication(argc, argv);
+    tests::initApplication();
+    Gui::Application::initApplication();
+    Gui::Application::initOpenInventor();
+
+    int result = 0;
+    {
+        auto guiApplication = std::make_unique<Gui::Application>(true);
+
+        PyGILState_STATE gilState = PyGILState_Ensure();
+        auto view = std::make_unique<Gui::MDIView>(nullptr, nullptr);
+        PyObject* wrapper = view->getPyObject();
+        PyObject* mainModule = PyImport_AddModule("__main__");
+        PyObject* mainDict = PyModule_GetDict(mainModule);
+        if (PyDict_SetItemString(mainDict, "_freecad_mdi_lifetime_view", wrapper) != 0) {
+            PyErr_Print();
+            result = 1;
+        }
+        Py_DECREF(wrapper);
+        view.reset();
+
+        // The native MDI view is gone while its Python wrapper remains
+        // reachable from __main__ until Py_Finalize().
+        guiApplication->prepareForShutdown();
+        App::GetApplication().prepareForShutdown();
+        PyGILState_Release(gilState);
+    }
+
+    Base::Interpreter().finalize();
+    if (Py_IsInitialized() != 0) {
+        result = 2;
+    }
+    return result;
+}

--- a/tests/src/Gui/PyResourceLifetimeShutdown.cpp
+++ b/tests/src/Gui/PyResourceLifetimeShutdown.cpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <QApplication>
+#include <QTemporaryFile>
+
+#include <Python.h>
+
+#include <Base/Interpreter.h>
+#include <Gui/Application.h>
+#include <Gui/ApplicationPy.h>
+
+#include <src/App/InitApplication.h>
+
+int main(int argc, char** argv)
+{
+    QApplication qtApplication(argc, argv);
+    tests::initApplication();
+    Gui::Application::initApplication();
+    Gui::Application::initOpenInventor();
+
+    QTemporaryFile uiFile;
+    if (!uiFile.open()) {
+        return 1;
+    }
+    uiFile.write(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<ui version=\"4.0\">"
+        "<class>Dialog</class>"
+        "<widget class=\"QDialog\" name=\"Dialog\"/>"
+        "<resources/><connections/>"
+        "</ui>"
+    );
+    uiFile.flush();
+    uiFile.close();
+
+    int result = 0;
+    {
+        Gui::Application guiApplication(false);
+
+        PyGILState_STATE gilState = PyGILState_Ensure();
+        PyObject* args = Py_BuildValue("(s)", uiFile.fileName().toUtf8().constData());
+        PyObject* resource = args ? Gui::ApplicationPy::sCreateDialog(nullptr, args) : nullptr;
+        Py_XDECREF(args);
+        if (!resource) {
+            PyErr_Print();
+            result = 2;
+        }
+        else {
+            PyObject* mainModule = PyImport_AddModule("__main__");
+            PyObject* mainDict = PyModule_GetDict(mainModule);
+            if (PyDict_SetItemString(mainDict, "_freecad_pyresource_lifetime", resource) != 0) {
+                PyErr_Print();
+                result = 3;
+            }
+            Py_DECREF(resource);
+        }
+        guiApplication.prepareForShutdown();
+        App::GetApplication().prepareForShutdown();
+        PyGILState_Release(gilState);
+    }
+
+    Base::Interpreter().finalize();
+    if (Py_IsInitialized() != 0) {
+        result = 4;
+    }
+    return result;
+}

--- a/tests/src/Gui/TaskDialogLifetimeShutdown.cpp
+++ b/tests/src/Gui/TaskDialogLifetimeShutdown.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <QApplication>
+
+#include <Python.h>
+
+#include <memory>
+
+#include <Base/Interpreter.h>
+#include <Gui/Application.h>
+#include <Gui/TaskView/TaskDialogPython.h>
+
+#include <src/App/InitApplication.h>
+
+int main(int argc, char** argv)
+{
+    QApplication qtApplication(argc, argv);
+    tests::initApplication();
+    Gui::Application::initApplication();
+
+    std::unique_ptr<Gui::TaskView::TaskDialogPython> taskDialog;
+    int result = 0;
+    {
+        auto guiApplication = std::make_unique<Gui::Application>(false);
+
+        PyGILState_STATE gilState = PyGILState_Ensure();
+        PyObject* mainModule = PyImport_AddModule("__main__");
+        PyObject* mainDict = PyModule_GetDict(mainModule);
+        PyObject* dialog
+            = PyRun_String("type('TaskDialogLifetime', (), {})()", Py_eval_input, mainDict, mainDict);
+        if (!dialog) {
+            PyErr_Print();
+            result = 1;
+        }
+        else {
+            Py::Object pyDialog(dialog, true);
+            taskDialog = std::make_unique<Gui::TaskView::TaskDialogPython>(pyDialog);
+
+            // Framework teardown clears the Python form reference while the
+            // interpreter is running. The native object itself deliberately
+            // survives until after Py_Finalize().
+            taskDialog->closed();
+            pyDialog = Py::None();
+        }
+        guiApplication->prepareForShutdown();
+        App::GetApplication().prepareForShutdown();
+        PyGILState_Release(gilState);
+    }
+
+    Base::Interpreter().finalize();
+    if (Py_IsInitialized() != 0) {
+        result = 2;
+    }
+
+    // This must not access Python: the interpreter has already finalized.
+    taskDialog.reset();
+    return result;
+}

--- a/tests/src/Gui/ViewerLifetime.cpp
+++ b/tests/src/Gui/ViewerLifetime.cpp
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <QtTest/QtTest>
+
+#include <Python.h>
+
+#include <memory>
+
+#include <App/Application.h>
+#include <Base/Interpreter.h>
+#include <Gui/Application.h>
+#include <Gui/MainWindow.h>
+#include <Gui/View3DInventorViewer.h>
+
+#include <src/App/InitApplication.h>
+
+class ViewerLifetimeTest: public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+        tests::initApplication();
+        Gui::Application::initApplication();
+        Gui::Application::initOpenInventor();
+        App::GetApplication()
+            .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
+            ->SetBool("ShowNaviCube", false);
+        _guiApplication = std::make_unique<Gui::Application>(false);
+        _mainWindow = std::make_unique<Gui::MainWindow>();
+    }
+
+    void wrapperIsInvalidatedAndNativeReferenceReleased()
+    {
+        PyGILState_STATE gilState = PyGILState_Ensure();
+        PyObject* wrapper = nullptr;
+
+        {
+            auto viewer = std::make_unique<Gui::View3DInventorViewer>(nullptr);
+            wrapper = viewer->getPyObject();
+            QCOMPARE(Py_REFCNT(wrapper), 2);
+            viewer.reset();
+        }
+
+        QCOMPARE(Py_REFCNT(wrapper), 1);
+        PyObject* representation = PyObject_Repr(wrapper);
+        QVERIFY(representation == nullptr);
+        QVERIFY(PyErr_ExceptionMatches(PyExc_RuntimeError));
+        PyErr_Clear();
+
+        Py_DECREF(wrapper);
+        PyGILState_Release(gilState);
+    }
+
+private:
+    std::unique_ptr<Gui::Application> _guiApplication;
+    std::unique_ptr<Gui::MainWindow> _mainWindow;
+};
+
+QTEST_MAIN(ViewerLifetimeTest)
+
+#include "ViewerLifetime.moc"

--- a/tests/src/Gui/ViewerLifetimeShutdown.cpp
+++ b/tests/src/Gui/ViewerLifetimeShutdown.cpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <QApplication>
+
+#include <Python.h>
+
+#include <memory>
+
+#include <App/Application.h>
+#include <Base/Interpreter.h>
+#include <Gui/Application.h>
+#include <Gui/MainWindow.h>
+#include <Gui/Navigation/NavigationStyle.h>
+#include <Gui/View3DInventorViewer.h>
+
+#include <src/App/InitApplication.h>
+
+int main(int argc, char** argv)
+{
+    QApplication qtApplication(argc, argv);
+    tests::initApplication();
+    Gui::Application::initApplication();
+    Gui::Application::initOpenInventor();
+    App::GetApplication()
+        .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
+        ->SetBool("ShowNaviCube", false);
+
+    int result = 0;
+    {
+        auto guiApplication = std::make_unique<Gui::Application>(false);
+        auto mainWindow = std::make_unique<Gui::MainWindow>();
+        auto viewer = std::make_unique<Gui::View3DInventorViewer>(nullptr);
+
+        PyGILState_STATE gilState = PyGILState_Ensure();
+        PyObject* wrapper = viewer->getPyObject();
+        PyObject* navigationWrapper = viewer->navigationStyle()->getPyObject();
+
+        // Keep the wrapper reachable from Python. Its native-owned reference
+        // is released when the viewer is destroyed below; the remaining
+        // Python reference is deliberately left for Py_Finalize() to release.
+        PyObject* mainModule = PyImport_AddModule("__main__");
+        PyObject* mainDict = PyModule_GetDict(mainModule);
+        if (PyDict_SetItemString(mainDict, "_freecad_viewer_lifetime_test", wrapper) != 0) {
+            PyErr_Print();
+            result = 1;
+        }
+        if (PyDict_SetItemString(mainDict, "_freecad_navigation_style_lifetime_test", navigationWrapper)
+            != 0) {
+            PyErr_Print();
+            result = 1;
+        }
+        Py_DECREF(wrapper);
+        Py_DECREF(navigationWrapper);
+        viewer.reset();
+
+        if (result == 0) {
+            PyObject* retained
+                = PyDict_GetItemString(mainDict, "_freecad_navigation_style_lifetime_test");
+            PyObject* access = PyObject_CallMethod(retained, "isRotationEnabled", nullptr);
+            if (access) {
+                Py_DECREF(access);
+                result = 2;
+            }
+            else if (!PyErr_ExceptionMatches(PyExc_ReferenceError)) {
+                PyErr_Print();
+                result = 3;
+            }
+            else {
+                PyErr_Clear();
+            }
+        }
+
+        guiApplication->prepareForShutdown();
+        App::GetApplication().prepareForShutdown();
+        PyGILState_Release(gilState);
+    }
+
+    Base::Interpreter().finalize();
+    if (Py_IsInitialized() != 0) {
+        result = 4;
+    }
+    return result;
+}


### PR DESCRIPTION
Fixes #27562.

FreeCAD can crash during shutdown when native C++ objects release Python references after the current thread no longer has a valid Python thread state. This became particularly visible with Python 3.14.

The original failure involved `View3DInventorViewer`: its native destructor released its Python wrapper with `Py_DECREF()`, eventually reaching CPython with no attached thread state.

A local GIL guard fixes that individual call site, but does not address the broader lifetime problem: native C++ objects may own Python references during shutdown, and attempting to attach a thread with `PyGILState_Ensure()` is not safe once interpreter finalization has begun.

This PR establishes a clear ownership and shutdown rule instead:

> **All Python references owned by native C++ must be released before Python interpreter finalization begins.**

## Solution

### Explicit native Python ownership

This introduces `Base::NativePythonReference`, an RAII wrapper for Python references owned by native C++ code:

- explicitly identifies C++-owned Python references;
- releases them synchronously while Python is running;
- handles release from threads without an attached Python state;
- tracks live native owners so interpreter shutdown can verify that none remain.

This is intentionally limited to **native C++ ownership**. Python-extension-owned references and interpreter-owned objects continue to follow their existing Python/interpreter lifetimes.

### Finalization boundary

Interpreter shutdown now has an explicit `beginFinalization()` boundary.

When this boundary is crossed:

1. new native Python ownership is rejected;
2. already-started native reference releases are allowed to finish;
3. the number of native-owned Python references must already be zero;
4. only then may `Py_Finalize()` run.

Conceptually:

```text
Python running
    |
    +-- stop asynchronous producers
    +-- destroy App/Gui native Python owners
    +-- release native-owned Python references
    |
    v
beginFinalization()
    |
    +-- prevent new native ownership
    +-- wait for in-flight releases
    +-- require native owner count == 0
    |
    v
Py_Finalize()
```

If native owners still exist at the finalization boundary, FreeCAD reports the invariant violation and skips `Py_Finalize()` rather than finalizing Python underneath live C++ references.

### Explicit shutdown ordering

The App and Gui shutdown paths now perform preparation before interpreter finalization.

This stops asynchronous/native producers and releases long-lived Python ownership while the interpreter is still fully operational, including areas such as:

- recompute worker activity;
- document and selection observers;
- workbench infrastructure;
- Python commands and callbacks;
- widget/UI factories;
- document/view wrappers;
- FeaturePython and ViewProvider callback state.

The relevant native owners were migrated to `NativePythonReference`.

### Viewer lifetime

`View3DInventorViewer` now owns its Python wrapper through `NativePythonReference`.

Destroying the native viewer releases only the native-owned wrapper reference. If Python still retains the wrapper, it remains alive but its native viewer is invalidated, so further access fails cleanly instead of dereferencing a destroyed C++ object.

Python can then release the remaining wrapper normally, including during interpreter finalization.

## Concurrency

Native reference release may need to attach the current thread to Python.

To avoid racing interpreter shutdown, the finalization transition and release authorization are synchronized:

- a release that has been authorized before finalization is counted as active;
- `beginFinalization()` prevents any new release from starting;
- finalization waits until all already-active releases have completed.

For `Py::Object` inputs, native ownership is registered **before** incrementing the Python reference count, so the finalization boundary cannot miss a newly created native owner.

## Tests and validation

Added coverage for native-reference release, detached-thread release, reset semantics, finalization refusal, and viewer-wrapper lifetime through shutdown.

Validated with Debug builds and GUI/tests enabled on:

- **Python 3.12**: all focused tests passed, including **20/20 repeated shutdowns** 
- **Python 3.14.6**: all focused tests passed, including **20/20 repeated shutdowns**,

Assisted-by: GPT-5.6
