### PR TITLE
Sketcher: stabilize screen-space constraint preselection

### DIFF
--- a/src/Gui/Utilities.cpp
+++ b/src/Gui/Utilities.cpp
@@ -21,6 +21,8 @@
  ***************************************************************************/
 
 
+#include <algorithm>
+
 #include <Inventor/SbTesselator.h>
 #include <QAbstractItemModel>
 #include <QAbstractItemView>
@@ -40,6 +42,23 @@ using namespace Gui;
 bool Gui::isInternalGuiTestRun()
 {
     return App::Application::Config()["RunMode"] == "Internal";
+}
+
+SbVec2f Gui::projectToViewportPixels(
+    const SbViewVolume& viewVolume,
+    const SbViewportRegion& viewportRegion,
+    const SbVec3f& point
+)
+{
+    SbVec3f projectedPoint = point;
+    viewVolume.projectToScreen(projectedPoint, projectedPoint);
+
+    const SbVec2s viewportOrigin = viewportRegion.getViewportOriginPixels();
+    const SbVec2s viewportSize = viewportRegion.getViewportSizePixels();
+    return {
+        projectedPoint[0] * viewportSize[0] + viewportOrigin[0],
+        projectedPoint[1] * viewportSize[1] + viewportOrigin[1]
+    };
 }
 
 

--- a/src/Gui/Utilities.h
+++ b/src/Gui/Utilities.h
@@ -32,7 +32,10 @@
 #include <Inventor/SbMatrix.h>
 #include <Inventor/SbRotation.h>
 #include <Inventor/SbVec2f.h>
+#include <Inventor/SbVec2s.h>
+#include <Inventor/SbVec3f.h>
 #include <Inventor/SbViewVolume.h>
+#include <Inventor/SbViewportRegion.h>
 
 class SbViewVolume;
 class QAbstractItemView;
@@ -450,6 +453,15 @@ namespace Gui
 {
 
 [[nodiscard]] GuiExport bool isInternalGuiTestRun();
+
+/**
+ * Project a world point through Coin's effective rendering viewport and return window pixels.
+ */
+[[nodiscard]] GuiExport SbVec2f projectToViewportPixels(
+    const SbViewVolume& viewVolume,
+    const SbViewportRegion& viewportRegion,
+    const SbVec3f& point
+);
 
 /**
  */

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -2716,36 +2716,12 @@ SbVec2f View3DInventorViewer::screenCoordsOfPath(SoPath* path) const
     SbMatrix mat = gma.getMatrix().transpose();
     mat.multMatrixVec(imageCoords, imageCoords);
 
-    // Now, project the object space coordinates of the object
-    // into "normalized" screen coordinates.
-    SbViewVolume vol = getSoRenderManager()->getCamera()->getViewVolume();
-    vol.projectToScreen(imageCoords, imageCoords);
-
-    // Translate "normalized" screen coordinates to pixel coords.
-    //
-    // Note: for some reason, projectToScreen() doesn't seem to
-    // handle non-square viewports properly.  The X and Y are
-    // scaled such that [0,1] fits within the smaller of the window
-    // width or height.  For instance, in a window that's 400px
-    // tall and 800px wide, the Y will be within [0,1], but X can
-    // vary within [-0.5,1.5]...
-    int width = getGLWidget()->width();
-    int height = getGLWidget()->height();
-
-    if (width >= height) {
-        // "Landscape" orientation, to square
-        imageCoords[0] *= height;
-        imageCoords[0] += (width - height) / 2.0;  // NOLINT
-        imageCoords[1] *= height;
-    }
-    else {
-        // "Portrait" orientation
-        imageCoords[0] *= width;
-        imageCoords[1] *= width;
-        imageCoords[1] += (height - width) / 2.0;  // NOLINT
-    }
-
-    return {imageCoords[0], imageCoords[1]};
+    const auto* renderManager = getSoRenderManager();
+    const SbViewportRegion& viewportRegion = renderManager->getViewportRegion();
+    SbViewportRegion renderViewportRegion = viewportRegion;
+    const SbViewVolume viewVolume
+        = renderManager->getCamera()->getViewVolume(viewportRegion, renderViewportRegion);
+    return Gui::projectToViewportPixels(viewVolume, renderViewportRegion, imageCoords);
 }
 
 std::vector<SbVec2f> View3DInventorViewer::getGLPolygon(const std::vector<SbVec2s>& pnts) const

--- a/src/Mod/Sketcher/Gui/CMakeLists.txt
+++ b/src/Mod/Sketcher/Gui/CMakeLists.txt
@@ -124,6 +124,7 @@ SET(SketcherGui_SRCS
     EditModeCoinManagerParameters.cpp
     EditModeCoinManager.cpp
     EditModeCoinManager.h
+    ScreenPickContext.h
     EditModeGeometryCoinManager.cpp
     EditModeGeometryCoinManager.h
     EditModeConstraintCoinManager.cpp

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -75,10 +75,10 @@ namespace
 {
 struct ScreenPreselectionPolicy
 {
-    static constexpr float PointMarkerHitPaddingPx = 5.0F;
+    // Endpoints retain a small extra allowance because they are common drag targets. This is
+    // intentionally in addition to the viewer's Selection radius.
     static constexpr float EndpointPointHitRadiusBonusPx = 2.0F;
     static constexpr float PointHoverHysteresisPx = 2.0F;
-    static constexpr float EdgeHitPaddingPx = 2.0F;
 };
 
 struct PreselectionPriority
@@ -156,7 +156,8 @@ struct GeometryScreenPreselector
         const SketcherGui::DrawingParameters& drawingParams,
         const SketcherGui::GeoList& geoListArg,
         std::function<SbVec2f(const SbVec3f&)> screenProjectorArg,
-        Base::Placement sketchPlacementArg
+        Base::Placement sketchPlacementArg,
+        const SketcherGui::ScreenPickContext& pickContextArg
     )
         : geometryLayerParameters(geometryLayerParams)
         , editModeScenegraphNodes(scenegraphNodes)
@@ -165,6 +166,7 @@ struct GeometryScreenPreselector
         , geolist(geoListArg)
         , projectToScreen(std::move(screenProjectorArg))
         , sketchPlacement(std::move(sketchPlacementArg))
+        , pickContext(pickContextArg)
 
     {}
 
@@ -416,8 +418,7 @@ private:
             && geometry->getTypeId() != Part::GeomPoint::getClassTypeId()
             && (pointPos == Sketcher::PointPos::start || pointPos == Sketcher::PointPos::end);
 
-        float pointHitRadius = markerExtent * 0.5f
-            + ScreenPreselectionPolicy::PointMarkerHitPaddingPx + extraRadiusPx;
+        float pointHitRadius = markerExtent * 0.5f + pickContext.selectionRadiusPx + extraRadiusPx;
         if (isEndpointOfNonPointGeometry) {
             pointHitRadius += ScreenPreselectionPolicy::EndpointPointHitRadiusBonusPx;
         }
@@ -442,7 +443,7 @@ private:
         }
 
         float lineWidth = drawStyle ? drawStyle->lineWidth.getValue() : 1.0F;
-        return std::max(3.0F, lineWidth * 0.5F + ScreenPreselectionPolicy::EdgeHitPaddingPx);
+        return lineWidth * 0.5F + pickContext.selectionRadiusPx;
     }
 
     const SketcherGui::GeometryLayerParameters& geometryLayerParameters;
@@ -452,6 +453,7 @@ private:
     const SketcherGui::GeoList& geolist;
     const std::function<SbVec2f(const SbVec3f&)> projectToScreen;
     const Base::Placement sketchPlacement;
+    const SketcherGui::ScreenPickContext& pickContext;
 };
 }  // namespace
 
@@ -537,8 +539,6 @@ void EditModeCoinManager::ParameterObserver::initParameters()
         {"MarkerSize", [this](const std::string&) { Client.updateElementSizeParameters(); }},
         {"EditSketcherFontName", [this](const std::string&) { Client.updateElementSizeParameters(); }},
         {"EditSketcherFontSize", [this](const std::string&) { Client.updateElementSizeParameters(); }},
