### PR TITLE
CAM: Add mtconnect import to machine editor

### DIFF
--- a/src/Mod/CAM/CAMTests/Fixtures/mtconnect/probe_foreign_vendor.xml
+++ b/src/Mod/CAM/CAMTests/Fixtures/mtconnect/probe_foreign_vendor.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Hand-written fixture modeled on a generic third-party (non-LinuxCNC)
+     MTConnect agent: older schema version, no vendor extension block,
+     suffixed axis names, INCH units, spindle identified only by its
+     ROTARY_VELOCITY data, and a per-axis VELOCITY specification. -->
+<MTConnectDevices xmlns="urn:mtconnect.org:MTConnectDevices:1.3">
+  <Header creationTime="2026-08-19T00:00:00Z" sender="vendor-agent" instanceId="1" version="1.3" assetCount="0" bufferSize="131072"/>
+  <Devices>
+    <Device id="d1" name="VMC-24" uuid="vendor-vmc24-001">
+      <Description manufacturer="Example Machine Works">24in vertical machining center</Description>
+      <DataItems>
+        <DataItem category="EVENT" type="AVAILABILITY" id="avail"/>
+      </DataItems>
+      <Components>
+        <Axes id="ax" name="base">
+          <Components>
+            <Linear id="x1" name="X1">
+              <Configuration>
+                <Specifications>
+                  <Specification id="x1_travel" type="POSITION" units="INCH" name="X travel">
+                    <Maximum>24</Maximum>
+                    <Minimum>0</Minimum>
+                  </Specification>
+                  <Specification id="x1_vel" type="VELOCITY" units="INCH/SECOND" name="X velocity">
+                    <Maximum>10</Maximum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="POSITION" id="xp" subType="ACTUAL" units="MILLIMETER"/>
+              </DataItems>
+            </Linear>
+            <Linear id="y1" name="Y1">
+              <Configuration>
+                <Specifications>
+                  <Specification id="y1_travel" type="POSITION" units="INCH" name="Y travel">
+                    <Maximum>16</Maximum>
+                    <Minimum>0</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="POSITION" id="yp" subType="ACTUAL" units="MILLIMETER"/>
+              </DataItems>
+            </Linear>
+            <Linear id="z1" name="Z1">
+              <Configuration>
+                <Specifications>
+                  <Specification id="z1_travel" type="POSITION" units="INCH" name="Z travel">
+                    <Maximum>20</Maximum>
+                    <Minimum>0</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="POSITION" id="zp" subType="ACTUAL" units="MILLIMETER"/>
+              </DataItems>
+            </Linear>
+            <Rotary id="sp" name="SPDL">
+              <Configuration>
+                <Specifications>
+                  <Specification id="sp_speed" type="ROTARY_VELOCITY" units="REVOLUTION/MINUTE" name="spindle speed">
+                    <Maximum>8100</Maximum>
+                    <Minimum>100</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="ROTARY_VELOCITY" id="ss" subType="ACTUAL" units="REVOLUTION/MINUTE"/>
+              </DataItems>
+            </Rotary>
+          </Components>
+        </Axes>
+      </Components>
+    </Device>
+  </Devices>
+</MTConnectDevices>

--- a/src/Mod/CAM/CAMTests/Fixtures/mtconnect/probe_multi_device.xml
+++ b/src/Mod/CAM/CAMTests/Fixtures/mtconnect/probe_multi_device.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Hand-written fixture: an agent hosting two machine devices plus its own
+     Agent self-description, to exercise device listing and selection. -->
+<MTConnectDevices xmlns="urn:mtconnect.org:MTConnectDevices:1.7">
+  <Header creationTime="2026-08-19T00:00:00Z" sender="shop-agent" instanceId="1" version="1.7" assetCount="0" bufferSize="131072"/>
+  <Devices>
+    <Agent id="agent1" name="shop_agent" uuid="shop_agent" mtconnectVersion="1.7">
+      <DataItems>
+        <DataItem category="EVENT" type="AVAILABILITY" id="agent_avail"/>
+      </DataItems>
+    </Agent>
+    <Device id="d1" name="mill-1" uuid="mill-1-uuid">
+      <Description manufacturer="Example Machine Works"/>
+      <DataItems>
+        <DataItem category="EVENT" type="AVAILABILITY" id="m1_avail"/>
+      </DataItems>
+      <Components>
+        <Axes id="m1_ax" name="base">
+          <Components>
+            <Linear id="m1_x" name="X">
+              <Configuration>
+                <Specifications>
+                  <Specification id="m1_x_travel" type="POSITION" units="MILLIMETER" name="X travel">
+                    <Maximum>500</Maximum>
+                    <Minimum>0</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="POSITION" id="m1_xp" subType="ACTUAL" units="MILLIMETER"/>
+              </DataItems>
+            </Linear>
+          </Components>
+        </Axes>
+      </Components>
+    </Device>
+    <Device id="d2" name="mill-2" uuid="mill-2-uuid">
+      <Description manufacturer="Example Machine Works"/>
+      <DataItems>
+        <DataItem category="EVENT" type="AVAILABILITY" id="m2_avail"/>
+      </DataItems>
+      <Components>
+        <Axes id="m2_ax" name="base">
+          <Components>
+            <Linear id="m2_x" name="X">
+              <Configuration>
+                <Specifications>
+                  <Specification id="m2_x_travel" type="POSITION" units="MILLIMETER" name="X travel">
+                    <Maximum>800</Maximum>
+                    <Minimum>0</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="POSITION" id="m2_xp" subType="ACTUAL" units="MILLIMETER"/>
+              </DataItems>
+            </Linear>
+          </Components>
+        </Axes>
+      </Components>
+    </Device>
+  </Devices>
+</MTConnectDevices>

