### PR TITLE
TechDraw: Upgrade Captions for TechDraw views

### DIFF
--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -78,6 +78,9 @@ const char* DrawView::ScaleTypeEnums[]= {"Page",
                                          "Automatic",
                                          "Custom",
                                          nullptr};
+const char* DrawView::CaptionPositionEnums[] = {"Top",
+                                                "Bottom",
+                                                nullptr};
 const double SCALEINCREMENT(0.1);
 App::PropertyFloatConstraint::Constraints DrawView::scaleRange = {Precision::Confusion(),
                                                                   std::numeric_limits<double>::max(),
@@ -103,7 +106,8 @@ DrawView::DrawView():
     Scale.setConstraints(&scaleRange);
 
     ADD_PROPERTY_TYPE(Caption, (""), group, App::Prop_Output, "Short text about the view");
-
+    CaptionPosition.setEnums(CaptionPositionEnums);
+    ADD_PROPERTY_TYPE(CaptionPosition, ("Bottom"), group, App::Prop_Output, "Position of the caption relative to the view");
     setScaleAttribute();
 }
 

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -78,8 +78,11 @@ const char* DrawView::ScaleTypeEnums[]= {"Page",
                                          "Automatic",
                                          "Custom",
                                          nullptr};
-const char* DrawView::CaptionPositionEnums[] = {"Top",
+const char* DrawView::CaptionSnapEnums[] = {"Top",
                                                 "Bottom",
+                                                "Left",
+                                                "Right",
+                                                "NoSnap",
                                                 nullptr};
 const double SCALEINCREMENT(0.1);
 App::PropertyFloatConstraint::Constraints DrawView::scaleRange = {Precision::Confusion(),
@@ -106,8 +109,9 @@ DrawView::DrawView():
     Scale.setConstraints(&scaleRange);
 
     ADD_PROPERTY_TYPE(Caption, (""), group, App::Prop_Output, "Short text about the view");
-    CaptionPosition.setEnums(CaptionPositionEnums);
-    ADD_PROPERTY_TYPE(CaptionPosition, ("Bottom"), group, App::Prop_Output, "Position of the caption relative to the view");
+    ADD_PROPERTY_TYPE(CaptionLocation, (Base::Vector3d(0.0, 0.0, 0.0)), group, App::Prop_Output, "Location of the caption relative to the view");
+    CaptionSnap.setEnums(CaptionSnapEnums);
+    ADD_PROPERTY_TYPE(CaptionSnap, ("Bottom"), group, App::Prop_Hidden, "Snap the caption to the view's top, bottom, left or right edge");
     setScaleAttribute();
 }
 

--- a/src/Mod/TechDraw/App/DrawView.h
+++ b/src/Mod/TechDraw/App/DrawView.h
@@ -61,6 +61,7 @@ public:
     App::PropertyEnumeration ScaleType;
     App::PropertyAngle Rotation;
     App::PropertyString Caption;
+    App::PropertyEnumeration CaptionPosition;
 
     /** @name methods override Feature */
     //@{
@@ -144,6 +145,7 @@ protected:
 
 private:
     static const char* ScaleTypeEnums[];
+    static const char* CaptionPositionEnums[];
     static App::PropertyFloatConstraint::Constraints scaleRange;
 
     bool m_overrideKeepUpdated;

--- a/src/Mod/TechDraw/App/DrawView.h
+++ b/src/Mod/TechDraw/App/DrawView.h
@@ -61,7 +61,8 @@ public:
     App::PropertyEnumeration ScaleType;
     App::PropertyAngle Rotation;
     App::PropertyString Caption;
-    App::PropertyEnumeration CaptionPosition;
+    App::PropertyVector CaptionLocation;
+    App::PropertyEnumeration CaptionSnap;
 
     /** @name methods override Feature */
     //@{
@@ -145,7 +146,7 @@ protected:
 
 private:
     static const char* ScaleTypeEnums[];
-    static const char* CaptionPositionEnums[];
+    static const char* CaptionSnapEnums[];
     static App::PropertyFloatConstraint::Constraints scaleRange;
 
     bool m_overrideKeepUpdated;

--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -54,6 +54,7 @@
 #include <Base/UnitsApi.h>
 
 #include "DrawComplexSection.h"
+#include "DrawPage.h"
 #include "DrawUtil.h"
 #include "DrawViewDetail.h"
 #include "DrawViewSection.h"
@@ -137,58 +138,40 @@ void DrawViewDetail::onChanged(const App::Property* prop)
 }
 
 std::string DrawViewDetail::makeCaption() {
-    std::string ref = Reference.getValue();
-    std::string mainCaption = "DETAIL " + ref;
+
+    std::string caption = Caption.getValue();
+
+    if (caption.find("<REF>") == std::string::npos && !m_refAdded) {
+        caption = "DETAIL <REF>";
+        m_refAdded = true;
+    }
+
+    if (caption.find("<SCALE>") != std::string::npos || m_scaleAdded) {
+        return caption;
+    }
 
     App::DocumentObject* baseObj = BaseView.getValue();
     auto* baseView = dynamic_cast<TechDraw::DrawView*>(baseObj);
     if (!baseView) {
-        return mainCaption;
+        return caption;
     }
-    double baseScale = baseView->Scale.getValue();
 
-    double relativeScale = Scale.getValue() / baseScale;
+    auto page = baseView->findParentPage();
+    if (!page) {
+        return caption;
+    }
+    double pageScale = page->Scale.getValue();
 
-    // If the relative scale is 1.0 it should not show scale
+    double relativeScale = Scale.getValue() / pageScale;
+
     if (relativeScale == 1.0) {
-        return mainCaption;
+        return caption;
     }
 
-    double num1, num2;
-
-    // turning a scale of 0.5 into 1:2 and a scale of 2 into 2:1 etc.
-    if (relativeScale < 1.0) {
-        num1 = 1.0;
-        num2 = 1.0 / relativeScale;
-    } else {
-        num1 = relativeScale;
-        num2 = 1.0;
-    }
-
-    std::string scaleText = "\nSCALE " + formatScale(num1) + ":" + formatScale(num2);
-
-    return mainCaption + scaleText;
+    m_scaleAdded = true;
+    return caption + "\nSCALE <SCALE>";
 }
 
