### PR TITLE
CAM: Fix getCycleTime estimates to actually use command F-values

### DIFF
--- a/src/Mod/CAM/App/Path.cpp
+++ b/src/Mod/CAM/App/Path.cpp
@@ -202,10 +202,8 @@ double Toolpath::getLength()
     return l;
 }
 
-double Toolpath::getCycleTime(double hFeed, double vFeed, double hRapid, double vRapid)
+double Toolpath::getCycleTime(double hFeed, double vFeed, double rapid)
 {
-    (void)vRapid;
-
     // check the feedrates are set
     if ((hFeed == 0) || (vFeed == 0)) {
         ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
@@ -217,8 +215,8 @@ double Toolpath::getCycleTime(double hFeed, double vFeed, double hRapid, double 
         return 0;
     }
 
-    if (hRapid == 0) {
-        hRapid = hFeed;
+    if (rapid == 0) {
+        rapid = hFeed;
     }
 
     if (vpcCommands.empty()) {
@@ -226,7 +224,7 @@ double Toolpath::getCycleTime(double hFeed, double vFeed, double hRapid, double 
     }
 
     double time = 0;
-    double fG0 = hRapid;
+    double fG0 = rapid;
     double fG1 = hFeed;
     Vector3d last(0, 0, 0);
     bool absolute = true;

--- a/src/Mod/CAM/App/Path.cpp
+++ b/src/Mod/CAM/App/Path.cpp
@@ -204,6 +204,8 @@ double Toolpath::getLength()
 
 double Toolpath::getCycleTime(double hFeed, double vFeed, double hRapid, double vRapid)
 {
+    (void)vRapid;
+
     // check the feedrates are set
     if ((hFeed == 0) || (vFeed == 0)) {
         ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
@@ -219,47 +221,47 @@ double Toolpath::getCycleTime(double hFeed, double vFeed, double hRapid, double 
         hRapid = hFeed;
     }
 
-    if (vRapid == 0) {
-        vRapid = vFeed;
-    }
-
     if (vpcCommands.empty()) {
         return 0;
     }
-    double l = 0;
+
     double time = 0;
-    bool verticalMove = false;
+    double fG0 = hRapid;
+    double fG1 = hFeed;
     Vector3d last(0, 0, 0);
     bool absolute = true;
     bool absoluteCenter = false;
     for (const auto& command : vpcCommands) {
         const std::string& name = command.Name;
-        float feedrate = hFeed;
+        double fCommand = command.getParam("F");
 
-        l = 0;
-        verticalMove = false;
-        Vector3d next = getNextPosition(command, last, absolute);
-
-        if (last.z != next.z) {
-            verticalMove = true;
-            feedrate = vFeed;
-        }
+        double l = 0;
+        double feedrate = hFeed;
+        Vector3d next = command.getPlacement(last).getPosition();
 
         if (isRapidCommand(name)) {
             // Rapid Move
-            l += (next - last).Length();
-            feedrate = hRapid;
-            if (verticalMove) {
-                feedrate = vRapid;
+            l = (next - last).Length();
+            if (fCommand) {
+                fG0 = fCommand;
             }
+            feedrate = fG0;
         }
         else if (name == "G1" || name == "G01") {
             // Feed Move
-            l += (next - last).Length();
+            l = (next - last).Length();
+            if (fCommand) {
+                fG1 = fCommand;
+            }
+            feedrate = fG1;
         }
         else if (isArcCommand(name)) {
             // Arc Move
             l += getArcLength(command, last, next, absoluteCenter);
+            if (fCommand) {
+                fG1 = fCommand;
+            }
+            feedrate = fG1;
         }
         else if (name == "G90") {
             absolute = true;

--- a/src/Mod/CAM/App/Path.cpp
+++ b/src/Mod/CAM/App/Path.cpp
@@ -235,7 +235,7 @@ double Toolpath::getCycleTime(double hFeed, double vFeed, double rapid)
 
         double l = 0;
         double feedrate = hFeed;
-        Vector3d next = command.getPlacement(last).getPosition();
+        Vector3d next = getNextPosition(command, last, absolute);
 
         if (isRapidCommand(name)) {
             // Rapid Move
@@ -255,7 +255,7 @@ double Toolpath::getCycleTime(double hFeed, double vFeed, double rapid)
         }
         else if (isArcCommand(name)) {
             // Arc Move
-            l += getArcLength(command, last, next, absoluteCenter);
+            l = getArcLength(command, last, next, absoluteCenter);
             if (fCommand) {
                 fG1 = fCommand;
             }

--- a/src/Mod/CAM/App/Path.h
+++ b/src/Mod/CAM/App/Path.h
@@ -26,6 +26,7 @@
 #include <Base/BoundBox.h>
 #include <Base/Persistence.h>
 #include <Base/Vector3D.h>
+#include <Base/Precision.h>
 
 #include "Command.h"
 

--- a/src/Mod/CAM/App/Path.h
+++ b/src/Mod/CAM/App/Path.h
@@ -55,14 +55,14 @@ public:
     void RestoreDocFile(Base::Reader& reader) override;
 
     // interface
-    void clear();                                         // clears the internal data
-    void addCommand(const Command& Cmd);                  // adds a command at the end
-    void addCommandNoRecalc(const Command& Cmd);          // adds a command without recalculation
-    void insertCommand(const Command& Cmd, int);          // inserts a command
-    void deleteCommand(int);                              // deletes a command
-    double getLength();                                   // return the Length (mm) of the Path
-    double getCycleTime(double, double, double, double);  // return the Cycle Time (s) of the Path
-    void recalculate();                                   // recalculates the points
+    void clear();                                 // clears the internal data
+    void addCommand(const Command& Cmd);          // adds a command at the end
+    void addCommandNoRecalc(const Command& Cmd);  // adds a command without recalculation
+    void insertCommand(const Command& Cmd, int);  // inserts a command
+    void deleteCommand(int);                      // deletes a command
+    double getLength();                           // return the Length (mm) of the Path
+    double getCycleTime(double, double, double);  // return the Cycle Time (s) of the Path
+    void recalculate();                           // recalculates the points
     void setFromGCode(const std::string);  // sets the path from the contents of the given GCode string
     std::string toGCode() const;           // gets a gcode string representation from the Path
     Base::BoundBox3d getBoundBox() const;

--- a/src/Mod/CAM/App/Path.pyi
+++ b/src/Mod/CAM/App/Path.pyi
@@ -67,7 +67,7 @@ class Path(Persistence):
     def getCycleTime(
         self, h_feed: float, v_feed: float, h_rapid: float, v_rapid: float, /
     ) -> float:
-        """return the cycle time estimation for this path in s"""
+        """Return the cycle time estimation for this path in s. Parameter F from command overrides feeds from arguments."""
         ...
     Length: Final[float]
     """the total length of this path in mm"""

--- a/src/Mod/CAM/App/Path.pyi
+++ b/src/Mod/CAM/App/Path.pyi
@@ -64,9 +64,7 @@ class Path(Persistence):
         ...
 
     @constmethod
-    def getCycleTime(
-        self, h_feed: float, v_feed: float, h_rapid: float, v_rapid: float, /
-    ) -> float:
+    def getCycleTime(self, h_feed: float, v_feed: float, rapid: float, /) -> float:
         """Return the cycle time estimation for this path in s. Parameter F from command overrides feeds from arguments."""
         ...
     Length: Final[float]

--- a/src/Mod/CAM/App/PathPyImp.cpp
+++ b/src/Mod/CAM/App/PathPyImp.cpp
@@ -196,9 +196,9 @@ PyObject* PathPy::deleteCommand(PyObject* args)
 
 PyObject* PathPy::getCycleTime(PyObject* args) const
 {
-    double hFeed, vFeed, hRapid, vRapid;
-    if (PyArg_ParseTuple(args, "dddd", &hFeed, &vFeed, &hRapid, &vRapid)) {
-        return PyFloat_FromDouble(getToolpathPtr()->getCycleTime(hFeed, vFeed, hRapid, vRapid));
+    double hFeed, vFeed, rapid;
+    if (PyArg_ParseTuple(args, "ddd", &hFeed, &vFeed, &rapid)) {
+        return PyFloat_FromDouble(getToolpathPtr()->getCycleTime(hFeed, vFeed, rapid));
     }
     return nullptr;
 }

--- a/src/Mod/CAM/CAMTests/TestPathCore.py
+++ b/src/Mod/CAM/CAMTests/TestPathCore.py
@@ -152,7 +152,7 @@ G0 Z0.500000
         )
         expected_length = 2 + math.pi / 2
         self.assertAlmostEqual(path.Length, expected_length, places=12)
-        self.assertAlmostEqual(path.getCycleTime(1, 1, 1, 1), expected_length, places=12)
+        self.assertAlmostEqual(path.getCycleTime(1, 1, 1), expected_length, places=12)
 
         absolute_center_path = Path.Path(
             [
@@ -183,8 +183,7 @@ G0 Z0.500000
 
         h_feed = 600.0 / 60
         v_feed = 300.0 / 60
-        h_rapid = 3000.0 / 60
-        v_rapid = 1500.0 / 60
+        rapid = 3000.0 / 60
 
         g1_length = 5.0
         g0_length = 5.0
@@ -198,14 +197,14 @@ G0 Z0.500000
                 path = Path.Path(
                     [
                         Path.Command("G1", {"X": g1_length, "F": feed}),
-                        Path.Command("G0", {"Y": g0_length, "F": h_rapid}),
+                        Path.Command("G0", {"Y": g0_length, "F": rapid}),
                         Path.Command("G1", {"X": g1_length + dx, "Z": dz, "F": feed}),
                     ]
                 )
-                t = path.getCycleTime(h_feed, v_feed, h_rapid, v_rapid)
+                t = path.getCycleTime(h_feed, v_feed, rapid)
 
                 t_g1 = g1_length / feed
-                t_g0 = g0_length / h_rapid
+                t_g0 = g0_length / rapid
                 t_ramp = ramp_length / feed
                 t_expected = t_g1 + t_g0 + t_ramp
 

--- a/src/Mod/CAM/CAMTests/TestPathCore.py
+++ b/src/Mod/CAM/CAMTests/TestPathCore.py
@@ -171,3 +171,46 @@ G0 Z0.500000
     # Path.Command("",{"X":1}).toGCode() gives " X1.00000".
     # Code should not rely on "modal" behavior.
     # No tests around this, therefore.
+
+    def test_ramp_cycle_time(self):
+        """
+        Test that getCycleTime for a ramp move uses F feed rate, not the default
+        vertical or horizontal feed rate.
+
+        The test path starts with a G1 setting the feed, then a G0 setting the
+        rapid feed, then does the ramp. The ramp should use the feed from the G1
+        """
+
+        h_feed = 600.0 / 60
+        v_feed = 300.0 / 60
+        h_rapid = 3000.0 / 60
+        v_rapid = 1500.0 / 60
+
+        g1_length = 5.0
+        g0_length = 5.0
+
+        dx = 3
+        dz = -4
+        ramp_length = math.hypot(dx, dz)
+
+        def check_ramp_cycle_time(feed):
+            with self.subTest(feed=feed):
+                path = Path.Path(
+                    [
+                        Path.Command("G1", {"X": g1_length, "F": feed}),
+                        Path.Command("G0", {"Y": g0_length, "F": h_rapid}),
+                        Path.Command("G1", {"X": g1_length + dx, "Z": dz, "F": feed}),
+                    ]
+                )
+                t = path.getCycleTime(h_feed, v_feed, h_rapid, v_rapid)
+
+                t_g1 = g1_length / feed
+                t_g0 = g0_length / h_rapid
+                t_ramp = ramp_length / feed
+                t_expected = t_g1 + t_g0 + t_ramp
+
+                self.assertAlmostEqual(t, t_expected)
+
+        check_ramp_cycle_time(h_feed)
+        check_ramp_cycle_time(v_feed)
+        check_ramp_cycle_time((h_feed + v_feed) / 2)

--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -686,7 +686,7 @@ def getCycleTimeEstimate(obj, formatted=True):
         )
 
     # Get the cycle time in seconds
-    seconds = obj.Path.getCycleTime(hFeedrate, vFeedrate, hRapidrate, vRapidrate)
+    seconds = obj.Path.getCycleTime(hFeedrate, vFeedrate, hRapidrate)
 
     if math.isnan(seconds):
         return translate("CAM", "Cycletime Error")

--- a/tests/src/Mod/CAM/App/Path.cpp
+++ b/tests/src/Mod/CAM/App/Path.cpp
@@ -178,7 +178,7 @@ TEST(PathTest, getCycleTime)
     path.addCommand(cmd);
     cmd.setFromGCode("G2 X3 Y1 I0 J1 F1");
     path.addCommand(cmd);
-    EXPECT_NEAR(path.getCycleTime(1.0, 1.0, 1.0, 1.0), 2.0 + std::numbers::pi * 3 / 2, 1e-12);
+    EXPECT_NEAR(path.getCycleTime(1.0, 1.0, 1.0), 2.0 + std::numbers::pi * 3 / 2, 1e-12);
 }
 
 TEST(PathTest, assign)

--- a/tests/src/Mod/CAM/App/Path.cpp
+++ b/tests/src/Mod/CAM/App/Path.cpp
@@ -176,7 +176,7 @@ TEST(PathTest, getCycleTime)
     Path::Command cmd;
     cmd.setFromGCode("G0 X2 Y0");
     path.addCommand(cmd);
-    cmd.setFromGCode("G2 X3 Y1 I0 J1 F10");
+    cmd.setFromGCode("G2 X3 Y1 I0 J1 F1");
     path.addCommand(cmd);
     EXPECT_NEAR(path.getCycleTime(1.0, 1.0, 1.0, 1.0), 2.0 + std::numbers::pi * 3 / 2, 1e-12);
 }


### PR DESCRIPTION
Taking over from #31252, addressing [#31110 comment](https://github.com/FreeCAD/FreeCAD/pull/31110#issuecomment-4937997013). Actually, let me make an issue for it: fixes #32169

> The implementation of getCycleTime in src/Mod/CAM/App/Path.cpp and completely ignores the specified F parameters and instead estimates time using hFeed (horizontal moves) or vFeed (non-horizontal moves) provided from python (ultimately from the tool controller). This is incorrect behavior, and I expect it produces notably incorrect cycle time estimates sometimes, for example on long, shallow horizontal-speed ramp entrances.
> 
> Correct behavior would be to keep track of the current G0 and G1 feed rates (perhaps initialized to sensible defaults from the tool controller's hFeed and hRapid). Then for each command update the appropriate feed rate variable if an F parameter is provided, and perform the time computation using the most recent G0/G1 feed rate.