### PR TITLE
PartGui: Keep BREP face preselection overlays on top

### DIFF
--- a/src/Mod/Part/Gui/SoBrepFaceSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepFaceSet.cpp
@@ -62,6 +62,43 @@ SO_NODE_SOURCE(SoBrepFaceSet)
 namespace
 {
 
+/// Controls how B-rep overlay primitives interact with the scene depth buffer.
+enum class OverlayDepthMode
+{
+    /// Keep normal occlusion so committed selection does not expose hidden geometry.
+    RespectDepth,
+    /// Render above model geometry for hover and preselection feedback.
+    DrawOnTop,
+};
+
+static float firstNonzeroTransparency(const float* values, int count)
+{
+    if (!values) {
+        return 0.0f;
+    }
+    for (int i = 0; i < count; ++i) {
+        if (values[i] != 0.0f) {
+            return values[i];
+        }
+    }
+    return 0.0f;
+}
+
+static float getBaseTransparency(const ViewProviderPartExt* viewProvider, SoState* state)
+{
+    const auto* lazy = SoLazyElement::getInstance(state);
+    const float stateTransparency
+        = firstNonzeroTransparency(lazy->getTransparencyPointer(), lazy->getNumTransparencies());
+    if (stateTransparency > 0.0f) {
+        return stateTransparency;
+    }
+    if (viewProvider) {
+        const auto transparencies = viewProvider->ShapeAppearance.getTransparencies();
+        return firstNonzeroTransparency(transparencies.data(), static_cast<int>(transparencies.size()));
+    }
+    return 0.0f;
+}
+
 static void buildOverlayCoordIndex(
     std::vector<int32_t>& out,
     const int32_t* coordIndex,
@@ -118,7 +155,8 @@ static void renderOverlayFaces(
     SoIndexedFaceSet* faceSet,
     const std::vector<int32_t>& coordIndex,
     const SbColor& color,
-    bool onTop
+    OverlayDepthMode depthMode,
+    float transparency = 0.0f
 )
 {
     if (!action || !faceSet || coordIndex.empty()) {
@@ -133,19 +171,43 @@ static void renderOverlayFaces(
     SoMaterialBindingElement::set(state, SoMaterialBindingElement::OVERALL);
     SoOverrideElement::setMaterialBindingOverride(state, faceSet, true);
 
-    if (onTop) {
-        SoDepthBufferElement::set(state, FALSE, FALSE, SoDepthBufferElement::ALWAYS, SbVec2f(0.0f, 1.0f));
-        SoShapeStyleElement::setTransparencyType(state, SoGLRenderAction::BLEND);
-        SoLazyElement::setTransparencyType(state, SoGLRenderAction::BLEND);
-    }
-    else {
-        SoPolygonOffsetElement::set(state, faceSet, -0.00001f, -1.0f, SoPolygonOffsetElement::FILLED, TRUE);
-        SoDepthBufferElement::set(state, TRUE, FALSE, SoDepthBufferElement::LEQUAL, SbVec2f(0.0f, 1.0f));
+    switch (depthMode) {
+        case OverlayDepthMode::DrawOnTop:
+            SoDepthBufferElement::set(
+                state,
+                FALSE,
+                FALSE,
+                SoDepthBufferElement::ALWAYS,
+                SbVec2f(0.0f, 1.0f)
+            );
+            SoShapeStyleElement::setTransparencyType(state, SoGLRenderAction::BLEND);
+            SoLazyElement::setTransparencyType(state, SoGLRenderAction::BLEND);
+            SoLazyElement::enableBlending(state, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            break;
+        case OverlayDepthMode::RespectDepth:
+            SoPolygonOffsetElement::set(
+                state,
+                faceSet,
+                -0.00001f,
+                -1.0f,
+                SoPolygonOffsetElement::FILLED,
+                TRUE
+            );
+            SoDepthBufferElement::set(
+                state,
+                TRUE,
+                FALSE,
+                SoDepthBufferElement::LEQUAL,
+                SbVec2f(0.0f, 1.0f)
+            );
+            break;
     }
 
     SoLazyElement::setEmissive(state, &color);
-    const uint32_t packed = color.getPackedValue(0.0f);
-    SoLazyElement::setPacked(state, faceSet, 1, &packed, false);
+    const uint32_t packed = color.getPackedValue(transparency);
+    // BLEND renders the temporary helper immediately. Delayed transparency
+    // cannot replay it because it is not part of the traversed scene graph.
+    SoLazyElement::setPacked(state, faceSet, 1, &packed, transparency > 0.0f);
 
     faceSet->coordIndex.setValues(0, static_cast<int32_t>(coordIndex.size()), coordIndex.data());
     faceSet->GLRender(action);
@@ -389,7 +451,12 @@ void SoBrepFaceSet::doAction(SoAction* action)
 
 void SoBrepFaceSet::renderHighlight(SoGLRenderAction* action, SelContextPtr ctx)
 {
-    if (!ctx || ctx->highlightIndex < 0) {
+    const bool wholeObjectSelected = ctx && ctx->isHighlightAll()
+        && (ctx->isSelectAll()
+            || (viewProvider
+                && Gui::Selection()
+                       .isSelected(viewProvider->getObject(), nullptr, Gui::ResolveMode::NoResolve)));
+    if (!ctx || ctx->highlightIndex < 0 || wholeObjectSelected) {
         return;
     }
 
@@ -411,10 +478,18 @@ void SoBrepFaceSet::renderHighlight(SoGLRenderAction* action, SelContextPtr ctx)
     }
     buildOverlayCoordIndex(overlayCoordIndex, ci, ciCount, partCounts, partCount, parts, selectAll);
 
-    const bool onTop = Gui::Selection().isClarifySelectionActive()
-        && Gui::SoDelayedAnnotationsElement::isProcessingDelayedPaths;
-
-    renderOverlayFaces(action, overlayFaceSet, overlayCoordIndex, ctx->highlightColor, onTop);
+    // Highlight/preselection is transient feedback and must remain visible
+    // when the highlighted face is behind another visible object. Committed
+    // selection keeps the depth-tested path in renderSelection().
+    const float transparency = getBaseTransparency(viewProvider, action->getState());
+    renderOverlayFaces(
+        action,
+        overlayFaceSet,
+        overlayCoordIndex,
+        ctx->highlightColor,
+        OverlayDepthMode::DrawOnTop,
+        transparency
+    );
 }
 
 void SoBrepFaceSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx, bool /*push*/)
@@ -431,7 +506,13 @@ void SoBrepFaceSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx,
     if (ctx->isSelectAll()) {
         std::set<int> dummy;
         buildOverlayCoordIndex(overlayCoordIndex, ci, ciCount, partCounts, partCount, dummy, true);
-        renderOverlayFaces(action, overlayFaceSet, overlayCoordIndex, ctx->selectionColor, false);
+        renderOverlayFaces(
+            action,
+            overlayFaceSet,
+            overlayCoordIndex,
+            ctx->selectionColor,
+            OverlayDepthMode::RespectDepth
+        );
         return;
     }
 
@@ -447,7 +528,13 @@ void SoBrepFaceSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx,
     }
 
     buildOverlayCoordIndex(overlayCoordIndex, ci, ciCount, partCounts, partCount, parts, false);
-    renderOverlayFaces(action, overlayFaceSet, overlayCoordIndex, ctx->selectionColor, false);
+    renderOverlayFaces(
+        action,
+        overlayFaceSet,
+        overlayCoordIndex,
+        ctx->selectionColor,
+        OverlayDepthMode::RespectDepth
+    );
 }
 
 bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction* action, SelContextPtr ctx, SelContextPtr ctx2)
@@ -455,9 +542,10 @@ bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction* action, SelContext
     // SoBrepFaceSet groups rendered triangles into topological faces via
     // partIndex. Coin's IndexedFaceSet consumes one material index per
     // rendered triangle face, so any per-part coloring must be remapped to
-    // per-face indices before GLRender(). Selection/highlight overlays reuse
-    // the same remap path.
-    const bool hasPrimary = ctx && (ctx->isHighlighted() || !ctx->selectionIndex.empty());
+    // per-face indices before GLRender(). Committed selection and secondary
+    // colors reuse this remap path; transient highlight is rendered separately
+    // as an on-top overlay.
+    const bool hasPrimarySelection = ctx && !ctx->selectionIndex.empty();
     const bool hasSecondary = ctx2 && (!ctx2->colors.empty() || !ctx2->selectionIndex.empty());
     auto* state = action->getState();
     const auto mb = SoMaterialBindingElement::get(state);
@@ -474,7 +562,7 @@ bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction* action, SelContext
     const int diffuseSize = element->getNumDiffuse();
     const bool needsBasePerPartRemap
         = (mb == SoMaterialBindingElement::PER_PART && diffuseSize >= partCount);
-    if (!hasPrimary && !hasSecondary && !needsBasePerPartRemap) {
+    if (!hasPrimarySelection && !hasSecondary && !needsBasePerPartRemap) {
         return false;
     }
     if (mb != SoMaterialBindingElement::OVERALL && !needsBasePerPartRemap) {
@@ -492,17 +580,8 @@ bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction* action, SelContext
 
     const float* trans = element->getTransparencyPointer();
     const int transSize = element->getNumTransparencies();
-    float trans0 = 0.0f;
-    bool hasBaseTransparency = false;
-    if (trans && transSize > 0) {
-        for (int i = 0; i < transSize; ++i) {
-            if (trans[i] != 0.0f) {
-                hasBaseTransparency = true;
-                trans0 = trans[i];
-                break;
-            }
-        }
-    }
+    const float trans0 = firstNonzeroTransparency(trans, transSize);
+    bool hasBaseTransparency = trans0 > 0.0f;
 
     state->push();
     packedColors.clear();
@@ -513,16 +592,12 @@ bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction* action, SelContext
 
     uint32_t diffuseColor = diffuse[0].getPackedValue(trans0);
     int singleColor = 0;
-    if (ctx && ctx->isHighlightAll() && !ctx->isSelectAll()) {
-        singleColor = 1;
-        diffuseColor = ctx->highlightColor.getPackedValue(trans0);
-    }
-    else if (ctx && ctx->isSelectAll()) {
+    if (ctx && ctx->isSelectAll()) {
         diffuseColor = ctx->selectionColor.getPackedValue(trans0);
-        singleColor = ctx->isHighlighted() ? -1 : 1;
+        singleColor = 1;
     }
     else if (ctx2 && ctx2->isSingleColor(diffuseColor, hasBaseTransparency)) {
-        singleColor = ctx ? -1 : 1;
+        singleColor = hasPrimarySelection ? -1 : 1;
     }
 
     const bool partialRender = ctx2 && !ctx2->selectionIndex.empty() && !ctx2->isSelectAll();
@@ -540,7 +615,7 @@ bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction* action, SelContext
     perPartMaterialIndex.reserve(partCount);
     const uint32_t fullyTransparent = SbColor(1.0f, 1.0f, 1.0f).getPackedValue(1.0f);
 
-    if (ctx && (ctx->isSelectAll() || ctx->isHighlightAll())) {
+    if (ctx && ctx->isSelectAll()) {
         perPartMaterialIndex.resize(partCount, 0);
         if (!partialRender) {
             packedColors.push_back(diffuseColor);
@@ -555,10 +630,6 @@ bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction* action, SelContext
                     }
                 }
             }
-        }
-        if (ctx->highlightIndex >= 0 && ctx->highlightIndex < partCount) {
-            packedColors.push_back(ctx->highlightColor.getPackedValue(trans0));
-            perPartMaterialIndex[ctx->highlightIndex] = static_cast<int32_t>(packedColors.size() - 1);
         }
     }
     else {
@@ -630,10 +701,6 @@ bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction* action, SelContext
                     perPartMaterialIndex[idx] = selectedIndex;
                 }
             }
-        }
-        if (ctx && ctx->highlightIndex >= 0 && ctx->highlightIndex < partCount) {
-            packedColors.push_back(ctx->highlightColor.getPackedValue(trans0));
-            perPartMaterialIndex[ctx->highlightIndex] = static_cast<int32_t>(packedColors.size() - 1);
         }
     }
 
@@ -715,6 +782,12 @@ void SoBrepFaceSet::GLRender(SoGLRenderAction* action)
         if (pushed) {
             state->pop();
         }
+        // Transparent shapes are deferred by Coin, but the transient selection
+        // context is not available when the path is replayed. Render only the
+        // highlight now; the deferred base shape will preserve its transparency.
+        if (getBaseTransparency(viewProvider, state) > 0.0f) {
+            renderHighlight(action, ctx);
+        }
         return;
     }
 