-std::string DrawViewDetail::formatScale(double scale)
-{
-    const int decimals = Base::UnitsApi::getDecimals();
-    std::ostringstream oss;
-    oss.precision(decimals);
-    oss << std::fixed << scale;
-    std::string result = oss.str();
-
-    // Removes trailing zeros and removes the decimal point
-    if (result.find('.') != std::string::npos) {
-        while (result.back() == '0') {
-            result.pop_back();
-        }
-        if (result.back() == '.') {
-            result.pop_back();
-        }
-    }
-    return result;
-}
 
 App::DocumentObjectExecReturn* DrawViewDetail::execute()
 {

--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -51,6 +51,7 @@
 #include <App/Document.h>
 #include <Base/Console.h>
 #include <Base/Parameter.h>
+#include <Base/UnitsApi.h>
 
 #include "DrawComplexSection.h"
 #include "DrawUtil.h"
@@ -128,11 +129,65 @@ void DrawViewDetail::onChanged(const App::Property* prop)
     }
 
     if (prop == &Reference) {
-        std::string lblText = "Detail " + std::string(Reference.getValue());
-        Label.setValue(lblText);
+        std::string captionText = makeCaption();
+        Caption.setValue(captionText);
     }
 
     DrawViewPart::onChanged(prop);
+}
+
+std::string DrawViewDetail::makeCaption() {
+    std::string ref = Reference.getValue();
+    std::string mainCaption = "DETAIL " + ref;
+
+    App::DocumentObject* baseObj = BaseView.getValue();
+    auto* baseView = dynamic_cast<TechDraw::DrawView*>(baseObj);
+    if (!baseView) {
+        return mainCaption;
+    }
+    double baseScale = baseView->Scale.getValue();
+
+    double relativeScale = Scale.getValue() / baseScale;
+
+    // If the relative scale is 1.0 it should not show scale
+    if (relativeScale == 1.0) {
+        return mainCaption;
+    }
+
+    double num1, num2;
+
+    // turning a scale of 0.5 into 1:2 and a scale of 2 into 2:1 etc.
+    if (relativeScale < 1.0) {
+        num1 = 1.0;
+        num2 = 1.0 / relativeScale;
+    } else {
+        num1 = relativeScale;
+        num2 = 1.0;
+    }
+
+    std::string scaleText = "\nSCALE " + formatScale(num1) + ":" + formatScale(num2);
+
+    return mainCaption + scaleText;
+}
+
+std::string DrawViewDetail::formatScale(double scale)
+{
+    const int decimals = Base::UnitsApi::getDecimals();
+    std::ostringstream oss;
+    oss.precision(decimals);
+    oss << std::fixed << scale;
+    std::string result = oss.str();
+
+    // Removes trailing zeros and removes the decimal point
+    if (result.find('.') != std::string::npos) {
+        while (result.back() == '0') {
+            result.pop_back();
+        }
+        if (result.back() == '.') {
+            result.pop_back();
+        }
+    }
+    return result;
 }
 
 App::DocumentObjectExecReturn* DrawViewDetail::execute()

--- a/src/Mod/TechDraw/App/DrawViewDetail.h
+++ b/src/Mod/TechDraw/App/DrawViewDetail.h
@@ -73,6 +73,7 @@ public:
     void handleChangedPropertyType(
         Base::XMLReader &reader, const char * TypeName, App::Property * prop) override;
 
