### PR TITLE
CAM: Give postprocessor properties an explicit editing scope

### DIFF
--- a/src/Mod/CAM/CAMTests/TestGenericPlasma.py
+++ b/src/Mod/CAM/CAMTests/TestGenericPlasma.py
@@ -116,7 +116,8 @@ class TestGenericPlasma(PathTestUtils.PathTestBase):
         schema = self.post.get_property_schema()
 
         # Check that we have the expected number of properties
-        # 5 machine-config properties + 1 runtime-only (mark_entry_only)
+        # 4 "job"-scoped properties + 2 "run"-scoped
+        # (force_rapid_feeds, mark_entry_only)
         self.assertEqual(len(schema), 6)
 
         # Check pierce_delay property

--- a/src/Mod/CAM/CAMTests/TestLinuxCNCPost.py
+++ b/src/Mod/CAM/CAMTests/TestLinuxCNCPost.py
@@ -26,7 +26,12 @@
 import Path
 from CAMTests import PathTestUtils
 from CAMTests import PostTestMocks
-from Path.Post.Processor import PostProcessorFactory
+from Path.Post.Processor import (
+    PostProcessorFactory,
+    SCOPE_JOB,
+    SCOPE_MACHINE,
+    properties_in_scope,
+)
 from Machine.models.machine import Machine, Toolhead, ToolheadType, OutputUnits
 
 Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
@@ -115,6 +120,26 @@ class TestLinuxCNCPost(PathTestUtils.PathTestBase):
         idx = lines.index("G21")  # throws IndexError if unexpectedly missing
         preamble = "\n".join(lines[:idx])
         return gcode, preamble
+
+    def test_blend_properties_are_job_scoped(self):
+        """Blend settings must be configurable in the machine editor.
+
+        They were previously "runtime": True, which made them Overview-tab
+        only and left no way to give a machine a default blending mode.
+        "job" scope keeps the per-run override while restoring the
+        machine-level default.
+        """
+        schema = self.post.__class__.get_full_property_schema()
+        by_name = {prop["name"]: prop for prop in schema}
+
+        for name in ("blend_mode", "blend_tolerance"):
+            with self.subTest(prop=name):
+                self.assertEqual(by_name[name].get("scope"), SCOPE_JOB)
+
+        # Scope "job" is what the machine editor renders alongside "machine".
+        editable = {p["name"] for p in properties_in_scope(schema, SCOPE_MACHINE, SCOPE_JOB)}
+        self.assertIn("blend_mode", editable)
+        self.assertIn("blend_tolerance", editable)
 
     def test_blend_mode_exact_path(self):
         """Test EXACT_PATH blend mode outputs G61."""

--- a/src/Mod/CAM/CAMTests/TestPostProcessor.py
+++ b/src/Mod/CAM/CAMTests/TestPostProcessor.py
@@ -31,7 +31,18 @@ import FreeCAD
 import Path
 import Path.Preferences
 import Path.Main.Job as PathJob
-from Path.Post.Processor import PostProcessor, PostProcessorFactory, _HeaderBuilder
+from Path.Post.Processor import (
+    PostProcessor,
+    PostProcessorFactory,
+    SCOPE_INTERNAL,
+    SCOPE_JOB,
+    SCOPE_MACHINE,
+    SCOPE_RUN,
+    VALID_SCOPES,
+    _HeaderBuilder,
+    properties_in_scope,
+    property_scope,
+)
 import Path.Post.Command as PathCommand
 from Path.Post.CAMErrors import CAMValueError
 from Path.Post.PostList import Postable
@@ -508,6 +519,91 @@ class TestPostProcessorClassification(unittest.TestCase):
         # Default implementation should return empty list
         squawks = processor.get_sanity_checks(mock_job)
         self.assertEqual(squawks, [])
