### PR TITLE
PD: Add angular start offsets to Revolution and Groove

### DIFF
--- a/src/Gui/Inventor/Draggers/Gizmo.cpp
+++ b/src/Gui/Inventor/Draggers/Gizmo.cpp
@@ -528,6 +528,7 @@ void RotationGizmo::draggingStarted()
 {
     initialValue = property->value().getValue();
     lastDragOffset = 0.0;
+    hasDragged = false;
     dragger->rotationIncrementCount.setValue(0);
 
     if (isDelayedUpdateEnabled()) {
@@ -542,12 +543,17 @@ void RotationGizmo::draggingFinished()
         property->valueChanged(property->value().getValue());
     }
 
+    if (!hasDragged && clickCallback) {
+        clickCallback();
+    }
+
     property->setFocus();
     property->selectAll();
 }
 
 void RotationGizmo::draggingContinued()
 {
+    hasDragged = true;
     const double period = getRotationPeriod(multFactor);
     double dragOffset = getClosestEquivalentAngle(getRotAngle(), lastDragOffset, period);
     lastDragOffset = dragOffset;
@@ -622,6 +628,11 @@ void RotationGizmo::setAddFactor(const double val)
 {
     addFactor = val;
     setRotAngle(property->value().getValue());
+}
+
+void RotationGizmo::setClickCallback(ClickCallback callback)
+{
+    clickCallback = std::move(callback);
 }
 
 void RotationGizmo::setVisibility(bool visible)

--- a/src/Gui/Inventor/Draggers/Gizmo.h
+++ b/src/Gui/Inventor/Draggers/Gizmo.h
@@ -146,6 +146,8 @@ private:
 class GuiExport RotationGizmo: public Gizmo
 {
 public:
+    using ClickCallback = std::function<void()>;
+
     RotationGizmo(QuantitySpinBox* property);
     ~RotationGizmo() override;
 
@@ -176,6 +178,7 @@ public:
     void setProperty(QuantitySpinBox* property);
     void setMultFactor(const double val);
     void setAddFactor(const double val);
+    void setClickCallback(ClickCallback callback);
     void setVisibility(bool visible);
 
 private:
@@ -186,6 +189,8 @@ private:
     QMetaObject::Connection quantityChangedConnection;
     QMetaObject::Connection formulaDialogConnection;
     double lastDragOffset = 0.0;
+    bool hasDragged = false;
+    ClickCallback clickCallback;
 
     void draggingStarted();
     void draggingFinished();

--- a/src/Mod/PartDesign/App/FeatureRevolved.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolved.cpp
@@ -22,10 +22,17 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <numbers>
+#include <optional>
+#include <ranges>
+#include <utility>
+#include <BRepAdaptor_Surface.hxx>
 #include <gp_Ax2.hxx>
 #include <gp_Lin.hxx>
 #include <gp_Pln.hxx>
-#include <utility>
 #include <Precision.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopLoc_Location.hxx>
@@ -33,9 +40,11 @@
 
 #include <App/Document.h>
 #include <Base/Console.h>
+#include <Base/Converter.h>
 #include <Base/Exception.h>
 #include <Base/Tools.h>
 #include <Base/Translation.h>
+#include <Mod/Part/App/Tools.h>
 #include <Mod/Part/App/TopoShapeOpCode.h>
 
 #include "FeatureRevolved.h"
@@ -66,19 +75,100 @@ bool isLegacyTwoAngles(const std::string& method)
     return method == "?TwoAngles" || method == "TwoAngles";
 }
 
+bool getProfileOrbit(const TopoShape& profileShape, const gp_Ax1& axis, gp_Pnt& center, gp_Vec& radial)
+{
+    Base::Vector3d profileCenter;
+    if (!profileShape.getCenterOfGravity(profileCenter)) {
+        return false;
+    }
+
+    const gp_Pnt profilePoint = Base::convertTo<gp_Pnt>(profileCenter);
+    const gp_Vec axisVector(axis.Direction());
+    const double parameter = gp_Vec(axis.Location(), profilePoint).Dot(axisVector);
+    center = axis.Location();
+    center.Translate(axisVector * parameter);
+    radial = gp_Vec(center, profilePoint);
+    return radial.Magnitude() > Precision::Confusion();
+}
+
+std::optional<double> getPlanarStartReferenceAngle(
+    const TopoShape& profileShape,
+    const TopoShape& referenceShape,
+    const gp_Ax1& axis
+)
+{
+    TopoShape referenceFace = referenceShape;
+    if (referenceFace.shapeType(true) != TopAbs_FACE) {
+        referenceFace = referenceFace.getSubTopoShape(TopAbs_FACE, 1);
+    }
+
+    BRepAdaptor_Surface surface(TopoDS::Face(referenceFace.getShape()));
+    if (surface.GetType() != GeomAbs_Plane) {
+        return std::nullopt;
+    }
+
+    gp_Pnt orbitCenter;
+    gp_Vec radial;
+    if (!getProfileOrbit(profileShape, axis, orbitCenter, radial)) {
+        return std::nullopt;
+    }
+
+    const gp_Pln plane = surface.Plane();
+    const gp_Vec normal(plane.Axis().Direction());
+    const gp_Vec tangent = gp_Vec(axis.Direction()).Crossed(radial);
+    const double cosineCoefficient = radial.Dot(normal);
+    const double sineCoefficient = tangent.Dot(normal);
+    const double constant = gp_Vec(plane.Location(), orbitCenter).Dot(normal);
+    const double amplitude = std::hypot(cosineCoefficient, sineCoefficient);
+
+    if (amplitude <= Precision::Confusion()) {
+        if (std::fabs(constant) <= Precision::Confusion()) {
+            return 0.0;
+        }
+        return std::nullopt;
+    }
+
+    const double solution = -constant / amplitude;
+    if (solution < -1.0 - Precision::Confusion() || solution > 1.0 + Precision::Confusion()) {
+        return std::nullopt;
+    }
+
+    const double phase = std::atan2(sineCoefficient, cosineCoefficient);
+    const double delta = std::acos(std::clamp(solution, -1.0, 1.0));
+    return std::min(normalizeAngleRadians(phase + delta), normalizeAngleRadians(phase - delta));
+}
+
 }  // namespace
 
 Revolved::Revolved()
 {
+    ADD_PROPERTY_TYPE(StartType, (0L), "Start", App::Prop_None, "How to define the revolution start");
+    StartType.setEnums(StartTypesEnums);
+    ADD_PROPERTY_TYPE(
+        StartOffset,
+        (0.0),
+        "Start",
+        App::Prop_None,
+        "Angular offset from the profile or selected start reference"
+    );
+    ADD_PROPERTY_TYPE(
+        StartReference,
+        (nullptr),
+        "Start",
+        App::Prop_None,
+        "Face, plane or sketch used as the start reference"
+    );
     Angle.setConstraints(&floatAngle);
     Angle2.setConstraints(&floatAngle);
+    StartOffset.setConstraints(&floatAngle);
 }
 
 short Revolved::mustExecute() const
 {
     if (Placement.isTouched() || SideType.isTouched() || Type.isTouched() || Type2.isTouched()
         || ReferenceAxis.isTouched() || Axis.isTouched() || Base.isTouched() || UpToFace.isTouched()
-        || UpToFace2.isTouched() || Angle.isTouched() || Angle2.isTouched()) {
+        || UpToFace2.isTouched() || Angle.isTouched() || Angle2.isTouched() || StartType.isTouched()
+        || StartOffset.isTouched() || StartReference.isTouched()) {
         return 1;
     }
     return ProfileBased::mustExecute();
@@ -209,9 +299,8 @@ App::DocumentObjectExecReturn* Revolved::tryExecuteRevolved(Part::RevolMode revo
         );
     }
 
