### PR TITLE
TechDraw: Add quick edit popup for dimension and fix various dimension rendering bugs

### DIFF
--- a/src/Mod/TechDraw/App/DimensionFormatter.cpp
+++ b/src/Mod/TechDraw/App/DimensionFormatter.cpp
@@ -49,7 +49,9 @@ bool DimensionFormatter::isMultiValueSchema() const
 std::string DimensionFormatter::formatValue(const qreal value,
                                             const QString& qFormatSpec,
                                             const Format partial,
-                                            const bool isDim) const
+                                            const bool isDim,
+                                            const double forcedFactor,
+                                            const std::string& forcedUnitText) const
 {
     bool distanceMeasure{true};
     const bool angularMeasure =
@@ -103,7 +105,13 @@ std::string DimensionFormatter::formatValue(const qreal value,
 
     double factor{1.0};
     std::string unitText{""};
-    asQuantity.getUserString(factor, unitText);
+    if (forcedFactor != 0.0) {
+        factor = forcedFactor;
+        unitText = forcedUnitText;
+    }
+    else {
+        asQuantity.getUserString(factor, unitText);
+    }
     std::string squareTag{"^2"};
 
     if (unitText.empty()) {
@@ -153,7 +161,10 @@ std::string DimensionFormatter::formatValue(const qreal value,
             unitStr = " " + unitText;
         }
 
-        return formatPrefix + formattedValueString + unitStr + formatSuffix;
+        std::string suffixStr = (isDim && (m_dimension->haveTolerance() || m_dimension->TheoreticalExact.getValue()))
+            ? std::string() : formatSuffix;
+
+        return formatPrefix + formattedValueString + unitStr + suffixStr;
     }
 
     if (partial == Format::UNIT) {
@@ -166,7 +177,9 @@ std::string DimensionFormatter::formatValue(const qreal value,
 
 //! get the formatted OverTolerance value
 // wf: is this a leftover from when we only had 1 tolerance instead of over/under?
-std::string DimensionFormatter::getFormattedToleranceValue(const Format partial) const
+std::string DimensionFormatter::getFormattedToleranceValue(const Format partial,
+                                                            const double forcedFactor,
+                                                            const std::string& forcedUnitText) const
 {
     QString FormatSpec = QString::fromUtf8(m_dimension->FormatSpecOverTolerance.getStrValue().data());
     QString ToleranceString;
@@ -177,7 +190,9 @@ std::string DimensionFormatter::getFormattedToleranceValue(const Format partial)
         ToleranceString = QString::fromUtf8(formatValue(m_dimension->OverTolerance.getValue(),
                                                         FormatSpec,
                                                         partial,
-                                                        false).c_str());
+                                                        true,
+                                                        forcedFactor,
+                                                        forcedUnitText).c_str());
 
     return ToleranceString.toStdString();
 }
@@ -194,14 +209,29 @@ std::pair<std::string, std::string> DimensionFormatter::getFormattedToleranceVal
         underTolerance = underFormatSpec;
         overTolerance = overFormatSpec;
     } else {
+        // force Under and Over to share the nominal value's unit/scale
+        // instead of each auto-picking its own from its own magnitude
+        Base::Quantity mainQuantity{m_dimension->getDimValue(), Base::Unit::Length};
+        double mainFactor{1.0};
+        std::string mainUnitText{};
+        mainQuantity.getUserString(mainFactor, mainUnitText);
+
         underTolerance = QString::fromUtf8(formatValue(m_dimension->UnderTolerance.getValue(),
                                                            underFormatSpec,
                                                            partial,
-                                                           false).c_str());
+                                                           false,
+                                                           mainFactor,
+                                                           mainUnitText).c_str());
         overTolerance = QString::fromUtf8(formatValue(m_dimension->OverTolerance.getValue(),
                                                           overFormatSpec,
                                                           partial,
-                                                          false).c_str());
+                                                          false,
+                                                          mainFactor,
+                                                          mainUnitText).c_str());
+
+        if (underTolerance.startsWith(QLatin1Char('+'))) {
+            underTolerance.replace(0, 1, QString::fromUtf8("\xE2\x88\x92")); // U+2212 MINUS SIGN
+        }
     }
 
     tolerances.first = underTolerance.toStdString();
