### PR TITLE
Introduce a generic XML parser and abstraction

### DIFF
--- a/cMake/FreeCadMacros.cmake
+++ b/cMake/FreeCadMacros.cmake
@@ -266,16 +266,24 @@ macro(generate_embed_from_py BASE_NAME OUTPUT_FILE)
 endmacro(generate_embed_from_py)
 
 macro(generate_from_any INPUT_FILE OUTPUT_FILE VARIABLE)
-		set(TOOL_PATH "${CMAKE_SOURCE_DIR}/src/Tools/PythonToCPP.py")
-		file(TO_NATIVE_PATH "${TOOL_PATH}" TOOL_NATIVE_PATH)
-		file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${INPUT_FILE}" SOURCE_NATIVE_PATH)
-		add_custom_command(
-		 		OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_FILE}"
-		 		COMMAND "${Python3_EXECUTABLE}" "${TOOL_NATIVE_PATH}" "${SOURCE_NATIVE_PATH}" "${OUTPUT_FILE}" "${VARIABLE}"
-				MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/${INPUT_FILE}"
-				DEPENDS "${TOOL_PATH}"
-				WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-				COMMENT "Building files out of ${INPUT_FILE}")
+    set(TOOL_PATH "${CMAKE_SOURCE_DIR}/src/Tools/PythonToCPP.py")
+    file(TO_NATIVE_PATH "${TOOL_PATH}" TOOL_NATIVE_PATH)
+    file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${INPUT_FILE}" SOURCE_NATIVE_PATH)
+    set(OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_FILE}")
+    add_custom_command(
+            OUTPUT "${OUTPUT_PATH}"
+            COMMAND "${Python3_EXECUTABLE}" "${TOOL_NATIVE_PATH}" "${SOURCE_NATIVE_PATH}" "${OUTPUT_FILE}" "${VARIABLE}"
+            MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/${INPUT_FILE}"
+            DEPENDS "${TOOL_PATH}"
+            WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+            COMMENT "Building files out of ${INPUT_FILE}")
+
+    set_source_files_properties(
+        "${OUTPUT_PATH}"
+        PROPERTIES
+            GENERATED TRUE
+            SKIP_AUTOGEN ON
+    )
 endmacro(generate_from_any)
 
 

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -132,7 +132,7 @@ generate_module_from_py(
     FreeCAD.Units
     Units_MODULE_GENERATED_SRCS
 )
-generate_from_any(Parameter.xsd Parameter.inl xmlSchemeString)
+generate_from_any(Resources/schemas/Parameter.xsd ParameterSchema.h ParameterSchema)
 
 if(SWIG_FOUND)
     # Create the file swigpyrun.hh and then compare with the file swigpyrun.h.
@@ -189,6 +189,7 @@ SET(FreeCADBase_UNITAPI_SRCS
     Unit.h
     Unit.cpp
     UnitPyImp.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/ParameterSchema.h
 )
 SOURCE_GROUP("Units" FILES ${FreeCADBase_UNITAPI_SRCS})
 
