### PR TITLE
New Crash Reporter Phase 2a: Python API

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -3008,7 +3008,10 @@ void Application::initCrashReporter()
         const std::string crashReportsDirectory {getUserAppDataDir() + "CrashReports"};
         Base::CrashReporter::Writer::prewarm();
         Base::CrashReporter::Writer::install(crashReportsDirectory);
-        Base::CrashReporter::Manager::scan(crashReportsDirectory);
+        Base::CrashReporter::Manager::scan(
+            crashReportsDirectory,
+            {},
+            App::ProgramInformation::prettyProductInfoWrapper());
     } catch (Base::Exception &e) {
         Base::Console().warning("Crash reporting failed during startup:\n%s\n", e.getMessage());
     } catch (std::exception &e) {

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -87,6 +87,8 @@
 #include <Base/ExceptionFactory.h>
 #include <Base/FileInfo.h>
 #include <Base/GeometryPyCXX.h>
+#include <Base/CrashReporter/CrashFramePy.h>
+#include <Base/CrashReporter/CrashReportPy.h>
 #include <Base/Interpreter.h>
 #include <Base/MatrixPy.h>
 #include <Base/QuantityPy.h>
@@ -458,6 +460,8 @@ void Application::setupPythonTypes()
     Base::InterpreterSingleton::addType(&Base::PlacementPy::Type, pAppModule, "Placement");
     Base::InterpreterSingleton::addType(&Base::RotationPy::Type, pAppModule, "Rotation");
     Base::InterpreterSingleton::addType(&Base::AxisPy::Type, pAppModule, "Axis");
+    Base::InterpreterSingleton::addType(&Base::CrashReportPy::Type, pAppModule, "CrashReport");
+    Base::InterpreterSingleton::addType(&Base::CrashFramePy::Type, pAppModule, "CrashFrame");
 
     // Note: Create an own module 'Base' which should provide the python
     // binding classes from the base module. At a later stage we should

--- a/src/App/ApplicationPy.cpp
+++ b/src/App/ApplicationPy.cpp
@@ -25,6 +25,7 @@
 
 #include <FCConfig.h>
 
+#include <algorithm>
 #include <array>
 
 #include <Base/Console.h>
@@ -41,6 +42,10 @@
 #include "DocumentObserverPython.h"
 #include "DocumentObjectPy.h"
 #include "RecoverySnapshot.h"
+
+#include <Base/CrashReporter/Manager.h>
+
+#include <Base/CrashReporter/CrashReportPy.h>
 
 
 // using Base::GetConsole;
@@ -1095,5 +1100,52 @@ PyObject* ApplicationPy::sCheckAbort(PyObject* /*self*/, PyObject* args)
         Py_Return;
     }
     PY_CATCH
+}
+
+PyObject* ApplicationPy::sGetLastCrashReport(PyObject* /*self*/, PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+    PY_TRY
+    {
+        const auto& reports = CrashReporter::Manager::reports();
+        const auto newest = std::ranges::max_element(
+            reports, {}, &CrashReporter::ParsedCrashReport::timestamp);
+        if (newest == reports.end()) {
+            Py_Return;
+        }
+        return new CrashReportPy(new ParsedCrashReport(*newest));
+    }
+    PY_CATCH
+}
+
+PyObject* ApplicationPy::sGetCrashReports(PyObject* /*self*/, PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+    PY_TRY
+    {
+        Py::List list;
+        for (const auto& report : CrashReporter::Manager::reports()) {
+            list.append(Py::asObject(new CrashReportPy(new ParsedCrashReport(report))));
+        }
+        return Py::new_reference_to(list);
+    }
+    PY_CATCH
+}
+
+PyObject* ApplicationPy::sClearCrashReports(PyObject* /*self*/, PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+    PY_TRY
+    {
+        CrashReporter::Manager::clear();
+    }
+    PY_CATCH
+    Py_Return;
 }
 // NOLINTEND(cppcoreguidelines-pro-type-*)

--- a/src/App/ApplicationPy.h
+++ b/src/App/ApplicationPy.h
@@ -88,6 +88,10 @@ public:
     static PyObject *sGetActiveTransaction   (PyObject *self,PyObject *args);
     static PyObject *sCloseActiveTransaction (PyObject *self,PyObject *args);
     static PyObject *sCheckAbort             (PyObject *self,PyObject *args);
+
+    static PyObject *sGetLastCrashReport     (PyObject *self,PyObject *args);
+    static PyObject *sGetCrashReports        (PyObject *self,PyObject *args);
+    static PyObject *sClearCrashReports      (PyObject *self,PyObject *args);
     // clang-format on
 };
 