@@ -236,31 +266,42 @@ std::string DimensionFormatter::getFormattedDimensionValue(const Format partial)
         !m_dimension->TheoreticalExact.getValue() &&
         (!DrawUtil::fpCompare(m_dimension->OverTolerance.getValue(), 0.0) ||
           m_dimension->ArbitraryTolerances.getValue())) {
+        Base::Quantity mainQuantity{m_dimension->getDimValue(), Base::Unit::Length};
+        double mainFactor{1.0};
+        std::string mainUnitText{};
+        mainQuantity.getUserString(mainFactor, mainUnitText);
+
+        if (partial == Format::UNIT) {
+            return mainUnitText;
+        }
+
         QString labelText = QString::fromUtf8(formatValue(m_dimension->getDimValue(),
                                                           qFormatSpec,
                                                           Format::FORMATTED,
                                                           true).c_str()); //just the number pref/spec[unit]/suf
-        QString unitText = QString::fromUtf8(formatValue(m_dimension->getDimValue(),
-                                                         qFormatSpec,
-                                                         Format::UNIT,
-                                                         false).c_str()); //just the unit
-        QString tolerance = QString::fromStdString(getFormattedToleranceValue(Format::FORMATTED).c_str());
+        QString tolerance = QString::fromStdString(
+            getFormattedToleranceValue(Format::FORMATTED, mainFactor, mainUnitText).c_str());
 
         // tolerance might start with a plus sign that we don't want, so cut it off
         // note plus sign is not at pos = 0!
         QRegularExpression plus(QStringLiteral("^\\s*\\+"));
         tolerance.remove(plus);
 
-        return (labelText +
-                 QString::fromUtf8(" \xC2\xB1 ") +          // +/- symbol
-                 tolerance).toStdString();
-
-        // Unreachable code??
-        if (partial == Format::UNIT) {
-            return unitText.toStdString();
+        QString formatSuffix = getPrefixSuffixSpec(qFormatSpec).value(1);
+        if (!formatSuffix.isEmpty() && labelText.endsWith(formatSuffix)) {
+            labelText.chop(formatSuffix.length());
         }
 
-        return "";
+        QString unitStr;
+        if (m_dimension->showUnits()) {
+            unitStr = QStringLiteral(" ") + QString::fromStdString(mainUnitText);
+        }
+
+        return (labelText +
+                 QString::fromUtf8(" \xC2\xB1") +           // +/- symbol, no trailing space
+                 tolerance +
+                 unitStr +
+                 formatSuffix).toStdString();
     }
 
     //tolerance not specified, so just format dimension value?

--- a/src/Mod/TechDraw/App/DimensionFormatter.h
+++ b/src/Mod/TechDraw/App/DimensionFormatter.h
@@ -51,8 +51,10 @@ public:
 
     //void setDimension(DrawViewDimension* dim) { m_dimension = dim; }
     bool isMultiValueSchema() const;
-    std::string formatValue(qreal value, const QString& qFormatSpec, Format partial, bool isDim) const;
-    std::string getFormattedToleranceValue(Format partial) const;
+    std::string formatValue(qreal value, const QString& qFormatSpec, Format partial, bool isDim,
+                             double forcedFactor = 0.0, const std::string& forcedUnitText = {}) const;
+    std::string getFormattedToleranceValue(Format partial, double forcedFactor = 0.0,
+                                            const std::string& forcedUnitText = {}) const;
     std::pair<std::string, std::string> getFormattedToleranceValues(Format partial) const;
     std::string getFormattedDimensionValue(Format partial) const;
     QStringList getPrefixSuffixSpec(const QString& fSpec) const;

--- a/src/Mod/TechDraw/Gui/CMakeLists.txt
+++ b/src/Mod/TechDraw/Gui/CMakeLists.txt
@@ -141,6 +141,8 @@ SET(TechDrawGui_SRCS
     TaskDimension.ui
     TaskDimension.cpp
     TaskDimension.h
+    DimensionQuickEdit.cpp
+    DimensionQuickEdit.h
     TaskGeomHatch.ui
     TaskGeomHatch.cpp
     TaskGeomHatch.h

--- a/src/Mod/TechDraw/Gui/DimensionQuickEdit.cpp
+++ b/src/Mod/TechDraw/Gui/DimensionQuickEdit.cpp
@@ -1,0 +1,685 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Ryan Kembrey
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "PreCompiled.h"
+
+#include <regex>
+
+#include <QApplication>
+#include <QActionGroup>
+#include <QComboBox>
+#include <QDoubleSpinBox>
+#include <QFont>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QKeyEvent>
+#include <QLineEdit>
+#include <QMenu>
+#include <QScreen>
+#include <QTimer>
+#include <QToolButton>
+#include <QVBoxLayout>
+
+#include <App/Document.h>
+#include <Base/Parameter.h>
+#include <Base/Tools.h>
+#include <Gui/Command.h>
+#include <Gui/Control.h>
+
+#include <Mod/TechDraw/App/DimensionFormatter.h>
+#include <Mod/TechDraw/App/DrawViewDimension.h>
+#include <Mod/TechDraw/App/Preferences.h>
+#include <Mod/TechDraw/Gui/QGIViewDimension.h>
+#include <Mod/TechDraw/Gui/TaskDimension.h>
+#include <Mod/TechDraw/Gui/ViewProviderDimension.h>
+
+#include "DimensionQuickEdit.h"
+
+using namespace TechDrawGui;
+using DrawViewDimension = TechDraw::DrawViewDimension;
+using Format = TechDraw::DimensionFormatter::Format;
+
+namespace
+{
+constexpr int PopupVerticalOffset = 44;  // px below the click point
+
+// size and spacing
+constexpr int PopupMarginLeftRight = 4;
+constexpr int PopupMarginTop = 4;
+constexpr int PopupMarginBottom = 4;
+constexpr int FieldSpacing = 4;
+constexpr int IconRowSpacing = 3;
+constexpr int PrefixSuffixWidth = 52;
+constexpr int ValueFieldWidth = 70;
+constexpr int DecimalsButtonWidth = 18;
+constexpr int ToolButtonHeight = 26;
+constexpr int ToolButtonWidth = 26;
+constexpr int SignToggleButtonWidth = 40;
+constexpr int MoreButtonWidth = 52;
+constexpr int SymbolComboWidth = 120;
+constexpr int ToleranceSpinBoxWidth = 70;
+
+// others
+constexpr double ToleranceSpinBoxMax = 1000.0;
+constexpr double ToleranceSingleStep = 0.01;
+constexpr int ToleranceDecimalPlaces = 3;
+constexpr int MaxDecimalPlaces = 6;
+constexpr double DefaultToleranceValue = 0.01;
+constexpr int LiveCommitDebounceMs = 250;
+
+const std::regex FormatSpecRegex(R"(%\.([0-9]+)([fFrRgGwWeE]))");
+
+struct SymbolEntry
+{
+    QString label;
+    QString text;
+};
+
+QList<SymbolEntry> buildSymbolList()
+{
+    QString diameterSymbol = QString::fromStdString(
+        TechDraw::Preferences::getPreferenceGroup("Dimensions")->GetASCII("DiameterSymbol", "\xe2\x8c\x80")
+    );
+
+    return {
+        {.label = QObject::tr("Insert symbol\u2026"), .text = QString()},
+        {.label = QObject::tr("\u00B0 Degree"), .text = QStringLiteral("\u00B0")},
+        {.label = QObject::tr("TYP"), .text = QStringLiteral(" TYP")},
+        {.label = QObject::tr("%1 Diameter").arg(diameterSymbol), .text = diameterSymbol},
+        {.label = QObject::tr("S%1 Spherical diameter").arg(diameterSymbol),
+         .text = QStringLiteral("S") + diameterSymbol},
+        {.label = QObject::tr("R Radius"), .text = QStringLiteral("R")},
+        {.label = QObject::tr("SR Spherical radius"), .text = QStringLiteral("SR")},
+        {.label = QObject::tr("\u25A1 Square"), .text = QStringLiteral("\u25A1")},
+        {.label = QObject::tr("nX Repetition"), .text = QStringLiteral("nX ")},
+
+    };
+}
+}  // namespace
+
+void DimensionQuickEdit::showFor(ViewProviderDimension* dimensionVP, const QPoint& globalPos)
+{
+    if (!dimensionVP) {
+        return;
+    }
+
+    auto* popup = new DimensionQuickEdit(dimensionVP);
+    QPoint topLeft(globalPos.x() - (popup->sizeHint().width() / 2), globalPos.y() + PopupVerticalOffset);
+    popup->move(popup->clampToScreen(topLeft));
+    popup->show();
+    popup->setFocus(Qt::PopupFocusReason);
+}
+
+DimensionQuickEdit::DimensionQuickEdit(ViewProviderDimension* dimensionVP, QWidget* parent)
+    : QWidget(parent, Qt::Popup | Qt::FramelessWindowHint)
+    , m_dimensionVP(dimensionVP)
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    setObjectName(QStringLiteral("DimensionQuickEdit"));
+
+    buildUi();
+    readFromFeature();
+
+    // one undo step for the whole popup session
+    if (auto* doc = m_dimensionVP->getDocument()) {
+        doc->openCommand("Edit dimension");
+    }
+}
+
+DimensionQuickEdit::~DimensionQuickEdit() = default;
+
+QPoint DimensionQuickEdit::clampToScreen(QPoint topLeft) const
+{
+    const QRect avail = QApplication::screenAt(topLeft)
+        ? QApplication::screenAt(topLeft)->availableGeometry()
+        : QApplication::primaryScreen()->availableGeometry();
+    const QSize hint = sizeHint();
+
+    int x = std::clamp(topLeft.x(), avail.left(), avail.right() - hint.width());
+    int y = std::clamp(topLeft.y(), avail.top(), avail.bottom() - hint.height());
+    return {x, y};
+}
+
+void DimensionQuickEdit::buildUi()
+{
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(PopupMarginLeftRight, PopupMarginTop, PopupMarginLeftRight, PopupMarginBottom);
+    outer->setSpacing(FieldSpacing);
+    outer->setSizeConstraint(QLayout::SetFixedSize);
+
+    auto* fields = new QGridLayout();
+    fields->setSpacing(FieldSpacing);
+
+    m_prefixEdit = new QLineEdit(this);
+    m_prefixEdit->setPlaceholderText(tr("prefix"));
+    m_prefixEdit->setFixedWidth(PrefixSuffixWidth);
+
+    m_valueEdit = new QLineEdit(this);
+    m_valueEdit->setReadOnly(true);
+    m_valueEdit->setFocusPolicy(Qt::NoFocus);  // functions as a display so we dont want editing or focus
+    m_valueEdit->setAlignment(Qt::AlignCenter);
+    m_valueEdit->setFixedWidth(ValueFieldWidth);
+    m_valueEdit->setToolTip(
+        tr("The computed value, shown live as the prefix/"
+           "suffix/tolerance is edited. Use the arrow for decimal places.")
+    );
+
+    m_decimalsBtn = new QToolButton(this);
+    m_decimalsBtn->setText(QStringLiteral("\u25BE"));  // black down-pointing small triangle
+    m_decimalsBtn->setToolTip(tr("Choose decimal places"));
+    m_decimalsBtn->setFixedSize(DecimalsButtonWidth, ToolButtonHeight);
+    auto* valueWithDecimals = new QHBoxLayout();
+    valueWithDecimals->setSpacing(0);
+    valueWithDecimals->addWidget(m_valueEdit);
+    valueWithDecimals->addWidget(m_decimalsBtn);
+
+    m_toleranceMode = new QComboBox(this);
+    m_toleranceMode->addItem(tr("No tolerance"), static_cast<int>(ToleranceMode::None));
+    m_toleranceMode->addItem(tr("Symmetric (\u00B1)"), static_cast<int>(ToleranceMode::Symmetric));
+    m_toleranceMode->addItem(tr("Bilateral (+/-)"), static_cast<int>(ToleranceMode::Bilateral));
+
+    m_toleranceOver = new QDoubleSpinBox(this);
+    m_toleranceOver->setRange(0.0, ToleranceSpinBoxMax);
+    m_toleranceOver->setDecimals(3);
+    m_toleranceOver->setSingleStep(ToleranceSingleStep);
+    m_toleranceOver->setFixedWidth(ToleranceSpinBoxWidth);
+
+    m_toleranceUnder = new QDoubleSpinBox(this);
+    m_toleranceUnder->setRange(0.0, ToleranceSpinBoxMax);
+    m_toleranceUnder->setDecimals(3);
+    m_toleranceUnder->setSingleStep(ToleranceSingleStep);
+    m_toleranceUnder->setFixedWidth(ToleranceSpinBoxWidth);
+
+    m_suffixEdit = new QLineEdit(this);
+    m_suffixEdit->setPlaceholderText(tr("suffix"));
+    m_suffixEdit->setFixedWidth(PrefixSuffixWidth);
+
+    // Track cursor focus across the two editable text fields so the
+    // symbol combo knows where to insert.
+    m_prefixEdit->installEventFilter(this);
+    m_suffixEdit->installEventFilter(this);
+    m_lastFocusedField = m_prefixEdit;  // default target for inserting symbol before any click
+
+    fields->addWidget(m_prefixEdit, 0, 0);
+    fields->addLayout(valueWithDecimals, 0, 1);
+    fields->addWidget(m_toleranceMode, 0, 2);
+    fields->addWidget(m_toleranceOver, 0, 3);
+    fields->addWidget(m_toleranceUnder, 0, 4);
+    fields->addWidget(m_suffixEdit, 0, 5);
+    outer->addLayout(fields);
+
+    auto makeToolButton =
+        [this](const QString& text, const QString& tip, bool checkable, int width = ToolButtonWidth) {
+            auto* btn = new QToolButton(this);
+            btn->setText(text);
+            btn->setToolTip(tip);
+            btn->setCheckable(checkable);
+            btn->setFixedSize(width, ToolButtonHeight);
+            return btn;
+        };
+
+    auto* icons = new QHBoxLayout();
+    icons->setSpacing(IconRowSpacing);
+
+    m_symbolCombo = new QComboBox(this);
+    m_symbolCombo->setToolTip(tr("Insert a symbol at the cursor in the focused field"));
+    m_symbolCombo->setFixedWidth(SymbolComboWidth);
+    for (const SymbolEntry& entry : buildSymbolList()) {
+        m_symbolCombo->addItem(entry.label);
+    }
+
+    m_referenceBtn = makeToolButton(
+        QStringLiteral("(x)"),
+        tr("Converts the dimension to a reference dimension, wrapping the value in parentheses."),
+        true,
+        SignToggleButtonWidth
+    );
+    m_basicBtn = makeToolButton(
+        QStringLiteral("[x]"),
+        tr("Converts the dimension to a basic (theoretically exact) dimension, wrapping the value "
+           "in square brackets. Enabling this clears any tolerances."),
+        true,
+        SignToggleButtonWidth
+    );
+    QFont basicFont = m_basicBtn->font();
+    basicFont.setPointSize(basicFont.pointSize() + 3);
+    m_basicBtn->setFont(basicFont);
+    QFont referenceFont = m_referenceBtn->font();
+    referenceFont.setPointSize(referenceFont.pointSize() + 3);
+    m_referenceBtn->setFont(referenceFont);
+    m_moreBtn = makeToolButton(
+        tr("More…"),
+        tr("Opens the dimension task panel for more configuration options."),
+        false,
+        MoreButtonWidth
+    );
+
+    icons->addWidget(m_symbolCombo);
+    icons->addWidget(m_referenceBtn);
+    icons->addWidget(m_basicBtn);
+    icons->addStretch();
+    icons->addWidget(m_moreBtn);
+    outer->addLayout(icons);
+
+    connect(m_prefixEdit, &QLineEdit::editingFinished, this, &DimensionQuickEdit::onPrefixOrSuffixChanged);
+    connect(m_suffixEdit, &QLineEdit::editingFinished, this, &DimensionQuickEdit::onPrefixOrSuffixChanged);
+    m_liveCommitTimer = new QTimer(this);
+    m_liveCommitTimer->setSingleShot(true);
+    m_liveCommitTimer->setInterval(LiveCommitDebounceMs);
+    connect(m_liveCommitTimer, &QTimer::timeout, this, &DimensionQuickEdit::onPrefixOrSuffixChanged);
+    connect(m_prefixEdit, &QLineEdit::textChanged, this, &DimensionQuickEdit::onPrefixOrSuffixLiveUpdate);
+    connect(m_suffixEdit, &QLineEdit::textChanged, this, &DimensionQuickEdit::onPrefixOrSuffixLiveUpdate);
+    connect(m_toleranceMode, QOverload<int>::of(&QComboBox::activated), this, [this](int index) {
+        onToleranceModeChanged(static_cast<ToleranceMode>(index));
+    });
+    connect(m_toleranceOver, &QDoubleSpinBox::editingFinished, this, [this]() {
+        onToleranceValueChanged();
+    });
+    connect(m_toleranceUnder, &QDoubleSpinBox::editingFinished, this, [this]() {
+        onToleranceValueChanged();
+    });
+    m_toleranceLiveCommitTimer = new QTimer(this);
+    m_toleranceLiveCommitTimer->setSingleShot(true);
+    m_toleranceLiveCommitTimer->setInterval(LiveCommitDebounceMs);
+    connect(m_toleranceLiveCommitTimer, &QTimer::timeout, this, [this]() {
+        onToleranceValueChanged();
+    });
+    connect(m_toleranceOver, &QDoubleSpinBox::valueChanged, this, [this](double) {
+        if (!m_populating) {
+            m_toleranceLiveCommitTimer->start();
+        }
+    });
+    connect(m_toleranceUnder, &QDoubleSpinBox::valueChanged, this, [this](double) {
+        if (!m_populating) {
+            m_toleranceLiveCommitTimer->start();
+        }
+    });
+    connect(m_decimalsBtn, &QToolButton::clicked, this, &DimensionQuickEdit::showDecimalsMenu);
+    connect(
+        m_symbolCombo,
+        QOverload<int>::of(&QComboBox::activated),
+        this,
+        &DimensionQuickEdit::onSymbolChanged
+    );
+    connect(m_referenceBtn, &QToolButton::clicked, this, &DimensionQuickEdit::onToggleReference);
+    connect(m_basicBtn, &QToolButton::clicked, this, &DimensionQuickEdit::onToggleBasic);
+    connect(m_moreBtn, &QToolButton::clicked, this, &DimensionQuickEdit::onMoreOptions);
+}
+
+void DimensionQuickEdit::readFromFeature()
+{
+    if (!m_dimensionVP) {
+        return;
+    }
+    auto* dim = freecad_cast<DrawViewDimension*>(m_dimensionVP->getObject());
+    if (!dim) {
+        return;
+    }
+
+    m_populating = true;
+
+    m_valueEdit->setText(QString::fromStdString(dim->getFormattedDimensionValue(Format::FORMATTED)));
+
+    std::string currentFormat = dim->FormatSpec.getStrValue();
+
+    QStringList prefixSuffix = dim->getPrefixSuffixSpec(QString::fromStdString(currentFormat));
+    m_formatPrefix = prefixSuffix.value(0).toStdString();
+    m_formatSuffix = prefixSuffix.value(1).toStdString();
+
+    m_referenceActive = !m_formatPrefix.empty() && m_formatPrefix.back() == '('
+        && !m_formatSuffix.empty() && m_formatSuffix.front() == ')';
+    if (m_referenceActive) {
+        m_formatPrefix.pop_back();
+        m_formatSuffix.erase(0, 1);
+    }
+
+    std::smatch match;
+    int decimals = 2;
+    if (std::regex_search(currentFormat, match, FormatSpecRegex) && match.size() > 2) {
+        decimals = std::stoi(match[1].str());
+        m_formatChar = match[2].str();
+    }
+    m_prefixEdit->setText(QString::fromStdString(m_formatPrefix));
+    m_suffixEdit->setText(QString::fromStdString(m_formatSuffix));
+    m_decimals = std::clamp(decimals, 0, MaxDecimalPlaces);
+    m_referenceBtn->setChecked(m_referenceActive);
+    m_symbolCombo->setCurrentIndex(0);  // since it just inserts the symbol, we reset the index back to 0
+
+    bool equalTol = dim->EqualTolerance.getValue();
+    double over = dim->OverTolerance.getValue();
+    double under = dim->UnderTolerance.getValue();
+    if (over == 0.0 && under == 0.0) {
+        m_toleranceMode->setCurrentIndex(static_cast<int>(ToleranceMode::None));
+    }
+    else if (equalTol) {
+        m_toleranceMode->setCurrentIndex(static_cast<int>(ToleranceMode::Symmetric));
+    }
+    else {
+        m_toleranceMode->setCurrentIndex(static_cast<int>(ToleranceMode::Bilateral));
+    }
+    m_toleranceOver->setValue(over);
+    m_toleranceUnder->setValue(under);
+    const auto currentMode = static_cast<ToleranceMode>(m_toleranceMode->currentIndex());
+    m_toleranceUnder->setEnabled(currentMode == ToleranceMode::Bilateral);
+    m_toleranceOver->setVisible(currentMode != ToleranceMode::None);
+    m_toleranceUnder->setVisible(currentMode == ToleranceMode::Bilateral);
+    updateTolerancePrefixes(currentMode);
+
+    m_basicBtn->setChecked(dim->TheoreticalExact.getValue());
+
+    m_populating = false;
+}
+
+void DimensionQuickEdit::updateValuePreview()
+{
+    if (!m_dimensionVP) {
+        return;
+    }
+    auto* dim = freecad_cast<DrawViewDimension*>(m_dimensionVP->getObject());
+    if (!dim) {
+        return;
+    }
+    m_valueEdit->setText(QString::fromStdString(dim->getFormattedDimensionValue(Format::FORMATTED)));
+}
+
+void DimensionQuickEdit::onPrefixOrSuffixLiveUpdate()
+{
+    if (m_populating || !m_dimensionVP) {
+        return;
+    }
+    auto* dim = freecad_cast<DrawViewDimension*>(m_dimensionVP->getObject());
+    if (!dim) {
+        return;
+    }
+
+    std::string prefix = (m_referenceActive ? "(" : "") + m_prefixEdit->text().toStdString();
+    std::string suffix = m_suffixEdit->text().toStdString() + (m_referenceActive ? ")" : "");
+    QString hypotheticalSpec = QString::fromStdString(
+        prefix + "%." + std::to_string(m_decimals) + m_formatChar + suffix
+    );
+
+    std::string preview
+        = dim->formatValue(dim->getDimValue(), hypotheticalSpec, Format::FORMATTED, true);
+    m_valueEdit->setText(QString::fromStdString(preview));
+
+    m_liveCommitTimer->start();
+}
+
+void DimensionQuickEdit::rebuildFormatSpec()
+{
+    if (!m_dimensionVP || m_populating) {
+        return;
+    }
+    auto* dim = freecad_cast<DrawViewDimension*>(m_dimensionVP->getObject());
+    if (!dim) {
+        return;
+    }
+
+    if (dim->Arbitrary.getValue()) {
+        dim->Arbitrary.setValue(false);
+    }
+
+    std::string valuePattern = "%." + std::to_string(m_decimals) + m_formatChar;
+    if (m_referenceActive) {
+        valuePattern = "(" + valuePattern + ")";
+    }
+    std::string spec = m_formatPrefix + valuePattern + m_formatSuffix;
+    dim->FormatSpec.setValue(spec);
+    dim->recomputeFeature();
+    markDirty();
+    updateValuePreview();
+}
+
+void DimensionQuickEdit::syncToleranceFormatSpecs()
+{
+    if (!m_dimensionVP) {
+        return;
+    }
+    auto* dim = freecad_cast<DrawViewDimension*>(m_dimensionVP->getObject());
+    if (!dim) {
+        return;
+    }
+    QString spec = QStringLiteral("%+.") + QString::number(ToleranceDecimalPlaces) + QStringLiteral("f");
+    dim->FormatSpecOverTolerance.setValue(spec.toStdString());
+    dim->FormatSpecUnderTolerance.setValue(spec.toStdString());
+}
+
+void DimensionQuickEdit::onToggleReference()
+{
+    m_referenceActive = m_referenceBtn->isChecked();
+    rebuildFormatSpec();
+}
+
+void DimensionQuickEdit::onPrefixOrSuffixChanged()
+{
+    if (m_populating) {
+        return;
+    }
+    m_liveCommitTimer->stop();
+    m_formatPrefix = m_prefixEdit->text().toStdString();
+    m_formatSuffix = m_suffixEdit->text().toStdString();
+    rebuildFormatSpec();
+}
+
+void DimensionQuickEdit::showDecimalsMenu()
+{
+    if (!m_dimensionVP) {
+        return;
+    }
+
+    static const QString DemoDigits = QStringLiteral("123456");
+
+    QMenu menu(this);
+    auto* group = new QActionGroup(&menu);
+    group->setExclusive(true);
+    for (int decimals = 0; decimals <= MaxDecimalPlaces; ++decimals) {
+        QString label = decimals == 0 ? QStringLiteral("0")
+                                      : QStringLiteral("0.") + DemoDigits.left(decimals);
+        QAction* action = menu.addAction(label);
+        action->setCheckable(true);
+        action->setChecked(decimals == m_decimals);
+        group->addAction(action);
+        connect(action, &QAction::triggered, this, [this, decimals]() {
+            m_decimals = decimals;
+            rebuildFormatSpec();
+            if (static_cast<ToleranceMode>(m_toleranceMode->currentIndex()) != ToleranceMode::None) {
+                syncToleranceFormatSpecs();
+                if (auto* dim = freecad_cast<DrawViewDimension*>(m_dimensionVP->getObject())) {
+                    dim->recomputeFeature();
+                    updateValuePreview();
+                }
+            }
+        });
+    }
+    menu.exec(m_decimalsBtn->mapToGlobal(QPoint(0, m_decimalsBtn->height())));
+}
+
+void DimensionQuickEdit::updateTolerancePrefixes(ToleranceMode mode)
+{
+    if (mode == ToleranceMode::Symmetric) {
+        m_toleranceOver->setPrefix(QStringLiteral("\u00B1 "));
+    }
+    else if (mode == ToleranceMode::Bilateral) {
+        m_toleranceOver->setPrefix(QStringLiteral("+ "));
+        m_toleranceUnder->setPrefix(QStringLiteral("\u2212 "));
+    }
+    else {
+        m_toleranceOver->setPrefix(QString());
+    }
+}
+
+void DimensionQuickEdit::onToleranceModeChanged(ToleranceMode mode)
+{
+    m_toleranceOver->setVisible(mode != ToleranceMode::None);
+    m_toleranceUnder->setVisible(mode == ToleranceMode::Bilateral);
+    m_toleranceUnder->setEnabled(mode == ToleranceMode::Bilateral);
+    updateTolerancePrefixes(mode);
+
+    if (m_populating || !m_dimensionVP) {
+        return;
+    }
+    auto* dim = freecad_cast<DrawViewDimension*>(m_dimensionVP->getObject());
+    if (!dim) {
+        return;
+    }
+
+    if (mode == ToleranceMode::None) {
+        dim->OverTolerance.setValue(0.0);
+        dim->UnderTolerance.setValue(0.0);
+    }
+    else {
+        dim->EqualTolerance.setValue(mode == ToleranceMode::Symmetric);
+        if (dim->OverTolerance.getValue() == 0.0) {
+            dim->OverTolerance.setValue(DefaultToleranceValue);
+            m_toleranceOver->setValue(DefaultToleranceValue);
+        }
+        if (mode == ToleranceMode::Bilateral && dim->UnderTolerance.getValue() == 0.0) {
+            dim->UnderTolerance.setValue(DefaultToleranceValue);
+            m_toleranceUnder->setValue(DefaultToleranceValue);
+        }
+        syncToleranceFormatSpecs();
+    }
+    m_toleranceLiveCommitTimer->stop();
+    dim->recomputeFeature();
+    markDirty();
+    updateValuePreview();
+}
+
+void DimensionQuickEdit::onToleranceValueChanged()
+{
+    if (m_populating || !m_dimensionVP) {
+        return;
+    }
+    m_toleranceLiveCommitTimer->stop();
+    auto* dim = freecad_cast<DrawViewDimension*>(m_dimensionVP->getObject());
+    if (!dim) {
+        return;
+    }
+
+    dim->OverTolerance.setValue(m_toleranceOver->value());
+    if (dim->EqualTolerance.getValue()) {
+        dim->UnderTolerance.setValue(m_toleranceOver->value());
+    }
+    else {
+        dim->UnderTolerance.setValue(m_toleranceUnder->value());
+    }
+    syncToleranceFormatSpecs();
+    dim->recomputeFeature();
+    markDirty();
+    updateValuePreview();
+}
+
+void DimensionQuickEdit::onSymbolChanged(int index)
+{
+    if (m_populating) {
+        return;
+    }
+    QList<SymbolEntry> symbols = buildSymbolList();
+    if (index <= 0 || index >= symbols.size()) {
+        return;  // index 0 is the placeholder itself
+    }
+    QLineEdit* target = m_lastFocusedField ? m_lastFocusedField : m_prefixEdit;
+
+    target->insert(symbols[index].text);
+    onPrefixOrSuffixChanged();
+
+    m_symbolCombo->setCurrentIndex(0);
+    target->setFocus();
+}
+
+void DimensionQuickEdit::onToggleBasic()
+{
+    if (!m_dimensionVP) {
+        return;
+    }
+    auto* dim = freecad_cast<DrawViewDimension*>(m_dimensionVP->getObject());
+    if (!dim) {
+        return;
+    }
+    bool checked = m_basicBtn->isChecked();
+    dim->TheoreticalExact.setValue(checked);
+
+    // theoretically exact dimensions don't carry a tolerance
+    if (checked
+        && static_cast<ToleranceMode>(m_toleranceMode->currentIndex()) != ToleranceMode::None) {
+        m_toleranceMode->setCurrentIndex(static_cast<int>(ToleranceMode::None));
+        onToleranceModeChanged(ToleranceMode::None);
+    }
+    else {
+        dim->recomputeFeature();
+        markDirty();
+    }
+    updateValuePreview();
+}
+
+void DimensionQuickEdit::onMoreOptions()
+{
+    ViewProviderDimension* vp = m_dimensionVP;
+    close();
+    if (!vp) {
+        return;
+    }
+    if (Gui::Control().activeDialog()) {
+        return;
+    }
+    auto* qgivDimension = dynamic_cast<QGIViewDimension*>(vp->getQView());
+    if (qgivDimension) {
+        Gui::Control().showDialog(new TaskDlgDimension(qgivDimension, vp));
+    }
+}
+
+void DimensionQuickEdit::showEvent(QShowEvent* event)
+{
+    QWidget::showEvent(event);
+}
+
+bool DimensionQuickEdit::eventFilter(QObject* watched, QEvent* event)
+{
+    if (event->type() == QEvent::FocusIn && (watched == m_prefixEdit || watched == m_suffixEdit)) {
+        m_lastFocusedField = qobject_cast<QLineEdit*>(watched);
+    }
+    return QWidget::eventFilter(watched, event);
+}
+
+void DimensionQuickEdit::hideEvent(QHideEvent* event)
+{
+    if (m_dimensionVP) {
+        if (auto* doc = m_dimensionVP->getDocument()) {
+            if (m_dirty) {
+                doc->commitCommand();
+            }
+            else {
+                doc->abortCommand();
+            }
+        }
+    }
+    QWidget::hideEvent(event);
+}
+
+void DimensionQuickEdit::keyPressEvent(QKeyEvent* event)
+{
+    if (event->key() == Qt::Key_Escape || event->key() == Qt::Key_Return
+        || event->key() == Qt::Key_Enter) {
+        close();
+        return;
+    }
+    QWidget::keyPressEvent(event);
+}

--- a/src/Mod/TechDraw/Gui/DimensionQuickEdit.cpp
+++ b/src/Mod/TechDraw/Gui/DimensionQuickEdit.cpp
@@ -336,8 +336,6 @@ void DimensionQuickEdit::readFromFeature()
 
     m_populating = true;
 
-    m_valueEdit->setText(QString::fromStdString(dim->getFormattedDimensionValue(Format::FORMATTED)));
-
     std::string currentFormat = dim->FormatSpec.getStrValue();
 
     QStringList prefixSuffix = dim->getPrefixSuffixSpec(QString::fromStdString(currentFormat));
@@ -362,6 +360,7 @@ void DimensionQuickEdit::readFromFeature()
     m_decimals = std::clamp(decimals, 0, MaxDecimalPlaces);
     m_referenceBtn->setChecked(m_referenceActive);
     m_symbolCombo->setCurrentIndex(0);  // since it just inserts the symbol, we reset the index back to 0
+    updateValuePreview();
 
     bool equalTol = dim->EqualTolerance.getValue();
     double over = dim->OverTolerance.getValue();
@@ -397,29 +396,16 @@ void DimensionQuickEdit::updateValuePreview()
     if (!dim) {
         return;
     }
-    m_valueEdit->setText(QString::fromStdString(dim->getFormattedDimensionValue(Format::FORMATTED)));
+    QString bareSpec = QString::fromStdString("%." + std::to_string(m_decimals) + m_formatChar);
+    m_valueEdit->setText(
+        QString::fromStdString(dim->formatValue(dim->getDimValue(), bareSpec, Format::FORMATTED, true)));
 }
 
 void DimensionQuickEdit::onPrefixOrSuffixLiveUpdate()
 {
-    if (m_populating || !m_dimensionVP) {
+    if (m_populating) {
         return;
     }
-    auto* dim = freecad_cast<DrawViewDimension*>(m_dimensionVP->getObject());
-    if (!dim) {
-        return;
-    }
-
-    std::string prefix = (m_referenceActive ? "(" : "") + m_prefixEdit->text().toStdString();
-    std::string suffix = m_suffixEdit->text().toStdString() + (m_referenceActive ? ")" : "");
-    QString hypotheticalSpec = QString::fromStdString(
-        prefix + "%." + std::to_string(m_decimals) + m_formatChar + suffix
-    );
-
-    std::string preview
-        = dim->formatValue(dim->getDimValue(), hypotheticalSpec, Format::FORMATTED, true);
-    m_valueEdit->setText(QString::fromStdString(preview));
-
     m_liveCommitTimer->start();
 }
 

--- a/src/Mod/TechDraw/Gui/DimensionQuickEdit.cpp
+++ b/src/Mod/TechDraw/Gui/DimensionQuickEdit.cpp
@@ -74,7 +74,9 @@ constexpr int ToolButtonHeight = 26;
 constexpr int ToolButtonWidth = 26;
 constexpr int SignToggleButtonWidth = 40;
 constexpr int MoreButtonWidth = 52;
-constexpr int SymbolComboWidth = 120;
+constexpr int SymbolComboWidth = 44;
+
+constexpr int DefaultSymbolIndex = 1;  // Diameter
 constexpr int ToleranceSpinBoxWidth = 70;
 
 // others
@@ -89,10 +91,11 @@ const std::regex FormatSpecRegex(R"(%\.([0-9]+)([fFrRgGwWeE]))");
 
 struct SymbolEntry
 {
-    QString label;
-    QString text;
+    QString tooltip;
+    QString symbol;
 };
 
+// Only COMMON symbols that can't be typed
 QList<SymbolEntry> buildSymbolList()
 {
     QString diameterSymbol = QString::fromStdString(
@@ -100,17 +103,13 @@ QList<SymbolEntry> buildSymbolList()
     );
 
     return {
-        {.label = QObject::tr("Insert symbol\u2026"), .text = QString()},
-        {.label = QObject::tr("\u00B0 Degree"), .text = QStringLiteral("\u00B0")},
-        {.label = QObject::tr("TYP"), .text = QStringLiteral(" TYP")},
-        {.label = QObject::tr("%1 Diameter").arg(diameterSymbol), .text = diameterSymbol},
-        {.label = QObject::tr("S%1 Spherical diameter").arg(diameterSymbol),
-         .text = QStringLiteral("S") + diameterSymbol},
-        {.label = QObject::tr("R Radius"), .text = QStringLiteral("R")},
-        {.label = QObject::tr("SR Spherical radius"), .text = QStringLiteral("SR")},
-        {.label = QObject::tr("\u25A1 Square"), .text = QStringLiteral("\u25A1")},
-        {.label = QObject::tr("nX Repetition"), .text = QStringLiteral("nX ")},
-
+        {.tooltip = QObject::tr("Degree"), .symbol = QStringLiteral("\u00B0")},
+        {.tooltip = QObject::tr("Diameter"), .symbol = diameterSymbol},
+        {.tooltip = QObject::tr("Counterbore"), .symbol = QStringLiteral("\u2334")},
+        {.tooltip = QObject::tr("Countersink"), .symbol = QStringLiteral("\u2335")},
+        {.tooltip = QObject::tr("Downward arrow"), .symbol = QStringLiteral("\u21A7")},
+        {.tooltip = QObject::tr("Square"), .symbol = QStringLiteral("\u25A1")},
+        {.tooltip = QObject::tr("Plus/minus"), .symbol = QStringLiteral("\u00B1")},
     };
 }
 }  // namespace
