### PR TITLE
New crash reporter - Phase 1(b) - bug fixes to the original Phase 1

### DIFF
--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 add_library(FreeCADBase SHARED)
+add_dependencies(FreeCADBase fc_version)
 
 if(WIN32)
     add_definitions(-DFCBase)

--- a/src/Base/CrashReporter/Format.h
+++ b/src/Base/CrashReporter/Format.h
@@ -87,7 +87,7 @@ enum class OS : std::uint8_t
     Linux,
     macOS,
     Windows,
-    BSD
+    BSDFamily  // Can't use "BSD" since it's #defined
 };
 
 enum class Architecture : std::uint8_t

--- a/src/Base/CrashReporter/Reader.cpp
+++ b/src/Base/CrashReporter/Reader.cpp
@@ -103,6 +103,23 @@ std::string stripSourceRoot(const std::string& path)
 
     return Base::FileInfo(normalized).fileName();
 }
+
+/**
+ * Trim the "+ offset" that a symbol-table lookup appends to a function name.
+ */
+std::string stripSymbolOffset(const std::string& symbol)
+{
+    const auto plus = symbol.rfind(" + ");
+    if (plus == std::string::npos || plus == 0) {
+        return symbol;
+    }
+    const auto offsetDigits = std::string_view {symbol}.substr(plus + 3);
+    if (offsetDigits.empty()
+        || offsetDigits.find_first_not_of("0123456789") != std::string_view::npos) {
+        return symbol;
+    }
+    return symbol.substr(0, plus);
+}
 #endif
 }  // namespace
 
