### PR TITLE
TechDraw: manual backport of PR #29430 (Line Format)

### DIFF
--- a/src/Mod/TechDraw/App/LineFormat.cpp
+++ b/src/Mod/TechDraw/App/LineFormat.cpp
@@ -32,13 +32,38 @@ using namespace TechDraw;
 
 //! general purpose line format specifier
 
-LineFormat::LineFormat()
+LineFormat::LineFormat() :
+    m_style(getDefEdgeStyle()),
+    m_weight(getDefEdgeWidth()),
+    m_color(getDefEdgeColor()),
+    m_visible(true),
+    m_lineNumber(LineGenerator::fromQtStyle((Qt::PenStyle)m_style))
 {
-    m_style = getDefEdgeStyle();
-    m_weight = getDefEdgeWidth();
-    m_color= getDefEdgeColor();
-    m_visible = true;
-    m_lineNumber = LineGenerator::fromQtStyle((Qt::PenStyle)m_style);
+}
+
+LineFormat::LineFormat(const int style,
+                       const double weight,
+                       const Base::Color& color,
+                       const bool visible) :
+    m_style(style),
+    m_weight(weight),
+    m_color(color),
+    m_visible(visible),
+    m_lineNumber(LineGenerator::fromQtStyle((Qt::PenStyle)m_style))
+{
+}
+
+LineFormat::LineFormat(const int style,
+                       const double weight,
+                       const Base::Color& color,
+                       const bool visible,
+                       const int lineNumber) :
+    m_style(style),
+    m_weight(weight),
+    m_color(color),
+    m_visible(visible),
+    m_lineNumber(lineNumber)
+{
 }
 
 // static loader of default format
@@ -53,7 +78,7 @@ void LineFormat::initCurrentLineFormat()
 
 LineFormat& LineFormat::getCurrentLineFormat()
 {
-    static TechDraw::LineFormat currentLineFormat;
+    static TechDraw::LineFormat currentLineFormat;      // only 1 of these
     return currentLineFormat;
 }
 
@@ -66,29 +91,6 @@ void LineFormat::setCurrentLineFormat(LineFormat& newFormat)
     getCurrentLineFormat().setLineNumber(newFormat.getLineNumber());
 }
 
-LineFormat::LineFormat(const int style,
-                       const double weight,
-                       const Base::Color& color,
-                       const bool visible) :
-    m_style(style),
-    m_weight(weight),
-    m_color(color),
-    m_visible(visible),
-    m_lineNumber(LineGenerator::fromQtStyle((Qt::PenStyle)m_style))
-{
-}
-LineFormat::LineFormat(const int style,
-           const double weight,
-           const Base::Color& color,
-           const bool visible,
-           const int lineNumber) :
-    m_style(style),
-    m_weight(weight),
-    m_color(color),
-    m_visible(visible),
-    m_lineNumber(lineNumber)
-{
-}
 
 void LineFormat::dump(const char* title)
 {
@@ -122,4 +124,12 @@ int LineFormat::getDefEdgeStyle()
     return Preferences::getPreferenceGroup("Decorations")->GetInt("CenterLineStyle", 2);   //dashed
 }
 
+//! true if both have same attributes.
+bool LineFormat::isEqual(const LineFormat& lf0, const LineFormat& lf1)
+{
+    return lf0.getColor() == lf1.getColor()  &&
+        lf0.getWidth() == lf1.getWidth()  &&
+        lf0.getVisible() == lf1.getVisible()  &&
+        lf0.getLineNumber() == lf1.getLineNumber();
+}
 