+    std::string makeCaption();
 
     void detailExec(TopoDS_Shape& s,
                     DrawViewPart* baseView,
@@ -102,6 +103,7 @@ protected:
     void getParameters(void);
     double m_fudge;
     bool debugDetail() const;
+    std::string formatScale(double scale);
 
     TopoDS_Shape m_scaledShape;
     gp_Ax2 m_viewAxis;

--- a/src/Mod/TechDraw/App/DrawViewDetail.h
+++ b/src/Mod/TechDraw/App/DrawViewDetail.h
@@ -103,7 +103,6 @@ protected:
     void getParameters(void);
     double m_fudge;
     bool debugDetail() const;
-    std::string formatScale(double scale);
 
     TopoDS_Shape m_scaledShape;
     gp_Ax2 m_viewAxis;
@@ -112,6 +111,8 @@ protected:
     QFutureWatcher<void> m_detailWatcher;
     QFuture<void> m_detailFuture;
     bool m_waitingForDetail;
+    bool m_scaleAdded = false;
+    bool m_refAdded = false;
 
     DrawViewPart* m_saveDvp;
     DrawViewSection* m_saveDvs;

--- a/src/Mod/TechDraw/Gui/QGICaption.cpp
+++ b/src/Mod/TechDraw/Gui/QGICaption.cpp
@@ -22,8 +22,20 @@
 
 # include <cassert>
 
+#include <QFocusEvent>
+#include <QGraphicsScene>
+#include <QGraphicsSceneMouseEvent>
+#include <QGraphicsView>
+#include <QGuiApplication>
+#include <QKeyEvent>
+#include <QTextCursor>
+
+#include <Mod/TechDraw/App/DrawView.h>
 
 #include "QGICaption.h"
+#include "QGIView.h"
+#include "Rez.h"
+#include "ZVALUE.h"
 
 
 using namespace TechDrawGui;
@@ -32,6 +44,154 @@ QGICaption::QGICaption()
 {
 //    setCacheMode(QGraphicsItem::NoCache);
 //    setAcceptHoverEvents(false);
-//    setFlag(QGraphicsItem::ItemIsSelectable, false);
-//    setFlag(QGraphicsItem::ItemIsMovable, false);
+    setFlag(QGraphicsItem::ItemIsSelectable, true);
+    setFlag(QGraphicsItem::ItemIsMovable, true);
+    setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
+    setTextInteractionFlags(Qt::NoTextInteraction);
+
+    setZValue(ZVALUE::VIEWCAPTION);
+}
+
+QVariant QGICaption::itemChange(GraphicsItemChange change, const QVariant &value)
+{
+    // only updates for caption of views
+    auto* parentView = dynamic_cast<QGIView*>(parentItem());
+    if (!parentView) {
+        return QGCustomText::itemChange(change, value);
+    }
+
+    TechDraw::DrawView* viewObj = parentView->getViewObject();
+    if (!viewObj) {
+        return QGCustomText::itemChange(change, value);
+    }
+
+    if (change == ItemPositionChange) {
+        return snapToView(value.toPointF());
+    }
+
+    if (change == ItemPositionHasChanged) {
+        QPointF newPos = value.toPointF();
+        Base::Vector3d newLocation(Rez::appX(newPos.x()), Rez::appX(-newPos.y()), 0.0);
+        viewObj->CaptionLocation.setValue(newLocation);
+    }
+
+    return QGCustomText::itemChange(change, value);
+}
+
+QPointF QGICaption::snapToView(QPointF pos) {
+    auto* parentView = dynamic_cast<QGIView*>(parentItem());
+    if (!parentView) {
+        return pos;
+    }
+
+    TechDraw::DrawView* viewObj = parentView->getViewObject();
+    if (!viewObj) {
+        return pos;
+    }
+
+    // Do not snap if control key is pressed
+    if (QGuiApplication::keyboardModifiers() & Qt::ControlModifier) {
+        viewObj->CaptionSnap.setValue("NoSnap");
+        return pos;
+    }
+
+    QRectF frameRect = parentView->getFrameRect();
+    QRectF captionRect = this->boundingRect();
+
+    QPointF topSnap = QPointF(frameRect.center().x() - (captionRect.width() / 2),
+                              frameRect.top() - captionRect.height());
+    QPointF bottomSnap = QPointF(frameRect.center().x() - (captionRect.width() / 2),
+                              frameRect.bottom());
+    QPointF leftSnap = QPointF(frameRect.left() - captionRect.width(),
+                              frameRect.center().y() - (captionRect.height() / 2));
+    QPointF rightSnap = QPointF(frameRect.right(),
+                              frameRect.center().y() - (captionRect.height() / 2));
+
+
+    constexpr double snapDistanceScreenPixels{15.0};
+    double zoomFactor = 1.0;
+    zoomFactor = scene()->views().first()->transform().m11();
+
+    double snapDistance = snapDistanceScreenPixels / zoomFactor;
+
+    for (const QPointF& snapPos : {topSnap, bottomSnap, leftSnap, rightSnap}) {
+        qreal distance = QLineF(pos, snapPos).length();
+        if (distance < snapDistance) {
+
+            viewObj->CaptionSnap.setValue(snapPos == topSnap ? "Top" :
+                                        snapPos == bottomSnap ? "Bottom" :
+                                        snapPos == leftSnap ? "Left" :
+                                        snapPos == rightSnap ? "Right" : "NoSnap");
+            return snapPos;
+        }
+
+    }
+
+    viewObj->CaptionSnap.setValue("NoSnap");
+    return pos;
+}
+
+void QGICaption::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
+{
+    setEditMode(true);
+    event->accept();
+}
+
+void QGICaption::focusOutEvent(QFocusEvent* event)
+{
+    setEditMode(false);
+
+    auto* parentView = dynamic_cast<QGIView*>(parentItem());
+    if (parentView) {
+        parentView->prepareCaption();
+    }
+
+    QGCustomText::focusOutEvent(event);
+}
+
+void QGICaption::keyPressEvent(QKeyEvent* event)
+{
+    if (m_isEditing
+        && (event->key() == Qt::Key_Escape || event->key() == Qt::Key_Return
+            || event->key() == Qt::Key_Enter)) {
+        clearFocus();
+        event->accept();
+        return;
+    }
+
+    QGCustomText::keyPressEvent(event);
+}
+
+void QGICaption::setEditMode(bool enable)
+{
+    auto* parentView = dynamic_cast<QGIView*>(parentItem());
+    TechDraw::DrawView* viewObj = parentView ? parentView->getViewObject() : nullptr;
+
+    m_isEditing = enable;
+
+    QTextCursor cursor = textCursor();
+
+    if (enable) {
+        // the text edited should be what is saved in the view object
+        // so it for an example has the <SCALE> tag used for detail views
+        if (viewObj) {
+            setPlainText(QString::fromUtf8(viewObj->Caption.getValue()));
+        }
+
+        setTextInteractionFlags(Qt::TextEditorInteraction);
+        setFocus(Qt::MouseFocusReason);
+
+        cursor.select(QTextCursor::Document);
+        setTextCursor(cursor);
+        return;
+    }
+
+    setTextInteractionFlags(Qt::NoTextInteraction);
+    cursor.clearSelection();
+    setTextCursor(cursor);
+    clearFocus();
+
+    if (viewObj) {
+        viewObj->Caption.setValue(toPlainText().toUtf8().constData());
+    }
 }

--- a/src/Mod/TechDraw/Gui/QGICaption.h
+++ b/src/Mod/TechDraw/Gui/QGICaption.h
@@ -39,6 +39,17 @@ public:
     enum {Type = UserType::QGICaption};
     int type() const override { return Type;}
 
+    bool m_isEditing = false;
+
+protected:
+    QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
+    QPointF snapToView(QPointF pos);
+    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event) override;
+    void focusOutEvent(QFocusEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
+
+private:
+    void setEditMode(bool enable);
 };
 
 }

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -727,19 +727,22 @@ void QGIView::layoutDecorations(const QRectF& contentArea,
                           paddedContentArea.top(),
                           frameWidth,
                           frameHeight).adjusted(-padding, - padding, padding, padding);
