### PR TITLE
CAM: Fix test-suite crash and abstract base test collection

### DIFF
--- a/src/Mod/CAM/CAMTests/TestCAMSanity.py
+++ b/src/Mod/CAM/CAMTests/TestCAMSanity.py
@@ -710,6 +710,10 @@ class TestCAMSanity(PathTestBase):
         mock_job.Machine = "test_machine"
         mock_job.Tools.Group = []
         mock_job.Operations.Group = []
+        # An un-post-processed job: _outputData() must take the "not
+        # post-processed" branch rather than open a path.
+        mock_job.LastPostProcessOutput = ""
+        mock_job.PostProcessorOutputFile = ""
 
         # Create a mock postprocessor with sanity checks
         class MockPostprocessor:
@@ -767,6 +771,8 @@ class TestCAMSanity(PathTestBase):
         mock_job.Machine = "error_machine"
         mock_job.Tools.Group = []
         mock_job.Operations.Group = []
+        mock_job.LastPostProcessOutput = ""
+        mock_job.PostProcessorOutputFile = ""
 
         class ErrorPostprocessor:
             def get_sanity_checks(self, job):
@@ -799,6 +805,8 @@ class TestCAMSanity(PathTestBase):
         mock_job = MagicMock()
         mock_job.Tools.Group = []
         mock_job.Operations.Group = []
+        mock_job.LastPostProcessOutput = ""
+        mock_job.PostProcessorOutputFile = ""
         # No machine attribute
 
         all_squawks, critical_squawks = Sanity.CAMSanity.validate_job(mock_job)

--- a/src/Mod/CAM/CAMTests/TestPathToolAssetStore.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolAssetStore.py
@@ -13,10 +13,14 @@ from Path.Tool.assets import (
 )
 
 
-class BaseTestPathToolAssetStore(unittest.TestCase):
+class BaseTestPathToolAssetStore:
     """
     Base test suite for Path Tool Asset Stores assuming full versioning support.
     Store-agnostic tests without direct file system access.
+
+    Deliberately not a TestCase subclass: unittest would otherwise collect and
+    run it directly, where the abstract `store` attribute does not exist.
+    Concrete suites inherit from both this mixin and unittest.TestCase.
     """
 
     store: AssetStore
@@ -337,7 +341,7 @@ class BaseTestPathToolAssetStore(unittest.TestCase):
         asyncio.run(async_test())
 
 
-class TestPathToolFileStore(BaseTestPathToolAssetStore):
+class TestPathToolFileStore(BaseTestPathToolAssetStore, unittest.TestCase):
     """Test suite for FileStore with full versioning support."""
 
     def setUp(self):
@@ -379,7 +383,7 @@ class TestPathToolFileStore(BaseTestPathToolAssetStore):
         asyncio.run(async_test())
 
 
-class TestPathToolMemoryStore(BaseTestPathToolAssetStore):
+class TestPathToolMemoryStore(BaseTestPathToolAssetStore, unittest.TestCase):
     """Test suite for MemoryStore."""
 
     def setUp(self):

--- a/src/Mod/CAM/CAMTests/TestPathToolBitSerializer.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolBitSerializer.py
@@ -18,10 +18,13 @@ from Path.Tool.shape import ToolBitShapeEndmill
 from typing import Mapping
 
 
-class _BaseToolBitSerializerTestCase(PathTestWithAssets):
-    """Base test case for ToolBit Serializers."""
+class _BaseToolBitSerializerTestCase:
+    """Base test case for ToolBit Serializers.
 
-    __test__ = False
+    Deliberately not a TestCase subclass: unittest would otherwise collect and
+    run it directly, where the abstract `serializer_class` attribute does not
+    exist. Concrete suites inherit from both this mixin and PathTestWithAssets.
+    """
 
     serializer_class: Type[AssetSerializer]
     test_tool_bit: ToolBit
@@ -54,7 +57,7 @@ class _BaseToolBitSerializerTestCase(PathTestWithAssets):
         self.assertEqual(len(dependencies), 0)
 
 
