### PR TITLE
AppImage: allow overriding QT_QPA_PLATFORM with FreeCAD-specific env var

### DIFF
--- a/package/rattler-build/linux/AppDir/AppRun
+++ b/package/rattler-build/linux/AppDir/AppRun
@@ -9,8 +9,8 @@ export PATH_TO_FREECAD_LIBDIR=${HERE}/usr/lib
 export FONTCONFIG_FILE=/etc/fonts/fonts.conf
 export FONTCONFIG_PATH=/etc/fonts
 
-# Fix: Use X to run on Wayland
-export QT_QPA_PLATFORM=xcb
+# Use X by default even on Wayland, but allow overriding via FREECAD_QT_QPA_PLATFORM
+export QT_QPA_PLATFORM=${FREECAD_QT_QPA_PLATFORM:-xcb}
 
 # Show packages info if DEBUG env variable is set
 if [ "$DEBUG" = 1 ]; then


### PR DESCRIPTION
With the recent Mesa & libdrm related packaging problems (#32061) people seem to keep trying to run the AppImage bundle with `QT_QPA_PLATFORM` set to something, which has no effect in status quo, being always forced to `xcb`.

FC on Wayland might still be considered undercooked (at least in AppImage contexts) but preventing users from overriding the QPA platform creates needless friction where one needs to unpack the AppRun script and shunt out that xcb-forcing line.

Changes this so one can set `FREECAD_QT_QPA_PLATFORM` to change the effective `QT_QPA_PLATFORM`; a separate env var is used because some users (myself included) run with an explicitly set `QT_QPA_PLATFORM=wayland` in their environment and removing the force-set would defeat our xcb preference.

- [x] :robot: → :wastebasket: 
