### PR TITLE
Gui: widen NaviCube ViewMenu hit target

### DIFF
--- a/src/Gui/Inventor/SoNaviCube.cpp
+++ b/src/Gui/Inventor/SoNaviCube.cpp
@@ -379,6 +379,10 @@ constexpr float BACKSIDE_HIT_LEFT = 0.79F;
 constexpr float BACKSIDE_HIT_TOP = 0.0F;
 constexpr float BACKSIDE_HIT_RIGHT = 1.0F;
 constexpr float BACKSIDE_HIT_BOTTOM = 0.16F;
+constexpr float VIEWMENU_HIT_LEFT = 0.82F;
+constexpr float VIEWMENU_HIT_TOP = 0.84F;
+constexpr float VIEWMENU_HIT_RIGHT = 0.98F;
+constexpr float VIEWMENU_HIT_BOTTOM = 0.97F;
 
 }  // namespace
 
@@ -1814,6 +1818,9 @@ void SoNaviCube::addButtonFace(PickId pickId) const
         case PickId::ViewMenu: {
             offx = 0.90F;
             offy = 0.95F;
+            // The icon has a bar and triangle with a gap; keep the full area clickable.
+            hitRect = {true, VIEWMENU_HIT_LEFT, VIEWMENU_HIT_TOP,
+                       VIEWMENU_HIT_RIGHT, VIEWMENU_HIT_BOTTOM};
             const auto bar = appendLoop({-13.0F, -20.0F, 13.0F, -20.0F, 13.0F, -16.0F, -13.0F, -16.0F});
             appendTriangles(bar, {0, 1, 2, 0, 2, 3});
             const auto triangle = appendLoop({-13.0F, -12.0F, 13.0F, -12.0F, 0.0F, 0.0F});

--- a/src/Gui/Inventor/SoNaviCube.cpp
+++ b/src/Gui/Inventor/SoNaviCube.cpp
@@ -1819,8 +1819,8 @@ void SoNaviCube::addButtonFace(PickId pickId) const
             offx = 0.90F;
             offy = 0.95F;
             // The icon has a bar and triangle with a gap; keep the full area clickable.
-            hitRect = {true, VIEWMENU_HIT_LEFT, VIEWMENU_HIT_TOP,
-                       VIEWMENU_HIT_RIGHT, VIEWMENU_HIT_BOTTOM};
+            hitRect
+                = {true, VIEWMENU_HIT_LEFT, VIEWMENU_HIT_TOP, VIEWMENU_HIT_RIGHT, VIEWMENU_HIT_BOTTOM};
             const auto bar = appendLoop({-13.0F, -20.0F, 13.0F, -20.0F, 13.0F, -16.0F, -13.0F, -16.0F});
             appendTriangles(bar, {0, 1, 2, 0, 2, 3});
             const auto triangle = appendLoop({-13.0F, -12.0F, 13.0F, -12.0F, 0.0F, 0.0F});


### PR DESCRIPTION



## Summary

Fixes the dead click zone on the NaviCube ViewMenu button reported in #32334.

The ViewMenu icon is drawn as two separate shapes (a horizontal bar and a dropdown triangle) with a gap between them. Hit testing only registered clicks on the drawn geometry, so clicks in the gap did nothing.

This adds a rectangular hit area for `PickId::ViewMenu`, using the same approach as the existing Backside button fix (commit 4a5546fa63).

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues

fixes #32334

## Before and After

**Before:** Clicking the gap between the bar and triangle on the ViewMenu button did not open the menu.

**After:** The full button area is clickable, including the gap. The icon appearance is unchanged.

### Manual test recording

https://github.com/Ayushjo/FreeCAD/releases/download/pr-32337-test-video/TestedFreeCad.mp4
https://github.com/user-attachments/assets/69b57e40-d1e6-4bd0-95b0-fa598c867dce

## Test plan

- [x] Built locally with pixi (`pixi run configure`, `pixi run build`)
- [x] Clicking the gap between the ViewMenu bar and triangle opens the menu
- [x] Clicking the bar and triangle directly still opens the menu
- [x] Other NaviCube buttons (Home, rotate arrows, backside, cube faces) still work

## AI assistance disclosure

AI tools were used in an assistive way during investigation and implementation. The change was reviewed, built, and tested locally before submission.

Assisted-by: Cursor (Auto)