### PR TITLE
[GUI] Close/expand dependency lists depending on content

### DIFF
--- a/src/Gui/Dialogs/DlgObjectSelection.cpp
+++ b/src/Gui/Dialogs/DlgObjectSelection.cpp
@@ -310,13 +310,17 @@ void DlgObjectSelection::updateDepSplitter()
         depSizes[0] = 0;
         depSizes[1] = total;
     }
-    // avoid collapsing user-selected sizes
     else if (hasDep && hasIn && (depSizes[0] == 0 || depSizes[1] == 0)) {
         depSizes[0] = depSizes[1] = total / 2;
     }
     // both lists empty - currently show empty lists while dependency checkbox selected
     else if (!hasDep && !hasIn) {
         depSizes[0] = depSizes[1] = total / 2;
+    }
+    else {
+        // implicit case where both have content and user has manually
+        // resized, nothing to do
+        return;
     }
     ui->splitter->setSizes(depSizes);
 }

--- a/src/Gui/Dialogs/DlgObjectSelection.cpp
+++ b/src/Gui/Dialogs/DlgObjectSelection.cpp
@@ -294,6 +294,28 @@ void DlgObjectSelection::updateAllItemState()
     }
 }
 
+void DlgObjectSelection::updateDepSplitter()
+{
+    bool hasDep = ui->depList->topLevelItemCount() > 0;
+    bool hasIn = ui->inList->topLevelItemCount() > 0;
+
+    auto depSizes = ui->splitter->sizes();
+    int total = depSizes[0] + depSizes[1];
+
+    if (hasDep && !hasIn) {
+        depSizes[0] = total;
+        depSizes[1] = 0;
+    }
+    else if (!hasDep && hasIn) {
+        depSizes[0] = 0;
+        depSizes[1] = total;
+    }
+    else if (hasDep && hasIn && (depSizes[0] == 0 || depSizes[1] == 0)) {
+        depSizes[0] = depSizes[1] = total / 2;
+    }
+    ui->splitter->setSizes(depSizes);
+}
+
 void DlgObjectSelection::setItemState(App::DocumentObject* obj, Qt::CheckState state, bool forced)
 {
     std::vector<QTreeWidgetItem*>* items = nullptr;
@@ -719,6 +741,7 @@ void DlgObjectSelection::onItemSelectionChanged()
     if (enabled2) {
         ui->inList->setSortingEnabled(true);
     }
+    updateDepSplitter();
 }
 
 void DlgObjectSelection::onUseOriginalsBtnClicked()

--- a/src/Gui/Dialogs/DlgObjectSelection.cpp
+++ b/src/Gui/Dialogs/DlgObjectSelection.cpp
@@ -310,7 +310,12 @@ void DlgObjectSelection::updateDepSplitter()
         depSizes[0] = 0;
         depSizes[1] = total;
     }
+    // avoid collapsing user-selected sizes
     else if (hasDep && hasIn && (depSizes[0] == 0 || depSizes[1] == 0)) {
+        depSizes[0] = depSizes[1] = total / 2;
+    }
+    // both lists empty - currently show empty lists while dependency checkbox selected
+    else if (!hasDep && !hasIn) {
         depSizes[0] = depSizes[1] = total / 2;
     }
     ui->splitter->setSizes(depSizes);

--- a/src/Gui/Dialogs/DlgObjectSelection.h
+++ b/src/Gui/Dialogs/DlgObjectSelection.h
@@ -129,6 +129,7 @@ private:
 
     void setItemState(App::DocumentObject* obj, Qt::CheckState state, bool forced = false);
     void updateAllItemState();
+    void updateDepSplitter();
 
 private:
     Ui_DlgObjectSelection* ui;


### PR DESCRIPTION
This PR attempts to fix #24130 by forcing the dependency lists to collapse/grow depending on their content. If an object only has "Depended by", the "Depending on" section of the splitter will collapse to allow the other table to properly fill its section of the window, and vice versa. I added a helper for this, which gets called in the onItemSelectionChanged slot. This is based on my understanding of Issue #24130, I wasn't 100% sure if this was the problem that was described there. 

I might request UI/UX review ( FYI @maxwxyz ) - currently if both dependency lists are empty, I've let the splitter show both tables as empty rather than collapse the entire right panel, to avoid overriding the user's selection on the Show dependency checkbox (see video). Alternate behaviour would be to collapse when no dependencies are found for an object. 
Also since the "Depended by"/"Depending on" tables are visually similar and this makes it slightly harder to distinguish which one is open at a glance.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Before and After Images
Before:

https://github.com/user-attachments/assets/f28d56aa-3577-4ed7-bf9d-d101d946f1cd

After:

https://github.com/user-attachments/assets/993ac537-7245-4709-b8bd-5680e4722b42

