### PR TITLE
Sketcher: Horizontal and Vertical Auto Constrain for point with hint line + hover system for hint lines

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -145,14 +145,6 @@ inline void ViewProviderSketchDrawSketchHandlerAttorney::drawParallelPerpendicul
     vp.drawParallelPerpendicularHint(HintLines, activeLineIndex);
 }
 
-inline bool ViewProviderSketchDrawSketchHandlerAttorney::isLineExtensionAutoConstraintHintVisible(
-    const ViewProviderSketch& vp,
-    const std::vector<Base::Vector2d>& HintCurve
-)
-{
-    return vp.isLineExtensionAutoConstraintHintVisible(HintCurve);
-}
-
 inline void ViewProviderSketchDrawSketchHandlerAttorney::drawEditMarkers(
     ViewProviderSketch& vp,
     const std::vector<Base::Vector2d>& EditMarkers,
@@ -717,10 +709,6 @@ bool DrawSketchHandler::seekLineExtensionAutoConstraint(
         return false;
     }
 
-    if (!isLineExtensionAutoConstraintHintVisible(bestAnchor, bestProjection)) {
-        return false;
-    }
-
     AutoConstraint constr;
     constr.Type = Sketcher::PointOnObject;
     constr.GeoId = bestGeoId;
@@ -749,14 +737,6 @@ void DrawSketchHandler::renderLineExtensionAutoConstraintHint() const
     drawLineExtensionAutoConstraintHint(
         {lineExtensionAutoConstraintHint.start, lineExtensionAutoConstraintHint.end}
     );
-}
-
-bool DrawSketchHandler::isLineExtensionAutoConstraintHintVisible(
-    const Base::Vector2d& start,
-    const Base::Vector2d& end
-) const
-{
-    return isLineExtensionAutoConstraintHintVisible(std::vector<Base::Vector2d> {start, end});
 }
 
 bool DrawSketchHandler::getLineExtensionAutoConstraintSnapPoint(Base::Vector2d& point) const
@@ -837,7 +817,7 @@ void DrawSketchHandler::seekPointAlignmentAutoConstraint(
         considerPoint(geoId, posId, toVector2d(obj->getPoint(geoId, posId)));
     }
 
