### PR TITLE
CAM: LeadInOut - Fix QuantitySpinBox tooltips

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/DressUpLeadInOutEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DressUpLeadInOutEdit.ui
@@ -74,7 +74,6 @@
         <item row="2" column="1">
          <widget class="Gui::QuantitySpinBox" name="dspAngleIn"/>
         </item>
-
         <item row="3" column="0">
          <widget class="QLabel" name="labelExtendIn">
           <property name="text">
@@ -85,7 +84,6 @@
         <item row="3" column="1">
          <widget class="Gui::QuantitySpinBox" name="dspExtendIn"/>
         </item>
-
         <item row="4" column="0">
          <widget class="QLabel" name="labelOffsetIn">
           <property name="text">
@@ -162,7 +160,6 @@
         <item row="2" column="1">
          <widget class="Gui::QuantitySpinBox" name="dspAngleOut"/>
         </item>
-
         <item row="3" column="0">
          <widget class="QLabel" name="labelExtendOut">
           <property name="text">
@@ -173,7 +170,6 @@
         <item row="3" column="1">
          <widget class="Gui::QuantitySpinBox" name="dspExtendOut"/>
         </item>
-
         <item row="4" column="0">
          <widget class="QLabel" name="labelOffsetOut">
           <property name="text">

--- a/src/Mod/CAM/Path/Base/Gui/Util.py
+++ b/src/Mod/CAM/Path/Base/Gui/Util.py
@@ -466,7 +466,7 @@ def getDocNode():
         if tw.topLevelItemCount() != 1 or tw.topLevelItem(0).text(0) != "Application":
             continue
         toptree = tw.topLevelItem(0)
-        for i in range(0, toptree.childCount()):
+        for i in range(toptree.childCount()):
             docitem = toptree.child(i)
             if docitem.text(0) == doc:
                 return docitem
@@ -478,12 +478,12 @@ def disableItem(item):
     Dropflag = QtCore.Qt.ItemFlag.ItemIsDropEnabled
     item.setFlags(item.flags() & ~Dragflag)
     item.setFlags(item.flags() & ~Dropflag)
-    for idx in range(0, item.childCount()):
+    for idx in range(item.childCount()):
         disableItem(item.child(idx))
 
 
 def findItem(docitem, objname):
-    for i in range(0, docitem.childCount()):
+    for i in range(docitem.childCount()):
         if docitem.child(i).text(0) == objname:
             return docitem.child(i)
         res = findItem(docitem.child(i), objname)

--- a/src/Mod/CAM/Path/Base/Gui/Util.py
+++ b/src/Mod/CAM/Path/Base/Gui/Util.py
@@ -33,6 +33,7 @@ __author__ = "sliptonic (Brad Collette)"
 __url__ = "https://www.freecad.org"
 __doc__ = "A collection of helper and utility functions for the CAM GUI."
 
+translate = FreeCAD.Qt.translate
 
 if False:
     Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
@@ -119,7 +120,7 @@ class QuantitySpinBox(QtCore.QObject):
             onBeforeChange ... an optional callback being executed before the value of the property is changed
     """
 
-    def __init__(self, widget, obj, prop, onBeforeChange=None):
+    def __init__(self, widget, obj, prop, onBeforeChange=None, setToolTip=False):
         super().__init__()
         Path.Log.track(widget)
         self.widget = widget
@@ -137,6 +138,8 @@ class QuantitySpinBox(QtCore.QObject):
         except AttributeError:
             # Widget may not have this signal
             pass
+        if setToolTip:
+            self.setToolTipWidget()
 
     def onFormulaDialogStateChanged(self, isOpen):
         """
@@ -182,6 +185,13 @@ class QuantitySpinBox(QtCore.QObject):
                 self.valid = False
         else:
             self.valid = False
+
+    def setToolTipWidget(self):
+        """set tooltip from property description"""
+        if self.valid:
+            self.widget.setToolTip(
+                translate("App::Property", self.obj.getDocumentationOfProperty(self.prop))
+            )
 
     def expression(self):
         """returns the expression if one is bound to the property"""

--- a/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
@@ -25,13 +25,12 @@ import FreeCAD as App
 import FreeCADGui
 import Part
 import Path
-import Path.Base.Generator.leadinout as leadinout
-
+from Path.Base.Generator import leadinout
 from Path.Base.Gui.Util import QuantitySpinBox
 from Path.Base.Util import toolControllerForOp
 from Path.Dressup import Utils as PathDressup
 from PathPythonGui.simple_edit_panel import SimpleEditPanel
-from PathScripts import PathUtils as PathUtils
+from PathScripts import PathUtils
 from Path.Base.MachineState import MachineState
 
 __doc__ = """LeadInOut Dressup USE ROLL-ON ROLL-OFF to profile"""
@@ -268,15 +267,13 @@ class ObjectDressup:
             )
             obj.AngleOut = 90
 
-        if styleOn:
-            if styleOn == "Arc":
-                obj.StyleIn = "Arc"
-                obj.AngleIn = 90
+        if styleOn and styleOn == "Arc":
+            obj.StyleIn = "Arc"
+            obj.AngleIn = 90
 