-    const Base::Vector3d b = Base.getValue();
-    gp_Dir dir(v.x, v.y, v.z);
-    gp_Pnt pnt(b.x, b.y, b.z);
+    gp_Dir dir = Base::convertTo<gp_Dir>(v);
+    gp_Pnt pnt = Base::convertTo<gp_Pnt>(Base.getValue());
     positionByPrevious();
     auto invObjLoc = getLocation().Inverted();
     pnt.Transform(invObjLoc.Transformation());
@@ -221,6 +310,19 @@ App::DocumentObjectExecReturn* Revolved::tryExecuteRevolved(Part::RevolMode revo
     if (Reversed.getValue()) {
         dir.Reverse();
     }
+
+    const gp_Ax1 revolutionAxis(pnt, dir);
+    const char* startType = StartType.getValueAsString();
+    const double startAngle = std::strcmp(startType, "Profile plane") == 0 ? 0.0
+        : std::strcmp(startType, "Offset") == 0 ? Base::toRadians(StartOffset.getValue())
+                                                : getStartReferenceAngle(
+                                                      sketchshape,
+                                                      StartReference,
+                                                      revolutionAxis,
+                                                      Base::toRadians(StartOffset.getValue()),
+                                                      invObjLoc
+                                                  );
+    sketchshape = rotateProfileToStart(sketchshape, revolutionAxis, startAngle);
 
     // Check distance between sketchshape and axis - to avoid failures and crashes
     TopExp_Explorer xp;
@@ -635,6 +737,98 @@ bool Revolved::suggestReversed()
     return suggestReversedAngle(angle);
 }
 
+double Revolved::getStartOffset() const
+{
+    const char* startType = StartType.getValueAsString();
+    if (std::strcmp(startType, "Profile plane") == 0) {
+        return 0.0;
+    }
+    if (std::strcmp(startType, "Offset") == 0) {
+        return StartOffset.getValue();
+    }
+
+    const Base::Vector3d axisBase = Base.getValue();
+    const Base::Vector3d axisDirection = Axis.getValue();
+    gp_Ax1 axis(Base::convertTo<gp_Pnt>(axisBase), Base::convertTo<gp_Dir>(axisDirection));
+    if (Reversed.getValue()) {
+        axis.Reverse();
+    }
+
+    TopLoc_Location identity;
+    return Base::toDegrees(getStartReferenceAngle(
+        getTopoShapeVerifiedFace(),
+        StartReference,
+        axis,
+        Base::toRadians(StartOffset.getValue()),
+        identity
+    ));
+}
+
+double Revolved::getStartReferenceAngle(
+    const TopoShape& profileShape,
+    const App::PropertyLinkSub& reference,
+    const gp_Ax1& axis,
+    double offset,
+    const TopLoc_Location& invObjLoc
+) const
+{
+    if (!reference.getValue()) {
+        return 0.0;
+    }
+
+    TopoShape referenceShape;
+    const auto& subValues = reference.getSubValues();
+    if (reference.getValue()->isDerivedFrom<Part::Part2DObject>()) {
+        if (!subValues.empty()) {
+            const Part::ShapeOptions options = Part::ShapeOption::NeedSubElement
+                | Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform;
+            referenceShape = Part::Feature::getTopoShape(
+                reference.getValue(),
+                options,
+                subValues.front().c_str()
+            );
+        }
+        if (!referenceShape.hasSubShape(TopAbs_FACE)) {
+            referenceShape = getTopoShapeVerifiedFace(false, false, reference.getValue(), subValues);
+        }
+    }
+    else {
+        getUpToFaceFromLinkSub(referenceShape, reference);
+    }
+    referenceShape.move(invObjLoc);
+
+    if (const auto angle = getPlanarStartReferenceAngle(profileShape, referenceShape, axis)) {
+        return *angle + offset;
+    }
+
+    gp_Pnt orbitCenter;
+    gp_Vec radial;
+    if (!getProfileOrbit(profileShape, axis, orbitCenter, radial)) {
+        throw Base::ValueError("Revolved: Cannot determine the profile path around the axis");
+    }
+
+    const auto faces = Part::findAllFacesCutBy(referenceShape, profileShape, axis);
+    if (faces.empty()) {
+        throw Base::ValueError("Revolved: Start reference does not intersect the profile path");
+    }
+
+    const auto nearest = std::ranges::min_element(faces, {}, &Part::cutTopoShapeFaces::distsq);
+    return nearest->distsq / radial.Magnitude() + offset;
+}
+
+TopoShape Revolved::rotateProfileToStart(const TopoShape& profileShape, const gp_Ax1& axis, double angle)
+{
+    if (std::fabs(angle) < Precision::Angular()) {
+        return profileShape;
+    }
+
+    TopoShape result = profileShape.makeElementCopy();
+    gp_Trsf transform;
+    transform.SetRotation(axis, angle);
+    result.move(transform);
+    return result;
+}
+
 void Revolved::updateAxis()
 {
     App::DocumentObject* pcReferenceAxis = ReferenceAxis.getValue();
@@ -768,6 +962,10 @@ void Revolved::updateProperties()
     Reversed.setReadOnly(isSymmetricAngleLike);
     UpToFace.setReadOnly(!isUpToFaceEnabled);
     UpToFace2.setReadOnly(!isUpToFace2Enabled);
+
+    const bool isStartOffsetEnabled = std::strcmp(StartType.getValueAsString(), "Profile plane") != 0;
+    StartOffset.setReadOnly(!isStartOffsetEnabled);
+    StartReference.setReadOnly(std::strcmp(StartType.getValueAsString(), "Reference") != 0);
 }
 
 void Revolved::onDocumentRestored()

