### PR TITLE
BIM: stop creating deprecated CutDistance property

### DIFF
--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -1222,14 +1222,6 @@ class _ViewProviderSectionPlane:
                 locked=True,
             )
             vobj.LineWidth = 1
-        if not "CutDistance" in pl:
-            vobj.addProperty(
-                "App::PropertyLength",
-                "CutDistance",
-                "SectionPlane",
-                QT_TRANSLATE_NOOP("App::Property", "Show the cut in the 3D view"),
-                locked=True,
-            )
         if not "LineColor" in pl:
             vobj.addProperty(
                 "App::PropertyColor",

--- a/src/Mod/BIM/bimtests/TestArchSectionPlane.py
+++ b/src/Mod/BIM/bimtests/TestArchSectionPlane.py
@@ -52,6 +52,11 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         self.assertEqual(
             section_plane.Label, "TestSectionPlane", "Section plane label is incorrect."
         )
+        self.assertNotIn(
+            "CutDistance",
+            section_plane.ViewObject.PropertiesList,
+            "New section planes should not have the deprecated CutDistance property.",
+        )
 
     def testSectionPlaneFitUsesLocalAxesAfterRotateY(self):
         """Resize-to-fit dimensions follow the rotated section plane axes."""

--- a/src/Mod/BIM/bimtests/TestArchSectionPlane.py
+++ b/src/Mod/BIM/bimtests/TestArchSectionPlane.py
@@ -52,11 +52,12 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         self.assertEqual(
             section_plane.Label, "TestSectionPlane", "Section plane label is incorrect."
         )
-        self.assertNotIn(
-            "CutDistance",
-            section_plane.ViewObject.PropertiesList,
-            "New section planes should not have the deprecated CutDistance property.",
-        )
+        if section_plane.ViewObject:
+            self.assertNotIn(
+                "CutDistance",
+                section_plane.ViewObject.PropertiesList,
+                "New section planes should not have the deprecated CutDistance property.",
+            )
 
     def testSectionPlaneFitUsesLocalAxesAfterRotateY(self):
         """Resize-to-fit dimensions follow the rotated section plane axes."""


### PR DESCRIPTION
Fixes #28909

## Summary

- stop adding the deprecated `CutDistance` view property to newly created Arch Section Plane objects
- add a regression assertion that new section planes do not expose `CutDistance`
- preserve existing documents: this change does not remove the property from objects that already contain it

## Validation

- rebased onto the current `main` without conflicts
- `python3 -m py_compile` for both changed Python modules
- `git diff --check origin/main...HEAD`
- the earlier weekly-build method-level probe covered new-object creation; full upstream CI is still required

## AI assistance disclosure

Codex assisted with the change. I reviewed and understand the complete patch, take responsibility for it, and will personally handle all communication on this PR.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.