### PR TITLE
Part: Provide detailed segment indices in loft separation error message

### DIFF
--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4531,7 +4531,11 @@ TopoShape& TopoShape::makeElementLoft(
     for (auto& sh : profiles) {
         if (i > 0) {
             if (!checkProfiles(sh, profiles[i - 1])) {
-                FC_THROWM(Base::CADKernelError, "Segments " << i << " and " << (i + 1) << " of a loft do not have sufficient separation");
+                FC_THROWM(
+                    Base::CADKernelError,
+                    "Segments " << i << " and " << (i + 1)
+                                << " of a loft do not have sufficient separation"
+                );
             }
         }
         const auto& shape = sh.getShape();

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4531,7 +4531,7 @@ TopoShape& TopoShape::makeElementLoft(
     for (auto& sh : profiles) {
         if (i > 0) {
             if (!checkProfiles(sh, profiles[i - 1])) {
-                FC_THROWM(Base::CADKernelError, "Segments of a loft do not have sufficient separation");
+                FC_THROWM(Base::CADKernelError, "Segments " << i << " and " << (i + 1) << " of a loft do not have sufficient separation");
             }
         }
         const auto& shape = sh.getShape();


### PR DESCRIPTION
This PR improves the generic `"Segments of a loft do not have sufficient separation"` error message in `TopoShapeExpansion.cpp` by injecting the specific segment indices (e.g., `Segments 1 and 2 of a loft...`). This makes debugging complex loft profiles much more intuitive for users when they accidentally select overlapping or identical profiles.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: Gemini (gemini-2.5-pro)

## Issues
Fixes #32162 

## Before and After Images

### Before

<img width="1920" height="1080" alt="Screenshot 2026-08-27 005819" src="https://github.com/user-attachments/assets/cbed4084-b14e-49ac-b484-1cee07d4d5ef" />

### After

<img width="1920" height="1080" alt="Screenshot 2026-08-27 012635" src="https://github.com/user-attachments/assets/4a455d1a-d983-4d2f-ab4b-378cb4da1bcd" />
