### PR TITLE
BIM: Prevent AttributeError for IFC4.IfcPropertyEnumeratedValue

### DIFF
--- a/src/Mod/BIM/nativeifc/ifc_psets.py
+++ b/src/Mod/BIM/nativeifc/ifc_psets.py
@@ -65,10 +65,32 @@ def get_psets(element):
         pset_dict = {}
         if pset.is_a("IfcPropertySet") and pset.HasProperties:
             for prop in pset.HasProperties:
-                pset_dict[prop.Name] = str(prop.NominalValue)
+                if hasattr(prop, "NominalValue") and prop.NominalValue is not None:
+                    pset_dict[prop.Name] = str(
+                        prop.NominalValue.wrappedValue
+                        if hasattr(prop.NominalValue, "wrappedValue")
+                        else prop.NominalValue
+                    )
+                elif hasattr(prop, "EnumerationValues") and prop.EnumerationValues:
+                    extracted_values = []
+                    for v in prop.EnumerationValues:
+                        val = v.wrappedValue if hasattr(v, "wrappedValue") else v
+                        extracted_values.append(str(val))
+                    pset_dict[prop.Name] = ", ".join(extracted_values)
         if pset.is_a("IfcMaterialProperties") and pset.Properties:
             for prop in pset.Properties:
-                pset_dict[prop.Name] = str(prop.NominalValue)
+                if hasattr(prop, "NominalValue") and prop.NominalValue is not None:
+                    pset_dict[prop.Name] = str(
+                        prop.NominalValue.wrappedValue
+                        if hasattr(prop.NominalValue, "wrappedValue")
+                        else prop.NominalValue
+                    )
+                elif hasattr(prop, "EnumerationValues") and prop.EnumerationValues:
+                    extracted_values = []
+                    for v in prop.EnumerationValues:
+                        val = v.wrappedValue if hasattr(v, "wrappedValue") else v
+                        extracted_values.append(str(val))
+                    pset_dict[prop.Name] = ", ".join(extracted_values)
         elif pset.is_a("IfcElementQuantity"):
             # TODO implement quantities
             pass


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Prevent AttributeError for IFC4.IfcPropertyEnumeratedValue as seen when opening IFC4 files exported from Hottengroth/HottCAD as descibed in #31872.

It could be that converting a list of enumerated values to a comma separated list is not the best solution UI-wise and there should be some follow-up to handle this, but as a hotfix to prevent the crash, the PR should serve well enough.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes #31872.

## Before and After Images
No GUI changes in this PR.
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
