### PR TITLE
Graphviz: Attach the dependency graph view to the document

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -724,8 +724,7 @@ StdCmdDependencyGraph::StdCmdDependencyGraph()
 void StdCmdDependencyGraph::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    App::Document* doc = App::GetApplication().getActiveDocument();
-    auto view = new Gui::GraphvizView(*doc);
+    auto view = new Gui::GraphvizView(getActiveGuiDocument());
     view->setWindowTitle(qApp->translate("Std_DependencyGraph", "Dependency Graph"));
     getMainWindow()->addWindow(view);
 }

--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -230,9 +230,9 @@ void GraphvizGraphicsView::mouseReleaseEvent(QMouseEvent* e)
 
 TYPESYSTEM_SOURCE_ABSTRACT(Gui::GraphvizView, Gui::MDIView)  // NOLINT
 
-GraphvizView::GraphvizView(App::Document& _doc, QWidget* parent)
-    : MDIView(nullptr, parent)
-    , doc(_doc)
+GraphvizView::GraphvizView(Gui::Document* _doc, QWidget* parent)
+    : MDIView(_doc, parent)
+    , doc(*_doc->getDocument())
     , nPending(0)
 {
     // Create scene
@@ -268,14 +268,14 @@ GraphvizView::GraphvizView(App::Document& _doc, QWidget* parent)
 
     // NOLINTBEGIN
     //  Connect signal from document
-    recomputeConnection = _doc.signalRecomputed.connect(
+    recomputeConnection = doc.signalRecomputed.connect(
         std::bind(&GraphvizView::updateSvgItem, this, sp::_1)
     );
-    undoConnection = _doc.signalUndo.connect(std::bind(&GraphvizView::updateSvgItem, this, sp::_1));
-    redoConnection = _doc.signalRedo.connect(std::bind(&GraphvizView::updateSvgItem, this, sp::_1));
+    undoConnection = doc.signalUndo.connect(std::bind(&GraphvizView::updateSvgItem, this, sp::_1));
+    redoConnection = doc.signalRedo.connect(std::bind(&GraphvizView::updateSvgItem, this, sp::_1));
     // NOLINTEND
 
-    updateSvgItem(_doc);
+    updateSvgItem(doc);
 }
 
 GraphvizView::~GraphvizView()

--- a/src/Gui/GraphvizView.h
+++ b/src/Gui/GraphvizView.h
@@ -24,6 +24,7 @@
 
 #include <fastsignals/signal.h>
 
+#include "Gui/Document.h"
 #include "MDIView.h"
 
 class QGraphicsScene;
@@ -43,7 +44,7 @@ class GuiExport GraphvizView: public MDIView
     TYPESYSTEM_HEADER_WITH_OVERRIDE();  // NOLINT
 
 public:
-    explicit GraphvizView(App::Document& _doc, QWidget* parent = nullptr);
+    explicit GraphvizView(Gui::Document* _doc, QWidget* parent = nullptr);
     ~GraphvizView() override;
 
     QByteArray exportGraph(const QString& filter);
@@ -72,7 +73,7 @@ private:
     void updateSvgItem(const App::Document& doc);
     void disconnectSignals();
 
-    const App::Document& doc;
+    App::Document& doc;
     std::string graphCode;
     QGraphicsScene* scene;
     QGraphicsView* view;


### PR DESCRIPTION
Fixes #32012

The `Gui.activeView()` does not return the `GraphvizView` as it does not attach it self to the document. This is because the `GraphvizView` constructor [initialize inherited `MDIView` with a null document](https://github.com/FreeCAD/FreeCAD/blob/main/src/Gui/GraphvizView.cpp#L232). This PR fixes that.

A cursory search for "public MDIView" and ": MDIView(" to find other `MDIView` descendants with a constructor taking a document and not passing it to `MDIView` did not reveal any other cases.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.