+    
+    outLockPos = QPointF(outFrameRect.left(), outFrameRect.bottom() - m_lockHeight);
 
-    double firstTextVerticalPos = outFrameRect.bottom();
+    double firstTextVerticalPos = outFrameRect.top() - labelRect.height();
+    outLabelPos = QPointF(outFrameRect.left(), firstTextVerticalPos);
+
     if (m_caption->toPlainText().isEmpty()) {
-        outLabelPos = QPointF(outFrameRect.center().x() - (labelRect.width() / 2),
-                              firstTextVerticalPos);
+        return;
+    }
+    if (getViewObject()->CaptionPosition.isValue("Bottom")) {
+        outCaptionPos = QPointF(outFrameRect.center().x() - (captionRect.width() / 2),
+                                  outFrameRect.bottom());
     } else {
         outCaptionPos = QPointF(outFrameRect.center().x() - (captionRect.width() / 2),
-                                firstTextVerticalPos);
-        outLabelPos = QPointF(outFrameRect.center().x() - (labelRect.width() / 2),
-                              firstTextVerticalPos + captionRect.height());
+                                  firstTextVerticalPos - captionRect.height());
     }
-
-    outLockPos = QPointF(outFrameRect.left(), outFrameRect.bottom() - m_lockHeight);
 }
 
 

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -34,6 +34,7 @@
 #include <App/DocumentObject.h>
 #include <Base/Console.h>
 #include <Base/Tools.h>
+#include <Base/UnitsApi.h>
 #include <Gui/Application.h>
 #include <Gui/Command.h>
 #include <Gui/Document.h>
@@ -45,6 +46,7 @@
 #include <Mod/TechDraw/App/DrawProjGroup.h>
 #include <Mod/TechDraw/App/DrawProjGroupItem.h>
 #include <Mod/TechDraw/App/DrawViewSection.h>
+#include <Mod/TechDraw/App/DrawViewDetail.h>
 #include <Mod/TechDraw/App/DrawViewPart.h>
 #include <Mod/TechDraw/App/DrawUtil.h>
 #include <Mod/TechDraw/App/DrawView.h>
@@ -701,7 +703,16 @@ void QGIView::prepareCaption()
                                  Preferences::labelFontSizeMM());
     m_font.setPixelSize(fontSize);
     m_caption->setFont(m_font);
-    QString captionStr = QString::fromUtf8(getViewObject()->Caption.getValue());
+
+    if (m_caption->m_isEditing) {
+        return;
+    }
+
+    std::string captionText = getViewObject()->Caption.getValue();
+    captionText = getScaleString(captionText);
+    captionText = getRefString(captionText);
+
+    QString captionStr = QString::fromUtf8(captionText.c_str());
     m_caption->setPlainText(captionStr);
 }
 
