### PR TITLE
CAM: Add FollowCurve pattern to 3D Surface operation for curve mapping

### DIFF
--- a/src/Mod/CAM/CAMTests/TestSurfaceGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestSurfaceGenerator.py
@@ -175,21 +175,47 @@ class TestSurfaceGenerator(unittest.TestCase):
         self.assertGreater(len(scan_lines), 0, "Spiral should generate lines.")
         self.assertGreater(len(scan_lines[0]), 10, "Spiral should have multiple points.")
 
-    def test70(self):
-        """Tests that the spiral generator respects the boundary."""
-        scan_lines = surface_cpp.generate_spiral_pattern_cpp(
-            0, 10, 0, 10, 5.0, 5.0, 1.0, 0.1, False, self.square_boundary
-        )
-        self.assertGreater(len(scan_lines), 0, "Clipped spiral should generate lines.")
+    def test80_follow_curve_on_surface(self):
+        """Tests FollowCurve cut pattern on 3D Surface operation follows curved height profile."""
+        import Path.Op.Surface as PathSurface
+        import Path.Main.Job as PathJob
 
-        # Check if all points are within the boundary
-        for line in scan_lines:
-            for point in line:
-                self.assertTrue(
-                    0.0 <= point[0] <= 10.0 and 0.0 <= point[1] <= 10.0,
-                    f"Point {point} is outside the 10x10 boundary.",
-                )
+        doc = FreeCAD.newDocument("TestFollowCurveDoc")
+        try:
+            # Create a curved surface solid (e.g. cylinder or sphere top)
+            sphere = Part.makeSphere(25.0)
+            box = Part.makeBox(60, 60, 30, FreeCAD.Vector(-30, -30, -30))
+            hemisphere = sphere.cut(box)
+            model_obj = doc.addObject("Part::Feature", "CurvedModel")
+            model_obj.Shape = hemisphere
+
+            # Create a 2D wire above/across the model (circle at Z=0, radius 15)
+            circle_edge = Part.makeCircle(15.0, FreeCAD.Vector(0, 0, 0))
+            wire_obj = doc.addObject("Part::Feature", "GuideWire")
+            wire_obj.Shape = Part.Wire([circle_edge])
+
+            job = PathJob.Create("Job", [model_obj])
+            op = PathSurface.Create("SurfaceOp", parentJob=job)
+            op.CutPattern = "FollowCurve"
+            op.Base = [(wire_obj, ["Wire1"])]
+            op.SampleInterval = 2.0
+            op.ToolController.Tool.Diameter = 6.0
+            doc.recompute()
+
+            commands = op.Path.Commands
+            self.assertGreater(len(commands), 5, "Should generate commands for FollowCurve")
+            
+            # Check that cutting moves (G1) have varying Z heights corresponding to the curved surface
+            z_coords = [c.Parameters["Z"] for c in commands if c.Name == "G1" and "Z" in c.Parameters]
+            self.assertGreater(len(z_coords), 5, "Should have multiple G1 moves with Z coordinates")
+            # For a 6mm flat endmill on a sphere of radius 25 at r=15, the corner of the endmill contacts
+            # the sphere at r = 15 - 3 = 12, where Z = sqrt(25^2 - 12^2) = sqrt(481) ~= 21.93 mm.
+            for z in z_coords:
+                self.assertAlmostEqual(z, 21.93, delta=0.5)
+        finally:
+            FreeCAD.closeDocument(doc.Name)
 
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/src/Mod/CAM/CAMTests/TestSurfaceGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestSurfaceGenerator.py
@@ -175,6 +175,21 @@ class TestSurfaceGenerator(unittest.TestCase):
         self.assertGreater(len(scan_lines), 0, "Spiral should generate lines.")
         self.assertGreater(len(scan_lines[0]), 10, "Spiral should have multiple points.")
 