--- a/src/Mod/TechDraw/App/LineFormat.cpp
+++ b/src/Mod/TechDraw/App/LineFormat.cpp
@@ -77,6 +77,18 @@ LineFormat::LineFormat(const int style,
     m_lineNumber(LineGenerator::fromQtStyle((Qt::PenStyle)m_style))
 {
 }
+LineFormat::LineFormat(const int style,
+           const double weight,
+           const Base::Color& color,
+           const bool visible,
+           const int lineNumber) :
+    m_style(style),
+    m_weight(weight),
+    m_color(color),
+    m_visible(visible),
+    m_lineNumber(lineNumber)
+{
+}
 
 void LineFormat::dump(const char* title)
 {

--- a/src/Mod/TechDraw/App/LineFormat.h
+++ b/src/Mod/TechDraw/App/LineFormat.h
@@ -81,6 +81,7 @@ public:
     static void initCurrentLineFormat();
     static LineFormat& getCurrentLineFormat();
     static void setCurrentLineFormat(LineFormat& newformat);
+    static bool isEqual(const LineFormat& lf0, const LineFormat& lf1);
 
 private:
     int m_style;

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>440</width>
-    <height>448</height>
+    <width>469</width>
+    <height>497</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -63,7 +63,7 @@
         </item>
         <item row="6" column="1">
          <widget class="Gui::PrefColorButton" name="pcbHighlight">
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>0</red>
             <green>0</green>
@@ -111,7 +111,7 @@
           <property name="toolTip">
            <string>Background color around pages</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>211</red>
             <green>211</green>
@@ -129,7 +129,7 @@
         <item row="0" column="2">
          <spacer name="horizontalSpacer_3">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -144,7 +144,7 @@
           <property name="toolTip">
            <string>Centerline color</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>0</red>
             <green>0</green>
@@ -183,7 +183,7 @@
           <property name="toolTip">
            <string>Preselection color</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>255</red>
             <green>255</green>
@@ -214,26 +214,6 @@
           </property>
           <property name="text">
            <string>Background</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="4">
-         <widget class="Gui::PrefColorButton" name="pcb_Face">
-          <property name="toolTip">
-           <string>Face color (if not transparent)</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>255</red>
-            <green>255</green>
-            <blue>255</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>FaceColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Colors</cstring>
           </property>
          </widget>
         </item>
@@ -279,7 +259,7 @@
           <property name="toolTip">
            <string>Color of dimension lines and text</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>0</red>
             <green>0</green>
@@ -299,7 +279,7 @@
           <property name="toolTip">
            <string>Use a light color for dark text and dark color for light text</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>255</red>
             <green>255</green>
@@ -326,7 +306,7 @@
           <property name="toolTip">
            <string>Hatch image color</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>0</red>
             <green>0</green>
@@ -346,7 +326,7 @@
           <property name="toolTip">
            <string>Section line color</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>0</red>
             <green>0</green>
@@ -366,7 +346,7 @@
           <property name="toolTip">
            <string>Geometric hatch pattern color</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>0</red>
             <green>0</green>
@@ -440,7 +420,7 @@
           <property name="toolTip">
            <string>Selected item color</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>0</red>
             <green>255</green>
@@ -460,7 +440,7 @@
           <property name="toolTip">
            <string>Default color for leader lines</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>0</red>
             <green>0</green>
@@ -475,39 +455,12 @@
           </property>
          </widget>
         </item>
-        <item row="7" column="3">
-         <widget class="Gui::PrefCheckBox" name="pcb_PaintFaces">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Object faces will be transparent</string>
-          </property>
-          <property name="text">
-           <string>Transparent faces</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ClearFace</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Colors</cstring>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="1">
          <widget class="Gui::PrefColorButton" name="pcb_Normal">
           <property name="toolTip">
            <string>Normal line color</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>0</red>
             <green>0</green>
@@ -527,7 +480,7 @@
           <property name="toolTip">
            <string>Hidden line color</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>0</red>
             <green>0</green>
@@ -544,7 +497,7 @@
         </item>
         <item row="7" column="1">
          <widget class="Gui::PrefColorButton" name="pcb_Grid">
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>0</red>
             <green>0</green>
@@ -571,7 +524,7 @@
           <property name="toolTip">
            <string>Color of vertices in views</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>0</red>
             <green>0</green>
@@ -622,7 +575,7 @@
           <property name="toolTip">
            <string>Section face color</string>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>211</red>
             <green>211</green>
@@ -646,7 +599,7 @@
         </item>
         <item row="8" column="1">
          <widget class="Gui::PrefColorButton" name="pcbUnderline">
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>0</red>
             <green>0</green>
@@ -658,6 +611,85 @@
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="3">
+         <widget class="Gui::PrefCheckBox" name="pcb_PaintFaces">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Object faces will be transparent</string>
+          </property>
+          <property name="text">
+           <string>Transparent faces</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ClearFace</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="4">
+         <widget class="Gui::PrefColorButton" name="pcb_Face">
+          <property name="toolTip">
+           <string>Face color (if not transparent)</string>
+          </property>
+          <property name="color" stdset="0">
+           <color>
+            <red>255</red>
+            <green>255</green>
+            <blue>255</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>FaceColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="3">
+         <widget class="QLabel" name="label_9">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Break line</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="4">
+         <widget class="Gui::PrefColorButton" name="pcb_Breakline">
+          <property name="toolTip">
+           <string>Break line color for broken views</string>
+          </property>
+          <property name="color" stdset="0">
+           <color>
+            <red>255</red>
+            <green>255</green>
+            <blue>255</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>BreakLineColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Decorations</cstring>
           </property>
          </widget>
         </item>
@@ -685,7 +717,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
@@ -680,9 +680,9 @@
           </property>
           <property name="color" stdset="0">
            <color>
-            <red>255</red>
-            <green>255</green>
-            <blue>255</blue>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
            </color>
           </property>
           <property name="prefEntry" stdset="0">

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColorsImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColorsImp.cpp
@@ -65,6 +65,7 @@ void DlgPrefsTechDrawColorsImp::saveSettings()
     ui->pcbMonochrome->onSave();
     ui->pcbLightTextColor->onSave();
     ui->pcbUnderline->onSave();
+    ui->pcb_Breakline->onSave();
 }
 
 void DlgPrefsTechDrawColorsImp::loadSettings()
@@ -91,6 +92,7 @@ void DlgPrefsTechDrawColorsImp::loadSettings()
     ui->pcbMonochrome->onRestore();
     ui->pcbLightTextColor->onRestore();
     ui->pcbUnderline->onRestore();
+    ui->pcb_Breakline->onRestore();
 }
 
 /**

--- a/src/Mod/TechDraw/Gui/PreferencesGui.cpp
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.cpp
@@ -99,7 +99,7 @@ QColor PreferencesGui::sectionLineQColor()
 Base::Color PreferencesGui::breaklineColor()
 {
     Base::Color fcColor;
-    fcColor.setPackedValue(Preferences::getPreferenceGroup("Decorations")->GetUnsigned("BreaklineColor", 0x000000FF));
+    fcColor.setPackedValue(Preferences::getPreferenceGroup("Decorations")->GetUnsigned("BreakLineColor", 0xFF0000FF));
     return fcColor;
 }
 
@@ -107,7 +107,7 @@ QColor PreferencesGui::breaklineQColor()
 {
 //if the Base::Color version has already lightened the color, we don't want to do it again
     Base::Color fcColor;
-    fcColor.setPackedValue(Preferences::getPreferenceGroup("Decorations")->GetUnsigned("BreaklineColor", 0x000000FF));
+    fcColor.setPackedValue(Preferences::getPreferenceGroup("Decorations")->GetUnsigned("BreakLineColor", 0x000000FF));
     return fcColor.asValue<QColor>();
 }
 

--- a/src/Mod/TechDraw/Gui/PreferencesGui.cpp
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.cpp
@@ -99,7 +99,7 @@ QColor PreferencesGui::sectionLineQColor()
 Base::Color PreferencesGui::breaklineColor()
 {
     Base::Color fcColor;
-    fcColor.setPackedValue(Preferences::getPreferenceGroup("Decorations")->GetUnsigned("BreakLineColor", 0xFF0000FF));
+    fcColor.setPackedValue(Preferences::getPreferenceGroup("Decorations")->GetUnsigned("BreakLineColor", 0x000000FF));
     return fcColor;
 }
 

--- a/src/Mod/TechDraw/Gui/QGIHighlight.cpp
+++ b/src/Mod/TechDraw/Gui/QGIHighlight.cpp
@@ -167,10 +167,15 @@ void QGIHighlight::setFont(QFont f, double fsize)
 }
 
 
-//obs?
+
 QColor QGIHighlight::getHighlightColor()
 {
-    return PreferencesGui::sectionLineQColor();
+    return m_pen.color();
+}
+
+void QGIHighlight::setHighlightColor(QColor newColor)
+{
+    m_pen.setColor(newColor);
 }
 
 int QGIHighlight::getHoleStyle()

--- a/src/Mod/TechDraw/Gui/QGIHighlight.h
+++ b/src/Mod/TechDraw/Gui/QGIHighlight.h
@@ -65,9 +65,11 @@ public:
     void onDragFinished() override;
 
     void setLinePen(QPen isoPen);
+    QColor getHighlightColor();
+    void setHighlightColor(QColor newColor);
 
 protected:
-    QColor getHighlightColor();
+
     void makeHighlight();
     void makeReference();
     void setTools();

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -1076,7 +1076,7 @@ void QGIViewPart::drawBreakLines()
         breakLine->setWidth(Rez::guiX(vp->HiddenWidth.getValue()));
         breakLine->setBreakType(breakType);
         breakLine->setZValue(ZVALUE::SECTIONLINE);
-        Base::Color color = prefBreaklineColor();
+        Base::Color color = vp->BreakLineColor.getValue();
         breakLine->setBreakColor(color.asValue<QColor>());
         breakLine->setRotation(-dbv->Rotation.getValue());
         breakLine->draw();

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -982,7 +982,6 @@ void QGIViewPart::drawHighlight(TechDraw::DrawViewDetail* viewDetail, bool b)
         highlight->setWidth(Rez::guiX(vp->IsoWidth.getValue()));
         highlight->setFont(getFont(), fontSize);
         highlight->setZValue(ZVALUE::HIGHLIGHT);
-        highlight->setColor(vp->HighlightLineColor.getValue().asValue<QColor>());
         highlight->setReferenceAngle(vpDetail->HighlightAdjust.getValue());
 
         //handle conversion of apparent X,Y to rotated

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -961,8 +961,6 @@ void QGIViewPart::drawHighlight(TechDraw::DrawViewDetail* viewDetail, bool b)
         scene()->addItem(highlight);
         highlight->setReference(viewDetail->Reference.getValue());
 
-        Base::Color color = Preferences::getAccessibleColor(vp->HighlightLineColor.getValue());
-        highlight->setColor(color.asValue<QColor>());
         highlight->setFeatureName(viewDetail->getNameInDocument());
 
         highlight->setInteractive(false);
@@ -981,8 +979,10 @@ void QGIViewPart::drawHighlight(TechDraw::DrawViewDetail* viewDetail, bool b)
                              vp->IsoWidth.getValue()));
         highlight->setWidth(Rez::guiX(vp->IsoWidth.getValue()));
         highlight->setFont(getFont(), fontSize);
+        Base::Color color = Preferences::getAccessibleColor(vp->HighlightLineColor.getValue());
+        highlight->setColor(color.asValue<QColor>());
         highlight->setZValue(ZVALUE::HIGHLIGHT);
-        highlight->setReferenceAngle(vpDetail->HighlightAdjust.getValue());
+        highlight->setReferenceAngle(vp->HighlightAdjust.getValue());
 
         //handle conversion of apparent X,Y to rotated
         QPointF rotCenter = highlight->mapFromParent(transformOriginPoint());

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -982,6 +982,7 @@ void QGIViewPart::drawHighlight(TechDraw::DrawViewDetail* viewDetail, bool b)
         highlight->setWidth(Rez::guiX(vp->IsoWidth.getValue()));
         highlight->setFont(getFont(), fontSize);
         highlight->setZValue(ZVALUE::HIGHLIGHT);
+        highlight->setColor(vp->HighlightLineColor.getValue().asValue<QColor>());
         highlight->setReferenceAngle(vpDetail->HighlightAdjust.getValue());
 
         //handle conversion of apparent X,Y to rotated

--- a/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
@@ -50,10 +50,10 @@ TaskLineDecor::TaskLineDecor(TechDraw::DrawViewPart* partFeat,
     ui(new Ui_TaskLineDecor),
     m_partFeat(partFeat),
     m_edges(edgeNames),
-    m_apply(true)
+    m_apply(true),
+    m_lineGenerator(new TechDraw::LineGenerator)
 {
     initializeRejectArrays();
-    m_lineGenerator = new TechDraw::LineGenerator;
 
     ui->setupUi(this);
 
@@ -122,20 +122,25 @@ TechDraw::LineFormat *TaskLineDecor::getFormatAccessPtr(const std::string &edgeN
             if (gf) {
                 return &gf->m_format;
             }
-            else {
-                ViewProviderViewPart *viewPart = dynamic_cast<ViewProviderViewPart *>(QGIView::getViewProvider(m_partFeat));
-                if (viewPart) {
-                    TechDraw::LineFormat lineFormat(Qt::SolidLine, viewPart->LineWidth.getValue(), LineFormat::getDefEdgeColor(), true);
-                    TechDraw::GeomFormat geomFormat(DrawUtil::getIndexFromName(edgeName), lineFormat);
+            ViewProviderViewPart *viewPart = dynamic_cast<ViewProviderViewPart *>(QGIView::getViewProvider(m_partFeat));
+            if (viewPart) {
+                // this gives any selected edge w/o a format a persistent format?
+                constexpr bool Visible{true};
+                TechDraw::LineFormat lineFormat(Qt::DotLine,
+                                                LineFormat::getCurrentLineFormat().getWidth(),
+                                                LineFormat::getCurrentLineFormat().getColor(),
+                                                Visible,
+                                                LineFormat::getCurrentLineFormat().getLineNumber());
+                TechDraw::GeomFormat geomFormat(DrawUtil::getIndexFromName(edgeName), lineFormat);
 
-                    std::string formatTag = m_partFeat->addGeomFormat(&geomFormat);
-                    if (newFormatTag) {
-                        *newFormatTag = formatTag;
-                    }
-
-                    return &m_partFeat->getGeomFormat(formatTag)->m_format;
+                std::string formatTag = m_partFeat->addGeomFormat(&geomFormat);
+                if (newFormatTag) {
+                    *newFormatTag = formatTag;
                 }
+
+                return &m_partFeat->getGeomFormat(formatTag)->m_format;
             }
+
         }
     }
     return {};
@@ -162,14 +167,16 @@ void TaskLineDecor::initializeRejectArrays()
 // get the current line tool appearance default
 void TaskLineDecor::getDefaults()
 {
-//    Base::Console().message("TLD::getDefaults()\n");
     m_color = LineFormat::getCurrentLineFormat().getColor();
     m_weight = LineFormat::getCurrentLineFormat().getWidth();
     m_visible = LineFormat::getCurrentLineFormat().getVisible();
     m_lineNumber = LineFormat::getCurrentLineFormat().getLineNumber();
 
     //set defaults to format of 1st edge
-    if (!m_originalFormats.empty()) {
+    // this is never empty. getFormatAccessPtr() creates a default GeomFormat
+    // for any edge in the selelction that doesn't already have one.
+    if (!m_originalFormats.empty()  &&
+        !LineFormat::isEqual(m_originalFormats.front(), LineFormat::getCurrentLineFormat())) {
         LineFormat &lf = m_originalFormats.front();
         m_style = lf.getStyle();
         m_color = lf.getColor();
@@ -304,7 +311,6 @@ void TaskRestoreLines::initUi()
 
 void TaskRestoreLines::onAllPressed()
 {
-//    Base::Console().message("TRL::onAllPressed()\n");
     onGeometryPressed();
     onCosmeticPressed();
     onCenterPressed();
@@ -312,7 +318,6 @@ void TaskRestoreLines::onAllPressed()
 
 void TaskRestoreLines::onGeometryPressed()
 {
-//    Base::Console().message("TRL::onGeometryPressed()\n");
     restoreInvisibleGeoms();
     ui->l_Geometry->setText(QString::number(0));
     ui->l_All->setText(QString::number(countInvisibleLines()));
@@ -320,7 +325,6 @@ void TaskRestoreLines::onGeometryPressed()
 
 void TaskRestoreLines::onCosmeticPressed()
 {
-//    Base::Console().message("TRL::onCosmeticPressed()\n");
     restoreInvisibleCosmetics();
     ui->l_Cosmetic->setText(QString::number(0));
     ui->l_All->setText(QString::number(countInvisibleLines()));
@@ -328,7 +332,6 @@ void TaskRestoreLines::onCosmeticPressed()
 
 void TaskRestoreLines::onCenterPressed()
 {
-//    Base::Console().message("TRL::onCenterPressed()\n");
     restoreInvisibleCenters();
     ui->l_Center->setText(QString::number(0));
     ui->l_All->setText(QString::number(countInvisibleLines()));
@@ -425,13 +428,11 @@ void TaskRestoreLines::restoreInvisibleCenters()
 
 bool TaskRestoreLines::accept()
 {
-//    Base::Console().message("TRL::accept()\n");
     return true;
 }
 
 bool TaskRestoreLines::reject()
 {
-//    Base::Console().message("TRL::reject()\n");
     return false;
 }
 
@@ -483,14 +484,12 @@ void TaskDlgLineDecor::clicked(int i)
 
 bool TaskDlgLineDecor::accept()
 {
-//    Base::Console().message("TDLD::accept()\n");
     widget->accept();
     return true;
 }
 
 bool TaskDlgLineDecor::reject()
 {
-//    Base::Console().message("TDLD::reject()\n");
     widget->reject();
     return true;
 }

--- a/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
@@ -167,6 +167,7 @@ void TaskLineDecor::initializeRejectArrays()
 // get the current line tool appearance default
 void TaskLineDecor::getDefaults()
 {
+    m_style = LineFormat::getCurrentLineFormat().getStyle();
     m_color = LineFormat::getCurrentLineFormat().getColor();
     m_weight = LineFormat::getCurrentLineFormat().getWidth();
     m_visible = LineFormat::getCurrentLineFormat().getVisible();

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -135,6 +135,8 @@ ViewProviderViewPart::ViewProviderViewPart()
                         "Adjusts the type of break line depiction on broken views");
     ADD_PROPERTY_TYPE(BreakLineStyle, (Preferences::BreakLineStyle()), bvgroup, App::Prop_None,
                         "Set break line style if applicable");
+    ADD_PROPERTY_TYPE(BreakLineColor, (PreferencesGui::breaklineColor()), bvgroup, App::Prop_None,
+                      "Set break line  color if applicable");
 
     ADD_PROPERTY_TYPE(ShowAllEdges ,(false),dgroup, App::Prop_None, "Temporarily show invisible lines");
 
@@ -197,6 +199,7 @@ void ViewProviderViewPart::onChanged(const App::Property* prop)
         prop == &(FaceColor) ||
         prop == &(FaceTransparency)  ||
         prop == &(BreakLineType)   ||
+        prop == &(BreakLineColor)   ||
         prop == &(BreakLineStyle) ) {
         // redraw QGIVP
         QGIView* qgiv = getQView();
@@ -425,6 +428,7 @@ int ViewProviderViewPart::prefHighlightStyle()
 {
     return Preferences::getPreferenceGroup("Decorations")->GetInt("HighlightStyle", 2);
 }
+
 
 // it can happen that Dimensions/Balloons/etc can lose their parent item if the
 // the parent is deleted, then undo is invoked.  The linkages on the App side are

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -221,6 +221,14 @@ void ViewProviderViewPart::attach(App::DocumentObject *pcFeat)
         sPixmap = "TechDraw_TreeMulti";
     } else if (dvd) {
         sPixmap = "actions/TechDraw_DetailView";
+        KeepLabel.setValue(true);
+        // these properties apply to the base view, not the detail
+        HighlightLineStyle.setStatus(App::Property::ReadOnly, true);
+        HighlightLineStyle.setStatus(App::Property::Hidden, true);
+        HighlightLineColor.setStatus(App::Property::ReadOnly, true);
+        HighlightLineColor.setStatus(App::Property::Hidden, true);
+        HighlightAdjust.setStatus(App::Property::ReadOnly, true);
+        HighlightAdjust.setStatus(App::Property::Hidden, true);
     }
 
     ViewProviderDrawingView::attach(pcFeat);

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
@@ -62,6 +62,7 @@ public:
     App::PropertyFloat  HighlightAdjust;
     App::PropertyEnumeration BreakLineType;
     App::PropertyEnumeration BreakLineStyle;
+    App::PropertyColor  BreakLineColor;
     App::PropertyBool   ShowAllEdges;
     App::PropertyColor   FaceColor;
     App::PropertyPercent FaceTransparency;


### PR DESCRIPTION
The automated backport of PR #29430 failed.  This PR applies the changes from PR #2943 to the releases/FreeCAD-1-1 branch.


- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.