### PR TITLE
Tools: complete Python API stub compatibility fixes

### DIFF
--- a/src/App/FreeCAD.module.pyi
+++ b/src/App/FreeCAD.module.pyi
@@ -10,7 +10,7 @@ those signatures use.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Literal, TypeAlias, overload
+from typing import Any, Literal, TypeAlias, overload
 
 from Base.Metadata import module
 from . import Console as Console  # pylint: disable=no-name-in-module,unused-import
@@ -24,13 +24,12 @@ module(
     CallbackPrefix="s",
 )
 
-if TYPE_CHECKING:
-    from Part import Feature as _PartFeature
-
 _FileTypeModules: TypeAlias = dict[str, str | list[str] | None]
 _LogLevelName: TypeAlias = Literal["Default", "Error", "Warning", "Message", "Log", "Trace"]
 GuiUp: int
 ActiveDocument: Document | None
+Gui: Any
+"""Optional GUI module alias installed by GUI initialization; use FreeCADGui for typed APIs."""
 
 # Parameter and configuration access
 def ParamGet(path: str, /) -> ParameterGrp:

--- a/src/Gui/FreeCADGui._MainWindow.pyi
+++ b/src/Gui/FreeCADGui._MainWindow.pyi
@@ -5,8 +5,9 @@
 from __future__ import annotations
 
 from FreeCADGui import InputHint, _MDIView
+import PySide.QtWidgets as QtWidgets
 
-class _MainWindow:
+class _MainWindow(QtWidgets.QMainWindow):
     """Wrapper around the FreeCAD main application window."""
 
     def getWindows(self) -> list[_MDIView]:

--- a/src/Mod/Part/App/Arc.pyi
+++ b/src/Mod/Part/App/Arc.pyi
@@ -5,7 +5,10 @@ from __future__ import annotations
 from Base.Metadata import export
 from Base.Vector import Vector
 from TrimmedCurve import TrimmedCurve
