### PR TITLE
CAM: Create Fablin Machine Post Processor

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/fablin_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fablin_post.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *   Copyright (c) 2026 Fae Corrigan <faecorrigandesign@gmail.com>         *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+from typing import Any, Dict
+from Path.Post.Processor import PostProcessor
+import Path
+import FreeCAD
+
+
+Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+
+translate = FreeCAD.Qt.translate
+
+debug = False
+if debug:
+    Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
+    Path.Log.trackModule(Path.Log.thisModule())
+else:
+    Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+
+Values = Dict[str, Any]
+
+POST_TYPE = "machine"
+
+
+class Fablin(PostProcessor):
+    coolant_End_Command = ""
+    @classmethod
+    def get_common_property_schema(cls):
+        """Return common properties with Fablin defaults (uses base defaults)."""
+        """Override common properties with Fablin-specific defaults."""
+        common_props = super().get_common_property_schema()
+        return common_props
+
+    @classmethod
+    def get_property_schema(cls):
+         return [
+            {
+                "name": "min_feed_rate",
+                "type": "float",
+                "label": translate("CAM", "Minimum Feed Rate"),
+                "default": 5.0,
+                "min": 0.0,
+                "max": 100000.0,
+                "decimals": 2,
+                "help": translate(
+                    "CAM",
+                    "Feed rates (in the current output units/min) below this value "
+                    "abort posting - this usually indicates a missing feed rate.",
+                ),
+            },
+            {
+                "name": "min_spindle_speed",
+                "type": "float",
+                "label": translate("CAM", "Minimum Spindle Speed"),
+                "default": 5.0,
+                "min": 0.0,
+                "max": 20000.0,
+                "decimals": 0,
+                "help": translate(
+                    "CAM",
+                    "Spindle speeds (in RPM) below this value abort posting - this "
+                    "usually indicates a missing spindle speed.",
+                ),
+            },
+            ]
+
+    def __init__(self, job):
+        super().__init__(
+            job=job,
+            tooltip=translate("CAM", "Fablin post processor"),
+            tooltipargs=[],
+            units="Metric",
+        )
+        Path.Log.debug("Fablin post processor initialized")
+
+    def init_values(self, values: Values) -> None:
+        """Initialize values that are used throughout the postprocessor."""
+        #
+        super().init_values(values)
+
+        values["POSTPROCESSOR_FILE_NAME"] = __name__
+        values["MACHINE_NAME"] = "Fablin"
+        
+        
+        if self._machine and hasattr(self._machine, "postprocessor_properties"):
+            props = self._machine.postprocessor_properties
+            values["MIN_FEED_RATE"] = props.get("min_feed_rate", 5.0)
+            values["MIN_SPINDLE_SPEED"] = props.get("min_spindle_speed", 5.0)
+        else:
+            values["MIN_FEED_RATE"] = 5.0
+            values["MIN_SPINDLE_SPEED"] = 5.0
+            
+        # Set any values here that need to override the default values set
+        # in the parent routine.
+        #
+        # Any commands in this value will be output after the header and
+        # safety block at the beginning of the G-code file.
+        #
+        values["PREAMBLE"] = """"""
+        #
+        # Any commands in this value will be output as the last commands
+        # in the G-code file.
+        #
+        values["POSTAMBLE"] = """M5"""
+    
+    def convert_command_to_gcode(self, command: Path.Command):
+        props = self._machine.postprocessor_properties
+        if command.Name == 'T':
+            return
+        return super().convert_command_to_gcode(command)
+    
+    def _convert_tool_change(self, command: Path.Command): #ignore any tool change text
+        return ""
+    
+    def _convert_fixture(self, command: Path.Command): #ignore any G54-59 commands
+        return""
+    
+    @property
+    def tooltip(self):
+
+        tooltip = """
+        Generate G-code from a Path that is compatible with the Fablin CNC controller.
+        Have a look at https://github.com/FABtotum/FABlin
+        """
+        return tooltip
+
+    @property
+    def tooltipArgs(self):
+        argtooltip = super().tooltipArgs
+
+        # One could add additional arguments here.
+        # argtooltip += """
+        # --arg1: This is the first argument
+        # --arg2: This is the second argument
+
+        # """
+        return argtooltip
+
+    @property
+    def units(self):
+        return self._units

--- a/src/Mod/CAM/Path/Post/scripts/fablin_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fablin_post.py
@@ -30,13 +30,6 @@ Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 
 translate = FreeCAD.Qt.translate
 
-debug = False
-if debug:
-    Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
-    Path.Log.trackModule(Path.Log.thisModule())
-else:
-    Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
-
 Values = Dict[str, Any]
 
 POST_TYPE = "machine"
@@ -47,8 +40,8 @@ class Fablin(PostProcessor):
 
     @classmethod
     def get_common_property_schema(cls):
-        """Return common properties with Fablin defaults (uses base defaults)."""
-        """Override common properties with Fablin-specific defaults."""
+        """Return common properties with Fablin defaults (uses base defaults)"""
+        """Override common properties with Fablin-specific defaults"""
         common_props = super().get_common_property_schema()
         return common_props
 
@@ -66,7 +59,7 @@ class Fablin(PostProcessor):
                 "help": translate(
                     "CAM",
                     "Feed rates (in the current output units/min) below this value "
-                    "abort posting - this usually indicates a missing feed rate.",
+                    "abort posting - this usually indicates a missing feed rate",
                 ),
             },
             {
@@ -80,7 +73,7 @@ class Fablin(PostProcessor):
                 "help": translate(
                     "CAM",
                     "Spindle speeds (in RPM) below this value abort posting - this "
-                    "usually indicates a missing spindle speed.",
+                    "usually indicates a missing spindle speed",
                 ),
             },
         ]
