### PR TITLE
TechDraw: Fix keep label

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -944,7 +944,14 @@ void QGIView::removeChild(QGIView* child)
 void QGIView::hideFrame()
 {
     m_border->hide();
-    m_label->hide();
+
+    ViewProviderDrawingView* vp = freecad_cast<ViewProviderDrawingView*>(getViewProvider(getViewObject()));
+    if (vp && vp->KeepLabel.getValue()) {
+        m_label->show();
+    }
+    else {
+        m_label->hide();
+    }
 }
 
 void QGIView::addArbitraryItem(QGraphicsItem* qgi)
@@ -1078,6 +1085,7 @@ void QGIView::makeMark(QPointF pos, QColor color)
 
 void QGIView::updateFrameVisibility()
 {
+    ViewProviderDrawingView* vp = freecad_cast<ViewProviderDrawingView*>(getViewProvider(getViewObject()));
     if (shouldShowFrame()) {
         m_border->show();
         m_label->show();
@@ -1086,7 +1094,11 @@ void QGIView::updateFrameVisibility()
         }
     } else {
         m_border->hide();
-        m_label->hide();
+        if (vp && vp->KeepLabel.getValue()) {
+            m_label->show();
+        } else {
+            m_label->hide();
+        }
         if (m_lock) {
              m_lock->hide();
         }

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -65,7 +65,7 @@ ViewProviderDrawingView::ViewProviderDrawingView() :
     static const char *group = "Base";
 
     auto showLabel = Preferences::alwaysShowLabel();
-    // TODO: KeepLabel is not used. Make it ReadOnly or Hidden?
+
     ADD_PROPERTY_TYPE(KeepLabel ,(showLabel), group, App::Prop_None, "Keep Label on Page even if toggled off");
     ADD_PROPERTY_TYPE(StackOrder,(0),group,App::Prop_None,"Over or under lap relative to other views");
 

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -219,6 +219,7 @@ void ViewProviderViewPart::attach(App::DocumentObject *pcFeat)
         sPixmap = "TechDraw_TreeMulti";
     } else if (dvd) {
         sPixmap = "actions/TechDraw_DetailView";
+        KeepLabel.setValue(true);
     }
 
     ViewProviderDrawingView::attach(pcFeat);

--- a/src/Mod/TechDraw/Gui/ViewProviderViewSection.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewSection.cpp
@@ -61,6 +61,8 @@ ViewProviderViewSection::ViewProviderViewSection()
     static const char *lgroup = "Section Line";
     sPixmap = "TechDraw_TreeSection";
 
+    KeepLabel.setValue(true);
+
     ADD_PROPERTY_TYPE(CutSurfaceColor, (Preferences::getPreferenceGroup("Colors")->GetUnsigned("FaceColor", 0xFFFFFF)),
                       fgroup, App::Prop_None, "Set color of the cut surface");
     ADD_PROPERTY_TYPE(CutSurfaceTransparency, (Preferences::getPreferenceGroup("Colors")->GetBool("ClearFace", false) ? 100 : 0),


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Currently the Keep Label property does not work. This has been fixed in this PR. 

I have made the Keep Label mode default True for section views and for detail views. 

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
closes #23540 
closes #21908 

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/1876c05d-cea9-41f3-9df8-4956df38181d


