### PR TITLE
Test: add shared GUI test support

### DIFF
--- a/src/Mod/PartDesign/TestPartDesignGui.py
+++ b/src/Mod/PartDesign/TestPartDesignGui.py
@@ -226,6 +226,7 @@ class PartDesignGuiTestCases(FreeCADGuiTestCase):
         self.BodyTarget = self.Doc.addObject("PartDesign::Body", "Body")
 
         Gui.Selection.addSelection(App.ActiveDocument.Pad)
+
         def accept_move_dialog(dialog):
             combo_box = dialog.findChild(QtGui.QComboBox)
             self.assertIsNotNone(combo_box, "ComboBox widget could not be found")
@@ -249,6 +250,7 @@ class PartDesignGuiTestCases(FreeCADGuiTestCase):
         )
         self.assertEqual(len(self.BodySource.Group), 0, "Source body feature count is wrong")
         self.assertEqual(len(self.BodyTarget.Group), 2, "Target body feature count is wrong")
+
 
 class PartDesignTransformed(unittest.TestCase):
     def setUp(self):

--- a/src/Mod/PartDesign/TestPartDesignGui.py
+++ b/src/Mod/PartDesign/TestPartDesignGui.py
@@ -35,6 +35,7 @@ import tempfile
 
 from PySide import QtGui, QtCore
 from PySide.QtGui import QApplication
+from Gui.TestCase import FreeCADGuiTestCase
 
 from PartDesignTests.TestMaterial import TestMaterial
 from PartDesignTests.TestActiveObject import TestActiveObject
@@ -62,31 +63,6 @@ class CallableCheckDialogWasClosed:
     def __call__(self):
         dialog = QApplication.activeModalWidget()
         self.test.assertIsNone(dialog, "Dialog box was not closed by accept()")
-
-
-class CallableCheckWarning:
-    def __init__(self, test):
-        self.test = test
-
-    def __call__(self):
-        dialog = QApplication.activeModalWidget()
-        self.test.assertIsNotNone(dialog, "Input dialog box could not be found")
-        if dialog is not None:
-            QtCore.QTimer.singleShot(0, dialog, QtCore.SLOT("accept()"))
-
-
-class CallableComboBox:
-    def __init__(self, test):
-        self.test = test
-
-    def __call__(self):
-        dialog = QApplication.activeModalWidget()
-        self.test.assertIsNotNone(dialog, "Warning dialog box could not be found")
-        if dialog is not None:
-            cbox = dialog.findChild(QtGui.QComboBox)
-            self.test.assertIsNotNone(cbox, "ComboBox widget could not be found")
-            if cbox is not None:
-                QtCore.QTimer.singleShot(0, dialog, QtCore.SLOT("accept()"))
 
 
 class CallableCheckExemptionDialog:
@@ -117,8 +93,9 @@ Gui = FreeCADGui
 # ---------------------------------------------------------------------------
 # define the test cases to test the FreeCAD PartDesign module
 # ---------------------------------------------------------------------------
-class PartDesignGuiTestCases(unittest.TestCase):
+class PartDesignGuiTestCases(FreeCADGuiTestCase):
     def setUp(self):
+        super().setUp()
         self.Doc = FreeCAD.newDocument("SketchGuiTest")
 
     def testRefuseToMoveSingleFeature(self):
@@ -177,9 +154,13 @@ class PartDesignGuiTestCases(unittest.TestCase):
         self.BodyTarget = self.Doc.addObject("PartDesign::Body", "Body")
 
         Gui.Selection.addSelection(App.ActiveDocument.Pad)
-        cobj = CallableCheckWarning(self)
-        QtCore.QTimer.singleShot(500, cobj)
-        Gui.runCommand("PartDesign_MoveFeature")
+        state = self.gui.run_with_modal_action(
+            lambda: Gui.runCommand("PartDesign_MoveFeature"),
+            lambda dialog: dialog.accept(),
+            delay_ms=500,
+        )
+        self.assertTrue(state["seen"], "Input dialog box could not be found")
+        self.assertIsNone(state.get("error"))
         # assert dependencies of the Sketch
         self.assertEqual(len(self.BodySource.Group), 3, "Source body feature count is wrong")
         self.assertEqual(len(self.BodyTarget.Group), 0, "Target body feature count is wrong")
@@ -245,9 +226,18 @@ class PartDesignGuiTestCases(unittest.TestCase):
         self.BodyTarget = self.Doc.addObject("PartDesign::Body", "Body")
 
         Gui.Selection.addSelection(App.ActiveDocument.Pad)
-        cobj = CallableComboBox(self)
-        QtCore.QTimer.singleShot(500, cobj)
-        Gui.runCommand("PartDesign_MoveFeature")
+        def accept_move_dialog(dialog):
+            combo_box = dialog.findChild(QtGui.QComboBox)
+            self.assertIsNotNone(combo_box, "ComboBox widget could not be found")
+            dialog.accept()
+
+        state = self.gui.run_with_modal_action(
+            lambda: Gui.runCommand("PartDesign_MoveFeature"),
+            accept_move_dialog,
+            delay_ms=500,
+        )
+        self.assertTrue(state["seen"], "Warning dialog box could not be found")
+        self.assertIsNone(state.get("error"))
         # assert dependencies of the Sketch
         self.Doc.recompute()
 
@@ -259,10 +249,6 @@ class PartDesignGuiTestCases(unittest.TestCase):
         )
         self.assertEqual(len(self.BodySource.Group), 0, "Source body feature count is wrong")
         self.assertEqual(len(self.BodyTarget.Group), 2, "Target body feature count is wrong")
-
-    def tearDown(self):
-        FreeCAD.closeDocument("SketchGuiTest")
-
 
 class PartDesignTransformed(unittest.TestCase):
     def setUp(self):

