### PR TITLE
Techdraw: Fix vertical mis-alignment of dimension text

### DIFF
--- a/src/Mod/TechDraw/Gui/QGCustomText.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomText.cpp
@@ -185,15 +185,16 @@ QRectF QGCustomText::tightBoundingRect() const
     QFontMetrics qfm(font());
     QRectF result = QGraphicsTextItem::boundingRect();
     QRectF tight = qfm.tightBoundingRect(toPlainText());
-    qreal x_adj = (result.width() - tight.width())/4.0;
-    qreal y_adj = (result.height() - tight.height())/4.0;
 
-    // Adjust the bounding box 50% towards the Qt tightBoundingRect(),
-    // except chomp some extra empty space above the font (1.75*y_adj)
-    // wf: this does not work with all fonts.  it depends on where the glyph is located within
-    //     the em square.  see https://github.com/FreeCAD/FreeCAD/issues/11452
-    // TODO: how to know where the glyph is going to be placed?
-    result.adjust(x_adj, 1.75*y_adj, -x_adj, -y_adj);
+    double baselineY = document()->documentMargin() + qfm.ascent();
+    double inkTop = baselineY + tight.top();
+    double inkBottom = baselineY + tight.bottom();
+
+    double x_adj = (result.width() - tight.width()) / 2.0;
+    result.setLeft(result.left() + x_adj);
+    result.setRight(result.right() - x_adj);
+    result.setTop(inkTop);
+    result.setBottom(inkBottom);
 
     return result;
 }


### PR DESCRIPTION
TechDraw dimensions were vertically out of alignment depending on font chosen. This is because the alignment was more or less guessed based of the bounding rect.

This PR fixes the alignment of dimension text with respect to the dimension line. This change affects all dim styles (referncing, inlined etc), and all dim types (Horizontal, vertical, radius etc). I've tested many fonts, sizes, and dim types, they all seem to be correctly positioned now. This is achieved by looking at the `ascent()` of the font metrics, the document margin and the tight bounds.

From my understanding, it is still possible for a font to be misaligned if the ascent value declared in the font file is wrong, but that would be a font bug, not freecad bug.

Ive attached some images below, but note again that these are not the only examples of dim alignment being fixed. The bug was happening everywhere.


- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Builds on previous PRs: #18771 and #19170

## Issues
I couldnt find an open issue, but this one #11452 is related


## Before 
<img width="249" height="775" alt="20260823_22h31m24s_grim" src="https://github.com/user-attachments/assets/bc05569d-0d63-4a12-84f7-e79c4987226a" />

<img width="795" height="404" alt="20260823_22h31m39s_grim" src="https://github.com/user-attachments/assets/eeea730f-20d7-4ea5-bf52-b9b355f63f55" />



## After


<img width="272" height="776" alt="20260824_20h38m32s_grim" src="https://github.com/user-attachments/assets/d6c9c194-0c49-4c41-a41c-792fe2b38c8e" />


<img width="643" height="292" alt="20260824_20h38m23s_grim" src="https://github.com/user-attachments/assets/c6a40c10-256a-46f5-9214-4cc711bd6233" />


