### PR TITLE
Gui: Fix a family of use-after-free crashes in the property editor and task view

### DIFF
--- a/src/App/ProgramInformation.cpp
+++ b/src/App/ProgramInformation.cpp
@@ -67,17 +67,18 @@ std::string ProgramInformation::prettyProductInfoWrapper()
     auto fi = QFileInfo(macosVersionFile);
     if (fi.exists() && fi.isReadable()) {
         auto plistFile = QFile(macosVersionFile);
-        plistFile.open(QIODevice::ReadOnly);
-        while (!plistFile.atEnd()) {
-            auto line = plistFile.readLine();
-            if (line.contains("ProductUserVisibleVersion")) {
-                auto nextLine = plistFile.readLine();
-                if (nextLine.contains("<string>")) {
-                    QRegularExpression re(QStringLiteral("\\s*<string>(.*)</string>"));
-                    auto matches = re.match(QString::fromUtf8(nextLine));
-                    if (matches.hasMatch()) {
-                        productName = QStringLiteral("macOS ") + matches.captured(1);
-                        break;
+        if (plistFile.open(QIODevice::ReadOnly)) {
+            while (!plistFile.atEnd()) {
+                auto line = plistFile.readLine();
+                if (line.contains("ProductUserVisibleVersion")) {
+                    auto nextLine = plistFile.readLine();
+                    if (nextLine.contains("<string>")) {
+                        QRegularExpression re(QStringLiteral("\\s*<string>(.*)</string>"));
+                        auto matches = re.match(QString::fromUtf8(nextLine));
+                        if (matches.hasMatch()) {
+                            productName = QStringLiteral("macOS ") + matches.captured(1);
+                            break;
+                        }
                     }
                 }
             }

--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -959,6 +959,13 @@ void TaskView::accept(App::Document* doc)
     // the dialog leaves the 'accept' method
     foundTaskInfo->ActiveDialog->setProperty("taskview_accept_or_reject", true);
     bool success = foundTaskInfo->ActiveDialog->accept();
+
+    // accept() can still remove this task through paths that bypass that postponement,
+    // leaving the iterator and ActiveDialog dangling; re-find the entry.
+    foundTaskInfo = std::ranges::find(taskInfos, doc, &TaskInfo::Document);
+    if (foundTaskInfo == taskInfos.end()) {
+        return;
+    }
     foundTaskInfo->ActiveDialog->setProperty("taskview_accept_or_reject", QVariant());
     if (success || foundTaskInfo->ActiveDialog->property("taskview_remove_dialog").isValid()) {
         removeDialog(doc);
@@ -977,6 +984,13 @@ void TaskView::reject(App::Document* doc)
     // the dialog leaves the 'reject' method
     foundTaskInfo->ActiveDialog->setProperty("taskview_accept_or_reject", true);
     bool success = foundTaskInfo->ActiveDialog->reject();
+
+    // reject() can still remove this task through paths that bypass that postponement,
+    // leaving the iterator and ActiveDialog dangling; re-find the entry.
+    foundTaskInfo = std::ranges::find(taskInfos, doc, &TaskInfo::Document);
+    if (foundTaskInfo == taskInfos.end()) {
+        return;
+    }
     foundTaskInfo->ActiveDialog->setProperty("taskview_accept_or_reject", QVariant());
     if (success || foundTaskInfo->ActiveDialog->property("taskview_remove_dialog").isValid()) {
         removeDialog(doc);

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3747,8 +3747,11 @@ SbVec3f View3DInventorViewer::getPointOnXYPlaneOfPlacement(
     SbVec2f pnt2d = getNormalizedPosition(pnt);
     SoCamera* pCam = this->getSoRenderManager()->getCamera();
 
+    // Called from assembly drag handling inside a Coin event traversal, which cannot
+    // propagate C++ exceptions out to the callers' guards. Report degenerate cases
+    // with a fallback point instead of throwing, as getPointOnLine() does.
     if (!pCam) {
-        throw Base::RuntimeError("No camera node found");
+        return {};  // return invalid point
     }
 
     SbViewVolume vol = pCam->getViewVolume();
@@ -3770,7 +3773,9 @@ SbVec3f View3DInventorViewer::getPointOnXYPlaneOfPlacement(
         return pt;  // Intersection point on the XY plane
     }
 
-    throw Base::RuntimeError("No intersection found");
+    // Pick ray parallel to the plane (viewed edge-on): fall back to the point on the
+    // ray closest to the plane origin, which is finite and close enough for one frame.
+    return line.getClosestPoint(planePosition);
 }
 
 SbVec3f projectPointOntoPlane(const SbVec3f& point, const SbPlane& plane)

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -25,6 +25,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <QApplication>
 #include <QClipboard>
+#include <QComboBox>
 #include <QCompleter>
 #include <QInputDialog>
 #include <QHeaderView>
@@ -483,6 +484,15 @@ void PropertyEditor::releaseEditorFocus()
     if (!activeEditor) {
         return;
     }
+
+    // An enum property is edited with a QComboBox whose drop-down is auto-opened by
+    // PropertyItemDelegate. Destroying the combo with the popup still open skips Qt's
+    // closePopup() teardown and leaves queued mouse events aimed at the freed popup,
+    // so close it while the combo is alive.
+    if (auto* combo = qobject_cast<QComboBox*>(activeEditor.data())) {
+        combo->hidePopup();
+    }
+
     for (QWidget* w = qApp->focusWidget(); w; w = w->parentWidget()) {
         if (w == activeEditor) {
             // setFocus() delivers a synchronous FocusOut that would otherwise cascade

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -338,6 +338,12 @@ void PropertyEditor::closeEditor()
     if (editingIndex.isValid()) {
         Base::StateLocker guard(closingEditor);
         bool hasFocus = activeEditor && activeEditor->hasFocus();
+
+        // closePersistentEditor() below destroys the editor; close an open combo
+        // drop-down first so Qt tears the popup down normally (see releaseEditorFocus()).
+        if (auto* combo = qobject_cast<QComboBox*>(activeEditor.data())) {
+            combo->hidePopup();
+        }
 #ifdef Q_OS_MACOS
         // Brute-force workaround for https://github.com/FreeCAD/FreeCAD/issues/14350
         int currentIndex = 0;

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -293,7 +293,11 @@ void PropertyEditor::commitData(QWidget* editor)
         // rebuild until control returns to the event loop.
         QMetaObject::invokeMethod(
             this,
-            [this]() { propertyModel->buildUp(PropertyModel::PropertyList()); },
+            [this]() {
+                // The model reset destroys every persistent editor.
+                releaseEditorFocus();
+                propertyModel->buildUp(PropertyModel::PropertyList());
+            },
             Qt::QueuedConnection
         );
     }
@@ -466,6 +470,27 @@ void PropertyEditor::recomputeDocument(App::Document* doc)
         Base::Console().error(
             "Unhandled unknown exception caught in PropertyEditor::recomputeDocument.\n"
         );
+    }
+}
+
+void PropertyEditor::releaseEditorFocus()
+{
+    // Call before the persistent editor is destroyed by a row removal or model reset.
+    // Qt does not reliably clear QApplicationPrivate::focus_widget when a focused
+    // editor is torn down that way, leaving the global focus widget -- a raw pointer,
+    // unlike our QPointer -- dangling. Move the focus back to the tree while the
+    // editor is still alive.
+    if (!activeEditor) {
+        return;
+    }
+    for (QWidget* w = qApp->focusWidget(); w; w = w->parentWidget()) {
+        if (w == activeEditor) {
+            // setFocus() delivers a synchronous FocusOut that would otherwise cascade
+            // into a re-entrant closeEditor() while the model is mid row-removal.
+            Base::StateLocker guard(closingEditor);
+            setFocus();
+            break;
+        }
     }
 }
 
@@ -643,6 +668,8 @@ void PropertyEditor::rowsAboutToBeRemoved(const QModelIndex& parent, int start, 
 
     if (editingIndex.isValid()) {
         if (editingIndex.row() >= start && editingIndex.row() <= end) {
+            // QTreeView is about to destroy the persistent editor of this row.
+            releaseEditorFocus();
             closeTransaction();
         }
         else {

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -67,6 +67,7 @@ PropertyEditor::PropertyEditor(QWidget* parent)
     , binding(false)
     , checkDocument(false)
     , closingEditor(false)
+    , recomputing(false)
     , dragInProgress(false)
 {
     propertyModel = new PropertyModel(this);
@@ -476,6 +477,10 @@ void PropertyEditor::closeTransaction()
     }
     if (doc->getBookedTransactionID() == transactionID) {
         if (autoupdate) {
+            // A recompute can delete objects, which re-enters buildUp() synchronously
+            // while the editor being closed is still receiving its FocusOut. Mark it
+            // so buildUp() defers the model reset.
+            Base::StateLocker guard(recomputing);
             recomputeDocument(doc);
         }
         doc->commitTransaction();
@@ -697,6 +702,19 @@ void PropertyEditor::buildUp(PropertyModel::PropertyList&& props, bool _checkDoc
             "While committing the data to the property the selection has changed.\n"
         );
         delaybuild = true;
+        return;
+    }
+
+    if (recomputing) {
+        // Re-entered from the recompute in closeTransaction(): resetting the model now
+        // would destroy an editor that is still mid event-dispatch, so defer.
+        QMetaObject::invokeMethod(
+            this,
+            [this, props = std::move(props), checkDoc = _checkDocument]() mutable {
+                buildUp(std::move(props), checkDoc);
+            },
+            Qt::QueuedConnection
+        );
         return;
     }
 

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -287,7 +287,14 @@ void PropertyEditor::commitData(QWidget* editor)
     committing = false;
     if (delaybuild) {
         delaybuild = false;
-        propertyModel->buildUp(PropertyModel::PropertyList());
+        // commitData() can run while a FocusOut is being delivered to the editor, and
+        // buildUp() resets the model, destroying that editor in place. Defer the
+        // rebuild until control returns to the event loop.
+        QMetaObject::invokeMethod(
+            this,
+            [this]() { propertyModel->buildUp(PropertyModel::PropertyList()); },
+            Qt::QueuedConnection
+        );
     }
 }
 

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -760,6 +760,10 @@ void PropertyEditor::buildUp(PropertyModel::PropertyList&& props, bool _checkDoc
     //
     // closeTransaction();
 
+    // The model reset below destroys every persistent editor: close an open combo
+    // popup and move focus off the editor first. No-op when nothing is being edited.
+    releaseEditorFocus();
+
     QModelIndex index = this->currentIndex();
     QStringList propertyPath = propertyModel->propertyPathFromIndex(index);
     if (!propertyPath.isEmpty()) {

--- a/src/Gui/propertyeditor/PropertyEditor.h
+++ b/src/Gui/propertyeditor/PropertyEditor.h
@@ -183,6 +183,7 @@ private:
     bool binding;
     bool checkDocument;
     bool closingEditor;
+    bool recomputing;
     bool dragInProgress;
 
     // max distance between mouse and a cell, small enough to trigger resize

--- a/src/Gui/propertyeditor/PropertyEditor.h
+++ b/src/Gui/propertyeditor/PropertyEditor.h
@@ -144,6 +144,7 @@ private:
     QMenu* setupExpansionSubmenu(QWidget* parent);
     void collapseAll();
     void setEditorMode(const QModelIndex& parent, int start, int end);
+    void releaseEditorFocus();
     void closeTransaction();
     void recomputeDocument(App::Document*);
     std::unordered_set<App::Property*> acquireSelectedProperties() const;


### PR DESCRIPTION
Six of these commits fix use-after-free crashes in the property editor that all share one
shape: something destroys the inline editor widget - or the drop-down of an enum combo box -
while Qt is still delivering an event to it. Each was found by crashing and reading the fault
back from the live process (see *How these were found* below); they are separate destroyers,
which is why they are separate commits rather than one patch.

### Property editor

| Commit | How it crashes |
| --- | --- |
| `editor use-after-free on focus-out` | Edit a property, then click in the 3D view. `commitData()` runs inside the delegate's event filter while a FocusOut is being delivered, and `buildUp()` resets the model, destroying that editor mid-dispatch. Now deferred to the event loop. |
| `UAF from recompute during editor close` | Same gesture, when the transaction's recompute deletes a document object: that re-enters `buildUp()` synchronously. A `recomputing` flag makes `buildUp()` defer the reset. |
| `UAF from dangling focus widget after row removal` | The editing row is removed while its editor holds focus. Qt does not clear `QApplicationPrivate::focus_widget`, so the *global* focus widget — a raw pointer — is left at freed memory and the next click delivers FocusOut to it. New `releaseEditorFocus()` moves focus off the editor while it is alive. |
| `UAF from combo-box popup destroyed by rebuild` | An enum property's drop-down is auto-opened by the delegate. Destroying the combo with the popup open skips Qt's `closePopup()` teardown, and a queued mouse release is later routed into `QComboBoxPrivate::itemSelected()` on the freed combo. `releaseEditorFocus()` now hides the popup first. |
| `Close combo popup on the main rebuild path` | Same crash reached through the main selection/recompute `buildUp()`, which never called `releaseEditorFocus()`. |
| `Close combo popup on the closeEditor() teardown path` | Same crash again through ordinary enum-editing teardown (`closeEditor()` → `closePersistentEditor()`), the third destroyer none of the other guards covered. |

### Task view

`TaskView::accept()` / `reject()` hold a raw `taskInfos` iterator and `ActiveDialog` across
`ActiveDialog->reject()`. That call is an arbitrary virtual which can remove the task through
paths that bypass the postponement property, erasing the entry and deleting the dialog — so
both the iterator and the pointer dangle for the rest of the method. Re-find the entry after
the call. Reproduced with Escape/Cancel in a task dialog.

### View3DInventorViewer

`getPointOnXYPlaneOfPlacement()` threw `Base::RuntimeError` when the pick ray is parallel to
the plane — reachable by dragging an assembly part with its joint plane edge-on. It is called
from inside a Coin event traversal (`SoHandleEventAction`), which cannot propagate C++
exceptions out to the callers' guards, so the throw reached `std::terminate()` (SIGABRT).
It now returns a fallback point, following the convention `getPointOnLine()` already uses.

### App

`prettyProductInfoWrapper()` ignored the result of `QFile::open()`, which is `[[nodiscard]]`
in newer Qt — `-Werror,-Wunused-result` fails the build — and read the plist whether or not
it opened. macOS-only path.

## How these were found

These are all crashes that hit me during ordinary use, so the workflow was to run FreeCAD
inside a debugger session with an MCP server attached:

```
pixi run lldb -o "protocol-server start MCP listen://localhost:59999" build/release/bin/FreeCAD
```

On each crash I employed Claude to diagnose the fault through that server — walking the stopped
process's stacks, frames, and the objects involved — and to resolve it. That is how the
distinct destroyers were told apart: the crashes look alike from the outside (a dead editor
receiving an event), but the stacks show different widgets doing the destroying, which is why
this is a series rather than one patch.

AI assistance used: Claude Opus 4.8 for the diagnosis and the fixes, Claude Opus 5 for a
later pass over the code comments and commit messages. The commits carry `Assisted-by:`
trailers naming both.

## Testing

Most crashes were hard to reproduce race conditions, but I no longer hit the issue.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues

* None found

## Before and After Images

* N/A
