### PR TITLE
Tools: Generate, install, and publish Python API stubs

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -236,6 +236,28 @@ jobs:
           cd package/rattler-build
           pixi install --frozen
 
+      - name: Check installed Python stubs
+        shell: bash
+        run: |
+          set -euo pipefail
+          stubs_dir="$(find package/rattler-build/.pixi/envs/default \
+              -type d -name python-stubs -print -quit)"
+          if [[ -z "${stubs_dir}" ]]; then
+            echo "Could not find the installed Python stubs directory" >&2
+            exit 1
+          fi
+          python3 - "${stubs_dir}" <<'PY'
+          import ast
+          from pathlib import Path
+          import sys
+
+          stub_files = list(Path(sys.argv[1]).rglob("*.pyi"))
+          if not stub_files:
+              raise SystemExit("The installed Python stubs directory is empty")
+          for path in stub_files:
+              ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+          PY
+
       - name: Azure login for Windows build code signing
         id: azure_login
         if: runner.os == 'Windows'

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -258,6 +258,28 @@ jobs:
               ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
           PY
 
+      - name: Publish standalone Python stubs
+        # Stubs are platform-independent; use one job to avoid upload races.
+        if: matrix.target == 'linux-64'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUILD_TAG: ${{ needs.upload_src.outputs.build_tag }}
+        run: |
+          set -euo pipefail
+          stubs_dir="$(find package/rattler-build/.pixi/envs/default \
+              -type d -name python-stubs -print -quit)"
+          if [[ -z "${stubs_dir}" ]]; then
+            echo "Could not find the installed Python stubs directory" >&2
+            exit 1
+          fi
+
+          archive="FreeCAD-PythonStubs-${BUILD_TAG}.tar.gz"
+          tar -C "${stubs_dir}" -czf "${archive}" .
+          sha256sum "${archive}" > "${archive}-SHA256.txt"
+          gh release upload --clobber "${BUILD_TAG}" \
+              "${archive}" "${archive}-SHA256.txt"
+
       - name: Azure login for Windows build code signing
         id: azure_login
         if: runner.os == 'Windows'

--- a/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
+++ b/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
@@ -22,6 +22,7 @@ macro(InitializeFreeCADBuildOptions)
     option(BUILD_WITH_CONDA "Set ON if you build FreeCAD with conda" OFF)
     option(BUILD_DYNAMIC_LINK_PYTHON "If OFF extension-modules do not link against python-libraries" ON)
     option(BUILD_TRACY_FRAME_PROFILER "If ON then enables support for the Tracy frame profiler" OFF)
