### PR TITLE
Gui: Don't hardcode the gutter color in PropertListEditor

### DIFF
--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -1348,15 +1348,24 @@ void PropertyListEditor::resizeEvent(QResizeEvent* e)
     lineNumberArea->setGeometry(QRect(cr.left(), cr.top(), lineNumberAreaWidth(), cr.height()));
 }
 
+void PropertyListEditor::changeEvent(QEvent* event)
+{
+    QPlainTextEdit::changeEvent(event);
+
+    if (event->type() == QEvent::PaletteChange || event->type() == QEvent::StyleChange) {
+        highlightCurrentLine();
+        lineNumberArea->update();
+    }
+}
+
 void PropertyListEditor::highlightCurrentLine()
 {
     QList<QTextEdit::ExtraSelection> extraSelections;
     if (!isReadOnly()) {
         QTextEdit::ExtraSelection selection;
 
-        QPalette palette = style()->standardPalette();
-        selection.format.setBackground(palette.highlight().color());
-        selection.format.setForeground(palette.highlightedText().color());
+        selection.format.setBackground(palette().highlight());
+        selection.format.setForeground(palette().highlightedText());
 
         selection.format.setProperty(QTextFormat::FullWidthSelection, true);
         selection.cursor = textCursor();
@@ -1370,7 +1379,7 @@ void PropertyListEditor::highlightCurrentLine()
 void PropertyListEditor::lineNumberAreaPaintEvent(QPaintEvent* event)
 {
     QPainter painter(lineNumberArea);
-    painter.fillRect(event->rect(), Qt::lightGray);
+    painter.setPen(palette().windowText().color());
 
     QTextBlock block = firstVisibleBlock();
     int blockNumber = block.blockNumber();
@@ -1380,7 +1389,6 @@ void PropertyListEditor::lineNumberAreaPaintEvent(QPaintEvent* event)
     while (block.isValid() && top <= event->rect().bottom()) {
         if (block.isVisible() && bottom >= event->rect().top()) {
             QString number = QString::number(blockNumber + 1);
-            painter.setPen(Qt::black);
             painter.drawText(0, top, lineNumberArea->width(), fontMetrics().height(), Qt::AlignRight, number);
         }
 

--- a/src/Gui/Widgets.h
+++ b/src/Gui/Widgets.h
@@ -530,6 +530,7 @@ public:
 
 protected:
     void resizeEvent(QResizeEvent* event) override;
+    void changeEvent(QEvent* event) override;
 
 private Q_SLOTS:
     void updateLineNumberAreaWidth(int newBlockCount);


### PR DESCRIPTION
This is the last unsolved part of https://github.com/FreeCAD/FreeCAD-themes/issues/5 -- the PropertyListEditor's line number gutter had hardcoded colors in it and the highlight color used the wrong palette. This removes the hardcoded colors in favor of just using the theme's colors as-is, and uses the correct palette for the highlight. I played around with doing the same sort of dynamic color calculation as DlgThemeEditor.cpp, but I didn't like the effect (and it's much stronger in light themes than dark). I can re-implement easily enough if that's desired.

Before (hardcoded, unthemable):
<img width="211" height="206" alt="Screenshot 2026-08-16 234922" src="https://github.com/user-attachments/assets/4dbb4a68-edd4-4e3a-b534-504346ce9072" />

After (responds to theme):
<img width="211" height="206" alt="Screenshot 2026-08-17 002131" src="https://github.com/user-attachments/assets/30328061-887b-498c-a76b-80affd127203" />

While working on this I also noticed that the theme changes weren't propagating immediately to this widget, so I also added the necessary  `changeEvent` handler so testing didn't drive me completely insane and the highlight color and gutter update immediately.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
