### PR TITLE
CAM: Fix modal gcode and blend command output

### DIFF
--- a/src/Mod/CAM/CAMTests/TestLinuxCNCPost.py
+++ b/src/Mod/CAM/CAMTests/TestLinuxCNCPost.py
@@ -252,6 +252,50 @@ class TestLinuxCNCPost(PathTestUtils.PathTestBase):
 
         self.assertIn("G64", preamble, "G64 command not found preamble: full gcode\n{gcode}")
 
+    def test_blend_command_separated_from_preamble(self):
+        """The blend command must not run into the last word of the preamble.
+
+        _expand_prefix() appends the blend command to PREAMBLE. Without a
+        separator the LinuxCNC default preamble came out as
+        "G17 G54 G40 G49 G80 G90G64 P0.0010", i.e. neither a G90 nor a G64.
+        """
+        self.profile_op.Path = Path.Path([])
+        self.post._machine.postprocessor_properties["blend_mode"] = "BLEND"
+        self.post._machine.postprocessor_properties["blend_tolerance"] = 0.001
+        self.post._machine.output.comments.enabled = False
+        self.post._machine.output.output_header = False
+
+        gcode, preamble = self._gcode_and_preamble()
+
+        self.assertIn(
+            "G17 G54 G40 G49 G80 G90 G64 P0.0010",
+            preamble,
+            f"Blend command should be a separate word, in\n{gcode}",
+        )
+
+    def test_blend_command_separator_cases(self):
+        """_expand_prefix() only adds a separator when one is missing.
+
+        An empty (or unset) preamble must not gain a leading space, and a
+        preamble that already ends in a newline must keep the blend command on
+        its own line.
+        """
+        cases = [
+            ("G17 G54 G40 G49 G80 G90", "G17 G54 G40 G49 G80 G90 G64 P0.0010"),
+            ("G17 G90\n", "G17 G90\nG64 P0.0010"),
+            ("G17 G90 ", "G17 G90 G64 P0.0010"),
+            ("", "G64 P0.0010"),
+            (None, "G64 P0.0010"),
+        ]
+
+        for preamble, expected in cases:
+            with self.subTest(preamble=preamble):
+                self.post.values["BLEND_MODE"] = "BLEND"
+                self.post.values["BLEND_TOLERANCE"] = 0.001
+                self.post.values["PREAMBLE"] = preamble
+                self.post._expand_prefix([])
+                self.assertEqual(self.post.values["PREAMBLE"], expected)
+
     def test_rigid_tapping_g84_basic(self):
         """
         Test G84 rigid tapping conversion to G33.1 sequence.

--- a/src/Mod/CAM/CAMTests/TestPostOutput.py
+++ b/src/Mod/CAM/CAMTests/TestPostOutput.py
@@ -1700,6 +1700,122 @@ class TestExport2Integration(unittest.TestCase):
                 f"Bare G0 with no parameters should be suppressed, found: {bare_g0}",
             )
 
+    def test129b_modal_commands_and_axes_together(self):
+        """
+        Test that modal G-code words and modal axes both apply to the same run
+        of moves.
+
+        Modal axis has to run on the original command so that the running axis
+        state is accumulated under the command's real name.  Deriving it from
+        the name-stripped command made every other move compare unequal to its
+        predecessor, so the G-code word came back on alternating lines, and the
+        stripped lines kept a leading separator from the empty command name:
+
+            BEFORE: G0 Z7.000
+                    G1 X3.750 Y2.625
+                    " X3.753 Y2.621"     <- leading space, G1 wrongly dropped/restored
+                    G1 X3.756 Y2.617     <- G1 re-emitted
+                    " X3.758 Y2.612"
+                    G1 Y2.598
+
+            AFTER:  G0 Z7.000
+                    G1 X3.750 Y2.625
+                    X3.753 Y2.621
+                    X3.756 Y2.617
+                    X3.758 Y2.612
+                    Y2.598               <- X unchanged, so only Y is emitted
+        """
+        machine = self._create_machine(
+            commands=False,
+            parameters=False,
+            axis_precision=3,
+            line_numbers=False,
+            comments_enabled=False,
+            output_header=False,
+        )
+
+        with self._modify_operation_path(
+            [
+                Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 7.0}),
+                Path.Command("G1", {"X": 3.750, "Y": 2.625}),
+                Path.Command("G1", {"X": 3.753, "Y": 2.621}),
+                Path.Command("G1", {"X": 3.756, "Y": 2.617}),
+                Path.Command("G1", {"X": 3.758, "Y": 2.612}),
+                Path.Command("G1", {"X": 3.758, "Y": 2.598}),
+            ]
+        ):
+            results = self._run_export2(machine)
+            gcode = self._get_first_section_gcode(results)
+
+            # NB: deliberately not stripped, a stripped line hides the leading
+            # separator that an empty command name used to leave behind.
+            lines = gcode.split("\n")
+
+            expected = [
+                "G1 X3.750 Y2.625",
+                "X3.753 Y2.621",
+                "X3.756 Y2.617",
+                "X3.758 Y2.612",
+                "Y2.598",
+            ]
+
+            self.assertIn(
+                expected[0],
+                lines,
+                f"First cut should carry its G1, in\n{gcode}",
+            )
+            start = lines.index(expected[0])
+            self.assertEqual(
+                lines[start : start + len(expected)],
+                expected,
+                f"Modal moves should keep the G1 only on the first line, in\n{gcode}",
+            )
+
+    def test129c_modal_commands_without_modal_axes(self):
+        """
+        Test that modal G-code words alone (duplicates.parameters=True) still
+        drop only the command word, keeping every parameter.
+
+        Expected:
+            G1 X3.750 Y2.625
+            X3.753 Y2.621
+            X3.758 Y2.625     <- Y is a duplicate, but axis modal is off
+        """
+        machine = self._create_machine(
+            commands=False,
+            parameters=True,
+            axis_precision=3,
+            line_numbers=False,
+            comments_enabled=False,
+            output_header=False,
+        )
+
+        with self._modify_operation_path(
+            [
+                Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 7.0}),
+                Path.Command("G1", {"X": 3.750, "Y": 2.625}),
+                Path.Command("G1", {"X": 3.753, "Y": 2.621}),
+                Path.Command("G1", {"X": 3.758, "Y": 2.625}),
+            ]
+        ):
+            results = self._run_export2(machine)
+            gcode = self._get_first_section_gcode(results)
+            lines = gcode.split("\n")
+
+            expected = [
+                "G1 X3.750 Y2.625",
+                "X3.753 Y2.621",
+                "X3.758 Y2.625",
+            ]
+
+            self.assertIn(expected[0], lines, f"First cut should carry its G1, in\n{gcode}")
+            start = lines.index(expected[0])
+            self.assertEqual(
+                lines[start : start + len(expected)],
+                expected,
+                f"Only the G1 word should be dropped, in\n{gcode}",
+            )
+
     def test130_modal_state_reset_after_tool_change(self):
         """
         Test that modal state resets after tool change so parameters are not

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -2094,16 +2094,16 @@ class PostProcessor:
 
             else:
 
