### PR TITLE
Part: Fix extrude to handle planar non-plane faces

### DIFF
--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -30,6 +30,7 @@
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepLib_FindSurface.hxx>
 #include <BRepPrimAPI_MakePrism.hxx>
+#include <BRepTools.hxx>
 #include <gp_Pln.hxx>
 #include <gp_Trsf.hxx>
 #include <Precision.hxx>
@@ -47,6 +48,7 @@
 #include "FeatureExtrusion.h"
 #include "ExtrusionHelper.h"
 #include "Part2DObject.h"
+#include "Tools.h"
 
 
 using namespace Part;
@@ -313,25 +315,27 @@ Base::Vector3d Extrusion::calculateShapeNormal(const App::PropertyLink& shapeLin
         );
     }
 
-    // find plane
+    // find plane containing the shapes edges
     BRepLib_FindSurface planeFinder(sh, -1, /*OnlyPlane=*/true);
     if (!planeFinder.Found()) {
         throw Base::ValueError("Can't find normal direction, because the shape is not on a plane.");
     }
 
     // find plane normal and return result.
-    GeomAdaptor_Surface surf(planeFinder.Surface());
-    gp_Dir normal = surf.Plane().Axis().Direction();
+    GeomAdaptor_Surface edgeSurf(planeFinder.Surface());
+    gp_Dir normal = edgeSurf.Plane().Axis().Direction();
 
-    // now we know the plane. But if there are faces, the
-    // plane normal direction is not dependent on face orientation (because findPlane only uses
-    // edges). let's fix that.
-    TopExp_Explorer ex(sh, TopAbs_FACE);
-    if (ex.More()) {
-        BRepAdaptor_Surface surf(TopoDS::Face(ex.Current()));
-        normal = surf.Plane().Axis().Direction();
-        if (ex.Current().Orientation() == TopAbs_REVERSED) {
-            normal.Reverse();
+    // If shape contains a face, calculate normal from that, so extrusion won't flip if shape is rotated
+    if (TopExp_Explorer ex(sh, TopAbs_FACE); ex.More()) {
+        const auto& face = TopoDS::Face(ex.Current());
+        // Arbitrarily find normal from center of surface as shape is known to be planar
+        double u1, u2, v1, v2;
+        BRepTools::UVBounds(face, u1, u2, v1, v2);
+        gp_Dir faceNormal;
+        Standard_Boolean success = false;
+        Tools::getNormal(face, (u1 + u2) / 2, (v1 + v2) / 2, Precision::Confusion(), faceNormal, success);
+        if (success) {
+            normal = faceNormal;
         }
     }
 


### PR DESCRIPTION
Fixes #31305

The svg attached to the issue was in 1.0.2 imported as a part with edges only. In 1.1.1 the part also contains a face. But if a face exist `Extrusion::calculateShapeNormal`, in the process of calculating the normal, uses `GeomAdaptor_Surface::Plane` on a surface created from the face. But that method does not calculate a plane, it expects the surface to be of type `GeomAbs_Plane` and returns the plane. As the face in the imported part is of type `GeomAbs_BSplineSurface` this fails.

This fix modifies `Extrusion::calculateShapeNormal` to calculate the normal from the u, v vectors on the surface.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.