### PR TITLE
CAM: tool change blocks

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPostOutput.py
+++ b/src/Mod/CAM/CAMTests/TestPostOutput.py
@@ -731,15 +731,15 @@ class TestExport2Integration(unittest.TestCase):
                     "safetyblock": "(safety)",
                     "pre_operation": "(preoperation)",
                     "post_operation": "(postoperation)",
-                    "pre_tool_change": "(pretoolchange)",
-                    "post_tool_change": "(posttoolchange)",
                     "pre_job": "(prejob)",
                     "post_job": "(postjob)",
                     "pre_fixture_change": "(prefixture)",
                     "post_fixture_change": "(postfixture)",
                     "pre_rotary_move": "(prerotary)",
                     "post_rotary_move": "(Postrotary)",
-                    "tool_return": "(toolreturn)",
+                    "pre_tool_change": "(pretoolchange)",
+                    "post_tool_change": "(posttoolchange)",  # immediate after m6
+                    "tool_return": "(toolreturn)",  # at end of tool-change item
                 },
             },
             "processing": {
@@ -1292,11 +1292,11 @@ class TestExport2Integration(unittest.TestCase):
                         lines[i + 2], "(Block-enable: 1)", "Block should be followed by enable: 1"
                     )
 
-    # ===== 110-119: _expand_tool_length_offset tests =====
+    # ===== 110-119: _expand_tool_change tests =====
 
     def test110_tool_length_offset_enabled(self):
         """
-        Test that _expand_tool_length_offset adds G43 after M6 in a tool controller path.
+        Test that _expand_tool_change adds G43 after M6 in a tool controller path.
 
         G43 (tool length offset) must be injected immediately after M6 in the tool
         controller postable's path.  M6 belongs in the tool_controller postable — not
@@ -1305,7 +1305,7 @@ class TestExport2Integration(unittest.TestCase):
 
         Given:  A tool_controller postable whose path is [M6 T1]
                 followed by an operation postable [G0 ...]
-        When:   _expand_tool_length_offset is called with output_tool_length_offset=True
+        When:   _expand_tool_change is called with output_tool_length_offset=True
         Then:   The tool_controller path becomes [M6 T1, G43 H1]
 
         Example:
@@ -1339,16 +1339,16 @@ class TestExport2Integration(unittest.TestCase):
         )
         postables = [("allitems", [tc_item, op_item])]
 
-        post._expand_tool_length_offset(postables)
+        post._expand_tool_change(postables)
 
         tc_commands = [cmd.Name for cmd in tc_item.path.Commands]
         self.assertIn("G43", tc_commands, "G43 should be injected into TC path after M6")
 
         m6_idx = tc_commands.index("M6")
+        g43_cmd = tc_item.path.Commands[m6_idx + 2]
         self.assertEqual(
-            tc_commands[m6_idx + 1], "G43", "G43 must immediately follow M6 in TC path"
+            g43_cmd.Name, "G43", "G43 must immediately follow M6\n(posttoolchange) in TC path"
         )
-        g43_cmd = tc_item.path.Commands[m6_idx + 1]
         self.assertIn("H", g43_cmd.Parameters, "G43 should carry an H (tool number) parameter")
         self.assertEqual(g43_cmd.Parameters["H"], 1, "G43 H value must match the T number in M6")
 
@@ -1896,9 +1896,9 @@ class TestExport2Integration(unittest.TestCase):
 
     # ===== 140-149: G-code blocks insertion tests =====
 
-    def test140_gcode_blocks_insertion(self):
+    def test140_blocks_insertion(self):
         """
-        Test that all G-code blocks from machine config are properly inserted.
+        Test that all blocks from machine config are properly inserted.
 
         Expected: safety, preamble, prejob, preoperation, postoperation,
                   postjob, and postamble all appear in output.

--- a/src/Mod/CAM/CAMTests/TestPostToolProcessing.py
+++ b/src/Mod/CAM/CAMTests/TestPostToolProcessing.py
@@ -62,7 +62,7 @@ class TestToolLengthOffset(unittest.TestCase):
         sections = [("test", [processor._make_postable("g43", commands, {"optimizable": True})])]
 
         # Convert G43 command
-        processor._expand_tool_length_offset(sections)
+        processor._expand_tool_change(sections)
         result = processor._convert_job_sections(sections)[0][1]
 
         extant_g43 = [l for l in result.split("\n") if l.startswith("G43")]
@@ -94,7 +94,7 @@ class TestToolLengthOffset(unittest.TestCase):
         sections = [("test", [processor._make_postable("g43", commands, {"optimizable": True})])]
 
         # Convert G43 command
