### PR TITLE
Assembly: Fix shortcut conflict between CreateBom and CreateJointRigidGroup

### DIFF
--- a/src/Mod/Assembly/CommandCreateJoint.py
+++ b/src/Mod/Assembly/CommandCreateJoint.py
@@ -534,7 +534,7 @@ class CommandCreateJointRigidGroup:
         return {
             "Pixmap": "Assembly_CreateJointRigidGroup",
             "MenuText": QT_TRANSLATE_NOOP("Assembly_CreateJointRigidGroup", "Create Rigid Group"),
-            "Accel": "O",
+            "Accel": "Y",
             "ToolTip": QT_TRANSLATE_NOOP(
                 "Assembly_CreateJointRigidGroup",
                 "<p>Create a rigid group.</p>"


### PR DESCRIPTION
Fixes #31982

Assembly_CreateBom and Assembly_CreateJointRigidGroup both used ""O"" as their accelerator, so ""O"" was ambiguous in the Assembly workbench. This keeps ""O"" for Bill of Materials (a primary toolbar command) and assigns ""Y"" to Create Rigid Group, a key not used by any other command.

AI assistance: DeepSeek (DeepSeek-V4-Pro-0813) was used in an assistive way for this change. I have reviewed the diff and I take full responsibility for it.

- [x]  I have read and understood the contributor guidelines (CONTRIBUTING.md)
- [x]  I have read and understood the AI Policy (AI_POLICY.md)
- [x]  This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.