### PR TITLE
Base: don't throw from FileInfo::exists() and isSymlink() on unstatable names

### DIFF
--- a/src/Base/FileInfo.cpp
+++ b/src/Base/FileInfo.cpp
@@ -281,7 +281,12 @@ bool FileInfo::hasExtension(std::initializer_list<const char*> Exts) const
 bool FileInfo::exists() const
 {
     fs::path path(stringToPath(FileName));
-    return fs::exists(path);
+    // Use the non-throwing overload: a name the filesystem cannot even stat, for instance
+    // one whose component exceeds NAME_MAX, simply does not exist as far as callers are
+    // concerned. The throwing overload propagates a filesystem_error out of what callers
+    // reasonably treat as a plain predicate.
+    std::error_code ec;
+    return fs::exists(path, ec);
 }
 
 bool FileInfo::isReadable() const
@@ -419,8 +424,9 @@ bool FileInfo::isDir() const
 bool FileInfo::isSymlink() const
 {
     fs::path path = stringToPath(FileName);
-    if (fs::exists(path)) {
-        return fs::is_symlink(path);
+    std::error_code ec;
+    if (fs::exists(path, ec)) {
+        return fs::is_symlink(path, ec);
     }
 
     return false;

--- a/tests/src/Base/FileInfo.cpp
+++ b/tests/src/Base/FileInfo.cpp
@@ -165,12 +165,8 @@ TEST_F(FileInfoTest, TestOverlongNameDoesNotThrow)
 {
     const Base::FileInfo overlong(tmp.filePath() + "/" + std::string(600, 'x'));
 
-    EXPECT_NO_THROW({
-        EXPECT_FALSE(overlong.exists());
-    });
-    EXPECT_NO_THROW({
-        EXPECT_FALSE(overlong.isSymlink());
-    });
+    EXPECT_NO_THROW({ EXPECT_FALSE(overlong.exists()); });
+    EXPECT_NO_THROW({ EXPECT_FALSE(overlong.isSymlink()); });
 }
 
 // The same must hold when the name has no directory separator at all, which is how an
@@ -179,12 +175,8 @@ TEST_F(FileInfoTest, TestOverlongNameWithoutSeparatorDoesNotThrow)
 {
     const Base::FileInfo overlong(std::string(600, 'x'));
 
-    EXPECT_NO_THROW({
-        EXPECT_FALSE(overlong.exists());
-    });
-    EXPECT_NO_THROW({
-        EXPECT_FALSE(overlong.isSymlink());
-    });
+    EXPECT_NO_THROW({ EXPECT_FALSE(overlong.exists()); });
+    EXPECT_NO_THROW({ EXPECT_FALSE(overlong.isSymlink()); });
 }
 
 // Tests for pathToString / stringToPath UTF-8 round-trip (PR #28222)

--- a/tests/src/Base/FileInfo.cpp
+++ b/tests/src/Base/FileInfo.cpp
@@ -157,6 +157,36 @@ TEST_F(FileInfoTest, TestCopyFile)
     EXPECT_TRUE(copy.deleteFile());
 }
 
+// A name whose component exceeds NAME_MAX cannot be stat()ed. exists() and isSymlink()
+// are predicates, so they must report "no" rather than propagate a filesystem_error to
+// callers that have no way to anticipate it (issue #31987: freecadcmd -c crashed when the
+// script text passed as the command-line argument was treated as a candidate path).
+TEST_F(FileInfoTest, TestOverlongNameDoesNotThrow)
+{
+    const Base::FileInfo overlong(tmp.filePath() + "/" + std::string(600, 'x'));
+
+    EXPECT_NO_THROW({
+        EXPECT_FALSE(overlong.exists());
+    });
+    EXPECT_NO_THROW({
+        EXPECT_FALSE(overlong.isSymlink());
+    });
+}
+
+// The same must hold when the name has no directory separator at all, which is how an
+// inline script arrives from the command line.
+TEST_F(FileInfoTest, TestOverlongNameWithoutSeparatorDoesNotThrow)
+{
+    const Base::FileInfo overlong(std::string(600, 'x'));
+
+    EXPECT_NO_THROW({
+        EXPECT_FALSE(overlong.exists());
+    });
+    EXPECT_NO_THROW({
+        EXPECT_FALSE(overlong.isSymlink());
+    });
+}
+
 // Tests for pathToString / stringToPath UTF-8 round-trip (PR #28222)
 
 class FileInfoPathConversionTest: public ::testing::Test


### PR DESCRIPTION
Fixes #31987

### The problem

`freecadcmd -c "<script>"` crashes outright when the script text is longer than `NAME_MAX` and contains no path separator in its first bytes:

```
$ freecadcmd -c "$(cat repro.py)"
Application unexpectedly terminated
```

The script never runs. The same script with a `/` in the first 255 bytes works fine.

### Root cause

`FileInfo::exists()` and `FileInfo::isSymlink()` used the **throwing** overload of `std::filesystem::exists()`:

```cpp
bool FileInfo::isSymlink() const
{
    fs::path path = stringToPath(FileName);
    if (fs::exists(path)) {          // throws on ENAMETOOLONG
        return fs::is_symlink(path);
    }
    return false;
}
```

A name the filesystem cannot `stat()` at all — such as one whose component exceeds `NAME_MAX` — therefore propagates a `filesystem_error` out of what callers reasonably treat as a plain predicate.

`Application::processFiles()` calls `isSymlink()` **before** entering its `try` block, and `processCmdLineFiles()` calls `exists()` outside one, so nothing catches it. The whole `-c` argument is treated as a single filename component, which is why the absence of a `/` matters.

### The fix

Both predicates now use the `std::error_code` overload, so an unstatable name reports "does not exist" instead of raising — which is what every caller already assumes. Two lines of behaviour change; the rest is a comment.

### Testing

Two regression tests added, covering an overlong name **with** and **without** a separator. Both **fail before this change** with the exact error from the issue:

```
filesystem error: in posix_stat: failed to determine attributes for the
specified path: File name too long ["xxxxx…"]
```

After the change:

```
[  PASSED  ] 593 tests.        # Base suite, was 591 + these 2
```

Verified manually on macOS 26.5 (arm64), built from source:

| Case | Before | After |
|---|---|---|
| Inline script > NAME_MAX, no `/` | `Application unexpectedly terminated`, script never ran | runs, prints `reached` |
| Same script with a `/` | worked | still works |
| Script passed as a `.py` file | worked | still works |
| Short inline script | worked | still works |

The issue was reported on Linux; it reproduces identically on macOS, so this is not platform-specific.

### One thing worth separating out

While testing I noticed `FreeCADGui.showMainWindow()` under `freecadcmd` segfaults during teardown *after* the script completes — including on the control cases that never hit this bug, and on a short script with no long argument at all. That is independent of this issue and not addressed here; happy to open a separate report if it isn't already known.

---

*Disclosure: I used AI assistance (claude-opus-5) while analysing the code paths and preparing this change. The reproduction, the before/after testing, and the verification that the new tests fail without the fix were done by me on my own machine, and I have reviewed the change and take responsibility for it.*