@@ -736,15 +747,99 @@ void QGIView::layoutDecorations(const QRectF& contentArea,
     if (m_caption->toPlainText().isEmpty()) {
         return;
     }
-    if (getViewObject()->CaptionPosition.isValue("Bottom")) {
-        outCaptionPos = QPointF(outFrameRect.center().x() - (captionRect.width() / 2),
-                                  outFrameRect.bottom());
+
+    DrawView* view = getViewObject();
+
+    QPointF captionTopPos = QPointF(outFrameRect.center().x() - (captionRect.width() / 2),
+                              outFrameRect.top() - captionRect.height());
+    QPointF captionBottomPos = QPointF(outFrameRect.center().x() - (captionRect.width() / 2),
+                              outFrameRect.bottom());
+    QPointF captionLeftPos = QPointF(outFrameRect.left() - captionRect.width(),
+                              outFrameRect.center().y() - (captionRect.height() / 2));
+    QPointF captionRightPos = QPointF(outFrameRect.right(),
+                              outFrameRect.center().y() - (captionRect.height() / 2));
+
+    if (view->CaptionSnap.getValue() == 0) {
+        outCaptionPos = captionTopPos;
+    } else if (view->CaptionSnap.getValue() == 1) {
+        outCaptionPos = captionBottomPos;
+    } else if (view->CaptionSnap.getValue() == 2) {
+        outCaptionPos = captionLeftPos;
+    } else if (view->CaptionSnap.getValue() == 3) {
+        outCaptionPos = captionRightPos;
     } else {
-        outCaptionPos = QPointF(outFrameRect.center().x() - (captionRect.width() / 2),
-                                  firstTextVerticalPos - captionRect.height());
+        outCaptionPos = captionBottomPos;
     }
 }
 
+
+std::string QGIView::getScaleString(std::string originalString) {
+    
+    auto removeDecimals = [](double scale) {
+        const int decimals = Base::UnitsApi::getDecimals();
+        std::ostringstream oss;
+        oss.precision(decimals);
+        oss << std::fixed << scale;
+        std::string result = oss.str();
+    
+        // Removes trailing zeros and removes the decimal point
+        if (result.find('.') != std::string::npos) {
+            while (result.back() == '0') {
+                result.pop_back();
+            }
+            if (result.back() == '.') {
+                result.pop_back();
+            }
+        }
+        return result;
+    };
+
+    auto view = getViewObject();
+    double viewScale = view->getScale();
+
+    auto page = view->findParentPage();
+    double pageScale = page->Scale.getValue();
+
+    double relativeScale = viewScale / pageScale;
+
+    while (originalString.find("<SCALE>") != std::string::npos) {
+        double num1, num2;
+
+        // turning a scale of 0.5 into 1:2 and a scale of 2 into 2:1 etc.
+        if (relativeScale < 1.0) {
+            num1 = 1.0;
+            num2 = 1.0 / relativeScale;
+        } else {
+            num1 = relativeScale;
+            num2 = 1.0;
+        }
+
+        std::string scaleString = removeDecimals(num1) + ":" + removeDecimals(num2);
+        size_t pos = originalString.find("<SCALE>");
+        originalString.replace(pos, std::string("<SCALE>").length(), scaleString);
+    }
+
+    return originalString;
+}
+
+std::string QGIView::getRefString(std::string originalString) {
+    auto view = getViewObject();
+
+    std::string refName;
+    if (auto* section = dynamic_cast<TechDraw::DrawViewSection*>(view)) {
+        refName = section->SectionSymbol.getValue();
+    } 
+    else if (auto* detail = dynamic_cast<TechDraw::DrawViewDetail*>(view)) {
+        refName = detail->Reference.getValue();
+    }
+
+    while (originalString.find("<REF>") != std::string::npos) {
+        size_t pos = originalString.find("<REF>");
+        originalString.replace(pos, std::string("<REF>").length(), refName);
+    }
+
+    return originalString;
+}
 
 void QGIView::drawBorder()
 {
@@ -768,13 +863,17 @@ void QGIView::drawBorder()
     QRectF captionRect = m_caption->boundingRect();
     QRectF labelRect = m_label->boundingRect();
 
-
-    QRectF finalFrameRect;
     QPointF finalCaptionPos, finalLabelPos, finalLockPos;
 
     layoutDecorations(contentArea, captionRect, labelRect,
-                      finalFrameRect, finalCaptionPos, finalLabelPos, finalLockPos);
+                      m_frameRect, finalCaptionPos, finalLabelPos, finalLockPos);
 
+    Base::Vector3d captionLocation = feat->CaptionLocation.getValue();
+
+    // CaptionSnap 4 is the NoSnap option, so we use the curent location
+    if (viewObj->CaptionSnap.getValue() == 4 || m_caption->m_isEditing) {
+        finalCaptionPos = QPointF(Rez::guiX(captionLocation.x), Rez::guiX(-captionLocation.y));
+    }
 
     m_caption->setPos(finalCaptionPos);
     m_label->setPos(finalLabelPos);
@@ -785,7 +884,7 @@ void QGIView::drawBorder()
     m_decorPen.setColor(m_colCurrent);
     m_border->setPen(m_decorPen);
     m_border->setPos(0., 0.);
-    m_border->setRect(finalFrameRect);
+    m_border->setRect(m_frameRect);
 
     prepareGeometryChange();
 }

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -124,7 +124,8 @@ public:
     void makeMark(Base::Vector3d pos, QColor color = Qt::red);
     void makeMark(QPointF pos, QColor color = Qt::red);
 
-
+    std::string getScaleString(std::string originalString);
+    std::string getRefString(std::string originalString);
     /** Methods to ensure that Y-Coordinates are orientated correctly.
      * @{ */
     inline qreal getY() { return y() * -1; }
