### PR TITLE
Core: use unique_ptr to prevent leaking zipios stream in DocumentRecovery

### DIFF
--- a/src/Gui/DocumentRecovery.cpp
+++ b/src/Gui/DocumentRecovery.cpp
@@ -494,7 +494,7 @@ bool zipDataIsValid(const QString& fcstdFile)
         auto entries = zf.entries();
         int n = 0;
         for (auto it = entries.begin(); it != entries.end(); ++it) {
-            auto s = zf.getInputStream(*it);
+            std::unique_ptr<std::istream> s(zf.getInputStream(*it));
             if (!s || !(*s)) {
                 return false;
             }
@@ -530,7 +530,7 @@ bool xmlFilesAreValid(const QString& fcstdFile)
             return false;
         }
         {
-            auto s = zf.getInputStream(doc);
+            std::unique_ptr<std::istream> s(zf.getInputStream(doc));
             QByteArray bytes;
             bytes.resize(0);
             std::string tmp((std::istreambuf_iterator<char>(*s)), std::istreambuf_iterator<char>());
@@ -545,7 +545,7 @@ bool xmlFilesAreValid(const QString& fcstdFile)
 
         // GuiDocument.xml is optional, but if it's present it must be well-formed
         if (auto gui = findEntry(zf, "GuiDocument.xml")) {
-            auto s = zf.getInputStream(gui);
+            std::unique_ptr<std::istream> s(zf.getInputStream(gui));
             std::string tmp((std::istreambuf_iterator<char>(*s)), std::istreambuf_iterator<char>());
             QXmlStreamReader xr(QByteArray(tmp.data(), int(tmp.size())));
             while (!xr.atEnd()) {


### PR DESCRIPTION
`ZipFile::getInputStream` returns a raw pointer:

https://github.com/FreeCAD/FreeCAD/blob/6add02aa6f8d63228a8a65a62e76b0e30767c65d/src/3rdParty/zipios%2B%2B/zipfile.cpp#L69-L82

`DocumentRecovery` was using this function without freeing the returned stream. This PR puts the returned stream into a `std::unique_ptr` to avoid a leak. This is similar to other uses of `getInputStream`, e.g. here:

https://github.com/FreeCAD/FreeCAD/blob/6add02aa6f8d63228a8a65a62e76b0e30767c65d/src/App/ProjectFile.cpp#L331

