### PR TITLE
PartDesign: Keep cloned Body inside active Part

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -528,6 +528,8 @@ void CmdPartDesignClone::activated(int iMsg)
     );
 
     if (objs.size() == 1) {
+        App::Part* activePart = PartDesignGui::getActivePart();
+
         // As suggested in https://forum.freecad.org/viewtopic.php?f=3&t=25265&p=198547#p207336
         // put the clone into its own new body.
         // This also fixes bug #3447 because the clone is a PD feature and thus
@@ -552,6 +554,13 @@ void CmdPartDesignClone::activated(int iMsg)
 
         auto bodyObj = obj->getDocument()->getObject(bodyName.c_str());
         auto cloneObj = obj->getDocument()->getObject(cloneName.c_str());
+
+        if (activePart) {
+            Gui::cmdAppObject(
+                activePart,
+                std::stringstream() << "addObject(" << getObjectCmd(bodyObj) << ")"
+            );
+        }
 
         // In the first step set the group link and tip of the body
         Gui::cmdAppObject(

--- a/src/Mod/PartDesign/TestPartDesignGui.py
+++ b/src/Mod/PartDesign/TestPartDesignGui.py
@@ -326,6 +326,34 @@ class CreateSketch(unittest.TestCase):
         param.SetBool("NewSketchUseAttachmentDialog", useAttachmentSaved)
 
 
+class TestClone(unittest.TestCase):
+    def setUp(self):
+        self.Doc = App.newDocument("PartDesignTestClone")
+        Gui.activateView("Gui::View3DInventor", True)
+
+    def tearDown(self):
+        Gui.Selection.clearSelection()
+        App.closeDocument(self.Doc.Name)
+
+    def testCloneRespectsActivePart(self):
+        part = self.Doc.addObject("App::Part", "Part")
+        body = self.Doc.addObject("PartDesign::Body", "Body")
+        part.addObject(body)
+
+        box = self.Doc.addObject("PartDesign::AdditiveBox", "Box")
+        body.addObject(box)
+        self.Doc.recompute()
+
+        Gui.activeView().setActiveObject("part", part)
+        Gui.Selection.clearSelection()
+        Gui.Selection.addSelection(body)
+        Gui.runCommand("PartDesign_Clone")
+
+        clone_body = self.Doc.getObject("Body001")
+        self.assertIsNotNone(clone_body)
+        self.assertIn(clone_body, part.Group)
+
+
 # class PartDesignGuiTestCases(unittest.TestCase):
 #   def setUp(self):
 #       self.Doc = FreeCAD.newDocument("SketchGuiTest")


### PR DESCRIPTION
Fix Clone Body created outside Part: remember the active Part, place the cloned Body inside it; fall back to old behavior if no Part is active; automated test added to verify.

This change was assisted by GPT-5 (OpenAI Codex). I reviewed the implementation and take responsibility for the submitted changes.

## Issues

Fixes #30013

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Testing

- `git diff --check`
- Python AST syntax check for `TestPartDesignGui.py`