@@ -149,6 +150,8 @@ public:
     void setCurrentColor(QColor color)  {m_colCurrent = color; }
     QColor getSettingColor() { return m_colSetting; }
     void   setSettingColor(QColor color) { m_colSetting = color; }
+
+    QRectF getFrameRect() const { return m_frameRect; }
 
     virtual void setStack(int z);
     virtual void setStackFromVP();
@@ -216,6 +219,8 @@ private:
     bool m_innerView;                                                  //View is inside another View
     bool m_multiselectActivated;
     bool snapping;
+
+    QRectF m_frameRect;
 
     QPen m_pen;
     QBrush m_brush;

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
@@ -562,7 +562,9 @@ void TaskComplexSection::createComplexSection()
         // unique Labels
         QString qTemp = ui->leSymbol->text();
         std::string temp = Base::Tools::escapeEncodeString(qTemp.toStdString());
-        std::string sectionLabel = Base::Tools::escapeEncodeString(makeSectionLabel(qTemp));
+        std::string sectionLabel = Base::Tools::escapeEncodeString(makeSectionLabel());
+        std::string sectionCaption = Base::Tools::escapeEncodeString(makeSectionCaption(qTemp));
+
         //NOLINTBEGIN
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.SectionSymbol = '%s'",
                            m_sectionName.c_str(), temp.c_str());
@@ -570,6 +572,9 @@ void TaskComplexSection::createComplexSection()
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.Label = '%s'",
                            m_sectionName.c_str(),
                            sectionLabel.c_str());
+        Command::doCommand(Command::Doc, "App.ActiveDocument.%s.Caption = '%s'",
+                           m_sectionName.c_str(),
+                           sectionCaption.c_str());
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.addView(App.ActiveDocument.%s)",
                            m_page->getNameInDocument(), m_sectionName.c_str());
 
@@ -650,7 +655,8 @@ void TaskComplexSection::updateComplexSection()
     if (m_section) {
         QString qTemp = ui->leSymbol->text();
         std::string temp = Base::Tools::escapeEncodeString(qTemp.toStdString());
-        std::string sectionLabel = Base::Tools::escapeEncodeString(makeSectionLabel(qTemp));
+        std::string sectionLabel = Base::Tools::escapeEncodeString(makeSectionLabel());
+        std::string sectionCaption = Base::Tools::escapeEncodeString(makeSectionCaption(qTemp));
         //NOLINTBEGIN
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.SectionSymbol = '%s'",
                            m_sectionName.c_str(), temp.c_str());
@@ -699,13 +705,18 @@ void TaskComplexSection::updateComplexSection()
     Gui::Command::commitCommand(tid);
 }
 
-std::string TaskComplexSection::makeSectionLabel(const QString& symbol)
+std::string TaskComplexSection::makeSectionLabel()
 {
     const std::string objectName{QT_TR_NOOP("ComplexSection")};
     std::string uniqueSuffix{m_sectionName.substr(objectName.length(), std::string::npos)};
     std::string uniqueLabel = "Section" + uniqueSuffix;
+    return ( uniqueLabel );
+}
+
+std::string TaskComplexSection::makeSectionCaption(QString symbol)
+{
     std::string temp = symbol.toStdString();
-    return ( uniqueLabel + " " + temp + " - " + temp );
+    return ( "SECTION " + temp + " - " + temp );
 }
 
 void TaskComplexSection::failNoObject()

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
@@ -563,7 +563,7 @@ void TaskComplexSection::createComplexSection()
         QString qTemp = ui->leSymbol->text();
         std::string temp = Base::Tools::escapeEncodeString(qTemp.toStdString());
         std::string sectionLabel = Base::Tools::escapeEncodeString(makeSectionLabel());
-        std::string sectionCaption = Base::Tools::escapeEncodeString(makeSectionCaption(qTemp));
+        std::string sectionCaption = Base::Tools::escapeEncodeString("SECTION <REF> - <REF>");
 
         //NOLINTBEGIN
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.SectionSymbol = '%s'",
@@ -656,7 +656,6 @@ void TaskComplexSection::updateComplexSection()
         QString qTemp = ui->leSymbol->text();
         std::string temp = Base::Tools::escapeEncodeString(qTemp.toStdString());
         std::string sectionLabel = Base::Tools::escapeEncodeString(makeSectionLabel());
-        std::string sectionCaption = Base::Tools::escapeEncodeString(makeSectionCaption(qTemp));
         //NOLINTBEGIN
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.SectionSymbol = '%s'",
                            m_sectionName.c_str(), temp.c_str());
@@ -713,11 +712,6 @@ std::string TaskComplexSection::makeSectionLabel()
     return ( uniqueLabel );
 }
 