@@ -243,8 +242,10 @@ void DimensionQuickEdit::buildUi()
     m_symbolCombo->setToolTip(tr("Insert a symbol at the cursor in the focused field"));
     m_symbolCombo->setFixedWidth(SymbolComboWidth);
     for (const SymbolEntry& entry : buildSymbolList()) {
-        m_symbolCombo->addItem(entry.label);
+        m_symbolCombo->addItem(entry.symbol);
+        m_symbolCombo->setItemData(m_symbolCombo->count() - 1, entry.tooltip, Qt::ToolTipRole);
     }
+    m_symbolCombo->setCurrentIndex(DefaultSymbolIndex);
 
     m_referenceBtn = makeToolButton(
         QStringLiteral("(x)"),
@@ -359,7 +360,7 @@ void DimensionQuickEdit::readFromFeature()
     m_suffixEdit->setText(QString::fromStdString(m_formatSuffix));
     m_decimals = std::clamp(decimals, 0, MaxDecimalPlaces);
     m_referenceBtn->setChecked(m_referenceActive);
-    m_symbolCombo->setCurrentIndex(0);  // since it just inserts the symbol, we reset the index back to 0
+    m_symbolCombo->setCurrentIndex(DefaultSymbolIndex);
     updateValuePreview();
 
     bool equalTol = dim->EqualTolerance.getValue();
@@ -579,15 +580,15 @@ void DimensionQuickEdit::onSymbolChanged(int index)
         return;
     }
     QList<SymbolEntry> symbols = buildSymbolList();
