### PR TITLE
Assembly: Fix crashes, a solver recursion, and transient state leaking into saved files

### DIFF
--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -847,9 +847,7 @@ void AssemblyObject::redrawJointPlacement(App::DocumentObject* joint)
 
     Base::PyGILStateLocker lock;
 
-    App::PropertyPythonObject* proxy = joint
-        ? dynamic_cast<App::PropertyPythonObject*>(joint->getPropertyByName("Proxy"))
-        : nullptr;
+    auto* proxy = dynamic_cast<App::PropertyPythonObject*>(joint->getPropertyByName("Proxy"));
 
     if (!proxy) {
         return;

--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -154,6 +154,9 @@ void AssemblyObject::onChanged(const App::Property* prop)
 
 int AssemblyObject::solve(bool enableRedo)
 {
+    // updateSolveStatus() solves on demand; suppress that while a solve is running.
+    Base::StateLocker lock(solveInProgress);
+
     ensureIdentityPlacements();
 
     syncGroundedJoints();
@@ -214,7 +217,9 @@ void AssemblyObject::updateSolveStatus()
     //+1 because there's a grounded joint to origin
     lastDoF = (1 + numberOfComponents()) * 6;
 
-    if (!mbdAssembly || !mbdAssembly->mbdSystem) {
+    // Solve on demand when queried before the system is solved, but not from within
+    // a solve: solve() calls this, so a failed solve would recurse indefinitely.
+    if (!solveInProgress && (!mbdAssembly || !mbdAssembly->mbdSystem)) {
         solve();
     }
 

--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -800,6 +800,24 @@ void AssemblyObject::updateRigidPlacementCache()
     });
 }
 
