### PR TITLE
Sketcher: split datum label preselection semantics

### DIFF
--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -1299,6 +1299,14 @@ void SoDatumLabel::setVertexZ(SbVec3f& point, float z) const
     point[2] = z;
 }
 
+SoDatumLabel::SelectionPart SoDatumLabel::classifySelectionPoint(const SbVec3f& objectPoint) const
+{
+    constexpr float annotationThreshold = (ZCONSTR + ZARROW_TEXT_OFFSET) * 0.5F;
+
+    return objectPoint[2] > annotationThreshold ? SelectionPart::Annotation
+                                                : SelectionPart::Presentation;
+}
+
 void SoDatumLabel::ensureCoinGeometry(const SbVec3f* points, int numPoints)
 {
     if (!points || numPoints <= 0 || !m_LineVertexProperty || !m_LineSet

--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -1301,10 +1301,12 @@ void SoDatumLabel::setVertexZ(SbVec3f& point, float z) const
 
 SoDatumLabel::SelectionPart SoDatumLabel::classifySelectionPoint(const SbVec3f& objectPoint) const
 {
-    constexpr float annotationThreshold = (ZCONSTR + ZARROW_TEXT_OFFSET) * 0.5F;
+    // Geometry lies on one of two known Z layers. Coin returns an intersection point rather
+    // than the stored vertex value, so classify it by the nearest layer without an epsilon.
+    constexpr float selectionBoundary = (ZCONSTR + ZARROW_TEXT_OFFSET) * 0.5F;
 
-    return objectPoint[2] > annotationThreshold ? SelectionPart::Annotation
-                                                : SelectionPart::Presentation;
+    return objectPoint[2] > selectionBoundary ? SelectionPart::Annotation
+                                              : SelectionPart::Presentation;
 }
 
 void SoDatumLabel::ensureCoinGeometry(const SbVec3f* points, int numPoints)

--- a/src/Gui/SoDatumLabel.h
+++ b/src/Gui/SoDatumLabel.h
@@ -75,6 +75,11 @@ public:
         ARCLENGTH
     };
 
+    /** Identifies which visual layer of a datum label produced a selection hit.
+     *
+     * Presentation contains the dimension and extension lines. Annotation contains the
+     * label text and arrowheads, which receive higher preselection priority.
+     */
     enum class SelectionPart
     {
         Presentation,
@@ -88,6 +93,12 @@ public:
     To draw on other planes, you need to attach a SoTransform to the SoDatumLabel (or parent).*/
     void setPoints(SbVec3f p1, SbVec3f p2);
 
+    /** Classifies a picked point as presentation geometry or annotation geometry.
+     *
+     * @param objectPoint Pick intersection in this node's object coordinate system.
+     * @return Annotation for the text/arrow Z layer; Presentation for the
+     *         dimension/extension-line Z layer.
+     */
     [[nodiscard]] SelectionPart classifySelectionPoint(const SbVec3f& objectPoint) const;
 
     /* returns the center point of the text of the label */

--- a/src/Gui/SoDatumLabel.h
+++ b/src/Gui/SoDatumLabel.h
@@ -75,12 +75,20 @@ public:
         ARCLENGTH
     };
 
+    enum class SelectionPart
+    {
+        Presentation,
+        Annotation
+    };
+
     static void initClass();
     SoDatumLabel();
 
     /*The points have to be on XY plane, ie they need to be 2D points.
     To draw on other planes, you need to attach a SoTransform to the SoDatumLabel (or parent).*/
     void setPoints(SbVec3f p1, SbVec3f p2);
+
+    [[nodiscard]] SelectionPart classifySelectionPoint(const SbVec3f& objectPoint) const;
 
     /* returns the center point of the text of the label */
     SbVec3f getLabelTextCenter();

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -84,10 +84,11 @@ struct ScreenPreselectionPolicy
 struct PreselectionPriority
 {
     static constexpr int None = 0;
-    static constexpr int ConstraintDatumLabel = 100;
+    static constexpr int ConstraintDatumPresentation = 100;
     static constexpr int Axis = 300;
     static constexpr int ConstraintFallback = 350;
     static constexpr int Edge = 400;
+    static constexpr int ConstraintDatumAnnotation = 425;
     static constexpr int ConstraintIcon = 450;
     static constexpr int Point = 500;
 };
@@ -103,8 +104,11 @@ int preselectionPriority(const EditModeCoinManager::PreselectionResult& result)
             if (result.ConstraintKind == Result::ConstraintHitKind::Icon) {
                 return PreselectionPriority::ConstraintIcon;
             }
-            if (result.ConstraintKind == Result::ConstraintHitKind::DatumLabel) {
-                return PreselectionPriority::ConstraintDatumLabel;
+            if (result.ConstraintKind == Result::ConstraintHitKind::DatumPresentation) {
+                return PreselectionPriority::ConstraintDatumPresentation;
+            }
+            if (result.ConstraintKind == Result::ConstraintHitKind::DatumAnnotation) {
+                return PreselectionPriority::ConstraintDatumAnnotation;
             }
             return PreselectionPriority::ConstraintFallback;
         case Result::HitKind::Edge:
@@ -1247,8 +1251,11 @@ EditModeCoinManager::PreselectionResult EditModeCoinManager::detectConstraintPre
             case ConstraintResult::HitKind::Icon:
                 target.ConstraintKind = PreselectionResult::ConstraintHitKind::Icon;
                 break;
-            case ConstraintResult::HitKind::DatumLabel:
-                target.ConstraintKind = PreselectionResult::ConstraintHitKind::DatumLabel;
+            case ConstraintResult::HitKind::DatumPresentation:
+                target.ConstraintKind = PreselectionResult::ConstraintHitKind::DatumPresentation;
+                break;
+            case ConstraintResult::HitKind::DatumAnnotation:
+                target.ConstraintKind = PreselectionResult::ConstraintHitKind::DatumAnnotation;
                 break;
             case ConstraintResult::HitKind::None:
                 target.ConstraintKind = PreselectionResult::ConstraintHitKind::None;

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -195,7 +195,8 @@ public:
         {
             None,
             Icon,
-            DatumLabel
+            DatumPresentation,
+            DatumAnnotation
         };
 
         enum SpecialValues

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2207,10 +2207,13 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
     }
 
     // Handle selection of datum labels (e.g., radius, distance dimensions).
-    if (dynamic_cast<SoDatumLabel*>(tail)) {
+    if (auto* datumLabel = dynamic_cast<SoDatumLabel*>(tail)) {
         for (int i = 0; i < editModeScenegraphNodes.constrGroup->getNumChildren(); ++i) {
             if (editModeScenegraphNodes.constrGroup->getChild(i) == sep) {
-                result.Kind = ConstraintPreselectionResult::HitKind::DatumLabel;
+                result.Kind = datumLabel->classifySelectionPoint(Point->getObjectPoint())
+                        == SoDatumLabel::SelectionPart::Annotation
+                    ? ConstraintPreselectionResult::HitKind::DatumAnnotation
+                    : ConstraintPreselectionResult::HitKind::DatumPresentation;
                 result.ConstrIndices.insert(i);
                 result.PickedPoint = Base::convertTo<Base::Vector3d>(Point->getPoint());
                 break;

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
@@ -104,7 +104,8 @@ public:
         {
             None,
             Icon,
-            DatumLabel
+            DatumPresentation,
+            DatumAnnotation
         };
 
         HitKind Kind = HitKind::None;

--- a/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
@@ -315,7 +315,7 @@ class SketcherGuiTestCases(unittest.TestCase):
             )
         )
         self.sketch.setLabelDistance(constraint_id, 0.0)
-        self.sketch.setLabelPosition(constraint_id, 0.0)
+        self.sketch.setLabelPosition(constraint_id, 12.0)
         self.expected_constraint_name = f"Constraint{constraint_id + 1}"
         self.doc.recompute()
         self.pump_gui_events(12)
@@ -336,3 +336,60 @@ class SketcherGuiTestCases(unittest.TestCase):
 
         self.assertGreater(len(edge_offsets), 0, detail)
         self.assertEqual(unexpected_probe_results, [], detail)
+
+    def testDistanceDatumTextWinsOverOverlappingCurve(self):
+        start_point = FreeCAD.Vector(80.0, 100.0, 0.0)
+        end_point = FreeCAD.Vector(130.0, 100.0, 0.0)
+        midpoint = FreeCAD.Vector(105.0, 100.0, 0.0)
+
+        line_id = self.sketch.addGeometry(
+            Part.LineSegment(start_point, end_point),
+            False,
+        )
+        self.doc.recompute()
+        self.pump_gui_events(6)
+
+        self.configure_view_state(self.view)
+        self.pump_gui_events(8)
+
+        midpoint_coin = tuple(int(value) for value in self.view.getPointOnViewport(midpoint))
+
+        before_info = SketcherGui.getActiveSketchPreselection(midpoint_coin)
+        before_kind = self.classify_preselection(before_info, "Constraint0")
+
+        constraint_id = self.sketch.addConstraint(
+            Sketcher.Constraint(
+                "Distance",
+                line_id,
+                1,
+                line_id,
+                2,
+                start_point.distanceToPoint(end_point),
+            )
+        )
+        self.sketch.setLabelDistance(constraint_id, 0.0)
+        self.sketch.setLabelPosition(constraint_id, 0.0)
+        self.expected_constraint_name = f"Constraint{constraint_id + 1}"
+        self.doc.recompute()
+        self.pump_gui_events(12)
+
+        text_coin = self.find_constraint_probe_viewport_point(
+            self.view,
+            midpoint,
+            self.expected_constraint_name,
+            span=32,
+            step=2,
+        )
+        after_info = (
+            SketcherGui.getActiveSketchPreselection(text_coin) if text_coin is not None else None
+        )
+        after_kind = self.classify_preselection(after_info, self.expected_constraint_name)
+
+        detail = (
+            f"before_info={before_info}, after_info={after_info}, "
+            f"midpoint_coin={midpoint_coin}, text_coin={text_coin}"
+        )
+
+        self.assertEqual(before_kind, "edge", detail)
+        self.assertIsNotNone(text_coin, detail)
+        self.assertEqual(after_kind, "target_constraint", detail)

--- a/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
@@ -65,6 +65,8 @@ class SketcherGuiTestCases(unittest.TestCase):
             return "vertex"
         if any(name.startswith("Edge") for name in names):
             return "edge"
+        if any(name.endswith("_Axis") for name in names):
+            return "axis"
         return "other"
 
     @classmethod
@@ -123,16 +125,16 @@ class SketcherGuiTestCases(unittest.TestCase):
     @classmethod
     def configure_view_state(cls, view, tilt=None):
         view.viewTop()
-        cls.pump_gui_events(2)
+        cls.pump_gui_events()
         view.fitAll()
-        cls.pump_gui_events(4)
+        cls.pump_gui_events()
 
         if tilt is not None:
             base_rotation = view.getCameraOrientation()
             view.setCameraOrientation(tilt.multiply(base_rotation))
-            cls.pump_gui_events(3)
+            cls.pump_gui_events()
             view.fitAll()
-            cls.pump_gui_events(4)
+            cls.pump_gui_events()
 
     @staticmethod
     def constraint_share(counts):
@@ -155,7 +157,7 @@ class SketcherGuiTestCases(unittest.TestCase):
         FreeCADGui.getMainWindow().show()
         self.pump_gui_events()
         FreeCADGui.ActiveDocument.setEdit(self.sketch.Name)
-        self.pump_gui_events(6)
+        self.pump_gui_events()
 
         self.view = FreeCADGui.ActiveDocument.ActiveView
 
@@ -164,19 +166,19 @@ class SketcherGuiTestCases(unittest.TestCase):
         FreeCADGui.Selection.clearSelection()
         if FreeCADGui.ActiveDocument:
             FreeCADGui.ActiveDocument.resetEdit()
-        self.pump_gui_events(4, 0.01)
+        self.pump_gui_events()
 
         if self.doc is not None:
             document_name = self.doc.Name
             self.doc = None
             FreeCAD.closeDocument(document_name)
-            self.pump_gui_events(4, 0.01)
+            self.pump_gui_events()
 
     def testPointOnObjectPreselectionMatchesTiltedHitArea(self):
         constraint_id, self.probe_point = self.build_issue_25840_sketch(self.sketch)
         self.expected_constraint_name = f"Constraint{constraint_id + 1}"
         self.doc.recompute()
-        self.pump_gui_events(6)
+        self.pump_gui_events()
 
         tilt_y = FreeCAD.Rotation(FreeCAD.Vector(0, 1, 0), 2.0)
 
@@ -232,10 +234,9 @@ class SketcherGuiTestCases(unittest.TestCase):
         )
         self.sketch.addGeometry(Part.Point(marker_point), False)
         self.doc.recompute()
-        self.pump_gui_events(6)
+        self.pump_gui_events()
 
         self.configure_view_state(self.view)
-        self.pump_gui_events(8)
 
         marker_coin = tuple(int(value) for value in self.view.getPointOnViewport(marker_point))
 
@@ -255,7 +256,7 @@ class SketcherGuiTestCases(unittest.TestCase):
         self.sketch.setLabelPosition(constraint_id, 0.0)
         self.expected_constraint_name = f"Constraint{constraint_id + 1}"
         self.doc.recompute()
-        self.pump_gui_events(12)
+        self.pump_gui_events()
 
         marker_info = SketcherGui.getActiveSketchPreselection(marker_coin)
         marker_kind = self.classify_preselection(marker_info, self.expected_constraint_name)
@@ -281,17 +282,16 @@ class SketcherGuiTestCases(unittest.TestCase):
     def testCurveWinsOverOverlappingDistanceDimensionLine(self):
         start_point = FreeCAD.Vector(80.0, 100.0, 0.0)
         end_point = FreeCAD.Vector(130.0, 100.0, 0.0)
-        midpoint = FreeCAD.Vector(105.0, 100.0, 0.0)
+        midpoint = (start_point + end_point) * 0.5
 
         line_id = self.sketch.addGeometry(
             Part.LineSegment(start_point, end_point),
             False,
         )
         self.doc.recompute()
-        self.pump_gui_events(6)
+        self.pump_gui_events()
 
         self.configure_view_state(self.view)
-        self.pump_gui_events(8)
 
         midpoint_coin = tuple(int(value) for value in self.view.getPointOnViewport(midpoint))
 
@@ -318,7 +318,7 @@ class SketcherGuiTestCases(unittest.TestCase):
         self.sketch.setLabelPosition(constraint_id, 12.0)
         self.expected_constraint_name = f"Constraint{constraint_id + 1}"
         self.doc.recompute()
-        self.pump_gui_events(12)
+        self.pump_gui_events()
 
         probe_results = []
         for dx, dy in edge_offsets:
@@ -340,17 +340,16 @@ class SketcherGuiTestCases(unittest.TestCase):
     def testDistanceDatumTextWinsOverOverlappingCurve(self):
         start_point = FreeCAD.Vector(80.0, 100.0, 0.0)
         end_point = FreeCAD.Vector(130.0, 100.0, 0.0)
-        midpoint = FreeCAD.Vector(105.0, 100.0, 0.0)
+        midpoint = (start_point + end_point) * 0.5
 
         line_id = self.sketch.addGeometry(
             Part.LineSegment(start_point, end_point),
             False,
         )
         self.doc.recompute()
-        self.pump_gui_events(6)
+        self.pump_gui_events()
 
         self.configure_view_state(self.view)
-        self.pump_gui_events(8)
 
         midpoint_coin = tuple(int(value) for value in self.view.getPointOnViewport(midpoint))
 
@@ -371,7 +370,7 @@ class SketcherGuiTestCases(unittest.TestCase):
         self.sketch.setLabelPosition(constraint_id, 0.0)
         self.expected_constraint_name = f"Constraint{constraint_id + 1}"
         self.doc.recompute()
-        self.pump_gui_events(12)
+        self.pump_gui_events()
 
         text_coin = self.find_constraint_probe_viewport_point(
             self.view,
@@ -393,3 +392,65 @@ class SketcherGuiTestCases(unittest.TestCase):
         self.assertEqual(before_kind, "edge", detail)
         self.assertIsNotNone(text_coin, detail)
         self.assertEqual(after_kind, "target_constraint", detail)
+
+    def testAngleDatumTextWinsOverHorizontalAxis(self):
+        first_line = self.sketch.addGeometry(
+            Part.LineSegment(
+                FreeCAD.Vector(0.0, 0.0, 0.0),
+                FreeCAD.Vector(50.0, 50.0 * math.tan(math.radians(30.0)), 0.0),
+            ),
+            False,
+        )
+        second_line = self.sketch.addGeometry(
+            Part.LineSegment(
+                FreeCAD.Vector(0.0, 0.0, 0.0),
+                FreeCAD.Vector(50.0, -50.0 * math.tan(math.radians(30.0)), 0.0),
+            ),
+            False,
+        )
+        self.doc.recompute()
+        self.pump_gui_events()
+
+        self.configure_view_state(self.view)
+
+        # The angle bisector is the horizontal axis, so the label text will be centered at
+        # x=20, y=0.
+        text_center = FreeCAD.Vector(20.0, 0.0, 0.0)
+        before_info = SketcherGui.getActiveSketchPreselection(
+            tuple(int(value) for value in self.view.getPointOnViewport(text_center))
+        )
+        before_kind = self.classify_preselection(before_info, "Constraint0")
+
+        constraint_id = self.sketch.addConstraint(
+            Sketcher.Constraint(
+                "Angle",
+                first_line,
+                1,
+                second_line,
+                1,
+                math.radians(-60.0),
+            )
+        )
+        self.sketch.setLabelDistance(constraint_id, 10.0)
+        self.expected_constraint_name = f"Constraint{constraint_id + 1}"
+        self.doc.recompute()
+        self.pump_gui_events()
+
+        text_coin = self.find_constraint_probe_viewport_point(
+            self.view,
+            text_center,
+            self.expected_constraint_name,
+            span=32,
+            step=2,
+        )
+        info = SketcherGui.getActiveSketchPreselection(text_coin) if text_coin is not None else None
+        kind = self.classify_preselection(info, self.expected_constraint_name)
+
+        detail = (
+            f"before_info={before_info}, before_kind={before_kind}, "
+            f"info={info}, kind={kind}, text_center={text_center}, text_coin={text_coin}"
+        )
+
+        self.assertEqual(before_kind, "axis", detail)
+        self.assertIsNotNone(text_coin, detail)
+        self.assertEqual(kind, "target_constraint", detail)


### PR DESCRIPTION
Fixes #32255.
Fixes https://github.com/FreeCAD/FreeCAD/issues/17744.

Dimension labels contain two kinds of visual elements: annotation elements such as text and arrowheads, which should appear in front of sketch geometry, and presentation elements such as witness, dimension, and helper lines, which should remain behind it.

Previously, Sketcher treated both as the same `DatumLabel` preselection type. This meant that increasing the priority enough for dimension text also caused dimension lines to mask sketch edges. Keeping the priority low avoided that problem, but made dimension text impossible to select when it overlapped geometry.

The fix splits `SoDatumLabel` hits into two semantic classes:

- Datum annotations: text and arrowheads, priority 425
- Datum presentation: witness, dimension, and helper lines, priority 100

Edges retain priority 400, while point markers and constraint icons retain higher priorities.

This gives the expected behavior:

- Clicking dimension text over a sketch edge selects the dimension.
- Clicking a dimension or witness line over a sketch edge selects the edge.
- Point markers remain easier to select than dimension text.

The regression coverage was also corrected. The existing edge-preselection test was unintentionally placing the dimension text directly on the edge, so it was testing the wrong scenario. The text was moved away for that test, and a separate test was added to verify that overlapping dimension text wins over the curve.