+    def test70(self):
+        """Tests that the spiral generator respects the boundary."""
+        scan_lines = surface_cpp.generate_spiral_pattern_cpp(
+            0, 10, 0, 10, 5.0, 5.0, 1.0, 0.1, False, self.square_boundary
+        )
+        self.assertGreater(len(scan_lines), 0, "Clipped spiral should generate lines.")
+
+        # Check if all points are within the boundary
+        for line in scan_lines:
+            for point in line:
+                self.assertTrue(
+                    0.0 <= point[0] <= 10.0 and 0.0 <= point[1] <= 10.0,
+                    f"Point {point} is outside the 10x10 boundary.",
+                )
+
     def test80_follow_curve_on_surface(self):
         """Tests FollowCurve cut pattern on 3D Surface operation follows curved height profile."""
         import Path.Op.Surface as PathSurface

--- a/src/Mod/CAM/CAMTests/TestSurfacePatternGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestSurfacePatternGenerator.py
@@ -321,3 +321,38 @@ class TestSurfacePattern(PathTestUtils.PathTestBase):
                 self.assertTrue(
                     0 <= x <= 20 and 0 <= y <= 20, f"Point ({x},{y}) is outside the boundary"
                 )
+
+    def test_generate_curve_pattern_straight_wire(self):
+        """Test sampling a straight 2D wire at fixed intervals."""
+        from Path.Base.Generator.surface_pattern import generate_curve_pattern
+
+        edge = Part.makeLine(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(10, 0, 0))
+        wire = Part.Wire([edge])
+        polylines = generate_curve_pattern([wire], sample_interval=2.0)
+        self.assertEqual(len(polylines), 1)
+        # 0, 2, 4, 6, 8, 10 -> at least 6 points
+        self.assertGreaterEqual(len(polylines[0]), 6)
+        self.assertAlmostEqual(polylines[0][0][0], 0.0)
+        self.assertAlmostEqual(polylines[0][-1][0], 10.0)
+
+    def test_generate_curve_pattern_circle_wire(self):
+        """Test sampling a circular wire into closed polyline coordinates."""
+        from Path.Base.Generator.surface_pattern import generate_curve_pattern
+
+        circle_edge = Part.makeCircle(5.0)
+        wire = Part.Wire([circle_edge])
+        polylines = generate_curve_pattern([wire], sample_interval=1.0)
+        self.assertEqual(len(polylines), 1)
+        self.assertGreater(len(polylines[0]), 20)
+
+    def test_generate_curve_pattern_empty_and_edges(self):
+        """Test generate_curve_pattern with empty input and bare edge/compound inputs."""
+        from Path.Base.Generator.surface_pattern import generate_curve_pattern
+
+        self.assertEqual(generate_curve_pattern([], sample_interval=1.0), [])
+
+        edge = Part.makeLine(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(5, 5, 0))
+        polylines = generate_curve_pattern([edge], sample_interval=1.0)
+        self.assertEqual(len(polylines), 1)
+        self.assertGreaterEqual(len(polylines[0]), 2)
+

--- a/src/Mod/CAM/CAMTests/TestSurfacePatternGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestSurfacePatternGenerator.py
@@ -25,6 +25,7 @@ import Part
 import FreeCAD
 import unittest
 import CAMTests.PathTestUtils as PathTestUtils
+import PathScripts.PathUtils as PathUtils
 
 Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 Path.Log.trackModule(Path.Log.thisModule())
@@ -355,4 +356,61 @@ class TestSurfacePattern(PathTestUtils.PathTestBase):
         polylines = generate_curve_pattern([edge], sample_interval=1.0)
         self.assertEqual(len(polylines), 1)
         self.assertGreaterEqual(len(polylines[0]), 2)
