### PR TITLE
TechDraw: Dimension Repair fails on bad reference

### DIFF
--- a/src/Mod/Part/App/PropertyTopoShapeList.cpp
+++ b/src/Mod/Part/App/PropertyTopoShapeList.cpp
@@ -251,13 +251,21 @@ void PropertyTopoShapeList::RestoreDocFile(Base::Reader& reader)
 
 App::Property* PropertyTopoShapeList::Copy() const
 {
-    PropertyTopoShapeList* p = new PropertyTopoShapeList();
+    auto* p = new PropertyTopoShapeList();
     std::vector<TopoShape> copiedShapes;
     for (auto& shape : _lValueList) {
+        if (shape.isNull()) {
+            // this is probabably(?) undo/redo saving the before state of this property, which includes invalid
+            // references.
+            Base::Console().error("PropertyTopoShapeList::Copy encountered a null shape. Undo may not be possible.\n");
+            continue;
+        }
         BRepBuilderAPI_Copy copy(shape.getShape());
         copiedShapes.emplace_back(copy.Shape());
     }
-    p->setValues(copiedShapes);
+    if (!copiedShapes.empty()) {
+        p->setValues(copiedShapes);
+    }
     return p;
 }
 

--- a/src/Mod/Part/App/PropertyTopoShapeList.cpp
+++ b/src/Mod/Part/App/PropertyTopoShapeList.cpp
@@ -255,9 +255,11 @@ App::Property* PropertyTopoShapeList::Copy() const
     std::vector<TopoShape> copiedShapes;
     for (auto& shape : _lValueList) {
         if (shape.isNull()) {
-            // this is probabably(?) undo/redo saving the before state of this property, which includes invalid
-            // references.
-            Base::Console().error("PropertyTopoShapeList::Copy encountered a null shape. Undo may not be possible.\n");
+            // this is probabably(?) undo/redo saving the before state of this property, which
+            // includes invalid references.
+            Base::Console().error(
+                "PropertyTopoShapeList::Copy encountered a null shape. Undo may not be possible.\n"
+            );
             continue;
         }
         BRepBuilderAPI_Copy copy(shape.getShape());

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -1723,22 +1723,28 @@ void DrawViewDimension::updateSavedGeometry()
         return;
     }
     std::vector<TopoShape> newGeometry;
-    const std::vector<TopoShape> oldGeometry = SavedGeometry.getValues();
-    // need to clean up old saved geometry objects here?
+    // const std::vector<TopoShape> oldGeometry = SavedGeometry.getValues();
+    // need to clean up old saved geometry objects here? or does the property handle deletion?
 
     for (auto& entry : references) {
         if (entry.getSubName().empty()) {
-            // view only reference has no geometry.
+            // view only reference has no subelement. 3d references will be next.
             continue;
         }
         if (entry.hasGeometry()) {
             newGeometry.emplace_back(entry.asCanonicalTopoShape());
         }
         else {
-            // have to put something in the vector so SavedGeometry and references stay in sync.
-                newGeometry.emplace_back(Part::TopoShape());
+            // If we can't get a shape for a reference, we will just keep the existing
+            // SavedGeometry as the lesser evil.
+            Base::Console().error("Dimension reference to %s:%s has no geometry\n",
+                            entry.getObjectName(), entry.getSubName());
+            Base::Console().warning("SavedGeometry for %s was not updated\n",
+                                        Label.getValue());
+            return;
         }
     }
+
     if (!newGeometry.empty()) {
         SavedGeometry.setValues(newGeometry);
         saveFeatureBox();


### PR DESCRIPTION
This PR implements a fix for issue #30168.  The failure in TaskDimRepair reported in the issue actually occurs in Part::PropertyTopoShapeList::Copy() when it passes a null TopoDS_Shape to BRepBuilderAPI_Copy.

The null shape is generated in DrawViewDimension::updateSavedGeometry() when a dimension reference does not point to valid geometry after a model update.  

In the old updateSavedGeometry() code, the null shape was inserted as a placeholder in the SavedGeometry property. 

In the new code, if the reference does not have valid geometry, SavedGeometry is not updated.  This prevents new occurrences of the problem. 

A second aspect of the fix, in PropertyTopoShapeList::Copy, handles files which already have null shapes in SavedGeometry. 

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.


<img width="1504" height="663" alt="DimRepairFixed" src="https://github.com/user-attachments/assets/6bdd3cd9-8f8b-4931-a3d3-32d4873cac9b" />
