### PR TITLE
CAM: Generalize the asset manager to multiple stores

### DIFF
--- a/src/Mod/CAM/CAMTests/TestCAMSanity.py
+++ b/src/Mod/CAM/CAMTests/TestCAMSanity.py
@@ -710,6 +710,10 @@ class TestCAMSanity(PathTestBase):
         mock_job.Machine = "test_machine"
         mock_job.Tools.Group = []
         mock_job.Operations.Group = []
+        # Real string values keep _outputData() away from filesystem calls
+        # that would misinterpret a MagicMock as a file descriptor.
+        mock_job.LastPostProcessOutput = ""
+        mock_job.PostProcessorOutputFile = ""
 
         # Create a mock postprocessor with sanity checks
         class MockPostprocessor:
@@ -767,6 +771,8 @@ class TestCAMSanity(PathTestBase):
         mock_job.Machine = "error_machine"
         mock_job.Tools.Group = []
         mock_job.Operations.Group = []
+        mock_job.LastPostProcessOutput = ""
+        mock_job.PostProcessorOutputFile = ""
 
         class ErrorPostprocessor:
             def get_sanity_checks(self, job):

--- a/src/Mod/CAM/CAMTests/TestPathToolAssetManager.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolAssetManager.py
@@ -379,15 +379,13 @@ class TestPathToolAssetManager(unittest.TestCase):
         # Assert returned data matches store's result
         self.assertEqual(retrieved_data, expected_data)
 
-        # Test error handling (store not found)
-        non_existent_uri = AssetUri("type://id/1")
-        # Test error handling (asset not found in any store, including non-existent ones)
+        # Asset not found in any store, including unregistered ones (which
+        # are skipped on reads)
         non_existent_uri = AssetUri("type://id/1")
         with self.assertRaises(FileNotFoundError) as cm:
             manager.get_raw(non_existent_uri, store="non_existent_store")
-        self.assertIn(
-            "Asset 'type://id/1' not found in stores '['non_existent_store']'", str(cm.exception)
-        )
+        self.assertIn("Asset 'type://id/1' not found in stores", str(cm.exception))
+        self.assertIn("non_existent_store", str(cm.exception))
 
     def test_is_empty(self):
         # Setup AssetManager with a real MemoryStore
@@ -406,10 +404,18 @@ class TestPathToolAssetManager(unittest.TestCase):
         self.assertTrue(manager.is_empty(store="memory_empty", asset_type="another_type"))
         self.assertFalse(manager.is_empty(store="memory_empty", asset_type="test_type"))
 
-        # Test error handling (store not found)
-        with self.assertRaises(ValueError) as cm:
-            manager.is_empty(store="non_existent_store")
-        self.assertIn("No store registered for name:", str(cm.exception))
+        # Unregistered stores are skipped on reads: nothing is visible there
+        self.assertTrue(manager.is_empty(store="non_existent_store"))
+
+        # Multi-store: empty only if every store in the list is empty
+        other_store = MemoryStore("memory_empty_other")
+        manager.register_store(other_store)
+        self.assertFalse(manager.is_empty(store=["memory_empty", "memory_empty_other"]))
+        self.assertTrue(
+            manager.is_empty(
+                store=["memory_empty", "memory_empty_other"], asset_type="another_type"
+            )
+        )
 
     def test_count_assets(self):
         # Setup AssetManager with a real MemoryStore
@@ -433,10 +439,15 @@ class TestPathToolAssetManager(unittest.TestCase):
         self.assertEqual(manager.count_assets(store="memory_count", asset_type="type1"), 2)
         self.assertEqual(manager.count_assets(store="memory_count", asset_type="type2"), 1)
 
-        # Test error handling (store not found)
-        with self.assertRaises(ValueError) as cm:
-            manager.count_assets(store="non_existent_store")
-        self.assertIn("No store registered for name:", str(cm.exception))
+        # Unregistered stores are skipped on reads: nothing is visible there
+        self.assertEqual(manager.count_assets(store="non_existent_store"), 0)
+
+        # Multi-store: counts the merged result, deduplicated by asset id
+        other_store = MemoryStore("memory_count_other")
+        manager.register_store(other_store)
+        manager.add_raw("type1", "asset1", b"shadowed", "memory_count_other")
+        manager.add_raw("type1", "asset4", b"data4", "memory_count_other")
+        self.assertEqual(manager.count_assets(store=["memory_count", "memory_count_other"]), 4)
 
     def test_get_bulk(self):
         # Setup AssetManager with a real MemoryStore and MockAsset class
@@ -506,13 +517,14 @@ class TestPathToolAssetManager(unittest.TestCase):
         manager.register_store(remote_store)
         manager.register_asset(MockAsset, DummyAssetSerializer)
 
+        previous_write_store = Preferences.getAssetStoreWriteStore()
         Preferences.setAssetStoreWriteStore("loobric")
         try:
             uri = manager.add_raw(MockAsset.asset_type, "pref_target", b"prefer remote")
             self.assertTrue(asyncio.run(remote_store.exists(uri)))
             self.assertFalse(asyncio.run(local_store.exists(uri)))
         finally:
-            Preferences.setAssetStoreWriteStore("local")
+            Preferences.setAssetStoreWriteStore(previous_write_store)
 
     def test_asset_observer_notifies_on_changes(self):
         manager = AssetManager()
@@ -531,6 +543,86 @@ class TestPathToolAssetManager(unittest.TestCase):
         self.assertEqual(notifications[0][0], "memory_observer")
         self.assertEqual(notifications[0][2], "created")
         self.assertEqual(notifications[1][2], "deleted")
+
+    def test_notify_asset_changed_feeds_observers(self):
+        manager = AssetManager()
+        store = MemoryStore("memory_external")
+        manager.register_store(store)
+
+        notifications = []
+        manager.add_asset_observer(
+            lambda store_name, uri, action: notifications.append((store_name, str(uri), action))
+        )
+
+        # A store announcing an out-of-band change (e.g. a sync worker pull)
+        manager.notify_asset_changed("memory_external", "mock_asset://pulled_id/1", "created")
+
+        self.assertEqual(
+            notifications, [("memory_external", "mock_asset://pulled_id/1", "created")]
+        )
+
+        with self.assertRaises(ValueError):
+            manager.notify_asset_changed("memory_external", "mock_asset://pulled_id/1", "renamed")
+
+    def test_list_assets_applies_limit_offset_to_merged_result(self):
+        manager = AssetManager()
+        first_store = MemoryStore("memory_page_first")
+        second_store = MemoryStore("memory_page_second")
+        manager.register_store(first_store)
+        manager.register_store(second_store)
+
+        manager.add_raw(MockAsset.asset_type, "id_a", b"a", "memory_page_first")
+        manager.add_raw(MockAsset.asset_type, "id_b", b"b", "memory_page_first")
+        # Shadowed duplicate must not consume a slot in the merged result
+        manager.add_raw(MockAsset.asset_type, "id_a", b"a2", "memory_page_second")
+        manager.add_raw(MockAsset.asset_type, "id_c", b"c", "memory_page_second")
+
+        stores = ["memory_page_first", "memory_page_second"]
+        merged = manager.list_assets(MockAsset.asset_type, store=stores)
+        self.assertEqual(len(merged), 3)
+
+        page = manager.list_assets(MockAsset.asset_type, limit=2, offset=1, store=stores)
+        self.assertEqual(page, merged[1:3])
+
+        tail = manager.list_assets(MockAsset.asset_type, offset=2, store=stores)
+        self.assertEqual(tail, merged[2:])
+
+    def test_list_assets_attributed_first_store_wins(self):
+        manager = AssetManager()
+        first_store = MemoryStore("memory_attr_first")
+        second_store = MemoryStore("memory_attr_second")
+        manager.register_store(first_store)
+        manager.register_store(second_store)
+
+        manager.add_raw(MockAsset.asset_type, "shared_id", b"first", "memory_attr_first")
+        manager.add_raw(MockAsset.asset_type, "shared_id", b"second", "memory_attr_second")
+        manager.add_raw(MockAsset.asset_type, "second_only", b"second", "memory_attr_second")
+
+        attributed = manager.list_assets_attributed(
+            MockAsset.asset_type, store=["memory_attr_first", "memory_attr_second"]
+        )
+
+        by_id = {uri.asset_id: store_name for uri, store_name in attributed}
+        self.assertEqual(
+            by_id,
+            {
+                "shared_id": "memory_attr_first",
+                "second_only": "memory_attr_second",
+            },
+        )
+
+    def test_unregistered_write_store_raises(self):
+        manager = AssetManager()
+        manager.register_store(MemoryStore("local"))
+
+        with self.assertRaises(ValueError) as cm:
+            manager.add_raw("test_type", "test_id", b"data", "non_existent_store")
+        self.assertIn("No store registered for name:", str(cm.exception))
+        self.assertIn("AssetStoreWriteStore", str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            manager.delete("test_type://test_id/1", store="non_existent_store")
+        self.assertIn("No store registered for name:", str(cm.exception))
 
     def test_fetch(self):
         # Setup AssetManager with a real MemoryStore and MockAsset class
@@ -587,10 +679,8 @@ class TestPathToolAssetManager(unittest.TestCase):
             data2.decode("utf-8"),
         )
 
-        # Test error handling (store not found)
-        with self.assertRaises(ValueError) as cm:
-            manager.fetch(store="non_existent_store")
-        self.assertIn("No store registered for name:", str(cm.exception))
+        # Unregistered stores are skipped on reads: nothing is visible there
+        self.assertEqual(manager_filtered.fetch(store="non_existent_store"), [])
 
     def test_copy(self):
         # Setup AssetManager with two MemoryStores and MockAsset class
@@ -921,10 +1011,12 @@ class TestPathToolAssetManager(unittest.TestCase):
         non_existent_uri = AssetUri.build("test_type", "non_existent_id", "1")
         self.assertFalse(manager.exists(non_existent_uri, store="memory_exists"))
 
-        # Test exists for a non-existent store (should raise ValueError)
-        with self.assertRaises(ValueError) as cm:
-            manager.exists(test_uri, store="non_existent_store")
-        self.assertIn("No store registered for name:", str(cm.exception))
+        # Unregistered stores are skipped on reads: nothing is visible there
+        self.assertFalse(manager.exists(test_uri, store="non_existent_store"))
+
+        # An unregistered store in the search order does not hide the
+        # registered ones
+        self.assertTrue(manager.exists(test_uri, store=["non_existent_store", "memory_exists"]))
 
 
 if __name__ == "__main__":

--- a/src/Mod/CAM/CAMTests/TestPathToolAssetManager.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolAssetManager.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock
 import pathlib
 import tempfile
 from typing import Any, Mapping, List, Type, Optional, cast