@@ -95,7 +88,7 @@ class Fablin(PostProcessor):
         Path.Log.debug("Fablin post processor initialized")
 
     def init_values(self, values: Values) -> None:
-        """Initialize values that are used throughout the postprocessor."""
+        """Initialize values that are used throughout the postprocessor"""
         #
         super().init_values(values)
 
@@ -122,9 +115,10 @@ class Fablin(PostProcessor):
         # in the G-code file.
         #
         values["POSTAMBLE"] = """M5"""
+        
+        return
 
     def convert_command_to_gcode(self, command: Path.Command):
-        props = self._machine.postprocessor_properties
         if command.Name == "T":
             return
         return super().convert_command_to_gcode(command)

--- a/src/Mod/CAM/Path/Post/scripts/fablin_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fablin_post.py
@@ -26,7 +26,6 @@ from Path.Post.Processor import PostProcessor
 import Path
 import FreeCAD
 
-
 Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 
 translate = FreeCAD.Qt.translate
@@ -45,6 +44,7 @@ POST_TYPE = "machine"
 
 class Fablin(PostProcessor):
     coolant_End_Command = ""
+
     @classmethod
     def get_common_property_schema(cls):
         """Return common properties with Fablin defaults (uses base defaults)."""
@@ -54,7 +54,7 @@ class Fablin(PostProcessor):
 
     @classmethod
     def get_property_schema(cls):
-         return [
+        return [
             {
                 "name": "min_feed_rate",
                 "type": "float",
@@ -83,7 +83,7 @@ class Fablin(PostProcessor):
                     "usually indicates a missing spindle speed.",
                 ),
             },
-            ]
+        ]
 
     def __init__(self, job):
         super().__init__(
@@ -101,8 +101,7 @@ class Fablin(PostProcessor):
 
         values["POSTPROCESSOR_FILE_NAME"] = __name__
         values["MACHINE_NAME"] = "Fablin"
-        
-        
+
         if self._machine and hasattr(self._machine, "postprocessor_properties"):
             props = self._machine.postprocessor_properties
             values["MIN_FEED_RATE"] = props.get("min_feed_rate", 5.0)
@@ -110,7 +109,7 @@ class Fablin(PostProcessor):
         else:
             values["MIN_FEED_RATE"] = 5.0
             values["MIN_SPINDLE_SPEED"] = 5.0
-            
+
         # Set any values here that need to override the default values set
         # in the parent routine.
         #
@@ -123,19 +122,19 @@ class Fablin(PostProcessor):
         # in the G-code file.
         #
         values["POSTAMBLE"] = """M5"""
-    
+
     def convert_command_to_gcode(self, command: Path.Command):
         props = self._machine.postprocessor_properties
-        if command.Name == 'T':
+        if command.Name == "T":
             return
         return super().convert_command_to_gcode(command)
-    
-    def _convert_tool_change(self, command: Path.Command): #ignore any tool change text
+
+    def _convert_tool_change(self, command: Path.Command):  # ignore any tool change text
         return ""
-    
-    def _convert_fixture(self, command: Path.Command): #ignore any G54-59 commands
-        return""
-    
+
+    def _convert_fixture(self, command: Path.Command):  # ignore any G54-59 commands
+        return ""
+
     @property
     def tooltip(self):
 

--- a/src/Mod/CAM/Path/Post/scripts/fablin_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fablin_post.py
@@ -1,25 +1,23 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Fae Corrigan
+# SPDX-FileNotice: Part of the FreeCAD project.
 
-# ***************************************************************************
-# *   Copyright (c) 2026 Fae Corrigan <faecorrigandesign@gmail.com>         *
-# *                                                                         *
-# *   This program is free software; you can redistribute it and/or modify  *
-# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
-# *   as published by the Free Software Foundation; either version 2 of     *
-# *   the License, or (at your option) any later version.                   *
-# *   for detail see the LICENCE text file.                                 *
-# *                                                                         *
-# *   This program is distributed in the hope that it will be useful,       *
-# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-# *   GNU Library General Public License for more details.                  *
-# *                                                                         *
-# *   You should have received a copy of the GNU Library General Public     *
-# *   License along with this program; if not, write to the Free Software   *
-# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-# *   USA                                                                   *
-# *                                                                         *
-# ***************************************************************************
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
 
 from typing import Any, Dict
 from Path.Post.Processor import PostProcessor

--- a/src/Mod/CAM/Path/Post/scripts/fablin_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fablin_post.py
@@ -115,7 +115,7 @@ class Fablin(PostProcessor):
         # in the G-code file.
         #
         values["POSTAMBLE"] = """M5"""
-        
+
         return
 
     def convert_command_to_gcode(self, command: Path.Command):


### PR DESCRIPTION

This PR adds a new machine post processor to replace the legacy Fablin Post Processor. 
The new post generates Gcode with the same output as the legacy post processor with these differences: 
Feed rate are now properly translates to correct values 
G0 is now properly converted to G1 (based on the Fablin website and comments in the legacy post)
Spindle Speeds are truncated to integer values
Updated Translate Drill Cycle conversion used

Note: This pull request is intended to bring a legacy post up to date with the new post standards. It has not been tested on machine hardware



- [X ] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally. No  AI was used to create this PR request

The Post processor was verified against this file with the included machine file:
[Fablin_Compare_Legacy_and_New_Machine.zip](https://github.com/user-attachments/files/31180195/Fablin_Compare_Legacy_and_New_Machine.zip)

The machine will be added to the community machines addon

The output was compared using the compare plugin in notepad++. There are two output files in the .zip file for comparison
