### PR TITLE
CAM: don't overwrite the tapping pitch with a feed rate

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathFeedRate.py
+++ b/src/Mod/CAM/CAMTests/TestPathFeedRate.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Bill Warner bill.warner@gmail.com
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+import Path
+import Path.Base.FeedRate as PathFeedRate
+
+from CAMTests.PathTestUtils import PathTestBase
+
+
+class _Quantity:
+    """Minimal stand-in for a FreeCAD Quantity exposing .Value."""
+
+    def __init__(self, value):
+        self.Value = value
+
+
+class _TestToolController:
+    """Tool controller with the feeds a tapping tool typically leaves at zero."""
+
+    def __init__(self, vert=0.0, horiz=0.0):
+        self.VertFeed = _Quantity(vert)
+        self.HorizFeed = _Quantity(horiz)
+        self.VertRapid = _Quantity(0.0)
+        self.HorizRapid = _Quantity(0.0)
+
+
+class TestPathFeedRate(PathTestBase):
+    """Test feed rate assignment across command types."""
+
+    def test00(self):
+        """Verify a tapping cycle keeps its pitch in F.
+
+        On G84/G74 the F word carries the thread pitch, not a feed rate.
+        setFeedRate must leave it alone; a tap tool commonly has VertFeed
+        of zero because the feed is derived as pitch x RPM.
+        """
+        for name in ("G84", "G74"):
+            cmd = Path.Command(name, {"X": 0.0, "Y": 0.0, "Z": -10.0, "R": 2.0, "F": 1.41224})
+            PathFeedRate.setFeedRate([cmd], _TestToolController(vert=0.0))
+            self.assertEqual(cmd.Parameters["F"], 1.41224)
+
+    def test01(self):
+        """Verify tapping pitch survives even when the tool has feeds set."""
+        cmd = Path.Command("G84", {"X": 0.0, "Y": 0.0, "Z": -10.0, "R": 2.0, "F": 1.41224})
+        PathFeedRate.setFeedRate([cmd], _TestToolController(vert=100.0, horiz=200.0))
+        self.assertEqual(cmd.Parameters["F"], 1.41224)
+
+    def test02(self):
+        """Verify standard drill cycles still get the vertical feed."""
+        cmd = Path.Command("G83", {"X": 0.0, "Y": 0.0, "Z": -10.0, "R": 2.0, "F": 0.0})
+        PathFeedRate.setFeedRate([cmd], _TestToolController(vert=123.0))
+        self.assertEqual(cmd.Parameters["F"], 123.0)
+
+    def test03(self):
+        """Verify ordinary feed moves still get a feed rate."""
+        cmd = Path.Command("G1", {"X": 10.0, "Y": 0.0, "Z": 0.0})
+        PathFeedRate.setFeedRate([cmd], _TestToolController(vert=50.0, horiz=250.0))
+        self.assertEqual(cmd.Parameters["F"], 250.0)

--- a/src/Mod/CAM/Constants.py
+++ b/src/Mod/CAM/Constants.py
@@ -37,6 +37,9 @@ GCODE_MOVE_DRILL = ["G73", "G81", "G82", "G83", "G85"]
 # Additional drilling cycles
 GCODE_DRILL_EXTENDED = ["G74", "G84", "G88", "G89"]
 
+# Tapping cycles (F is the thread pitch, not a feed rate)
+GCODE_MOVE_TAP = ["G74", "G84"]
+
 # Cutting moves (feed moves and arcs)
 GCODE_MOVE_MILL = GCODE_MOVE_STRAIGHT + GCODE_MOVE_ARC
 

--- a/src/Mod/CAM/Path/Base/FeedRate.py
+++ b/src/Mod/CAM/Path/Base/FeedRate.py
@@ -47,7 +47,9 @@ def setFeedRate(commandlist, ToolController):
 
     Every motion command in the list will have a feed rate parameter added or overwritten based
     on the information stored in the tool controller. If a motion is a plunge (vertical) motion, the
-    VertFeed value will be used, otherwise the HorizFeed value will be used instead."""
+    VertFeed value will be used, otherwise the HorizFeed value will be used instead.
+
+    Tapping cycles are left untouched, as their F word is the thread pitch."""
 
     def _isVertical(currentposition, command):
         x = command.Parameters["X"] if "X" in command.Parameters else currentposition.x
@@ -62,6 +64,10 @@ def setFeedRate(commandlist, ToolController):
 
     for command in commandlist:
         if command.Name not in Path.Geom.CmdMoveAll:
+            continue
+
+        # On tapping cycles the F word is the thread pitch, not a feed rate
+        if command.Name in Path.Geom.CmdMoveTap:
             continue
 
         # Canned drill cycles (G73, G81, G82, G83, G85) are vertical cutting operations

--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -93,6 +93,7 @@ CmdMoveDrill = Constants.GCODE_MOVE_DRILL
 CmdMoveArc = Constants.GCODE_MOVE_ARC
 CmdMoveMill = Constants.GCODE_MOVE_MILL
 CmdMove = Constants.GCODE_MOVE
+CmdMoveTap = Constants.GCODE_MOVE_TAP
 CmdMoveAll = Constants.GCODE_MOVE_ALL
 
 


### PR DESCRIPTION
Fixing #32149: tapping cycles post with `F0.000` since #32072.

I started getting the F0.000 again on tapping cycles.  this fixes that.

## Verification performed

Test fails on unmodified `upstream/main`:

```
FAIL: test00  AssertionError: 0.0 != 1.41224
FAIL: test01  AssertionError: 100.0 != 1.41224
```

Passes with the commit applied, and the wider suites stay green:

```
Ran 332 tests  OK (skipped=1, expected failures=4)
```

Suites run: TestPathFeedRate, TestPathGeom, TestDrillCycleExpander,
TestPathTapGenerator, TestPathDrillGenerator, TestPostOutput, TestTestPost,
TestOpenSBPPost, TestLinuxCNCPost, TestFanucPost, TestCentroidPost,
TestDressupPost, TestPathAdaptive, TestPathHelix, TestPathFacingGenerator.

## Summary of changes
On G74/G84 the F word carries the thread pitch, not a feed rate. #32072 added the extended drill cycles to GCODE_MOVE_ALL, which brought them into setFeedRate(). They are not in GCODE_MOVE_DRILL, so they fall through to the vertical branch and F is overwritten with the tool controller's VertFeed. A tap tool commonly has no VertFeed set, because the feed is derived as pitch x RPM, so tapping cycles posted as F0.000.

Add GCODE_MOVE_TAP and skip those commands when assigning feed rates. Boring cycles (G88/G89) are unchanged, since their F is a feed rate.


Assisted-by: claude-opus-5

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.


## Issues
Fixes #32149