-    if (index <= 0 || index >= symbols.size()) {
-        return;  // index 0 is the placeholder itself
+    if (index < 0 || index >= symbols.size()) {
+        return;
     }
     QLineEdit* target = m_lastFocusedField ? m_lastFocusedField : m_prefixEdit;
 
-    target->insert(symbols[index].text);
+    target->insert(symbols[index].symbol);
     onPrefixOrSuffixChanged();
 
-    m_symbolCombo->setCurrentIndex(0);
+    m_symbolCombo->setCurrentIndex(DefaultSymbolIndex);
     target->setFocus();
 }
 

--- a/src/Mod/TechDraw/Gui/DimensionQuickEdit.h
+++ b/src/Mod/TechDraw/Gui/DimensionQuickEdit.h
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Ryan Kembrey
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <QWidget>
+
+class QLineEdit;
+class QComboBox;
+class QDoubleSpinBox;
+class QToolButton;
+class QTimer;
+
+namespace TechDrawGui
+{
+
+enum class ToleranceMode : std::uint8_t { None, Symmetric, Bilateral };
+
+class ViewProviderDimension;
+
+class DimensionQuickEdit: public QWidget
+{
+    Q_OBJECT
+
+public:
+    static void showFor(ViewProviderDimension* dimensionVP, const QPoint& globalPos);
+
+    ~DimensionQuickEdit() override;
+
+protected:
+    void showEvent(QShowEvent* event) override;
+    void hideEvent(QHideEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+private:
+    explicit DimensionQuickEdit(ViewProviderDimension* dimensionVP, QWidget* parent = nullptr);
+
+    void buildUi();
+    void readFromFeature();
+    QPoint clampToScreen(QPoint topLeft) const;
+
+    void onPrefixOrSuffixChanged();
+    void onPrefixOrSuffixLiveUpdate();
+    void onToleranceModeChanged(ToleranceMode mode);
+    void onToleranceValueChanged();
+    void showDecimalsMenu();
+    void onSymbolChanged(int index);
+    void onToggleReference();
+    void onToggleBasic();
+    void onMoreOptions();
+
+    void rebuildFormatSpec();
+    void syncToleranceFormatSpecs();
+    void updateValuePreview();
+    void updateTolerancePrefixes(ToleranceMode mode);
+    void markDirty()
+    {
+        m_dirty = true;
+    }
+
+    ViewProviderDimension* m_dimensionVP = nullptr;
+    bool m_dirty = false;
+    bool m_populating = false;
+
+    QLineEdit* m_prefixEdit = nullptr;
+    QLineEdit* m_valueEdit = nullptr;
+    QToolButton* m_decimalsBtn = nullptr;
+    int m_decimals = 2;
+    QTimer* m_liveCommitTimer = nullptr;
+    QTimer* m_toleranceLiveCommitTimer = nullptr;
+    QComboBox* m_toleranceMode = nullptr;
+    QDoubleSpinBox* m_toleranceOver = nullptr;
+    QDoubleSpinBox* m_toleranceUnder = nullptr;
+    QLineEdit* m_suffixEdit = nullptr;
+
+    QLineEdit* m_lastFocusedField = nullptr;
+
+    QComboBox* m_symbolCombo = nullptr;
+    QToolButton* m_referenceBtn = nullptr;
+    QToolButton* m_basicBtn = nullptr;
+    QToolButton* m_moreBtn = nullptr;
+
+    std::string m_formatPrefix;
+    std::string m_formatSuffix;
+    std::string m_formatChar = "w";
+    bool m_referenceActive = false;
+};
+
+}  // namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGIDatumLabel.cpp
+++ b/src/Mod/TechDraw/Gui/QGIDatumLabel.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include <QApplication>
+#include <QFontMetrics>
 #include <QGraphicsSceneMouseEvent>
 
 #include <Gui/Application.h>
@@ -72,6 +73,9 @@ QGIDatumLabel::QGIDatumLabel() : m_dragState(DragState::NoDrag)
     m_unitText = new QGCustomText();
     m_unitText->setTightBounding(true);
     m_unitText->setParentItem(m_textItems);
+    m_suffixText = new QGCustomText();
+    m_suffixText->setTightBounding(true);
+    m_suffixText->setParentItem(m_textItems);
 
     m_frame = new QGraphicsRectItem();
     QPen framePen;
@@ -328,9 +332,17 @@ QRectF QGIDatumLabel::boundingRect() const
 
 QRectF QGIDatumLabel::tightBoundingRect() const
 {
+    return computeTextBoundingRect(true);
+}
+
+QRectF QGIDatumLabel::computeTextBoundingRect(bool includeSuffix) const
+{
     QRectF totalRect;
     for (QGraphicsItem* item : m_textItems->childItems()) {
         auto* customText = dynamic_cast<QGCustomText*>(item);
+        if (!includeSuffix && customText == m_suffixText) {
+            continue;
+        }
         if (customText && !customText->toPlainText().isEmpty()) {
             QRectF itemRect = customText->alignmentRect();
             QPointF pos = customText->pos();
@@ -348,7 +360,7 @@ QRectF QGIDatumLabel::tightBoundingRect() const
 
 void QGIDatumLabel::updateFrameRect() {
     prepareGeometryChange();
-    m_frame->setRect(tightBoundingRect());
+    m_frame->setRect(computeTextBoundingRect(false));
 }
 
 void QGIDatumLabel::boundingRectChanged()
@@ -416,13 +428,27 @@ void QGIDatumLabel::updateChildren()
 
     //set tolerance position
     QRectF overBox = m_tolTextOver->alignmentRect();
+    QRectF underBox = m_tolTextUnder->alignmentRect();
     double tolLeft  = unitRight;
+
+    // align digits vertically rather than align left, because the + and - glyphs may differ in width, throwing off the alignment of the text
+    QFontMetrics tolFm(m_tolTextOver->font());
+    QString overSign = m_tolTextOver->toPlainText().left(1);
+    QString underSign = m_tolTextUnder->toPlainText().left(1);
+    double overSignWidth = overSign.isEmpty() ? 0.0 : tolFm.horizontalAdvance(overSign);
+    double underSignWidth = underSign.isEmpty() ? 0.0 : tolFm.horizontalAdvance(underSign);
+    double maxSignWidth = overSignWidth > underSignWidth ? overSignWidth : underSignWidth;
 
     // Adjust for difference in tight and original bounding box sizes, note the y-coord down system
     QPointF tol_adj = m_tolTextOver->tightBoundingAdjust();
-    m_tolTextOver->justifyLeftAt(tolLeft + tol_adj.x(), middle + tol_adj.y()/2.0, false);
+    m_tolTextOver->justifyLeftAt(tolLeft + (maxSignWidth - overSignWidth) + tol_adj.x(),
+                                  middle + tol_adj.y()/2.0, false);
     tol_adj = m_tolTextUnder->tightBoundingAdjust();
-    m_tolTextUnder->justifyLeftAt(tolLeft + tol_adj.x(), middle + overBox.height() + tol_adj.y()/2.0, false);
+    m_tolTextUnder->justifyLeftAt(tolLeft + (maxSignWidth - underSignWidth) + tol_adj.x(),
+                                   middle + overBox.height() + tol_adj.y()/2.0, false);
+
+    double tolRight = tolLeft + std::max(overBox.width(), underBox.width());
+    m_suffixText->setPos(tolRight, 0.0);
 }
 
 Base::Vector2d QGIDatumLabel::getPosToCenterVec() const
@@ -436,6 +462,7 @@ void QGIDatumLabel::setFont(QFont font)
     prepareGeometryChange();
     m_dimText->setFont(font);
     m_unitText->setFont(font);
+    m_suffixText->setFont(font);
     QFont tFont(font);
     double fontSize = font.pixelSize();
     double tolAdj = getTolAdjust();
@@ -525,7 +552,31 @@ void QGIDatumLabel::setToleranceString()
     boundingRectChanged();
 }
 
+void QGIDatumLabel::setSuffixString()
+{
+    prepareGeometryChange();
+    QGIViewDimension* qgivd = dynamic_cast<QGIViewDimension*>(parentItem());
+    if (!qgivd) {
+        return;
+    }
+    const auto dim(dynamic_cast<TechDraw::DrawViewDimension*>(qgivd->getViewObject()));
+    if (!dim) {
+        return;
+    }
 
+    if ((dim->hasOverUnderTolerance() && !dim->EqualTolerance.getValue())
+        || dim->TheoreticalExact.getValue()) {
+        QStringList prefixSuffix
+            = dim->getPrefixSuffixSpec(QString::fromStdString(dim->FormatSpec.getStrValue()));
+        m_suffixText->setPlainText(prefixSuffix.value(1));
+    }
+    else {
+        m_suffixText->setPlainText(QString());
+    }
+
+    updateFrameRect();
+    boundingRectChanged();
+}
 
 int QGIDatumLabel::getPrecision()
 {
@@ -548,6 +599,7 @@ void QGIDatumLabel::setPrettySel()
     m_tolTextOver->setPrettySel();
     m_tolTextUnder->setPrettySel();
     m_unitText->setPrettySel();
+    m_suffixText->setPrettySel();
     setFrameColor(PreferencesGui::selectQColor());
     Q_EMIT setPretty(SEL);
 }
@@ -559,6 +611,7 @@ void QGIDatumLabel::setPrettyPre()
     m_tolTextOver->setPrettyPre();
     m_tolTextUnder->setPrettyPre();
     m_unitText->setPrettyPre();
+    m_suffixText->setPrettyPre();
     setFrameColor(PreferencesGui::preselectQColor());
     Q_EMIT setPretty(PRE);
 }
@@ -570,6 +623,7 @@ void QGIDatumLabel::setPrettyNormal()
     m_tolTextOver->setPrettyNormal();
     m_tolTextUnder->setPrettyNormal();
     m_unitText->setPrettyNormal();
+    m_suffixText->setPrettyNormal();
     setFrameColor(m_colNormal);
     Q_EMIT setPretty(NORMAL);
 }