+from Path import Preferences
 from Path.Tool.assets import (
     AssetManager,
     FileStore,
@@ -472,6 +473,64 @@ class TestPathToolAssetManager(unittest.TestCase):
         # Test handling of non-existent store (should skip and not raise ValueError)
         # The test already asserts that the non-existent asset is None, which is the expected behavior.
         manager.get_bulk(uris, store="non_existent_store")
+
+    def test_list_assets_merges_multiple_stores_without_duplicates(self):
+        manager = AssetManager()
+        local_store = MemoryStore("memory_list_local")
+        remote_store = MemoryStore("memory_list_remote")
+        manager.register_store(local_store)
+        manager.register_store(remote_store)
+        manager.register_asset(MockAsset, DummyAssetSerializer)
+
+        manager.add_raw(MockAsset.asset_type, "shared_id", b"local data", "memory_list_local")
+        manager.add_raw(MockAsset.asset_type, "remote_only", b"remote data", "memory_list_remote")
+
+        listed = manager.list_assets(
+            MockAsset.asset_type, store=["memory_list_local", "memory_list_remote"]
+        )
+
+        self.assertEqual(len(listed), 2)
+        self.assertEqual(
+            {str(uri) for uri in listed},
+            {
+                "mock_asset://shared_id/1",
+                "mock_asset://remote_only/1",
+            },
+        )
+
+    def test_write_target_uses_configured_default_store(self):
+        manager = AssetManager()
+        local_store = MemoryStore("local")
+        remote_store = MemoryStore("loobric")
+        manager.register_store(local_store)
+        manager.register_store(remote_store)
+        manager.register_asset(MockAsset, DummyAssetSerializer)
+
+        Preferences.setAssetStoreWriteStore("loobric")
+        try:
+            uri = manager.add_raw(MockAsset.asset_type, "pref_target", b"prefer remote")
+            self.assertTrue(asyncio.run(remote_store.exists(uri)))
+            self.assertFalse(asyncio.run(local_store.exists(uri)))
+        finally:
+            Preferences.setAssetStoreWriteStore("local")
+
+    def test_asset_observer_notifies_on_changes(self):
+        manager = AssetManager()
+        store = MemoryStore("memory_observer")
+        manager.register_store(store)
+        manager.register_asset(MockAsset, DummyAssetSerializer)
+
+        notifications = []
+        manager.add_asset_observer(
+            lambda store_name, uri, action: notifications.append((store_name, str(uri), action))
+        )
+
+        uri = manager.add_raw(MockAsset.asset_type, "notify_me", b"data", "memory_observer")
+        manager.delete(uri, store="memory_observer")
+
+        self.assertEqual(notifications[0][0], "memory_observer")
+        self.assertEqual(notifications[0][2], "created")
+        self.assertEqual(notifications[1][2], "deleted")
 
     def test_fetch(self):
         # Setup AssetManager with a real MemoryStore and MockAsset class

--- a/src/Mod/CAM/CAMTests/TestPathToolAssetStore.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolAssetStore.py
@@ -13,10 +13,14 @@ from Path.Tool.assets import (
 )
 
 
-class BaseTestPathToolAssetStore(unittest.TestCase):
+class BaseTestPathToolAssetStore:
     """
     Base test suite for Path Tool Asset Stores assuming full versioning support.
     Store-agnostic tests without direct file system access.
+
+    Deliberately not a TestCase subclass: unittest would otherwise collect and
+    run it directly, where the abstract `store` attribute does not exist.
+    Concrete suites inherit from both this mixin and unittest.TestCase.
     """
 
     store: AssetStore
@@ -337,7 +341,7 @@ class BaseTestPathToolAssetStore(unittest.TestCase):
         asyncio.run(async_test())
 
 
-class TestPathToolFileStore(BaseTestPathToolAssetStore):
+class TestPathToolFileStore(BaseTestPathToolAssetStore, unittest.TestCase):
     """Test suite for FileStore with full versioning support."""
 
     def setUp(self):
@@ -379,7 +383,7 @@ class TestPathToolFileStore(BaseTestPathToolAssetStore):
         asyncio.run(async_test())
 
 
-class TestPathToolMemoryStore(BaseTestPathToolAssetStore):
+class TestPathToolMemoryStore(BaseTestPathToolAssetStore, unittest.TestCase):
     """Test suite for MemoryStore."""
 
     def setUp(self):

--- a/src/Mod/CAM/CAMTests/TestPathToolBitSerializer.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolBitSerializer.py
@@ -18,10 +18,13 @@ from Path.Tool.shape import ToolBitShapeEndmill
 from typing import Mapping
 
 
-class _BaseToolBitSerializerTestCase(PathTestWithAssets):
-    """Base test case for ToolBit Serializers."""
+class _BaseToolBitSerializerTestCase:
+    """Base test case for ToolBit Serializers.
 
-    __test__ = False
+    Deliberately not a TestCase subclass: unittest would otherwise collect and
+    run it directly, where the abstract `serializer_class` attribute does not
+    exist. Concrete suites inherit from both this mixin and PathTestWithAssets.
+    """
 
     serializer_class: Type[AssetSerializer]
     test_tool_bit: ToolBit
@@ -54,7 +57,7 @@ class _BaseToolBitSerializerTestCase(PathTestWithAssets):
         self.assertEqual(len(dependencies), 0)
 
 
-class TestCamoticsToolBitSerializer(_BaseToolBitSerializerTestCase):
+class TestCamoticsToolBitSerializer(_BaseToolBitSerializerTestCase, PathTestWithAssets):
     serializer_class = CamoticsToolBitSerializer
 
     def test_serialize(self):
@@ -93,7 +96,7 @@ class TestCamoticsToolBitSerializer(_BaseToolBitSerializerTestCase):
         self.assertEqual(deserialized_bit.get_shape_name(), "Endmill")
 
 
-class TestFCTBSerializer(_BaseToolBitSerializerTestCase):
+class TestFCTBSerializer(_BaseToolBitSerializerTestCase, PathTestWithAssets):
     serializer_class = FCTBSerializer
 
     def test_serialize(self):
@@ -173,7 +176,7 @@ class TestFCTBSerializer(_BaseToolBitSerializerTestCase):
         self.assertEqual(data["my_ext"], {"foo": 1})
 
 
-class TestYamlToolBitSerializer(_BaseToolBitSerializerTestCase):
+class TestYamlToolBitSerializer(_BaseToolBitSerializerTestCase, PathTestWithAssets):
     serializer_class = YamlToolBitSerializer
 
     def test_serialize(self):

--- a/src/Mod/CAM/CAMTests/__init__.py
+++ b/src/Mod/CAM/CAMTests/__init__.py
@@ -17,8 +17,6 @@ _EXCLUDE_MODULES = {
 
 _EXCLUDE_MEMBERS = {
     "TestMachine": ["TestOutputOptions"],
-    "TestPathToolAssetStore": ["BaseTestPathToolAssetStore"],
-    "TestPathToolBitSerializer": ["_BaseToolBitSerializerTestCase"],
     "TestPostToolProcessing": ["TestEmptyMoveSuppression"],
 }
 

--- a/src/Mod/CAM/Path/Main/Sanity/Sanity.py
+++ b/src/Mod/CAM/Path/Main/Sanity/Sanity.py
@@ -213,15 +213,19 @@ class CAMSanity:
         data["postprocessor"] = str(obj.PostProcessor)
         data["postprocessorFlags"] = str(obj.PostProcessorArgs)
 
-        if obj.PostProcessorOutputFile != "":
-            fname = obj.PostProcessorOutputFile
+        if str(obj.PostProcessorOutputFile) != "":
+            fname = str(obj.PostProcessorOutputFile)
             data["outputfilename"] = os.path.splitext(os.path.basename(fname))[0]
 
         for op in obj.Operations.Group:
             if "Stop" in op.Name and hasattr(op, "Stop") and op.Stop is True:
                 data["optionalstops"] = "True"
 
-        if obj.LastPostProcessOutput == "":
+        # Coerce to str before any filesystem access: a non-str value (e.g. a
+        # mock in tests) would otherwise be treated as a file descriptor by
+        # open()/os.stat() via __index__, hijacking and closing fd 1.
+        last_output = str(obj.LastPostProcessOutput)
+        if last_output == "":
             data["filesize"] = str(0.0)
             data["linecount"] = str(0)
             data["squawkData"].append(
@@ -231,9 +235,10 @@ class CAMSanity:
                 )
             )
         else:
-            if os.path.isfile(obj.LastPostProcessOutput):
-                data["filesize"] = str(os.path.getsize(obj.LastPostProcessOutput) / 1000)
-                data["linecount"] = str(sum(1 for line in open(obj.LastPostProcessOutput)))
+            if os.path.isfile(last_output):
+                data["filesize"] = str(os.path.getsize(last_output) / 1000)
+                with open(last_output) as gcode_file:
+                    data["linecount"] = str(sum(1 for line in gcode_file))
             else:
                 data["filesize"] = str(0.0)
                 data["linecount"] = str(0)

--- a/src/Mod/CAM/Path/Preferences.py
+++ b/src/Mod/CAM/Path/Preferences.py
@@ -59,6 +59,8 @@ ToolGroup = PreferencesGroup + "/Tools"
 ToolPath = "ToolPath"
 LastToolLibrary = "LastToolLibrary"
 LastToolLibrarySortKey = "LastToolLibrarySortKey"
+AssetStoreSearchOrder = "AssetStoreSearchOrder"
+AssetStoreWriteStore = "AssetStoreWriteStore"
 
 # Linear tolerance to use when generating Paths, eg when tessellating geometry
 GeometryTolerance = "GeometryTolerance"
@@ -196,6 +198,38 @@ def getLastToolLibrarySortKey() -> Optional[str]:
 def setLastToolLibrarySortKey(name: str):
     pref = tool_preferences()
     pref.SetString(LastToolLibrarySortKey, name)
+
+
+def getAssetStoreSearchOrder(default: Optional[tuple[str, ...]] = None) -> tuple[str, ...]:
+    pref = tool_preferences()
+    value = pref.GetString(AssetStoreSearchOrder, "")
+    if value:
+        stores = [store.strip() for store in value.split(",") if store.strip()]
+        if stores:
+            return tuple(stores)
+    if default is None:
+        return ("local", "builtin")
+    return default
+
+
+def setAssetStoreSearchOrder(stores: tuple[str, ...] | list[str] | str):
+    if isinstance(stores, str):
+        value = stores
+    else:
+        value = ",".join(stores)
+    pref = tool_preferences()
+    pref.SetString(AssetStoreSearchOrder, value)
+
+
+def getAssetStoreWriteStore(default: str = "local") -> str:
+    pref = tool_preferences()
+    value = pref.GetString(AssetStoreWriteStore, "")
+    return value or default
+
+
+def setAssetStoreWriteStore(store: str):
+    pref = tool_preferences()
+    pref.SetString(AssetStoreWriteStore, store)
 
 
 def allAvailablePostProcessors():

--- a/src/Mod/CAM/Path/Tool/assets/manager.py
+++ b/src/Mod/CAM/Path/Tool/assets/manager.py
@@ -36,7 +36,9 @@ from typing import (
     Set,
     Mapping,
     Tuple,
+    Callable,
 )
+from Path import Preferences
 from dataclasses import dataclass
 from PySide import QtCore, QtGui
 from .store.base import AssetStore
@@ -68,6 +70,7 @@ class AssetManager:
         self._asset_classes: Dict[str, Type[Asset]] = {}
         self.asset_cache = AssetCache(max_size_bytes=cache_max_size_bytes)
         self._cacheable_stores: Set[str] = set()
+        self._asset_observers: List[Callable[[str, AssetUri, str], None]] = []
         logger.debug(f"AssetManager initialized (Thread: {threading.current_thread().name})")
 
     def register_store(self, store: AssetStore, cacheable: bool = False):
@@ -76,6 +79,37 @@ class AssetManager:
         self.stores[store.name] = store
         if cacheable:
             self._cacheable_stores.add(store.name)
+
+    def add_asset_observer(self, callback: Callable[[str, AssetUri, str], None]):
+        """Registers a callback for asset create/update/delete notifications."""
+        self._asset_observers.append(callback)
+
+    def _notify_asset_observers(self, store_name: str, uri: AssetUri, action: str):
+        for callback in list(self._asset_observers):
+            try:
+                callback(store_name, uri, action)
+            except Exception as exc:
+                logger.warning(f"Asset observer failed for {store_name}/{uri}: {exc}")
+
+    def _normalize_store_names(
+        self, store: Optional[Union[str, Sequence[str]]] = None
+    ) -> Sequence[str]:
+        if store is None:
+            return Preferences.getAssetStoreSearchOrder()
+        if isinstance(store, str):
+            return (store,)
+        return tuple(store)
+
+    def _get_write_store_name(self, store: Optional[str] = None) -> str:
+        if store:
+            return store
+        return Preferences.getAssetStoreWriteStore()
+
+    def get_default_search_stores(self) -> Sequence[str]:
+        return self._normalize_store_names(None)
+
+    def get_default_write_store(self) -> str:
+        return self._get_write_store_name(None)
 
     def get_serializer_for_class(self, asset_class: Type[Asset]):
         for serializer, theasset_class in self._serializers:
@@ -672,7 +706,7 @@ class AssetManager:
     def exists(
         self,
         uri: Union[AssetUri, str],
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
     ) -> bool:
         """
         Returns True if the asset exists in any of the specified stores, False otherwise.
@@ -708,7 +742,7 @@ class AssetManager:
                     continue  # Try next store
             return False  # Not found in any store
 
-        stores_list = [store] if isinstance(store, str) else store
+        stores_list = self._normalize_store_names(store)
         try:
             return asyncio.run(_exists_async(stores_list))
         except Exception as e:
@@ -723,18 +757,14 @@ class AssetManager:
         asset_type: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
         depth: Optional[int] = None,
     ) -> List[Asset]:
         """Fetches asset instances based on type, limit, and offset (synchronous), to a specified depth."""
-        stores_list = [store] if isinstance(store, str) else store
+        stores_list = self._normalize_store_names(store)
         logger.debug(f"Fetch(type='{asset_type}', stores='{stores_list}', depth='{depth}')")
-        # Note: list_assets currently only supports a single store.
-        # If fetching from multiple stores is needed for listing, this needs
-        # to be updated. For now, list from the first store.
-        list_store = stores_list[0] if stores_list else "local"
-        asset_uris = self.list_assets(asset_type, limit, offset, list_store)
-        results = self.get_bulk(asset_uris, stores_list, depth)  # Pass stores_list to get_bulk
+        asset_uris = self.list_assets(asset_type, limit, offset, stores_list)
+        results = self.get_bulk(asset_uris, stores_list, depth)
         # Filter out non-Asset objects (e.g., None for not found, or exceptions if collected)
         return [asset for asset in results if isinstance(asset, Asset)]
 
@@ -743,20 +773,14 @@ class AssetManager:
         asset_type: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
         depth: Optional[int] = None,
     ) -> List[Asset]:
         """Fetches asset instances based on type, limit, and offset (asynchronous), to a specified depth."""
-        stores_list = [store] if isinstance(store, str) else store
+        stores_list = self._normalize_store_names(store)
         logger.debug(f"FetchAsync(type='{asset_type}', stores='{stores_list}', depth='{depth}')")
-        # Note: list_assets_async currently only supports a single store.
-        # If fetching from multiple stores is needed for listing, this needs
-        # to be updated. For now, list from the first store.
-        list_store = stores_list[0] if stores_list else "local"
-        asset_uris = await self.list_assets_async(asset_type, limit, offset, list_store)
-        results = await self.get_bulk_async(
-            asset_uris, stores_list, depth
-        )  # Pass stores_list to get_bulk_async
+        asset_uris = await self.list_assets_async(asset_type, limit, offset, stores_list)
+        results = await self.get_bulk_async(asset_uris, stores_list, depth)
         return [asset for asset in results if isinstance(asset, Asset)]
 
     def list_assets(
@@ -764,37 +788,41 @@ class AssetManager:
         asset_type: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
     ) -> List[AssetUri]:
-        stores_list = [store] if isinstance(store, str) else store
+        stores_list = self._normalize_store_names(store)
         logger.debug(f"ListAssets(type='{asset_type}', stores='{stores_list}')")
-        # Note: list_assets_async currently only supports a single store.
-        # If listing from multiple stores is needed, this needs to be updated.
-        # For now, list from the first store.
-        list_store = stores_list[0] if stores_list else "local"
-        return asyncio.run(self.list_assets_async(asset_type, limit, offset, list_store))
+        return asyncio.run(self.list_assets_async(asset_type, limit, offset, stores_list))
 
     async def list_assets_async(
         self,
         asset_type: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
     ) -> List[AssetUri]:
-        stores_list = [store] if isinstance(store, str) else store
+        stores_list = self._normalize_store_names(store)
         logger.debug(f"ListAssetsAsync executing for type='{asset_type}', stores='{stores_list}'")
-        # Note: list_assets_async currently only supports a single store.
-        # If listing from multiple stores is needed, this needs to be updated.
-        # For now, list from the first store.
-        list_store = stores_list[0] if stores_list else "local"
-        logger.debug(
-            f"ListAssetsAsync: Looking up store '{list_store}'. Available stores: {list(self.stores.keys())}"
-        )
-        try:
-            selected_store = self.stores[list_store]
-        except KeyError:
-            raise ValueError(f"No store registered for name: {list_store}")
-        return await selected_store.list_assets(asset_type, limit, offset)
+
+        seen_uris: Set[AssetUri] = set()
+        merged_uris: List[AssetUri] = []
+        for store_name in stores_list:
+            logger.debug(
+                f"ListAssetsAsync: Looking up store '{store_name}'. Available stores: {list(self.stores.keys())}"
+            )
+            try:
+                selected_store = self.stores[store_name]
+            except KeyError:
+                raise ValueError(f"No store registered for name: {store_name}")
+
+            store_uris = await selected_store.list_assets(asset_type, limit, offset)
+            for uri in store_uris:
+                if uri in seen_uris:
+                    continue
+                seen_uris.add(uri)
+                merged_uris.append(uri)
+
+        return merged_uris
 
     def count_assets(
         self,
@@ -836,64 +864,71 @@ class AssetManager:
                 return True
         return False
 
-    async def add_async(self, obj: Asset, store: str = "local") -> AssetUri:
+    async def add_async(self, obj: Asset, store: Optional[str] = None) -> AssetUri:
         """
         Adds an asset to the store, either creating a new one or updating an existing one.
         Uses obj.get_url() to determine if the asset exists.
         """
-        logger.debug(f"AddAsync: Adding {type(obj).__name__} to store '{store}'")
+        target_store = self._get_write_store_name(store)
+        logger.debug(f"AddAsync: Adding {type(obj).__name__} to store '{target_store}'")
         uri = obj.get_uri()
         if not self._is_registered_type(obj):
             logger.warning(f"Asset has unregistered type '{uri.asset_type}' ({type(obj).__name__})")
 
         serializer = self.get_serializer_for_class(obj.__class__)
         data = obj.to_bytes(serializer)
-        return await self.add_raw_async(uri.asset_type, uri.asset_id, data, store)
+        return await self.add_raw_async(uri.asset_type, uri.asset_id, data, target_store)
 
-    def add(self, obj: Asset, store: str = "local") -> AssetUri:
+    def add(self, obj: Asset, store: Optional[str] = None) -> AssetUri:
         """Synchronous wrapper for adding an asset to the store."""
+        target_store = self._get_write_store_name(store)
         logger.debug(
-            f"Add: Adding {type(obj).__name__} to store '{store}' from T:{threading.current_thread().name}"
+            f"Add: Adding {type(obj).__name__} to store '{target_store}' from T:{threading.current_thread().name}"
         )
-        return asyncio.run(self.add_async(obj, store))
+        return asyncio.run(self.add_async(obj, target_store))
 
     async def add_raw_async(
-        self, asset_type: str, asset_id: str, data: bytes, store: str = "local"
+        self, asset_type: str, asset_id: str, data: bytes, store: Optional[str] = None
     ) -> AssetUri:
         """
         Adds raw asset data to the store, either creating a new asset or updating an existing one.
         """
-        logger.debug(f"AddRawAsync: type='{asset_type}', id='{asset_id}', store='{store}'")
+        target_store = self._get_write_store_name(store)
+        logger.debug(f"AddRawAsync: type='{asset_type}', id='{asset_id}', store='{target_store}'")
         if not asset_type or not asset_id:
             raise ValueError("asset_type and asset_id must be provided for add_raw.")
         if not isinstance(data, bytes):
             raise TypeError("Data for add_raw must be bytes.")
-        selected_store = self.stores.get(store)
+        selected_store = self.stores.get(target_store)
         if not selected_store:
-            raise ValueError(f"No store registered for name: {store}")
+            raise ValueError(f"No store registered for name: {target_store}")
         uri = AssetUri.build(asset_type=asset_type, asset_id=asset_id)
         try:
             uri = await selected_store.update(uri, data)
             logger.debug(f"AddRawAsync: Updated existing asset at {uri}")
+            action = "updated"
         except FileNotFoundError:
             logger.debug(
                 f"AddRawAsync: Asset not found, creating new asset with {asset_type} and {asset_id}"
             )
             uri = await selected_store.create(asset_type, asset_id, data)
+            action = "created"
 
-        if store in self._cacheable_stores:
+        if target_store in self._cacheable_stores:
             self.asset_cache.invalidate_for_uri(str(uri))  # Invalidate after add/update
+        self._notify_asset_observers(target_store, uri, action)
         return uri
 
     def add_raw(
-        self, asset_type: str, asset_id: str, data: bytes, store: str = "local"
+        self, asset_type: str, asset_id: str, data: bytes, store: Optional[str] = None
     ) -> AssetUri:
         """Synchronous wrapper for adding raw asset data to the store."""
+        target_store = self._get_write_store_name(store)
         logger.debug(
-            f"AddRaw: type='{asset_type}', id='{asset_id}', store='{store}' from T:{threading.current_thread().name}"
+            f"AddRaw: type='{asset_type}', id='{asset_id}', store='{target_store}' from T:{threading.current_thread().name}"
         )
         try:
-            return asyncio.run(self.add_raw_async(asset_type, asset_id, data, store))
+            return asyncio.run(self.add_raw_async(asset_type, asset_id, data, target_store))
         except Exception as e:
             logger.error(
                 f"AddRaw: Error for type='{asset_type}', id='{asset_id}': {e}",
@@ -1093,25 +1128,29 @@ class AssetManager:
         """
         return self.add_raw(asset_type, asset_id or path.stem, path.read_bytes(), store=store)
 
-    def delete(self, uri: Union[AssetUri, str], store: str = "local") -> None:
-        logger.debug(f"Delete URI '{uri}' from store '{store}'")
+    def delete(self, uri: Union[AssetUri, str], store: Optional[str] = None) -> None:
+        target_store = self._get_write_store_name(store)
+        logger.debug(f"Delete URI '{uri}' from store '{target_store}'")
         asset_uri_obj = AssetUri(uri) if isinstance(uri, str) else uri
 
         async def _do_delete_async():
-            selected_store = self.stores[store]
+            selected_store = self.stores[target_store]
             await selected_store.delete(asset_uri_obj)
-            if store in self._cacheable_stores:
+            if target_store in self._cacheable_stores:
                 self.asset_cache.invalidate_for_uri(str(asset_uri_obj))
+            self._notify_asset_observers(target_store, asset_uri_obj, "deleted")
 
         asyncio.run(_do_delete_async())
 
-    async def delete_async(self, uri: Union[AssetUri, str], store: str = "local") -> None:
-        logger.debug(f"DeleteAsync URI '{uri}' from store '{store}'")
+    async def delete_async(self, uri: Union[AssetUri, str], store: Optional[str] = None) -> None:
+        target_store = self._get_write_store_name(store)
+        logger.debug(f"DeleteAsync URI '{uri}' from store '{target_store}'")
         asset_uri_obj = AssetUri(uri) if isinstance(uri, str) else uri
-        selected_store = self.stores[store]
+        selected_store = self.stores[target_store]
         await selected_store.delete(asset_uri_obj)
-        if store in self._cacheable_stores:
+        if target_store in self._cacheable_stores:
             self.asset_cache.invalidate_for_uri(str(asset_uri_obj))
+        self._notify_asset_observers(target_store, asset_uri_obj, "deleted")
 
     async def is_empty_async(self, asset_type: Optional[str] = None, store: str = "local") -> bool:
         """Checks if the asset store has any assets of a given type (asynchronous)."""

--- a/src/Mod/CAM/Path/Tool/assets/manager.py
+++ b/src/Mod/CAM/Path/Tool/assets/manager.py
@@ -95,6 +95,13 @@ class AssetManager:
         """
         self._asset_observers.append(callback)
 
+    def remove_asset_observer(self, callback: Callable[[str, AssetUri, str], None]):
+        """Removes a previously registered asset observer. No-op if absent."""
+        try:
+            self._asset_observers.remove(callback)
+        except ValueError:
+            pass
+
     def notify_asset_changed(self, store_name: str, uri: Union[AssetUri, str], action: str) -> None:
         """Announces a store-originated asset change to all observers.
 

--- a/src/Mod/CAM/Path/Tool/assets/manager.py
+++ b/src/Mod/CAM/Path/Tool/assets/manager.py
@@ -71,6 +71,7 @@ class AssetManager:
         self.asset_cache = AssetCache(max_size_bytes=cache_max_size_bytes)
         self._cacheable_stores: Set[str] = set()
         self._asset_observers: List[Callable[[str, AssetUri, str], None]] = []
+        self._warned_unregistered_stores: Set[str] = set()
         logger.debug(f"AssetManager initialized (Thread: {threading.current_thread().name})")
 
     def register_store(self, store: AssetStore, cacheable: bool = False):
@@ -81,8 +82,37 @@ class AssetManager:
             self._cacheable_stores.add(store.name)
 
     def add_asset_observer(self, callback: Callable[[str, AssetUri, str], None]):
-        """Registers a callback for asset create/update/delete notifications."""
+        """Registers a callback for asset create/update/delete notifications.
+
+        The callback receives (store_name, uri, action) with action one of
+        "created", "updated", or "deleted".
+
+        Thread contract: callbacks may arrive on any thread — manager write
+        paths invoke them on the calling thread, and stores announcing
+        out-of-band changes via notify_asset_changed() may do so from worker
+        threads. Qt consumers must trampoline to the GUI thread themselves
+        (e.g. via a queued signal connection).
+        """
         self._asset_observers.append(callback)
+
+    def notify_asset_changed(self, store_name: str, uri: Union[AssetUri, str], action: str) -> None:
+        """Announces a store-originated asset change to all observers.
+
+        Stores call this when their contents change outside the manager's
+        write paths (e.g. a sync worker pulling a remote change into a local
+        mirror), so that subscribed UIs can refresh. The manager's own write
+        paths notify automatically; stores must not call this for writes that
+        went through the manager.
+
+        action is one of "created", "updated", or "deleted". May be called
+        from any thread; see add_asset_observer() for the thread contract.
+        """
+        if action not in ("created", "updated", "deleted"):
+            raise ValueError(f"Invalid asset change action: {action!r}")
+        asset_uri_obj = AssetUri(uri) if isinstance(uri, str) else uri
+        if store_name in self._cacheable_stores:
+            self.asset_cache.invalidate_for_uri(str(asset_uri_obj))
+        self._notify_asset_observers(store_name, asset_uri_obj, action)
 
     def _notify_asset_observers(self, store_name: str, uri: AssetUri, action: str):
         for callback in list(self._asset_observers):
@@ -104,6 +134,40 @@ class AssetManager:
         if store:
             return store
         return Preferences.getAssetStoreWriteStore()
+
+    def _get_read_store(self, store_name: str) -> Optional[AssetStore]:
+        """Looks up a store for a read operation.
+
+        Returns None for unregistered names, warning once per session per
+        name: a store from an uninstalled addon degrades to "those assets
+        are not visible" instead of breaking every read that resolves the
+        search order.
+        """
+        selected_store = self.stores.get(store_name)
+        if selected_store is None and store_name not in self._warned_unregistered_stores:
+            self._warned_unregistered_stores.add(store_name)
+            logger.warning(
+                f"Asset store '{store_name}' is not registered; skipping it on reads. "
+                f"Check the AssetStoreSearchOrder preference, or install the addon "
+                f"providing the store."
+            )
+        return selected_store
+
+    def _get_write_store(self, store: Optional[str] = None) -> AssetStore:
+        """Resolves the write store, raising for unregistered names.
+
+        Writes never fall back silently to another store: a wrong write
+        target must fail loudly rather than scatter assets.
+        """
+        store_name = self._get_write_store_name(store)
+        selected_store = self.stores.get(store_name)
+        if selected_store is None:
+            raise ValueError(
+                f"No store registered for name: {store_name}. Writes require a "
+                f"registered store — install the addon providing it, pass store= "
+                f"explicitly, or reset the AssetStoreWriteStore preference to 'local'."
+            )
+        return selected_store
 
     def get_default_search_stores(self) -> Sequence[str]:
         return self._normalize_store_names(None)
@@ -174,9 +238,8 @@ class AssetManager:
             )
 
         for current_store_name in store_names:
-            store = self.stores.get(current_store_name)
+            store = self._get_read_store(current_store_name)
             if not store:
-                logger.warning(f"Store '{current_store_name}' not registered. Skipping.")
                 continue
 
             # Log store search path for toolbits
@@ -411,18 +474,19 @@ class AssetManager:
     def get(
         self,
         uri: Union[AssetUri, str],
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
         depth: Optional[int] = None,
     ) -> Asset:
         """
         Retrieves an asset by its URI (synchronous wrapper), to a specified depth.
+        With store=None the configured search order is used.
         IMPORTANT: Assumes this method is CALLED ONLY from the main UI thread
                    if Asset.from_bytes performs UI operations.
         Depth None means infinite depth. Depth 0 means only this asset, no dependencies.
         """
         # Log entry with thread info for verification
         calling_thread_name = threading.current_thread().name
-        stores_list = [store] if isinstance(store, str) else store
+        stores_list = self._normalize_store_names(store)
 
         # Log all asset get requests
         asset_uri_obj = AssetUri(uri) if isinstance(uri, str) else uri
@@ -504,7 +568,7 @@ class AssetManager:
     def get_or_none(
         self,
         uri: Union[AssetUri, str],
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
         depth: Optional[int] = None,
     ) -> Optional[Asset]:
         """
@@ -519,17 +583,18 @@ class AssetManager:
     async def get_async(
         self,
         uri: Union[AssetUri, str],
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
         depth: Optional[int] = None,
     ) -> Optional[Asset]:
         """
         Retrieves an asset by its URI (asynchronous), to a specified depth.
