### PR TITLE
Draft: WorkingPlaneProxy: make ViewData and VisibilityMap properties hidden

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_wpproxy.py
+++ b/src/Mod/Draft/draftviewproviders/view_wpproxy.py
@@ -61,11 +61,11 @@ class ViewProviderWorkingPlaneProxy:
 
         vobj.addProperty("App::PropertyColor", "LineColor", "Base", "", locked=True)
 
-        vobj.addProperty("App::PropertyFloatList", "ViewData", "Base", "", locked=True)
+        vobj.addProperty("App::PropertyFloatList", "ViewData", "Base", "", locked=True, hidden=True)
 
         vobj.addProperty("App::PropertyBool", "RestoreView", "Base", "", locked=True)
 
-        vobj.addProperty("App::PropertyMap", "VisibilityMap", "Base", "", locked=True)
+        vobj.addProperty("App::PropertyMap", "VisibilityMap", "Base", "", locked=True, hidden=True)
 
         vobj.addProperty("App::PropertyBool", "RestoreState", "Base", "", locked=True)
 

--- a/src/Mod/Draft/draftviewproviders/view_wpproxy.py
+++ b/src/Mod/Draft/draftviewproviders/view_wpproxy.py
@@ -61,11 +61,13 @@ class ViewProviderWorkingPlaneProxy:
 
         vobj.addProperty("App::PropertyColor", "LineColor", "Base", "", locked=True)
 
-        vobj.addProperty("App::PropertyFloatList", "ViewData", "Base", "", locked=True, hidden=True)
+        vobj.addProperty("App::PropertyFloatList", "ViewData", "Base", "", locked=True)
+        vobj.setPropertyStatus("ViewData", "Hidden")
 
         vobj.addProperty("App::PropertyBool", "RestoreView", "Base", "", locked=True)
 
-        vobj.addProperty("App::PropertyMap", "VisibilityMap", "Base", "", locked=True, hidden=True)
+        vobj.addProperty("App::PropertyMap", "VisibilityMap", "Base", "", locked=True)
+        vobj.setPropertyStatus("VisibilityMap", "Hidden")
 
         vobj.addProperty("App::PropertyBool", "RestoreState", "Base", "", locked=True)
 


### PR DESCRIPTION
The VisibilityMap property was automatically hidden in <=v1.1 as it is a App::PropertyMap property. Both that property and the ViewData should not be presented to the average user. There is no code to update old objects, IMO that would be too much for such a minor issue.

Related #32234.