@@ -226,11 +243,16 @@ ParsedCrashReport Base::CrashReporter::parse(const std::string& pathToRawReportF
             parsedFrame.rawAddress = frame.raw_address;
             parsedFrame.moduleOffset = frame.object_address;
 
-            // To avoid any PII in the backtrace, only include the filename, not the full path:
-            parsedFrame.modulePath = FileInfo(modulePathMap[frame.raw_address]).fileName();
+            const std::string& objectPath = modulePathMap[frame.raw_address];
 
-            parsedFrame.symbol = frame.symbol;
-            parsedFrame.file = stripSourceRoot(frame.filename);  // Avoid PII!
+            // To avoid any PII in the backtrace, only include the filename, not the full path:
+            parsedFrame.modulePath = FileInfo(objectPath).fileName();
+
+            parsedFrame.symbol = stripSymbolOffset(frame.symbol);
+
+            // `file` means a source file, if we've got it
+            const bool haveRealSourceFile = !frame.filename.empty() && frame.filename != objectPath;
+            parsedFrame.file = haveRealSourceFile ? stripSourceRoot(frame.filename) : std::string {};
             parsedFrame.line = frame.line.has_value() ? std::optional(frame.line.value())
                                                       : std::nullopt;
             parsedFrame.isInline = frame.is_inline;

--- a/src/Base/CrashReporter/Reader.cpp
+++ b/src/Base/CrashReporter/Reader.cpp
@@ -106,6 +106,12 @@ std::string stripSourceRoot(const std::string& path)
 
 /**
  * Trim the "+ offset" that a symbol-table lookup appends to a function name.
+ *
+ * This is purely heuristic: the "<name> + <decimal>" form is an implementation detail of cpptrace's
+ * symbol-table resolution, and was observed in its Mach-O backend and is not part of its documented
+ * API. If cpptrace ever changes the format, this stops matching and the offsets reappear in the
+ * symbols; the `realCrashCapturesUsableFrames` test is designed to catch that. Note that requiring
+ * all digits after the " + " keeps demangled template arguments such as "thinger<1 + 2>" intact.
  */
 std::string stripSymbolOffset(const std::string& symbol)
 {

--- a/src/Base/CrashReporter/Writer.cpp
+++ b/src/Base/CrashReporter/Writer.cpp
@@ -48,8 +48,18 @@
 #include <string>
 #include <string_view>
 
+
 #include <Build/Version.h>
 #include <FCConfig.h>
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_BACKTRACE_SYMBOLS
+# include <dlfcn.h>     // For dladdr
+# include <execinfo.h>  // For backtrace
+#endif
 
 // The Writer is intentionally C-style (fixed static buffers, raw write) for async-signal-safety,
 // so array decay and pointer arithmetic are pervasive and deliberate, not bounds hazards.
@@ -61,7 +71,8 @@
 #endif
 
 static std::atomic_flag writing;
-static std::string resolvedCrashFilePath;  // Stored in UTF-8 (so on Windows, convert first)
+static std::string resolvedCrashFilePath;    // Stored in UTF-8 (so on Windows, convert first)
+static bool canCaptureSignalSafely = false;  // Determined during the prewarm phase
 
 // Cygwin is a POSIX layer, so it uses the signal handlers rather than the Windows path.
 #if defined(FC_OS_LINUX) || defined(FC_OS_MACOSX) || defined(FC_OS_BSD) || defined(FC_OS_CYGWIN)
@@ -174,6 +185,7 @@ static void crashHandler(int sig, siginfo_t* info, [[maybe_unused]] void* uconte
     if (writing.test_and_set()) {
         return;
     }
+
     header.faultAddress = reinterpret_cast<std::uint64_t>(info->si_addr);
     header.code = static_cast<uint32_t>(sig);
     header.timestamp = std::time(nullptr);
@@ -193,24 +205,66 @@ static void crashHandler(int sig, siginfo_t* info, [[maybe_unused]] void* uconte
     // Now the call stack, if we have cpptrace:
     std::uint32_t frameCount = 0;
 # ifdef FC_HAVE_CPPTRACE
-    cpptrace::frame_ptr rawFrames[MaxFrames];
-    constexpr std::size_t skip {0};  // Don't skip any frames at this stage
-    std::size_t nFrames = cpptrace::safe_generate_raw_trace(rawFrames, MaxFrames, skip);
-    cpptrace::safe_object_frame objectFrame;
-    for (std::uint32_t frame = 0; frame < nFrames && frameCount < MaxFrames; ++frame) {
-        cpptrace::get_safe_object_frame(rawFrames[frame], &objectFrame);
-        Frame extractedFrame;
-        extractedFrame.rawAddress = objectFrame.raw_address;
-        extractedFrame.moduleOffset = objectFrame.address_relative_to_object_start;
-        extractedFrame.moduleStringOffset = addToStringTable(objectFrame.object_path);
-        std::memcpy(
-            &fileBuffer[sizeof(Header) + frameCount * sizeof(Frame)],
-            &extractedFrame,
-            sizeof(Frame)
-        );
-        ++frameCount;
+    if (canCaptureSignalSafely) {
+        cpptrace::frame_ptr rawFrames[MaxFrames];
+        constexpr std::size_t skip {0};  // Don't skip any frames at this stage
+        std::size_t nFrames = cpptrace::safe_generate_raw_trace(rawFrames, MaxFrames, skip);
+        cpptrace::safe_object_frame objectFrame;
+        for (std::uint32_t frame = 0; frame < nFrames && frameCount < MaxFrames; ++frame) {
+            cpptrace::get_safe_object_frame(rawFrames[frame], &objectFrame);
+            Frame extractedFrame;
+            extractedFrame.rawAddress = objectFrame.raw_address;
+            extractedFrame.moduleOffset = objectFrame.address_relative_to_object_start;
+            extractedFrame.moduleStringOffset = addToStringTable(objectFrame.object_path);
+            std::memcpy(
+                &fileBuffer[sizeof(Header) + frameCount * sizeof(Frame)],
+                &extractedFrame,
+                sizeof(Frame)
+            );
+            ++frameCount;
+        }
     }
+    else
 # endif
+    {
+        // The capture is NOT async-signal-safe: this is mostly macOS, where we currently cannot
+        // get a version of cpptrace compiled against libunwind via pixi.
+# ifdef HAVE_BACKTRACE_SYMBOLS
+        void* callstack[MaxFrames];
+        int nFrames = backtrace(callstack, MaxFrames);
+        for (int frame = 0; frame < nFrames && frameCount < MaxFrames; ++frame) {
+            Dl_info frameInfoStruct {};
+
+            // A Dl_info contains:
+            // const char* dli_fname -- pathname of the shared object containing the address
+            // void* dli_fbase -- base address (mach_header) at which the image is mapped
+            // const char* dli_sname -- nearest run-time symbol at or below the address
+            // void* dli_saddr -- value of the symbol returned in dli_sname
+            const int found = dladdr(callstack[frame], &frameInfoStruct);
+
+            Frame extractedFrame;
+            extractedFrame.rawAddress = reinterpret_cast<std::uint64_t>(callstack[frame]);
+            if (found == 0 /*yes, zero... not very POSIX-ish*/
+                || frameInfoStruct.dli_fname == nullptr) {
+                // We don't really know anything about this module (except the address)
+                extractedFrame.moduleOffset = 0;
+                extractedFrame.moduleStringOffset = NoString;
+            }
+            else {
+                const auto address = reinterpret_cast<std::uintptr_t>(callstack[frame]);
+                const auto base = reinterpret_cast<std::uintptr_t>(frameInfoStruct.dli_fbase);
+                extractedFrame.moduleOffset = address - base;
+                extractedFrame.moduleStringOffset = addToStringTable(frameInfoStruct.dli_fname);
+            }
+            std::memcpy(
+                &fileBuffer[sizeof(Header) + frameCount * sizeof(Frame)],
+                &extractedFrame,
+                sizeof(Frame)
+            );
+            ++frameCount;
+        }
+# endif
+    }
     std::uint32_t fileSize = finishHeader(frameCount);
     if (fileSize > 0) {
         writeRawBufferPOSIX(fileSize);
@@ -241,9 +295,14 @@ void Writer::handleException(_EXCEPTION_POINTERS* exceptionInfo)
     if (writing.test_and_set()) {
         return;
     }
-    header.code = exceptionInfo->ExceptionRecord->ExceptionCode;
-    // NOLINTNEXTLINE
-    header.faultAddress = reinterpret_cast<uint64_t>(exceptionInfo->ExceptionRecord->ExceptionAddress);
+    const auto* record = exceptionInfo->ExceptionRecord;
+    header.code = record->ExceptionCode;
+    // The faulting data address is only defined for these two codes; the faulting instruction is
+    // frame 0 of the captured stack.
+    if (record->ExceptionCode == EXCEPTION_ACCESS_VIOLATION
+        || record->ExceptionCode == EXCEPTION_IN_PAGE_ERROR) {
+        header.faultAddress = record->ExceptionInformation[1];
+    }
     header.threadID = GetCurrentThreadId();
     header.timestamp = std::time(nullptr);
 
@@ -309,7 +368,9 @@ void Writer::prewarm()
     }
 
     // Record whether we will be doing a signal-safe capture
-    if (cpptrace::can_signal_safe_unwind() && cpptrace::can_get_safe_object_frame()) {
+    canCaptureSignalSafely = cpptrace::can_signal_safe_unwind()
+        && cpptrace::can_get_safe_object_frame();
+    if (canCaptureSignalSafely) {
         header.flags |= Flags::CaptureWasSignalSafe;
     }
 # endif

--- a/src/Base/CrashReporter/Writer.cpp
+++ b/src/Base/CrashReporter/Writer.cpp
@@ -186,6 +186,24 @@ static void crashHandler(int sig, siginfo_t* info, [[maybe_unused]] void* uconte
         return;
     }
 
+    // A fault inside this handler has to kill the process, not hang it. The earlier call to
+    // install() blocks all five signals while the handler runs. But a synchronous fault on a
+    // blocked signal *cannot* be delivered. However, it tries (forever). To resolve, both steps
+    // below are required:
+    // 1) Restore SIG_DFL for each signal process-wide so we terminate instead of hang
+    // 2) Unblock our five signals on this (the currently crashing) thread.
+    // Note that restoring SIG_DFL alone still hangs, and using SA_RESETHAND/SA_NODEFER doesn't
+    // work since we have an explicit sa_mask entry. The downside is that a crash in another thread
+    // truncates our write, but the file format was designed to let us handle that case reasonably
+    // gracefully.
+    sigset_t unblockAll {};
+    sigemptyset(&unblockAll);
+    for (int s : {SIGSEGV, SIGABRT, SIGBUS, SIGFPE, SIGILL}) {
+        std::signal(s, SIG_DFL);
+        sigaddset(&unblockAll, s);
+    }
+    pthread_sigmask(SIG_UNBLOCK, &unblockAll, nullptr);
+
     header.faultAddress = reinterpret_cast<std::uint64_t>(info->si_addr);
     header.code = static_cast<uint32_t>(sig);
     header.timestamp = std::time(nullptr);

--- a/src/Base/CrashReporter/Writer.cpp
+++ b/src/Base/CrashReporter/Writer.cpp
@@ -419,7 +419,7 @@ void Writer::install(const std::string& crashReportDirectory)
 #elif defined(FC_OS_LINUX)
     header.osID = OS::Linux;
 #elif defined(FC_OS_BSD)
-    header.osID = OS::BSD;
+    header.osID = OS::BSDFamily;
 #else
     // Cygwin has no enumerator, so it keeps the initialized OS::None.
 #endif

--- a/tests/src/Base/CrashReporter_tests.cpp
+++ b/tests/src/Base/CrashReporter_tests.cpp
@@ -23,14 +23,15 @@
 # include <sys/resource.h>
 #endif
 
-/// The fault code for a crash that has a faulting data address, on the platform this test
-/// binary was built for. These are the only codes for which the Writer can populate one.
-constexpr std::uint32_t addressCarryingFaultCode()
+/// Whether this is a fault code that carries a faulting data address, on the platform this test
+/// binary was built for. These are the only codes for which the Writer can populate one. POSIX
+/// has two: an unmapped access is reported as SIGBUS rather than SIGSEGV on some platforms.
+constexpr bool isAddressCarryingFaultCode(std::uint32_t code)
 {
 #ifdef FC_OS_WIN32
-    return EXCEPTION_ACCESS_VIOLATION;
+    return code == EXCEPTION_ACCESS_VIOLATION;
 #else
-    return SIGSEGV;
+    return code == SIGSEGV || code == SIGBUS;
 #endif
 }
 
@@ -508,9 +509,8 @@ TEST_F(CrashReporterTests, FC_REAL_CAPTURE_TEST)  // NOLINT
         }
     }
 
-    // A null dereference: SIGBUS is accepted because some platforms report an unmapped access that
-    // way rather than as SIGSEGV.
-    EXPECT_TRUE(report.code == addressCarryingFaultCode() || report.code == SIGBUS);
+    EXPECT_TRUE(isAddressCarryingFaultCode(report.code))
+        << "unexpected fault code: " << report.code;
     EXPECT_FALSE(report.partialWrite);
 }
 

--- a/tests/src/Base/CrashReporter_tests.cpp
+++ b/tests/src/Base/CrashReporter_tests.cpp
@@ -18,7 +18,21 @@
 # include <windows.h>
 # include <cstdlib>  // IWYU pragma: keep
 # include <Base/CrashReporter/WindowsCrashReporter.h>
+#else
+# include <csignal>
+# include <sys/resource.h>
 #endif
+
+/// The fault code for a crash that has a faulting data address, on the platform this test
+/// binary was built for. These are the only codes for which the Writer can populate one.
+constexpr std::uint32_t addressCarryingFaultCode()
+{
+#ifdef FC_OS_WIN32
+    return EXCEPTION_ACCESS_VIOLATION;
+#else
+    return SIGSEGV;
+#endif
+}
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers,cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-pro-type-vararg,hicpp-vararg,cppcoreguidelines-owning-memory,cppcoreguidelines-avoid-non-const-global-variables,cert-err58-cpp)
 
@@ -425,6 +439,11 @@ static void installAndCrash(const std::string& crashDir)
 {
 #ifdef _MSC_VER
     SetErrorMode(SEM_NOGPFAULTERRORBOX | SEM_FAILCRITICALERRORS);
+#else
+    // These tests crash on purpose, several times per run on three platforms. Without this the
+    // build directory (and /cores on macOS) collects dumps nobody asked for.
+    const rlimit noCoreDumps {0, 0};
+    setrlimit(RLIMIT_CORE, &noCoreDumps);
 #endif
     Base::CrashReporter::Writer::prewarm();
     Base::CrashReporter::Writer::install(crashDir);
@@ -432,6 +451,44 @@ static void installAndCrash(const std::string& crashDir)
     Base::CrashReporter::WindowsCrashReporter::install(crashDir);
 #endif
     crashReporterFaultSite();
+}
+
+// Windows needs --gtest_catch_exceptions=0, because gtest's own SEH handler would otherwise eat
+// the fault before SetUnhandledExceptionFilter sees it. That flag cannot be assumed in CI, so the
+// assertion test runs automatically on POSIX only;
+#ifdef _MSC_VER
+# define FC_REAL_CAPTURE_TEST DISABLED_realCrashCapturesUsableFrames
+#else
+# define FC_REAL_CAPTURE_TEST realCrashCapturesUsableFrames
+#endif
+
+TEST_F(CrashReporterTests, FC_REAL_CAPTURE_TEST)  // NOLINT
+{
+    const std::string crashDir = resolveCrashDir(tempDir);
+    EXPECT_DEATH(installAndCrash(crashDir), "");  // NOLINT
+
+    const auto path = findSoleFcrashIn(crashDir);
+    ASSERT_FALSE(path.empty());
+    const auto report = Base::CrashReporter::parse(path);
+
+    // The point of the whole exercise: a real crash has to produce a real stack.
+    ASSERT_GT(report.stackFrames.size(), 0U);
+
+    // Every frame must carry a genuine instruction address.
+    for (const auto& frame : report.stackFrames) {
+        EXPECT_NE(frame.rawAddress, 0U);
+    }
+
+    // At least one frame must be attributed to a module. Not all of them: an unattributable frame
+    // is legitimate and is recorded with NoString
+    EXPECT_TRUE(std::ranges::any_of(report.stackFrames, [](const auto& frame) {
+        return !frame.modulePath.empty();
+    }));
+
+    // A null dereference: SIGBUS is accepted because some platforms report an unmapped access that
+    // way rather than as SIGSEGV.
+    EXPECT_TRUE(report.code == addressCarryingFaultCode() || report.code == SIGBUS);
+    EXPECT_FALSE(report.partialWrite);
 }
 
 // This test is always disabled in CI runs: to run it, use a direct manual call:

--- a/tests/src/Base/CrashReporter_tests.cpp
+++ b/tests/src/Base/CrashReporter_tests.cpp
@@ -485,6 +485,24 @@ TEST_F(CrashReporterTests, FC_REAL_CAPTURE_TEST)  // NOLINT
         return !frame.modulePath.empty();
     }));
 
