### PR TITLE
BIM: Stop inferring space floor elevation

### DIFF
--- a/src/Mod/BIM/ArchIFC.py
+++ b/src/Mod/BIM/ArchIFC.py
@@ -344,7 +344,6 @@ class IfcRoot:
 
         - OverallWidth
         - OverallHeight
-        - ElevationWithFlooring
         - Elevation
         - NominalDiameter
         - BarLength
@@ -379,8 +378,6 @@ class IfcRoot:
                 obj.setExpression("OverallHeight", "Height.Value")
             else:
                 obj.setExpression("OverallHeight", "Shape.BoundBox.ZLength")
-        elif attribute["name"] == "ElevationWithFlooring" and "Shape" in obj.PropertiesList:
-            obj.setExpression("ElevationWithFlooring", "Shape.BoundBox.ZMin")
         elif attribute["name"] == "Elevation" and "Placement" in obj.PropertiesList:
             obj.setExpression("Elevation", "Placement.Base.z")
         elif attribute["name"] == "NominalDiameter" and "Diameter" in obj.PropertiesList:

--- a/src/Mod/BIM/bimtests/TestArchSpace.py
+++ b/src/Mod/BIM/bimtests/TestArchSpace.py
@@ -32,6 +32,7 @@ import Part
 import FreeCAD as App
 from FreeCAD import Units
 from bimtests import TestArchBase
+from importers import exportIFC
 import WorkingPlane
 
 
@@ -61,6 +62,27 @@ class TestArchSpace(TestArchBase.TestArchBase):
         b.Shape = sb
         s = Arch.makeSpace([b])
         self.assertTrue(s, "Arch Space failed")
+
+    def testSpaceElevationWithFlooring(self):
+        operation = "Checking Arch Space elevation with flooring..."
+        self.printTestMessage(operation)
+
+        base = App.ActiveDocument.addObject("Part::Feature", "ElevatedBox")
+        base.Shape = Part.makeBox(1000, 1000, 1000, App.Vector(0, 0, 1000))
+        space = Arch.makeSpace(base)
+        App.ActiveDocument.recompute()
+
+        self.assertEqual(space.Shape.BoundBox.ZMin, 1000.0)
+        self.assertNotIn("ElevationWithFlooring", dict(space.ExpressionEngine))
+        self.assertEqual(space.ElevationWithFlooring.Value, 0.0)
+
+        attributes = exportIFC.exportIFC2X3Attributes(space, {})
+        self.assertNotIn("ElevationWithFlooring", attributes)
+
+        space.ElevationWithFlooring = 125
+        self.assertEqual(space.ElevationWithFlooring.Value, 125.0)
+        attributes = exportIFC.exportIFC2X3Attributes(space, {})
+        self.assertAlmostEqual(attributes["ElevationWithFlooring"], 0.125)
 
     def testSpaceBBox(self):
         operation = "Checking Arch Space bound box..."

--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -1795,13 +1795,13 @@ def exportIFC2X3Attributes(obj, kwargs, scale=0.001):
                 internal = "INTERNAL"
             else:
                 internal = "EXTERNAL"
-        kwargs.update(
-            {
-                "CompositionType": "ELEMENT",
-                "InteriorOrExteriorSpace": internal,
-                "ElevationWithFlooring": obj.Shape.BoundBox.ZMin * scale,
-            }
-        )
+        attributes = {
+            "CompositionType": "ELEMENT",
+            "InteriorOrExteriorSpace": internal,
+        }
+        if hasattr(obj, "ElevationWithFlooring") and obj.ElevationWithFlooring.Value:
+            attributes["ElevationWithFlooring"] = obj.ElevationWithFlooring.Value * scale
+        kwargs.update(attributes)
     elif ifctype == "IfcReinforcingBar":
         kwargs.update({"NominalDiameter": obj.Diameter.Value, "BarLength": obj.Length.Value})
     elif ifctype == "IfcBuildingStorey":


### PR DESCRIPTION
This stops `ElevationWithFlooring` from being filled with the bottom of the space geometry. That value represents the top of the finished floor, and the space alone does not tell us how thick the floor covering is.

While tracing the export path, I noticed that IFC2X3 does not use the generic property exporter here. Simply removing the old special case would also drop a value entered manually by the user. The exporter now leaves the default zero out, but still writes `ElevationWithFlooring` when it has been set explicitly.

I added a regression test with an elevated space to cover both cases.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues

Fixes #31869.

## Before and After Images

Not applicable. This does not change the GUI.

## Testing

- FreeCAD pre-commit hooks on all modified files
- Focused runtime validation with the official FreeCAD weekly Windows build
- Python syntax and strict UTF-8 checks on all modified files
- `git diff --check`

I used Codex with GPT-5.6 Sol to help inspect the existing code and earlier attempt, prepare the implementation and regression test, and run the checks above. I reviewed and understand every change and take responsibility for it.
