### PR TITLE
gui: send save messages to active window (if it exists) fixes #32090 w/ unit test

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -845,7 +845,10 @@ void StdCmdSave::activated(int iMsg)
         }
     }
 
-    doCommand(Command::Gui, "Gui.activeView().sendMessage(\"Save\")");
+    if (!getMainWindow()->activeWindow()) {
+        return;
+    }
+    doCommand(Command::Gui, "Gui.getMainWindow().getActiveWindow().sendMessage(\"Save\")");
 }
 
 bool StdCmdSave::isActive()
@@ -874,7 +877,10 @@ StdCmdSaveAs::StdCmdSaveAs()
 void StdCmdSaveAs::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.activeView().sendMessage(\"SaveAs\")");
+    if (!getMainWindow()->activeWindow()) {
+        return;
+    }
+    doCommand(Command::Gui, "Gui.getMainWindow().getActiveWindow().sendMessage(\"SaveAs\")");
 }
 
 bool StdCmdSaveAs::isActive()
@@ -905,7 +911,10 @@ StdCmdSaveCopy::StdCmdSaveCopy()
 void StdCmdSaveCopy::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "Gui.activeView().sendMessage(\"SaveCopy\")");
+    if (!getMainWindow()->activeWindow()) {
+        return;
+    }
+    doCommand(Command::Gui, "Gui.getMainWindow().getActiveWindow().sendMessage(\"SaveCopy\")");
 }
 
 bool StdCmdSaveCopy::isActive()

--- a/src/Gui/MDIViewPy.cpp
+++ b/src/Gui/MDIViewPy.cpp
@@ -232,7 +232,7 @@ Py::Object MDIViewPy::supportMessage(const Py::Tuple& args)
     try {
         bool ok = false;
         if (_view) {
-            _view->onHasMsg(psMsgStr);
+            ok = _view->onHasMsg(psMsgStr);
         }
         return Py::Boolean(ok);
     }

--- a/src/Mod/Test/GuiDocument.py
+++ b/src/Mod/Test/GuiDocument.py
@@ -344,3 +344,74 @@ class TestGuiDocument(unittest.TestCase):
 
         self.assertTrue(self._processEventsUntil(lambda: os.path.exists(self._recoveryArchive())))
         self._assertRecoveryArchiveContains(expected_label="AutoSaveBurst7")
