### PR TITLE
Sketcher: Horizontal and Vertical Auto Constrain for point with hint line

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -767,6 +767,77 @@ void DrawSketchHandler::resetTangentAutoConstraintHint()
     tangentAutoConstraintHint = TangentAutoConstraintHint();
 }
 
+void DrawSketchHandler::seekPointAlignmentAutoConstraint(
+    std::vector<AutoConstraint>& suggestedConstraints,
+    const Base::Vector2d& Pos,
+    AutoConstraint::TargetType type
+)
+{
+    if (type != AutoConstraint::VERTEX && type != AutoConstraint::VERTEX_NO_TANGENCY) {
+        return;
+    }
+
+    for (const auto& constraint : suggestedConstraints) {
+        if (constraint.Type == Coincident || constraint.Type == PointOnObject
+            || constraint.Type == Symmetric) {
+            return;
+        }
+    }
+
+    SketchObject* obj = sketchgui->getSketchObject();
+    if (!obj) {
+        return;
+    }
+
+    Base::Vector2d segmentStart;
+    const bool hasSegmentStart = getStartPointOfCurrentSegment(segmentStart);
+    double bestDeviation = getAutoConstraintSearchDistance();
+    AutoConstraint bestConstraint {Sketcher::None, GeoEnum::GeoUndef, PointPos::none};
+    LineExtensionAutoConstraintHint bestHint;
+
+    auto considerPoint = [&](int geoId, PointPos posId, const Base::Vector2d& anchor) {
+        const Base::Vector2d cursorOffset = Pos - anchor;
+        if (cursorOffset.Sqr() < Precision::SquareConfusion()
+            || (hasSegmentStart && (anchor - segmentStart).Sqr() < Precision::SquareConfusion())) {
+            return;
+        }
+
+        auto considerAlignment =
+            [&](ConstraintType constraintType, double deviation, const Base::Vector2d& position) {
+                if (deviation > bestDeviation) {
+                    return;
+                }
+
+                bestDeviation = deviation;
+                bestConstraint = {constraintType, geoId, posId};
+                bestHint.isValid = true;
+                bestHint.start = anchor;
+                bestHint.end = position;
+            };
+
+        considerAlignment(Horizontal, std::abs(cursorOffset.y), {Pos.x, anchor.y});
+        considerAlignment(Vertical, std::abs(cursorOffset.x), {anchor.x, Pos.y});
+    };
+
+    const int highestVertex = getHighestVertexIndex();
+    for (int vertexIndex = 0; vertexIndex <= highestVertex; ++vertexIndex) {
+        int geoId = GeoEnum::GeoUndef;
+        PointPos posId = PointPos::none;
+        obj->getGeoVertexIndex(vertexIndex, geoId, posId);
+        if (geoId == GeoEnum::GeoUndef) {
+            continue;
+        }
+        considerPoint(geoId, posId, toVector2d(obj->getPoint(geoId, posId)));
+    }
+
+    if (!bestHint.isValid || !isLineExtensionAutoConstraintHintVisible(bestHint.start, bestHint.end)) {
+        return;
+    }
+
+    suggestedConstraints.push_back(bestConstraint);
+    lineExtensionAutoConstraintHint = bestHint;
+}
+
 bool DrawSketchHandler::updateTangentAutoConstraintHint()
 {
     resetTangentAutoConstraintHint();
@@ -1262,6 +1333,7 @@ int DrawSketchHandler::seekAutoConstraint(
 
     seekPreselectionAutoConstraint(suggestedConstraints, Pos, Dir, type);
     seekLineExtensionAutoConstraint(suggestedConstraints, Pos, type);
+    seekPointAlignmentAutoConstraint(suggestedConstraints, Pos, type);
 
     if (Dir.Length() > 1e-8 && type != AutoConstraint::CURVE) {
         bool tangentCreated = false;
@@ -1376,7 +1448,16 @@ bool DrawSketchHandler::generateOneAutoConstraintFromSuggestion(
         case Sketcher::Vertical: {
             auto c = std::make_unique<Sketcher::Constraint>();
             c->Type = ac.Type;
-            c->First = (geoId2 != Sketcher::GeoEnum::GeoUndef ? geoId2 : geoId1);
+            if (posId1 != Sketcher::PointPos::none && posId2 != Sketcher::PointPos::none
+                && geoId2 != Sketcher::GeoEnum::GeoUndef) {
+                c->First = geoId1;
+                c->FirstPos = posId1;
+                c->Second = geoId2;
+                c->SecondPos = posId2;
+            }
+            else {
+                c->First = (geoId2 != Sketcher::GeoEnum::GeoUndef ? geoId2 : geoId1);
+            }
             autoConstraints.push_back(std::move(c));
         } break;
         case Sketcher::Perpendicular: {
@@ -1648,18 +1729,44 @@ void DrawSketchHandler::createAutoConstraints(
                 // case the caller as to set geoId2, then it will be used as target instead of
                 // geoId2
             case Sketcher::Horizontal: {
-                Gui::cmdAppObjectArgs(
-                    sketchgui->getObject(),
-                    "addConstraint(Sketcher.Constraint('Horizontal',%d)) ",
-                    geoId2 != GeoEnum::GeoUndef ? geoId2 : geoId1
-                );
+                if (posId1 != Sketcher::PointPos::none && cstr.PosId != Sketcher::PointPos::none
+                    && geoId2 != GeoEnum::GeoUndef) {
+                    Gui::cmdAppObjectArgs(
+                        sketchgui->getObject(),
+                        "addConstraint(Sketcher.Constraint('Horizontal',%d,%d,%d,%d)) ",
+                        geoId1,
+                        static_cast<int>(posId1),
+                        geoId2,
+                        static_cast<int>(cstr.PosId)
+                    );
+                }
+                else {
+                    Gui::cmdAppObjectArgs(
+                        sketchgui->getObject(),
+                        "addConstraint(Sketcher.Constraint('Horizontal',%d)) ",
+                        geoId2 != GeoEnum::GeoUndef ? geoId2 : geoId1
+                    );
+                }
             } break;
             case Sketcher::Vertical: {
-                Gui::cmdAppObjectArgs(
-                    sketchgui->getObject(),
-                    "addConstraint(Sketcher.Constraint('Vertical',%d)) ",
-                    geoId2 != GeoEnum::GeoUndef ? geoId2 : geoId1
-                );
+                if (posId1 != Sketcher::PointPos::none && cstr.PosId != Sketcher::PointPos::none
+                    && geoId2 != GeoEnum::GeoUndef) {
+                    Gui::cmdAppObjectArgs(
+                        sketchgui->getObject(),
+                        "addConstraint(Sketcher.Constraint('Vertical',%d,%d,%d,%d)) ",
+                        geoId1,
+                        static_cast<int>(posId1),
+                        geoId2,
+                        static_cast<int>(cstr.PosId)
+                    );
+                }
+                else {
+                    Gui::cmdAppObjectArgs(
+                        sketchgui->getObject(),
+                        "addConstraint(Sketcher.Constraint('Vertical',%d)) ",
+                        geoId2 != GeoEnum::GeoUndef ? geoId2 : geoId1
+                    );
+                }
             } break;
             case Sketcher::Perpendicular: {
                 Gui::cmdAppObjectArgs(

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -399,6 +399,11 @@ protected:
         const Base::Vector2d& Pos,
         AutoConstraint::TargetType type
     );
+    void seekPointAlignmentAutoConstraint(
+        std::vector<AutoConstraint>& constraints,
+        const Base::Vector2d& Pos,
+        AutoConstraint::TargetType type
+    );
 
     void resetLineExtensionAutoConstraintHint();
     void renderLineExtensionAutoConstraintHint() const;


### PR DESCRIPTION
#30332 Extending the PR to provide horizontal and vertical auto-constraints for points. Previously, this could only be done with constraint tools; now it's added as an auto-constraint. This feature is available in all other CAD programs. I did it entirely myself, but since I wasn't sure, I asked GPT 5 how it's done.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/a7e9386c-60ce-46bb-8418-c35311ade640



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
