### PR TITLE
Sketcher: replace solve() & friends' int return codes with enums

### DIFF
--- a/cMake/FreeCAD_Helpers/CompilerChecksAndSetups.cmake
+++ b/cMake/FreeCAD_Helpers/CompilerChecksAndSetups.cmake
@@ -28,6 +28,7 @@ macro(CompilerChecksAndSetups)
     endif(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION)
 
     # Enabled C++20 for Freecad 1.1 and later
+    add_definitions(-DMINIMUM_CPLUSPLUS_VERSION=202002L)
     set(BUILD_ENABLE_CXX_STD "C++20"  CACHE STRING  "Enable C++ standard")
     set_property(CACHE BUILD_ENABLE_CXX_STD PROPERTY STRINGS
                  "C++20"

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -482,4 +482,14 @@ struct Overloads: Ts...
 template<class... Ts>
 Overloads(Ts...) -> Overloads<Ts...>;
 
+
+#if MINIMUM_CPLUSPLUS_VERSION >= 202302L
+[[deprecated("Replace with std::to_underlying() now that C++23 is required")]]
+#endif
+template<typename E>
+constexpr auto to_underlying(E e) noexcept
+{
+    return static_cast<std::underlying_type_t<E>>(e);
+}
+
 }  // namespace Base

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -492,4 +492,16 @@ constexpr auto to_underlying(E e) noexcept
     return static_cast<std::underlying_type_t<E>>(e);
 }
 
+#if MINIMUM_CPLUSPLUS_VERSION >= 202302L
+[[deprecated("Replace with std::unreachable() now that C++23 is required")]]
+#endif
+[[noreturn]] inline void unreachable()
+{
+#if defined(_MSC_VER) && !defined(__clang__)
+    __assume(false);
+#else
+    __builtin_unreachable();
+#endif
+}
+
 }  // namespace Base

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -4955,7 +4955,7 @@ bool Sketch::updateNonDrivingConstraints()
 
 // solving ==========================================================
 
