### PR TITLE
CAM: implement ANNOT_NO_ENGAGEMENT_FEED in Processor.py (for #31691)

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathFacingGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathFacingGenerator.py
@@ -900,7 +900,7 @@ class TestPathFacingGenerator(PathTestBase):
         import Path
 
         p = Path.Path(commands)
-        print(p.toGCode())
+        # print(p.toGCode())
 
     def test_spiral_milling_direction(self):
         """Test spiral with different milling directions."""
@@ -968,8 +968,8 @@ class TestPathFacingGenerator(PathTestBase):
         import Path
 
         p = Path.Path(commands)
-        print("Centered on origin G-code:")
-        print(p.toGCode())
+        # print("Centered on origin G-code:")
+        # print(p.toGCode())
 
     def test_spiral_axis_preference_variations(self):
         """Test spiral with different axis preferences and milling directions."""
@@ -1011,8 +1011,8 @@ class TestPathFacingGenerator(PathTestBase):
                 import Path
 
                 p = Path.Path(commands)
-                print(f"\n{axis_pref} axis, {milling_dir} milling G-code:")
-                print(p.toGCode())
+                # print(f"\n{axis_pref} axis, {milling_dir} milling G-code:")
+                # print(p.toGCode())
 
     def test_spiral_angled_rectangle(self):
         """Test spiral with angled rectangle to verify it follows polygon shape, not bounding box."""
@@ -1057,8 +1057,8 @@ class TestPathFacingGenerator(PathTestBase):
                 import Path
 
                 p = Path.Path(commands)
-                print(f"\nAngled rectangle {axis_pref} axis G-code:")
-                print(p.toGCode())
+                # print(f"\nAngled rectangle {axis_pref} axis G-code:")
+                # print(p.toGCode())
 
     def test_spiral_continuous_cutting(self):
         """Test that spiral maintains continuous cutting motion throughout."""

--- a/src/Mod/CAM/CAMTests/TestPostOutput.py
+++ b/src/Mod/CAM/CAMTests/TestPostOutput.py
@@ -438,7 +438,7 @@ class TestExport2Integration(unittest.TestCase):
         cls.job.OrderOutputBy = "Operation"
         cls.job.Fixtures = ["G54"]
 
-        cls.job.Machine = "Millstone"
+        cls.job.Machine = "linuxcnc"
 
         from Path.Tool.toolbit import ToolBit
 
@@ -1142,6 +1142,60 @@ class TestExport2Integration(unittest.TestCase):
             self.assertGreaterEqual(
                 g1_count, 4, f"Should have at least 4 G1 commands, found {g1_count}"
             )
+
+    def test080_translate_no_engagement(self):
+        """
+        Test that _expand_translate_rapids converts G0 to G1
+        when TRANSLATE_NO_ENGAGEMENT_FEED && ANNOT_NO_ENGAGEMENT_FEED
+        """
+        config = self._get_full_machine_config()
+        machine = Machine.from_dict(config)
+
+        # Do G0->G1
+        machine.postprocessor_properties["translate_no_engagement_feed"] = True
+        with self._modify_operation_path(
+            [
+                Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 5.0}),  # not translated
+                Path.Command(
+                    "G0",
+                    {"X": 10.0, "Y": 10.0, "F": 100.0},  # should replace F
+                    {Constants.ANNOT_NO_ENGAGEMENT_FEED: "500"},
+                ),  # translated
+                Path.Command("G1", {"X": 20.0, "Y": 10.0, "F": 100.0}),
+            ]
+        ):
+            results = self._run_export2(machine)[0][1]
+            _, interested = results.split("(preoperation)\n")
+            interested, _ = interested.split("(postoperation)")
+            expected = """G0 X0.000 Y0.000 Z5.000
+G1 X10.000 Y10.000 F30000.000
+G1 X20.000 Y10.000 F6000.000
+"""
+
+            self.assertEqual(expected, interested)
+
+        # Don't G0->G1
+        machine.postprocessor_properties["translate_no_engagement_feed"] = False
+        with self._modify_operation_path(
+            [
+                Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 5.0}),
+                # not translated, and F is dropped ("f_for_rapid_moves")
+                Path.Command(
+                    "G0",
+                    {"X": 10.0, "Y": 10.0, "F": 500.0},
+                    {Constants.ANNOT_NO_ENGAGEMENT_FEED: "True"},
+                ),  # not translated
+                Path.Command("G1", {"X": 20.0, "Y": 10.0, "F": 100.0}),
+            ]
+        ):
+            results = self._run_export2(machine)[0][1]
+            _, interested = results.split("(preoperation)\n")
+            interested, _ = interested.split("(postoperation)")
+            expected = """G0 X0.000 Y0.000 Z5.000
+G0 X10.000 Y10.000
+G1 X20.000 Y10.000 F6000.000
+"""
+            self.assertEqual(interested, expected)
 
     # ===== 090-099: _expand_xy_before_z tests =====
 