-        if styleOff:
-            if styleOff == "Arc":
-                obj.StyleOut = "Arc"
-                obj.AngleOut = 90
+        if styleOff and styleOff == "Arc":
+            obj.StyleOut = "Arc"
+            obj.AngleOut = 90
 
         for prop in ("Length", "LengthIn"):
             if hasattr(obj, prop):
@@ -439,9 +436,9 @@ class ObjectDressup:
         ):
 
             def _isVertical(currentposition, cmd):
-                x = cmd.Parameters["X"] if "X" in cmd.Parameters else currentposition.x
-                y = cmd.Parameters["Y"] if "Y" in cmd.Parameters else currentposition.y
-                z = cmd.Parameters["Z"] if "Z" in cmd.Parameters else currentposition.z
+                x = cmd.Parameters.get("X", currentposition.x)
+                y = cmd.Parameters.get("Y", currentposition.y)
+                z = cmd.Parameters.get("Z", currentposition.z)
                 endpoint = App.Vector(x, y, z)
                 if Path.Geom.pointsCoincide(currentposition, endpoint):
                     return True

--- a/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
@@ -117,13 +117,13 @@ class ObjectDressup:
             "App::PropertyAngle",
             "AngleIn",
             "Path Lead-in",
-            QT_TRANSLATE_NOOP("App::Property", "Angle of the Lead-In (1..90)"),
+            QT_TRANSLATE_NOOP("App::Property", "Angle of the Lead-In"),
         )
         obj.addProperty(
             "App::PropertyAngle",
             "AngleOut",
             "Path Lead-out",
-            QT_TRANSLATE_NOOP("App::Property", "Angle of the Lead-Out (1..90)"),
+            QT_TRANSLATE_NOOP("App::Property", "Angle of the Lead-Out"),
         )
         obj.addProperty(
             "App::PropertyLength",
@@ -612,16 +612,33 @@ class TaskDressupLeadInOut(SimpleEditPanel):
         self.connectWidget("InvertOut", self.form.chkInvertDirectionOut)
         self.connectWidget("StyleIn", self.form.cboStyleIn)
         self.connectWidget("StyleOut", self.form.cboStyleOut)
-        self.radiusIn = QuantitySpinBox(self.form.dspRadiusIn, self.obj, "RadiusIn")
-        self.radiusOut = QuantitySpinBox(self.form.dspRadiusOut, self.obj, "RadiusOut")
-        self.angleIn = QuantitySpinBox(self.form.dspAngleIn, self.obj, "AngleIn")
-        self.angleOut = QuantitySpinBox(self.form.dspAngleOut, self.obj, "AngleOut")
-        self.extendIn = QuantitySpinBox(self.form.dspExtendIn, self.obj, "ExtendIn")
-        self.extendOut = QuantitySpinBox(self.form.dspExtendOut, self.obj, "ExtendOut")
-        self.offsetIn = QuantitySpinBox(self.form.dspOffsetIn, self.obj, "OffsetIn")
-        self.offsetOut = QuantitySpinBox(self.form.dspOffsetOut, self.obj, "OffsetOut")
         self.connectWidget("RapidPlunge", self.form.chkRapidPlunge)
-        self.threshold = QuantitySpinBox(self.form.dspThreshold, self.obj, "RetractThreshold")
+
+        self.radiusIn = QuantitySpinBox(
+            self.form.dspRadiusIn, self.obj, "RadiusIn", setToolTip=True
+        )
+        self.radiusOut = QuantitySpinBox(
+            self.form.dspRadiusOut, self.obj, "RadiusOut", setToolTip=True
+        )
+        self.angleIn = QuantitySpinBox(self.form.dspAngleIn, self.obj, "AngleIn", setToolTip=True)
+        self.angleOut = QuantitySpinBox(
+            self.form.dspAngleOut, self.obj, "AngleOut", setToolTip=True
+        )
+        self.extendIn = QuantitySpinBox(
+            self.form.dspExtendIn, self.obj, "ExtendIn", setToolTip=True
+        )
+        self.extendOut = QuantitySpinBox(
+            self.form.dspExtendOut, self.obj, "ExtendOut", setToolTip=True
+        )
+        self.offsetIn = QuantitySpinBox(
+            self.form.dspOffsetIn, self.obj, "OffsetIn", setToolTip=True
+        )
+        self.offsetOut = QuantitySpinBox(
+            self.form.dspOffsetOut, self.obj, "OffsetOut", setToolTip=True
+        )
+        self.threshold = QuantitySpinBox(
+            self.form.dspThreshold, self.obj, "RetractThreshold", setToolTip=True
+        )
 
         self.radiusIn.updateWidget()
         self.radiusOut.updateWidget()


### PR DESCRIPTION
### Description

Tool tips applied automatically to `QDoubleSpinBox`, but not to `QuantitySpinBox`

Fix regression after 
- #24818

---

### Changes

- Set tooltips for `QuantitySpinBox`
- Fixed linter errors