### PR TITLE
CAM: Remove redundant "translate drill cycle" from MBPP ui

### DIFF
--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -488,16 +488,6 @@ class PostProcessor:
                 ),
             },
             {
-                "name": "translate_drill_cycles",
-                "type": "bool",
-                "label": translate("CAM", "Expand drill-cycles"),
-                "default": False,
-                "help": translate(
-                    "CAM",
-                    "Expand drill-cycles (cf. 'Drill Cycles to Translate') to moves",
-                ),
-            },
-            {
                 "name": "tool_change",
                 "type": "bool",
                 "label": translate("CAM", "Allow tool-change"),

--- a/src/Mod/CAM/Path/Post/scripts/opensbp_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/opensbp_post.py
@@ -239,6 +239,7 @@ class OpenSBPPost(PostProcessor):
         # Override .values
 
         self.values["COMMENT_SYMBOL"] = "'"
+        self.values["TRANSLATE_DRILL_CYCLES"] = True
 
         # schema by [name]
         schema = {x["name"]: x for x in self.get_common_property_schema()}
@@ -246,7 +247,7 @@ class OpenSBPPost(PostProcessor):
         # These schema defaults are r/o: force them
         for property_name in (
             "supported_commands drill_cycles_to_translate"
-            " translate_drill_cycles output_tool_length_offset"
+            " output_tool_length_offset"
             " f_for_rapid_moves".split(  # FIXME: the merge logic doesn't respect our updated default
                 " "
             )


### PR DESCRIPTION
Remove translate_drill_cycles from Processor.py get_common_property_schema

Fixes #32092 

@sliptonic: I did the easy fix. Update the issue if you want the UI control in the other location.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

