### PR TITLE
Start: Allow removing a single Recent Files entry

### DIFF
--- a/src/Mod/Start/App/RecentFilesModel.cpp
+++ b/src/Mod/Start/App/RecentFilesModel.cpp
@@ -56,13 +56,13 @@ void RecentFilesModel::recentFileAdded(const QString& filename)
 
 void RecentFilesModel::removeFile(const QString& filename)
 {
-    auto numRows {_parameterGroup->GetInt("RecentFiles", 0)};
+    auto numRows {static_cast<std::size_t>(_parameterGroup->GetInt("RecentFiles", 0))};
 
     // Collect the entries that are being kept, in their current order, skipping the one
     // being removed.
     std::vector<std::string> keptPaths;
-    keptPaths.reserve(static_cast<std::size_t>(numRows));
-    for (int i = 0; i < numRows; ++i) {
+    keptPaths.reserve(numRows);
+    for (std::size_t i = 0; i < numRows; ++i) {
         auto entry = fmt::format("MRU{}", i);
         auto path = _parameterGroup->GetASCII(entry.c_str(), "");
         if (QString::fromStdString(path) != filename) {
@@ -70,22 +70,22 @@ void RecentFilesModel::removeFile(const QString& filename)
         }
     }
 
-    if (static_cast<int>(keptPaths.size()) == numRows) {
+    if (keptPaths.size() == numRows) {
         // The requested file wasn't found in the list; nothing to do.
         return;
     }
 
     // Rewrite the MRU entries so that they are contiguous again, then update the count.
-    for (int i = 0; i < numRows; ++i) {
+    for (std::size_t i = 0; i < numRows; ++i) {
         auto entry = fmt::format("MRU{}", i);
-        if (i < static_cast<int>(keptPaths.size())) {
-            _parameterGroup->SetASCII(entry.c_str(), keptPaths[static_cast<std::size_t>(i)].c_str());
+        if (i < keptPaths.size()) {
+            _parameterGroup->SetASCII(entry.c_str(), keptPaths[i].c_str());
         }
         else {
             _parameterGroup->RemoveASCII(entry.c_str());
         }
     }
-    _parameterGroup->SetInt("RecentFiles", static_cast<int>(keptPaths.size()));
+    _parameterGroup->SetInt("RecentFiles", static_cast<long>(keptPaths.size()));
 
     loadRecentFiles();
 }

--- a/src/Mod/Start/App/RecentFilesModel.cpp
+++ b/src/Mod/Start/App/RecentFilesModel.cpp
@@ -53,3 +53,39 @@ void RecentFilesModel::recentFileAdded(const QString& filename)
     Q_UNUSED(filename)
     loadRecentFiles();
 }
+
+void RecentFilesModel::removeFile(const QString& filename)
+{
+    auto numRows {_parameterGroup->GetInt("RecentFiles", 0)};
+
+    // Collect the entries that are being kept, in their current order, skipping the one
+    // being removed.
+    std::vector<std::string> keptPaths;
+    keptPaths.reserve(static_cast<std::size_t>(numRows));
+    for (int i = 0; i < numRows; ++i) {
+        auto entry = fmt::format("MRU{}", i);
+        auto path = _parameterGroup->GetASCII(entry.c_str(), "");
+        if (QString::fromStdString(path) != filename) {
+            keptPaths.push_back(path);
+        }
+    }
+
+    if (static_cast<int>(keptPaths.size()) == numRows) {
+        // The requested file wasn't found in the list; nothing to do.
+        return;
+    }
+
+    // Rewrite the MRU entries so that they are contiguous again, then update the count.
+    for (int i = 0; i < numRows; ++i) {
+        auto entry = fmt::format("MRU{}", i);
+        if (i < static_cast<int>(keptPaths.size())) {
+            _parameterGroup->SetASCII(entry.c_str(), keptPaths[static_cast<std::size_t>(i)].c_str());
+        }
+        else {
+            _parameterGroup->RemoveASCII(entry.c_str());
+        }
+    }
+    _parameterGroup->SetInt("RecentFiles", static_cast<int>(keptPaths.size()));
+
+    loadRecentFiles();
+}

--- a/src/Mod/Start/App/RecentFilesModel.h
+++ b/src/Mod/Start/App/RecentFilesModel.h
@@ -43,6 +43,10 @@ public:
     void loadRecentFiles();
     void recentFileAdded(const QString& filename);
 
+    /// Remove a single entry from the Recent Files list (and its thumbnail), identified by its
+    /// full file path. Does nothing if the given path is not currently in the Recent Files list.
+    void removeFile(const QString& filename);
+
 private:
     Base::Reference<ParameterGrp> _parameterGroup;
 };

--- a/src/Mod/Start/Gui/FileCardView.cpp
+++ b/src/Mod/Start/Gui/FileCardView.cpp
@@ -26,6 +26,9 @@
 #include <App/Application.h>
 #include "../App/DisplayedFilesModel.h"
 #include <algorithm>
+#include <QAction>
+#include <QContextMenuEvent>
+#include <QMenu>
 
 namespace StartGui
 {
@@ -84,6 +87,43 @@ QSize FileCardView::sizeHint() const
         (cardSize.width() + m_cardSpacing) * numCards + m_cardSpacing,
         cardSize.height() + 2 * m_cardSpacing
     };
+}
+
+void FileCardView::setAllowRemoval(bool allow)
+{
+    m_allowRemoval = allow;
+}
+
+bool FileCardView::allowsRemoval() const
+{
+    return m_allowRemoval;
+}
+
+void FileCardView::contextMenuEvent(QContextMenuEvent* event)
+{
+    if (!m_allowRemoval) {
+        QListView::contextMenuEvent(event);
+        return;
+    }
+
+    const QModelIndex index = indexAt(event->pos());
+    if (!index.isValid()) {
+        QListView::contextMenuEvent(event);
+        return;
+    }
+
+    const auto filePath =
+        index.data(static_cast<int>(Start::DisplayedFilesModelRoles::path)).toString();
+    if (filePath.isEmpty()) {
+        QListView::contextMenuEvent(event);
+        return;
+    }
+
+    QMenu menu(this);
+    QAction* removeAction = menu.addAction(tr("Remove from Recent Files"));
+    if (menu.exec(event->globalPos()) == removeAction) {
+        Q_EMIT fileRemovalRequested(filePath);
+    }
 }
 
 }  // namespace StartGui