--- a/src/Mod/Sketcher/CMakeLists.txt
+++ b/src/Mod/Sketcher/CMakeLists.txt
@@ -34,6 +34,7 @@ if(BUILD_GUI)
     list (APPEND Sketcher_TestScripts
           SketcherTests/TestConstraintPreselectionGui.py
           SketcherTests/GuiTestCase.py
+          SketcherTests/Support.py
           SketcherTests/TestPlacementUpdate.py
           SketcherTests/TestOnViewParameterGui.py
           SketcherTests/TestExternalFacePreselection.py

--- a/src/Mod/Sketcher/SketcherTests/GuiTestCase.py
+++ b/src/Mod/Sketcher/SketcherTests/GuiTestCase.py
@@ -1,171 +1,23 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import unittest
+"""Compatibility imports for the former Sketcher-only GUI test helper.
 
-import FreeCAD
+Generic GUI tests should inherit from :class:`Gui.TestCase.FreeCADGuiTestCase`;
+Sketcher tests should use :class:`SketcherTests.Support.SketcherGuiTestCase`.
+This module remains so out-of-tree Sketcher tests can migrate independently.
+The former implicit key-event settling delay is not retained; callers should
+wait for the resulting GUI state explicitly.
+"""
 
-try:
-    import FreeCADGui
+from Gui.TestCase import FreeCADGuiTestCase
+from Gui.Wait import (
+    GUI_MODULE_AVAILABLE,
+    FreeCAD,
+    FreeCADGui,
+    QtCore,
+    QtGui,
+    gui_available,
+)
+from SketcherTests.Support import SketcherGuiTestCase
 
-    GUI_MODULE_AVAILABLE = True
-except ImportError:
-    FreeCADGui = None
-    GUI_MODULE_AVAILABLE = False
-
-try:
-    from PySide import QtCore, QtGui
-
-    QT_MODULE_AVAILABLE = True
-except ImportError:
-    QtCore = None
-    QtGui = None
-    QT_MODULE_AVAILABLE = False
-
-
-def gui_available():
-    if not GUI_MODULE_AVAILABLE:
-        return False
-
-    try:
-        return FreeCADGui.getMainWindow() is not None
-    except (AttributeError, RuntimeError):
-        return False
-
-
-class SketcherGuiTestCase(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
-        if not gui_available():
-            self.skipTest("GUI not available")
-
-    def tearDown(self):
-        try:
-            self.cleanup_gui_document(getattr(self, "doc", None))
-        finally:
-            super().tearDown()
-
-    def pump(self, timeout_ms=50):
-        if not QT_MODULE_AVAILABLE:
-            return
-
-        loop = QtCore.QEventLoop()
-        QtCore.QTimer.singleShot(timeout_ms, loop.quit)
-        loop.exec_()
-
-    def flush_gui(self, timeout_ms=0):
-        if not gui_available():
-            return
-
-        if QT_MODULE_AVAILABLE:
-            QtGui.QApplication.processEvents()
-
-        FreeCADGui.updateGui()
-
-        if timeout_ms:
-            self.pump(timeout_ms)
-
-    def cleanup_gui_document(self, doc, timeout_ms=80):
-        if not gui_available():
-            return
-
-        gui_doc = FreeCADGui.ActiveDocument
-        if gui_doc is not None:
-            gui_doc.resetEdit()
-            self.flush_gui(timeout_ms)
-
-        if FreeCADGui.Control.activeDialog() is not None:
-            FreeCADGui.Control.closeDialog()
-            self.flush_gui(timeout_ms)
-
-        if doc is not None and doc.Name in FreeCAD.listDocuments():
-            FreeCAD.closeDocument(doc.Name)
-            self.flush_gui(timeout_ms)
-
-    def wait_until(self, predicate, timeout_ms=1000, step_ms=50):
-        remaining = timeout_ms
-        while remaining > 0:
-            if predicate():
-                return True
-            self.flush_gui(step_ms)
-            remaining -= step_ms
-        return predicate()
-
-    def send_mouse(self, widget, event_type, pos, button, buttons):
-        global_pos = widget.mapToGlobal(pos)
-        event = QtGui.QMouseEvent(
-            event_type,
-            pos,
-            global_pos,
-            button,
-            buttons,
-            QtCore.Qt.NoModifier,
-        )
-        QtGui.QApplication.sendEvent(widget, event)
-
-    def click(self, widget, pos):
-        self.send_mouse(
-            widget,
-            QtCore.QEvent.MouseButtonPress,
-            pos,
-            QtCore.Qt.LeftButton,
-            QtCore.Qt.LeftButton,
-        )
-        self.send_mouse(
-            widget,
-            QtCore.QEvent.MouseButtonRelease,
-            pos,
-            QtCore.Qt.LeftButton,
-            QtCore.Qt.NoButton,
-        )
-        self.pump(120)
-
-    def right_click(self, widget, pos):
-        self.send_mouse(
-            widget,
-            QtCore.QEvent.MouseButtonPress,
-            pos,
-            QtCore.Qt.RightButton,
-            QtCore.Qt.RightButton,
-        )
-        self.send_mouse(
-            widget,
-            QtCore.QEvent.MouseButtonRelease,
-            pos,
-            QtCore.Qt.RightButton,
-            QtCore.Qt.NoButton,
-        )
-        self.pump(120)
-
-    def move(self, widget, pos):
-        self.send_mouse(
-            widget,
-            QtCore.QEvent.MouseMove,
-            pos,
-            QtCore.Qt.NoButton,
-            QtCore.Qt.NoButton,
-        )
-        self.pump(80)
-
-    def key_click(self, widget, key, text=""):
-        press = QtGui.QKeyEvent(QtCore.QEvent.KeyPress, key, QtCore.Qt.NoModifier, text)
-        release = QtGui.QKeyEvent(QtCore.QEvent.KeyRelease, key, QtCore.Qt.NoModifier, text)
-        QtGui.QApplication.sendEvent(widget, press)
-        QtGui.QApplication.sendEvent(widget, release)
-        self.pump(60)
-
-    def clamp_to_widget(self, widget, pos, margin=10):
-        rect = widget.rect()
-        return QtCore.QPoint(
-            max(margin, min(pos.x(), rect.right() - margin)),
-            max(margin, min(pos.y(), rect.bottom() - margin)),
-        )
-
-    def device_pixel_ratio(self, widget):
-        return widget.devicePixelRatioF()
-
-    def viewport_to_qpoint(self, view, viewport, point):
-        _, height = view.getSize()
-        scale = self.device_pixel_ratio(viewport)
-        x = int(round(point[0] / scale))
-        y = int(round((height - point[1] - 1) / scale))
-        return QtCore.QPoint(x, y)
+QT_MODULE_AVAILABLE = QtCore is not None

--- a/src/Mod/Sketcher/SketcherTests/Support.py
+++ b/src/Mod/Sketcher/SketcherTests/Support.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Sketcher-specific edit-mode assertions for GUI tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import FreeCAD
+from Gui.Harness import FreeCADGui
+from Gui.TestCase import FreeCADGuiTestCase
+
+
+class SketcherGuiTestCase(FreeCADGuiTestCase):
+    """Add exact Sketcher edit-target assertions to the generic test base."""
+
+    def enter_sketch_edit(self, document: FreeCAD.Document, sketch: Any) -> Any:
+        """Enter ``sketch`` edit mode and return its GUI document."""
+        gui_document = self.gui.enter_edit(document, sketch.Name)
+        self.assert_sketch_edit_active(gui_document, sketch)
+        return gui_document
+
+    @staticmethod
+    def _active_gui_document(gui_document: Any | None = None) -> Any | None:
+        return gui_document if gui_document is not None else FreeCADGui.ActiveDocument
+
+    def assert_sketch_edit_active(
+        self,
+        gui_document: Any | None = None,
+        sketch: Any | None = None,
+    ) -> None:
+        """Assert that Sketcher is editing, optionally checking its exact object."""
+        gui_document = self._active_gui_document(gui_document)
+        edit = gui_document.getInEdit() if gui_document is not None else None
+        self.assertIsNotNone(edit, "Expected sketch edit mode to remain active")
+        self.assertTrue(
+            edit.isDerivedFrom("SketcherGui::ViewProviderSketch"),
+            "Expected a Sketcher view provider to remain in edit mode",
+        )
+        if sketch is not None:
+            edit_object = getattr(edit, "Object", None)
+            self.assertEqual(
+                getattr(edit_object, "Name", None),
+                sketch.Name,
+                "Expected the requested sketch to be the active edit target",
+            )
+
+    def assert_sketch_edit_inactive(self, gui_document: Any | None = None) -> None:
+        """Assert that the selected GUI document is not in Sketcher edit mode."""
+        gui_document = self._active_gui_document(gui_document)
+        edit = gui_document.getInEdit() if gui_document is not None else None
+        self.assertIsNone(edit, "Expected sketch edit mode to be inactive")

--- a/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
@@ -1,33 +1,228 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import math
-import time
-import unittest
+from collections.abc import Sequence
+from typing import Any, Literal, TypeAlias
 
 import FreeCAD
 import FreeCADGui
 import Part
 import Sketcher
 import SketcherGui
-from PySide6 import QtCore, QtWidgets
+from SketcherTests.Support import SketcherGuiTestCase
 
 
-class SketcherGuiTestCases(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        if not FreeCAD.GuiUp:
-            raise unittest.SkipTest("Cannot run GUI tests in a CLI environment.")
+CoinPoint: TypeAlias = tuple[int, int]
+"""A point in FreeCAD's physical viewport coordinate system."""
 
-        FreeCADGui.getMainWindow().show()
-        cls.pump_gui_events()
+PreselectionInfo: TypeAlias = dict[str, Any]
+"""The mapping returned by ``SketcherGui.getActiveSketchPreselection``."""
 
-    @staticmethod
-    def pump_gui_events(iterations=6, delay=0.01):
-        app = QtWidgets.QApplication.instance()
-        for _ in range(iterations):
-            app.processEvents(QtCore.QEventLoop.AllEvents, int(delay * 1000))
-            if delay > 0.0:
-                time.sleep(delay)
+PreselectionKind: TypeAlias = Literal[
+    "target_constraint",
+    "other_constraint",
+    "edge",
+    "vertex",
+    "other",
+    "none",
+]
+"""Classification returned for a Sketcher preselection probe."""
+
+
+def classify_preselection(
+    info: PreselectionInfo | None,
+    expected_constraint_name: str,
+) -> PreselectionKind:
+    """Classify one Sketcher preselection result for a probe assertion."""
+    if not info or not info.get("ObjectName"):
+        return "none"
+
+    names = info.get("SubElementNames") or []
+    if expected_constraint_name in names:
+        return "target_constraint"
+    if any(name.startswith("Constraint") for name in names):
+        return "other_constraint"
+    if any(name.startswith("Vertex") for name in names):
+        return "vertex"
+    if any(name.startswith("Edge") for name in names):
+        return "edge"
+    return "other"
+
+
+def scan_preselection_at_viewport(
+    center_coin: CoinPoint,
+    expected_constraint_name: str,
+    span: int = 16,
+    step: int = 2,
+) -> dict[PreselectionKind, int]:
+    """Count Sketcher preselection classifications around a point."""
+    counts = {
+        "target_constraint": 0,
+        "other_constraint": 0,
+        "edge": 0,
+        "vertex": 0,
+        "other": 0,
+        "none": 0,
+    }
+
+    for dy in range(-span, span + 1, step):
+        for dx in range(-span, span + 1, step):
+            coin_point = (center_coin[0] + dx, center_coin[1] + dy)
+            info = SketcherGui.getActiveSketchPreselection(coin_point)
+            counts[classify_preselection(info, expected_constraint_name)] += 1
+    return counts
+
+
+def find_constraint_probe_viewport_point(
+    view: Any,
+    seed_world_point: Any,
+    expected_constraint_name: str,
+    span: int = 64,
+    step: int = 8,
+) -> CoinPoint | None:
+    """Find the center of a visible target-constraint preselection area."""
+    center_coin = tuple(int(value) for value in view.getPointOnViewport(seed_world_point))
+    sum_x = 0
+    sum_y = 0
+    target_count = 0
+
+    for dy in range(-span, span + 1, step):
+        for dx in range(-span, span + 1, step):
+            coin_point = (center_coin[0] + dx, center_coin[1] + dy)
+            info = SketcherGui.getActiveSketchPreselection(coin_point)
+            if classify_preselection(info, expected_constraint_name) != "target_constraint":
+                continue
+            sum_x += coin_point[0]
+            sum_y += coin_point[1]
+            target_count += 1
+
+    if target_count == 0:
+        return None
+    return (int(round(sum_x / target_count)), int(round(sum_y / target_count)))
+
+
+def wait_for_constraint_probe_viewport_point(
+    test_case: SketcherGuiTestCase,
+    view: Any,
+    seed_world_point: Any,
+    expected_constraint_name: str,
+) -> CoinPoint:
+    """Wait until a target constraint has a usable viewport probe point."""
+    probe_point: list[CoinPoint] = []
+
+    def find_probe_point() -> bool:
+        point = find_constraint_probe_viewport_point(
+            view,
+            seed_world_point,
+            expected_constraint_name,
+        )
+        if point is None:
+            return False
+        probe_point[:] = [point]
+        return True
+
+    test_case.assertTrue(
+        test_case.gui.wait_until(
+            find_probe_point,
+            timeout_ms=1000,
+            description="constraint preselection probe point",
+        ),
+        "Expected the constraint preselection scene to become available",
+    )
+    return probe_point[0]
+
+
+def preselection_offsets(
+    center_coin: CoinPoint,
+    expected_constraint_name: str,
+    expected_kind: PreselectionKind,
+    span: int,
+    step: int,
+) -> list[CoinPoint]:
+    """Return offsets whose preselection has the expected classification."""
+    offsets: list[CoinPoint] = []
+    for dy in range(-span, span + 1, step):
+        for dx in range(-span, span + 1, step):
+            coin_point = (center_coin[0] + dx, center_coin[1] + dy)
+            info = SketcherGui.getActiveSketchPreselection(coin_point)
+            if classify_preselection(info, expected_constraint_name) == expected_kind:
+                offsets.append((dx, dy))
+    return offsets
+
+
+def wait_for_preselection_offsets(
+    test_case: SketcherGuiTestCase,
+    center_coin: CoinPoint,
+    expected_constraint_name: str,
+    expected_kind: PreselectionKind,
+    span: int,
+    step: int,
+) -> list[CoinPoint]:
+    """Wait until at least one expected preselection offset is available."""
+    offsets: list[CoinPoint] = []
+
+    def find_offsets() -> bool:
+        offsets[:] = preselection_offsets(
+            center_coin,
+            expected_constraint_name,
+            expected_kind,
+            span,
+            step,
+        )
+        return bool(offsets)
+
+    test_case.assertTrue(
+        test_case.gui.wait_until(
+            find_offsets,
+            timeout_ms=1000,
+            description=f"{expected_kind} preselection offsets",
+        ),
+        f"Expected at least one {expected_kind} preselection point",
+    )
+    return offsets
+
+
+def wait_for_preselection_results(
+    test_case: SketcherGuiTestCase,
+    center_coin: CoinPoint,
+    offsets: Sequence[CoinPoint],
+    expected_constraint_name: str,
+    expected_kind: PreselectionKind,
+) -> list[tuple[int, int, PreselectionKind, PreselectionInfo | None]]:
+    """Wait until all probe points have the expected classification."""
+    results: list[tuple[int, int, PreselectionKind, PreselectionInfo | None]] = []
+
+    def find_results() -> bool:
+        results[:] = []
+        for dx, dy in offsets:
+            coin_point = (center_coin[0] + dx, center_coin[1] + dy)
+            info = SketcherGui.getActiveSketchPreselection(coin_point)
+            kind = classify_preselection(info, expected_constraint_name)
+            results.append((dx, dy, kind, info))
+        return bool(results) and all(result[2] == expected_kind for result in results)
+
+    test_case.assertTrue(
+        test_case.gui.wait_until(
+            find_results,
+            timeout_ms=1000,
+            description=f"{expected_kind} preselection results",
+        ),
+        f"Expected all preselection points to classify as {expected_kind}",
+    )
+    return results
+
+
+def configure_view_state(view: Any, tilt: Any | None = None) -> None:
+    """Set a standard Sketcher view and optionally apply a camera tilt."""
+    view.viewTop()
+    view.fitAll()
+    if tilt is not None:
+        base_rotation = view.getCameraOrientation()
+        view.setCameraOrientation(tilt.multiply(base_rotation))
+        view.fitAll()
+
+
+class SketcherGuiTestCases(SketcherGuiTestCase):
 
     @staticmethod
     def build_issue_25840_sketch(sketch):
@@ -52,89 +247,6 @@ class SketcherGuiTestCases(unittest.TestCase):
         return constraint_id, FreeCAD.Vector(30.973626440922192, -20.12834717, 0.0)
 
     @staticmethod
-    def classify_preselection(info, expected_constraint_name):
-        if not info or not info["ObjectName"]:
-            return "none"
-
-        names = info.get("SubElementNames") or []
-        if expected_constraint_name in names:
-            return "target_constraint"
-        if any(name.startswith("Constraint") for name in names):
-            return "other_constraint"
-        if any(name.startswith("Vertex") for name in names):
-            return "vertex"
-        if any(name.startswith("Edge") for name in names):
-            return "edge"
-        return "other"
-
-    @classmethod
-    def scan_preselection_at_viewport(cls, center_coin, expected_constraint_name, span=16, step=2):
-        counts = {
-            "target_constraint": 0,
-            "other_constraint": 0,
-            "edge": 0,
-            "vertex": 0,
-            "other": 0,
-            "none": 0,
-        }
-
-        for dy in range(-span, span + 1, step):
-            for dx in range(-span, span + 1, step):
-                coin_point = (center_coin[0] + dx, center_coin[1] + dy)
-                info = SketcherGui.getActiveSketchPreselection(coin_point)
-                kind = cls.classify_preselection(info, expected_constraint_name)
-                counts[kind] += 1
-
-        return counts
-
-    @classmethod
-    def find_constraint_probe_viewport_point(
-        cls,
-        view,
-        seed_world_point,
-        expected_constraint_name,
-        span=64,
-        step=8,
-    ):
-        center_coin = tuple(int(value) for value in view.getPointOnViewport(seed_world_point))
-        sum_x = 0
-        sum_y = 0
-        target_count = 0
-
-        for dy in range(-span, span + 1, step):
-            for dx in range(-span, span + 1, step):
-                coin_point = (center_coin[0] + dx, center_coin[1] + dy)
-                info = SketcherGui.getActiveSketchPreselection(coin_point)
-                if cls.classify_preselection(info, expected_constraint_name) != "target_constraint":
-                    continue
-
-                sum_x += coin_point[0]
-                sum_y += coin_point[1]
-                target_count += 1
-
-        if target_count == 0:
-            return None
-
-        return (
-            int(round(sum_x / target_count)),
-            int(round(sum_y / target_count)),
-        )
-
-    @classmethod
-    def configure_view_state(cls, view, tilt=None):
-        view.viewTop()
-        cls.pump_gui_events(2)
-        view.fitAll()
-        cls.pump_gui_events(4)
-
-        if tilt is not None:
-            base_rotation = view.getCameraOrientation()
-            view.setCameraOrientation(tilt.multiply(base_rotation))
-            cls.pump_gui_events(3)
-            view.fitAll()
-            cls.pump_gui_events(4)
-
-    @staticmethod
     def constraint_share(counts):
         total_hits = (
             counts["target_constraint"]
@@ -148,35 +260,19 @@ class SketcherGuiTestCases(unittest.TestCase):
         return counts["target_constraint"] / total_hits
 
     def setUp(self):
+        super().setUp()
         self.doc = FreeCAD.newDocument("SketchGuiTest")
         self.sketch = self.doc.addObject("Sketcher::SketchObject", "Sketch")
         self.doc.recompute()
 
-        FreeCADGui.getMainWindow().show()
-        self.pump_gui_events()
-        FreeCADGui.ActiveDocument.setEdit(self.sketch.Name)
-        self.pump_gui_events(6)
+        self.enter_sketch_edit(self.doc, self.sketch)
 
         self.view = FreeCADGui.ActiveDocument.ActiveView
-
-    def tearDown(self):
-        FreeCADGui.Selection.clearPreselection()
-        FreeCADGui.Selection.clearSelection()
-        if FreeCADGui.ActiveDocument:
-            FreeCADGui.ActiveDocument.resetEdit()
-        self.pump_gui_events(4, 0.01)
-
-        if self.doc is not None:
-            document_name = self.doc.Name
-            self.doc = None
-            FreeCAD.closeDocument(document_name)
-            self.pump_gui_events(4, 0.01)
 
     def testPointOnObjectPreselectionMatchesTiltedHitArea(self):
         constraint_id, self.probe_point = self.build_issue_25840_sketch(self.sketch)
         self.expected_constraint_name = f"Constraint{constraint_id + 1}"
         self.doc.recompute()
-        self.pump_gui_events(6)
 
         tilt_y = FreeCAD.Rotation(FreeCAD.Vector(0, 1, 0), 2.0)
 
@@ -185,14 +281,14 @@ class SketcherGuiTestCases(unittest.TestCase):
             "exact_top": None,
             "tilt_y_2deg": tilt_y,
         }.items():
-            self.configure_view_state(self.view, tilt)
-            probe_point = self.find_constraint_probe_viewport_point(
+            configure_view_state(self.view, tilt)
+            probe_point = wait_for_constraint_probe_viewport_point(
+                self,
                 self.view,
                 self.probe_point,
                 self.expected_constraint_name,
             )
-            self.assertIsNotNone(probe_point)
-            counts_by_state[name] = self.scan_preselection_at_viewport(
+            counts_by_state[name] = scan_preselection_at_viewport(
                 probe_point,
                 self.expected_constraint_name,
                 span=12,
@@ -232,21 +328,19 @@ class SketcherGuiTestCases(unittest.TestCase):
         )
         self.sketch.addGeometry(Part.Point(marker_point), False)
         self.doc.recompute()
-        self.pump_gui_events(6)
 
-        self.configure_view_state(self.view)
-        self.pump_gui_events(8)
+        configure_view_state(self.view)
 
         marker_coin = tuple(int(value) for value in self.view.getPointOnViewport(marker_point))
 
-        vertex_offsets = []
-        for dy in range(-12, 13, 2):
-            for dx in range(-12, 13, 2):
-                probe_coin = (marker_coin[0] + dx, marker_coin[1] + dy)
-                probe_info = SketcherGui.getActiveSketchPreselection(probe_coin)
-                probe_kind = self.classify_preselection(probe_info, "Constraint0")
-                if probe_kind == "vertex":
-                    vertex_offsets.append((dx, dy))
+        vertex_offsets = wait_for_preselection_offsets(
+            self,
+            marker_coin,
+            "Constraint0",
+            "vertex",
+            span=12,
+            step=2,
+        )
 
         constraint_id = self.sketch.addConstraint(
             Sketcher.Constraint("Distance", line_id, 1, line_id, 2, 40.0)
@@ -255,23 +349,43 @@ class SketcherGuiTestCases(unittest.TestCase):
         self.sketch.setLabelPosition(constraint_id, 0.0)
         self.expected_constraint_name = f"Constraint{constraint_id + 1}"
         self.doc.recompute()
-        self.pump_gui_events(12)
 
+        constraint_probe = wait_for_constraint_probe_viewport_point(
+            self,
+            self.view,
+            marker_point,
+            self.expected_constraint_name,
+        )
+
+        self.assertTrue(
+            self.gui.wait_until(
+                lambda: classify_preselection(
+                    SketcherGui.getActiveSketchPreselection(marker_coin),
+                    self.expected_constraint_name,
+                )
+                == "vertex",
+                timeout_ms=1000,
+                description="marker vertex preselection",
+            ),
+            "Expected the marker to remain preselectable as a vertex",
+        )
         marker_info = SketcherGui.getActiveSketchPreselection(marker_coin)
-        marker_kind = self.classify_preselection(marker_info, self.expected_constraint_name)
+        marker_kind = classify_preselection(marker_info, self.expected_constraint_name)
 
-        probe_results = []
-        for dx, dy in vertex_offsets:
-            probe_coin = (marker_coin[0] + dx, marker_coin[1] + dy)
-            probe_info = SketcherGui.getActiveSketchPreselection(probe_coin)
-            probe_kind = self.classify_preselection(probe_info, self.expected_constraint_name)
-            probe_results.append((dx, dy, probe_kind, probe_info))
+        probe_results = wait_for_preselection_results(
+            self,
+            marker_coin,
+            vertex_offsets,
+            self.expected_constraint_name,
+            "vertex",
+        )
 
         unexpected_probe_results = [result for result in probe_results if result[2] != "vertex"]
 
         detail = (
             f"marker_info={marker_info}, vertex_offsets={vertex_offsets}, "
-            f"probe_results={probe_results}, marker_coin={marker_coin}"
+            f"probe_results={probe_results}, marker_coin={marker_coin}, "
+            f"constraint_probe={constraint_probe}"
         )
 
         self.assertGreater(len(vertex_offsets), 0, detail)
@@ -288,21 +402,19 @@ class SketcherGuiTestCases(unittest.TestCase):
             False,
         )
         self.doc.recompute()
-        self.pump_gui_events(6)
 
-        self.configure_view_state(self.view)
-        self.pump_gui_events(8)
+        configure_view_state(self.view)
 
         midpoint_coin = tuple(int(value) for value in self.view.getPointOnViewport(midpoint))
 
-        edge_offsets = []
-        for dy in range(-10, 11, 2):
-            for dx in range(-16, 17, 2):
-                probe_coin = (midpoint_coin[0] + dx, midpoint_coin[1] + dy)
-                probe_info = SketcherGui.getActiveSketchPreselection(probe_coin)
-                probe_kind = self.classify_preselection(probe_info, "Constraint0")
-                if probe_kind == "edge":
-                    edge_offsets.append((dx, dy))
+        edge_offsets = wait_for_preselection_offsets(
+            self,
+            midpoint_coin,
+            "Constraint0",
+            "edge",
+            span=16,
+            step=2,
+        )
 
         constraint_id = self.sketch.addConstraint(
             Sketcher.Constraint(
@@ -318,20 +430,27 @@ class SketcherGuiTestCases(unittest.TestCase):
         self.sketch.setLabelPosition(constraint_id, 0.0)
         self.expected_constraint_name = f"Constraint{constraint_id + 1}"
         self.doc.recompute()
-        self.pump_gui_events(12)
 
-        probe_results = []
-        for dx, dy in edge_offsets:
-            probe_coin = (midpoint_coin[0] + dx, midpoint_coin[1] + dy)
-            probe_info = SketcherGui.getActiveSketchPreselection(probe_coin)
-            probe_kind = self.classify_preselection(probe_info, self.expected_constraint_name)
-            probe_results.append((dx, dy, probe_kind, probe_info))
+        constraint_probe = wait_for_constraint_probe_viewport_point(
+            self,
+            self.view,
+            midpoint,
+            self.expected_constraint_name,
+        )
+
+        probe_results = wait_for_preselection_results(
+            self,
+            midpoint_coin,
+            edge_offsets,
+            self.expected_constraint_name,
+            "edge",
+        )
 
         unexpected_probe_results = [result for result in probe_results if result[2] != "edge"]
 
         detail = (
             f"edge_offsets={edge_offsets}, probe_results={probe_results}, "
-            f"midpoint_coin={midpoint_coin}"
+            f"midpoint_coin={midpoint_coin}, constraint_probe={constraint_probe}"
         )
 
         self.assertGreater(len(edge_offsets), 0, detail)

--- a/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestConstraintPreselectionGui.py
@@ -11,7 +11,6 @@ import Sketcher
 import SketcherGui
 from SketcherTests.Support import SketcherGuiTestCase
 
-
 CoinPoint: TypeAlias = tuple[int, int]
 """A point in FreeCAD's physical viewport coordinate system."""
 

--- a/src/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py
+++ b/src/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py
@@ -37,7 +37,7 @@ import unittest
 import FreeCAD
 import Part
 import Sketcher
-from SketcherTests.GuiTestCase import SketcherGuiTestCase
+from SketcherTests.Support import SketcherGuiTestCase
 
 try:
     import FreeCADGui
@@ -47,7 +47,7 @@ except (ImportError, AttributeError):
     GUI_AVAILABLE = False
 
 if GUI_AVAILABLE:
-    from PySide import QtCore, QtGui
+    from PySide import QtCore
 
 
 class TestExternalFacePreselection(SketcherGuiTestCase):
@@ -93,23 +93,41 @@ class TestExternalFacePreselection(SketcherGuiTestCase):
         self.body = body
         self.pad = pad
 
-    def hover_for_preselection(self, viewport, center_pos, span=6, step=2):
+    def hover_for_preselection(
+        self,
+        viewport,
+        center_pos,
+        expected_sub_element=None,
+        span=6,
+        step=2,
+    ):
+        def has_expected_sub_element():
+            presel = FreeCADGui.Selection.getPreselection()
+            if not presel.ObjectName:
+                return False
+            if expected_sub_element is None:
+                return True
+            return any(expected_sub_element in name for name in presel.SubElementNames)
+
         for dy in range(-span, span + 1, step):
             for dx in range(-span, span + 1, step):
                 pos = QtCore.QPoint(center_pos.x() + dx, center_pos.y() + dy)
-                event = QtGui.QMouseEvent(
+                FreeCADGui.Selection.clearPreselection()
+                self.gui.send_mouse(
+                    viewport,
                     QtCore.QEvent.MouseMove,
                     pos,
-                    viewport.mapToGlobal(pos),
                     QtCore.Qt.NoButton,
                     QtCore.Qt.NoButton,
-                    QtCore.Qt.NoModifier,
                 )
-                QtGui.QApplication.sendEvent(viewport, event)
-                self.pump(100)
+                self.gui.wait_until(
+                    has_expected_sub_element,
+                    timeout_ms=100,
+                    description="face preselection",
+                )
 
                 presel = FreeCADGui.Selection.getPreselection()
-                if presel.ObjectName:
+                if has_expected_sub_element():
                     return presel
 
         return FreeCADGui.Selection.getPreselection()
@@ -123,8 +141,7 @@ class TestExternalFacePreselection(SketcherGuiTestCase):
 
         from pivy import coin
 
-        FreeCADGui.ActiveDocument.setEdit(self.testSketch.Name)
-        self.pump(300)
+        self.enter_sketch_edit(self.doc, self.testSketch)
 
         view = FreeCADGui.ActiveDocument.ActiveView
         viewer = view.getViewer()
@@ -164,8 +181,7 @@ class TestExternalFacePreselection(SketcherGuiTestCase):
 
         from pivy import coin
 
-        FreeCADGui.ActiveDocument.setEdit(self.testSketch.Name)
-        self.pump(300)
+        self.enter_sketch_edit(self.doc, self.testSketch)
 
         view = FreeCADGui.ActiveDocument.ActiveView
         viewer = view.getViewer()
@@ -201,8 +217,8 @@ class TestExternalFacePreselection(SketcherGuiTestCase):
         """A face on the Pad must be preselectable via mouse hover
         while the External Geometry tool is active (#28639)."""
 
-        FreeCADGui.ActiveDocument.setEdit(self.testSketch.Name)
-        self.pump(300)
+        self.enter_sketch_edit(self.doc, self.testSketch)
+        self.gui.pump(300)
 
         # Add geometry + constraints so constraint icons are rendered.
         self.testSketch.addGeometry(
@@ -214,12 +230,12 @@ class TestExternalFacePreselection(SketcherGuiTestCase):
         self.testSketch.addConstraint(Sketcher.Constraint("DistanceX", 0, 1, 0, 2, 20.0))
         self.testSketch.addConstraint(Sketcher.Constraint("DistanceY", 1, 1, 1, 2, 20.0))
         self.doc.recompute()
-        self.pump(300)
+        self.gui.pump(300)
 
         view = FreeCADGui.ActiveDocument.ActiveView
         view.viewFront()
         view.fitAll()
-        self.pump(300)
+        self.gui.pump(300)
 
         face_center_3d = FreeCAD.Vector(0, -20, 10)
 
@@ -238,20 +254,24 @@ class TestExternalFacePreselection(SketcherGuiTestCase):
             )
 
         self.assertTrue(
-            self.wait_until(face_center_is_framed, timeout_ms=5000, step_ms=100),
+            self.gui.wait_until(face_center_is_framed, timeout_ms=5000, step_ms=100),
             "Camera never framed the Pad face; getPointOnScreen stayed at the "
             "viewport edge, so no valid interior hover point could be computed.",
         )
 
         # Activate External Geometry tool
+        FreeCADGui.Selection.clearSelection()
+        FreeCADGui.Selection.clearPreselection()
         FreeCADGui.runCommand("Sketcher_Projection", 0)
-        self.pump(300)
+        # The projection command creates the Coin hit-test nodes through the
+        # render event queue. Let that queue settle before probing the view.
+        self.gui.pump(300)
 
         # Simulate mouse hover over the front face center
         viewport = view.graphicsView().viewport()
         screen_pt = view.getPointOnScreen(face_center_3d)
-        hover_pos = self.viewport_to_qpoint(view, viewport, screen_pt)
-        presel = self.hover_for_preselection(viewport, hover_pos)
+        hover_pos = self.gui.active_view().viewport_to_screen(screen_pt, viewport)
+        presel = self.hover_for_preselection(viewport, hover_pos, expected_sub_element="Face")
         self.assertNotEqual(
             presel.ObjectName,
             "",

--- a/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
@@ -2,7 +2,9 @@
 
 import FreeCAD
 from PySide import QtCore, QtGui
-from SketcherTests.GuiTestCase import FreeCADGui, SketcherGuiTestCase
+from Gui.Wait import FreeCADGui
+from Support import temporary_preference
+from SketcherTests.Support import SketcherGuiTestCase
 
 
 class TestOnViewParameterGui(SketcherGuiTestCase):
@@ -41,48 +43,19 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
 
     def key_text(self, widget, text):
         for ch in text:
-            self.key_click(widget, self.KEYS[ch], ch)
+            self.gui.key_click(widget, self.KEYS[ch], ch)
 
     def active_spinbox(self):
-        widget = QtGui.QApplication.focusWidget()
-        if isinstance(widget, QtGui.QAbstractSpinBox):
-            return widget
-        if isinstance(widget, QtGui.QLineEdit):
-            parent = widget.parent()
-            if isinstance(parent, QtGui.QAbstractSpinBox):
-                return parent
-        return None
+        return self.gui.focused_widget(QtGui.QAbstractSpinBox)
 
     def visible_spinboxes(self):
-        main_window = FreeCADGui.getMainWindow()
-        return [
-            spinbox
-            for spinbox in main_window.findChildren(QtGui.QAbstractSpinBox)
-            if spinbox.isVisible()
-        ]
-
-    def active_task_dialog(self):
-        return FreeCADGui.Control.activeTaskDialog()
-
-    def assert_sketch_edit_active(self):
-        edit = FreeCADGui.ActiveDocument.getInEdit()
-        self.assertIsNotNone(edit, "Expected sketch edit mode to remain active")
-        self.assertTrue(
-            edit.isDerivedFrom("SketcherGui::ViewProviderSketch"),
-            "Expected a Sketcher view provider to remain in edit mode",
-        )
-
-    def assert_sketch_edit_inactive(self):
-        self.assertIsNone(
-            FreeCADGui.ActiveDocument.getInEdit(),
-            "Expected sketch edit mode to be inactive",
-        )
+        return self.gui.find_widgets(QtGui.QAbstractSpinBox, visible_only=True)
 
     def begin_sketch_edit_with_task_dialog(self):
-        FreeCADGui.ActiveDocument.setEdit(self.sketch.Name)
-        self.pump(200)
-        self.assert_sketch_edit_active()
-        self.assertIsNotNone(self.active_task_dialog(), "Expected the Sketcher task dialog to open")
+        self.enter_sketch_edit(self.doc, self.sketch)
+        self.assertIsNotNone(
+            self.gui.wait_for_task_panel(), "Expected the Sketcher task dialog to open"
+        )
 
     def begin_rectangle_with_visible_ovp(self):
         self.begin_sketch_edit_with_task_dialog()
@@ -90,10 +63,9 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
         view = FreeCADGui.ActiveDocument.ActiveView
         view.viewTop()
         view.fitAll()
-        self.pump(100)
 
-        viewport = view.graphicsView().viewport()
         origin = FreeCAD.Vector(0, 0, 0)
+        viewport = self.gui.active_view().viewport
 
         def wait_for_origin_point():
             first_point = None
@@ -106,7 +78,7 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
                     return False
 
                 view.fitAll()
-                point = self.viewport_to_qpoint(view, viewport, view.getPointOnScreen(origin))
+                point = self.gui.active_view().world_to_screen(origin)
                 interior_rect = viewport.rect().adjusted(20, 20, -20, -20)
                 if not interior_rect.contains(point):
                     return False
@@ -115,29 +87,32 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
                 return True
 
             self.assertTrue(
-                self.wait_until(origin_is_framed, timeout_ms=5000, step_ms=100),
+                self.gui.wait_until(origin_is_framed, timeout_ms=5000, step_ms=100),
                 "Expected the sketch origin to project to an interior viewport point",
             )
             self.assertIsNotNone(first_point)
             return first_point
 
         FreeCADGui.runCommand("Sketcher_CreateRectangle")
-        self.pump(250)
 
         first_point = wait_for_origin_point()
 
-        move_target = self.clamp_to_widget(
+        move_target = self.gui.clamp_to_widget(
             viewport,
             QtCore.QPoint(first_point.x() + 80, first_point.y() - 60),
         )
 
-        self.move(viewport, first_point)
-        self.click(viewport, first_point)
-        self.move(viewport, move_target)
+        self.gui.move(viewport, first_point)
+        self.gui.click(viewport, first_point)
+        self.gui.move(viewport, move_target)
 
         self.assertTrue(
-            self.wait_until(lambda: len(self.visible_spinboxes()) == 2, timeout_ms=1000),
+            self.gui.wait_until(lambda: len(self.visible_spinboxes()) == 2, timeout_ms=1000),
             "Expected the rectangle OVPs to become visible after the first click",
+        )
+        self.assertIsNotNone(
+            self.gui.wait_for_focus(QtGui.QAbstractSpinBox, timeout_ms=1000),
+            "Expected the first rectangle OVP to receive focus",
         )
 
         return viewport, first_point
@@ -148,7 +123,7 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
         FreeCADGui.ActiveDocument.resetEdit()
 
         self.assertTrue(
-            self.wait_until(lambda: self.active_task_dialog() is None, timeout_ms=1000),
+            self.gui.wait_until(lambda: self.gui.active_task_panel() is None, timeout_ms=1000),
             "Expected resetEdit() to close the Sketcher task dialog",
         )
         self.assert_sketch_edit_inactive()
@@ -156,10 +131,10 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
     def test_task_dialog_reject_exits_sketch_edit(self):
         self.begin_sketch_edit_with_task_dialog()
 
-        self.active_task_dialog().reject()
+        self.gui.active_task_panel().reject()
 
         self.assertTrue(
-            self.wait_until(lambda: self.active_task_dialog() is None, timeout_ms=1000),
+            self.gui.wait_until(lambda: self.gui.active_task_panel() is None, timeout_ms=1000),
             "Expected reject() to close the Sketcher task dialog",
         )
         self.assert_sketch_edit_inactive()
@@ -167,10 +142,10 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
     def test_task_dialog_accept_exits_sketch_edit(self):
         self.begin_sketch_edit_with_task_dialog()
 
-        self.active_task_dialog().accept()
+        self.gui.active_task_panel().accept()
 
         self.assertTrue(
-            self.wait_until(lambda: self.active_task_dialog() is None, timeout_ms=1000),
+            self.gui.wait_until(lambda: self.gui.active_task_panel() is None, timeout_ms=1000),
             "Expected accept() to close the Sketcher task dialog",
         )
         self.assert_sketch_edit_inactive()
@@ -188,10 +163,10 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
         first_spinbox = self.active_spinbox()
         self.assertIsNotNone(first_spinbox, "Expected the first rectangle OVP to have focus")
         self.key_text(first_spinbox, "10")
-        self.key_click(first_spinbox, QtCore.Qt.Key_Tab, "\t")
+        self.gui.key_click(first_spinbox, QtCore.Qt.Key_Tab, "\t")
 
         self.assertTrue(
-            self.wait_until(
+            self.gui.wait_until(
                 lambda: self.active_spinbox() is not None
                 and self.active_spinbox() is not first_spinbox,
                 timeout_ms=1000,
@@ -202,10 +177,16 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
         second_spinbox = self.active_spinbox()
         self.assertIsNotNone(second_spinbox, "Expected the second rectangle OVP to have focus")
         self.key_text(second_spinbox, "20")
-        self.key_click(second_spinbox, QtCore.Qt.Key_Return, "\r")
+        self.gui.key_click(second_spinbox, QtCore.Qt.Key_Return, "\r")
 
-        self.pump(500)
-
+        self.assertTrue(
+            self.gui.wait_until(
+                lambda: self.sketch.GeometryCount >= 4,
+                timeout_ms=1000,
+                description="rectangle geometry",
+            ),
+            "Expected the rectangle to be created after accepting both OVPs",
+        )
         self.assertGreaterEqual(
             self.sketch.GeometryCount,
             4,
@@ -217,72 +198,75 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
 
         first_spinbox = self.active_spinbox()
         self.assertIsNotNone(first_spinbox, "Expected the first rectangle OVP to have focus")
-        self.key_click(first_spinbox, QtCore.Qt.Key_Escape)
+        self.gui.key_click(first_spinbox, QtCore.Qt.Key_Escape)
 
         self.assertTrue(
-            self.wait_until(lambda: len(self.visible_spinboxes()) == 0, timeout_ms=1000),
+            self.gui.wait_until(lambda: len(self.visible_spinboxes()) == 0, timeout_ms=1000),
             "Expected Esc to close the rectangle OVPs",
         )
         self.assertEqual(self.sketch.GeometryCount, 0)
         self.assert_sketch_edit_active()
 
-        restart_point = self.clamp_to_widget(
+        restart_point = self.gui.clamp_to_widget(
             viewport,
             QtCore.QPoint(first_point.x() + 120, first_point.y() + 50),
         )
-        restart_move = self.clamp_to_widget(
+        restart_move = self.gui.clamp_to_widget(
             viewport,
             QtCore.QPoint(restart_point.x() + 70, restart_point.y() - 40),
         )
 
-        self.move(viewport, restart_point)
-        self.click(viewport, restart_point)
-        self.move(viewport, restart_move)
+        self.gui.move(viewport, restart_point)
+        self.gui.click(viewport, restart_point)
+        self.gui.move(viewport, restart_move)
 
         self.assertTrue(
-            self.wait_until(lambda: len(self.visible_spinboxes()) == 2, timeout_ms=1000),
+            self.gui.wait_until(lambda: len(self.visible_spinboxes()) == 2, timeout_ms=1000),
             "Expected Esc to reset the rectangle tool back to its first stage",
         )
         self.assertEqual(self.sketch.GeometryCount, 0)
-        self.assertIsNotNone(self.active_spinbox())
+        self.assertIsNotNone(
+            self.gui.wait_for_focus(QtGui.QAbstractSpinBox, timeout_ms=1000),
+            "Expected the first rectangle OVP to receive focus after reset",
+        )
 
     def test_rectangle_ovp_escape_then_right_click_exits_tool(self):
         viewport, first_point = self.begin_rectangle_with_visible_ovp()
 
         first_spinbox = self.active_spinbox()
         self.assertIsNotNone(first_spinbox, "Expected the first rectangle OVP to have focus")
-        self.key_click(first_spinbox, QtCore.Qt.Key_Escape)
+        self.gui.key_click(first_spinbox, QtCore.Qt.Key_Escape)
 
         self.assertTrue(
-            self.wait_until(lambda: len(self.visible_spinboxes()) == 0, timeout_ms=1000),
+            self.gui.wait_until(lambda: len(self.visible_spinboxes()) == 0, timeout_ms=1000),
             "Expected Esc to close the rectangle OVPs",
         )
         self.assertEqual(self.sketch.GeometryCount, 0)
         self.assert_sketch_edit_active()
 
-        cancel_point = self.clamp_to_widget(
+        cancel_point = self.gui.clamp_to_widget(
             viewport,
             QtCore.QPoint(first_point.x() + 120, first_point.y() + 50),
         )
-        retry_move = self.clamp_to_widget(
+        retry_move = self.gui.clamp_to_widget(
             viewport,
             QtCore.QPoint(cancel_point.x() + 70, cancel_point.y() - 40),
         )
 
-        self.right_click(viewport, cancel_point)
+        self.gui.right_click(viewport, cancel_point)
         self.assertTrue(
-            self.wait_until(lambda: len(self.visible_spinboxes()) == 0, timeout_ms=400),
+            self.gui.wait_until(lambda: len(self.visible_spinboxes()) == 0, timeout_ms=400),
             "Expected right click to keep the rectangle OVPs closed after canceling",
         )
         self.assertEqual(self.sketch.GeometryCount, 0)
         self.assert_sketch_edit_active()
 
-        self.move(viewport, cancel_point)
-        self.click(viewport, cancel_point)
-        self.move(viewport, retry_move)
+        self.gui.move(viewport, cancel_point)
+        self.gui.click(viewport, cancel_point)
+        self.gui.move(viewport, retry_move)
 
         self.assertFalse(
-            self.wait_until(lambda: len(self.visible_spinboxes()) == 2, timeout_ms=500),
+            self.gui.wait_until(lambda: len(self.visible_spinboxes()) == 2, timeout_ms=500),
             "Expected right click to exit the rectangle tool after OVP Esc",
         )
         self.assertEqual(self.sketch.GeometryCount, 0)
@@ -292,10 +276,10 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
 
         first_spinbox = self.active_spinbox()
         self.assertIsNotNone(first_spinbox, "Expected the first rectangle OVP to have focus")
-        self.key_click(first_spinbox, QtCore.Qt.Key_Escape)
+        self.gui.key_click(first_spinbox, QtCore.Qt.Key_Escape)
 
         self.assertTrue(
-            self.wait_until(lambda: len(self.visible_spinboxes()) == 0, timeout_ms=1000),
+            self.gui.wait_until(lambda: len(self.visible_spinboxes()) == 0, timeout_ms=1000),
             "Expected the first Esc to close the rectangle OVPs",
         )
         self.assertEqual(self.sketch.GeometryCount, 0)
@@ -304,45 +288,48 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
         view = FreeCADGui.ActiveDocument.ActiveView
         graphics_view = view.graphicsView()
         graphics_view.setFocus(QtCore.Qt.OtherFocusReason)
-        self.pump(100)
+        self.assertIsNotNone(
+            self.gui.wait_for_focus(parent=graphics_view, timeout_ms=500),
+            "Expected the Sketcher viewport to receive focus",
+        )
 
-        self.key_click(graphics_view, QtCore.Qt.Key_Escape)
+        self.gui.key_click(graphics_view, QtCore.Qt.Key_Escape)
         self.assert_sketch_edit_active()
 
-        cancel_point = self.clamp_to_widget(
+        cancel_point = self.gui.clamp_to_widget(
             viewport,
             QtCore.QPoint(first_point.x() + 120, first_point.y() + 50),
         )
-        retry_move = self.clamp_to_widget(
+        retry_move = self.gui.clamp_to_widget(
             viewport,
             QtCore.QPoint(cancel_point.x() + 70, cancel_point.y() - 40),
         )
 
-        self.move(viewport, cancel_point)
-        self.click(viewport, cancel_point)
-        self.move(viewport, retry_move)
+        self.gui.move(viewport, cancel_point)
+        self.gui.click(viewport, cancel_point)
+        self.gui.move(viewport, retry_move)
 
         self.assertFalse(
-            self.wait_until(lambda: len(self.visible_spinboxes()) == 2, timeout_ms=500),
+            self.gui.wait_until(lambda: len(self.visible_spinboxes()) == 2, timeout_ms=500),
             "Expected the second Esc to exit the rectangle tool",
         )
         self.assertEqual(self.sketch.GeometryCount, 0)
 
         graphics_view.setFocus(QtCore.Qt.OtherFocusReason)
-        self.pump(100)
-        self.key_click(graphics_view, QtCore.Qt.Key_Escape)
+        self.assertIsNotNone(
+            self.gui.wait_for_focus(parent=graphics_view, timeout_ms=500),
+            "Expected the Sketcher viewport to receive focus",
+        )
+        self.gui.key_click(graphics_view, QtCore.Qt.Key_Escape)
 
         self.assertTrue(
-            self.wait_until(lambda: self.active_task_dialog() is None, timeout_ms=1000),
+            self.gui.wait_until(lambda: self.gui.active_task_panel() is None, timeout_ms=1000),
             "Expected the third Esc to close the Sketcher task dialog",
         )
         self.assert_sketch_edit_inactive()
 
     def test_auto_color_restores_line_color_from_preferences(self):
-        view_params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View")
         color_key = "SketchEdgeColor"
-        had_color = color_key in view_params.GetUnsigneds()
-        old_color = view_params.GetUnsigned(color_key, 0)
 
         try:
             manual_color = 0x112233FF
@@ -353,16 +340,23 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
             view.LineColor = manual_color
             self.assertEqual(self.pack_color(view.LineColor), manual_color)
 
-            view_params.SetUnsigned(color_key, preference_color)
-            self.pump(100)
-            self.assertEqual(self.pack_color(view.LineColor), manual_color)
+            with temporary_preference(
+                "User parameter:BaseApp/Preferences/View",
+                color_key,
+                preference_color,
+                "Unsigned Long",
+            ):
+                self.assertEqual(self.pack_color(view.LineColor), manual_color)
 
-            view.AutoColor = True
-            self.pump(100)
-
-            self.assertEqual(self.pack_color(view.LineColor), preference_color)
+                view.AutoColor = True
+                self.assertTrue(
+                    self.gui.wait_until(
+                        lambda: self.pack_color(view.LineColor) == preference_color,
+                        timeout_ms=1000,
+                        description="automatic sketch edge color",
+                    ),
+                    "Expected AutoColor to apply the preference color",
+                )
+                self.assertEqual(self.pack_color(view.LineColor), preference_color)
         finally:
-            if had_color:
-                view_params.SetUnsigned(color_key, old_color)
-            else:
-                view_params.RemUnsigned(color_key)
+            view.AutoColor = True

--- a/src/Mod/Sketcher/SketcherTests/TestPlacementUpdate.py
+++ b/src/Mod/Sketcher/SketcherTests/TestPlacementUpdate.py
@@ -5,7 +5,8 @@
 import FreeCAD
 
 from FreeCAD import Base
-from SketcherTests.GuiTestCase import FreeCADGui, SketcherGuiTestCase
+from Gui.Wait import FreeCADGui
+from SketcherTests.Support import SketcherGuiTestCase
 
 
 class TestSketchPlacementUpdate(SketcherGuiTestCase):
@@ -73,7 +74,7 @@ class TestSketchPlacementUpdate(SketcherGuiTestCase):
         relative to the attachment face.
         """
         # enter edit mode
-        FreeCADGui.ActiveDocument.setEdit(self.sketch.Name)
+        self.enter_sketch_edit(self.doc, self.sketch)
 
         # get initial editing transform (it's a property, not a method)
         initial_transform = FreeCADGui.ActiveDocument.EditingTransform
@@ -100,7 +101,7 @@ class TestSketchPlacementUpdate(SketcherGuiTestCase):
         test that multiple AttachmentOffset changes in edit mode all update correctly.
         """
         # enter edit mode
-        FreeCADGui.ActiveDocument.setEdit(self.sketch.Name)
+        self.enter_sketch_edit(self.doc, self.sketch)
 
         transforms = []
 
@@ -155,7 +156,7 @@ class TestSketchPlacementUpdate(SketcherGuiTestCase):
         self.doc.recompute()
 
         # enter edit mode
-        FreeCADGui.ActiveDocument.setEdit(unattached.Name)
+        self.enter_sketch_edit(self.doc, unattached)
 
         initial_transform = FreeCADGui.ActiveDocument.EditingTransform
 

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -17,6 +17,8 @@ SET(Test_SRCS
     GuiRecompute.py
     TestApp.py
     TestGui.py
+    TestGuiSupport.py
+    Support.py
     UnicodeTests.py
     UnitTests.py
     Workbench.py
@@ -48,8 +50,29 @@ SOURCE_GROUP("" FILES ${Test_SRCS} ${TestData_SRCS})
 
 if(BUILD_GUI)
     add_subdirectory(Gui)
-    list (APPEND Test_SRCS InitGui.py)
+    list (APPEND Test_SRCS
+        InitGui.py
+        Gui/__init__.py
+        Gui/Harness.py
+        Gui/README.md
+        Gui/TestCase.py
+        Gui/View3D.py
+        Gui/Wait.py
+    )
 endif(BUILD_GUI)
+
+set(Test_Install_SRCS ${Test_SRCS})
+if(BUILD_GUI)
+    set(TestGuiSupport_SRCS
+        Gui/__init__.py
+        Gui/Harness.py
+        Gui/README.md
+        Gui/TestCase.py
+        Gui/View3D.py
+        Gui/Wait.py
+    )
+    list(REMOVE_ITEM Test_Install_SRCS ${TestGuiSupport_SRCS})
+endif()
 
 set(Test_COPY_OUTPUTS)
 foreach(test_src ${Test_SRCS})
@@ -136,10 +159,19 @@ endif()
 
 INSTALL(
     FILES
-        ${Test_SRCS}
+        ${Test_Install_SRCS}
     DESTINATION
         Mod/Test
 )
+
+if(BUILD_GUI)
+    INSTALL(
+        FILES
+            ${TestGuiSupport_SRCS}
+        DESTINATION
+            Mod/Test/Gui
+    )
+endif()
 
 INSTALL(
     FILES

--- a/src/Mod/Test/Gui/Harness.py
+++ b/src/Mod/Test/Gui/Harness.py
@@ -131,9 +131,7 @@ class GuiHarness:
             timeout_ms=timeout_ms,
             description=f"edit mode for {document.Name}.{object_name}",
         ):
-            raise RuntimeError(
-                f"Timed out entering edit mode for {document.Name}.{object_name}"
-            )
+            raise RuntimeError(f"Timed out entering edit mode for {document.Name}.{object_name}")
         self.flush_gui()
         return gui_document
 
@@ -416,7 +414,9 @@ class GuiHarness:
 
     def move(self, widget: Any, pos: Any) -> None:
         """Move the pointer to pos in widget and flush hover work."""
-        self.send_mouse(widget, QtCore.QEvent.MouseMove, pos, QtCore.Qt.NoButton, QtCore.Qt.NoButton)
+        self.send_mouse(
+            widget, QtCore.QEvent.MouseMove, pos, QtCore.Qt.NoButton, QtCore.Qt.NoButton
+        )
         self.pump(80)
 
     @staticmethod

--- a/src/Mod/Test/Gui/Harness.py
+++ b/src/Mod/Test/Gui/Harness.py
@@ -1,0 +1,484 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""FreeCAD-specific lifecycle, synchronization, and input helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import time
+from typing import Any, TypedDict, TypeVar, overload
+
+import FreeCAD
+
+from . import Wait
+from .View3D import View3D
+
+FreeCADGui = Wait.FreeCADGui
+QtCore = Wait.QtCore
+QtGui = Wait.QtGui
+QtWidgets = Wait.QtWidgets
+
+WidgetT = TypeVar("WidgetT")
+
+
+class ModalActionState(TypedDict, total=False):
+    """Status returned by GuiHarness.run_with_modal_action."""
+
+    seen: bool
+    expired: bool
+    error: BaseException
+
+
+class GuiHarness:
+    """GUI services shared by Python unittest tests.
+
+    The harness owns per-test cleanup and provides the primitives used by
+    current GUI tests: event processing, state-based waiting, focus and
+    task-panel lookup, edit-mode entry, input events, and viewport access.
+    """
+
+    def __init__(self) -> None:
+        self._documents_before_test: set[str] = set()
+        self.last_wait_diagnostics: str = ""
+
+    def set_up(self) -> None:
+        """Record initial documents, show the main window, and flush events."""
+        self._documents_before_test = set(FreeCAD.listDocuments())
+        main_window = FreeCADGui.getMainWindow()
+        if main_window is not None:
+            main_window.show()
+        self.flush_gui()
+
+    def tear_down(self) -> None:
+        """Restore GUI state and close documents created by the test."""
+        if not Wait.gui_available():
+            return
+
+        try:
+            self._close_dialog()
+            active = FreeCADGui.ActiveDocument
+            if active is not None and active.getInEdit() is not None:
+                active.resetEdit()
+            FreeCADGui.Selection.clearSelection()
+            FreeCADGui.Selection.clearPreselection()
+            self.flush_gui(80)
+        finally:
+            for name in list(FreeCAD.listDocuments()):
+                if name not in self._documents_before_test:
+                    try:
+                        FreeCAD.closeDocument(name)
+                    except RuntimeError:
+                        pass
+            try:
+                FreeCADGui.Selection.clearSelection()
+                FreeCADGui.Selection.clearPreselection()
+                self.flush_gui(80)
+            except RuntimeError:
+                pass
+
+    def pump(self, timeout_ms: int = 50) -> None:
+        """Process Qt events for approximately timeout_ms milliseconds."""
+        Wait.pump(timeout_ms)
+
+    def flush_gui(self, timeout_ms: int = 0) -> None:
+        """Flush pending Qt and FreeCAD GUI work."""
+        Wait.flush_gui(timeout_ms)
+
+    def wait_until(
+        self,
+        predicate: Wait.Predicate,
+        timeout_ms: int = 1000,
+        step_ms: int = 10,
+        description: str | None = None,
+    ) -> bool:
+        """Wait for a state predicate while continuing to process GUI events."""
+        result = Wait.wait_until(predicate, timeout_ms, step_ms)
+        if not result:
+            self.last_wait_diagnostics = self.diagnostics(description)
+        return result
+
+    def enter_edit(
+        self,
+        document: FreeCAD.Document,
+        object_name: str,
+        timeout_ms: int = 1000,
+    ) -> Any:
+        """Enter object_name edit mode and verify the exact target.
+
+        If another object is already being edited, callers must reset that
+        session explicitly before requesting a different object.
+        """
+        if FreeCADGui is None or not Wait.gui_available():
+            raise RuntimeError("Cannot enter edit mode without a usable GUI")
+
+        try:
+            gui_document = FreeCADGui.getDocument(document.Name)
+        except (AttributeError, RuntimeError) as exc:
+            raise RuntimeError(f"Cannot find GUI document {document.Name!r}") from exc
+        if gui_document is None:
+            raise RuntimeError(f"Cannot find GUI document {document.Name!r}")
+
+        current_object_name = self._edited_object_name(gui_document)
+        if current_object_name is not None and current_object_name != object_name:
+            raise RuntimeError(
+                f"Cannot enter edit mode for {document.Name}.{object_name}: "
+                f"{document.Name}.{current_object_name} is already being edited"
+            )
+
+        gui_document.setEdit(object_name)
+        if not self.wait_until(
+            lambda: self._edited_object_name(gui_document) == object_name,
+            timeout_ms=timeout_ms,
+            description=f"edit mode for {document.Name}.{object_name}",
+        ):
+            raise RuntimeError(
+                f"Timed out entering edit mode for {document.Name}.{object_name}"
+            )
+        self.flush_gui()
+        return gui_document
+
+    @staticmethod
+    def _edited_object_name(gui_document: Any) -> str | None:
+        """Return the document-object name currently being edited."""
+        edit_view_provider = gui_document.getInEdit()
+        if edit_view_provider is None:
+            return None
+        edit_object = getattr(edit_view_provider, "Object", None)
+        return getattr(edit_object, "Name", None)
+
+    def main_window(self) -> Any | None:
+        """Return the FreeCAD main window, if available."""
+        return FreeCADGui.getMainWindow() if Wait.gui_available() else None
+
+    def find_widget(
+        self,
+        widget_type: type[WidgetT],
+        parent: Any | None = None,
+        object_name: str | None = None,
+        visible_only: bool = False,
+    ) -> WidgetT | None:
+        """Find the first matching descendant of parent."""
+        if parent is None:
+            parent = self.main_window()
+        if parent is None:
+            return None
+
+        if object_name is not None:
+            widget = parent.findChild(widget_type, object_name)
+            if widget is not None and (not visible_only or widget.isVisible()):
+                return widget
+            return None
+
+        widgets = parent.findChildren(widget_type)
+        return next(
+            (widget for widget in widgets if not visible_only or widget.isVisible()),
+            None,
+        )
+
+    def find_widgets(
+        self,
+        widget_type: type[WidgetT],
+        parent: Any | None = None,
+        visible_only: bool = False,
+    ) -> list[WidgetT]:
+        """Return all matching descendants, optionally visible ones."""
+        if parent is None:
+            parent = self.main_window()
+        if parent is None:
+            return []
+        widgets = parent.findChildren(widget_type)
+        return [widget for widget in widgets if not visible_only or widget.isVisible()]
+
+    @overload
+    def focused_widget(
+        self,
+        widget_type: type[WidgetT],
+        parent: Any | None = None,
+    ) -> WidgetT | None: ...
+
+    @overload
+    def focused_widget(
+        self,
+        widget_type: None = None,
+        parent: Any | None = None,
+    ) -> Any | None: ...
+
+    def focused_widget(
+        self,
+        widget_type: type[WidgetT] | None = None,
+        parent: Any | None = None,
+    ) -> Any | None:
+        """Return the focused widget or its matching widget ancestor."""
+        app = Wait.qt_application()
+        widget = app.focusWidget() if app is not None else None
+
+        while widget is not None:
+            matches_type = widget_type is None or isinstance(widget, widget_type)
+            matches_parent = parent is None or widget is parent or parent.isAncestorOf(widget)
+            if matches_type and matches_parent:
+                return widget
+            widget = widget.parentWidget()
+        return None
+
+    @overload
+    def wait_for_focus(
+        self,
+        widget_type: type[WidgetT],
+        parent: Any | None = None,
+        timeout_ms: int = 1000,
+    ) -> WidgetT | None: ...
+
+    @overload
+    def wait_for_focus(
+        self,
+        widget_type: None = None,
+        parent: Any | None = None,
+        timeout_ms: int = 1000,
+    ) -> Any | None: ...
+
+    def wait_for_focus(
+        self,
+        widget_type: type[WidgetT] | None = None,
+        parent: Any | None = None,
+        timeout_ms: int = 1000,
+    ) -> Any | None:
+        """Wait until a widget or matching ancestor owns keyboard focus."""
+        found: list[Any] = []
+
+        def find() -> bool:
+            widget = self.focused_widget(widget_type, parent)
+            if widget is not None:
+                found.append(widget)
+                return True
+            return False
+
+        if self.wait_until(find, timeout_ms, description="focus change"):
+            return found[0]
+        return None
+
+    def active_task_panel(self) -> Any | None:
+        """Return FreeCAD's active task panel, if one is open."""
+        return FreeCADGui.Control.activeTaskDialog()
+
+    def wait_for_task_panel(self, timeout_ms: int = 1000) -> Any | None:
+        """Wait for and return FreeCAD's active task panel."""
+        found: list[Any] = []
+
+        def find() -> bool:
+            panel = self.active_task_panel()
+            if panel is not None:
+                found.append(panel)
+                return True
+            return False
+
+        if self.wait_until(find, timeout_ms, description="task panel"):
+            return found[0]
+        return None
+
+    def _active_modal(self) -> Any | None:
+        app = Wait.qt_application()
+        return app.activeModalWidget() if app is not None else None
+
+    def _close_dialog(self) -> None:
+        """Close an active FreeCAD task dialog or modal widget."""
+        if FreeCADGui.Control.activeDialog() is not None:
+            FreeCADGui.Control.closeDialog()
+            self.flush_gui(80)
+
+        modal = self._active_modal()
+        if modal is not None:
+            modal.reject()
+            self.flush_gui(80)
+
+    def run_with_modal_action(
+        self,
+        operation: Callable[[], object],
+        action: Callable[[Any], None],
+        delay_ms: int = 0,
+        timeout_ms: int = 1000,
+    ) -> ModalActionState:
+        """Run a synchronous operation while safely handling one modal.
+
+        A local timer watches the operation's nested event loop. It remains
+        active after the deadline so a late modal is rejected instead of
+        blocking the test. The timer is always stopped when operation returns.
+        """
+        state: ModalActionState = {"seen": False, "expired": False}
+        deadline = time.monotonic() + max(0, timeout_ms) / 1000.0
+        not_before = time.monotonic() + max(0, delay_ms) / 1000.0
+        stopped = False
+        timer = QtCore.QTimer()
+        timer.setInterval(10)
+
+        def stop() -> None:
+            nonlocal stopped
+            if stopped:
+                return
+            stopped = True
+            timer.stop()
+            timer.deleteLater()
+
+        def check_modal() -> None:
+            if stopped:
+                return
+            now = time.monotonic()
+            if now < not_before:
+                return
+
+            dialog = self._active_modal()
+            if dialog is not None:
+                if now >= deadline:
+                    state["expired"] = True
+                    try:
+                        dialog.reject()
+                    except (AttributeError, RuntimeError):
+                        pass
+                    return
+
+                state["seen"] = True
+                try:
+                    action(dialog)
+                except Exception as exc:
+                    state["error"] = exc
+                    try:
+                        dialog.reject()
+                    except (AttributeError, RuntimeError):
+                        pass
+                finally:
+                    stop()
+            elif now >= deadline:
+                state["expired"] = True
+
+        timer.timeout.connect(check_modal)
+        timer.start()
+        try:
+            operation()
+        finally:
+            if not state["seen"] and time.monotonic() >= deadline:
+                state["expired"] = True
+            stop()
+        return state
+
+    def active_view(self) -> View3D:
+        """Return a HiDPI-aware adapter for the active FreeCAD view."""
+        return View3D(FreeCADGui.ActiveDocument.ActiveView)
+
+    @staticmethod
+    def _focus_for_click(widget: Any) -> None:
+        window = widget.window()
+        if window is not None:
+            window.activateWindow()
+
+        focus_target = widget
+        while focus_target is not None:
+            if focus_target.focusPolicy() != QtCore.Qt.NoFocus:
+                focus_target.setFocus(QtCore.Qt.MouseFocusReason)
+                break
+            focus_target = focus_target.parentWidget()
+
+    def click(self, widget: Any, pos: Any) -> None:
+        """Send a left click to widget and process deferred work."""
+        self._focus_for_click(widget)
+        self.send_mouse(
+            widget,
+            QtCore.QEvent.MouseButtonPress,
+            pos,
+            QtCore.Qt.LeftButton,
+            QtCore.Qt.LeftButton,
+        )
+        self.send_mouse(
+            widget,
+            QtCore.QEvent.MouseButtonRelease,
+            pos,
+            QtCore.Qt.LeftButton,
+            QtCore.Qt.NoButton,
+        )
+        self.pump(120)
+
+    def right_click(self, widget: Any, pos: Any) -> None:
+        """Send a right click to widget and process deferred work."""
+        self._focus_for_click(widget)
+        self.send_mouse(
+            widget,
+            QtCore.QEvent.MouseButtonPress,
+            pos,
+            QtCore.Qt.RightButton,
+            QtCore.Qt.RightButton,
+        )
+        self.send_mouse(
+            widget,
+            QtCore.QEvent.MouseButtonRelease,
+            pos,
+            QtCore.Qt.RightButton,
+            QtCore.Qt.NoButton,
+        )
+        self.pump(120)
+
+    def move(self, widget: Any, pos: Any) -> None:
+        """Move the pointer to pos in widget and flush hover work."""
+        self.send_mouse(widget, QtCore.QEvent.MouseMove, pos, QtCore.Qt.NoButton, QtCore.Qt.NoButton)
+        self.pump(80)
+
+    @staticmethod
+    def send_mouse(widget: Any, event_type: Any, pos: Any, button: Any, buttons: Any) -> None:
+        """Send one synthetic Qt mouse event to widget."""
+        global_pos = widget.mapToGlobal(pos)
+        event = QtGui.QMouseEvent(
+            event_type,
+            pos,
+            global_pos,
+            button,
+            buttons,
+            QtCore.Qt.NoModifier,
+        )
+        QtWidgets.QApplication.sendEvent(widget, event)
+
+    @staticmethod
+    def key_click(widget: Any, key: int, text: str = "") -> None:
+        """Send a synthetic key press/release pair to widget."""
+        press = QtGui.QKeyEvent(QtCore.QEvent.KeyPress, key, QtCore.Qt.NoModifier, text)
+        release = QtGui.QKeyEvent(QtCore.QEvent.KeyRelease, key, QtCore.Qt.NoModifier, text)
+        QtWidgets.QApplication.sendEvent(widget, press)
+        QtWidgets.QApplication.sendEvent(widget, release)
+
+    @staticmethod
+    def clamp_to_widget(widget: Any, pos: Any, margin: int = 10) -> Any:
+        """Clamp a Qt point inside widget while preserving margin."""
+        rect = widget.rect()
+        return QtCore.QPoint(
+            max(margin, min(pos.x(), rect.right() - margin)),
+            max(margin, min(pos.y(), rect.bottom() - margin)),
+        )
+
+    def diagnostics(self, waiting_for: str | None = None) -> str:
+        """Return a readable snapshot of the current GUI state."""
+        lines: list[str] = []
+        if waiting_for:
+            lines.append(f"Waiting for: {waiting_for}")
+        try:
+            lines.append(f"Workbench: {FreeCADGui.activeWorkbench().name()}")
+        except (AttributeError, RuntimeError):
+            lines.append("Workbench: unavailable")
+        try:
+            document = FreeCAD.ActiveDocument
+            lines.append(f"Document: {document.Name if document else 'none'}")
+        except (AttributeError, RuntimeError):
+            lines.append("Document: unavailable")
+        try:
+            edit = FreeCADGui.ActiveDocument.getInEdit() if FreeCADGui.ActiveDocument else None
+            lines.append(f"Edit object: {edit.Name if edit else 'none'}")
+        except (AttributeError, RuntimeError):
+            lines.append("Edit object: unavailable")
+        try:
+            focus = QtWidgets.QApplication.focusWidget()
+            lines.append(f"Focus widget: {focus.objectName() if focus else 'none'}")
+        except (AttributeError, RuntimeError):
+            lines.append("Focus widget: unavailable")
+        modal = self._active_modal()
+        lines.append(f"Active modal: {type(modal).__name__ if modal else 'none'}")
+        try:
+            task_panel = self.active_task_panel()
+            lines.append(f"Task panel: {type(task_panel).__name__ if task_panel else 'none'}")
+        except (AttributeError, RuntimeError):
+            lines.append("Task panel: unavailable")
+        return "\n".join(lines)

--- a/src/Mod/Test/Gui/README.md
+++ b/src/Mod/Test/Gui/README.md
@@ -1,0 +1,118 @@
+# Shared GUI test support
+
+Gui contains the common Python support used by FreeCAD's GUI tests. It is a
+small layer over unittest, Qt, and the FreeCAD GUI API. Workbench-specific
+helpers should build on it instead of duplicating lifecycle and event-loop
+handling.
+
+## Quick start
+
+    from PySide import QtWidgets
+
+    import FreeCAD
+    from Gui.TestCase import FreeCADGuiTestCase
+
+
+    class TestExample(FreeCADGuiTestCase):
+        def test_button(self):
+            document = FreeCAD.newDocument("GuiExample")
+            document.addObject("Part::Feature", "Feature")
+
+            button = self.gui.find_widget(
+                QtWidgets.QPushButton,
+                object_name="stableButtonName",
+                visible_only=True,
+            )
+            self.assertIsNotNone(button)
+            self.gui.click(button, button.rect().center())
+
+FreeCADGuiTestCase creates self.gui for each test. Its teardown exits edit
+mode, closes active dialogs, clears selection and preselection, closes
+documents created by the test, and processes pending events. Tests should call
+the base setUp and tearDown methods.
+
+## Synchronization
+
+Use gui.wait_until for observable state transitions:
+
+    self.gui.wait_until(
+        lambda: spin_box.value() == 42,
+        timeout_ms=1000,
+        description="spin box value",
+    )
+
+The predicate is evaluated while Qt events are processed and once more at the
+timeout boundary. When a wait fails, GuiHarness.last_wait_diagnostics contains
+the current workbench, document, edit object, focus widget, modal, and task
+panel.
+
+Use gui.pump only when a short fixed interval is meaningful, such as allowing
+an animation to run. Do not use time.sleep in GUI tests because it blocks the
+event loop.
+
+## State and lookup
+
+Use the generic ``temporary_preference`` helper for temporary application
+settings. All original typed entries for the key are restored on exit:
+
+    from Support import temporary_preference
+
+    with temporary_preference(
+        "User parameter:BaseApp/Preferences/Mod/Test",
+        "TemporaryInteger",
+        42,
+    ):
+        self.assertEqual(
+            FreeCAD.ParamGet(
+                "User parameter:BaseApp/Preferences/Mod/Test"
+            ).GetInt("TemporaryInteger"),
+            42,
+        )
+
+Prefer stable selectors in this order: Qt objectName, FreeCAD command or
+action identity, widget type with a known parent, accessible properties,
+visible translated text, and coordinates as a last resort.
+
+Use gui.find_widget and gui.find_widgets for widget lookup. Use
+gui.wait_for_focus when a control may focus an internal child, such as the
+line edit inside a spin box. gui.wait_for_task_panel waits for a FreeCAD task
+panel.
+
+## Modal commands
+
+For a synchronous command that opens a modal dialog inside its own nested event
+loop, use gui.run_with_modal_action:
+
+    state = self.gui.run_with_modal_action(
+        lambda: Gui.runCommand("SomeCommand"),
+        lambda dialog: dialog.accept(),
+    )
+    self.assertTrue(state["seen"])
+
+The local watchdog remains active after the deadline so a late modal is
+rejected instead of blocking the test. It is stopped automatically when the
+operation returns.
+
+## Viewport coordinates
+
+gui.active_view returns a View3D adapter for HiDPI-safe conversion between
+FreeCAD's physical viewport coordinates and Qt logical points:
+
+    view = self.gui.active_view()
+    view.world_to_screen(FreeCAD.Vector(0, 0, 0))
+
+Use gui.send_mouse, gui.click, gui.right_click, gui.move, and gui.key_click
+for input events. View3D intentionally provides coordinate conversion only;
+input remains an explicit harness operation.
+
+## C++ QtTest support
+
+The C++ equivalent lives in tests/src/Gui/TestSupport.h under the GuiTest
+namespace. It provides ensureGuiApplication, waitUntil, find, and
+DocumentGuard. It uses RAII and std::chrono while leaving QtTest assertions
+and input primitives available to each test.
+
+Both language APIs share the same principles: wait for state rather than a
+fixed delay, prefer stable widget identities, and leave the GUI clean for the
+next test. Add a generic helper only when current tests need it or when it is
+required for safe cleanup and synchronization.

--- a/src/Mod/Test/Gui/TestCase.py
+++ b/src/Mod/Test/Gui/TestCase.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""unittest base class for FreeCAD GUI tests."""
+
+from __future__ import annotations
+
+import unittest
+
+from .Harness import GuiHarness
+from .Wait import gui_available
+
+
+class FreeCADGuiTestCase(unittest.TestCase):
+    """Base class that owns one :class:`GuiHarness` per test."""
+
+    gui: GuiHarness
+
+    def setUp(self) -> None:
+        """Skip without a GUI and initialize the per-test harness."""
+        super().setUp()
+        if not gui_available():
+            self.skipTest("GUI not available")
+        self.gui = GuiHarness()
+        self.gui.set_up()
+
+    def tearDown(self) -> None:
+        """Restore GUI state before allowing ``unittest`` teardown."""
+        try:
+            if hasattr(self, "gui"):
+                self.gui.tear_down()
+        finally:
+            super().tearDown()
+
+
+# Compatibility name for code that already uses the generic concept.
+GuiTestCase = FreeCADGuiTestCase

--- a/src/Mod/Test/Gui/View3D.py
+++ b/src/Mod/Test/Gui/View3D.py
@@ -10,7 +10,6 @@ import FreeCAD
 
 from . import Wait
 
-
 ViewportPoint: TypeAlias = tuple[float, float]
 """A point in FreeCAD's physical viewport coordinate system."""
 

--- a/src/Mod/Test/Gui/View3D.py
+++ b/src/Mod/Test/Gui/View3D.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""HiDPI-independent viewport coordinate conversion."""
+
+from __future__ import annotations
+
+from typing import Any, TypeAlias
+
+import FreeCAD
+
+from . import Wait
+
+
+ViewportPoint: TypeAlias = tuple[float, float]
+"""A point in FreeCAD's physical viewport coordinate system."""
+
+
+class View3D:
+    """Convert between FreeCAD viewport pixels and Qt logical pixels."""
+
+    def __init__(self, view: Any) -> None:
+        self.view: Any = view
+
+    @property
+    def viewport(self) -> Any:
+        """Return the Qt viewport receiving mouse events."""
+        return self.view.graphicsView().viewport()
+
+    @staticmethod
+    def device_pixel_ratio(widget: Any) -> float:
+        """Return ``widget``'s device-pixel ratio for Qt 5 or Qt 6."""
+        method = getattr(widget, "devicePixelRatioF", None)
+        if method is not None:
+            return method()
+        return widget.devicePixelRatio()
+
+    def world_to_screen(self, point: FreeCAD.Vector) -> Any:
+        """Convert a FreeCAD world point to a logical Qt viewport point."""
+        return self.viewport_to_screen(self.view.getPointOnScreen(point))
+
+    def viewport_to_screen(
+        self,
+        point: ViewportPoint,
+        viewport: Any | None = None,
+    ) -> Any:
+        """Convert a physical viewport point to a logical Qt point."""
+        _, height = self.view.getSize()
+        if viewport is None:
+            viewport = self.viewport
+        scale = self.device_pixel_ratio(viewport)
+        x = int(round(point[0] / scale))
+        y = int(round((height - point[1] - 1) / scale))
+        return Wait.QtCore.QPoint(x, y)

--- a/src/Mod/Test/Gui/Wait.py
+++ b/src/Mod/Test/Gui/Wait.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Qt event processing and synchronization primitives for GUI tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import time
+from typing import Any, TypeAlias
+
+import FreeCAD
+
+try:
+    import FreeCADGui
+
+    GUI_MODULE_AVAILABLE = True
+except ImportError:
+    FreeCADGui = None
+    GUI_MODULE_AVAILABLE = False
+
+try:
+    from PySide import QtCore, QtGui, QtWidgets
+except ImportError:
+    try:
+        from PySide6 import QtCore, QtGui, QtWidgets
+    except ImportError:
+        QtCore = None
+        QtGui = None
+        QtWidgets = None
+
+
+Predicate: TypeAlias = Callable[[], bool]
+"""A condition polled by :func:`wait_until`."""
+
+
+def gui_available() -> bool:
+    """Return whether a usable FreeCAD main window is available."""
+    if not GUI_MODULE_AVAILABLE:
+        return False
+
+    try:
+        return FreeCAD.GuiUp and FreeCADGui.getMainWindow() is not None
+    except (AttributeError, RuntimeError):
+        return False
+
+
+def qt_application() -> Any | None:
+    """Return the active Qt application, if the Qt bindings are available."""
+    if QtWidgets is None:
+        return None
+
+    return QtWidgets.QApplication.instance()
+
+
+def pump(timeout_ms: int = 50) -> None:
+    """Process GUI events for approximately ``timeout_ms`` milliseconds.
+
+    This is useful when a test deliberately wants to give an animation or a
+    known asynchronous operation time to run. Prefer :func:`wait_until` when
+    the test can express a state that proves the operation completed.
+    """
+    if QtCore is None or qt_application() is None:
+        return
+
+    loop = QtCore.QEventLoop()
+    QtCore.QTimer.singleShot(max(0, timeout_ms), loop.quit)
+    exec_method = getattr(loop, "exec", None) or loop.exec_
+    exec_method()
+
+
+def flush_gui(timeout_ms: int = 0) -> None:
+    """Flush pending Qt and FreeCAD GUI work.
+
+    If ``timeout_ms`` is non-zero, continue processing events for roughly
+    that long after the immediate flush.
+    """
+    if not gui_available():
+        return
+
+    app = qt_application()
+    if app is not None:
+        app.processEvents()
+
+    FreeCADGui.updateGui()
+
+    if timeout_ms:
+        pump(timeout_ms)
+
+
+def wait_until(
+    predicate: Predicate,
+    timeout_ms: int = 1000,
+    step_ms: int = 10,
+) -> bool:
+    """Poll ``predicate`` while processing GUI events until it becomes true.
+
+    The predicate is evaluated immediately, then again after each event-loop
+    iteration. The final predicate evaluation is returned when the timeout is
+    reached, so a state change that happens at the boundary is not lost.
+    """
+    timeout_ms = max(0, timeout_ms)
+    step_ms = max(1, step_ms)
+    deadline = time.monotonic() + timeout_ms / 1000.0
+
+    while True:
+        if predicate():
+            return True
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return bool(predicate())
+
+        flush_gui(min(step_ms, max(1, int(remaining * 1000))))

--- a/src/Mod/Test/Gui/__init__.py
+++ b/src/Mod/Test/Gui/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Small public entry point for shared Python GUI test support."""
+
+from .Harness import GuiHarness
+from .TestCase import FreeCADGuiTestCase
+from .Wait import gui_available
+
+__all__ = [
+    "FreeCADGuiTestCase",
+    "GuiHarness",
+    "gui_available",
+]

--- a/src/Mod/Test/InitGui.py
+++ b/src/Mod/Test/InitGui.py
@@ -93,6 +93,7 @@ Gui.addWorkbench(TestWorkbench())
 
 # Base system tests
 FreeCAD.__unit_test__ += [
+    "TestGuiSupport",
     "Workbench",
     "Menu",
     "Menu.MenuDeleteCases",

--- a/src/Mod/Test/Support.py
+++ b/src/Mod/Test/Support.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""State-isolation helpers shared by FreeCAD tests."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any, Literal, TypeAlias
+
+import FreeCAD
+
+
+_ParameterType: TypeAlias = Literal[
+    "Boolean", "Integer", "Unsigned Long", "Float", "String"
+]
+_ParameterValue: TypeAlias = bool | int | float | str
+_ParameterEntry: TypeAlias = tuple[_ParameterType, str, _ParameterValue]
+
+_SETTERS: dict[_ParameterType, str] = {
+    "Boolean": "SetBool",
+    "Integer": "SetInt",
+    "Unsigned Long": "SetUnsigned",
+    "Float": "SetFloat",
+    "String": "SetString",
+}
+_REMOVERS: dict[_ParameterType, str] = {
+    "Boolean": "RemBool",
+    "Integer": "RemInt",
+    "Unsigned Long": "RemUnsigned",
+    "Float": "RemFloat",
+    "String": "RemString",
+}
+
+
+def _type_for(value: _ParameterValue) -> _ParameterType:
+    if isinstance(value, bool):
+        return "Boolean"
+    if isinstance(value, int):
+        return "Integer"
+    if isinstance(value, float):
+        return "Float"
+    return "String"
+
+
+def _set_parameter(
+    group: Any,
+    name: str,
+    value: _ParameterValue,
+    value_type: _ParameterType | None = None,
+) -> None:
+    parameter_type = value_type or _type_for(value)
+    getattr(group, _SETTERS[parameter_type])(name, value)
+
+
+def _remove_parameter(group: Any, name: str) -> None:
+    """Remove every typed parameter with this name."""
+    for remover in _REMOVERS.values():
+        try:
+            getattr(group, remover)(name)
+        except (AttributeError, RuntimeError):
+            pass
+
+
+@contextmanager
+def temporary_preference(
+    path: str,
+    key: str,
+    value: _ParameterValue,
+    value_type: _ParameterType | None = None,
+) -> Iterator[None]:
+    """Temporarily set a parameter and restore all typed values for its key.
+
+    FreeCAD parameters are keyed by both type and name. Snapshotting every
+    entry with the requested name prevents a temporary value of another type
+    from surviving when the context exits.
+    """
+    group = FreeCAD.ParamGet(path)
+    original: tuple[_ParameterEntry, ...] = tuple(
+        entry for entry in (group.GetContents() or []) if entry[1] == key
+    )
+
+    try:
+        _set_parameter(group, key, value, value_type)
+        yield
+    finally:
+        _remove_parameter(group, key)
+        for parameter_type, name, old_value in original:
+            _set_parameter(group, name, old_value, parameter_type)

--- a/src/Mod/Test/Support.py
+++ b/src/Mod/Test/Support.py
@@ -8,10 +8,7 @@ from typing import Any, Literal, TypeAlias
 
 import FreeCAD
 
-
-_ParameterType: TypeAlias = Literal[
-    "Boolean", "Integer", "Unsigned Long", "Float", "String"
-]
+_ParameterType: TypeAlias = Literal["Boolean", "Integer", "Unsigned Long", "Float", "String"]
 _ParameterValue: TypeAlias = bool | int | float | str
 _ParameterEntry: TypeAlias = tuple[_ParameterType, str, _ParameterValue]
 

--- a/src/Mod/Test/TestGuiSupport.py
+++ b/src/Mod/Test/TestGuiSupport.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""High-value regression tests for the shared Python GUI support."""
+
+from types import SimpleNamespace
+import time
+from unittest.mock import Mock, patch
+
+from PySide import QtCore, QtWidgets
+
+import FreeCAD
+from Gui.TestCase import FreeCADGuiTestCase
+from Support import temporary_preference
+
+
+class TestGuiSupport(FreeCADGuiTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.window = QtWidgets.QDialog(self.gui.main_window())
+        self.window.setObjectName("GuiTestSupportWindow")
+        self.window.setModal(False)
+        self.window.setGeometry(10, 10, 320, 120)
+        self.window.show()
+        self.window.activateWindow()
+        self.window.raise_()
+        self.gui.flush_gui()
+
+    def tearDown(self):
+        try:
+            self.window.close()
+            self.window.deleteLater()
+            self.gui.flush_gui(20)
+        finally:
+            super().tearDown()
+
+    def test_preference_guard_restores_original_value(self):
+        path = "User parameter:BaseApp/Preferences/Mod/Test/GuiSupport"
+        key = "TemporaryInteger"
+        group = FreeCAD.ParamGet(path)
+        original = next(
+            (entry for entry in (group.GetContents() or []) if entry[1] == key),
+            None,
+        )
+
+        with temporary_preference(path, key, 42):
+            self.assertEqual(group.GetInt(key), 42)
+
+        restored = next(
+            (entry for entry in (group.GetContents() or []) if entry[1] == key),
+            None,
+        )
+        self.assertEqual(restored, original)
+
+    def test_preference_guard_restores_original_across_type_change(self):
+        path = "User parameter:BaseApp/Preferences/Mod/Test/GuiSupport"
+        key = "TemporaryMixedType"
+        group = FreeCAD.ParamGet(path)
+
+        with temporary_preference(path, key, "original", value_type="String"):
+            original = tuple(
+                entry for entry in (group.GetContents() or []) if entry[1] == key
+            )
+
+            with temporary_preference(path, key, 42):
+                self.assertEqual(group.GetInt(key), 42)
+
+            restored = tuple(
+                entry for entry in (group.GetContents() or []) if entry[1] == key
+            )
+            self.assertEqual(restored, original)
+
+    def test_enter_edit_rejects_different_current_object(self):
+        document = SimpleNamespace(Name="GuiSupportEditTarget")
+        current_edit = SimpleNamespace(Object=SimpleNamespace(Name="FirstSketch"))
+        gui_document = Mock()
+        gui_document.getInEdit.return_value = current_edit
+        gui_api = Mock()
+        gui_api.getDocument.return_value = gui_document
+
+        with patch("Gui.Harness.FreeCADGui", gui_api), patch(
+            "Gui.Harness.Wait.gui_available", return_value=True
+        ):
+            with self.assertRaisesRegex(RuntimeError, "already being edited"):
+                self.gui.enter_edit(document, "SecondSketch")
+
+        gui_document.setEdit.assert_not_called()
+
+    def test_late_modal_is_rejected_by_modal_watchdog(self):
+        late = QtWidgets.QDialog(self.window)
+        late.setModal(True)
+
+        def open_late():
+            late.exec()
+
+        def operation():
+            QtCore.QTimer.singleShot(60, open_late)
+            self.gui.pump(250)
+
+        try:
+            state = self.gui.run_with_modal_action(
+                operation,
+                lambda dialog: dialog.accept(),
+                timeout_ms=20,
+            )
+            self.assertTrue(state["expired"])
+            self.assertFalse(late.isVisible())
+        finally:
+            late.close()
+            late.deleteLater()
+            self.gui.flush_gui(20)
+
+    def test_modal_action_cancelled_before_deadline_is_not_expired(self):
+        state = self.gui.run_with_modal_action(
+            lambda: None,
+            lambda dialog: dialog.accept(),
+            timeout_ms=500,
+        )
+
+        self.assertFalse(state["seen"])
+        self.assertFalse(state["expired"])
+
+    def test_modal_action_records_expiry_after_blocking_operation(self):
+        state = self.gui.run_with_modal_action(
+            lambda: time.sleep(0.05),
+            lambda dialog: dialog.accept(),
+            timeout_ms=10,
+        )
+
+        self.assertFalse(state["seen"])
+        self.assertTrue(state["expired"])
+
+    def test_wait_for_focus_returns_control_that_owns_focus(self):
+        spinbox = QtWidgets.QSpinBox(self.window)
+        spinbox.setObjectName("GuiTestSupportSpinBox")
+        spinbox.show()
+        self.window.activateWindow()
+
+        self.gui.click(spinbox, spinbox.rect().center())
+        focused = self.gui.wait_for_focus(
+            QtWidgets.QAbstractSpinBox,
+            parent=self.window,
+            timeout_ms=500,
+        )
+        self.assertIs(focused, spinbox)
+
+    def test_wait_until_processes_deferred_gui_work(self):
+        state = {"ready": False}
+        QtCore.QTimer.singleShot(20, lambda: state.update(ready=True))
+
+        self.assertTrue(
+            self.gui.wait_until(lambda: state["ready"], timeout_ms=500),
+            "Expected the deferred GUI callback to run",
+        )

--- a/src/Mod/Test/TestGuiSupport.py
+++ b/src/Mod/Test/TestGuiSupport.py
@@ -58,16 +58,12 @@ class TestGuiSupport(FreeCADGuiTestCase):
         group = FreeCAD.ParamGet(path)
 
         with temporary_preference(path, key, "original", value_type="String"):
-            original = tuple(
-                entry for entry in (group.GetContents() or []) if entry[1] == key
-            )
+            original = tuple(entry for entry in (group.GetContents() or []) if entry[1] == key)
 
             with temporary_preference(path, key, 42):
                 self.assertEqual(group.GetInt(key), 42)
 
-            restored = tuple(
-                entry for entry in (group.GetContents() or []) if entry[1] == key
-            )
+            restored = tuple(entry for entry in (group.GetContents() or []) if entry[1] == key)
             self.assertEqual(restored, original)
 
     def test_enter_edit_rejects_different_current_object(self):

--- a/tests/src/Gui/ObjectSelection.cpp
+++ b/tests/src/Gui/ObjectSelection.cpp
@@ -2,6 +2,8 @@
 
 #include <QTest>
 #include <QTreeWidget>
+#include <functional>
+#include <memory>
 
 #include <App/Application.h>
 #include <App/Document.h>
@@ -11,6 +13,7 @@
 #include "Gui/Application.h"
 #include "Gui/Dialogs/DlgObjectSelection.h"
 #include "Gui/MetaTypes.h"
+#include "TestSupport.h"
 
 class ObjectSelectionTest: public QObject
 {
@@ -19,24 +22,22 @@ class ObjectSelectionTest: public QObject
 public:
     ObjectSelectionTest()
     {
-        tests::initApplication();
-        // Gui::Application::Instance must not be nullptr when the dialog calls getViewProvider()
-        if (!Gui::Application::Instance) {
-            new Gui::Application(false);
-        }
+        // Gui::Application::Instance must not be nullptr when the dialog calls getViewProvider().
+        GuiTest::ensureGuiApplication();
     }
 
 private Q_SLOTS:
 
     void init()
     {
-        docName = App::GetApplication().getUniqueDocumentName("test");
-        doc = App::GetApplication().newDocument(docName.c_str(), "testUser");
+        document = std::make_unique<GuiTest::DocumentGuard>("test");
+        doc = document->get();
     }
 
     void cleanup()
     {
-        App::GetApplication().closeDocument(docName.c_str());
+        document.reset();
+        doc = nullptr;
     }
 
     void testUncheckPropagatesToAllInstances()
@@ -47,7 +48,7 @@ private Q_SLOTS:
         QCOMPARE(items.size(), 2);
         assertAllHaveState(items, Qt::Checked);
 
-        toggle(items.first(), Qt::Unchecked);
+        QVERIFY(toggle(items.first(), Qt::Unchecked, items));
 
         assertAllHaveState(items, Qt::Unchecked);
     }
@@ -58,10 +59,10 @@ private Q_SLOTS:
         Gui::DlgObjectSelection dialog({dependency, dependent});
         auto items = instancesOf(dialog, dependency);
         QCOMPARE(items.size(), 2);
-        toggle(items.first(), Qt::Unchecked);
+        QVERIFY(toggle(items.first(), Qt::Unchecked, items));
         assertAllHaveState(items, Qt::Unchecked);
 
-        toggle(items.first(), Qt::Checked);
+        QVERIFY(toggle(items.first(), Qt::Checked, items));
 
         assertAllHaveState(items, Qt::Checked);
     }
@@ -74,10 +75,10 @@ private Q_SLOTS:
         auto items = instancesOf(dialog, dependency);
         QCOMPARE(items.size(), 2);
 
-        toggle(items.last(), Qt::Unchecked);
+        QVERIFY(toggle(items.last(), Qt::Unchecked, items));
         assertAllHaveState(items, Qt::Unchecked);
 
-        toggle(items.last(), Qt::Checked);
+        QVERIFY(toggle(items.last(), Qt::Checked, items));
         assertAllHaveState(items, Qt::Checked);
     }
 
@@ -90,7 +91,7 @@ private Q_SLOTS:
         doc->recompute();
 
         Gui::DlgObjectSelection dialog({first, second});
-        auto* depList = dialog.findChild<QTreeWidget*>(QStringLiteral("depList"));
+        auto* depList = GuiTest::find<QTreeWidget>(dialog, "depList");
         QVERIFY(depList);
         for (int i = 0; i < depList->topLevelItemCount(); ++i) {
             depList->topLevelItem(i)->setSelected(true);
@@ -101,7 +102,7 @@ private Q_SLOTS:
         QCOMPARE(firstItems.size(), 1);
         QCOMPARE(secondItems.size(), 1);
 
-        toggle(firstItems.first(), Qt::Unchecked);
+        QVERIFY(toggle(firstItems.first(), Qt::Unchecked, firstItems));
 
         assertAllHaveState(firstItems, Qt::Unchecked);
         assertAllHaveState(secondItems, Qt::Checked);
@@ -123,9 +124,9 @@ private:
 
     /// Every tree item that stands for @p obj. The nested items are created lazily, so the tree
     /// has to be expanded before the duplicates exist at all.
-    static QList<QTreeWidgetItem*> instancesOf(const QWidget& dialog, App::DocumentObject* obj)
+    static QList<QTreeWidgetItem*> instancesOf(QWidget& dialog, App::DocumentObject* obj)
     {
-        auto* tree = dialog.findChild<QTreeWidget*>(QStringLiteral("treeWidget"));
+        auto* tree = GuiTest::find<QTreeWidget>(dialog, "treeWidget");
         if (!tree) {
             return {};
         }
@@ -149,10 +150,18 @@ private:
     }
 
     /// Clicking a checkbox, plus the wait for the dialog's deferred consistency pass
-    static void toggle(QTreeWidgetItem* item, Qt::CheckState state)
+    static bool toggle(
+        QTreeWidgetItem* item,
+        Qt::CheckState state,
+        const QList<QTreeWidgetItem*>& allItems
+    )
     {
         item->setCheckState(0, state);
-        QTest::qWait(deferredUpdateDelay);
+        return GuiTest::waitUntil([&] {
+            return std::all_of(allItems.cbegin(), allItems.cend(), [state](auto* candidate) {
+                return candidate->checkState(0) == state;
+            });
+        });
     }
 
     static void assertAllHaveState(const QList<QTreeWidgetItem*>& items, Qt::CheckState state)
@@ -162,10 +171,7 @@ private:
         }
     }
 
-    /// The dialog reconciles the check states from a 10 ms single shot timer
-    static constexpr int deferredUpdateDelay = 50;
-
-    std::string docName;
+    std::unique_ptr<GuiTest::DocumentGuard> document;
     App::Document* doc = nullptr;
     App::DocumentObject* dependency = nullptr;
     App::DocumentObject* dependent = nullptr;

--- a/tests/src/Gui/ObjectSelection.cpp
+++ b/tests/src/Gui/ObjectSelection.cpp
@@ -150,11 +150,7 @@ private:
     }
 
     /// Clicking a checkbox, plus the wait for the dialog's deferred consistency pass
-    static bool toggle(
-        QTreeWidgetItem* item,
-        Qt::CheckState state,
-        const QList<QTreeWidgetItem*>& allItems
-    )
+    static bool toggle(QTreeWidgetItem* item, Qt::CheckState state, const QList<QTreeWidgetItem*>& allItems)
     {
         item->setCheckState(0, state);
         return GuiTest::waitUntil([&] {

--- a/tests/src/Gui/QuantitySpinBox.cpp
+++ b/tests/src/Gui/QuantitySpinBox.cpp
@@ -8,7 +8,7 @@
 #include <Base/UnitsApi.h>
 
 #include "Gui/QuantitySpinBox.h"
-#include <src/App/InitApplication.h>
+#include "TestSupport.h"
 
 // NOLINTBEGIN(readability-magic-numbers)
 
@@ -36,7 +36,7 @@ class testQuantitySpinBox: public QObject
 public:
     testQuantitySpinBox()
     {
-        tests::initApplication();
+        GuiTest::ensureGuiApplication();
         qsb = std::make_unique<Gui::QuantitySpinBox>();
     }
 

--- a/tests/src/Gui/TestSupport.h
+++ b/tests/src/Gui/TestSupport.h
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <string>
+
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QTimer>
+#include <QWidget>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <Gui/Application.h>
+
+#include <src/App/InitApplication.h>
+
+namespace GuiTest
+{
+
+/**
+ * Initialize the application and ensure that a GUI application singleton
+ * exists for a Qt GUI test.
+ *
+ * The default keeps the application in the same mode as the existing GUI
+ * tests. Pass true when the test explicitly needs GUI-enabled application
+ * state.
+ */
+inline void ensureGuiApplication(bool guiEnabled = false)
+{
+    tests::initApplication();
+    if (!Gui::Application::Instance) {
+        new Gui::Application(guiEnabled);
+    }
+}
+
+/**
+ * Poll a condition while processing Qt events.
+ *
+ * The predicate is checked immediately and once more at the timeout boundary.
+ * This should be preferred to a fixed QTest::qWait when the test can express
+ * the state that proves an asynchronous GUI operation completed.
+ */
+template<typename Predicate>
+bool waitUntil(
+    Predicate&& predicate,
+    std::chrono::milliseconds timeout = std::chrono::seconds(1),
+    std::chrono::milliseconds step = std::chrono::milliseconds(10)
+)
+{
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    step = std::max(step, std::chrono::milliseconds(1));
+
+    while (true) {
+        if (predicate()) {
+            return true;
+        }
+
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= deadline) {
+            return static_cast<bool>(predicate());
+        }
+
+        const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now);
+        const auto wait = std::min(step, std::max(remaining, std::chrono::milliseconds(1)));
+        QEventLoop loop;
+        QTimer::singleShot(static_cast<int>(wait.count()), &loop, [&loop] { loop.quit(); });
+        loop.exec(QEventLoop::AllEvents);
+    }
+}
+
+/** Find a descendant widget by its Qt object name. */
+template<typename Widget>
+Widget* find(QWidget& parent, const char* objectName)
+{
+    return parent.findChild<Widget*>(QString::fromLatin1(objectName));
+}
+
+/** Own one application document and close it when the guard is destroyed. */
+class DocumentGuard
+{
+public:
+    /** Create a uniquely named test document. */
+    explicit DocumentGuard(const char* baseName = "gui_test")
+    {
+        ensureGuiApplication();
+        _name = App::GetApplication().getUniqueDocumentName(baseName);
+        _document = App::GetApplication().newDocument(_name.c_str(), "testUser");
+    }
+
+    DocumentGuard(const DocumentGuard&) = delete;
+    DocumentGuard& operator=(const DocumentGuard&) = delete;
+
+    /** Close the owned document, if it is still open. */
+    ~DocumentGuard()
+    {
+        close();
+    }
+
+    App::Document* get() const
+    {
+        return _document;
+    }
+
+    /** Return the owned document, or nullptr after close(). */
+    App::Document* operator->() const
+    {
+        return _document;
+    }
+
+    /** Close the owned document and make this guard empty. */
+    void close()
+    {
+        if (!_document) {
+            return;
+        }
+
+        if (App::GetApplication().getDocument(_name.c_str())) {
+            App::GetApplication().closeDocument(_name.c_str());
+        }
+        _document = nullptr;
+    }
+
+private:
+    std::string _name;
+    App::Document* _document = nullptr;
+};
+
+}  // namespace GuiTest


### PR DESCRIPTION
Add lean, reusable GUI test support for FreeCAD’s Python and C++ tests.

This PR takes an incremental approach to GUI testing in FreeCAD. Rather than introducing a large end-to-end framework upfront, it factors out patterns already repeated across the existing Python and C++ GUI tests: lifecycle cleanup, event-loop synchronization, widget lookup, focus handling, edit-mode transitions, modal commands, preference isolation, and viewport coordinate conversion.

The goal is to give those patterns a shared vocabulary and concrete implementations, then use them with real PartDesign and Sketcher tests to discover what a useful GUI testing framework should look like. Python and C++ retain idiomatic implementations, while sharing the same concepts and conventions. This establishes a small foundation that can evolve based on actual test consumers.