+
+
+class TestPropertyScope(unittest.TestCase):
+    """Tests for property_scope() and properties_in_scope().
+
+    Scope decides which UI surface may edit a postprocessor property:
+    the machine editor ("machine", "job"), the post-processing dialog
+    ("job" on Options, "run" on Overview), or neither ("internal").
+    """
+
+    def test00_explicit_scope_is_returned(self):
+        """An entry declaring a valid scope gets that scope back."""
+        for scope in VALID_SCOPES:
+            with self.subTest(scope=scope):
+                self.assertEqual(property_scope({"name": "p", "scope": scope}), scope)
+
+    def test01_missing_scope_defaults_to_job(self):
+        """An entry declaring no scope is editable in both surfaces.
+
+        This preserves the historical behaviour of postprocessor-specific
+        properties written before the scope key existed.
+        """
+        self.assertEqual(property_scope({"name": "p"}), SCOPE_JOB)
+
+    def test02_runtime_true_is_an_alias_for_run(self):
+        """The deprecated "runtime": True spelling still means "run" scope.
+
+        Out-of-tree postprocessors written against the older API must keep
+        working without modification.
+        """
+        self.assertEqual(property_scope({"name": "p", "runtime": True}), SCOPE_RUN)
+
+    def test03_runtime_false_defaults_to_job(self):
+        """An explicit "runtime": False is not a scope declaration."""
+        self.assertEqual(property_scope({"name": "p", "runtime": False}), SCOPE_JOB)
+
+    def test04_explicit_scope_beats_runtime_alias(self):
+        """When both keys are present, "scope" wins over the deprecated alias."""
+        prop = {"name": "p", "scope": SCOPE_MACHINE, "runtime": True}
+        self.assertEqual(property_scope(prop), SCOPE_MACHINE)
+
+    def test05_unknown_scope_degrades_to_job(self):
+        """A typo must leave the property visible rather than silently hidden."""
+        self.assertEqual(property_scope({"name": "p", "scope": "mahcine"}), SCOPE_JOB)
+
+    def test06_properties_in_scope_filters_and_preserves_order(self):
+        """Filtering keeps schema order and accepts several scopes at once."""
+        schema = [
+            {"name": "a", "scope": SCOPE_MACHINE},
+            {"name": "b", "scope": SCOPE_RUN},
+            {"name": "c", "scope": SCOPE_JOB},
+            {"name": "d", "scope": SCOPE_INTERNAL},
+            {"name": "e"},  # defaults to job
+        ]
+
+        editor = [p["name"] for p in properties_in_scope(schema, SCOPE_MACHINE, SCOPE_JOB)]
+        self.assertEqual(editor, ["a", "c", "e"])
+
+        overview = [p["name"] for p in properties_in_scope(schema, SCOPE_RUN)]
+        self.assertEqual(overview, ["b"])
+
+        self.assertEqual(properties_in_scope(schema, SCOPE_INTERNAL)[0]["name"], "d")
+
+    def test07_properties_in_scope_handles_empty_schema(self):
+        """None and [] are both acceptable schemas."""
+        self.assertEqual(properties_in_scope(None, SCOPE_JOB), [])
+        self.assertEqual(properties_in_scope([], SCOPE_JOB), [])
+
+    def test08_every_common_property_declares_a_scope(self):
+        """The common schema must not rely on the default scope.
+
+        Common properties are machine configuration by default; leaving the
+        key off would silently promote them to "job" and expose them on the
+        post-processing dialog.
+        """
+        for prop in PostProcessor.get_common_property_schema():
+            with self.subTest(prop=prop["name"]):
+                self.assertIn("scope", prop)
+                self.assertIn(prop["scope"], VALID_SCOPES)
+
+    def test09_scopes_partition_the_full_schema(self):
+        """The four scopes are exhaustive and mutually exclusive."""
+        schema = PostProcessor.get_full_property_schema()
+        buckets = [properties_in_scope(schema, scope) for scope in VALID_SCOPES]
+        self.assertEqual(sum(len(b) for b in buckets), len(schema))
 
 
 class TestConfigurationBundle(unittest.TestCase):

--- a/src/Mod/CAM/Machine/ui/editor/machine_editor.py
+++ b/src/Mod/CAM/Machine/ui/editor/machine_editor.py
@@ -38,7 +38,12 @@ from Machine.models.machine import (
     WrapStrategy,
 )
 from Path.Main.Gui.Editor import CodeEditor
-from Path.Post.Processor import PostProcessorFactory
+from Path.Post.Processor import (
+    PostProcessorFactory,
+    SCOPE_JOB,
+    SCOPE_MACHINE,
+    properties_in_scope,
+)
 from Machine.ui.editor.postprocessor_properties import PostProcessorPropertyManager
 from Machine.ui.editor.output_options_layout import build_output_options
 import re
@@ -2108,12 +2113,12 @@ class MachineEditorDialog(QtGui.QDialog):
                 self.post_properties_group.setVisible(False)
                 return
 
