### PR TITLE
PartDesign: identify loft profiles with insufficient separation

### DIFF
--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4531,7 +4531,10 @@ TopoShape& TopoShape::makeElementLoft(
     for (auto& sh : profiles) {
         if (i > 0) {
             if (!checkProfiles(sh, profiles[i - 1])) {
-                FC_THROWM(Base::CADKernelError, "Segments of a loft do not have sufficient separation");
+                FC_THROWM(
+                    Base::CADKernelError,
+                    "Loft profiles " << i << " and " << (i + 1) << " do not have sufficient separation"
+                );
             }
         }
         const auto& shape = sh.getShape();

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -1858,15 +1858,24 @@ TEST_F(TopoShapeExpansionTest, makeElementLoftRejectsCoincidentProfiles)  // NOL
 
     // Arrange
     auto [face1, wire1, edge1, edge2, edge3, edge4] = CreateRectFace(5, 5);
+    auto transform {gp_Trsf()};
+    transform.SetTranslation(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(0.0, 0.0, 10.0));
+    auto shiftedWire = wire1;
+    shiftedWire.Move(TopLoc_Location(transform));
     TopoShape firstProfile {wire1, 1L};
-    TopoShape secondProfile {wire1, 2L};
-    std::vector<TopoShape> shapes = {firstProfile, secondProfile};
+    TopoShape secondProfile {shiftedWire, 2L};
+    TopoShape thirdProfile {shiftedWire, 3L};
+    std::vector<TopoShape> shapes = {firstProfile, secondProfile, thirdProfile};
 
     // Act / Assert
-    EXPECT_THROW(  // NOLINT
-        (new TopoShape())->makeElementLoft(shapes, IsSolid::notSolid, IsRuled::notRuled),
-        Base::CADKernelError
-    );
+    try {
+        TopoShape loft;
+        loft.makeElementLoft(shapes, IsSolid::notSolid, IsRuled::notRuled);
+        FAIL() << "Expected coincident loft profiles to be rejected";
+    }
+    catch (const Base::CADKernelError& e) {
+        EXPECT_STREQ(e.what(), "Loft profiles 2 and 3 do not have sufficient separation");
+    }
 }
 
 TEST_F(TopoShapeExpansionTest, makeElementPipeShell)


### PR DESCRIPTION
## Summary

Improve the PartDesign loft separation error so it identifies the adjacent loft profiles that fail the separation check instead of returning only the generic message.

For example, a failure between the second and third profiles now reports:

`Loft profiles 2 and 3 do not have sufficient separation`

## What changed

- include the 1-based profile positions in the `makeElementLoft` separation error
- strengthen the existing regression test so the failure occurs on profiles 2/3 and asserts the exact diagnostic

## Validation

Validation performed on this focused change before submission:

- focused coincident-profile regression: 2/2 passed
- `TopoShapeExpansion` suite: 89/89 passed

Fixes #32162
