### PR TITLE
Sketcher: Close datum edit transaction on rejection

### DIFF
--- a/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
@@ -79,8 +79,7 @@ bool SketcherGui::checkConstraintName(const Sketcher::SketchObject* sketch, std:
 
 EditDatumDialog::EditDatumDialog(int tid, ViewProviderSketch* vp, int ConstrNbr)
     : ConstrNbr(ConstrNbr)
-    , success(false)
-    , transactionID(tid)
+    , transaction(tid)
 {
     sketch = vp->getSketchObject();
     const std::vector<Sketcher::Constraint*>& Constraints = sketch->Constraints.getValues();
@@ -90,14 +89,17 @@ EditDatumDialog::EditDatumDialog(int tid, ViewProviderSketch* vp, int ConstrNbr)
 EditDatumDialog::EditDatumDialog(int tid, Sketcher::SketchObject* pcSketch, int ConstrNbr)
     : sketch(pcSketch)
     , ConstrNbr(ConstrNbr)
-    , transactionID(tid)
+    , transaction(tid)
 {
     const std::vector<Sketcher::Constraint*>& Constraints = sketch->Constraints.getValues();
     Constr = Constraints[ConstrNbr];
 }
 
 EditDatumDialog::~EditDatumDialog()
-{}
+{
+    // Abort unless the transaction was explicitly closed.
+    transaction.close(App::TransactionCloseMode::Abort);
+}
 
 int EditDatumDialog::exec(bool atCursor)
 {
@@ -105,6 +107,7 @@ int EditDatumDialog::exec(bool atCursor)
     if (Constr->isDimensional()) {
 
         if (sketch->hasConflicts()) {
+            transaction.close(App::TransactionCloseMode::Abort);
             Gui::TranslatedUserWarning(
                 sketch,
                 QObject::tr("Dimensional constraint"),
@@ -313,7 +316,7 @@ void EditDatumDialog::accepted()
                 );
             }
 
-            Gui::Command::commitCommand(transactionID);
+            transaction.close(App::TransactionCloseMode::Commit);
 
             // THIS IS A WORK-AROUND NOT TO DELAY 0.19 RELEASE
             //
@@ -338,7 +341,7 @@ void EditDatumDialog::accepted()
         catch (const Base::Exception& e) {
             Gui::NotifyUserError(sketch, QT_TRANSLATE_NOOP("Notifications", "Value Error"), e.what());
 
-            Gui::Command::abortCommand(transactionID);
+            transaction.close(App::TransactionCloseMode::Abort);
 
             if (sketch->noRecomputes) {  // if setdatum failed, it is highly likely that solver
                                          // information is invalid.
@@ -350,7 +353,7 @@ void EditDatumDialog::accepted()
 
 void EditDatumDialog::rejected()
 {
-    Gui::Command::abortCommand(transactionID);
+    transaction.close(App::TransactionCloseMode::Abort);
     sketch->recomputeFeature();
 }
 

--- a/src/Mod/Sketcher/Gui/EditDatumDialog.h
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.h
@@ -27,6 +27,8 @@
 #include <QObject>
 #include <memory>
 
+#include <App/AutoTransaction.h>
+
 
 namespace Sketcher
 {
@@ -57,9 +59,9 @@ private:
     Sketcher::SketchObject* sketch;
     Sketcher::Constraint* Constr;
     int ConstrNbr;
-    bool success;
+    bool success {false};
     std::unique_ptr<Ui_InsertDatum> ui_ins_datum;
-    int transactionID;
+    App::AutoTransaction transaction;
 
 private Q_SLOTS:
     void accepted();

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -20,6 +20,15 @@ add_executable(Gui_tests_run
 # Qt tests
 setup_qt_test(ObjectSelection)
 setup_qt_test(QuantitySpinBox)
+if(BUILD_SKETCHER)
+    setup_qt_test(SketcherEditDatumDialog)
+
+    target_sources(SketcherEditDatumDialog_Tests_run PRIVATE
+        ${CMAKE_SOURCE_DIR}/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
+    )
+
+    target_link_libraries(SketcherEditDatumDialog_Tests_run Sketcher)
+endif()
 
 target_link_libraries(Gui_tests_run PRIVATE
     GTest::gmock_main

--- a/tests/src/Gui/SketcherEditDatumDialog.cpp
+++ b/tests/src/Gui/SketcherEditDatumDialog.cpp
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <QDialog>
+#include <QTest>
+
+#include <vector>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/TransactionDefs.h>
+#include <Gui/Application.h>
+#include <Mod/Part/App/Geometry.h>
+#include <Mod/Sketcher/App/SketchObject.h>
+#include <Mod/Sketcher/Gui/CommandSketcherTools.h>
+#include <Mod/Sketcher/Gui/EditDatumDialog.h>
+#include <Mod/Sketcher/Gui/Utils.h>
+#include <Mod/Sketcher/Gui/ViewProviderSketch.h>
+
+#include <src/App/InitApplication.h>
+
+// The conflict path does not call these helpers. Stub them so
+// EditDatumDialog.cpp can be linked without SketcherGui.
+Sketcher::SketchObject* SketcherGui::ViewProviderSketch::getSketchObject() const
+{
+    return nullptr;
+}
+
+bool SketcherGui::tryAutoRecompute(Sketcher::SketchObject*)
+{
+    return false;
+}
+
+void SketcherGui::centerScale(double)
+{}
+
+class SketcherEditDatumDialogTest: public QObject
+{
+    Q_OBJECT
+
+public:
+    SketcherEditDatumDialogTest()
+    {
+        tests::initApplication();
+        if (!Gui::Application::Instance) {
+            new Gui::Application(false);
+        }
+    }
+
+private Q_SLOTS:
+    void init()
+    {
+        docName = App::GetApplication().getUniqueDocumentName("sketcher_edit_datum");
+        doc = App::GetApplication().newDocument(docName.c_str(), "testUser");
+        sketch = static_cast<Sketcher::SketchObject*>(
+            doc->addObject("Sketcher::SketchObject", "Sketch")
+        );
+        std::vector<Part::Geometry*> geometry;
+        auto addLine = [&geometry](const Base::Vector3d& start, const Base::Vector3d& end) {
+            auto* line = new Part::GeomLineSegment();
+            line->setPoints(start, end);
+            geometry.push_back(line);
+        };
+        addLine(Base::Vector3d(-5, 5, 0), Base::Vector3d(-5, -5, 0));
+        addLine(Base::Vector3d(-5, -5, 0), Base::Vector3d(5, -5, 0));
+        addLine(Base::Vector3d(5, -5, 0), Base::Vector3d(5, 5, 0));
+        addLine(Base::Vector3d(5, 5, 0), Base::Vector3d(-5, 5, 0));
+
+        std::vector<Sketcher::Constraint*> constraints;
+        auto addConstraint = [&constraints](
+                                 Sketcher::ConstraintType type,
+                                 int first,
+                                 Sketcher::PointPos firstPos = Sketcher::PointPos::none,
+                                 int second = Sketcher::GeoEnum::GeoUndef,
+                                 Sketcher::PointPos secondPos = Sketcher::PointPos::none,
+                                 int third = Sketcher::GeoEnum::GeoUndef) {
+            auto* constraint = new Sketcher::Constraint();
+            constraint->Type = type;
+            constraint->First = first;
+            constraint->FirstPos = firstPos;
+            constraint->Second = second;
+            constraint->SecondPos = secondPos;
+            constraint->Third = third;
+            constraints.push_back(constraint);
+        };
+
+        addConstraint(Sketcher::Coincident, 0, Sketcher::PointPos::end, 1, Sketcher::PointPos::start);
+        addConstraint(Sketcher::Coincident, 1, Sketcher::PointPos::end, 2, Sketcher::PointPos::start);
+        addConstraint(Sketcher::Coincident, 2, Sketcher::PointPos::end, 3, Sketcher::PointPos::start);
+        addConstraint(Sketcher::Coincident, 3, Sketcher::PointPos::end, 0, Sketcher::PointPos::start);
+        addConstraint(Sketcher::Vertical, 0);
+        addConstraint(Sketcher::Horizontal, 1);
+        addConstraint(Sketcher::Equal, 3, Sketcher::PointPos::none, 2);
+        addConstraint(Sketcher::Symmetric,
+                      2,
+                      Sketcher::PointPos::end,
+                      1,
+                      Sketcher::PointPos::end,
+                      Sketcher::GeoEnum::HAxis);
+        addConstraint(Sketcher::Symmetric,
+                      2,
+                      Sketcher::PointPos::end,
+                      0,
+                      Sketcher::PointPos::start,
+                      Sketcher::GeoEnum::VAxis);
+
+        auto* distance = new Sketcher::Constraint();
+        distance->Type = Sketcher::DistanceX;
+        distance->First = 3;
+        distance->FirstPos = Sketcher::PointPos::end;
+        distance->Second = 3;
+        distance->SecondPos = Sketcher::PointPos::start;
+        distance->setValue(10.0);
+        constraints.push_back(distance);
+        editedConstraint = 9;
+
+        sketch->Geometry.setValues(std::move(geometry));
+        sketch->Constraints.setValues(std::move(constraints));
+        doc->recompute();
+    }
+
+    void cleanup()
+    {
+        if (doc) {
+            if (doc->getBookedTransactionID() != App::NullTransaction) {
+                doc->abortTransaction();
+            }
+            App::GetApplication().closeDocument(docName.c_str());
+        }
+        doc = nullptr;
+        sketch = nullptr;
+    }
+
+    void conflictRejectsAndClosesItsTransaction()
+    {
+        QCOMPARE(sketch->hasConflicts(), 0);
+
+        const int existingTransactionID = doc->openTransaction("Edit Sketch. Constraints");
+        QVERIFY(existingTransactionID != App::NullTransaction);
+        QCOMPARE(sketch->setDatum(editedConstraint, 0.0), 0);
+        doc->recompute();
+        QVERIFY(sketch->solve() != 0);
+        doc->commitTransaction();
+        QVERIFY(sketch->hasConflicts() != 0);
+        const int undoCountBefore = doc->getAvailableUndos();
+        QVERIFY(undoCountBefore > 0);
+
+        const int transactionID = doc->openTransaction("Modify sketch constraints");
+        QVERIFY(transactionID != App::NullTransaction);
+
+        {
+            SketcherGui::EditDatumDialog dialog(transactionID, sketch, editedConstraint);
+            QCOMPARE(dialog.exec(false), QDialog::Rejected);
+            QVERIFY(!dialog.isSuccess());
+        }
+
+        QCOMPARE(doc->getBookedTransactionID(), App::NullTransaction);
+        QCOMPARE(doc->getAvailableUndos(), undoCountBefore);
+
+        QVERIFY(doc->undo());
+        QCOMPARE(sketch->getDatum(editedConstraint), 10.0);
+        QCOMPARE(sketch->solve(), 0);
+        QCOMPARE(sketch->hasConflicts(), 0);
+    }
+
+private:
+    std::string docName;
+    App::Document* doc {nullptr};
+    Sketcher::SketchObject* sketch {nullptr};
+    int editedConstraint {-1};
+};
+
+QTEST_MAIN(SketcherEditDatumDialogTest)
+#include "SketcherEditDatumDialog.moc"

--- a/tests/src/Gui/SketcherEditDatumDialog.cpp
+++ b/tests/src/Gui/SketcherEditDatumDialog.cpp
@@ -72,7 +72,8 @@ private Q_SLOTS:
                                  Sketcher::PointPos firstPos = Sketcher::PointPos::none,
                                  int second = Sketcher::GeoEnum::GeoUndef,
                                  Sketcher::PointPos secondPos = Sketcher::PointPos::none,
-                                 int third = Sketcher::GeoEnum::GeoUndef) {
+                                 int third = Sketcher::GeoEnum::GeoUndef
+                             ) {
             auto* constraint = new Sketcher::Constraint();
             constraint->Type = type;
             constraint->First = first;
@@ -90,18 +91,22 @@ private Q_SLOTS:
         addConstraint(Sketcher::Vertical, 0);
         addConstraint(Sketcher::Horizontal, 1);
         addConstraint(Sketcher::Equal, 3, Sketcher::PointPos::none, 2);
-        addConstraint(Sketcher::Symmetric,
-                      2,
-                      Sketcher::PointPos::end,
-                      1,
-                      Sketcher::PointPos::end,
-                      Sketcher::GeoEnum::HAxis);
-        addConstraint(Sketcher::Symmetric,
-                      2,
-                      Sketcher::PointPos::end,
-                      0,
-                      Sketcher::PointPos::start,
-                      Sketcher::GeoEnum::VAxis);
+        addConstraint(
+            Sketcher::Symmetric,
+            2,
+            Sketcher::PointPos::end,
+            1,
+            Sketcher::PointPos::end,
+            Sketcher::GeoEnum::HAxis
+        );
+        addConstraint(
+            Sketcher::Symmetric,
+            2,
+            Sketcher::PointPos::end,
+            0,
+            Sketcher::PointPos::start,
+            Sketcher::GeoEnum::VAxis
+        );
 
         auto* distance = new Sketcher::Constraint();
         distance->Type = Sketcher::DistanceX;


### PR DESCRIPTION
Fixes #17864

When `EditDatumDialog` rejects before being shown because the sketch has conflicts, the transaction supplied by the caller remained open and disrupted normal Undo handling.

This change:

- Manages the supplied transaction with `App::AutoTransaction`.
- Aborts the transaction on rejection and early exits.
- Preserves the existing commit boundary on acceptance.
- Adds a regression test verifying transaction closure and preservation of existing Undo history.

Assisted-by: GPT 5.6 Sol