### PR TITLE
CAM: Tapping - Deprecated

### DIFF
--- a/src/Mod/CAM/Path/Op/Tapping.py
+++ b/src/Mod/CAM/Path/Op/Tapping.py
@@ -97,13 +97,6 @@ class ObjectTapping(PathCircularHoleBase.ObjectOp):
 
     def initCircularHoleOperation(self, obj):
         """initCircularHoleOperation(obj) ... add tapping specific properties to obj."""
-        # DEPRECATED: This operation is deprecated. Use Drilling operation with Strategy=Tapping instead.
-        Path.Log.warning(
-            "DEPRECATED: The Tapping operation is deprecated and will be removed in a future release. "
-            "Please use the Drilling operation with Strategy set to 'Tapping' instead. "
-            "Existing Tapping operations will continue to work but you cannot create new ones."
-        )
-
         obj.addProperty(
             "App::PropertyFloat",
             "DwellTime",
@@ -298,6 +291,13 @@ class ObjectTapping(PathCircularHoleBase.ObjectOp):
             obj.DwellTime = job.SetupSheet.DwellTime
         else:
             obj.DwellTime = 1
+
+    def opOnDocumentRestored(self, obj):
+        Path.Log.warning(
+            "The Tapping operation is deprecated and will be removed in a future release."
+            "\nPlease use the Drilling operation with Strategy set to 'Tapping' instead."
+            "\nExisting Tapping operations will continue to work but you cannot create new ones."
+        )
 
 
 def SetupProperties():


### PR DESCRIPTION
I never use **Tapping** op, but see annoying warning message every time while open **Job** dialog

> DEPRECATED: The Tapping operation is deprecated and will be removed in a future release ...

Repeat warning messages which not related to current work stuff make users ignore all warnings completely 
If still need to inform users about some changes, need to find more appropriate way

Suggested to move `Warning` in `opOnDocumentRestored()`, so only while open document with legacy **Tapping** op see the warning message