+namespace
+{
+// A singular solve can return NaN or infinite placements. NaN coordinates defeat
+// the bounding-box rejection in SoRayPickAction, so writing one into the document
+// makes every ray pick hit everything; reject them at the solver/document boundary.
+bool isFinitePlacement(const Base::Placement& plc)
+{
+    const Base::Vector3d& pos = plc.getPosition();
+    double q0 {};
+    double q1 {};
+    double q2 {};
+    double q3 {};
+    plc.getRotation().getValue(q0, q1, q2, q3);
+    return std::isfinite(pos.x) && std::isfinite(pos.y) && std::isfinite(pos.z) && std::isfinite(q0)
+        && std::isfinite(q1) && std::isfinite(q2) && std::isfinite(q3);
+}
+}  // namespace
+
 void AssemblyObject::setNewPlacements()
 {
     for (auto& pair : objectPartMap) {
@@ -820,6 +838,14 @@ void AssemblyObject::setNewPlacements()
         Base::Placement newPlacement = getMbdPlacement(mbdPart);
         if (!pair.second.offsetPlc.isIdentity()) {
             newPlacement = newPlacement * pair.second.offsetPlc;
+        }
+        if (!isFinitePlacement(newPlacement)) {
+            Base::Console().warning(
+                "Assembly: solver returned a non-finite placement for '%s'; keeping its "
+                "previous position.\n",
+                obj->getFullName().c_str()
+            );
+            continue;
         }
         if (!propPlacement->getValue().isSame(newPlacement)) {
             propPlacement->setValue(newPlacement);

--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -878,23 +878,32 @@ void AssemblyObject::redrawJointPlacement(App::DocumentObject* joint)
 
     Base::PyGILStateLocker lock;
 
-    auto* proxy = dynamic_cast<App::PropertyPythonObject*>(joint->getPropertyByName("Proxy"));
+    try {
+        auto* proxy = dynamic_cast<App::PropertyPythonObject*>(joint->getPropertyByName("Proxy"));
 
-    if (!proxy) {
-        return;
+        if (!proxy) {
+            return;
+        }
+
+        Py::Object jointPy = proxy->getValue();
+
+        if (!jointPy.hasAttr("redrawJointPlacements")) {
+            return;
+        }
+
+        Py::Object attr = jointPy.getAttr("redrawJointPlacements");
+        if (attr.ptr() && attr.isCallable()) {
+            Py::Tuple args(1);
+            args.setItem(0, Py::asObject(joint->getPyObject()));
+            Py::Callable(attr).apply(args);
+        }
     }
-
-    Py::Object jointPy = proxy->getValue();
-
-    if (!jointPy.hasAttr("redrawJointPlacements")) {
-        return;
-    }
-
-    Py::Object attr = jointPy.getAttr("redrawJointPlacements");
-    if (attr.ptr() && attr.isCallable()) {
-        Py::Tuple args(1);
-        args.setItem(0, Py::asObject(joint->getPyObject()));
-        Py::Callable(attr).apply(args);
+    catch (Py::Exception&) {
+        // Callers run inside Qt event handlers, which cannot propagate C++ exceptions
+        // out of the joint's Python callback. Report the error and keep redrawing the
+        // remaining joints.
+        Base::PyException e;
+        e.reportException();
     }
 }
 

--- a/src/Mod/Assembly/App/AssemblyObject.h
+++ b/src/Mod/Assembly/App/AssemblyObject.h
@@ -280,6 +280,9 @@ private:
 
     bool bundleFixed;
 
+    // True while solve() is running; breaks the solve()/updateSolveStatus() cycle.
+    bool solveInProgress {false};
+
     int lastDoF;
     bool lastHasConflict;
     bool lastHasRedundancies;

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -124,11 +124,15 @@ ViewProviderAssembly::ViewProviderAssembly()
     m_preTransactionConn = App::GetApplication().signalBeforeOpenTransaction.connect(
         std::bind(&ViewProviderAssembly::slotAboutToOpenTransaction, this, std::placeholders::_1)
     );
+    m_startSaveConn = App::GetApplication().signalStartSaveDocument.connect(
+        std::bind(&ViewProviderAssembly::slotStartSave, this, std::placeholders::_1, std::placeholders::_2)
+    );
 }
 
 ViewProviderAssembly::~ViewProviderAssembly()
 {
     m_preTransactionConn.disconnect();
+    m_startSaveConn.disconnect();
     QObject::disconnect(workbenchConnection);
 
     updateTaskPanel(false);
@@ -1650,6 +1654,21 @@ void ViewProviderAssembly::clearJointElementHighlight()
 void ViewProviderAssembly::slotAboutToOpenTransaction(const std::string& cmdName)
 {
     Q_UNUSED(cmdName);
+    this->clearIsolate();
+    this->clearTemporaryExplosion();
+}
+
+void ViewProviderAssembly::slotStartSave(const App::Document& doc, const std::string& filename)
+{
+    Q_UNUSED(filename);
+
+    // Isolation and temporary explosion mutate persisted state (Selectable,
+    // Visibility, Placements) and hold their restore data only in memory, so clear
+    // both before serialization rather than writing the transient state to file.
+    Gui::Document* guiDoc = getDocument();
+    if (!guiDoc || guiDoc->getDocument() != &doc) {
+        return;  // not our document
+    }
     this->clearIsolate();
     this->clearTemporaryExplosion();
 }

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -522,6 +522,12 @@ bool ViewProviderAssembly::tryMouseMove(const SbVec2s& cursorPos, Gui::View3DInv
             newPos = Base::Vector3d(vec[0], vec[1], vec[2]);
         }
 
+        // Cursor deltas are world-space but the placements written below are in the
+        // assembly's local frame, so rotate them into it. Identity for an unrotated
+        // assembly. Mirrors the asmPlc correction in draggerMotionCallback.
+        Base::Rotation asmInvRot
+            = App::GeoFeature::getGlobalPlacement(getObject<AssemblyObject>()).getRotation().inverse();
+
         for (auto& objToMove : docsToMove) {
             App::DocumentObject* obj = objToMove.obj;
             auto* propPlacement = obj->getPlacementProperty();
@@ -596,8 +602,8 @@ bool ViewProviderAssembly::tryMouseMove(const SbVec2s& cursorPos, Gui::View3DInv
                     Base::Vector3d pos = plc.getPosition() + (newPos - initialPosition);
                     plc.setPosition(pos);
                 }
-                else {  // DragMode::Translation
-                    Base::Vector3d delta = newPos - prevPosition;
+                else {  // DragMode::Translation / TranslationNoSolve
+                    Base::Vector3d delta = asmInvRot.multVec(newPos - prevPosition);
 
                     Base::Vector3d pos = propPlacement->getValue().getPosition() + delta;
                     plc.setPosition(pos);

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -127,12 +127,16 @@ ViewProviderAssembly::ViewProviderAssembly()
     m_startSaveConn = App::GetApplication().signalStartSaveDocument.connect(
         std::bind(&ViewProviderAssembly::slotStartSave, this, std::placeholders::_1, std::placeholders::_2)
     );
+    m_deletedObjectConn = App::GetApplication().signalDeletedObject.connect(
+        std::bind(&ViewProviderAssembly::slotDeletedObject, this, std::placeholders::_1)
+    );
 }
 
 ViewProviderAssembly::~ViewProviderAssembly()
 {
     m_preTransactionConn.disconnect();
     m_startSaveConn.disconnect();
+    m_deletedObjectConn.disconnect();
     QObject::disconnect(workbenchConnection);
 
     updateTaskPanel(false);
@@ -1677,6 +1681,26 @@ void ViewProviderAssembly::slotStartSave(const App::Document& doc, const std::st
     }
     this->clearIsolate();
     this->clearTemporaryExplosion();
+}
+
+void ViewProviderAssembly::slotDeletedObject(const App::DocumentObject& obj)
+{
+    // Isolation and temporary explosion hold raw DocumentObject restore targets, and
+    // objects can be deleted without a transaction opening (undo/redo, removeObject,
+    // document close). Drop stale references so a later clear does not dereference
+    // freed memory. Pointer identity only -- obj may already be half-destroyed.
+    auto* deleted = const_cast<App::DocumentObject*>(&obj);
+
+    stateBackup.erase(deleted);
+
+    if (isolatedJoint == deleted) {
+        clearJointElementHighlight();
+        isolatedJoint = nullptr;
+    }
+
+    if (temporaryExplosion == deleted) {
+        temporaryExplosion = nullptr;
+    }
 }
 
 bool ViewProviderAssembly::explodeTemporarily(App::DocumentObject* explodedView)

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.h
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.h
@@ -266,6 +266,7 @@ private:
     );
 
     void slotAboutToOpenTransaction(const std::string& cmdName);
+    void slotStartSave(const App::Document& doc, const std::string& filename);
     void slotActivatedVP(const Gui::ViewProviderDocumentObject* vp, const char* name);
 
     void onWorkbenchActivated(const QString& name);
@@ -301,6 +302,7 @@ private:
     fastsignals::connection connectActivatedVP;
     fastsignals::connection connectSolverUpdate;
     fastsignals::scoped_connection m_preTransactionConn;
+    fastsignals::scoped_connection m_startSaveConn;
 };
 
 }  // namespace AssemblyGui

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.h
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.h
@@ -267,6 +267,7 @@ private:
 
     void slotAboutToOpenTransaction(const std::string& cmdName);
     void slotStartSave(const App::Document& doc, const std::string& filename);
+    void slotDeletedObject(const App::DocumentObject& obj);
     void slotActivatedVP(const Gui::ViewProviderDocumentObject* vp, const char* name);
 
     void onWorkbenchActivated(const QString& name);
@@ -303,6 +304,7 @@ private:
     fastsignals::connection connectSolverUpdate;
     fastsignals::scoped_connection m_preTransactionConn;
     fastsignals::scoped_connection m_startSaveConn;
+    fastsignals::scoped_connection m_deletedObjectConn;
 };
 
 }  // namespace AssemblyGui

--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -1114,6 +1114,11 @@ class ViewProviderJoint:
 
     def updateData(self, joint, prop):
         """If a property of the handled feature has changed we have the chance to handle this here"""
+        # The JCS switches are created in attach(); updateData() can fire on a
+        # property change before attach() has run (e.g. during document restore).
+        if not hasattr(self, "switch_JCS1"):
+            return
+
         if prop == "Placement1" and hasattr(joint, "Reference1"):
             self.redrawJointPlacement(self.switch_JCS1, joint.Placement1, joint.Reference1)
 
@@ -1121,6 +1126,11 @@ class ViewProviderJoint:
             self.redrawJointPlacement(self.switch_JCS2, joint.Placement2, joint.Reference2)
 
     def redrawJointPlacements(self, joint):
+        # Called from AssemblyObject::solve(), which can run before attach() has
+        # created the JCS switches (e.g. right after a document restore).
+        if not hasattr(self, "switch_JCS1"):
+            return
+
         if not hasattr(joint, "Reference1") or not hasattr(joint, "Reference2"):
             return
 


### PR DESCRIPTION
Eight commits against the Assembly workbench, independent of each other apart from the small
cleanup that precedes the Python-exception fix. They came out of
extended work on larger assemblies, where every one of these was hit in practice.

### Crashes

**`Contain Python exception in redrawJointPlacement()`** — double-clicking an assembly to edit
runs `solve()` → `redrawJointPlacement()`, which calls the joint's Python
`redrawJointPlacements` callback. That callback can raise (an `AttributeError` when the joint's
view provider has not built its scene-graph nodes yet, e.g. just after document restore), and
`solve()` calls it outside its try/catch. The `Py::Exception` then unwinds through the Qt event
loop, which cannot propagate C++ exceptions, and `std::terminate()`s the app. Guarded at the
single C++/Python boundary so all callers are covered.

**`Guard joint view provider redraw against pre-attach calls`** — the Python half of the same
crash: `ViewProviderJoint.redrawJointPlacements()` / `updateData()` touch `switch_JCS1`, which
only exists after `attach()`. They now return early instead of raising.

**`Fix isolate use-after-free from dangling deleted-object pointers`** — joint isolation and
temporary explosion keep raw `App::DocumentObject*` restore targets. Isolation is normally
cleared when a transaction opens, but objects can be deleted through paths that open none
(undo/redo, programmatic `removeObject`, document close), leaving a stale pointer that a later
`clearIsolate()` dereferences — including through its own `isAttachedToDocument()` "guard",
which reads the freed vtable. Now dropped via `signalDeletedObject`, using pointer identity
only.

**`Reject non-finite solver placements`** — a singular solve can return NaN placements. Writing
one into the document poisons the scene graph: NaN coordinates defeat the bounding-box
rejection in `SoRayPickAction`, so a single navigation ray pick "hits" essentially every
primitive and returns millions of points, freezing the GUI. Rejected at the solver/document
boundary, with a warning naming the object.

### Solver

**`Prevent solve/updateSolveStatus infinite recursion`** — `updateSolveStatus()` solves on
demand when the system is not solved, but `solve()` ends by calling `updateSolveStatus()` (and
calls it from both catch handlers). When a solve cannot produce a solved system — a singular or
degenerate constraint configuration — the two call each other until the stack overflows.
Observed live as an unbounded alternating call stack. A `solveInProgress` flag suppresses only
the re-entrant call; top-level callers are unaffected.

### Dragging

**`Fix free-drag direction for transformed assemblies`** — plain `Translation` drag adds a
world-space cursor delta straight to a placement expressed in the assembly's local frame, so in
a rotated in-place subassembly the part moves along a skewed direction instead of tracking the
cursor. Rotated by the inverse of the assembly's global rotation, mirroring the correction the
dragger-handle path already applies in `draggerMotionCallback`.

Note: the joint-constrained modes (`TranslationOnAxis`, `TranslationOnPlane`, `Ball`,
`RotationOnPlane`) share the same latent world-vs-local assumption and would also misbehave in a
transformed assembly. I left those out deliberately — their math is coupled to the joint
coordinate system and deserves a separate, test-backed change.

### Saved-file hygiene

**`Clear joint isolation and temporary explosion before save`** — both give transient visual
feedback by mutating *persisted* state (`Selectable`, `Visibility`, part `Placement`s) with
restore data held only in memory. Saving while either is active writes that transient state to
disk, where it can never be undone on reload — the symptom is parts that are unselectable after
reopening the file. Cleared on `signalStartSaveDocument`.

**`Remove duplicate nullptr check`** — small cleanup in the function the Python-exception fix
touches; kept separate so that commit stays readable.

## How these were found

The crashes and the freeze all hit me during ordinary use of larger assemblies, so the workflow
was to run FreeCAD inside a debugger session with an MCP server attached:

```
pixi run lldb -o "protocol-server start MCP listen://localhost:59999" build/release/bin/FreeCAD
```

On each fault I employed Claude to diagnose it through that server — walking the stopped
process's stacks, frames, and the objects involved — and to resolve it. That is what separated
symptoms from causes here: the NaN placements, for instance, present as the GUI locking up
during navigation, and only the stopped process shows a single ray pick returning millions of
points; the solver recursion presents as a hang, and the stack shows `solve()` and
`updateSolveStatus()` alternating without bound.

The two non-crash fixes came from behaviour rather than the debugger: the drag skew from parts
not tracking the cursor in a rotated in-place subassembly, and the save leak from parts being
unselectable after reopening a file that had been saved while a joint was isolated.

AI assistance used: Claude Opus 4.8 for the diagnosis and the fixes, Claude Opus 5 for a
later pass over the code comments and commit messages. The commits carry `Assisted-by:`
trailers naming both.

## Testing

* Most were hard to reproduce intermittant failures.  I no longer experience them during use.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues

* None

## Before and After Images

* N/A