-        processor._expand_tool_length_offset(sections)
+        processor._expand_tool_change(sections)
         result = processor._convert_job_sections(sections)[0][1]
 
         extant_g43 = [l for l in result.split("\n") if l.startswith("G43")]
@@ -138,6 +138,7 @@ class TestToolProcessing(unittest.TestCase):
         # Create tool controller
         self.tc1 = PathToolController.Create("TC_Test_Tool1", tool1, 1)
         self.tc1.Label = "TC: 6mm Endmill"
+        self.tc1.SpindleSpeed = 1000.0
 
         # Create job
         self.job = PathJob.Create("TestJob", [base_obj], None)
@@ -435,7 +436,10 @@ class TestToolProcessing(unittest.TestCase):
         machine_config = self._get_full_machine_config()
         # Add pre/post tool change blocks to postprocessor properties
         machine_config["postprocessor"]["properties"]["pre_tool_change"] = "(pretoolchange)"
-        machine_config["postprocessor"]["properties"]["post_tool_change"] = "(posttoolchange)"
+        machine_config["postprocessor"]["properties"][
+            "post_tool_change"
+        ] = "(posttoolchange)\n(ptc2)"
+        machine_config["postprocessor"]["properties"]["tool_return"] = "(toolreturn)"
         machine = Machine.from_dict(machine_config)
 
         # Add a second tool controller to trigger tool changes
@@ -504,6 +508,25 @@ class TestToolProcessing(unittest.TestCase):
                     pre_idx,
                     post_idx,
                     f"Pre-tool-change should come before post-tool-change in---\n{all_output}\n--",
+                )
+
+            # POST_TOOL_CHANGE immediately after M6
+            m6_indices = [i for i, line in enumerate(lines) if line.startswith("M6")]
+            for pre_idx, post_idx in zip(m6_indices, posttool_indices):
+                self.assertEqual(
+                    post_idx - pre_idx,
+                    1,
+                    f"M6 immediately before post-tool-change in---\n{all_output}\n--",
+                )
+
+            # TOOL_RETURN after G43
+            m3_indices = [i for i, line in enumerate(lines) if line.startswith("M3")]
+            toolreturn_indices = [i for i, line in enumerate(lines) if "(toolreturn)" in line]
+            for pre_idx, post_idx in zip(m3_indices, toolreturn_indices):
+                self.assertEqual(
+                    post_idx - pre_idx,
+                    1,
+                    f"toolreturn immediately after G43 in---\n{all_output}\n--",
                 )
 
             # Verify tool change commands (M6) are present

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -1618,9 +1618,7 @@ class PostProcessor:
                 if output_tool_length_offset and "T" in cmd.Parameters:
                     tool_num = cmd.Parameters["T"]
                     Path.Log.debug(f"Added G43 H{tool_num} after M6 in operation {item.label}")
-                    changes.extend(
-                        self._expand_tool_length_offset_post_command(item, cmd)
-                    )
+                    changes.extend(self._expand_tool_length_offset_post_command(item, cmd))
 
                 if changes:
                     return 1, changes

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -550,7 +550,10 @@ class PostProcessor:
                 "type": "text",
                 "label": translate("CAM", "Post-Tool Change"),
                 "default": "",