-    if (!bestHint.isValid || !isLineExtensionAutoConstraintHintVisible(bestHint.start, bestHint.end)) {
+    if (!bestHint.isValid) {
         return;
     }
 
@@ -1949,16 +1929,6 @@ void DrawSketchHandler::drawLineExtensionAutoConstraintHint(
 ) const
 {
     ViewProviderSketchDrawSketchHandlerAttorney::drawLineExtensionAutoConstraintHint(
-        *sketchgui,
-        HintCurve
-    );
-}
-
-bool DrawSketchHandler::isLineExtensionAutoConstraintHintVisible(
-    const std::vector<Base::Vector2d>& HintCurve
-) const
-{
-    return ViewProviderSketchDrawSketchHandlerAttorney::isLineExtensionAutoConstraintHintVisible(
         *sketchgui,
         HintCurve
     );

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -385,6 +385,12 @@ QString DrawSketchHandler::getToolWidgetText() const
 void DrawSketchHandler::activate(ViewProviderSketch* vp)
 {
     sketchgui = vp;
+    geometryTagsAtToolStart.clear();
+    for (const auto* geometry : sketchgui->getSketchObject()->getInternalGeometry()) {
+        if (geometry) {
+            geometryTagsAtToolStart.insert(geometry->getTag());
+        }
+    }
 
     if (!Gui::ToolHandler::activate()) {
         sketchgui->purgeHandler();
@@ -405,6 +411,7 @@ void DrawSketchHandler::deactivate()
     clearEditMarkers();
     clearLineExtensionAutoConstraintHintDrawing();
     resetParallelPerpendicularHint();
+    autoConstraintHintReferences.clear();
     resetPositionText();
     setAngleSnapping(false);
 
@@ -667,7 +674,7 @@ bool DrawSketchHandler::seekLineExtensionAutoConstraint(
 
     for (int geoId = 0; geoId <= getHighestCurveIndex(); ++geoId) {
         const Part::Geometry* geo = obj->getGeometry(geoId);
-        if (!geo) {
+        if (!geo || !isAutoConstraintHintReference(geoId, PointPos::none)) {
             continue;
         }
 
@@ -765,6 +772,77 @@ bool DrawSketchHandler::getLineExtensionAutoConstraintSnapPoint(Base::Vector2d& 
 void DrawSketchHandler::resetTangentAutoConstraintHint()
 {
     tangentAutoConstraintHint = TangentAutoConstraintHint();
+}
+
+void DrawSketchHandler::seekPointAlignmentAutoConstraint(
+    std::vector<AutoConstraint>& suggestedConstraints,
+    const Base::Vector2d& Pos,
+    AutoConstraint::TargetType type
+)
+{
+    if (type != AutoConstraint::VERTEX && type != AutoConstraint::VERTEX_NO_TANGENCY) {
+        return;
+    }
+
+    for (const auto& constraint : suggestedConstraints) {
+        if (constraint.Type == Coincident || constraint.Type == PointOnObject
+            || constraint.Type == Symmetric) {
+            return;
+        }
+    }
+
+    SketchObject* obj = sketchgui->getSketchObject();
+    if (!obj) {
+        return;
+    }
+
+    Base::Vector2d segmentStart;
+    const bool hasSegmentStart = getStartPointOfCurrentSegment(segmentStart);
+    double bestDeviation = getAutoConstraintSearchDistance();
+    AutoConstraint bestConstraint {Sketcher::None, GeoEnum::GeoUndef, PointPos::none};
+    LineExtensionAutoConstraintHint bestHint;
+
+    auto considerPoint = [&](int geoId, PointPos posId, const Base::Vector2d& anchor) {
+        const Base::Vector2d cursorOffset = Pos - anchor;
+        if (cursorOffset.Sqr() < Precision::SquareConfusion()
+            || (hasSegmentStart && (anchor - segmentStart).Sqr() < Precision::SquareConfusion())) {
+            return;
+        }
+
+        auto considerAlignment =
+            [&](ConstraintType constraintType, double deviation, const Base::Vector2d& position) {
+                if (deviation > bestDeviation) {
+                    return;
+                }
+
+                bestDeviation = deviation;
+                bestConstraint = {constraintType, geoId, posId};
+                bestHint.isValid = true;
+                bestHint.start = anchor;
+                bestHint.end = position;
+            };
+
+        considerAlignment(Horizontal, std::abs(cursorOffset.y), {Pos.x, anchor.y});
+        considerAlignment(Vertical, std::abs(cursorOffset.x), {anchor.x, Pos.y});
+    };
+
+    const int highestVertex = getHighestVertexIndex();
+    for (int vertexIndex = 0; vertexIndex <= highestVertex; ++vertexIndex) {
+        int geoId = GeoEnum::GeoUndef;
+        PointPos posId = PointPos::none;
+        obj->getGeoVertexIndex(vertexIndex, geoId, posId);
+        if (geoId == GeoEnum::GeoUndef || !isAutoConstraintHintReference(geoId, posId)) {
+            continue;
+        }
+        considerPoint(geoId, posId, toVector2d(obj->getPoint(geoId, posId)));
+    }
+
+    if (!bestHint.isValid || !isLineExtensionAutoConstraintHintVisible(bestHint.start, bestHint.end)) {
+        return;
+    }
+
+    suggestedConstraints.push_back(bestConstraint);
+    lineExtensionAutoConstraintHint = bestHint;
 }
 
 bool DrawSketchHandler::updateTangentAutoConstraintHint()
@@ -1243,25 +1321,20 @@ int DrawSketchHandler::seekAutoConstraint(
 
     updateParallelPerpendicularEndpointHint();
 
-    // Reference line hover-selection detection
-    PreselectionData preselection = getPreselectionData();
-    bool horOrVert = fabs(preselection.hitShapeDir.x) < Precision::Confusion()
-        || fabs(preselection.hitShapeDir.y) < Precision::Confusion();
-    if (preselection.isLine && !horOrVert && preselection.geoId != GeoEnum::GeoUndef) {
-        if (preselection.geoId != lastHoveredGeoId) {
-            lastHoveredGeoId = preselection.geoId;
-            startHoverTimer();
-        }
-    }
-    else {
-        if (lastHoveredGeoId != GeoEnum::GeoUndef) {
-            lastHoveredGeoId = GeoEnum::GeoUndef;
+    const auto reference = getHoveredHintReference(getPreselectionData());
+    if (reference != lastHoveredHintReference) {
+        lastHoveredHintReference = reference;
+        if (reference.geoId == GeoEnum::GeoUndef) {
             stopHoverTimer();
+        }
+        else {
+            startHoverTimer();
         }
     }
 
     seekPreselectionAutoConstraint(suggestedConstraints, Pos, Dir, type);
     seekLineExtensionAutoConstraint(suggestedConstraints, Pos, type);
+    seekPointAlignmentAutoConstraint(suggestedConstraints, Pos, type);
 
     if (Dir.Length() > 1e-8 && type != AutoConstraint::CURVE) {
         bool tangentCreated = false;
@@ -1376,7 +1449,16 @@ bool DrawSketchHandler::generateOneAutoConstraintFromSuggestion(
         case Sketcher::Vertical: {
             auto c = std::make_unique<Sketcher::Constraint>();
             c->Type = ac.Type;
-            c->First = (geoId2 != Sketcher::GeoEnum::GeoUndef ? geoId2 : geoId1);
+            if (posId1 != Sketcher::PointPos::none && posId2 != Sketcher::PointPos::none
+                && geoId2 != Sketcher::GeoEnum::GeoUndef) {
+                c->First = geoId1;
+                c->FirstPos = posId1;
+                c->Second = geoId2;
+                c->SecondPos = posId2;
+            }
+            else {
+                c->First = (geoId2 != Sketcher::GeoEnum::GeoUndef ? geoId2 : geoId1);
+            }
             autoConstraints.push_back(std::move(c));
         } break;
         case Sketcher::Perpendicular: {
@@ -1648,18 +1730,44 @@ void DrawSketchHandler::createAutoConstraints(
                 // case the caller as to set geoId2, then it will be used as target instead of
                 // geoId2
             case Sketcher::Horizontal: {
-                Gui::cmdAppObjectArgs(
-                    sketchgui->getObject(),
-                    "addConstraint(Sketcher.Constraint('Horizontal',%d)) ",
-                    geoId2 != GeoEnum::GeoUndef ? geoId2 : geoId1
-                );
+                if (posId1 != Sketcher::PointPos::none && cstr.PosId != Sketcher::PointPos::none
+                    && geoId2 != GeoEnum::GeoUndef) {
+                    Gui::cmdAppObjectArgs(
+                        sketchgui->getObject(),
+                        "addConstraint(Sketcher.Constraint('Horizontal',%d,%d,%d,%d)) ",
+                        geoId1,
+                        static_cast<int>(posId1),
+                        geoId2,
+                        static_cast<int>(cstr.PosId)
+                    );
+                }
+                else {
+                    Gui::cmdAppObjectArgs(
+                        sketchgui->getObject(),
+                        "addConstraint(Sketcher.Constraint('Horizontal',%d)) ",
+                        geoId2 != GeoEnum::GeoUndef ? geoId2 : geoId1
+                    );
+                }
             } break;
             case Sketcher::Vertical: {
-                Gui::cmdAppObjectArgs(
-                    sketchgui->getObject(),
-                    "addConstraint(Sketcher.Constraint('Vertical',%d)) ",
-                    geoId2 != GeoEnum::GeoUndef ? geoId2 : geoId1
-                );
+                if (posId1 != Sketcher::PointPos::none && cstr.PosId != Sketcher::PointPos::none
+                    && geoId2 != GeoEnum::GeoUndef) {
+                    Gui::cmdAppObjectArgs(
+                        sketchgui->getObject(),
+                        "addConstraint(Sketcher.Constraint('Vertical',%d,%d,%d,%d)) ",
+                        geoId1,
+                        static_cast<int>(posId1),
+                        geoId2,
+                        static_cast<int>(cstr.PosId)
+                    );
+                }
+                else {
+                    Gui::cmdAppObjectArgs(
+                        sketchgui->getObject(),
+                        "addConstraint(Sketcher.Constraint('Vertical',%d)) ",
+                        geoId2 != GeoEnum::GeoUndef ? geoId2 : geoId1
+                    );
+                }
             } break;
             case Sketcher::Perpendicular: {
                 Gui::cmdAppObjectArgs(
@@ -1887,7 +1995,7 @@ void DrawSketchHandler::resetParallelPerpendicularHint()
     parallelPerpendicularActiveHintLine = -1;
     parallelPerpendicularRefFromEndpoint = false;
     resetTangentAutoConstraintHint();
-    lastHoveredGeoId = GeoEnum::GeoUndef;
+    lastHoveredHintReference = {};
     stopHoverTimer();
     clearParallelPerpendicularHintDrawing();
 }
@@ -1953,9 +2061,7 @@ bool DrawSketchHandler::updateParallelPerpendicularEndpointHint()
         if ((lineStart - startPoint).Sqr() < Precision::SquareConfusion()
             || (lineEnd - startPoint).Sqr() < Precision::SquareConfusion()) {
             parallelPerpendicularRefGeoId = geoId;
-            lastHoveredGeoId = geoId;
             parallelPerpendicularRefFromEndpoint = true;
-            stopHoverTimer();
             return true;
         }
     }
@@ -2024,6 +2130,41 @@ bool DrawSketchHandler::snapToParallelPerpendicularHint(Base::Vector2d& point)
     return true;
 }
 
+DrawSketchHandler::AutoConstraintHintReference DrawSketchHandler::getHoveredHintReference(
+    const PreselectionData& preselection
+) const
+{
+    const auto* obj = sketchgui->getSketchObject();
+    const auto* geometry = obj && preselection.geoId != GeoEnum::GeoUndef
+        ? obj->getGeometry(preselection.geoId)
+        : nullptr;
+    if (!geometry || (preselection.posId == PointPos::none && !preselection.isLine)) {
+        return {};
+    }
+
+    return {preselection.geoId, preselection.posId, geometry->getTag()};
+}
+
+bool DrawSketchHandler::isAutoConstraintHintReference(int geoId, PointPos posId) const
+{
+    const auto* obj = sketchgui->getSketchObject();
+    const auto* geometry = obj ? obj->getGeometry(geoId) : nullptr;
+    if (!geometry) {
+        return false;
+    }
+
+    if (geoId >= 0 && !geometryTagsAtToolStart.contains(geometry->getTag())) {
+        return true;
+    }
+
+    // Hovering a line acquires all its points and its extension. Hovering a point
+    // acquires only that point and the extension of its line.
+    const auto reference = autoConstraintHintReferences.find(geometry->getTag());
+    return reference != autoConstraintHintReferences.end()
+        && (posId == PointPos::none || reference->second.contains(PointPos::none)
+            || reference->second.contains(posId));
+}
+
 void DrawSketchHandler::startHoverTimer()
 {
     if (!hoverTimer) {
@@ -2043,8 +2184,25 @@ void DrawSketchHandler::stopHoverTimer()
 
 void DrawSketchHandler::onHoverTimeout()
 {
-    if (lastHoveredGeoId != GeoEnum::GeoUndef) {
-        parallelPerpendicularRefGeoId = lastHoveredGeoId;
+    if (!sketchgui->Autoconstraints.getValue()
+        || lastHoveredHintReference.geoId == GeoEnum::GeoUndef) {
+        return;
+    }
+
+    PreselectionData preselection = getPreselectionData();
+    if (lastHoveredHintReference != getHoveredHintReference(preselection)) {
+        return;
+    }
+
+    autoConstraintHintReferences[lastHoveredHintReference.geometryTag].insert(
+        lastHoveredHintReference.posId
+    );
+
+    // Preserve the existing directional reference behavior for non-axis-aligned lines.
+    bool horOrVert = fabs(preselection.hitShapeDir.x) < Precision::Confusion()
+        || fabs(preselection.hitShapeDir.y) < Precision::Confusion();
+    if (preselection.isLine && !horOrVert) {
+        parallelPerpendicularRefGeoId = preselection.geoId;
         parallelPerpendicularRefFromEndpoint = false;
         renderDirectionalAutoConstraintHints();
     }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -124,10 +124,6 @@ private:
         ViewProviderSketch& vp,
         const std::vector<Base::Vector2d>& HintCurve
     );
-    static inline bool isLineExtensionAutoConstraintHintVisible(
-        const ViewProviderSketch& vp,
-        const std::vector<Base::Vector2d>& HintCurve
-    );
     static inline void drawEditMarkers(
         ViewProviderSketch& vp,
         const std::vector<Base::Vector2d>& EditMarkers,
@@ -293,7 +289,6 @@ protected:
     void drawEdit(const std::list<std::vector<Base::Vector2d>>& list) const;
     void drawEdit(const std::vector<Part::Geometry*>& geometries) const;
     void drawLineExtensionAutoConstraintHint(const std::vector<Base::Vector2d>& HintCurve) const;
-    bool isLineExtensionAutoConstraintHintVisible(const std::vector<Base::Vector2d>& HintCurve) const;
     void drawEditMarkers(
         const std::vector<Base::Vector2d>& EditMarkers,
         unsigned int augmentationlevel = 0
@@ -413,10 +408,6 @@ protected:
     void resetLineExtensionAutoConstraintHint();
     void renderLineExtensionAutoConstraintHint() const;
 
-    bool isLineExtensionAutoConstraintHintVisible(
-        const Base::Vector2d& start,
-        const Base::Vector2d& end
-    ) const;
     bool getLineExtensionAutoConstraintSnapPoint(Base::Vector2d& point) const;
 
     void resetTangentAutoConstraintHint();

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -24,6 +24,11 @@
 
 #pragma once
 
+#include <map>
+#include <set>
+
+#include <boost/uuid/uuid.hpp>
+
 #include <QPixmap>
 #include <QCoreApplication>
 
@@ -399,6 +404,11 @@ protected:
         const Base::Vector2d& Pos,
         AutoConstraint::TargetType type
     );
+    void seekPointAlignmentAutoConstraint(
+        std::vector<AutoConstraint>& constraints,
+        const Base::Vector2d& Pos,
+        AutoConstraint::TargetType type
+    );
 
     void resetLineExtensionAutoConstraintHint();
     void renderLineExtensionAutoConstraintHint() const;
@@ -441,12 +451,27 @@ protected:
     int currentTransactionID {0};
 
 private:
+    struct AutoConstraintHintReference
+    {
+        int geoId {Sketcher::GeoEnum::GeoUndef};
+        Sketcher::PointPos posId {Sketcher::PointPos::none};
+        boost::uuids::uuid geometryTag {};
+
+        bool operator==(const AutoConstraintHintReference&) const = default;
+    };
+
+    AutoConstraintHintReference getHoveredHintReference(const PreselectionData& preselection) const;
+    bool isAutoConstraintHintReference(int geoId, Sketcher::PointPos posId) const;
+
+    // Preserve across continuous creation resets; geometry tags survive reindexing.
+    std::set<boost::uuids::uuid> geometryTagsAtToolStart;
+    std::map<boost::uuids::uuid, std::set<Sketcher::PointPos>> autoConstraintHintReferences;
+    AutoConstraintHintReference lastHoveredHintReference;
     LineExtensionAutoConstraintHint lineExtensionAutoConstraintHint;
     TangentAutoConstraintHint tangentAutoConstraintHint;
     int parallelPerpendicularRefGeoId {Sketcher::GeoEnum::GeoUndef};
     int parallelPerpendicularActiveHintLine {-1};
     bool parallelPerpendicularRefFromEndpoint {false};
-    int lastHoveredGeoId {Sketcher::GeoEnum::GeoUndef};
     QTimer* hoverTimer {nullptr};
 };
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3364,22 +3364,7 @@ bool ViewProviderSketch::isConstructionMode() const
 
 void ViewProviderSketch::setGeometryCreationMode(GeometryCreationMode newMode)
 {
-    if (geometryCreationMode == newMode) {
-        return;
-    }
-
     geometryCreationMode = newMode;
-
-    if (!editCoinManager) {
-        return;
-    }
-
-    editCoinManager->updateEditCurveAppearance(newMode);
-
-    Gui::MDIView* mdi = getActiveView();
-    if (mdi && mdi->isDerivedFrom<Gui::View3DInventor>()) {
-        static_cast<Gui::View3DInventor*>(mdi)->getViewer()->redraw();
-    }
 }
 
 GeometryCreationMode ViewProviderSketch::getGeometryCreationMode() const
@@ -3804,40 +3789,6 @@ void ViewProviderSketch::drawParallelPerpendicularHint(
 )
 {
     editCoinManager->drawParallelPerpendicularHint(HintLines, activeLineIndex);
-}
-
-bool ViewProviderSketch::isLineExtensionAutoConstraintHintVisible(
-    const std::vector<Base::Vector2d>& HintCurve
-) const
-{
-    Gui::MDIView* mdi = this->getActiveView();
-    Gui::View3DInventor* view = qobject_cast<Gui::View3DInventor*>(mdi);
-    if (!view || !isInEditMode()) {
-        return false;
-    }
-
-    Gui::View3DInventorViewer* viewer = view->getViewer();
-    if (!viewer || !viewer->getGLWidget()) {
-        return false;
-    }
-
-    const int width = viewer->getGLWidget()->width();
-    const int height = viewer->getGLWidget()->height();
-    if (width <= 0 || height <= 0) {
-        return false;
-    }
-
-    for (const auto& point : HintCurve) {
-        const SbVec2f screenCoordinates = getScreenCoordinates(
-            SbVec2f(static_cast<float>(point.x), static_cast<float>(point.y))
-        );
-        if (screenCoordinates[0] < 0.0F || screenCoordinates[0] > width
-            || screenCoordinates[1] < 0.0F || screenCoordinates[1] > height) {
-            return false;
-        }
-    }
-
-    return true;
 }
 
 void ViewProviderSketch::drawEditMarkers(const std::vector<Base::Vector2d>& EditMarkers,

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -1007,7 +1007,6 @@ private:
     void drawEdit(const std::vector<Base::Vector2d>& EditCurve);
     void drawEdit(const std::list<std::vector<Base::Vector2d>>& list);
     void drawLineExtensionAutoConstraintHint(const std::vector<Base::Vector2d>& HintCurve);
-    bool isLineExtensionAutoConstraintHintVisible(const std::vector<Base::Vector2d>& HintCurve) const;
     void drawParallelPerpendicularHint(const std::vector<Base::Vector2d>& HintLines, int activeLineIndex);
     /// draw the edit markers
     void drawEditMarkers(


### PR DESCRIPTION
#30332 Extending the PR to provide horizontal and vertical auto-constraints for points. Previously, this could only be done with constraint tools; now it's added as an auto-constraint. This feature is available in all other CAD programs. I did it entirely myself, but since I wasn't sure, I asked GPT 5 how it's done.

It replaces #32080. It adds a hover feature to other hint line elements, but the hover feature applies to previous drawings, not the current one. So it works a little differently than existing ones. Not everything drawn in the tool needs to be hovered, but if it's closed and reopened, it's added to the hover feature. I think this limitation is sufficient.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/d2842000-714f-47a8-ba0a-4a879cff5a41



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
