### PR TITLE
Fix #32027 PartDesign Loft tooltip

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1601,7 +1601,7 @@ CmdPartDesignAdditiveLoft::CmdPartDesignAdditiveLoft()
     sGroup = QT_TR_NOOP("PartDesign");
     sMenuText = QT_TR_NOOP("Additive Loft");
     sToolTipText = QT_TR_NOOP(
-        "Lofts the selected sketch or profile along a path and adds it to the body"
+        "Creates a solid between one or more sketches, profiles or faces and adds it to the body"
     );
     sWhatsThis = "PartDesign_AdditiveLoft";
     sStatusTip = sToolTipText;
@@ -1651,7 +1651,7 @@ CmdPartDesignSubtractiveLoft::CmdPartDesignSubtractiveLoft()
     sGroup = QT_TR_NOOP("PartDesign");
     sMenuText = QT_TR_NOOP("Subtractive Loft");
     sToolTipText = QT_TR_NOOP(
-        "Lofts the selected sketch or profile along a path and removes it from the body"
+        "Creates a solid between one or more sketches, profiles or faces and removes it from the body"
     );
     sWhatsThis = "PartDesign_SubtractiveLoft";
     sStatusTip = sToolTipText;

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1650,9 +1650,8 @@ CmdPartDesignSubtractiveLoft::CmdPartDesignSubtractiveLoft()
     sAppModule = "PartDesign";
     sGroup = QT_TR_NOOP("PartDesign");
     sMenuText = QT_TR_NOOP("Subtractive Loft");
-    sToolTipText = QT_TR_NOOP(
-        "Creates a solid between one or more sketches, profiles or faces and removes it from the body"
-    );
+    sToolTipText
+        = QT_TR_NOOP("Creates a solid between one or more sketches, profiles or faces and removes it from the body");
     sWhatsThis = "PartDesign_SubtractiveLoft";
     sStatusTip = sToolTipText;
     sPixmap = "PartDesign_SubtractiveLoft";

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1651,7 +1651,7 @@ CmdPartDesignSubtractiveLoft::CmdPartDesignSubtractiveLoft()
     sGroup = QT_TR_NOOP("PartDesign");
     sMenuText = QT_TR_NOOP("Subtractive Loft");
     sToolTipText
-        = QT_TR_NOOP("Creates a solid between one or more sketches, profiles or faces and removes it from the body");
+        = QT_TR_NOOP("Lofts the selected sketch or profile through one or more sections and removes it from the body");
     sWhatsThis = "PartDesign_SubtractiveLoft";
     sStatusTip = sToolTipText;
     sPixmap = "PartDesign_SubtractiveLoft";

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1601,7 +1601,7 @@ CmdPartDesignAdditiveLoft::CmdPartDesignAdditiveLoft()
     sGroup = QT_TR_NOOP("PartDesign");
     sMenuText = QT_TR_NOOP("Additive Loft");
     sToolTipText = QT_TR_NOOP(
-        "Creates a solid between one or more sketches, profiles or faces and adds it to the body"
+        "Lofts the selected sketch or profile through one or more sections and adds it to the body"
     );
     sWhatsThis = "PartDesign_AdditiveLoft";
     sStatusTip = sToolTipText;


### PR DESCRIPTION
## Description

Fixes the incorrect tooltip for the Part Design Loft tool.

The tooltip previously described Loft as sweeping a profile along a path. It now describes Loft as creating a solid between one or more sketches, profiles, or faces.

- [x] This PR is not unverified AI output; I take responsibility for it, and all communication from my side in this PR is done by me personally.