### PR TITLE
Gui: Replace duplicated task panel checks with TaskDialog::canClose()

### DIFF
--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
@@ -180,13 +180,7 @@ bool ViewProviderFemAnalysis::setEdit(int ModNum)
         // if (padDlg && anaDlg->getPadView() != this)
         //     padDlg = 0; // another pad left open its task panel
         // if (dlg && !padDlg) {
-        //     QMessageBox msgBox;
-        //     msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-        //     msgBox.setInformativeText(QObject::tr("Do you want to close this dialog?"));
-        //     msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-        //     msgBox.setDefaultButton(QMessageBox::Yes);
-        //     int ret = msgBox.exec();
-        //     if (ret == QMessageBox::Yes)
+        //     if (dlg->canClose())
         //         Gui::Control().closeDialog();
         //     else
         //         return false;

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
@@ -37,7 +37,6 @@
 #include <Inventor/nodes/SoTransform.h>
 
 #include <QApplication>
-#include <QMessageBox>
 #include <QTextStream>
 
 #include <App/Document.h>
@@ -151,13 +150,7 @@ bool ViewProviderFemPostFunction::setEdit(int ModNum)
             postDlg = nullptr;  // another pad left open its task panel
         }
         if (dlg && !postDlg) {
-            QMessageBox msgBox(Gui::getMainWindow());
-            msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-            msgBox.setInformativeText(QObject::tr("Do you want to close this dialog?"));
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-            int ret = msgBox.exec();
-            if (ret == QMessageBox::Yes) {
+            if (dlg->canClose()) {
                 Gui::Control().reject();
             }
             else {

--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -45,7 +45,6 @@
 #include <vtkPointData.h>
 
 #include <QApplication>
-#include <QMessageBox>
 #include <QTextStream>
 
 #include <App/Document.h>
@@ -895,13 +894,7 @@ bool ViewProviderFemPostObject::setEdit(int ModNum)
             postDlg = nullptr;  // another pad left open its task panel
         }
         if (dlg && !postDlg) {
-            QMessageBox msgBox(Gui::getMainWindow());
-            msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-            msgBox.setInformativeText(QObject::tr("Do you want to close this dialog?"));
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-            int ret = msgBox.exec();
-            if (ret == QMessageBox::Yes) {
+            if (dlg->canClose()) {
                 Gui::Control().reject();
             }
             else {

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -46,6 +46,7 @@
 #include <Gui/MainWindow.h>
 #include <Gui/Selection/Selection.h>
 #include <Gui/Selection/SelectionObject.h>
+#include <Gui/TaskView/TaskDialog.h>
 #include <Mod/Sketcher/App/SketchObject.h>
 #include <Mod/PartDesign/App/Body.h>
 #include <Mod/PartDesign/App/FeatureBoolean.h>
@@ -1174,13 +1175,7 @@ void prepareProfileBased(
         PartDesignGui::TaskDlgFeaturePick* pickDlg
             = qobject_cast<PartDesignGui::TaskDlgFeaturePick*>(dlg);
         if (dlg && !pickDlg) {
-            QMessageBox msgBox(Gui::getMainWindow());
-            msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-            msgBox.setInformativeText(QObject::tr("Close this dialog?"));
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-            int ret = msgBox.exec();
-            if (ret == QMessageBox::Yes) {
+            if (dlg->canClose()) {
                 Gui::Control().closeDialog();
             }
             else {

--- a/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
+++ b/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
@@ -61,6 +61,7 @@
 #include <Gui/ViewParams.h>
 #include <Gui/ViewProviderPlane.h>
 #include <Gui/Selection/SelectionFilter.h>
+#include <Gui/TaskView/TaskDialog.h>
 
 using namespace PartDesignGui;
 
@@ -759,13 +760,7 @@ private:
         PartDesignGui::TaskDlgFeaturePick* pickDlg
             = qobject_cast<PartDesignGui::TaskDlgFeaturePick*>(dlg);
         if (dlg && !pickDlg) {
-            QMessageBox msgBox(Gui::getMainWindow());
-            msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-            msgBox.setInformativeText(QObject::tr("Close this dialog?"));
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-            int ret = msgBox.exec();
-            if (ret == QMessageBox::Yes) {
+            if (dlg->canClose()) {
                 Gui::Control().closeDialog();
             }
             else {

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -22,7 +22,6 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QMessageBox>
 #include <QAction>
 #include <QMenu>
 #include <Inventor/nodes/SoSeparator.h>
@@ -40,6 +39,7 @@
 #include <Gui/Selection/SoFCUnifiedSelection.h>
 #include <Gui/Inventor/So3DAnnotation.h>
 #include <Gui/MainWindow.h>
+#include <Gui/TaskView/TaskDialog.h>
 #include <Gui/Utilities.h>
 #include <Mod/PartDesign/App/Body.h>
 #include <Mod/PartDesign/App/FeatureAddSub.h>
@@ -133,13 +133,7 @@ bool ViewProvider::setEdit(int ModNum)
             featureDlg = nullptr;  // another feature left open its task panel
         }
         if (dlg && !featureDlg) {
-            QMessageBox msgBox(Gui::getMainWindow());
-            msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-            msgBox.setInformativeText(QObject::tr("Close this dialog?"));
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-
-            if (msgBox.exec() == QMessageBox::Yes) {
+            if (dlg->canClose()) {
                 Gui::Control().reject();
             }
             else {

--- a/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
@@ -34,7 +34,6 @@
 #include <Inventor/nodes/SoSeparator.h>
 #include <Inventor/nodes/SoShapeHints.h>
 #include <Precision.hxx>
-#include <QMessageBox>
 #include <QAction>
 #include <QMenu>
 
@@ -45,6 +44,7 @@
 #include <Gui/Command.h>
 #include <Gui/Control.h>
 #include <Gui/MainWindow.h>
+#include <Gui/TaskView/TaskDialog.h>
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
 #include <Gui/ViewProviderCoordinateSystem.h>
@@ -255,13 +255,7 @@ bool ViewProviderDatum::setEdit(int ModNum)
             datumDlg = nullptr;  // another datum feature left open its task panel
         }
         if (dlg && !datumDlg) {
-            QMessageBox msgBox(Gui::getMainWindow());
-            msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-            msgBox.setInformativeText(QObject::tr("Close this dialog?"));
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-            int ret = msgBox.exec();
-            if (ret == QMessageBox::Yes) {
+            if (dlg->canClose()) {
                 Gui::Control().closeDialog();
             }
             else {

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -25,7 +25,6 @@
 
 #include <QApplication>
 #include <QMenu>
-#include <QMessageBox>
 #include <TopExp.hxx>
 #include <TopTools_IndexedMapOfShape.hxx>
 
@@ -38,6 +37,7 @@
 #include <Gui/Control.h>
 #include <Gui/Document.h>
 #include <Gui/MainWindow.h>
+#include <Gui/TaskView/TaskDialog.h>
 #include <Gui/ViewParams.h>
 #include <Mod/PartDesign/App/ShapeBinder.h>
 
@@ -94,13 +94,7 @@ bool ViewProviderShapeBinder::setEdit(int ModNum)
         Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
         TaskDlgShapeBinder* sbDlg = qobject_cast<TaskDlgShapeBinder*>(dlg);
         if (dlg && !sbDlg) {
-            QMessageBox msgBox(Gui::getMainWindow());
-            msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-            msgBox.setInformativeText(QObject::tr("Close this dialog?"));
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-            int ret = msgBox.exec();
-            if (ret == QMessageBox::Yes) {
+            if (dlg->canClose()) {
                 Gui::Control().reject();
             }
             else {

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -70,6 +70,7 @@
 #include <Gui/MenuManager.h>
 #include <Gui/Selection/Selection.h>
 #include <Gui/Selection/SelectionObject.h>
+#include <Gui/TaskView/TaskDialog.h>
 #include <Gui/Selection/SoFCUnifiedSelection.h>
 // #include <Gui/Inventor/SoFCSwitch.h>
 #include <Gui/Utilities.h>
@@ -4164,13 +4165,7 @@ bool ViewProviderSketch::setEdit(int ModNum)
         sketchDlg = nullptr;// another sketch left open its task panel
     }
     if (dlg && !sketchDlg) {
-        QMessageBox msgBox(Gui::getMainWindow());
-        msgBox.setText(tr("A dialog is already open in the task panel"));
-        msgBox.setInformativeText(tr("Close this dialog?"));
-        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-        msgBox.setDefaultButton(QMessageBox::Yes);
-        int ret = msgBox.exec();
-        if (ret == QMessageBox::Yes) {
+        if (dlg->canClose()) {
             Gui::Control().closeDialog();
         }
         else {


### PR DESCRIPTION
This PR completes #32267 by replacing all duplicated QMessageBox blocks for the "A dialog is already open in the task panel" prompt with the shared `TaskDialog::canClose()` helper across all 9 files listed in the issue.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted by Cursor on formatting

## Issues
Closes #32267

## Summary
- Replaced inline `QMessageBox` confirmation blocks with `dlg->canClose()` in FEM, PartDesign, and Sketcher GUI code
- Updated commented-out reference code in `ViewProviderAnalysis.cpp` to use the same maintainable pattern
- Preserved existing `reject()` vs `closeDialog()` behavior per call site
- Removed unused `QMessageBox` includes where safe; kept them where still needed elsewhere

This PR covers all 9 files from the issue (including `ViewProvider.cpp` and `ViewProviderDatum.cpp` not addressed in #32310).

## Before and After Images
N/A — pure code-quality refactor with no GUI visual changes. User-facing behavior remains identical.

## Test plan
- [ ] Part Design: open a Pad task panel, double-click another feature → prompt appears; Yes closes dialog, No cancels
- [ ] Part Design: repeat for datum feature and ShapeBinder
- [ ] Sketcher: open sketch edit, try opening another sketch edit → same prompt behavior
- [ ] FEM: open post result edit with another task dialog open → same prompt behavior