--- a/src/Mod/CAM/CAMTests/Fixtures/mtconnect/probe_xyz_inch.xml
+++ b/src/Mod/CAM/CAMTests/Fixtures/mtconnect/probe_xyz_inch.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MTConnectDevices xmlns="urn:mtconnect.org:MTConnectDevices:1.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:x="urn:linuxcnc:mtconnect:1" xsi:schemaLocation="urn:mtconnect.org:MTConnectDevices:1.7 http://schemas.mtconnect.org/schemas/MTConnectDevices_1.7.xsd">
+  <Header creationTime="1970-01-01T00:00:00Z" sender="linuxcnc-mtconnect" instanceId="1" version="1.7" deviceModelChangeTime="1970-01-01T00:00:00Z" assetCount="0" assetBufferSize="1024" bufferSize="131072" />
+  <Devices>
+    <Agent id="agent_LinuxCNC-HAL-SIM-AXIS" name="LinuxCNC-HAL-SIM-AXIS_agent" uuid="linuxcnc-0001_agent" mtconnectVersion="1.7">
+      <Description manufacturer="LinuxCNC">LinuxCNC MTConnect agent</Description>
+      <DataItems>
+        <DataItem category="EVENT" type="AVAILABILITY" id="agent_avail" />
+        <DataItem category="EVENT" type="DEVICE_ADDED" id="agent_device_added" />
+        <DataItem category="EVENT" type="DEVICE_REMOVED" id="agent_device_removed" />
+        <DataItem category="EVENT" type="DEVICE_CHANGED" id="agent_device_changed" />
+      </DataItems>
+    </Agent>
+    <Device id="dev_LinuxCNC-HAL-SIM-AXIS" name="LinuxCNC-HAL-SIM-AXIS" uuid="linuxcnc-0001">
+      <Description manufacturer="LinuxCNC">
+        <x:Kinematics module="trivkins" coordinates="XYZ" joints="3" linearUnits="MILLIMETER" nativeLinearUnits="INCH">
+          <x:JointMap>
+            <x:Joint number="0" kind="LINEAR" axis="X" min="-254" max="254" home="0" homeOffset="0" />
+            <x:Joint number="1" kind="LINEAR" axis="Y" min="-254" max="254" home="0" homeOffset="0" />
+            <x:Joint number="2" kind="LINEAR" axis="Z" min="-203.2" max="3.048" home="0" homeOffset="25.4" />
+          </x:JointMap>
+          <x:Axis name="X" kind="LINEAR" vector="1 0 0" min="-254" max="254" />
+          <x:Axis name="Y" kind="LINEAR" vector="0 1 0" min="-254" max="254" />
+          <x:Axis name="Z" kind="LINEAR" vector="0 0 1" min="-203.2" max="3.048" />
+        </x:Kinematics>
+      </Description>
+      <Configuration>
+        <CoordinateSystems>
+          <CoordinateSystem id="world" type="WORLD" name="world" />
+          <CoordinateSystem id="machine" type="MACHINE" name="machine" parentIdRef="world">
+            <Origin>0 0 0</Origin>
+          </CoordinateSystem>
+        </CoordinateSystems>
+      </Configuration>
+      <DataItems>
+        <DataItem category="EVENT" type="AVAILABILITY" id="avail" />
+        <DataItem category="EVENT" type="ASSET_CHANGED" id="assetchg" />
+        <DataItem category="EVENT" type="ASSET_REMOVED" id="assetrm" />
+      </DataItems>
+      <Components>
+        <Controller id="ctrl" name="controller">
+          <DataItems>
+            <DataItem category="EVENT" type="EMERGENCY_STOP" id="estop" />
+            <DataItem category="EVENT" type="CONTROLLER_MODE" id="mode" />
+          </DataItems>
+          <Components>
+            <Path id="path" name="path">
+              <DataItems>
+                <DataItem category="EVENT" type="EXECUTION" id="execution" />
+                <DataItem category="EVENT" type="PROGRAM" id="program" />
+                <DataItem category="EVENT" type="LINE_NUMBER" id="line" subType="ACTUAL" />
+                <DataItem category="SAMPLE" type="PATH_FEEDRATE" id="pathfeed" units="MILLIMETER/SECOND" nativeUnits="INCH/SECOND" />
+                <DataItem category="SAMPLE" type="PATH_FEEDRATE" id="feedovr" subType="OVERRIDE" units="PERCENT" />
+                <DataItem category="EVENT" type="TOOL_NUMBER" id="toolnum" />
+                <DataItem category="EVENT" type="TOOL_ASSET_ID" id="toolasset" />
+                <DataItem category="EVENT" type="WORK_OFFSET" id="workoffset" representation="TABLE" />
+                <DataItem category="EVENT" type="TOOL_OFFSET" id="tooloffset" representation="TABLE" />
+                <DataItem category="SAMPLE" type="x:COORDINATE_ROTATION" id="xyrotation" units="DEGREE" />
+              </DataItems>
+            </Path>
+          </Components>
+        </Controller>
+        <Axes id="axes" name="axes">
+          <Components>
+            <Linear id="axis_x" name="X">
+              <Configuration>
+                <Motion id="motion_x" type="PRISMATIC" actuation="DIRECT" coordinateSystemIdRef="machine">
+                  <Axis>1 0 0</Axis>
+                </Motion>
+                <Specifications>
+                  <Specification id="axis_x_travel" type="POSITION" units="MILLIMETER" name="X travel">
+                    <Maximum>254</Maximum>
+                    <Minimum>-254</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="POSITION" id="pos_x" subType="ACTUAL" units="MILLIMETER" nativeUnits="INCH" />
+                <DataItem category="SAMPLE" type="POSITION" id="poscmd_x" subType="COMMANDED" units="MILLIMETER" nativeUnits="INCH" />
+              </DataItems>
+            </Linear>
+            <Linear id="axis_y" name="Y">
+              <Configuration>
+                <Motion id="motion_y" type="PRISMATIC" actuation="DIRECT" coordinateSystemIdRef="machine">
+                  <Axis>0 1 0</Axis>
+                </Motion>
+                <Specifications>
+                  <Specification id="axis_y_travel" type="POSITION" units="MILLIMETER" name="Y travel">
+                    <Maximum>254</Maximum>
+                    <Minimum>-254</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="POSITION" id="pos_y" subType="ACTUAL" units="MILLIMETER" nativeUnits="INCH" />
+                <DataItem category="SAMPLE" type="POSITION" id="poscmd_y" subType="COMMANDED" units="MILLIMETER" nativeUnits="INCH" />
+              </DataItems>
+            </Linear>
+            <Linear id="axis_z" name="Z">
+              <Configuration>
+                <Motion id="motion_z" type="PRISMATIC" actuation="DIRECT" coordinateSystemIdRef="machine">
+                  <Axis>0 0 1</Axis>
+                </Motion>
+                <Specifications>
+                  <Specification id="axis_z_travel" type="POSITION" units="MILLIMETER" name="Z travel">
+                    <Maximum>3.048</Maximum>
+                    <Minimum>-203.2</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="POSITION" id="pos_z" subType="ACTUAL" units="MILLIMETER" nativeUnits="INCH" />
+                <DataItem category="SAMPLE" type="POSITION" id="poscmd_z" subType="COMMANDED" units="MILLIMETER" nativeUnits="INCH" />
+              </DataItems>
+            </Linear>
+            <Rotary id="spindle" name="S">
+              <DataItems>
+                <DataItem category="SAMPLE" type="ROTARY_VELOCITY" id="spdl_speed" subType="ACTUAL" units="REVOLUTION/MINUTE" />
+                <DataItem category="SAMPLE" type="ROTARY_VELOCITY" id="spdl_speed_cmd" subType="COMMANDED" units="REVOLUTION/MINUTE" />
+                <DataItem category="EVENT" type="ROTARY_MODE" id="spdl_mode" />
+                <DataItem category="EVENT" type="DIRECTION" id="spdl_dir" subType="ROTARY" />
+              </DataItems>
+            </Rotary>
+          </Components>
+        </Axes>
+        <Systems id="systems" name="systems">
+          <Components>
+            <Coolant id="coolant" name="coolant">
+              <DataItems>
+                <DataItem category="EVENT" type="x:FLOOD" id="coolant_flood" />
+                <DataItem category="EVENT" type="x:MIST" id="coolant_mist" />
+              </DataItems>
+            </Coolant>
+          </Components>
+        </Systems>
+      </Components>
+    </Device>
+  </Devices>
+</MTConnectDevices>