-std::string TaskComplexSection::makeSectionCaption(QString symbol)
-{
-    std::string temp = symbol.toStdString();
-    return ( "SECTION " + temp + " - " + temp );
-}
 
 void TaskComplexSection::failNoObject()
 {

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.h
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.h
@@ -106,7 +106,8 @@ protected Q_SLOTS:
 
 private:
     double requiredRotation(double inputAngle);
-    std::string makeSectionLabel(const QString& symbol);
+    std::string makeSectionLabel();
+    std::string makeSectionCaption(QString symbol);
 
     void createComplexSection();
     void updateComplexSection();

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.h
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.h
@@ -107,7 +107,6 @@ protected Q_SLOTS:
 private:
     double requiredRotation(double inputAngle);
     std::string makeSectionLabel();
-    std::string makeSectionCaption(QString symbol);
 
     void createComplexSection();
     void updateComplexSection();

--- a/src/Mod/TechDraw/Gui/TaskDetail.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDetail.cpp
@@ -449,6 +449,10 @@ void TaskDetail::createDetail()
     }
     m_detailFeat = dvd;
     dvd->Source.setValues(getBaseFeat()->Source.getValues());
+    QString qRef = ui->leReference->text();
+    std::string ref = qRef.toStdString();
+    dvd->Reference.setValue(ref);
+    dvd->Caption.setValue(m_detailFeat->makeCaption());
 
     Gui::Command::doCommand(Command::Doc, "App.activeDocument().%s.BaseView = App.activeDocument().%s",
                             m_detailName.c_str(), m_baseName.c_str());
@@ -486,6 +490,8 @@ void TaskDetail::updateDetail()
         QString qRef = ui->leReference->text();
         std::string ref = qRef.toStdString();
         detailFeat->Reference.setValue(ref);
+
+        detailFeat->Caption.setValue(detailFeat->makeCaption());
 
         Gui::Command::updateActive();
         Gui::Command::commitCommand(tid);

--- a/src/Mod/TechDraw/Gui/TaskDetail.h
+++ b/src/Mod/TechDraw/Gui/TaskDetail.h
@@ -81,6 +81,8 @@ protected:
     void changeEvent(QEvent *event) override;
     void startDragger();
 
+    std::string makeCaption();
+
     void createDetail();
     void updateDetail();
 

--- a/src/Mod/TechDraw/Gui/TaskSectionView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.cpp
@@ -503,12 +503,16 @@ TechDraw::DrawViewSection* TaskSectionView::createSectionView(void)
         QString qTemp = ui->leSymbol->text();
         std::string temp = Base::Tools::escapeEncodeString(qTemp.toStdString());
         std::string sectionLabel = Base::Tools::escapeEncodeString(makeSectionLabel());
+        std::string sectionCaption = Base::Tools::escapeEncodeString("SECTION <REF> - <REF>");
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.SectionSymbol = '%s'",
                            m_sectionName.c_str(), temp.c_str());
 
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.Label = '%s'",
                            m_sectionName.c_str(),
                            sectionLabel.c_str());
+        Command::doCommand(Command::Doc, "App.ActiveDocument.%s.Caption = '%s'",
+                           m_sectionName.c_str(),
+                           sectionCaption.c_str());
         Command::doCommand(Command::Doc, "App.activeDocument().%s.translateLabel('DrawViewSection', 'Section', '%s')",
               m_sectionName.c_str(), sectionLabel.c_str());
 
@@ -582,16 +586,12 @@ void TaskSectionView::updateSectionView()
         QString qTemp = ui->leSymbol->text();
         std::string temp = Base::Tools::escapeEncodeString(qTemp.toStdString());
         std::string sectionLabel = Base::Tools::escapeEncodeString(makeSectionLabel());
-        std::string sectionCaption = Base::Tools::escapeEncodeString(makeSectionCaption(qTemp));
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.SectionSymbol = '%s'",
                            m_sectionName.c_str(), temp.c_str());
 
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.Label = '%s'",
                            m_sectionName.c_str(),
                            sectionLabel.c_str());
-        Command::doCommand(Command::Doc, "App.ActiveDocument.%s.Caption = '%s'",
-                           m_sectionName.c_str(),
-                           sectionCaption.c_str());
         Command::doCommand(Command::Doc, "App.activeDocument().%s.translateLabel('DrawViewSection', 'Section', '%s')",
               m_sectionName.c_str(), sectionLabel.c_str());
 
@@ -633,11 +633,6 @@ std::string TaskSectionView::makeSectionLabel()
     std::string uniqueSuffix{m_sectionName.substr(objectName.length(), std::string::npos)};
     std::string uniqueLabel = "Section" + uniqueSuffix;
     return ( uniqueLabel );
-}
-
-std::string TaskSectionView::makeSectionCaption(QString symbol) {
-    std::string temp = symbol.toStdString();
-    return ( "SECTION " + temp + " - " + temp );
 }
 
 void TaskSectionView::failNoObject(void)

--- a/src/Mod/TechDraw/Gui/TaskSectionView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.cpp
@@ -502,7 +502,7 @@ TechDraw::DrawViewSection* TaskSectionView::createSectionView(void)
         // unique Labels
         QString qTemp = ui->leSymbol->text();
         std::string temp = Base::Tools::escapeEncodeString(qTemp.toStdString());
-        std::string sectionLabel = Base::Tools::escapeEncodeString(makeSectionLabel(qTemp));
+        std::string sectionLabel = Base::Tools::escapeEncodeString(makeSectionLabel());
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.SectionSymbol = '%s'",
                            m_sectionName.c_str(), temp.c_str());
 
@@ -581,13 +581,17 @@ void TaskSectionView::updateSectionView()
 
         QString qTemp = ui->leSymbol->text();
         std::string temp = Base::Tools::escapeEncodeString(qTemp.toStdString());