-            # Create widgets for each property in the schema
-            # Skip runtime-only properties — they are shown in the post-processing
-            # dialog, not persisted in the machine configuration.
-            for prop in schema:
-                if prop.get("runtime", False):
-                    continue
+            # Create widgets for each property in the schema.  The machine
+            # editor owns the "machine" and "job" scopes: "machine" properties
+            # are only editable here, "job" properties get their default here
+            # and can be overridden per run in the post-processing dialog.
+            # "run" and "internal" properties never appear in this editor.
+            for prop in properties_in_scope(schema, SCOPE_MACHINE, SCOPE_JOB):
                 prop_name = prop.get("name")
                 prop_label = prop.get("label", prop_name)
                 prop_default = prop.get("default")

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -105,10 +105,10 @@ class PostProcessDialog:
         # Post-processor parameter widgets (from get_property_schema)
         self._post_param_widgets = (
             {}
-        )  # runtime params on Overview: {param_name: (widget, schema_entry)}
+        )  # "run"-scoped params on Overview: {param_name: (widget, schema_entry)}
         self._post_config_widgets = (
             {}
-        )  # non-runtime params on Options: {param_name: (widget, schema_entry)}
+        )  # "job"-scoped params on Options: {param_name: (widget, schema_entry)}
         # Stores generated G-code: {full_path_filename: gcode_string}
         self._generated_outputs = {}
         # Original (subpart, gcode) sections — used to regenerate filenames
@@ -265,19 +265,22 @@ class PostProcessDialog:
 
         container.deleteLater()
 
-        # Populate runtime post-processor params on Overview tab
+        # Populate "job"-scoped post-processor properties on the Options tab,
+        # after the machine output groups and before the trailing spacer.
+        self._rebuild_post_config_section(machine, scroll_layout, insert_idx)
+
+        # Populate "run"-scoped post-processor params on Overview tab
         self._rebuild_post_params_section(machine)
 
     def _rebuild_post_config_section(self, machine, scroll_layout, insert_idx):
-        """Build non-runtime postprocessor property widgets on the Options tab.
+        """Build the "job"-scoped postprocessor property widgets on the Options tab.
 
