### PR TITLE
BIM: ArchCovering: _cleanup_snapper did not check if Snapper is available

### DIFF
--- a/src/Mod/BIM/ArchCoveringGui.py
+++ b/src/Mod/BIM/ArchCoveringGui.py
@@ -1578,7 +1578,8 @@ if FreeCAD.GuiUp:
                     self.obj_to_edit.ViewObject.Selectable = self._old_selectable
 
             FreeCAD.activeDraftCommand = None
-            FreeCADGui.Snapper.off()
+            if hasattr(FreeCADGui, "Snapper"):
+                FreeCADGui.Snapper.off()
             self.update_hints()
 
         def get_hints(self):


### PR DESCRIPTION
When editing a Covering object the Snapper can be unavailable. The `_cleanup_snapper` function did not take this into account.

1. Restart in Safe Mode.
2. The current WB should be Part Design and not be changed.
3. Open the file attached to this issue: #30777.
4. Double click the Covering object in the Tree View.
5. Do not change anything, just press OK.
5. Result: Snapper attribute error.

No AI was used.

```
OS: Ubuntu 22.04.5 LTS (ubuntu:GNOME/ubuntu/wayland)
Architecture: x86_64
Version: 26.3.0dev.20260812 (Git shallow)
Build date: 2026/08/12 05:41:29
Build type: Release
Branch: (HEAD detached at dc1ef6e88)
Hash: dc1ef6e880d6f5cf5d5a6eb3749373141eb0deb8
Python 3.11.14, Qt 6.8.3, Coin 4.0.10 (bundled), Pivy 0.6.11 (bundled), Vtk 9.3.1, boost 1_86, Eigen3 3.4.0, PySide 6.8.3
shiboken 6.8.3, xerces-c 3.3.0, Clipper2 , IfcOpenShell 0.8.0, OCC 7.8.1
Locale: Dutch/Netherlands (nl_NL)
Stylesheet/Theme/QtStyle: unset/FreeCAD Classic/
QPA/File dialog/Color dialog: xcb/via Qt/via Qt
Navigation Style/Orbit Style/Rotation Mode: CAD/Trackball/Drag at cursor
Logical DPI/Physical DPI/Pixel Ratio: 96/86.1283/1
OpenGL version/vendor/renderer: 4.5 (Compatibility Profile) Mesa 23.2.1-1ubuntu3.1~22.04.4/AMD/KABINI (, LLVM 15.0.7, DRM 2.50, 6.8.0-136-generic)
Installed mods:
```
