### PR TITLE
Sketcher: skip recompute if edited without changes

### DIFF
--- a/src/3rdParty/zipios++/zipoutputstream.cpp
+++ b/src/3rdParty/zipios++/zipoutputstream.cpp
@@ -78,6 +78,10 @@ void ZipOutputStream::setMethod( StorageMethod method ) {
   ozf->setMethod( method ) ;
 }
 
+void ZipOutputStream::setStoreDate( bool store ) {
+  ozf->setStoreDate( store ) ;
+}
+
 
 ZipOutputStream::~ZipOutputStream() {
   // It's ok to call delete with a Null pointer.

--- a/src/3rdParty/zipios++/zipoutputstream.h
+++ b/src/3rdParty/zipios++/zipoutputstream.h
@@ -64,6 +64,9 @@ public:
       supported. */
   void setMethod( StorageMethod method ) ;
 
+  /** Sets whether the date & time fields are filled with current time or left empty. */
+  void setStoreDate( bool store ) ;
+
   /** Destructor. */
   virtual ~ZipOutputStream() ;
 

--- a/src/3rdParty/zipios++/zipoutputstreambuf.cpp
+++ b/src/3rdParty/zipios++/zipoutputstreambuf.cpp
@@ -23,7 +23,8 @@ ZipOutputStreambuf::ZipOutputStreambuf( streambuf *outbuf, bool del_outbuf )
     _open_entry( false    ),
     _open      ( true     ),
     _method    ( DEFLATED ),
-    _level     ( 6        )
+    _level     ( 6        ),
+    _storeDate ( true     )
 {
 }
 
@@ -102,6 +103,10 @@ void ZipOutputStreambuf::setMethod( StorageMethod method ) {
     throw FCollException( "Specified compression method not supported" ) ;
 }
 
+void ZipOutputStreambuf::setStoreDate( bool store ) {
+  _storeDate = store ;
+}
+
 //
 // Protected and private methods
 //
@@ -146,14 +151,18 @@ void ZipOutputStreambuf::updateEntryHeaderInfo() {
   entry.setCompressedSize( curr_pos - entry.getLocalHeaderOffset() 
 			   - entry.getLocalHeaderSize() ) ;
 
-  // Mark Donszelmann: added current date and time
-  time_t ltime;
-  time( &ltime );
-  struct tm *now;
-  now = localtime( &ltime );
-  int dosTime = (now->tm_year - 80) << 25 | (now->tm_mon + 1) << 21 | now->tm_mday << 16 |
-              now->tm_hour << 11 | now->tm_min << 5 | now->tm_sec >> 1;
-  entry.setTime(dosTime);
+  if (_storeDate) {
+    // Mark Donszelmann: added current date and time
+    time_t ltime;
+    time( &ltime );
+    struct tm *now;
+    now = localtime( &ltime );
+    int dosTime = (now->tm_year - 80) << 25 | (now->tm_mon + 1) << 21 | now->tm_mday << 16 |
+        now->tm_hour << 11 | now->tm_min << 5 | now->tm_sec >> 1;
+    entry.setTime(dosTime);
+  } else {
+    entry.setTime(0);
+  }
 
   // write ZipLocalEntry header to header position
   os.seekp( entry.getLocalHeaderOffset() ) ;

--- a/src/3rdParty/zipios++/zipoutputstreambuf.h
+++ b/src/3rdParty/zipios++/zipoutputstreambuf.h
@@ -59,6 +59,9 @@ public:
       supported. */
   void setMethod( StorageMethod method ) ;
 
+  /** Sets whether the date & time fields are filled with current time or left empty. */
+  void setStoreDate( bool store ) ;
+
   /** Destructor. */
   virtual ~ZipOutputStreambuf() ;
 
@@ -83,6 +86,7 @@ private:
   bool _open ;
   StorageMethod _method ;
   int _level ;
+  bool _storeDate ;
 };
 
 

--- a/src/Base/Persistence.cpp
+++ b/src/Base/Persistence.cpp
@@ -206,6 +206,8 @@ void Persistence::dumpToStream(std::ostream& stream, int compression)
         writer.setLevel(compression);
         writer.putNextEntry("Persistence.xml");
         writer.setMode("BinaryBrep");
+        // This is necessary to make successive dumps reproducible.
+        writer.setStoreDate(false);
 
         // save the content (we need to encapsulate it with xml tags to be able to read single
         // element xmls like happen for properties)

--- a/src/Base/Writer.h
+++ b/src/Base/Writer.h
@@ -242,6 +242,10 @@ public:
     {
         ZipStream.setLevel(level);
     }
+    void setStoreDate(bool store)
+    {
+        ZipStream.setStoreDate(store);
+    }
     void putNextEntry(const char* filename, const char* objName = nullptr) override;
 
     ZipWriter(const ZipWriter&) = delete;

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -4544,13 +4544,47 @@ void ViewProviderSketch::unsetEdit(int ModNum)
             getSketchObject()->purgeTouched();
         }
         else {
-            App::AutoTransaction trans(getDocument()->getDocument(), "Sketch recompute");
-            try {
-                // and update the sketch
-                // getSketchObject()->getDocument()->recompute();
-                Gui::Command::updateActive();
+            // Since SketchObjects aren't hashable in-place (yet), use dumpToStream to produce
+            // a hashable set of bytes.
+            const size_t hashBeforeEditing = std::hash<std::string_view>{}(sketchBackup.view());
+
+            // An edited but untouched sketch still sets a few properties as touched,
+            // untouch them temporarily for comparison to pre-editing sketch state.
+            auto *sketch = getSketchObject();
+            const bool constraintsTouched = sketch->Constraints.isTouched();
+            sketch->Constraints.purgeTouched();
+            const bool fullyConstainedTouched = sketch->FullyConstrained.isTouched();
+            sketch->FullyConstrained.purgeTouched();
+            const bool geometryTouched = sketch->Geometry.isTouched();
+            sketch->Geometry.purgeTouched();
+
+            sketchBackup.str("");
+            sketchBackup.clear();
+            getObject()->dumpToStream(sketchBackup, 0);
+            sketchBackup.seekg(0);
+            const size_t hashAfterEditing = std::hash<std::string_view>{}(sketchBackup.view());
+
+            if (constraintsTouched) {
+                sketch->Constraints.touch();
             }
-            catch (...) {
+            if (fullyConstainedTouched) {
+                sketch->FullyConstrained.touch();
+            }
+            if (geometryTouched) {
+                sketch->Geometry.touch();
+            }
+
+            if (hashAfterEditing == hashBeforeEditing) {
+                sketch->purgeTouched();
+            } else {
+                App::AutoTransaction trans(getDocument()->getDocument(), "Sketch recompute");
+                try {
+                    // and update the sketch
+                    // getSketchObject()->getDocument()->recompute();
+                    Gui::Command::updateActive();
+                }
+                catch (...) {
+                }
             }
         }
     }


### PR DESCRIPTION
* Investigated and implemented as part of the 2026-08-29 hackathon.
* Fixes #6290, though not thoroughly.

Implements sketch state hashing based on their `dumpToStream()` outputs; for basic cases where no geometry is changed, or changes are undone with `Std_Undo`, this results in equal hashes. More involved cases like changing a dimension and back generally result in different geometry due to float imprecision.

Goes with the `dumpToStream()` route instead of direct object hashing since that's not yet possible with `std::hash` or similar.

Introduces a Zipios++ option to disable saving file timestamps, necessary here as otherwise the generated zip snapshots are not reproducible.

- [x] :robot: → :wastebasket: 
