### PR TITLE
(cp) Start: Update cached thumbnail of Start page

### DIFF
--- a/src/Mod/Start/App/DisplayedFilesModel.cpp
+++ b/src/Mod/Start/App/DisplayedFilesModel.cpp
@@ -140,6 +140,15 @@ QVariant DisplayedFilesModel::data(const QModelIndex& index, int role) const
     return {};
 }
 
+static std::size_t indexOfFile(const std::vector<FileStats>& fileInfoCache, const std::string& filePath)
+{
+    auto it = std::ranges::find_if(fileInfoCache, [filePath](const FileStats& row) {
+        auto pathIt = row.find(DisplayedFilesModelRoles::path);
+        return pathIt != row.end() && pathIt->second == filePath;
+    });
+    return std::distance(fileInfoCache.begin(), it);
+}
+
 void DisplayedFilesModel::addFile(const QString& filePath)
 {
     const QFileInfo qfi(filePath);
@@ -158,14 +167,7 @@ void DisplayedFilesModel::addFile(const QString& filePath)
 
     const auto lowercaseExtension = qfi.suffix().toLower();
     if (lowercaseExtension == QLatin1String("fcstd")) {
-        const auto runner = new FcstdInfoSource(filePath);
-        connect(
-            runner->signals(),
-            &FcstdInfoSource::Signals::infoAvailable,
-            this,
-            &DisplayedFilesModel::processNewFcstdInfo
-        );
-        QThreadPool::globalInstance()->start(runner);
+        updateFcstdInfo(filePath);
         return;
     }
     const QStringList ignoredExtensions {
@@ -186,6 +188,53 @@ void DisplayedFilesModel::addFile(const QString& filePath)
         &ThumbnailSource::Signals::thumbnailAvailable,
         this,
         &DisplayedFilesModel::processNewThumbnail
+    );
+    QThreadPool::globalInstance()->start(runner);
+}
+
+void DisplayedFilesModel::modifiedFile(const QString& filePath)
+{
+    const QFileInfo qfi(filePath);
+    if (!qfi.isReadable()) {
+        return;
+    }
+    if (!freecadCanOpen(qfi.suffix())) {
+        return;
+    }
+
+    const std::string path = filePath.toStdString();
+    QVector<int> changedRoles;
+    std::size_t index;
+    {
+        QMutexLocker locker(&_mutex);
+        index = indexOfFile(_fileInfoCache, path);
+        if (index == _fileInfoCache.size()) {
+            return;
+        }
+
+        auto& info = _fileInfoCache[index];
+        for (const auto& stat : getCommonFileInfo(path)) {
+            info.insert_or_assign(stat.first, stat.second);
+            changedRoles.append(static_cast<int>(stat.first));
+        }
+    }
+
+    const QModelIndex modelIndex = createIndex(index, 0);
+    Q_EMIT(dataChanged(modelIndex, modelIndex, changedRoles));
+
+    if (qfi.suffix().toLower() == QLatin1String("fcstd")) {
+        updateFcstdInfo(filePath);
+    }
+}
+
+void DisplayedFilesModel::updateFcstdInfo(const QString& filePath)
+{
+    const auto runner = new FcstdInfoSource(filePath);
+    connect(
+        runner->signals(),
+        &FcstdInfoSource::Signals::infoAvailable,
+        this,
+        &DisplayedFilesModel::processNewFcstdInfo
     );
     QThreadPool::globalInstance()->start(runner);
 }
@@ -213,15 +262,6 @@ QHash<int, QByteArray> DisplayedFilesModel::roleNames() const
     return nameMap;
 }
 
-static std::size_t indexOfFile(const std::vector<FileStats>& fileInfoCache, const std::string& filePath)
-{
-    auto it = std::ranges::find_if(fileInfoCache, [filePath](const FileStats& row) {
-        auto pathIt = row.find(DisplayedFilesModelRoles::path);
-        return pathIt != row.end() && pathIt->second == filePath;
-    });
-    return std::distance(fileInfoCache.begin(), it);
-}
-
 void DisplayedFilesModel::processNewFcstdInfo(
     const QString& filePath,
     const FileStats& stats,
@@ -237,8 +277,8 @@ void DisplayedFilesModel::processNewFcstdInfo(
 
     QVector<int> changedRoles;
     auto& info = _fileInfoCache[index];
-    for (auto stat : stats) {
-        info.insert(stat);
+    for (const auto& stat : stats) {
+        info.insert_or_assign(stat.first, stat.second);
         changedRoles.append(static_cast<int>(stat.first));
     }
 

--- a/src/Mod/Start/App/DisplayedFilesModel.h
+++ b/src/Mod/Start/App/DisplayedFilesModel.h
@@ -62,6 +62,7 @@ public:
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
 
     void addFile(const QString& filePath);
+    void modifiedFile(const QString& filePath);
 
     void clear();
 
@@ -77,6 +78,8 @@ protected:
     void processNewThumbnail(const QString& file, const QByteArray& thumbnail);
 
 private:
+    void updateFcstdInfo(const QString& filePath);
+
     mutable QMutex _mutex;
     std::vector<FileStats> _fileInfoCache;
     QMap<QString, QByteArray> _imageCache;

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -43,6 +43,7 @@
 #include "FirstStartWidget.h"
 #include "FlowLayout.h"
 #include "NewFileButton.h"
+#include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <App/Application.h>
 #include <Base/Interpreter.h>
@@ -204,6 +205,14 @@ StartView::StartView(QWidget* parent)
     isInitialized = true;
 
     retranslateUi();
+
+    // NOLINTBEGIN
+    _saveddoc = App::GetApplication().signalFinishSaveDocument.connect(
+        [this](const App::Document& doc, const std::string&) {
+            _recentFilesModel.modifiedFile(QString::fromStdString(doc.FileName.getStrValue()));
+        }
+    );
+    // NOLINTEND
 }
 
 void StartView::configureNewFileButtons(QLayout* layout) const

--- a/src/Mod/Start/Gui/StartView.h
+++ b/src/Mod/Start/Gui/StartView.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <fastsignals/signal.h>
+
 #include <Mod/Start/StartGlobal.h>
 #include <Base/Type.h>
 #include <Gui/MDIView.h>
@@ -117,6 +119,7 @@ private:
     QLabel* _customFolderLabel;
     QPushButton* _openFirstStart;
     QCheckBox* _showOnStartupCheckBox;
+    fastsignals::scoped_connection _saveddoc;
 
     bool isInitialized = false;
 


### PR DESCRIPTION
Cherry-picked from @wwmayer https://codeberg.org/wwmayer/FreeCAD11/commits/branch/issue_32117

When saving a document then update its cached information and thumbnail that are shown in the Start page

This fixes https://github.com/FreeCAD/FreeCAD/issues/32117