@@ -582,6 +636,7 @@ void QGIDatumLabel::setColor(QColor color)
     m_tolTextOver->setColor(m_colNormal);
     m_tolTextUnder->setColor(m_colNormal);
     m_unitText->setColor(m_colNormal);
+    m_suffixText->setColor(m_colNormal);
     setFrameColor(m_colNormal);
 }
 

--- a/src/Mod/TechDraw/Gui/QGIDatumLabel.h
+++ b/src/Mod/TechDraw/Gui/QGIDatumLabel.h
@@ -59,6 +59,7 @@ public:
     QFont getFont() const { return m_dimText->font(); }
     void setDimString(QString text, qreal maxWidth=-1);
     void setToleranceString();
+    void setSuffixString();
     void setPrettySel();
     void setPrettyPre();
     void setPrettyNormal();
@@ -109,6 +110,8 @@ protected:
     void setSeps(std::vector<int> newSeps) { seps = newSeps; }
 
 private:
+    QRectF computeTextBoundingRect(bool includeSuffix) const;
+
     bool verticalSep;
     std::vector<int> seps;
 
@@ -118,6 +121,7 @@ private:
     QGCustomText* m_tolTextOver;
     QGCustomText* m_tolTextUnder;
     QGCustomText* m_unitText;
+    QGCustomText* m_suffixText;
     QGraphicsItemGroup* m_textItems;
     QGraphicsRectItem* m_frame;
     QColor m_colNormal;

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -306,6 +306,7 @@ void QGIViewDimension::updateDim()
     prepareGeometryChange();
     datumLabel->setDimString(QString::fromStdString(labelText));
     datumLabel->setToleranceString();