--- a/src/Mod/CAM/CAMTests/Fixtures/mtconnect/probe_xyz_mm.xml
+++ b/src/Mod/CAM/CAMTests/Fixtures/mtconnect/probe_xyz_mm.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MTConnectDevices xmlns="urn:mtconnect.org:MTConnectDevices:1.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:x="urn:linuxcnc:mtconnect:1" xsi:schemaLocation="urn:mtconnect.org:MTConnectDevices:1.7 http://schemas.mtconnect.org/schemas/MTConnectDevices_1.7.xsd">
+  <Header creationTime="1970-01-01T00:00:00Z" sender="linuxcnc-mtconnect" instanceId="1" version="1.7" deviceModelChangeTime="1970-01-01T00:00:00Z" assetCount="0" assetBufferSize="1024" bufferSize="131072" />
+  <Devices>
+    <Agent id="agent_LinuxCNC-HAL-SIM-AXIS" name="LinuxCNC-HAL-SIM-AXIS_agent" uuid="linuxcnc-0001_agent" mtconnectVersion="1.7">
+      <Description manufacturer="LinuxCNC">LinuxCNC MTConnect agent</Description>
+      <DataItems>
+        <DataItem category="EVENT" type="AVAILABILITY" id="agent_avail" />
+        <DataItem category="EVENT" type="DEVICE_ADDED" id="agent_device_added" />
+        <DataItem category="EVENT" type="DEVICE_REMOVED" id="agent_device_removed" />
+        <DataItem category="EVENT" type="DEVICE_CHANGED" id="agent_device_changed" />
+      </DataItems>
+    </Agent>
+    <Device id="dev_LinuxCNC-HAL-SIM-AXIS" name="LinuxCNC-HAL-SIM-AXIS" uuid="linuxcnc-0001">
+      <Description manufacturer="LinuxCNC">
+        <x:Kinematics module="trivkins" coordinates="XYZ" joints="3" linearUnits="MILLIMETER" nativeLinearUnits="MILLIMETER">
+          <x:JointMap>
+            <x:Joint number="0" kind="LINEAR" axis="X" min="-254" max="254" home="0" homeOffset="0" />
+            <x:Joint number="1" kind="LINEAR" axis="Y" min="-254" max="254" home="0" homeOffset="0" />
+            <x:Joint number="2" kind="LINEAR" axis="Z" min="-50.8" max="101.6" home="0" homeOffset="25.4" />
+          </x:JointMap>
+          <x:Axis name="X" kind="LINEAR" vector="1 0 0" min="-254" max="254" />
+          <x:Axis name="Y" kind="LINEAR" vector="0 1 0" min="-254" max="254" />
+          <x:Axis name="Z" kind="LINEAR" vector="0 0 1" min="-50.8" max="101.6" />
+        </x:Kinematics>
+      </Description>
+      <Configuration>
+        <CoordinateSystems>
+          <CoordinateSystem id="world" type="WORLD" name="world" />
+          <CoordinateSystem id="machine" type="MACHINE" name="machine" parentIdRef="world">
+            <Origin>0 0 0</Origin>
+          </CoordinateSystem>
+        </CoordinateSystems>
+      </Configuration>
+      <DataItems>
+        <DataItem category="EVENT" type="AVAILABILITY" id="avail" />
+        <DataItem category="EVENT" type="ASSET_CHANGED" id="assetchg" />
+        <DataItem category="EVENT" type="ASSET_REMOVED" id="assetrm" />
+      </DataItems>
+      <Components>
+        <Controller id="ctrl" name="controller">
+          <DataItems>
+            <DataItem category="EVENT" type="EMERGENCY_STOP" id="estop" />
+            <DataItem category="EVENT" type="CONTROLLER_MODE" id="mode" />
+          </DataItems>
+          <Components>
+            <Path id="path" name="path">
+              <DataItems>
+                <DataItem category="EVENT" type="EXECUTION" id="execution" />
+                <DataItem category="EVENT" type="PROGRAM" id="program" />
+                <DataItem category="EVENT" type="LINE_NUMBER" id="line" subType="ACTUAL" />
+                <DataItem category="SAMPLE" type="PATH_FEEDRATE" id="pathfeed" units="MILLIMETER/SECOND" />
+                <DataItem category="SAMPLE" type="PATH_FEEDRATE" id="feedovr" subType="OVERRIDE" units="PERCENT" />
+                <DataItem category="EVENT" type="TOOL_NUMBER" id="toolnum" />
+                <DataItem category="EVENT" type="TOOL_ASSET_ID" id="toolasset" />
+                <DataItem category="EVENT" type="WORK_OFFSET" id="workoffset" representation="TABLE" />
+                <DataItem category="EVENT" type="TOOL_OFFSET" id="tooloffset" representation="TABLE" />
+                <DataItem category="SAMPLE" type="x:COORDINATE_ROTATION" id="xyrotation" units="DEGREE" />
+              </DataItems>
+            </Path>
+          </Components>
+        </Controller>
+        <Axes id="axes" name="axes">
+          <Components>
+            <Linear id="axis_x" name="X">
+              <Configuration>
+                <Motion id="motion_x" type="PRISMATIC" actuation="DIRECT" coordinateSystemIdRef="machine">
+                  <Axis>1 0 0</Axis>
+                </Motion>
+                <Specifications>
+                  <Specification id="axis_x_travel" type="POSITION" units="MILLIMETER" name="X travel">
+                    <Maximum>254</Maximum>
+                    <Minimum>-254</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="POSITION" id="pos_x" subType="ACTUAL" units="MILLIMETER" />
+                <DataItem category="SAMPLE" type="POSITION" id="poscmd_x" subType="COMMANDED" units="MILLIMETER" />
+              </DataItems>
+            </Linear>
+            <Linear id="axis_y" name="Y">
+              <Configuration>
+                <Motion id="motion_y" type="PRISMATIC" actuation="DIRECT" coordinateSystemIdRef="machine">
+                  <Axis>0 1 0</Axis>
+                </Motion>
+                <Specifications>
+                  <Specification id="axis_y_travel" type="POSITION" units="MILLIMETER" name="Y travel">
+                    <Maximum>254</Maximum>
+                    <Minimum>-254</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="POSITION" id="pos_y" subType="ACTUAL" units="MILLIMETER" />
+                <DataItem category="SAMPLE" type="POSITION" id="poscmd_y" subType="COMMANDED" units="MILLIMETER" />
+              </DataItems>
+            </Linear>
+            <Linear id="axis_z" name="Z">
+              <Configuration>
+                <Motion id="motion_z" type="PRISMATIC" actuation="DIRECT" coordinateSystemIdRef="machine">
+                  <Axis>0 0 1</Axis>
+                </Motion>
+                <Specifications>
+                  <Specification id="axis_z_travel" type="POSITION" units="MILLIMETER" name="Z travel">
+                    <Maximum>101.6</Maximum>
+                    <Minimum>-50.8</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="POSITION" id="pos_z" subType="ACTUAL" units="MILLIMETER" />
+                <DataItem category="SAMPLE" type="POSITION" id="poscmd_z" subType="COMMANDED" units="MILLIMETER" />
+              </DataItems>
+            </Linear>
+            <Rotary id="spindle" name="S">
+              <DataItems>
+                <DataItem category="SAMPLE" type="ROTARY_VELOCITY" id="spdl_speed" subType="ACTUAL" units="REVOLUTION/MINUTE" />
+                <DataItem category="SAMPLE" type="ROTARY_VELOCITY" id="spdl_speed_cmd" subType="COMMANDED" units="REVOLUTION/MINUTE" />
+                <DataItem category="EVENT" type="ROTARY_MODE" id="spdl_mode" />
+                <DataItem category="EVENT" type="DIRECTION" id="spdl_dir" subType="ROTARY" />
+              </DataItems>
+            </Rotary>
+          </Components>
+        </Axes>
+        <Systems id="systems" name="systems">
+          <Components>
+            <Coolant id="coolant" name="coolant">
+              <DataItems>
+                <DataItem category="EVENT" type="x:FLOOD" id="coolant_flood" />
+                <DataItem category="EVENT" type="x:MIST" id="coolant_mist" />
+              </DataItems>
+            </Coolant>
+          </Components>
+        </Systems>
+      </Components>
+    </Device>
+  </Devices>
+</MTConnectDevices>

