### PR TITLE
PD: Preserve taper direction for multi-sided pockets

### DIFF
--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -44,6 +44,7 @@
 #include <App/Document.h>
 #include <App/ObjectIdentifier.h>
 #include <Base/Converter.h>
+#include <Base/ProgramVersion.h>
 #include <Base/Tools.h>
 #include <Mod/Part/App/ExtrusionHelper.h>
 #include <Mod/Part/App/Tools.h>
@@ -65,7 +66,16 @@ App::PropertyQuantityConstraint::Constraints FeatureExtrude::signedLengthConstra
 double FeatureExtrude::maxAngle = 90 - Base::toDegrees<double>(Precision::Angular());
 App::PropertyAngle::Constraints FeatureExtrude::floatAngle = {-maxAngle, maxAngle, 1.0};
 
-FeatureExtrude::FeatureExtrude() = default;
+FeatureExtrude::FeatureExtrude()
+{
+    ADD_PROPERTY_TYPE(
+        UseLegacyTaperDirection,
+        (false),
+        "Compatibility",
+        App::Prop_Hidden,
+        "Use legacy profile copying for tapered extrusions"
+    );
+}
 
 short FeatureExtrude::mustExecute() const
 {
@@ -75,7 +85,7 @@ short FeatureExtrude::mustExecute() const
         || ReferenceAxis.isTouched() || AlongSketchNormal.isTouched() || Offset.isTouched()
         || Offset2.isTouched() || StartType.isTouched() || StartOffset.isTouched()
         || StartReference.isTouched() || UpToFace.isTouched() || UpToFace2.isTouched()
-        || UpToShape.isTouched() || UpToShape2.isTouched()) {
+        || UpToShape.isTouched() || UpToShape2.isTouched() || UseLegacyTaperDirection.isTouched()) {
         return 1;
     }
     return ProfileBased::mustExecute();
@@ -525,10 +535,15 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
             : std::strcmp(startType, "Offset") == 0
             ? StartOffset.getValue()
             : getStartReferenceOffset(sketchshape, StartReference, dir, StartOffset.getValue(), invObjLoc);
-        TopoShape startSketch = moveProfileToStart(sketchshape, dir, startOffset);
+        const bool useLegacyTaperDirection = UseLegacyTaperDirection.getValue();
+        TopoShape startSketch
+            = moveProfileToStart(sketchshape, dir, startOffset, useLegacyTaperDirection);
 
-        // Reuse the profile for tapered sides. Deep copies can change OCCT's signed wire offset
-        // for transformed sketches and invert the taper.
+        // Preserve the old deep-copy path for restored files because it can affect both generated
+        // topology and taper direction. New features reuse the profile for each side.
+        auto profileForSide = [useLegacyTaperDirection](const TopoShape& profile) {
+            return useLegacyTaperDirection ? profile.makeElementCopy() : profile;
+        };
         std::vector<TopoShape> prisms;  // Stores prisms, all in global CS
         double taper1 = TaperAngle.getValue();
         double offset1 = Offset.getValue();