+    datumLabel->setSuffixString();
 
     datumLabel->setFramed(dim->TheoreticalExact.getValue());
     datumLabel->setLineWidth(m_lineWidth);

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -26,6 +26,7 @@
 # include <QAction>
 # include <QColor>
 # include <QMenu>
+# include <QCursor>
 
 
 #include <QMessageBox>
@@ -52,6 +53,7 @@
 #include "QGIViewDimension.h"
 #include "ViewProviderPage.h"
 #include "ViewProviderDimension.h"
+#include "DimensionQuickEdit.h"
 
 using namespace TechDrawGui;
 using namespace TechDraw;
@@ -157,7 +159,7 @@ bool ViewProviderDimension::setEdit(int ModNum)
     Gui::Selection().clearSelection();
     auto qgivDimension(dynamic_cast<QGIViewDimension*>(getQView()));
     if (qgivDimension) {
-        Gui::Control().showDialog(new TaskDlgDimension(qgivDimension, this));
+        DimensionQuickEdit::showFor(this, QCursor::pos());
     }
     return true;
 }


### PR DESCRIPTION
## Summary
In TechDraw, when double clicking on a dimension, the Dimension Task Panel opens, where user can configure attributes of the dimension. 

<img width="573" height="874" alt="20260829_22h30m02s_grim" src="https://github.com/user-attachments/assets/bf0ef59a-3fc1-41fb-9ffb-d50890bcff24" />

