### PR TITLE
Part: Anchor MidPlane on the true bisector for non-parallel faces

### DIFF
--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -143,40 +143,59 @@ PlanarFaceInfo getPlanarFaceInfo(const TopoShape& shape, double precision)
     return result;
 }
 
-gp_Dir getMidPlaneNormal(const PlanarFaceInfo& firstFace, const PlanarFaceInfo& secondFace)
+// Plane as normal . X = offset, with a normal that is not normalized.
+struct BisectorPlane
+{
+    gp_Vec normal;
+    double offset;
+
+    bool isDegenerate() const
+    {
+        return normal.SquareMagnitude() < Precision::SquareConfusion();
+    }
+
+    gp_Pnt project(const gp_Pnt& point) const
+    {
+        const gp_Vec vector(point.XYZ());
+        return gp_Pnt(
+            (vector + normal * ((offset - normal.Dot(vector)) / normal.SquareMagnitude())).XYZ()
+        );
+    }
+};
+
+// The dihedral bisectors of the two faces, from n1.(X-c1) = +/- n2.(X-c2). Both contain the
+// faces' intersection line.
+BisectorPlane getMidPlane(const PlanarFaceInfo& firstFace, const PlanarFaceInfo& secondFace)
 {
     const gp_Vec firstNormal(firstFace.normal);
     const gp_Vec secondNormal(secondFace.normal);
-    const gp_Vec normalSum = firstNormal.Added(secondNormal);
-    const gp_Vec normalDifference = firstNormal.Subtracted(secondNormal);
+    const double firstOffset = firstNormal.Dot(gp_Vec(firstFace.center.XYZ()));
+    const double secondOffset = secondNormal.Dot(gp_Vec(secondFace.center.XYZ()));
 
-    // The sum and difference are the normals of the two dihedral bisector planes. Select the
-    // one that separates the face centers, so the plane lies between the selected faces.
+    const BisectorPlane sum {firstNormal + secondNormal, firstOffset + secondOffset};
+    const BisectorPlane difference {firstNormal - secondNormal, firstOffset - secondOffset};
+
+    // Parallel faces degenerate one of the two, and never both.
+    if (sum.isDegenerate()) {
+        return difference;
+    }
+    if (difference.isDegenerate()) {
+        return sum;
+    }
+
+    // The centers sit at -n2.d and n1.d from the sum bisector and at n2.d and n1.d from the
+    // difference one, so this sign picks the bisector that has them on opposite sides.
     const gp_Vec centerDirection(firstFace.center, secondFace.center);
-    const auto alignment = [&centerDirection](const gp_Vec& normal) {
-        const double dotProduct = centerDirection.Dot(normal);
-        return dotProduct * dotProduct / normal.SquareMagnitude();
-    };
-
-    if (normalSum.SquareMagnitude() < Precision::SquareConfusion()) {
-        return gp_Dir(normalDifference);
+    const double separation = centerDirection.Dot(firstNormal) * centerDirection.Dot(secondNormal);
+    if (separation > 0.0) {
+        return sum;
     }
-    if (normalDifference.SquareMagnitude() < Precision::SquareConfusion()) {
-        return gp_Dir(normalSum);
-    }
-    const double sumAlignment = alignment(normalSum);
-    const double differenceAlignment = alignment(normalDifference);
-    if (sumAlignment > differenceAlignment) {
-        return gp_Dir(normalSum);
-    }
-    if (differenceAlignment > sumAlignment) {
-        return gp_Dir(normalDifference);
+    if (separation < 0.0) {
+        return difference;
     }
 
-    // The center direction does not distinguish the two planes. Keep the acute-angle bisector.
-    return gp_Dir(
-        normalSum.SquareMagnitude() >= normalDifference.SquareMagnitude() ? normalSum : normalDifference
-    );
+    // A center lies on the other face's plane, so neither separates them.
+    return sum.normal.SquareMagnitude() >= difference.normal.SquareMagnitude() ? sum : difference;
 }
 }  // namespace
 
@@ -1654,12 +1673,13 @@ Base::Placement AttachEngine3D::_calculateAttachedPlacement(
             const PlanarFaceInfo firstFace = getPlanarFaceInfo(*shapes[0], precision);
             const PlanarFaceInfo secondFace = getPlanarFaceInfo(*shapes[1], precision);
 
-            SketchNormal = getMidPlaneNormal(firstFace, secondFace);
-            SketchBasePoint = gp_Pnt(
-                (firstFace.center.X() + secondFace.center.X()) * 0.5,
-                (firstFace.center.Y() + secondFace.center.Y()) * 0.5,
-                (firstFace.center.Z() + secondFace.center.Z()) * 0.5
+            const BisectorPlane midPlane = getMidPlane(firstFace, secondFace);
+            const gp_Pnt centersMidPoint(
+                gp_Vec(firstFace.center.XYZ()).Added(secondFace.center.XYZ()).Multiplied(0.5).XYZ()
             );
+
+            SketchNormal = gp_Dir(midPlane.normal);
+            SketchBasePoint = midPlane.project(centersMidPoint);
         } break;
         case mmTangentPlane: {
             if (shapes.size() < 2) {

--- a/src/Mod/Part/Gui/AttacherTexts.cpp
+++ b/src/Mod/Part/Gui/AttacherTexts.cpp
@@ -111,8 +111,9 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
                     qApp->translate("Attacher3D", "Midplane between faces", "Attachment3D mode caption"),
                     qApp->translate(
                         "Attacher3D",
-                        "Plane origin is midway between the centers of two planar faces and its "
-                        "orientation equally bisects their angle.",
+                        "Plane origin is midway between two planar faces and its orientation "
+                        "equally bisects their angle. For non-parallel faces the plane contains "
+                        "their intersection line.",
                         "Attachment3D mode tooltip"
                     )
                 );
@@ -363,8 +364,9 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
                     qApp->translate("Attacher2D", "Midplane between faces", "AttachmentPlane mode caption"),
                     qApp->translate(
                         "Attacher2D",
-                        "Plane origin is midway between the centers of two planar faces and its "
-                        "orientation equally bisects their angle.",
+                        "Plane origin is midway between two planar faces and its orientation "
+                        "equally bisects their angle. For non-parallel faces the plane contains "
+                        "their intersection line.",
                         "AttachmentPlane mode tooltip"
                     )
                 );

--- a/tests/src/Mod/Part/App/AttachExtension.cpp
+++ b/tests/src/Mod/Part/App/AttachExtension.cpp
@@ -116,8 +116,8 @@ TEST_F(AttachExtensionTest, testMidPlaneBisectsFaceAngle)
 
     const Base::Vector3d position = midPlane->Placement.getValue().getPosition();
     EXPECT_NEAR(position.x, 50.0, 1e-7);
-    EXPECT_NEAR(position.y, 25.0, 1e-7);
-    EXPECT_NEAR(position.z, 30.0, 1e-7);
+    EXPECT_NEAR(position.y, 27.5, 1e-7);
+    EXPECT_NEAR(position.z, 27.5, 1e-7);
 
     Base::Vector3d secondNormal;
     secondPlacement.getRotation().multVec(Base::Vector3d(0, 0, 1), secondNormal);
@@ -130,6 +130,10 @@ TEST_F(AttachExtensionTest, testMidPlaneBisectsFaceAngle)
     EXPECT_NEAR(normal.x, expectedNormal.x, 1e-7);
     EXPECT_NEAR(normal.y, expectedNormal.y, 1e-7);
     EXPECT_NEAR(normal.z, expectedNormal.z, 1e-7);
+
+    // The faces are z = 0 and y = 0, so they intersect on the X axis.
+    EXPECT_NEAR(normal.Dot(Base::Vector3d(0, 0, 0) - position), 0.0, 1e-7);
+    EXPECT_NEAR(normal.Dot(Base::Vector3d(10, 0, 0) - position), 0.0, 1e-7);
 }
 
 TEST_F(AttachExtensionTest, testMidPlaneBisectsConnectedFaces)
@@ -151,14 +155,55 @@ TEST_F(AttachExtensionTest, testMidPlaneBisectsConnectedFaces)
     const Base::Placement placement = midPlane->Placement.getValue();
     const Base::Vector3d position = placement.getPosition();
     EXPECT_NEAR(position.x, 50.0, 1e-7);
-    EXPECT_NEAR(position.y, 45.0, 1e-7);
-    EXPECT_NEAR(position.z, 15.0, 1e-7);
+    EXPECT_NEAR(position.y, 50.0, 1e-7);
+    EXPECT_NEAR(position.z, 10.0, 1e-7);
 
     Base::Vector3d normal;
     placement.getRotation().multVec(Base::Vector3d(0, 0, 1), normal);
     EXPECT_NEAR(normal.x, 0.0, 1e-7);
     EXPECT_NEAR(normal.y, -std::sqrt(0.5), 1e-7);
     EXPECT_NEAR(normal.z, std::sqrt(0.5), 1e-7);
+
+    // Face6 (z = Height) and Face4 (y = Width) meet at the edge y = 60, z = 20.
+    EXPECT_NEAR(normal.Dot(Base::Vector3d(0, 60, 20) - position), 0.0, 1e-7);
+    EXPECT_NEAR(normal.Dot(Base::Vector3d(100, 60, 20) - position), 0.0, 1e-7);
+}
+
+TEST_F(AttachExtensionTest, testMidPlaneBisectsObliqueFaceAngle)
+{
+    auto firstPlane = getDocument()->addObject<Part::Plane>("FirstPlane");
+    auto secondPlane = getDocument()->addObject<Part::Plane>("SecondPlane");
+    auto midPlane = getDocument()->addObject<Part::Plane>("MidPlane");
+
+    ASSERT_TRUE(firstPlane);
+    ASSERT_TRUE(secondPlane);
+    ASSERT_TRUE(midPlane);
+
+    // Rotating the second plane about the Y axis through the origin keeps both planes on the
+    // Y axis, so the faces intersect there at a 50 degree dihedral angle. The differing sizes
+    // put the face centers off the bisector, so the base point has to be corrected onto it.
+    const double angle = 50.0 * std::numbers::pi / 180.0;
+    secondPlane->Length.setValue(60.0);
+    secondPlane->Width.setValue(60.0);
+    secondPlane->Placement.setValue(
+        Base::Placement(Base::Vector3d(0, 0, 0), Base::Rotation(Base::Vector3d(0, 1, 0), angle))
+    );
+    midPlane->AttachmentSupport.setValues({firstPlane, secondPlane}, {"", ""});
+    midPlane->MapMode.setValue("MidPlane");
+
+    getDocument()->recompute();
+
+    const Base::Placement placement = midPlane->Placement.getValue();
+    const Base::Vector3d position = placement.getPosition();
+    Base::Vector3d normal;
+    placement.getRotation().multVec(Base::Vector3d(0, 0, 1), normal);
+
+    EXPECT_NEAR(normal.x, std::sin(angle / 2.0), 1e-7);
+    EXPECT_NEAR(normal.y, 0.0, 1e-7);
+    EXPECT_NEAR(normal.z, std::cos(angle / 2.0), 1e-7);
+
+    EXPECT_NEAR(normal.Dot(Base::Vector3d(0, 0, 0) - position), 0.0, 1e-7);
+    EXPECT_NEAR(normal.Dot(Base::Vector3d(0, 10, 0) - position), 0.0, 1e-7);
 }
 
 TEST_F(AttachExtensionTest, testAttacherEngineType)


### PR DESCRIPTION
Follow up to fix the issue described in https://github.com/FreeCAD/FreeCAD/pull/31574#issuecomment-5334859171
Mid plane now anchors on the true bisector.
Assisted-by: claude-opus-5

File to test from that comment (axis line should be in the plane): 
[Example.zip](https://github.com/user-attachments/files/31209868/Example.zip)


<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
<img width="612" height="559" alt="Bildschirmfoto 2026-08-19 um 07 58 44" src="https://github.com/user-attachments/assets/7380a561-498d-4eb8-a097-ba598f08dfe2" />



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
