### PR TITLE
TechDraw: Fix selection state for face centerline

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
@@ -774,6 +774,8 @@ void execCenterLine(Gui::Command* cmd)
                                                         edgeNames.front(),
                                                         true));
     }
+
+    Gui::Selection().clearSelection();
 }
 
 //===========================================================================


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
When drawing a face centerline TechDraw still thinks that that the face is selected even though it is not. Therefore it is necessary to clear the selection when the centerline has been created. This syncs the selection for the UI and the selection system. 

This is quite common in TechDraw and somewhat the same as #28772


- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
closes #32197