-        These mirror the same properties shown in the machine editor and allow
+        These mirror properties the machine editor also shows, and allow
         per-run overrides of machine-config values like pierce_delay, cooling_delay, etc.
         """
-        # Clear previous non-runtime config widgets
-        for name, (widget, _schema) in self._post_config_widgets.items():
-            # The widget is inside a group box tracked by _dynamic_output_groups
-            pass
+        # Clear previous job-scoped config widgets.  The widgets themselves live
+        # in a group box tracked by _dynamic_output_groups, which the caller
+        # removes and deletes before this runs, so only the map needs clearing.
         self._post_config_widgets.clear()
 
         if machine is None:
@@ -302,26 +305,40 @@ class PostProcessDialog:
             return
 
         try:
-            schema = post_class.get_property_schema()
+            schema = post_class.get_full_property_schema()
         except Exception:
             return
 
-        non_runtime = [e for e in schema if not e.get("runtime", False)] if schema else []
-        if not non_runtime:
+        # "machine" and "internal" properties are not offered here: the former
+        # are machine-editor-only by declaration, the latter are never shown.
+        from Path.Post.Processor import SCOPE_JOB, properties_in_scope
+
+        job_scoped = properties_in_scope(schema, SCOPE_JOB)
+        if not job_scoped:
             return
 
-        # Build the configuration bundle to get values with job overrides applied
+        # Build the configuration bundle to get values with job overrides applied.
+        # The postprocessor resolved its own machine from the job, but the combo
+        # box may point somewhere else; the dialog's selection wins, matching
+        # what _apply_options_to_machine() does before export.  The bundle
+        # dereferences _machine, which is None when the job names a machine the
+        # factory cannot find, so fall back to the raw properties in that case.
         bundle = {}
         if post_obj is not None and hasattr(post_obj, "build_configuration_bundle"):
-            bundle = post_obj.build_configuration_bundle()
-            Path.Log.debug(f"Post config bundle for dialog: {bundle}")
+            try:
+                post_obj._machine = machine
+                bundle = post_obj.build_configuration_bundle()
+                Path.Log.debug(f"Post config bundle for dialog: {bundle}")
+            except Exception as e:
+                Path.Log.warning(f"Could not build post config bundle for dialog: {e}")
+                bundle = {}
 
         pp_props = bundle if bundle else (getattr(machine, "postprocessor_properties", {}) or {})
 
         group = QtGui.QGroupBox(translate("CAM_Post", "Postprocessor Properties"))
         form = QtGui.QFormLayout(group)
 
-        for entry in non_runtime:
+        for entry in job_scoped:
             name = entry.get("name", "")
             param_type = entry.get("type", "string")
             label_text = entry.get("label", name)
@@ -375,21 +392,14 @@ class PostProcessDialog:
                 widget.setToolTip(help_text)
                 widget.value_getter = lambda w=widget: w.text()
 
-            # if widget is not None:
-            #     # Connect signal to recompute warnings when value changes
-            #     if isinstance(widget, (QtGui.QCheckBox, QtGui.QLineEdit, QtGui.QPlainTextEdit)):
-            #         (
-            #             widget.textChanged.connect(self._recompute_warnings)
-            #             if hasattr(widget, "textChanged")
-            #             else widget.stateChanged.connect(self._recompute_warnings)
-            #         )
-            #     elif isinstance(widget, (QtGui.QSpinBox, QtGui.QDoubleSpinBox)):
-            #         widget.valueChanged.connect(self._recompute_warnings)
-            #     elif isinstance(widget, QtGui.QComboBox):
-            #         widget.currentIndexChanged.connect(self._recompute_warnings)
-
-            #     form.addRow(label_text, widget)
-            #     self._post_config_widgets[name] = (widget, entry)
+            if widget is not None:
+                # No change signals are connected here.  _recompute_warnings()
+                # runs a full CAMSanity.validate_job(), which is far too costly
+                # to fire per keystroke, and the Overview tab's widgets are
+                # likewise unconnected.  Values are read on demand by
+                # _collect_post_param_values() via each widget's value_getter.
+                form.addRow(label_text, widget)
+                self._post_config_widgets[name] = (widget, entry)
 
         scroll_layout.insertWidget(insert_idx, group)
         self._dynamic_output_groups.append(group)
@@ -436,16 +446,18 @@ class PostProcessDialog:
 
         # Get the property schema
         try:
-            schema = post_class.get_property_schema()
+            schema = post_class.get_full_property_schema()
         except Exception as e:
             Path.Log.warning(f"Could not get property schema: {e}")
             placeholder.setVisible(True)
             return
 
-        # Only runtime parameters are shown on the Overview tab
-        runtime_schema = [e for e in schema if e.get("runtime", False)] if schema else []
+        # Only "run"-scoped parameters are shown on the Overview tab
+        from Path.Post.Processor import SCOPE_RUN, properties_in_scope
 
-        if not runtime_schema:
+        run_scoped = properties_in_scope(schema, SCOPE_RUN)
+
+        if not run_scoped:
             placeholder.setVisible(True)
             return
 
@@ -454,7 +466,7 @@ class PostProcessDialog:
         # Get current machine postprocessor_properties for initial values
         pp_props = getattr(machine, "postprocessor_properties", {}) or {}
 
-        for entry in runtime_schema:
+        for entry in run_scoped:
 
             name = entry.get("name", "")
             param_type = entry.get("type", "string")
@@ -522,17 +534,17 @@ class PostProcessDialog:
                 self._post_param_widgets[name] = (widget, entry)
 
     def _collect_post_param_values(self):
-        """Read current values from all post-parameter widgets (runtime + non-runtime).
+        """Read current values from all post-parameter widgets ("job" + "run" scoped).
 
         Returns:
             dict: {param_name: value} for all post-processor parameters.
         """
         values = {}
-        # Non-runtime config from Options tab
+        # "job"-scoped config from Options tab
         for name, (widget, _schema) in self._post_config_widgets.items():
             if hasattr(widget, "value_getter"):
                 values[name] = widget.value_getter()
-        # Runtime params from Overview tab (override if same key exists)
+        # "run"-scoped params from Overview tab (override if same key exists)
         for name, (widget, _schema) in self._post_param_widgets.items():
             if hasattr(widget, "value_getter"):
                 values[name] = widget.value_getter()

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -217,6 +217,89 @@ Values = Dict[str, Any]
 Visible = Dict[str, bool]
 
 