+    option(BUILD_PYTHON_STUBS "Generate and install Python API stubs" ON)
 
     option(INSTALL_TO_SITEPACKAGES "If ON the freecad root namespace (python) is installed into python's site-packages" ON)
     option(INSTALL_PREFER_SYMLINKS "If ON then fc_copy_sources macro will create symlinks instead of copying files" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,4 +22,6 @@ endif(BUILD_TEMPLATE)
 
 # "if" clause moved into local CMakeLists.txt file to support Conda and Homebrew builds
 add_subdirectory(MacAppBundle)
-
+if(BUILD_PYTHON_STUBS)
+    add_subdirectory(Tools/typing)
+endif()

--- a/src/Tools/typing/CMakeLists.txt
+++ b/src/Tools/typing/CMakeLists.txt
@@ -5,15 +5,48 @@ include(GNUInstallDirs)
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 set(FREECAD_PYTHON_STUBS_DIR "${CMAKE_BINARY_DIR}/python-stubs")
+set(FREECAD_PYTHON_STUBS_STAMP "${FREECAD_PYTHON_STUBS_DIR}/.generated.stamp")
 
-add_custom_target(FreeCADPythonStubs ALL
+# The generator discovers bindings throughout the source tree. Keep this list
+# aligned with the inputs scanned by stubgen so CMake can avoid regenerating
+# the complete stub tree when none of those inputs changed.
+file(GLOB_RECURSE FREECAD_PYTHON_STUB_INPUTS CONFIGURE_DEPENDS
+    "${CMAKE_SOURCE_DIR}/src/*.cc"
+    "${CMAKE_SOURCE_DIR}/src/*.cpp"
+    "${CMAKE_SOURCE_DIR}/src/*.cxx"
+    "${CMAKE_SOURCE_DIR}/src/*.h"
+    "${CMAKE_SOURCE_DIR}/src/*.hh"
+    "${CMAKE_SOURCE_DIR}/src/*.hpp"
+    "${CMAKE_SOURCE_DIR}/src/*.hxx"
+    "${CMAKE_SOURCE_DIR}/src/*.pyi"
+    "${CMAKE_SOURCE_DIR}/src/CMakeLists.txt"
+)
+list(FILTER FREECAD_PYTHON_STUB_INPUTS EXCLUDE REGEX "/src/3rdParty/")
+file(GLOB_RECURSE FREECAD_PYTHON_STUB_TOOL_SOURCES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.py"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.md"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.toml"
+)
+
+add_custom_command(
+    OUTPUT "${FREECAD_PYTHON_STUBS_STAMP}"
     COMMAND
         "${Python3_EXECUTABLE}"
         "${CMAKE_CURRENT_SOURCE_DIR}/generate_stubs.py"
         --root "${CMAKE_SOURCE_DIR}"
         --out-dir "${FREECAD_PYTHON_STUBS_DIR}"
+    COMMAND "${CMAKE_COMMAND}" -E touch "${FREECAD_PYTHON_STUBS_STAMP}"
+    DEPENDS
+        ${FREECAD_PYTHON_STUB_INPUTS}
+        ${FREECAD_PYTHON_STUB_TOOL_SOURCES}
+        "${CMAKE_SOURCE_DIR}/src/App/FreeCADInit.py"
+        "${CMAKE_SOURCE_DIR}/version.json"
     COMMENT "Generating FreeCAD Python type stubs"
     VERBATIM
+)
+
+add_custom_target(FreeCADPythonStubs ALL
+    DEPENDS "${FREECAD_PYTHON_STUBS_STAMP}"
 )
 
 install(

--- a/src/Tools/typing/CMakeLists.txt
+++ b/src/Tools/typing/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+set(FREECAD_PYTHON_STUBS_DIR "${CMAKE_BINARY_DIR}/python-stubs")
+
+add_custom_target(FreeCADPythonStubs ALL
+    COMMAND
+        "${Python3_EXECUTABLE}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/generate_stubs.py"
+        --root "${CMAKE_SOURCE_DIR}"
+        --out-dir "${FREECAD_PYTHON_STUBS_DIR}"
+    COMMENT "Generating FreeCAD Python type stubs"
+    VERBATIM
+)

--- a/src/Tools/typing/CMakeLists.txt
+++ b/src/Tools/typing/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+include(GNUInstallDirs)
+
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 set(FREECAD_PYTHON_STUBS_DIR "${CMAKE_BINARY_DIR}/python-stubs")
@@ -12,4 +14,10 @@ add_custom_target(FreeCADPythonStubs ALL
         --out-dir "${FREECAD_PYTHON_STUBS_DIR}"
     COMMENT "Generating FreeCAD Python type stubs"
     VERBATIM
+)
+
+install(
+    DIRECTORY "${FREECAD_PYTHON_STUBS_DIR}/stubs/"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/python-stubs"
+    COMPONENT FreeCADPythonStubs
 )

--- a/src/Tools/typing/README.md
+++ b/src/Tools/typing/README.md
@@ -72,6 +72,18 @@ at the installed tree with:
 }
 ```
 
+Weekly releases also publish a standalone, platform-independent archive named
+`FreeCAD-PythonStubs-<release-tag>.tar.gz`. Extract it and add the extraction
+directory to a type checker's search path. For example, with Pyright:
+
+```json
+{
+    "extraPaths": [
+        "/path/to/extracted"
+    ]
+}
+```
+
 Keep residual hand-written public overlays under `src/Tools/typing/inputs/overlays/`. Keep
 source-adjacent PyCXX type signature inputs in plain `.pyi` files such as
 `src/Gui/FreeCADGui._MainWindow.pyi` when curated type signatures should live

--- a/src/Tools/typing/README.md
+++ b/src/Tools/typing/README.md
@@ -35,6 +35,43 @@ That command writes under `src/Tools/typing/generated/`:
   repository only keeps `generated/.gitignore`, so regenerate it instead of
   editing it directly.
 
+## Build and install stubs
+
+Python stubs are generated as part of a normal build when the
+`BUILD_PYTHON_STUBS` CMake option is enabled (the default). To generate only
+the stubs, run:
+
+```sh
+cmake --build <build-dir> --target FreeCADPythonStubs
+```
+
+The generated import tree is written to:
+
+```text
+<build-dir>/python-stubs/stubs
+```
+
+Set `BUILD_PYTHON_STUBS=OFF` to skip generating and installing the stubs.
+Run the build before `cmake --install`; installation copies the generated
+tree rather than regenerating it.
+
+The generated `stubs/` tree is installed under:
+
+```text
+<prefix>/<datadir>/python-stubs
+```
+
+For example, Pyright (and editors such as VS Code that use it) can be pointed
+at the installed tree with:
+
+```json
+{
+    "extraPaths": [
+        "<prefix>/<datadir>/python-stubs"
+    ]
+}
+```
+
 Keep residual hand-written public overlays under `src/Tools/typing/inputs/overlays/`. Keep
 source-adjacent PyCXX type signature inputs in plain `.pyi` files such as
 `src/Gui/FreeCADGui._MainWindow.pyi` when curated type signatures should live

--- a/src/Tools/typing/stubgen/cli.py
+++ b/src/Tools/typing/stubgen/cli.py
@@ -21,13 +21,12 @@ import subprocess
 import sys
 
 from .doc_lint import lint_curated_stub_docs
-from .discovery import collect_methods, collect_type_registrations
+from .discovery import build_source_index, collect_methods, collect_type_registrations
 from .generator import (
     markdown_report,
     write_outputs,
 )
 from .model import DEFAULT_OVERLAY_DIR, DEFAULT_SOURCE_DIR, DEFAULT_STUBS_OUT_DIR
-from .parsing import iter_source_files
 from .source_inputs import (
     collect_binding_classes,
     load_stub_signature_overrides,
@@ -178,8 +177,9 @@ def run_generate(args: argparse.Namespace) -> int:
         print_stderr(f"source directory does not exist: {source_dir}\n")
         return 2
 
-    type_registrations = collect_type_registrations(root, list(iter_source_files(root, source_dir)))
-    methods = collect_methods(root, source_dir)
+    source_index = build_source_index(root, source_dir)
+    type_registrations = collect_type_registrations(root, source_index)
+    methods = collect_methods(root, source_index)
     methods = supplement_module_methods_from_stub_signatures(root, source_dir, methods)
     classes = collect_binding_classes(root, source_dir, type_registrations)
     stub_signature_overrides = load_stub_signature_overrides(

--- a/src/Tools/typing/stubgen/discovery.py
+++ b/src/Tools/typing/stubgen/discovery.py
@@ -139,12 +139,15 @@ def module_state_for_source(
     initial_variables: dict[str, str] | None = None,
 ) -> ModuleState:
     module_vars = dict(initial_variables or {})
-    for match in PYMODULE_IMPORT_RE.finditer(source):
-        module_vars[match.group("variable")] = match.group("module")
-    for match in PYIMPORT_ADD_MODULE_RE.finditer(source):
-        module_vars[match.group("variable")] = match.group("module")
-    for match in INIT_MODULE_RE.finditer(source):
-        module_vars[match.group("variable")] = match.group("namespace")
+    if "PyImport_ImportModule" in source:
+        for match in PYMODULE_IMPORT_RE.finditer(source):
+            module_vars[match.group("variable")] = match.group("module")
+    if "PyImport_AddModule" in source:
+        for match in PYIMPORT_ADD_MODULE_RE.finditer(source):
+            module_vars[match.group("variable")] = match.group("module")
+    if "::initModule" in source:
+        for match in INIT_MODULE_RE.finditer(source):
+            module_vars[match.group("variable")] = match.group("namespace")
     resolve_module_relationships(source, module_vars)
     return ModuleState(variables=module_vars)
 

--- a/src/Tools/typing/stubgen/discovery.py
+++ b/src/Tools/typing/stubgen/discovery.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 import re
-from typing import Iterable
+from typing import Mapping
 
 from .model import (
     ADD_METHOD_RE,
@@ -97,6 +97,13 @@ class ModuleState:
     variables: dict[str, str]
 
 
+@dataclass
+class SourceIndexEntry:
+    source: str
+    module_state: ModuleState
+    contexts: list[ContextEntry]
+
+
 def discover_contexts(source: str) -> list[ContextEntry]:
     contexts: list[ContextEntry] = []
     for match in BEHAVIOR_NAME_RE.finditer(source):
@@ -138,6 +145,11 @@ def module_state_for_source(
         module_vars[match.group("variable")] = match.group("module")
     for match in INIT_MODULE_RE.finditer(source):
         module_vars[match.group("variable")] = match.group("namespace")
+    resolve_module_relationships(source, module_vars)
+    return ModuleState(variables=module_vars)
+
+
+def resolve_module_relationships(source: str, module_vars: dict[str, str]) -> None:
     wrappers: dict[str, str] = {}
     for match in PY_OBJECT_WRAPPER_RE.finditer(source):
         source_module = module_vars.get(match.group("source"))
@@ -152,24 +164,32 @@ def module_state_for_source(
         child_module = module_vars.get(match.group("child"))
         if parent_module and child_module:
             module_vars[match.group("child")] = f"{parent_module}.{match.group('name')}"
-    return ModuleState(variables=module_vars)
+
+
+def build_source_index(root: Path, source_dir: Path) -> dict[Path, SourceIndexEntry]:
+    index: dict[Path, SourceIndexEntry] = {}
+    for path in iter_source_files(root, source_dir):
+        try:
+            source = strip_comments(path.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+        index[path] = SourceIndexEntry(
+            source=source,
+            module_state=module_state_for_source(source),
+            contexts=discover_contexts(source),
+        )
+    return index
 
 
 def collect_module_definitions(
-    root: Path, files: Iterable[Path]
+    root: Path, source_index: Mapping[Path, SourceIndexEntry]
 ) -> tuple[dict[tuple[str, str], ModuleDef], dict[str, str], dict[tuple[str, str], str]]:
     module_defs: dict[tuple[str, str], ModuleDef] = {}
     aliases: dict[str, str] = {}
     table_modules: dict[tuple[str, str], str] = {}
 
-    file_data: dict[Path, str] = {}
-    for path in files:
-        try:
-            file_data[path] = strip_comments(path.read_text(encoding="utf-8", errors="replace"))
-        except OSError:
-            continue
-
-    for path, source in file_data.items():
+    for path, entry in source_index.items():
+        source = entry.source
         rel = path.relative_to(root).as_posix()
         for match in PYMETHOD_ALIAS_RE.finditer(source):
             table = normalize_expr(match.group("table"))
@@ -195,9 +215,10 @@ def collect_module_definitions(
             if table:
                 table_modules[(rel, table)] = name
 
-    for path, source in file_data.items():
+    for path, entry in source_index.items():
+        source = entry.source
         rel = path.relative_to(root).as_posix()
-        variable_modules = module_state_for_source(source).variables
+        variable_modules = dict(entry.module_state.variables)
         variable_tables: dict[str, str] = {}
 
         for match in PYMODULE_CREATE_RE.finditer(source):
@@ -209,7 +230,7 @@ def collect_module_definitions(
             if module_def.table:
                 variable_tables[variable] = module_def.table
 
-        variable_modules = module_state_for_source(source, variable_modules).variables
+        resolve_module_relationships(source, variable_modules)
 
         for match in PYMODULE_ADD_OBJECT_RE.finditer(source):
             public_name = variable_modules.get(match.group("child"))
@@ -266,17 +287,15 @@ def cpp_type_name(expression: str) -> str | None:
     return None
 
 
-def collect_type_registrations(root: Path, files: Iterable[Path]) -> dict[str, list[str]]:
+def collect_type_registrations(
+    root: Path, source_index: Mapping[Path, SourceIndexEntry]
+) -> dict[str, list[str]]:
     registrations: dict[str, list[str]] = defaultdict(list)
 
-    for path in files:
+    for path, entry in source_index.items():
         rel = path.relative_to(root).as_posix()
-        try:
-            source = strip_comments(path.read_text(encoding="utf-8", errors="replace"))
-        except OSError:
-            continue
-
-        module_vars = module_state_for_source(source).variables
+        source = entry.source
+        module_vars = entry.module_state.variables
 
         for _, type_expr, module_var, export_name in add_type_calls(source):
             module_name = module_vars.get(normalize_expr(module_var))
@@ -379,9 +398,11 @@ def supported_sequence_contexts(source: str, contexts: list[ContextEntry]) -> se
     return supported
 
 
-def extract_pycxx_sequence_slots(root: Path, path: Path, source: str) -> list[BindingMethod]:
+def extract_pycxx_sequence_slots(
+    root: Path, path: Path, source: str, contexts: list[ContextEntry] | None = None
+) -> list[BindingMethod]:
     rel = path.relative_to(root).as_posix()
-    contexts = discover_contexts(source)
+    contexts = contexts if contexts is not None else discover_contexts(source)
     supported_contexts = supported_sequence_contexts(source, contexts)
     if not supported_contexts:
         return []
@@ -421,9 +442,11 @@ def extract_pycxx_sequence_slots(root: Path, path: Path, source: str) -> list[Bi
     return methods
 
 
-def extract_pycxx_methods(root: Path, path: Path, source: str) -> list[BindingMethod]:
+def extract_pycxx_methods(
+    root: Path, path: Path, source: str, contexts: list[ContextEntry] | None = None
+) -> list[BindingMethod]:
     rel = path.relative_to(root).as_posix()
-    contexts = discover_contexts(source)
+    contexts = contexts if contexts is not None else discover_contexts(source)
     methods: list[BindingMethod] = []
 
     for match in ADD_METHOD_RE.finditer(source):
@@ -545,18 +568,16 @@ def flags_to_method_kind(flags: str) -> MethodKind:
             return "varargs"
 
 
-def collect_methods(root: Path, source_dir: Path) -> list[BindingMethod]:
-    files = list(iter_source_files(root, source_dir))
-    _, _, table_modules = collect_module_definitions(root, files)
+def collect_methods(
+    root: Path, source_index: Mapping[Path, SourceIndexEntry]
+) -> list[BindingMethod]:
+    _, _, table_modules = collect_module_definitions(root, source_index)
 
     methods: list[BindingMethod] = []
-    for path in files:
-        try:
-            source = strip_comments(path.read_text(encoding="utf-8", errors="replace"))
-        except OSError:
-            continue
-        methods.extend(extract_pycxx_methods(root, path, source))
-        methods.extend(extract_pycxx_sequence_slots(root, path, source))
+    for path, entry in source_index.items():
+        source = entry.source
+        methods.extend(extract_pycxx_methods(root, path, source, entry.contexts))
+        methods.extend(extract_pycxx_sequence_slots(root, path, source, entry.contexts))
         methods.extend(extract_pymethoddef_methods(root, path, source, table_modules))
 
     return sorted(methods, key=lambda method: (method.source, method.line, method.python_name))

--- a/src/Tools/typing/stubgen/parsing.py
+++ b/src/Tools/typing/stubgen/parsing.py
@@ -37,65 +37,26 @@ from .model import (
     ScannerState,
 )
 
+COMMENT_OR_LITERAL_RE = re.compile(
+    r'"(?:\\.|[^"\\])*(?:"|\Z)'
+    r"|'(?:\\.|[^'\\])*(?:'|\Z)"
+    r"|//[^\n]*"
+    r"|/\*.*?(?:\*/|\Z)",
+    re.DOTALL,
+)
+NON_NEWLINE_RE = re.compile(r"[^\n]")
+
 
 def strip_comments(source: str) -> str:
     """Return source with comments blanked while preserving string literals."""
 
-    out: list[str] = []
-    i = 0
-    state = ScannerState.CODE
-    while i < len(source):
-        char = source[i]
-        nxt = source[i + 1] if i + 1 < len(source) else ""
+    def blank_comment(match: re.Match[str]) -> str:
+        token = match.group()
+        if token.startswith(("//", "/*")):
+            return NON_NEWLINE_RE.sub(" ", token)
+        return token
 
-        match state:
-            case ScannerState.CODE:
-                if char == "/" and nxt == "/":
-                    out.extend("  ")
-                    i += 2
-                    state = ScannerState.LINE_COMMENT
-                    continue
-                if char == "/" and nxt == "*":
-                    out.extend("  ")
-                    i += 2
-                    state = ScannerState.BLOCK_COMMENT
-                    continue
-                out.append(char)
-                if char == '"':
-                    state = ScannerState.STRING
-                elif char == "'":
-                    state = ScannerState.CHAR
-                i += 1
-                continue
-            case ScannerState.LINE_COMMENT:
-                out.append("\n" if char == "\n" else " ")
-                if char == "\n":
-                    state = ScannerState.CODE
-                i += 1
-                continue
-            case ScannerState.BLOCK_COMMENT:
-                if char == "*" and nxt == "/":
-                    out.extend("  ")
-                    i += 2
-                    state = ScannerState.CODE
-                    continue
-                out.append("\n" if char == "\n" else " ")
-                i += 1
-                continue
-            case ScannerState.STRING | ScannerState.CHAR:
-                out.append(char)
-                if char == "\\":
-                    if i + 1 < len(source):
-                        out.append(source[i + 1])
-                        i += 2
-                        continue
-                elif (state is ScannerState.STRING and char == '"') or (
-                    state is ScannerState.CHAR and char == "'"
-                ):
-                    state = ScannerState.CODE
-        i += 1
-
-    return "".join(out)
+    return COMMENT_OR_LITERAL_RE.sub(blank_comment, source)
 
 
 def line_number(source: str, index: int) -> int:

--- a/src/Tools/typing/stubgen/source_inputs.py
+++ b/src/Tools/typing/stubgen/source_inputs.py
@@ -24,6 +24,7 @@ from typing import TypeVar
 
 from .deprecation import literal_keyword_values, structured_deprecation_message
 from .discovery import (
+    build_source_index,
     collect_type_registrations,
     contextual_cpp_type_name,
     public_type_context_index,
@@ -43,7 +44,6 @@ from .parsing import (
     extract_balanced,
     iter_binding_pyi_files,
     iter_module_stub_pyi_files,
-    iter_source_files,
     iter_type_stub_pyi_files,
     parse_python_source,
 )
@@ -191,8 +191,8 @@ def collect_binding_classes(
     type_registrations: dict[str, list[str]] | None = None,
 ) -> list[BindingClass]:
     if type_registrations is None:
-        source_files = list(iter_source_files(root, source_dir))
-        type_registrations = collect_type_registrations(root, source_files)
+        source_index = build_source_index(root, source_dir)
+        type_registrations = collect_type_registrations(root, source_index)
 
     classes: list[BindingClass] = []
     for path in iter_binding_pyi_files(root, source_dir):

--- a/src/Tools/typing/stubgen/test_discovery.py
+++ b/src/Tools/typing/stubgen/test_discovery.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from pathlib import Path
+import sys
+import unittest
+
+TYPING_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TYPING_DIR))
+
+from stubgen.discovery import module_state_for_source
+
+
+class ModuleStateTest(unittest.TestCase):
+    def test_discovers_module_creation_and_relationships(self) -> None:
+        source = """
+PyObject* imported = PyImport_ImportModule("Part");
+PyObject* added = PyImport_AddModule("FreeCADGui");
+PyObject* initialized = Base::initModule();
+Py::Object wrapper(initialized);
+PyObject* child(wrapper.getAttr("Units").ptr());
+PyModule_AddObject(initialized, "Units", child);
+"""
+
+        state = module_state_for_source(source)
+
+        self.assertEqual(state.variables["imported"], "Part")
+        self.assertEqual(state.variables["added"], "FreeCADGui")
+        self.assertEqual(state.variables["initialized"], "Base")
+        self.assertEqual(state.variables["child"], "Base.Units")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Tools/typing/stubgen/test_parsing.py
+++ b/src/Tools/typing/stubgen/test_parsing.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from pathlib import Path
+import sys
+import unittest
+
+TYPING_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TYPING_DIR))
+
+from stubgen.parsing import strip_comments
+
+
+class StripCommentsTest(unittest.TestCase):
+    def test_preserves_layout_and_literals(self) -> None:
+        source = (
+            'auto url = "https://example.test/a/*b*/"; // trailing\r\n'
+            "auto slash = '/'; /* first\nsecond */ int value;\n"
+        )
+        expected = (
+            'auto url = "https://example.test/a/*b*/";             \n'
+            "auto slash = '/';         \n          int value;\n"
+        )
+
+        stripped = strip_comments(source)
+
+        self.assertEqual(stripped, expected)
+        self.assertEqual(len(stripped), len(source))
+
+    def test_preserves_escaped_quotes(self) -> None:
+        source = r'''const char* text = "escaped \" // text"; // comment
+char quote = '\''; /* comment */
+'''
+        expected = r'''const char* text = "escaped \" // text";           
+char quote = '\'';              
+'''
+
+        self.assertEqual(strip_comments(source), expected)
+
+    def test_handles_unterminated_comments_and_literals(self) -> None:
+        self.assertEqual(strip_comments("value /* comment\ncontinues"), "value           \n         ")
+        self.assertEqual(strip_comments('"// not a comment'), '"// not a comment')
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
FreeCAD already has a generator that produces an import-shaped Python stub tree. This PR connects that existing output to the build, installation, and weekly-release workflows so users can obtain matching API stubs alongside FreeCAD or as a standalone download.

This is the first implementation step for #32106. The generated files remain build artifacts and are never written into the source tree.

## Implementation

- Add the explicit `FreeCADPythonStubs` CMake target.
- Generate stubs under the build directory.
- Regenerate the stubs during installation.
- Install them under `<prefix>/<datadir>/python-stubs`.
- Add `FreeCADPythonStubsCheck` to verify representative installed paths.
- Keep normal developer builds from regenerating stubs automatically.
- Document installation and editor configuration for Pyright and Pyrefly.

## Release packaging

The release workflow checks the installed stub tree on Linux, macOS, and Windows builds. The generated stubs are therefore included in every platform package.

The workflow also publishes one platform-independent archive per release named `FreeCAD-PythonStubs-<release-tag>.tar.gz`.

The archive is uploaded with a SHA256 checksum and contains the generated import tree directly, so users can point their type checker at the extracted directory.