--- a/src/Mod/PartDesign/App/FeatureRevolved.h
+++ b/src/Mod/PartDesign/App/FeatureRevolved.h
@@ -53,6 +53,9 @@ public:
     App::PropertyVector Axis;
     App::PropertyAngle Angle;
     App::PropertyAngle Angle2;
+    App::PropertyEnumeration StartType;
+    App::PropertyAngle StartOffset;
+    App::PropertyLinkSub StartReference;
 
     /** if this property is set to a valid link, both Axis and Base properties
      *  are calculated according to the linked line
@@ -67,6 +70,9 @@ public:
 
     /// suggests a value for Reversed flag so that material is always added to the support
     bool suggestReversed();
+
+    /// Returns the effective angular offset from the profile plane in degrees.
+    double getStartOffset() const;
 
     enum class RevolMethod
     {
@@ -122,6 +128,15 @@ private:
         Part::RevolMode revolMode
     );
     void setResult(const TopoShape& base, const TopoShape& revolved);
+
+    double getStartReferenceAngle(
+        const TopoShape& profileShape,
+        const App::PropertyLinkSub& reference,
+        const gp_Ax1& axis,
+        double offset,
+        const TopLoc_Location& invObjLoc
+    ) const;
+    static TopoShape rotateProfileToStart(const TopoShape& profileShape, const gp_Ax1& axis, double angle);
 
     /// updates Axis from ReferenceAxis
     void updateAxis();

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <numbers>
 #include <optional>
 #include <ranges>
 #include <Bnd_Box.hxx>
@@ -46,6 +47,7 @@
 #include <gp_Pln.hxx>
 #include <gp_Trsf.hxx>
 #include <GProp_GProps.hxx>
+#include <Precision.hxx>
 #include <ShapeAnalysis.hxx>
 #include <Standard_Version.hxx>
 #include <TopExp.hxx>
@@ -62,6 +64,7 @@
 #include <App/Datums.h>
 #include <Base/Converter.h>
 #include <Base/Reader.h>
+#include <Base/Tools.h>
 #include <Mod/Part/App/FaceMakerCheese.h>
 #include <Mod/Part/App/Tools.h>
 
@@ -74,6 +77,13 @@
 FC_LOG_LEVEL_INIT("PartDesign", true, true);
 
 using namespace PartDesign;
+
+double PartDesign::normalizeAngleRadians(double angle)
+{
+    constexpr double fullRotation = 2.0 * std::numbers::pi;
+    angle = Base::fmod(angle, fullRotation);
+    return fullRotation - angle < Precision::Angular() ? 0.0 : angle;
+}
 
 PROPERTY_SOURCE(PartDesign::ProfileBased, PartDesign::FeatureAddSub)
 

--- a/src/Mod/PartDesign/App/FeatureSketchBased.h
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.h
@@ -38,6 +38,9 @@ class TopLoc_Location;
 namespace PartDesign
 {
 
+/// Normalize an angle in radians to [0, 2 pi), snapping a near-full turn to zero.
+PartDesignExport double normalizeAngleRadians(double angle);
+
 class PartDesignExport ProfileBased: public PartDesign::FeatureAddSub
 {
     PROPERTY_HEADER_WITH_OVERRIDE(PartDesign::ProfileBased);

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -219,29 +219,11 @@ void TaskExtrudeParameters::updateStartUI()
 void TaskExtrudeParameters::updateStartReferenceName()
 {
     auto extrude = getObject<PartDesign::FeatureExtrude>();
-    App::DocumentObject* reference = extrude->StartReference.getValue();
-    const auto subValues = extrude->StartReference.getSubValues();
-    const std::string subName = subValues.empty() ? "" : subValues.front();
-
-    if (!reference) {
-        ui->lineStartReference->clear();
-        ui->lineStartReference->setProperty("FeatureName", QVariant());
-        ui->lineStartReference->setProperty("FaceName", QVariant());
-        ui->lineStartReference->setPlaceholderText(tr("No start reference selected"));
-        return;
-    }
-
-    QString text = QString::fromUtf8(reference->Label.getValue());
-    if (subName.rfind("Face", 0) == 0) {
-        text += QStringLiteral(":%1%2").arg(tr("Face"), QString::fromStdString(subName.substr(4)));
-    }
-    else if (!subName.empty()) {
-        text += QStringLiteral(":%1").arg(QString::fromStdString(subName));
-    }
-
-    ui->lineStartReference->setText(text);
-    ui->lineStartReference->setProperty("FeatureName", QByteArray(reference->getNameInDocument()));
-    ui->lineStartReference->setProperty("FaceName", QByteArray(subName.c_str()));
+    updateReferenceName(
+        ui->lineStartReference,
+        extrude->StartReference,
+        tr("No start reference selected")
+    );
 }
 
 void TaskExtrudeParameters::createSideControllers()

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -1123,29 +1123,7 @@ void TaskHoleParameters::updateStartUI()
 void TaskHoleParameters::updateStartReferenceName()
 {
     auto hole = getObject<PartDesign::Hole>();
-    App::DocumentObject* reference = hole->StartReference.getValue();
-    const auto subValues = hole->StartReference.getSubValues();
-    const std::string subName = subValues.empty() ? "" : subValues.front();
-
-    if (!reference) {
-        ui->lineStartReference->clear();
-        ui->lineStartReference->setProperty("FeatureName", QVariant());
-        ui->lineStartReference->setProperty("FaceName", QVariant());
-        ui->lineStartReference->setPlaceholderText(tr("No start reference selected"));
-        return;
-    }
-
-    QString text = QString::fromUtf8(reference->Label.getValue());
-    if (subName.rfind("Face", 0) == 0) {
-        text += QStringLiteral(":%1%2").arg(tr("Face"), QString::fromStdString(subName.substr(4)));
-    }
-    else if (!subName.empty()) {
-        text += QStringLiteral(":%1").arg(QString::fromStdString(subName));
-    }
-
-    ui->lineStartReference->setText(text);
-    ui->lineStartReference->setProperty("FeatureName", QByteArray(reference->getNameInDocument()));
-    ui->lineStartReference->setProperty("FaceName", QByteArray(subName.c_str()));
+    updateReferenceName(ui->lineStartReference, hole->StartReference, tr("No start reference selected"));
 }
 
 QString TaskHoleParameters::getStartReference() const

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
@@ -22,6 +22,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <cstring>
 #include <QAbstractButton>
 #include <QSignalBlocker>
 
@@ -30,6 +31,7 @@
 #include <App/Origin.h>
 #include <Base/Console.h>
 #include <Base/Converter.h>
+#include <Base/Rotation.h>
 #include <Base/Tools.h>
 #include <Gui/Application.h>
 #include <Gui/CommandT.h>
@@ -72,8 +74,8 @@ TaskRevolutionParameters::TaskRevolutionParameters(
     : TaskSketchBasedParameters(RevolutionView, parent, pixname, title)
     , ui(new Ui_TaskRevolutionParameters)
     , proxy(new QWidget(this))
-    , selectionFace(false)
     , isGroove(false)
+    , selectionMode(SelectionMode::None)
     , activeSelectionSide(Side::First)
 {
     // we need a separate container widget to add all controls to
@@ -131,13 +133,47 @@ void TaskRevolutionParameters::setupDialog()
 {
     createSideControllers();
 
+    auto revolved = getObject<PartDesign::Revolved>();
     ui->checkBoxMidplane->hide();
     ui->checkBoxReversed->setChecked(propReversed->getValue());
+    ui->lineStartReference->setPlaceholderText(tr("No start reference selected"));
+    ui->startOffsetEdit->setToolTip(tr("Angular offset from the profile or selected start reference"));
+    ui->startMode->setCurrentIndex(revolved->StartType.getValue());
+    ui->startOffsetEdit->setValue(revolved->StartOffset.getValue());
+    ui->startOffsetEdit->setMinimum(revolved->StartOffset.getMinimum());
+    ui->startOffsetEdit->setMaximum(revolved->StartOffset.getMaximum());
+    ui->startOffsetEdit->setSingleStep(revolved->StartOffset.getStepSize());
+    ui->startOffsetEdit->bind(revolved->StartOffset);
+    updateStartReferenceName();
 
     setupSideDialog(m_side1);
     setupSideDialog(m_side2);
 
     translateSidesList(propSideType->getValue());
+    updateStartUI();
+}
+
+void TaskRevolutionParameters::updateStartUI()
+{
+    const auto mode = static_cast<StartMode>(ui->startMode->currentIndex());
+    const bool hasOffset = mode != StartMode::ProfilePlane;
+    const bool hasReference = mode == StartMode::Reference;
+
+    ui->labelStartOffset->setVisible(hasOffset);
+    ui->startOffsetEdit->setVisible(hasOffset);
+    ui->labelStartReference->setVisible(hasReference);
+    ui->lineStartReference->setVisible(hasReference);
+    ui->buttonStartReference->setVisible(hasReference);
+}
+
+void TaskRevolutionParameters::updateStartReferenceName()
+{
+    auto revolved = getObject<PartDesign::Revolved>();
+    updateReferenceName(
+        ui->lineStartReference,
+        revolved->StartReference,
+        tr("No start reference selected")
+    );
 }
 
 void TaskRevolutionParameters::createSideControllers()
@@ -393,6 +429,12 @@ void TaskRevolutionParameters::connectSignals()
             this, &TaskRevolutionParameters::onAxisChanged);
     connect(ui->checkBoxReversed, &QCheckBox::toggled,
             this, &TaskRevolutionParameters::onReversed);
+    connect(ui->startMode, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, &TaskRevolutionParameters::onStartModeChanged);
+    connect(ui->startOffsetEdit, qOverload<double>(&Gui::PrefQuantitySpinBox::valueChanged),
+            this, &TaskRevolutionParameters::onStartOffsetChanged);
+    connect(ui->buttonStartReference, &QAbstractButton::toggled,
+            this, &TaskRevolutionParameters::onSelectStartReferenceToggle);
     connect(ui->checkBoxUpdateView, &QCheckBox::toggled,
             this, &TaskRevolutionParameters::onUpdateView);
     connect(ui->changeMode, qOverload<int>(&QComboBox::currentIndexChanged),
@@ -428,39 +470,87 @@ void TaskRevolutionParameters::updateUI(Side side)
     updateWholeUI(side);
 }
 
+void TaskRevolutionParameters::setSelectionMode(SelectionMode mode, Side side)
+{
+    QSignalBlocker face1Blocker(ui->buttonFace);
+    QSignalBlocker face2Blocker(ui->buttonFace2);
+    QSignalBlocker startBlocker(ui->buttonStartReference);
+
+    ui->buttonFace->setChecked(mode == SelectionMode::Face && side == Side::First);
+    ui->buttonFace2->setChecked(mode == SelectionMode::Face && side == Side::Second);
+    ui->buttonStartReference->setChecked(mode == SelectionMode::StartReference);
+
+    selectionMode = mode;
+    activeSelectionSide = side;
+
+    handleLineFaceNameNo(ui->lineFaceName);
+    handleLineFaceNameNo(ui->lineFaceName2);
+    ui->buttonStartReference->setText(tr("Pick Reference"));
+    ui->lineStartReference->setPlaceholderText(tr("No start reference selected"));
+
+    switch (mode) {
+        case SelectionMode::Face:
+            handleLineFaceNameClick(getSideController(side).lineFaceName);
+            onSelectReference(AllowSelection::FACE);
+            break;
+        case SelectionMode::StartReference:
+            ui->buttonStartReference->setText(tr("Cancel"));
+            ui->lineStartReference->setPlaceholderText(tr("Select face, plane..."));
+            onSelectReference(AllowSelection::FACE);
+            break;
+        case SelectionMode::Axis:
+            onSelectReference(AllowSelection::EDGE | AllowSelection::PLANAR | AllowSelection::CIRCLE);
+            break;
+        case SelectionMode::None:
+            onSelectReference(AllowSelection::NONE);
+            break;
+    }
+}
+
 void TaskRevolutionParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 {
     if (msg.Type == Gui::SelectionChanges::AddSelection) {
-        if (selectionFace) {
-            auto& side = getSideController(activeSelectionSide);
-            QString refText = onAddSelection(msg, *side.UpToFace);
-            if (refText.length() > 0) {
-                QSignalBlocker block(side.lineFaceName);
-                side.lineFaceName->setText(refText);
-                side.lineFaceName->setProperty("FeatureName", QByteArray(msg.pObjectName));
-                side.lineFaceName->setProperty("FaceName", QByteArray(msg.pSubName));
-                // Turn off reference selection mode
-                side.buttonFace->setChecked(false);
+        switch (selectionMode) {
+            case SelectionMode::Face: {
+                auto& side = getSideController(activeSelectionSide);
+                QString refText = onAddSelection(msg, *side.UpToFace);
+                if (refText.length() > 0) {
+                    QSignalBlocker block(side.lineFaceName);
+                    side.lineFaceName->setText(refText);
+                    side.lineFaceName->setProperty("FeatureName", QByteArray(msg.pObjectName));
+                    side.lineFaceName->setProperty("FaceName", QByteArray(msg.pSubName));
+                    setSelectionMode(SelectionMode::None);
+                }
+                else {
+                    clearFaceName(side.lineFaceName);
+                }
+                break;
             }
-            else {
-                clearFaceName(side.lineFaceName);
-            }
-        }
-        else {
-            exitSelectionMode();
-            std::vector<std::string> axis;
-            App::DocumentObject* selObj {};
-            if (getReferencedSelection(getObject(), msg, selObj, axis) && selObj) {
-                propReferenceAxis->setValue(selObj, axis);
-
-                recomputeFeature();
-                updateUI(Side::First);
-
+            case SelectionMode::StartReference: {
+                auto revolved = getObject<PartDesign::Revolved>();
+                onAddSelection(msg, revolved->StartReference);
+                updateStartReferenceName();
+                setSelectionMode(SelectionMode::None);
                 setGizmoPositions();
+                break;
             }
+            case SelectionMode::Axis: {
+                std::vector<std::string> axis;
+                App::DocumentObject* selectedObject {};
+                if (getReferencedSelection(getObject(), msg, selectedObject, axis) && selectedObject) {
+                    propReferenceAxis->setValue(selectedObject, axis);
+                    setSelectionMode(SelectionMode::None);
+                    recomputeFeature();
+                    updateUI(Side::First);
+                    setGizmoPositions();
+                }
+                break;
+            }
+            case SelectionMode::None:
+                break;
         }
     }
-    else if (msg.Type == Gui::SelectionChanges::ClrSelection && selectionFace) {
+    else if (msg.Type == Gui::SelectionChanges::ClrSelection && selectionMode == SelectionMode::Face) {
         clearFaceName(getSideController(activeSelectionSide).lineFaceName);
     }
 }
@@ -469,25 +559,22 @@ void TaskRevolutionParameters::onButtonFace(bool pressed, Side side)
 {
     auto& sideCtrl = getSideController(side);
     if (pressed) {
-        Side otherSide = side == Side::First ? Side::Second : Side::First;
-        auto& otherCtrl = getSideController(otherSide);
-        QSignalBlocker blockOther(otherCtrl.buttonFace);
-        otherCtrl.buttonFace->setChecked(false);
-        handleLineFaceNameNo(otherCtrl.lineFaceName);
-
-        // to distinguish that this is NOT the axis selection
-        selectionFace = true;
-        activeSelectionSide = side;
-        handleLineFaceNameClick(sideCtrl.lineFaceName);
-
-        // only faces are allowed
-        TaskSketchBasedParameters::onSelectReference(AllowSelection::FACE);
+        setSelectionMode(SelectionMode::Face, side);
     }
-    else if (activeSelectionSide == side) {
-        selectionFace = false;
-        handleLineFaceNameNo(sideCtrl.lineFaceName);
+    else if (selectionMode == SelectionMode::Face && activeSelectionSide == side) {
+        setSelectionMode(SelectionMode::None);
         sideCtrl.buttonFace->clearFocus();
-        TaskSketchBasedParameters::onSelectReference(AllowSelection::NONE);
+    }
+}
+
+void TaskRevolutionParameters::onSelectStartReferenceToggle(bool checked)
+{
+    if (checked) {
+        setSelectionMode(SelectionMode::StartReference);
+    }
+    else if (selectionMode == SelectionMode::StartReference) {
+        setSelectionMode(SelectionMode::None);
+        ui->buttonStartReference->clearFocus();
     }
 }
 
@@ -572,7 +659,7 @@ void TaskRevolutionParameters::onAngleChanged(double len)
 {
     if (getObject()) {
         m_side1.Angle->setValue(len);
-        exitSelectionMode();
+        setSelectionMode(SelectionMode::None);
         recomputeFeature();
 
         setGizmoPositions();
@@ -583,11 +670,35 @@ void TaskRevolutionParameters::onAngle2Changed(double len)
 {
     if (getObject()) {
         m_side2.Angle->setValue(len);
-        exitSelectionMode();
+        setSelectionMode(SelectionMode::None);
         recomputeFeature();
 
         setGizmoPositions();
     }
+}
+
+void TaskRevolutionParameters::onStartModeChanged(int type)
+{
+    auto revolved = getObject<PartDesign::Revolved>();
+    const auto mode = static_cast<StartMode>(type);
+    revolved->StartType.setValue(type);
+    if (mode == StartMode::Reference && !revolved->StartReference.getValue()) {
+        ui->buttonStartReference->setChecked(true);
+    }
+    else if (mode != StartMode::Reference) {
+        setSelectionMode(SelectionMode::None);
+    }
+
+    updateStartUI();
+    recomputeFeature();
+    setGizmoPositions();
+}
+
+void TaskRevolutionParameters::onStartOffsetChanged(double angle)
+{
+    getObject<PartDesign::Revolved>()->StartOffset.setValue(angle);
+    recomputeFeature();
+    setGizmoPositions();
 }
 
 void TaskRevolutionParameters::onAxisChanged(int num)
@@ -614,9 +725,7 @@ void TaskRevolutionParameters::onAxisChanged(int num)
         if (auto sketch = dynamic_cast<Part::Part2DObject*>(pcRevolution->Profile.getValue())) {
             Gui::cmdAppObjectShow(sketch);
         }
-        TaskSketchBasedParameters::onSelectReference(
-            AllowSelection::EDGE | AllowSelection::PLANAR | AllowSelection::CIRCLE
-        );
+        setSelectionMode(SelectionMode::Axis);
     }
     else {
         if (!pcRevolution->getDocument()->isIn(lnk.getValue())) {
@@ -624,7 +733,7 @@ void TaskRevolutionParameters::onAxisChanged(int num)
             return;
         }
         propReferenceAxis->Paste(lnk);
-        exitSelectionMode();
+        setSelectionMode(SelectionMode::None);
     }
 
     try {
@@ -796,6 +905,9 @@ void TaskRevolutionParameters::changeEvent(QEvent* event)
 {
     TaskBox::changeEvent(event);
     if (event->type() == QEvent::LanguageChange) {
+        QSignalBlocker startMode(ui->startMode);
+        QSignalBlocker startOffset(ui->startOffsetEdit);
+        QSignalBlocker startReference(ui->lineStartReference);
         QSignalBlocker angle(ui->revolveAngle);
         QSignalBlocker angle2(ui->revolveAngle2);
         QSignalBlocker face(ui->lineFaceName);
@@ -810,6 +922,7 @@ void TaskRevolutionParameters::changeEvent(QEvent* event)
         translateModeList(ui->changeMode, ui->changeMode->currentIndex());
         translateModeList(ui->changeMode2, ui->changeMode2->currentIndex());
         translateSidesList(ui->sidesMode->currentIndex());
+        updateStartReferenceName();
         translateFaceName(ui->lineFaceName);
         translateFaceName(ui->lineFaceName2);
     }
@@ -818,6 +931,7 @@ void TaskRevolutionParameters::changeEvent(QEvent* event)
 void TaskRevolutionParameters::apply()
 {
     // Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Revolution changed"));
+    ui->startOffsetEdit->apply();
     ui->revolveAngle->apply();
     ui->revolveAngle2->apply();
     std::vector<std::string> sub;
@@ -830,6 +944,9 @@ void TaskRevolutionParameters::apply()
     FCMD_OBJ_CMD(tobj, "Reversed = " << (getReversed() ? 1 : 0));
     FCMD_OBJ_CMD(tobj, "Type = " << getMode());
     FCMD_OBJ_CMD(tobj, "Type2 = " << getMode2());
+    FCMD_OBJ_CMD(tobj, "StartOffset = " << ui->startOffsetEdit->value().getValue());
+    FCMD_OBJ_CMD(tobj, "StartType = " << ui->startMode->currentIndex());
+    FCMD_OBJ_CMD(tobj, "StartReference = " << getFaceName(ui->lineStartReference).toUtf8().data());
 
     QString facename = QStringLiteral("None");
     QString facename2 = QStringLiteral("None");
@@ -849,10 +966,19 @@ void TaskRevolutionParameters::setupGizmos(ViewProvider* vp)
         return;
     }
 
-    rotationGizmo = new Gui::RadialGizmo(ui->revolveAngle);
-    rotationGizmo2 = new Gui::RadialGizmo(ui->revolveAngle2);
+    const auto toggleReversed = [this] {
+        if (ui->checkBoxReversed->isEnabled()) {
+            ui->checkBoxReversed->setChecked(!ui->checkBoxReversed->isChecked());
+        }
+    };
 
-    gizmoContainer = GizmoContainer::create({rotationGizmo, rotationGizmo2}, vp);
+    rotationGizmo = new Gui::RadialGizmo(ui->revolveAngle);
+    rotationGizmo->setClickCallback(toggleReversed);
+    rotationGizmo2 = new Gui::RadialGizmo(ui->revolveAngle2);
+    rotationGizmo2->setClickCallback(toggleReversed);
+    startOffsetGizmo = new Gui::RotationGizmo(ui->startOffsetEdit);
+
+    gizmoContainer = GizmoContainer::create({rotationGizmo, rotationGizmo2, startOffsetGizmo}, vp);
     rotationGizmo->flipArrow();
     rotationGizmo2->flipArrow();
 
@@ -916,14 +1042,38 @@ void TaskRevolutionParameters::setGizmoPositions()
         axisDir = -axisDir;
     }
 
-    rotationGizmo->Gizmo::setDraggerPlacement(basePos + axisComp, normalComp);
+    auto revolved = getObject<PartDesign::Revolved>();
+    Base::Vector3d startDirection = normalComp;
+    Base::Vector3d referenceDirection = normalComp;
+    try {
+        const double effectiveStartOffset = revolved->getStartOffset();
+        startDirection
+            = Base::Rotation(axisDir, Base::toRadians(effectiveStartOffset)).multVec(normalComp);
+        referenceDirection
+            = Base::Rotation(
+                  axisDir,
+                  Base::toRadians(effectiveStartOffset - revolved->StartOffset.getValue())
+            )
+                  .multVec(normalComp);
+    }
+    catch (const Base::Exception&) {
+    }
+
+    const Base::Vector3d axisPosition = basePos + axisComp;
+    rotationGizmo->Gizmo::setDraggerPlacement(axisPosition, startDirection);
     rotationGizmo->getDraggerContainer()->setArcNormalDirection(Base::convertTo<SbVec3f>(axisDir));
     rotationGizmo->setVisibility(revolutionType == "Angle" || isLegacyTwoAngles(revolutionType));
 
-    rotationGizmo2->Gizmo::setDraggerPlacement(basePos + axisComp, normalComp);
+    rotationGizmo2->Gizmo::setDraggerPlacement(axisPosition, startDirection);
     rotationGizmo2->getDraggerContainer()->setArcNormalDirection(Base::convertTo<SbVec3f>(-axisDir));
     rotationGizmo2->setVisibility(
         (sideType == "Two sides" && revolutionType2 == "Angle") || isLegacyTwoAngles(revolutionType)
+    );
+
+    startOffsetGizmo->Gizmo::setDraggerPlacement(axisPosition, referenceDirection);
+    startOffsetGizmo->getDraggerContainer()->setArcNormalDirection(Base::convertTo<SbVec3f>(axisDir));
+    startOffsetGizmo->setVisibility(
+        std::strcmp(revolved->StartType.getValueAsString(), "Profile plane") != 0
     );
 
     if (!symmetric) {

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.h
@@ -44,6 +44,7 @@ namespace Gui
 {
 class QuantitySpinBox;
 class RadialGizmo;
+class RotationGizmo;
 class Gizmo;
 class ViewProvider;
 class ViewProviderCoordinateSystem;
@@ -88,6 +89,9 @@ private Q_SLOTS:
     void onAngle2Changed(double);
     void onAxisChanged(int);
     void onReversed(bool);
+    void onStartModeChanged(int);
+    void onStartOffsetChanged(double);
+    void onSelectStartReferenceToggle(bool);
     void onModeChangedSide1(int);
     void onModeChangedSide2(int);
     void onSidesModeChanged(int);
@@ -114,6 +118,21 @@ protected:
     {
         First,
         Second,
+    };
+
+    enum class StartMode
+    {
+        ProfilePlane,
+        Offset,
+        Reference,
+    };
+
+    enum class SelectionMode
+    {
+        None,
+        Face,
+        StartReference,
+        Axis,
     };
 
     enum class Mode
@@ -163,6 +182,8 @@ private:
     void connectSignals();
     void updateUI(Side side);
     void updateWholeUI(Side side);
+    void updateStartUI();
+    void updateStartReferenceName();
     void updateSideUI(const SideController& side, Mode mode, bool isParentVisible, bool setFocus);
     void translateModeList(QComboBox* box, int index);
     void translateSidesList(int index);
@@ -174,13 +195,14 @@ private:
     void onModeChanged(int index, Side side);
     void onButtonFace(bool pressed, Side side);
     void onFaceName(const QString& text, Side side);
+    void setSelectionMode(SelectionMode mode, Side side = Side::First);
     Gui::ViewProviderCoordinateSystem* getOriginView() const;
 
 private:
     std::unique_ptr<Ui_TaskRevolutionParameters> ui;
     QWidget* proxy;
-    bool selectionFace;
     bool isGroove;
+    SelectionMode selectionMode;
     Side activeSelectionSide;
     double defaultGizmoMultFactor;
 
@@ -197,6 +219,7 @@ private:
     std::unique_ptr<Gui::GizmoContainer> gizmoContainer;
     Gui::RadialGizmo* rotationGizmo = nullptr;
     Gui::RadialGizmo* rotationGizmo2 = nullptr;
+    Gui::RotationGizmo* startOffsetGizmo = nullptr;
     void setupGizmos(ViewProvider* vp);
     void setGizmoPositions();
 };

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>278</width>
-    <height>340</height>
+    <height>450</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,23 +17,114 @@
    <item>
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
-      <widget class="QLabel" name="sidesLabel">
+      <widget class="QLabel" name="labelStart">
        <property name="text">
-        <string>Mode</string>
+        <string>Start</string>
        </property>
       </widget>
      </item>
      <item row="0" column="1">
+      <widget class="QComboBox" name="startMode">
+       <item>
+        <property name="text">
+         <string>Profile plane</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Offset</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Reference</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="1" column="0" rowspan="2">
+      <widget class="QLabel" name="labelStartReference">
+       <property name="text">
+        <string>Reference</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="lineStartReference">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QPushButton" name="buttonStartReference">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Pick Reference</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelStartOffset">
+       <property name="text">
+        <string>Offset</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="Gui::PrefQuantitySpinBox" name="startOffsetEdit" native="true">
+       <property name="keyboardTracking" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">deg</string>
+       </property>
+       <property name="minimum">
+        <double>-360.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>360.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="sidesLabel">
+       <property name="text">
+        <string>Direction</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
       <widget class="QComboBox" name="sidesMode"/>
      </item>
-     <item row="1" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="textLabel1">
        <property name="text">
         <string>Axis</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="5" column="1">
       <widget class="QComboBox" name="axis">
        <item>
         <property name="text">
@@ -67,7 +158,7 @@
        </item>
       </widget>
      </item>
-     <item row="2" column="0" colspan="2">
+     <item row="6" column="0" colspan="2">
       <layout class="QHBoxLayout" name="side1HeaderLayout">
        <property name="leftMargin">
         <number>0</number>
@@ -97,14 +188,14 @@
        </item>
       </layout>
      </item>
-     <item row="3" column="0">
+     <item row="7" column="0">
       <widget class="QLabel" name="textLabelMode">
        <property name="text">
         <string>Type</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="7" column="1">
       <widget class="QComboBox" name="changeMode">
        <item>
         <property name="text">
@@ -113,14 +204,14 @@
        </item>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="8" column="0">
       <widget class="QLabel" name="labelAngle">
        <property name="text">
         <string>Angle</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="8" column="1">
       <widget class="Gui::QuantitySpinBox" name="revolveAngle">
        <property name="keyboardTracking">
         <bool>false</bool>
@@ -142,7 +233,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="0" colspan="2">
+     <item row="9" column="0" colspan="2">
       <layout class="QGridLayout" name="gridLayout_5">
        <item row="0" column="0">
         <widget class="QToolButton" name="buttonFace">
@@ -169,7 +260,7 @@
        </item>
       </layout>
      </item>
-     <item row="6" column="0" colspan="2">
+     <item row="10" column="0" colspan="2">
       <layout class="QHBoxLayout" name="side2HeaderLayout">
        <property name="leftMargin">
         <number>0</number>
@@ -199,24 +290,24 @@
        </item>
       </layout>
      </item>
-     <item row="7" column="0">
+     <item row="11" column="0">
       <widget class="QLabel" name="typeLabel2">
        <property name="text">
         <string>Type</string>
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
+     <item row="11" column="1">
       <widget class="QComboBox" name="changeMode2"/>
      </item>
-     <item row="8" column="0">
+     <item row="12" column="0">
       <widget class="QLabel" name="labelAngle2">
        <property name="text">
         <string>Angle</string>
        </property>
       </widget>
      </item>
-     <item row="8" column="1">
+     <item row="12" column="1">
       <widget class="Gui::QuantitySpinBox" name="revolveAngle2">
        <property name="keyboardTracking">
         <bool>false</bool>
@@ -238,7 +329,7 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="0" colspan="2">
+     <item row="13" column="0" colspan="2">
       <layout class="QGridLayout" name="gridLayout_6">
        <item row="0" column="0">
         <widget class="QToolButton" name="buttonFace2">
@@ -309,8 +400,17 @@
    <extends>QWidget</extends>
    <header>Gui/QuantitySpinBox.h</header>
   </customwidget>
+  <customwidget>
+   <class>Gui::PrefQuantitySpinBox</class>
+   <extends>Gui::QuantitySpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>startMode</tabstop>
+  <tabstop>lineStartReference</tabstop>
+  <tabstop>buttonStartReference</tabstop>
+  <tabstop>startOffsetEdit</tabstop>
   <tabstop>sidesMode</tabstop>
   <tabstop>axis</tabstop>
   <tabstop>changeMode</tabstop>

--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
@@ -24,6 +24,7 @@
  ***************************************************************************/
 
 