@@ -725,16 +798,12 @@ void SoBrepFaceSet::GLRender(SoGLRenderAction* action)
 
     if (!pushed) {
         // If overrideMaterialBinding() cannot express the current material
-        // binding through Coin state, render selection and highlight with
-        // explicit overlay passes instead.
+        // binding through Coin state, render committed selection explicitly.
         if (ctx2 && !hasSecondaryColors && !ctx2->selectionIndex.empty()) {
             renderSelection(action, ctx2);
         }
         if (ctx && !ctx->selectionIndex.empty()) {
             renderSelection(action, ctx);
-        }
-        if (ctx) {
-            renderHighlight(action, ctx);
         }
     }
 
@@ -766,16 +835,14 @@ void SoBrepFaceSet::GLRender(SoGLRenderAction* action)
                 renderHighlight(action, octx);
             }
         }
-        // Keep live face preselection on top when it overlaps the explicit
-        // overlay selection/highlight fields.
-        if (hasContextHighlight) {
-            renderHighlight(action, ctx);
-        }
-
         if (oldDepthFunc != GL_LEQUAL) {
             glDepthFunc(oldDepthFunc);
         }
     }
+
+    // Live highlight/preselection is always the final face overlay. It is not
+    // encoded by overrideMaterialBinding(), so it is rendered exactly once.
+    renderHighlight(action, ctx);
 }
 
 void SoBrepFaceSet::GLRenderBelowPath(SoGLRenderAction* action)