--- a/src/Mod/CAM/Constants.py
+++ b/src/Mod/CAM/Constants.py
@@ -226,10 +226,14 @@ NOT_PARAMETER_MODAL = {
 ANNOT_ALLOW_UNSUPPORTED = "allow_unsupported"
 
 # G0 moves which can be replaced by G1 with No-Engagement Feed
+# using the float-value of the annotation as the F parameter
+# when Machine Postprocessor Option TRANSLATE_NO_ENGAGEMENT_FEED is true
 ANNOT_NO_ENGAGEMENT_FEED = "NoEngagementFeed"
+
 # When de-dup'ing, do not look back at this or previous commands in the stream
 # True|absent|False
 ANNOT_MODAL_BARRIER = "modal_barrier"
+
 # Don't optimize this G0 into next/previous ones, the motion is salient
 ANNOT_NO_COLLAPSE_G0 = "no_collapse_g0"
 

--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -309,7 +309,10 @@ def GenerateGCode(op, obj, adaptiveResults):
                             op.commandlist.append(Path.Command("G0", {"Z": z}))
 
                         cmd = Path.Command("G0", {"X": x, "Y": y})
-                        cmd.Annotations = {Constants.ANNOT_NO_ENGAGEMENT_FEED: str(op.horizFeed)}
+                        if op.noEngagementFeed:
+                            cmd.Annotations = {
+                                Constants.ANNOT_NO_ENGAGEMENT_FEED: str(op.noEngagementFeed)
+                            }
                         op.commandlist.append(cmd)
 
                     elif motionType == area.AdaptiveMotionType.LinkNotClear:

--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -309,7 +309,7 @@ def GenerateGCode(op, obj, adaptiveResults):
                             op.commandlist.append(Path.Command("G0", {"Z": z}))
 
                         cmd = Path.Command("G0", {"X": x, "Y": y})
-                        cmd.Annotations = {Constants.ANNOT_NO_ENGAGEMENT_FEED: "True"}
+                        cmd.Annotations = {Constants.ANNOT_NO_ENGAGEMENT_FEED: str(op.horizFeed)}
                         op.commandlist.append(cmd)
 
                     elif motionType == area.AdaptiveMotionType.LinkNotClear:

--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -442,13 +442,17 @@ class ObjectOp(object):
         self.commandlist = None
         self.horizFeed = None
         self.horizRapid = None
+        self.vertFeed = None
+        self.vertRapid = None
+        self.leadInFeed = None
+        self.leadOutFeed = None
+        self.rampFeed = None
+        self.noEngagementFeed = None
         self.job = None
         self.model = None
         self.radius = None
         self.stock = None
         self.tool = None
-        self.vertFeed = None
-        self.vertRapid = None
         self.addNewProps = None
         self.isBaseValid = True
 
@@ -1126,6 +1130,10 @@ class ObjectOp(object):
                 self.horizFeed = tc.HorizFeed.Value
                 self.vertRapid = tc.VertRapid.Value
                 self.horizRapid = tc.HorizRapid.Value
+                self.leadInFeed = tc.LeadInFeed.Value
+                self.leadOutFeed = tc.LeadOutFeed.Value
+                self.rampFeed = tc.RampFeed.Value
+                self.noEngagementFeed = tc.NoEngagementFeed.Value
                 tool = tc.Proxy.getTool(tc)
                 if not tool or float(tool.Diameter) == 0:
                     Path.Log.error(

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -660,6 +660,19 @@ class PostProcessor:
                     "Whether to output the F parameter for G0 (rapid moves)",
                 ),
             },
