### PR TITLE
BIM: fix BIM_Report format changes in spreadsheet due to rounding

### DIFF
--- a/src/Mod/BIM/ArchReport.py
+++ b/src/Mod/BIM/ArchReport.py
@@ -589,12 +589,16 @@ class _ArchReport:
 
     def _write_cell(self, spreadsheet, cell_address, value):
         """Intelligently writes a value to a spreadsheet cell based on its type."""
-        # Handle FreeCAD Quantity objects by extracting their raw numerical value.
+        # Numerical values are rounded to 8 decimals as this is the max. precision for
+        # saved spreadsheet values. This avoids format changes: a float becomes an integer
+        # upon saving and reopening, then becomes a float again if the Report is recomputed.
+        # See: https://github.com/FreeCAD/FreeCAD/issues/32097.
         if isinstance(value, FreeCAD.Units.Quantity):
-            spreadsheet.set(cell_address, str(value.Value))
+            # Handle FreeCAD Quantity objects by extracting their raw numerical value.
+            spreadsheet.set(cell_address, str(round(value.Value, 8)))
         elif isinstance(value, (int, float)):
             # Write other numbers directly without quotes for calculations.
-            spreadsheet.set(cell_address, str(value))
+            spreadsheet.set(cell_address, str(round(value, 8)))
         elif value is None:
             # Write an empty literal string for None.
             spreadsheet.set(cell_address, "''")


### PR DESCRIPTION
Fixes #32097.

Numerical spreadsheet values are rounded to 8 decimals upon saving. This means that a value such as `9030000.000000002` will be formatted as a float when entered, but when the file is reopened the value will be `9030000` and be formatted as an integer.

This PR adds rounding to the `_write_cell` function to avoid this.

No AI was used.