--- a/src/Mod/CAM/CAMTests/Fixtures/mtconnect/probe_xyzac_trt.xml
+++ b/src/Mod/CAM/CAMTests/Fixtures/mtconnect/probe_xyzac_trt.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MTConnectDevices xmlns="urn:mtconnect.org:MTConnectDevices:1.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:x="urn:linuxcnc:mtconnect:1" xsi:schemaLocation="urn:mtconnect.org:MTConnectDevices:1.7 http://schemas.mtconnect.org/schemas/MTConnectDevices_1.7.xsd">
+  <Header creationTime="1970-01-01T00:00:00Z" sender="linuxcnc-mtconnect" instanceId="1" version="1.7" deviceModelChangeTime="1970-01-01T00:00:00Z" assetCount="0" assetBufferSize="1024" bufferSize="131072" />
+  <Devices>
+    <Agent id="agent_sim-xyzac-trt-kins__switchkins_" name="sim-xyzac-trt-kins (switchkins)_agent" uuid="linuxcnc-0001_agent" mtconnectVersion="1.7">
+      <Description manufacturer="LinuxCNC">LinuxCNC MTConnect agent</Description>
+      <DataItems>
+        <DataItem category="EVENT" type="AVAILABILITY" id="agent_avail" />
+        <DataItem category="EVENT" type="DEVICE_ADDED" id="agent_device_added" />
+        <DataItem category="EVENT" type="DEVICE_REMOVED" id="agent_device_removed" />
+        <DataItem category="EVENT" type="DEVICE_CHANGED" id="agent_device_changed" />
+      </DataItems>
+    </Agent>
+    <Device id="dev_sim-xyzac-trt-kins__switchkins_" name="sim-xyzac-trt-kins (switchkins)" uuid="linuxcnc-0001">
+      <Description manufacturer="LinuxCNC">
+        <x:Kinematics module="xyzac-trt-kins" coordinates="XYZAC" joints="5" linearUnits="MILLIMETER" nativeLinearUnits="MILLIMETER" params="sparm=identityfirst">
+          <x:JointMap>
+            <x:Joint number="0" kind="LINEAR" axis="X" min="-200" max="200" home="0" />
+            <x:Joint number="1" kind="LINEAR" axis="Y" min="-100" max="100" home="0" />
+            <x:Joint number="2" kind="LINEAR" axis="Z" min="-120" max="120" home="0" />
+            <x:Joint number="3" kind="ANGULAR" axis="A" min="-100" max="50" home="0" />
+            <x:Joint number="4" kind="ANGULAR" axis="C" min="-36000" max="36000" home="0" />
+          </x:JointMap>
+          <x:Axis name="X" kind="LINEAR" vector="1 0 0" min="-200" max="200" />
+          <x:Axis name="Y" kind="LINEAR" vector="0 1 0" min="-100" max="100" />
+          <x:Axis name="Z" kind="LINEAR" vector="0 0 1" min="-120" max="120" />
+          <x:Axis name="A" kind="ANGULAR" vector="1 0 0" min="-100" max="50" />
+          <x:Axis name="C" kind="ANGULAR" vector="0 0 1" min="-36000" max="36000" />
+        </x:Kinematics>
+      </Description>
+      <Configuration>
+        <CoordinateSystems>
+          <CoordinateSystem id="world" type="WORLD" name="world" />
+          <CoordinateSystem id="machine" type="MACHINE" name="machine" parentIdRef="world">
+            <Origin>0 0 0</Origin>
+          </CoordinateSystem>
+        </CoordinateSystems>
+      </Configuration>
+      <DataItems>
+        <DataItem category="EVENT" type="AVAILABILITY" id="avail" />
+        <DataItem category="EVENT" type="ASSET_CHANGED" id="assetchg" />
+        <DataItem category="EVENT" type="ASSET_REMOVED" id="assetrm" />
+      </DataItems>
+      <Components>
+        <Controller id="ctrl" name="controller">
+          <DataItems>
+            <DataItem category="EVENT" type="EMERGENCY_STOP" id="estop" />
+            <DataItem category="EVENT" type="CONTROLLER_MODE" id="mode" />
+          </DataItems>
+          <Components>
+            <Path id="path" name="path">
+              <DataItems>
+                <DataItem category="EVENT" type="EXECUTION" id="execution" />
+                <DataItem category="EVENT" type="PROGRAM" id="program" />
+                <DataItem category="EVENT" type="LINE_NUMBER" id="line" subType="ACTUAL" />
+                <DataItem category="SAMPLE" type="PATH_FEEDRATE" id="pathfeed" units="MILLIMETER/SECOND" />
+                <DataItem category="SAMPLE" type="PATH_FEEDRATE" id="feedovr" subType="OVERRIDE" units="PERCENT" />
+                <DataItem category="EVENT" type="TOOL_NUMBER" id="toolnum" />
+                <DataItem category="EVENT" type="TOOL_ASSET_ID" id="toolasset" />
+                <DataItem category="EVENT" type="WORK_OFFSET" id="workoffset" representation="TABLE" />
+                <DataItem category="EVENT" type="TOOL_OFFSET" id="tooloffset" representation="TABLE" />
+                <DataItem category="SAMPLE" type="x:COORDINATE_ROTATION" id="xyrotation" units="DEGREE" />
+              </DataItems>
+            </Path>
+          </Components>
+        </Controller>
+        <Axes id="axes" name="axes">
+          <Components>
+            <Linear id="axis_x" name="X">
+              <Configuration>
+                <Motion id="motion_x" type="PRISMATIC" actuation="DIRECT" coordinateSystemIdRef="machine">
+                  <Axis>1 0 0</Axis>
+                </Motion>
+                <Specifications>
+                  <Specification id="axis_x_travel" type="POSITION" units="MILLIMETER" name="X travel">
+                    <Maximum>200</Maximum>
+                    <Minimum>-200</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="POSITION" id="pos_x" subType="ACTUAL" units="MILLIMETER" />
+                <DataItem category="SAMPLE" type="POSITION" id="poscmd_x" subType="COMMANDED" units="MILLIMETER" />
+              </DataItems>
+            </Linear>
+            <Linear id="axis_y" name="Y">
+              <Configuration>
+                <Motion id="motion_y" type="PRISMATIC" actuation="DIRECT" coordinateSystemIdRef="machine">
+                  <Axis>0 1 0</Axis>
+                </Motion>
+                <Specifications>
+                  <Specification id="axis_y_travel" type="POSITION" units="MILLIMETER" name="Y travel">
+                    <Maximum>100</Maximum>
+                    <Minimum>-100</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="POSITION" id="pos_y" subType="ACTUAL" units="MILLIMETER" />
+                <DataItem category="SAMPLE" type="POSITION" id="poscmd_y" subType="COMMANDED" units="MILLIMETER" />
+              </DataItems>
+            </Linear>
+            <Linear id="axis_z" name="Z">
+              <Configuration>
+                <Motion id="motion_z" type="PRISMATIC" actuation="DIRECT" coordinateSystemIdRef="machine">
+                  <Axis>0 0 1</Axis>
+                </Motion>
+                <Specifications>
+                  <Specification id="axis_z_travel" type="POSITION" units="MILLIMETER" name="Z travel">
+                    <Maximum>120</Maximum>
+                    <Minimum>-120</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="POSITION" id="pos_z" subType="ACTUAL" units="MILLIMETER" />
+                <DataItem category="SAMPLE" type="POSITION" id="poscmd_z" subType="COMMANDED" units="MILLIMETER" />
+              </DataItems>
+            </Linear>
+            <Rotary id="axis_a" name="A">
+              <Configuration>
+                <Motion id="motion_a" type="REVOLUTE" actuation="DIRECT" coordinateSystemIdRef="machine">
+                  <Axis>1 0 0</Axis>
+                </Motion>
+                <Specifications>
+                  <Specification id="axis_a_travel" type="ANGLE" units="DEGREE" name="A travel">
+                    <Maximum>50</Maximum>
+                    <Minimum>-100</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="ANGLE" id="pos_a" subType="ACTUAL" units="DEGREE" />
+                <DataItem category="SAMPLE" type="ANGLE" id="poscmd_a" subType="COMMANDED" units="DEGREE" />
+              </DataItems>
+            </Rotary>
+            <Rotary id="axis_c" name="C">
+              <Configuration>
+                <Motion id="motion_c" type="REVOLUTE" actuation="DIRECT" coordinateSystemIdRef="machine">
+                  <Axis>0 0 1</Axis>
+                </Motion>
+                <Specifications>
+                  <Specification id="axis_c_travel" type="ANGLE" units="DEGREE" name="C travel">
+                    <Maximum>36000</Maximum>
+                    <Minimum>-36000</Minimum>
+                  </Specification>
+                </Specifications>
+              </Configuration>
+              <DataItems>
+                <DataItem category="SAMPLE" type="ANGLE" id="pos_c" subType="ACTUAL" units="DEGREE" />
+                <DataItem category="SAMPLE" type="ANGLE" id="poscmd_c" subType="COMMANDED" units="DEGREE" />
+              </DataItems>
+            </Rotary>
+            <Rotary id="spindle" name="S">
+              <DataItems>
+                <DataItem category="SAMPLE" type="ROTARY_VELOCITY" id="spdl_speed" subType="ACTUAL" units="REVOLUTION/MINUTE" />
+                <DataItem category="SAMPLE" type="ROTARY_VELOCITY" id="spdl_speed_cmd" subType="COMMANDED" units="REVOLUTION/MINUTE" />
+                <DataItem category="EVENT" type="ROTARY_MODE" id="spdl_mode" />
+                <DataItem category="EVENT" type="DIRECTION" id="spdl_dir" subType="ROTARY" />
+              </DataItems>
+            </Rotary>
+          </Components>
+        </Axes>
+        <Systems id="systems" name="systems">
+          <Components>
+            <Coolant id="coolant" name="coolant">
+              <DataItems>
+                <DataItem category="EVENT" type="x:FLOOD" id="coolant_flood" />
+                <DataItem category="EVENT" type="x:MIST" id="coolant_mist" />
+              </DataItems>
+            </Coolant>
+          </Components>
+        </Systems>
+      </Components>
+    </Device>
+  </Devices>
+</MTConnectDevices>

