### PR TITLE
Fem: Fix constraint symbol paths

### DIFF
--- a/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
@@ -54,7 +54,6 @@ ViewProviderFemConstraint::ViewProviderFemConstraint()
     , pSymbol(nullptr)
     , pExtraSymbol(nullptr)
     , pExtraTrans(nullptr)
-    , ivFile(nullptr)
 {
     pShapeSep = new SoSeparator();
     pShapeSep->ref();
@@ -94,14 +93,21 @@ void ViewProviderFemConstraint::attach(App::DocumentObject* pcObject)
     addDisplayMaskMode(sep, "Base");
 }
 
-std::string ViewProviderFemConstraint::resourceSymbolDir = App::Application::getResourceDir()
-    + "Mod/Fem/Resources/symbols/";
+std::filesystem::path ViewProviderFemConstraint::resourceSymbolDir
+    = Base::FileInfo::stringToPath(App::Application::getResourceDir())
+    / Base::FileInfo::stringToPath("Mod/Fem/Resources/symbols/").make_preferred();
 
-void ViewProviderFemConstraint::loadSymbol(const char* fileName)
+const std::filesystem::path& ViewProviderFemConstraint::getResourceSymbolDir()
 {
-    ivFile = fileName;
+    return resourceSymbolDir;
+}
+
+void ViewProviderFemConstraint::loadSymbol(const std::filesystem::path& ivFile)
+{
+    std::string ivStr = Base::FileInfo::pathToString(ivFile);
+    const char* fileName = ivStr.c_str();
     SoInput in;
-    if (!in.openFile(ivFile)) {
+    if (!in.openFile(fileName)) {
         std::stringstream str;
         str << "Error opening symbol file " << fileName;
         throw Base::ImportError(str.str());

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraint.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraint.h
@@ -77,10 +77,11 @@ public:
      * copies at points on the surface and an optional separator with a symbol
      * excluded from multiple copies.
      */
-    void loadSymbol(const char* fileName);
+    void loadSymbol(const std::filesystem::path& ivFile);
 
     static std::string gethideMeshShowPartStr();
     static std::string gethideMeshShowPartStr(const std::string showConstr);
+    static const std::filesystem::path& getResourceSymbolDir();
 
 protected:
     void onChanged(const App::Property* prop) override;
@@ -109,9 +110,8 @@ protected:
     SoSeparator* pExtraSymbol;
     SoTransform* pExtraTrans;
     SoMultipleCopy* pMultCopy;
-    const char* ivFile;
 
-    static std::string resourceSymbolDir;
+    static std::filesystem::path resourceSymbolDir;
 };
 
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraint.pyi
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraint.pyi
@@ -40,3 +40,6 @@ class ViewProviderFemConstraint(ViewProviderGeometryObject):
 
     RotateSymbol: bool
     """Apply rotation on copies of the constraint symbol"""
+
+    ResourceSymbolDir: Final[str] = ""
+    """Path to system resource symbol directory"""

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintContact.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintContact.cpp
@@ -36,7 +36,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderFemConstraintContact, FemGui::ViewProviderFe
 ViewProviderFemConstraintContact::ViewProviderFemConstraintContact()
 {
     sPixmap = "FEM_ConstraintContact";
-    loadSymbol((resourceSymbolDir + "ConstraintContact.iv").c_str());
+    loadSymbol(resourceSymbolDir / "ConstraintContact.iv");
     ShapeAppearance.setDiffuseColor(0.2f, 0.3f, 0.2f);
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp
@@ -41,7 +41,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderFemConstraintDisplacement, FemGui::ViewProvi
 ViewProviderFemConstraintDisplacement::ViewProviderFemConstraintDisplacement()
 {
     sPixmap = "FEM_ConstraintDisplacement";
-    loadSymbol((resourceSymbolDir + "ConstraintDisplacement.iv").c_str());
+    loadSymbol(resourceSymbolDir / "ConstraintDisplacement.iv");
     ShapeAppearance.setDiffuseColor(0.2f, 0.3f, 0.2f);
 
     // do not rotate symbol according to boundary normal

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintFixed.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintFixed.cpp
@@ -36,7 +36,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderFemConstraintFixed, FemGui::ViewProviderFemC
 ViewProviderFemConstraintFixed::ViewProviderFemConstraintFixed()
 {
     sPixmap = "FEM_ConstraintFixed";
-    loadSymbol((resourceSymbolDir + "ConstraintFixed.iv").c_str());
+    loadSymbol(resourceSymbolDir / "ConstraintFixed.iv");
 }
 
 ViewProviderFemConstraintFixed::~ViewProviderFemConstraintFixed() = default;

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintForce.cpp
@@ -42,7 +42,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderFemConstraintForce, FemGui::ViewProviderFemC
 ViewProviderFemConstraintForce::ViewProviderFemConstraintForce()
 {
     sPixmap = "FEM_ConstraintForce";
-    loadSymbol((resourceSymbolDir + "ConstraintForce.iv").c_str());
+    loadSymbol(resourceSymbolDir / "ConstraintForce.iv");
 }
 
 ViewProviderFemConstraintForce::~ViewProviderFemConstraintForce() = default;

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintHeatflux.cpp
@@ -37,7 +37,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderFemConstraintHeatflux, FemGui::ViewProviderF
 ViewProviderFemConstraintHeatflux::ViewProviderFemConstraintHeatflux()
 {
     sPixmap = "FEM_ConstraintHeatflux";
-    loadSymbol((resourceSymbolDir + "ConstraintHeatFlux.iv").c_str());
+    loadSymbol(resourceSymbolDir / "ConstraintHeatFlux.iv");
     ShapeAppearance.setDiffuseColor(1.0f, 0.0f, 0.0f);
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPlaneRotation.cpp
@@ -37,7 +37,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderFemConstraintPlaneRotation, FemGui::ViewProv
 ViewProviderFemConstraintPlaneRotation::ViewProviderFemConstraintPlaneRotation()
 {
     sPixmap = "FEM_ConstraintPlaneRotation";
-    loadSymbol((resourceSymbolDir + "ConstraintPlaneRotation.iv").c_str());
+    loadSymbol(resourceSymbolDir / "ConstraintPlaneRotation.iv");
     // Note change "planerotation" in line above to new constraint name, make sure it is the same as
     // in taskFem* cpp file
     ShapeAppearance.setDiffuseColor(0.2f, 0.3f, 0.2f);

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPressure.cpp
@@ -41,7 +41,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderFemConstraintPressure, FemGui::ViewProviderF
 ViewProviderFemConstraintPressure::ViewProviderFemConstraintPressure()
 {
     sPixmap = "FEM_ConstraintPressure";
-    loadSymbol((resourceSymbolDir + "ConstraintPressure.iv").c_str());
+    loadSymbol(resourceSymbolDir / "ConstraintPressure.iv");
     ShapeAppearance.setDiffuseColor(0.0f, 0.2f, 0.8f);
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPyImp.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPyImp.cpp
@@ -23,7 +23,7 @@
 
 #include <Inventor/nodes/SoSeparator.h>
 
-
+#include <Base/FileInfo.h>
 #include <Base/Interpreter.h>
 
 #include "ViewProviderFemConstraintPy.h"
@@ -48,7 +48,7 @@ PyObject* ViewProviderFemConstraintPy::loadSymbol(PyObject* args)
         return nullptr;
     }
 
-    getViewProviderFemConstraintPtr()->loadSymbol(name);
+    getViewProviderFemConstraintPtr()->loadSymbol(Base::FileInfo::stringToPath(name));
 
     Py_Return;
 }
@@ -101,6 +101,14 @@ Py::Boolean ViewProviderFemConstraintPy::getRotateSymbol() const
 void ViewProviderFemConstraintPy::setRotateSymbol(Py::Boolean arg)
 {
     getViewProviderFemConstraintPtr()->setRotateSymbol((arg));
+}
+
+Py::String ViewProviderFemConstraintPy::getResourceSymbolDir() const
+{
+    std::string dir = Base::FileInfo::pathToString(
+        getViewProviderFemConstraintPtr()->getResourceSymbolDir()
+    );
+    return Py::String(dir);
 }
 
 PyObject* ViewProviderFemConstraintPy::getCustomAttributes(const char* /*attr*/) const

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintRigidBody.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintRigidBody.cpp
@@ -39,7 +39,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderFemConstraintRigidBody, FemGui::ViewProvider
 ViewProviderFemConstraintRigidBody::ViewProviderFemConstraintRigidBody()
 {
     sPixmap = "FEM_ConstraintRigidBody";
-    loadSymbol((resourceSymbolDir + "ConstraintRigidBody.iv").c_str());
+    loadSymbol(resourceSymbolDir / "ConstraintRigidBody.iv");
     ShapeAppearance.setDiffuseColor(0.0f, 0.5f, 0.0f);
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintSpring.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintSpring.cpp
@@ -35,7 +35,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderFemConstraintSpring, FemGui::ViewProviderFem
 ViewProviderFemConstraintSpring::ViewProviderFemConstraintSpring()
 {
     sPixmap = "FEM_ConstraintSpring";
-    loadSymbol((resourceSymbolDir + "ConstraintSpring.iv").c_str());
+    loadSymbol(resourceSymbolDir / "ConstraintSpring.iv");
     ShapeAppearance.setDiffuseColor(0.0f, 0.2f, 0.8f);
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintTemperature.cpp
@@ -36,7 +36,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderFemConstraintTemperature, FemGui::ViewProvid
 ViewProviderFemConstraintTemperature::ViewProviderFemConstraintTemperature()
 {
     sPixmap = "FEM_ConstraintTemperature";
-    loadSymbol((resourceSymbolDir + "ConstraintTemperature.iv").c_str());
+    loadSymbol(resourceSymbolDir / "ConstraintTemperature.iv");
     ShapeAppearance.setDiffuseColor(1.0f, 0.0f, 0.0f);
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintTransform.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintTransform.cpp
@@ -46,7 +46,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderFemConstraintTransform, FemGui::ViewProvider
 ViewProviderFemConstraintTransform::ViewProviderFemConstraintTransform()
 {
     sPixmap = "FEM_ConstraintTransform";
-    loadSymbol((resourceSymbolDir + "ConstraintTransform.iv").c_str());
+    loadSymbol(resourceSymbolDir / "ConstraintTransform.iv");
 }
 
 ViewProviderFemConstraintTransform::~ViewProviderFemConstraintTransform() = default;

--- a/src/Mod/Fem/femviewprovider/view_constraint_currentdensity.py
+++ b/src/Mod/Fem/femviewprovider/view_constraint_currentdensity.py
@@ -30,6 +30,7 @@ __url__ = "https://www.freecad.org"
 #  \brief view provider for the constraint current density object
 
 from pivy import coin
+from os import path
 
 from femtaskpanels import task_constraint_currentdensity
 from . import view_base_femconstraint
@@ -50,7 +51,7 @@ class VPConstraintCurrentDensity(view_base_femconstraint.VPBaseFemConstraint):
 
     def attach(self, vobj):
         super().attach(vobj)
-        vobj.loadSymbol(self.resource_symbol_dir + "ConstraintCurrentDensity.iv")
+        vobj.loadSymbol(path.join(vobj.ResourceSymbolDir, "ConstraintCurrentDensity.iv"))
 
     def updateData(self, obj, prop):
         if prop == "Mode":

--- a/src/Mod/Fem/femviewprovider/view_constraint_electricchargedensity.py
+++ b/src/Mod/Fem/femviewprovider/view_constraint_electricchargedensity.py
@@ -29,6 +29,8 @@ __url__ = "https://www.freecad.org"
 #  \ingroup FEM
 #  \brief view provider for the constraint electric charge density object
 
+from os import path
+
 from femtaskpanels import task_constraint_electricchargedensity
 from . import view_base_femconstraint
 
@@ -48,4 +50,4 @@ class VPConstraintElectricChargeDensity(view_base_femconstraint.VPBaseFemConstra
 
     def attach(self, vobj):
         super().attach(vobj)
-        vobj.loadSymbol(self.resource_symbol_dir + "ConstraintElectricChargeDensity.iv")
+        vobj.loadSymbol(path.join(vobj.ResourceSymbolDir, "ConstraintElectricChargeDensity.iv"))

--- a/src/Mod/Fem/femviewprovider/view_constraint_electromagnetic.py
+++ b/src/Mod/Fem/femviewprovider/view_constraint_electromagnetic.py
@@ -30,6 +30,8 @@ __url__ = "https://www.freecad.org"
 #  \ingroup FEM
 #  \brief view provider for constraint electromagnetic object
 
+from os import path
+
 from femtaskpanels import task_constraint_electromagnetic
 from . import view_base_femconstraint
 
@@ -49,4 +51,4 @@ class VPConstraintElectromagnetic(view_base_femconstraint.VPBaseFemConstraint):
 
     def attach(self, vobj):
         super().attach(vobj)
-        vobj.loadSymbol(self.resource_symbol_dir + "ConstraintElectromagnetic.iv")
+        vobj.loadSymbol(path.join(vobj.ResourceSymbolDir, "ConstraintElectromagnetic.iv"))

--- a/src/Mod/Fem/femviewprovider/view_constraint_sectionprint.py
+++ b/src/Mod/Fem/femviewprovider/view_constraint_sectionprint.py
@@ -29,6 +29,8 @@ __url__ = "https://www.freecad.org"
 #  \ingroup FEM
 #  \brief view provider for constraint section print object
 
+from os import path
+
 from femtaskpanels import task_constraint_sectionprint
 from . import view_base_femconstraint
 
@@ -51,4 +53,4 @@ class VPConstraintSectionPrint(view_base_femconstraint.VPBaseFemConstraint):
 
     def attach(self, vobj):
         super().attach(vobj)
-        vobj.loadSymbol(self.resource_symbol_dir + "ConstraintSectionPrint.iv")
+        vobj.loadSymbol(path.join(vobj.ResourceSymbolDir, "ConstraintSectionPrint.iv"))

--- a/src/Mod/Fem/femviewprovider/view_constraint_tie.py
+++ b/src/Mod/Fem/femviewprovider/view_constraint_tie.py
@@ -29,6 +29,8 @@ __url__ = "https://www.freecad.org"
 #  \ingroup FEM
 #  \brief view provider for constraint tie object
 
+from os import path
+
 from femtaskpanels import task_constraint_tie
 from . import view_base_femconstraint
 
@@ -51,4 +53,4 @@ class VPConstraintTie(view_base_femconstraint.VPBaseFemConstraint):
 
     def attach(self, vobj):
         super().attach(vobj)
-        vobj.loadSymbol(self.resource_symbol_dir + "ConstraintTie.iv")
+        vobj.loadSymbol(path.join(vobj.ResourceSymbolDir, "ConstraintTie.iv"))


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
See https://forum.freecad.org/viewtopic.php?t=107175
There was a possible mix of path separator types.

@chennes, could you please check this on Windows to make sure the issue is solved? Simply create the constraints that have associated symbols and verify that they are generated without error.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