+
+    def testSaveDispatchesToFocusedMacroEditor(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+
+            self.doc.saveAs(os.path.join(temp_dir, "TestDoc.FCStd"))
+            doc_path = self.doc.FileName
+
+            macro_path = os.path.join(temp_dir, "test_macro.FCMacro")
+            with open(macro_path, "w", encoding="utf-8") as macro_file:
+                macro_file.write("# original\n")
+
+            FreeCADGui.open(macro_path)
+
+            main_window = FreeCADGui.getMainWindow()
+
+            def active_type_id():
+                view = main_window.getActiveWindow()
+                return view.getTypeId() if view else ""
+
+            self.assertTrue(self._processEventsUntil(lambda: "EditorView" in active_type_id()))
+
+            editor = main_window.getActiveWindow()
+
+            self.assertIn("EditorView", editor.getTypeId())
+
+            text_edits = [
+                widget
+                for widget in main_window.findChildren(QtWidgets.QPlainTextEdit)
+                if widget.toPlainText().startswith("# original")
+            ]
+
+            self.assertEqual(len(text_edits), 1)
+
+            text_edit = text_edits[0]
+
+            def closeEditor():
+                text_edit.document().setModified(False)
+                main_window.removeWindow(editor)
+
+            self.addCleanup(closeEditor)
+
+            text_edit.insertPlainText("# modified\n")
+
+            QtWidgets.QApplication.processEvents(
+                QtCore.QEventLoop.ProcessEventsFlag.AllEvents,
+                50,
+            )
+
+            self.assertTrue(editor.supportMessage("Save"))
+
+            gui_doc = FreeCADGui.getDocument(self.doc.Name)
+
+            self.doc.addObject("App::FeaturePython", "ModifiedObject")
+
+            self.assertTrue(gui_doc.Modified)
+
+            doc_mtime_before = os.stat(doc_path).st_mtime_ns
+
+            FreeCADGui.runCommand("Std_Save", 0)
+
+            with open(macro_path, encoding="utf-8") as macro_file:
+                macro_contents = macro_file.read()
+
+            self.assertIn("# modified", macro_contents)
+            self.assertTrue(gui_doc.Modified)
+
+            doc_mtime_after = os.stat(doc_path).st_mtime_ns
+
+            # Std_Save must reach the focused macro editor, not the active document,
+            # the macro is written and the document is left untouched
+            self.assertEqual(doc_mtime_after, doc_mtime_before)


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

this PR fixes #32090 ie. if one decided to try and save macro an error with the following message would appear with the latest API changes being made. (error message below).

```
NoneType' object has no attribute 'sendMessage
```

this PR adds a unit test that can run without the gui even though the following file was edited. ie. `./src/Mod/Test/GuiDocument.py`

to run the newly added unit test use the below command. (i am able to run this command on my build box through ssh, so **no** gui was harmed while drafting this PR. 🤡

```
QT_QPA_PLATFORM=offscreen \
/opt/code/fcgit/installs/issue.tshooting.qt6.py313/bin/FreeCAD -t \ 
GuiDocument.TestGuiDocument.testSaveDispatchesToFocusedMacroEditor
```

with just adding the changes from the unit test in this PR, one will get a failing test with the following output from the above command,

```
FreeCAD 26.3.0, Libs: 26.3.0devR48347 (Git)
(C) 2001-2026 FreeCAD contributors
FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.

QOpenGLWidget is not supported on this platform.
This plugin does not support propagateSizeHints()
This plugin does not support propagateSizeHints()
QOpenGLWidget is not supported on this platform.
No valid GL context found!
No valid GL context found!
No valid GL context found!
testSaveDispatchesToFocusedMacroEditor (GuiDocument.TestGuiDocument.testSaveDispatchesToFocusedMacroEditor) ... FAIL

======================================================================
FAIL: testSaveDispatchesToFocusedMacroEditor (GuiDocument.TestGuiDocument.testSaveDispatchesToFocusedMacroEditor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/code/git/github/forks/freecad-git/installs/issue.tshooting.qt6.py313/Mod/Test/GuiDocument.py", line 407, in testSaveDispatchesToFocusedMacroEditor
    self.assertIn("# modified", macro_contents)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: '# modified' not found in '# original\n'

----------------------------------------------------------------------
Ran 1 test in 0.053s

FAILED (failures=1)
System exit
```

i also have a branch where i scaffold out the unit test, and i used a bunch of python print statements to help me troubleshoot the unit test while writing it. obviously i've removed the print statements for brevity.

- https://github.com/ipatch/FreeCAD/tree/ipatch.tshoot.32090-macro.save-unit-test-with-print-statements

while writing / scaffolding out that unit test i came across another bug in the freecad source code because the unit test was running, but would not exit, and leave the freecad process in a "suspended / unresponsive state" thus requiring manaully killing the process with a tool like `kill`

so i had to make the following changes.

```diff
diff --git a/src/Gui/MDIViewPy.cpp b/src/Gui/MDIViewPy.cpp
index a1ba434eb1..f4e7759e3d 100644
--- a/src/Gui/MDIViewPy.cpp
+++ b/src/Gui/MDIViewPy.cpp
@@ -232,7 +232,7 @@ Py::Object MDIViewPy::supportMessage(const Py::Tuple& args)
     try {
         bool ok = false;
         if (_view) {
-            _view->onHasMsg(psMsgStr);
+            ok = _view->onHasMsg(psMsgStr);
         }
         return Py::Boolean(ok);
     }
```

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by Claude Opus 5

<!--
Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06
-->

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/32090

## Before and After Images

see the original linked issue above for images / text related to this issue.

