### PR TITLE
Sketcher: Prevent crash during drag auto-constraints

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <exception>
 #include <limits>
 #include <memory>
 #include <numbers>
@@ -33,6 +34,8 @@
 
 #include <App/Application.h>
 #include <Precision.hxx>
+#include <Base/Console.h>
+#include <Base/Exception.h>
 #include <Base/Vector3D.h>
 #include <Mod/Part/App/Geometry.h>
 #include <Mod/Sketcher/App/Sketch.h>
@@ -49,6 +52,7 @@ namespace
 {
 constexpr double DragAutoConstraintSnapDistanceFactor = 0.25;
 constexpr int DefaultDragAutoConstraintDelay = 400;
+constexpr int MaximumDragAutoConstraintDelay = 5000;
 
 int getDragAutoConstraintDelay()
 {
@@ -56,15 +60,15 @@ int getDragAutoConstraintDelay()
         "User parameter:BaseApp/Preferences/Mod/Sketcher/General"
     );
     const auto delay = hGrp->GetInt("DragAutoConstraintDelay", DefaultDragAutoConstraintDelay);
-    return static_cast<int>(std::clamp(delay, 0L, static_cast<long>(std::numeric_limits<int>::max())));
+    return static_cast<int>(std::clamp(delay, 0L, static_cast<long>(MaximumDragAutoConstraintDelay)));
 }
 }  // namespace
 
 DrawSketchHandlerDragAutoConstraint::DrawSketchHandlerDragAutoConstraint()
-    : dwellTimerContext(std::make_unique<QObject>())
-{}
-
-DrawSketchHandlerDragAutoConstraint::~DrawSketchHandlerDragAutoConstraint() = default;
+{
+    dwellTimer.setSingleShot(true);
+    QObject::connect(&dwellTimer, &QTimer::timeout, &dwellTimer, [this]() { onDwellTimerTimeout(); });
+}
 
 bool DrawSketchHandlerDragAutoConstraint::canSuggestFor(const std::vector<GeoElementId>& dragged) const
 {
@@ -100,7 +104,7 @@ void DrawSketchHandlerDragAutoConstraint::addAutoConstraint(ConstraintType type,
 
 void DrawSketchHandlerDragAutoConstraint::clear()
 {
-    ++dwellTimerGeneration;
+    dwellTimer.stop();
     suggestedConstraints.clear();
     draggedElements.clear();
     unsetCursor();
@@ -218,7 +222,7 @@ void DrawSketchHandlerDragAutoConstraint::update(
     const Base::Vector2d& /*pos*/
 )
 {
-    const auto timerGeneration = ++dwellTimerGeneration;
+    dwellTimer.stop();
     suggestedConstraints.clear();
     unsetCursor();
 
@@ -228,11 +232,26 @@ void DrawSketchHandlerDragAutoConstraint::update(
         return;
     }
 
-    QTimer::singleShot(getDragAutoConstraintDelay(), dwellTimerContext.get(), [this, timerGeneration]() {
-        if (timerGeneration == dwellTimerGeneration) {
-            updateSuggestions();
-        }
-    });
+    dwellTimer.start(getDragAutoConstraintDelay());
+}
+
+void DrawSketchHandlerDragAutoConstraint::onDwellTimerTimeout()
+{
+    try {
+        updateSuggestions();
+    }
+    catch (const Base::Exception& e) {
+        clear();
+        Base::Console().error("Failed to update drag auto-constraints: %s\n", e.what());
+    }
+    catch (const std::exception& e) {
+        clear();
+        Base::Console().error("C++ exception while updating drag auto-constraints: %s\n", e.what());
+    }
+    catch (...) {
+        clear();
+        Base::Console().error("Unknown exception while updating drag auto-constraints\n");
+    }
 }
 
 void DrawSketchHandlerDragAutoConstraint::updateSuggestions()

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.cpp
@@ -315,7 +315,7 @@ void DrawSketchHandlerDragAutoConstraint::updateSuggestions()
         CurveCandidate bestCurve;
 
         auto considerCurve = [&](int geoId, double distance, bool lineCenter = false) {
-            if (geoId == dragged.GeoId || distance >= snapDistance || distance >= bestCurve.distance) {
+            if (distance >= snapDistance || distance >= bestCurve.distance) {
                 return;
             }
 
@@ -326,7 +326,7 @@ void DrawSketchHandlerDragAutoConstraint::updateSuggestions()
 
         for (int geoId = 0; geoId <= obj->getHighestCurveIndex(); ++geoId) {
             const Part::Geometry* geo = getSolvedGeometry(geoId);
-            if (!geo) {
+            if (!geo || geoId == dragged.GeoId) {
                 continue;
             }
 
@@ -355,9 +355,16 @@ void DrawSketchHandlerDragAutoConstraint::updateSuggestions()
                 const auto* curve = static_cast<const Part::GeomCurve*>(geo);
                 double parameter;
 
-                if (curve->closestParameter(toVector3d(actualPos), parameter)) {
-                    const Base::Vector2d closestPoint = toVector2d(curve->pointAtParameter(parameter));
-                    considerCurve(geoId, (actualPos - closestPoint).Length());
+                try {
+                    if (curve->closestParameter(toVector3d(actualPos), parameter)) {
+                        const Base::Vector2d closestPoint = toVector2d(
+                            curve->pointAtParameter(parameter)
+                        );
+                        considerCurve(geoId, (actualPos - closestPoint).Length());
+                    }
+                }
+                catch (const Base::CADKernelError&) {
+                    continue;
                 }
             }
         }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerDragAutoConstraint.h
@@ -24,15 +24,13 @@
 
 #pragma once
 
-#include <cstddef>
-#include <memory>
 #include <vector>
+
+#include <QTimer>
 
 #include <Mod/Sketcher/App/GeoEnum.h>
 
 #include "DrawSketchHandler.h"
-
-class QObject;
 
 namespace Part
 {
@@ -46,7 +44,6 @@ class DrawSketchHandlerDragAutoConstraint final: public DrawSketchHandler
 {
 public:
     DrawSketchHandlerDragAutoConstraint();
-    ~DrawSketchHandlerDragAutoConstraint() override;
 
     void mouseMove(SnapManager::SnapHandle /*snapHandle*/) override
     {}
@@ -88,14 +85,14 @@ private:
         const AutoConstraint& constraint
     ) const;
     void removeInvalidConstraints(const Sketcher::GeoElementId& dragged);
+    void onDwellTimerTimeout();
     void updateSuggestions();
 
 private:
     std::vector<AutoConstraint> suggestedConstraints;
     std::vector<Sketcher::GeoElementId> draggedElements;
     Base::Vector2d startPos {0.0, 0.0};
-    std::unique_ptr<QObject> dwellTimerContext;
-    std::size_t dwellTimerGeneration {0};
+    QTimer dwellTimer;
 };
 
 }  // namespace SketcherGui


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
This is a follow-up to #31295 and #31725.

- Skip the dragged geometry before evaluating point-on-object candidates
- Ignore individual curve projection failures during optional auto-constraint suggestions
- Replace accumulated single-shot callbacks with one restartable dwell timer
- Handle exceptions inside the Qt timer callback so they cannot terminate FreeCAD

Assisted-by: GPT-5.6-Terra

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes #32112


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
