### PR TITLE
(cp) Sketcher: Fix adding ellipse

### DIFF
--- a/src/Mod/Sketcher/App/SketchObjectExternal.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectExternal.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include <BRepAdaptor_Curve.hxx>
 #include <BRepAdaptor_Surface.hxx>
@@ -1899,8 +1900,14 @@ void processEdge(const TopoDS_Edge& edge,
         //           + minorRadius * sin(t) * origAxisMinorDir
         gp_Vec2d PA = ProjVecOnPlane_UV(origAxisMajor, sketchPlane);
         gp_Vec2d PB = ProjVecOnPlane_UV(origAxisMinor, sketchPlane);
-        double t_max = 2.0 * PA.Dot(PB) / (PA.SquareMagnitude() - PB.SquareMagnitude());
-        t_max = 0.5 * atan(t_max);// gives new major axis is most cases, but not all
+        double t_max = 0.0;
+        const double dPAPB = PA.SquareMagnitude() - PB.SquareMagnitude();
+
+        // For dPAPB=0 it's a circle where we use t_max=0
+        if (std::fabs(dPAPB) > std::numeric_limits<double>::epsilon()) {
+            t_max = 2.0 * PA.Dot(PB) / (PA.SquareMagnitude() - PB.SquareMagnitude());
+            t_max = 0.5 * atan(t_max);// gives new major axis is most cases, but not all
+        }
         double t_min = t_max + 0.5 * pi;
 
         // ON_max = OM(t_max) gives the point, which projected on the sketch plane,

--- a/src/Mod/Sketcher/CMakeLists.txt
+++ b/src/Mod/Sketcher/CMakeLists.txt
@@ -23,6 +23,7 @@ set(Sketcher_TestScripts
     SketcherTests/TestSketchCarbonCopyReverseMapping.py
     SketcherTests/TestSketchCarbonCopyReverseMapping.FCStd
     SketcherTests/TestSketchInternalFaces.py
+    SketcherTests/TestSketcherEllipse.py
 )
 
 if(BUILD_GUI)

--- a/src/Mod/Sketcher/SketcherTests/TestSketcherEllipse.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketcherEllipse.py
@@ -1,0 +1,56 @@
+import math
+import unittest
+import FreeCAD
+import Part
+import Sketcher
+
+App = FreeCAD
+
+
+# ---------------------------------------------------------------------------
+# define the test cases to test the FreeCAD Sketcher module
+# ---------------------------------------------------------------------------
+
+
+class TestSketcherEllipse(unittest.TestCase):
+    def setUp(self):
+        self.doc = FreeCAD.newDocument("SketchEllipse")
+
+    def tearDown(self):
+        # FreeCAD.closeDocument(self.doc.Name)
+        pass
+
+    def addExternalEllipse(self, tilt):
+        n = App.Vector(math.sin(math.radians(tilt)), 0, math.cos(math.radians(tilt)))
+        plane = Part.makePlane(100, 100)
+        plane.Placement = App.Placement(App.Vector(-20, -50), App.Rotation(App.Vector(0, 0, 1), n))
+        cylinder = Part.makeCylinder(1.6, 200, App.Vector(0, 0, -100))
+        section = cylinder.section(plane)
+
+        obj = self.doc.addObject("Part::Feature", "Section")
+        obj.Shape = section
+
+        sk = self.doc.addObject("Sketcher::SketchObject", "Sketch")
+        sk.addExternal(obj.Name, "Edge1")
+        self.doc.recompute()
+
+        geo = sk.ExternalGeo[-1]
+        self.assertEqual(type(geo), Part.Circle)
+
+    def testProjectEllipse1(self):
+        self.addExternalEllipse(30)
+
+    def testProjectEllipse2(self):
+        self.addExternalEllipse(44)
+
+    def testProjectEllipse3(self):
+        self.addExternalEllipse(44.9)
+
+    def testProjectEllipse4(self):
+        self.addExternalEllipse(45)
+
+    def testProjectEllipse5(self):
+        self.addExternalEllipse(45.1)
+
+    def testProjectEllipse6(self):
+        self.addExternalEllipse(60)

--- a/src/Mod/Sketcher/SketcherTests/TestSketcherEllipse.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketcherEllipse.py
@@ -54,3 +54,29 @@ class TestSketcherEllipse(unittest.TestCase):
 
     def testProjectEllipse6(self):
         self.addExternalEllipse(60)
+
+    def testProjectEllipse7(self):
+        ell = self.doc.addObject("Part::Ellipse", "Ellipse")
+        ell.Placement.Rotation.setYawPitchRoll(-61.194, -36.5151, -66.0633)
+        ell.MinorRadius = 2.0
+        self.doc.recompute()
+
+        c = ell.Shape.Edge1.Curve
+        angle = math.acos(c.MinorRadius / c.MajorRadius)
+        R = App.Rotation(c.YAxis, Radian=angle)
+        proj_dir = R * c.Axis
+
+        line = self.doc.addObject("Part::Feature", "Axis")
+        line.Shape = Part.makeLine(c.Location, c.Location + 10 * proj_dir)
+
+        sketch = self.doc.addObject("Sketcher::SketchObject", "Sketch")
+        sketch.MapReversed = False
+        sketch.AttachmentSupport = [(line, "Edge1")]
+        sketch.MapPathParameter = 0.000000
+        sketch.MapMode = "NormalToEdge"
+
+        sketch.addExternal(ell.Name, "Edge1")
+        self.doc.recompute()
+
+        geo = sketch.ExternalGeo[-1]
+        self.assertEqual(type(geo), Part.Circle)

--- a/src/Mod/Sketcher/TestSketcherApp.py
+++ b/src/Mod/Sketcher/TestSketcherApp.py
@@ -30,6 +30,7 @@ from SketcherTests.TestSketchExpression import TestSketchExpression
 from SketcherTests.TestSketchValidateCoincidents import TestSketchValidateCoincidents
 from SketcherTests.TestSketchCarbonCopyReverseMapping import TestSketchCarbonCopyReverseMapping
 from SketcherTests.TestSketchInternalFaces import TestSketchInternalFaces
+from SketcherTests.TestSketcherEllipse import TestSketcherEllipse
 
 # Path and PartDesign tests use these functions that used to live here
 # but moved to SketcherTests/TestSketcherSolver.py


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Cherry-picked from https://codeberg.org/xwzCAD/FreeCAD/pulls/300

Fix a possible invalid expression "0/0" when adding the projection of an
ellipse that converts into a circle.

This fixes https://github.com/FreeCAD/FreeCAD/issues/32199