--- a/src/Mod/Test/TestSelectionVisual.py
+++ b/src/Mod/Test/TestSelectionVisual.py
@@ -29,6 +29,9 @@ class TestSelectionVisual(unittest.TestCase):
 
     _COLOR_DELTA_MIN = 0.15
     _COLOR_DELTA_RESTORE_MAX = 0.05
+    _CENTER_SAMPLE_RADIUS = 2
+    _SELECTION_COLOR = 0x00FF00FF
+    _HIGHLIGHT_COLOR = 0xFF00FFFF
 
     def setUp(self):
         self.doc = FreeCAD.newDocument("TestSelectionVisual")
@@ -41,11 +44,31 @@ class TestSelectionVisual(unittest.TestCase):
         self._had_navi_cube = self.viewer.isEnabledNaviCube()
         self.viewer.setEnabledNaviCube(False)
 
+        self._view_preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View")
+        self._saved_colors = {}
+        for key, value in (
+            ("SelectionColor", self._SELECTION_COLOR),
+            ("HighlightColor", self._HIGHLIGHT_COLOR),
+        ):
+            self._saved_colors[key] = (
+                key in self._view_preferences.GetUnsigneds(),
+                self._view_preferences.GetUnsigned(key, 0),
+            )
+            self._view_preferences.SetUnsigned(key, value)
+        self._flush_gui()
+
     def tearDown(self):
         with suppress(Exception):
             Selection.clearPreselection()
         with suppress(Exception):
             Selection.clearSelection()
