### PR TITLE
Spreadsheet: stop trackpad touches from ending cell edits

### DIFF
--- a/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
@@ -246,6 +246,29 @@ void ZoomableView::resizeEvent(QResizeEvent* event)
     updateView();
 }
 
+bool ZoomableView::viewportEvent(QEvent* event)
+{
+    // The spreadsheet has no touch interaction of its own: zooming is driven by
+    // wheelEvent() and everything else is mouse and keyboard. On macOS a passive
+    // trackpad touch (a resting palm, no button pressed) is still delivered here and
+    // reaches the scene, which moves focus away from an open cell editor. The delegate
+    // then commits and closes the editor, interrupting the user mid-typing (issue #23131).
+    //
+    // Dropping raw touch events keeps focus with the cell editor. Real clicks arrive as
+    // mouse events and are unaffected.
+    switch (event->type()) {
+        case QEvent::TouchBegin:
+        case QEvent::TouchUpdate:
+        case QEvent::TouchEnd:
+        case QEvent::TouchCancel:
+            return true;
+        default:
+            break;
+    }
+
+    return QGraphicsView::viewportEvent(event);
+}
+
 void ZoomableView::wheelEvent(QWheelEvent* event)
 {
     if (event->modifiers() & Qt::ControlModifier) {

--- a/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
@@ -248,14 +248,8 @@ void ZoomableView::resizeEvent(QResizeEvent* event)
 
 bool ZoomableView::viewportEvent(QEvent* event)
 {
-    // The spreadsheet has no touch interaction of its own: zooming is driven by
-    // wheelEvent() and everything else is mouse and keyboard. On macOS a passive
-    // trackpad touch (a resting palm, no button pressed) is still delivered here and
-    // reaches the scene, which moves focus away from an open cell editor. The delegate
-    // then commits and closes the editor, interrupting the user mid-typing (issue #23131).
-    //
-    // Dropping raw touch events keeps focus with the cell editor. Real clicks arrive as
-    // mouse events and are unaffected.
+    // Swallow touch events: mid-typing trackpad touch commits cell, clobbered by remaining
+    // keystrokes (#23131)
     switch (event->type()) {
         case QEvent::TouchBegin:
         case QEvent::TouchUpdate:

--- a/src/Mod/Spreadsheet/Gui/ZoomableView.h
+++ b/src/Mod/Spreadsheet/Gui/ZoomableView.h
@@ -75,6 +75,7 @@ protected:
     void keyPressEvent(QKeyEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
+    bool viewportEvent(QEvent* event) override;
 
     static constexpr int zoom_step_mwheel {5}, zoom_step_kb {10};
 };


### PR DESCRIPTION
Fixes #23131

## Demo

[![Watch the demo](https://img.youtube.com/vi/JEQUEYAIyPw/maxresdefault.jpg)](https://youtu.be/JEQUEYAIyPw)

## Quick Summary

- Bug: a stray trackpad touch (no click) could end spreadsheet cell editing mid-typing, losing text.
- Cause: the touch reached ZoomableView and moved focus off the open cell editor, which Qt then treated as "finished editing."
- Fix: ZoomableView::viewportEvent() drops raw touch events; mouse clicks are unaffected.
- Proof: before/after recording, same repro steps on unmodified main vs. this branch: https://youtu.be/JEQUEYAIyPw
- AI disclosure: Claude (Sonnet 5) assisted with investigation and drafting; I reviewed, built, and tested this myself. This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Open Questions:

 - This is my first time contributing back to the FreeCAD main repository. Should I have raised an issue for this or something?
 - I'm trying to follow the advice given to me on the discord but I could have easily missed something so please let me know. https://discord.com/channels/870877411049357352/1099444468895199232/1543540292949385277