### PR TITLE
TechDraw: Screen Mode Added

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -46,6 +46,7 @@
 #include <App/DocumentObject.h>
 #include <Base/Console.h>
 #include <Base/Stream.h>
+#include <Base/Tools.h>
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>
@@ -105,6 +106,9 @@ MDIViewPage::MDIViewPage(ViewProviderPage* pageVp, Gui::Document* doc, QWidget* 
 
     m_toggleGridAction = new QAction(tr("Show &Grid"), this);
     connect(m_toggleGridAction, &QAction::triggered, this, &MDIViewPage::toggleGrid);
+
+    m_toggleScreenModeAction = new QAction(tr("Screen Mode"), this);
+    connect(m_toggleScreenModeAction, &QAction::triggered, this, &MDIViewPage::toggleScreenMode);
 
     m_exportSVGAction = new QAction(tr("&Export SVG"), this);
 
@@ -630,6 +634,7 @@ bool MDIViewPage::addSelectionGroups(QMenu& menu)
 void MDIViewPage::addPageGroup(QMenu& menu)
 {
     menu.addAction(m_toggleGridAction);
+    menu.addAction(m_toggleScreenModeAction);
     menu.addAction(m_toggleFrameAction);
     menu.addAction(m_toggleKeepUpdatedAction);
     menu.addSeparator();
@@ -641,6 +646,9 @@ void MDIViewPage::addPageGroup(QMenu& menu)
 
     m_toggleGridAction->setCheckable(true);
     m_toggleGridAction->setChecked(m_vpPage->ShowGrid.getValue());
+
+    m_toggleScreenModeAction->setCheckable(true);
+    m_toggleScreenModeAction->setChecked(PreferencesGui::screenMode());
 
     m_toggleFrameAction->setCheckable(true);
     m_toggleFrameAction->setChecked(m_vpPage->getFrameState());
@@ -713,6 +721,10 @@ void MDIViewPage::toggleGrid()
     m_vpPage->ShowGrid.setValue(!m_vpPage->ShowGrid.getValue());
 }
 
+void MDIViewPage::toggleScreenMode() {
+    PreferencesGui::setScreenMode(!PreferencesGui::screenMode());
+}
+
 void MDIViewPage::toggleKeepUpdated()
 {
     bool state = m_vpPage->getDrawPage()->KeepUpdated.getValue();
@@ -722,6 +734,7 @@ void MDIViewPage::toggleKeepUpdated()
 void MDIViewPage::viewAll()
 {
     m_vpPage->getQGVPage()->fitInView(m_scene->itemsBoundingRect(), Qt::KeepAspectRatio);
+    m_scene->updateScreenScale();
 }
 
 QString MDIViewPage::defaultFileName()
@@ -742,6 +755,11 @@ QString MDIViewPage::defaultFileName()
 
 void MDIViewPage::saveSVG(std::string filename)
 {
+    bool screenMode = PreferencesGui::screenMode();
+    PreferencesGui::setScreenMode(false);
+    Base::ScopeGuard restoreScreenMode([screenMode]() {
+        PreferencesGui::setScreenMode(screenMode);
+    });
     auto vpp = getViewProviderPage();
     if (!vpp) {
         return;
@@ -770,6 +788,12 @@ void MDIViewPage::saveSVG()
 
 void MDIViewPage::saveDXF(std::string filename)
 {
+    bool screenMode = PreferencesGui::screenMode();
+    PreferencesGui::setScreenMode(false);
+    Base::ScopeGuard restoreScreenMode([screenMode]() {
+        PreferencesGui::setScreenMode(screenMode);
+    });
+
     PagePrinter::saveDXF(getViewProviderPage(), filename);
 }
 
@@ -792,6 +816,12 @@ void MDIViewPage::saveDXF()
 
 void MDIViewPage::savePDF(const std::string& filename) const
 {
+    bool screenMode = PreferencesGui::screenMode();
+    PreferencesGui::setScreenMode(false);
+    Base::ScopeGuard restoreScreenMode([screenMode]() {
+        PreferencesGui::setScreenMode(screenMode);
+    });
+    
     auto vpp = getViewProviderPage();
     if (!vpp) {
         return;

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -125,6 +125,7 @@ public Q_SLOTS:
     void slotContextExportPdf();
     void toggleFrame();
     void toggleGrid();
+    void toggleScreenMode();
     void toggleKeepUpdated();
     void sceneSelectionChanged();
     void printAll();
@@ -162,6 +163,7 @@ private:
 
     QAction *m_toggleFrameAction;
     QAction *m_toggleGridAction;
+    QAction *m_toggleScreenModeAction;
     QAction *m_toggleKeepUpdatedAction;
     QAction *m_exportSVGAction;
     QAction *m_exportDXFAction;

--- a/src/Mod/TechDraw/Gui/PreferencesGui.cpp
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.cpp
@@ -224,6 +224,16 @@ bool PreferencesGui::multiSelection()
     return greedy || Preferences::getPreferenceGroup("General")->GetBool("multiSelection", false);
 }
 
+bool PreferencesGui::screenMode()
+{
+    return Preferences::getPreferenceGroup("View")->GetBool("ScreenMode", true);
+}
+
+void PreferencesGui::setScreenMode(bool enable)
+{
+    Preferences::getPreferenceGroup("View")->SetBool("ScreenMode", enable);
+}
+
 Base::Color PreferencesGui::pageColor()
 {
     Base::Color result;

--- a/src/Mod/TechDraw/Gui/PreferencesGui.h
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.h
@@ -87,6 +87,9 @@ static QColor gridQColor();
 static double gridSpacing();
 static bool multiSelection();
 
+static bool screenMode();
+static void setScreenMode(bool enable);
+
 static QColor       getAccessibleQColor(QColor orig);
 static QColor       lightTextQColor();
 static QColor       reverseColor(QColor orig);

--- a/src/Mod/TechDraw/Gui/QGICMark.cpp
+++ b/src/Mod/TechDraw/Gui/QGICMark.cpp
@@ -40,17 +40,21 @@ QGICMark::QGICMark(int index) : QGIVertex(index)
 {
     m_markFuzz = PreferencesGui::markFuzz();
     m_size = 3.0;
+    m_thickness = 0.0;
     setThick(0.75);
     draw();
 }
 void QGICMark::draw()
 {
+    double size = m_size * m_scale;
     QPainterPath cmPath;
-    cmPath.moveTo(0.0, m_size);
-    cmPath.lineTo(0.0, -m_size);
-    cmPath.moveTo(m_size, 0.0);
-    cmPath.lineTo(-m_size, 0.0);
+    cmPath.moveTo(0.0, size);
+    cmPath.lineTo(0.0, -size);
+    cmPath.moveTo(size, 0.0);
+    cmPath.lineTo(-size, 0.0);
     setPath(cmPath);
+
+    setWidth(m_thickness * m_scale);
 }
 
 void QGICMark::setSize(float s)
@@ -61,7 +65,13 @@ void QGICMark::setSize(float s)
 
 void QGICMark::setThick(float t)
 {
-    m_pen.setWidthF(t);
+    m_thickness = t;
+    draw();
+}
+
+void QGICMark::setScreenScale(double scale)
+{
+    m_scale = scale;
     draw();
 }
 

--- a/src/Mod/TechDraw/Gui/QGICMark.cpp
+++ b/src/Mod/TechDraw/Gui/QGICMark.cpp
@@ -39,8 +39,6 @@ using namespace TechDrawGui;
 QGICMark::QGICMark(int index) : QGIVertex(index)
 {
     m_markFuzz = PreferencesGui::markFuzz();
-    m_size = 3.0;
-    m_thickness = 0.0;
     setThick(0.75);
     draw();
 }

--- a/src/Mod/TechDraw/Gui/QGICMark.cpp
+++ b/src/Mod/TechDraw/Gui/QGICMark.cpp
@@ -44,7 +44,7 @@ QGICMark::QGICMark(int index) : QGIVertex(index)
 }
 void QGICMark::draw()
 {
-    double size = m_size * m_scale;
+    double size = m_size * m_screenScale;
     QPainterPath cmPath;
     cmPath.moveTo(0.0, size);
     cmPath.lineTo(0.0, -size);
@@ -52,7 +52,7 @@ void QGICMark::draw()
     cmPath.lineTo(-size, 0.0);
     setPath(cmPath);
 
-    setWidth(m_thickness * m_scale);
+    setWidth(m_thickness * m_screenScale);
 }
 
 void QGICMark::setSize(float s)
@@ -69,7 +69,7 @@ void QGICMark::setThick(float t)
 
 void QGICMark::setScreenScale(double scale)
 {
-    m_scale = scale;
+    ScreenScalable::setScreenScale(scale);
     draw();
 }
 

--- a/src/Mod/TechDraw/Gui/QGICMark.h
+++ b/src/Mod/TechDraw/Gui/QGICMark.h
@@ -46,9 +46,10 @@ public:
     void draw(void);
     float getSize() { return m_size; }
     void setSize(float s);
-    float getThick() { return m_pen.widthF(); }
+    float getThick() { return m_thickness; }
     void setThick(float t);
     void setPrettyNormal() override;
+    void setScreenScale(double scale) override;
 
     double getMarkFuzz(void) const;
 
@@ -57,6 +58,7 @@ protected:
 
 private:
     float m_size;
+    float m_thickness;
     double m_markFuzz;
 };
 

--- a/src/Mod/TechDraw/Gui/QGICMark.h
+++ b/src/Mod/TechDraw/Gui/QGICMark.h
@@ -57,8 +57,8 @@ protected:
     QColor getCMarkColor();
 
 private:
-    float m_size;
-    float m_thickness;
+    float m_size{3.0};
+    float m_thickness{0.0};
     double m_markFuzz;
 };
 

--- a/src/Mod/TechDraw/Gui/QGIEdge.cpp
+++ b/src/Mod/TechDraw/Gui/QGIEdge.cpp
@@ -113,3 +113,15 @@ void QGIEdge::setLinePen(const QPen& linePen)
     m_pen = linePen;
 }
 
+void QGIEdge::setWidth(double width)
+{
+    m_width = width;
+    QGIPrimPath::setWidth(m_width * m_scale);
+}
+
+void QGIEdge::setScreenScale(double scale)
+{
+    m_scale = scale;
+    QGIPrimPath::setWidth(m_width * m_scale);
+}
+

--- a/src/Mod/TechDraw/Gui/QGIEdge.cpp
+++ b/src/Mod/TechDraw/Gui/QGIEdge.cpp
@@ -116,12 +116,12 @@ void QGIEdge::setLinePen(const QPen& linePen)
 void QGIEdge::setWidth(double width)
 {
     m_width = width;
-    QGIPrimPath::setWidth(m_width * m_scale);
+    QGIPrimPath::setWidth(m_width * m_screenScale);
 }
 
 void QGIEdge::setScreenScale(double scale)
 {
-    m_scale = scale;
-    QGIPrimPath::setWidth(m_width * m_scale);
+    ScreenScalable::setScreenScale(scale);
+    QGIPrimPath::setWidth(m_width * m_screenScale);
 }
 

--- a/src/Mod/TechDraw/Gui/QGIEdge.cpp
+++ b/src/Mod/TechDraw/Gui/QGIEdge.cpp
@@ -30,6 +30,7 @@
 #include <Base/Console.h>
 #include <Base/Parameter.h>
 #include <Gui/Control.h>
+#include <Gui/ViewParams.h>
 #include <Mod/TechDraw/App/DrawUtil.h>
 
 #include "QGIEdge.h"
@@ -115,7 +116,7 @@ void QGIEdge::setLinePen(const QPen& linePen)
 
 void QGIEdge::setWidth(double width)
 {
-    m_width = width;
+    m_width = PreferencesGui::screenMode() ? Gui::ViewParams::instance()->getDefaultShapeLineWidth() : width;
     QGIPrimPath::setWidth(m_width * m_screenScale);
 }
 
@@ -123,5 +124,6 @@ void QGIEdge::setScreenScale(double scale)
 {
     ScreenScalable::setScreenScale(scale);
     QGIPrimPath::setWidth(m_width * m_screenScale);
+    setEdgeFuzzScale(m_screenScale);
 }
 

--- a/src/Mod/TechDraw/Gui/QGIEdge.h
+++ b/src/Mod/TechDraw/Gui/QGIEdge.h
@@ -53,6 +53,9 @@ public:
     void setPrettyNormal() override;
     void setLinePen(const QPen& isoPen);
 
+    void setWidth(double width) override;
+    void setScreenScale(double scale);
+
     void setSource(TechDraw::SourceType source) { m_source = source; }
     TechDraw::SourceType getSource() const { return m_source;}
 
@@ -70,6 +73,9 @@ private:
     bool isCosmetic;
     bool isHiddenEdge;
     bool isSmoothEdge;
+
+    double m_width = 1.0;
+    double m_scale = 1.0;
 
     TechDraw::SourceType m_source{TechDraw::SourceType::GEOMETRY};
 };

--- a/src/Mod/TechDraw/Gui/QGIEdge.h
+++ b/src/Mod/TechDraw/Gui/QGIEdge.h
@@ -27,11 +27,12 @@
 
 #include "QGIPrimPath.h"
 #include "QGIUserTypes.h"
+#include "ScreenScalable.h"
 
 namespace TechDrawGui
 {
 
-class TechDrawGuiExport QGIEdge : public QGIPrimPath
+class TechDrawGuiExport QGIEdge : public QGIPrimPath, public ScreenScalable
 {
 public:
     explicit QGIEdge(int index);
@@ -54,7 +55,7 @@ public:
     void setLinePen(const QPen& isoPen);
 
     void setWidth(double width) override;
-    void setScreenScale(double scale);
+    void setScreenScale(double scale) override;
 
     void setSource(TechDraw::SourceType source) { m_source = source; }
     TechDraw::SourceType getSource() const { return m_source;}
@@ -75,7 +76,6 @@ private:
     bool isSmoothEdge;
 
     double m_width = 1.0;
-    double m_scale = 1.0;
 
     TechDraw::SourceType m_source{TechDraw::SourceType::GEOMETRY};
 };

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
@@ -450,12 +450,12 @@ QPainterPath QGILeaderLine::makeLeaderPath(std::vector<QPointF> qPoints)
         ArrowType choice = static_cast<ArrowType>(featLeader->StartSymbol.getValue());
         if (choice != ArrowType::NONE) {
             startAdjLength = QGIArrow::getOverlapAdjust(choice,
-                                                        QGIArrow::getPrefArrowSize());
+                                                        QGIArrow::getPrefArrowSize() * m_scale);
         }
         choice = static_cast<ArrowType>(featLeader->EndSymbol.getValue());
         if (choice != ArrowType::NONE) {
             endAdjLength = QGIArrow::getOverlapAdjust(choice,
-                                                      QGIArrow::getPrefArrowSize());
+                                                      QGIArrow::getPrefArrowSize() * m_scale);
         }
 
         //get adjustment directions