+    // A symbol is a function name. When a frame resolves from a symbol table rather than from
+    // debug information the symbolicator appends "+ <offset>", which would put a byte offset into
+    // the key consumers group crashes by, so the Reader trims it.
+    for (const auto& frame : report.stackFrames) {
+        const auto plus = frame.symbol.rfind(" + ");
+        const bool endsWithOffset = plus != std::string::npos
+            && frame.symbol.find_first_not_of("0123456789", plus + 3) == std::string::npos;
+        EXPECT_FALSE(endsWithOffset) << "symbol still carries an offset: " << frame.symbol;
+    }
+
+    // `file` is a source file. A frame with no debug information has none, and must not fall back
+    // to naming the object it resolved against.
+    for (const auto& frame : report.stackFrames) {
+        if (!frame.file.empty()) {
+            EXPECT_NE(frame.file, frame.modulePath);
+        }
+    }
+
     // A null dereference: SIGBUS is accepted because some platforms report an unmapped access that
     // way rather than as SIGSEGV.
     EXPECT_TRUE(report.code == addressCarryingFaultCode() || report.code == SIGBUS);

--- a/tests/src/Base/CrashReporter_tests.cpp
+++ b/tests/src/Base/CrashReporter_tests.cpp
@@ -509,8 +509,7 @@ TEST_F(CrashReporterTests, FC_REAL_CAPTURE_TEST)  // NOLINT
         }
     }
 
