### PR TITLE
TechDraw: fix GeomHatch pattern color being ignored

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIFace.cpp
+++ b/src/Mod/TechDraw/Gui/QGIFace.cpp
@@ -230,15 +230,7 @@ void QGIFace::addLineSet(LineSet& ls)
 void QGIFace::lineSetToFillItems(LineSet& ls)
 {
     m_patMaker->setScale(m_fillScale);
-    m_patMaker->setPen(setGeomPen());
     m_patMaker->lineSetToFillItems(ls);
-}
-
-QPen QGIFace::setGeomPen()
-{
-    QPen result;
-    result.setStyle(Qt::SolidLine);
-    return result;
 }
 
 

--- a/src/Mod/TechDraw/Gui/QGIFace.h
+++ b/src/Mod/TechDraw/Gui/QGIFace.h
@@ -138,7 +138,6 @@ protected:
     double calcOffset(TechDraw::BaseGeomPtr geom, TechDraw::LineSet ls);
 
 
-    QPen setGeomPen();
     std::vector<double> decodeDashSpec(TechDraw::DashSpec dash);
 
 


### PR DESCRIPTION
## Summary

A bug introduced in [2607c74e47](https://github.com/FreeCAD/FreeCAD/commit/2607c74e472a8795e20fad7326a9e07b889c4b79)([#19788](https://github.com/FreeCAD/FreeCAD/pull/19788))

Geometric hatch lines always render black - `ColorPattern` has no effect. `lineSetToFillItems()` overwrote `PATPathMaker`'s pen with a default `QPen` from `setGeomPen()`, discarding what `setHatchColor()` had set. `setGeomPen()` read `m_geomColor`/`m_geomWeight`, removed in the said PR - the function and its call site were left behind. Both removed now.

This also restores `WeightPattern` affecting the rendered line width — `m_lineWidth` is only used for dash length calculation in `decodeDashSpec()`, so with the pen overwritten every pattern drew at width 0 (cosmetic). Existing drawings with geometric hatches will render with thicker pattern lines, matching 1.0 behaviour.

Broken in 1.1.0, 1.1.1, 1.1.2, 1.1.3 and current `main` - backport candidate.

Tested with a project file with coloured hatching specified. Rendered black before the modification and renders correctly after the fix.

Claude Opus 5 AI model was used to diagnose the problem and propose the bugfix.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues

No open issue found regarding this bug. 

## Before and After Images

Before:
<img width="820" height="640" alt="image" src="https://github.com/user-attachments/assets/d356ff29-704f-4120-af4c-cd9bb3309d18" />

After:
<img width="819" height="639" alt="image" src="https://github.com/user-attachments/assets/c3f020b9-44ca-47e8-abab-3a6e96526356" />