--- a/src/App/FreeCAD.module.pyi
+++ b/src/App/FreeCAD.module.pyi
@@ -284,3 +284,15 @@ def checkAbort() -> None:
     abort by pressing Esc.
     """
     ...
+
+def getLastCrashReport() -> CrashReport | None:
+    """If the last run of FreeCAD crashed, this will return the most recent crash report."""
+    ...
+
+def getCrashReports() -> list[CrashReport]:
+    """Get all "live" crash reports (retained according to the retention policy)."""
+    ...
+
+def clearCrashReports() -> None:
+    """Clear all existing crash reports. Safe to call while holding a crash report."""
+    ...

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -120,6 +120,8 @@ generate_from_py(Axis)
 generate_from_py(Unit)
 generate_from_py(Quantity)
 generate_from_py(Precision)
+generate_from_py(CrashReporter/CrashFrame)
+generate_from_py(CrashReporter/CrashReport)
 generate_module_from_py(
     FreeCAD.Qt
     Qt_MODULE_GENERATED_SRCS
@@ -163,6 +165,8 @@ SET(FreeCADBase_Pyi_SRCS
     Type.pyi
     Unit.pyi
     Precision.pyi
+    CrashReporter/CrashFrame.pyi
+    CrashReporter/CrashReport.pyi
     FreeCAD.Qt.module.pyi
     FreeCAD.Console.module.pyi
     FreeCAD.Units.module.pyi
@@ -337,6 +341,8 @@ SET(FreeCADBase_HPP_SRCS
 )
 
 SET (FreeCADBase_CrashReporter_SRCS
+    CrashReporter/CrashFramePyImp.cpp
+    CrashReporter/CrashReportPyImp.cpp
     CrashReporter/FaultCodes.h
     CrashReporter/FaultCodes.cpp
     CrashReporter/Format.h

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -337,6 +337,8 @@ SET(FreeCADBase_HPP_SRCS
 )
 
 SET (FreeCADBase_CrashReporter_SRCS
+    CrashReporter/FaultCodes.h
+    CrashReporter/FaultCodes.cpp
     CrashReporter/Format.h
     CrashReporter/Manager.h
     CrashReporter/Manager.cpp

--- a/src/Base/CrashReporter/CrashFrame.pyi
+++ b/src/Base/CrashReporter/CrashFrame.pyi
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+from Metadata import export, forward_declarations
+from PyObjectBase import PyObjectBase
+from typing import Final
+
+@export(
+    PythonName="FreeCAD.CrashFrame",
+    Twin="ParsedFrame",
+    TwinPointer="ParsedFrame",
+    Include="Base/CrashReporter/Reader.h",
+    Constructor=False,
+    Delete=True,
+)
+@forward_declarations("""
+    namespace Base {
+        using ParsedFrame = CrashReporter::ParsedFrame;
+    }""")
+class CrashFrame(PyObjectBase):
+    """
+    A single frame of data from a (possibly symbolicated) crash report.
+    """
+
+    address: Final[int] = 0
+
+    module_offset: Final[int | None] = None
+
+    module: Final[str] = ""
+
+    symbol: Final[str | None] = None
+
+    file: Final[str | None] = None
+
+    line: Final[int | None] = None
+
+    is_inline: Final[bool] = False

--- a/src/Base/CrashReporter/CrashFramePyImp.cpp
+++ b/src/Base/CrashReporter/CrashFramePyImp.cpp
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 The FreeCAD project association AISBL
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include <CXX/Python3/Objects.hxx>
+
+#include <fmt/format.h>
+
+#include <string>
+#include <string_view>
+
+#include "CrashReporter/CrashFramePy.h"
+#include "CrashReporter/CrashFramePy.cpp"  // NOLINT
+
+using namespace Base;
+using namespace std::literals::string_view_literals;
+
+std::string CrashFramePy::representation() const
+{
+    const PointerType frame = getParsedFramePtr();
+    const std::string& module = frame->modulePath;
+    return fmt::format(
+        "<CrashFrame 0x{:016X} in {}: {}>",
+        frame->rawAddress,
+        module.empty() ? "<unknown module>"sv : module,
+        frame->symbol.has_value() ? *frame->symbol : "<unresolved>"sv
+    );
+}
+
+Py::Long CrashFramePy::getaddress() const
+{
+    return Py::Long(getParsedFramePtr()->rawAddress);
+}
+
+Py::String CrashFramePy::getmodule() const
+{
+    return getParsedFramePtr()->modulePath;
+}
+
+Py::Boolean CrashFramePy::getis_inline() const
+{
+    return getParsedFramePtr()->isInline;
+}
+
+// These getters return "value or None", so slicing the typed PyCXX wrapper down to Py::Object
+// is intentional: the discarded accepts() override is the one we do not want to enforce.
+Py::Object CrashFramePy::getmodule_offset() const
+{
+    const auto& moduleOffset = getParsedFramePtr()->moduleOffset;
+    if (!moduleOffset.has_value()) {
+        return Py::None();
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-slicing)
+    return Py::Long(moduleOffset.value());
+}
+
+Py::Object CrashFramePy::getsymbol() const
+{
+    const auto& symbol = getParsedFramePtr()->symbol;
+    if (!symbol.has_value()) {
+        return Py::None();
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-slicing)
+    return Py::String(symbol.value());
+}
+
+Py::Object CrashFramePy::getfile() const
+{
+    const auto& file = getParsedFramePtr()->file;
+    if (!file.has_value()) {
+        return Py::None();
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-slicing)
+    return Py::String(file.value());
+}
+
+Py::Object CrashFramePy::getline() const
+{
+    const auto& line = getParsedFramePtr()->line;
+    if (!line.has_value()) {
+        return Py::None();
+    }
+    // We need the inner static_cast to ensure that Py::Long uses the right constructor
+    // NOLINTNEXTLINE(cppcoreguidelines-slicing)
+    return Py::Long(static_cast<unsigned long>(line.value()));
+}
+
+PyObject* CrashFramePy::getCustomAttributes(const char* /*attr*/) const
+{
+    return nullptr;
+}
+
+int CrashFramePy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
+{
+    return 0;
+}

--- a/src/Base/CrashReporter/CrashReport.pyi
+++ b/src/Base/CrashReporter/CrashReport.pyi
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+from Metadata import export, forward_declarations
+from PyObjectBase import PyObjectBase
+from typing import Final
+
+from CrashFrame import CrashFrame
+
+@export(
+    PythonName="FreeCAD.CrashReport",
+    Twin="ParsedCrashReport",
+    TwinPointer="ParsedCrashReport",
+    Include="Base/CrashReporter/Reader.h",
+    Constructor=False,
+    Delete=True,
+)
+@forward_declarations("""
+    namespace Base {
+        using ParsedCrashReport = CrashReporter::ParsedCrashReport;
+    }""")
+class CrashReport(PyObjectBase):
+    """
+    A complete crash report.
+    """
+
+    path_to_raw_report_file: Final[str] = ""
+    fault_address: Final[int | None] = None
+    thread_id: Final[int] = 0
+    timestamp: Final[float] = 0.0
+    process_id: Final[int] = 0
+    fault_code: Final[int] = 0
+    fault_name: Final[str] = ""
+    partial_write: Final[bool] = False
+    capture_was_signal_safe: Final[bool] = False
+    build_id: Final[str | None] = None
+    minidump_path: Final[str | None] = None
+    os: Final[str] = "none"
+    os_version: Final[str | None] = None
+    architecture: Final[str] = "unknown"
+    freecad_version: Final[tuple[int, int, int, str]] = (0, 0, 0, "")
+    symbolicated: Final[bool] = False
+    stack_frames: Final[list[CrashFrame]] = []

--- a/src/Base/CrashReporter/CrashReportPyImp.cpp
+++ b/src/Base/CrashReporter/CrashReportPyImp.cpp
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 The FreeCAD project association AISBL
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include <CXX/Python3/Objects.hxx>
+
+#include <chrono>
+#include <fmt/format.h>
+#include <fmt/chrono.h>
+#include <string>
+
+#include "FaultCodes.h"
+
+#include "CrashReporter/CrashFramePy.h"
+
+#include "CrashReporter/CrashReportPy.h"
+#include "CrashReporter/CrashReportPy.cpp"  // NOLINT
+
+using namespace Base;
+
+std::string CrashReportPy::representation() const
+{
+    const PointerType report = getParsedCrashReportPtr();
+    const std::string timestamp = fmt::format( /*ISO-8601 UTC*/
+        "{:%FT%TZ}", std::chrono::floor<std::chrono::seconds>(report->timestamp));
+    return fmt::format(
+        "<CrashReport {} at {}, {} frames, {}{}>",
+        report->faultName,
+        timestamp,
+        report->stackFrames.size(),
+        report->symbolicated ? "symbolicated" : "unsymbolicated",
+        report->partialWrite ? ", partial" : ""  // Partial should be rare
+    );
+}
+
+Py::String CrashReportPy::getpath_to_raw_report_file() const
+{
+    return getParsedCrashReportPtr()->pathToRawReportFile;
+}
+
+// These getters return "value or None", so slicing the typed PyCXX wrapper down to Py::Object
+// is intentional: the discarded accepts() override is the one we do not want to enforce.
+Py::Object CrashReportPy::getfault_address() const
+{
+    const auto& faultAddress = getParsedCrashReportPtr()->faultAddress;
+    if (!faultAddress.has_value()) {
+        return Py::None();
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-slicing)
+    return Py::Long(faultAddress.value());
+}
+
+Py::Long CrashReportPy::getthread_id() const
+{
+    return Py::Long(getParsedCrashReportPtr()->threadID);
+}
+
+Py::Float CrashReportPy::gettimestamp() const
+{
+    // Not going to try to use a Python-native DateTime object here, callers can convert easily
+    const auto& ts = getParsedCrashReportPtr()->timestamp;
+    return Py::Float(std::chrono::duration<double>(ts.time_since_epoch()).count());
+}
+
+Py::Long CrashReportPy::getprocess_id() const
+{
+    return Py::Long(static_cast<unsigned long>(getParsedCrashReportPtr()->processID));
+}
+
+Py::Long CrashReportPy::getfault_code() const
+{
+    return Py::Long(static_cast<unsigned long>(getParsedCrashReportPtr()->code));
+}
+
+Py::String CrashReportPy::getfault_name() const
+{
+    return getParsedCrashReportPtr()->faultName;
+}
+
+Py::Boolean CrashReportPy::getpartial_write() const
+{
+    return getParsedCrashReportPtr()->partialWrite;
+}
+
+Py::Boolean CrashReportPy::getcapture_was_signal_safe() const
+{
+    return getParsedCrashReportPtr()->captureWasSignalSafe;
+}
+
+Py::Object CrashReportPy::getbuild_id() const
+{
+    const auto& buildID = getParsedCrashReportPtr()->buildID;
+    if (!buildID.has_value()) {
+        return Py::None();
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-slicing)
+    return Py::String(buildID.value());
+}
+
+Py::Object CrashReportPy::getminidump_path() const
+{
+    const auto& minidumpPath = getParsedCrashReportPtr()->minidumpPath;
+    if (!minidumpPath.has_value()) {
+        return Py::None();
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-slicing)
+    return Py::String(minidumpPath.value());
+}
+
+Py::String CrashReportPy::getos() const
+{
+    return toPyString(osName(getParsedCrashReportPtr()->osID));
+}
+
+Py::Object CrashReportPy::getos_version() const
+{
+    const auto& osVersion = getParsedCrashReportPtr()->osVersion;
+    if (!osVersion.has_value()) {
+        return Py::None();
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-slicing)
+    return Py::String(osVersion.value());
+}
+
+Py::String CrashReportPy::getarchitecture() const
+{
+    return toPyString(architectureName(getParsedCrashReportPtr()->architectureID));
+}
+
+Py::Tuple CrashReportPy::getfreecad_version() const
+{
+    const PointerType report = getParsedCrashReportPtr();
+    Py::Tuple version(4);
+    version.setItem(0, Py::Long(report->freecadVersionMajor));
+    version.setItem(1, Py::Long(report->freecadVersionMinor));
+    version.setItem(2, Py::Long(report->freecadVersionPatch));
+    version.setItem(3, Py::String(report->freecadVersionSuffix));
+    return version;
+}
+
+Py::Boolean CrashReportPy::getsymbolicated() const
+{
+    return getParsedCrashReportPtr()->symbolicated;
+}
+
+Py::List CrashReportPy::getstack_frames() const
+{
+    Py::List frames;
+    for (const auto& frame : getParsedCrashReportPtr()->stackFrames) {
+        frames.append(Py::asObject(new CrashFramePy(new ParsedFrame(frame))));
+    }
+    return frames;
+}
+
+PyObject* CrashReportPy::getCustomAttributes(const char* /*attr*/) const
+{
+    return nullptr;
+}
+
+int CrashReportPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
+{
+    return 0;
+}

--- a/src/Base/CrashReporter/FaultCodes.cpp
+++ b/src/Base/CrashReporter/FaultCodes.cpp
@@ -127,4 +127,34 @@ std::string faultCodeName(std::uint32_t code)
     return fmt::format("UNKNOWN(0x{:08X})", code);
 }
 
+std::string_view osName(OS osID)
+{
+    switch (osID) {
+        case OS::Linux:
+            return "linux";
+        case OS::macOS:
+            return "macos";
+        case OS::Windows:
+            return "windows";
+        case OS::BSDFamily:
+            return "bsd";
+        case OS::None:
+            return "unknown";
+    }
+    return "unknown";
+}
+
+std::string_view architectureName(Architecture architectureID)
+{
+    switch (architectureID) {
+        case Architecture::x64:
+            return "x86_64";
+        case Architecture::aarch64:
+            return "aarch64";
+        case Architecture::None:
+            return "unknown";
+    }
+    return "unknown";
+}
+
 }  // namespace Base::CrashReporter

--- a/src/Base/CrashReporter/FaultCodes.cpp
+++ b/src/Base/CrashReporter/FaultCodes.cpp
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 The FreeCAD project association AISBL
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "FaultCodes.h"
+
+#include <FCConfig.h>
+#include <fmt/format.h>
+
+#if defined(FC_OS_LINUX) || defined(FC_OS_BSD) || defined(FC_OS_MACOSX)
+# include <csignal>
+#elif defined(FC_OS_WIN32)
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# ifndef NOMINMAX
+#  define NOMINMAX
+# endif
+# include <windows.h>
+#endif
+
+#include <array>
+#include <algorithm>
+
+namespace Base::CrashReporter
+{
+
+// clang-format off
+namespace
+{
+#if defined(FC_OS_LINUX) || defined(FC_OS_BSD) || defined(FC_OS_MACOSX)
+
+constexpr std::array faultCodeToDescription {
+    FaultDescription {.code = SIGILL,  .name = "SIGILL",  .addressIsRelevant = true},
+    FaultDescription {.code = SIGABRT, .name = "SIGABRT", .addressIsRelevant = false},
+    FaultDescription {.code = SIGFPE,  .name = "SIGFPE",  .addressIsRelevant = true},
+    FaultDescription {.code = SIGBUS,  .name = "SIGBUS",  .addressIsRelevant = true},
+    FaultDescription {.code = SIGSEGV, .name = "SIGSEGV", .addressIsRelevant = true}
+};
+
+#elif defined(FC_OS_WIN32)
+
+// The six codes at the end have no winnt.h macro: three live in ntstatus.h, which cannot be
+// included alongside windows.h without WIN32_NO_STATUS, and the last is an MSVC exception-handling
+// implementation detail that Microsoft does not document as a constant (but it comes up in real
+// life often enough that we should handle it).
+// For documentation of values see MS-ERREF section 2.3.1 --
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref
+constexpr std::array faultCodeToDescription {
+    FaultDescription {.code = EXCEPTION_GUARD_PAGE,               .name = "EXCEPTION_GUARD_PAGE",               .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_DATATYPE_MISALIGNMENT,    .name = "EXCEPTION_DATATYPE_MISALIGNMENT",    .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_BREAKPOINT,               .name = "EXCEPTION_BREAKPOINT",               .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_SINGLE_STEP,              .name = "EXCEPTION_SINGLE_STEP",              .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_INVALID_HANDLE,           .name = "EXCEPTION_INVALID_HANDLE",           .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_ILLEGAL_INSTRUCTION,      .name = "EXCEPTION_ILLEGAL_INSTRUCTION",      .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_ACCESS_VIOLATION,         .name = "EXCEPTION_ACCESS_VIOLATION",         .addressIsRelevant = true},
+    FaultDescription {.code = EXCEPTION_IN_PAGE_ERROR,            .name = "EXCEPTION_IN_PAGE_ERROR",            .addressIsRelevant = true},
+    FaultDescription {.code = EXCEPTION_NONCONTINUABLE_EXCEPTION, .name = "EXCEPTION_NONCONTINUABLE_EXCEPTION", .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_INVALID_DISPOSITION,      .name = "EXCEPTION_INVALID_DISPOSITION",      .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_ARRAY_BOUNDS_EXCEEDED,    .name = "EXCEPTION_ARRAY_BOUNDS_EXCEEDED",    .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_FLT_DENORMAL_OPERAND,     .name = "EXCEPTION_FLT_DENORMAL_OPERAND",     .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_FLT_DIVIDE_BY_ZERO,       .name = "EXCEPTION_FLT_DIVIDE_BY_ZERO",       .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_FLT_INEXACT_RESULT,       .name = "EXCEPTION_FLT_INEXACT_RESULT",       .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_FLT_INVALID_OPERATION,    .name = "EXCEPTION_FLT_INVALID_OPERATION",    .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_FLT_OVERFLOW,             .name = "EXCEPTION_FLT_OVERFLOW",             .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_FLT_STACK_CHECK,          .name = "EXCEPTION_FLT_STACK_CHECK",          .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_FLT_UNDERFLOW,            .name = "EXCEPTION_FLT_UNDERFLOW",            .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_INT_DIVIDE_BY_ZERO,       .name = "EXCEPTION_INT_DIVIDE_BY_ZERO",       .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_INT_OVERFLOW,             .name = "EXCEPTION_INT_OVERFLOW",             .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_PRIV_INSTRUCTION,         .name = "EXCEPTION_PRIV_INSTRUCTION",         .addressIsRelevant = false},
+    FaultDescription {.code = EXCEPTION_STACK_OVERFLOW,           .name = "EXCEPTION_STACK_OVERFLOW",           .addressIsRelevant = false},
+    FaultDescription {.code = 0xC0000374U,                        .name = "STATUS_HEAP_CORRUPTION",             .addressIsRelevant = false},
+    FaultDescription {.code = 0xC0000409U,                        .name = "STATUS_STACK_BUFFER_OVERRUN",        .addressIsRelevant = false},
+    FaultDescription {.code = 0xC0000420U,                        .name = "STATUS_ASSERTION_FAILURE",           .addressIsRelevant = false},
+    FaultDescription {.code = 0xC0000417U,                        .name = "STATUS_INVALID_CRUNTIME_PARAMETER",  .addressIsRelevant = false},
+    FaultDescription {.code = 0xC0000602U,                        .name = "STATUS_FAIL_FAST_EXCEPTION",         .addressIsRelevant = false},
+    FaultDescription {.code = 0xE06D7363U,                        .name = "MSVC_CPP_EXCEPTION",                 .addressIsRelevant = false}
+};
+
+#else
+
+// Where are we?! Actually, probably Cygwin. Don't panic, we're just a bit lost.
+constexpr std::array<FaultDescription, 0> faultCodeToDescription {};
+
+#endif
+}
+
+// clang-format on
+
+[[nodiscard]] bool faultAddressIsMeaningful(std::uint32_t code)
+{
+    const auto description = std::ranges::find(faultCodeToDescription, code, &FaultDescription::code);
+    if (description != faultCodeToDescription.end()) {
+        return description->addressIsRelevant;
+    }
+    return false;
+}
+
+std::optional<FaultDescription> describeFaultCode(std::uint32_t code)
+{
+    const auto signal = std::ranges::find(faultCodeToDescription, code, &FaultDescription::code);
+    return signal != faultCodeToDescription.end() ? std::make_optional(*signal) : std::nullopt;
+}
+
+std::string faultCodeName(std::uint32_t code)
+{
+    if (const auto description = describeFaultCode(code)) {
+        return std::string(description->name);
+    }
+    return fmt::format("UNKNOWN(0x{:08X})", code);
+}
+
+}  // namespace Base::CrashReporter

--- a/src/Base/CrashReporter/FaultCodes.h
+++ b/src/Base/CrashReporter/FaultCodes.h
@@ -66,4 +66,20 @@ std::optional<FaultDescription> BaseExport describeFaultCode(std::uint32_t code)
  */
 [[nodiscard]] std::string BaseExport faultCodeName(std::uint32_t code);
 
+/**
+ * Translate from an internal OS ID to a user-readable string.
+ *
+ * @param osID The operating system identifier stored in the crash report
+ * @return A human-readable operating system name for that osID
+ */
+[[nodiscard]] std::string_view BaseExport osName(OS osID);
+
+/**
+ * Translate from an internal architecture ID to a user-readable string.
+ *
+ * @param architectureID The architecture identifier stored in the crash report
+ * @return A human-readable architecture name for that architectureID
+ */
+[[nodiscard]] std::string_view BaseExport architectureName(Architecture architectureID);
+
 }  // namespace Base::CrashReporter

--- a/src/Base/CrashReporter/FaultCodes.h
+++ b/src/Base/CrashReporter/FaultCodes.h
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 The FreeCAD project association AISBL
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+// Fault code mapping: translates from the signal code number to the name of the signal and an
+// indicator about whether that signal has an "address" that is relevant.
+
+#pragma once
+
+#include <FCGlobal.h>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <Base/CrashReporter/Format.h>
+
+namespace Base::CrashReporter
+{
+
+struct FaultDescription
+{
+    std::uint32_t code;
+    std::string_view name;
+    bool addressIsRelevant;
+};
+
+/**
+ * Determine whether the fault address is expected to hold meaning for a given code.
+ *
+ * @param[in] code The signal/fault code
+ * @return True if the address is expected to contain useful information, otherwise false
+ */
+[[nodiscard]] bool BaseExport faultAddressIsMeaningful(std::uint32_t code);
+
+/**
+ * Map a signal/exception number to a description.
+ *
+ * @param[in] code The signal/fault code
+ * @return A description of the signal, or std::nullopt
+ */
+std::optional<FaultDescription> BaseExport describeFaultCode(std::uint32_t code);
+
+/**
+ * Get a text representation of the fault that a given code represents.
+ *
+ * @param code The signal/fault code
+ * @return The user-visible label for a signal code. Still not quite "friendly", but better than a
+ * random-looking number.
+ */
+[[nodiscard]] std::string BaseExport faultCodeName(std::uint32_t code);
+
+}  // namespace Base::CrashReporter

--- a/src/Base/CrashReporter/Format.h
+++ b/src/Base/CrashReporter/Format.h
@@ -124,7 +124,6 @@ struct Header
     std::uint32_t buildIDStringOffset = NoString;
     std::uint32_t freecadVersionSuffixStringOffset = NoString;
     std::uint32_t minidumpPathStringOffset = NoString;
-    std::uint32_t exceptionMessageStringOffset = NoString;
 
     OS osID = OS::None;
     Architecture architectureID = Architecture::None;
@@ -132,8 +131,8 @@ struct Header
     std::uint8_t freecadVersionMinor = 0;
     std::uint8_t freecadVersionPatch = 0;
 
-    // The real data above takes up 81 bytes: pad it out to the HeaderSize
-    std::array<std::uint8_t, HeaderSize - 81> padding = {};
+    // The real data above takes up 77 bytes: pad it out to the HeaderSize
+    std::array<std::uint8_t, HeaderSize - 77> padding = {};
 };
 
 static_assert(sizeof(Header) == HeaderSize);

--- a/src/Base/CrashReporter/Manager.cpp
+++ b/src/Base/CrashReporter/Manager.cpp
@@ -202,12 +202,12 @@ void Manager::enforceRetention(RetentionPolicy policy)
     }
 }
 
-std::pair<std::string, std::string> Manager::archiveFile(
+std::pair<std::string, std::optional<std::string>> Manager::archiveFile(
     const std::string& fcrashPath,
-    const std::string& dumpPath
+    const std::optional<std::string>& dumpPath
 )
 {
-    std::pair<std::string, std::string> newPaths {fcrashPath, dumpPath};
+    std::pair<std::string, std::optional<std::string>> newPaths {fcrashPath, dumpPath};
     auto archivePath = getArchive();
     if (!archivePath.exists()) {
         if (!archivePath.createDirectories()) {
@@ -219,8 +219,8 @@ std::pair<std::string, std::string> Manager::archiveFile(
         fcrashInfo.renameFile((archiveBase + "/" + fcrashInfo.fileName()).c_str());
         newPaths.first = fcrashInfo.filePath();
     }
-    if (!dumpPath.empty()) {
-        if (FileInfo dmpInfo {dumpPath}; dmpInfo.exists()) {
+    if (dumpPath.has_value() && !dumpPath.value().empty()) {
+        if (FileInfo dmpInfo {dumpPath.value()}; dmpInfo.exists()) {
             dmpInfo.renameFile((archiveBase + "/" + dmpInfo.fileName()).c_str());
             newPaths.second = dmpInfo.filePath();
         }

--- a/src/Base/CrashReporter/Manager.cpp
+++ b/src/Base/CrashReporter/Manager.cpp
@@ -42,7 +42,11 @@ using namespace Base::CrashReporter;
 static std::string s_crashReportDirectory;
 static std::vector<ParsedCrashReport> s_reports;
 
-void Manager::scan(const std::string& crashReportDirectory, RetentionPolicy policy)
+void Manager::scan(
+    const std::string& crashReportDirectory,
+    RetentionPolicy policy,
+    const std::string& osVersion
+)
 {
     FileInfo fileInfo {crashReportDirectory};
     if (!fileInfo.exists()) {
@@ -63,6 +67,9 @@ void Manager::scan(const std::string& crashReportDirectory, RetentionPolicy poli
             // This is what we are looking for: read it
             try {
                 auto report = parse(contentItem.filePath());
+                if (!osVersion.empty()) {
+                    report.osVersion = osVersion;
+                }
                 archive(report);
                 report.stackFrames = trimLeadingPlumbingFrames(report.stackFrames);
                 s_reports.push_back(report);

--- a/src/Base/CrashReporter/Manager.h
+++ b/src/Base/CrashReporter/Manager.h
@@ -24,6 +24,7 @@
 
 #include <chrono>
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -97,12 +98,12 @@ private:
      * @param fcrashPath path to the *.fcrash file
      * @param dumpPath path to the *.dmp file
      *
-     * @returns a pair of new path strings pointing to the archived files (the minidump string will
-     * be empty if there was no minidump file).
+     * @returns a pair of new path strings pointing to the archived files (the minidump optional
+     * will be `nullopt` if there was no minidump file).
      */
-    static std::pair<std::string, std::string> archiveFile(
+    static std::pair<std::string, std::optional<std::string>> archiveFile(
         const std::string& fcrashPath,
-        const std::string& dumpPath = {}
+        const std::optional<std::string>& dumpPath = std::nullopt
     );
 };
 

--- a/src/Base/CrashReporter/Manager.h
+++ b/src/Base/CrashReporter/Manager.h
@@ -57,8 +57,14 @@ public:
      *
      * @param crashReportDirectory The path to the new crash reports
      * @param policy A report retention policy that overrides the defaults (optional)
+     * @param osVersion A string description of the version of the current operating system version:
+     * passed in here so that nothing in Base needs to be able to access that information.
      */
-    static void scan(const std::string& crashReportDirectory, RetentionPolicy policy = {});
+    static void scan(
+        const std::string& crashReportDirectory,
+        RetentionPolicy policy = {},
+        const std::string& osVersion = {}
+    );
 
     /**
      * Get the reports that were discovered by the last run of `scan()`.

--- a/src/Base/CrashReporter/Reader.cpp
+++ b/src/Base/CrashReporter/Reader.cpp
@@ -21,6 +21,7 @@
 
 #include "Reader.h"
 #include "Format.h"
+#include "FaultCodes.h"
 
 #include <Build/Version.h>
 
@@ -51,10 +52,10 @@ using namespace Base::CrashReporter;
 
 namespace
 {
-std::string_view extractStringFromTable(std::span<const char> stringTable, std::size_t offset)
+std::optional<std::string> extractStringFromTable(std::span<const char> stringTable, std::size_t offset)
 {
     if (offset == NoString) {
-        return {};
+        return std::nullopt;
     }
     if (offset + sizeof(std::uint16_t) > stringTable.size()) {
         throw Base::BadFormatError("String buffer ran out of data");
@@ -69,7 +70,7 @@ std::string_view extractStringFromTable(std::span<const char> stringTable, std::
         throw Base::BadFormatError("String length exceeds storage");
     }
 
-    return {stringTable.data() + offset + sizeof(std::uint16_t), length};
+    return std::string {stringTable.data() + offset + sizeof(std::uint16_t), length};
 }
 
 #ifdef FC_HAVE_CPPTRACE
@@ -97,7 +98,7 @@ std::string stripSourceRoot(const std::string& path)
         = std::filesystem::path(FC_SOURCE_DIR).lexically_normal().generic_string();
 
     if (!sourceRoot.empty() && normalized.size() > sourceRoot.size()
-        && normalized.starts_with(sourceRoot) && normalized[sourceRoot.size()] == '/') {
+        && normalized.starts_with(sourceRoot) && normalized.at(sourceRoot.size()) == '/') {
         return normalized.substr(sourceRoot.size() + 1);
     }
 
@@ -174,13 +175,17 @@ ParsedCrashReport Base::CrashReporter::parse(const std::string& pathToRawReportF
         || hasFlag(header.flags, Flags::PartialWrite);
 
     parsedReport.pathToRawReportFile = pathToRawReportFile;
-    parsedReport.faultAddress = header.faultAddress;
+    parsedReport.code = header.code;
+    parsedReport.faultName = faultCodeName(header.code);
+    if (faultAddressIsMeaningful(header.code)) {
+        parsedReport.faultAddress = header.faultAddress;
+    }
+
     parsedReport.threadID = header.threadID;
     parsedReport.timestamp = std::chrono::system_clock::time_point {
         std::chrono::seconds {header.timestamp}
     };
     parsedReport.processID = header.processID;
-    parsedReport.code = header.code;
 
     parsedReport.captureWasSignalSafe = hasFlag(header.flags, Flags::CaptureWasSignalSafe);
 
@@ -192,8 +197,6 @@ ParsedCrashReport Base::CrashReporter::parse(const std::string& pathToRawReportF
 
     parsedReport.buildID = extractStringFromTable(stringTable, header.buildIDStringOffset);
     parsedReport.minidumpPath = extractStringFromTable(stringTable, header.minidumpPathStringOffset);
-    parsedReport.exceptionMessage
-        = extractStringFromTable(stringTable, header.exceptionMessageStringOffset);
 
     // parsedReport.osVersion = Set by App-level consumer at report-submission, Base has no easy
     // access to OS information
@@ -204,7 +207,7 @@ ParsedCrashReport Base::CrashReporter::parse(const std::string& pathToRawReportF
     parsedReport.freecadVersionMinor = header.freecadVersionMinor;
     parsedReport.freecadVersionPatch = header.freecadVersionPatch;
     parsedReport.freecadVersionSuffix
-        = extractStringFromTable(stringTable, header.freecadVersionSuffixStringOffset);
+        = extractStringFromTable(stringTable, header.freecadVersionSuffixStringOffset).value_or("");
 
     // Read the stack frames (with some error checking):
     if (header.frameCount > MaxFrames) {
@@ -216,8 +219,7 @@ ParsedCrashReport Base::CrashReporter::parse(const std::string& pathToRawReportF
 
 #if defined(FC_HAVE_CPPTRACE) && defined(FCRepositoryHash)
     // Check to see if the current running version is the same as the one in the fcrash file:
-    const bool doSymbolication = !parsedReport.buildID.empty()
-        && parsedReport.buildID == std::string(FCRepositoryHash);
+    const bool doSymbolication = parsedReport.buildID == FCRepositoryHash;
 #else
     constexpr bool doSymbolication = false;
 #endif
@@ -237,7 +239,8 @@ ParsedCrashReport Base::CrashReporter::parse(const std::string& pathToRawReportF
             cpptrace::object_frame objectFrame;
             objectFrame.raw_address = rawFrame.rawAddress;
             objectFrame.object_address = rawFrame.moduleOffset;
-            objectFrame.object_path = extractStringFromTable(stringTable, rawFrame.moduleStringOffset);
+            objectFrame.object_path
+                = extractStringFromTable(stringTable, rawFrame.moduleStringOffset).value_or("");
             modulePathMap[objectFrame.raw_address] = objectFrame.object_path;  // For later lookup
             objectTrace.frames.push_back(std::move(objectFrame));
         }
@@ -254,12 +257,16 @@ ParsedCrashReport Base::CrashReporter::parse(const std::string& pathToRawReportF
             // To avoid any PII in the backtrace, only include the filename, not the full path:
             parsedFrame.modulePath = FileInfo(objectPath).fileName();
 
-            parsedFrame.symbol = stripSymbolOffset(frame.symbol);
+            parsedFrame.symbol = frame.symbol.empty()
+                ? std::nullopt
+                : std::make_optional(stripSymbolOffset(frame.symbol));
 
             // `file` means a source file, if we've got it
             const bool haveRealSourceFile = !frame.filename.empty() && frame.filename != objectPath;
-            parsedFrame.file = haveRealSourceFile ? stripSourceRoot(frame.filename) : std::string {};
-            parsedFrame.line = frame.line.has_value() ? std::optional(frame.line.value())
+            parsedFrame.file = haveRealSourceFile
+                ? std::make_optional(stripSourceRoot(frame.filename))
+                : std::nullopt;
+            parsedFrame.line = frame.line.has_value() ? std::make_optional(frame.line.value())
                                                       : std::nullopt;
             parsedFrame.isInline = frame.is_inline;
             parsedReport.stackFrames.push_back(std::move(parsedFrame));
@@ -280,8 +287,12 @@ ParsedCrashReport Base::CrashReporter::parse(const std::string& pathToRawReportF
             ParsedFrame parsedFrame;
             parsedFrame.rawAddress = rawFrame.rawAddress;
             parsedFrame.moduleOffset = rawFrame.moduleOffset;
-            std::string modulePath {extractStringFromTable(stringTable, rawFrame.moduleStringOffset)};
-            parsedFrame.modulePath = FileInfo(modulePath).fileName();  // Avoid PII!
+            std::optional<std::string> modulePath {
+                extractStringFromTable(stringTable, rawFrame.moduleStringOffset)
+            };
+
+            // Strip any potential PII from the crashing filename:
+            parsedFrame.modulePath = FileInfo(modulePath.value_or("")).fileName();
 
             parsedReport.stackFrames.push_back(std::move(parsedFrame));
         }
@@ -305,7 +316,7 @@ std::vector<ParsedFrame> Base::CrashReporter::trimLeadingPlumbingFrames(
 
     auto isAnchor = [&](const ParsedFrame& frame) {
         return std::ranges::any_of(dispatchAnchors, [&](std::string_view anchor) {
-            return frame.symbol.find(anchor) != std::string::npos;
+            return frame.symbol.has_value() && frame.symbol.value().find(anchor) != std::string::npos;
         });
     };
 

--- a/src/Base/CrashReporter/Reader.cpp
+++ b/src/Base/CrashReporter/Reader.cpp
@@ -198,8 +198,7 @@ ParsedCrashReport Base::CrashReporter::parse(const std::string& pathToRawReportF
     parsedReport.buildID = extractStringFromTable(stringTable, header.buildIDStringOffset);
     parsedReport.minidumpPath = extractStringFromTable(stringTable, header.minidumpPathStringOffset);
 
-    // parsedReport.osVersion = Set by App-level consumer at report-submission, Base has no easy
-    // access to OS information
+    // parsedReport.osVersion = Set by the manager, which is called from App (which has this info)
     parsedReport.osID = header.osID;
     parsedReport.architectureID = header.architectureID;
 

--- a/src/Base/CrashReporter/Reader.h
+++ b/src/Base/CrashReporter/Reader.h
@@ -38,15 +38,15 @@ struct ParsedFrame
 {
     // Raw Data
     std::uint64_t rawAddress = 0;
-    std::uint64_t moduleOffset = 0;
+    std::optional<std::uint64_t> moduleOffset {};
     // NOTE: Nothing that leaves the Reader may contain PII. Both modulePath and file arrive as
     // absolute paths from the machine that did the build, which for a self-built FreeCAD means
     // the developer's home directory, so both are reduced before they are stored here.
     std::string modulePath {};  // Filename only
 
     // Symbolicated frame
-    std::string symbol {};
-    std::string file {};  // Relative to the source root where that can be determined
+    std::optional<std::string> symbol {};
+    std::optional<std::string> file {};  // Relative to the source root where that can be determined
     std::optional<std::uint32_t> line {};
     bool isInline {false};
 };
@@ -55,22 +55,22 @@ struct ParsedCrashReport
 {
     std::string pathToRawReportFile {};
 
-    std::uint64_t faultAddress = 0;
+    std::optional<std::uint64_t> faultAddress {};
     std::uint64_t threadID = 0;
     std::chrono::system_clock::time_point timestamp {};
 
     std::uint32_t processID = 0;
     std::uint32_t code = 0;  // Signal number or SEH ExceptionCode
+    std::string faultName {};
 
     bool partialWrite {false};
     bool captureWasSignalSafe {false};
 
-    std::string buildID {};
-    std::string minidumpPath {};
-    std::string exceptionMessage {};
+    std::optional<std::string> buildID {};
+    std::optional<std::string> minidumpPath {};
 
     OS osID = OS::None;
-    std::string osVersion {};
+    std::optional<std::string> osVersion {};
     Architecture architectureID = Architecture::None;
 
     std::uint8_t freecadVersionMajor = 0;

--- a/src/Base/CrashReporter/Reader.h
+++ b/src/Base/CrashReporter/Reader.h
@@ -70,7 +70,12 @@ struct ParsedCrashReport
     std::optional<std::string> minidumpPath {};
 
     OS osID = OS::None;
+
+    // Note that osVersion is always going to be the *reading* version, not the *crashing* version:
+    // the code to get the version can't be run async-signal-safe during a crash, so some tiny
+    // percentage of the time (an OS upgrade between the crash and the reload) this will be wrong.
     std::optional<std::string> osVersion {};
+
     Architecture architectureID = Architecture::None;
 
     std::uint8_t freecadVersionMajor = 0;

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -22,6 +22,7 @@ SET(Test_SRCS
     Workbench.py
     unittestgui.py
     testmakeWireString.py
+    TestCrashReporter.py
     TestPythonSyntax.py
     TestPerf.py
     TestTreeSelection.py

--- a/src/Mod/Test/Init.py
+++ b/src/Mod/Test/Init.py
@@ -33,4 +33,5 @@ FreeCAD.__unit_test__ += [
     "StringHasher",
     "UnicodeTests",
     "TestPythonSyntax",
+    "TestCrashReporter",
 ]

--- a/src/Mod/Test/TestCrashReporter.py
+++ b/src/Mod/Test/TestCrashReporter.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 FreeCAD contributors
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+"""Tests of the Python wrappers for the Crash Reporter. Note that most CrashReporter testing
+happens on the C++ side, so this file contains only the tests necessary to prove that the
+Python bindings correctly interface with the C++ code. They are not end-to-end tests of the
+crash reporting system."""
+
+import inspect
+import types
+import unittest
+
+import FreeCAD as App
+
+
+class TestCrashReporter(unittest.TestCase):
+
+    def testGetCrashReportsReturnsAList(self):
+        """Never none, never some other type: just a list"""
+        self.assertIsInstance(App.getCrashReports(), list)
+
+    def testGetLastCrashReportReturnsReportOrNone(self):
+        """Always returns either a CrashReport object or None, no other type"""
+        report = App.getLastCrashReport()
+        self.assertIsInstance(report, (App.CrashReport, type(None)))
+
+    def testNoConstruction(self):
+        """There is intentionally no way for Python to create a CrashReport (which would almost
+        certainly be pure trash), so make sure someone doesn't accidentally flip the switch to
+        make a constructor for these types."""
+        for dont_make_one_of_these in [App.CrashReport, App.CrashFrame]:
+            # With Constructor=False, FreeCAD raises a RuntimeError, not a TypeError, here
+            with self.assertRaises(RuntimeError):
+                _ = dont_make_one_of_these()
+
+    def testCrashReportAPICheck(self):
+        """The API should not be inadvertently changed. If you add something to it, make sure you
+        *also* add it to this list. If you remove something... well, don't do that :), you'll probably
+        break some Addons."""
+        crash_report_attributes = (
+            "path_to_raw_report_file",
+            "fault_address",
+            "thread_id",
+            "timestamp",
+            "process_id",
+            "fault_code",
+            "fault_name",
+            "partial_write",
+            "capture_was_signal_safe",
+            "build_id",
+            "minidump_path",
+            "os",
+            "os_version",
+            "architecture",
+            "freecad_version",
+            "symbolicated",
+            "stack_frames",
+        )
+
+        self.assertEqual(
+            set(crash_report_attributes),
+            {n for n in dir(App.CrashReport) if not n.startswith("_")},
+        )
+
+        # We can also make sure it's really a binding, and not something else
+        for attr in crash_report_attributes:
+            with self.subTest(attribute=attr):
+                self.assertIsInstance(
+                    inspect.getattr_static(App.CrashReport, attr),
+                    types.GetSetDescriptorType,
+                )
+
+    def testCrashFrameAPICheck(self):
+        """Same reasoning as testCrashReportAPICheck, above"""
+        crash_frame_attributes = (
+            "address",
+            "module_offset",
+            "module",
+            "symbol",
+            "file",
+            "line",
+            "is_inline",
+        )
+
+        self.assertEqual(
+            set(crash_frame_attributes),
+            {n for n in dir(App.CrashFrame) if not n.startswith("_")},
+        )
+
+        # We can also make sure it's really a binding, and not something else
+        for attr in crash_frame_attributes:
+            with self.subTest(attribute=attr):
+                self.assertIsInstance(
+                    inspect.getattr_static(App.CrashFrame, attr),
+                    types.GetSetDescriptorType,
+                )
+
+    def testMethodsDontTakeArguments(self):
+        """None of the functions in this API take any arguments."""
+
+        # Noting for the record that if this ever *doesn't* fail, clearCrashReports will end up
+        # clearing the caller's *real* crash report directory. So don't go changing this API
+        # without updating the tests!!
+        functions = [App.getLastCrashReport, App.getCrashReports, App.clearCrashReports]
+        for func in functions:
+            with self.subTest(func=func):
+                with self.assertRaises(TypeError):
+                    func(42)

--- a/tests/src/Base/CrashReporter_tests.cpp
+++ b/tests/src/Base/CrashReporter_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <Base/CrashReporter/FaultCodes.h>
 #include <Base/CrashReporter/Reader.h>
 #include <Base/CrashReporter/Writer.h>
 #include <Base/CrashReporter/Manager.h>
@@ -14,7 +15,13 @@
 #include <cstring>  // IWYU pragma: keep
 #include <fstream>
 
-#ifdef _MSC_VER
+#ifdef FC_OS_WIN32
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# ifndef NOMINMAX
+#  define NOMINMAX
+# endif
 # include <windows.h>
 # include <cstdlib>  // IWYU pragma: keep
 # include <Base/CrashReporter/WindowsCrashReporter.h>
@@ -23,15 +30,34 @@
 # include <sys/resource.h>
 #endif
 
-/// Whether this is a fault code that carries a faulting data address, on the platform this test
-/// binary was built for. These are the only codes for which the Writer can populate one. POSIX
-/// has two: an unmapped access is reported as SIGBUS rather than SIGSEGV on some platforms.
+/// For tests that need a fault that specifically contains an address
+constexpr std::uint32_t syntheticFaultCodeWithAddress()
+{
+#ifdef FC_OS_WIN32
+    return EXCEPTION_ACCESS_VIOLATION;
+#else
+    return SIGSEGV;
+#endif
+}
+
+/// The reverse of the above: a code that does *not* contain an address
+constexpr std::uint32_t syntheticFaultCodeWithoutAddress()
+{
+#ifdef FC_OS_WIN32
+    return EXCEPTION_STACK_OVERFLOW;
+#else
+    return SIGABRT;
+#endif
+}
+
+/// A check for the above: not general, specific to this test suite -- all tests below use this set
+/// of three utility methods to manage this bit of machinery.
 constexpr bool isAddressCarryingFaultCode(std::uint32_t code)
 {
 #ifdef FC_OS_WIN32
-    return code == EXCEPTION_ACCESS_VIOLATION;
+    return code == syntheticFaultCodeWithAddress();
 #else
-    return code == SIGSEGV || code == SIGBUS;
+    return code == syntheticFaultCodeWithAddress() || code == SIGBUS;
 #endif
 }
 
@@ -40,7 +66,9 @@ constexpr bool isAddressCarryingFaultCode(std::uint32_t code)
 class CrashReporterTests: public testing::Test
 {
 public:
-    static std::vector<char> createGoodCrashReport();
+    static std::vector<char> createGoodCrashReport(
+        std::uint32_t faultCode = syntheticFaultCodeWithAddress()
+    );
 
     /// Sometimes we need a name that can actually be parsed (for example, to test `scan()`). This
     /// creates an on-disk file with a name that the code internals can parse.
@@ -59,10 +87,10 @@ public:
         bool withDump = false
     );
 
-    /// Check for existence of archived fcrash with this timestamp and PID
+    /// Check for the existence of archived fcrash with this timestamp and PID
     static bool archivedFcrashExists(const std::filesystem::path& dir, std::int64_t ts, int pid);
 
-    /// Check for existence of archived minidump with this timestamp and PID
+    /// Check for the existence of archived minidump with this timestamp and PID
     static bool archivedDumpExists(const std::filesystem::path& dir, std::int64_t ts, int pid);
 
 protected:
@@ -79,20 +107,31 @@ uint32_t addStringToTable(std::vector<char>& stringTable, const std::string& str
     return offset;
 }
 
-std::vector<char> CrashReporterTests::createGoodCrashReport()
+std::vector<char> CrashReporterTests::createGoodCrashReport(std::uint32_t faultCode)
 {
     std::vector<char> buffer;
 
     Base::CrashReporter::Header header;
+
+    // Always planted, whatever the fault code
     header.faultAddress = 0xDEADBEEFCAFEF00D;
+
     header.threadID = 0x1122334455667788;
     header.timestamp = 1700000000;
     header.processID = 0xABCD;
-    header.code = 11;  // SIGSEGV
+    header.code = faultCode;
     header.freecadVersionMajor = 5;
     header.freecadVersionMinor = 6;
     header.freecadVersionPatch = 7;
+#ifdef FC_OS_MACOSX
+    header.osID = Base::CrashReporter::OS::macOS;
+#elif defined(FC_OS_WIN32)
     header.osID = Base::CrashReporter::OS::Windows;
+#elif defined(FC_OS_LINUX)
+    header.osID = Base::CrashReporter::OS::Linux;
+#elif defined(FC_OS_BSD)
+    header.osID = Base::CrashReporter::OS::BSDFamily;
+#endif
     header.architectureID = Base::CrashReporter::Architecture::x64;
 
     std::vector<char> stringTable;
@@ -101,7 +140,6 @@ std::vector<char> CrashReporterTests::createGoodCrashReport()
 #else
     header.buildIDStringOffset = addStringToTable(stringTable, "R43210");
 #endif
-    header.exceptionMessageStringOffset = addStringToTable(stringTable, "A bad thing happened");
     header.freecadVersionSuffixStringOffset = addStringToTable(stringTable, "dev");
     header.minidumpPathStringOffset = Base::CrashReporter::NoString;
 
@@ -239,9 +277,22 @@ TEST_F(CrashReporterTests, parseGoodCrashReportLoads)  // NOLINT
         ofs.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
     }
     auto report = Base::CrashReporter::parse(fcrashPath.string());
+
+    // On all platforms we've specifically chosen a fault code that has an address, so make sure
+    // it's there:
     EXPECT_EQ(report.faultAddress, 0xDEADBEEFCAFEF00D);
     EXPECT_EQ(report.threadID, 0x1122334455667788);
+
+#ifdef FC_OS_MACOSX
+    EXPECT_EQ(report.osID, Base::CrashReporter::OS::macOS);
+#elif defined(FC_OS_WIN32)
     EXPECT_EQ(report.osID, Base::CrashReporter::OS::Windows);
+#elif defined(FC_OS_LINUX)
+    EXPECT_EQ(report.osID, Base::CrashReporter::OS::Linux);
+#elif defined(FC_OS_BSD)
+    EXPECT_EQ(report.osID, Base::CrashReporter::OS::BSDFamily);
+#endif
+
     EXPECT_EQ(report.architectureID, Base::CrashReporter::Architecture::x64);
     EXPECT_FALSE(report.partialWrite);
 #ifdef FCRepositoryHash
@@ -249,14 +300,61 @@ TEST_F(CrashReporterTests, parseGoodCrashReportLoads)  // NOLINT
 #else
     EXPECT_EQ(report.buildID, "R43210");
 #endif
-    EXPECT_EQ(report.exceptionMessage, "A bad thing happened");
-    EXPECT_TRUE(report.minidumpPath.empty());  // NoString -> empty
+    EXPECT_FALSE(report.minidumpPath.has_value());
     ASSERT_EQ(report.stackFrames.size(), 4U);
     EXPECT_EQ(report.stackFrames.at(0).rawAddress, 0x11111111U);
     EXPECT_EQ(report.stackFrames.at(0).modulePath, "Module1");
     EXPECT_EQ(report.stackFrames.at(1).modulePath, "Module1");  // deduped offset
     EXPECT_EQ(report.stackFrames.at(2).modulePath, "Module2");
     EXPECT_TRUE(report.stackFrames.at(3).modulePath.empty());  // NoString frame
+}
+
+TEST_F(CrashReporterTests, parseDropsFaultAddressForCodeThatHasNone)  // NOLINT
+{
+    auto fcrashPath = tempDir.path() / "no_fault_address.fcrash";
+    {
+        std::ofstream ofs(fcrashPath, std::ios::binary);
+        auto buffer = createGoodCrashReport(syntheticFaultCodeWithoutAddress());
+        ofs.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+    }
+    auto report = Base::CrashReporter::parse(fcrashPath.string());
+
+    // The record carries 0xDEADBEEFCAFEF00D like every other fixture, but this fault code has no
+    // faulting data address, so the Reader must drop it rather than pass it on.
+    EXPECT_FALSE(report.faultAddress.has_value());
+    EXPECT_EQ(report.code, syntheticFaultCodeWithoutAddress());
+
+    // The record is well-formed: everything else must still parse.
+    EXPECT_FALSE(report.partialWrite);
+    EXPECT_EQ(report.threadID, 0x1122334455667788);
+    EXPECT_EQ(report.processID, 0xABCDU);
+    ASSERT_EQ(report.stackFrames.size(), 4U);
+}
+
+TEST_F(CrashReporterTests, parseNamesUnrecognizedFaultCodeWithItsHexValue)  // NOLINT
+{
+    // Not a valid fault code on any platform we support, so it cannot be in the lookup table.
+    constexpr std::uint32_t unrecognizedCode = std::numeric_limits<std::uint32_t>::max();
+
+    auto fcrashPath = tempDir.path() / "unrecognized_fault_code.fcrash";
+    {
+        std::ofstream ofs(fcrashPath, std::ios::binary);
+        auto buffer = createGoodCrashReport(unrecognizedCode);
+        ofs.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+    }
+    auto report = Base::CrashReporter::parse(fcrashPath.string());
+
+    // The exact spelling is deliberately pinned: downstream consumers might be doing something with
+    // this, don't change it without good cause. (The address doesn't matter, but the form does)
+    EXPECT_EQ(report.faultName, "UNKNOWN(0xFFFFFFFF)");
+
+    // Nothing is known about the code, so nothing can be claimed about its address either.
+    EXPECT_FALSE(report.faultAddress.has_value());
+
+    // The record itself is well-formed: only the code is unrecognized.
+    EXPECT_FALSE(report.partialWrite);
+    EXPECT_EQ(report.code, unrecognizedCode);
+    ASSERT_EQ(report.stackFrames.size(), 4U);
 }
 
 TEST_F(CrashReporterTests, parseBadMagicNumber)  // NOLINT
@@ -533,7 +631,7 @@ TEST_F(CrashReporterTests, DISABLED_DeliberateSegfaultRoundTrip)  // NOLINT
     // Keep this code around: you can uncomment it to check out a new/different OS's call stack
     // to add those symbols to the skip-list
     for (std::size_t i = 0; i < report.stackFrames.size(); ++i) {
-        std::printf("[%2zu] %s\n", i, report.stackFrames.at(i).symbol.c_str());
+        std::printf("[%2zu] %s\n", i, report.stackFrames.at(i).symbol.value_or("<unresolved>").c_str());
     }
     std::fflush(stdout);
     // END DISCOVERY CODE
@@ -588,12 +686,12 @@ TEST_F(CrashReporterTests, trimLeadingPlumbingFramesKeepsUnsymbolicatedTopFrame)
 {
     const std::vector<Base::CrashReporter::ParsedFrame> frames = {
         {.symbol = "__kernel_rt_sigreturn"},
-        {.symbol = ""},  // unsymbolicated: treated as real
+        {.symbol = std::nullopt},  // unsymbolicated: treated as real
         {.symbol = "App::foo()"},
     };
     const auto trimmed = Base::CrashReporter::trimLeadingPlumbingFrames(frames);
     EXPECT_EQ(trimmed.size(), frames.size() - 1);
-    EXPECT_TRUE(trimmed.front().symbol.empty());  // Our unsymbolicated frame is still here
+    EXPECT_FALSE(trimmed.front().symbol.has_value());  // Our unsymbolicated frame is still here
 }
 
 
@@ -857,5 +955,33 @@ TEST_F(CrashReporterTests, retentionDeletesCompanionDump)  // NOLINT
     EXPECT_FALSE(archivedFcrashExists(tempDir.path(), now - (200 * secondsPerDay), 1236));
     EXPECT_FALSE(archivedDumpExists(tempDir.path(), now - (200 * secondsPerDay), 1236));
 }
+
+TEST_F(CrashReporterTests, faultAddressIsMeaningfulReturnsFalseForCodeWithoutAddress)
+{
+    EXPECT_FALSE(Base::CrashReporter::faultAddressIsMeaningful(syntheticFaultCodeWithoutAddress()));
+}
+
+TEST_F(CrashReporterTests, faultAddressIsMeaningfulReturnsTrueForCodeWithAddress)
+{
+    // Spot check (don't bother with an exhaustive test, it's tautological)
+    EXPECT_TRUE(Base::CrashReporter::faultAddressIsMeaningful(syntheticFaultCodeWithAddress()));
+}
+
+TEST_F(CrashReporterTests, describeFaultCodeGivesValidResultForValidCode)
+{
+    // Spot check (don't bother with an exhaustive test, it's tautological)
+    auto description = Base::CrashReporter::describeFaultCode(syntheticFaultCodeWithAddress());
+    ASSERT_NE(description, std::nullopt);
+    EXPECT_FALSE(description->name.empty());
+}
+
+TEST_F(CrashReporterTests, describeFaultCodeGivesNulloptForBadCode)
+{
+    auto description = Base::CrashReporter::describeFaultCode(
+        std::numeric_limits<std::uint32_t>::max()
+    );
+    EXPECT_EQ(description, std::nullopt);
+}
+
 
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers,cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-pro-type-vararg,hicpp-vararg,cppcoreguidelines-owning-memory,cppcoreguidelines-avoid-non-const-global-variables,cert-err58-cpp)

--- a/tests/src/Base/CrashReporter_tests.cpp
+++ b/tests/src/Base/CrashReporter_tests.cpp
@@ -806,6 +806,39 @@ TEST_F(CrashReporterTests, clearBeforeScanDoesNothing)  // NOLINT
     Base::CrashReporter::Manager::clear();  // Doesn't crash, throw, etc.
 }
 
+TEST_F(CrashReporterTests, scanSetsOSVersionWhenPresent)  // NOLINT
+{
+    // Arrange
+    const auto buffer = createGoodCrashReport();
+    placeReport(tempDir.path(), 1700000000, 1234, buffer);
+
+    // Act
+    Base::CrashReporter::Manager::scan(tempDir.string(), {}, "The best version");
+    const auto& reports = Base::CrashReporter::Manager::reports();
+    ASSERT_EQ(reports.size(), 1U);
+
+    // Assert
+    const auto osVersion = reports.at(0).osVersion;
+    EXPECT_EQ(osVersion, "The best version");
+}
+
+TEST_F(CrashReporterTests, scanDoesNotSetOSVersionWhenNotPresent)  // NOLINT
+{
+    // Arrange
+    const auto buffer = createGoodCrashReport();
+    placeReport(tempDir.path(), 1700000000, 1234, buffer);
+
+    // Act
+    Base::CrashReporter::Manager::
+        scan(tempDir.string(), {} /*, No version string set here: defaults to an empty optional*/);
+    const auto& reports = Base::CrashReporter::Manager::reports();
+    ASSERT_EQ(reports.size(), 1U);
+
+    // Assert
+    const auto osVersion = reports.at(0).osVersion;
+    EXPECT_FALSE(osVersion.has_value());
+}
+
 
 namespace
 {
@@ -956,18 +989,18 @@ TEST_F(CrashReporterTests, retentionDeletesCompanionDump)  // NOLINT
     EXPECT_FALSE(archivedDumpExists(tempDir.path(), now - (200 * secondsPerDay), 1236));
 }
 
-TEST_F(CrashReporterTests, faultAddressIsMeaningfulReturnsFalseForCodeWithoutAddress)
+TEST_F(CrashReporterTests, faultAddressIsMeaningfulReturnsFalseForCodeWithoutAddress)  // NOLINT
 {
     EXPECT_FALSE(Base::CrashReporter::faultAddressIsMeaningful(syntheticFaultCodeWithoutAddress()));
 }
 
-TEST_F(CrashReporterTests, faultAddressIsMeaningfulReturnsTrueForCodeWithAddress)
+TEST_F(CrashReporterTests, faultAddressIsMeaningfulReturnsTrueForCodeWithAddress)  // NOLINT
 {
     // Spot check (don't bother with an exhaustive test, it's tautological)
     EXPECT_TRUE(Base::CrashReporter::faultAddressIsMeaningful(syntheticFaultCodeWithAddress()));
 }
 
-TEST_F(CrashReporterTests, describeFaultCodeGivesValidResultForValidCode)
+TEST_F(CrashReporterTests, describeFaultCodeGivesValidResultForValidCode)  // NOLINT
 {
     // Spot check (don't bother with an exhaustive test, it's tautological)
     auto description = Base::CrashReporter::describeFaultCode(syntheticFaultCodeWithAddress());
@@ -975,7 +1008,7 @@ TEST_F(CrashReporterTests, describeFaultCodeGivesValidResultForValidCode)
     EXPECT_FALSE(description->name.empty());
 }
 
-TEST_F(CrashReporterTests, describeFaultCodeGivesNulloptForBadCode)
+TEST_F(CrashReporterTests, describeFaultCodeGivesNulloptForBadCode)  // NOLINT
 {
     auto description = Base::CrashReporter::describeFaultCode(
         std::numeric_limits<std::uint32_t>::max()

--- a/tests/src/Base/CrashReporter_tests.cpp
+++ b/tests/src/Base/CrashReporter_tests.cpp
@@ -593,21 +593,26 @@ TEST_F(CrashReporterTests, FC_REAL_CAPTURE_TEST)  // NOLINT
     // debug information the symbolicator appends "+ <offset>", which would put a byte offset into
     // the key consumers group crashes by, so the Reader trims it.
     for (const auto& frame : report.stackFrames) {
-        const auto plus = frame.symbol.rfind(" + ");
+        if (!frame.symbol.has_value()) {
+            continue;
+        }
+        const auto& symbol = frame.symbol.value();
+        const auto plus = symbol.rfind(" + ");
         const bool endsWithOffset = plus != std::string::npos
-            && frame.symbol.find_first_not_of("0123456789", plus + 3) == std::string::npos;
-        EXPECT_FALSE(endsWithOffset) << "symbol still carries an offset: " << frame.symbol;
+            && symbol.find_first_not_of("0123456789", plus + 3) == std::string::npos;
+        EXPECT_FALSE(endsWithOffset) << "symbol still carries an offset: " << symbol;
     }
 
     // `file` is a source file. A frame with no debug information has none, and must not fall back
     // to naming the object it resolved against.
     for (const auto& frame : report.stackFrames) {
-        if (!frame.file.empty()) {
-            EXPECT_NE(frame.file, frame.modulePath);
+        if (frame.file.has_value()) {
+            EXPECT_NE(frame.file.value(), frame.modulePath);
         }
     }
 
     EXPECT_TRUE(isAddressCarryingFaultCode(report.code)) << "unexpected fault code: " << report.code;
+    EXPECT_TRUE(report.faultAddress.has_value());
     EXPECT_FALSE(report.partialWrite);
 }
 


### PR DESCRIPTION
The next phase of the new crash reporter work: getting a functional Python API. It requires some C++-side changes, and includes a small change to the CrashReport file format. I did *not* increment the format's version number, since right now this new code is the only consumer and we have not released it yet.

The biggest change is that I shifted the C++ API towards more rigorous use of `std::optional` to better describe the intent of the code (rather than using empty strings, int=-1, etc.). This does mean I touched more code than originally intended during what is ostensibly a Python API PR). I can split into a separate PR if preferred.

`Base` doesn't have good access to a well-formatted "OS Version" string now (we use a Qt function to get at it), but I didn't want to move the handling out of Base, where IMO it really belongs. So I ended up passing that string through the `scan` call. Maybe not ideal, but I thought it was better than any alternatives. `prettyProductInfoWrapper` in App is *not* a thin wrapper that could be easily shifted to Base, on macOS it does some actual work. Other potential candidates don't give very nice results: for example, `uname()` gives "Darwin 25.5.0" rather than "macOS 15.5".

NB: I tried to structure these commits the way I'd prefer they be merged (e.g. via a merge commit). Happy to discuss :).

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

(the Python tests) Assisted-by: swiss-ai/Apertus-v1.5-70B
(the C++ tests) Assisted-by: Claude Opus 5
