### PR TITLE
Gui: Expose mouse-wheel-filter preference in UI, default to on

### DIFF
--- a/src/Gui/GuiApplication.cpp
+++ b/src/Gui/GuiApplication.cpp
@@ -369,20 +369,31 @@ void GUISingleApplication::processMessages()
 
 WheelEventFilter::WheelEventFilter(QObject* parent)
     : QObject(parent)
+    , hGrp(App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/General"))
 {}
+
+bool WheelEventFilter::isEnabled() const
+{
+    return hGrp->GetBool("ComboBoxWheelEventFilter", true);
+}
 
 bool WheelEventFilter::eventFilter(QObject* obj, QEvent* ev)
 {
     if (qobject_cast<QComboBox*>(obj) && ev->type() == QEvent::Wheel) {
-        return true;
+        return isEnabled();
     }
     auto sb = qobject_cast<QAbstractSpinBox*>(obj);
     if (sb) {
         if (ev->type() == QEvent::Show) {
-            sb->setFocusPolicy(Qt::StrongFocus);
+            if (isEnabled()) {
+                sb->setFocusPolicy(Qt::StrongFocus);
+            }
+            else if (sb->focusPolicy() == Qt::StrongFocus) {
+                sb->setFocusPolicy(Qt::WheelFocus);
+            }
         }
         else if (ev->type() == QEvent::Wheel) {
-            return !sb->hasFocus();
+            return isEnabled() && !sb->hasFocus();
         }
     }
     return false;

--- a/src/Gui/GuiApplication.h
+++ b/src/Gui/GuiApplication.h
@@ -25,6 +25,7 @@
 
 #include "GuiApplicationNativeEventAware.h"
 #include <Base/Interpreter.h>  // For Base::SystemExitException
+#include <Base/Parameter.h>
 #include <QList>
 #include <memory>
 
@@ -90,6 +91,11 @@ class WheelEventFilter: public QObject
 public:
     explicit WheelEventFilter(QObject* parent);
     bool eventFilter(QObject* obj, QEvent* ev) override;
+
+private:
+    bool isEnabled() const;
+
+    ParameterGrp::handle hGrp;
 };
 
 }  // namespace Gui

--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -78,7 +78,7 @@ InputField::InputField(QWidget* parent)
     setValidator(new InputValidator(this));
     if (!App::GetApplication()
              .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-             ->GetBool("ComboBoxWheelEventFilter", false)) {
+             ->GetBool("ComboBoxWheelEventFilter", true)) {
         setFocusPolicy(Qt::WheelFocus);
     }
     else {

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -253,6 +253,7 @@ void DlgSettingsGeneral::saveSettings()
         requireRestart();
     }
     ui->FineGrainedRecompute->onSave();
+    ui->ComboBoxWheelEventFilter->onSave();
 
     setRecentFileSize();
     bool force = setLanguage();
@@ -307,6 +308,7 @@ void DlgSettingsGeneral::loadSettings()
     ui->ActivateOverlay->onRestore();
     setProperty("ActivateOverlay", ui->ActivateOverlay->isChecked());
     ui->FineGrainedRecompute->onRestore();
+    ui->ComboBoxWheelEventFilter->onRestore();
 
     // search for the language files
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("General");

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.ui
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.ui
@@ -357,6 +357,26 @@ display the splash screen.</string>
          </property>
         </widget>
        </item>
+       <item row="7" column="1">
+        <widget class="Gui::PrefCheckBox" name="ComboBoxWheelEventFilter">
+         <property name="toolTip">
+          <string>Prevent the mouse wheel from changing the value of combo boxes,
+and spin boxes with hover focus</string>
+         </property>
+         <property name="text">
+          <string>Ignore mouse wheel on hover focused input fields</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+         <property name="prefEntry" stdset="0">
+          <cstring>ComboBoxWheelEventFilter</cstring>
+         </property>
+         <property name="prefPath" stdset="0">
+          <cstring>General</cstring>
+         </property>
+        </widget>
+       </item>
        <item row="7" column="0">
         <widget class="Gui::PrefCheckBox" name="FineGrainedRecompute">
          <property name="toolTip">

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -291,12 +291,10 @@ void StartupPostProcess::setToolBarIconSize()
 
 void StartupPostProcess::setWheelEventFilter()
 {
-    // filter wheel events for combo boxes
-    ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("General");
-    if (hGrp->GetBool("ComboBoxWheelEventFilter", false)) {
-        auto filter = new WheelEventFilter(qtApp);
-        qtApp->installEventFilter(filter);
-    }
+    // filter wheel events for combo boxes; the filter itself honours the preference so that
+    // it can be toggled without a restart
+    auto filter = new WheelEventFilter(qtApp);
+    qtApp->installEventFilter(filter);
 }
 
 void StartupPostProcess::setLocale()


### PR DESCRIPTION
The ComboBoxWheelEventFilter parameter already existed, but was hidden in Edit parameters, defaulted to off, and was only read at startup so changing it required a restart.

Add a checkbox for it in Preferences (General -> Application), default it to on, and check the parameter when a wheel event arrives so toggling it takes effect right away.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