+
+    def test_preprocess_wires_and_edges(self):
+        """Test extraction of Edge and Wire subobjects from Base geometry in ProcessSelectedFaces."""
+        from Path.Op.SurfaceSupport import ProcessSelectedFaces
+
+        edge1 = Part.makeLine(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(10, 0, 0))
+        edge2 = Part.makeLine(FreeCAD.Vector(10, 0, 0), FreeCAD.Vector(10, 10, 0))
+        wire = Part.Wire([edge1, edge2])
+        box_solid = Part.makeBox(20, 20, 10)
+
+        mock_model = MockFeature(box_solid, label="ModelFeature")
+        # Mock Base: (mock_model, ["Edge1", "Wire1"])
+        class MockValue:
+            def __init__(self, val):
+                self.Value = val
+
+        class MockModelGroup:
+            def __init__(self, items):
+                self.Group = items
+
+        class MockJob:
+            def __init__(self, models):
+                self.Model = MockModelGroup(models)
+                self.Stock = None
+                self.GeometryTolerance = MockValue(0.01)
+
+            def isDerivedFrom(self, type_name):
+                return type_name == "Path::FeaturePython" or type_name == "Path::Job"
+
+        class MockOp:
+            def __init__(self, base, job):
+                self.Base = base
+                self.AvoidLastX_Faces = 0
+                self.ScanType = "Planar"
+                self.BoundBox = "BaseBoundBox"
+                self.HandleMultipleFeatures = "Collectively"
+                self.InternalFeaturesCut = False
+                self.LinearDeflection = MockValue(0.001)
+                self.BoundaryAdjustment = MockValue(0.0)
+                self.BoundaryEnforcement = False
+                self.InList = [job]
+
+        job = MockJob([mock_model])
+        op = MockOp([(mock_model, ["Edge1", "Wire1"])], job)
+
+        psf = ProcessSelectedFaces(job, op)
+        psf.radius = 3.0
+        psf.depthParams = PathUtils.depth_params(10.0, 5.0, 0.0, 1.0, 0.0, -5.0)
+
+        # Check preProcessModel
+        result = psf.preProcessModel("Op.Surface")
+        self.assertIsNotNone(result)
+        self.assertTrue(hasattr(psf, "selectedWires"))
+        self.assertEqual(len(psf.selectedWires), 2)
+        # Verify selectedWires contains Wire/Edge objects
+        for item in psf.selectedWires:
+            self.assertTrue(isinstance(item, (Part.Wire, Part.Edge)))
 

--- a/src/Mod/CAM/Path/Base/Generator/surface_pattern.py
+++ b/src/Mod/CAM/Path/Base/Generator/surface_pattern.py
@@ -641,3 +641,55 @@ def generate_offset_scan_lines(
         offset_lines.reverse()
 
     return offset_lines
+
+
+# ---------------------------------------------------------------------------
+# Curve Pattern Generator
+# ---------------------------------------------------------------------------
+
+
+def generate_curve_pattern(shapes, sample_interval, offset_dist=0.0):
+    """
+    Discretize a list of 2D/3D Edges or Wires into continuous XY polylines for dropcutter scanning.
+
+    Args:
+        shapes: List of Part.Edge, Part.Wire, or Compound objects.
+        sample_interval: Maximum distance between consecutive sampled points (mm).
+        offset_dist: Optional 2D lateral offset distance (mm).
+
+    Returns:
+        A list of polylines, where each polyline is a list of (x, y, 0.0) coordinate tuples.
+    """
+    if sample_interval <= 0:
+        sample_interval = 1.0
+
+    polylines = []
+    for shape in shapes:
+        wires = []
+        if isinstance(shape, Part.Wire):
+            wires.append(shape)
+        elif hasattr(shape, "Wires") and len(shape.Wires) > 0:
+            wires.extend(shape.Wires)
+        elif hasattr(shape, "Edges") and len(shape.Edges) > 0:
+            wires.append(Part.Wire(shape.Edges))
+
+        for wire in wires:
+            if offset_dist != 0.0:
+                try:
+                    wire = wire.makeOffset2D(offset_dist)
+                except Exception as e:
+                    Path.Log.warning(f"Failed to offset wire: {e}")
+
+            # Discretize wire along length
+            length = wire.Length
+            if length <= 0.0:
+                continue
+
+            num_samples = max(2, int(math.ceil(length / sample_interval)) + 1)
+            pts = wire.discretize(num_samples)
+            polyline = [(p.x, p.y, 0.0) for p in pts]
+            if polyline:
+                polylines.append(polyline)
+
+    return polylines
+

--- a/src/Mod/CAM/Path/Op/Surface.py
+++ b/src/Mod/CAM/Path/Op/Surface.py
@@ -50,6 +50,8 @@ import Path
 import Path.Op.Base as PathOp
 import Path.Op.SurfaceSupport as PathSurfaceSupport
 import PathScripts.PathUtils as PathUtils
+from Path.Base.Generator.surface_pattern import generate_curve_pattern
+from Path.Base.Generator.surface_dropcutter import batch_dropcutter
 import math
 import time
 
@@ -83,6 +85,7 @@ class ObjectSurface(PathOp.ObjectOp):
             | PathOp.FeatureStepDown
             | PathOp.FeatureCoolant
             | PathOp.FeatureBaseFaces
+            | PathOp.FeatureBaseEdges
         )
 
     def initOperation(self, obj):
