### PR TITLE
CAM: fix ToolBit shape lookup for thread-mill

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathToolShapeClasses.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolShapeClasses.py
@@ -193,6 +193,34 @@ class TestPathToolShapeClasses(PathTestWithAssets):
         self.assertEqual(ToolBitShape.get_subclass_by_name("slitting-saw"), ToolBitShapeSlittingSaw)
         self.assertIsNone(ToolBitShape.get_subclass_by_name("nonexistent"))
 
+    def test_resolve_asset_by_class_name(self):
+        """
+        Every concrete shape must be resolvable by its own class name alone,
+        with no filename or alias hint - this is the identifier ToolBit.
+        onDocumentRestored() falls back to using when ShapeID doesn't
+        resolve directly (e.g. for documents saved before ShapeID existed),
+        and what from_dict() may see from a template/.fctb dict that only
+        has a bare "shape-type". Regression test for the "ThreadMill" class
+        being stored as "thread-mill.fcstd": that mismatch meant this
+        lookup-by-class-name silently built an empty placeholder shape (no
+        geometry) instead of loading the real asset, which then crashed
+        with an AssertionError the first time something needed to build the
+        tool's 3D body (e.g. creating a Job from a template).
+        """
+        for shape_class in ToolBitShape.__subclasses__():
+            if shape_class.name.lower() in ("custom", "dummy"):
+                # Custom has no backing asset file by design; "dummy" is the
+                # DummyShape test fixture defined above, not a real shape.
+                continue
+            with self.subTest(shape_class=shape_class.name):
+                shape = ToolBitShape.resolve_asset(shape_class.name, assets=self.assets)
+                self.assertIsInstance(shape, shape_class)
+                self.assertIsNotNone(
+                    shape._data,
+                    f"resolving '{shape_class.name}' by class name alone produced a "
+                    "placeholder shape with no geometry data",
+                )
+
     # The following tests for default parameters and labels
     # should also not use mocks for FreeCAD document operations or Units.
     # They should rely on the actual FreeCAD environment and the

--- a/src/Mod/CAM/Path/Tool/shape/models/base.py
+++ b/src/Mod/CAM/Path/Tool/shape/models/base.py
@@ -560,6 +560,53 @@ class ToolBitShape(Asset):
         )
 
     @classmethod