+#include <QLineEdit>
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
 #include <QTextStream>
@@ -101,6 +102,37 @@ const QString TaskSketchBasedParameters::onAddSelection(
     recomputeFeature();
 
     return refStr;
+}
+
+void TaskSketchBasedParameters::updateReferenceName(
+    QLineEdit* lineEdit,
+    const App::PropertyLinkSub& reference,
+    const QString& emptyPlaceholder
+)
+{
+    App::DocumentObject* referencedObject = reference.getValue();
+    const auto subValues = reference.getSubValues();
+    const std::string subName = subValues.empty() ? "" : subValues.front();
+
+    if (!referencedObject) {
+        lineEdit->clear();
+        lineEdit->setProperty("FeatureName", QVariant());
+        lineEdit->setProperty("FaceName", QVariant());
+        lineEdit->setPlaceholderText(emptyPlaceholder);
+        return;
+    }
+
+    QString text = QString::fromUtf8(referencedObject->Label.getValue());
+    if (subName.rfind("Face", 0) == 0) {
+        text += QStringLiteral(":%1%2").arg(tr("Face"), QString::fromStdString(subName.substr(4)));
+    }
+    else if (!subName.empty()) {
+        text += QStringLiteral(":%1").arg(QString::fromStdString(subName));
+    }
+
+    lineEdit->setText(text);
+    lineEdit->setProperty("FeatureName", QByteArray(referencedObject->getNameInDocument()));
+    lineEdit->setProperty("FaceName", QByteArray(subName.c_str()));
 }
 
 void TaskSketchBasedParameters::startReferenceSelection(App::DocumentObject*, App::DocumentObject* base)

