### PR TITLE
Gui: Include command name in dropdown action tooltips

### DIFF
--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -1030,7 +1030,7 @@ const char* Command::endCmdHelp()
 void Command::applyCommandData(const char* context, Action* action)
 {
     action->setText(QCoreApplication::translate(context, getMenuText()));
-    action->setToolTip(QCoreApplication::translate(context, getToolTipText()));
+    action->setToolTip(QCoreApplication::translate(context, getToolTipText()),QCoreApplication::translate(context, getMenuText()));
     action->setWhatsThis(QCoreApplication::translate(context, getWhatsThis()));
     if (sStatusTip) {
         action->setStatusTip(QCoreApplication::translate(context, getStatusTip()));

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -1030,7 +1030,10 @@ const char* Command::endCmdHelp()
 void Command::applyCommandData(const char* context, Action* action)
 {
     action->setText(QCoreApplication::translate(context, getMenuText()));
-    action->setToolTip(QCoreApplication::translate(context, getToolTipText()),QCoreApplication::translate(context, getMenuText()));
+    action->setToolTip(
+        QCoreApplication::translate(context, getToolTipText()),
+        QCoreApplication::translate(context, getMenuText())
+    );
     action->setWhatsThis(QCoreApplication::translate(context, getWhatsThis()));
     if (sStatusTip) {
         action->setStatusTip(QCoreApplication::translate(context, getStatusTip()));


### PR DESCRIPTION
Use two-argument setToolTip in applyCommandData to trigger Gui::Action::createToolTip formatting, matching the behavior already present in GroupCommand::setup and PythonGroupCommand::languageChange.

Fixes #32190

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