+
+        if hasattr(self, "_saved_colors"):
+            for key, (was_set, value) in self._saved_colors.items():
+                if was_set:
+                    self._view_preferences.SetUnsigned(key, value)
+                else:
+                    self._view_preferences.RemUnsigned(key)
 
         with suppress(Exception):
             self.view.setAxisCross(self._had_axis_cross)
@@ -59,15 +82,15 @@ class TestSelectionVisual(unittest.TestCase):
         plane = self._create_test_plane()
         self._prepare_view()
 
-        base_color = self._center_pixel_color()
+        base_color = self._center_region_color()
 
         Selection.addSelection(plane)
         self._flush_gui()
-        selection_color = self._center_pixel_color()
+        selection_color = self._center_region_color()
 
         Selection.setPreselection(plane, "Face1")
         self._flush_gui()
-        preselection_color = self._center_pixel_color()
+        preselection_color = self._center_region_color()
 
         self.assertGreater(
             self._color_distance(base_color, selection_color),
@@ -86,19 +109,163 @@ class TestSelectionVisual(unittest.TestCase):
             ),
         )
 
+    def test_whole_preselection_does_not_override_whole_selection(self):
+        plane = self._create_test_plane()
+        self._prepare_view()
+
+        base_color = self._center_region_color()
+
+        Selection.addSelection(plane)
+        self._flush_gui()
+        selection_color = self._center_region_color()
+
+        Selection.setPreselection(plane, tp=2)  # SelectionChanges::MsgSource::TreeView
+        self._flush_gui()
+        overlapping_color = self._center_region_color()
+
+        Selection.clearPreselection()
+        Selection.clearSelection()
+        Selection.setPreselection(plane, "Face1")
+        self._flush_gui()
+        highlight_color = self._center_region_color()
+
+        self._assert_color_changed(
+            base_color,
+            selection_color,
+            "Whole-object selection did not visibly change the rendered face.",
+        )
+        self._assert_color_changed(
+            selection_color,
+            highlight_color,
+            "Whole-object selection and preselection colors were not distinguishable.",
+        )
+        selection_distance = self._color_distance(overlapping_color, selection_color)
+        highlight_distance = self._color_distance(overlapping_color, highlight_color)
+        self.assertGreater(
+            highlight_distance - selection_distance,
+            self._COLOR_DELTA_MIN,
+            msg=(
+                "Whole-object preselection color won over committed selection. "
+                f"selection={selection_color}, overlap={overlapping_color}, "
+                f"highlight={highlight_color}"
+            ),
+        )
+
+    def test_whole_preselection_is_not_suppressed_by_partial_selection(self):
+        shape = self.doc.addObject("Part::Feature", "TwoFaces")
+        shape.Shape = Part.makeCompound(
+            [
+                Part.makePlane(40, 40, FreeCAD.Vector(-45, -20, 0)),
+                Part.makePlane(40, 40, FreeCAD.Vector(5, -20, 0)),
+            ]
+        )
+        shape.ViewObject.ShapeColor = (0.66, 0.66, 0.74)
+        self.doc.recompute()
+        self._prepare_view()
+
+        unselected_face_color = self._region_color(0.72, 0.5)
+
+        Selection.addSelection(shape, "Face1")
+        self._flush_gui()
+        partially_selected_color = self._region_color(0.72, 0.5)
+
+        Selection.setPreselection(shape, tp=2)  # SelectionChanges::MsgSource::TreeView
+        self._flush_gui()
+        tree_preselection_color = self._region_color(0.72, 0.5)
+
+        self._assert_color_restored(
+            unselected_face_color,
+            partially_selected_color,
+            "Selecting Face1 unexpectedly changed the unselected face.",
+        )
+        self._assert_color_changed(
+            partially_selected_color,
+            tree_preselection_color,
+            "Partial selection incorrectly suppressed whole-object tree preselection.",
+        )
+
+    def test_preselection_preserves_object_transparency(self):
+        plane = self._create_test_plane()
+        plane.ViewObject.Transparency = 70
+        self._prepare_view()
+
+        transparent_base_color = self._center_region_color()
+
+        Selection.setPreselection(plane, "Face1")
+        self._flush_gui()
+        transparent_highlight_color = self._center_region_color()
+
+        Selection.clearPreselection()
+        plane.ViewObject.Transparency = 0
+        self._flush_gui()
+        Selection.setPreselection(plane, "Face1")
+        self._flush_gui()
+        opaque_highlight_color = self._center_region_color()
+
+        self._assert_color_changed(
+            transparent_base_color,
+            transparent_highlight_color,
+            "Preselection did not visibly highlight the transparent face.",
+        )
+        self.assertGreater(
+            self._color_distance(transparent_highlight_color, opaque_highlight_color),
+            self._COLOR_DELTA_MIN,
+            msg=(
+                "Preselection made the transparent face opaque. "
+                f"transparent={transparent_highlight_color}, opaque={opaque_highlight_color}"
+            ),
+        )
+
+    def test_link_preselection_preserves_source_transparency(self):
+        source = self._create_test_plane()
+        source.ViewObject.Transparency = 70
+
+        link = self.doc.addObject("App::Link", "PlaneLink")
+        link.LinkedObject = source
+        source.ViewObject.Visibility = False
+        self.doc.recompute()
+        self._prepare_view()
+
+        transparent_base_color = self._center_region_color()
+
+        Selection.setPreselection(link, "Face1")
+        self._flush_gui()
+        transparent_highlight_color = self._center_region_color()
+
+        Selection.clearPreselection()
+        source.ViewObject.Transparency = 0
+        self._flush_gui()
+        Selection.setPreselection(link, "Face1")
+        self._flush_gui()
+        opaque_highlight_color = self._center_region_color()
+
+        self._assert_color_changed(
+            transparent_base_color,
+            transparent_highlight_color,
+            "Preselection did not visibly highlight the transparent Link.",
+        )
+        self.assertGreater(
+            self._color_distance(transparent_highlight_color, opaque_highlight_color),
+            self._COLOR_DELTA_MIN,
+            msg=(
+                "Link preselection ignored source transparency. "
+                f"transparent={transparent_highlight_color}, opaque={opaque_highlight_color}"
+            ),
+        )
+
     def test_selection_can_be_cleared(self):
         plane = self._create_test_plane()
         self._prepare_view()
 