@@ -449,6 +452,7 @@ class ObjectSurface(PathOp.ObjectOp):
             "CutPattern": [
                 (translate("CAM_Surface", "Circular"), "Circular"),
                 (translate("CAM_Surface", "CircularZigZag"), "CircularZigZag"),
+                (translate("CAM_Surface", "FollowCurve"), "FollowCurve"),
                 (translate("CAM_Surface", "Line"), "Line"),
                 (translate("CAM_Surface", "Offset"), "Offset"),
                 (translate("CAM_Surface", "Spiral"), "Spiral"),
@@ -907,6 +911,7 @@ class ObjectSurface(PathOp.ObjectOp):
             FACES, VOIDS = pPM
             self.modelSTLs = PSF.modelSTLs
             self.profileShapes = PSF.profileShapes
+            self.selectedWires = getattr(PSF, "selectedWires", [])
 
             for idx, model in enumerate(JOB.Model.Group):
                 Path.Log.debug(idx)
@@ -988,6 +993,7 @@ class ObjectSurface(PathOp.ObjectOp):
         self.ClearHeightOffset = None
         self.depthParams = None
         self.midDep = None
+        self.selectedWires = None
         del self.modelSTLs
         del self.safeSTLs
         del self.modelTypes
@@ -998,6 +1004,7 @@ class ObjectSurface(PathOp.ObjectOp):
         del self.ClearHeightOffset
         del self.depthParams
         del self.midDep
+        del self.selectedWires
 
         execTime = time.time() - startTime
         if execTime > 60.0:
@@ -1125,26 +1132,35 @@ class ObjectSurface(PathOp.ObjectOp):
 
         geoScan = []
         if obj.ProfileEdges != "Only":
-            self.showDebugObject(cmpdShp, "CutArea")
-            # get internal path geometry and perform OCL scan with that geometry
-            PGG = PathSurfaceSupport.PathGeometryGenerator(obj, cmpdShp, obj.CutPattern)
-            if self.showDebugObjects:
-                PGG.setDebugObjectsGroup(self.tempGroup)
-            self.tmpCOM = PGG.getCenterOfPattern()
-            pathGeom = PGG.generatePathGeometry()
-            if pathGeom is False:
-                msg = translate("PathSurface", "No clearing shape returned.")
-                Path.Log.error(msg)
-                return []
-            if obj.CutPattern == "Offset":
-                useGeom = self._offsetFacesToPointData(obj, pathGeom, profile=False)
-                if useGeom is False:
-                    msg = translate("PathSurface", "No clearing path geometry returned.")
+            if obj.CutPattern == "FollowCurve":
+                selected_wires = getattr(self, "selectedWires", [])
+                polylines = generate_curve_pattern(selected_wires, obj.SampleInterval.Value)
+                if not polylines:
+                    msg = translate("PathSurface", "No valid curve geometry found for FollowCurve.")
                     Path.Log.error(msg)
                     return []
-                geoScan = [self._planarPerformOclScan(obj, pdc, useGeom, True)]
+                geoScan = self._planarPerformOclScan(obj, pdc, polylines, False)
             else:
-                geoScan = self._planarPerformOclScan(obj, pdc, pathGeom, False)
+                self.showDebugObject(cmpdShp, "CutArea")
+                # get internal path geometry and perform OCL scan with that geometry
+                PGG = PathSurfaceSupport.PathGeometryGenerator(obj, cmpdShp, obj.CutPattern)
+                if self.showDebugObjects:
+                    PGG.setDebugObjectsGroup(self.tempGroup)
+                self.tmpCOM = PGG.getCenterOfPattern()
+                pathGeom = PGG.generatePathGeometry()
+                if pathGeom is False:
+                    msg = translate("PathSurface", "No clearing shape returned.")
+                    Path.Log.error(msg)
+                    return []
+                if obj.CutPattern == "Offset":
+                    useGeom = self._offsetFacesToPointData(obj, pathGeom, profile=False)
+                    if useGeom is False:
+                        msg = translate("PathSurface", "No clearing path geometry returned.")
+                        Path.Log.error(msg)
+                        return []
+                    geoScan = [self._planarPerformOclScan(obj, pdc, useGeom, True)]
+                else:
+                    geoScan = self._planarPerformOclScan(obj, pdc, pathGeom, False)
 
         if obj.ProfileEdges == "Only":  # ['None', 'Only', 'First', 'Last']
             SCANDATA.extend(profScan)
@@ -1293,6 +1309,17 @@ class ObjectSurface(PathOp.ObjectOp):
                                 scan.append(FreeCAD.Vector(scan[0].x, scan[0].y, scan[0].z))
                             stpOvr.append(scan)
                 if erFlg is False:
+                    SCANS.append(stpOvr)
+        elif obj.CutPattern == "FollowCurve":
+            # pathGeom is a list of polylines: [[(x,y,z), (x,y,z), ...], ...]
+            # Drop tool along each polyline segment
+            for poly in pathGeom:
+                stpOvr = []
+                for i in range(len(poly) - 1):
+                    A = poly[i]
+                    B = poly[i + 1]
+                    stpOvr.append(self._planarDropCutScan(pdc, (A[0], A[1]), (B[0], B[1])))
+                if stpOvr:
                     SCANS.append(stpOvr)
         # Eif
 

--- a/src/Mod/CAM/Path/Op/Surface.py
+++ b/src/Mod/CAM/Path/Op/Surface.py
@@ -51,7 +51,6 @@ import Path.Op.Base as PathOp
 import Path.Op.SurfaceSupport as PathSurfaceSupport
 import PathScripts.PathUtils as PathUtils
 from Path.Base.Generator.surface_pattern import generate_curve_pattern
-from Path.Base.Generator.surface_dropcutter import batch_dropcutter
 import math
 import time
 

--- a/src/Mod/CAM/Path/Op/SurfaceSupport.py
+++ b/src/Mod/CAM/Path/Op/SurfaceSupport.py
@@ -654,6 +654,11 @@ class ProcessSelectedFaces:
                         break
                 TUPS.append((mdlIdx, bs, sb))  # (model idx, base, sub)
 
+        # If wires are present or no specific model was flagged, ensure all models are enabled for STL
+        if not any(self.modelSTLs):
+            for m in range(0, lenGRP):
+                self.modelSTLs[m] = True
+
         # Apply `AvoidXFaces` value
         faceCnt = len(TUPS)
         add = faceCnt - self.obj.AvoidLastX_Faces

--- a/src/Mod/CAM/Path/Op/SurfaceSupport.py
+++ b/src/Mod/CAM/Path/Op/SurfaceSupport.py
@@ -486,6 +486,7 @@ class ProcessSelectedFaces:
         self.JOB = JOB
         self.obj = obj
         self.profileEdges = "None"
+        self.selectedWires = []
 
         if hasattr(obj, "ProfileEdges"):
             self.profileEdges = obj.ProfileEdges
@@ -545,7 +546,7 @@ class ProcessSelectedFaces:
             Path.Log.debug(" -obj.Base exists. Pre-processing for selected faces.")
 
             hasFace, hasVoid = self._identifyFacesAndVoids(FACES, VOIDS)  # modifies FACES and VOIDS
-            hasGeometry = True if hasFace or hasVoid else False
+            hasGeometry = True if hasFace or hasVoid or len(self.selectedWires) > 0 else False
 
             # Cycle through each base model, processing faces for each
             for m in range(0, lenGRP):
@@ -554,7 +555,7 @@ class ProcessSelectedFaces:
                 fShapes[m] = mFS
                 vShapes[m] = mVS
                 self.profileShapes[m] = mPS
-                if mFS or mVS:
+                if mFS or mVS or len(self.selectedWires) > 0:
                     proceed = True
             if hasGeometry and not proceed:
                 return False
@@ -673,6 +674,9 @@ class ProcessSelectedFaces:
                     V[m].append((shape, faceIdx))
                     Path.Log.debug(".. Avoiding {}".format(sub))
                     hasVoid = True
+            elif isinstance(shape, (Part.Wire, Part.Edge)):
+                self.selectedWires.append(shape)
+                Path.Log.debug(".. Curve {}".format(sub))
         return (hasFace, hasVoid)
 
     def _preProcessFacesAndVoids(self, base, FCS, VDS):
@@ -928,7 +932,9 @@ class ProcessSelectedFaces:
     def _calculateOffsetValue(self, isHole, isVoid=False):
         """_calculateOffsetValue(self.obj, isHole, isVoid) ... internal function.
         Calculate the offset for the Path.Area() function."""
-        self.JOB = PathUtils.findParentJob(self.obj)
+        parentJob = PathUtils.findParentJob(self.obj)
+        if parentJob is not None:
+            self.JOB = parentJob
         # We need to offset by at least our linear tessellation deflection
         # (default GeometryTolerance / 4) to avoid false retracts at the
         # boundaries.


### PR DESCRIPTION
## Description
This PR adds the capability to map and cut arbitrary 2D/3D outside curves (Sketches, Draft Wires, sub-edges) onto top 3D surface meshes using OpenCamLib (OCL) drop-cutter algorithms in the CAM 3D Surface operation.

### Changes
1. **Generator (`Path/Base/Generator/surface_pattern.py`)**: Added `generate_curve_pattern` to discretize wires/edges into sampled continuous XY polylines.
2. **Selection Support (`Path/Op/SurfaceSupport.py`)**: Updated `ProcessSelectedFaces` to identify and extract selected `Edge` and `Wire` subobjects into `self.selectedWires` and automatically enable base model STL generation when wire-only selections are present.
3. **3D Surface Operation (`Path/Op/Surface.py`)**:
   - Added `PathOp.FeatureBaseEdges` to `ObjectSurface.opFeatures`.
   - Registered `"FollowCurve"` in `CutPattern` enumeration.
   - Connected `FollowCurve` to OCL drop-cutter scanning pipeline.
4. **UI Integration (`Path/Op/Gui/Surface.py`)**: Task Panel dynamically populates and synchronizes `FollowCurve` in the CutPattern dropdown.
5. **Testing (`CAMTests/TestSurfacePatternGenerator.py`, `CAMTests/TestSurfaceGenerator.py`)**: Added comprehensive unit tests for discretization and end-to-end G-code drop-cutting over curved 3D solids.

## Documentation
- Adds `FollowCurve` to 3D Surface `CutPattern` property.

## Verification
- Unit and integration tests pass cleanly (`TestSurfacePatternGenerator`, `TestSurfaceGenerator`, `TestSurfaceDropCutterGenerator`, `TestPathRotarySurface`).