@@ -224,7 +225,7 @@ SET(FreeCADBase_CPP_SRCS
     Matrix.cpp
     MatrixPyImp.cpp
     Observer.cpp
-    Parameter.xsd
+    Resources/schemas/Parameter.xsd
     Parameter.cpp
     ParameterObserver.cpp
     ParameterPy.cpp
@@ -264,6 +265,7 @@ SET(FreeCADBase_CPP_SRCS
     ViewProj.cpp
     Writer.cpp
     XMLTools.cpp
+    XMLParser.cpp
     ZipHeader.cpp
 )
 
@@ -333,6 +335,7 @@ SET(FreeCADBase_HPP_SRCS
     ViewProj.h
     Writer.h
     XMLTools.h
+    XMLParser.h
     ZipHeader.h
 )
 

--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -50,7 +50,7 @@
 #include <fmt/printf.h>
 
 #include "Parameter.h"
-#include "Parameter.inl"
+#include "ParameterSchema.h"
 #include "Console.h"
 #include "Exception.h"
 #include "FileInfo.h"
@@ -2076,7 +2076,7 @@ bool ParameterManager::CheckDocument() const
 
         // Either load the XSD file from disk or use the built-in string
         // const char* xsdFile = "...";
-        std::string xsdStr(xmlSchemeString);  // NOLINT
+        std::string xsdStr(ParameterSchema);  // NOLINT
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         MemBufInputSource xsdFile(
             reinterpret_cast<const XMLByte*>(xsdStr.c_str()),

--- a/src/Base/Resources/schemas/Parameter.xsd
+++ b/src/Base/Resources/schemas/Parameter.xsd
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 To verify the user.cfg file against the XSD scheme add the following to the FCParameters element:
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/Base/XMLParser.cpp
+++ b/src/Base/XMLParser.cpp
@@ -1,0 +1,391 @@
+#include "XMLParser.h"
+
+#include <fmt/format.h>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <format>
+
+#include <xercesc/dom/DOM.hpp>
+#include <xercesc/dom/DOMDocument.hpp>
+#include <xercesc/dom/DOMElement.hpp>
+#include <xercesc/dom/DOMNamedNodeMap.hpp>
+#include <xercesc/dom/DOMNode.hpp>
+#include <xercesc/framework/LocalFileFormatTarget.hpp>
+#include <xercesc/framework/LocalFileInputSource.hpp>
+#include <xercesc/framework/MemBufFormatTarget.hpp>
+#include <xercesc/framework/MemBufInputSource.hpp>
+#include <xercesc/parsers/XercesDOMParser.hpp>
+#include <xercesc/sax/EntityResolver.hpp>
+#include <xercesc/sax/ErrorHandler.hpp>
+#include <xercesc/sax/SAXParseException.hpp>
+#include <xercesc/util/XMLException.hpp>
+#include <xercesc/util/XercesDefs.hpp>
+#include <xercesc/util/XercesVersion.hpp>
+
+
+#include "Exception.h"
+#include "XMLTools.h"
+
+using namespace XERCES_CPP_NAMESPACE;
+
+namespace
+{
+
+/**
+ * Custom error handler, stores errors and fatal errors,
+ * That can then be retrieved using `getErrors`.
+ */
+class DOMTreeErrorReporter: public ErrorHandler
+{
+public:
+    void warning(const SAXParseException& toCatch) override
+    {
+        (void)toCatch;  // Ignore all warnings.
+    }
+    void fatalError(const SAXParseException& toCatch) override
+    {
+        this->handleError(toCatch, "Fatal error");
+    }
+    void error(const SAXParseException& toCatch) override
+    {
+        this->handleError(toCatch, "Error");
+    }
+    void resetErrors() override
+    {
+        errors.clear();
+    }
+
+    std::vector<std::string> getErrors()
+    {
+        return errors;
+    }
+
+private:
+    std::vector<std::string> errors;
+    void handleError(const SAXParseException& toCatch, const std::string& errorType)
+    {
+        std::stringstream str;
+        str << errorType << " at file \"" << StrX(toCatch.getSystemId()) << "\", line "
+            << toCatch.getLineNumber() << ", column " << toCatch.getColumnNumber()
+            << "\n   Message: " << StrX(toCatch.getMessage()) << "\n";
+        errors.emplace_back(str.str());
+    }
+};
+
+
+class DOMPrintErrorHandler: public DOMErrorHandler
+{
+public:
+    DOMPrintErrorHandler() = default;
+    ~DOMPrintErrorHandler() override = default;
+
+    bool handleError(const DOMError& domError) override
+    {
+        // Display whatever error message passed from the serializer
+        char* msg = XMLString::transcode(domError.getMessage());
+        errors.emplace_back(msg);
+        XMLString::release(&msg);
+
+        // Instructs the serializer to continue serialization if possible.
+        return true;
+    }
+    void resetErrors()
+    {
+        errors.clear();
+    }
+
+    std::vector<std::string> getErrors()
+    {
+        return errors;
+    }
+
+    /* Unimplemented constructors and operators */
+    DOMPrintErrorHandler(const DOMPrintErrorHandler&) = delete;
+    DOMPrintErrorHandler(DOMPrintErrorHandler&&) = delete;
+    void operator=(const DOMPrintErrorHandler&) = delete;
+    void operator=(DOMPrintErrorHandler&&) = delete;
+
+private:
+    std::vector<std::string> errors;
+};
+
+
+void InitXercesC()
+{
+    XMLPlatformUtils::Initialize();
+}
+
+std::unique_ptr<Base::XMLElement> toXMLElement(DOMNode* document)
+{
+    auto element = std::make_unique<Base::XMLElement>();
+    if (!document) {
+        return element;
+    }
+    element->tag = StrX(document->getNodeName()).c_str();
+    if (document->hasAttributes()) {
+        DOMNamedNodeMap* attrs = document->getAttributes();
+        for (XMLSize_t i = 0; i < attrs->getLength(); i++) {
+            DOMNode* attr = attrs->item(i);
+            element->attrs[StrX(attr->getNodeName()).c_str()] = StrX(attr->getNodeValue()).c_str();
+        }
+    }
+
+    const DOMNodeList* children = document->getChildNodes();
+    for (XMLSize_t i = 0; i < children->getLength(); i++) {
+        DOMNode* child = children->item(i);
+        switch (child->getNodeType()) {
+            case DOMNode::ELEMENT_NODE:
+                element->children.emplace_back(::toXMLElement(child));
+                break;
+            case DOMNode::TEXT_NODE:
+                element->content = StrXUTF8(child->getNodeValue()).c_str();
+                break;
+            default:
+                break;
+        }
+    }
+    return element;
+}
+
+void toDOMDocument(const Base::XMLElement& source, DOMElement* root)
+{
+    for (const auto& attr : source.attrs) {
+        root->setAttribute(
+            XStr(attr.first.c_str()).unicodeForm(),
+            XStr(attr.second.c_str()).unicodeForm()
+        );
+    }
+    if (!source.content.empty()) {
+        root->setTextContent(XStr(source.content.c_str()).unicodeForm());
+    }
+    for (const auto& child : source.children) {
+        auto* childNode = root->getOwnerDocument()->createElement(
+            XStr(child->tag.c_str()).unicodeForm()
+        );
+        root->appendChild(childNode);
+        ::toDOMDocument(*child, childNode);
+    }
+}
+
+void saveDocumentToTarget(DOMDocument* doc, XMLFormatTarget* myFormTarget)
+{
+    if (!doc) {
+        return;
+    }
+
+    DOMImplementation* impl = DOMImplementationRegistry::getDOMImplementation(
+        XUTF8StrLiteral("LS").unicodeForm()
+    );
+    DOMLSSerializer* theSerializer = static_cast<DOMImplementationLS*>(impl)->createLSSerializer();
+    DOMLSOutput* theOutput = static_cast<DOMImplementationLS*>(impl)->createLSOutput();
+
+    // Plug in our own error handler
+    DOMPrintErrorHandler myErrorHandler;
+    DOMConfiguration* config = theSerializer->getDomConfig();
+
+    config->setParameter(XMLUni::fgDOMErrorHandler, &myErrorHandler);
+
+    // set feature if the serializer supports the feature/mode
+    if (config->canSetParameter(XMLUni::fgDOMWRTSplitCdataSections, true)) {
+        config->setParameter(XMLUni::fgDOMWRTSplitCdataSections, true);
+    }
+
+    if (config->canSetParameter(XMLUni::fgDOMWRTDiscardDefaultContent, true)) {
+        config->setParameter(XMLUni::fgDOMWRTDiscardDefaultContent, true);
+    }
+
+    if (config->canSetParameter(XMLUni::fgDOMWRTFormatPrettyPrint, true)) {
+        config->setParameter(XMLUni::fgDOMWRTFormatPrettyPrint, true);
+    }
+
+    theOutput->setByteStream(myFormTarget);
+    theSerializer->write(doc, theOutput);
+
+    theOutput->release();
+    theSerializer->release();
+}
+}  // namespace
+
+
+namespace Base
+{
+std::unique_ptr<XMLElement> XMLElement::clone() const
+{
+    auto result = std::make_unique<XMLElement>();
+
+    result->tag = tag;
+    result->attrs = attrs;
+    result->content = content;
+
+    result->children.reserve(children.size());
+
+    for (const auto& child : children) {
+        result->children.push_back(child->clone());
+    }
+
+    return result;
+}
+
+std::unique_ptr<XMLElement> ParseXMLFile(const fs::path& path)
+{
+    try {
+        InitXercesC();
+
+#if defined(FC_OS_WIN32)
+        std::wstring name = path.wstring();
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        LocalFileInputSource inputSource(reinterpret_cast<const XMLCh*>(name.c_str()));
+#else
+        LocalFileInputSource inputSource(XStr(path.string().c_str()).unicodeForm());
+#endif
+
+        XercesDOMParser parser;
+        DOMTreeErrorReporter errReporter {};
+        parser.setErrorHandler(&errReporter);
+        parser.parse(inputSource);
+
+        DOMDocument* document = parser.adoptDocument();
+
+        if (!document || !document->getDocumentElement()) {
+            throw XMLBaseException("Malformed document: Invalid document");
+        }
+
+        if (!errReporter.getErrors().empty()) {
+            std::stringstream errorMessage;
+            errorMessage << "An error occured during the parsing of the XML file " << path << ": ";
+            for (auto& err : errReporter.getErrors()) {
+                errorMessage << err << "\n";
+            }
+            throw XMLBaseException {errorMessage.str()};
+        }
+
+        DOMElement* rootElement = document->getDocumentElement();
+        auto xmlContent = ::toXMLElement(rootElement);
+        document->release();
+
+        return xmlContent;
+    }
+    catch (const XMLException& e) {
+        throw XMLBaseException {
+            fmt::format("An error occurred during parsing: {}", StrX(e.getMessage()).c_str())
+        };
+    }
+    catch (const DOMException& e) {
+        throw XMLBaseException {
+            fmt::format("A DOM error occurred during parsing. DOMException code: {}", e.code)
+        };
+    }
+
+    return ::toXMLElement(nullptr);  // technically unreachable
+}
+
+void SaveXMLFile(const fs::path& path, const XMLElement& xmlTree)
+{
+    try {
+        InitXercesC();
+
+        DOMImplementation* impl = DOMImplementationRegistry::getDOMImplementation(
+            XUTF8StrLiteral("Core LS").unicodeForm()
+        );
+        DOMDocument* doc
+            = impl->createDocument(nullptr, XStr(xmlTree.tag.c_str()).unicodeForm(), nullptr);
+        DOMElement* root = doc->getDocumentElement();
+
+        ::toDOMDocument(xmlTree, root);
+
+#if defined(FC_OS_WIN32)
+        std::wstring name = path.wstring();
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        LocalFileFormatTarget myFormTarget {reinterpret_cast<const XMLCh*>(name.c_str())};
+#else
+        LocalFileFormatTarget myFormTarget {LocalFileFormatTarget(path.string().c_str())};
+#endif
+
+        ::saveDocumentToTarget(doc, &myFormTarget);
+        doc->release();
+    }
+    catch (XMLException& e) {
+        throw Base::XMLBaseException {fmt::format(
+            "An error occurred during creation of output transcoder. Msg is:\n{}\n",
+            StrX(e.getMessage()).c_str()
+        )};
+    }
+}
+
+std::optional<std::vector<std::string>> CheckXMLDocument(
+    const XMLElement& xmlTree,
+    const std::string& xsdString
+)
+{
+    try {
+        InitXercesC();
+
+        DOMImplementation* impl = DOMImplementationRegistry::getDOMImplementation(
+            XUTF8StrLiteral("Core LS").unicodeForm()
+        );
+        DOMDocument* doc
+            = impl->createDocument(nullptr, XStr(xmlTree.tag.c_str()).unicodeForm(), nullptr);
+        DOMElement* root = doc->getDocumentElement();
+
+        ::toDOMDocument(xmlTree, root);
+
+        //
+        // Plug in a format target to receive the resultant
+        // XML stream from the serializer.
+        //
+        // LocalFileFormatTarget prints the resultant XML stream
+        // to a file once it receives any thing from the serializer.
+        //
+        MemBufFormatTarget myFormTarget;
+        ::saveDocumentToTarget(doc, &myFormTarget);
+        doc->release();
+
+        // Either use the file saved on disk or write the current XML into a buffer in memory
+        MemBufInputSource xmlFile(myFormTarget.getRawBuffer(), myFormTarget.getLen(), "(memory)");
+
+        // Either load the XSD file from disk or use the built-in string
+        std::string xsdStr(xsdString);  // NOLINT
+        MemBufInputSource xsdFile(
+            reinterpret_cast<const XMLByte*>(xsdStr.c_str()),
+            xsdStr.size(),
+            "Schema.xsd"
+        );
+
+        XercesDOMParser parser;
+        Grammar* grammar = parser.loadGrammar(xsdFile, Grammar::SchemaGrammarType, true);
+        if (!grammar) {
+            return std::vector<std::string> {"Grammar file cannot be loaded"};
+        }
+
+        parser.setExternalNoNamespaceSchemaLocation("Schema.xsd");
+        parser.cacheGrammarFromParse(true);
+        parser.setValidationScheme(XercesDOMParser::Val_Auto);
+        parser.setDoNamespaces(true);
+        parser.setDoSchema(true);
+        parser.setDisableDefaultEntityResolution(true);
+
+        DOMTreeErrorReporter errHandler;
+        parser.setErrorHandler(&errHandler);
+        parser.parse(xmlFile);
+
+        if (parser.getErrorCount() > 0) {
+            std::stringstream str;
+            str << "Unexpected XML structure detected: " << parser.getErrorCount();
+            for (auto& err : errHandler.getErrors()) {
+                str << err << "\n";
+            }
+
+            return std::vector<std::string> {str.str()};
+        }
+    }
+    catch (XMLException& e) {
+        return std::vector<std::string> {
+            fmt::format("An error occurred while checking document: {}", StrX(e.getMessage()).c_str())
+        };
+    }
+    return std::nullopt;
+}
+
+}  // namespace Base

--- a/src/Base/XMLParser.h
+++ b/src/Base/XMLParser.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+#include <map>
+
+#include <FCGlobal.h>
+
+namespace fs = std::filesystem;
+
+namespace Base
+{
+
+/**
+ * Internal structure storing a XML hierarchy,
+ * hiding the actual XML parsing library to internal consumers.
+ *
+ * This structure is recursive, children elements are owned by their parent.
+ * Implicit copies are disabled, use the `clone` function for a deep copy of the structure.
+ */
+struct BaseExport XMLElement
+{
+    XMLElement() = default;
+    ~XMLElement() = default;
+
+    std::string tag;
+    std::map<std::string, std::string> attrs;
+    std::vector<std::unique_ptr<XMLElement>> children;
+    std::string content;
+
+    // Disable costly recursive copies
+    FC_DISABLE_COPY(XMLElement)
+
+    // Accept move semantics
+    FC_DEFAULT_MOVE(XMLElement)
+
+    // Explicit deep copy
+    std::unique_ptr<XMLElement> clone() const;
+};
+
+/**
+ * Parse an XML document stored on disk.
+ * Throws `XMLBaseException` on error.
+ */
+BaseExport std::unique_ptr<XMLElement> ParseXMLFile(const fs::path& path);
+
+/**
+ * Save an XML document to disk.
+ * Throws `XMLBaseException` on error.
+ */
+BaseExport void SaveXMLFile(const fs::path& path, const XMLElement& xmlTree);
+
+/**
+ * Verify the conformance of an XML document to an XSD schema.
+ * Return std::nullopt on success, or a list of errors on failure.
+ */
+BaseExport std::optional<std::vector<std::string>> CheckXMLDocument(
+    const XMLElement& xmlTree,
+    const std::string& xsdString
+);
+
+}  // namespace Base

--- a/tests/src/Base/CMakeLists.txt
+++ b/tests/src/Base/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(Base_tests_run
         Vector3D.cpp
         ViewProj.cpp
         Writer.cpp
+        XMLParser.cpp
         XMLTools.cpp
 )
 

--- a/tests/src/Base/XMLParser.cpp
+++ b/tests/src/Base/XMLParser.cpp
@@ -1,0 +1,142 @@
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+
+#include "Base/XMLParser.h"
+#include "Base/Exception.h"
+#include "Base/FileInfo.h"
+#include "Base/ParameterSchema.h"
+namespace fs = std::filesystem;
+
+namespace
+{
+const std::string validParameterXML = R"(<?xml version="1.0" encoding="UTF-8" standalone="no" ?>)"
+                                      "<FCParameters>"
+                                      R"(<FCParamGroup Name="LogLevels">)"
+                                      R"(<FCInt Name="Default" Value="2"/>)"
+                                      R"(<FCText Name="AutoloadModule">PartDesignWorkbench</FCText>)"
+                                      "</FCParamGroup>"
+                                      "</FCParameters>";
+
+fs::path writeXMLFile(const std::string& content)
+{
+    const fs::path tmpfile = Base::FileInfo::getTempFileName();
+    std::ofstream fout(tmpfile);
+    fout << content;
+    fout.close();
+    return tmpfile;
+}
+}  // namespace
+
+class XMLParserTest: public ::testing::Test
+{
+};
+
+TEST_F(XMLParserTest, TestLoadValidDocument)
+{
+    fs::path tmpfile = writeXMLFile(validParameterXML);
+    auto parsedXML = Base::ParseXMLFile(tmpfile);
+    EXPECT_EQ(parsedXML->tag, "FCParameters");
+    EXPECT_EQ(parsedXML->attrs.size(), 0);
+    EXPECT_EQ(parsedXML->content.size(), 0);
+    EXPECT_EQ(parsedXML->children.size(), 1);
+
+    auto&& paramGroup = parsedXML->children[0];
+    EXPECT_EQ(paramGroup->tag, "FCParamGroup");
+    EXPECT_EQ(paramGroup->attrs.size(), 1);
+    EXPECT_EQ(paramGroup->attrs["Name"], "LogLevels");
+    EXPECT_EQ(paramGroup->content.size(), 0);
+    EXPECT_EQ(paramGroup->children.size(), 2);
+
+    auto&& intParam = paramGroup->children[0];
+    EXPECT_EQ(intParam->tag, "FCInt");
+    EXPECT_EQ(intParam->attrs.size(), 2);
+    EXPECT_EQ(intParam->attrs["Name"], "Default");
+    EXPECT_EQ(intParam->attrs["Value"], "2");
+    EXPECT_EQ(intParam->content.size(), 0);
+    EXPECT_EQ(intParam->children.size(), 0);
+
+    auto&& strParam = paramGroup->children[1];
+    EXPECT_EQ(strParam->tag, "FCText");
+    EXPECT_EQ(strParam->attrs.size(), 1);
+    EXPECT_EQ(strParam->attrs["Name"], "AutoloadModule");
+    EXPECT_EQ(strParam->content, "PartDesignWorkbench");
+    EXPECT_EQ(strParam->children.size(), 0);
+}
+
+TEST_F(XMLParserTest, TestLoadInvalidDocument)
+{
+    const std::string invalidParamFile = validParameterXML + "<Look mom, I'm not XML compliant!";
+    fs::path tmpfile = writeXMLFile(invalidParamFile);
+    EXPECT_THROW({ auto parsedXML = Base::ParseXMLFile(tmpfile); }, Base::XMLBaseException);
+}
+
+TEST_F(XMLParserTest, TestLoadEmptyDocument)
+{
+    const std::string emptyFile;
+    fs::path tmpfile = writeXMLFile(emptyFile);
+    EXPECT_THROW({ auto parsedXML = Base::ParseXMLFile(tmpfile); }, Base::XMLBaseException);
+}
+
+TEST_F(XMLParserTest, TestLoadInvalidPath)
+{
+    EXPECT_THROW(
+        { auto parsedXML = Base::ParseXMLFile(Base::FileInfo::getTempFileName()); },
+        Base::XMLBaseException
+    );
+}
+
+TEST_F(XMLParserTest, TestCheckValidFile)
+{
+    fs::path tmpfile = writeXMLFile(validParameterXML);
+    auto parsedXML = Base::ParseXMLFile(tmpfile);
+
+    auto res = Base::CheckXMLDocument(*parsedXML, ParameterSchema);
+    EXPECT_FALSE(res.has_value());
+}
+
+TEST_F(XMLParserTest, TestCheckInvalidFile)
+{
+    fs::path tmpfile = writeXMLFile(validParameterXML);
+    auto parsedXML = Base::ParseXMLFile(tmpfile);
+    parsedXML->tag = "NotFCParameters";
+
+    auto res = Base::CheckXMLDocument(*parsedXML, ParameterSchema);
+    EXPECT_TRUE(res.has_value());
+    EXPECT_TRUE(res.value().size() == 1);
+    EXPECT_TRUE(res.value()[0].find("Unexpected XML structure detected") != std::string::npos);
+}
+
+TEST_F(XMLParserTest, TestWriteValidDocument)
+{
+    fs::path tmpfile = writeXMLFile(validParameterXML);
+    auto parsedXML = Base::ParseXMLFile(tmpfile);
+
+    const fs::path saveTo = Base::FileInfo::getTempFileName();
+    Base::SaveXMLFile(saveTo, *parsedXML);
+
+    std::ifstream fin(saveTo);
+    std::string line;
+    std::getline(fin, line);
+    EXPECT_EQ(line, R"(<?xml version="1.0" encoding="UTF-8" standalone="no" ?>)");
+    std::getline(fin, line);
+    EXPECT_EQ(line, R"(<FCParameters>)");
+    std::getline(fin, line);
+    EXPECT_EQ(line, "");
+    std::getline(fin, line);
+    line.erase(0, line.find_first_not_of(' '));
+    EXPECT_EQ(line, R"(<FCParamGroup Name="LogLevels">)");
+    std::getline(fin, line);
+    line.erase(0, line.find_first_not_of(' '));
+    EXPECT_EQ(line, R"(<FCInt Name="Default" Value="2"/>)");
+    std::getline(fin, line);
+    line.erase(0, line.find_first_not_of(' '));
+    EXPECT_EQ(line, R"(<FCText Name="AutoloadModule">PartDesignWorkbench</FCText>)");
+    std::getline(fin, line);
+    line.erase(0, line.find_first_not_of(' '));
+    EXPECT_EQ(line, R"(</FCParamGroup>)");
+    std::getline(fin, line);
+    EXPECT_EQ(line, "");
+    std::getline(fin, line);
+    EXPECT_EQ(line, "</FCParameters>");
+}


### PR DESCRIPTION
The new `XMLElement` struct stores a XML hierarchy, independently from the library used for the actual XML parsing. The objective of this is to decouple the XercesC from the rest of the app, and make consumers use a common abstraction.

It was purposefully not added in `XMLTools.h`, so that the header is free from XercesC includes at all.

Most of the XercesC code was copied from Parameters.cpp, which was then simplified.

The next PR will use this new abstraction to remove the XercesC dependency that Parameters.cpp/h has.

- [x] No AI used