-    EXPECT_TRUE(isAddressCarryingFaultCode(report.code))
-        << "unexpected fault code: " << report.code;
+    EXPECT_TRUE(isAddressCarryingFaultCode(report.code)) << "unexpected fault code: " << report.code;
     EXPECT_FALSE(report.partialWrite);
 }
 

--- a/tests/src/Base/CrashReporter_tests.cpp
+++ b/tests/src/Base/CrashReporter_tests.cpp
@@ -410,9 +410,14 @@ std::string findSoleFcrashIn(const std::string& path)
 #else
 # define FC_NOINLINE __attribute__((noinline))
 #endif
+// The target is loaded through a volatile pointer so that the compiler cannot see a literal null.
+// Given one, GCC at -O2 proves the store is unreachable UB and deletes the call to this function,
+// leaving the release build with nothing to crash on.
+static int* volatile deliberateNullTarget = nullptr;
+
 extern "C" FC_NOINLINE void crashReporterFaultSite()
 {
-    volatile int* p = nullptr;
+    volatile int* p = deliberateNullTarget;
     *p = 13;
     std::atomic_signal_fence(std::memory_order_seq_cst);  // defeat tail-call/reorder
 }


### PR DESCRIPTION
I started work on Phase 2 of this project (the Python API) and of course immediately found a few problems with the phase 1 work. Most of these are things that bit me on macOS. I broke it up into three commits, each of which is independent and can be reviewed on its own (since this code can get pretty unwieldy in a hurry).

1) pixi on macOS has no libunwind, but there was no code to handle the POSIX-but-not-async-signal-safe local-symbolication case
2) Prevent a hang during crash handling if the handling code itself crashes
3) Make sure no PII sneaks in through a file path stored as the module name, and strip off any "+ 1234" offset that was confusing downstream code.

ETA1: And now bonus commit 4 😁 -- gcc was subverting my attempts to crash in the tests, add some more code to force it to not discard the line that faults.

ETA2: And bonus commit 5 to fix compilation on BSD. Fixes #32051, with thanks to @darkdi and @rmx-it

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

