### PR TITLE
CAM: Helix - Use start point to orient first helix

### DIFF
--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -328,7 +328,6 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         obj.setEditorMode("Direction", ("ReadOnly", "Hidden"))
         obj.setPropertyStatus("Direction", ("ReadOnly", "Output"))
 
-        obj.setEditorMode("RotationAngle", 2)  # hide
         obj.setEditorMode("FinishHelixCircle", 2)  # hide
         obj.setEditorMode("FinishSpiralCircle", 2)  # hide
         obj.setEditorMode("OverrideArcFeedRate", 2)  # hide
@@ -581,7 +580,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
     # Automatic calculation angle of direction
     def getDirAngle(self, obj, holes, i):
         p1 = FreeCAD.Vector(holes[i]["x"], holes[i]["y"], 0)
-        p2 = FreeCAD.Vector()  # by default orient to (0,0)
+        p2 = Path.Geom.xy(obj.StartPoint)
 
         if obj.StartAt == "Inside":
             if i < len(holes) - 1:
@@ -590,7 +589,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             elif len(holes) > 1:
                 # orient last hole to previous hole
                 p2 = FreeCAD.Vector(holes[i - 1]["x"], holes[i - 1]["y"], 0)
-        else:
+        else:  # Outside
             if i:
                 # orient each hole (except first) to previous hole
                 p2 = FreeCAD.Vector(holes[i - 1]["x"], holes[i - 1]["y"], 0)


### PR DESCRIPTION
### Changes

- Use property `StartPoint` to define orientation of the first helix, instead of (0,0)

- Unhide property `RotationAngle`
Got question about this property several times

Test project: [sort.zip](https://github.com/user-attachments/files/31414740/sort.zip)

<img width="1014" height="491" alt="Screenshot_20260825_124043_hor_lossy" src="https://github.com/user-attachments/assets/04f33dfb-2fe5-4fad-8412-d7bffc530605" />