@@ -542,7 +542,7 @@ void QGILeaderLine::setArrows(std::vector<QPointF> pathPoints)
     if (choice != ArrowType::NONE) {
         m_arrow1->setStyle(choice);
         m_arrow1->setWidth(getLineWidth());
-        m_arrow1->setSize(QGIArrow::getPrefArrowSize());
+        m_arrow1->setSize(QGIArrow::getPrefArrowSize() * m_scale);
         m_arrow1->setDirMode(true);
         m_arrow1->setDirection(stdX);
         if (pathPoints.size() > 1) {
@@ -565,7 +565,7 @@ void QGILeaderLine::setArrows(std::vector<QPointF> pathPoints)
     if (choice != ArrowType::NONE) {
         m_arrow2->setStyle(choice);
         m_arrow2->setWidth(getLineWidth());
-        m_arrow2->setSize(QGIArrow::getPrefArrowSize());
+        m_arrow2->setSize(QGIArrow::getPrefArrowSize() * m_scale);
         m_arrow2->setDirMode(true);
         m_arrow2->setDirection(-stdX);
         if (pathPoints.size() > 1) {
@@ -629,13 +629,19 @@ void QGILeaderLine::abandonEdit()
     restoreState();
 }
 
+void QGILeaderLine::setScreenScale(double scale)
+{
+    m_scale = scale;
+    draw();
+}
+
 double QGILeaderLine::getLineWidth()
 {
     auto vp = static_cast<ViewProviderLeader*>(getViewProvider(getViewObject()));
     if (!vp) {
         return Rez::guiX(LineGroup::getDefaultWidth("Graphic"));
     }
-    return Rez::guiX(vp->LineWidth.getValue());
+    return Rez::guiX(vp->LineWidth.getValue() * m_scale);
 }
 
 TechDraw::DrawLeaderLine* QGILeaderLine::getLeaderFeature()

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
@@ -450,12 +450,12 @@ QPainterPath QGILeaderLine::makeLeaderPath(std::vector<QPointF> qPoints)
         ArrowType choice = static_cast<ArrowType>(featLeader->StartSymbol.getValue());
         if (choice != ArrowType::NONE) {
             startAdjLength = QGIArrow::getOverlapAdjust(choice,
-                                                        QGIArrow::getPrefArrowSize() * m_scale);
+                                                        QGIArrow::getPrefArrowSize() * m_screenScale);
         }
         choice = static_cast<ArrowType>(featLeader->EndSymbol.getValue());
         if (choice != ArrowType::NONE) {
             endAdjLength = QGIArrow::getOverlapAdjust(choice,
-                                                      QGIArrow::getPrefArrowSize() * m_scale);
+                                                      QGIArrow::getPrefArrowSize() * m_screenScale);
         }
 
         //get adjustment directions
@@ -542,7 +542,7 @@ void QGILeaderLine::setArrows(std::vector<QPointF> pathPoints)
     if (choice != ArrowType::NONE) {
         m_arrow1->setStyle(choice);
         m_arrow1->setWidth(getLineWidth());
-        m_arrow1->setSize(QGIArrow::getPrefArrowSize() * m_scale);
+        m_arrow1->setSize(QGIArrow::getPrefArrowSize() * m_screenScale);
         m_arrow1->setDirMode(true);
         m_arrow1->setDirection(stdX);
         if (pathPoints.size() > 1) {
@@ -565,7 +565,7 @@ void QGILeaderLine::setArrows(std::vector<QPointF> pathPoints)
     if (choice != ArrowType::NONE) {
         m_arrow2->setStyle(choice);
         m_arrow2->setWidth(getLineWidth());
-        m_arrow2->setSize(QGIArrow::getPrefArrowSize() * m_scale);
+        m_arrow2->setSize(QGIArrow::getPrefArrowSize() * m_screenScale);
         m_arrow2->setDirMode(true);
         m_arrow2->setDirection(-stdX);
         if (pathPoints.size() > 1) {
@@ -631,7 +631,7 @@ void QGILeaderLine::abandonEdit()
 
 void QGILeaderLine::setScreenScale(double scale)
 {
-    m_scale = scale;
+    ScreenScalable::setScreenScale(scale);
     draw();
 }
 
@@ -641,7 +641,7 @@ double QGILeaderLine::getLineWidth()
     if (!vp) {
         return Rez::guiX(LineGroup::getDefaultWidth("Graphic"));
     }
-    return Rez::guiX(vp->LineWidth.getValue() * m_scale);
+    return Rez::guiX(vp->LineWidth.getValue() * m_screenScale);
 }
 
 TechDraw::DrawLeaderLine* QGILeaderLine::getLeaderFeature()

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
@@ -450,12 +450,12 @@ QPainterPath QGILeaderLine::makeLeaderPath(std::vector<QPointF> qPoints)
         ArrowType choice = static_cast<ArrowType>(featLeader->StartSymbol.getValue());
         if (choice != ArrowType::NONE) {
             startAdjLength = QGIArrow::getOverlapAdjust(choice,
-                                                        QGIArrow::getPrefArrowSize() * m_screenScale);
+                                                        QGIArrow::getPrefArrowSize());
         }
         choice = static_cast<ArrowType>(featLeader->EndSymbol.getValue());
         if (choice != ArrowType::NONE) {
             endAdjLength = QGIArrow::getOverlapAdjust(choice,
-                                                      QGIArrow::getPrefArrowSize() * m_screenScale);
+                                                      QGIArrow::getPrefArrowSize());
         }
 
         //get adjustment directions
@@ -542,7 +542,7 @@ void QGILeaderLine::setArrows(std::vector<QPointF> pathPoints)
     if (choice != ArrowType::NONE) {
         m_arrow1->setStyle(choice);
         m_arrow1->setWidth(getLineWidth());
-        m_arrow1->setSize(QGIArrow::getPrefArrowSize() * m_screenScale);
+        m_arrow1->setSize(QGIArrow::getPrefArrowSize());
         m_arrow1->setDirMode(true);
         m_arrow1->setDirection(stdX);
         if (pathPoints.size() > 1) {
@@ -565,7 +565,7 @@ void QGILeaderLine::setArrows(std::vector<QPointF> pathPoints)
     if (choice != ArrowType::NONE) {
         m_arrow2->setStyle(choice);
         m_arrow2->setWidth(getLineWidth());
-        m_arrow2->setSize(QGIArrow::getPrefArrowSize() * m_screenScale);
+        m_arrow2->setSize(QGIArrow::getPrefArrowSize());
         m_arrow2->setDirMode(true);
         m_arrow2->setDirection(-stdX);
         if (pathPoints.size() > 1) {
@@ -629,19 +629,13 @@ void QGILeaderLine::abandonEdit()
     restoreState();
 }
 
-void QGILeaderLine::setScreenScale(double scale)
-{
-    ScreenScalable::setScreenScale(std::clamp(scale, Precision::Confusion(), 1.0));
-    draw();
-}
-
 double QGILeaderLine::getLineWidth()
 {
     auto vp = static_cast<ViewProviderLeader*>(getViewProvider(getViewObject()));
     if (!vp) {
         return Rez::guiX(LineGroup::getDefaultWidth("Graphic"));
     }
-    return Rez::guiX(vp->LineWidth.getValue() * m_screenScale);
+    return Rez::guiX(vp->LineWidth.getValue());
 }
 
 TechDraw::DrawLeaderLine* QGILeaderLine::getLeaderFeature()

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
@@ -631,7 +631,7 @@ void QGILeaderLine::abandonEdit()
 
 void QGILeaderLine::setScreenScale(double scale)
 {
-    ScreenScalable::setScreenScale(scale);
+    ScreenScalable::setScreenScale(std::clamp(scale, Precision::Confusion(), 1.0));
     draw();
 }
 

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.h
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.h
@@ -101,6 +101,8 @@ public:
     bool useOldCoords() const;
     Base::Vector3d getAttachPoint();
 
+    void setScreenScale(double scale);
+
 
 public Q_SLOTS:
     void onLineEditFinished(QPointF tipDisplace,
@@ -141,6 +143,8 @@ private:
     std::vector<Base::Vector3d> m_savePoints;
 
     bool m_blockDraw;//prevent redraws while updating.
+
+    double m_scale = 1.0;
 };
 
 }// namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.h
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.h
@@ -34,6 +34,7 @@
 
 #include "QGIView.h"
 #include "QGIUserTypes.h"
+#include "ScreenScalable.h"
 
 
 namespace TechDraw
@@ -51,7 +52,7 @@ class QGEPath;
 
 //*******************************************************************
 
-class TechDrawGuiExport QGILeaderLine: public QGIView
+class TechDrawGuiExport QGILeaderLine: public QGIView, public ScreenScalable
 {
     Q_OBJECT
 
@@ -101,7 +102,7 @@ public:
     bool useOldCoords() const;
     Base::Vector3d getAttachPoint();
 
-    void setScreenScale(double scale);
+    void setScreenScale(double scale) override;
 
 
 public Q_SLOTS:
@@ -143,8 +144,6 @@ private:
     std::vector<Base::Vector3d> m_savePoints;
 
     bool m_blockDraw;//prevent redraws while updating.
-
-    double m_scale = 1.0;
 };
 
 }// namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.h
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.h
@@ -34,8 +34,6 @@
 
 #include "QGIView.h"
 #include "QGIUserTypes.h"
-#include "ScreenScalable.h"
-
 
 namespace TechDraw
 {
@@ -52,7 +50,7 @@ class QGEPath;
 
 //*******************************************************************
 
-class TechDrawGuiExport QGILeaderLine: public QGIView, public ScreenScalable
+class TechDrawGuiExport QGILeaderLine: public QGIView
 {
     Q_OBJECT
 
@@ -101,8 +99,6 @@ public:
 
     bool useOldCoords() const;
     Base::Vector3d getAttachPoint();
-
-    void setScreenScale(double scale) override;
 
 
 public Q_SLOTS:

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
@@ -30,6 +30,7 @@
 #include <App/Application.h>
 
 #include <Gui/Selection/Selection.h>
+#include <Gui/ViewParams.h>
 
 #include <Mod/TechDraw/App/DrawView.h>
 
@@ -57,7 +58,10 @@ QGIPrimPath::QGIPrimPath():
 
     multiselectActivated = false;
 
-    m_edgeFuzz = PreferencesGui::edgeFuzz();
+    double defaultScreenEdge = Gui::ViewParams::instance()->getDefaultShapeLineWidth();
+    m_edgeFuzzBase = PreferencesGui::screenMode() ? defaultScreenEdge : PreferencesGui::edgeFuzz();
+    m_edgeFuzz = m_edgeFuzzBase;
+
     m_colNormal = getNormalColor();
     m_pen.setColor(m_colNormal);
     m_styleNormal = Qt::SolidLine;

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.h
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.h
@@ -57,6 +57,7 @@ public:
     virtual void setPrettySel();
     virtual void setWidth(double w);
     virtual double getWidth() { return m_pen.widthF();}
+    void setEdgeFuzzScale(double scale) { m_edgeFuzz = m_edgeFuzzBase * scale; }
     Qt::PenStyle getStyle() { return m_pen.style(); }
     void setStyle(Qt::PenStyle s);
     void setStyle(int s);
@@ -109,6 +110,7 @@ protected:
     Qt::BrushStyle m_fillNormal;               //current Normal fill style
 
     double m_edgeFuzz;
+    double m_edgeFuzzBase;
     bool m_highlightFill = true;
 };
 

--- a/src/Mod/TechDraw/Gui/QGIVertex.cpp
+++ b/src/Mod/TechDraw/Gui/QGIVertex.cpp
@@ -49,6 +49,18 @@ QGIVertex::QGIVertex(int index) :
 void QGIVertex::setRadius(double r)
 {
     m_radius = r;
+    makePoint();
+}
+
+void QGIVertex::setScreenScale(double scale)
+{
+    m_scale = scale;
+    makePoint();
+}
+
+void QGIVertex::makePoint()
+{
+    double r = m_radius * m_scale;
     QPainterPath p;
     p.addEllipse(-r/2.0, -r/2.0, r, r);
     setPath(p);

--- a/src/Mod/TechDraw/Gui/QGIVertex.cpp
+++ b/src/Mod/TechDraw/Gui/QGIVertex.cpp
@@ -54,13 +54,13 @@ void QGIVertex::setRadius(double r)
 
 void QGIVertex::setScreenScale(double scale)
 {
-    m_scale = scale;
+    ScreenScalable::setScreenScale(scale);
     makePoint();
 }
 
 void QGIVertex::makePoint()
 {
-    double r = m_radius * m_scale;
+    double r = m_radius * m_screenScale;
     QPainterPath p;
     p.addEllipse(-r/2.0, -r/2.0, r, r);
     setPath(p);

--- a/src/Mod/TechDraw/Gui/QGIVertex.h
+++ b/src/Mod/TechDraw/Gui/QGIVertex.h
@@ -48,6 +48,7 @@ public:
 
     double getRadius() const { return m_radius; }
     virtual void setRadius(double r);
+    virtual void setScreenScale(double scale);
 
     Base::Vector2d toVector2d() const;
     Base::Vector2d vector2dBetweenPoints(const QGIVertex* p2) const;
@@ -55,8 +56,11 @@ public:
 protected:
     bool multiselectEligible() override { return true; }
 
+    void makePoint();
+
     int projIndex;
     double m_radius;
+    double m_scale = 1.0;
 };
 
 }

--- a/src/Mod/TechDraw/Gui/QGIVertex.h
+++ b/src/Mod/TechDraw/Gui/QGIVertex.h
@@ -26,6 +26,7 @@
 
 #include "QGIPrimPath.h"
 #include "QGIUserTypes.h"
+#include "ScreenScalable.h"
 
 namespace Base {
 class Vector2d;
@@ -34,7 +35,7 @@ class Vector2d;
 namespace TechDrawGui
 {
 
-class TechDrawGuiExport QGIVertex : public QGIPrimPath
+class TechDrawGuiExport QGIVertex : public QGIPrimPath, public ScreenScalable
 {
 public:
     explicit QGIVertex(int index);
@@ -48,7 +49,7 @@ public:
 
     double getRadius() const { return m_radius; }
     virtual void setRadius(double r);
-    virtual void setScreenScale(double scale);
+    void setScreenScale(double scale) override;
 
     Base::Vector2d toVector2d() const;
     Base::Vector2d vector2dBetweenPoints(const QGIVertex* p2) const;
@@ -60,7 +61,6 @@ protected:
 
     int projIndex;
     double m_radius;
-    double m_scale = 1.0;
 };
 
 }

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -803,14 +803,14 @@ void QGIViewBalloon::drawBalloon(bool originDrag)
     double yAdj = 0.0;
     ArrowType endType = static_cast<ArrowType>(balloon->EndType.getValue());
     double arrowAdj = QGIArrow::getOverlapAdjust(
-        endType, balloon->EndTypeScale.getValue() * QGIArrow::getPrefArrowSize());
+        endType, balloon->EndTypeScale.getValue() * QGIArrow::getPrefArrowSize() * m_scale);
 
     if (endType == ArrowType::NONE) {
         arrow->hide();
     }
     else {
         arrow->setStyle(endType);
-        arrow->setSize(balloon->EndTypeScale.getValue() * QGIArrow::getPrefArrowSize());
+        arrow->setSize(balloon->EndTypeScale.getValue() * QGIArrow::getPrefArrowSize() * m_scale);
         arrow->draw();
         arrow->setPos(DU::toQPointF(arrowTipPosInParent));
 
@@ -935,10 +935,16 @@ void QGIViewBalloon::setSvgPens(void)
 
 void QGIViewBalloon::setPens(void)
 {
-    balloonLines->setWidth(m_lineWidth);
-    balloonShape->setWidth(m_lineWidth);
+    balloonLines->setWidth(m_lineWidth * m_scale);
+    balloonShape->setWidth(m_lineWidth * m_scale);
     balloonShape->setFillColor(PreferencesGui::pageQColor());
-    arrow->setWidth(m_lineWidth);
+    arrow->setWidth(m_lineWidth * m_scale);
+}
+
+void QGIViewBalloon::setScreenScale(double scale)
+{
+    m_scale = scale;
+    draw();
 }
 
 void QGIViewBalloon::setNormalColorAll()

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -803,14 +803,14 @@ void QGIViewBalloon::drawBalloon(bool originDrag)
     double yAdj = 0.0;
     ArrowType endType = static_cast<ArrowType>(balloon->EndType.getValue());
     double arrowAdj = QGIArrow::getOverlapAdjust(
-        endType, balloon->EndTypeScale.getValue() * QGIArrow::getPrefArrowSize() * m_scale);
+        endType, balloon->EndTypeScale.getValue() * QGIArrow::getPrefArrowSize() * m_screenScale);
 
     if (endType == ArrowType::NONE) {
         arrow->hide();
     }
     else {
         arrow->setStyle(endType);
-        arrow->setSize(balloon->EndTypeScale.getValue() * QGIArrow::getPrefArrowSize() * m_scale);
+        arrow->setSize(balloon->EndTypeScale.getValue() * QGIArrow::getPrefArrowSize() * m_screenScale);
         arrow->draw();
         arrow->setPos(DU::toQPointF(arrowTipPosInParent));
 
@@ -935,15 +935,15 @@ void QGIViewBalloon::setSvgPens(void)
 
 void QGIViewBalloon::setPens(void)
 {
-    balloonLines->setWidth(m_lineWidth * m_scale);
-    balloonShape->setWidth(m_lineWidth * m_scale);
+    balloonLines->setWidth(m_lineWidth * m_screenScale);
+    balloonShape->setWidth(m_lineWidth * m_screenScale);
     balloonShape->setFillColor(PreferencesGui::pageQColor());
-    arrow->setWidth(m_lineWidth * m_scale);
+    arrow->setWidth(m_lineWidth * m_screenScale);
 }
 
 void QGIViewBalloon::setScreenScale(double scale)
 {
-    m_scale = scale;
+    ScreenScalable::setScreenScale(scale);
     draw();
 }
 

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -943,7 +943,7 @@ void QGIViewBalloon::setPens(void)
 
 void QGIViewBalloon::setScreenScale(double scale)
 {
-    ScreenScalable::setScreenScale(scale);
+    ScreenScalable::setScreenScale(std::clamp(scale, Precision::Confusion(), 1.0));
     draw();
 }
 

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -803,14 +803,14 @@ void QGIViewBalloon::drawBalloon(bool originDrag)
     double yAdj = 0.0;
     ArrowType endType = static_cast<ArrowType>(balloon->EndType.getValue());
     double arrowAdj = QGIArrow::getOverlapAdjust(
-        endType, balloon->EndTypeScale.getValue() * QGIArrow::getPrefArrowSize() * m_screenScale);
+        endType, balloon->EndTypeScale.getValue() * QGIArrow::getPrefArrowSize());
 
     if (endType == ArrowType::NONE) {
         arrow->hide();
     }
     else {
         arrow->setStyle(endType);
-        arrow->setSize(balloon->EndTypeScale.getValue() * QGIArrow::getPrefArrowSize() * m_screenScale);
+        arrow->setSize(balloon->EndTypeScale.getValue() * QGIArrow::getPrefArrowSize());
         arrow->draw();
         arrow->setPos(DU::toQPointF(arrowTipPosInParent));
 
@@ -935,16 +935,10 @@ void QGIViewBalloon::setSvgPens(void)
 
 void QGIViewBalloon::setPens(void)
 {
-    balloonLines->setWidth(m_lineWidth * m_screenScale);
-    balloonShape->setWidth(m_lineWidth * m_screenScale);
+    balloonLines->setWidth(m_lineWidth);
+    balloonShape->setWidth(m_lineWidth);
     balloonShape->setFillColor(PreferencesGui::pageQColor());
-    arrow->setWidth(m_lineWidth * m_screenScale);
-}
-
-void QGIViewBalloon::setScreenScale(double scale)
-{
-    ScreenScalable::setScreenScale(std::clamp(scale, Precision::Confusion(), 1.0));
-    draw();
+    arrow->setWidth(m_lineWidth);
 }
 
 void QGIViewBalloon::setNormalColorAll()

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.h
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.h
@@ -213,6 +213,8 @@ public:
     // balloons handle their own dragging
     void dragFinished() override { };
 
+    void setScreenScale(double scale);
+
 public Q_SLOTS:
     void balloonLabelDragged(bool ctrl);
     void balloonLabelDragFinished();
@@ -255,6 +257,8 @@ private:
     Base::Vector3d m_saveOriginOffset;
     Base::Vector3d m_saveOrigin;
     Base::Vector3d m_savePosition;
+
+    double m_scale = 1.0;
 };
 
 }// namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.h
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.h
@@ -36,6 +36,7 @@
 #include "QGCustomText.h"
 #include "QGIView.h"
 #include "QGIUserTypes.h"
+#include "ScreenScalable.h"
 
 
 namespace TechDraw
@@ -162,7 +163,7 @@ private:
 
 //*******************************************************************
 
-class TechDrawGuiExport QGIViewBalloon: public QGIView
+class TechDrawGuiExport QGIViewBalloon: public QGIView, public ScreenScalable
 {
     Q_OBJECT
 
@@ -213,7 +214,7 @@ public:
     // balloons handle their own dragging
     void dragFinished() override { };
 
-    void setScreenScale(double scale);
+    void setScreenScale(double scale) override;
 
 public Q_SLOTS:
     void balloonLabelDragged(bool ctrl);
@@ -257,8 +258,6 @@ private:
     Base::Vector3d m_saveOriginOffset;
     Base::Vector3d m_saveOrigin;
     Base::Vector3d m_savePosition;
-
-    double m_scale = 1.0;
 };
 
 }// namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.h
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.h
@@ -36,7 +36,6 @@
 #include "QGCustomText.h"
 #include "QGIView.h"
 #include "QGIUserTypes.h"
-#include "ScreenScalable.h"
 
 
 namespace TechDraw
@@ -163,7 +162,7 @@ private:
 
 //*******************************************************************
 
-class TechDrawGuiExport QGIViewBalloon: public QGIView, public ScreenScalable
+class TechDrawGuiExport QGIViewBalloon: public QGIView
 {
     Q_OBJECT
 
@@ -213,8 +212,6 @@ public:
 
     // balloons handle their own dragging
     void dragFinished() override { };
-
-    void setScreenScale(double scale) override;
 
 public Q_SLOTS:
     void balloonLabelDragged(bool ctrl);

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -933,7 +933,7 @@ void QGIViewDimension::drawArrows(int count, const Base::Vector2d positions[], d
 
         arrow->setStyle(forcePoint ? ArrowType::DOT : static_cast<ArrowType>(vp->ArrowStyle.getValue()));
         auto arrowSize = vp->Arrowsize.getValue();
-        arrow->setSize(arrowSize);
+        arrow->setSize(arrowSize * m_scale);
         arrow->setFlipped(flipped);
 
         if (vp->ArrowStyle.getValue() != static_cast<int>(ArrowType::NONE)) {
@@ -2515,9 +2515,15 @@ void QGIViewDimension::setSvgPens()
 
 void QGIViewDimension::setPens()
 {
-    dimLines->setWidth(m_lineWidth);
-    aHead1->setWidth(m_lineWidth);
-    aHead2->setWidth(m_lineWidth);
+    dimLines->setWidth(m_lineWidth * m_scale);
+    aHead1->setWidth(m_lineWidth * m_scale);
+    aHead2->setWidth(m_lineWidth * m_scale);
+}
+
+void QGIViewDimension::setScreenScale(double scale)
+{
+    m_scale = scale;
+    draw();
 }
 
 double QGIViewDimension::toDeg(double angle) { return Base::toDegrees(angle); }

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -933,7 +933,7 @@ void QGIViewDimension::drawArrows(int count, const Base::Vector2d positions[], d
 
         arrow->setStyle(forcePoint ? ArrowType::DOT : static_cast<ArrowType>(vp->ArrowStyle.getValue()));
         auto arrowSize = vp->Arrowsize.getValue();
-        arrow->setSize(arrowSize * m_scale);
+        arrow->setSize(arrowSize * m_screenScale);
         arrow->setFlipped(flipped);
 
         if (vp->ArrowStyle.getValue() != static_cast<int>(ArrowType::NONE)) {
@@ -2515,14 +2515,14 @@ void QGIViewDimension::setSvgPens()
 
 void QGIViewDimension::setPens()
 {
-    dimLines->setWidth(m_lineWidth * m_scale);
-    aHead1->setWidth(m_lineWidth * m_scale);
-    aHead2->setWidth(m_lineWidth * m_scale);
+    dimLines->setWidth(m_lineWidth * m_screenScale);
+    aHead1->setWidth(m_lineWidth * m_screenScale);
+    aHead2->setWidth(m_lineWidth * m_screenScale);
 }
 
 void QGIViewDimension::setScreenScale(double scale)
 {
-    m_scale = scale;
+    ScreenScalable::setScreenScale(scale);
     draw();
 }
 

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -933,7 +933,7 @@ void QGIViewDimension::drawArrows(int count, const Base::Vector2d positions[], d
 
         arrow->setStyle(forcePoint ? ArrowType::DOT : static_cast<ArrowType>(vp->ArrowStyle.getValue()));
         auto arrowSize = vp->Arrowsize.getValue();
-        arrow->setSize(arrowSize * m_screenScale);
+        arrow->setSize(arrowSize);
         arrow->setFlipped(flipped);
 
         if (vp->ArrowStyle.getValue() != static_cast<int>(ArrowType::NONE)) {
@@ -2515,15 +2515,9 @@ void QGIViewDimension::setSvgPens()
 
 void QGIViewDimension::setPens()
 {
-    dimLines->setWidth(m_lineWidth * m_screenScale);
-    aHead1->setWidth(m_lineWidth * m_screenScale);
-    aHead2->setWidth(m_lineWidth * m_screenScale);
-}
-
-void QGIViewDimension::setScreenScale(double scale)
-{
-    ScreenScalable::setScreenScale(std::clamp(scale, Precision::Confusion(), 1.0));
-    draw();
+    dimLines->setWidth(m_lineWidth);
+    aHead1->setWidth(m_lineWidth);
+    aHead2->setWidth(m_lineWidth);
 }
 
 double QGIViewDimension::toDeg(double angle) { return Base::toDegrees(angle); }

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -2522,7 +2522,7 @@ void QGIViewDimension::setPens()
 
 void QGIViewDimension::setScreenScale(double scale)
 {
-    ScreenScalable::setScreenScale(scale);
+    ScreenScalable::setScreenScale(std::clamp(scale, Precision::Confusion(), 1.0));
     draw();
 }
 

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.h
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.h
@@ -91,6 +91,7 @@ public:
 
     void setNormalColorAll();
     TechDraw::DrawViewDimension* getDimFeat() { return dvDimension; }
+    void setScreenScale(double scale);
 
 public Q_SLOTS:
     void onPrettyChanged(int state);
@@ -220,6 +221,7 @@ private:
     QGIArrow* aHead1;
     QGIArrow* aHead2;
     double m_lineWidth;
+    double m_scale = 1.0;
     QGIDatumLabel* areaLeaderPointLabel;
     bool isAreaLeaderPointDragged;
 

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.h
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.h
@@ -37,6 +37,7 @@
 #include "QGIView.h"
 #include "QGIUserTypes.h"
 #include "Rez.h"
+#include "ScreenScalable.h"
 
 
 namespace TechDraw {
@@ -60,7 +61,7 @@ class ViewProviderDimension;
 enum class DragState;
 
 
-class TechDrawGuiExport QGIViewDimension : public QGIView
+class TechDrawGuiExport QGIViewDimension : public QGIView, public ScreenScalable
 {
     Q_OBJECT
 
@@ -91,7 +92,7 @@ public:
 
     void setNormalColorAll();
     TechDraw::DrawViewDimension* getDimFeat() { return dvDimension; }
-    void setScreenScale(double scale);
+    void setScreenScale(double scale) override;
 
 public Q_SLOTS:
     void onPrettyChanged(int state);
@@ -221,7 +222,6 @@ private:
     QGIArrow* aHead1;
     QGIArrow* aHead2;
     double m_lineWidth;
-    double m_scale = 1.0;
     QGIDatumLabel* areaLeaderPointLabel;
     bool isAreaLeaderPointDragged;
 

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.h
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.h
@@ -37,7 +37,6 @@
 #include "QGIView.h"
 #include "QGIUserTypes.h"
 #include "Rez.h"
-#include "ScreenScalable.h"
 
 
 namespace TechDraw {
@@ -61,7 +60,7 @@ class ViewProviderDimension;
 enum class DragState;
 
 
-class TechDrawGuiExport QGIViewDimension : public QGIView, public ScreenScalable
+class TechDrawGuiExport QGIViewDimension : public QGIView
 {
     Q_OBJECT
 
@@ -92,7 +91,6 @@ public:
 
     void setNormalColorAll();
     TechDraw::DrawViewDimension* getDimFeat() { return dvDimension; }
-    void setScreenScale(double scale) override;
 
 public Q_SLOTS:
     void onPrettyChanged(int state);

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -1377,6 +1377,10 @@ double QGIViewPart::getLineWidth() {
 }
 
 double QGIViewPart::getVertexSize() {
+    if (PreferencesGui::screenMode()) {
+        return PreferencesGui::get3dMarkerSize();
+    }
+
     return getLineWidth() * Preferences::vertexScale();
 }
 

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -24,6 +24,7 @@
 #include <QDomDocument>
 #include <QFile>
 #include <QGraphicsSceneEvent>
+#include <QGraphicsView>
 #include <QPainter>
 #include <QSvgGenerator>
 #include <QTemporaryFile>
@@ -60,13 +61,16 @@
 #include <Mod/TechDraw/App/DrawWeldSymbol.h>
 #include <Mod/TechDraw/App/Preferences.h>
 
+#include "QGICMark.h"
 #include "QGIDrawingTemplate.h"
+#include "QGIEdge.h"
 #include "QGILeaderLine.h"
 #include "QGIProjGroup.h"
 #include "QGIRichAnno.h"
 #include "QGISVGTemplate.h"
 #include "QGITemplate.h"
 #include "QGIUserTypes.h"
+#include "QGIVertex.h"
 #include "QGIViewAnnotation.h"
 #include "QGIViewBalloon.h"
 #include "QGIViewClip.h"
@@ -845,6 +849,49 @@ void QGSPage::refreshViews()
             itemView->updateView(true);
         }
     }
+
+    updateScreenScale();
+}
+
+void QGSPage::updateScreenScale()
+{
+    double scale = 1.0;
+    if (PreferencesGui::screenMode()) {
+        const QList<QGraphicsView*> allViews = views();
+        
+        if (!allViews.empty()) {
+            double zoom = allViews.first()->transform().m11();
+            scale = 1.0 / zoom;
+        }
+    }
+
+    // The items should not be larger than their original size only smaller
+    scale = std::clamp(scale, Precision::Confusion(), 1.0);
+
+    const QList<QGraphicsItem*> allItems = items();
+    
+    for (auto* item : allItems) {
+        switch (item->type()) {
+            case QGIEdge::Type:
+                static_cast<QGIEdge*>(item)->setScreenScale(scale);
+                break;
+            case QGIVertex::Type:
+            case QGICMark::Type:
+                static_cast<QGIVertex*>(item)->setScreenScale(scale);
+                break;
+            case QGIViewDimension::Type:
+                static_cast<QGIViewDimension*>(item)->setScreenScale(scale);
+                break;
+            case QGIViewBalloon::Type:
+                static_cast<QGIViewBalloon*>(item)->setScreenScale(scale);
+                break;
+            case QGILeaderLine::Type:
+                static_cast<QGILeaderLine*>(item)->setScreenScale(scale);
+                break;
+            default:
+                break;
+        }
+    }
 }
 
 void QGSPage::findMissingViews(const std::vector<App::DocumentObject*>& list,
@@ -984,6 +1031,8 @@ void QGSPage::redrawAllViews()
     for (std::vector<QGIView*>::const_iterator it = upviews.begin(); it != upviews.end(); ++it) {
         (*it)->updateView(true);
     }
+
+    updateScreenScale();
 }
 
 //NOTE: this doesn't add missing views.   see fixOrphans()
@@ -997,6 +1046,8 @@ void QGSPage::redraw1View(TechDraw::DrawView* dView)
             (*it)->updateView(true);
         }
     }
+
+    updateScreenScale();
 }
 
 // RichTextAnno needs to know when it is rendering an Svg as the font size

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -866,9 +866,6 @@ void QGSPage::updateScreenScale()
         }
     }
 
-    // The items should not be larger than their original size only smaller
-    scale = std::clamp(scale, Precision::Confusion(), 1.0);
-
     const QList<QGraphicsItem*> allItems = items();
 
     for (auto* item : allItems) {

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -84,6 +84,7 @@
 #include "QGIWeldSymbol.h"
 #include "QGSPage.h"
 #include "Rez.h"
+#include "ScreenScalable.h"
 #include "ViewProviderDrawingView.h"
 #include "ViewProviderPage.h"
 #include "ZVALUE.h"
@@ -869,27 +870,10 @@ void QGSPage::updateScreenScale()
     scale = std::clamp(scale, Precision::Confusion(), 1.0);
 
     const QList<QGraphicsItem*> allItems = items();
-    
+
     for (auto* item : allItems) {
-        switch (item->type()) {
-            case QGIEdge::Type:
-                static_cast<QGIEdge*>(item)->setScreenScale(scale);
-                break;
-            case QGIVertex::Type:
-            case QGICMark::Type:
-                static_cast<QGIVertex*>(item)->setScreenScale(scale);
-                break;
-            case QGIViewDimension::Type:
-                static_cast<QGIViewDimension*>(item)->setScreenScale(scale);
-                break;
-            case QGIViewBalloon::Type:
-                static_cast<QGIViewBalloon*>(item)->setScreenScale(scale);
-                break;
-            case QGILeaderLine::Type:
-                static_cast<QGILeaderLine*>(item)->setScreenScale(scale);
-                break;
-            default:
-                break;
+        if (auto* scalable = dynamic_cast<ScreenScalable*>(item)) {
+            scalable->setScreenScale(scale);
         }
     }
 }

--- a/src/Mod/TechDraw/Gui/QGSPage.h
+++ b/src/Mod/TechDraw/Gui/QGSPage.h
@@ -141,6 +141,7 @@ public:
     bool getExportingAny() const { return getExportingPdf() || getExportingSvg(); }
 
     virtual void refreshViews();
+    void updateScreenScale();
 
     /// Renders the page to SVG with filename.
     void saveSvg(QString filename);

--- a/src/Mod/TechDraw/Gui/QGVNavStyle.cpp
+++ b/src/Mod/TechDraw/Gui/QGVNavStyle.cpp
@@ -298,6 +298,7 @@ void QGVNavStyle::zoom(double factor)
 
     setAnchor();
     getViewer()->scale(factor, factor);
+    getViewer()->getScene()->updateScreenScale();
     m_zoomPending = false;
 }
 

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -82,6 +82,7 @@ class QGVPage::Private: public ParameterGrp::ObserverType
 public:
     /// handle to the viewer parameter group
     ParameterGrp::handle hGrp;
+    ParameterGrp::handle hGrpView;
     QGVPage* page;
     explicit Private(QGVPage* page) : page(page)
     {
@@ -89,6 +90,9 @@ public:
         hGrp = App::GetApplication().GetParameterGroupByPath(
             "User parameter:BaseApp/Preferences/View");
         hGrp->Attach(this);
+
+        hGrpView = Preferences::getPreferenceGroup("View");
+        hGrpView->Attach(this);
     }
     void init()
     {
@@ -127,12 +131,21 @@ public:
                 page->setTransformationAnchor(QGVPage::AnchorViewCenter);
             }
         }
+        else if (strcmp(Reason, "ScreenMode") == 0) {
+            // If the screen mode changes we instantly update the screen scale of all items
+            if (page->getScene()) {
+                page->getScene()->updateScreenScale();
+            }
+        }
     }
     void detach()
     {
         hGrp = App::GetApplication().GetParameterGroupByPath(
             "User parameter:BaseApp/Preferences/View");
         hGrp->Detach(this);
+
+        hGrpView = Preferences::getPreferenceGroup("View");
+        hGrpView->Detach(this);
     }
 };
 

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -132,9 +132,8 @@ public:
             }
         }
         else if (strcmp(Reason, "ScreenMode") == 0) {
-            // If the screen mode changes we instantly update the screen scale of all items
             if (page->getScene()) {
-                page->getScene()->updateScreenScale();
+                page->getScene()->refreshViews();
             }
         }
     }

--- a/src/Mod/TechDraw/Gui/ScreenScalable.h
+++ b/src/Mod/TechDraw/Gui/ScreenScalable.h
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Morten Vajhøj
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+
+#pragma once
+
+class ScreenScalable
+{
+public:
+    virtual void setScreenScale(double scale) { m_screenScale = scale; }
+
+protected:
+    ~ScreenScalable() = default;
+    double m_screenScale = 1.0;
+};


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
This PR adds "Screen Mode" to TechDraw. Currently when zooming in on views the vertices or edges can block other geometry in complex models. The Screen Mode makes the edges scale based on how zoomed in the user is. This scales Edges, Vertices, Dimensions, Balloons and Leader Lines. 

Changing the mode can be done by right clicking the page and toggling the button "Screen Mode". It is "On" by default but cna be turned of in the context menu

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

closes #25114 
closes #27773 

## Before and After Images

https://github.com/user-attachments/assets/54b9f4ff-8f62-4ed9-bf1d-e6caac56ec6f


