### PR TITLE
PD: Restore circular axis selection for polar patterns

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPatternParameters.cpp
@@ -262,14 +262,10 @@ void TaskPatternParameters::enterReferenceSelectionMode()
     showBase();    // Show the base features/body
     Gui::Selection().clearSelection();
 
-    AllowSelectionFlags allowedReferences = AllowSelection::EDGE | AllowSelection::PLANAR;
-    if (getObject<PartDesign::PolarPattern>()) {
-        allowedReferences |= AllowSelection::CIRCLE;
-    }
-    else {
-        allowedReferences |= AllowSelection::FACE;
-    }
-    addReferenceSelectionGate(allowedReferences);
+    bool isPolar = getObject<PartDesign::PolarPattern>();
+  
+    AllowSelectionFlags commonReferences = AllowSelection::EDGE | AllowSelection::PLANAR;
+    addReferenceSelectionGate(commonReferences | (isPolar ? AllowSelection::CIRCLE : AllowSelection::FACE));
     Gui::getMainWindow()->showMessage(
         tr("Select a direction reference (edge, face, datum line)")
     );  // User feedback

--- a/src/Mod/PartDesign/Gui/TaskPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPatternParameters.cpp
@@ -263,9 +263,11 @@ void TaskPatternParameters::enterReferenceSelectionMode()
     Gui::Selection().clearSelection();
 
     bool isPolar = getObject<PartDesign::PolarPattern>();
-  
+
     AllowSelectionFlags commonReferences = AllowSelection::EDGE | AllowSelection::PLANAR;
-    addReferenceSelectionGate(commonReferences | (isPolar ? AllowSelection::CIRCLE : AllowSelection::FACE));
+    addReferenceSelectionGate(
+        commonReferences | (isPolar ? AllowSelection::CIRCLE : AllowSelection::FACE)
+    );
     Gui::getMainWindow()->showMessage(
         tr("Select a direction reference (edge, face, datum line)")
     );  // User feedback

--- a/src/Mod/PartDesign/Gui/TaskPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPatternParameters.cpp
@@ -261,8 +261,15 @@ void TaskPatternParameters::enterReferenceSelectionMode()
     hideObject();  // Hide the pattern feature itself
     showBase();    // Show the base features/body
     Gui::Selection().clearSelection();
-    // Add selection gate (allow edges, faces, potentially datums)
-    addReferenceSelectionGate(AllowSelection::EDGE | AllowSelection::FACE | AllowSelection::PLANAR);
+
+    AllowSelectionFlags allowedReferences = AllowSelection::EDGE | AllowSelection::PLANAR;
+    if (getObject<PartDesign::PolarPattern>()) {
+        allowedReferences |= AllowSelection::CIRCLE;
+    }
+    else {
+        allowedReferences |= AllowSelection::FACE;
+    }
+    addReferenceSelectionGate(allowedReferences);
     Gui::getMainWindow()->showMessage(
         tr("Select a direction reference (edge, face, datum line)")
     );  // User feedback


### PR DESCRIPTION
Fixes https://forum.freecad.org/viewtopic.php?t=107242
PD Polar pattern accepted circular edges in the past and their axis was chosen. In 1.1 this is not possible anymore.
Restored so Polar Pattern accepts straight edges, circular edges, arcs, and datum/sketch axes.
No AI used.