--- a/src/Mod/CAM/CAMTests/TestMachineMTConnectImport.py
+++ b/src/Mod/CAM/CAMTests/TestMachineMTConnectImport.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.               #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses      #
+#                                                                              #
+################################################################################
+
+"""Tests for building a Machine from an MTConnect probe document.
+
+The LinuxCNC fixtures (probe_xyz_mm.xml, probe_xyz_inch.xml,
+probe_xyzac_trt.xml) were generated with `python3 -m mtc.device_model` from
+LinuxCNC sim configurations and include the LinuxCNC vendor extension block,
+which the generic importer must ignore.  probe_foreign_vendor.xml and
+probe_multi_device.xml are hand-written to model third-party agents.
+"""
+
+import pathlib
+import unittest
+
+from Machine.models.machine import AxisRole, Machine
+from Machine.models.mtconnect_import import (
+    ProbeParseError,
+    list_devices,
+    machine_from_probe,
+)
+
+FIXTURE_DIR = pathlib.Path(__file__).parent / "Fixtures" / "mtconnect"
+
+
+def fixture(name):
+    return (FIXTURE_DIR / name).read_text(encoding="utf-8")
+
+
+class TestProbeParsing(unittest.TestCase):
+    def test_rejects_malformed_xml(self):
+        with self.assertRaises(ProbeParseError):
+            machine_from_probe("<not-even-xml")
+
+    def test_rejects_non_probe_document(self):
+        with self.assertRaises(ProbeParseError):
+            machine_from_probe("<SomeOtherDocument/>")
+
+    def test_rejects_probe_without_devices(self):
+        xml = '<MTConnectDevices xmlns="urn:mtconnect.org:MTConnectDevices:1.7"><Devices/></MTConnectDevices>'
+        with self.assertRaises(ProbeParseError):
+            machine_from_probe(xml)
+
+
+class TestDeviceSelection(unittest.TestCase):
+    def test_list_devices_excludes_agent(self):
+        devices = list_devices(fixture("probe_multi_device.xml"))
+        self.assertEqual([d["name"] for d in devices], ["mill-1", "mill-2"])
+
+    def test_multiple_devices_require_a_name(self):
+        with self.assertRaises(ProbeParseError):
+            machine_from_probe(fixture("probe_multi_device.xml"))
+
+    def test_select_device_by_name(self):
+        machine, _ = machine_from_probe(fixture("probe_multi_device.xml"), device_name="mill-2")
+        self.assertEqual(machine.name, "mill-2")
+        self.assertEqual(machine.linear_axes["X"].max_limit, 800)
+
+    def test_unknown_device_name(self):
+        with self.assertRaises(ProbeParseError):
+            machine_from_probe(fixture("probe_multi_device.xml"), device_name="lathe-9")
+
+
+class TestLinuxCNC3Axis(unittest.TestCase):
+    """Generated from the LinuxCNC axis_mm sim config."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.machine, cls.report = machine_from_probe(fixture("probe_xyz_mm.xml"))
+
+    def test_identity(self):
+        self.assertEqual(self.machine.name, "LinuxCNC-HAL-SIM-AXIS")
+        self.assertEqual(self.machine.manufacturer, "LinuxCNC")
+
+    def test_axes_and_limits(self):
+        self.assertEqual(set(self.machine.linear_axes), {"X", "Y", "Z"})
+        self.assertEqual(self.machine.rotary_axes, {})
+        self.assertEqual(self.machine.linear_axes["X"].min_limit, -254)
+        self.assertEqual(self.machine.linear_axes["X"].max_limit, 254)
+        self.assertEqual(self.machine.linear_axes["Z"].min_limit, -50.8)
+        self.assertEqual(self.machine.linear_axes["Z"].max_limit, 101.6)
+
+    def test_units_are_metric(self):
+        self.assertEqual(self.machine.configuration_units, "metric")
+
+    def test_machine_type(self):
+        self.assertEqual(self.machine.machine_type, "xyz")
+
+    def test_z_is_head_linear(self):
+        self.assertEqual(self.machine.linear_axes["Z"].role, AxisRole.HEAD_LINEAR)
+        self.assertEqual(self.machine.linear_axes["X"].role, AxisRole.TABLE_LINEAR)
+
+    def test_spindle_toolhead_created(self):
+        self.assertEqual(len(self.machine.toolheads), 1)
+        self.assertTrue(self.machine.toolheads[0].is_rotary())
+
+    def test_coolant_detected(self):
+        self.assertTrue(self.machine.toolheads[0].coolant_flood)
+        self.assertTrue(self.machine.toolheads[0].coolant_mist)
+
+    def test_chain_is_valid(self):
+        self.assertEqual(self.machine.validate_kinematic_chain(), [])
+
+    def test_provenance_recorded(self):
+        self.assertIn("MTConnect", self.machine.description)
+        self.assertIn("linuxcnc-0001", self.machine.description)
+
+
+class TestLinuxCNCInchMachine(unittest.TestCase):
+    """An inch-native LinuxCNC machine still publishes canonical millimetres."""
+
+    def test_imports_as_metric_with_mm_values(self):
+        machine, _ = machine_from_probe(fixture("probe_xyz_inch.xml"))
+        self.assertEqual(machine.configuration_units, "metric")
+        self.assertEqual(machine.linear_axes["X"].max_limit, 254)
+        self.assertEqual(machine.linear_axes["Z"].min_limit, -203.2)
+
+
+class TestLinuxCNC5Axis(unittest.TestCase):
+    """Generated from the LinuxCNC xyzac-trt sim config (extension ignored)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.machine, cls.report = machine_from_probe(fixture("probe_xyzac_trt.xml"))
+
+    def test_machine_type(self):
+        self.assertEqual(self.machine.machine_type, "xyzac")
+
+    def test_rotary_limits(self):
+        self.assertEqual(self.machine.rotary_axes["A"].min_limit, -100)
+        self.assertEqual(self.machine.rotary_axes["A"].max_limit, 50)
+        self.assertEqual(self.machine.rotary_axes["C"].min_limit, -36000)
+        self.assertEqual(self.machine.rotary_axes["C"].max_limit, 36000)
+
+    def test_chain_matches_factory_config(self):
+        factory = Machine.create_AC_table_config()
+        for letter in ("A", "C"):
+            imported = self.machine.rotary_axes[letter]
+            reference = factory.rotary_axes[letter]
+            self.assertEqual(imported.role, reference.role, letter)
+            self.assertEqual(imported.parent, reference.parent, letter)
+            self.assertEqual(imported.sequence, reference.sequence, letter)
+            self.assertEqual(
+                (
+                    imported.rotation_vector.x,
+                    imported.rotation_vector.y,
+                    imported.rotation_vector.z,
+                ),
+                (
+                    reference.rotation_vector.x,
+                    reference.rotation_vector.y,
+                    reference.rotation_vector.z,
+                ),
+                letter,
+            )
+        self.assertEqual(self.machine.primary_rotary_axis, factory.primary_rotary_axis)
+        self.assertEqual(self.machine.secondary_rotary_axis, factory.secondary_rotary_axis)
+
+    def test_chain_assumption_reported(self):
+        self.assertTrue(any("table" in item.lower() for item in self.report.assumed))
+        self.assertIn("Import assumptions:", self.machine.kinematics.notes)
+
+    def test_spindle_not_imported_as_axis(self):
+        self.assertEqual(set(self.machine.rotary_axes), {"A", "C"})
+
+    def test_chain_is_valid(self):
+        self.assertEqual(self.machine.validate_kinematic_chain(), [])
+
+    def test_serialization_roundtrip(self):
+        data = self.machine.to_dict()
+        restored = Machine.from_dict(data)
+        self.assertEqual(restored.machine_type, "xyzac")
+        self.assertEqual(restored.rotary_axes["A"].parent, "C")
+
+
+class TestForeignVendor(unittest.TestCase):
+    """A third-party agent: INCH units, suffixed names, no extension block."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.machine, cls.report = machine_from_probe(fixture("probe_foreign_vendor.xml"))
+
+    def test_identity(self):
+        self.assertEqual(self.machine.name, "VMC-24")
+        self.assertEqual(self.machine.manufacturer, "Example Machine Works")
+
+    def test_imperial_units_kept(self):
+        self.assertEqual(self.machine.configuration_units, "imperial")
+        self.assertEqual(self.machine.linear_axes["X"].max_limit, 24)
+        self.assertEqual(self.machine.linear_axes["Y"].max_limit, 16)
+        self.assertEqual(self.machine.linear_axes["Z"].max_limit, 20)
+
+    def test_suffixed_names_normalized(self):
+        self.assertEqual(set(self.machine.linear_axes), {"X", "Y", "Z"})
+
+    def test_velocity_converted_to_per_minute(self):
+        # 10 in/s -> 600 in/min in an imperial configuration
+        self.assertEqual(self.machine.linear_axes["X"].max_velocity, 600)
+
+    def test_spindle_detected_by_rotary_velocity(self):
+        self.assertEqual(self.machine.rotary_axes, {})
+        toolhead = self.machine.toolheads[0]
+        self.assertEqual(toolhead.min_rpm, 100)
+        self.assertEqual(toolhead.max_rpm, 8100)
+
+    def test_no_coolant(self):
+        self.assertFalse(self.machine.toolheads[0].coolant_flood)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -187,6 +187,7 @@ SET(PathPythonToolsFeedsSpeeds_SRCS
 
 SET(PathPythonMachineUi_SRCS
     Machine/ui/__init__.py
+    Machine/ui/mtconnect_import_dialog.py
 )
 
 SET(PathPythonMachineUiEditor_SRCS
@@ -199,6 +200,7 @@ SET(PathPythonMachineUiEditor_SRCS
 SET(PathPythonMachineModels_SRCS
     Machine/models/__init__.py
     Machine/models/machine.py
+    Machine/models/mtconnect_import.py
 )
 
 SET(PathPythonToolsToolBit_SRCS
@@ -677,6 +679,7 @@ SET(Tests_SRCS
     CAMTests/TestSurfaceMeshGenerator.py
     CAMTests/TestSurfaceWaterlineGenerator.py
     CAMTests/TestSurfaceZLevelGenerator.py
+    CAMTests/TestMachineMTConnectImport.py
 )
 
 # Generate _cam_test_modules.py listing all Test*.py modules for __init__.py
@@ -696,6 +699,14 @@ SET(Tests_Fixtures
     CAMTests/Fixtures/OpHelix_v0-21.FCStd
     CAMTests/Fixtures/test_17748_cam_profile.FCStd
     CAMTests/Fixtures/test_28534_truncated_pocket.FCStd
+)
+
+SET(Tests_Fixtures_MTConnect
+    CAMTests/Fixtures/mtconnect/probe_xyz_mm.xml
+    CAMTests/Fixtures/mtconnect/probe_xyz_inch.xml
+    CAMTests/Fixtures/mtconnect/probe_xyzac_trt.xml
+    CAMTests/Fixtures/mtconnect/probe_foreign_vendor.xml
+    CAMTests/Fixtures/mtconnect/probe_multi_device.xml
 )
 
 SET(PathImages_Ops
@@ -778,6 +789,7 @@ SET(test_files
   ${Path_Scripts}
   ${Tests_SRCS}
   ${Tests_Fixtures}
+  ${Tests_Fixtures_MTConnect}
 )
 
 ADD_CUSTOM_TARGET(Tests ALL
@@ -1088,6 +1100,13 @@ INSTALL(
         ${Tests_Fixtures}
     DESTINATION
         Mod/CAM/CAMTests/Fixtures
+)
+
+INSTALL(
+    FILES
+        ${Tests_Fixtures_MTConnect}
+    DESTINATION
+        Mod/CAM/CAMTests/Fixtures/mtconnect
 )
 
 INSTALL(

--- a/src/Mod/CAM/Machine/models/mtconnect_import.py
+++ b/src/Mod/CAM/Machine/models/mtconnect_import.py
@@ -1,0 +1,519 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.               #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses      #
+#                                                                              #
+################################################################################
+
+"""Build a Machine from an MTConnect probe document.
+
+An MTConnect agent describes its machine in the MTConnectDevices ("probe")
+document, conventionally served at http://<host>:<port>/probe.  This module
+parses the standard-namespace content of that document — Linear/Rotary axis
+components, their travel and velocity Specifications, the spindle's
+ROTARY_VELOCITY band, and coolant presence — and populates a Machine.
+
+Only the standard MTConnect component tree is read.  Vendor extension
+elements (foreign XML namespaces) are ignored, so any MTConnect 1.3+ agent
+is a valid source; a vendor extension can only add fidelity, never break the
+import.
+
+The probe cannot know table-vs-head mounting or rotary chain order — that is
+not part of the standard device model.  When rotary axes are found, the
+chain is wired to the same defaults as the Machine factory configurations
+(A/C and A/B as table rotaries, B/C as head rotaries) and the assumption is
+recorded in the ImportReport and the machine's kinematics notes for the user
+to review in the Machine Editor.
+
+All lengths in a conforming probe are canonical millimetres; a source that
+declares INCH units in its Specifications is imported as an imperial
+configuration with values kept in inches.
+"""
+
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+import FreeCAD
+
+from Machine.models.machine import (
+    AxisRole,
+    LinearAxis,
+    Machine,
+    RotaryAxis,
+    Toolhead,
+    ToolheadType,
+)
+
+translate = FreeCAD.Qt.translate
+
+LINEAR_LETTERS = "XYZUVW"
+ROTARY_LETTERS = "ABC"
+SPINDLE_NAMES = {"S", "SPINDLE"}
+
+# Canonical direction vectors used when the probe carries no Motion element.
+AXIS_VECTORS = {
+    "X": (1, 0, 0),
+    "Y": (0, 1, 0),
+    "Z": (0, 0, 1),
+    "A": (1, 0, 0),
+    "B": (0, 1, 0),
+    "C": (0, 0, 1),
+    "U": (1, 0, 0),
+    "V": (0, 1, 0),
+    "W": (0, 0, 1),
+}
+
+# Native length unit -> millimetres.
+_LENGTH_TO_MM = {
+    "MILLIMETER": 1.0,
+    "INCH": 25.4,
+    "CENTIMETER": 10.0,
+    "METER": 1000.0,
+}
+
+
+class ProbeParseError(ValueError):
+    """The document is not a usable MTConnectDevices probe."""
+
+
+@dataclass
+class ImportReport:
+    """What an import took from the probe, assumed, or could not use."""
+
+    device_name: str = ""
+    imported: List[str] = field(default_factory=list)
+    assumed: List[str] = field(default_factory=list)
+    skipped: List[str] = field(default_factory=list)
+
+    def summary(self) -> str:
+        lines = []
+        if self.imported:
+            lines.append(translate("CAM_MachineImport", "Imported:"))
+            lines.extend("  - " + item for item in self.imported)
+        if self.assumed:
+            lines.append(translate("CAM_MachineImport", "Assumed (please review):"))
+            lines.extend("  - " + item for item in self.assumed)
+        if self.skipped:
+            lines.append(translate("CAM_MachineImport", "Not imported:"))
+            lines.extend("  - " + item for item in self.skipped)
+        return "\n".join(lines)
+
+
+def _local(element) -> str:
+    """Element name without its XML namespace."""
+    return element.tag.rsplit("}", 1)[-1]
+
+
+def _parse_root(xml_text: str):
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as e:
+        raise ProbeParseError(f"Not well-formed XML: {e}")
+    if _local(root) != "MTConnectDevices":
+        raise ProbeParseError(
+            f"Root element is '{_local(root)}', expected 'MTConnectDevices'. "
+            "Is this the /probe endpoint of an MTConnect agent?"
+        )
+    return root
+
+
+def _device_elements(root):
+    """All Device elements, excluding the agent's self-description."""
+    devices = []
+    for parent in root.iter():
+        if _local(parent) != "Devices":
+            continue
+        for child in parent:
+            if _local(child) == "Device":
+                devices.append(child)
+    return devices
+
+
+def list_devices(xml_text: str) -> List[dict]:
+    """Names and uuids of the machine devices described by a probe document."""
+    root = _parse_root(xml_text)
+    return [
+        {"name": dev.get("name", ""), "uuid": dev.get("uuid", "")} for dev in _device_elements(root)
+    ]
+
+
+def _own_children(component, localname):
+    """Descendants matched by localname without crossing into sub-components.
+
+    A Linear/Rotary component's Configuration and DataItems belong to that
+    component; anything under a nested Components element belongs to a child
+    component and must not be attributed to this one.
+    """
+    found = []
+
+    def walk(element):
+        for child in element:
+            name = _local(child)
+            if name == "Components":
+                continue
+            if name == localname:
+                found.append(child)
+            walk(child)
+
+    walk(component)
+    return found
+
+
+def _spec_bounds(spec) -> Tuple[Optional[float], Optional[float]]:
+    minimum = maximum = None
+    for child in spec.iter():
+        try:
+            if _local(child) == "Minimum":
+                minimum = float(child.text)
+            elif _local(child) == "Maximum":
+                maximum = float(child.text)
+        except (TypeError, ValueError):
+            continue
+    return minimum, maximum
+
+
+def _axis_letter(name: str) -> Optional[str]:
+    """Normalize a component name ('X', 'x', 'X1') to an axis letter."""
+    name = (name or "").strip().upper()
+    if len(name) == 1 and name in LINEAR_LETTERS + ROTARY_LETTERS:
+        return name
+    if len(name) > 1 and name[0] in LINEAR_LETTERS + ROTARY_LETTERS and name[1:].isdigit():
+        return name[0]
+    return None
+
+
+def _motion_vector(component) -> Optional[FreeCAD.Vector]:
+    for motion in _own_children(component, "Motion"):
+        for child in motion:
+            if _local(child) == "Axis" and child.text:
+                try:
+                    x, y, z = (float(v) for v in child.text.split())
+                    return FreeCAD.Vector(x, y, z)
+                except ValueError:
+                    return None
+    return None
+
+
+@dataclass
+class _ParsedComponent:
+    element: object
+    name: str
+    kind: str  # "Linear" or "Rotary"
+    letter: Optional[str]
+    specs: dict  # spec type -> (units, min, max)
+    dataitem_types: set
+    vector: Optional[FreeCAD.Vector]
+
+
+def _parse_component(component) -> _ParsedComponent:
+    specs = {}
+    for spec in _own_children(component, "Specification"):
+        spec_type = (spec.get("type") or "").upper()
+        if spec_type:
+            specs[spec_type] = (spec.get("units") or "", *_spec_bounds(spec))
+    dataitem_types = set()
+    for item in _own_children(component, "DataItem"):
+        item_type = (item.get("type") or "").upper()
+        # Vendor extension types are prefixed ('x:FLOOD'); keep the local part.
+        dataitem_types.add(item_type.rsplit(":", 1)[-1])
+    name = component.get("name", "")
+    return _ParsedComponent(
+        element=component,
+        name=name,
+        kind=_local(component),
+        letter=_axis_letter(name),
+        specs=specs,
+        dataitem_types=dataitem_types,
+        vector=_motion_vector(component),
+    )
+
+
+def _axis_components(device):
+    """Linear/Rotary components in the device, with parent tracking."""
+    components = []
+
+    def walk(element):
+        for child in element:
+            if _local(child) in ("Linear", "Rotary") and _local(element) == "Components":
+                components.append(_parse_component(child))
+            walk(child)
+
+    walk(device)
+    return components
+
+
+def _is_spindle(comp: _ParsedComponent) -> bool:
+    if comp.name.strip().upper() in SPINDLE_NAMES:
+        return True
+    if "ROTARY_VELOCITY" in comp.dataitem_types or "SPINDLE_SPEED" in comp.dataitem_types:
+        return True
+    return "ROTARY_VELOCITY" in comp.specs
+
+
+def _length_factor(units: str, imperial: bool) -> float:
+    """Convert a spec value in `units` to configuration units (mm or inch)."""
+    to_mm = _LENGTH_TO_MM.get(units, 1.0)
+    return to_mm / 25.4 if imperial else to_mm
+
+
+def _velocity_to_config_units(value: float, units: str, imperial: bool) -> float:
+    """Convert a velocity spec to mm/min or in/min."""
+    units = units or ""
+    length_unit = units.split("/", 1)[0]
+    value *= _length_factor(length_unit, imperial)
+    if units.endswith("/SECOND"):
+        value *= 60.0
+    return value
+
+
+def _canonical_vector(letter: str) -> FreeCAD.Vector:
+    return FreeCAD.Vector(*AXIS_VECTORS.get(letter, (0, 0, 1)))
+
+
+def _wire_rotary_chain(machine: Machine, report: ImportReport):
+    """Apply the factory-default chain wiring for the discovered rotary set.
+
+    The probe cannot state table-vs-head mounting, so these follow the same
+    conventions as the Machine factory configurations and are flagged for
+    review.
+    """
+    letters = set(machine.rotary_axes)
+    wiring = {
+        frozenset("AC"): ("C", "A", AxisRole.TABLE_ROTARY, "A/C table (trunnion)"),
+        frozenset("AB"): ("A", "B", AxisRole.TABLE_ROTARY, "A/B table"),
+        frozenset("BC"): ("B", "C", AxisRole.HEAD_ROTARY, "B/C head"),
+    }
+    if frozenset(letters) in wiring:
+        first, second, role, label = wiring[frozenset(letters)]
+        machine.rotary_axes[first].role = role
+        machine.rotary_axes[first].sequence = 0
+        machine.rotary_axes[first].parent = None
+        machine.rotary_axes[second].role = role
+        machine.rotary_axes[second].sequence = 1
+        machine.rotary_axes[second].parent = first
+        # Match the factory configs' alignment argument order exactly.
+        if frozenset(letters) == frozenset("AC"):
+            machine.set_alignment_axes("C", "A")
+        elif frozenset(letters) == frozenset("BC"):
+            machine.set_alignment_axes("C", "B")
+        else:
+            machine.set_alignment_axes("A", "B")
+        report.assumed.append(
+            translate(
+                "CAM_MachineImport",
+                "Rotary axes wired as a {label} configuration; the probe does "
+                "not describe rotary mounting. Review roles and chain order.",
+            ).format(label=label)
+        )
+    elif len(letters) == 1:
+        letter = next(iter(letters))
+        machine.rotary_axes[letter].role = AxisRole.TABLE_ROTARY
+        machine.rotary_axes[letter].sequence = 0
+        machine.set_alignment_axes(letter, None)
+        report.assumed.append(
+            translate(
+                "CAM_MachineImport",
+                "Rotary axis {letter} assumed to be a table rotary. Review its role.",
+            ).format(letter=letter)
+        )
+    elif letters:
+        report.skipped.append(
+            translate(
+                "CAM_MachineImport",
+                "Rotary axes {letters} have no default chain wiring; "
+                "assign roles and parents in the editor.",
+            ).format(letters=", ".join(sorted(letters)))
+        )
+
+
+def machine_from_probe(
+    xml_text: str, device_name: Optional[str] = None, source: Optional[str] = None
+) -> Tuple[Machine, ImportReport]:
+    """Build a Machine from an MTConnect probe document.
+
+    Args:
+        xml_text: the MTConnectDevices XML.
+        device_name: which Device to import when the agent hosts several;
+            optional when the document describes exactly one machine.
+        source: where the document came from (URL or file), recorded in the
+            machine description.
+
+    Returns:
+        (machine, report). The machine is in-memory only; saving is the
+        caller's (normally the Machine Editor's) responsibility.
+    """
+    root = _parse_root(xml_text)
+    devices = _device_elements(root)
+    if not devices:
+        raise ProbeParseError("The probe document describes no machine devices.")
+    if device_name is not None:
+        matches = [d for d in devices if d.get("name") == device_name]
+        if not matches:
+            raise ProbeParseError(f"No device named '{device_name}' in the probe document.")
+        device = matches[0]
+    elif len(devices) == 1:
+        device = devices[0]
+    else:
+        names = ", ".join(d.get("name", "?") for d in devices)
+        raise ProbeParseError(
+            f"The probe document describes several devices ({names}); pass device_name."
+        )
+
+    report = ImportReport(device_name=device.get("name", ""))
+    machine = Machine(name=device.get("name") or "Imported Machine")
+
+    manufacturer = ""
+    for child in device:
+        if _local(child) == "Description":
+            manufacturer = child.get("manufacturer", "")
+            break
+    machine.manufacturer = manufacturer
+
+    provenance = translate("CAM_MachineImport", "Imported from MTConnect probe")
+    if source:
+        provenance += f" ({source})"
+    uuid = device.get("uuid", "")
+    if uuid:
+        provenance += f", device uuid {uuid}"
+    machine.description = provenance
+
+    components = _axis_components(device)
+    linear = [c for c in components if c.kind == "Linear"]
+    rotary = [c for c in components if c.kind == "Rotary" and not _is_spindle(c)]
+    spindles = [c for c in components if c.kind == "Rotary" and _is_spindle(c)]
+
+    # A probe that declares INCH travel specifications is imported as an
+    # imperial configuration; conforming agents emit canonical millimetres.
+    imperial = any(c.specs.get("POSITION", ("",))[0] == "INCH" for c in linear)
+    machine.configuration_units = "imperial" if imperial else "metric"
+
+    for comp in linear:
+        if comp.letter is None:
+            report.skipped.append(
+                translate(
+                    "CAM_MachineImport", "Linear component '{name}' is not a recognized axis."
+                ).format(name=comp.name)
+            )
+            continue
+        axis = LinearAxis(comp.letter, comp.vector or _canonical_vector(comp.letter))
+        units, minimum, maximum = comp.specs.get("POSITION", ("", None, None))
+        factor = _length_factor(units, imperial)
+        detail = ""
+        if minimum is not None:
+            axis.min_limit = minimum * factor
+        if maximum is not None:
+            axis.max_limit = maximum * factor
+        if minimum is not None or maximum is not None:
+            detail = f" ({axis.min_limit:g} .. {axis.max_limit:g} {machine.unit_format})"
+        vunits, _, vmax = comp.specs.get("VELOCITY", ("", None, None))
+        if vmax is not None:
+            axis.max_velocity = _velocity_to_config_units(vmax, vunits, imperial)
+        if comp.letter == "Z":
+            axis.role = AxisRole.HEAD_LINEAR
+        machine.linear_axes[comp.letter] = axis
+        report.imported.append(
+            translate("CAM_MachineImport", "Linear axis {letter}{detail}").format(
+                letter=comp.letter, detail=detail
+            )
+        )
+
+    for comp in rotary:
+        if comp.letter is None:
+            report.skipped.append(
+                translate(
+                    "CAM_MachineImport",
+                    "Rotary component '{name}' is neither an A/B/C axis nor a spindle.",
+                ).format(name=comp.name)
+            )
+            continue
+        axis = RotaryAxis(comp.letter, comp.vector or _canonical_vector(comp.letter))
+        _, minimum, maximum = comp.specs.get("ANGLE", ("", None, None))
+        detail = ""
+        if minimum is not None:
+            axis.min_limit = minimum
+        if maximum is not None:
+            axis.max_limit = maximum
+        if minimum is not None or maximum is not None:
+            detail = f" ({axis.min_limit:g} .. {axis.max_limit:g} deg)"
+        machine.rotary_axes[comp.letter] = axis
+        report.imported.append(
+            translate("CAM_MachineImport", "Rotary axis {letter}{detail}").format(
+                letter=comp.letter, detail=detail
+            )
+        )
+
+    _wire_rotary_chain(machine, report)
+
+    # Coolant presence: a Coolant component anywhere in the device.
+    coolant_components = [el for el in device.iter() if _local(el) == "Coolant"]
+    has_coolant = bool(coolant_components)
+    has_mist = any(
+        "MIST" in item_type
+        for comp in coolant_components
+        for item_type in _parse_component(comp).dataitem_types
+    )
+
+    toolhead = Toolhead(name="Spindle", toolhead_type=ToolheadType.ROTARY)
+    toolhead.coolant_flood = has_coolant
+    toolhead.coolant_mist = has_mist
+    if spindles:
+        comp = spindles[0]
+        _, rpm_min, rpm_max = comp.specs.get("ROTARY_VELOCITY", ("", None, None))
+        detail = ""
+        if rpm_min is not None:
+            toolhead.min_rpm = rpm_min
+        if rpm_max is not None:
+            toolhead.max_rpm = rpm_max
+        if rpm_min is not None or rpm_max is not None:
+            detail = f" ({toolhead.min_rpm:g} .. {toolhead.max_rpm:g} rpm)"
+        report.imported.append(
+            translate("CAM_MachineImport", "Spindle{detail}").format(detail=detail)
+        )
+        if len(spindles) > 1:
+            report.skipped.append(
+                translate(
+                    "CAM_MachineImport", "Additional spindles found; only the first was imported."
+                )
+            )
+    else:
+        report.assumed.append(
+            translate(
+                "CAM_MachineImport",
+                "No spindle described by the probe; a default rotary toolhead was added.",
+            )
+        )
+    machine.toolheads.append(toolhead)
+
+    if not any("VELOCITY" in comp.specs for comp in linear):
+        report.assumed.append(
+            translate(
+                "CAM_MachineImport",
+                "Axis velocities are not published by this machine; defaults were used.",
+            )
+        )
+
+    notes = [provenance]
+    if report.assumed:
+        notes.append(translate("CAM_MachineImport", "Import assumptions:"))
+        notes.extend("- " + item for item in report.assumed)
+    machine.kinematics.notes = "\n".join(notes)
+
+    for problem in machine.validate_kinematic_chain():
+        report.skipped.append(problem)
+
+    return machine, report