-        std::string sectionLabel = Base::Tools::escapeEncodeString(makeSectionLabel(qTemp));
+        std::string sectionLabel = Base::Tools::escapeEncodeString(makeSectionLabel());
+        std::string sectionCaption = Base::Tools::escapeEncodeString(makeSectionCaption(qTemp));
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.SectionSymbol = '%s'",
                            m_sectionName.c_str(), temp.c_str());
 
         Command::doCommand(Command::Doc, "App.ActiveDocument.%s.Label = '%s'",
                            m_sectionName.c_str(),
                            sectionLabel.c_str());
+        Command::doCommand(Command::Doc, "App.ActiveDocument.%s.Caption = '%s'",
+                           m_sectionName.c_str(),
+                           sectionCaption.c_str());
         Command::doCommand(Command::Doc, "App.activeDocument().%s.translateLabel('DrawViewSection', 'Section', '%s')",
               m_sectionName.c_str(), sectionLabel.c_str());
 
@@ -623,13 +627,17 @@ void TaskSectionView::updateSectionView()
     Gui::Command::commitCommand(tid);
 }
 
-std::string TaskSectionView::makeSectionLabel(QString symbol)
+std::string TaskSectionView::makeSectionLabel()
 {
     const std::string objectName("SectionView");
     std::string uniqueSuffix{m_sectionName.substr(objectName.length(), std::string::npos)};
     std::string uniqueLabel = "Section" + uniqueSuffix;
+    return ( uniqueLabel );
+}
+
+std::string TaskSectionView::makeSectionCaption(QString symbol) {
     std::string temp = symbol.toStdString();
-    return ( uniqueLabel + " " + temp + " - " + temp );
+    return ( "SECTION " + temp + " - " + temp );
 }
 
 void TaskSectionView::failNoObject(void)

--- a/src/Mod/TechDraw/Gui/TaskSectionView.h
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.h
@@ -94,7 +94,6 @@ protected Q_SLOTS:
 private:
     double requiredRotation(double inputAngle);
     std::string makeSectionLabel();
-    std::string makeSectionCaption(QString symbol);
     bool directionChanged() const { return m_directionChanged; }
     void directionChanged(bool newState) { m_directionChanged = newState; }
 

--- a/src/Mod/TechDraw/Gui/TaskSectionView.h
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.h
@@ -93,7 +93,8 @@ protected Q_SLOTS:
 
 private:
     double requiredRotation(double inputAngle);
-    std::string makeSectionLabel(QString symbol);
+    std::string makeSectionLabel();
+    std::string makeSectionCaption(QString symbol);
     bool directionChanged() const { return m_directionChanged; }
     void directionChanged(bool newState) { m_directionChanged = newState; }
 

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -222,7 +222,7 @@ void ViewProviderViewPart::attach(App::DocumentObject *pcFeat)
         sPixmap = "TechDraw_TreeMulti";
     } else if (dvd) {
         sPixmap = "actions/TechDraw_DetailView";
-        KeepLabel.setValue(true);
+
         // these properties apply to the base view, not the detail
         HighlightLineStyle.setStatus(App::Property::ReadOnly, true);
         HighlightLineStyle.setStatus(App::Property::Hidden, true);

--- a/src/Mod/TechDraw/Gui/ViewProviderViewSection.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewSection.cpp
@@ -61,8 +61,6 @@ ViewProviderViewSection::ViewProviderViewSection()
     static const char *lgroup = "Section Line";
     sPixmap = "TechDraw_TreeSection";
 
-    KeepLabel.setValue(true);
-
     ADD_PROPERTY_TYPE(CutSurfaceColor, (Preferences::getPreferenceGroup("Colors")->GetUnsigned("FaceColor", 0xFFFFFF)),
                       fgroup, App::Prop_None, "Set color of the cut surface");
     ADD_PROPERTY_TYPE(CutSurfaceTransparency, (Preferences::getPreferenceGroup("Colors")->GetBool("ClearFace", false) ? 100 : 0),

--- a/src/Mod/TechDraw/Gui/ZVALUE.h
+++ b/src/Mod/TechDraw/Gui/ZVALUE.h
@@ -18,5 +18,6 @@ namespace ZVALUE {
     const int BALLOON = 120;
     const int ANNOTATION = 120;
     const int TRACKER = 125;
+    const int VIEWCAPTION = 150;
     const int LOCK = 200;
 }


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This PR includes changes to TechDraw views' label location and adds text tto the views caption. The changes are:

1. Labels have been moved to the top left corner of the view
2. Captions are where the label once was
3. Captions location can be moved to the top using a setting/property in the view
4. Section views get an automatic caption when they are created
5. Detail views get a Caption which also includes the scale in a: X : Y format
6. Captions are now moveable and snap to the bottom, top, left or right of the view
7. Holding control disables the snapping
8. A `<SCALE>` tag shows the scale of the view in relation to the pages scale
9. A `<REF>` tag holds the reference to Section View or Detail View like "A" in "SECTION A - A"
10. The caption can be edited directly from the UI

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
Adds to #21908

## Before and After Images

Updated Video showing snapping and editing

https://github.com/user-attachments/assets/447ce13d-cc17-4d0c-93b5-8c36ee636112