@@ -559,7 +574,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
                     // directions.
                     L /= 2.0;
                     TopoShape prism1 = generateSingleExtrusionSide(
-                        startSketch,
+                        profileForSide(startSketch),
                         method,
                         L,
                         taper1,
@@ -578,7 +593,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
                     gp_Dir dir2 = dir;
                     dir2.Reverse();
                     TopoShape prism2 = generateSingleExtrusionSide(
-                        startSketch,
+                        profileForSide(startSketch),
                         method,
                         L,
                         taper1,
@@ -712,7 +727,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
             }
             else {
                 TopoShape prism1 = generateSingleExtrusionSide(
-                    startSketch,
+                    profileForSide(startSketch),
                     method,
                     L,
                     taper1,
@@ -730,7 +745,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
 
                 // Side 2
                 TopoShape prism2 = generateSingleExtrusionSide(
-                    startSketch,
+                    profileForSide(startSketch),
                     method2,
                     L2,
                     taper2,
@@ -1009,12 +1024,22 @@ TopoShape FeatureExtrude::generateSingleExtrusionSide(
     return prism;
 }
 
+void FeatureExtrude::Restore(Base::XMLReader& reader)
+{
+    // SideType was introduced in 1.1. If the property exists in the file, restoring the remaining
+    // properties below overrides this version-based default.
+    UseLegacyTaperDirection.setValue(Base::getVersion(reader.ProgramVersion) >= Base::Version::v1_1);
+    ProfileBased::Restore(reader);
+}
+
 void FeatureExtrude::onDocumentRestored()
 {
     Base::StateLocker migrating(migratingDeprecatedProperties);
 
     // property Type no longer has TwoLengths.
     if (strcmp(Type.getValueAsString(), "?TwoLengths") == 0) {
+        // TwoLengths predates SideType and used the original profile for both taper directions.
+        UseLegacyTaperDirection.setValue(false);
         Type.setValue("Length");
         Type2.setValue("Length");
         SideType.setValue("Two sides");
@@ -1057,6 +1082,11 @@ void FeatureExtrude::onDocumentRestored()
         }
     }
     else if (Midplane.getValue()) {
+        // A missing SideType restores as One side. This distinguishes old Midplane documents from
+        // newer scripts that saved both Midplane and the corresponding SideType.
+        if (strcmp(SideType.getValueAsString(), "One side") == 0) {
+            UseLegacyTaperDirection.setValue(false);
+        }
         Midplane.setValue(false);
         SideType.setValue("Symmetric");
     }

--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -527,6 +527,8 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
             : getStartReferenceOffset(sketchshape, StartReference, dir, StartOffset.getValue(), invObjLoc);
         TopoShape startSketch = moveProfileToStart(sketchshape, dir, startOffset);
 
+        // Reuse the profile for tapered sides. Deep copies can change OCCT's signed wire offset
+        // for transformed sketches and invert the taper.
         std::vector<TopoShape> prisms;  // Stores prisms, all in global CS
         double taper1 = TaperAngle.getValue();
         double offset1 = Offset.getValue();
@@ -557,7 +559,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
                     // directions.
                     L /= 2.0;
                     TopoShape prism1 = generateSingleExtrusionSide(
-                        startSketch.makeElementCopy(),
+                        startSketch,
                         method,
                         L,
                         taper1,
@@ -576,7 +578,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
                     gp_Dir dir2 = dir;
                     dir2.Reverse();
                     TopoShape prism2 = generateSingleExtrusionSide(
-                        startSketch.makeElementCopy(),
+                        startSketch,
                         method,
                         L,
                         taper1,
@@ -710,7 +712,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
             }
             else {
                 TopoShape prism1 = generateSingleExtrusionSide(
-                    startSketch.makeElementCopy(),
+                    startSketch,
                     method,
                     L,
                     taper1,
@@ -728,7 +730,7 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
 
                 // Side 2
                 TopoShape prism2 = generateSingleExtrusionSide(
-                    startSketch.makeElementCopy(),
+                    startSketch,
                     method2,
                     L2,
                     taper2,

--- a/src/Mod/PartDesign/App/FeatureExtrude.h
+++ b/src/Mod/PartDesign/App/FeatureExtrude.h
@@ -60,6 +60,8 @@ public:
     App::PropertyLength Offset;
     App::PropertyLength Offset2;
     App::PropertyLinkSub ReferenceAxis;
+    /** Compatibility property preserving profile-copy behavior in restored documents. */
+    App::PropertyBool UseLegacyTaperDirection;
 
     static App::PropertyQuantityConstraint::Constraints signedLengthConstraint;
     static double maxAngle;
@@ -81,6 +83,7 @@ public:
     static const char* SideTypesEnums[];
 
 protected:
+    void Restore(Base::XMLReader& reader) override;
     void onDocumentRestored() override;
     Base::Vector3d computeDirection(const Base::Vector3d& sketchVector, bool inverse);
     bool hasTaperedAngle() const;

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -1831,7 +1831,7 @@ App::DocumentObjectExecReturn* Hole::execute()
                                                           StartOffset.getValue(),
                                                           invObjLoc
                                                       );
-        profileshape = moveProfileToStart(profileshape, holeDirection, startOffset);
+        profileshape = moveProfileToStart(profileshape, holeDirection, startOffset, true);
 
         if (method == "Dimension") {
             length = Depth.getValue();

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -880,7 +880,9 @@ TopoShape ProfileBased::moveProfileToStart(
         return profileShape;
     }
 
-    TopoShape result = profileShape.makeElementCopy();
+    // Translating the profile only requires a new location. Rebuilding its topology can change
+    // OCCT's signed wire offset and invert a subsequent taper for transformed sketches.
+    TopoShape result = profileShape;
     gp_Trsf transform;
     transform.SetTranslation(gp_Vec(direction) * offset);
     result.move(transform);

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -873,16 +873,15 @@ double ProfileBased::getStartReferenceOffset(
 TopoShape ProfileBased::moveProfileToStart(
     const TopoShape& profileShape,
     const gp_Dir& direction,
-    double offset
+    double offset,
+    bool copyProfile
 )
 {
     if (std::fabs(offset) < Precision::Confusion()) {
         return profileShape;
     }
 
-    // Translating the profile only requires a new location. Rebuilding its topology can change
-    // OCCT's signed wire offset and invert a subsequent taper for transformed sketches.
-    TopoShape result = profileShape;
+    TopoShape result = copyProfile ? profileShape.makeElementCopy() : profileShape;
     gp_Trsf transform;
     transform.SetTranslation(gp_Vec(direction) * offset);
     result.move(transform);

--- a/src/Mod/PartDesign/App/FeatureSketchBased.h
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.h
@@ -187,7 +187,8 @@ protected:
     static TopoShape moveProfileToStart(
         const TopoShape& profileShape,
         const gp_Dir& direction,
-        double offset
+        double offset,
+        bool copyProfile
     );
 
     /// Create a shape with shapes and faces from a given LinkSubList

--- a/src/Mod/PartDesign/PartDesignTests/TestPocket.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestPocket.py
@@ -84,6 +84,7 @@ class TestPocket(unittest.TestCase):
         self.Pocket.Profile = self.PocketSketch
         self.Pocket.Length = 5
         self.Pocket.TaperAngle = 20
+        self.assertFalse(self.Pocket.UseLegacyTaperDirection)
         self.Doc.recompute()
 
         oneSidedVolume = self.Pocket.Shape.Volume
@@ -108,6 +109,18 @@ class TestPocket(unittest.TestCase):
         self.Doc.recompute()
 
         self.assertAlmostEqual(self.Pocket.AddSubShape.BoundBox.XMax, expectedRadius)
+
+        self.Pocket.UseLegacyTaperDirection = True
+        self.Pocket.SideType = "One side"
+        self.Doc.recompute()
+
+        self.assertAlmostEqual(self.Pocket.AddSubShape.BoundBox.XMax, radius)
+
+        self.Pocket.StartType = "Profile plane"
+        self.Pocket.SideType = "Two sides"
+        self.Doc.recompute()
+
+        self.assertAlmostEqual(self.Pocket.AddSubShape.BoundBox.XMax, radius)
 
     def testStartOffset(self):
         self.Body = self.Doc.addObject("PartDesign::Body", "Body")

--- a/src/Mod/PartDesign/PartDesignTests/TestPocket.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestPocket.py
@@ -21,9 +21,11 @@
 # *                                                                         *
 # ***************************************************************************
 
+import math
 import unittest
 
 import FreeCAD
+import Part
 import TestSketcherApp
 
 
@@ -53,6 +55,59 @@ class TestPocket(unittest.TestCase):
         self.Pocket.Length = 1
         self.Doc.recompute()
         self.assertAlmostEqual(self.Pocket.Shape.Volume, 75.0)
+
+    def testPocketPreservesTaperDirection(self):
+        self.Body = self.Doc.addObject("PartDesign::Body", "Body")
+        self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "PadSketch")
+        self.Body.addObject(self.PadSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (-10, -10), (20, 20))
+
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Body.addObject(self.Pad)
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 10
+        self.Doc.recompute()
+
+        self.PocketSketch = self.Doc.addObject("Sketcher::SketchObject", "PocketSketch")
+        self.Body.addObject(self.PocketSketch)
+        self.PocketSketch.Placement = FreeCAD.Placement(
+            FreeCAD.Vector(), FreeCAD.Rotation(FreeCAD.Vector(1, 0, 0), 180)
+        )
+        self.PocketSketch.MakeInternals = False
+        radius = 2.0
+        self.PocketSketch.addGeometry(
+            Part.Circle(FreeCAD.Vector(), FreeCAD.Vector(0, 0, 1), radius), False
+        )
+
+        self.Pocket = self.Doc.addObject("PartDesign::Pocket", "Pocket")
+        self.Body.addObject(self.Pocket)
+        self.Pocket.Profile = self.PocketSketch
+        self.Pocket.Length = 5
+        self.Pocket.TaperAngle = 20
+        self.Doc.recompute()
+
+        oneSidedVolume = self.Pocket.Shape.Volume
+        expectedRadius = radius + self.Pocket.Length.Value * math.tan(math.radians(20))
+        self.assertAlmostEqual(self.Pocket.AddSubShape.BoundBox.XMax, expectedRadius)
+
+        self.Pocket.StartType = "Offset"
+        self.Pocket.StartOffset = 1
+        self.Doc.recompute()
+
+        self.assertAlmostEqual(self.Pocket.AddSubShape.BoundBox.XMax, expectedRadius)
+
+        self.Pocket.StartType = "Profile plane"
+        self.Pocket.SideType = "Two sides"
+        self.Pocket.Length2 = 5
+        self.Doc.recompute()
+
+        self.assertAlmostEqual(self.Pocket.AddSubShape.BoundBox.XMax, expectedRadius)
+        self.assertAlmostEqual(self.Pocket.Shape.Volume, oneSidedVolume)
+
+        self.Pocket.StartType = "Offset"
+        self.Doc.recompute()
+
+        self.assertAlmostEqual(self.Pocket.AddSubShape.BoundBox.XMax, expectedRadius)
 
     def testStartOffset(self):
         self.Body = self.Doc.addObject("PartDesign::Body", "Body")

--- a/tests/src/Mod/PartDesign/App/BackwardCompatibility.cpp
+++ b/tests/src/Mod/PartDesign/App/BackwardCompatibility.cpp
@@ -143,6 +143,7 @@ TEST_F(BackwardCompatibilityTest, TestTwoLengthsPadWithExpression)
     auto pad = dynamic_cast<PartDesign::Pad*>(doc->getObject("Pad"));
     ASSERT_NE(pad, nullptr);
 
+    EXPECT_FALSE(pad->UseLegacyTaperDirection.getValue());
     EXPECT_DOUBLE_EQ(pad->Length.getValue(), 5.0);
     EXPECT_DOUBLE_EQ(pad->Length2.getValue(), 10.0);
 


### PR DESCRIPTION
- Reuses the transformed sketch profile for tapered symmetric and two-sided extrusions
- Test added

Assisted-by: Gpt-5.6-Sol

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/32262



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