--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.h
@@ -32,9 +32,12 @@
 #include "TaskFeatureParameters.h"
 #include "EnumFlags.h"
 
+class QLineEdit;
+
 namespace App
 {
 class Property;
+class PropertyLinkSub;
 class PropertyLinkSubList;
 }  // namespace App
 
@@ -76,6 +79,11 @@ protected:
     QVariant objectNameByLabel(const QString& label, const QVariant& suggest) const;
 
     QString getFaceReference(const QString& obj, const QString& sub) const;
+    void updateReferenceName(
+        QLineEdit* lineEdit,
+        const App::PropertyLinkSub& reference,
+        const QString& emptyPlaceholder
+    );
     /// Create a label for the 2D feature: the objects name if it's already 2D,
     /// or the subelement's name if the object is a solid.
     QString make2DLabel(const App::DocumentObject* section, const std::vector<std::string>& subValues);

--- a/src/Mod/PartDesign/PartDesignTests/TestRevolve.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestRevolve.py
@@ -24,6 +24,8 @@
 import unittest
 
 import FreeCAD
+import Part
+import Sketcher
 
 
 class TestRevolve(unittest.TestCase):
@@ -64,6 +66,69 @@ class TestRevolve(unittest.TestCase):
         self.Body.addObject(self.Groove)
         self.Doc.recompute()
         self.assertEqual(len(self.Groove.Shape.Faces), 5)
