### PR TITLE
[stubs] add PEP561 markers and make stubs deployable to pypi as freec…

### DIFF
--- a/src/Tools/typing/README.md
+++ b/src/Tools/typing/README.md
@@ -34,6 +34,26 @@ That command writes under `src/Tools/typing/generated/`:
   is the output used by the smoke checks. It is disposable local output; the
   repository only keeps `generated/.gitignore`, so regenerate it instead of
   editing it directly.
+- `stubs/<Module>/py.typed`: a PEP 561 marker emitted into each top-level
+  module directory so type checkers (Pyright, MyPy, Pyrefly) discover the
+  stubs when the package is installed.
+- `pyproject.toml`: a packaging manifest for distributing the stubs on PyPI
+  as `freecad-typings`. It uses the `hatchling` build backend and the FreeCAD
+  version from `version.json`, and copies the `stubs/` tree to the wheel root
+  so the top-level modules import directly (e.g. `import FreeCAD`).
+
+Build and publish the stub package with `uv` from the generated directory:
+
+```sh
+cd src/Tools/typing/generated
+uv build                 # creates dist/freecad_typings-<version>.tar.gz and .whl
+uv publish               # uploads to PyPI (set UV_PUBLISH_TOKEN or log in first)
+```
+
+To push a release candidate or development snapshot instead, use the alias
+`uv publish --publish-url https://test.pypi.org/legacy/` (test PyPI) or pass
+an explicit index URL. Regenerate before publishing whenever the bindings
+change so the wheel reflects the current API.
 
 Keep residual hand-written public overlays under `src/Tools/typing/inputs/overlays/`. Keep
 source-adjacent PyCXX type signature inputs in plain `.pyi` files such as

--- a/src/Tools/typing/stubgen/PYPROJECT_TEMPLATE.toml
+++ b/src/Tools/typing/stubgen/PYPROJECT_TEMPLATE.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "freecad-typings"
+version = "{version}"
+description = "Type stubs for FreeCAD Python API"
+readme = "README.md"
+license = "LGPL-2.1-or-later"
+requires-python = ">=3.11"
+authors = [{{ name = "FreeCAD Developers", email = "contact@freecad.org" }}]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[project.urls]
+Homepage = "https://www.freecad.org/"
+Documentation = "https://wiki.freecad.org/Power_users_hub"
+Repository = "https://github.com/FreeCAD/FreeCAD"
+Issues = "https://github.com/FreeCAD/FreeCAD/issues"
+Changelog = "https://github.com/FreeCAD/FreeCAD/releases"
+Funding = "https://www.freecad.org/sponsor.php"
+Forum = "https://forum.freecad.org/"
+
+[tool.hatch.build.targets.sdist]
+ignore-vcs = true
+include = ["stubs/**", "pyproject.toml", "README.md"]
+
+[tool.hatch.build.targets.wheel]
+force-include = {{ "stubs" = "." }}

--- a/src/Tools/typing/stubgen/README_TEMPLATE.md
+++ b/src/Tools/typing/stubgen/README_TEMPLATE.md
@@ -1,0 +1,37 @@
+# freecad-typings
+
+Type stubs for the [FreeCAD] Python API (version `{version}`).
+
+This package provides [PEP 561] `py.typed` stubs generated from FreeCAD's
+C++ Python bindings, so static type checkers and IDEs can understand the
+FreeCAD objects, modules, and functions available at runtime.
+
+## Installation
+
+### pip
+
+```sh
+pip install freecad-typings
+```
+
+### uv
+
+```sh
+uv add freecad-typings
+```
+
+## Modules
+
+The stubs cover the public FreeCAD Python modules, including `FreeCAD`,
+`FreeCADGui`, `Part`, and the other core workbench modules.
+
+## Usage
+
+Once installed, type checkers (e.g. `pyright`, `pyre`, `mypy`) and editors
+will automatically pick up the stubs for the FreeCAD modules.
+
+These stubs are generated and intended for static analysis; they are not a
+runtime replacement for the real FreeCAD binary.
+
+[FreeCAD]: https://www.freecad.org/
+[PEP 561]: https://peps.python.org/pep-0561/

--- a/src/Tools/typing/stubgen/generator.py
+++ b/src/Tools/typing/stubgen/generator.py
@@ -64,8 +64,9 @@ from .property_contracts import (
     render_property_aliases,
 )
 from .property_hierarchy import property_hierarchy_from
-from .render import type_stub_lines, write_pyproject, write_readme, write_stub_file
+from .render import type_stub_lines, write_stub_file
 from .type_hierarchy import TypeHierarchy, discover_type_hierarchy
+from .project import Project
 
 
 @dataclass(frozen=True)
@@ -345,11 +346,10 @@ def write_outputs(
         module_names,
         root,
     )
+
     write_pep561_markers(out_dir / "stubs", module_names)