-        {"ConstraintIconHitPadding",
-         [this](const std::string&) { Client.updateElementSizeParameters(); }},
         {"EdgeWidth",
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
              updateWidth(drawingParameters.CurveWidth, param, 2);
@@ -1426,6 +1426,7 @@ bool EditModeCoinManager::detectGeometryPreselection(
     const SoPickedPointList& points,
     const SbVec2s& cursorPos,
     int hoveredPointIndex,
+    const ScreenPickContext& pickContext,
     PreselectionResult& result
 )
 {
@@ -1442,7 +1443,8 @@ bool EditModeCoinManager::detectGeometryPreselection(
         drawingParameters,
         geolist,
         projectToScreen,
-        sketchPlacement
+        sketchPlacement,
+        pickContext
     };
 
     if (detectPointPreselection(points, result)) {
@@ -1549,7 +1551,7 @@ EditModeCoinManager::PreselectionCandidates EditModeCoinManager::collectPreselec
     addCandidate(detectConstraintPreselection(points, cursorPos, pickContext));
 
     PreselectionResult geometry;
-    detectGeometryPreselection(points, cursorPos, hoveredPointIndex, geometry);
+    detectGeometryPreselection(points, cursorPos, hoveredPointIndex, pickContext, geometry);
     addCandidate(geometry);
 
     PreselectionResult axis;
@@ -2130,7 +2132,6 @@ void EditModeCoinManager::updateElementSizeParameters()
 
     int sketcherfontSize = hGrp->GetInt("EditSketcherFontSize", defaultFontSizePixels);
     int constraintSymbolSizePref = hGrp->GetInt("ConstraintSymbolSize", defaultFontSizePixels);
-    drawingParameters.constraintIconHitPaddingPx = hGrp->GetInt("ConstraintIconHitPadding", 3);
 
     double dpi = getApplicationLogicalDPIX();
     double devicePixelRatio = getDevicePixelRatio();

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -1236,7 +1236,8 @@ void EditModeCoinManager::setAxisPickStyle(bool on)
 
 EditModeCoinManager::PreselectionResult EditModeCoinManager::detectConstraintPreselection(
     const SoPickedPointList& points,
-    const SbVec2s& cursorPos
+    const SbVec2s& cursorPos,
+    const ScreenPickContext& pickContext
 )
 {
     PreselectionResult result;
@@ -1263,7 +1264,8 @@ EditModeCoinManager::PreselectionResult EditModeCoinManager::detectConstraintPre
         }
     };
 
-    auto constraintHit = pEditModeConstraintCoinManager->detectPreselectionConstr(cursorPos);
+    auto constraintHit
+        = pEditModeConstraintCoinManager->detectPreselectionConstr(cursorPos, pickContext);
     if (constraintHit.hasHit()) {
         toPreselectionResult(constraintHit, result);
         return result;
@@ -1275,7 +1277,8 @@ EditModeCoinManager::PreselectionResult EditModeCoinManager::detectConstraintPre
             continue;
         }
 
-        constraintHit = pEditModeConstraintCoinManager->detectPreselectionConstr(point, cursorPos);
+        constraintHit
+            = pEditModeConstraintCoinManager->detectPreselectionConstr(point, cursorPos, pickContext);
         if (!constraintHit.hasHit()) {
             continue;
         }
@@ -1532,7 +1535,8 @@ bool EditModeCoinManager::detectAxisPreselection(
 EditModeCoinManager::PreselectionCandidates EditModeCoinManager::collectPreselectionCandidates(
     const SoPickedPointList& points,
     const SbVec2s& cursorPos,
-    int hoveredPointIndex
+    int hoveredPointIndex,
+    const ScreenPickContext& pickContext
 )
 {
     PreselectionCandidates candidates;
@@ -1542,7 +1546,7 @@ EditModeCoinManager::PreselectionCandidates EditModeCoinManager::collectPreselec
         }
     };
 
-    addCandidate(detectConstraintPreselection(points, cursorPos));
+    addCandidate(detectConstraintPreselection(points, cursorPos, pickContext));
 
     PreselectionResult geometry;
     detectGeometryPreselection(points, cursorPos, hoveredPointIndex, geometry);
@@ -1574,11 +1578,12 @@ EditModeCoinManager::PreselectionResult EditModeCoinManager::resolvePreselection
 EditModeCoinManager::PreselectionResult EditModeCoinManager::detectPreselection(
     const SoPickedPointList& points,
     const SbVec2s& cursorPos,
+    const ScreenPickContext& pickContext,
     int hoveredPointIndex
 )
 {
     return resolvePreselectionCandidates(
-        collectPreselectionCandidates(points, cursorPos, hoveredPointIndex)
+        collectPreselectionCandidates(points, cursorPos, hoveredPointIndex, pickContext)
     );
 }
 

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -341,6 +341,7 @@ private:
         const SoPickedPointList& points,
         const SbVec2s& cursorPos,
         int hoveredPointIndex,
+        const ScreenPickContext& pickContext,
         PreselectionResult& result
     );
     bool detectPointPreselection(const SoPickedPointList& points, PreselectionResult& result);

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -35,6 +35,7 @@
 #include "GeometryCreationMode.h"
 
 #include "EditModeCoinManagerParameters.h"
+#include "ScreenPickContext.h"
 
 
 class SbVec3f;
@@ -281,6 +282,7 @@ public:
     PreselectionResult detectPreselection(
         const SoPickedPointList& points,
         const SbVec2s& cursorPos,
+        const ScreenPickContext& pickContext,
         int hoveredPointIndex = PreselectionResult::InvalidPoint
     );
     /// The client is responsible for unref-ing the SoGroup to release the memory.
@@ -331,7 +333,8 @@ public:
 private:
     PreselectionResult detectConstraintPreselection(
         const SoPickedPointList& points,
-        const SbVec2s& cursorPos
+        const SbVec2s& cursorPos,
+        const ScreenPickContext& pickContext
     );
     bool detectOriginPreselection(const SoPickedPoint* point, PreselectionResult& result);
     bool detectGeometryPreselection(
@@ -349,7 +352,8 @@ private:
     PreselectionCandidates collectPreselectionCandidates(
         const SoPickedPointList& points,
         const SbVec2s& cursorPos,
-        int hoveredPointIndex
+        int hoveredPointIndex,
+        const ScreenPickContext& pickContext
     );
     PreselectionResult resolvePreselectionCandidates(const PreselectionCandidates& candidates) const;
 

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -137,10 +137,9 @@ struct DrawingParameters
     int coinFontSize = 17;            // Font size to be used by coin
     int labelFontSize = 17;  // Font size to be used by SoDatumLabel, which uses a QPainter and a
                              // QFont internally
-    static QString labelFontName;        // Font face to be used by SoDatumLabel
-    int constraintIconSize = 15;         // Size of constraint icons
-    int constraintIconHitPaddingPx = 3;  // Extra hit padding for constraint icons
-    int markerSize = 7;                  // Size used for markers
+    static QString labelFontName;  // Font face to be used by SoDatumLabel
+    int constraintIconSize = 15;   // Size of constraint icons
+    int markerSize = 7;            // Size used for markers
 
     // transparency of visible axis
     float axisTransparency = 0.3f;

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2452,8 +2452,11 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
         static_cast<float>(cursorScreenPos[0]) - iconScreenCenter[0] + iconSize[0] / 2.0F,
         iconScreenCenter[1] - static_cast<float>(cursorScreenPos[1]) + iconSize[1] / 2.0F
     );
-    const QRectF iconBounds(0.0, 0.0, iconSize[0], iconSize[1]);
-    const float iconDistanceToBoundsSquared = distanceSquaredToRect(iconPoint, iconBounds);
+    const QRectF iconBoundsForDistance(0.0, 0.0, iconSize[0], iconSize[1]);
+    const float iconDistanceToBoundsSquared = distanceSquaredToRect(iconPoint, iconBoundsForDistance);
+    const float selectionRadiusPx = pickContext.selectionRadiusPx;
+    const float selectionRadiusSquared = selectionRadiusPx * selectionRadiusPx;
+
     const float dx = static_cast<float>(cursorScreenPos[0]) - iconScreenCenter[0];
     const float dy = static_cast<float>(cursorScreenPos[1]) - iconScreenCenter[1];
     if (distanceToBoundsSquared) {
@@ -2463,19 +2466,11 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
         *distanceToCenterSquared = dx * dx + dy * dy;
     }
 
-    int relativeX = static_cast<int>(iconPoint.x());
-    int relativeY = static_cast<int>(iconPoint.y());
-    const QMargins iconHitPadding(
-        drawingParameters.constraintIconHitPaddingPx,
-        drawingParameters.constraintIconHitPaddingPx,
-        drawingParameters.constraintIconHitPaddingPx,
-        drawingParameters.constraintIconHitPaddingPx
-    );
-
     if (combinedConstrBoxes.count(constrIdsStr)) {
         float closestBoxDistanceSquared = std::numeric_limits<float>::max();
         for (const auto& boxInfo : combinedConstrBoxes.at(constrIdsStr)) {
             const float boxDistanceSquared = distanceSquaredToRect(iconPoint, boxInfo.first);
+            closestBoxDistanceSquared = std::min(closestBoxDistanceSquared, boxDistanceSquared);
             if (boxDistanceSquared <= selectionRadiusSquared) {
                 result.ConstrIndices.insert(boxInfo.second.begin(), boxInfo.second.end());
             }
@@ -2490,8 +2485,7 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
         return result;
     }
 
-    QRect iconBounds(0, 0, iconSize[0], iconSize[1]);
-    if (iconBounds.marginsAdded(iconHitPadding).contains(relativeX, relativeY)) {
+    if (iconDistanceToBoundsSquared <= selectionRadiusSquared) {
         result.Kind = ConstraintPreselectionResult::HitKind::Icon;
         result.ConstrIndices = parseConstraintIds(constrIdsStr);
         result.PickedPoint = *resultPoint;

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -25,6 +25,7 @@
 #include <FCConfig.h>
 
 #include <QPainter>
+#include <QPointF>
 #include <QRegularExpression>
 #include <Bnd_Box.hxx>
 #include <algorithm>
@@ -80,6 +81,23 @@
 using namespace Gui;
 using namespace SketcherGui;
 using namespace Sketcher;
+
+namespace
+{
+float distanceSquaredToRect(const QPointF& point, const QRectF& rect)
+{
+    const float left = static_cast<float>(rect.left());
+    const float top = static_cast<float>(rect.top());
+    const float right = left + static_cast<float>(rect.width());
+    const float bottom = top + static_cast<float>(rect.height());
+
+    const float pointX = static_cast<float>(point.x());
+    const float pointY = static_cast<float>(point.y());
+    const float dx = std::max({left - pointX, 0.0F, pointX - right});
+    const float dy = std::max({top - pointY, 0.0F, pointY - bottom});
+    return dx * dx + dy * dy;
+}
+}  // namespace
 
 //**************************** EditModeConstraintCoinManager class ******************************
 
@@ -2242,28 +2260,46 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
     Base::Vector3d* pickedPoint
 )
 {
-    ConstraintPreselectionResult result;
+    struct IconCandidate
+    {
+        ConstraintPreselectionResult result;
+        float distanceToBoundsSquared = std::numeric_limits<float>::max();
+        float distanceToCenterSquared = std::numeric_limits<float>::max();
+        int constraintIndex = std::numeric_limits<int>::max();
+    };
 
-    auto detectIcon = [&](SoSeparator* sep, SoImage* iconNode, int iconIndex) {
+    std::vector<IconCandidate> candidates;
+
+    auto collectCandidate = [&](SoSeparator* sep, SoImage* iconNode, int iconIndex) {
         if (!pickContext.constraintGroupPath) {
-            return ConstraintPreselectionResult {};
+            return;
         }
 
         SoPath* iconPath = pickContext.constraintGroupPath->copy();
         iconPath->ref();
         iconPath->append(sep);
         iconPath->append(iconNode);
-        auto iconResult = detectPreselectionIcon(
+
+        float distanceToBoundsSquared = std::numeric_limits<float>::max();
+        float distanceToCenterSquared = std::numeric_limits<float>::max();
+        auto result = detectPreselectionIcon(
             sep,
             iconNode,
             iconIndex,
             iconPath,
             cursorScreenPos,
             pickContext,
-            pickedPoint
+            nullptr,
+            &distanceToBoundsSquared,
+            &distanceToCenterSquared
         );
         iconPath->unref();
-        return iconResult;
+        if (result.hasHit()) {
+            const int constraintIndex = *result.ConstrIndices.begin();
+            candidates.push_back(
+                {result, distanceToBoundsSquared, distanceToCenterSquared, constraintIndex}
+            );
+        }
     };
 
     for (int i = 0; i < editModeScenegraphNodes.constrGroup->getNumChildren(); ++i) {
@@ -2276,10 +2312,7 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
             iconIndex < sep->getNumChildren()) {
             auto* iconNode = dynamic_cast<SoImage*>(sep->getChild(iconIndex));
             if (iconNode) {
-                result = detectIcon(sep, iconNode, iconIndex);
-                if (result.hasHit()) {
-                    return result;
-                }
+                collectCandidate(sep, iconNode, iconIndex);
             }
         }
 
@@ -2287,15 +2320,31 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
             iconIndex < sep->getNumChildren()) {
             auto* iconNode = dynamic_cast<SoImage*>(sep->getChild(iconIndex));
             if (iconNode) {
-                result = detectIcon(sep, iconNode, iconIndex);
-                if (result.hasHit()) {
-                    return result;
-                }
+                collectCandidate(sep, iconNode, iconIndex);
             }
         }
     }
 
-    return result;
+    if (candidates.empty()) {
+        ConstraintPreselectionResult noHit;
+        return noHit;
+    }
+
+    const auto closest
+        = std::ranges::min_element(candidates, [](const IconCandidate& lhs, const IconCandidate& rhs) {
+              if (lhs.distanceToBoundsSquared != rhs.distanceToBoundsSquared) {
+                  return lhs.distanceToBoundsSquared < rhs.distanceToBoundsSquared;
+              }
+              if (lhs.distanceToCenterSquared != rhs.distanceToCenterSquared) {
+                  return lhs.distanceToCenterSquared < rhs.distanceToCenterSquared;
+              }
+              return lhs.constraintIndex < rhs.constraintIndex;
+          });
+
+    if (pickedPoint) {
+        *pickedPoint = closest->result.PickedPoint;
+    }
+    return closest->result;
 }
 
 std::set<int> EditModeConstraintCoinManager::parseConstraintIds(const QString& constrIdsStr) const
@@ -2373,7 +2422,9 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
     const SoPath* iconPath,
     const SbVec2s& cursorScreenPos,
     const ScreenPickContext& pickContext,
-    Base::Vector3d* pickedPoint
+    Base::Vector3d* pickedPoint,
+    float* distanceToBoundsSquared,
+    float* distanceToCenterSquared
 ) const
 {
     ConstraintPreselectionResult result;
@@ -2397,8 +2448,23 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
         return result;
     }
 
-    int relativeX = static_cast<int>(cursorScreenPos[0] - iconScreenCenter[0] + iconSize[0] / 2.0f);
-    int relativeY = static_cast<int>(iconScreenCenter[1] - cursorScreenPos[1] + iconSize[1] / 2.0f);
+    const QPointF iconPoint(
+        static_cast<float>(cursorScreenPos[0]) - iconScreenCenter[0] + iconSize[0] / 2.0F,
+        iconScreenCenter[1] - static_cast<float>(cursorScreenPos[1]) + iconSize[1] / 2.0F
+    );
+    const QRectF iconBounds(0.0, 0.0, iconSize[0], iconSize[1]);
+    const float iconDistanceToBoundsSquared = distanceSquaredToRect(iconPoint, iconBounds);
+    const float dx = static_cast<float>(cursorScreenPos[0]) - iconScreenCenter[0];
+    const float dy = static_cast<float>(cursorScreenPos[1]) - iconScreenCenter[1];
+    if (distanceToBoundsSquared) {
+        *distanceToBoundsSquared = iconDistanceToBoundsSquared;
+    }
+    if (distanceToCenterSquared) {
+        *distanceToCenterSquared = dx * dx + dy * dy;
+    }
+
+    int relativeX = static_cast<int>(iconPoint.x());
+    int relativeY = static_cast<int>(iconPoint.y());
     const QMargins iconHitPadding(
         drawingParameters.constraintIconHitPaddingPx,
         drawingParameters.constraintIconHitPaddingPx,
@@ -2407,10 +2473,15 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
     );
 
     if (combinedConstrBoxes.count(constrIdsStr)) {
+        float closestBoxDistanceSquared = std::numeric_limits<float>::max();
         for (const auto& boxInfo : combinedConstrBoxes.at(constrIdsStr)) {
-            if (boxInfo.first.marginsAdded(iconHitPadding).contains(relativeX, relativeY)) {
+            const float boxDistanceSquared = distanceSquaredToRect(iconPoint, boxInfo.first);
+            if (boxDistanceSquared <= selectionRadiusSquared) {
                 result.ConstrIndices.insert(boxInfo.second.begin(), boxInfo.second.end());
             }
+        }
+        if (distanceToBoundsSquared) {
+            *distanceToBoundsSquared = closestBoxDistanceSquared;
         }
         if (!result.ConstrIndices.empty()) {
             result.Kind = ConstraintPreselectionResult::HitKind::Icon;

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -37,6 +37,8 @@
 #include <Inventor/SbImage.h>
 #include <Inventor/SbVec3f.h>
 #include <Inventor/SoPickedPoint.h>
+#include <Inventor/SoPath.h>
+#include <Inventor/actions/SoGetMatrixAction.h>
 #include <Inventor/nodes/SoAnnotation.h>
 #include <Inventor/nodes/SoDrawStyle.h>
 #include <Inventor/nodes/SoGroup.h>
@@ -60,6 +62,8 @@
 #include <Gui/SoDatumLabel.h>
 #include <Gui/Tools.h>
 #include <Gui/Utilities.h>
+#include <Inventor/elements/SoViewVolumeElement.h>
+#include <Inventor/elements/SoViewportRegionElement.h>
 #include <Mod/Part/App/Geometry.h>
 #include <Mod/Sketcher/App/Constraint.h>
 #include <Mod/Sketcher/App/GeoEnum.h>
@@ -2185,7 +2189,8 @@ QString EditModeConstraintCoinManager::getPresentationString(
 
 EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCoinManager::detectPreselectionConstr(
     const SoPickedPoint* Point,
-    const SbVec2s& cursorScreenPos
+    const SbVec2s& cursorScreenPos,
+    const ScreenPickContext& pickContext
 )
 {
     ConstraintPreselectionResult result;
@@ -2202,7 +2207,14 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
 
     for (int childIdx = 0; childIdx < sep->getNumChildren(); ++childIdx) {
         if (tail == sep->getChild(childIdx) && dynamic_cast<SoImage*>(tail)) {
-            return detectPreselectionIcon(sep, static_cast<SoImage*>(tail), childIdx, cursorScreenPos);
+            return detectPreselectionIcon(
+                sep,
+                static_cast<SoImage*>(tail),
+                childIdx,
+                path,
+                cursorScreenPos,
+                pickContext
+            );
         }
     }
 
@@ -2226,10 +2238,33 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
 
 EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCoinManager::detectPreselectionConstr(
     const SbVec2s& cursorScreenPos,
+    const ScreenPickContext& pickContext,
     Base::Vector3d* pickedPoint
 )
 {
     ConstraintPreselectionResult result;
+
+    auto detectIcon = [&](SoSeparator* sep, SoImage* iconNode, int iconIndex) {
+        if (!pickContext.constraintGroupPath) {
+            return ConstraintPreselectionResult {};
+        }
+
+        SoPath* iconPath = pickContext.constraintGroupPath->copy();
+        iconPath->ref();
+        iconPath->append(sep);
+        iconPath->append(iconNode);
+        auto iconResult = detectPreselectionIcon(
+            sep,
+            iconNode,
+            iconIndex,
+            iconPath,
+            cursorScreenPos,
+            pickContext,
+            pickedPoint
+        );
+        iconPath->unref();
+        return iconResult;
+    };
 
     for (int i = 0; i < editModeScenegraphNodes.constrGroup->getNumChildren(); ++i) {
         auto* sep = dynamic_cast<SoSeparator*>(editModeScenegraphNodes.constrGroup->getChild(i));
@@ -2241,7 +2276,7 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
             iconIndex < sep->getNumChildren()) {
             auto* iconNode = dynamic_cast<SoImage*>(sep->getChild(iconIndex));
             if (iconNode) {
-                result = detectPreselectionIcon(sep, iconNode, iconIndex, cursorScreenPos, pickedPoint);
+                result = detectIcon(sep, iconNode, iconIndex);
                 if (result.hasHit()) {
                     return result;
                 }
@@ -2252,7 +2287,7 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
             iconIndex < sep->getNumChildren()) {
             auto* iconNode = dynamic_cast<SoImage*>(sep->getChild(iconIndex));
             if (iconNode) {
-                result = detectPreselectionIcon(sep, iconNode, iconIndex, cursorScreenPos, pickedPoint);
+                result = detectIcon(sep, iconNode, iconIndex);
                 if (result.hasHit()) {
                     return result;
                 }
@@ -2277,6 +2312,8 @@ bool EditModeConstraintCoinManager::resolveIconScreenGeometry(
     SoSeparator* sep,
     SoImage* iconNode,
     int iconIndex,
+    const SoPath* iconPath,
+    const ScreenPickContext& pickContext,
     SbVec2f& iconScreenCenter,
     SbVec3s& iconSize,
     QString& constrIdsStr,
@@ -2298,34 +2335,32 @@ bool EditModeConstraintCoinManager::resolveIconScreenGeometry(
         return false;
     }
 
-    auto* firstTransNode = dynamic_cast<SoZoomTranslation*>(
-        sep->getChild(static_cast<int>(ConstraintNodePosition::FirstTranslationIndex))
-    );
-    if (!firstTransNode) {
+    if (!iconPath) {
         return false;
     }
 
-    SbVec3f absPos = firstTransNode->abPos.getValue();
-    SbVec3f trans = firstTransNode->translation.getValue();
-    float scaleFactor = firstTransNode->getScaleFactor();
+    // Use the current Coin transformation chain instead of reconstructing the
+    // icon position from the last action that traversed each SoZoomTranslation.
+    const auto& viewportRegion = pickContext.renderViewportRegion;
+    const auto& viewVolume = pickContext.renderViewVolume;
+    SoPath* path = iconPath->copy();
+    path->ref();
 
-    if (iconIndex == static_cast<int>(ConstraintNodePosition::SecondIconIndex)
-        && static_cast<int>(ConstraintNodePosition::SecondTranslationIndex) < sep->getNumChildren()) {
-        auto* secondTransNode = dynamic_cast<SoZoomTranslation*>(
-            sep->getChild(static_cast<int>(ConstraintNodePosition::SecondTranslationIndex))
-        );
-        if (secondTransNode) {
-            absPos += secondTransNode->abPos.getValue();
-            trans += secondTransNode->translation.getValue();
-            scaleFactor = secondTransNode->getScaleFactor();
-        }
-    }
+    SoGetMatrixAction matrixAction(viewportRegion);
+    SoViewVolumeElement::set(matrixAction.getState(), iconNode, viewVolume);
+    SoViewportRegionElement::set(matrixAction.getState(), viewportRegion);
+    matrixAction.apply(path);
 
-    SbVec3f iconWorldPos = absPos + scaleFactor * trans;
-    iconScreenCenter = ViewProviderSketchCoinAttorney::getScreenCoordinates(viewProvider, iconWorldPos);
+    SbVec3f iconWorldPos;
+    matrixAction.getMatrix().multVecMatrix(SbVec3f(0.f, 0.f, 0.f), iconWorldPos);
+    path->unref();
 
+    iconScreenCenter = pickContext.projectRenderPointToViewport(iconWorldPos);
     if (pickedPoint) {
-        *pickedPoint = Base::convertTo<Base::Vector3d>(iconWorldPos);
+        const Base::Vector3d worldPoint = Base::convertTo<Base::Vector3d>(iconWorldPos);
+        ViewProviderSketchCoinAttorney::getEditingPlacement(viewProvider)
+            .inverse()
+            .multVec(worldPoint, *pickedPoint);
     }
 
     return true;
@@ -2335,7 +2370,9 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
     SoSeparator* sep,
     SoImage* iconNode,
     int iconIndex,
+    const SoPath* iconPath,
     const SbVec2s& cursorScreenPos,
+    const ScreenPickContext& pickContext,
     Base::Vector3d* pickedPoint
 ) const
 {
@@ -2346,9 +2383,17 @@ EditModeConstraintCoinManager::ConstraintPreselectionResult EditModeConstraintCo
     Base::Vector3d hitPoint;
     Base::Vector3d* resultPoint = pickedPoint ? pickedPoint : &hitPoint;
 
-    if (
-        !resolveIconScreenGeometry(sep, iconNode, iconIndex, iconScreenCenter, iconSize, constrIdsStr, resultPoint)
-    ) {
+    if (!resolveIconScreenGeometry(
+            sep,
+            iconNode,
+            iconIndex,
+            iconPath,
+            pickContext,
+            iconScreenCenter,
+            iconSize,
+            constrIdsStr,
+            resultPoint
+        )) {
         return result;
     }
 

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
@@ -40,6 +40,7 @@
 #include <Mod/Sketcher/App/Constraint.h>
 
 #include "EditModeCoinManagerParameters.h"
+#include "ScreenPickContext.h"
 
 
 class SbVec3f;
@@ -159,10 +160,12 @@ public:
 
     ConstraintPreselectionResult detectPreselectionConstr(
         const SoPickedPoint* Point,
-        const SbVec2s& cursorScreenPos
+        const SbVec2s& cursorScreenPos,
+        const ScreenPickContext& pickContext
     );
     ConstraintPreselectionResult detectPreselectionConstr(
         const SbVec2s& cursorScreenPos,
+        const ScreenPickContext& pickContext,
         Base::Vector3d* pickedPoint = nullptr
     );
 
@@ -193,6 +196,8 @@ private:
         SoSeparator* sep,
         SoImage* iconNode,
         int iconIndex,
+        const SoPath* iconPath,
+        const ScreenPickContext& pickContext,
         SbVec2f& iconScreenCenter,
         SbVec3s& iconSize,
         QString& constrIdsStr,
@@ -202,7 +207,9 @@ private:
         SoSeparator* sep,
         SoImage* iconNode,
         int iconIndex,
+        const SoPath* iconPath,
         const SbVec2s& cursorScreenPos,
+        const ScreenPickContext& pickContext,
         Base::Vector3d* pickedPoint = nullptr
     ) const;
 

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
@@ -210,7 +210,9 @@ private:
         const SoPath* iconPath,
         const SbVec2s& cursorScreenPos,
         const ScreenPickContext& pickContext,
-        Base::Vector3d* pickedPoint = nullptr
+        Base::Vector3d* pickedPoint = nullptr,
+        float* distanceToBoundsSquared = nullptr,
+        float* distanceToCenterSquared = nullptr
     ) const;
 
     /** @name Protected helpers for drawing constraint icons*/

--- a/src/Mod/Sketcher/Gui/ScreenPickContext.h
+++ b/src/Mod/Sketcher/Gui/ScreenPickContext.h
@@ -17,6 +17,8 @@ struct ScreenPickContext
 {
     SbViewportRegion renderViewportRegion;
     SbViewVolume renderViewVolume;
+    float selectionRadiusPx = 0.0F;
+
     // Borrowed from the SoSearchAction that created this context. It remains valid for the
     // duration of the preselection operation.
     const SoPath* constraintGroupPath = nullptr;

--- a/src/Mod/Sketcher/Gui/ScreenPickContext.h
+++ b/src/Mod/Sketcher/Gui/ScreenPickContext.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <Inventor/SbViewVolume.h>
+#include <Inventor/SbViewportRegion.h>
+
+#include <Gui/Utilities.h>
+
+class SoPath;
+
+namespace SketcherGui
+{
+
+/** The Coin rendering, viewport, and tolerance state shared by one screen-pick operation. */
+struct ScreenPickContext
+{
+    SbViewportRegion renderViewportRegion;
+    SbViewVolume renderViewVolume;
+    // Borrowed from the SoSearchAction that created this context. It remains valid for the
+    // duration of the preselection operation.
+    const SoPath* constraintGroupPath = nullptr;
+
+    [[nodiscard]] SbVec2f projectRenderPointToViewport(const SbVec3f& point) const
+    {
+        return Gui::projectToViewportPixels(renderViewVolume, renderViewportRegion, point);
+    }
+};
+
+}  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -958,6 +958,7 @@ EditModeCoinManager::PreselectionResult ViewProviderSketch::getPreselectionResul
     const ScreenPickContext pickContext {
         renderViewportRegion,
         renderViewVolume,
+        std::max(0.0F, viewer->getPickRadius()),
         search.isFound() ? search.getPath() : nullptr
     };
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -28,6 +28,7 @@
 #include <Inventor/SbLine.h>
 #include <Inventor/SbTime.h>
 #include <Inventor/SoPickedPoint.h>
+#include <Inventor/actions/SoSearchAction.h>
 #include <Inventor/actions/SoRayPickAction.h>
 #include <Inventor/actions/SoGetBoundingBoxAction.h>
 #include <Inventor/details/SoPointDetail.h>
@@ -931,6 +932,35 @@ EditModeCoinManager::PreselectionResult ViewProviderSketch::getPreselectionResul
 ) const
 {
     SoPickedPointList points = getPickedPointsOnRay(pos, viewer);
+    if (!viewer || !viewer->getSoRenderManager()) {
+        return {};
+    }
+
+    auto* renderManager = viewer->getSoRenderManager();
+    auto* sceneGraph = renderManager->getSceneGraph();
+    auto* camera = renderManager->getCamera();
+    if (!sceneGraph || !camera) {
+        return {};
+    }
+
+    const auto& viewportRegion = renderManager->getViewportRegion();
+    SoSearchAction search;
+    search.setName("ConstraintGroup");
+    search.setInterest(SoSearchAction::FIRST);
+    search.setSearchingAll(TRUE);
+    search.apply(sceneGraph);
+
+    SbViewportRegion renderViewportRegion = viewportRegion;
+    const SbViewVolume renderViewVolume = camera->getViewVolume(
+        viewportRegion,
+        renderViewportRegion
+    );
+    const ScreenPickContext pickContext {
+        renderViewportRegion,
+        renderViewVolume,
+        search.isFound() ? search.getPath() : nullptr
+    };
+
     int hoveredPointIndex = EditModeCoinManager::PreselectionResult::InvalidPoint;
     if (viewProviderParameters.hasLastPreselectionResult
         && viewProviderParameters.lastPreselectionResult.Kind
@@ -938,7 +968,7 @@ EditModeCoinManager::PreselectionResult ViewProviderSketch::getPreselectionResul
         hoveredPointIndex = viewProviderParameters.lastPreselectionResult.PointIndex;
     }
 
-    return editCoinManager->detectPreselection(points, pos, hoveredPointIndex);
+    return editCoinManager->detectPreselection(points, pos, pickContext, hoveredPointIndex);
 }
 
 void ViewProviderSketch::cachePreselectionResult(

--- a/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
@@ -30,6 +30,28 @@ class SketcherGuiTestCases(unittest.TestCase):
                 time.sleep(delay)
 
     @staticmethod
+    def build_issue_25840_sketch(sketch):
+        # Mirrors the uploaded repro geometry from issue #25840.
+        first_line = sketch.addGeometry(
+            Part.LineSegment(
+                FreeCAD.Vector(-17.60407066, 31.05172348, 0.0),
+                FreeCAD.Vector(44.00962448, -33.86270142, 0.0),
+            ),
+            False,
+        )
+        second_line = sketch.addGeometry(
+            Part.LineSegment(
+                FreeCAD.Vector(50.4888, 6.2351, 0.0),
+                FreeCAD.Vector(30.973626440922192, -20.12834717, 0.0),
+            ),
+            False,
+        )
+        constraint_id = sketch.addConstraint(
+            Sketcher.Constraint("PointOnObject", second_line, 2, first_line)
+        )
+        return constraint_id, FreeCAD.Vector(30.973626440922192, -20.12834717, 0.0)
+
+    @staticmethod
     def build_issue_20811_sketch(sketch):
         # Mirrors ConstraintSelect.FCStd from issue #20811 without requiring a binary fixture.
         first_line = sketch.addGeometry(
@@ -142,6 +164,30 @@ class SketcherGuiTestCases(unittest.TestCase):
             int(round(sum(point[0] for point in target_points) / len(target_points))),
             int(round(sum(point[1] for point in target_points) / len(target_points))),
         )
+
+    @classmethod
+    def scan_preselection_at_viewport(cls, center_coin, expected_constraint_name, span=16, step=2):
+        counts = {
+            "target_constraint": 0,
+            "other_constraint": 0,
+            "edge": 0,
+            "vertex": 0,
+            "other": 0,
+            "none": 0,
+        }
+
+        for dy in range(-span, span + 1, step):
+            for dx in range(-span, span + 1, step):
+                coin_point = (center_coin[0] + dx, center_coin[1] + dy)
+                info = SketcherGui.getActiveSketchPreselection(coin_point)
+                counts[cls.classify_preselection(info, expected_constraint_name)] += 1
+
+        return counts
+
+    @staticmethod
+    def constraint_share(counts):
+        hits = sum(counts[kind] for kind in counts if kind != "none")
+        return counts["target_constraint"] / hits if hits else 0.0
 
     @staticmethod
     def project_coin_path_point_to_viewport(view_volume, viewport_region, point):
@@ -450,6 +496,46 @@ class SketcherGuiTestCases(unittest.TestCase):
             self.doc = None
             FreeCAD.closeDocument(document_name)
             self.pump_gui_events()
+
+    def testPointOnObjectPreselectionMatchesTiltedHitArea(self):
+        constraint_id, probe_point = self.build_issue_25840_sketch(self.sketch)
+        expected_name = f"Constraint{constraint_id + 1}"
+        self.doc.recompute()
+        self.pump_gui_events()
+
+        counts_by_state = {}
+        for name, tilt in {
+            "exact_top": None,
+            "tilt_y_2deg": FreeCAD.Rotation(FreeCAD.Vector(0, 1, 0), 2.0),
+        }.items():
+            self.configure_view_state(self.view, tilt)
+            probe_viewport = self.find_constraint_probe_viewport_point(
+                self.view,
+                probe_point,
+                expected_name,
+            )
+            self.assertIsNotNone(probe_viewport)
+            counts_by_state[name] = self.scan_preselection_at_viewport(
+                probe_viewport,
+                expected_name,
+                span=12,
+            )
+
+        exact_top = counts_by_state["exact_top"]
+        tilted = counts_by_state["tilt_y_2deg"]
+        detail = (
+            f"exact_top={exact_top}, tilt_y_2deg={tilted}, "
+            f"constraint_share={self.constraint_share(exact_top):.3f}"
+        )
+
+        self.assertGreater(tilted["target_constraint"], 0, detail)
+        self.assertGreater(exact_top["target_constraint"], 0, detail)
+        self.assertGreaterEqual(
+            exact_top["target_constraint"],
+            int(tilted["target_constraint"] * 0.8),
+            detail,
+        )
+        self.assertGreaterEqual(self.constraint_share(exact_top), 0.20, detail)
 
     def testConstraintIconMousePreselectionMatchesRenderedPosition(self):
         self.use_attached_issue_sketch()
@@ -878,9 +964,12 @@ class SketcherGuiTestCases(unittest.TestCase):
 
         midpoint_coin = self.get_stable_viewport_point(self.view, midpoint)
 
+        # Limit probes to the pick region around the line's geometric midpoint. The dimension
+        # line passes through this point, while its datum text is positioned farther along it.
+        probe_radius = max(1, int(math.ceil(self.viewer.getPickRadius())))
         edge_offsets = []
-        for dy in range(-10, 11, 2):
-            for dx in range(-14, 15, 2):
+        for dy in range(-probe_radius, probe_radius + 1):
+            for dx in range(-probe_radius, probe_radius + 1):
                 probe_coin = (midpoint_coin[0] + dx, midpoint_coin[1] + dy)
                 probe_info = SketcherGui.getActiveSketchPreselection(probe_coin)
                 probe_kind = self.classify_preselection(probe_info, "Constraint0")

--- a/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
@@ -9,7 +9,7 @@ import FreeCADGui
 import Part
 import Sketcher
 import SketcherGui
-from PySide6 import QtCore, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 
 
 class SketcherGuiTestCases(unittest.TestCase):
@@ -30,26 +30,73 @@ class SketcherGuiTestCases(unittest.TestCase):
                 time.sleep(delay)
 
     @staticmethod
-    def build_issue_25840_sketch(sketch):
-        # Mirrors the uploaded repro geometry from issue #25840.
+    def build_issue_20811_sketch(sketch):
+        # Mirrors ConstraintSelect.FCStd from issue #20811 without requiring a binary fixture.
         first_line = sketch.addGeometry(
             Part.LineSegment(
-                FreeCAD.Vector(-17.60407066, 31.05172348, 0.0),
-                FreeCAD.Vector(44.00962448, -33.86270142, 0.0),
+                FreeCAD.Vector(0.0, 0.0, 0.0),
+                FreeCAD.Vector(0.0, 24.181930730600406, 0.0),
             ),
             False,
         )
         second_line = sketch.addGeometry(
             Part.LineSegment(
-                FreeCAD.Vector(50.4888, 6.2351, 0.0),
-                FreeCAD.Vector(30.973626440922192, -20.12834717, 0.0),
+                FreeCAD.Vector(0.0, 24.181930730600406, 0.0),
+                FreeCAD.Vector(14.77492472860838, 30.362974758199655, 0.0),
             ),
             False,
         )
-        constraint_id = sketch.addConstraint(
-            Sketcher.Constraint("PointOnObject", second_line, 2, first_line)
+        arc = sketch.addGeometry(
+            Part.ArcOfCircle(
+                Part.Circle(
+                    FreeCAD.Vector(20.44726296326554, 16.80404036490776, 0.0),
+                    FreeCAD.Vector(0.0, 0.0, 1.0),
+                    14.697623036734457,
+                ),
+                0.0,
+                1.96702,
+            ),
+            False,
         )
-        return constraint_id, FreeCAD.Vector(30.973626440922192, -20.12834717, 0.0)
+        third_line = sketch.addGeometry(
+            Part.LineSegment(
+                FreeCAD.Vector(35.144886, 16.80404036490776, 0.0),
+                FreeCAD.Vector(35.144886, 14.202975, 0.0),
+            ),
+            False,
+        )
+        fourth_line = sketch.addGeometry(
+            Part.LineSegment(
+                FreeCAD.Vector(35.144886, 14.202975, 0.0),
+                FreeCAD.Vector(0.0, 0.0, 0.0),
+            ),
+            False,
+        )
+
+        sketch.addConstraint(Sketcher.Constraint("Coincident", -1, 1, first_line, 1))
+        sketch.addConstraint(Sketcher.Constraint("PointOnObject", first_line, 2, -2))
+        sketch.addConstraint(Sketcher.Constraint("Coincident", first_line, 2, second_line, 1))
+        tangent_one = sketch.addConstraint(Sketcher.Constraint("Tangent", second_line, 2, arc, 2))
+        tangent_two = sketch.addConstraint(Sketcher.Constraint("Tangent", arc, 1, third_line, 1))
+        sketch.addConstraint(Sketcher.Constraint("Coincident", third_line, 2, fourth_line, 1))
+        sketch.addConstraint(Sketcher.Constraint("Coincident", fourth_line, 2, first_line, 1))
+        sketch.addConstraint(Sketcher.Constraint("Vertical", third_line))
+
+        return tangent_one, tangent_two
+
+    def use_attached_issue_sketch(self):
+        FreeCADGui.ActiveDocument.resetEdit()
+        self.doc.removeObject(self.sketch.Name)
+        body = self.doc.addObject("PartDesign::Body", "Body")
+        sketch = self.doc.addObject("Sketcher::SketchObject", "IssueSketch")
+        body.addObject(sketch)
+        sketch.AttachmentSupport = [(body.Origin.OriginFeatures[3], "")]
+        sketch.MapMode = "FlatFace"
+        self.sketch = sketch
+        self.doc.recompute()
+        FreeCADGui.ActiveDocument.setEdit(sketch.Name)
+        self.pump_gui_events(6)
+        self.view = FreeCADGui.ActiveDocument.ActiveView
 
     @staticmethod
     def classify_preselection(info, expected_constraint_name):
@@ -69,58 +116,245 @@ class SketcherGuiTestCases(unittest.TestCase):
             return "axis"
         return "other"
 
-    @classmethod
-    def scan_preselection_at_viewport(cls, center_coin, expected_constraint_name, span=16, step=2):
-        counts = {
-            "target_constraint": 0,
-            "other_constraint": 0,
-            "edge": 0,
-            "vertex": 0,
-            "other": 0,
-            "none": 0,
-        }
+    @staticmethod
+    def project_coin_path_point_to_viewport(view_volume, viewport_region, point):
+        projected = view_volume.projectToScreen(point)
+        origin_x, origin_y = viewport_region.getViewportOriginPixels()
+        width, height = viewport_region.getViewportSizePixels()
+        return (
+            projected[0] * width + origin_x,
+            projected[1] * height + origin_y,
+        )
 
-        for dy in range(-span, span + 1, step):
-            for dx in range(-span, span + 1, step):
-                coin_point = (center_coin[0] + dx, center_coin[1] + dy)
-                info = SketcherGui.getActiveSketchPreselection(coin_point)
-                kind = cls.classify_preselection(info, expected_constraint_name)
-                counts[kind] += 1
+    def get_rendered_constraint_icon_geometry(self, constraint_id):
+        """Return Coin's current screen geometry for a rendered constraint icon.
 
-        return counts
+        The current camera view volume is supplied to SoGetMatrixAction on a
+        scenegraph copy, without refreshing the live SoZoomTranslation cache
+        used by the picker. The actual visible icon is selected when multiple
+        constraints share one image.
+        """
+        from pivy import coin
 
-    @classmethod
-    def find_constraint_probe_viewport_point(
-        cls,
-        view,
-        seed_world_point,
-        expected_constraint_name,
-        span=64,
-        step=8,
-    ):
-        center_coin = tuple(int(value) for value in view.getPointOnViewport(seed_world_point))
-        sum_x = 0
-        sum_y = 0
-        target_count = 0
+        viewer = self.view.getViewer()
+        scene_root = viewer.getSoRenderManager().getSceneGraph()
+        matrix_root = scene_root.copy(True)
+        matrix_root.ref()
+        search = coin.SoSearchAction()
+        search.setName("ConstraintGroup")
+        search.setSearchingAll(True)
+        search.apply(matrix_root)
+        self.assertTrue(search.isFound(), "Could not find ConstraintGroup in the scene graph")
 
-        for dy in range(-span, span + 1, step):
-            for dx in range(-span, span + 1, step):
-                coin_point = (center_coin[0] + dx, center_coin[1] + dy)
-                info = SketcherGui.getActiveSketchPreselection(coin_point)
-                if cls.classify_preselection(info, expected_constraint_name) != "target_constraint":
+        group_path = search.getPath()
+        group = group_path.getTail()
+        separator = None
+        icon = None
+        visible_ids = None
+        target_id = str(constraint_id)
+        for separator_index in range(group.getNumChildren()):
+            candidate_separator = group.getChild(separator_index)
+            if not candidate_separator.isOfType(coin.SoSeparator.getClassTypeId()):
+                continue
+
+            for candidate_icon_index in (2, 5):
+                if candidate_icon_index + 1 >= candidate_separator.getNumChildren():
+                    continue
+                candidate_icon = candidate_separator.getChild(candidate_icon_index)
+                candidate_info = candidate_separator.getChild(candidate_icon_index + 1)
+                if not candidate_icon.isOfType(coin.SoImage.getClassTypeId()):
+                    continue
+                if not candidate_info.isOfType(coin.SoInfo.getClassTypeId()):
                     continue
 
-                sum_x += coin_point[0]
-                sum_y += coin_point[1]
-                target_count += 1
+                ids = candidate_info.string.getValue().getString().split(",")
+                icon_size = None
+                try:
+                    icon_size = candidate_icon.image.getValue()[1]
+                    if candidate_icon.width.getValue() != -1:
+                        icon_size[0] = candidate_icon.width.getValue()
+                    if candidate_icon.height.getValue() != -1:
+                        icon_size[1] = candidate_icon.height.getValue()
+                except (UnicodeDecodeError, RuntimeError):
+                    # Coin may expose image metadata that cannot be decoded by
+                    # every backend, so treat the icon size as unknown.
+                    icon_size = None
+                if target_id in ids and (
+                    icon_size is None or (icon_size[0] > 0 and icon_size[1] > 0)
+                ):
+                    separator = candidate_separator
+                    icon = candidate_icon
+                    visible_ids = ids
+                    break
+            if icon is not None:
+                break
 
-        if target_count == 0:
-            return None
-
-        return (
-            int(round(sum_x / target_count)),
-            int(round(sum_y / target_count)),
+        self.assertIsNotNone(
+            icon,
+            f"Could not find a visible icon for Constraint{constraint_id + 1}",
         )
+
+        viewport_region = viewer.getSoRenderManager().getViewportRegion()
+        camera = viewer.getSoRenderManager().getCamera()
+        self.assertIsNotNone(camera, "Could not find the active camera")
+        render_viewport_region = coin.SbViewportRegion(viewport_region)
+        view_volume = camera.getViewVolume(viewport_region, render_viewport_region)
+        icon_path = group_path.copy()
+        icon_path.append(separator)
+        icon_path.append(icon)
+        icon_path.ref()
+        try:
+            matrix_action = coin.SoGetMatrixAction(viewport_region)
+            coin.SoViewVolumeElement.set(matrix_action.getState(), icon, view_volume)
+            coin.SoViewportRegionElement.set(matrix_action.getState(), render_viewport_region)
+            matrix_action.apply(icon_path)
+            world_center = matrix_action.getMatrix().multVecMatrix(coin.SbVec3f(0.0, 0.0, 0.0))
+
+            bbox_action = coin.SoGetBoundingBoxAction(viewport_region)
+            coin.SoViewVolumeElement.set(bbox_action.getState(), icon, view_volume)
+            coin.SoViewportRegionElement.set(bbox_action.getState(), render_viewport_region)
+            bbox_action.apply(icon_path)
+            lower_bound = coin.SbVec3f()
+            upper_bound = coin.SbVec3f()
+            bbox_action.getBoundingBox().getBounds(lower_bound, upper_bound)
+        finally:
+            icon_path.unref()
+
+        screen_center = self.project_coin_path_point_to_viewport(
+            view_volume, render_viewport_region, world_center
+        )
+        lower_screen = self.project_coin_path_point_to_viewport(
+            view_volume, render_viewport_region, lower_bound
+        )
+        upper_screen = self.project_coin_path_point_to_viewport(
+            view_volume, render_viewport_region, upper_bound
+        )
+        image_width = abs(upper_screen[0] - lower_screen[0])
+        image_height = abs(upper_screen[1] - lower_screen[1])
+        # Merged constraint images stack one rendered constraint entry per row.
+        target_row = visible_ids.index(target_id)
+        row_height = image_height / len(visible_ids)
+        target_center_y = screen_center[1] + image_height / 2.0 - row_height * (target_row + 0.5)
+        geometry_values = (*screen_center, image_width, row_height, target_center_y)
+        if not all(math.isfinite(value) for value in geometry_values):
+            matrix_root.unref()
+            raise RuntimeError(
+                f"Rendered constraint icon geometry is not finite: {geometry_values}; "
+                f"world_center={tuple(world_center)}, lower={tuple(lower_bound)}, "
+                f"upper={tuple(upper_bound)}, viewport={render_viewport_region.getViewportSizePixels()}, "
+                f"vv={(view_volume.getWidth(), view_volume.getHeight(), view_volume.getDepth())}"
+            )
+
+        rendered_center = (
+            int(round(screen_center[0])),
+            int(round(target_center_y)),
+        )
+        ray_pick = coin.SoRayPickAction(viewport_region)
+        ray_pick.setPoint(coin.SbVec2s(*rendered_center))
+        ray_pick.setRadius(0.0)
+        ray_pick.setPickAll(True)
+        ray_pick.apply(matrix_root)
+        icon_is_coin_pickable = any(
+            any(
+                picked_point.getPath().getNode(node_index) == icon
+                for node_index in range(picked_point.getPath().getLength())
+            )
+            for picked_point in ray_pick.getPickedPointList()
+        )
+        if not icon_is_coin_pickable:
+            matrix_root.unref()
+            raise RuntimeError(
+                f"Coin did not pick the rendered constraint icon at {rendered_center}"
+            )
+
+        matrix_root.unref()
+        return (
+            rendered_center,
+            (image_width, row_height),
+        )
+
+    def get_stable_rendered_constraint_icon_geometry(self, constraint_id, timeout=2.0):
+        deadline = time.monotonic() + timeout
+        previous = None
+        last_error = None
+
+        while time.monotonic() < deadline:
+            try:
+                geometry = self.get_rendered_constraint_icon_geometry(constraint_id)
+            except (AssertionError, RuntimeError) as error:
+                last_error = error
+            else:
+                if previous is not None:
+                    previous_center, previous_size = previous
+                    center, size = geometry
+                    if (
+                        center != (0, 0)
+                        and all(value > 0.0 for value in size)
+                        and center == previous_center
+                        and all(
+                            math.isclose(left, right, abs_tol=0.01)
+                            for left, right in zip(size, previous_size)
+                        )
+                    ):
+                        return geometry
+                previous = geometry
+
+            self.view.redraw()
+            self.pump_gui_events(1)
+
+        if last_error is not None:
+            message = f"Rendered constraint icon did not stabilize: {last_error}"
+        else:
+            message = f"Rendered constraint icon did not stabilize: {previous}"
+        raise AssertionError(message)
+
+    def rendered_center_to_qpoint(self, rendered_center):
+        viewport = self.view.graphicsView().viewport()
+        width, height = self.view.getSize()
+        scale = viewport.devicePixelRatioF()
+        return QtCore.QPoint(
+            int(round(rendered_center[0] / scale)),
+            int(round((height - rendered_center[1] - 1) / scale)),
+        )
+
+    def move_mouse_to_rendered_center(self, rendered_center):
+        viewport = self.view.graphicsView().viewport()
+        position = self.rendered_center_to_qpoint(rendered_center)
+        event = QtGui.QMouseEvent(
+            QtCore.QEvent.Type.MouseMove,
+            position,
+            viewport.mapToGlobal(position),
+            QtCore.Qt.MouseButton.NoButton,
+            QtCore.Qt.MouseButton.NoButton,
+            QtCore.Qt.KeyboardModifier.NoModifier,
+        )
+        QtWidgets.QApplication.sendEvent(viewport, event)
+        self.pump_gui_events(12)
+
+    def preselect_constraint_within_rendered_icon(
+        self, rendered_center, rendered_size, expected_constraint_name
+    ):
+        max_offset_x = max(0, int(math.floor(rendered_size[0] / 2.0)) - 2)
+        max_offset_y = max(0, int(math.floor(rendered_size[1] / 2.0)) - 2)
+        offsets = []
+        for offset_y in (0, -max_offset_y, max_offset_y):
+            for offset_x in (0, -max_offset_x, max_offset_x):
+                offset = (offset_x, offset_y)
+                if offset not in offsets:
+                    offsets.append(offset)
+
+        attempts = []
+        for offset_x, offset_y in offsets:
+            probe = (rendered_center[0] + offset_x, rendered_center[1] + offset_y)
+            FreeCADGui.Selection.clearPreselection()
+            self.move_mouse_to_rendered_center(probe)
+            preselection = FreeCADGui.Selection.getPreselection()
+            names = tuple(preselection.SubElementNames or [])
+            attempts.append((probe, preselection.ObjectName, names))
+            if preselection.ObjectName == self.sketch.Name and expected_constraint_name in names:
+                return probe, attempts
+
+        return None, attempts
 
     @classmethod
     def configure_view_state(cls, view, tilt=None):
@@ -136,18 +370,21 @@ class SketcherGuiTestCases(unittest.TestCase):
             view.fitAll()
             cls.pump_gui_events()
 
-    @staticmethod
-    def constraint_share(counts):
-        total_hits = (
-            counts["target_constraint"]
-            + counts["other_constraint"]
-            + counts["edge"]
-            + counts["vertex"]
-            + counts["other"]
-        )
-        if total_hits == 0:
-            return 0.0
-        return counts["target_constraint"] / total_hits
+    @classmethod
+    def get_stable_viewport_point(cls, view, world_point):
+        deadline = time.monotonic() + 2.0
+        previous = None
+        point = (0, 0)
+        while time.monotonic() < deadline:
+            point = tuple(int(value) for value in view.getPointOnViewport(world_point))
+            if point != (0, 0) and point == previous:
+                return point
+            if point == (0, 0):
+                view.fitAll()
+            view.redraw()
+            previous = point
+            cls.pump_gui_events(1)
+        raise AssertionError(f"Viewport point did not stabilize: {point}")
 
     def setUp(self):
         self.doc = FreeCAD.newDocument("SketchGuiTest")
@@ -160,8 +397,21 @@ class SketcherGuiTestCases(unittest.TestCase):
         self.pump_gui_events()
 
         self.view = FreeCADGui.ActiveDocument.ActiveView
+        self.pump_gui_events(12)
+        graphics_view = self.view.graphicsView()
+        graphics_view.resize(600, 600)
+        self.pump_gui_events(8)
+        self.view.viewTop()
+        self.pump_gui_events(4)
+        self.view.fitAll()
+        self.pump_gui_events(8)
+
+        self.viewer = self.view.getViewer()
+        self.original_pick_radius = self.viewer.getPickRadius()
+        self.viewer.setPickRadius(3.0)
 
     def tearDown(self):
+        self.viewer.setPickRadius(self.original_pick_radius)
         FreeCADGui.Selection.clearPreselection()
         FreeCADGui.Selection.clearSelection()
         if FreeCADGui.ActiveDocument:
@@ -174,54 +424,361 @@ class SketcherGuiTestCases(unittest.TestCase):
             FreeCAD.closeDocument(document_name)
             self.pump_gui_events()
 
-    def testPointOnObjectPreselectionMatchesTiltedHitArea(self):
-        constraint_id, self.probe_point = self.build_issue_25840_sketch(self.sketch)
-        self.expected_constraint_name = f"Constraint{constraint_id + 1}"
+    def testConstraintIconMousePreselectionMatchesRenderedPosition(self):
+        self.use_attached_issue_sketch()
+        _, tangent_id = self.build_issue_20811_sketch(self.sketch)
+        expected_name = f"Constraint{tangent_id + 1}"
         self.doc.recompute()
         self.pump_gui_events()
 
-        tilt_y = FreeCAD.Rotation(FreeCAD.Vector(0, 1, 0), 2.0)
+        self.configure_view_state(self.view)
+        viewer = self.view.getViewer()
+        old_pick_radius = viewer.getPickRadius()
+        viewer.setPickRadius(0.5)
+        graphics_view = self.view.graphicsView()
+        original_size = graphics_view.size()
+        main_window = FreeCADGui.getMainWindow()
+        original_window_size = main_window.size()
+        failures = []
 
-        counts_by_state = {}
-        for name, tilt in {
-            "exact_top": None,
-            "tilt_y_2deg": tilt_y,
-        }.items():
-            self.configure_view_state(self.view, tilt)
-            probe_point = self.find_constraint_probe_viewport_point(
-                self.view,
-                self.probe_point,
-                self.expected_constraint_name,
+        try:
+            for size in ((900, 400), (600, 600), (600, 860), (400, 900)):
+                graphics_view.resize(*size)
+                self.pump_gui_events(12)
+                self.view.fitAll()
+                self.pump_gui_events(12)
+
+                width, height = self.view.getSize()
+                rendered_center, rendered_size = self.get_stable_rendered_constraint_icon_geometry(
+                    tangent_id
+                )
+                selected_probe, attempts = self.preselect_constraint_within_rendered_icon(
+                    rendered_center, rendered_size, expected_name
+                )
+                if selected_probe is None:
+                    failures.append(
+                        f"viewport={width}x{height}, rendered_center={rendered_center}, "
+                        f"rendered_size={rendered_size}, attempts={attempts}"
+                    )
+        finally:
+            viewer.setPickRadius(old_pick_radius)
+            QtWidgets.QApplication.sendEvent(
+                graphics_view.viewport(),
+                QtCore.QEvent(QtCore.QEvent.Type.Leave),
             )
-            self.assertIsNotNone(probe_point)
-            counts_by_state[name] = self.scan_preselection_at_viewport(
-                probe_point,
-                self.expected_constraint_name,
-                span=12,
+            FreeCADGui.Selection.clearPreselection()
+            graphics_view.resize(original_size)
+            main_window.resize(original_window_size)
+            self.pump_gui_events(4)
+            self.view.fitAll()
+            self.pump_gui_events(4)
+
+        self.assertFalse(failures, "\n".join(failures))
+
+    def testConstraintIconMousePreselectionUpdatesAfterViewportAspectRatioChange(self):
+        self.use_attached_issue_sketch()
+        _, tangent_id = self.build_issue_20811_sketch(self.sketch)
+        expected_name = f"Constraint{tangent_id + 1}"
+        self.doc.recompute()
+        self.pump_gui_events(12)
+
+        self.configure_view_state(self.view)
+        viewer = self.view.getViewer()
+        old_pick_radius = viewer.getPickRadius()
+        viewer.setPickRadius(0.5)
+        graphics_view = self.view.graphicsView()
+        original_size = graphics_view.size()
+        main_window = FreeCADGui.getMainWindow()
+        original_window_size = main_window.size()
+        failures = []
+
+        try:
+            for state, size in (
+                ("square_before", (600, 600)),
+                ("tall", (400, 900)),
+                ("square_after", (600, 600)),
+            ):
+                graphics_view.resize(*size)
+                self.pump_gui_events(12)
+                if state == "square_before":
+                    self.view.fitAll()
+                    self.pump_gui_events(12)
+
+                width, height = self.view.getSize()
+                rendered_center, rendered_size = self.get_stable_rendered_constraint_icon_geometry(
+                    tangent_id
+                )
+                selected_probe, attempts = self.preselect_constraint_within_rendered_icon(
+                    rendered_center, rendered_size, expected_name
+                )
+                if selected_probe is None:
+                    failures.append(
+                        f"state={state}, viewport={width}x{height}, "
+                        f"aspect={width / height:.3f}, rendered_center={rendered_center}, "
+                        f"rendered_size={rendered_size}, attempts={attempts}"
+                    )
+        finally:
+            viewer.setPickRadius(old_pick_radius)
+            QtWidgets.QApplication.sendEvent(
+                graphics_view.viewport(),
+                QtCore.QEvent(QtCore.QEvent.Type.Leave),
             )
+            FreeCADGui.Selection.clearPreselection()
+            graphics_view.resize(original_size)
+            main_window.resize(original_window_size)
+            self.pump_gui_events(4)
+            self.view.fitAll()
+            self.pump_gui_events(4)
 
-        exact_top = counts_by_state["exact_top"]
-        tilt_y = counts_by_state["tilt_y_2deg"]
-        max_tilt_hits = tilt_y["target_constraint"]
-        exact_top_share = self.constraint_share(exact_top)
+        self.assertFalse(failures, "\n".join(failures))
 
-        detail = (
-            f"exact_top={exact_top}, tilt_y_2deg={tilt_y}, "
-            f"constraint_share={exact_top_share:.3f}"
+    def testNearestOverlappingConstraintIconPreselection(self):
+        first_line = self.sketch.addGeometry(
+            Part.LineSegment(
+                FreeCAD.Vector(-10.0, 0.0, 0.0),
+                FreeCAD.Vector(-10.0, 20.0, 0.0),
+            ),
+            False,
+        )
+        second_line = self.sketch.addGeometry(
+            Part.LineSegment(
+                FreeCAD.Vector(10.0, 0.0, 0.0),
+                FreeCAD.Vector(10.0, 20.0, 0.0),
+            ),
+            False,
+        )
+        first_constraint = self.sketch.addConstraint(Sketcher.Constraint("Vertical", first_line))
+        second_constraint = self.sketch.addConstraint(Sketcher.Constraint("Vertical", second_line))
+        self.doc.recompute()
+        self.pump_gui_events(8)
+        self.view.graphicsView().resize(600, 600)
+        self.pump_gui_events(8)
+        self.configure_view_state(self.view)
+        self.pump_gui_events(12)
+
+        viewer = self.view.getViewer()
+        viewer.setPickRadius(5.0)
+
+        from pivy import coin
+
+        search = coin.SoSearchAction()
+        search.setName("ConstraintGroup")
+        search.setSearchingAll(True)
+        search.apply(self.view.getViewer().getSoRenderManager().getSceneGraph())
+        self.assertTrue(search.isFound(), "Could not find ConstraintGroup in the scene graph")
+        group = search.getPath().getTail()
+
+        first_translation = group.getChild(first_constraint).getChild(1)
+        second_translation = group.getChild(second_constraint).getChild(1)
+        first_translation.translation = coin.SbVec3f(0.0, 0.0, 0.0)
+        second_translation.translation = coin.SbVec3f(0.0, 0.0, 0.0)
+
+        first_translation.abPos = coin.SbVec3f(0.0, 0.0, 0.004)
+        reference_delta = 100.0
+        first_reference = self.get_stable_viewport_point(self.view, FreeCAD.Vector(0.0, 0.0, 0.0))
+        second_reference = self.get_stable_viewport_point(
+            self.view, FreeCAD.Vector(reference_delta, 0.0, 0.0)
+        )
+        pixels_per_unit = abs(second_reference[0] - first_reference[0]) / reference_delta
+        self.assertGreater(pixels_per_unit, 0.0)
+        pixel_delta = 10.0 / pixels_per_unit
+
+        second_translation.abPos = coin.SbVec3f(pixel_delta, 0.0, 0.004)
+        self.pump_gui_events(8)
+        first_center = self.get_stable_rendered_constraint_icon_geometry(first_constraint)[0]
+        second_center = self.get_stable_rendered_constraint_icon_geometry(second_constraint)[0]
+        distance = abs(second_center[0] - first_center[0])
+        self.assertTrue(
+            8.0 <= distance <= 12.0,
+            f"Could not place icons in overlapping hit regions: distance={distance}, "
+            f"viewport={self.view.getSize()}",
+        )
+        probe = (
+            int(round(second_center[0] - 4.0)),
+            int(round(second_center[1])),
+        )
+        info = SketcherGui.getActiveSketchPreselection(probe)
+        expected = f"Constraint{second_constraint + 1}"
+
+        self.assertEqual(
+            self.classify_preselection(info, expected),
+            "target_constraint",
+            f"first_center={first_center}, second_center={second_center}, "
+            f"probe={probe}, preselection={info}",
         )
 
-        self.assertGreater(max_tilt_hits, 0, detail)
-        self.assertGreater(exact_top["target_constraint"], 0, detail)
-        self.assertGreaterEqual(
-            exact_top["target_constraint"],
-            int(max_tilt_hits * 0.8),
-            detail,
+    def testConstraintIconPreselectionHonorsSelectionRadius(self):
+        line_id = self.sketch.addGeometry(
+            Part.LineSegment(
+                FreeCAD.Vector(-20.0, -10.0, 0.0),
+                FreeCAD.Vector(-20.0, 10.0, 0.0),
+            ),
+            False,
         )
-        self.assertGreaterEqual(
-            exact_top_share,
-            0.20,
-            detail,
-        )
+        constraint_id = self.sketch.addConstraint(Sketcher.Constraint("Vertical", line_id))
+        expected_name = f"Constraint{constraint_id + 1}"
+        self.doc.recompute()
+        self.pump_gui_events(12)
+
+        self.configure_view_state(self.view)
+        viewer = self.view.getViewer()
+        old_pick_radius = viewer.getPickRadius()
+        viewer.setPickRadius(0.5)
+        graphics_view = self.view.graphicsView()
+        original_size = graphics_view.size()
+        main_window = FreeCADGui.getMainWindow()
+        original_window_size = main_window.size()
+
+        try:
+            graphics_view.resize(600, 600)
+            self.pump_gui_events(12)
+            self.view.fitAll()
+            self.pump_gui_events(12)
+
+            from pivy import coin
+
+            search = coin.SoSearchAction()
+            search.setName("ConstraintGroup")
+            search.setSearchingAll(True)
+            search.apply(viewer.getSoRenderManager().getSceneGraph())
+            self.assertTrue(search.isFound(), "Could not find ConstraintGroup in the scene graph")
+            icon_translation = search.getPath().getTail().getChild(constraint_id).getChild(1)
+            icon_translation.translation = coin.SbVec3f(0.0, 0.0, 0.0)
+            icon_translation.abPos = coin.SbVec3f(20.0, 20.0, 0.004)
+            self.pump_gui_events(8)
+
+            rendered_center, rendered_size = self.get_stable_rendered_constraint_icon_geometry(
+                constraint_id
+            )
+            half_width = rendered_size[0] / 2.0
+
+            probes = (
+                (0.5, 0.0, "target_constraint"),
+                (0.5, 2.0, "none"),
+                (5.0, 4.0, "target_constraint"),
+                (5.0, 7.0, "none"),
+                (35.0, 20.0, "target_constraint"),
+                (35.0, 38.0, "none"),
+            )
+            results = []
+            for pick_radius, distance_outside, expected in probes:
+                viewer.setPickRadius(pick_radius)
+                self.pump_gui_events(2)
+                probe_x = rendered_center[0]
+                if distance_outside:
+                    probe_x += half_width + distance_outside
+                probe = (
+                    int(round(probe_x)),
+                    rendered_center[1],
+                )
+                FreeCADGui.Selection.clearPreselection()
+                self.move_mouse_to_rendered_center(probe)
+                preselection = FreeCADGui.Selection.getPreselection()
+                names = preselection.SubElementNames or []
+                actual = (
+                    "target_constraint"
+                    if preselection.ObjectName == self.sketch.Name and expected_name in names
+                    else "none"
+                )
+                results.append((pick_radius, distance_outside, probe, expected, actual, names))
+
+            detail = (
+                f"rendered_center={rendered_center}, rendered_size={rendered_size}, "
+                f"results={results}"
+            )
+            self.assertEqual(
+                [result[4] for result in results],
+                [result[3] for result in results],
+                detail,
+            )
+        finally:
+            viewer.setPickRadius(old_pick_radius)
+            QtWidgets.QApplication.sendEvent(
+                graphics_view.viewport(),
+                QtCore.QEvent(QtCore.QEvent.Type.Leave),
+            )
+            FreeCADGui.Selection.clearPreselection()
+            graphics_view.resize(original_size)
+            main_window.resize(original_window_size)
+            self.pump_gui_events(4)
+            self.view.fitAll()
+            self.pump_gui_events(4)
+
+    def testPointPreselectionHonorsSelectionRadius(self):
+        point = FreeCAD.Vector(20.0, 20.0, 0.0)
+        self.sketch.addGeometry(Part.Point(point), False)
+        self.doc.recompute()
+        self.pump_gui_events(8)
+
+        self.configure_view_state(self.view)
+        viewer = self.view.getViewer()
+        old_pick_radius = viewer.getPickRadius()
+        viewer.setPickRadius(0.5)
+
+        try:
+            center = self.get_stable_viewport_point(self.view, point)
+            probes = (
+                (0.5, 6, "none"),
+                (5.0, 8, "vertex"),
+                (35.0, 25, "vertex"),
+                (35.0, 45, "none"),
+            )
+            results = []
+            for pick_radius, offset, expected in probes:
+                viewer.setPickRadius(pick_radius)
+                self.pump_gui_events(2)
+                info = SketcherGui.getActiveSketchPreselection((center[0] + offset, center[1]))
+                actual = self.classify_preselection(info, "Constraint0")
+                results.append((pick_radius, offset, expected, actual, info))
+
+            self.assertEqual(
+                [result[3] for result in results],
+                [result[2] for result in results],
+                f"center={center}, results={results}",
+            )
+        finally:
+            viewer.setPickRadius(old_pick_radius)
+            FreeCADGui.Selection.clearPreselection()
+            self.pump_gui_events(4)
+
+    def testCurvePreselectionHonorsSelectionRadius(self):
+        start = FreeCAD.Vector(20.0, 20.0, 0.0)
+        end = FreeCAD.Vector(40.0, 20.0, 0.0)
+        self.sketch.addGeometry(Part.LineSegment(start, end), False)
+        self.doc.recompute()
+        self.pump_gui_events(8)
+
+        self.configure_view_state(self.view)
+        viewer = self.view.getViewer()
+        old_pick_radius = viewer.getPickRadius()
+        viewer.setPickRadius(0.5)
+
+        try:
+            midpoint = FreeCAD.Vector(30.0, 20.0, 0.0)
+            center = self.get_stable_viewport_point(self.view, midpoint)
+            probes = (
+                (0.5, 2, "none"),
+                (5.0, 4, "edge"),
+                (35.0, 20, "edge"),
+                (35.0, 38, "none"),
+            )
+            results = []
+            for pick_radius, offset, expected in probes:
+                viewer.setPickRadius(pick_radius)
+                self.pump_gui_events(2)
+                info = SketcherGui.getActiveSketchPreselection((center[0], center[1] + offset))
+                actual = self.classify_preselection(info, "Constraint0")
+                results.append((pick_radius, offset, expected, actual, info))
+
+            self.assertEqual(
+                [result[3] for result in results],
+                [result[2] for result in results],
+                f"center={center}, results={results}",
+            )
+        finally:
+            viewer.setPickRadius(old_pick_radius)
+            FreeCADGui.Selection.clearPreselection()
+            self.pump_gui_events(4)
 
     def testPointMarkerWinsOverOverlappingConstraintLabel(self):
         start_point = FreeCAD.Vector(80.0, 100.0, 0.0)
@@ -238,7 +795,7 @@ class SketcherGuiTestCases(unittest.TestCase):
 
         self.configure_view_state(self.view)
 
-        marker_coin = tuple(int(value) for value in self.view.getPointOnViewport(marker_point))
+        marker_coin = self.get_stable_viewport_point(self.view, marker_point)
 
         vertex_offsets = []
         for dy in range(-12, 13, 2):
@@ -293,7 +850,7 @@ class SketcherGuiTestCases(unittest.TestCase):
 
         self.configure_view_state(self.view)
 
-        midpoint_coin = tuple(int(value) for value in self.view.getPointOnViewport(midpoint))
+        midpoint_coin = self.get_stable_viewport_point(self.view, midpoint)
 
         edge_offsets = []
         for dy in range(-10, 11, 2):

--- a/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
@@ -95,7 +95,7 @@ class SketcherGuiTestCases(unittest.TestCase):
         self.sketch = sketch
         self.doc.recompute()
         FreeCADGui.ActiveDocument.setEdit(sketch.Name)
-        self.pump_gui_events(6)
+        self.pump_gui_events()
         self.view = FreeCADGui.ActiveDocument.ActiveView
 
     @staticmethod
@@ -115,6 +115,33 @@ class SketcherGuiTestCases(unittest.TestCase):
         if any(name.endswith("_Axis") for name in names):
             return "axis"
         return "other"
+
+    @classmethod
+    def find_constraint_probe_viewport_point(
+        cls,
+        view,
+        seed_world_point,
+        expected_constraint_name,
+        span=64,
+        step=8,
+    ):
+        center_coin = tuple(int(value) for value in view.getPointOnViewport(seed_world_point))
+        target_points = []
+
+        for dy in range(-span, span + 1, step):
+            for dx in range(-span, span + 1, step):
+                coin_point = (center_coin[0] + dx, center_coin[1] + dy)
+                info = SketcherGui.getActiveSketchPreselection(coin_point)
+                if cls.classify_preselection(info, expected_constraint_name) == "target_constraint":
+                    target_points.append(coin_point)
+
+        if not target_points:
+            return None
+
+        return (
+            int(round(sum(point[0] for point in target_points) / len(target_points))),
+            int(round(sum(point[1] for point in target_points) / len(target_points))),
+        )
 
     @staticmethod
     def project_coin_path_point_to_viewport(view_volume, viewport_region, point):
@@ -480,7 +507,7 @@ class SketcherGuiTestCases(unittest.TestCase):
         _, tangent_id = self.build_issue_20811_sketch(self.sketch)
         expected_name = f"Constraint{tangent_id + 1}"
         self.doc.recompute()
-        self.pump_gui_events(12)
+        self.pump_gui_events()
 
         self.configure_view_state(self.view)
         viewer = self.view.getViewer()
@@ -554,7 +581,6 @@ class SketcherGuiTestCases(unittest.TestCase):
         self.view.graphicsView().resize(600, 600)
         self.pump_gui_events(8)
         self.configure_view_state(self.view)
-        self.pump_gui_events(12)
 
         viewer = self.view.getViewer()
         viewer.setPickRadius(5.0)
@@ -618,7 +644,7 @@ class SketcherGuiTestCases(unittest.TestCase):
         constraint_id = self.sketch.addConstraint(Sketcher.Constraint("Vertical", line_id))
         expected_name = f"Constraint{constraint_id + 1}"
         self.doc.recompute()
-        self.pump_gui_events(12)
+        self.pump_gui_events()
 
         self.configure_view_state(self.view)
         viewer = self.view.getViewer()
@@ -854,7 +880,7 @@ class SketcherGuiTestCases(unittest.TestCase):
 
         edge_offsets = []
         for dy in range(-10, 11, 2):
-            for dx in range(-16, 17, 2):
+            for dx in range(-14, 15, 2):
                 probe_coin = (midpoint_coin[0] + dx, midpoint_coin[1] + dy)
                 probe_info = SketcherGui.getActiveSketchPreselection(probe_coin)
                 probe_kind = self.classify_preselection(probe_info, "Constraint0")

--- a/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
@@ -320,6 +320,7 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
         )
 
         active_marker = self.origin_marker_index()
+        self.move(viewport, first_point)
         self.right_click(viewport, first_point)
         self.assertTrue(
             self.wait_until(
@@ -369,6 +370,7 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
                 f"Expected {command} to activate the hollow origin marker",
             )
             active_marker = self.origin_marker_index()
+            self.move(viewport, first_point)
             self.right_click(viewport, first_point)
             self.assertTrue(
                 self.wait_until(


### PR DESCRIPTION
Fixes #20811

Constraint preselection could become unreliable when the viewport aspect ratio changed. In a tall or narrow viewport, a tangent constraint icon could be visibly rendered in one location while picking still tested another location. Returning to a squarer viewport could make the same icon pickable again.

The underlying problem was that rendering used Coin’s current camera, viewport, and transformation state, while picking manually reconstructed icon positions using cached `SoZoomTranslation` data. Those two paths could get out of sync after resizing the viewport or changing the camera.

Sketcher preselection currently combines two mechanisms:

- Coin ray picking for scene geometry.
- Custom screen-space picking for constraint icons, point markers, and curve hit areas.

This PR makes the screen-space path use an explicit per-operation context containing the current viewport, view volume, selection radius, and constraint-group path. Constraint icons are then resolved through the same current Coin transformation chain used for rendering. The context also avoids searching the entire scenegraph once per icon.

The PR also:

- Prefers the nearest overlapping constraint icon.
- Applies the viewer selection radius consistently to constraints, points, and curves.
- Preserves the small additional endpoint allowance used for common drag targets.
- Keeps the existing semantic preselection priorities unchanged.
- Adds GUI regression coverage for aspect-ratio changes, viewport resize transitions, selection radius behavior, overlapping icons, and existing priority rules.

This area is still not completely clean from a long-term architectural perspective. Screen-space candidate generation remains split between the general Coin manager and the constraint manager, while other preselection paths still use Coin ray picking. There is also no single generic candidate type and resolver shared by points, curves, and constraint icons.

A future cleanup should separate screen-space geometry generation from candidate resolution and have each picker produce common candidates containing visible bounds, distance, semantic priority, and stable tie-breaking information. That would make the complete preselection pipeline more uniform, but it is broader than the bug fixed here and should be considered separately.