-        base_color = self._center_pixel_color()
+        base_color = self._center_region_color()
 
         Selection.addSelection(plane)
         self._flush_gui()
-        selection_color = self._center_pixel_color()
+        selection_color = self._center_region_color()
 
         Selection.clearSelection()
         self._flush_gui()
-        cleared_color = self._center_pixel_color()
+        cleared_color = self._center_region_color()
 
         self._assert_color_changed(
             base_color,
@@ -115,15 +282,15 @@ class TestSelectionVisual(unittest.TestCase):
         plane = self._create_test_plane()
         self._prepare_view()
 
-        base_color = self._center_pixel_color()
+        base_color = self._center_region_color()
 
         Selection.setPreselection(plane, "Face1")
         self._flush_gui()
-        preselection_color = self._center_pixel_color()
+        preselection_color = self._center_region_color()
 
         Selection.clearPreselection()
         self._flush_gui()
-        cleared_color = self._center_pixel_color()
+        cleared_color = self._center_region_color()
 
         self._assert_color_changed(
             base_color,
@@ -134,6 +301,49 @@ class TestSelectionVisual(unittest.TestCase):
             base_color,
             cleared_color,
             "Clearing preselection did not restore the original rendering.",
+        )
+
+    def test_tree_preselection_is_on_top_but_committed_selection_is_depth_tested(self):
+        front = self.doc.addObject("Part::Box", "Front")
+        front.Length = 40
+        front.Width = 40
+        front.Height = 10
+        front.Placement.Base = FreeCAD.Vector(0, 0, 10)
+        front.ViewObject.ShapeColor = (0.2, 0.2, 0.8)
+
+        back = self.doc.addObject("Part::Box", "Back")
+        back.Length = 40
+        back.Width = 40
+        back.Height = 10
+        back.ViewObject.ShapeColor = (0.8, 0.8, 0.2)
+        self.doc.recompute()
+        self._prepare_view()
+
+        base_color = self._center_region_color()
+
+        Selection.addSelection(back)
+        self._flush_gui()
+        committed_selection_color = self._center_region_color()
+        self.assertLess(
+            self._color_distance(base_color, committed_selection_color),
+            self._COLOR_DELTA_RESTORE_MAX,
+            msg=(
+                "Committed selection exposed an occluded face. "
+                f"base={base_color}, selection={committed_selection_color}"
+            ),
+        )
+
+        Selection.clearSelection()
+        Selection.setPreselection(back, tp=2)  # SelectionChanges::MsgSource::TreeView
+        self._flush_gui()
+        tree_preselection_color = self._center_region_color()
+        self.assertGreater(
+            self._color_distance(base_color, tree_preselection_color),
+            self._COLOR_DELTA_MIN,
+            msg=(
+                "Tree preselection remained depth-tested. "
+                f"base={base_color}, preselection={tree_preselection_color}"
+            ),
         )
 
     def _create_test_plane(self):
@@ -165,10 +375,27 @@ class TestSelectionVisual(unittest.TestCase):
             self.view.redraw()
             time.sleep(0.05)
 
-    def _center_pixel_color(self):
+    def _center_region_color(self):
+        return self._region_color(0.5, 0.5)
+
+    def _region_color(self, x_fraction, y_fraction):
         image = self.viewer.grabFramebuffer()
-        color = image.pixelColor(image.width() // 2, image.height() // 2)
-        return (color.redF(), color.greenF(), color.blueF())
+        radius = self._CENTER_SAMPLE_RADIUS
+        self.assertGreater(image.width(), 2 * radius)
+        self.assertGreater(image.height(), 2 * radius)
+
+        center_x = round((image.width() - 1) * x_fraction)
+        center_y = round((image.height() - 1) * y_fraction)
+        totals = [0.0, 0.0, 0.0]
+        count = 0
+        for y in range(center_y - radius, center_y + radius + 1):
+            for x in range(center_x - radius, center_x + radius + 1):
+                color = image.pixelColor(x, y)
+                totals[0] += color.redF()
+                totals[1] += color.greenF()
+                totals[2] += color.blueF()
+                count += 1
+        return tuple(channel / count for channel in totals)
 
     def _assert_color_changed(self, before, after, message):
         self.assertGreater(


### PR DESCRIPTION
This regression was noticed on Discord by @kevenwyld while investigating hidden-item preselection: https://discord.com/channels/870877411049357352/1542054827394080808/1543391256288432249

Tree-view preselection could show BREP edges through obstructing geometry while the corresponding faces remained depth-tested. FreeCAD 1.1.3 rendered the complete preselection overlay on top, which is the expected behavior.

The regression is in the BREP face rendering path rather than the edge/point depth distinction introduced by https://github.com/FreeCAD/FreeCAD/commit/a340c1d0475bde9649a069a025507427cb60f428.

`SoBrepFaceSet::overrideMaterialBinding()` was encoding transient highlight state into the normal material pass. This made the highlighted faces participate in normal depth testing and skipped the explicit highlight overlay.

This change:

- gives BREP face overlays explicit `RespectDepth` and `DrawOnTop` modes, matching edges and points;
- keeps committed selection in the depth-tested material/selection path;
- removes transient highlight state from `overrideMaterialBinding()`;
- renders live highlight/preselection exactly once as the final on-top face overlay.

A visual regression test uses two overlapping boxes and verifies both sides of the behavior:

- committed selection of the occluded box does not expose its hidden face;
- tree preselection of the same box is visible over the obstructing box.

The visual tests use deterministic selection colors and average a small center region to avoid preference and single-pixel rendering sensitivity.