+        With store=None the configured search order is used.
         NOTE: If Asset.from_bytes does UI work, this method should ideally be awaited
         from an asyncio loop that is integrated with the main UI thread (e.g., via QtAsyncio).
         If awaited from a plain worker thread's asyncio loop, from_bytes will run on that worker.
         """
         calling_thread_name = threading.current_thread().name
-        stores_list = [store] if isinstance(store, str) else store
+        stores_list = self._normalize_store_names(store)
         logger.debug(
             f"AssetManager.get_async(uri='{uri}', stores='{stores_list}', depth='{depth}') called from thread: {calling_thread_name}"
         )
@@ -557,10 +622,10 @@ class AssetManager:
     def get_raw(
         self,
         uri: Union[AssetUri, str],
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
     ) -> bytes:
         """Retrieves raw asset data by its URI (synchronous wrapper)."""
-        stores_list = [store] if isinstance(store, str) else store
+        stores_list = self._normalize_store_names(store)
         logger.debug(
             f"AssetManager.get_raw(uri='{uri}', stores='{stores_list}') from T:{threading.current_thread().name}"
         )
@@ -577,19 +642,18 @@ class AssetManager:
     async def get_raw_async(
         self,
         uri: Union[AssetUri, str],
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
     ) -> bytes:
         """Retrieves raw asset data by its URI (asynchronous)."""
-        stores_list = [store] if isinstance(store, str) else store
+        stores_list = self._normalize_store_names(store)
         logger.debug(
             f"AssetManager.get_raw_async(uri='{uri}', stores='{stores_list}') from T:{threading.current_thread().name}"
         )
         asset_uri_obj = AssetUri(uri) if isinstance(uri, str) else uri
 
         for current_store_name in stores_list:
-            thestore = self.stores.get(current_store_name)
+            thestore = self._get_read_store(current_store_name)
             if not thestore:
-                logger.warning(f"Store '{current_store_name}' not registered. Skipping.")
                 continue
             try:
                 raw_data = await thestore.get(asset_uri_obj)
@@ -608,11 +672,11 @@ class AssetManager:
     def get_bulk(
         self,
         uris: Sequence[Union[AssetUri, str]],
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
         depth: Optional[int] = None,
     ) -> List[Any]:
         """Retrieves multiple assets by their URIs (synchronous wrapper), to a specified depth."""
-        stores_list = [store] if isinstance(store, str) else store
+        stores_list = self._normalize_store_names(store)
         logger.debug(
             f"AssetManager.get_bulk for {len(uris)} URIs from stores '{stores_list}', depth '{depth}'"
         )
@@ -672,11 +736,11 @@ class AssetManager:
     async def get_bulk_async(
         self,
         uris: Sequence[Union[AssetUri, str]],
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
         depth: Optional[int] = None,
     ) -> List[Any]:
         """Retrieves multiple assets by their URIs (asynchronous), to a specified depth."""
-        stores_list = [store] if isinstance(store, str) else store
+        stores_list = self._normalize_store_names(store)
         logger.debug(
             f"AssetManager.get_bulk_async for {len(uris)} URIs from stores '{stores_list}', depth '{depth}'"
         )
@@ -718,10 +782,9 @@ class AssetManager:
                 f"ExistsAsync (internal): Trying stores '{stores_list}'. Available stores: {list(self.stores.keys())}"
             )
             for current_store_name in stores_list:
-                store = self.stores.get(current_store_name)
+                store = self._get_read_store(current_store_name)
                 if not store:
-                    logger.error(f"Store '{current_store_name}' not registered. Skipping.")
-                    raise ValueError(f"No store registered for name: {store}")
+                    continue
                 try:
                     exists = await store.exists(asset_uri_obj)
                     if exists:
@@ -801,61 +864,77 @@ class AssetManager:
         offset: Optional[int] = None,
         store: Optional[Union[str, Sequence[str]]] = None,
     ) -> List[AssetUri]:
+        attributed = await self.list_assets_attributed_async(asset_type, limit, offset, store)
+        return [uri for uri, _store_name in attributed]
+
+    def list_assets_attributed(
+        self,
+        asset_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        store: Optional[Union[str, Sequence[str]]] = None,
+    ) -> List[Tuple[AssetUri, str]]:
+        """Like list_assets, but returns (uri, store_name) pairs (synchronous)."""
+        return asyncio.run(self.list_assets_attributed_async(asset_type, limit, offset, store))
+
+    async def list_assets_attributed_async(
+        self,
+        asset_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        store: Optional[Union[str, Sequence[str]]] = None,
+    ) -> List[Tuple[AssetUri, str]]:
+        """Lists assets across the given stores as (uri, store_name) pairs.
+
+        Assets present in more than one store appear once, attributed to the
+        first store in the search order that contains them (first-wins
+        shadowing — the attribution matches what fetch/get would resolve).
+        limit and offset apply to the merged, deduplicated result, not to the
+        individual stores.
+        """
         stores_list = self._normalize_store_names(store)
         logger.debug(f"ListAssetsAsync executing for type='{asset_type}', stores='{stores_list}'")
 
-        seen_uris: Set[AssetUri] = set()
-        merged_uris: List[AssetUri] = []
+        # Dedup keys on asset id, not the full URI: the same asset may exist
+        # in two stores at different versions, and the first store in the
+        # search order must shadow the others regardless.
+        seen_ids: Set[Tuple[str, str]] = set()
+        merged: List[Tuple[AssetUri, str]] = []
         for store_name in stores_list:
-            logger.debug(
-                f"ListAssetsAsync: Looking up store '{store_name}'. Available stores: {list(self.stores.keys())}"
-            )
-            try:
-                selected_store = self.stores[store_name]
-            except KeyError:
-                raise ValueError(f"No store registered for name: {store_name}")
+            selected_store = self._get_read_store(store_name)
+            if not selected_store:
+                continue
 
-            store_uris = await selected_store.list_assets(asset_type, limit, offset)
+            store_uris = await selected_store.list_assets(asset_type)
             for uri in store_uris:
-                if uri in seen_uris:
+                key = (uri.asset_type, uri.asset_id)
+                if key in seen_ids:
                     continue
-                seen_uris.add(uri)
-                merged_uris.append(uri)
+                seen_ids.add(key)
+                merged.append((uri, store_name))
 
-        return merged_uris
+        start = offset or 0
+        end = None if limit is None else start + limit
+        return merged[start:end]
 
     def count_assets(
         self,
         asset_type: Optional[str] = None,
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
     ) -> int:
-        stores_list = [store] if isinstance(store, str) else store
-        logger.debug(f"CountAssets(type='{asset_type}', stores='{stores_list}')")
-        # Note: count_assets_async currently only supports a single store.
-        # If counting across multiple stores is needed, this needs to be updated.
-        # For now, count from the first store.
-        count_store = stores_list[0] if stores_list else "local"
-        return asyncio.run(self.count_assets_async(asset_type, count_store))
+        logger.debug(f"CountAssets(type='{asset_type}', stores='{store}')")
+        return asyncio.run(self.count_assets_async(asset_type, store))
 
     async def count_assets_async(
         self,
         asset_type: Optional[str] = None,
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
     ) -> int:
-        stores_list = [store] if isinstance(store, str) else store
+        """Counts distinct assets across the given stores (deduplicated by URI)."""
+        stores_list = self._normalize_store_names(store)
         logger.debug(f"CountAssetsAsync executing for type='{asset_type}', stores='{stores_list}'")
-        # Note: count_assets_async currently only supports a single store.
-        # If counting across multiple stores is needed, this needs to be updated.
-        # For now, count from the first store.
-        count_store = stores_list[0] if stores_list else "local"
-        logger.debug(
-            f"CountAssetsAsync: Looking up store '{count_store}'. Available stores: {list(self.stores.keys())}"
-        )
-        try:
-            selected_store = self.stores[count_store]
-        except KeyError:
-            raise ValueError(f"No store registered for name: {count_store}")
-        return await selected_store.count_assets(asset_type)
+        merged = await self.list_assets_attributed_async(asset_type, store=stores_list)
+        return len(merged)
 
     def _is_registered_type(self, obj: Asset) -> bool:
         """Helper to extract asset_type, id, and data from an object instance."""
@@ -899,9 +978,7 @@ class AssetManager:
             raise ValueError("asset_type and asset_id must be provided for add_raw.")
         if not isinstance(data, bytes):
             raise TypeError("Data for add_raw must be bytes.")
-        selected_store = self.stores.get(target_store)
-        if not selected_store:
-            raise ValueError(f"No store registered for name: {target_store}")
+        selected_store = self._get_write_store(target_store)
         uri = AssetUri.build(asset_type=asset_type, asset_id=asset_id)
         try:
             uri = await selected_store.update(uri, data)
@@ -1119,51 +1196,54 @@ class AssetManager:
         self,
         asset_type: str,
         path: pathlib.Path,
-        store: str = "local",
+        store: Optional[str] = None,
         asset_id: Optional[str] = None,
     ) -> AssetUri:
         """
         Convenience wrapper around add_raw().
         If asset_id is None, the path.stem is used as the id.