Whilst this panel has a lot of features and is relatively powerful, it is not super convenient compared to other UX methods of editing dimension attributes. The user has to focus their attention to the side of the screen, move the mouse over there, and sift through a large number of options for what is frequently just a small change, such as adding a prefix. And following through on the adding prefix example, there is additionally cognitive load, in that the user must work out that they have to edit a format specifier to add a prefix or suffix. That is where a small window that pops up near the cursor with frequently adjusted params comes in handy.

This idea came from exploring how Onshape is handling editing of dimension attributes. Initially discussed here on discord:
https://discord.com/channels/870877411049357352/1516411470915571732/1516412982899249252

Here is a screenshot of the popup panel from Onshape:
<img width="509" height="158" alt="20260825_21h18m19s_grim" src="https://github.com/user-attachments/assets/27a13ef9-5795-4895-b42b-114d8d96dd86" />

Jumping ahead a little, here is in total what I have come up with:

<img width="1071" height="352" alt="20260829_22h28m10s_grim" src="https://github.com/user-attachments/assets/2124a087-49b8-4ac2-ac8e-2a43365fba2a" />

---

This PR is broken into 2 commits. One commit for the new feature (Dimension Quick Edit), and another unplanned commit which fixes many rendering bugs I encountered along the way (the friends, you could say).