-from Geometry import Geom_Circle, Geom_Ellipse
+from Circle import Circle
+from Ellipse import Ellipse
+from Hyperbola import Hyperbola
+from Parabola import Parabola
 from typing import overload
 
 @export(
@@ -26,8 +29,14 @@ class Arc(TrimmedCurve):
     """
 
     @overload
-    def __init__(self, circ: Geom_Circle, T: type = ...) -> None: ...
+    def __init__(self, circ: Circle, u1: float, u2: float, sense: bool = ..., /) -> None: ...
     @overload
-    def __init__(self, circ: Geom_Ellipse, T: type = ...) -> None: ...
+    def __init__(self, ellipse: Ellipse, u1: float, u2: float, sense: bool = ..., /) -> None: ...
+    @overload
+    def __init__(self, parabola: Parabola, u1: float, u2: float, sense: bool = ..., /) -> None: ...
+    @overload
+    def __init__(
+        self, hyperbola: Hyperbola, u1: float, u2: float, sense: bool = ..., /
+    ) -> None: ...
     @overload
     def __init__(self, p1: Vector, p2: Vector, p3: Vector, /) -> None: ...

--- a/src/Mod/Part/App/Circle.pyi
+++ b/src/Mod/Part/App/Circle.pyi
@@ -5,7 +5,6 @@ from __future__ import annotations
 from Base.Metadata import export
 from Base.Vector import Vector
 from Conic import Conic
-from Point import Point
 from typing import overload
 
 @export(
@@ -47,6 +46,6 @@ class Circle(Conic):
     @overload
     def __init__(self, circle: "Circle", distance: float) -> None: ...
     @overload
-    def __init__(self, center: Point, normal: Vector, radius: float) -> None: ...
+    def __init__(self, center: Vector, normal: Vector, radius: float) -> None: ...
     @overload
-    def __init__(self, point1: Point, point2: Point, point3: Point) -> None: ...
+    def __init__(self, point1: Vector, point2: Vector, point3: Vector) -> None: ...

--- a/src/Mod/Part/App/LineSegment.pyi
+++ b/src/Mod/Part/App/LineSegment.pyi
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from Base.Metadata import export
 from Base.Type import Type
+from Base.Vector import Vector
 from TrimmedCurve import TrimmedCurve
-from Point import Point
+from Line import Line
 from typing import overload
 
 @export(
@@ -26,7 +27,7 @@ class LineSegment(TrimmedCurve):
     Part.LineSegment(LineSegment)
         Creates a copy of the given line segment
 
-    Part.LineSegment(Point1,Point2)
+    Part.LineSegment(Vector1,Vector2)
         Creates a line segment that goes through two given points
     """
 
@@ -39,10 +40,14 @@ class LineSegment(TrimmedCurve):
     @overload
     def __init__(self) -> None: ...
     @overload
-    def __init__(self, line_segment: "LineSegment") -> None: ...
+    def __init__(self, line_segment: "LineSegment", /) -> None: ...
     @overload
-    def __init__(self, point1: Point, point2: Point) -> None: ...
-    def setParameterRange(self) -> None:
+    def __init__(self, line_segment: "LineSegment", first: float, last: float, /) -> None: ...
+    @overload
+    def __init__(self, line: Line, first: float, last: float, /) -> None: ...
+    @overload
+    def __init__(self, point1: Vector, point2: Vector, /) -> None: ...
+    def setParameterRange(self, first: float, last: float, /) -> None:
         """
         Set the parameter range of the underlying line geometry
         """

--- a/src/Mod/PartDesign/Gui/ViewProvider.pyi
+++ b/src/Mod/PartDesign/Gui/ViewProvider.pyi
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from Base.Metadata import export
-from Gui.ViewProviderPartExt import ViewProviderPartExt
+from PartGui import ViewProviderPartExt
 
 @export(
     Include="Mod/PartDesign/Gui/ViewProvider.h",

--- a/src/Mod/Sketcher/App/Constraint.pyi
+++ b/src/Mod/Sketcher/App/Constraint.pyi
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from Base.Metadata import export
+from Base.Quantity import Quantity
 from Base.Persistence import Persistence
-from typing import Final
+from typing import Final, overload
 
 @export(
     Include="Mod/Sketcher/App/Constraint.h",
@@ -18,6 +19,188 @@ class Constraint(Persistence):
     Author: Juergen Riegel (FreeCAD@juergen-riegel.net)
     Licence: LGPL
     """
+
+    @overload
+    def __init__(self) -> None: ...
+    @overload
+    def __init__(self, constraint_type: str, elements: list[int], /) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        elements: list[int],
+        text: str,
+        font: str,
+        is_text_height: bool = ...,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(self, constraint_type: str, first_index: int, /) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        first_index: int,
+        second: int | float | Quantity,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        first_index: int,
+        second: int | float | Quantity,
+        activated: bool,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        first_index: int,
+        second: int | float | Quantity,
+        activated: bool,
+        driving: bool,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        first_index: int,
+        first_position: int,
+        second: int | float | Quantity,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        first_index: int,
+        first_position: int,
+        second: int | float | Quantity,
+        activated: bool,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        first_index: int,
+        first_position: int,
+        second: int | float | Quantity,
+        activated: bool,
+        driving: bool,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        first_index: int,
+        first_position: int,
+        second: int,
+        value: int | float | Quantity,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        first_index: int,
+        first_position: int,
+        second: int,
+        value: int | float | Quantity,
+        activated: bool,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        first_index: int,
+        first_position: int,
+        second: int,
+        value: int | float | Quantity,
+        activated: bool,
+        driving: bool,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        first_index: int,
+        first_position: int,
+        second: int,
+        second_position: int,
+        third: int | float | Quantity,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        first_index: int,
+        first_position: int,
+        second: int,
+        second_position: int,
+        third: int | float | Quantity,
+        activated: bool,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        first_index: int,
+        first_position: int,
+        second: int,
+        second_position: int,
+        third: int | float | Quantity,
+        activated: bool,
+        driving: bool,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        first_index: int,
+        first_position: int,
+        second: int,
+        second_position: int,
+        third: int,
+        third_position: int | float | Quantity,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        first_index: int,
+        first_position: int,
+        second: int,
+        second_position: int,
+        third: int,
+        third_position: int | float | Quantity,
+        activated: bool,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        constraint_type: str,
+        first_index: int,
+        first_position: int,
+        second: int,
+        second_position: int,
+        third: int,
+        third_position: int | float | Quantity,
+        activated: bool,
+        driving: bool,
+        /,
+    ) -> None: ...
 
     Type: Final[str] = ""
     """Get the constraint type"""

--- a/src/Mod/Sketcher/App/SketchObject.pyi
+++ b/src/Mod/Sketcher/App/SketchObject.pyi
@@ -9,7 +9,7 @@ from Base.Axis import Axis
 from Part.App.Part2DObject import Part2DObject
 from Part.App.Geometry import Geometry
 from Sketcher.App.Constraint import Constraint
-from typing import List, Tuple, Union, Final, overload
+from typing import TYPE_CHECKING, Final, List, Tuple, Union, overload
 
 @export(
     Include="Mod/Sketcher/App/SketchObject.h",
@@ -22,6 +22,13 @@ class SketchObject(Part2DObject):
     Author: Juergen Riegel
     Licence: LGPL
     """
+
+    if TYPE_CHECKING:
+        Geometry: List[Geometry] = ...
+        """The sketch's geometric elements."""
+
+        Constraints: List[Constraint] = ...
+        """The sketch's constraints."""
 
     MissingPointOnPointConstraints: List = ...
     """Returns a list of (First FirstPos Second SecondPos Type) tuples with all the detected endpoint constraints."""
@@ -505,9 +512,15 @@ class SketchObject(Part2DObject):
         """
         ...
 
-    def setVirtualSpace(self) -> None:
+    @overload
+    def setVirtualSpace(self, constraintIndex: int, state: bool, /) -> None: ...
+    @overload
+    def setVirtualSpace(
+        self, constraintIndices: List[int] | Tuple[int, ...], state: bool, /
+    ) -> None: ...
+    def setVirtualSpace(self, constraintIndex: int, state: bool, /) -> None:
         """
-        Set the VirtualSpace status of a constraint
+        Set the VirtualSpace status of one or more constraints.
         """
         ...
 

--- a/src/Tools/typing/inputs/overlays/PySide/QtCore.pyi
+++ b/src/Tools/typing/inputs/overlays/PySide/QtCore.pyi
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Callable
+try:
+    from PySide6.QtCore import *
+
+    # Pyrefly does not currently resolve QTimer through the wildcard re-export,
+    # so keep this compatibility export explicit.
+    from PySide6.QtCore import QTimer as QTimer
+except ImportError:
+    from PySide2.QtCore import *
+
+    # Keep the Qt5 compatibility export explicit for the same reason.
+    from PySide2.QtCore import QTimer as QTimer
 
 def QT_TRANSLATE_NOOP(context: str, source_text: str, /) -> str: ...
-
-class QTimer:
-    @staticmethod
-    def singleShot(msec: int, slot: Callable[[], object], /) -> None: ...

--- a/src/Tools/typing/inputs/overlays/PySide/QtGui.pyi
+++ b/src/Tools/typing/inputs/overlays/PySide/QtGui.pyi
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+# FreeCAD's Qt5/Qt6 compatibility module also reexports QtWidgets from QtGui.
+try:
+    from PySide6.QtGui import *
+    from PySide6.QtGui import QColor as QColor
+    from PySide6.QtWidgets import *
+except ImportError:
+    from PySide2.QtGui import *
+    from PySide2.QtGui import QColor as QColor
+    from PySide2.QtWidgets import *

--- a/src/Tools/typing/inputs/overlays/PySide/QtNetwork.pyi
+++ b/src/Tools/typing/inputs/overlays/PySide/QtNetwork.pyi
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+try:
+    from PySide6.QtNetwork import *
+    from PySide6.QtNetwork import QNetworkRequest as QNetworkRequest
+except ImportError:
+    from PySide2.QtNetwork import *
+    from PySide2.QtNetwork import QNetworkRequest as QNetworkRequest

--- a/src/Tools/typing/inputs/overlays/PySide/QtSvg.pyi
+++ b/src/Tools/typing/inputs/overlays/PySide/QtSvg.pyi
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+try:
+    from PySide6.QtSvg import *
+    from PySide6.QtSvg import QSvgRenderer as QSvgRenderer
+except ImportError:
+    from PySide2.QtSvg import *
+    from PySide2.QtSvg import QSvgRenderer as QSvgRenderer

--- a/src/Tools/typing/inputs/overlays/PySide/QtSvgWidgets.pyi
+++ b/src/Tools/typing/inputs/overlays/PySide/QtSvgWidgets.pyi
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+# Named imports in stubs are private unless explicitly re-exported with a
+# self-alias, so spell out the Qt5 compatibility exports below.
+try:
+    from PySide6.QtSvgWidgets import *
+except ImportError:
+    from PySide2.QtSvg import (
+        QGraphicsSvgItem as QGraphicsSvgItem,
+        QSvgWidget as QSvgWidget,
+    )

--- a/src/Tools/typing/inputs/overlays/PySide/QtUiTools.pyi
+++ b/src/Tools/typing/inputs/overlays/PySide/QtUiTools.pyi
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+try:
+    from PySide6.QtUiTools import *
+    from PySide6.QtUiTools import QUiLoader as QUiLoader
+except ImportError:
+    from PySide2.QtUiTools import *
+    from PySide2.QtUiTools import QUiLoader as QUiLoader

--- a/src/Tools/typing/inputs/overlays/PySide/QtWebEngineWidgets.pyi
+++ b/src/Tools/typing/inputs/overlays/PySide/QtWebEngineWidgets.pyi
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+try:
+    from PySide6.QtWebEngineWidgets import *
+    from PySide6.QtWebEngineCore import QWebEnginePage as QWebEnginePage
+except ImportError:
+    from PySide2.QtWebEngineWidgets import *

--- a/src/Tools/typing/inputs/overlays/PySide/QtWidgets.pyi
+++ b/src/Tools/typing/inputs/overlays/PySide/QtWidgets.pyi
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+try:
+    from PySide6.QtWidgets import *
+    from PySide6.QtWidgets import QMainWindow as QMainWindow, QWidget as QWidget
+except ImportError:
+    from PySide2.QtWidgets import *
+    from PySide2.QtWidgets import QMainWindow as QMainWindow, QWidget as QWidget

--- a/src/Tools/typing/inputs/overlays/PySide/__init__.pyi
+++ b/src/Tools/typing/inputs/overlays/PySide/__init__.pyi
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""The compatibility package installed by FreeCAD's PySide setup."""
+
+from __future__ import annotations
+
+try:
+    from PySide6 import __version__ as __version__, __version_info__ as __version_info__
+except ImportError:
+    from PySide2 import __version__ as __version__, __version_info__ as __version_info__

--- a/src/Tools/typing/smoke/smoke.py
+++ b/src/Tools/typing/smoke/smoke.py
@@ -42,6 +42,7 @@ from PySide import (
 )
 import QtUnitGui
 import SpreadsheetGui
+import Sketcher
 import TechDrawGui
 from FreeCAD import DocumentObject, ParameterGrp
 from FreeCAD.Base import (
@@ -176,6 +177,18 @@ def exercise(
     path_command = cast(PathApp.Command, object())
     part_design_view_provider = cast(PartDesignGui.ViewProvider, object())
     part_design_object = part_design_view_provider.Object
+    constraint = Sketcher.Constraint("Distance", 0, 1.0)
+    active_constraint = Sketcher.Constraint("Distance", 0, 1.0, True, False)
+    text_constraint = Sketcher.Constraint("Text", [0, 1], "label", "Sans")
+    sketch = cast(Sketcher.SketchObject, object())
+    sketch_geometry = sketch.Geometry
+    sketch_constraints = sketch.Constraints
+    sketch.setVirtualSpace(0, True)
+    sketch.setVirtualSpace((0, 1), False)
+    line_segment = Part.LineSegment(vector, vector)
+    ranged_line_segment = Part.LineSegment(line_segment, 0.0, 1.0)
+    circle_from_vectors = Part.Circle(vector, vector, 1.0)
+    arc = Part.Arc(circle_from_vectors, 0.0, 1.0)
     qt_timer = QtCore.QTimer
     QtCore.QTimer.singleShot(0, lambda: None)
     pyside_version_value = pyside_version

--- a/src/Tools/typing/smoke/smoke.py
+++ b/src/Tools/typing/smoke/smoke.py
@@ -150,6 +150,7 @@ def exercise(
     resource_from_dialog = FreeCADGui.createDialog("dialog.ui")
     single_viewer = FreeCADGui.createViewer()
     split_viewer = FreeCADGui.createViewer(2, "Split")
+    freecad_gui_alias = FreeCAD.Gui
     active_workbench = FreeCADGui.activeWorkbench()
     workbench_by_name = FreeCADGui.getWorkbench("NoneWorkbench")
     workbenches = FreeCADGui.listWorkbenches()

--- a/src/Tools/typing/smoke/smoke.py
+++ b/src/Tools/typing/smoke/smoke.py
@@ -28,6 +28,18 @@ import FreeCADGui.Selection as GuiSelection
 import Materials
 import PartDesignGui
 import PathApp
+from PySide import (
+    __version__ as pyside_version,
+    __version_info__ as pyside_version_info,
+    QtCore,
+    QtGui,
+    QtNetwork,
+    QtSvg,
+    QtSvgWidgets,
+    QtUiTools,
+    QtWebEngineWidgets,
+    QtWidgets,
+)
 import QtUnitGui
 import SpreadsheetGui
 import TechDrawGui
@@ -161,6 +173,17 @@ def exercise(
     material = cast(Materials.Material, object())
     path_command = cast(PathApp.Command, object())
     part_design_view_provider = cast(PartDesignGui.ViewProvider, object())
+    qt_timer = QtCore.QTimer
+    QtCore.QTimer.singleShot(0, lambda: None)
+    pyside_version_value = pyside_version
+    pyside_version_info_value = pyside_version_info
+    qt_color = QtGui.QColor
+    qt_request = QtNetwork.QNetworkRequest
+    qt_svg_renderer = QtSvg.QSvgRenderer
+    qt_svg_widget = QtSvgWidgets.QSvgWidget
+    qt_ui_loader = QtUiTools.QUiLoader
+    qt_web_page = QtWebEngineWidgets.QWebEnginePage
+    qt_widget = QtWidgets.QWidget
     selection_filter = GuiSelection.Filter("SELECT Part::Feature")
     preselection = GuiSelection.getPreselection()
     selection = GuiSelection.getSelection()

--- a/src/Tools/typing/smoke/smoke.py
+++ b/src/Tools/typing/smoke/smoke.py
@@ -162,6 +162,8 @@ def exercise(
     resolve_mode: GuiSelection.ResolveMode = GuiSelection.ResolveMode.NoResolve
     selection_style_enum: GuiSelection.SelectionStyle = GuiSelection.SelectionStyle.NormalSelection
     main_window = cast(FreeCADGui._MainWindow, object())
+    main_window.statusBar()
+    main_window.findChildren(FreeCADGui._MainWindow)
     mdi_view = cast(FreeCADGui._MDIView, object())
     task_dialog = cast(FreeCADGui._TaskDialog, object())
     split_view = cast(FreeCADGui._AbstractSplitView, object())
@@ -173,6 +175,7 @@ def exercise(
     material = cast(Materials.Material, object())
     path_command = cast(PathApp.Command, object())
     part_design_view_provider = cast(PartDesignGui.ViewProvider, object())
+    part_design_object = part_design_view_provider.Object
     qt_timer = QtCore.QTimer
     QtCore.QTimer.singleShot(0, lambda: None)
     pyside_version_value = pyside_version

--- a/src/Tools/typing/stubgen/module_merge.py
+++ b/src/Tools/typing/stubgen/module_merge.py
@@ -461,6 +461,23 @@ def type_stub_support_sources(source: str, class_symbol: str) -> tuple[str, str]
     return module_support_source_text, class_support_source
 
 
+def type_stub_class_bases(source: str, class_symbol: str) -> list[ast.expr]:
+    """Return the explicitly declared bases from one source-adjacent type stub."""
+
+    tree = ast.parse(source)
+    target_class = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == class_symbol
+        ),
+        None,
+    )
+    if target_class is None:
+        return []
+    return copy.deepcopy(target_class.bases)
+
+
 def merged_module_source(target_source: str, target_tree: ast.Module) -> str:
     merged = ast.unparse(target_tree).rstrip() + "\n"
     preamble = leading_comment_block(target_source)
@@ -492,8 +509,9 @@ def merge_type_class_support_nodes(
     target_source: str,
     class_symbol: str,
     support_source: str,
+    class_bases: list[ast.expr] | None = None,
 ) -> str:
-    if not support_source.strip():
+    if not support_source.strip() and not class_bases:
         return target_source
 
     target_tree = ast.parse(target_source)
@@ -509,10 +527,13 @@ def merge_type_class_support_nodes(
     if target_class is None:
         return target_source
 
+    if class_bases:
+        target_class.bases = copy.deepcopy(class_bases)
+
     existing_symbols = class_body_defined_symbols(target_class.body)
     support_nodes = filtered_type_class_support_nodes(support_tree.body, existing_symbols)
     if not support_nodes:
-        return target_source
+        return merged_module_source(target_source, target_tree)
 
     insertion_index = class_support_insertion_index(target_class.body)
     target_class.body = (
@@ -613,16 +634,30 @@ def copy_type_support_stubs(
         )
         if not target.exists():
             continue
+        source_text = source.read_text(encoding="utf-8")
         module_support_source_text, class_support_source = type_stub_support_sources(
-            source.read_text(encoding="utf-8"),
+            source_text,
             class_symbol,
         )
+        class_bases = type_stub_class_bases(source_text, class_symbol)
         original = target.read_text(encoding="utf-8")
         merged = original
         if module_support_source_text.strip():
             merged = merge_module_support_nodes(merged, module_support_source_text)
         if class_support_source.strip():
-            merged = merge_type_class_support_nodes(merged, class_symbol, class_support_source)
+            merged = merge_type_class_support_nodes(
+                merged,
+                class_symbol,
+                class_support_source,
+                class_bases,
+            )
+        elif class_bases:
+            merged = merge_type_class_support_nodes(
+                merged,
+                class_symbol,
+                "",
+                class_bases,
+            )
         if merged == original:
             continue
         target.write_text(merged, encoding="utf-8")


### PR DESCRIPTION
## Summary

Implements the missing Python typing surfaces reported in #32106:

- Sketcher constraint constructors, SketchObject properties, and setVirtualSpace overloads
- Part geometry Vector constructors and Arc overloads
- PySide Qt5/Qt6 compatibility modules
- FreeCAD.Gui, QMainWindow, and PartDesign view-provider inheritance
- Generator support for preserving helper-stub class bases
- Expanded typing smoke coverage

Fixes #32106