--- a/src/Mod/CAM/Machine/ui/editor/machine_editor.py
+++ b/src/Mod/CAM/Machine/ui/editor/machine_editor.py
@@ -387,7 +387,7 @@ class MachineEditorDialog(QtGui.QDialog):
         ("-Z", [0, 0, -1]),
     ]
 
-    def __init__(self, machine_filename: Optional[str] = None, parent=None):
+    def __init__(self, machine_filename: Optional[str] = None, parent=None, machine=None):
         super().__init__(parent)
         self.setMinimumSize(700, 900)
         self.resize(700, 900)
@@ -399,7 +399,10 @@ class MachineEditorDialog(QtGui.QDialog):
         self.filename = machine_filename
         self.machine = None  # Store the Machine object
 
-        if machine_filename:
+        if machine is not None:
+            # An in-memory machine not yet saved to disk (e.g. an import)
+            self.machine = machine
+        elif machine_filename:
             self.machine = MachineFactory.load_configuration(machine_filename)
         else:
             self.machine = Machine(name="New Machine")

--- a/src/Mod/CAM/Machine/ui/mtconnect_import_dialog.py
+++ b/src/Mod/CAM/Machine/ui/mtconnect_import_dialog.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.               #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses      #
+#                                                                              #
+################################################################################
+
+"""Dialog for importing a Machine from an MTConnect agent.
+
+Accepts the URL of a machine's MTConnect agent (the /probe endpoint) or the
+path of a saved probe XML file, fetches and parses the document, and returns
+the resulting in-memory Machine together with the ImportReport.  Saving is
+left to the Machine Editor, which the caller opens with the imported machine.
+"""
+
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import FreeCAD
+from PySide import QtGui
+
+from Machine.models.mtconnect_import import (
+    ProbeParseError,
+    list_devices,
+    machine_from_probe,
+)
+
+translate = FreeCAD.Qt.translate
+
+FETCH_TIMEOUT_SECONDS = 5
+# Probe documents are tens of kilobytes; anything near this size is not one.
+MAX_DOCUMENT_BYTES = 4 * 1024 * 1024
+
+
+class FetchError(Exception):
+    """The probe document could not be retrieved."""
+
+
+def _fetch_url(url: str) -> str:
+    try:
+        with urllib.request.urlopen(url, timeout=FETCH_TIMEOUT_SECONDS) as response:
+            return response.read(MAX_DOCUMENT_BYTES).decode("utf-8", errors="replace")
+    except (urllib.error.URLError, OSError, ValueError) as e:
+        raise FetchError(str(e))
+
+
+def fetch_probe(source: str) -> str:
+    """Return probe XML from a URL or local file path.
+
+    A URL without a path (e.g. http://machine:5000) is retried with /probe
+    appended, matching the MTConnect convention.
+    """
+    source = source.strip()
+    if os.path.isfile(source):
+        with open(source, "r", encoding="utf-8", errors="replace") as f:
+            return f.read(MAX_DOCUMENT_BYTES)
+
+    url = source if "://" in source else "http://" + source
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise FetchError(translate("CAM_MachineImport", "Only http and https URLs are supported."))
+    if parsed.path in ("", "/"):
+        return _fetch_url(url.rstrip("/") + "/probe")
+    return _fetch_url(url)
+
+
+class MTConnectImportDialog(QtGui.QDialog):
+    """Prompt for a probe source and build a Machine from it."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(translate("CAM_MachineImport", "Import Machine from MTConnect"))
+        self.machine = None
+        self.report = None
+
+        layout = QtGui.QVBoxLayout(self)
+        label = QtGui.QLabel(
+            translate(
+                "CAM_MachineImport",
+                "Enter the URL of the machine's MTConnect agent "
+                "(for example http://machine:5000/probe) or select a saved "
+                "probe XML file.",
+            )
+        )
+        label.setWordWrap(True)
+        layout.addWidget(label)
+
+        source_layout = QtGui.QHBoxLayout()
+        self.source_edit = QtGui.QLineEdit()
+        self.source_edit.setPlaceholderText("http://machine:5000/probe")
+        source_layout.addWidget(self.source_edit)
+        browse_button = QtGui.QToolButton()
+        browse_button.setIcon(QtGui.QIcon.fromTheme("folder-open"))
+        browse_button.setToolTip(translate("CAM_MachineImport", "Select a probe XML file"))
+        browse_button.clicked.connect(self._browse)
+        source_layout.addWidget(browse_button)
+        layout.addLayout(source_layout)
+
+        buttons = QtGui.QDialogButtonBox(QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel)
+        buttons.button(QtGui.QDialogButtonBox.Ok).setText(translate("CAM_MachineImport", "Import"))
+        buttons.accepted.connect(self._import)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self.source_edit.setFocus()
+
+    def _browse(self):
+        filename, _ = QtGui.QFileDialog.getOpenFileName(
+            self,
+            translate("CAM_MachineImport", "Select Probe XML File"),
+            "",
+            translate("CAM_MachineImport", "XML files (*.xml);;All files (*)"),
+        )
+        if filename:
+            self.source_edit.setText(filename)
+
+    def _import(self):
+        source = self.source_edit.text().strip()
+        if not source:
+            return
+        try:
+            xml_text = fetch_probe(source)
+            devices = list_devices(xml_text)
+            device_name = None
+            if len(devices) > 1:
+                names = [d["name"] for d in devices]
+                device_name, ok = QtGui.QInputDialog.getItem(
+                    self,
+                    translate("CAM_MachineImport", "Select Device"),
+                    translate("CAM_MachineImport", "This agent describes several machines:"),
+                    names,
+                    0,
+                    False,
+                )
+                if not ok:
+                    return
+            self.machine, self.report = machine_from_probe(
+                xml_text, device_name=device_name, source=source
+            )
+        except (FetchError, ProbeParseError) as e:
+            QtGui.QMessageBox.warning(
+                self,
+                translate("CAM_MachineImport", "Import Failed"),
+                str(e),
+            )
+            return
+        self.accept()
+
+    @classmethod
+    def get_machine(cls, parent=None):
+        """Run the dialog; return (machine, report) or None if cancelled."""
+        dialog = cls(parent)
+        if dialog.exec_() == QtGui.QDialog.Accepted and dialog.machine is not None:
+            summary = dialog.report.summary() if dialog.report else ""
+            if summary:
+                QtGui.QMessageBox.information(
+                    parent,
+                    translate("CAM_MachineImport", "Machine Imported"),
+                    translate(
+                        "CAM_MachineImport",
+                        "The machine was imported. Review it in the editor.\n\n{summary}",
+                    ).format(summary=summary),
+                )
+            return dialog.machine, dialog.report
+        return None

--- a/src/Mod/CAM/Path/Tool/assets/ui/preferences.py
+++ b/src/Mod/CAM/Path/Tool/assets/ui/preferences.py
@@ -108,12 +108,20 @@ class AssetPreferencesPage:
         self.machines_list = QtGui.QListWidget()
         self.machines_layout.addWidget(self.machines_list)
 
-        # Buttons: Add / Edit / Delete
+        # Buttons: Add / Import / Edit / Delete
         self.btn_layout = QtGui.QHBoxLayout()
         self.add_machine_btn = QtGui.QPushButton(translate("CAM_PreferencesAssets", "Add"))
+        self.import_machine_btn = QtGui.QPushButton(translate("CAM_PreferencesAssets", "Import..."))
+        self.import_machine_btn.setToolTip(
+            translate(
+                "CAM_PreferencesAssets",
+                "Create a machine from the probe document of an MTConnect agent",
+            )
+        )
         self.edit_machine_btn = QtGui.QPushButton(translate("CAM_PreferencesAssets", "Edit"))
         self.delete_machine_btn = QtGui.QPushButton(translate("CAM_PreferencesAssets", "Delete"))
         self.btn_layout.addWidget(self.add_machine_btn)
+        self.btn_layout.addWidget(self.import_machine_btn)
         self.btn_layout.addWidget(self.edit_machine_btn)
         self.btn_layout.addWidget(self.delete_machine_btn)
         self.machines_layout.addLayout(self.btn_layout)
@@ -133,6 +141,7 @@ class AssetPreferencesPage:
 
         # Wire up buttons
         self.add_machine_btn.clicked.connect(self.add_machine)
+        self.import_machine_btn.clicked.connect(self.import_machine)
         self.edit_machine_btn.clicked.connect(self.edit_machine)
         self.delete_machine_btn.clicked.connect(self.delete_machine)
 
@@ -201,6 +210,25 @@ class AssetPreferencesPage:
                 self.machines_list.addItem(item)
         except Exception as e:
             Path.Log.error(f"Failed to create machine file: {e}")
+
+    def import_machine(self):
+        # Create a new machine from an MTConnect agent's probe document
+        try:
+            from Machine.ui.mtconnect_import_dialog import MTConnectImportDialog
+
+            result = MTConnectImportDialog.get_machine(self.form)
+            if not result:
+                return
+            machine, _report = result
+            editor = MachineEditorDialog(machine=machine)
+            if editor.exec_() == QtGui.QDialog.Accepted:
+                filename = editor.filename
+                display_name = MachineFactory.get_machine_display_name(filename)
+                item = QtGui.QListWidgetItem(display_name)
+                item.setData(QtCore.Qt.UserRole, filename)
+                self.machines_list.addItem(item)
+        except Exception as e:
+            Path.Log.error(f"Failed to import machine: {e}")
 
     def edit_machine(self):
         try:


### PR DESCRIPTION
Adds the ability to create a new CAM machine by  importing from an MTConnect probe stream.

MTConnect is a standard for machine tools to publish information directly.  The probe stream carries information on kinematic configuration and joint/axis limits.  For more information on MTConnect, see this PR which added the capability to linuxcnc https://github.com/LinuxCNC/linuxcnc/pull/4318

This PR adds a feature to the machine editor dialog so it can consume the stream.  The user can input the URL of a machine.  The probe stream (XML) is parsed and a machine configuration created.  

The feature also allows importing a similar xml file directly.

Unit tests for the feature are included.

coded with assistance from claude code fable.