+        With store=None the configured write store is used.
         """
         return self.add_raw(asset_type, asset_id or path.stem, path.read_bytes(), store=store)
 
     def delete(self, uri: Union[AssetUri, str], store: Optional[str] = None) -> None:
-        target_store = self._get_write_store_name(store)
-        logger.debug(f"Delete URI '{uri}' from store '{target_store}'")
-        asset_uri_obj = AssetUri(uri) if isinstance(uri, str) else uri
-
-        async def _do_delete_async():
-            selected_store = self.stores[target_store]
-            await selected_store.delete(asset_uri_obj)
-            if target_store in self._cacheable_stores:
-                self.asset_cache.invalidate_for_uri(str(asset_uri_obj))
-            self._notify_asset_observers(target_store, asset_uri_obj, "deleted")
-
-        asyncio.run(_do_delete_async())
+        asyncio.run(self.delete_async(uri, store))
 
     async def delete_async(self, uri: Union[AssetUri, str], store: Optional[str] = None) -> None:
         target_store = self._get_write_store_name(store)
         logger.debug(f"DeleteAsync URI '{uri}' from store '{target_store}'")
         asset_uri_obj = AssetUri(uri) if isinstance(uri, str) else uri
-        selected_store = self.stores[target_store]
+        selected_store = self._get_write_store(target_store)
         await selected_store.delete(asset_uri_obj)
         if target_store in self._cacheable_stores:
             self.asset_cache.invalidate_for_uri(str(asset_uri_obj))
         self._notify_asset_observers(target_store, asset_uri_obj, "deleted")
 
-    async def is_empty_async(self, asset_type: Optional[str] = None, store: str = "local") -> bool:
-        """Checks if the asset store has any assets of a given type (asynchronous)."""
-        logger.debug(f"IsEmptyAsync: type='{asset_type}', store='{store}'")
-        logger.debug(
-            f"IsEmptyAsync: Looking up store '{store}'. Available stores: {list(self.stores.keys())}"
-        )
-        selected_store = self.stores.get(store)
-        if not selected_store:
-            raise ValueError(f"No store registered for name: {store}")
-        return await selected_store.is_empty(asset_type)
+    async def is_empty_async(
+        self,
+        asset_type: Optional[str] = None,
+        store: Optional[Union[str, Sequence[str]]] = None,
+    ) -> bool:
+        """Checks whether any of the given stores has assets of the type.
 
-    def is_empty(self, asset_type: Optional[str] = None, store: str = "local") -> bool:
+        Returns True only if every registered store in the resolved list is
+        empty (i.e. no asset of the type is visible via the search order).
+        """
+        stores_list = self._normalize_store_names(store)
+        logger.debug(f"IsEmptyAsync: type='{asset_type}', stores='{stores_list}'")
+        for store_name in stores_list:
+            selected_store = self._get_read_store(store_name)
+            if not selected_store:
+                continue
+            if not await selected_store.is_empty(asset_type):
+                return False
+        return True
+
+    def is_empty(
+        self,
+        asset_type: Optional[str] = None,
+        store: Optional[Union[str, Sequence[str]]] = None,
+    ) -> bool:
         """Checks if the asset store has any assets of a given type (synchronous wrapper)."""
         logger.debug(
             f"IsEmpty: type='{asset_type}', store='{store}' from T:{threading.current_thread().name}"
@@ -1180,32 +1260,33 @@ class AssetManager:
     async def list_versions_async(
         self,
         uri: Union[AssetUri, str],
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
     ) -> List[AssetUri]:
-        """Lists available versions for a given asset URI (asynchronous)."""
-        stores_list = [store] if isinstance(store, str) else store
+        """Lists available versions for a given asset URI (asynchronous).
+
+        Searches the stores in order and returns the versions from the first
+        store that has any — consistent with first-wins shadowing on reads.
+        """
+        stores_list = self._normalize_store_names(store)
         logger.debug(f"ListVersionsAsync: uri='{uri}', stores='{stores_list}'")
         asset_uri_obj = AssetUri(uri) if isinstance(uri, str) else uri
 
-        # Note: list_versions_async currently only supports a single store.
-        # If listing versions across multiple stores is needed, this needs to be updated.
-        # For now, list from the first store.
-        list_store = stores_list[0] if stores_list else "local"
-        logger.debug(
-            f"ListVersionsAsync: Looking up store '{list_store}'. Available stores: {list(self.stores.keys())}"
-        )
-        selected_store = self.stores.get(list_store)
-        if not selected_store:
-            raise ValueError(f"No store registered for name: {list_store}")
-        return await selected_store.list_versions(asset_uri_obj)
+        for store_name in stores_list:
+            selected_store = self._get_read_store(store_name)
+            if not selected_store:
+                continue
+            versions = await selected_store.list_versions(asset_uri_obj)
+            if versions:
+                return versions
+        return []
 
     def list_versions(
         self,
         uri: Union[AssetUri, str],
-        store: Union[str, Sequence[str]] = "local",
+        store: Optional[Union[str, Sequence[str]]] = None,
     ) -> List[AssetUri]:
         """Lists available versions for a given asset URI (synchronous wrapper)."""
-        stores_list = [store] if isinstance(store, str) else store
+        stores_list = self._normalize_store_names(store)
         logger.debug(
             f"ListVersions: uri='{uri}', stores='{stores_list}' from T:{threading.current_thread().name}"
         )

--- a/src/Mod/CAM/Path/Tool/assets/ui/filedialog.py
+++ b/src/Mod/CAM/Path/Tool/assets/ui/filedialog.py
@@ -84,8 +84,8 @@ class AssetOpenDialog(QFileDialog):
             external_toolbits = []  # Track toolbits found externally
 
             for dependency_uri in dependencies:
-                # First check if dependency exists in asset manager stores
-                if self.asset_manager.exists(dependency_uri, store=["local", "builtin"]):
+                # First check if dependency exists in the search-order stores
+                if self.asset_manager.exists(dependency_uri):
                     continue
 
                 # If not in stores, check if it exists relative to the library file

--- a/src/Mod/CAM/Path/Tool/camassets.py
+++ b/src/Mod/CAM/Path/Tool/camassets.py
@@ -36,7 +36,9 @@ else:
     Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 
 
-def ensure_library_assets_initialized(asset_manager: AssetManager, store_name: str = "local"):
+def ensure_library_assets_initialized(
+    asset_manager: AssetManager, store_name: Optional[str] = None
+):
     """
     Ensures the given store is initialized with built-in library
     if it is currently empty.