+    def resolve_asset(cls, identifier: str, assets=None) -> "ToolBitShape":
+        """
+        Resolves an identifier (name, filename, or URI) to a loaded
+        ToolBitShape asset.
+
+        Some built-in shapes have an asset filename that doesn't match their
+        class name, even case-insensitively (e.g. the "ThreadMill" class is
+        stored as "thread-mill.fcstd"). If the identifier doesn't resolve
+        directly, retry using the identified shape class's own canonical
+        name and its known aliases (see Tools/Shape/shape_aliases.json)
+        before giving up, so callers only need to fall back to an empty
+        placeholder shape when the shape genuinely isn't a known/available
+        asset. This doesn't rely on case-insensitive filename matching, so
+        it works the same regardless of the underlying asset store.
+
+        Args:
+            identifier: a shape name, filename, alias, or asset URI.
+            assets: the AssetManager to resolve against. Defaults to the
+                global cam_assets (accepts an injectable manager so tests
+                can use an isolated asset store).
+
+        Raises FileNotFoundError if no candidate identifier resolves.
+        """
+        if assets is None:
+            assets = cam_assets
+
+        uri = cls.resolve_name(identifier)
+        try:
+            return cast("ToolBitShape", assets.get(uri))
+        except FileNotFoundError:
+            pass
+
+        shape_class = cls.get_subclass_by_name(uri.asset_id)
+        if shape_class:
+            candidates = [shape_class.name.lower(), *shape_class.aliases]
+            for candidate in candidates:
+                try:
+                    return cast("ToolBitShape", assets.get(cls.resolve_name(candidate)))
+                except FileNotFoundError:
+                    continue
+
+        raise FileNotFoundError(
+            f"No shape asset found for '{identifier}' (tried canonical name "
+            f"and aliases of {shape_class.__name__ if shape_class else 'unknown class'})"
+        )
+
+    @classmethod
     def schema(cls) -> Mapping[str, Tuple[str, str]]:
         """
         Subclasses must define the dictionary mapping parameter names to

--- a/src/Mod/CAM/Path/Tool/toolbit/models/base.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/models/base.py
@@ -31,12 +31,11 @@ import pathlib
 from abc import ABC
 from itertools import chain
 from lazy_loader.lazy_loader import LazyLoader
-from typing import Any, List, Optional, Tuple, Type, Union, Mapping, cast
+from typing import Any, List, Optional, Tuple, Type, Union, Mapping
 from PySide.QtCore import QT_TRANSLATE_NOOP
 from Path.Base.Generator import toolchange
 from ...docobject import DetachedDocumentObject
 from ...assets.asset import Asset
-from ...camassets import cam_assets
 from ...shape import ToolBitShape, ToolBitShapeCustom, ToolBitShapeIcon
 from ..util import to_json, format_value
 from ..migration import ParameterAccessor, migrate_parameters
@@ -161,11 +160,10 @@ class ToolBit(Asset, ABC):
 
         # Create a ToolBitShape instance.
         if not shallow:  # Shallow means: skip loading of child assets
-            shape_asset_uri = ToolBitShape.resolve_name(shape_id)
             try:
-                tool_bit_shape = cast(ToolBitShape, cam_assets.get(shape_asset_uri))
+                tool_bit_shape = ToolBitShape.resolve_asset(shape_id)
             except FileNotFoundError:
-                Path.Log.debug(f"ToolBit.from_dict: Shape asset {shape_asset_uri} not found.")
+                Path.Log.debug(f"ToolBit.from_dict: Shape asset '{shape_id}' not found.")
                 # Rely on the fallback below
             else:
                 toolbit = cls.from_shape(tool_bit_shape, attrs, id=attrs.get("id"))
@@ -528,16 +526,22 @@ class ToolBit(Asset, ABC):
         self._create_base_properties()
         self._promote_toolbit()
 
-        # Get the shape instance based on the ShapeType. We try two approaches
-        # to find the shape and shape class:
-        #   1. If the asset with the given type exists, use that.
+        # Get the shape instance based on ShapeID/ShapeType. We try two
+        # approaches to find the shape and shape class:
+        #   1. If the asset with the given ID exists, use that.
         #   2. Otherwise create a new empty instance
-        shape_uri = ToolBitShape.resolve_name(self.obj.ShapeType)
         try:
             # Best case: we directly find the shape file in our assets.
-            self._tool_bit_shape = cast(ToolBitShape, cam_assets.get(shape_uri))
+            # ShapeID is the real asset id (e.g. "thread-mill"), unlike
+            # ShapeType which is always the shape class name (e.g.
+            # "ThreadMill") and doesn't necessarily match the asset
+            # filename.
+            self._tool_bit_shape = ToolBitShape.resolve_asset(self.obj.ShapeID)
         except FileNotFoundError:
             # Otherwise, try to at least identify the type of the shape.
+            # A custom shape's ShapeID is an embedded filename with no
+            # matching class, so identify the class from ShapeType instead.
+            shape_uri = ToolBitShape.resolve_name(self.obj.ShapeType)
             shape_class = ToolBitShape.get_subclass_by_name(shape_uri.asset_id)
             if not shape_class:
                 raise ValueError(


### PR DESCRIPTION
CAM: fix ToolBit shape lookup for classes whose asset filename doesn't match the class name

A ToolBit's ShapeType/shape-type is always the shape class name (e.g. "ThreadMill"), and ToolBit.onDocumentRestored()/from_dict() looked up the matching asset by that exact name. Most built-in shapes' class names lowercase straight to their asset filename (Endmill -> endmill.fcstd), so this worked. The ThreadMill shape is stored as thread-mill.fcstd, which doesn't match "ThreadMill" even case-insensitively, so the lookup always missed and silently fell back to an empty placeholder ToolBitShape with no geometry data. That placeholder then crashed with an AssertionError in ToolBitShape.make_body() the first time something needed to build the tool's visual representation - e.g. creating a Job from a template containing a thread mill tool.

Tools/Shape/shape_aliases.json already lists "thread-mill" as a known alias of "ThreadMill", but nothing consulted it when resolving the asset file, only when resolving the Python class.

Add ToolBitShape.resolve_asset(), which retries the shape class's own canonical name and declared aliases before giving up, and use it from both ToolBit.onDocumentRestored() and ToolBit.from_dict() in place of the raw resolve_name()+cam_assets.get() call. Add a regression test that resolves every concrete shape class by its bare class name alone, the scenario that broke for ThreadMill.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Co-Authored-By: Claude Sonnet 5

Fixes #32075