+# ---------------------------------------------------------------------------
+# Property scope
+# ---------------------------------------------------------------------------
+#
+# Every entry in a postprocessor property schema declares a *scope*: the tier
+# at which the property may be edited.  The scopes correspond one-to-one with
+# the merge tiers in build_configuration_bundle().
+#
+SCOPE_MACHINE = "machine"
+"""Edited in the machine editor only; suppressed in the post-processing dialog.
+Persisted in the .fcm machine file.  Use for properties that describe the
+machine or controller itself and must not vary between runs."""
+
+SCOPE_JOB = "job"
+"""Edited in the machine editor (which sets the default) and overridable per
+run on the post-processing dialog's Options tab.  Persisted in the .fcm file;
+per-run changes go through Job.PostProcessorPropertyOverrides."""
+
+SCOPE_RUN = "run"
+"""Edited only on the post-processing dialog's Overview tab.  Never shown in
+the machine editor and never written back to the .fcm file - the value applies
+to a single export."""
+
+SCOPE_INTERNAL = "internal"
+"""Never presented in any UI.  Use for schema entries that exist so the
+postprocessor can read them from the configuration bundle but which are
+derived rather than user-set."""
+
+VALID_SCOPES = (SCOPE_MACHINE, SCOPE_JOB, SCOPE_RUN, SCOPE_INTERNAL)
+
+#: Scope assumed when a schema entry declares none.  Matches the historical
+#: behaviour of postprocessor-specific properties without a "runtime" key.
+DEFAULT_SCOPE = SCOPE_JOB
+
+
+def property_scope(prop: Dict[str, Any]) -> str:
+    """Return the scope of a property schema entry.
+
+    Reads the "scope" key.  For backwards compatibility with schemas written
+    against the older API, a truthy "runtime" key is accepted as an alias for
+    SCOPE_RUN.  Entries declaring neither get DEFAULT_SCOPE.
+
+    An unrecognised scope is logged and treated as DEFAULT_SCOPE so that a
+    typo in a third-party postprocessor degrades to a visible property rather
+    than silently hiding it.
+
+    Args:
+        prop: A single property schema dictionary.
+
+    Returns:
+        One of VALID_SCOPES.
+    """
+    scope = prop.get("scope")
+    if scope is None:
+        # Deprecated: "runtime": True is the old spelling of scope "run".
+        if prop.get("runtime", False):
+            return SCOPE_RUN
+        return DEFAULT_SCOPE
+    if scope not in VALID_SCOPES:
+        Path.Log.warning(
+            f"Unknown property scope {scope!r} for property "
+            f"{prop.get('name', '?')!r}; treating as {DEFAULT_SCOPE!r}"
+        )
+        return DEFAULT_SCOPE
+    return scope
+
+
+def properties_in_scope(schema, *scopes) -> List[Dict[str, Any]]:
+    """Filter a property schema down to the entries in the given scopes.
+
+    Args:
+        schema: A property schema (list of dicts), or None.
+        *scopes: One or more scope constants to keep.
+
+    Returns:
+        The matching schema entries, in schema order.
+    """
+    if not schema:
+        return []
+    wanted = set(scopes)
+    return [prop for prop in schema if property_scope(prop) in wanted]
+
+
 class PostProcessorFactory:
     """Factory class for creating post processors."""
 