+            {
+                "name": "translate_no_engagement_feed",
+                "scope": SCOPE_MACHINE,
+                "type": "bool",
+                "label": translate(
+                    "CAM", "Output non-engaging moves at the no-engagement feed rate"
+                ),
+                "default": False,
+                "help": translate(
+                    "CAM",
+                    'Certain G0\'s become G1 for operations that have "No-Engagement Feedrate"',
+                ),
+            },
         ]
 
     @classmethod
@@ -1343,14 +1356,15 @@ class PostProcessor:
                     item.path = Path.Path(new_commands)
 
     def _expand_translate_rapids(self, postables):
-        """Replace G0 rapid moves with G1 linear moves.
-
-        When machine processing.translate_rapid_moves is True, replaces
-        G0/G00 commands with G1 using the tool controller rapid rate.
+        """Replace G0 rapid moves with G1 linear moves for TRANSLATE_RAPID_MOVES.
+        Replace G0 with G1 if ANNOT_NO_ENGAGEMENT_FEED and TRANSLATE_NO_ENGAGEMENT_FEED.
 
         Subclasses can override to customize rapid move translation.
         """
-        if not self.values["TRANSLATE_RAPID_MOVES"]:
+        if (
+            not self.values["TRANSLATE_RAPID_MOVES"]
+            and not self.values["TRANSLATE_NO_ENGAGEMENT_FEED"]
+        ):
             return
 
         for section_name, sublist in postables:
@@ -1359,8 +1373,47 @@ class PostProcessor:
                     new_commands = []
                     Path.Log.debug(f"Translating rapid moves for {item.label}")
                     for cmd in item.path.Commands:
-                        if cmd.Name in Constants.GCODE_MOVE_RAPID:
+
+                        # Modify to G1?
+                        if (
+                            self.values["TRANSLATE_RAPID_MOVES"]
+                            and cmd.Name in Constants.GCODE_MOVE_RAPID
+                        ):
                             cmd.Name = "G1"
+
+                        # G0->G1 for non-engagement-feed
+                        elif (
+                            self.values["TRANSLATE_NO_ENGAGEMENT_FEED"]
+                            and (
+                                feed_str := cmd.Annotations.get(
+                                    Constants.ANNOT_NO_ENGAGEMENT_FEED, None
+                                )
+                            )
+                            is not None
+                        ):
+                            if not isinstance(feed_str, str):
+                                raise CAMAttributeError(
+                                    f"Expected ANNOT_NO_ENGAGEMENT_FEED to be a string convertable to a float, saw {feed_str.__class__.__name__} '{feed_str}'",
+                                    job=self._job,
+                                    operation=self._operation,
+                                    command=cmd,
+                                    pp=self.values["MACHINE_NAME"],
+                                )
+
+                            cmd.Name = "G1"
+                            try:
+                                feed = float(feed_str)
+                            except:
+                                # any conversion error
+                                raise CAMAttributeError(
+                                    f"Expected ANNOT_NO_ENGAGEMENT_FEED to be convertable to a float, saw '{feed_str}'",
+                                    job=self._job,
+                                    operation=self._operation,
+                                    command=cmd,
+                                    pp=self.values["MACHINE_NAME"],
+                                )
+                            cmd.Parameters = {**cmd.Parameters, **{"F": feed}}
+
                         new_commands.append(cmd)
                     item.path = Path.Path(new_commands)
 


### PR DESCRIPTION
Implements rest of #31691, especially see [comment](https://github.com/FreeCAD/FreeCAD/pull/31691#issuecomment-5296404816)

- [ ] Check the help text in Processor.py

add test080_translate_no_engagement. add translate_no_engagement_feed post-processor option.
 implement ANNOT_NO_ENGAGEMENT_FEED.
no print in TestPathFacingGenerator.py.
 fix warnings for TestPostOutput.py. 

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

@tarman3 @sliptonic 