### PR TITLE
PartDesign: Do not infer base from sketch attachment

### DIFF
--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -65,6 +65,7 @@
 #include <Mod/Part/App/FaceMakerCheese.h>
 #include <Mod/Part/App/Tools.h>
 
+#include "Body.h"
 #include "FeatureSketchBased.h"
 #include "DatumLine.h"
 #include "DatumPlane.h"
@@ -703,6 +704,11 @@ Part::Feature* ProfileBased::getBaseObject(bool silent) const
     const char* err = nullptr;
     App::DocumentObject* spt = sketch->AttachmentSupport.getValue();
     if (spt) {
+        // Attaching to a Body positions the profile but must not import its complete tip shape.
+        // Feature supports remain implicit bases for compatibility with legacy files.
+        if (spt->isDerivedFrom<PartDesign::Body>()) {
+            return Feature::getBaseObject(silent);
+        }
         if (spt->isDerivedFrom<Part::Feature>()) {
             rv = static_cast<Part::Feature*>(spt);
         }

--- a/src/Mod/PartDesign/PartDesignTests/TestPad.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestPad.py
@@ -74,6 +74,28 @@ class TestPad(unittest.TestCase):
         self.Doc.recompute()
         self.assertEqual(len(self.Pad.Shape.Faces), 6)
 
+    def testSketchAttachmentDoesNotImportExternalBody(self):
+        source_body = self.Doc.addObject("PartDesign::Body", "SourceBody")
+        source_box = source_body.newObject("PartDesign::AdditiveBox", "SourceBox")
+        source_box.Length = 1
+        source_box.Width = 1
+        source_box.Height = 1
+
+        target_body = self.Doc.addObject("PartDesign::Body", "TargetBody")
+        sketch = target_body.newObject("Sketcher::SketchObject", "SketchPad")
+        sketch.AttachmentSupport = (source_body, [""])
+        sketch.MapMode = "ObjectXY"
+        TestSketcherApp.CreateRectangleSketch(sketch, (2, 0), (1, 1))
+
+        pad = target_body.newObject("PartDesign::Pad", "Pad")
+        pad.Profile = sketch
+        pad.Length = 1
+        self.Doc.recompute()
+
+        self.assertIsNone(pad.BaseFeature)
+        self.assertEqual(len(pad.Shape.Solids), 1)
+        self.assertAlmostEqual(pad.Shape.Volume, 1)
+
     def testStartOffsetAndReference(self):
         self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "SketchPad")
         TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 0), (1, 1))


### PR DESCRIPTION
Body-owned features already use BaseFeature. Keep profile and support inference only for bodyless legacy features and cover cross-body sketch support with a regression test.

- Modern Body features now use only their explicit BaseFeature; sketch attachment solids are no longer imported
- Legacy bodyless Part Design behavior remains compatible

Assisted-by: GPT-5.6-Sol

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/32221


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