-                "help": translate("CAM", "G-code commands inserted after tool changes."),
+                "help": translate(
+                    "CAM",
+                    "G-code to execute immediately after a tool change (M6), before the spindle is turned on. Use for a custom tool length offset routine, custom cutter compensation, or a return motion before the spindle starts.",
+                ),
             },
             {
                 "name": "tool_return",
@@ -558,7 +561,10 @@ class PostProcessor:
                 "type": "text",
                 "label": translate("CAM", "Tool Return after tool changes"),
                 "default": "",
-                "help": translate("CAM", "G-code commands inserted after tool changes."),
+                "help": translate(
+                    "CAM",
+                    "G-code to execute immediately after the spindle is turned on after a tool change.",
+                ),
             },
             {
                 "name": "pre_rotary_move",
@@ -1576,34 +1582,52 @@ class PostProcessor:
         Path.Log.debug(f"Added G43 H{tool_num} after M6 in operation {item.label}")
         return [Path.Command("G43", {"H": tool_num}, {Constants.ANNOT_ADDED_TLO: True})]
 
-    def _expand_tool_length_offset(self, postables):
-        """Inject or remove G43 tool length offset commands.
-
-        When OUTPUT_TOOL_LENGTH_OFFSET is True, adds G43 commands after M6
-        tool change commands in operations and tool change items.
-
-        When OUTPUT_TOOL_LENGTH_OFFSET is False, removes any existing G43
-        commands from operation paths.
-
-        Simplified single-pass implementation.
+    def _expand_tool_change(self, postables):
+        """Expand what follows a tool change (M6).
+        Immediately after each M6, inserts in order:
+          1. POST_TOOL_CHANGE lines, verbatim, if non-empty
+          2. G43 H<tool>, if OUTPUT_TOOL_LENGTH_OFFSET
+        When OUTPUT_TOOL_LENGTH_OFFSET is off, existing G43 commands are
+        replaced with a comment.
         """
+
         output_tool_length_offset = self.values["OUTPUT_TOOL_LENGTH_OFFSET"]
         Path.Log.debug(f"OUTPUT_TOOL_LENGTH_OFFSET value: {output_tool_length_offset}")
 
         def edit(section_name, item, cmd, section_state):
-            # suppress
-            if not output_tool_length_offset:
-                if cmd.Name in Constants.GCODE_TOOL_LENGTH_OFFSET:
+            # suppress G43
+            if cmd.Name in Constants.GCODE_TOOL_LENGTH_OFFSET:
+                if not output_tool_length_offset:
                     return 0, [Path.Command(f"(TLO suppressed {cmd.toGCode()})")]
                 else:
                     return None, None
 
-            # add
-            else:
-                if cmd.Name in Constants.MCODE_TOOL_CHANGE and "T" in cmd.Parameters:
-                    return 1, self._expand_tool_length_offset_post_command(item, cmd)
+            # append things after M6
+            elif cmd.Name in Constants.MCODE_TOOL_CHANGE:
+                # accumulate changes
+                changes = []
+
+                # POST_TOOL_CHANGE
+                if (block := self.values["POST_TOOL_CHANGE"]) != "":
+                    # instead of inserting an item of type=='str'
+                    for l in block.split("\n"):
+                        if l != "":
+                            changes.append(Path.Command("", {}, {Constants.ANNOT_AS_IS: l}))
+
+                # add G43
+                if output_tool_length_offset and "T" in cmd.Parameters:
+                    tool_num = cmd.Parameters["T"]
+                    Path.Log.debug(f"Added G43 H{tool_num} after M6 in operation {item.label}")
+                    changes.extend(
+                        self._expand_tool_length_offset_post_command(item, cmd)
+                    )
+
+                if changes:
+                    return 1, changes
                 else:
                     return None, None
+            else:
+                return None, None
 
         self._edit_command_list(postables, edit)
 
@@ -1761,7 +1785,7 @@ class PostProcessor:
 
         self._edit_item_list(postables, wrap_rotary)
 
-    def _expand_tool_change(self, postables):
+    def _suppress_tool_change(self, postables):
         """Suppress M6 if not TOOL_CHANGE"""
 
         def suppress_m6(section_name: str, item, section_state: dict):
@@ -1871,7 +1895,7 @@ class PostProcessor:
 
             # item -> 'str' Postable's
             if item.item_type == "tool_controller":
-                return 1, [pblock("POST_TOOL_CHANGE"), pblock("TOOL_RETURN")]
+                return 1, [pblock("TOOL_RETURN")]
             elif item.item_type == "fixture":
                 return 1, [pblock("POST_FIXTURE_CHANGE")]
             elif item.item_type == "operation":
@@ -2254,11 +2278,11 @@ class PostProcessor:
         self._expand_translate_rapids(postables)
         self._expand_xy_before_z(postables)
         self._expand_bcnc_commands(postables)
-        self._expand_tool_length_offset(postables)
+        self._expand_tool_change(postables)
+        self._suppress_tool_change(postables)
 
         postables = self._expand_post_item(postables)
         self._expand_trailing_lines(postables)
-        self._expand_tool_change(postables)
         self._expand_rotary_move(postables)
 
         # must be last expansion
@@ -2596,6 +2620,8 @@ class PostProcessor:
 
         # Pass through G-code as-is
         if "as-is" in command.Annotations:
+            # and we no longer know the MachineState
+            self.machine_state.setState(None)
             return command.Annotations[Constants.ANNOT_AS_IS]
 
         # "ignored" commands need not be in "SUPPORTED_COMMANDS"


### PR DESCRIPTION
fixes #31988

Now does this:

```
(pretoolchange)
(TC: 3mm Endmill)
M6 T2
(posttoolchange)
G43 H2
(toolreturn)
```

Note: will not add POST_TOOL_CHANGE if M6 is suppressed (`tool_change` is false). Will add TOOL_RETURN.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
