### PR TITLE
Expression: do not clamp large integer literals to INT_MAX (fixes #23419)

### DIFF
--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -350,7 +350,7 @@ static inline int essentiallyInteger(double a, long &l, int &i) {
             return 1;
         }
         else if (intpart <= static_cast<double>(std::numeric_limits<long>::max())) {
-            l = static_cast<int>(intpart);
+            l = static_cast<long>(intpart);
             return 2;
         }
     }

--- a/tests/src/App/ExpressionParser.cpp
+++ b/tests/src/App/ExpressionParser.cpp
@@ -272,6 +272,14 @@ TEST_F(ExpressionParserTest, dimensionlessExpressionsParseAsLongOrDouble)
     EXPECT_THAT(parseExpr("1 / 2"), IsDouble(0.5)) << "simple fraction parses as double";
     EXPECT_THAT(parseExpr("40 mm / (2 cm)"), IsLong(2.0))
         << "dimensionless ratio of like units parses as long";
+    // Regression test for FreeCAD issue #23419: integer literals that exceed INT_MAX but
+    // fit in a long must keep their value, not get clamped to 2147483647.
+    EXPECT_THAT(parseExpr("9999999999"), IsLong(9999999999L))
+        << "10-digit literal must not clamp to INT_MAX (#23419)";
+    EXPECT_THAT(parseExpr("12000054321"), IsLong(12000054321L))
+        << "11-digit literal (#23419)";
+    EXPECT_THAT(parseExpr("-9999999999"), IsLong(-9999999999L))
+        << "large negative literal stays correct (#23419)";
 }
 
 TEST_F(ExpressionParserTest, expressionsWithFunctionsParse)

--- a/tests/src/App/ExpressionParser.cpp
+++ b/tests/src/App/ExpressionParser.cpp
@@ -276,8 +276,7 @@ TEST_F(ExpressionParserTest, dimensionlessExpressionsParseAsLongOrDouble)
     // fit in a long must keep their value, not get clamped to 2147483647.
     EXPECT_THAT(parseExpr("9999999999"), IsLong(9999999999L))
         << "10-digit literal must not clamp to INT_MAX (#23419)";
-    EXPECT_THAT(parseExpr("12000054321"), IsLong(12000054321L))
-        << "11-digit literal (#23419)";
+    EXPECT_THAT(parseExpr("12000054321"), IsLong(12000054321L)) << "11-digit literal (#23419)";
     EXPECT_THAT(parseExpr("-9999999999"), IsLong(-9999999999L))
         << "large negative literal stays correct (#23419)";
 }


### PR DESCRIPTION
## Problem
Integer literals in expressions larger than `INT_MAX` (2147483647) but within `long` range were silently clamped to `2147483647`, e.g. `9999999999` evaluated to `2147483647`. This affected `evalExpression()` results directly, as well as values assigned to both integer and float properties via expressions.

Fixes #23419

## Root cause
In `essentiallyInteger()` (`Expression.cpp`), the branch handling positive values that exceed `INT_MAX` but fit in a `long` cast the value with `static_cast<int>` instead of `static_cast<long>`, truncating it to 32 bits before saturating. The equivalent negative-value branch already used the correct `static_cast<long>`.

## Fix
One-line fix: cast to `long` to match the branch's own return code (2 = "value fits in a long").

## Testing
- Extended `dimensionlessExpressionsParseAsLongOrDouble` with cases for 10/11-digit positive and negative literals that previously clamped incorrectly.
- Manually verified via `evalExpression()` and via `setExpression()` on both `App::PropertyInteger` and `App::PropertyFloat` properties.
- Full local test suite (1670 gtests across all modules) passes with no regressions.