@@ -48,7 +50,7 @@ def ensure_library_assets_initialized(asset_manager: AssetManager, store_name: s
             asset_manager.add_file("toolbitlibrary", path)
 
 
-def ensure_toolbits_have_shape_type(asset_manager: AssetManager, store_name: str = "local"):
+def ensure_toolbits_have_shape_type(asset_manager: AssetManager, store_name: Optional[str] = None):
     from .shape import ToolBitShape
 
     toolbit_uris = asset_manager.list_assets(
@@ -95,7 +97,9 @@ def ensure_toolbits_have_shape_type(asset_manager: AssetManager, store_name: str
             asset_manager.add_raw("toolbit", uri.asset_id, data, store=store_name)
 
 
-def ensure_toolbit_assets_initialized(asset_manager: AssetManager, store_name: str = "local"):
+def ensure_toolbit_assets_initialized(
+    asset_manager: AssetManager, store_name: Optional[str] = None
+):
     """
     Ensures the given store is initialized with built-in bits
     if it is currently empty.
@@ -109,7 +113,9 @@ def ensure_toolbit_assets_initialized(asset_manager: AssetManager, store_name: s
     ensure_toolbits_have_shape_type(asset_manager, store_name)
 
 
-def ensure_toolbitshape_assets_present(asset_manager: AssetManager, store_name: str = "local"):
+def ensure_toolbitshape_assets_present(
+    asset_manager: AssetManager, store_name: Optional[str] = None
+):
     """
     Ensures the given store is initialized with built-in shapes
     if it is currently empty. This copies all built-in shapes,
@@ -149,7 +155,9 @@ def ensure_toolbitshape_assets_present(asset_manager: AssetManager, store_name: 
                 asset_manager.add_file("toolbitshapepng", path, asset_id=path.stem + ".png")
 
 
-def ensure_toolbitshape_assets_initialized(asset_manager: AssetManager, store_name: str = "local"):
+def ensure_toolbitshape_assets_initialized(
+    asset_manager: AssetManager, store_name: Optional[str] = None
+):
     """
     Ensures the toolbitshape directory structure exists without adding any files.
     """
@@ -160,13 +168,14 @@ def ensure_toolbitshape_assets_initialized(asset_manager: AssetManager, store_na
     shape_path.mkdir(parents=True, exist_ok=True)
 
 
-def ensure_assets_initialized(asset_manager: AssetManager, store="local"):
+def ensure_assets_initialized(asset_manager: AssetManager, store: Optional[str] = None):
     """
     Ensures the given store is initialized with built-in assets.
     """
-    ensure_library_assets_initialized(asset_manager, store)
-    ensure_toolbit_assets_initialized(asset_manager, store)
-    ensure_toolbitshape_assets_initialized(asset_manager, store)
+    target_store = store or Preferences.getAssetStoreWriteStore()
+    ensure_library_assets_initialized(asset_manager, target_store)
+    ensure_toolbit_assets_initialized(asset_manager, target_store)
+    ensure_toolbitshape_assets_initialized(asset_manager, target_store)
 
 
 def _on_asset_path_changed(group, key, value):

--- a/src/Mod/CAM/Path/Tool/camassets.py
+++ b/src/Mod/CAM/Path/Tool/camassets.py
@@ -22,11 +22,11 @@
 # ***************************************************************************
 import json
 import pathlib
-from typing import Optional, Union, Sequence
+from typing import Optional
 import Path
 from Path import Preferences
 from Path.Preferences import addToolPreferenceObserver
-from .assets import AssetManager, AssetUri, Asset, FileStore
+from .assets import AssetManager, AssetUri, FileStore
 from .toolbit.migration import ParameterAccessor, migrate_parameters
 
 if False:
@@ -47,7 +47,7 @@ def ensure_library_assets_initialized(
 
     if asset_manager.is_empty("toolbitlibrary", store=store_name):
         for path in builtin_library_path.glob("*.fctl"):
-            asset_manager.add_file("toolbitlibrary", path)
+            asset_manager.add_file("toolbitlibrary", path, store=store_name)
 
 
 def ensure_toolbits_have_shape_type(asset_manager: AssetManager, store_name: Optional[str] = None):
@@ -108,7 +108,7 @@ def ensure_toolbit_assets_initialized(
 
     if asset_manager.is_empty("toolbit", store=store_name):
         for path in builtin_toolbit_path.glob("*.fctb"):
-            asset_manager.add_file("toolbit", path)
+            asset_manager.add_file("toolbit", path, store=store_name)
 
     ensure_toolbits_have_shape_type(asset_manager, store_name)
 
@@ -136,7 +136,7 @@ def ensure_toolbitshape_assets_present(
                 asset_id=path.stem,
             )
             if not asset_manager.exists(uri, store=store_name):
-                asset_manager.add_file("toolbitshape", path)
+                asset_manager.add_file("toolbitshape", path, store=store_name)
 
         for path in builtin_shape_path.glob("*.svg"):
             uri = AssetUri.build(
@@ -144,7 +144,9 @@ def ensure_toolbitshape_assets_present(
                 asset_id=path.stem + ".svg",
             )
             if not asset_manager.exists(uri, store=store_name):
-                asset_manager.add_file("toolbitshapesvg", path, asset_id=path.stem + ".svg")
+                asset_manager.add_file(
+                    "toolbitshapesvg", path, store=store_name, asset_id=path.stem + ".svg"
+                )
 
         for path in builtin_shape_path.glob("*.png"):
             uri = AssetUri.build(
@@ -152,7 +154,9 @@ def ensure_toolbitshape_assets_present(
                 asset_id=path.stem + ".png",
             )
             if not asset_manager.exists(uri, store=store_name):
-                asset_manager.add_file("toolbitshapepng", path, asset_id=path.stem + ".png")
+                asset_manager.add_file(
+                    "toolbitshapepng", path, store=store_name, asset_id=path.stem + ".png"
+                )
 
 
 def ensure_toolbitshape_assets_initialized(
@@ -219,9 +223,11 @@ builtin_asset_store = FileStore(
 
 class CamAssetManager(AssetManager):
     """
-    Custom CAM Asset Manager that extends the base AssetManager, such
-    that the get methods return fallbacks: if the asset is not present
-    in the "local" store, then it falls back to the builtin-asset store.
+    Custom CAM Asset Manager that registers the user's "local" store and the
+    "builtin" store. Read APIs inherited from AssetManager resolve store=None
+    through the configured search order (default "local,builtin"), so local
+    assets shadow the built-in ones and additional stores registered by
+    addons participate without callers naming them.
     """
 
     def __init__(self):
@@ -236,30 +242,6 @@ class CamAssetManager(AssetManager):
             Path.Log.error(f"Failed to initialize CAM assets in {user_asset_store._base_dir}: {e}")
         else:
             Path.Log.debug(f"Using CAM assets in {user_asset_store._base_dir}")
-
-    def get(
-        self,
-        uri: Union[AssetUri, str],
-        store: Union[str, Sequence[str]] = ("local", "builtin"),
-        depth: Optional[int] = None,
-    ) -> Asset:
-        """
-        Gets an asset from the "local" store, falling back to the "builtin"
-        store if not found locally.
-        """
-        return super().get(uri, store=store, depth=depth)
-
-    def get_or_none(
-        self,
-        uri: Union[AssetUri, str],
-        store: Union[str, Sequence[str]] = ("local", "builtin"),
-        depth: Optional[int] = None,
-    ) -> Optional[Asset]:
-        """
-        Gets an asset from the "local" store, falling back to the "builtin"
-        store if not found locally.
-        """
-        return super().get_or_none(uri, store=store, depth=depth)
 
 
 # Set up the CAM asset manager.

--- a/src/Mod/CAM/Path/Tool/library/serializers/fctl.py
+++ b/src/Mod/CAM/Path/Tool/library/serializers/fctl.py
@@ -139,53 +139,19 @@ class FCTLSerializer(AssetSerializer):
             f"FCTL DEEP_DESERIALIZE: Found {len(dependency_uris)} toolbit dependencies: {[uri.asset_id for uri in dependency_uris]}"
         )
 
-        # Fetch all toolbit dependencies
+        # Fetch all toolbit dependencies via the configured store search order
         resolved_dependencies = {}
         for dep_uri in dependency_uris:
             try:
-                Path.Log.info(
-                    f"FCTL DEEP_DESERIALIZE: Fetching toolbit '{dep_uri.asset_id}' from stores ['local', 'builtin']"
-                )
-
-                # Check if toolbit exists in each store individually for debugging
-                search_stores = cam_assets.get_default_search_stores()
-                exists_local = cam_assets.exists(
-                    dep_uri, store=search_stores[0] if search_stores else "local"
-                )
-                exists_builtin = cam_assets.exists(dep_uri, store="builtin")
-                Path.Log.info(
-                    f"FCTL DEEP_DESERIALIZE: Toolbit '{dep_uri.asset_id}' exists - local: {exists_local}, builtin: {exists_builtin}"
-                )
-
-                search_stores = cam_assets.get_default_search_stores()
-                toolbit = cam_assets.get(dep_uri, store=list(search_stores) + ["builtin"], depth=0)
+                toolbit = cam_assets.get(dep_uri, depth=0)
                 resolved_dependencies[dep_uri] = toolbit
-                Path.Log.info(
+                Path.Log.debug(
                     f"FCTL DEEP_DESERIALIZE: Successfully fetched toolbit '{dep_uri.asset_id}'"
                 )
             except Exception as e:
                 Path.Log.warning(
                     f"FCTL DEEP_DESERIALIZE: Failed to fetch toolbit '{dep_uri.asset_id}': {e}"
                 )
-
-                # Try to get more detailed error information
-                try:
-                    # Check what's actually in the stores
-                    search_stores = cam_assets.get_default_search_stores()
-                    local_toolbits = cam_assets.list_assets(
-                        "toolbit", store=search_stores if search_stores else ("local",)
-                    )
-                    local_ids = [uri.asset_id for uri in local_toolbits]
-                    Path.Log.info(
-                        f"FCTL DEBUG: Local store has {len(local_ids)} toolbits: {local_ids[:10]}{'...' if len(local_ids) > 10 else ''}"
-                    )
-
-                    if dep_uri.asset_id in local_ids:
-                        Path.Log.warning(
-                            f"FCTL DEBUG: Toolbit '{dep_uri.asset_id}' IS in local store list but get() failed!"
-                        )
-                except Exception as list_error:
-                    Path.Log.error(f"FCTL DEBUG: Failed to list local toolbits: {list_error}")
 
         Path.Log.info(
             f"FCTL DEEP_DESERIALIZE: Resolved {len(resolved_dependencies)} of {len(dependency_uris)} dependencies"
@@ -219,14 +185,10 @@ class FCTLSerializer(AssetSerializer):
         resolved_dependencies = {}
         for dep_uri in dependency_uris:
             try:
-                # First try to get from asset manager stores
-                Path.Log.info(
-                    f"FCTL EXTERNAL: Trying to fetch toolbit '{dep_uri.asset_id}' from stores ['local', 'builtin']"
-                )
-                search_stores = cam_assets.get_default_search_stores()
-                toolbit = cam_assets.get(dep_uri, store=list(search_stores) + ["builtin"], depth=0)
+                # First try to get from the search-order stores
+                toolbit = cam_assets.get(dep_uri, depth=0)
                 resolved_dependencies[dep_uri] = toolbit
-                Path.Log.info(
+                Path.Log.debug(
                     f"FCTL EXTERNAL: Successfully fetched toolbit '{dep_uri.asset_id}' from stores"
                 )
             except Exception as e:

--- a/src/Mod/CAM/Path/Tool/library/serializers/fctl.py
+++ b/src/Mod/CAM/Path/Tool/library/serializers/fctl.py
@@ -148,13 +148,17 @@ class FCTLSerializer(AssetSerializer):
                 )
 
                 # Check if toolbit exists in each store individually for debugging
-                exists_local = cam_assets.exists(dep_uri, store="local")
+                search_stores = cam_assets.get_default_search_stores()
+                exists_local = cam_assets.exists(
+                    dep_uri, store=search_stores[0] if search_stores else "local"
+                )
                 exists_builtin = cam_assets.exists(dep_uri, store="builtin")
                 Path.Log.info(
                     f"FCTL DEEP_DESERIALIZE: Toolbit '{dep_uri.asset_id}' exists - local: {exists_local}, builtin: {exists_builtin}"
                 )
 
-                toolbit = cam_assets.get(dep_uri, store=["local", "builtin"], depth=0)
+                search_stores = cam_assets.get_default_search_stores()
+                toolbit = cam_assets.get(dep_uri, store=list(search_stores) + ["builtin"], depth=0)
                 resolved_dependencies[dep_uri] = toolbit
                 Path.Log.info(
                     f"FCTL DEEP_DESERIALIZE: Successfully fetched toolbit '{dep_uri.asset_id}'"
@@ -167,7 +171,10 @@ class FCTLSerializer(AssetSerializer):
                 # Try to get more detailed error information
                 try:
                     # Check what's actually in the stores
-                    local_toolbits = cam_assets.list_assets("toolbit", store="local")
+                    search_stores = cam_assets.get_default_search_stores()
+                    local_toolbits = cam_assets.list_assets(
+                        "toolbit", store=search_stores if search_stores else ("local",)
+                    )
                     local_ids = [uri.asset_id for uri in local_toolbits]
                     Path.Log.info(
                         f"FCTL DEBUG: Local store has {len(local_ids)} toolbits: {local_ids[:10]}{'...' if len(local_ids) > 10 else ''}"
@@ -216,7 +223,8 @@ class FCTLSerializer(AssetSerializer):
                 Path.Log.info(
                     f"FCTL EXTERNAL: Trying to fetch toolbit '{dep_uri.asset_id}' from stores ['local', 'builtin']"
                 )
-                toolbit = cam_assets.get(dep_uri, store=["local", "builtin"], depth=0)
+                search_stores = cam_assets.get_default_search_stores()
+                toolbit = cam_assets.get(dep_uri, store=list(search_stores) + ["builtin"], depth=0)
                 resolved_dependencies[dep_uri] = toolbit
                 Path.Log.info(
                     f"FCTL EXTERNAL: Successfully fetched toolbit '{dep_uri.asset_id}' from stores"

--- a/src/Mod/CAM/Path/Tool/library/ui/browser.py
+++ b/src/Mod/CAM/Path/Tool/library/ui/browser.py
@@ -54,7 +54,7 @@ class LibraryBrowserWidget(ToolBitBrowserWidget, ToolBitTypeFilterMixin):
     def __init__(
         self,
         asset_manager: AssetManager,
-        store: str = "local",
+        store=None,
         parent=None,
         compact=True,
         show_all_tools=False,
@@ -91,11 +91,7 @@ class LibraryBrowserWidget(ToolBitBrowserWidget, ToolBitTypeFilterMixin):
         library_uri = Path.Preferences.getLastToolLibrary()
         if library_uri:
             try:
-                library = self._asset_manager.get(
-                    library_uri,
-                    store=self._asset_manager.get_default_search_stores(),
-                    depth=1,
-                )
+                library = self._asset_manager.get(library_uri, store=self._store_name, depth=1)
                 self.set_current_library(library)
             except Exception as e:
                 Path.Log.warning(f"Failed to load last tool library: {e}")
@@ -425,7 +421,7 @@ class LibraryBrowserWidget(ToolBitBrowserWidget, ToolBitTypeFilterMixin):
             existing_toolbit = None
             try:
                 existing_toolbit = self._asset_manager.get(
-                    toolbit_uri, store=["local", "builtin"], depth=0
+                    toolbit_uri, store=self._store_name, depth=0
                 )
                 Path.Log.info(f"COPY PASTE: Found existing toolbit {original_id}, using reference")
             except FileNotFoundError:
@@ -480,7 +476,7 @@ class LibraryBrowserWidget(ToolBitBrowserWidget, ToolBitTypeFilterMixin):
             toolbit_uri = toolbit.get_uri()
             try:
                 existing_toolbit = self._asset_manager.get(
-                    toolbit_uri, store=["local", "builtin"], depth=0
+                    toolbit_uri, store=self._store_name, depth=0
                 )
                 Path.Log.info(f"CUT PASTE: Found existing toolbit {original_id}, using reference")
 
@@ -545,7 +541,7 @@ class LibraryBrowserWithCombo(LibraryBrowserWidget):
     def __init__(
         self,
         asset_manager: AssetManager,
-        store: str = "local",
+        store=None,
         parent=None,
         compact=True,
         show_all_tools=False,

--- a/src/Mod/CAM/Path/Tool/library/ui/browser.py
+++ b/src/Mod/CAM/Path/Tool/library/ui/browser.py
@@ -91,7 +91,11 @@ class LibraryBrowserWidget(ToolBitBrowserWidget, ToolBitTypeFilterMixin):
         library_uri = Path.Preferences.getLastToolLibrary()
         if library_uri:
             try:
-                library = self._asset_manager.get(library_uri, store="local", depth=1)
+                library = self._asset_manager.get(
+                    library_uri,
+                    store=self._asset_manager.get_default_search_stores(),
+                    depth=1,
+                )
                 self.set_current_library(library)
             except Exception as e:
                 Path.Log.warning(f"Failed to load last tool library: {e}")

--- a/src/Mod/CAM/Path/Tool/library/ui/editor.py
+++ b/src/Mod/CAM/Path/Tool/library/ui/editor.py
@@ -601,7 +601,7 @@ class LibraryEditor(QWidget):
         Path.Log.info(f"IMPORT CHECK: toolbit_uri={toolbit_uri}")
         existing_toolbit = None
         try:
-            existing_toolbit = cam_assets.get(toolbit_uri, store=["local", "builtin"], depth=0)
+            existing_toolbit = cam_assets.get(toolbit_uri, depth=0)
             Path.Log.info(
                 f"IMPORT CHECK: Toolbit {toolbit.id} already exists, using existing reference"
             )

--- a/src/Mod/CAM/Path/Tool/shape/ui/shapeselector.py
+++ b/src/Mod/CAM/Path/Tool/shape/ui/shapeselector.py
@@ -64,13 +64,12 @@ class ShapeSelector:
             button.clicked.connect(cb)
 
     def update_shapes(self):
-        # Retrieve each shape asset
+        # Retrieve each shape asset. Custom shapes come from the configured
+        # store search order; the explicit builtin fetch keeps stock shapes
+        # visible even when shadowed by a custom one.
         builtin = cam_assets.fetch(asset_type="toolbitshape", store="builtin")
         builtin = {c.id: c for c in builtin}
-        custom = cam_assets.fetch(
-            asset_type="toolbitshape",
-            store=cam_assets.get_default_search_stores(),
-        )
+        custom = cam_assets.fetch(asset_type="toolbitshape")
         for shape in custom:
             builtin.pop(shape.id, None)
 

--- a/src/Mod/CAM/Path/Tool/shape/ui/shapeselector.py
+++ b/src/Mod/CAM/Path/Tool/shape/ui/shapeselector.py
@@ -67,7 +67,10 @@ class ShapeSelector:
         # Retrieve each shape asset
         builtin = cam_assets.fetch(asset_type="toolbitshape", store="builtin")
         builtin = {c.id: c for c in builtin}
-        custom = cam_assets.fetch(asset_type="toolbitshape", store="local")
+        custom = cam_assets.fetch(
+            asset_type="toolbitshape",
+            store=cam_assets.get_default_search_stores(),
+        )
         for shape in custom:
             builtin.pop(shape.id, None)
 

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/browser.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/browser.py
@@ -52,14 +52,19 @@ class ToolBitBrowserWidget(QtGui.QWidget):
     toolSelected = QtCore.Signal(str)  # Emits ToolBit URI string
     # Signal emitted when a tool is requested for editing (e.g., double-click)
     itemDoubleClicked = QtCore.Signal(ToolBit)  # Emits ToolBit URI string
+    # Emitted (possibly from a worker thread) when a store announces an
+    # asset change; delivery to the GUI thread is handled by Qt.
+    _assets_changed_externally = QtCore.Signal()
 
     # Debounce timer for search input
     _search_timer_interval = 300  # milliseconds
+    # Debounce timer for store-originated refreshes (e.g. sync workers)
+    _external_change_timer_interval = 250  # milliseconds
 
     def __init__(
         self,
         asset_manager: AssetManager,
-        store: str = "local",
+        store: Optional[Sequence[str]] = None,
         parent=None,
         tool_no_factory=None,
         tool_fetcher=None,
@@ -71,7 +76,10 @@ class ToolBitBrowserWidget(QtGui.QWidget):
         self._compact_mode = compact
 
         self._is_fetching = False
+        # None = browse the configured store search order. The write store
+        # is only consulted when saving, never to restrict what is shown.
         self._store_name = store
+        self._store_by_id: dict = {}  # asset_id -> name of the resolving store
         self._all_assets: Sequence[ToolBit] = []  # Store all fetched assets
         self._current_search = ""  # Track current search term
         self._sort_key = "tool_no" if tool_no_factory else "label"
@@ -129,6 +137,33 @@ class ToolBitBrowserWidget(QtGui.QWidget):
         # of items that need to be fetched.
         self.tool_fetcher = tool_fetcher or self._tool_fetcher
 
+        # Refresh when a store announces an out-of-band change (e.g. a sync
+        # worker pulled a teammate's tool). The observer may fire on any
+        # thread; the signal/timer pair trampolines to the GUI thread and
+        # debounces bursts.
+        self._external_change_timer = QtCore.QTimer(self)
+        self._external_change_timer.setSingleShot(True)
+        self._external_change_timer.setInterval(self._external_change_timer_interval)
+        self._external_change_timer.timeout.connect(self.refresh)
+        self._assets_changed_externally.connect(self._external_change_timer.start)
+        self._subscribe_to_asset_changes()
+
+    def _subscribe_to_asset_changes(self):
+        def observer(store_name, uri, action):
+            if uri.asset_type not in ("toolbit", "toolbitlibrary"):
+                return
+            try:
+                self._assets_changed_externally.emit()
+            except RuntimeError:
+                # The underlying C++ widget is already gone.
+                pass
+
+        manager = self._asset_manager
+        manager.add_asset_observer(observer)
+        # The lambda captures the manager and the callback, not the widget,
+        # so the cleanup survives the widget's destruction.
+        self.destroyed.connect(lambda *_: manager.remove_asset_observer(observer))
+
     def showEvent(self, event):
         """Handles the widget show event to trigger initial data fetch."""
         super().showEvent(event)
@@ -170,12 +205,40 @@ class ToolBitBrowserWidget(QtGui.QWidget):
         self._is_fetching = True
         try:
             self._all_assets = self.tool_fetcher()
+            self._refresh_store_attribution()
         finally:
             self._is_fetching = False
         Path.Log.debug(f"Loaded {len(self._all_assets)} ToolBits.")
 
         self._sort_assets()
         self._update_list()
+
+    def _refresh_store_attribution(self):
+        """Rebuilds the asset_id -> store name map used for store badges."""
+        try:
+            attributed = self._asset_manager.list_assets_attributed(
+                "toolbit", store=self._store_name
+            )
+            self._store_by_id = {uri.asset_id: name for uri, name in attributed}
+        except Exception as e:
+            Path.Log.debug(f"Store attribution unavailable: {e}")
+            self._store_by_id = {}
+
+    def _primary_store_name(self) -> Optional[str]:
+        """The first store in the browsed search order (assets from it get no badge)."""
+        if isinstance(self._store_name, str):
+            return self._store_name
+        if self._store_name:
+            return self._store_name[0]
+        stores = self._asset_manager.get_default_search_stores()
+        return stores[0] if stores else None
+
+    def _store_badge_for(self, toolbit) -> Optional[str]:
+        """Returns the badge to display for a toolbit, or None for the primary store."""
+        store_name = self._store_by_id.get(toolbit.get_id())
+        if not store_name or store_name == self._primary_store_name():
+            return None
+        return store_name
 
     def _sort_assets(self):
         """Sorts the in-memory assets based on the current sort key."""
@@ -214,16 +277,17 @@ class ToolBitBrowserWidget(QtGui.QWidget):
         # Iterate through filtered assets and update the list widget
         for i, asset in enumerate(filtered_assets):
             uri = str(asset.get_uri())
+            badge = self._store_badge_for(asset)
             if uri in current_items:
                 # Item exists, remove the old one and insert the new one
                 item = current_items[uri]
                 row = self._tool_list_widget.row(item)
                 self._tool_list_widget.takeItem(row)
-                self._tool_list_widget.insert_toolbit(i, asset)
+                self._tool_list_widget.insert_toolbit(i, asset, store_badge=badge)
                 del current_items[uri]
             else:
                 # Insert new item
-                self._tool_list_widget.insert_toolbit(i, asset)
+                self._tool_list_widget.insert_toolbit(i, asset, store_badge=badge)
 
         # Remove items that are no longer in filtered_assets
         for uri, item in current_items.items():
@@ -481,12 +545,8 @@ class ToolBitBrowserWidget(QtGui.QWidget):
 
         libraries_with_toolbit = []
         try:
-            # Get all libraries from the asset manager
-            all_libraries = self._asset_manager.fetch(
-                "toolbitlibrary",
-                store=self._asset_manager.get_default_search_stores(),
-                depth=1,
-            )
+            # Get all libraries from the asset manager (search order)
+            all_libraries = self._asset_manager.fetch("toolbitlibrary", depth=1)
 
             for library in all_libraries:
                 if isinstance(library, Library):

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/browser.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/browser.py
@@ -482,7 +482,11 @@ class ToolBitBrowserWidget(QtGui.QWidget):
         libraries_with_toolbit = []
         try:
             # Get all libraries from the asset manager
-            all_libraries = self._asset_manager.fetch("toolbitlibrary", store="local", depth=1)
+            all_libraries = self._asset_manager.fetch(
+                "toolbitlibrary",
+                store=self._asset_manager.get_default_search_stores(),
+                depth=1,
+            )
 
             for library in all_libraries:
                 if isinstance(library, Library):

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/selector.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/selector.py
@@ -48,10 +48,11 @@ class ToolBitSelector(QtWidgets.QDialog):
         self.setMinimumSize(700, 500)
         self.setWindowTitle(FreeCAD.Qt.translate("CAM", "Select Toolbit"))
 
-        # Use LibraryBrowserWithCombo which handles library selection and "All Tools" option
+        # Use LibraryBrowserWithCombo which handles library selection and "All Tools" option.
+        # Browsing follows the configured store search order; the write store
+        # only matters when a tool is saved.
         self._browser_widget = LibraryBrowserWithCombo(
             asset_manager=cam_assets,
-            store=cam_assets.get_default_write_store(),
             compact=compact,
             show_all_tools=show_all_tools,
         )

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/selector.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/selector.py
@@ -51,7 +51,7 @@ class ToolBitSelector(QtWidgets.QDialog):
         # Use LibraryBrowserWithCombo which handles library selection and "All Tools" option
         self._browser_widget = LibraryBrowserWithCombo(
             asset_manager=cam_assets,
-            store="local",
+            store=cam_assets.get_default_write_store(),
             compact=compact,
             show_all_tools=show_all_tools,
         )

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/tablecell.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/tablecell.py
@@ -46,6 +46,7 @@ class TwoLineTableCell(QtGui.QWidget):
         self.pocket = ""
         self.upper_text = ""
         self.lower_text = ""
+        self.store_badge = ""
         self.search_highlight = ""
 
         palette = self.palette()
@@ -60,6 +61,7 @@ class TwoLineTableCell(QtGui.QWidget):
         self.label_upper.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents)
 
         color = interpolate_colors(bg_color, fg_color, 0.8)
+        self._muted_color_name = color.name()
         style = "margin-bottom: 8px; color: {};".format(color.name())
         self.label_lower = QtGui.QLabel()
         self.label_lower.setStyleSheet(style)
@@ -112,7 +114,11 @@ class TwoLineTableCell(QtGui.QWidget):
         self.label_right.setText(text)
 
         text = self._highlight(self.upper_text)
-        self.label_upper.setText(f"<b>{text}</b>")
+        if self.store_badge:
+            badge = f' <font color="{self._muted_color_name}">[{self.store_badge}]</font>'
+        else:
+            badge = ""
+        self.label_upper.setText(f"<b>{text}</b>{badge}")
 
         text = self._highlight(self.lower_text)
         self.label_lower.setText(text)
@@ -128,6 +134,11 @@ class TwoLineTableCell(QtGui.QWidget):
 
     def set_upper_text(self, text):
         self.upper_text = text
+        self._update()
+
+    def set_store_badge(self, store_name):
+        """Shows which asset store the item resolves from ("" hides the badge)."""
+        self.store_badge = store_name or ""
         self._update()
 
     def set_lower_text(self, text):

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/toollist.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/toollist.py
@@ -82,7 +82,9 @@ class ToolBitListWidget(QtGui.QListWidget):
         drag.exec_(QtCore.Qt.CopyAction | QtCore.Qt.MoveAction)
         Path.Log.debug("startDrag: Drag executed.")
 
-    def _create_toolbit_item(self, toolbit: ToolBit, tool_no: int | None = None):
+    def _create_toolbit_item(
+        self, toolbit: ToolBit, tool_no: int | None = None, store_badge: str | None = None
+    ):
         """
         Creates a QListWidgetItem and populates it with ToolBit data.
         """
@@ -101,6 +103,7 @@ class ToolBitListWidget(QtGui.QListWidget):
         cell.set_tool_no(final_tool_no)
         cell.set_upper_text(toolbit.label)
         cell.set_lower_text(toolbit.summary)
+        cell.set_store_badge(store_badge)
         cell.set_icon_from_shape(toolbit._tool_bit_shape)
 
         # Set the custom widget for the list item
@@ -112,7 +115,9 @@ class ToolBitListWidget(QtGui.QListWidget):
 
         return item
 
-    def add_toolbit(self, toolbit: ToolBit, tool_no: int | None = None):
+    def add_toolbit(
+        self, toolbit: ToolBit, tool_no: int | None = None, store_badge: str | None = None
+    ):
         """
         Adds a ToolBit to the list.
 
@@ -120,11 +125,19 @@ class ToolBitListWidget(QtGui.QListWidget):
             toolbit (ToolBit): The ToolBit object to add.
             tool_no (int | None): The tool number associated with the ToolBit,
                                   or None if not applicable.
+            store_badge (str | None): Name of the asset store to display as a
+                                      badge, or None for no badge.
         """
-        item = self._create_toolbit_item(toolbit, tool_no)
+        item = self._create_toolbit_item(toolbit, tool_no, store_badge)
         self.addItem(item)
 
-    def insert_toolbit(self, row: int, toolbit: ToolBit, tool_no: int | None = None):
+    def insert_toolbit(
+        self,
+        row: int,
+        toolbit: ToolBit,
+        tool_no: int | None = None,
+        store_badge: str | None = None,
+    ):
         """
         Inserts a ToolBit to the list at the specified row.
 
@@ -133,8 +146,10 @@ class ToolBitListWidget(QtGui.QListWidget):
             toolbit (ToolBit): The ToolBit object to add.
             tool_no (int | None): The tool number associated with the ToolBit,
                                   or None if not applicable.
+            store_badge (str | None): Name of the asset store to display as a
+                                      badge, or None for no badge.
         """
-        item = self._create_toolbit_item(toolbit, tool_no)
+        item = self._create_toolbit_item(toolbit, tool_no, store_badge)
         self.insertItem(row, item)
 
     def clear_list(self):
@@ -204,7 +219,9 @@ class CompactToolBitListWidget(ToolBitListWidget):
     CompactTwoLineTableCell widgets.
     """
 
-    def _create_toolbit_item(self, toolbit: ToolBit, tool_no: int | None = None):
+    def _create_toolbit_item(
+        self, toolbit: ToolBit, tool_no: int | None = None, store_badge: str | None = None
+    ):
         """
         Creates a QListWidgetItem and populates it with ToolBit data
         using CompactTwoLineTableCell.
@@ -223,6 +240,7 @@ class CompactToolBitListWidget(ToolBitListWidget):
         cell.set_tool_no(final_tool_no)
         cell.set_upper_text(toolbit.label)
         cell.set_lower_text(toolbit.summary)
+        cell.set_store_badge(store_badge)
         cell.set_icon_from_shape(toolbit._tool_bit_shape)
 
         # Set the custom widget for the list item

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/typefilter.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/typefilter.py
@@ -205,5 +205,7 @@ class ToolBitTypeFilterMixin:
         search_term = search_edit.text()
         filtered_assets = self._apply_type_and_search_filter(assets, search_term)
 
+        badge_for = getattr(self, "_store_badge_for", None)
         for asset in filtered_assets:
-            tool_list_widget.add_toolbit(asset)
+            store_badge = badge_for(asset) if badge_for else None
+            tool_list_widget.add_toolbit(asset, store_badge=store_badge)


### PR DESCRIPTION

The asset manager hardcoded the "local" store, so addon-registered stores (e.g. a remote, team-managed tool server) could not participate in tool browsing, fetching, or saving. This PR removes that assumption.

Changes

- All read APIs (get, fetch, list_assets, exists, is_empty, count_assets, …) accept an optional store and default to a configurable search order; results are merged across stores with first-wins deduplication by asset id.
- Write APIs (add, add_raw, delete) default to a configurable write store.
- Two new preferences with helpers in Path/Preferences.py: AssetStoreSearchOrder (default local,builtin) and AssetStoreWriteStore (default local). Unregistered names are skipped on read with a warning; writes fail loudly naming the preference.
- Change notifications: add_asset_observer / remove_asset_observer fire on manager writes, and stores can announce out-of-band changes via notify_asset_changed (any-thread contract; browsers refresh via a debounced Qt signal).
- list_assets_attributed returns (uri, store_name) pairs; tool UIs browse via the search order and badge assets resolved from a non-primary store.
- Removes hardcoded ["local", "builtin"] lists from browser/editor/dialog call sites, and fixes seeding helpers that checked one store for emptiness but wrote to "local".

Default behavior with no additional stores registered is unchanged. Stacked on #<test-hygiene PR> (first commit). New and updated tests in TestPathToolAssetManager.py; full TestCAMApp is green on the stack.


Assisted-by: claude code fable 5
