### PR TITLE
CAM: don't unit convert the dwell time on imperial output

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPostOutput.py
+++ b/src/Mod/CAM/CAMTests/TestPostOutput.py
@@ -2013,3 +2013,45 @@ class TestExport2Integration(unittest.TestCase):
                 "nc",
                 "Existing property should not be overwritten",
             )
+
+    def test080_dwell_not_scaled_in_imperial(self):
+        """
+        Test that a dwell time survives imperial output unscaled.
+
+        P on G4 and on a canned cycle is a time in seconds, not a distance.
+        Scaling it as an axis value divides it by 25.4, so a 0.1 second dwell
+        posts as P0.004.
+        """
+        config = self._get_full_machine_config()
+        machine = Machine.from_dict(config)
+        machine.output.units = OutputUnits.IMPERIAL
+
+        with self._modify_operation_path(
+            [
+                Path.Command("G4", {"P": 0.5}),
+                Path.Command(
+                    "G82", {"X": 0.0, "Y": 0.0, "Z": -10.0, "R": 2.0, "F": 100.0, "P": 0.1}
+                ),
+            ]
+        ):
+            results = self._run_export2(machine)
+            gcode = self._get_first_section_gcode(results)
+            lines = [line.strip() for line in gcode.split("\n") if line.strip()]
+
+            def p_value(line):
+                for word in line.split():
+                    if word.startswith("P"):
+                        return float(word[1:])
+                return None
+
+            g4 = next((l for l in lines if l.startswith("G4")), None)
+            self.assertIsNotNone(g4, "expected a G4 dwell in the output")
+            self.assertAlmostEqual(
+                p_value(g4), 0.5, places=4, msg=f"G4 dwell must not be unit-scaled: {g4}"
+            )
+
+            g82 = next((l for l in lines if l.startswith("G82")), None)
+            self.assertIsNotNone(g82, "expected a G82 cycle in the output")
+            self.assertAlmostEqual(
+                p_value(g82), 0.1, places=4, msg=f"cycle dwell must not be unit-scaled: {g82}"
+            )

--- a/src/Mod/CAM/Constants.py
+++ b/src/Mod/CAM/Constants.py
@@ -61,6 +61,9 @@ GCODE_UNITS_INCHES = ["G20"]
 # Dwell
 GCODE_DWELL = ["G4", "G04"]
 
+# Commands whose P word is a dwell time in seconds, not a distance
+GCODE_P_IS_DWELL = GCODE_DWELL + ["G73", "G74", "G76", "G82", "G83", "G84", "G86", "G88", "G89"]
+
 GCODE_CUTTER_COMPENSATION = ["G40", "G41", "G42"]
 
 # Canned cycle cancel

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -2614,7 +2614,7 @@ class PostProcessor:
         else:
             return f"{block_delete_string}{comment_symbol} {comment_text}"  # FIXME: no extra space
 
-    def format_parameter(self, param_name, value):
+    def format_parameter(self, param_name, value, command_name=None):
 
         def _convert_axis_param(value):
             # Apply unit conversion based on machine units setting
@@ -2652,6 +2652,14 @@ class PostProcessor:
             """Format integer parameter."""
             return str(int(value))
 
+        def format_p_param(value):
+            """Format P according to what it means for this command."""
+            if command_name in Constants.GCODE_P_IS_DWELL:
+                # A dwell keeps the axis precision but must not be unit converted
+                precision = self.values["AXIS_PRECISION"]
+                return f"{value:.{precision}f}"
+            return format_axis_param(value)
+
         # Parameter type mappings
         param_formatters = {
             # Axis parameters
@@ -2673,8 +2681,8 @@ class PostProcessor:
             # Feed and spindle
             "F": format_feed_param,
             "S": format_spindle_param,
-            # P parameter - use axis formatting to support decimal values (e.g., G4 P2.5)
-            "P": format_axis_param,
+            # P is a dwell on G4 and the canned cycles, a distance on G5/G64
+            "P": format_p_param,
             # Integer parameters
             "D": format_int_param,
             "H": format_int_param,
@@ -2749,7 +2757,7 @@ class PostProcessor:
                 ):
                     continue  # no F for G0, or the F is 0.0 which should be skipped too
 
-                formatted_value = self.format_parameter(parameter, current_value)
+                formatted_value = self.format_parameter(parameter, current_value, command_name)
                 command_line.append(f"{parameter}{formatted_value}")
 
         # Format the command line


### PR DESCRIPTION
Fixing #32163: dwell times are divided by 25.4 on imperial output.

I set a 0.100 second dwell on a tapping cycle and it posted as `P0.004`. A plain `G4 P0.5` comes out as `G4 P0.020` the same way.

Claude AI findings:

> `P` means different things depending on the command — a dwell time in seconds on `G4` and the canned cycles, a distance on `G5`/`G64`. `format_parameter()` mapped it to the axis formatter unconditionally, and that formatter applies the mm-to-inch conversion, so the dwell got treated as a length.
> 
> This makes the `P` formatter check which command it belongs to and skip the unit conversion for the dwell commands. Axis precision is still applied, so the output formatting is otherwise unchanged — only the numeric value differs, and only on imperial.
> 
> Worth noting the non-machine post path already got this right: `UtilsParse.default_P_parameter()` is command-aware and deliberately leaves dwell values alone. Only the machine-based path in `Processor.py` was scaling them.
> 
> `format_parameter()` now takes the command name as an optional third argument, so post processors that call it with two arguments (opensbp) keep working.

Assisted-by: claude-opus-5

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
#32163

