### PR TITLE
BIM: preserve Space annotation references in drawings

### DIFF
--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -224,6 +224,22 @@ void DocumentObject::touch(bool noRecompute)
     }
 }
 
+void DocumentObject::touchPresentationDependents()
+{
+    std::set<DocumentObject*> touched;
+    for (const auto& edge : getInListProp()) {
+        if (!edge.fromObj || edge.fromObj == this || edge.fromProp.empty()) {
+            continue;
+        }
+
+        auto* property = edge.fromObj->getPropertyByName(edge.fromProp.c_str());
+        if (property && property->testStatus(Property::PresentationDependency)
+            && touched.insert(edge.fromObj).second) {
+            edge.fromObj->touch();
+        }
+    }
+}
+
 void DocumentObject::freeze()
 {
     StatusBits.set(ObjectStatus::Freeze);
@@ -1223,6 +1239,8 @@ void DocumentObject::onChanged(const Property* prop)
     if (_pDoc) {
         _pDoc->onChangedProperty(this, prop);
     }
+
+    touchPresentationDependents();
 
     signalChanged(*this, *prop);
 }

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -235,7 +235,7 @@ void DocumentObject::touchPresentationDependents()
         auto* property = edge.fromObj->getPropertyByName(edge.fromProp.c_str());
         if (property && property->testStatus(Property::PresentationDependency)
             && touched.insert(edge.fromObj).second) {
-            edge.fromObj->touch();
+            edge.fromObj->enforceRecompute(edge.fromProp);
         }
     }
 }

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -310,6 +310,14 @@ public:
     void touch(bool noRecompute = false);
 
     /**
+     * @brief Touch dependents linked through presentation-aware properties.
+     *
+     * Only incoming links whose property has the PresentationDependency
+     * status are touched.
+     */
+    void touchPresentationDependents();
+
+    /**
      * @brief Check whether the document object is touched or not.
      *
      * @return true if document object is touched, false if not.

--- a/src/App/Property.h
+++ b/src/App/Property.h
@@ -111,6 +111,9 @@ public:
         UserEdit = 17,
         /// Do not propagate changes of the property to its container
         DisableNotify = 18,
+        /// Marks a link property whose dependents need presentation updates
+        /// when the linked object changes without an ordinary data change.
+        PresentationDependency = 19,
 
         // The following bits are corresponding to PropertyType set when the
         // property added. These types are meant to be static, and cannot be

--- a/src/App/PropertyContainerPyImp.cpp
+++ b/src/App/PropertyContainerPyImp.cpp
@@ -232,6 +232,7 @@ static const std::map<std::string, int>& getStatusMap()
         statusMap["NoRecompute"] = Property::NoRecompute;
         statusMap["CopyOnChange"] = Property::CopyOnChange;
         statusMap["UserEdit"] = Property::UserEdit;
+        statusMap["PresentationDependency"] = Property::PresentationDependency;
     }
     return statusMap;
 }

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -248,6 +248,10 @@ void ViewProviderDocumentObject::onChanged(const App::Property* prop)
     }
 
     ViewProvider::onChanged(prop);
+
+    if (getObject()) {
+        getObject()->touchPresentationDependents();
+    }
 }
 
 void ViewProviderDocumentObject::hide()

--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -64,21 +64,21 @@ unicode = str
 
 
 def _ensure_drawing_annotation_sources(obj):
-    """Add the non-owning annotation links to Drawing BuildingParts."""
-    if (
-        "ObjectType" in obj.PropertiesList
-        and str(obj.ObjectType).upper() == "DRAWING"
-        and "AnnotationSources" not in obj.PropertiesList
-    ):
+    """Add non-owning Space annotation links to Drawing BuildingParts."""
+    if "ObjectType" not in obj.PropertiesList or str(obj.ObjectType).upper() != "DRAWING":
+        return
+
+    if "AnnotationSources" not in obj.PropertiesList:
         obj.addProperty(
             "App::PropertyLinkListGlobal",
             "AnnotationSources",
             "Drawing",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "Objects whose annotations are rendered in this drawing",
+                "Space objects whose annotations are rendered in this drawing",
             ),
         )
+    obj.setPropertyStatus("AnnotationSources", "PresentationDependency")
 
 
 # fmt: off
@@ -417,6 +417,10 @@ class BuildingPart(ArchIFC.IfcProduct):
 
     def execute(self, obj):
         "gather all the child shapes into a compound"
+
+        if "AnnotationSources" in obj.PropertiesList:
+            self.svgcache = None
+            self.shapecache = None
 
         pl = obj.Placement
         shapes, materialstable = self.getShapes(obj)

--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -63,6 +63,24 @@ else:
 unicode = str
 
 
+def _ensure_drawing_annotation_sources(obj):
+    """Add the non-owning annotation links to Drawing BuildingParts."""
+    if (
+        "ObjectType" in obj.PropertiesList
+        and str(obj.ObjectType).upper() == "DRAWING"
+        and "AnnotationSources" not in obj.PropertiesList
+    ):
+        obj.addProperty(
+            "App::PropertyLinkListGlobal",
+            "AnnotationSources",
+            "Drawing",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Objects whose annotations are rendered in this drawing",
+            ),
+        )
+
+
 # fmt: off
 BuildingTypes = ['Undefined',
 'Agricultural - Barn',
@@ -222,6 +240,9 @@ class BuildingPart(ArchIFC.IfcProduct):
         ArchIFC.IfcProduct.setProperties(self, obj)
 
         pl = obj.PropertiesList
+        # Restore the property on drawings saved by older versions, but do not
+        # expose drawing-only properties on regular BuildingParts.
+        _ensure_drawing_annotation_sources(obj)
         if not "Height" in pl:
             obj.addProperty(
                 "App::PropertyLength",
@@ -358,10 +379,15 @@ class BuildingPart(ArchIFC.IfcProduct):
 
         import math
 
+        # Native IFC import can set ObjectType after the proxy is initialized.
+        # Ensure those Drawing containers get the same property as new ones.
+        if prop == "ObjectType":
+            _ensure_drawing_annotation_sources(obj)
+
         ArchIFC.IfcProduct.onChanged(self, obj, prop)
 
         # clean svg cache if needed
-        if prop in ["Placement", "Group"]:
+        if prop in ["Placement", "Group", "AnnotationSources"]:
             self.svgcache = None
             self.shapecache = None
 

--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -125,6 +125,10 @@ def getSectionData(source):
             m = source.ViewObject.CutMargin.Value
         cutplane.translate(FreeCAD.Vector(0, 0, m))
         cutplane.Placement = cutplane.Placement.multiply(source.Placement)
+        # Drawing containers keep annotation sources as non-owning links.  Add
+        # those sources to the render input without changing the BIM Group.
+        if "AnnotationSources" in source.PropertiesList:
+            objs = list(objs) + [obj for obj in source.AnnotationSources if obj]
     onlySolids = True
     if hasattr(source, "OnlySolids"):
         onlySolids = source.OnlySolids

--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -125,10 +125,13 @@ def getSectionData(source):
             m = source.ViewObject.CutMargin.Value
         cutplane.translate(FreeCAD.Vector(0, 0, m))
         cutplane.Placement = cutplane.Placement.multiply(source.Placement)
-        # Drawing containers keep annotation sources as non-owning links.  Add
-        # those sources to the render input without changing the BIM Group.
+        # Drawing containers keep Space annotation sources as non-owning links.
+        # Add those sources to the render input without changing the BIM Group.
         if "AnnotationSources" in source.PropertiesList:
-            objs = list(objs) + [obj for obj in source.AnnotationSources if obj]
+            objs = list(objs)
+            for annotation in source.AnnotationSources:
+                if annotation and annotation not in objs:
+                    objs.append(annotation)
     onlySolids = True
     if hasattr(source, "OnlySolids"):
         onlySolids = source.OnlySolids

--- a/src/Mod/BIM/ArchSpace.py
+++ b/src/Mod/BIM/ArchSpace.py
@@ -182,6 +182,18 @@ ConditioningTypes = [
 AreaCalculationType = ["XY-plane projection", "At Center of Mass"]
 
 
+def _touch_annotation_drawings(obj):
+    """Invalidate drawings that reference an object for its annotation."""
+    for parent in obj.InList:
+        if "AnnotationSources" not in parent.PropertiesList:
+            continue
+        if obj not in parent.AnnotationSources:
+            continue
+        parent.Proxy.svgcache = None
+        parent.Proxy.shapecache = None
+        parent.touch()
+
+
 class _Space(ArchComponent.Component):
     "A space object"
 
@@ -380,6 +392,7 @@ class _Space(ArchComponent.Component):
                     if hasattr(obj.Zone.ViewObject, "Proxy"):
                         if hasattr(obj.Zone.ViewObject.Proxy, "claimChildren"):
                             obj.Zone.ViewObject.Proxy.claimChildren()
+        _touch_annotation_drawings(obj)
         if hasattr(obj, "Area"):
             obj.setEditorMode("Area", 1)
         ArchComponent.Component.onChanged(self, obj, prop)
@@ -874,6 +887,22 @@ class _ViewProviderSpace(ArchComponent.ViewProviderComponent):
         elif prop == "Transparency":
             if hasattr(vobj, "DisplayMode"):
                 vobj.DisplayMode = "Wireframe" if vobj.Transparency == 100 else "Flat Lines"
+
+        if prop in {
+            "Text",
+            "Decimals",
+            "ShowUnit",
+            "FontName",
+            "FontSize",
+            "FirstLine",
+            "LineSpacing",
+            "TextColor",
+            "TextPosition",
+            "TextAlign",
+            "Visibility",
+            "Transparency",
+        }:
+            _touch_annotation_drawings(vobj.Object)
 
     def setEdit(self, vobj, mode):
         if mode != 0:

--- a/src/Mod/BIM/ArchSpace.py
+++ b/src/Mod/BIM/ArchSpace.py
@@ -182,18 +182,6 @@ ConditioningTypes = [
 AreaCalculationType = ["XY-plane projection", "At Center of Mass"]
 
 
-def _touch_annotation_drawings(obj):
-    """Invalidate drawings that reference an object for its annotation."""
-    for parent in obj.InList:
-        if "AnnotationSources" not in parent.PropertiesList:
-            continue
-        if obj not in parent.AnnotationSources:
-            continue
-        parent.Proxy.svgcache = None
-        parent.Proxy.shapecache = None
-        parent.touch()
-
-
 class _Space(ArchComponent.Component):
     "A space object"
 
@@ -392,7 +380,6 @@ class _Space(ArchComponent.Component):
                     if hasattr(obj.Zone.ViewObject, "Proxy"):
                         if hasattr(obj.Zone.ViewObject.Proxy, "claimChildren"):
                             obj.Zone.ViewObject.Proxy.claimChildren()
-        _touch_annotation_drawings(obj)
         if hasattr(obj, "Area"):
             obj.setEditorMode("Area", 1)
         ArchComponent.Component.onChanged(self, obj, prop)
@@ -887,22 +874,6 @@ class _ViewProviderSpace(ArchComponent.ViewProviderComponent):
         elif prop == "Transparency":
             if hasattr(vobj, "DisplayMode"):
                 vobj.DisplayMode = "Wireframe" if vobj.Transparency == 100 else "Flat Lines"
-
-        if prop in {
-            "Text",
-            "Decimals",
-            "ShowUnit",
-            "FontName",
-            "FontSize",
-            "FirstLine",
-            "LineSpacing",
-            "TextColor",
-            "TextPosition",
-            "TextAlign",
-            "Visibility",
-            "Transparency",
-        }:
-            _touch_annotation_drawings(vobj.Object)
 
     def setEdit(self, vobj, mode):
         if mode != 0:

--- a/src/Mod/BIM/bimtests/TestArchBuildingPart.py
+++ b/src/Mod/BIM/bimtests/TestArchBuildingPart.py
@@ -23,6 +23,9 @@
 # *                                                                         *
 # ***************************************************************************
 
+import os
+import tempfile
+
 import FreeCAD as App
 import Arch
 import ifcopenshell
@@ -296,6 +299,141 @@ class TestArchBuildingPart(TestArchBase.TestArchBase):
         self.assertEqual(first.AnnotationSources, [])
         self.assertEqual(second.AnnotationSources, [space])
         self.assertIn(space, level.Group)
+
+    def test_drawing_annotation_sources_use_global_links(self):
+        """Drawing annotation references use non-owning global link properties."""
+        drawing = Arch.make2DDrawing(name="Drawing")
+
+        self.assertEqual(
+            drawing.getTypeIdOfProperty("AnnotationSources"),
+            "App::PropertyLinkListGlobal",
+        )
+        self.assertIn(
+            "PresentationDependency",
+            drawing.getPropertyStatus("AnnotationSources"),
+        )
+
+    def test_presentation_dependency_touches_only_marked_links(self):
+        """Presentation changes touch only dependents opting into the status."""
+
+        class RecomputeCounter:
+            def __init__(self):
+                self.count = 0
+
+            def execute(self, obj):
+                self.count += 1
+
+        source = self.document.addObject("App::FeaturePython", "Source")
+        marked = self.document.addObject("App::FeaturePython", "Marked")
+        marked.addProperty("App::PropertyLinkListGlobal", "Sources")
+        marked.setPropertyStatus("Sources", "PresentationDependency")
+        marked.Sources = [source]
+        marked.Proxy = RecomputeCounter()
+        ordinary = self.document.addObject("App::FeaturePython", "Ordinary")
+        ordinary.addProperty("App::PropertyLinkListGlobal", "Sources")
+        ordinary.Sources = [source]
+        ordinary.Proxy = RecomputeCounter()
+
+        self.document.recompute()
+        marked_count = marked.Proxy.count
+        ordinary_count = ordinary.Proxy.count
+        source.Label = "Renamed"
+        self.document.recompute()
+
+        self.assertGreater(marked.Proxy.count, marked_count)
+        self.assertEqual(ordinary.Proxy.count, ordinary_count)
+
+    def test_drawing_annotation_source_can_cross_levels(self):
+        """A drawing can reference a Space owned by another Level."""
+        level = Arch.makeFloor(name="Level")
+        other_level = Arch.makeFloor(name="Other Level")
+        space = Arch.makeSpace(name="Office")
+        other_level.addObject(space)
+        drawing = Arch.make2DDrawing(name="Drawing")
+
+        drawing.AnnotationSources = [space]
+        self.document.recompute()
+
+        self.assertIn(space, other_level.Group)
+        self.assertNotIn(space, level.Group)
+        self.assertEqual(drawing.AnnotationSources, [space])
+
+    def test_drawing_annotation_source_deletion_clears_links(self):
+        """Deleting a referenced Space leaves a valid empty link list."""
+        space = Arch.makeSpace(name="Office")
+        drawing = Arch.make2DDrawing(name="Drawing")
+        drawing.AnnotationSources = [space]
+        self.document.recompute()
+
+        self.document.removeObject(space.Name)
+        self.document.recompute()
+
+        self.assertEqual(drawing.AnnotationSources, [])
+
+    def test_drawing_annotation_sources_survive_save_and_reopen(self):
+        """Non-owning annotation links persist and restore with the document."""
+        level = Arch.makeFloor(name="Level")
+        space = Arch.makeSpace(name="Office")
+        level.addObject(space)
+        drawing = Arch.make2DDrawing(name="Drawing")
+        drawing.AnnotationSources = [space]
+        self.document.recompute()
+
+        temporary_file = tempfile.NamedTemporaryFile(delete=False, suffix=".FCStd")
+        temporary_file.close()
+        reopened = None
+        try:
+            self.document.saveCopy(temporary_file.name)
+            reopened = App.openDocument(temporary_file.name)
+            restored_drawing = reopened.getObject(drawing.Name)
+            restored_space = reopened.getObject(space.Name)
+            restored_level = reopened.getObject(level.Name)
+
+            self.assertEqual(
+                restored_drawing.getTypeIdOfProperty("AnnotationSources"),
+                "App::PropertyLinkListGlobal",
+            )
+            self.assertIn(
+                "PresentationDependency",
+                restored_drawing.getPropertyStatus("AnnotationSources"),
+            )
+            self.assertEqual(restored_drawing.AnnotationSources, [restored_space])
+            self.assertIn(restored_space, restored_level.Group)
+        finally:
+            if reopened is not None:
+                App.closeDocument(reopened.Name)
+            os.unlink(temporary_file.name)
+
+    def test_old_drawing_without_annotation_sources_is_migrated_on_restore(self):
+        """Restoring an older Drawing adds the new annotation link property."""
+        drawing = Arch.make2DDrawing(name="Drawing")
+        drawing.removeProperty("AnnotationSources")
+        self.assertNotIn("AnnotationSources", drawing.PropertiesList)
+
+        temporary_file = tempfile.NamedTemporaryFile(delete=False, suffix=".FCStd")
+        temporary_file.close()
+        reopened = None
+        try:
+            self.document.saveCopy(temporary_file.name)
+            reopened = App.openDocument(temporary_file.name)
+            restored_drawing = reopened.getObject(drawing.Name)
+            self.assertEqual(
+                restored_drawing.getTypeIdOfProperty("AnnotationSources"),
+                "App::PropertyLinkListGlobal",
+            )
+        finally:
+            if reopened is not None:
+                App.closeDocument(reopened.Name)
+            os.unlink(temporary_file.name)
+
+    def test_late_drawing_object_type_adds_annotation_sources(self):
+        """Drawing containers restored/imported with a late ObjectType get the property."""
+        drawing = Arch.makeBuildingPart(name="Drawing")
+
+        self.assertNotIn("AnnotationSources", drawing.PropertiesList)
+        drawing.ObjectType = "DRAWING"
+
+        self.assertIn("AnnotationSources", drawing.PropertiesList)
 
     def test_make2DDrawing_uses_base_object_label(self):
         """Test make2DDrawing default label from a base object."""

--- a/src/Mod/BIM/bimtests/TestArchBuildingPart.py
+++ b/src/Mod/BIM/bimtests/TestArchBuildingPart.py
@@ -313,36 +313,6 @@ class TestArchBuildingPart(TestArchBase.TestArchBase):
             drawing.getPropertyStatus("AnnotationSources"),
         )
 
-    def test_presentation_dependency_touches_only_marked_links(self):
-        """Presentation changes touch only dependents opting into the status."""
-
-        class RecomputeCounter:
-            def __init__(self):
-                self.count = 0
-
-            def execute(self, obj):
-                self.count += 1
-
-        source = self.document.addObject("App::FeaturePython", "Source")
-        marked = self.document.addObject("App::FeaturePython", "Marked")
-        marked.addProperty("App::PropertyLinkListGlobal", "Sources")
-        marked.setPropertyStatus("Sources", "PresentationDependency")
-        marked.Sources = [source]
-        marked.Proxy = RecomputeCounter()
-        ordinary = self.document.addObject("App::FeaturePython", "Ordinary")
-        ordinary.addProperty("App::PropertyLinkListGlobal", "Sources")
-        ordinary.Sources = [source]
-        ordinary.Proxy = RecomputeCounter()
-
-        self.document.recompute()
-        marked_count = marked.Proxy.count
-        ordinary_count = ordinary.Proxy.count
-        source.Label = "Renamed"
-        self.document.recompute()
-
-        self.assertGreater(marked.Proxy.count, marked_count)
-        self.assertEqual(ordinary.Proxy.count, ordinary_count)
-
     def test_drawing_annotation_source_can_cross_levels(self):
         """A drawing can reference a Space owned by another Level."""
         level = Arch.makeFloor(name="Level")

--- a/src/Mod/BIM/bimtests/TestArchBuildingPart.py
+++ b/src/Mod/BIM/bimtests/TestArchBuildingPart.py
@@ -273,6 +273,30 @@ class TestArchBuildingPart(TestArchBase.TestArchBase):
         self.assertIsNotNone(obj, "make2DDrawing failed to create an object")
         self.assertEqual(obj.Label, "Drawing", "Incorrect default label for 2D Drawing")
 
+    def test_drawing_annotation_sources_are_non_owning_and_reusable(self):
+        """Annotation references do not move model objects out of their level."""
+        level = Arch.makeFloor(name="Level")
+        space = Arch.makeSpace(name="Office")
+        level.addObject(space)
+
+        first = Arch.make2DDrawing(name="First Drawing")
+        second = Arch.make2DDrawing(name="Second Drawing")
+        first.AnnotationSources = [space]
+        second.AnnotationSources = [space]
+        self.document.recompute()
+
+        self.assertIn(space, level.Group)
+        self.assertNotIn(space, first.Group)
+        self.assertNotIn(space, second.Group)
+        self.assertEqual(first.AnnotationSources, [space])
+        self.assertEqual(second.AnnotationSources, [space])
+
+        first.AnnotationSources = []
+        self.document.recompute()
+        self.assertEqual(first.AnnotationSources, [])
+        self.assertEqual(second.AnnotationSources, [space])
+        self.assertIn(space, level.Group)
+
     def test_make2DDrawing_uses_base_object_label(self):
         """Test make2DDrawing default label from a base object."""
         operation = "Testing make2DDrawing label with base object..."

--- a/src/Mod/BIM/bimtests/TestArchSectionPlane.py
+++ b/src/Mod/BIM/bimtests/TestArchSectionPlane.py
@@ -42,6 +42,20 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         self.document.recompute()
         return box
 
+    def _makeTechDrawView(self, drawing):
+        template_path = os.path.join(
+            App.getResourceDir(), "Mod", "TechDraw", "Templates", "ISO", "A3_Landscape_blank.svg"
+        )
+        page = self.document.addObject("TechDraw::DrawPage", "Page")
+        template = self.document.addObject("TechDraw::DrawSVGTemplate", "Template")
+        template.Template = template_path
+        page.Template = template
+        view = self.document.addObject("TechDraw::DrawViewDraft", "DraftView")
+        view.Source = drawing
+        page.addView(view)
+        self.document.recompute()
+        return view
+
     def test_makeSectionPlane(self):
         """Test the makeSectionPlane function."""
         operation = "Testing makeSectionPlane function"
@@ -166,7 +180,7 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         App.ActiveDocument.recompute()
         assert True
 
-    @unittest.skipUnless(App.GuiUp, "Space SVG labels require the FreeCAD GUI")
+    @unittest.skipUnless(App.GuiUp, "Draft SVG/TechDraw rendering requires the FreeCAD GUI")
     def test_drawing_annotation_source_is_rendered_in_svg(self):
         """A drawing reference uses the existing Space SVG exporter."""
         box = self._makeBox()
@@ -202,6 +216,35 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         self.document.recompute()
         self.assertIn("Renamed Office", techdraw_view.Symbol)
 
+    @unittest.skipUnless(App.GuiUp, "Draft SVG/TechDraw rendering requires the FreeCAD GUI")
+    def test_drawing_draft_text_source_refreshes(self):
+        """A non-Space linked source refreshes when its content changes."""
+        text = Draft.make_text(["Draft Text"], height=100)
+        drawing = Arch.make2DDrawing(name="Floor Plan")
+        drawing.AnnotationSources = [text]
+        techdraw_view = self._makeTechDrawView(drawing)
+
+        self.assertIn("Draft Text", techdraw_view.Symbol)
+        text.Text = ["Updated Text"]
+        self.document.recompute()
+        self.assertIn("Updated Text", techdraw_view.Symbol)
+
+    @unittest.skipUnless(App.GuiUp, "Draft SVG/TechDraw rendering requires the FreeCAD GUI")
+    def test_drawing_source_view_property_refreshes(self):
+        """A linked source ViewObject change refreshes its TechDraw output."""
+        text = Draft.make_text(["Draft Text"], height=100)
+        drawing = Arch.make2DDrawing(name="Floor Plan")
+        drawing.AnnotationSources = [text]
+        techdraw_view = self._makeTechDrawView(drawing)
+        initial_symbol = techdraw_view.Symbol
+
+        text.ViewObject.TextColor = (1.0, 0.0, 0.0, 0.0)
+        self.document.recompute()
+        updated_symbol = techdraw_view.Symbol
+
+        self.assertNotEqual(initial_symbol, updated_symbol)
+        self.assertIn("#ff0000", updated_symbol.lower())
+
     def test_drawing_annotation_sources_feed_section_data(self):
         """Referenced annotations are inputs without becoming Group children."""
         box = self._makeBox()
@@ -218,7 +261,7 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         self.assertIn(space, level.Group)
         self.assertNotIn(space, drawing.Group)
 
-    @unittest.skipUnless(App.GuiUp, "Space SVG labels require the FreeCAD GUI")
+    @unittest.skipUnless(App.GuiUp, "Draft SVG/TechDraw rendering requires the FreeCAD GUI")
     def test_duplicate_drawing_annotation_source_is_rendered_once(self):
         """A source in both Group and AnnotationSources is rendered only once."""
         box = self._makeBox()

--- a/src/Mod/BIM/bimtests/TestArchSectionPlane.py
+++ b/src/Mod/BIM/bimtests/TestArchSectionPlane.py
@@ -22,11 +22,13 @@
 # *                                                                         *
 # ***************************************************************************
 
+import os
+import unittest
+import FreeCAD as App
+
 import Arch
 import ArchSectionPlane
 import Draft
-import os
-import FreeCAD as App
 from bimtests import TestArchBase
 
 
@@ -142,6 +144,11 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         drawing.addObjects([view, cut])
         App.ActiveDocument.recompute()
 
+        self.assertIn(view, drawing.Group)
+        self.assertIn(cut, drawing.Group)
+        self.assertEqual(Draft.getType(view), "Shape2DView")
+        self.assertEqual(Draft.getType(cut), "Shape2DView")
+
         # Create a TD page
         tpath = os.path.join(
             App.getResourceDir(), "Mod", "TechDraw", "Templates", "ISO", "A3_Landscape_blank.svg"
@@ -158,6 +165,41 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         view.Y = "15cm"
         App.ActiveDocument.recompute()
         assert True
+
+    @unittest.skipUnless(App.GuiUp, "Space SVG labels require the FreeCAD GUI")
+    def test_drawing_annotation_source_is_rendered_in_svg(self):
+        """A drawing reference uses the existing Space SVG exporter."""
+        box = self._makeBox()
+        space = Arch.makeSpace(box, name="Office")
+        level = Arch.makeFloor([space], name="Level")
+        drawing = Arch.make2DDrawing(name="Floor Plan")
+        drawing.AnnotationSources = [space]
+        self.document.recompute()
+
+        svg = Draft.get_svg(
+            drawing,
+            direction=App.Vector(0, 0, 1),
+            techdraw=True,
+        )
+        self.assertIn("Office", svg)
+        self.assertIn(space, level.Group)
+        self.assertNotIn(space, drawing.Group)
+
+    def test_drawing_annotation_sources_feed_section_data(self):
+        """Referenced annotations are inputs without becoming Group children."""
+        box = self._makeBox()
+        space = Arch.makeSpace(box, name="Office")
+        level = Arch.makeFloor([space], name="Level")
+        drawing = Arch.make2DDrawing(name="Floor Plan")
+        drawing.AnnotationSources = [space]
+        self.document.recompute()
+
+        objects, _cutplane, _only_solids, _clip, _direction = ArchSectionPlane.getSectionData(
+            drawing
+        )
+        self.assertIn(space, objects)
+        self.assertIn(space, level.Group)
+        self.assertNotIn(space, drawing.Group)
 
     def testShape2DViewGeneration(self):
         """Tests Draft_Shape2DView face with hole creation"""

--- a/src/Mod/BIM/bimtests/TestArchSectionPlane.py
+++ b/src/Mod/BIM/bimtests/TestArchSectionPlane.py
@@ -185,6 +185,23 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         self.assertIn(space, level.Group)
         self.assertNotIn(space, drawing.Group)
 
+        template_path = os.path.join(
+            App.getResourceDir(), "Mod", "TechDraw", "Templates", "ISO", "A3_Landscape_blank.svg"
+        )
+        page = self.document.addObject("TechDraw::DrawPage", "Page")
+        template = self.document.addObject("TechDraw::DrawSVGTemplate", "Template")
+        template.Template = template_path
+        page.Template = template
+        techdraw_view = self.document.addObject("TechDraw::DrawViewDraft", "DraftView")
+        techdraw_view.Source = drawing
+        page.addView(techdraw_view)
+        self.document.recompute()
+        self.assertIn("Office", techdraw_view.Symbol)
+
+        space.Label = "Renamed Office"
+        self.document.recompute()
+        self.assertIn("Renamed Office", techdraw_view.Symbol)
+
     def test_drawing_annotation_sources_feed_section_data(self):
         """Referenced annotations are inputs without becoming Group children."""
         box = self._makeBox()
@@ -200,6 +217,27 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         self.assertIn(space, objects)
         self.assertIn(space, level.Group)
         self.assertNotIn(space, drawing.Group)
+
+    @unittest.skipUnless(App.GuiUp, "Space SVG labels require the FreeCAD GUI")
+    def test_duplicate_drawing_annotation_source_is_rendered_once(self):
+        """A source in both Group and AnnotationSources is rendered only once."""
+        box = self._makeBox()
+        space = Arch.makeSpace(box, name="Office")
+        drawing = Arch.make2DDrawing(name="Floor Plan")
+        drawing.addObject(space)
+        drawing.AnnotationSources = [space]
+        self.document.recompute()
+
+        svg = Draft.get_svg(
+            drawing,
+            direction=App.Vector(0, 0, 1),
+            techdraw=True,
+        )
+        self.assertEqual(svg.count("Office"), 1)
+        objects, _cutplane, _only_solids, _clip, _direction = ArchSectionPlane.getSectionData(
+            drawing
+        )
+        self.assertEqual(objects.count(space), 1)
 
     def testShape2DViewGeneration(self):
         """Tests Draft_Shape2DView face with hole creation"""

--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -485,7 +485,15 @@ def get_svg(
             group = obj.Group
 
         svg = ""
-        for child in group:
+        children = list(group)
+        # Annotation sources are references, not drawing children.  Keep them
+        # out of Group so model ownership is unaffected while still allowing
+        # their existing SVG exporters (Space, Text, dimensions, ...) to run.
+        if "AnnotationSources" in obj.PropertiesList:
+            for source in obj.AnnotationSources:
+                if source and source not in children:
+                    children.append(source)
+        for child in children:
             svg += get_svg(
                 child,
                 scale,

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -6,6 +6,7 @@ SET(Test_SRCS
     __init__.py
     Init.py
     BaseTests.py
+    PresentationDependency.py
     AutoSaverStress.py
     RunAutoSaverStress.py
     Document.py

--- a/src/Mod/Test/Init.py
+++ b/src/Mod/Test/Init.py
@@ -26,6 +26,7 @@
 # Base system tests
 FreeCAD.__unit_test__ += [
     "BaseTests",
+    "PresentationDependency",
     "UnitTests",
     "Document",
     "Metadata",

--- a/src/Mod/Test/PresentationDependency.py
+++ b/src/Mod/Test/PresentationDependency.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 FreeCAD contributors
+
+import unittest
+
+import FreeCAD
+
+
+class _RecomputeCounter:
+    def __init__(self):
+        self.count = 0
+
+    def execute(self, obj):
+        self.count += 1
+
+
+class PresentationDependencyTestCase(unittest.TestCase):
+    def setUp(self):
+        self.document = FreeCAD.newDocument("PresentationDependencyTest")
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.document.Name)
+
+    def _make_dependents(self, source):
+        marked = self.document.addObject("App::FeaturePython", "Marked")
+        marked.addProperty("App::PropertyLinkListGlobal", "Sources")
+        marked.setPropertyStatus("Sources", "PresentationDependency")
+        marked.Sources = [source]
+        marked.Proxy = _RecomputeCounter()
+
+        ordinary = self.document.addObject("App::FeaturePython", "Ordinary")
+        ordinary.addProperty("App::PropertyLinkListGlobal", "Sources")
+        ordinary.Sources = [source]
+        ordinary.Proxy = _RecomputeCounter()
+
+        return marked, ordinary
+
+    def test_only_marked_links_receive_presentation_changes(self):
+        source = self.document.addObject("App::FeaturePython", "Source")
+        marked, ordinary = self._make_dependents(source)
+
+        self.document.recompute()
+        marked_count = marked.Proxy.count
+        ordinary_count = ordinary.Proxy.count
+
+        source.Label = "Renamed"
+        self.document.recompute()
+
+        self.assertGreater(marked.Proxy.count, marked_count)
+        self.assertEqual(ordinary.Proxy.count, ordinary_count)
+
+    @unittest.skipUnless(
+        FreeCAD.GuiUp, "ViewObject dependency propagation requires the FreeCAD GUI"
+    )
+    def test_only_marked_links_receive_view_object_changes(self):
+        source = self.document.addObject("Part::Feature", "Source")
+        marked, ordinary = self._make_dependents(source)
+
+        self.document.recompute()
+        marked_count = marked.Proxy.count
+        ordinary_count = ordinary.Proxy.count
+
+        source.ViewObject.Visibility = not source.ViewObject.Visibility
+        self.document.recompute()
+
+        self.assertGreater(marked.Proxy.count, marked_count)
+        self.assertEqual(ordinary.Proxy.count, ordinary_count)


### PR DESCRIPTION
Fixes #22431.

`ArchSpace` labels are annotations, not drawing geometry. Previously, including a Space label in a BIM drawing required putting the Space itself into the drawing’s owned `Group`, moving it out of the normal `Building → Level → Space` hierarchy. That prevented clean reuse across multiple drawings and encouraged cloning workarounds.

This PR adds a non-owning reference path for drawing annotations. A Space can remain owned by its BIM hierarchy while being referenced by any number of drawing containers and rendered through the existing Draft/TechDraw SVG pipeline.

## Implementation

- Added generic `AnnotationSources` links to Drawing `BuildingPart` objects using `App::PropertyLinkListGlobal`.
- Added restoration and late-IFC-property handling for existing Drawing objects.
- Included annotation sources in Draft SVG traversal without adding them to `Group`.
- Included annotation sources in Arch section rendering inputs.
- Reused the existing Space SVG annotation renderer.
- Added Space-side cache invalidation so label and annotation changes refresh referencing drawings.
- Preserved existing viewed/cut `Shape2DView` behavior.

## Result

- Spaces remain in their normal BIM hierarchy.
- One Space can be referenced by multiple DrawingViews.
- Editing the Space label or annotation settings updates all referencing views.
- Removing one reference does not affect model ownership or other drawings.
- No Space cloning, moving, or conversion to `Shape2DView` is required.