-int Sketch::solve()
+GCS::SolveStatus Sketch::solve()
 {
     captureGroupStates();
 
@@ -4977,50 +4977,50 @@ int Sketch::solve()
 
     SolveTime = Base::TimeElapsed::diffTimeF(start_time, end_time);
 
-    if (result == GCS::Success) {
+    if (result == GCS::SolveStatus::Success) {
         applyGroupTransformations();
     }
 
     return result;
 }
 
-int Sketch::internalSolve(std::string& solvername, int level)
+GCS::SolveStatus Sketch::internalSolve(std::string& solvername, int level)
 {
     if (!isInitMove) {  // make sure we are in single subsystem mode
         clearTemporaryConstraints();
         isFine = true;
     }
 
-    int ret = -1;
+    GCS::SolveStatus status;
     bool valid_solution;
     int defaultsoltype = -1;
 
     if (isInitMove) {
         solvername = "DogLeg";  // DogLeg is used for dragging (same as before)
-        ret = GCSsys.solve(isFine, GCS::DogLeg);
+        status = GCSsys.solve(isFine, GCS::DogLeg);
     }
     else {
         switch (defaultSolver) {
             case 0:
                 solvername = "BFGS";
-                ret = GCSsys.solve(isFine, GCS::BFGS);
+                status = GCSsys.solve(isFine, GCS::BFGS);
                 defaultsoltype = 2;
                 break;
             case 1:  // solving with the LevenbergMarquardt solver
                 solvername = "LevenbergMarquardt";
-                ret = GCSsys.solve(isFine, GCS::LevenbergMarquardt);
+                status = GCSsys.solve(isFine, GCS::LevenbergMarquardt);
                 defaultsoltype = 1;
                 break;
             case 2:  // solving with the BFGS solver
                 solvername = "DogLeg";
-                ret = GCSsys.solve(isFine, GCS::DogLeg);
+                status = GCSsys.solve(isFine, GCS::DogLeg);
                 defaultsoltype = 0;
                 break;
         }
     }
 
     // if successfully solved try to write the parameters back
-    if (ret == GCS::Success) {
+    if (status == GCS::SolveStatus::Success) {
         GCSsys.applySolution();
         valid_solution = updateGeometry();
         if (!valid_solution) {
@@ -5050,15 +5050,15 @@ int Sketch::internalSolve(std::string& solvername, int level)
             switch (soltype) {
                 case 0:
                     solvername = "DogLeg";
-                    ret = GCSsys.solve(isFine, GCS::DogLeg);
+                    status = GCSsys.solve(isFine, GCS::DogLeg);
                     break;
                 case 1:  // solving with the LevenbergMarquardt solver
                     solvername = "LevenbergMarquardt";
-                    ret = GCSsys.solve(isFine, GCS::LevenbergMarquardt);
+                    status = GCSsys.solve(isFine, GCS::LevenbergMarquardt);
                     break;
                 case 2:  // solving with the BFGS solver
                     solvername = "BFGS";
-                    ret = GCSsys.solve(isFine, GCS::BFGS);
+                    status = GCSsys.solve(isFine, GCS::BFGS);
                     break;
                 // last resort: augment the system with a second subsystem and use the SQP solver
                 case 3:
@@ -5074,19 +5074,19 @@ int Sketch::internalSolve(std::string& solvername, int level)
                         );
                     }
                     GCSsys.initSolution();
-                    ret = GCSsys.solve(isFine);
+                    status = GCSsys.solve(isFine);
                     break;
             }
 
             // if successfully solved try to write the parameters back
-            if (ret == GCS::Success) {
+            if (status == GCS::SolveStatus::Success) {
                 GCSsys.applySolution();
                 valid_solution = updateGeometry();
                 if (!valid_solution) {
                     GCSsys.undoSolution();
                     updateGeometry();
                     Base::Console().warning("Invalid solution from %s solver.\n", solvername.c_str());
-                    ret = GCS::SuccessfulSolutionInvalid;
+                    status = GCS::SolveStatus::SuccessfulSolutionInvalid;
                 }
                 else {
                     updateNonDrivingConstraints();
@@ -5136,11 +5136,11 @@ int Sketch::internalSolve(std::string& solvername, int level)
 
     // For OCCT reliant geometry that needs an extra solve() for example to update non-driving
     // constraints.
-    if (resolveAfterGeometryUpdated && ret == GCS::Success && level == 0) {
+    if (resolveAfterGeometryUpdated && status == GCS::SolveStatus::Success && level == 0) {
         return internalSolve(solvername, 1);
     }
 
-    return ret;
+    return status;
 }
 
 int Sketch::initMove(const std::vector<GeoElementId>& geoEltIds, bool fine)
@@ -5461,11 +5461,15 @@ int Sketch::initBSplinePieceMove(int geoId, PointPos pos, const Base::Vector3d& 
     return 0;
 }
 
-int Sketch::moveGeometries(const std::vector<GeoElementId>& geoEltIds, Base::Vector3d toPoint, bool relative)
+GCS::SolveStatus Sketch::moveGeometries(
+    const std::vector<GeoElementId>& geoEltIds,
+    Base::Vector3d toPoint,
+    bool relative
+)
 {
     if (hasConflicts()) {
         // don't try to move sketches that contain conflicting constraints
-        return -1;
+        return GCS::SolveStatus::Failed;
     }
 
     if (!isInitMove) {
@@ -5574,7 +5578,7 @@ int Sketch::moveGeometries(const std::vector<GeoElementId>& geoEltIds, Base::Vec
     return solve();
 }
 
-int Sketch::moveGeometry(int geoId, PointPos pos, Base::Vector3d toPoint, bool relative)
+GCS::SolveStatus Sketch::moveGeometry(int geoId, PointPos pos, Base::Vector3d toPoint, bool relative)
 {
     std::vector<GeoElementId> geoEltIds = {GeoElementId(geoId, pos)};
     return moveGeometries(geoEltIds, toPoint, relative);

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -138,7 +138,6 @@ Sketch::Sketch()
     , GCSsys()
     , ConstraintsCounter(0)
     , isInitMove(false)
-    , isFine(true)
     , moveStep(0)
     , defaultSolver(GCS::DogLeg)
     , defaultSolverRedundant(GCS::DogLeg)
@@ -4988,7 +4987,6 @@ GCS::SolveStatus Sketch::internalSolve(std::string& solvername, int level)
 {
     if (!isInitMove) {  // make sure we are in single subsystem mode
         clearTemporaryConstraints();
-        isFine = true;
     }
 
     GCS::SolveStatus status;
@@ -4997,23 +4995,23 @@ GCS::SolveStatus Sketch::internalSolve(std::string& solvername, int level)
 
     if (isInitMove) {
         solvername = "DogLeg";  // DogLeg is used for dragging (same as before)
-        status = GCSsys.solve(isFine, GCS::DogLeg);
+        status = GCSsys.solve(GCS::DogLeg);
     }
     else {
         switch (defaultSolver) {
             case 0:
                 solvername = "BFGS";
-                status = GCSsys.solve(isFine, GCS::BFGS);
+                status = GCSsys.solve(GCS::BFGS);
                 defaultsoltype = 2;
                 break;
             case 1:  // solving with the LevenbergMarquardt solver
                 solvername = "LevenbergMarquardt";
-                status = GCSsys.solve(isFine, GCS::LevenbergMarquardt);
+                status = GCSsys.solve(GCS::LevenbergMarquardt);
                 defaultsoltype = 1;
                 break;
             case 2:  // solving with the BFGS solver
                 solvername = "DogLeg";
-                status = GCSsys.solve(isFine, GCS::DogLeg);
+                status = GCSsys.solve(GCS::DogLeg);
                 defaultsoltype = 0;
                 break;
         }
@@ -5050,15 +5048,15 @@ GCS::SolveStatus Sketch::internalSolve(std::string& solvername, int level)
             switch (soltype) {
                 case 0:
                     solvername = "DogLeg";
-                    status = GCSsys.solve(isFine, GCS::DogLeg);
+                    status = GCSsys.solve(GCS::DogLeg);
                     break;
                 case 1:  // solving with the LevenbergMarquardt solver
                     solvername = "LevenbergMarquardt";
-                    status = GCSsys.solve(isFine, GCS::LevenbergMarquardt);
+                    status = GCSsys.solve(GCS::LevenbergMarquardt);
                     break;
                 case 2:  // solving with the BFGS solver
                     solvername = "BFGS";
-                    status = GCSsys.solve(isFine, GCS::BFGS);
+                    status = GCSsys.solve(GCS::BFGS);
                     break;
                 // last resort: augment the system with a second subsystem and use the SQP solver
                 case 3:
@@ -5074,7 +5072,7 @@ GCS::SolveStatus Sketch::internalSolve(std::string& solvername, int level)
                         );
                     }
                     GCSsys.initSolution();
-                    status = GCSsys.solve(isFine);
+                    status = GCSsys.solve();
                     break;
             }
 
@@ -5143,14 +5141,13 @@ GCS::SolveStatus Sketch::internalSolve(std::string& solvername, int level)
     return status;
 }
 
-int Sketch::initMove(const std::vector<GeoElementId>& geoEltIds, bool fine)
+int Sketch::initMove(const std::vector<GeoElementId>& geoEltIds)
 {
     if (hasConflicts()) {
         // don't try to move sketches that contain conflicting constraints
         isInitMove = false;
         return -1;
     }
-    isFine = fine;
 
     clearTemporaryConstraints();
 
@@ -5385,10 +5382,10 @@ int Sketch::initMove(const std::vector<GeoElementId>& geoEltIds, bool fine)
     return 0;
 }
 
-int Sketch::initMove(int geoId, PointPos pos, bool fine)
+int Sketch::initMove(int geoId, PointPos pos)
 {
     std::vector<GeoElementId> geoEltIds = {GeoElementId(geoId, pos)};
-    return initMove(geoEltIds, fine);
+    return initMove(geoEltIds);
 }
 
 void Sketch::resetInitMove()
@@ -5396,10 +5393,8 @@ void Sketch::resetInitMove()
     isInitMove = false;
 }
 
-int Sketch::initBSplinePieceMove(int geoId, PointPos pos, const Base::Vector3d& firstPoint, bool fine)
+int Sketch::initBSplinePieceMove(int geoId, PointPos pos, const Base::Vector3d& firstPoint)
 {
-    isFine = fine;
-
     geoId = checkGeoId(geoId);
 
     clearTemporaryConstraints();
@@ -5419,7 +5414,7 @@ int Sketch::initBSplinePieceMove(int geoId, PointPos pos, const Base::Vector3d& 
 
     // If spline has too few poles, just move all
     if (bsp.poles.size() <= std::size_t(bsp.degree + 1)) {
-        return initMove(geoId, pos, fine);
+        return initMove(geoId, pos);
     }
 
     // Find the closest knot

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -52,8 +52,10 @@ public:
     void Restore(Base::XMLReader& /*reader*/) override;
 
     /// solve the actual set up sketch
-    int solve();
-    /// resets the solver
+    GCS::SolveStatus solve();
+    /** Reset the solver.
+     * @return DoF degree count.
+     */
     int resetSolver();
     /// get standard (aka fine) solver precision
     double getSolverPrecision()
@@ -192,12 +194,12 @@ public:
      * a condition for satisfying the new point location!
      * The relative flag permits moving relatively to the current position
      */
-    int moveGeometries(
+    GCS::SolveStatus moveGeometries(
         const std::vector<GeoElementId>& geoEltIds,
         Base::Vector3d toPoint,
         bool relative = false
     );
-    int moveGeometry(int geoId, PointPos pos, Base::Vector3d toPoint, bool relative = false);
+    GCS::SolveStatus moveGeometry(int geoId, PointPos pos, Base::Vector3d toPoint, bool relative = false);
 
     /**
      * Sets whether the initial solution should be recalculated while dragging after a certain
@@ -810,7 +812,7 @@ private:
 
     void buildInternalAlignmentGeometryMap(const std::vector<Constraint*>& constraintList);
 
-    int internalSolve(std::string& solvername, int level = 0);
+    GCS::SolveStatus internalSolve(std::string& solvername, int level = 0);
 
     /// checks if the index bounds and converts negative indices to positive
     int checkGeoId(int geoId) const;

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -173,13 +173,13 @@ public:
     /** initializes a point (or curve) drag by setting the current
      * sketch status as a reference
      */
-    int initMove(const std::vector<GeoElementId>& geoEltIds, bool fine = true);
-    int initMove(int geoId, PointPos pos, bool fine = true);
+    int initMove(const std::vector<GeoElementId>& geoEltIds);
+    int initMove(int geoId, PointPos pos);
 
     /** Initializes a B-spline piece drag by setting the current
      * sketch status as a reference. Only moves piece around `firstPoint`.
      */
-    int initBSplinePieceMove(int geoId, PointPos pos, const Base::Vector3d& firstPoint, bool fine = true);
+    int initBSplinePieceMove(int geoId, PointPos pos, const Base::Vector3d& firstPoint);
 
     /** Resets the initialization of a point or curve drag
      */
@@ -647,7 +647,6 @@ private:
     std::vector<GCS::BSpline> BSplines;
 
     bool isInitMove;
-    bool isFine;
     Base::Vector3d initToPoint;
     double moveStep;
 

--- a/src/Mod/Sketcher/App/SketchAnalysis.cpp
+++ b/src/Mod/Sketcher/App/SketchAnalysis.cpp
@@ -618,17 +618,17 @@ Sketcher::Constraint* SketchAnalysis::create(const ConstraintIds& id)
 
 void SketchAnalysis::solveSketch(const char* errorText)
 {
-    int status {};
+    SketchSolveStatus status;
     int dofs {};
     solvesketch(status, dofs, true);
 
-    if (status == int(Solver::RedundantConstraints)) {
+    if (status == SketchSolveStatus::RedundantConstraints) {
         sketch->autoRemoveRedundants(DeleteOption::NoFlag);
 
         solvesketch(status, dofs, false);
     }
 
-    if (status) {
+    if (status != SketchSolveStatus::Success) {
         THROWMT(Base::RuntimeError, errorText);
     }
 }
@@ -832,7 +832,7 @@ void SketchAnalysis::makeMissingEqualityOneByOne()
     radiusequalityConstraints.clear();
 }
 
-void SketchAnalysis::solvesketch(int& status, int& dofs, bool updategeo)
+void SketchAnalysis::solvesketch(SketchSolveStatus& status, int& dofs, bool updategeo)
 {
     status = sketch->solve(updategeo);
 
@@ -844,14 +844,14 @@ void SketchAnalysis::solvesketch(int& status, int& dofs, bool updategeo)
     }
 
     if (sketch->getLastHasRedundancies()) {
-        status = int(Solver::RedundantConstraints);
+        status = SketchSolveStatus::RedundantConstraints;
     }
 
     if (dofs < 0) {
-        status = int(Solver::OverConstrained);
+        status = SketchSolveStatus::Overconstrained;
     }
     else if (sketch->getLastHasConflicts()) {
-        status = int(Solver::ConflictingConstraints);
+        status = SketchSolveStatus::ConflictingConstraints;
     }
 }
 

--- a/src/Mod/Sketcher/App/SketchAnalysis.h
+++ b/src/Mod/Sketcher/App/SketchAnalysis.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <memory>
 #include <vector>
 
 #include <Precision.hxx>
@@ -41,11 +40,15 @@ namespace Sketcher
 class SketchObject;
 
 
-enum class Solver
+enum class SketchSolveStatus : int8_t
 {
-    RedundantConstraints = -2,
+    Success = 0,
+    Overconstrained = -4,
     ConflictingConstraints = -3,
-    OverConstrained = -4,
+    MalformedConstraints = -5,
+    SolverError = -1,
+    RedundantConstraints = -2,
+    InvalidGeometry = -6,
 };
 
 
@@ -182,7 +185,7 @@ public:
     /// solves the sketch and retrieves the error status, and the degrees of freedom.
     /// It enables to solve updating the geometry (so moving the geometry to match the constraints)
     /// or preserving the geometry.
-    void solvesketch(int& status, int& dofs, bool updategeo);
+    void solvesketch(SketchSolveStatus& status, int& dofs, bool updategeo);
 
     // third type of routines
     std::vector<Base::Vector3d> getOpenVertices() const;

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -141,7 +141,7 @@ SketchObject::SketchObject() : geoLastId(0)
     lastHasRedundancies = false;
     lastHasPartialRedundancies = false;
     lastHasMalformedConstraints = false;
-    lastSolverStatus = 0;
+    lastSolverStatus = GCS::SolveStatus::Success;
     lastSolveTime = 0;
 
     solverNeedsUpdate = false;
@@ -221,29 +221,29 @@ App::DocumentObjectExecReturn* SketchObject::execute()
 
     // This includes a regular solve including full geometry update, except when an error
     // ensues
-    int err = this->solve(true);
-
-    if (err == -4) {// over-constrained sketch
-        std::string msg = "Over-constrained sketch\n";
+    std::string msg;
+    switch (solve(true)) {
+    case SketchSolveStatus::Success:
+        break;
+    case SketchSolveStatus::Overconstrained:
+        msg = "Over-constrained sketch\n";
         appendConflictMsg(lastConflicting, msg);
-        return new App::DocumentObjectExecReturn(msg.c_str(), this);
-    }
-    else if (err == -3) {// conflicting constraints
-        std::string msg = "Sketch with conflicting constraints\n";
+        // TODO: std::move(msg) when DocumentObjectExecReturn takes string by value
+        return new App::DocumentObjectExecReturn(msg, this);
+    case SketchSolveStatus::ConflictingConstraints:
+        msg = "Sketch with conflicting constraints\n";
         appendConflictMsg(lastConflicting, msg);
-        return new App::DocumentObjectExecReturn(msg.c_str(), this);
-    }
-    else if (err == -2) {// redundant constraints
-        std::string msg = "Sketch with redundant constraints\n";
+        return new App::DocumentObjectExecReturn(msg, this);
+    case SketchSolveStatus::RedundantConstraints:
+        msg = "Sketch with redundant constraints\n";
         appendRedundantMsg(lastRedundant, msg);
-        return new App::DocumentObjectExecReturn(msg.c_str(), this);
-    }
-    else if (err == -5) {
-        std::string msg = "Sketch with malformed constraints\n";
+        return new App::DocumentObjectExecReturn(msg, this);
+    case SketchSolveStatus::MalformedConstraints:
+        msg = "Sketch with malformed constraints\n";
         appendMalformedConstraintsMsg(lastMalformedConstraints, msg);
-        return new App::DocumentObjectExecReturn(msg.c_str(), this);
-    }
-    else if (err == -1) {// Solver failed
+        return new App::DocumentObjectExecReturn(msg, this);
+    case SketchSolveStatus::SolverError:
+    case SketchSolveStatus::InvalidGeometry:
         return new App::DocumentObjectExecReturn("Solving the sketch failed", this);
     }
 
@@ -686,25 +686,30 @@ void SketchObject::generateId(const Part::Geometry* geo)
     FC_TRACE("found " << found.front());
     preReturn(found.front());
 }
-// clang-format off
 
-int SketchObject::setTextAndFont(int ConstrId, std::string& newText, std::string& newFont, bool isHeight, bool isConstruction)
+SketchSolveStatus SketchObject::setTextAndFont(
+    int ConstrId,
+    std::string& newText,
+    std::string& newFont,
+    bool isHeight,
+    bool isConstruction
+)
 {
-;    // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
     Base::StateLocker lock(managedoperation, true);
 
     // set the changed value for the constraint
     if (this->Constraints.hasInvalidGeometry()) {
-        return -6;
+        return SketchSolveStatus::InvalidGeometry;
     }
     const std::vector<Constraint*>& vals = this->Constraints.getValues();
     if (ConstrId < 0 || ConstrId >= int(vals.size())) {
-        return -1;
+        return SketchSolveStatus::SolverError;
     }
 
     auto* constr = vals[ConstrId];
     if (constr->Type != Text || !constr->hasElement(0)) {
-        return -1;
+        return SketchSolveStatus::SolverError;
     }
 
     // First we replace the old geometries by the new text.
@@ -729,7 +734,7 @@ int SketchObject::setTextAndFont(int ConstrId, std::string& newText, std::string
             }
             geoIdsToDelete.push_back(constr->getGeoId(i));
             if (handleLast) {
-                --handleGeoId; // handle line is added after all text geos.
+                --handleGeoId;  // handle line is added after all text geos.
             }
         }
 
@@ -738,17 +743,19 @@ int SketchObject::setTextAndFont(int ConstrId, std::string& newText, std::string
 
     auto* line = dynamic_cast<const Part::GeomLineSegment*>(getGeometry(handleGeoId));
     if (!line) {
-        return -1;
+        return SketchSolveStatus::SolverError;
     }
 
     // Generate text geos based on new text/font :
     std::vector<std::unique_ptr<Part::Geometry>> newGeos;
     std::vector<TopoDS_Shape> shapes = Part::makeTextWires(newText, newFont);
-    Part::transformAndConvertToGeometry(newGeos,
-                                    shapes,
-                                    line->getStartPoint(),
-                                    line->getEndPoint(),
-                                    isHeight);
+    Part::transformAndConvertToGeometry(
+        newGeos,
+        shapes,
+        line->getStartPoint(),
+        line->getEndPoint(),
+        isHeight
+    );
 
     // Add the geometries to sketch
     int lastGeoid = getHighestCurveIndex();
@@ -775,7 +782,7 @@ int SketchObject::setTextAndFont(int ConstrId, std::string& newText, std::string
     if (hasExistingText) {
         constr = new Constraint();
         constr->Type = Text;
-        constr->truncateElements(0); // remove the First/Second/Third that are created automatically
+        constr->truncateElements(0);  // remove the First/Second/Third that are created automatically
         constr->addElement(GeoElementId(handleGeoId));
     }
     for (int i = lastGeoid + 1; i <= newLastGeoid; ++i) {
@@ -789,16 +796,17 @@ int SketchObject::setTextAndFont(int ConstrId, std::string& newText, std::string
         addConstraint(constr);
     }
 
-    int err = solve();
+    auto status = solve();
 
-    if (err) {
+    if (status == SketchSolveStatus::Success) {
         constr->setText(oldText);
         constr->setFont(oldFont);
         constr->setIsTextHeight(oldIsHeight);
     }
 
-    return err;
+    return status;
 }
+// clang-format off
 
 void SketchObject::acceptGeometry()
 {
@@ -1405,7 +1413,7 @@ void SketchObject::onSketchRestore()
         // this may happen when saving a sketch directly in edit mode
         // but never performed a recompute before
         if (Shape.getValue().IsNull() && hasConflicts() == 0) {
-            if (this->solve(true) == 0)
+            if (this->solve(true) == SketchSolveStatus::Success)
                 Shape.setValue(solvedSketch.toShape());
         }
 

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -790,16 +790,11 @@ public: /* Solver exposed interface */
     /// Forwards a request for a temporary initMove to the solver using the current sketch state as
     /// a reference (enables dragging)
 
-    inline int initTemporaryMove(std::vector<GeoElementId> moved, bool fine = true);
-    inline int initTemporaryMove(int geoId, PointPos pos, bool fine = true);
+    inline int initTemporaryMove(std::vector<GeoElementId> moved);
+    inline int initTemporaryMove(int geoId, PointPos pos);
     /// Forwards a request for a temporary initBSplinePieceMove to the solver using the current
     /// sketch state as a reference (enables dragging)
-    inline int initTemporaryBSplinePieceMove(
-        int geoId,
-        PointPos pos,
-        const Base::Vector3d& firstPoint,
-        bool fine = true
-    );
+    inline int initTemporaryBSplinePieceMove(int geoId, PointPos pos, const Base::Vector3d& firstPoint);
     /** Forwards a request for point or curve temporary movement to the solver using the current
      * state as a reference (enables dragging). NOTE: A temporary move operation must always be
      * preceded by a initTemporaryMove() operation.
@@ -1252,26 +1247,25 @@ private:
     mutable std::map<std::string, std::string> internalElementMap;
 };
 
-inline int SketchObject::initTemporaryMove(std::vector<GeoElementId> moved, bool fine /*=true*/)
+inline int SketchObject::initTemporaryMove(std::vector<GeoElementId> moved)
 {
     if (solverNeedsUpdate) {
         solve();
     }
 
-    return solvedSketch.initMove(moved, fine);
+    return solvedSketch.initMove(moved);
 }
 
-inline int SketchObject::initTemporaryMove(int geoId, PointPos pos, bool fine /*=true*/)
+inline int SketchObject::initTemporaryMove(int geoId, PointPos pos)
 {
     std::vector<GeoElementId> moved = {GeoElementId(geoId, pos)};
-    return initTemporaryMove(moved, fine);
+    return initTemporaryMove(moved);
 }
 
 inline int SketchObject::initTemporaryBSplinePieceMove(
     int geoId,
     PointPos pos,
-    const Base::Vector3d& firstPoint,
-    bool fine
+    const Base::Vector3d& firstPoint
 )
 {
     // if a previous operation did not update the geometry (including geometry extensions)
@@ -1281,7 +1275,7 @@ inline int SketchObject::initTemporaryBSplinePieceMove(
         solve();
     }
 
-    return solvedSketch.initBSplinePieceMove(geoId, pos, firstPoint, fine);
+    return solvedSketch.initBSplinePieceMove(geoId, pos, firstPoint);
 }
 
 inline GCS::SolveStatus SketchObject::

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -340,25 +340,20 @@ public:
      * the sketch object */
     int diagnoseAdditionalConstraints(std::vector<Sketcher::Constraint*> additionalconstraints);
 
-    /** solves the sketch and updates the geometry, but not all the dependent features (does not
-       recompute) When a recompute is necessary, recompute triggers execute() which solves the
-       sketch and updates all dependent features When a solve only is necessary (e.g. DoF changed),
-       solve() solves the sketch and updates the geometry (if updateGeoAfterSolving==true), but does
-       not trigger any recompute.
-       @return 0 if no error, if error, the following codes in this order of priority:
-       -4 if overconstrained,
-       -3 if conflicting constraints,
-       -5 if malformed constraints,
-       -1 if solver error,
-       -2 if redundant constraints
-    */
-    int solve(bool updateGeoAfterSolving = true);
+    /** Solves the sketch and (optionally) updates the geometry.
+     * Does not trigger a recompute of any dependent features; when that is necessary, call
+     * execute() instead. A change in DoF does not require updating dependents, for instance.
+     * @return SketchSolveStatus::Success if no error, or else any of these in this order of
+     *         priority: Overconstrained, ConflictingConstraints, MalformedConstraints,
+     *         SolverError, RedundantConstraints.
+     */
+    SketchSolveStatus solve(bool updateGeoAfterSolving = true);
     /// set the datum of a Distance or Angle constraint and solve
-    int setDatum(int ConstrId, double Datum);
+    SketchSolveStatus setDatum(int ConstrId, double Datum);
     /// get the datum of a Distance or Angle constraint
     double getDatum(int ConstrId) const;
     /// set the text and font of a text constraint
-    int setTextAndFont(
+    SketchSolveStatus setTextAndFont(
         int ConstrId,
         std::string& newText,
         std::string& newFont,
@@ -422,13 +417,13 @@ public:
     /// set the visibility of a group of constraints at once
     int setVisibility(std::vector<int> constrIds, bool isVisible);
     /// move this point to a new location and solve
-    int moveGeometries(
+    SketchSolveStatus moveGeometries(
         const std::vector<GeoElementId>& geoEltIds,
         const Base::Vector3d& toPoint,
         bool relative = false,
         bool updateGeoBeforeMoving = false
     );
-    int moveGeometry(
+    SketchSolveStatus moveGeometry(
         int GeoId,
         PointPos PosId,
         const Base::Vector3d& toPoint,
@@ -481,9 +476,9 @@ public:
     );
 
     /// trim a curve
-    int trim(int geoId, const Base::Vector3d& point, bool includeSketchAxes = false);
+    SketchSolveStatus trim(int geoId, const Base::Vector3d& point, bool includeSketchAxes = false);
     /// extend a curve
-    int extend(int geoId, double increment, PointPos endPoint);
+    SketchSolveStatus extend(int geoId, double increment, PointPos endPoint);
     /// Once smaller pieces have been created from a larger curve (by split or trim, say), derive
     /// the constraint that will replace the given one (which is to be deleted). NOTE: Currently
     /// assuming all constraints on the end points of the old curve have been transferred or
@@ -746,7 +741,7 @@ public:
         return lastHasMalformedConstraints;
     }
     /// gets solver status of last solver execution
-    inline int getLastSolverStatus() const
+    inline GCS::SolveStatus getLastSolverStatus() const
     {
         return lastSolverStatus;
     }
@@ -809,12 +804,12 @@ public: /* Solver exposed interface */
      * state as a reference (enables dragging). NOTE: A temporary move operation must always be
      * preceded by a initTemporaryMove() operation.
      */
-    inline int moveGeometriesTemporary(
+    inline GCS::SolveStatus moveGeometriesTemporary(
         std::vector<GeoElementId> moved,
         Base::Vector3d toPoint,
         bool relative = false
     );
-    inline int moveGeometryTemporary(
+    inline GCS::SolveStatus moveGeometryTemporary(
         int geoId,
         PointPos pos,
         Base::Vector3d toPoint,
@@ -1194,7 +1189,7 @@ private:
     bool lastHasRedundancies;
     bool lastHasPartialRedundancies;
     bool lastHasMalformedConstraints;
-    int lastSolverStatus;
+    GCS::SolveStatus lastSolverStatus;
     float lastSolveTime;
 
     std::vector<int> lastConflicting;
@@ -1289,12 +1284,13 @@ inline int SketchObject::initTemporaryBSplinePieceMove(
     return solvedSketch.initBSplinePieceMove(geoId, pos, firstPoint, fine);
 }
 
-inline int SketchObject::
+inline GCS::SolveStatus SketchObject::
     moveGeometriesTemporary(std::vector<GeoElementId> geoEltIds, Base::Vector3d toPoint, bool relative /*=false*/)
 {
     return solvedSketch.moveGeometries(geoEltIds, toPoint, relative);
 }
-inline int SketchObject::moveGeometryTemporary(int geoId, PointPos pos, Base::Vector3d toPoint, bool relative /*=false*/)
+inline GCS::SolveStatus SketchObject::
+    moveGeometryTemporary(int geoId, PointPos pos, Base::Vector3d toPoint, bool relative /*=false*/)
 {
     std::vector<GeoElementId> moved = {GeoElementId(geoId, pos)};
     return moveGeometriesTemporary(moved, toPoint, relative);

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -74,7 +74,7 @@ void SketchObject::retrieveSolverDiagnostics()
     lastMalformedConstraints = solvedSketch.getMalformedConstraints();
 }
 
-int SketchObject::solve(bool updateGeoAfterSolving /*=true*/)
+SketchSolveStatus SketchObject::solve(bool updateGeoAfterSolving /*=true*/)
 {
     // no need to check input data validity as this is an sketchobject managed operation.
     Base::StateLocker lock(managedoperation, true);
@@ -107,31 +107,31 @@ int SketchObject::solve(bool updateGeoAfterSolving /*=true*/)
     lastSolveTime = 0.0;
 
     // Failure is default for notifying the user unless otherwise proven
-    lastSolverStatus = GCS::Failed;
+    lastSolverStatus = GCS::SolveStatus::Failed;
 
-    int err = 0;
+    auto status = SketchSolveStatus::Success;
 
     // redundancy is a lower priority problem than conflict/over-constraint/solver error
     // we set it here because we are indeed going to solve, as we can. However, we still want to
     // provide the right error code.
     if (lastHasRedundancies) {// redundant constraints
-        err = -2;
+        status = SketchSolveStatus::RedundantConstraints;
     }
 
     if (lastDoF < 0) {// over-constrained sketch
-        err = -4;
+        status = SketchSolveStatus::Overconstrained;
     }
     else if (lastHasConflict) {// conflicting constraints
         // The situation is exactly the same as in the over-constrained situation.
-        err = -3;
+        status = SketchSolveStatus::ConflictingConstraints;
     }
     else if (lastHasMalformedConstraints) {
-        err = -5;
+        status = SketchSolveStatus::MalformedConstraints;
     }
     else {
         lastSolverStatus = solvedSketch.solve();
-        if (lastSolverStatus != 0) {// solving
-            err = -1;
+        if (lastSolverStatus != GCS::SolveStatus::Success) {// solving
+            status = SketchSolveStatus::SolverError;
         }
     }
 
@@ -165,7 +165,7 @@ int SketchObject::solve(bool updateGeoAfterSolving /*=true*/)
     // In uncommon situations, the analysis of QR decomposition leads to full rank, but the result
     // does not converge. We avoid marking a sketch as fully constrained when no convergence is
     // achieved.
-    if (err == 0) {
+    if (status == SketchSolveStatus::Success) {
         FullyConstrained.setValue(lastDoF == 0);
         if (updateGeoAfterSolving) {
             // set the newly solved geometry
@@ -178,30 +178,30 @@ int SketchObject::solve(bool updateGeoAfterSolving /*=true*/)
 
     signalSolverUpdate();
 
-    return err;
+    return status;
 }
 
-int SketchObject::setDatum(int ConstrId, double Datum)
+SketchSolveStatus SketchObject::setDatum(int ConstrId, double Datum)
 {
     // no need to check input data validity as this is an sketchobject managed operation.
     Base::StateLocker lock(managedoperation, true);
 
     // set the changed value for the constraint
     if (this->Constraints.hasInvalidGeometry())
-        return -6;
+        return SketchSolveStatus::InvalidGeometry;
     const std::vector<Constraint*>& vals = this->Constraints.getValues();
     if (ConstrId < 0 || ConstrId >= int(vals.size()))
-        return -1;
+        return SketchSolveStatus::SolverError;
     ConstraintType type = vals[ConstrId]->Type;
     // for tangent, value==0 is autodecide, value==Pi/2 is external and value==-Pi/2 is internal
     if (!vals[ConstrId]->isDimensional() && type != Tangent && type != Perpendicular)
-        return -1;
+        return SketchSolveStatus::SolverError;
 
     if ((type == Radius || type == Diameter || type == Weight) && Datum <= 0)
-        return (Datum == 0) ? -5 : -4;
+        return (Datum == 0) ? SketchSolveStatus::MalformedConstraints : SketchSolveStatus::Overconstrained;
 
     if (type == Distance && Datum == 0)
-            return -5;
+            return SketchSolveStatus::MalformedConstraints;
 
     // copy the list
     std::vector<Constraint*> newVals(vals);
@@ -211,12 +211,12 @@ int SketchObject::setDatum(int ConstrId, double Datum)
 
     this->Constraints.setValues(std::move(newVals));
 
-    int err = solve();
+    const auto status = solve();
 
-    if (err)
+    if (status != SketchSolveStatus::Success)
         this->Constraints.getValues()[ConstrId]->setValue(oldDatum);// newVals is a shell now
 
-    return err;
+    return status;
 }
 double SketchObject::getDatum(int ConstrId) const
 {

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -375,7 +375,7 @@ SketchSolveStatus SketchObject::extend(int GeoId, double increment, PointPos end
 
     const std::vector<Part::Geometry*>& geomList = getInternalGeometry();
     Part::Geometry* geom = geomList[GeoId];
-    SketchSolveStatus status;
+    auto status = SketchSolveStatus::Success;
     if (geom->is<Part::GeomLineSegment>()) {
         auto* seg = static_cast<Part::GeomLineSegment*>(geom);
         Base::Vector3d startVec = seg->getStartPoint();

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -37,15 +37,15 @@
 #include "SketchObject.h"
 
 
-#undef DEBUG
-// #define DEBUG
-
-// clang-format off
 using namespace Sketcher;
 using namespace Base;
 
-int SketchObject::moveGeometries(const std::vector<GeoElementId>& geoEltIds, const Base::Vector3d& toPoint, bool relative,
-                            bool updateGeoBeforeMoving)
+SketchSolveStatus SketchObject::moveGeometries(
+    const std::vector<GeoElementId>& geoEltIds,
+    const Base::Vector3d& toPoint,
+    bool relative,
+    bool updateGeoBeforeMoving
+)
 {
 
     // no need to check input data validity as this is an sketchobject managed operation.
@@ -61,17 +61,22 @@ int SketchObject::moveGeometries(const std::vector<GeoElementId>& geoEltIds, con
 
     if (updateGeoBeforeMoving || solverNeedsUpdate) {
         lastDoF = solvedSketch.setUpSketch(
-            getCompleteGeometry(), Constraints.getValues(), getExternalGeometryCount());
+            getCompleteGeometry(),
+            Constraints.getValues(),
+            getExternalGeometryCount()
+        );
 
         retrieveSolverDiagnostics();
 
         solverNeedsUpdate = false;
     }
 
-    if (lastDoF < 0)// over-constrained sketch
-        return -1;
-    if (lastHasConflict)// conflicting constraints
-        return -1;
+    if (lastDoF < 0) {  // over-constrained sketch
+        return SketchSolveStatus::SolverError;
+    }
+    if (lastHasConflict) {  // conflicting constraints
+        return SketchSolveStatus::SolverError;
+    }
 
     // move the point and solve
     lastSolverStatus = solvedSketch.moveGeometries(geoEltIds, toPoint, relative);
@@ -79,26 +84,33 @@ int SketchObject::moveGeometries(const std::vector<GeoElementId>& geoEltIds, con
     // moving the point can not result in a conflict that we did not have
     // or a redundancy that we did not have before, or a change of DoF
 
-    if (lastSolverStatus == 0) {
+    if (lastSolverStatus == GCS::SolveStatus::Success) {
         std::vector<Part::Geometry*> geomlist = solvedSketch.extractGeometry();
         Geometry.setValues(geomlist);
-        for (auto* geo :  geomlist) {
+        for (auto* geo : geomlist) {
             delete geo;
         }
     }
 
-    solvedSketch.resetInitMove();// reset solver point moving mechanism
+    solvedSketch.resetInitMove();  // reset solver point moving mechanism
 
-    return lastSolverStatus;
+    return lastSolverStatus == GCS::SolveStatus::Success ? SketchSolveStatus::Success
+                                                         : SketchSolveStatus::SolverError;
 }
 
-int SketchObject::moveGeometry(int geoId, PointPos pos, const Base::Vector3d& toPoint, bool relative,
-    bool updateGeoBeforeMoving)
+SketchSolveStatus SketchObject::moveGeometry(
+    int geoId,
+    PointPos pos,
+    const Base::Vector3d& toPoint,
+    bool relative,
+    bool updateGeoBeforeMoving
+)
 {
-    std::vector<GeoElementId> geoEltIds = { GeoElementId(geoId, pos) };
+    std::vector<GeoElementId> geoEltIds = {GeoElementId(geoId, pos)};
     return moveGeometries(geoEltIds, toPoint, relative, updateGeoBeforeMoving);
 }
 
+// clang-format off
 int SketchObject::delGeometries(const std::vector<int>& GeoIds, DeleteOptions options)
 {
     return delGeometries(GeoIds.begin(), GeoIds.end(), options);
@@ -356,14 +368,14 @@ int SketchObject::fillet(int GeoId1, int GeoId2, const Base::Vector3d& refPnt1,
     return 0;
 }
 
-int SketchObject::extend(int GeoId, double increment, PointPos endpoint)
+SketchSolveStatus SketchObject::extend(int GeoId, double increment, PointPos endpoint)
 {
     if (GeoId < 0 || GeoId > getHighestCurveIndex())
-        return -1;
+        return SketchSolveStatus::SolverError;
 
     const std::vector<Part::Geometry*>& geomList = getInternalGeometry();
     Part::Geometry* geom = geomList[GeoId];
-    int retcode = -1;
+    SketchSolveStatus status;
     if (geom->is<Part::GeomLineSegment>()) {
         auto* seg = static_cast<Part::GeomLineSegment*>(geom);
         Base::Vector3d startVec = seg->getStartPoint();
@@ -374,7 +386,7 @@ int SketchObject::extend(int GeoId, double increment, PointPos endpoint)
             newPoint.Normalize();
             newPoint.Scale(scaleFactor, scaleFactor, scaleFactor);
             newPoint = newPoint + endVec;
-            retcode = moveGeometry(GeoId, Sketcher::PointPos::start, newPoint, false, true);
+            status = moveGeometry(GeoId, Sketcher::PointPos::start, newPoint, false, true);
         }
         else if (endpoint == PointPos::end) {
             Base::Vector3d newPoint = endVec - startVec;
@@ -382,7 +394,7 @@ int SketchObject::extend(int GeoId, double increment, PointPos endpoint)
             newPoint.Normalize();
             newPoint.Scale(scaleFactor, scaleFactor, scaleFactor);
             newPoint = newPoint + startVec;
-            retcode = moveGeometry(GeoId, Sketcher::PointPos::end, newPoint, false, true);
+            status = moveGeometry(GeoId, Sketcher::PointPos::end, newPoint, false, true);
         }
     }
     else if (geom->is<Part::GeomArcOfCircle>()) {
@@ -391,17 +403,17 @@ int SketchObject::extend(int GeoId, double increment, PointPos endpoint)
         arc->getRange(startArc, endArc, true);
         if (endpoint == PointPos::start) {
             arc->setRange(startArc - increment, endArc, true);
-            retcode = 0;
+            status = SketchSolveStatus::Success;
         }
         else if (endpoint == PointPos::end) {
             arc->setRange(startArc, endArc + increment, true);
-            retcode = 0;
+            status = SketchSolveStatus::Success;
         }
     }
-    if (retcode == 0 && noRecomputes) {
+    if (status == SketchSolveStatus::Success && noRecomputes) {
         solve();
     }
-    return retcode;
+    return status;
 }
 
 // clang-format on
@@ -774,10 +786,10 @@ void createNewConstraintsForTrim(
     }
 }
 
-int SketchObject::trim(int GeoId, const Base::Vector3d& point, bool includeSketchAxes)
+SketchSolveStatus SketchObject::trim(int GeoId, const Base::Vector3d& point, bool includeSketchAxes)
 {
     if (!isGeoIdAllowedForTrim(this, GeoId)) {
-        return -1;
+        return SketchSolveStatus::SolverError;
     }
     // Remove internal geometry beforehand for now
     // FIXME: we should be able to transfer these to new curves smoothly
@@ -785,7 +797,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point, bool includeSketc
     const auto* geoAsCurve = getGeometry<Part::GeomCurve>(GeoId);
 
     if (geoAsCurve == nullptr) {
-        return -1;
+        return SketchSolveStatus::SolverError;
     }
 
     bool isOriginalCurveConstruction = GeometryFacade::getConstruction(geoAsCurve);
@@ -819,14 +831,14 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point, bool includeSketc
         )) {
         // If no suitable trim points are found, then trim defaults to deleting the geometry
         delGeometry(GeoId, DeleteOption::IncludeInternalGeometry);
-        return 0;
+        return SketchSolveStatus::Success;
     }
 
     // TODO: find trim parameters
     std::vector<std::pair<double, double>> paramsOfNewGeos;
     paramsOfNewGeos.reserve(2);
     if (!getParamLimitsOfNewGeosForTrim(this, GeoId, cuttingGeoIds, cutPoints, paramsOfNewGeos)) {
-        return -1;
+        return SketchSolveStatus::SolverError;
     }
 
     //******************* Step B => Creation of new geometries
@@ -839,7 +851,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point, bool includeSketc
     switch (paramsOfNewGeos.size()) {
         case 0: {
             delGeometry(GeoId, DeleteOption::IncludeInternalGeometry);
-            return 0;
+            return SketchSolveStatus::Success;
         }
         case 1: {
             newIds.push_back(GeoId);
@@ -851,7 +863,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point, bool includeSketc
             break;
         }
         default: {
-            return -1;
+            return SketchSolveStatus::SolverError;
         }
     }
 
@@ -1004,7 +1016,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point, bool includeSketc
         delete cons;
     }
 
-    return 0;
+    return SketchSolveStatus::Success;
 }
 
 int SketchObject::split(int GeoId, const Base::Vector3d& point)

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -61,8 +61,8 @@ PyObject* SketchObjectPy::solve(PyObject* args)
     if (!PyArg_ParseTuple(args, "")) {
         return nullptr;
     }
-    int ret = this->getSketchObjectPtr()->solve();
-    return Py_BuildValue("i", ret);
+    const auto status = this->getSketchObjectPtr()->solve();
+    return Py_BuildValue("i", Base::to_underlying(status));
 }
 
 PyObject* SketchObjectPy::addGeometry(PyObject* args)
@@ -789,7 +789,7 @@ PyObject* SketchObjectPy::setTextAndFont(PyObject* args, PyObject* /*kwd*/)
     std::string font(fontStr);
 
     // Call the C++ implementation
-    int err = this->getSketchObjectPtr()->setTextAndFont(
+    auto status = this->getSketchObjectPtr()->setTextAndFont(
         constrIndex,
         text,
         font,
@@ -798,12 +798,12 @@ PyObject* SketchObjectPy::setTextAndFont(PyObject* args, PyObject* /*kwd*/)
     );
 
     // Handle errors returned from the C++ function
-    if (err) {
+    if (status != SketchSolveStatus::Success) {
         std::stringstream str;
-        if (err == -1) {
+        if (status == SketchSolveStatus::SolverError) {
             str << "Invalid constraint index or not a Text constraint: " << constrIndex;
         }
-        else if (err == -6) {
+        else if (status == SketchSolveStatus::InvalidGeometry) {
             str << "Cannot set text/font because of invalid geometry in the sketch";
         }
         else {  // Generic error for solver failures etc.
@@ -910,26 +910,26 @@ PyObject* SketchObjectPy::setDatum(PyObject* args)
         return nullptr;
     } while (false);
 
-    int err = this->getSketchObjectPtr()->setDatum(Index, Datum);
-    if (err) {
+    const auto status = this->getSketchObjectPtr()->setDatum(Index, Datum);
+    if (status != SketchSolveStatus::Success) {
         std::stringstream str;
-        if (err == -1) {
+        if (status == SketchSolveStatus::SolverError) {
             str << "Invalid constraint index: " << Index;
         }
-        else if (err == -3) {
+        else if (status == SketchSolveStatus::ConflictingConstraints) {
             str << "Cannot set the datum because the sketch contains conflicting constraints";
         }
-        else if (err == -2) {
+        else if (status == SketchSolveStatus::RedundantConstraints) {
             str << "Datum " << Quantity.getUserString() << " for the constraint with index "
                 << Index << " is invalid";
         }
-        else if (err == -4) {
+        else if (status == SketchSolveStatus::Overconstrained) {
             str << "Negative datum values are not valid for the constraint with index " << Index;
         }
-        else if (err == -5) {
+        else if (status == SketchSolveStatus::MalformedConstraints) {
             str << "Zero is not a valid datum for the constraint with index " << Index;
         }
-        else if (err == -6) {
+        else if (status == SketchSolveStatus::InvalidGeometry) {
             str << "Cannot set the datum because of invalid geometry";
         }
         else {
@@ -1404,7 +1404,8 @@ PyObject* SketchObjectPy::moveGeometries(PyObject* args)
     Base::Vector3d v1 = static_cast<Base::VectorPy*>(pcObj)->value();
 
     // Call the C++ method
-    if (this->getSketchObjectPtr()->moveGeometries(geoEltIds, v1, (relative > 0))) {
+    if (this->getSketchObjectPtr()->moveGeometries(geoEltIds, v1, (relative > 0))
+        != SketchSolveStatus::Success) {
         PyErr_SetString(PyExc_ValueError, "Failed to move geometries.");
         return nullptr;
     }
@@ -1427,7 +1428,8 @@ PyObject* SketchObjectPy::moveGeometry(PyObject* args)
     Base::Vector3d v1 = static_cast<Base::VectorPy*>(pcObj)->value();
 
     if (this->getSketchObjectPtr()
-            ->moveGeometry(GeoId, static_cast<Sketcher::PointPos>(PointType), v1, (relative > 0))) {
+            ->moveGeometry(GeoId, static_cast<Sketcher::PointPos>(PointType), v1, (relative > 0))
+        != SketchSolveStatus::Success) {
         std::stringstream str;
         str << "Not able to move point with the id and type: (" << GeoId << ", " << PointType << ")";
         PyErr_SetString(PyExc_ValueError, str.str().c_str());
@@ -1593,7 +1595,8 @@ PyObject* SketchObjectPy::trim(PyObject* args)
 
     Base::Vector3d v1 = static_cast<Base::VectorPy*>(pcObj)->value();
 
-    if (this->getSketchObjectPtr()->trim(GeoId, v1, Base::asBoolean(includeAxes))) {
+    if (this->getSketchObjectPtr()->trim(GeoId, v1, Base::asBoolean(includeAxes))
+        != SketchSolveStatus::Success) {
         std::stringstream str;
         str << "Not able to trim curve with the given index: " << GeoId;
         PyErr_SetString(PyExc_ValueError, str.str().c_str());
@@ -1610,8 +1613,8 @@ PyObject* SketchObjectPy::extend(PyObject* args)
     int GeoId;
 
     if (PyArg_ParseTuple(args, "idi", &GeoId, &increment, &endPoint)) {
-        if (this->getSketchObjectPtr()
-                ->extend(GeoId, increment, static_cast<Sketcher::PointPos>(endPoint))) {
+        if (this->getSketchObjectPtr()->extend(GeoId, increment, static_cast<Sketcher::PointPos>(endPoint))
+            != SketchSolveStatus::Success) {
             std::stringstream str;
             str << "Not able to extend geometry with id : (" << GeoId << ") for increment ("
                 << increment << ") and point position (" << endPoint << ")";

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -800,15 +800,17 @@ PyObject* SketchObjectPy::setTextAndFont(PyObject* args, PyObject* /*kwd*/)
     // Handle errors returned from the C++ function
     if (status != SketchSolveStatus::Success) {
         std::stringstream str;
-        if (status == SketchSolveStatus::SolverError) {
-            str << "Invalid constraint index or not a Text constraint: " << constrIndex;
-        }
-        else if (status == SketchSolveStatus::InvalidGeometry) {
-            str << "Cannot set text/font because of invalid geometry in the sketch";
-        }
-        else {  // Generic error for solver failures etc.
-            str << "Failed to set text/font for constraint with index " << constrIndex
-                << ". The operation would result in an invalid sketch.";
+        switch (status) {
+            case SketchSolveStatus::SolverError:
+                str << "Invalid constraint index or not a Text constraint: " << constrIndex;
+                break;
+            case SketchSolveStatus::InvalidGeometry:
+                str << "Cannot set text/font because of invalid geometry in the sketch";
+                break;
+            default:  // Generic error for solver failures etc.
+                str << "Failed to set text/font for constraint with index " << constrIndex
+                    << ". The operation would result in an invalid sketch.";
+                break;
         }
         PyErr_SetString(PyExc_ValueError, str.str().c_str());
         return nullptr;
@@ -913,28 +915,30 @@ PyObject* SketchObjectPy::setDatum(PyObject* args)
     const auto status = this->getSketchObjectPtr()->setDatum(Index, Datum);
     if (status != SketchSolveStatus::Success) {
         std::stringstream str;
-        if (status == SketchSolveStatus::SolverError) {
-            str << "Invalid constraint index: " << Index;
-        }
-        else if (status == SketchSolveStatus::ConflictingConstraints) {
-            str << "Cannot set the datum because the sketch contains conflicting constraints";
-        }
-        else if (status == SketchSolveStatus::RedundantConstraints) {
-            str << "Datum " << Quantity.getUserString() << " for the constraint with index "
-                << Index << " is invalid";
-        }
-        else if (status == SketchSolveStatus::Overconstrained) {
-            str << "Negative datum values are not valid for the constraint with index " << Index;
-        }
-        else if (status == SketchSolveStatus::MalformedConstraints) {
-            str << "Zero is not a valid datum for the constraint with index " << Index;
-        }
-        else if (status == SketchSolveStatus::InvalidGeometry) {
-            str << "Cannot set the datum because of invalid geometry";
-        }
-        else {
-            str << "Unexpected problem at setting datum " << Quantity.getUserString()
-                << " for the constraint with index " << Index;
+        switch (status) {
+            case SketchSolveStatus::SolverError:
+                str << "Invalid constraint index: " << Index;
+                break;
+            case SketchSolveStatus::ConflictingConstraints:
+                str << "Cannot set the datum because the sketch contains conflicting constraints";
+                break;
+            case SketchSolveStatus::RedundantConstraints:
+                str << "Datum " << Quantity.getUserString() << " for the constraint with index "
+                    << Index << " is invalid";
+                break;
+            case SketchSolveStatus::Overconstrained:
+                str << "Negative datum values are not valid for the constraint with index " << Index;
+                break;
+            case SketchSolveStatus::MalformedConstraints:
+                str << "Zero is not a valid datum for the constraint with index " << Index;
+                break;
+            case SketchSolveStatus::InvalidGeometry:
+                str << "Cannot set the datum because of invalid geometry";
+                break;
+            default:
+                str << "Unexpected problem at setting datum " << Quantity.getUserString()
+                    << " for the constraint with index " << Index;
+                break;
         }
         PyErr_SetString(PyExc_ValueError, str.str().c_str());
         return nullptr;

--- a/src/Mod/Sketcher/App/SketchPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchPyImp.cpp
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 
+#include <Base/Tools.h>
 #include <Base/VectorPy.h>
 #include <Mod/Part/App/GeometryCurvePy.h>
 #include <Mod/Part/App/TopoShapePy.h>
@@ -63,7 +64,7 @@ PyObject* SketchPy::solve(PyObject* args)
         return nullptr;
     }
     getSketchPtr()->resetSolver();
-    return Py::new_reference_to(Py::Long(getSketchPtr()->solve()));
+    return Py::new_reference_to(Py::Long(Base::to_underlying(getSketchPtr()->solve())));
 }
 
 PyObject* SketchPy::addGeometry(PyObject* args)
@@ -163,8 +164,14 @@ PyObject* SketchPy::moveGeometry(PyObject* args)
 
     return Py::new_reference_to(
         Py::Long(
-            getSketchPtr()
-                ->moveGeometry(index1, static_cast<Sketcher::PointPos>(index2), *toPoint, (relative > 0))
+            Base::to_underlying(
+                getSketchPtr()->moveGeometry(
+                    index1,
+                    static_cast<Sketcher::PointPos>(index2),
+                    *toPoint,
+                    (relative > 0)
+                )
+            )
         )
     );
 }

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -54,6 +54,8 @@
 #include <limits>
 #include <numbers>
 
+#include <Base/Tools.h>
+
 #include "GCS.h"
 #include "qp_eq.h"
 
@@ -1753,7 +1755,7 @@ void System::initSolution(Algorithm alg)
     }
 
     // storing reference configuration
-    setReference();
+    saveReference();
 
     // diagnose conflicting or redundant constraints
     if (!hasDiagnosis) {
@@ -1875,7 +1877,7 @@ void System::initSolution(Algorithm alg)
     isInit = true;
 }
 
-void System::setReference()
+void System::saveReference()
 {
     reference.clear();
     reference.reserve(plist.size());
@@ -1884,7 +1886,7 @@ void System::setReference()
     }
 }
 
-void System::resetToReference()
+void System::restoreReference()
 {
     if (reference.size() == plist.size()) {
         VEC_D::const_iterator ref = reference.begin();
@@ -1895,39 +1897,36 @@ void System::resetToReference()
     }
 }
 
-SolveStatus System::solve(VEC_pD& params, bool isFine, Algorithm alg, bool isRedundantsolving)
+SolveStatus System::solve(VEC_pD& params, Algorithm alg, bool isRedundantsolving)
 {
     declareUnknowns(params);
     initSolution();
-    return solve(isFine, alg, isRedundantsolving);
+    return solve(alg, isRedundantsolving);
 }
 
-SolveStatus System::solve(bool isFine, Algorithm alg, bool isRedundantsolving)
+SolveStatus System::solve(Algorithm alg, bool isRedundantsolving)
 {
     if (!isInit) {
         return SolveStatus::Failed;
     }
 
-    bool isReset = false;
+    bool referenceRestored = false;
     // return success by default in order to permit coincidence constraints to be applied
     // even if no other system has to be solved
     auto status = SolveStatus::Success;
-    for (int cid = 0; cid < int(subSystems.size()); cid++) {
-        if ((subSystems[cid] || subSystemsAux[cid]) && !isReset) {
-            resetToReference();
-            isReset = true;
+    for (size_t cid = 0; cid < subSystems.size(); cid++) {
+        if ((subSystems[cid] || subSystemsAux[cid]) && !referenceRestored) {
+            restoreReference();
+            referenceRestored = true;
         }
         if (subSystems[cid] && subSystemsAux[cid]) {
-            status = std::max(
-                status,
-                solve(subSystems[cid], subSystemsAux[cid], isFine, isRedundantsolving)
-            );
+            status = solve(subSystems[cid], subSystemsAux[cid], isRedundantsolving);
         }
         else if (subSystems[cid]) {
-            status = std::max(status, solve(subSystems[cid], isFine, alg, isRedundantsolving));
+            status = solve(subSystems[cid], alg, isRedundantsolving);
         }
         else if (subSystemsAux[cid]) {
-            status = std::max(status, solve(subSystemsAux[cid], isFine, alg, isRedundantsolving));
+            status = solve(subSystemsAux[cid], alg, isRedundantsolving);
         }
     }
     if (status == SolveStatus::Success) {
@@ -1946,23 +1945,21 @@ SolveStatus System::solve(bool isFine, Algorithm alg, bool isRedundantsolving)
     return status;
 }
 
-SolveStatus System::solve(SubSystem* subsys, bool isFine, Algorithm alg, bool isRedundantsolving)
+SolveStatus System::solve(SubSystem* subsys, Algorithm alg, bool isRedundantsolving)
 {
-    if (alg == BFGS) {
-        return solve_BFGS(subsys, isFine, isRedundantsolving);
-    }
-    else if (alg == LevenbergMarquardt) {
-        return solve_LM(subsys, isRedundantsolving);
-    }
-    else if (alg == DogLeg) {
-        return solve_DL(subsys, isRedundantsolving);
-    }
-    else {
-        return SolveStatus::Failed;
+    switch (alg) {
+        case Algorithm::BFGS:
+            return solve_BFGS(subsys, isRedundantsolving);
+        case Algorithm::LevenbergMarquardt:
+            return solve_LM(subsys, isRedundantsolving);
+        case Algorithm::DogLeg:
+            return solve_DL(subsys, isRedundantsolving);
+        default:
+            Base::unreachable();
     }
 }
 
-SolveStatus System::solve_BFGS(SubSystem* subsys, bool /*isFine*/, bool isRedundantsolving)
+SolveStatus System::solve_BFGS(SubSystem* subsys, bool isRedundantsolving)
 {
 #ifdef _GCS_EXTRACT_SOLVER_SUBSYSTEM_
     extractSubsystem(subsys, isRedundantsolving);
@@ -1996,7 +1993,6 @@ SolveStatus System::solve_BFGS(SubSystem* subsys, bool /*isFine*/, bool isRedund
     subsys->getParams(x);
     h = x - h;  // = x - xold
 
-    // double convergence = isFine ? convergence : XconvergenceRough;
     int maxIterNumber = (sketchSizeMultiplier ? maxIter * xsize : maxIter);
     double convCriterion = convergence;
     if (isRedundantsolving) {
@@ -4530,7 +4526,7 @@ void System::extractSubsystem(SubSystem* subsys, bool isRedundantsolving)
 
 // The following solver variant solves a system compound of two subsystems
 // treating the first of them as of higher priority than the second
-SolveStatus System::solve(SubSystem* subsysA, SubSystem* subsysB, bool /*isFine*/, bool isRedundantsolving)
+SolveStatus System::solve(SubSystem* subsysA, SubSystem* subsysB, bool isRedundantsolving)
 {
     int xsizeA = subsysA->pSize();
     int xsizeB = subsysB->pSize();
@@ -4723,7 +4719,7 @@ void System::evaluateDrivenConstraints()
 
 void System::undoSolution()
 {
-    resetToReference();
+    restoreReference();
 }
 
 void System::makeReducedJacobian(
@@ -5597,7 +5593,7 @@ void System::identifyConflictingRedundantConstraints(
     });
 
     SubSystem* subSysTmp = new SubSystem(clistTmp, pdiagnoselist);
-    auto status = solve(subSysTmp, true, alg, true);
+    auto status = solve(subSysTmp, alg, true);
 
     if (debugMode == Minimal || debugMode == IterationLevel) {
         std::string solvername;
@@ -5626,7 +5622,7 @@ void System::identifyConflictingRedundantConstraints(
                 return (err * err < this->convergenceRedundant);
             }
         );
-        resetToReference();
+        restoreReference();
 
         if (debugMode == Minimal || debugMode == IterationLevel) {
             Base::Console().log("Sketcher Redundant solving: %d redundants\n", redundant.size());

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -1895,39 +1895,42 @@ void System::resetToReference()
     }
 }
 
-int System::solve(VEC_pD& params, bool isFine, Algorithm alg, bool isRedundantsolving)
+SolveStatus System::solve(VEC_pD& params, bool isFine, Algorithm alg, bool isRedundantsolving)
 {
     declareUnknowns(params);
     initSolution();
     return solve(isFine, alg, isRedundantsolving);
 }
 
-int System::solve(bool isFine, Algorithm alg, bool isRedundantsolving)
+SolveStatus System::solve(bool isFine, Algorithm alg, bool isRedundantsolving)
 {
     if (!isInit) {
-        return Failed;
+        return SolveStatus::Failed;
     }
 
     bool isReset = false;
     // return success by default in order to permit coincidence constraints to be applied
     // even if no other system has to be solved
-    int res = Success;
+    auto status = SolveStatus::Success;
     for (int cid = 0; cid < int(subSystems.size()); cid++) {
         if ((subSystems[cid] || subSystemsAux[cid]) && !isReset) {
             resetToReference();
             isReset = true;
         }
         if (subSystems[cid] && subSystemsAux[cid]) {
-            res = std::max(res, solve(subSystems[cid], subSystemsAux[cid], isFine, isRedundantsolving));
+            status = std::max(
+                status,
+                solve(subSystems[cid], subSystemsAux[cid], isFine, isRedundantsolving)
+            );
         }
         else if (subSystems[cid]) {
-            res = std::max(res, solve(subSystems[cid], isFine, alg, isRedundantsolving));
+            status = std::max(status, solve(subSystems[cid], isFine, alg, isRedundantsolving));
         }
         else if (subSystemsAux[cid]) {
-            res = std::max(res, solve(subSystemsAux[cid], isFine, alg, isRedundantsolving));
+            status = std::max(status, solve(subSystemsAux[cid], isFine, alg, isRedundantsolving));
         }
     }
-    if (res == Success) {
+    if (status == SolveStatus::Success) {
         for (std::set<Constraint*>::const_iterator constr = redundant.begin();
              constr != redundant.end();
              ++constr) {
@@ -1936,15 +1939,14 @@ int System::solve(bool isFine, Algorithm alg, bool isRedundantsolving)
             // chances are low I've broken anything.
             double err = (*constr)->error();
             if (err * err > (isRedundantsolving ? convergenceRedundant : convergence)) {
-                res = Converged;
-                return res;
+                return SolveStatus::Converged;
             }
         }
     }
-    return res;
+    return status;
 }
 
-int System::solve(SubSystem* subsys, bool isFine, Algorithm alg, bool isRedundantsolving)
+SolveStatus System::solve(SubSystem* subsys, bool isFine, Algorithm alg, bool isRedundantsolving)
 {
     if (alg == BFGS) {
         return solve_BFGS(subsys, isFine, isRedundantsolving);
@@ -1956,11 +1958,11 @@ int System::solve(SubSystem* subsys, bool isFine, Algorithm alg, bool isRedundan
         return solve_DL(subsys, isRedundantsolving);
     }
     else {
-        return Failed;
+        return SolveStatus::Failed;
     }
 }
 
-int System::solve_BFGS(SubSystem* subsys, bool /*isFine*/, bool isRedundantsolving)
+SolveStatus System::solve_BFGS(SubSystem* subsys, bool /*isFine*/, bool isRedundantsolving)
 {
 #ifdef _GCS_EXTRACT_SOLVER_SUBSYSTEM_
     extractSubsystem(subsys, isRedundantsolving);
@@ -1968,7 +1970,7 @@ int System::solve_BFGS(SubSystem* subsys, bool /*isFine*/, bool isRedundantsolvi
 
     int xsize = subsys->pSize();
     if (xsize == 0) {
-        return Success;
+        return SolveStatus::Success;
     }
 
     subsys->redirectParams();
@@ -2079,15 +2081,15 @@ int System::solve_BFGS(SubSystem* subsys, bool /*isFine*/, bool isRedundantsolvi
     subsys->revertParams();
 
     if (err <= smallF) {
-        return Success;
+        return SolveStatus::Success;
     }
     if (h.norm() <= convCriterion) {
-        return Converged;
+        return SolveStatus::Converged;
     }
-    return Failed;
+    return SolveStatus::Failed;
 }
 
-int System::solve_LM(SubSystem* subsys, bool isRedundantsolving)
+SolveStatus System::solve_LM(SubSystem* subsys, bool isRedundantsolving)
 {
 #ifdef _GCS_EXTRACT_SOLVER_SUBSYSTEM_
     extractSubsystem(subsys, isRedundantsolving);
@@ -2097,7 +2099,7 @@ int System::solve_LM(SubSystem* subsys, bool isRedundantsolving)
     int csize = subsys->cSize();
 
     if (xsize == 0) {
-        return Success;
+        return SolveStatus::Success;
     }
 
     Eigen::VectorXd e(csize),
@@ -2263,10 +2265,10 @@ int System::solve_LM(SubSystem* subsys, bool isRedundantsolving)
 
     subsys->revertParams();
 
-    return (stop == 1) ? Success : Failed;
+    return (stop == 1) ? SolveStatus::Success : SolveStatus::Failed;
 }
 
-int System::solve_DL(SubSystem* subsys, bool isRedundantsolving)
+SolveStatus System::solve_DL(SubSystem* subsys, bool isRedundantsolving)
 {
 #ifdef _GCS_EXTRACT_SOLVER_SUBSYSTEM_
     extractSubsystem(subsys, isRedundantsolving);
@@ -2276,7 +2278,7 @@ int System::solve_DL(SubSystem* subsys, bool isRedundantsolving)
     int csize = subsys->cSize();
 
     if (xsize == 0) {
-        return Success;
+        return SolveStatus::Success;
     }
 
     double tolg = DL_tolg;
@@ -2479,7 +2481,7 @@ int System::solve_DL(SubSystem* subsys, bool isRedundantsolving)
         Base::Console().log(tmp.c_str());
     }
 
-    return (stop == 1) ? Success : Failed;
+    return (stop == 1) ? SolveStatus::Success : SolveStatus::Failed;
 }
 
 #ifdef _GCS_EXTRACT_SOLVER_SUBSYSTEM_
@@ -4528,7 +4530,7 @@ void System::extractSubsystem(SubSystem* subsys, bool isRedundantsolving)
 
 // The following solver variant solves a system compound of two subsystems
 // treating the first of them as of higher priority than the second
-int System::solve(SubSystem* subsysA, SubSystem* subsysB, bool /*isFine*/, bool isRedundantsolving)
+SolveStatus System::solve(SubSystem* subsysA, SubSystem* subsysB, bool /*isFine*/, bool isRedundantsolving)
 {
     int xsizeA = subsysA->pSize();
     int xsizeB = subsysB->pSize();
@@ -4679,20 +4681,20 @@ int System::solve(SubSystem* subsysA, SubSystem* subsysB, bool /*isFine*/, bool 
         }
     }
 
-    int ret;
+    SolveStatus status;
     if (subsysA->error() <= smallF) {
-        ret = Success;
+        status = SolveStatus::Success;
     }
     else if (h.norm() <= (isRedundantsolving ? convergenceRedundant : convergence)) {
-        ret = Converged;
+        status = SolveStatus::Converged;
     }
     else {
-        ret = Failed;
+        status = SolveStatus::Failed;
     }
 
     subsysA->revertParams();
     subsysB->revertParams();
-    return ret;
+    return status;
 }
 
 void System::applySolution()
@@ -5595,7 +5597,7 @@ void System::identifyConflictingRedundantConstraints(
     });
 
     SubSystem* subSysTmp = new SubSystem(clistTmp, pdiagnoselist);
-    int res = solve(subSysTmp, true, alg, true);
+    auto status = solve(subSysTmp, true, alg, true);
 
     if (debugMode == Minimal || debugMode == IterationLevel) {
         std::string solvername;
@@ -5614,7 +5616,7 @@ void System::identifyConflictingRedundantConstraints(
         Base::Console().log("Sketcher::RedundantSolving-%s-\n", solvername.c_str());
     }
 
-    if (res == Success) {
+    if (status == SolveStatus::Success) {
         subSysTmp->applySolution();
         std::ranges::copy_if(
             skipped,

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -59,11 +59,11 @@ enum class SolveStatus : uint8_t
                                     // resulting geometry is OCE-invalid
 };
 
-enum Algorithm
+enum Algorithm : uint8_t
 {
-    BFGS = 0,
-    LevenbergMarquardt = 1,
-    DogLeg = 2
+    BFGS,
+    LevenbergMarquardt,
+    DogLeg,
 };
 
 enum DogLegGaussStep
@@ -127,8 +127,10 @@ private:
     void clearSubSystems();
 
     VEC_D reference;
-    void setReference();      // copies the current parameter values to reference
-    void resetToReference();  // reverts all parameter values to the stored reference
+    /// Copies the current parameter values to reference.
+    void saveReference();
+    /// Reverts all parameter values to the stored reference.
+    void restoreReference();
 
     std::vector<VEC_pD> plists;  // partitioned plist except equality constraints
     // partitioned clist except equality constraints
@@ -145,7 +147,7 @@ private:
 
     bool emptyDiagnoseMatrix;  // false only if there is at least one driving constraint.
 
-    SolveStatus solve_BFGS(SubSystem* subsys, bool isFine = true, bool isRedundantsolving = false);
+    SolveStatus solve_BFGS(SubSystem* subsys, bool isRedundantsolving = false);
     SolveStatus solve_LM(SubSystem* subsys, bool isRedundantsolving = false);
     SolveStatus solve_DL(SubSystem* subsys, bool isRedundantsolving = false);
 
@@ -608,25 +610,10 @@ public:
     void declareDrivenParams(VEC_pD& params);
     void initSolution(Algorithm alg = DogLeg);
 
-    SolveStatus solve(bool isFine = true, Algorithm alg = DogLeg, bool isRedundantsolving = false);
-    SolveStatus solve(
-        VEC_pD& params,
-        bool isFine = true,
-        Algorithm alg = DogLeg,
-        bool isRedundantsolving = false
-    );
-    SolveStatus solve(
-        SubSystem* subsys,
-        bool isFine = true,
-        Algorithm alg = DogLeg,
-        bool isRedundantsolving = false
-    );
-    SolveStatus solve(
-        SubSystem* subsysA,
-        SubSystem* subsysB,
-        bool isFine = true,
-        bool isRedundantsolving = false
-    );
+    SolveStatus solve(Algorithm alg = DogLeg, bool isRedundantsolving = false);
+    SolveStatus solve(VEC_pD& params, Algorithm alg = DogLeg, bool isRedundantsolving = false);
+    SolveStatus solve(SubSystem* subsys, Algorithm alg = DogLeg, bool isRedundantsolving = false);
+    SolveStatus solve(SubSystem* subsysA, SubSystem* subsysB, bool isRedundantsolving = false);
 
     void applySolution();
     void evaluateDrivenConstraints();

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -50,7 +50,7 @@ namespace GCS
 // Solver
 ///////////////////////////////////////
 
-enum SolveStatus
+enum class SolveStatus : uint8_t
 {
     Success = 0,                    // Found a solution zeroing the error function
     Converged = 1,                  // Found a solution minimizing the error function
@@ -145,9 +145,9 @@ private:
 
     bool emptyDiagnoseMatrix;  // false only if there is at least one driving constraint.
 
-    int solve_BFGS(SubSystem* subsys, bool isFine = true, bool isRedundantsolving = false);
-    int solve_LM(SubSystem* subsys, bool isRedundantsolving = false);
-    int solve_DL(SubSystem* subsys, bool isRedundantsolving = false);
+    SolveStatus solve_BFGS(SubSystem* subsys, bool isFine = true, bool isRedundantsolving = false);
+    SolveStatus solve_LM(SubSystem* subsys, bool isRedundantsolving = false);
+    SolveStatus solve_DL(SubSystem* subsys, bool isRedundantsolving = false);
 
     void makeReducedJacobian(
         Eigen::MatrixXd& J,
@@ -608,15 +608,25 @@ public:
     void declareDrivenParams(VEC_pD& params);
     void initSolution(Algorithm alg = DogLeg);
 
-    int solve(bool isFine = true, Algorithm alg = DogLeg, bool isRedundantsolving = false);
-    int solve(VEC_pD& params, bool isFine = true, Algorithm alg = DogLeg, bool isRedundantsolving = false);
-    int solve(
+    SolveStatus solve(bool isFine = true, Algorithm alg = DogLeg, bool isRedundantsolving = false);
+    SolveStatus solve(
+        VEC_pD& params,
+        bool isFine = true,
+        Algorithm alg = DogLeg,
+        bool isRedundantsolving = false
+    );
+    SolveStatus solve(
         SubSystem* subsys,
         bool isFine = true,
         Algorithm alg = DogLeg,
         bool isRedundantsolving = false
     );
-    int solve(SubSystem* subsysA, SubSystem* subsysB, bool isFine = true, bool isRedundantsolving = false);
+    SolveStatus solve(
+        SubSystem* subsysA,
+        SubSystem* subsysB,
+        bool isFine = true,
+        bool isRedundantsolving = false
+    );
 
     void applySolution();
     void evaluateDrivenConstraints();

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -4516,7 +4516,7 @@ void CmdSketcherConstrainBlock::activated(int iMsg)
     auto* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     // Check that the solver does not report redundant/conflicting constraints
-    if (Obj->getLastSolverStatus() != GCS::Success || Obj->getLastHasConflicts()
+    if (Obj->getLastSolverStatus() != GCS::SolveStatus::Success || Obj->getLastHasConflicts()
         || Obj->getLastHasRedundancies()) {
         Gui::TranslatedUserWarning(Obj,
                                    QObject::tr("Wrong solver status"),

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2191,7 +2191,7 @@ bool ViewProviderSketch::doDragStep(double x, double y)
         }
     }
 
-    if (getSketchObject()->moveGeometriesTemporary(drag.Dragged, vec, drag.relative) == 0) {
+    if (getSketchObject()->moveGeometriesTemporary(drag.Dragged, vec, drag.relative) == GCS::SolveStatus::Success) {
         setPositionText(Base::Vector2d(x, y));
         draw(true, false);
         return true;
@@ -4490,7 +4490,7 @@ void ViewProviderSketch::UpdateSolverInformation()
                     QStringLiteral("(%1)").arg(
                         intListHelper(getSketchObject()->getLastPartiallyRedundant())));
     }
-    else if (getSketchObject()->getLastSolverStatus() != 0) {
+    else if (getSketchObject()->getLastSolverStatus() != GCS::SolveStatus::Success) {
         signalSetUp(QStringLiteral("solver_failed"),
                     tr("Solver failed to converge"),
                     QStringLiteral(""),
@@ -4982,9 +4982,9 @@ bool ViewProviderSketch::onDelete(const std::vector<std::string>& subList)
             }
         }
 
-        int ret = getSketchObject()->solve();
+        const auto status = getSketchObject()->solve();
 
-        if (ret != 0) {
+        if (status == SketchSolveStatus::Success) {
             // if the sketched could not be solved, we first redraw to update the UI geometry as
             // onChanged did not update it.
             UpdateSolverInformation();

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2135,8 +2135,7 @@ void ViewProviderSketch::initDragging(int geoId, Sketcher::PointPos pos, Gui::Vi
             getSketchObject()->initTemporaryBSplinePieceMove(
                 geoId,
                 Sketcher::PointPos::none,
-                Base::Vector3d(drag.xInit, drag.yInit, 0.0),
-                false);
+                Base::Vector3d(drag.xInit, drag.yInit, 0.0));
             return;
         }
     }
@@ -2146,7 +2145,7 @@ void ViewProviderSketch::initDragging(int geoId, Sketcher::PointPos pos, Gui::Vi
         }
     }
 
-    getSketchObject()->initTemporaryMove(drag.Dragged, false);
+    getSketchObject()->initTemporaryMove(drag.Dragged);
 }
 
 bool ViewProviderSketch::doDragStep(double x, double y)

--- a/tests/src/Mod/Sketcher/App/SketchObjectChanges.cpp
+++ b/tests/src/Mod/Sketcher/App/SketchObjectChanges.cpp
@@ -310,10 +310,10 @@ TEST_F(SketchObjectTest, testTrimWithoutIntersection)
     Base::Vector3d trimPoint(2.0, 3.1, 0.0);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     // Once this line segment is trimmed, nothing should remain
     EXPECT_EQ(getObject()->getHighestCurveIndex(), geoId - 1);
 }
@@ -335,10 +335,10 @@ TEST_F(SketchObjectTest, testTrimLineSegmentEnd)
     int geoId = getObject()->addGeometry(&lineSeg);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     // TODO: Once this line segment is trimmed, the curve should be "smaller"
     EXPECT_EQ(getObject()->getHighestCurveIndex(), geoId);
     // TODO: There should be a "point-on-object" constraint on the intersecting curves
@@ -370,10 +370,10 @@ TEST_F(SketchObjectTest, testTrimLineSegmentMid)
     int geoId = getObject()->addGeometry(&lineSeg);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     // TODO: Once this line segment is trimmed, there should be two "smaller" curves in its place
     EXPECT_EQ(getObject()->getHighestCurveIndex(), geoId + 1);
     // TODO: There should be a "point-on-object" constraint on the intersecting curves
@@ -399,10 +399,10 @@ TEST_F(SketchObjectTest, testTrimCircleEnd)
     int geoId = getObject()->addGeometry(&circle);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     // TODO: Once this circle is trimmed, the circle should be deleted.
     EXPECT_EQ(getObject()->getHighestCurveIndex(), geoId - 1);
 }
@@ -431,10 +431,10 @@ TEST_F(SketchObjectTest, testTrimCircleMid)
     int geoId = getObject()->addGeometry(&circle);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     // TODO: Once this circle is trimmed, there should be one arc.
     EXPECT_EQ(getObject()->getHighestCurveIndex(), geoId);
     // There should be one "coincident" and one "point-on-object" constraint on the intersecting
@@ -463,10 +463,10 @@ TEST_F(SketchObjectTest, testTrimArcOfCircleEnd)
     int geoId = getObject()->addGeometry(&arcOfCircle);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     EXPECT_EQ(getObject()->getHighestCurveIndex(), geoId);
     // There should be a "point-on-object" constraint on the intersecting curves
     int numberOfCoincidentConstraints = countConstraintsOfType(getObject(), Sketcher::Coincident);
@@ -497,10 +497,10 @@ TEST_F(SketchObjectTest, testTrimArcOfCircleMid)
     int geoId = getObject()->addGeometry(&arcOfCircle);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     EXPECT_EQ(getObject()->getHighestCurveIndex(), geoId + 1);
     // There should be a "point-on-object" constraint on the intersecting curves
     int numberOfPointOnObjectConstraints = countConstraintsOfType(getObject(), Sketcher::PointOnObject);
@@ -527,14 +527,14 @@ TEST_F(SketchObjectTest, testTrimEllipseEnd)
     int geoId = getObject()->addGeometry(&ellipse);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
     // remove all internal geometry
     for (int iterGeoId = 0; iterGeoId < getObject()->getHighestCurveIndex(); ++iterGeoId) {
         getObject()->deleteUnusedInternalGeometryAndUpdateGeoId(iterGeoId);
     }
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     // Once this ellipse is trimmed, the ellipse should be deleted.
     // Only remaining: line segment
     EXPECT_EQ(getObject()->getHighestCurveIndex(), 0);
@@ -566,14 +566,14 @@ TEST_F(SketchObjectTest, testTrimEllipseMid)
     getObject()->deleteUnusedInternalGeometry(geoId);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
     // remove all internal geometry
     for (int iterGeoId = 0; iterGeoId < getObject()->getHighestCurveIndex(); ++iterGeoId) {
         getObject()->deleteUnusedInternalGeometryAndUpdateGeoId(iterGeoId);
     }
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     // Once this ellipse is trimmed, there should be one arc and line segments.
     EXPECT_EQ(getObject()->getHighestCurveIndex(), 2);
     // There should be one "coincident" and one "point-on-object" constraint on the intersecting
@@ -602,10 +602,10 @@ TEST_F(SketchObjectTest, testTrimPeriodicBSplineEnd)
     int geoId = getObject()->addGeometry(periodicBSpline.get());
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     // FIXME: This will fail because of deleted internal geometry
     // Once this periodicBSpline is trimmed, the periodicBSpline should be deleted, leaving only the
     // line segment.
@@ -637,14 +637,14 @@ TEST_F(SketchObjectTest, testTrimPeriodicBSplineMid)
     int geoId = getObject()->addGeometry(periodicBSpline.get());
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
     // remove all internal geometry
     for (int iterGeoId = 0; iterGeoId < getObject()->getHighestCurveIndex(); ++iterGeoId) {
         getObject()->deleteUnusedInternalGeometryAndUpdateGeoId(iterGeoId);
     }
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     // Only remaining: Two line segments and the B-spline
     EXPECT_EQ(getObject()->getHighestCurveIndex(), 2);
     // There should be one "coincident" and one "point-on-object" constraint on the intersecting
@@ -673,14 +673,14 @@ TEST_F(SketchObjectTest, testTrimNonPeriodicBSplineEnd)
     int geoId = getObject()->addGeometry(nonPeriodicBSpline.get());
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
     // remove all internal geometry
     for (int iterGeoId = 0; iterGeoId < getObject()->getHighestCurveIndex(); ++iterGeoId) {
         getObject()->deleteUnusedInternalGeometryAndUpdateGeoId(iterGeoId);
     }
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     // Only remaining: one line segment and the trimmed B-spline
     EXPECT_EQ(getObject()->getHighestCurveIndex(), 1);
     // FIXME: There should be a "point-on-object" constraint on the intersecting curves
@@ -712,7 +712,7 @@ TEST_F(SketchObjectTest, testTrimNonPeriodicBSplineMid)
     int geoId = getObject()->addGeometry(nonPeriodicBSpline.get());
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
     // remove all internal geometry
     for (int i = 0; i < getObject()->getHighestCurveIndex(); ++i) {
         if (getObject()->getGeometry(i)->is<Part::GeomBSplineCurve>()) {
@@ -721,7 +721,7 @@ TEST_F(SketchObjectTest, testTrimNonPeriodicBSplineMid)
     }
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     // Only remaining: one line segment and the trimmed B-spline
     EXPECT_EQ(getObject()->getHighestCurveIndex(), 3);
     // There should be a "point-on-object" constraint on the intersecting curves
@@ -760,10 +760,10 @@ TEST_F(SketchObjectTest, testTrimEffectOnConstruction)
     int geoId = getObject()->addGeometry(&circle, true);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     for (int i = 0; i < getObject()->getHighestCurveIndex(); ++i) {
         auto* geom = getObject()->getGeometry(i);
         if (geom->is<Part::GeomArcOfCircle>()) {
@@ -800,10 +800,10 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnFullLengthConstraints)
     EXPECT_EQ(countConstraintsOfType(getObject(), Sketcher::ConstraintType::Distance), 1);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     EXPECT_EQ(countConstraintsOfType(getObject(), Sketcher::ConstraintType::Distance), 0);
 }
 
@@ -836,10 +836,10 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnSymmetricConstraints)
     EXPECT_EQ(countConstraintsOfType(getObject(), Sketcher::ConstraintType::Symmetric), 1);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     EXPECT_EQ(countConstraintsOfType(getObject(), Sketcher::ConstraintType::Symmetric), 0);
 }
 
@@ -871,10 +871,10 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnUnrelatedTangent)
     EXPECT_EQ(countConstraintsOfType(getObject(), Sketcher::ConstraintType::Tangent), 1);
 
     // Act
-    int result = getObject()->trim(geoId, trimPoint);
+    const auto result = getObject()->trim(geoId, trimPoint);
 
     // Assert
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(result, SketchSolveStatus::Success);
     // TODO: find tangent and confirm nature
     const auto& constraints = getObject()->Constraints.getValues();
     auto tangIt = std::ranges::find(

--- a/tests/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -149,13 +149,13 @@ TEST_F(ConstraintsTest, tangentBSplineAndArc)  // NOLINT
     System()->addConstraintPointOnArc(point, arc, 0, true);
     System()->addConstraintPointOnBSpline(point, bspline, &bsplineParam, 0, true);
     System()->addConstraintAngleViaPointAndParam(bspline, arc, point, &bsplineParam, &desiredAngle, 0, true);
-    int solveResult = System()->solve(params);
-    if (solveResult == GCS::Success) {
+    const auto solveResult = System()->solve(params);
+    if (solveResult == GCS::SolveStatus::Success) {
         System()->applySolution();
     }
 
     // Assert
-    EXPECT_EQ(solveResult, GCS::Success);
+    EXPECT_EQ(solveResult, GCS::SolveStatus::Success);
     // is point on arc?
     EXPECT_DOUBLE_EQ(
         (arcRadius) * (arcRadius),


### PR DESCRIPTION
`GCS::SolveStatus` was already a thing for the actual solver engines' main calls, but it was an unscoped enum and returned as `int`. `Sketch{,Object}` either forwarded them, or sometimes introduced their own set of negative integers with other meanings, making everything hard to read and track.

Preserves the numerical values of the enum cases, as the Python API returns them as a number. This ought to be revised one day but will mean breaking the API.

The test suite passes and the likelihood of this breaking anything is low.

- [x] :robot: → :wastebasket: 

