### PR TITLE
PartDesign: report conflicting profile labels in Loft errors

### DIFF
--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -265,12 +265,12 @@ BooleanException::BooleanException(const std::string& sMessage)
 // ------------------------------------------------
 
 LoftProfileSeparationException::LoftProfileSeparationException(
-    std::size_t firstProfile,
-    std::size_t secondProfile
+    std::size_t firstProfileIndex,
+    std::size_t secondProfileIndex
 )
     : CADKernelError("Segments of a loft do not have sufficient separation")
-    , firstProfile(firstProfile)
-    , secondProfile(secondProfile)
+    , firstProfileIndex(firstProfileIndex)
+    , secondProfileIndex(secondProfileIndex)
 {}
 
 // ------------------------------------------------

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -264,6 +264,17 @@ BooleanException::BooleanException(const std::string& sMessage)
 
 // ------------------------------------------------
 
+LoftProfileSeparationException::LoftProfileSeparationException(
+    std::size_t firstProfile,
+    std::size_t secondProfile
+)
+    : CADKernelError("Segments of a loft do not have sufficient separation")
+    , firstProfile(firstProfile)
+    , secondProfile(secondProfile)
+{}
+
+// ------------------------------------------------
+
 TYPESYSTEM_SOURCE(Part::ShapeSegment, Data::Segment)
 
 std::string ShapeSegment::getName() const

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <iosfwd>
 #include <list>
 #include <unordered_map>
@@ -96,6 +97,28 @@ public:
     explicit BooleanException(const std::string& sMessage);
     /// Destruction
     ~BooleanException() noexcept override = default;
+};
+
+/** A loft contains two consecutive profiles without sufficient separation. */
+// NOLINTNEXTLINE cppcoreguidelines-special-member-functions
+class PartExport LoftProfileSeparationException: public Base::CADKernelError
+{
+public:
+    LoftProfileSeparationException(std::size_t firstProfile, std::size_t secondProfile);
+    ~LoftProfileSeparationException() noexcept override = default;
+
+    std::size_t getFirstProfile() const
+    {
+        return firstProfile;
+    }
+    std::size_t getSecondProfile() const
+    {
+        return secondProfile;
+    }
+
+private:
+    std::size_t firstProfile;
+    std::size_t secondProfile;
 };
 
 class PartExport ShapeSegment: public Data::Segment

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -104,21 +104,21 @@ public:
 class PartExport LoftProfileSeparationException: public Base::CADKernelError
 {
 public:
-    LoftProfileSeparationException(std::size_t firstProfile, std::size_t secondProfile);
+    LoftProfileSeparationException(std::size_t firstProfileIndex, std::size_t secondProfileIndex);
     ~LoftProfileSeparationException() noexcept override = default;
 
-    std::size_t getFirstProfile() const
+    std::size_t getFirstProfileIndex() const
     {
-        return firstProfile;
+        return firstProfileIndex;
     }
-    std::size_t getSecondProfile() const
+    std::size_t getSecondProfileIndex() const
     {
-        return secondProfile;
+        return secondProfileIndex;
     }
 
 private:
-    std::size_t firstProfile;
-    std::size_t secondProfile;
+    std::size_t firstProfileIndex;
+    std::size_t secondProfileIndex;
 };
 
 class PartExport ShapeSegment: public Data::Segment

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4527,11 +4527,11 @@ TopoShape& TopoShape::makeElementLoft(
         FC_THROWM(Base::CADKernelError, "Need at least two vertices, edges or wires to create loft face");
     }
 
-    int i = 0;
+    std::size_t i = 0;
     for (auto& sh : profiles) {
         if (i > 0) {
             if (!checkProfiles(sh, profiles[i - 1])) {
-                FC_THROWM(Base::CADKernelError, "Segments of a loft do not have sufficient separation");
+                throw LoftProfileSeparationException(i - 1, i);
             }
         }
         const auto& shape = sh.getShape();

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -254,11 +254,11 @@ App::DocumentObjectExecReturn* Loft::execute()
                 ));
             }
             catch (const Part::LoftProfileSeparationException& e) {
-                const auto first = e.getFirstProfile();
-                const auto second = e.getSecondProfile();
-                if (second < sectionLabels.size()) {
+                const auto firstIndex = e.getFirstProfileIndex();
+                const auto secondIndex = e.getSecondProfileIndex();
+                if (firstIndex < sectionLabels.size() && secondIndex < sectionLabels.size()) {
                     return new App::DocumentObjectExecReturn(
-                        "'" + sectionLabels[first] + "' and '" + sectionLabels[second]
+                        "'" + sectionLabels[firstIndex] + "' and '" + sectionLabels[secondIndex]
                         + "' do not have sufficient separation"
                     );
                 }

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -194,6 +194,21 @@ App::DocumentObjectExecReturn* Loft::execute()
             );
         }
 
+        const auto& firstSection = multisections.front();
+        const auto& profileSubelements = Profile.getSubValues();
+        const auto isWholeObjectReference = [](const std::vector<std::string>& subelements) {
+            return subelements.empty() || (subelements.size() == 1 && subelements.front().empty());
+        };
+        const bool referencesSameSubelements = profileSubelements == firstSection.second
+            || (isWholeObjectReference(profileSubelements)
+                && isWholeObjectReference(firstSection.second));
+        if (Profile.getValue() == firstSection.first && referencesSameSubelements) {
+            const std::string label = Profile.getValue()->Label.getStrValue();
+            return new App::DocumentObjectExecReturn(
+                "'" + label + "' cannot be used as both the profile and the first section"
+            );
+        }
+
         std::vector<std::vector<TopoShape>> wiresections;
         wiresections.reserve(wires.size());
         for (auto& wire : wires) {
@@ -206,6 +221,13 @@ App::DocumentObjectExecReturn* Loft::execute()
                  getSectionShape("Section", subSet.first, subSet.second, wiresections.size())) {
                 wiresections[i++].push_back(s);
             }