@@ -316,6 +399,7 @@ class PostProcessor:
         return [  # FIXME: this list does not match _merge_machine_config(), nor machine_editor.py
             {
                 "name": "file_extension",
+                "scope": SCOPE_MACHINE,
                 "type": "string",
                 "label": translate("CAM", "File Extension"),
                 "default": "nc",
@@ -327,6 +411,7 @@ class PostProcessor:
             },
             {
                 "name": "supports_tool_radius_compensation",
+                "scope": SCOPE_MACHINE,
                 "type": "bool",
                 "label": translate("CAM", "Tool Radius Compensation (G41/G42)"),
                 "default": False,
@@ -338,6 +423,7 @@ class PostProcessor:
             },
             {
                 "name": "supported_commands",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Supported G-code Commands"),
                 "default": "\n".join(all_supported_commands),
@@ -349,6 +435,7 @@ class PostProcessor:
             },
             {
                 "name": "drill_cycles_to_translate",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Drill Cycles to Translate"),
                 "default": "\n".join(Constants.GCODE_MOVE_DRILL),
@@ -361,6 +448,7 @@ class PostProcessor:
             },
             {
                 "name": "preamble",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Preamble"),
                 "default": "",
@@ -370,6 +458,7 @@ class PostProcessor:
             },
             {
                 "name": "postamble",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Postamble"),
                 "default": "",
@@ -377,6 +466,7 @@ class PostProcessor:
             },
             {
                 "name": "safetyblock",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Safety Block"),
                 "default": "",
@@ -387,6 +477,7 @@ class PostProcessor:
             },
             {
                 "name": "pre_job",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Pre-Job"),
                 "default": "",
@@ -394,6 +485,7 @@ class PostProcessor:
             },
             {
                 "name": "post_job",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Post-Job"),
                 "default": "",
@@ -401,6 +493,7 @@ class PostProcessor:
             },
             {
                 "name": "pre_fixture_change",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Pre-Fixture"),
                 "default": "",
@@ -408,6 +501,7 @@ class PostProcessor:
             },
             {
                 "name": "post_fixture_change",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Post-Fixture"),
                 "default": "",
@@ -415,6 +509,7 @@ class PostProcessor:
             },
             {
                 "name": "pre_operation",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Pre-Operation"),
                 "default": "",
@@ -422,6 +517,7 @@ class PostProcessor:
             },
             {
                 "name": "post_operation",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Post-Operation"),
                 "default": "",
@@ -429,6 +525,7 @@ class PostProcessor:
             },
             {
                 "name": "pre_tool_change",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Pre-Tool Change"),
                 "default": "",
@@ -436,6 +533,7 @@ class PostProcessor:
             },
             {
                 "name": "post_tool_change",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Post-Tool Change"),
                 "default": "",
@@ -443,6 +541,7 @@ class PostProcessor:
             },
             {
                 "name": "tool_return",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Tool Return after tool changes"),
                 "default": "",
@@ -450,6 +549,7 @@ class PostProcessor:
             },
             {
                 "name": "pre_rotary_move",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Pre-Rotary Move"),
                 "default": "",
@@ -457,6 +557,7 @@ class PostProcessor:
             },
             {
                 "name": "post_rotary_move",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Post-Rotary Move"),
                 "default": "",
@@ -464,6 +565,7 @@ class PostProcessor:
             },
             {
                 "name": "show_dialog",
+                "scope": SCOPE_RUN,
                 "type": "bool",
                 "label": translate("CAM", "Show Pre-processing Dialogs"),
                 "default": True,
@@ -475,6 +577,7 @@ class PostProcessor:
             },
             {
                 "name": "parameter_order",
+                "scope": SCOPE_MACHINE,
                 "type": "text",  # one line
                 "label": translate("CAM", "Generated Parameter Order for GCode"),
                 "default": "XYZABCFSIJTQRPH",  # FIXME: only list `supported`
@@ -482,6 +585,7 @@ class PostProcessor:
             },
             {
                 "name": "output_tool_length_offset",
+                "scope": SCOPE_MACHINE,
                 "type": "bool",
                 "label": translate("CAM", "TLO after tool-change"),
                 "default": True,
@@ -492,6 +596,7 @@ class PostProcessor:
             },
             {
                 "name": "tool_change",
+                "scope": SCOPE_JOB,
                 "type": "bool",
                 "label": translate("CAM", "Allow tool-change"),
                 "default": True,
@@ -502,6 +607,7 @@ class PostProcessor:
             },
             {
                 "name": "output_units",
+                "scope": SCOPE_MACHINE,
                 "type": "str",
                 "label": translate("CAM", "Unit-command in output"),
                 "default": OutputUnits.METRIC,
@@ -512,6 +618,7 @@ class PostProcessor:
             },
             {
                 "name": "axis_precision",
+                "scope": SCOPE_MACHINE,
                 "type": "int",
                 "label": translate("CAM", "Axis precision in output"),
                 "default": 2,  # degrees
@@ -522,6 +629,7 @@ class PostProcessor:
             },
             {
                 "name": "feed_precision",
+                "scope": SCOPE_MACHINE,
                 "type": "int",
                 "label": translate("CAM", "Feedrate precision in output"),
                 "default": 3,
@@ -532,6 +640,7 @@ class PostProcessor:
             },
             {
                 "name": "spindle_decimals",
+                "scope": SCOPE_MACHINE,
                 "type": "int",
                 "label": translate("CAM", "Spindle-speed precision in output"),
                 "default": 1,  # rpm
@@ -542,6 +651,7 @@ class PostProcessor:
             },
             {
                 "name": "f_for_rapid_moves",
+                "scope": SCOPE_MACHINE,
                 "type": "bool",
                 "label": translate("CAM", "Output F parameter for G0 (rapid)"),
                 "default": False,
@@ -566,7 +676,16 @@ class PostProcessor:
         - type: str - Property type: 'bool', 'int', 'float', 'str', 'text', 'choice', 'file'
         - label: str - Human-readable label for the UI
         - default: Any - Default value for the property
-        - runtime: Bool - True means only appears on the post-process Overview tab, written to .postprocessor_properties
+        - scope: str - Where the property may be edited.  One of:
+            SCOPE_MACHINE  ("machine")  machine editor only; suppressed in the
+                                        post-processing dialog
+            SCOPE_JOB      ("job")      machine editor sets the default; the
+                                        dialog's Options tab overrides it per run
+            SCOPE_RUN      ("run")      dialog Overview tab only; never shown in
+                                        the machine editor, never persisted
+            SCOPE_INTERNAL ("internal") never presented in any UI
+          Omitting the key means SCOPE_JOB.  The deprecated "runtime": True is
+          still honoured as an alias for SCOPE_RUN.
         - help: str - Help text describing the property
         - Additional type-specific keys:
           - For 'int'/'float': min, max, decimals (float only)

--- a/src/Mod/CAM/Path/Post/scripts/generic_plasma_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/generic_plasma_post.py
@@ -27,7 +27,7 @@ Generic Postprocessor for plasma, laser, and waterjet cutters that require a pie
 from typing import Any, Dict
 import copy
 
-from Path.Post.Processor import PostProcessor
+from Path.Post.Processor import PostProcessor, SCOPE_JOB, SCOPE_RUN
 
 import Constants
 import Path
@@ -87,6 +87,7 @@ class GenericPlasma(PostProcessor):
         return [
             {
                 "name": "pierce_delay",
+                "scope": SCOPE_JOB,
                 "type": "integer",
                 "label": translate("CAM", "Pierce Delay"),
                 "default": 1000,
@@ -99,6 +100,7 @@ class GenericPlasma(PostProcessor):
             },
             {
                 "name": "cooling_delay",
+                "scope": SCOPE_JOB,
                 "type": "integer",
                 "label": translate("CAM", "Cooling Delay"),
                 "default": 500,
@@ -111,6 +113,7 @@ class GenericPlasma(PostProcessor):
             },
             {
                 "name": "marking_delay",
+                "scope": SCOPE_JOB,
                 "type": "integer",
                 "label": translate("CAM", "Marking Delay"),
                 "default": 100,
@@ -123,6 +126,7 @@ class GenericPlasma(PostProcessor):
             },
             {
                 "name": "torch_zaxis_control",
+                "scope": SCOPE_JOB,
                 "type": "bool",
                 "label": translate("CAM", "Torch Z-Axis Control"),
                 "default": True,
@@ -134,10 +138,10 @@ class GenericPlasma(PostProcessor):
             },
             {
                 "name": "force_rapid_feeds",
+                "scope": SCOPE_RUN,
                 "type": "bool",
                 "label": translate("CAM", "Force Rapid Feeds"),
                 "default": False,
-                "runtime": True,
                 "help": translate(
                     "CAM",
                     "Force rapid-feed speeds for all feed specified commands. "
@@ -146,10 +150,10 @@ class GenericPlasma(PostProcessor):
             },
             {
                 "name": "mark_entry_only",
+                "scope": SCOPE_RUN,
                 "type": "bool",
                 "label": translate("CAM", "Mark Entry Points Only"),
                 "default": False,
-                "runtime": True,
                 "help": translate(
                     "CAM",
                     "Mark first entry points only (for drilling prep). "

--- a/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
@@ -29,7 +29,7 @@
 
 from typing import Any, Dict
 
-from Path.Post.Processor import PostProcessor
+from Path.Post.Processor import PostProcessor, SCOPE_JOB
 
 import Path
 import FreeCAD
@@ -88,8 +88,8 @@ class Linuxcnc(PostProcessor):
         return [
             {
                 "name": "blend_mode",
+                "scope": SCOPE_JOB,
                 "type": "choice",
-                "runtime": True,
                 "label": translate("CAM", "Path Blending Mode"),
                 "default": "BLEND",
                 "choices": ["EXACT_PATH", "EXACT_STOP", "BLEND"],
@@ -101,8 +101,8 @@ class Linuxcnc(PostProcessor):
             },
             {
                 "name": "blend_tolerance",
+                "scope": SCOPE_JOB,
                 "type": "float",
-                "runtime": True,
                 "label": translate("CAM", "Blend Tolerance"),
                 "default": 0.0,
                 "min": 0.0,

--- a/src/Mod/CAM/Path/Post/scripts/opensbp_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/opensbp_post.py
@@ -40,7 +40,7 @@ import Path
 
 Path.Log.debug(f"### RELOADED {__file__}")
 import Constants
-from Path.Post.Processor import PostProcessor
+from Path.Post.Processor import PostProcessor, SCOPE_MACHINE
 
 translate = FreeCAD.Qt.translate
 
@@ -161,6 +161,7 @@ class OpenSBPPost(PostProcessor):
         return [
             {
                 "name": "automatic_tool_changer",
+                "scope": SCOPE_MACHINE,
                 "type": "bool",
                 "label": translate("CAM", "Automatic Tool Changer"),
                 "default": False,
@@ -172,6 +173,7 @@ class OpenSBPPost(PostProcessor):
             },
             {
                 "name": "automatic_spindle",
+                "scope": SCOPE_MACHINE,
                 "type": "bool",
                 "label": translate("CAM", "Automatic Spindle Control"),
                 "default": False,
@@ -184,6 +186,7 @@ class OpenSBPPost(PostProcessor):
             # FIXME: should be a general option
             {
                 "name": "suppressed_commands",
+                "scope": SCOPE_MACHINE,
                 "type": "text",
                 "label": translate("CAM", "Suppressed (tolerated) G-code Commands"),
                 "default": "\n".join(cls.GCodeSuppressed),

--- a/src/Mod/CAM/Roadmap/ADR/ADR-000.md
+++ b/src/Mod/CAM/Roadmap/ADR/ADR-000.md
@@ -199,6 +199,24 @@ _Avoid_: controller (overlaps with Tool Controller), CNC.
 JSON serialization of a **Machine** definition. Templates ship in `Machine/machines/` and are loaded into a **Job**. Distinct from a **Job Template** — different file format and scope.
 _Avoid_: machine config, machine profile, bare "template".
 
+**Post-Processing Dialog**:
+The dialog shown when generating G-code from a **Job** (`DlgPostProcess`). Its Overview tab carries **Run scope** **Post-Processor Properties**; its Options tab carries **Job scope** ones.
+_Avoid_: export dialog, output dialog, post dialog.
+
+**Post-Processor Property**:
+A single named setting in a **Post-Processor**'s property schema (`get_full_property_schema()`), stored by name in a **Machine**'s `postprocessor_properties`. Every property declares a **Property Scope**.
+_Avoid_: post argument, post option, post parameter (those name the legacy `--arg` command line, which is a different mechanism).
+
+**Property Scope**:
+The tier at which a **Post-Processor Property** may be edited. Exactly one of:
+- **Machine scope** — edited in the **Machine Editor** only, and suppressed in the **Post-Processing Dialog**. Describes the machine or controller itself and must not vary between runs (e.g. file extension, comment style, axis precision).
+- **Job scope** — the **Machine Editor** sets the default; the **Post-Processing Dialog**'s Options tab overrides it for a single run. Persisted in the **Machine Template**, overridden via `Job.PostProcessorPropertyOverrides`.
+- **Run scope** — edited only on the **Post-Processing Dialog**'s Overview tab, never shown in the **Machine Editor**, and never persisted. Applies to one export (e.g. dry-run and marking-only switches).
+- **Internal scope** — never presented in any UI; derived rather than user-set.
+
+Scope declares *where a property may be edited*, which is independent of *where it was declared* (the common schema on `PostProcessor` versus a **Post-Processor**'s own `get_property_schema()`). The scopes correspond one-to-one with the merge tiers in `build_configuration_bundle()`.
+_Avoid_: runtime property (the deprecated `runtime: True` spelling means **Run scope**), per-run flag, override level.
+
 **Sanity Check** (also **CAMSanity**):
 A pre-output validation pass over a **Job** that produces an HTML **Sanity Check report** flagging missing tools, unset feeds, suspicious depths, etc. Canonical user-facing term.
 _Avoid_: linter, validator, pre-flight check, job report.
@@ -214,6 +232,7 @@ _Avoid_: linter, validator, pre-flight check, job report.
 - An **Operation** uses zero or more **Generators** to build its **Toolpath**.
 - The **Resolver** walks a chain of **Providers** to suggest F&S for a (**Tool Bit**, material, op-type) combination; suggestions are written to a **Tool Controller** with **Feed/Speed Provenance** stamped per field.
 - A **Job** + a **Post-Processor** + a **Machine** produce the final G-code output.
+- A **Post-Processor** declares many **Post-Processor Properties**; each carries exactly one **Property Scope**, which determines whether the **Machine Editor**, the **Post-Processing Dialog**, or neither may edit it.
 - **Sanity Check** runs over a **Job** and emits a report; it does not modify the **Job**.
 
 ## Example dialogue


### PR DESCRIPTION
A postprocessor property schema had a single "runtime" boolean deciding where a property could be edited, which could only express two of the three cases we actually have.  The third case existed only by accident: a property was hidden from the post-processing dialog if it happened to be declared in get_common_property_schema() rather than in a postprocessor's own get_property_schema(), because the dialog called get_property_schema() while the machine editor called get_full_property_schema().  That conflated *where a property was declared* with *where it may be edited*.

The visible symptom was LinuxCNC's blend_mode and blend_tolerance.  They were marked "runtime": True so an operator could change them per export, which also removed them from the machine editor - leaving no way to give a machine a default blending mode even though the postprocessor reads one from machine.postprocessor_properties and the dialog seeds its widgets from the same place.

Replace the boolean with an explicit scope, one of:

  machine   machine editor only; suppressed in the post-processing dialog
  job       machine editor sets the default, dialog Options tab overrides
            it for a single run
  run       dialog Overview tab only; never in the editor, never persisted
  internal  never presented in any UI

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.


Assisted-by Claude Code Fable
