### PR TITLE
PD: Preserve Boolean tool scene-graph location

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
@@ -240,7 +240,8 @@ void ViewProviderBoolean::exposeViewProvider(
             }
         );
         if (state != exposure.viewProviders.end()) {
-            state->topLevelExposed = addToTopLevelSceneGraph(getDocument(), vp);
+            const bool added = addToTopLevelSceneGraph(getDocument(), vp);
+            state->topLevelExposed = state->topLevelExposed || added;
         }
     }
 }
@@ -339,10 +340,10 @@ void ViewProviderBoolean::onBodyActivated(const Gui::ViewProviderDocumentObject*
     }
 
     for (auto it = groups.rbegin(); it != groups.rend(); ++it) {
-        exposeViewProvider(exposure, *it, true, true);
+        exposeViewProvider(exposure, *it, true, it == groups.rbegin());
     }
 
-    exposeViewProvider(exposure, matchingMember, true, true);
+    exposeViewProvider(exposure, matchingMember, true, groups.empty());
 }
 
 void ViewProviderBoolean::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
@@ -356,6 +357,8 @@ bool ViewProviderBoolean::onDelete(const std::vector<std::string>& s)
 {
     auto* feature = getObject<PartDesign::Boolean>();
 
+    restoreActiveBodyExposure();
+
     // if abort command deleted the object the bodies are visible again
     for (auto body : feature->Group.getValues()) {
         if (auto vp = Gui::Application::Instance->getViewProvider(body)) {
@@ -368,7 +371,24 @@ bool ViewProviderBoolean::onDelete(const std::vector<std::string>& s)
 
 void ViewProviderBoolean::beforeDelete()
 {
+    auto* feature = getObject<PartDesign::Boolean>();
+    const bool removing = feature && feature->testStatus(App::ObjectStatus::Remove);
+    const auto members = removing ? feature->Group.getValues() : std::vector<App::DocumentObject*> {};
+
     restoreActiveBodyExposure();
+
+    // Object removal unclaims the tools before this callback. Put each member back at its real
+    // scene-graph location after restoring the temporary exposure.
+    for (auto* member : members) {
+        auto* memberVP = Gui::Application::Instance->getViewProvider(member);
+        if (App::GeoFeatureGroupExtension::getGroupOfObject(member)) {
+            removeFromTopLevelSceneGraph(getDocument(), memberVP);
+        }
+        else {
+            addToTopLevelSceneGraph(getDocument(), memberVP);
+        }
+    }
+
     ViewProvider::beforeDelete();
 }
 

--- a/src/Mod/PartDesign/PartDesignTests/TestActiveObject.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestActiveObject.py
@@ -84,6 +84,29 @@ class TestActiveObject(unittest.TestCase):
 
         return boolean, tools
 
+    @staticmethod
+    def _countActiveSceneGraphPaths(viewObject):
+        from pivy import coin
+
+        search = coin.SoSearchAction()
+        search.setNode(viewObject.RootNode)
+        search.setInterest(coin.SoSearchAction.ALL)
+        search.setSearchingAll(False)
+        search.apply(FreeCADGui.activeView().getSceneGraph())
+        return search.getPaths().getLength()
+
+    def _nestInParts(self, documentObject, count):
+        outerPart = self.doc.addObject("App::Part", "ToolPart0")
+        parent = outerPart
+        for index in range(1, count):
+            child = self.doc.addObject("App::Part", f"ToolPart{index}")
+            parent.addObject(child)
+            parent = child
+        parent.addObject(documentObject)
+        self.doc.recompute()
+        FreeCADGui.updateGui()
+        return outerPart
+
     def testBooleanActiveBodyVisibilitySwitch(self):
         boolean, tools = self._createBooleanWithTwoTools()
         view = FreeCADGui.activeView()
@@ -161,6 +184,40 @@ class TestActiveObject(unittest.TestCase):
         self.assertFalse(innerBody.ViewObject.isVisible())
         self.assertTrue(innerLaterFeature.ViewObject.isVisible())
         self.assertTrue(outerLaterFeature.ViewObject.isVisible())
+
+    def testBooleanActiveBodyUsesSinglePlacementPath(self):
+        _, tools = self._createBooleanWithTwoTools()
+        self._nestInParts(tools[0], 3)
+
+        FreeCADGui.activeView().setActiveObject("pdbody", tools[0])
+
+        self.assertEqual(self._countActiveSceneGraphPaths(tools[0].ViewObject), 1)
+
+    def testBooleanActiveBodyExposureRestoresAfterResync(self):
+        boolean, tools = self._createBooleanWithTwoTools()
+        view = FreeCADGui.activeView()
+        view.setActiveObject("pdbody", tools[0])
+
+        boolean.ViewObject.Visibility = False
+        boolean.ViewObject.Visibility = True
+        view.setActiveObject("pdbody", None)
+        FreeCADGui.updateGui()
+
+        self.assertEqual(self._countActiveSceneGraphPaths(tools[0].ViewObject), 0)
+
+    def testBooleanActiveBodyExposureIsRemovedOnDelete(self):
+        boolean, tools = self._createBooleanWithTwoTools()
+        outerPart = self._nestInParts(tools[0], 3)
+        view = FreeCADGui.activeView()
+        view.setActiveObject("pdbody", tools[0])
+
+        boolean.ViewObject.Visibility = False
+        boolean.ViewObject.Visibility = True
+        self.doc.removeObject(boolean.Name)
+        outerPart.ViewObject.hide()
+        FreeCADGui.updateGui()
+
+        self.assertEqual(self._countActiveSceneGraphPaths(tools[0].ViewObject), 0)
 
     def testBooleanActiveBodyVisibilityWhenBooleanIsNotTip(self):
         boolean, tools = self._createBooleanWithTwoTools()


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Noticed an issue from https://github.com/FreeCAD/FreeCAD/pull/30002

Test file:
[test.zip](https://github.com/user-attachments/files/31386104/test.zip)

On main when activating the Body in the Boolean of Body001 it becomes visible, but:
- the body is displayed 4 times
- keeps being visible when boolean is deleted

This PR fixes it
- Nested tool Bodies now render once through their outermost real placement path
- Deletion restores visibility before showing released tools
- Released nested tools are removed from the viewer root, while genuine root-level tools remain

Assisted-by: GPT-5.6-Sol

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
#### Before

https://github.com/user-attachments/assets/81700da4-e518-400d-a49b-5425daa5dde6



#### After




https://github.com/user-attachments/assets/f7251879-15a4-4919-8457-1b1a1ec81b42


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
