### PR TITLE
Fixes #32194: Seed PRNG for random shape colors using std::random_device

### DIFF
--- a/src/App/Material.cpp
+++ b/src/App/Material.cpp
@@ -330,10 +330,11 @@ App::Material Material::getDefaultAppearance()
         color.setPackedRGB(packed);
     };
     auto intRandom = [](int min, int max) -> int {
-        static std::mt19937 generator;
-        std::uniform_int_distribution<int> distribution(min, max);
-        return distribution(generator);
-    };
+    static std::random_device rd;
+    static std::mt19937 generator(rd());
+    std::uniform_int_distribution<int> distribution(min, max);
+    return distribution(generator);
+};
 
     App::Material mat(App::Material::DEFAULT);
     mat.transparency = Base::fromPercent(hGrp->GetInt("DefaultShapeTransparency", 0));

--- a/src/Mod/Material/App/MaterialManager.cpp
+++ b/src/Mod/Material/App/MaterialManager.cpp
@@ -150,10 +150,11 @@ std::shared_ptr<App::Material> MaterialManager::defaultAppearance()
         color.a = 1.0;  // The default color sets fully transparent, not opaque
     };
     auto intRandom = [](int min, int max) -> int {
-        static std::mt19937 generator;
-        std::uniform_int_distribution<int> distribution(min, max);
-        return distribution(generator);
-    };
+    static std::random_device rd;
+    static std::mt19937 generator(rd());
+    std::uniform_int_distribution<int> distribution(min, max);
+    return distribution(generator);
+};
 
     App::Material mat(App::Material::DEFAULT);
     bool randomColor = hGrp->GetBool("RandomColor", false);


### PR DESCRIPTION
This PR fixes the unseeded random color generator bug reported in #32194. 

The pseudo-random number generator (`std::mt19937`) used to assign random colors to shapes in the preferences was previously unseeded, causing it to default to a static seed. This resulted in FreeCAD outputting the exact same sequence of colors every time the application was launched. This is fixed by initializing the generator with a random seed from `std::random_device` in both `Material.cpp` and `MaterialManager.cpp`.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

*Note: The code changes and PR description were drafted with assistance from Google's Gemini AI, but the logic has been manually verified, built, and tested locally by me to ensure correctness.*

## Issues
Fixes #32194

## Before and After Images/Videos

**Before the Fix (Unseeded/Static Sequence):**






**After the Fix (Properly Seeded/Random Sequence):**



