### PR TITLE
Spreadsheet: don't let a stray trackpad touch end cell editing

### DIFF
--- a/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
@@ -246,6 +246,29 @@ void ZoomableView::resizeEvent(QResizeEvent* event)
     updateView();
 }
 
+bool ZoomableView::viewportEvent(QEvent* event)
+{
+    // The spreadsheet has no touch interaction of its own: zooming is driven by
+    // wheelEvent() and everything else is mouse and keyboard. On macOS a passive
+    // trackpad touch (a resting palm, no button pressed) is still delivered here and
+    // reaches the scene, which moves focus away from an open cell editor. The delegate
+    // then commits and closes the editor, interrupting the user mid-typing (issue #23131).
+    //
+    // Dropping raw touch events keeps focus with the cell editor. Real clicks arrive as
+    // mouse events and are unaffected.
+    switch (event->type()) {
+        case QEvent::TouchBegin:
+        case QEvent::TouchUpdate:
+        case QEvent::TouchEnd:
+        case QEvent::TouchCancel:
+            return true;
+        default:
+            break;
+    }
+
+    return QGraphicsView::viewportEvent(event);
+}
+
 void ZoomableView::wheelEvent(QWheelEvent* event)
 {
     if (event->modifiers() & Qt::ControlModifier) {

--- a/src/Mod/Spreadsheet/Gui/ZoomableView.h
+++ b/src/Mod/Spreadsheet/Gui/ZoomableView.h
@@ -75,6 +75,7 @@ protected:
     void keyPressEvent(QKeyEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
+    bool viewportEvent(QEvent* event) override;
 
     static constexpr int zoom_step_mwheel {5}, zoom_step_kb {10};
 };


### PR DESCRIPTION
Fixes #23131

### The problem

On macOS a passive trackpad touch — a resting palm, no button pressed — ends spreadsheet cell editing mid-typing.

### Root cause

The touch is delivered to the spreadsheet's `QGraphicsView` (`ZoomableView`) and reaches the scene, which moves focus away from the open cell editor reporting `Qt::MouseFocusReason`. `QStyledItemDelegate::eventFilter` then commits and closes the editor.

I traced this with a Qt event filter on macOS 26.5 (arm64), FreeCAD 26.3.0dev built from source. **There is no mouse button press anywhere in the sequence:**

```
118976 ms  KeyPress     on QLineEdit  key=72        <- still typing in the cell
119067 ms  TouchBegin                               <- palm rests on the trackpad
119075 ms  TouchUpdate
119076 ms  FocusOut     on QLineEdit  reason=Mouse  <- edit terminated, 9 ms later
119076 ms  Hide         on QLineEdit                <- editor destroyed
119076 ms  FocusIn      on QTableView('cells')  reason=Mouse
```

In the 300 ms window around this there are zero `MouseButtonPress`/`MouseButtonRelease` events, while the same 1365-event trace contains 74 of them elsewhere — so the filter does capture clicks when they occur.

Note that `QFocusEvent::reason()` alone cannot distinguish this case, because a genuine click also reports `reason=Mouse`. The distinguishing signal is the absence of a button press.

### The fix

The spreadsheet has no touch interaction of its own — zooming is driven by `wheelEvent()` and everything else is mouse and keyboard. `ZoomableView::viewportEvent` now drops raw touch events, so they never reach the scene and focus stays with the cell editor. Real clicks arrive as mouse events and are unaffected.

I first tried gating the commit in `LineEdit::focusOutEvent`, but that only suppresses the cursor movement — the editor is still destroyed by the delegate's `FocusOut` handling, so the symptom remained. That approach is not in this PR.

### Testing

Tested on macOS 26.5 (arm64), Qt 6, built from source, with the same event filter still attached to verify behaviour rather than relying on impressions:

- **Palm resting on the trackpad while typing** — typing continues, cell stays open. 1736 touch events were delivered during the session and **zero** of them terminated an editor.
- **Clicking another cell while editing** — still commits and moves the cursor as before. The single remaining `FocusOut reason=Mouse` in the trace was immediately preceded by a real `MouseButtonPress`.
- **Zoom** — two-finger scroll and pinch still work (`wheelEvent` is untouched).

I'd still welcome guidance on whether you'd prefer this handled at the view level as here, or further down in the delegate — I raised that question on the issue before opening this.

---

*Disclosure: I used AI assistance (claude-opus-5) while analysing the code paths and preparing this change. The reproduction, the event traces, and the testing above were done by me on my own hardware, and I have reviewed the change and take responsibility for it.*