--- a/src/Mod/Start/Gui/FileCardView.cpp
+++ b/src/Mod/Start/Gui/FileCardView.cpp
@@ -112,8 +112,8 @@ void FileCardView::contextMenuEvent(QContextMenuEvent* event)
         return;
     }
 
-    const auto filePath =
-        index.data(static_cast<int>(Start::DisplayedFilesModelRoles::path)).toString();
+    const auto filePath
+        = index.data(static_cast<int>(Start::DisplayedFilesModelRoles::path)).toString();
     if (filePath.isEmpty()) {
         QListView::contextMenuEvent(event);
         return;

--- a/src/Mod/Start/Gui/FileCardView.h
+++ b/src/Mod/Start/Gui/FileCardView.h
@@ -39,8 +39,23 @@ public:
 
     QSize sizeHint() const override;
 
+    /// Controls whether right-clicking a card offers a "Remove" context menu entry. Off by
+    /// default; intended for card views (such as Recent Files) where individual entries can
+    /// meaningfully be removed by the user, as opposed to e.g. the bundled Examples list.
+    void setAllowRemoval(bool allow);
+    bool allowsRemoval() const;
+
+Q_SIGNALS:
+    /// Emitted when the user selects "Remove" from a card's context menu. filePath is the full
+    /// path of the file backing that card, taken from the model's "path" role.
+    void fileRemovalRequested(const QString& filePath);
+
+protected:
+    void contextMenuEvent(QContextMenuEvent* event) override;
+
 private:
     int m_cardSpacing;
+    bool m_allowRemoval {false};
 };
 
 }  // namespace StartGui

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -195,9 +195,7 @@ StartView::StartView(QWidget* parent)
         recentFilesListWidget,
         &FileCardView::fileRemovalRequested,
         this,
-        [this](const QString& filePath) {
-            _recentFilesModel.removeFile(filePath);
-        }
+        [this](const QString& filePath) { _recentFilesModel.removeFile(filePath); }
     );
 
     QTimer::singleShot(2000, this, [this, recentFilesListWidget]() {

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -190,6 +190,15 @@ StartView::StartView(QWidget* parent)
         configureExamplesListWidget(examplesListWidget);
     }
     configureRecentFilesListWidget(recentFilesListWidget, _recentFilesLabel);
+    recentFilesListWidget->setAllowRemoval(true);
+    connect(
+        recentFilesListWidget,
+        &FileCardView::fileRemovalRequested,
+        this,
+        [this](const QString& filePath) {
+            _recentFilesModel.removeFile(filePath);
+        }
+    );
 
     QTimer::singleShot(2000, this, [this, recentFilesListWidget]() {
         auto updateFun = [this, recentFilesListWidget]() {


### PR DESCRIPTION
No way to remove one Recent Files thumbnail without clearing the whole list.

Add RecentFilesModel::removeFile(path) (rewrites the RecentFiles MRU param group) and a right-click "Remove from Recent Files" entry on FileCardView, wired up only for the Recent Files card view.

Fixes https://github.com/FreeCAD/FreeCAD/issues/13346

Assisted-by: Claude Sonnet 5 (claude-sonnet-5)

 [+] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