+        }
+
+        std::vector<std::string> sectionLabels;
+        sectionLabels.reserve(multisections.size() + 1);
+        sectionLabels.push_back(Profile.getValue()->Label.getStrValue());
+        for (const auto& section : multisections) {
+            sectionLabels.push_back(section.first->Label.getStrValue());
         }
 
         bool closed = Closed.getValue();
@@ -223,12 +245,25 @@ App::DocumentObjectExecReturn* Loft::execute()
             for (auto& wire : sectionWires) {
                 wire.move(invObjLoc);
             }
-            shells.push_back(TopoShape(0, hasher).makeElementLoft(
-                sectionWires,
-                Part::IsSolid::notSolid,
-                Ruled.getValue() ? Part::IsRuled::ruled : Part::IsRuled::notRuled,
-                closed ? Part::IsClosed::closed : Part::IsClosed::notClosed
-            ));
+            try {
+                shells.push_back(TopoShape(0, hasher).makeElementLoft(
+                    sectionWires,
+                    Part::IsSolid::notSolid,
+                    Ruled.getValue() ? Part::IsRuled::ruled : Part::IsRuled::notRuled,
+                    closed ? Part::IsClosed::closed : Part::IsClosed::notClosed
+                ));
+            }
+            catch (const Part::LoftProfileSeparationException& e) {
+                const auto first = e.getFirstProfile();
+                const auto second = e.getSecondProfile();
+                if (second < sectionLabels.size()) {
+                    return new App::DocumentObjectExecReturn(
+                        "'" + sectionLabels[first] + "' and '" + sectionLabels[second]
+                        + "' do not have sufficient separation"
+                    );
+                }
+                throw;
+            }
         }
 
         // build the top and bottom face, sew the shell and build the final solid

--- a/src/Mod/PartDesign/PartDesignTests/TestLoft.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestLoft.py
@@ -58,6 +58,64 @@ class TestLoft(unittest.TestCase):
         self.Doc.recompute()
         self.assertAlmostEqual(self.AdditiveLoft.Shape.Volume, 1)
 
+    def testDuplicateProfileReportsItsLabel(self):
+        body = self.Doc.addObject("PartDesign::Body", "Body")
+
+        profile = body.newObject("Sketcher::SketchObject", "Profile")
+        profile.Label = "Profile A"
+        profile.addGeometry(
+            Part.Circle(Base.Vector(), Base.Vector(0, 0, 1), 10),
+            False,
+        )
+
+        section = body.newObject("Sketcher::SketchObject", "Section")
+        section.Label = "Section B"
+        section.Placement.Base.z = 20
+        section.addGeometry(
+            Part.Circle(Base.Vector(), Base.Vector(0, 0, 1), 8),
+            False,
+        )
+
+        loft = body.newObject("PartDesign::AdditiveLoft", "AdditiveLoft")
+        loft.Profile = profile
+        loft.Sections = [profile, section]
+        self.Doc.recompute()
+
+        self.assertFalse(loft.isValid())
+        self.assertIn(
+            "'Profile A' cannot be used as both the profile and the first section",
+            loft.getStatusString(),
+        )
+
+    def testUnseparatedSectionsReportTheirLabels(self):
+        body = self.Doc.addObject("PartDesign::Body", "Body")
+
+        sketches = []
+        for name, label, z in (
+            ("Profile", "Profile A", 0),
+            ("SectionB", "Section B", 20),
+            ("SectionC", "Section C", 20),
+        ):
+            sketch = body.newObject("Sketcher::SketchObject", name)
+            sketch.Label = label
+            sketch.Placement.Base.z = z
+            sketch.addGeometry(
+                Part.Circle(Base.Vector(), Base.Vector(0, 0, 1), 10),
+                False,
+            )
+            sketches.append(sketch)
+
+        loft = body.newObject("PartDesign::AdditiveLoft", "AdditiveLoft")
+        loft.Profile = sketches[0]
+        loft.Sections = sketches[1:]
+        self.Doc.recompute()
+
+        self.assertFalse(loft.isValid())
+        self.assertIn(
+            "'Section B' and 'Section C' do not have sufficient separation",
+            loft.getStatusString(),
+        )
+
     def testSimpleSubtractiveLoftCase(self):
         self.Body = self.Doc.addObject("PartDesign::Body", "Body")
         self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "SketchPad")


### PR DESCRIPTION
- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Description

Fixes #32162.

PartDesign Loft now identifies the profiles that cause insufficient-separation errors by their document
labels. It also reports a specific error when the same object is used as both the profile and the first
section.

The geometry layer in Part reports the conflicting profile indices through a structured exception.
PartDesign translates those indices into user-facing object labels.

## Testing

- Added regression tests for both error cases
- PartDesign tests: 7 passed
- Part and PartDesign compiled successfully
- clang-format produced no changes

## Before and after

**Before**

https://github.com/user-attachments/assets/21c733b8-c121-46d2-9ee1-e25e8c56d3fe

**After**

https://github.com/user-attachments/assets/f60b587a-41ec-46a5-a8a9-7b28f5332e0a

## AI disclosure

GPT-5 (Codex) assisted with code investigation, implementation, tests, review, and preparation of this
pull request. I reviewed and validated the resulting changes.