Here is a summary of all bugs i encountered and fixed: (all screenshots below are of the BUGGY code, not the fix)

1) Tolerance values could render in a different unit to the nominal dimension. For example 10.2mm +0.020 would render as 10.2 +20. Under the hood techdraw was seeing that 0.02mm would be better expressed in micrometers. This is not what we want for a tolerance dimension. 


2) TechDraw would use `w` in format specifier for tolerances, which would truncate the zeros off. this is not what we want, because tolerance is meant to show the full precision. So default has been changed to `f`
<img width="532" height="134" alt="20260829_22h42m11s_grim" src="https://github.com/user-attachments/assets/1a89d340-82de-47aa-92cd-bab9547a0d3b" />

3) Suffix was being rendered before the tolerance, but it should be after 
<img width="1031" height="147" alt="20260829_22h44m57s_grim" src="https://github.com/user-attachments/assets/7dead7ff-8fe7-4f66-92d0-9d140de0df80" />

4) Theoretically exact border would include the prefix and suffix. It shouldn't. It should include dimension value and any prefixed symbols
<img width="390" height="80" alt="20260829_23h18m18s_grim" src="https://github.com/user-attachments/assets/70b7bad5-13e4-436c-913e-5c5e2c46dd5f" />

> Note on my fix, i made it exlude suffix from the frame, but include prefix, because we dont really know if user will put a symbol in there or just some natural language or both. Worth figuring out a better system in the future
<img width="411" height="67" alt="20260829_23h32m55s_grim" src="https://github.com/user-attachments/assets/5e9f3fb7-3540-465d-9912-8ae9480ad6b8" />


##  Video (After)
This video is a full demonstration of the tool. (no audio)

https://github.com/user-attachments/assets/43c48a94-986d-4f3e-a9ad-a88fd44d4b30


## Issues
Fix #29490
I couldnt find any others



##  AI Stuff

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by Claude Sonnet 

AI disclaimer: initial quick dimension feature was generated with AI. Then over the span of about 4 days I reviewed every line of code, and tested all functionality and added new things, improved code quality etc. As I was testing, I fixed many bugs in the dimension formatter. I understand and have reviewed all code personally in this PR.





