### PR TITLE
Gui: Remove repeated-click hierarchy selection

### DIFF
--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -2180,28 +2180,6 @@ int SelectionSingleton::checkSelection(
     return 0;
 }
 
-const char* SelectionSingleton::getSelectedElement(App::DocumentObject* obj, const char* pSubName) const
-{
-    if (!obj) {
-        return {};
-    }
-
-    for (list<_SelObj>::const_iterator It = _SelList.begin(); It != _SelList.end(); ++It) {
-        if (It->pObject == obj) {
-            auto len = It->SubName.length();
-            if (!len) {
-                return "";
-            }
-            if (pSubName && strncmp(pSubName, It->SubName.c_str(), It->SubName.length()) == 0) {
-                if (pSubName[len] == 0 || pSubName[len - 1] == '.') {
-                    return It->SubName.c_str();
-                }
-            }
-        }
-    }
-    return nullptr;
-}
-
 void SelectionSingleton::slotDeletedObject(const App::DocumentObject& Obj)
 {
     if (!Obj.isAttachedToDocument()) {

--- a/src/Gui/Selection/Selection.h
+++ b/src/Gui/Selection/Selection.h
@@ -432,8 +432,6 @@ public:
     ) const;
     bool hasSelectionGate(App::Document* pDoc) const;
 
-    const char* getSelectedElement(App::DocumentObject*, const char* pSubName) const;
-
     /// set the preselected object (mostly by the 3D view)
     int setPreselect(
         const char* pDocName,

--- a/src/Gui/Selection/SoFCUnifiedSelection.cpp
+++ b/src/Gui/Selection/SoFCUnifiedSelection.cpp
@@ -856,7 +856,6 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
         }
     };
 
-    bool hasNext = false;
     const SoPickedPoint* pp = info.pp;
     const SoDetail* det = pp->getDetail();
     SoDetail* detNext = nullptr;
@@ -866,7 +865,6 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
     auto preselectionMode = static_cast<SelectionModes>(this->preselectionMode.getValue());
     static char buf[513];
     auto subName = info.element;
-    std::string objectName = objname;
 
     if (ctrlDown) {
         if (Gui::Selection().isSelected(docname, objname, info.element.c_str(), ResolveMode::NoResolve)) {
@@ -913,9 +911,9 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
                 && detailPath->getLength()) {
                 pPath = detailPath;
                 det = detNext;
-                FC_TRACE("select next " << objectName << ", " << subName);
+                FC_TRACE("select " << objname << ", " << subName);
                 if (ok) {
-                    type = hasNext ? SoSelectionElementAction::All : SoSelectionElementAction::Append;
+                    type = SoSelectionElementAction::Append;
                 }
                 else {
                     // don't apply any visual action when selection fails -
@@ -927,70 +925,14 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
         }
     }
     else {
-        // Hierarchy ascending
-        //
-        // If the clicked subelement is already selected, check if there is an
-        // upper hierarchy, and select that hierarchy instead.
-        //
-        // For example, let's suppose PickedInfo above reports
-        // 'link.link2.box.Face1', and below Selection().getSelectedElement returns
-        // 'link.link2.box.', meaning that 'box' is the current selected hierarchy,
-        // and the user is clicking the box again.  So we shall go up one level,
-        // and select 'link.link2.'
-        //
-
-
-        // We need to convert the short name in the selection to a full element path to look it up
-        // Ex:  Body.Pad.Face9  to Body.Pad.;g3;SKT;:H12dc,E;FAC;:H12dc:4,F;:G0;XTR;:H12dc:8,F.Face9
         getFullSubElementName(subName);
-        const char* subSelected_cstr
-            = Gui::Selection().getSelectedElement(vpd->getObject(), subName.c_str());
-        std::string subSelected = subSelected_cstr == nullptr ? "" : subSelected_cstr;
-
-        FC_TRACE(
-            "select " << (!subSelected.empty() ? subSelected : "'null'") << ", " << objectName
-                      << ", " << subName
-        );
-        std::string newElement;
-        if (!subSelected.empty()) {
-            newElement = Data::newElementName(subSelected.c_str());
-            subSelected = newElement.c_str();
-            std::string nextsub;
-            size_t next = subSelected.rfind('.');
-            if (next != std::string::npos && next != 0) {
-                if (next == subSelected.size() - 1) {
-                    // The convention of dot separated SubName demands a mandatory
-                    // ending dot for every object name reference inside SubName.
-                    // The non-object sub-element, however, must not end with a dot.
-                    // So, next[1]==0 here means current selection is a whole object
-                    // selection (because no sub-element), so we shall search
-                    // upwards for the second last dot, which is the end of the
-                    // parent name of the current selected object
-                    next = subSelected.rfind('.', next - 1);
-                }
-                if (next != std::string::npos) {
-                    nextsub = subSelected.substr(0, next + 1);
-                }
-            }
-            if (!nextsub.empty() || !subSelected.empty()) {
-                hasNext = true;
-                subName = nextsub;
-                detailPath->truncate(0);
-                if (vpd->getDetailPath(subName.c_str(), detailPath, true, detNext)
-                    && detailPath->getLength()) {
-                    pPath = detailPath;
-                    det = detNext;
-                    FC_TRACE("select next " << objectName << ", " << subName);
-                }
-            }
-        }
 
         FC_TRACE("clearing selection");
         Gui::Selection().clearSelection();
         FC_TRACE("add selection");
         bool ok = Gui::Selection().addSelection(
             docname,
-            objectName.c_str(),
+            objname,
             subName.c_str(),
             pt[0],
             pt[1],
@@ -1000,7 +942,7 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
             Gui::SelectionChanges::PickedPoint::Valid
         );
         if (ok) {
-            type = hasNext ? SoSelectionElementAction::All : SoSelectionElementAction::Append;
+            type = SoSelectionElementAction::Append;
         }
 
         if (preselectionMode == OFF) {
@@ -1009,7 +951,7 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
                 512,
                 "Selected: %s.%s.%s (%g, %g, %g)",
                 docname,
-                objectName.c_str(),
+                objname,
                 subName.c_str(),
                 fabs(pt[0]) > 1e-7 ? pt[0] : 0.0,
                 fabs(pt[1]) > 1e-7 ? pt[1] : 0.0,


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Briefly discussed at todays merge meeting but the current behavior had negative impacts at many places in the app (attachment, select sketch face after creating the sketch,...)

A click in the 3D view should select the geometry under the cursor. 
Currently, repeating the same click silently changes the selection scope by walking upward through the object hierarchy. For example, successive clicks can change the selection from a face to its Body, Part or Link even though the cursor has not moved.

This behavior has several usability problems:

- It makes selection state-dependent: the same click produces a different result depending on what was already selected
- It can accidentally broaden the scope of subsequent commands from a subelement to an entire container
- The selected parent may not correspond to the geometry directly under the pointer
- The behavior is not discoverable or communicated by the UI
- It conflicts with double-click interactions because the second click can change the selection before the double-click action completes
- Users cannot currently disable it independently
- Hierarchy depth becomes coupled to an arbitrary number of repeated clicks
- Current behavior is not implemented in all WBs (e.g. Sketcher or TechDraw), so we have a mixed UI
- Following actions (e.g. delete) might remove the wrong object. Trying to pad a sketch face result in an error...


This change makes selection predictable: repeatedly clicking the same visible element does not select any other obejct.
Selecting a different element still replaces the selection. Ctrl/greedy multiselection behavior is unchanged.
Assisted-by: GPT-5.6-Terra
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
