### PR TITLE
[GUI] Fix F11 fullscreen toggle activating wrong view on second press

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2006,11 +2006,6 @@ Action* StdViewDockUndockFullscreen::createAction()
 
 void StdViewDockUndockFullscreen::activated(int iMsg)
 {
-    // Check if main window is in fullscreen mode.
-    if (getMainWindow()->isFullScreen()) {
-        getMainWindow()->showNormal();
-    }
-
     MDIView* view = getMainWindow()->activeWindow();
     if (!view) {  // no active view
         return;
@@ -2028,8 +2023,9 @@ void StdViewDockUndockFullscreen::activated(int iMsg)
         return;
     }
 
-    // Change the view mode after an mdi view was already visible doesn't
-    // work well with Qt5 any more because of some strange OpenGL behaviour.
+    // Changing the view mode after an mdi view was already visible causes
+    // the window to reload strangely while flashing to black, identified
+    // as an OpenGL problem.
     // A workaround is to clone the mdi view, set its view mode and delete
     // the original view.
 
@@ -2039,13 +2035,14 @@ void StdViewDockUndockFullscreen::activated(int iMsg)
     if (clone) {
         if (mode == MDIView::Child) {
             getMainWindow()->addWindow(clone);
+            getMainWindow()->setActiveWindow(clone);
+            qApp->processEvents();  // let the close and any queued activation settle
+            view->deleteSelf();
         }
         else {
+            view->deleteSelf();
             clone->setCurrentViewMode(mode);
         }
-
-        // destroy the old view
-        view->deleteSelf();
     }
     else {
         // no clone needed, simply change the view mode


### PR DESCRIPTION
Reorders the clone/delete sequence so the clone's activation is always the last write, and forces pending activation events to process before the old view is deleted, preventing visible switching back to another existing tab before the previously active tab is recreated.

Also removes a redundant Std_MainFullscreen check that was only relevant to the alt+f11 path and clarifies a stale comment on the MDI view mode change workaround that incorrectly attributed the OpenGL flickering fix to Qt5 (since it is still present in Qt6 - the behaviour without this cloning path is that moving in and out of full screen looks like it visually opens a new window whilst flickering to and from a black screen. The comment attributed it to an OpenGL problem so I just updated the comment).

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
Fixes #24058 

## Before and After Images
Before:

https://github.com/user-attachments/assets/1e75dfaf-bc3c-47df-b684-194c2148f151

Occasional flickering caused by not fully processing pending events (this is more visible on my machine and less visible in the screen recording, not sure why):

https://github.com/user-attachments/assets/b9fc478e-ee8c-448d-b07f-0ce724c2e6fb

Fix:

https://github.com/user-attachments/assets/4babc174-0556-4a0f-b39c-c164ff8f54af