+
+    def testRevolutionStartOffsetAndReference(self):
+        profile = self.Doc.addObject("Sketcher::SketchObject", "Profile")
+        points = [
+            FreeCAD.Vector(2, 0),
+            FreeCAD.Vector(3, 0),
+            FreeCAD.Vector(3, 1),
+            FreeCAD.Vector(2, 1),
+        ]
+        for start, end in zip(points, points[1:] + points[:1]):
+            profile.addGeometry(Part.LineSegment(start, end), False)
+
+        axis = self.Doc.addObject("Part::Feature", "Axis")
+        axis.Shape = Part.makeLine(FreeCAD.Vector(0, -1, 0), FreeCAD.Vector(0, 2, 0))
+
+        revolution = self.Doc.addObject("PartDesign::Revolution", "OffsetRevolution")
+        revolution.Profile = profile
+        revolution.ReferenceAxis = (axis, ["Edge1"])
+        revolution.Angle = 30
+        revolution.StartType = "Offset"
+        revolution.StartOffset = 105
+        self.Doc.recompute()
+
+        direct_bounds = revolution.AddSubShape.BoundBox
+        direct_values = (
+            direct_bounds.XMin,
+            direct_bounds.XMax,
+            direct_bounds.YMin,
+            direct_bounds.YMax,
+            direct_bounds.ZMin,
+            direct_bounds.ZMax,
+        )
+        self.assertLess(direct_bounds.XMax, -0.5)
+        self.assertLess(direct_bounds.ZMax, -1.4)
+
+        reference = self.Doc.addObject("Part::Feature", "StartReference")
+        reference.Shape = Part.Face(
+            Part.makePolygon(
+                [
+                    FreeCAD.Vector(0, -1, -1),
+                    FreeCAD.Vector(0, 2, -1),
+                    FreeCAD.Vector(0, 2, -4),
+                    FreeCAD.Vector(0, -1, -4),
+                    FreeCAD.Vector(0, -1, -1),
+                ]
+            )
+        )
+        revolution.StartReference = (reference, ["Face1"])
+        revolution.StartType = "Reference"
+        revolution.StartOffset = 15
+        self.Doc.recompute()
+
+        reference_bounds = revolution.AddSubShape.BoundBox
+        reference_values = (
+            reference_bounds.XMin,
+            reference_bounds.XMax,
+            reference_bounds.YMin,
+            reference_bounds.YMax,
+            reference_bounds.ZMin,
+            reference_bounds.ZMax,
+        )
+        for actual, expected in zip(reference_values, direct_values):
+            self.assertAlmostEqual(actual, expected)
 
     def tearDown(self):
         # closing doc