-class TestCamoticsToolBitSerializer(_BaseToolBitSerializerTestCase):
+class TestCamoticsToolBitSerializer(_BaseToolBitSerializerTestCase, PathTestWithAssets):
     serializer_class = CamoticsToolBitSerializer
 
     def test_serialize(self):
@@ -93,7 +96,7 @@ class TestCamoticsToolBitSerializer(_BaseToolBitSerializerTestCase):
         self.assertEqual(deserialized_bit.get_shape_name(), "Endmill")
 
 
-class TestFCTBSerializer(_BaseToolBitSerializerTestCase):
+class TestFCTBSerializer(_BaseToolBitSerializerTestCase, PathTestWithAssets):
     serializer_class = FCTBSerializer
 
     def test_serialize(self):
@@ -173,7 +176,7 @@ class TestFCTBSerializer(_BaseToolBitSerializerTestCase):
         self.assertEqual(data["my_ext"], {"foo": 1})
 
 
-class TestYamlToolBitSerializer(_BaseToolBitSerializerTestCase):
+class TestYamlToolBitSerializer(_BaseToolBitSerializerTestCase, PathTestWithAssets):
     serializer_class = YamlToolBitSerializer
 
     def test_serialize(self):

--- a/src/Mod/CAM/CAMTests/__init__.py
+++ b/src/Mod/CAM/CAMTests/__init__.py
@@ -22,8 +22,6 @@ _EXCLUDE_MODULES = {
 
 _EXCLUDE_MEMBERS = {
     "TestMachine": ["TestOutputOptions"],
-    "TestPathToolAssetStore": ["BaseTestPathToolAssetStore"],
-    "TestPathToolBitSerializer": ["_BaseToolBitSerializerTestCase"],
     "TestPostToolProcessing": ["TestEmptyMoveSuppression"],
 }
 

--- a/src/Mod/CAM/Path/Main/Sanity/Sanity.py
+++ b/src/Mod/CAM/Path/Main/Sanity/Sanity.py
@@ -233,7 +233,8 @@ class CAMSanity:
         else:
             if os.path.isfile(obj.LastPostProcessOutput):
                 data["filesize"] = str(os.path.getsize(obj.LastPostProcessOutput) / 1000)
-                data["linecount"] = str(sum(1 for line in open(obj.LastPostProcessOutput)))
+                with open(obj.LastPostProcessOutput) as gcode_file:
+                    data["linecount"] = str(sum(1 for line in gcode_file))
             else:
                 data["filesize"] = str(0.0)
                 data["linecount"] = str(0)


### PR DESCRIPTION
Two test-infrastructure problems, no behavior change for users.

**TestCAMApp aborts when stdout is a regular file.**

This works....
```
./bin/FreeCADCmd -t TestCAMApp 
```

Redirecting stdout fails...
```
./bin/FreeCADCmd -t TestCAMApp > mytest.txt
```

Three TestCAMSanity tests (320, 321, 322) build a bare MagicMock job.
CAMSanity._outputData() passes job.LastPostProcessOutput to os.path.isfile()
and open(), which accept an integer file descriptor. MagicMock answers
__index__ with 1, so the test opened fd 1 read-only, hit EBADF, and closed
stdout when the file object was collected. The runner then died and the suite ended without a summary.

The mocks now set LastPostProcessOutput and PostProcessorOutputFile to
empty strings, the same as the shared _make_mock_job() helper, so the tests
take the "not post-processed" branch. The only change in Sanity.py is a
context manager around the gcode file read; the old generator expression
never closed it.

**Abstract test bases were collected as tests.**
BaseTestPathToolAssetStore and _BaseToolBitSerializerTestCase subclassed
TestCase, so running their module on its own
(`FreeCADCmd -t CAMTests.TestPathToolAssetStore`) executed them and failed
on the missing abstract attributes. They are now plain mixins that the
concrete suites combine with TestCase or PathTestWithAssets, and the
_EXCLUDE_MEMBERS entries that hid them are gone.

Verified: full suite passes with stdout redirected to a file, and both
modules pass when run directly.

Assisted-by: claude code fable 5
