### PR TITLE
BIM: Avoid 'No supported edges' warning for wall base with faces

### DIFF
--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -1465,7 +1465,7 @@ class _Wall(ArchComponent.Component):
                         if baseface:
                             base, placement = self.rebase(baseface)
 
-                    else:  # if not self.basewires:
+                    elif not (base and placement):
                         FreeCAD.Console.PrintWarning(
                             translate(
                                 "Arch",


### PR DESCRIPTION
There would be a 'No supported edges in Base object' warning for a wall based on a Draft_Rectangle with MakeFace set to true.

No AI was used.