--- a/tests/src/Mod/PartDesign/App/Revolution.cpp
+++ b/tests/src/Mod/PartDesign/App/Revolution.cpp
@@ -271,6 +271,27 @@ TEST_F(RevolutionTest, GrooveTwoSidesThroughAll)
     );
 }
 
+// The angular start offset moves the groove profile before the cut is generated.
+TEST_F(RevolutionTest, GrooveStartOffset)
+{
+    // Arrange
+    addBaseCylinder();
+    auto groove = addGroove();
+    groove->Angle.setValue(30.0);
+    groove->StartType.setValue("Offset");
+    groove->StartOffset.setValue(90.0);
+
+    // Act
+    getDocument()->recompute();
+
+    // Assert
+    ASSERT_FALSE(groove->isError()) << groove->getStatusString();
+    EXPECT_NEAR(volumeOf(groove->Shape.getValue()), cylinderVolume() - torusVolume(30.0), volumeTolerance);
+
+    const Base::BoundBox3d bbox = groove->AddSubShape.getShape().getBoundBox();
+    EXPECT_LT(bbox.MaxZ, -15.0);
+}
+
 // Side 2 set to "Up to face" with no face picked yet is the state the task panel starts
 // in. This should show up as a recompute error (rather than an uncaught exception).
 TEST_F(RevolutionTest, SecondSideUpToFaceWithoutTargetIsAnError)


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Following the changes for Pad/Pocket and after Two sided mode (https://github.com/FreeCAD/FreeCAD/pull/31044) was introduced for revolved features this PR adds the same logic and UI to the Revolve and Groove tools in Part design:
- Adds Start offset (angular in this case) with options: Profile plane (default), Offset, and Reference
- Added matching task controls, reference picker, angular offset dragger
- Clicking either visible angle arrow now toggles Reversed, same as Pad/Pocket
- Tests added

Assisted-by: GPT-5.6-Sol
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/7eb09733-c755-4806-a3ce-f0d3b241fe51



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