-                # Modal GCode
-                if not self.values["OUTPUT_DUPLICATE_COMMANDS"]:
-                    next_previous, new_command = modal_gcode(cmd, section_state["previous"])
-                else:
-                    new_command = cmd
-                    next_previous = cmd
+                # Modal Axis always runs on the original command, so "previous"
+                # accumulates the axis state under the command's real name.
+                # Deriving it from a name-stripped command instead makes every
+                # other duplicate compare unequal and re-emit its gcode word.
+                next_previous, axis_command = modal_axis(cmd, section_state["previous"])
+                new_command = axis_command if not self.values["OUTPUT_DOUBLES"] else cmd
 
-                # Modal Axis
-                if not self.values["OUTPUT_DOUBLES"]:
-                    next_previous, new_command = modal_axis(new_command, section_state["previous"])
+                # Modal GCode
+                if not self.values["OUTPUT_DUPLICATE_COMMANDS"] and new_command is not None:
+                    _, new_command = modal_gcode(new_command, section_state["previous"])
 
                 section_state["previous"] = next_previous
 
@@ -2837,7 +2837,11 @@ class PostProcessor:
             prefix = self.values["LINE_NUMBER_PREFIX"]
             command_line.append(f"{prefix}{ int(params['N']):d}")
 
-        command_line.append(command_name)
+        # A modal-stripped command has no name. Appending it anyway leaves an
+        # empty leading element, which format_command_line renders as a leading
+        # separator: "G1 X1.0 Y2.0" followed by " X3.0 Y4.0".
+        if command_name:
+            command_line.append(command_name)
 
         # Format parameters with clean, stateless implementation
         parameter_order = self.values.get(
@@ -2878,6 +2882,11 @@ class PostProcessor:
 
                 formatted_value = self.format_parameter(parameter, current_value, command_name)
                 command_line.append(f"{parameter}{formatted_value}")
+
+        # Nothing left to emit, e.g. a modal command whose parameters were all
+        # suppressed as duplicates.
+        if not command_line:
+            return None
 
         # Format the command line
         formatted_line = format_command_line(self.values, command_line)

--- a/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
@@ -165,9 +165,12 @@ class Linuxcnc(PostProcessor):
         """inject blend command"""
         blend = self._get_blend_command()
 
-        if self.values["PREAMBLE"] is None:
-            self.values["PREAMBLE"] = ""
-        self.values["PREAMBLE"] += blend
+        preamble = self.values["PREAMBLE"] or ""
+        # Separate the blend command from whatever the preamble ends with,
+        # otherwise "... G80 G90" + "G64 P0.0010" runs together as "G90G64".
+        if preamble and not preamble[-1].isspace():
+            preamble += " "
+        self.values["PREAMBLE"] = preamble + blend
 
         super()._expand_prefix(postables)
 


### PR DESCRIPTION
Modal dedup no longer drops or misplaces command words, and the LinuxCNC blend command is separated from the preamble instead of concatenated.

### Modal G-code words alternating
`Processor.py` — `_optimize_duplicates_doubles`

**Before**
```
G0 Z7.000
G1 X3.750 Y2.625
 X3.753 Y2.621
G1 X3.756 Y2.617
 X3.758 Y2.612
G1 Y2.598
```

**After**
```
G0 Z7.000
G1 X3.750 Y2.625
X3.753 Y2.621
X3.756 Y2.617
X3.758 Y2.612
Y2.598
```

### Leading space on stripped lines
`Processor.py` — `_convert_move`

**Before**
```
G1 X3.750 Y2.625
 X3.753 Y2.621
```

**After**
```
G1 X3.750 Y2.625
X3.753 Y2.621
```

### Blend command glued to preamble
`linuxcnc_post.py` — `_expand_prefix`

**Before**
```
G17 G54 G40 G49 G80 G90G64 P0.0010
G17 G54 G40 G49 G80 G90G61
G17 G54 G40 G49 G80 G90G61.1
```

**After**
```
G17 G54 G40 G49 G80 G90 G64 P0.0010
G17 G54 G40 G49 G80 G90 G61
G17 G54 G40 G49 G80 G90 G61.1
```



- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
