### PR TITLE
partially revert #30615 to previous spacemouse zoom pivot behavior

### DIFF
--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -2394,15 +2394,10 @@ SbBool NavigationStyle::processMotionEvent(const SoMotion3Event* const ev)
 
     SbVec3f dir = ev->getTranslation();
 
-    const float zoom = dir[2] * 0.0001;
-    dir[2] = 0.0;
-    float zoomFactor = 1.0 + zoom;
-    if (zoomFactor < 0.1F) {
-        zoomFactor = 0.1F;
-    }
-
     if (camera->getTypeId().isDerivedFrom(SoOrthographicCamera::getClassTypeId())) {
-        static_cast<SoOrthographicCamera*>(camera)->scaleHeight(zoomFactor);
+        auto oCam = static_cast<SoOrthographicCamera*>(camera);
+        oCam->scaleHeight(1.0 + (dir[2] * 0.0001));
+        dir[2] = 0.0;  // don't move the cam for z translation.
     }
 
     // Use the active navigation rotation center mode for SpaceMouse rotations
@@ -2440,12 +2435,6 @@ SbBool NavigationStyle::processMotionEvent(const SoMotion3Event* const ev)
     else {
         newRotation.multVec(SbVec3f(0.0, 0.0, -1.0), newDirection);
         newPosition = center - (newDirection * camera->focalDistance.getValue());
-    }
-
-    if (camera->getTypeId().isDerivedFrom(SoPerspectiveCamera::getClassTypeId())) {
-        const SbVec3f zoomPivot = useMotionRotationCenter ? motionRotationCenter : center;
-        newPosition = zoomPivot + (newPosition - zoomPivot) * zoomFactor;
-        camera->focalDistance.setValue(camera->focalDistance.getValue() * zoomFactor);
     }
 
     newRotation.multVec(dir, dir);


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
## Description

In addition to some concerns brought up by @jffmichi about significant workflow changes and the need for an option, I discovered a bug after merge that makes this no longer a good idea.  It probably wasn't a good idea to put both changes in the same PR in the first place.  I will be better about that in the future.  My apologies.

## Description of the bug I found after the fact:

It turns out that the way zoom with the mouse wheel and zoom with the spacemouse interact creates an increasing lateral distance between the rotation center and the view's focal point.

The issue I was trying to fix was this same difference increasing as the focal point moved away from `rotationCenter` in Z.  What I did in the original PR worked, but mouse zoom pivots about the mouse cursor, while spacemouse zoom pivots about rotationCenter, so as you repeat zoom actions between the mouse and the spacemouse they get further and further apart laterally, even though they no longer get further apart in Z.  So unfortunately you still get to the same stuck feeling where zoom starts to move laterally more than it does in Z, it's just now even less obvious why that's happening to the user.  In fact it requires such extreme zoom in / push out repetition that I didn't notice it in testing either.

This all depends on the rotation mode being set to "Drag at cursor" or "Object center".  The default rotation mode is window center where the spacemouse already zooms about the focal point.  If I figure out a good way to deal with this I'll open a new PR with only this change, toggleable this time, in it.  For now I think going back to the previous behavior is best.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
This was just merged so I didn't see any issues related to it.  But if there were any complaints about the zoom behavior in perspective it's probably because of this.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

Before: 

https://github.com/user-attachments/assets/dfc6bab0-7508-49f1-83f1-7b199832d325

After: 

https://github.com/user-attachments/assets/5883a896-d64a-4e35-a43b-40f8a6994ce7

## Notes for reviewers

The collapsed diff of changes between the original PR #30615 plus this one should be:

```
diff --git a/src/Gui/Navigation/NavigationStyle.cpp b/src/Gui/Navigation/NavigationStyle.cpp
index 88cd0c9000..682b7f4482 100644
--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -617,8 +617,9 @@ void NavigationStyle::lookAtPoint(const SbVec2s screenpos)

 void NavigationStyle::lookAtPoint(const SbVec3f& position)
 {
-    this->rotationCenterFound = false;
     translateCamera(position - viewer->getFocalPoint());
+    this->rotationCenter = position;
+    this->rotationCenterFound = true;
 }

 SoCamera* NavigationStyle::getCamera() const
```


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
