### PR TITLE
CAM: Mbpp drill expand bug

### DIFF
--- a/src/Mod/CAM/CAMTests/TestDrillCycleExpander.py
+++ b/src/Mod/CAM/CAMTests/TestDrillCycleExpander.py
@@ -119,13 +119,14 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_04_g81_with_g98(self):
         """Test 1: Basic G81 (simple drill) with G98 retract"""
-        machine_state = MachineState(
-            {"X": 0, "Y": 0, "Z": 30.0, "G0F": 110, "ReturnMode": "Z"}
-        )  # G98
+        machine_state = MachineState({"X": 0, "Y": 0, "Z": 30.0, "G0F": 110})
         expander = DrillCycleExpander(machine_state)
 
+        # Generated drill commands actually have annotation
         input_cmds = [
-            Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
+            Path.Command(
+                "G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}, {"RetractMode": "G98"}
+            ),
         ]
 
         expected_cmds = [

--- a/src/Mod/CAM/Path/Post/DrillCycleExpander.py
+++ b/src/Mod/CAM/Path/Post/DrillCycleExpander.py
@@ -135,6 +135,10 @@ class DrillCycleExpander:
                     f"To expand a drill-cycle{why_clause}, we need a previous command that established parameters {missing}, but they are None at command {command.toGCode()}"
                 )
 
+        # PostUtils.cannedCycleTerminator expands out a G98, if it was called
+        if r := command.Annotations.get("RetractMode", None):
+            self.machine_state.addCommand(Path.Command(r))
+
         # always need machine_state params:
         require_previous("", "X", "Y", "Z", "ReturnMode")
 
@@ -325,7 +329,7 @@ class DrillCycleExpander:
                 "Z": next_depth,
                 "F": self.machine_state.F,
             }
-            if feedrate:
+            if feedrate is not None:
                 move_params["F"] = feedrate
             cmd = Path.Command("G1", move_params)
             expanded.append(cmd)

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -488,16 +488,6 @@ class PostProcessor:
                 ),
             },
             {
-                "name": "translate_drill_cycles",
-                "type": "bool",
-                "label": translate("CAM", "Expand drill-cycles"),
-                "default": False,
-                "help": translate(
-                    "CAM",
-                    "Expand drill-cycles (cf. 'Drill Cycles to Translate') to moves",
-                ),
-            },
-            {
                 "name": "tool_change",
                 "type": "bool",
                 "label": translate("CAM", "Allow tool-change"),

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -2046,8 +2046,8 @@ class PostProcessor:
         # postables = self._expand_pre_job(postables) # FIXME: need an item for a job, handled by _expand_prefix for now
         postables = self._expand_pre_item(postables)
 
-        self._expand_translate_drill_cycles(postables)
         self._expand_canned_cycles(postables)
+        self._expand_translate_drill_cycles(postables)
         self._expand_split_arcs(postables)
         self._expand_spindle_wait(postables)
         self._expand_coolant_delay(postables)

--- a/src/Mod/CAM/Path/Post/scripts/opensbp_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/opensbp_post.py
@@ -239,6 +239,7 @@ class OpenSBPPost(PostProcessor):
         # Override .values
 
         self.values["COMMENT_SYMBOL"] = "'"
+        self.values["TRANSLATE_DRILL_CYCLES"] = True
 
         # schema by [name]
         schema = {x["name"]: x for x in self.get_common_property_schema()}
@@ -246,7 +247,7 @@ class OpenSBPPost(PostProcessor):
         # These schema defaults are r/o: force them
         for property_name in (
             "supported_commands drill_cycles_to_translate"
-            " translate_drill_cycles output_tool_length_offset"
+            " output_tool_length_offset"
             " f_for_rapid_moves".split(  # FIXME: the merge logic doesn't respect our updated default
                 " "
             )


### PR DESCRIPTION
Drill-cycle-expansion gave errors about "To expand a drill-cycle, we need..." for a normal g83.

We weren't seeing the `RetractMode` annotation. Now we expand-canned first (to get the retract-mode), then drill-cycle-expand.

Also fixes a crash when move-speed is 0 (F0).

@Connor9220 This may have been your "crash"?

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
