### PR TITLE
CAM: Custom op is strict

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathCustom.py
+++ b/src/Mod/CAM/CAMTests/TestPathCustom.py
@@ -32,6 +32,7 @@ from Path.Op import Custom
 from Path.Base.MachineState import MachineState
 from Path.Post.Processor import PostProcessor
 from Path.Post.PostList import Postable
+from Path.Post.CAMErrors import CAMValueError
 from Machine.models.machine import Machine, OutputUnits
 from CAMTests import PathTestUtils
 
@@ -63,7 +64,7 @@ class TestPathCustomConverted(PathTestUtils.PathTestBase):
             item_type="operation",
             data={},
             path=op.Path,
-            source=None,
+            source=op,
         )
         return op, postable
 
@@ -102,18 +103,16 @@ G1 X1.000
         )
 
     def test_unsupported(self):
-        """Processor allows unsupported gcode"""
+        """Processor does not allow unsupported gcode,
+        gives helpful error
+        """
         _, postable = self._make_op("G666 X1")
 
         output = []
-        self.pp._convert_item_commands(postable, output)
-        self.assertEqual(
-            "\n".join(output),
-            """(Custom)
-(Begin Custom)
-G666 X1.000
-(End Custom)""",
-        )
+        self.pp._operation = postable
+        with self.assertRaisesRegex(CAMValueError, "Unsupported command") as cm:
+            self.pp._convert_item_commands(postable, output)
+        self.assertIn("in the Custom op", str(cm.exception))  # the helpful bit
 
     def test_as_is_one_line(self):
         """Processor allows add lines without processing"""

--- a/src/Mod/CAM/CAMTests/TestPostOutput.py
+++ b/src/Mod/CAM/CAMTests/TestPostOutput.py
@@ -33,6 +33,7 @@ import Path
 import Path.Post.Command as PathCommand
 from Path.Post import PostList
 import Path.Post.Utils as PostUtils
+from Path.Post.CAMErrors import CAMValueError
 import Path.Main.Job as PathJob
 import Path.Tool.Controller as PathToolController
 from Machine.models.machine import Machine, OutputUnits, Toolhead, ToolheadType
@@ -788,6 +789,23 @@ class TestExport2Integration(unittest.TestCase):
         cmd = Path.Command("G0 X1 F0")
         gcode = post.convert_command_to_gcode(cmd)
         self.assertNotIn(" F", gcode)
+
+    def test004_unsupported_convert(self):
+        """Test if throws on unsupported"""
+
+        machine = self._create_machine()
+        post = self._create_postprocessor(machine)
+
+        # Basic unsupported
+        cmd = Path.Command("G9999")
+        with self.assertRaisesRegex(CAMValueError, "Unsupported command") as cm:
+            gcode = post.convert_command_to_gcode(cmd)
+        self.assertIn("Unsupported command: G9999", str(cm.exception))
+
+        # But, allow ANNOT_ALLOW_UNSUPPORTED
+        cmd = Path.Command("G9999", {}, {Constants.ANNOT_ALLOW_UNSUPPORTED: "True"})
+        gcode = post.convert_command_to_gcode(cmd)
+        self.assertIn("G9999", gcode)
 
     # ===== 010-019: Basic smoke tests =====
 

--- a/src/Mod/CAM/Path/Op/Custom.py
+++ b/src/Mod/CAM/Path/Op/Custom.py
@@ -205,7 +205,8 @@ class ObjectCustom(PathOp.ObjectOp):
                 line = line.strip()
                 line = self.parseExpressions(obj, line, i)
                 try:
-                    newcommand = Path.Command(line, {}, {Constants.ANNOT_ALLOW_UNSUPPORTED: "True"})
+                    # Custom is strict: supported+non-conforming, or mark "as-is"
+                    newcommand = Path.Command(line, {})
                     self.commandlist.append(newcommand)
                 except ValueError:
                     if len(self.errors) < 7:

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -2601,8 +2601,20 @@ class PostProcessor:
             and not command.Name.startswith("T")
             and not command.Annotations.get(Constants.ANNOT_ALLOW_UNSUPPORTED, False)
         ):
+            # Try to help them if it is Custom op
+            extra = ""
+            if (
+                self._operation
+                and getattr(self._operation, "source", None)
+                and getattr(self._operation.source, "Proxy")
+                and isinstance(self._operation.source.Proxy, Path.Op.Custom.ObjectCustom)
+            ):
+                extra = translate(
+                    "CAM",
+                    " (in the Custom op, uncheck Post Process Output, or put '!' in front of specific command)",
+                )
             raise CAMValueError(
-                f"Unsupported command: {command.Name}",
+                f"Unsupported command: {command.Name}{extra}",
                 job=self._job,
                 operation=self._operation,
                 command=command,


### PR DESCRIPTION
If a command is not as-is ("!" prefix, or mark the whole op), it must be supported (or non-conforming).

We give a slightly more helpful message.

Fixes #32103

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