-    write_pyproject(out_dir, root)
-    write_readme(
-        out_dir,
-        root,
-        Path(__file__).with_name("README_TEMPLATE.md"),
-    )
+    project = Project(root)
+    project.write_pyproject(out_dir)
+    project.write_readme(out_dir)
+
     return GenerationResult(overlay_count, cpp_property_report)

--- a/src/Tools/typing/stubgen/generator.py
+++ b/src/Tools/typing/stubgen/generator.py
@@ -64,7 +64,7 @@ from .property_contracts import (
     render_property_aliases,
 )
 from .property_hierarchy import property_hierarchy_from
-from .render import type_stub_lines, write_stub_file
+from .render import type_stub_lines, write_stub_file, write_pyproject
 from .type_hierarchy import TypeHierarchy, discover_type_hierarchy
 
 
@@ -281,6 +281,13 @@ def append_document_add_object_overloads(
         target.write_text(merged, encoding="utf-8")
 
 
+def write_pep561_markers(out_dir: Path, module_names: set[str]) -> None:
+    top_level = {name.split(".", 1)[0] for name in module_names}
+    for pkg in sorted(top_level):
+        (out_dir / pkg).mkdir(parents=True, exist_ok=True)
+        (out_dir / pkg / "py.typed").touch()
+
+
 def write_outputs(
     out_dir: Path,
     root: Path,
@@ -338,4 +345,6 @@ def write_outputs(
         module_names,
         root,
     )
+    write_pep561_markers(out_dir / "stubs", module_names)
+    write_pyproject(out_dir, root)
     return GenerationResult(overlay_count, cpp_property_report)

--- a/src/Tools/typing/stubgen/generator.py
+++ b/src/Tools/typing/stubgen/generator.py
@@ -64,7 +64,7 @@ from .property_contracts import (
     render_property_aliases,
 )
 from .property_hierarchy import property_hierarchy_from
-from .render import type_stub_lines, write_stub_file, write_pyproject
+from .render import type_stub_lines, write_pyproject, write_readme, write_stub_file
 from .type_hierarchy import TypeHierarchy, discover_type_hierarchy
 
 
@@ -347,4 +347,9 @@ def write_outputs(
     )
     write_pep561_markers(out_dir / "stubs", module_names)
     write_pyproject(out_dir, root)
+    write_readme(
+        out_dir,
+        root,
+        Path(__file__).with_name("README_TEMPLATE.md"),
+    )
     return GenerationResult(overlay_count, cpp_property_report)

--- a/src/Tools/typing/stubgen/project.py
+++ b/src/Tools/typing/stubgen/project.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from dataclasses import dataclass
+from functools import cached_property
+import json
+
+
+@dataclass
+class Project:
+    root: Path
+
+    @cached_property
+    def version(self) -> str:
+        version_file = self.root / "version.json"
+        with open(version_file, encoding="utf-8") as f:
+            data = json.load(f)
+        suffix = data.get("version_suffix", "")
+        if suffix:
+            suffix = f".{suffix}"
+        major, minor, patch = (
+            data["version_major"],
+            data["version_minor"],
+            data["version_patch"],
+        )
+        return f"{major}.{minor}.{patch}{suffix}"
+
+    def _render_template(self, template: str, out_path: Path, /, **vars) -> None:
+        text = Path(__file__).with_name(template).read_text(encoding="utf-8")
+        out_path.write_text(
+            text.format(**vars),
+            encoding="utf-8",
+        )
+
+    def write_pyproject(self, out_dir: Path) -> None:
+        """Write the package pyproject.toml from a template, filling metadata."""
+        self._render_template(
+            "PYPROJECT_TEMPLATE.toml",
+            out_dir / "pyproject.toml",
+            version=self.version,
+        )
+
+    def write_readme(self, out_dir: Path) -> None:
+        """Write the package README from a template, filling in the version."""
+        self._render_template(
+            "README_TEMPLATE.md",
+            out_dir / "README.md",
+            version=self.version,
+        )

--- a/src/Tools/typing/stubgen/render.py
+++ b/src/Tools/typing/stubgen/render.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+import json
 import re
 
 from .model import BindingMethod, PublicTypeGroup, StubSignatureOverrides
@@ -260,3 +261,48 @@ def type_stub_lines(
         lines.append("")
 
     return lines
+
+
+PYPROJECT_TEMPLATE = """\
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "freecad-typings"
+version = "{version}"
+description = "Type stubs for FreeCAD Python API"
+license = "LGPL-2.1-or-later"
+requires-python = ">=3.11"
+authors = [{{ name = "FreeCAD Project" }}]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[tool.hatch.build.targets.sdist]
+ignore-vcs = true
+include = ["stubs/**", "pyproject.toml"]
+
+[tool.hatch.build.targets.wheel]
+force-include = {{ "stubs" = "." }}
+"""
+
+
+def _freecad_version(root: Path) -> str:
+    version_file = root / "version.json"
+    with open(version_file, encoding="utf-8") as f:
+        data = json.load(f)
+    return "{version_major}.{version_minor}.{version_patch}{version_suffix}".format(**data)
+
+
+def write_pyproject(out_dir: Path, root: Path) -> None:
+    (out_dir / "pyproject.toml").write_text(
+        PYPROJECT_TEMPLATE.format(version=_freecad_version(root)),
+        encoding="utf-8",
+    )

--- a/src/Tools/typing/stubgen/render.py
+++ b/src/Tools/typing/stubgen/render.py
@@ -272,6 +272,7 @@ build-backend = "hatchling.build"
 name = "freecad-typings"
 version = "{version}"
 description = "Type stubs for FreeCAD Python API"
+readme = "README.md"
 license = "LGPL-2.1-or-later"
 requires-python = ">=3.11"
 authors = [{{ name = "FreeCAD Project" }}]
@@ -287,7 +288,7 @@ classifiers = [
 
 [tool.hatch.build.targets.sdist]
 ignore-vcs = true
-include = ["stubs/**", "pyproject.toml"]
+include = ["stubs/**", "pyproject.toml", "README.md"]
 
 [tool.hatch.build.targets.wheel]
 force-include = {{ "stubs" = "." }}
@@ -298,7 +299,15 @@ def _freecad_version(root: Path) -> str:
     version_file = root / "version.json"
     with open(version_file, encoding="utf-8") as f:
         data = json.load(f)
-    return "{version_major}.{version_minor}.{version_patch}{version_suffix}".format(**data)
+    suffix = data.get("version_suffix", "")
+    if suffix:
+        suffix = f".{suffix}"
+    major, minor, patch = (
+        data["version_major"],
+        data["version_minor"],
+        data["version_patch"],
+    )
+    return f"{major}.{minor}.{patch}{suffix}"
 
 
 def write_pyproject(out_dir: Path, root: Path) -> None:
@@ -306,3 +315,10 @@ def write_pyproject(out_dir: Path, root: Path) -> None:
         PYPROJECT_TEMPLATE.format(version=_freecad_version(root)),
         encoding="utf-8",
     )
+
+
+def write_readme(out_dir: Path, root: Path, template_path: Path) -> None:
+    """Write the package README from a template, filling in the version."""
+    template = template_path.read_text(encoding="utf-8")
+    rendered = template.replace("{version}", _freecad_version(root))
+    (out_dir / "README.md").write_text(rendered, encoding="utf-8")

--- a/src/Tools/typing/stubgen/render.py
+++ b/src/Tools/typing/stubgen/render.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
-import json
 import re
 
 from .model import BindingMethod, PublicTypeGroup, StubSignatureOverrides
@@ -261,64 +260,3 @@ def type_stub_lines(
         lines.append("")
 
     return lines
-
-
-PYPROJECT_TEMPLATE = """\
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "freecad-typings"
-version = "{version}"
-description = "Type stubs for FreeCAD Python API"
-readme = "README.md"
-license = "LGPL-2.1-or-later"
-requires-python = ">=3.11"
-authors = [{{ name = "FreeCAD Project" }}]
-classifiers = [
-    "Development Status :: 4 - Beta",
-    "Intended Audience :: Developers",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Typing :: Typed",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-]
-
-[tool.hatch.build.targets.sdist]
-ignore-vcs = true
-include = ["stubs/**", "pyproject.toml", "README.md"]
-
-[tool.hatch.build.targets.wheel]
-force-include = {{ "stubs" = "." }}
-"""
-
-
-def _freecad_version(root: Path) -> str:
-    version_file = root / "version.json"
-    with open(version_file, encoding="utf-8") as f:
-        data = json.load(f)
-    suffix = data.get("version_suffix", "")
-    if suffix:
-        suffix = f".{suffix}"
-    major, minor, patch = (
-        data["version_major"],
-        data["version_minor"],
-        data["version_patch"],
-    )
-    return f"{major}.{minor}.{patch}{suffix}"
-
-
-def write_pyproject(out_dir: Path, root: Path) -> None:
-    (out_dir / "pyproject.toml").write_text(
-        PYPROJECT_TEMPLATE.format(version=_freecad_version(root)),
-        encoding="utf-8",
-    )
-
-
-def write_readme(out_dir: Path, root: Path, template_path: Path) -> None:
-    """Write the package README from a template, filling in the version."""
-    template = template_path.read_text(encoding="utf-8")
-    rendered = template.replace("{version}", _freecad_version(root))
-    (out_dir / "README.md").write_text(rendered, encoding="utf-8")


### PR DESCRIPTION
Add  PEP561 markers and make stubs deployable to pypi as freecad-typings

Assisted-by: opencode/big-pickle

# Example
```bash
uv build
uv publish
```