### PR TITLE
Fix #14520: correct inverted colors on PDF import

### DIFF
--- a/src/Gui/ImageView.cpp
+++ b/src/Gui/ImageView.cpp
@@ -79,6 +79,16 @@ bool ImageView::loadFile(const QString& fileName)
         return false;
     }
 
+    // Same premultiplied-alpha correction as in ViewProviderImagePlane.
+    if (image.hasAlphaChannel()) {
+        QImage opaque(image.size(), QImage::Format_RGB32);
+        opaque.fill(Qt::white);
+        QPainter painter(&opaque);
+        painter.drawImage(0, 0, image);
+        painter.end();
+        image = opaque;
+    }
+
     setImage(image);
     setWindowFilePath(fileName);
 

--- a/src/Gui/ViewProviderImagePlane.cpp
+++ b/src/Gui/ViewProviderImagePlane.cpp
@@ -26,6 +26,7 @@
 #include <QFileInfo>
 #include <QImage>
 #include <QMenu>
+#include <QPainter>
 #include <QString>
 #include <QSvgRenderer>
 #include <Inventor/nodes/SoCoordinate3.h>
@@ -236,6 +237,22 @@ QImage ViewProviderImagePlane::loadRaster(const char* fileName) const
 {
     QImage img;
     img.load(QString::fromUtf8(fileName));
+
+    // Images may carry premultiplied alpha (e.g. PDF loaded through the
+    // Qt PDF image plugin), where transparent regions are alpha=0 / RGB=0.
+    // Using them as-is renders the page background black and darkens all
+    // colors.  Compositing onto white yields the expected appearance.
+    if (!img.isNull() && img.hasAlphaChannel()) {
+        QImage opaque(img.size(), QImage::Format_RGB32);
+        opaque.fill(Qt::white);
+        QPainter painter(&opaque);
+        painter.drawImage(0, 0, img);
+        painter.end();
+        opaque.setDotsPerMeterX(img.dotsPerMeterX());
+        opaque.setDotsPerMeterY(img.dotsPerMeterY());
+        return opaque;
+    }
+
     return img;
 }
 


### PR DESCRIPTION
PDF files opened via File > Open, File > Import or Tools > Load Image were displayed with a black background and darkened colors.

Cause: the Qt PDF image plugin hands QImageReader an image in Format_ARGB32_Premultiplied, where the transparent page background is alpha=0 / RGB=0.  Both display paths used those pixels directly.

Fix: composite images that carry an alpha channel onto a white RGB32 background, in ViewProviderImagePlane::loadRaster() (3D view) and in ImageView::loadFile() (2D viewer).

No new build dependencies.
Closes: https://github.com/FreeCAD/FreeCAD/issues/14520

[+ ] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: Claude Sonnet 5 (claude-sonnet-5)

