### PR TITLE
Measure: Mass properties : Add material button

### DIFF
--- a/src/Mod/Material/Gui/AppMatGui.cpp
+++ b/src/Mod/Material/Gui/AppMatGui.cpp
@@ -35,6 +35,7 @@
 #include "WorkbenchManipulator.h"
 #include "MaterialTreeWidget.h"
 #include "MaterialTreeWidgetPy.h"
+#include "MaterialSelector.h"
 
 #if defined(BUILD_MATERIAL_EXTERNAL)
 #include "DlgSettingsExternal.h"
@@ -129,6 +130,7 @@ PyMOD_INIT_FUNC(MatGui)
 
     // Add custom widgets
     new Gui::WidgetProducer<MatGui::MaterialTreeWidget>;
+    new Gui::WidgetProducer<MatGui::MaterialSelector>;
 
 
     PyMOD_Return(matGuiModule);

--- a/src/Mod/Material/Gui/CMakeLists.txt
+++ b/src/Mod/Material/Gui/CMakeLists.txt
@@ -113,6 +113,8 @@ SET(MatGui_SRCS
     MaterialSave.cpp
     MaterialSave.h
     MaterialSave.ui
+    MaterialSelector.cpp
+    MaterialSelector.h
     MaterialsEditor.cpp
     MaterialsEditor.h
     MaterialsEditor.ui

--- a/src/Mod/Material/Gui/MaterialSelector.cpp
+++ b/src/Mod/Material/Gui/MaterialSelector.cpp
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "MaterialSelector.h"
+
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QMessageBox>
+#include <QVBoxLayout>
+
+#include <exception>
+#include <memory>
+#include <unordered_set>
+
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <Base/Exception.h>
+#include <Mod/Material/App/MaterialFilter.h>
+#include <Mod/Material/App/MaterialManager.h>
+#include <Mod/Material/App/PropertyMaterial.h>
+
+#include "MaterialTreeWidget.h"
+
+using namespace MatGui;
+
+MaterialSelector::MaterialSelector(QWidget* parent)
+    : QPushButton(parent)
+{
+    setText(tr("No material"));
+    setEnabled(false);
+    connect(this, &QPushButton::clicked, this, &MaterialSelector::chooseMaterial);
+}
+
+void MaterialSelector::setObjects(const std::vector<App::DocumentObject*>& objects)
+{
+    assignedObjects.clear();
+    std::unordered_set<App::DocumentObject*> seen;
+    for (auto* object : objects) {
+        if (object && seen.insert(object).second) {
+            assignedObjects.emplace_back(object);
+        }
+    }
+    refresh();
+}
+
+void MaterialSelector::clearObjects()
+{
+    assignedObjects.clear();
+    refresh();
+}
+
+void MaterialSelector::refresh()
+{
+    QStringList materialNames;
+    bool hasAssignableMaterial = false;
+
+    for (const auto& reference : assignedObjects) {
+        auto* object = reference.getObject();
+        if (!object) {
+            continue;
+        }
+        auto* materialProperty = freecad_cast<Materials::PropertyMaterial*>(
+            object->getPropertyByName("ShapeMaterial")
+        );
+        if (!materialProperty) {
+            continue;
+        }
+        hasAssignableMaterial = hasAssignableMaterial || !materialProperty->isReadOnly();
+
+        QString name = materialProperty->getValue().getName();
+        if (name.isEmpty()) {
+            name = tr("No material");
+        }
+        if (!materialNames.contains(name)) {
+            materialNames.append(name);
+        }
+    }
+
+    setEnabled(hasAssignableMaterial);
+    if (materialNames.isEmpty()) {
+        setText(tr("No material"));
+    }
+    else if (materialNames.size() <= 2) {
+        setText(materialNames.join(QStringLiteral(", ")));
+    }
+    else {
+        setText(
+            materialNames.first() + QStringLiteral(", ") + materialNames.at(1)
+            + QStringLiteral(", \u2026")
+        );
+    }
+}
+
+bool MaterialSelector::requirePhysical() const
+{
+    return physicalRequired;
+}
+
+void MaterialSelector::setRequirePhysical(bool required)
+{
+    physicalRequired = required;
+}
+
+void MaterialSelector::chooseMaterial()
+{
+    std::vector<App::DocumentObject*> targets;
+    QString commonUuid;
+    bool hasCommonMaterial = true;
+
+    for (const auto& reference : assignedObjects) {
+        auto* object = reference.getObject();
+        if (!object) {
+            continue;
+        }
+        auto* materialProperty = freecad_cast<Materials::PropertyMaterial*>(
+            object->getPropertyByName("ShapeMaterial")
+        );
+        if (!materialProperty || materialProperty->isReadOnly()) {
+            continue;
+        }
+
+        targets.push_back(object);
+        const QString uuid = materialProperty->getValue().getUUID();
+        if (targets.size() == 1) {
+            commonUuid = uuid;
+        }
+        else if (uuid != commonUuid) {
+            hasCommonMaterial = false;
+        }
+    }
+
+    if (targets.empty()) {
+        return;
+    }
+
+    QDialog dialog(this);
+    dialog.setWindowTitle(tr("Assign Material"));
+    auto* layout = new QVBoxLayout(&dialog);
+
+    Materials::MaterialFilter filter;
+    filter.requirePhysical(physicalRequired);
+    auto* picker = new MaterialTreeWidget(filter, &dialog);
+    picker->setObjectName(QStringLiteral("materialTreeWidget"));
+    picker->setExpanded(true);
+    if (hasCommonMaterial && !commonUuid.isEmpty()) {
+        picker->setMaterial(commonUuid);
+    }
+    layout->addWidget(picker);
+
+    auto* buttons = new QDialogButtonBox(
+        QDialogButtonBox::Ok | QDialogButtonBox::Cancel,
+        &dialog
+    );
+    auto* okButton = buttons->button(QDialogButtonBox::Ok);
+    okButton->setEnabled(!picker->getMaterialUUID().isEmpty());
+    connect(
+        picker,
+        &MaterialTreeWidget::materialSelected,
+        okButton,
+        [okButton](const std::shared_ptr<Materials::Material>& material) {
+            okButton->setEnabled(static_cast<bool>(material));
+        }
+    );
+    connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+    layout->addWidget(buttons);
+
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    try {
+        const auto material = Materials::MaterialManager::getManager().getMaterial(
+            picker->getMaterialUUID()
+        );
+        if (!material) {
+            return;
+        }
+
+        std::unordered_set<App::Document*> documents;
+        for (auto* target : targets) {
+            if (auto* document = target->getDocument()) {
+                documents.insert(document);
+            }
+        }
+        std::vector<App::Document*> openedDocuments;
+        try {
+            for (auto* document : documents) {
+                document->openTransaction("Assign Material");
+                openedDocuments.push_back(document);
+            }
+            for (auto* target : targets) {
+                auto* materialProperty = freecad_cast<Materials::PropertyMaterial*>(
+                    target->getPropertyByName("ShapeMaterial")
+                );
+                if (materialProperty && !materialProperty->isReadOnly()) {
+                    materialProperty->setValue(*material);
+                }
+            }
+            for (auto* document : openedDocuments) {
+                document->commitTransaction();
+            }
+        }
+        catch (...) {
+            for (auto* document : openedDocuments) {
+                if (document->hasPendingTransaction()) {
+                    document->abortTransaction();
+                }
+            }
+            throw;
+        }
+
+        refresh();
+        Q_EMIT materialChanged();
+    }
+    catch (const Base::Exception& error) {
+        QMessageBox::warning(this, tr("Assign Material"), QString::fromUtf8(error.what()));
+    }
+    catch (const std::exception& error) {
+        QMessageBox::warning(this, tr("Assign Material"), QString::fromUtf8(error.what()));
+    }
+}

--- a/src/Mod/Material/Gui/MaterialSelector.h
+++ b/src/Mod/Material/Gui/MaterialSelector.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <QPushButton>
+
+#include <vector>
+
+#include <App/DocumentObserver.h>
+#include <Mod/Material/MaterialGlobal.h>
+
+namespace MatGui
+{
+
+/** A compact material picker for one or more document objects.
+ *
+ * The selector displays the common material name, up to two distinct names,
+ * or an ellipsis for a larger mixed selection. Clicking it opens the material
+ * tree and assigns the chosen material to every writable ShapeMaterial
+ * property in one undoable transaction per document.
+ */
+class MatGuiExport MaterialSelector: public QPushButton
+{
+    Q_OBJECT
+    Q_PROPERTY(bool requirePhysical READ requirePhysical WRITE setRequirePhysical)
+
+public:
+    explicit MaterialSelector(QWidget* parent = nullptr);
+
+    void setObjects(const std::vector<App::DocumentObject*>& objects);
+    void clearObjects();
+    void refresh();
+
+    bool requirePhysical() const;
+    void setRequirePhysical(bool required);
+
+Q_SIGNALS:
+    void materialChanged();
+
+private Q_SLOTS:
+    void chooseMaterial();
+
+private:
+    std::vector<App::DocumentObjectT> assignedObjects;
+    bool physicalRequired = false;
+};
+
+}  // namespace MatGui

--- a/src/Mod/Measure/CMakeLists.txt
+++ b/src/Mod/Measure/CMakeLists.txt
@@ -10,6 +10,7 @@ set(Measure_Scripts
     MassPropertiesGui.py
     UtilsMeasure.py
     MeasureCOM.py
+    TestMeasureGui.py
 )
 
 if(BUILD_GUI)

--- a/src/Mod/Measure/Gui/CMakeLists.txt
+++ b/src/Mod/Measure/Gui/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 set(MeasureGui_LIBS
     Measure
+    MatGui
     #Part
     FreeCADGui
 )

--- a/src/Mod/Measure/Gui/TaskMassProperties.cpp
+++ b/src/Mod/Measure/Gui/TaskMassProperties.cpp
@@ -74,6 +74,10 @@
 
 #include <Mod/Part/App/PartFeature.h>
 #include <Mod/Part/App/Tools.h>
+#include <Mod/Material/App/MaterialFilter.h>
+#include <Mod/Material/App/MaterialManager.h>
+#include <Mod/Material/App/PropertyMaterial.h>
+#include <Mod/Material/Gui/MaterialTreeWidget.h>
 
 #include <BRepAdaptor_Curve.hxx>
 #include <BRep_Builder.hxx>
@@ -318,6 +322,12 @@ TaskMassProperties::TaskMassProperties()
         this,
         &TaskMassProperties::onLcsButtonPressed
     );
+    connect(
+        panel->ui.materialButton,
+        &QPushButton::clicked,
+        this,
+        &TaskMassProperties::onMaterialButtonPressed
+    );
 
     const int preferredSchemaIndex = getPreferredUnitsSchemaIndex();
 
@@ -500,6 +510,8 @@ void TaskMassProperties::removeTemporaryObjects()
 
 void TaskMassProperties::clearUiFields()
 {
+    panel->ui.materialButton->setEnabled(false);
+    panel->ui.materialButton->setText(tr("No material"));
     panel->ui.volumeEdit->clear();
     panel->ui.massEdit->clear();
     panel->ui.densityEdit->clear();
@@ -525,6 +537,168 @@ void TaskMassProperties::clearUiFields()
     panel->ui.inertiaJzText->clear();
 
     panel->ui.axisInertiaText->clear();
+}
+
+void TaskMassProperties::updateMaterialButton()
+{
+    std::unordered_set<App::DocumentObject*> seenObjects;
+    QStringList materialNames;
+    bool hasAssignableMaterial = false;
+
+    for (const auto& input : objectsToMeasure) {
+        if (!input.object || !seenObjects.insert(input.object).second) {
+            continue;
+        }
+
+        auto* materialProperty = freecad_cast<Materials::PropertyMaterial*>(
+            input.object->getPropertyByName("ShapeMaterial")
+        );
+        if (!materialProperty) {
+            continue;
+        }
+        hasAssignableMaterial = hasAssignableMaterial || !materialProperty->isReadOnly();
+
+        QString name = materialProperty->getValue().getName();
+        if (name.isEmpty()) {
+            name = tr("No material");
+        }
+        if (!materialNames.contains(name)) {
+            materialNames.append(name);
+        }
+    }
+
+    panel->ui.materialButton->setEnabled(hasAssignableMaterial);
+    if (materialNames.isEmpty()) {
+        panel->ui.materialButton->setText(tr("No material"));
+    }
+    else if (materialNames.size() <= 2) {
+        panel->ui.materialButton->setText(materialNames.join(QStringLiteral(", ")));
+    }
+    else {
+        panel->ui.materialButton->setText(
+            materialNames.first() + QStringLiteral(", ") + materialNames.at(1)
+            + QStringLiteral(", \u2026")
+        );
+    }
+}
+
+void TaskMassProperties::onMaterialButtonPressed()
+{
+    std::vector<App::DocumentObject*> targets;
+    std::unordered_set<App::DocumentObject*> seenObjects;
+    QString commonUuid;
+    bool hasCommonMaterial = true;
+
+    for (const auto& input : objectsToMeasure) {
+        if (!input.object || !seenObjects.insert(input.object).second) {
+            continue;
+        }
+
+        auto* materialProperty = freecad_cast<Materials::PropertyMaterial*>(
+            input.object->getPropertyByName("ShapeMaterial")
+        );
+        if (!materialProperty || materialProperty->isReadOnly()) {
+            continue;
+        }
+
+        targets.push_back(input.object);
+        const QString uuid = materialProperty->getValue().getUUID();
+        if (targets.size() == 1) {
+            commonUuid = uuid;
+        }
+        else if (uuid != commonUuid) {
+            hasCommonMaterial = false;
+        }
+    }
+
+    if (targets.empty()) {
+        return;
+    }
+
+    QDialog dialog(panel);
+    dialog.setWindowTitle(tr("Assign Material"));
+    auto* layout = new QVBoxLayout(&dialog);
+
+    Materials::MaterialFilter filter;
+    filter.requirePhysical(true);
+    auto* picker = new MatGui::MaterialTreeWidget(filter, &dialog);
+    picker->setObjectName(QStringLiteral("materialTreeWidget"));
+    picker->setExpanded(true);
+    if (hasCommonMaterial && !commonUuid.isEmpty()) {
+        picker->setMaterial(commonUuid);
+    }
+    layout->addWidget(picker);
+
+    auto* buttons = new QDialogButtonBox(
+        QDialogButtonBox::Ok | QDialogButtonBox::Cancel,
+        &dialog
+    );
+    auto* okButton = buttons->button(QDialogButtonBox::Ok);
+    okButton->setEnabled(!picker->getMaterialUUID().isEmpty());
+    connect(
+        picker,
+        &MatGui::MaterialTreeWidget::materialSelected,
+        okButton,
+        [okButton](const std::shared_ptr<Materials::Material>& material) {
+            okButton->setEnabled(static_cast<bool>(material));
+        }
+    );
+    connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+    layout->addWidget(buttons);
+
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    try {
+        const auto material = Materials::MaterialManager::getManager().getMaterial(
+            picker->getMaterialUUID()
+        );
+        if (!material) {
+            return;
+        }
+
+        std::unordered_set<App::Document*> documents;
+        for (auto* target : targets) {
+            if (auto* doc = target->getDocument()) {
+                documents.insert(doc);
+            }
+        }
+        for (auto* doc : documents) {
+            doc->openTransaction("Assign Material");
+        }
+
+        try {
+            for (auto* target : targets) {
+                auto* materialProperty = freecad_cast<Materials::PropertyMaterial*>(
+                    target->getPropertyByName("ShapeMaterial")
+                );
+                if (materialProperty && !materialProperty->isReadOnly()) {
+                    materialProperty->setValue(*material);
+                }
+            }
+            for (auto* doc : documents) {
+                doc->commitTransaction();
+            }
+        }
+        catch (...) {
+            for (auto* doc : documents) {
+                if (doc->hasPendingTransaction()) {
+                    doc->abortTransaction();
+                }
+            }
+            throw;
+        }
+
+        tryUpdate();
+    }
+    catch (const Base::Exception& e) {
+        QMessageBox::warning(panel, tr("Assign Material"), QString::fromUtf8(e.what()));
+    }
+    catch (const std::exception& e) {
+        QMessageBox::warning(panel, tr("Assign Material"), QString::fromUtf8(e.what()));
+    }
 }
 
 void TaskMassProperties::onSelectionChanged(const Gui::SelectionChanges& msg)
@@ -1143,6 +1317,8 @@ void TaskMassProperties::tryUpdate()
         this->removeTemporaryObjects();
         return;
     }
+
+    updateMaterialButton();
 
     updateInertiaVisibility();
 

--- a/src/Mod/Measure/Gui/TaskMassProperties.cpp
+++ b/src/Mod/Measure/Gui/TaskMassProperties.cpp
@@ -74,10 +74,7 @@
 
 #include <Mod/Part/App/PartFeature.h>
 #include <Mod/Part/App/Tools.h>
-#include <Mod/Material/App/MaterialFilter.h>
-#include <Mod/Material/App/MaterialManager.h>
-#include <Mod/Material/App/PropertyMaterial.h>
-#include <Mod/Material/Gui/MaterialTreeWidget.h>
+#include <Mod/Material/Gui/MaterialSelector.h>
 
 #include <BRepAdaptor_Curve.hxx>
 #include <BRep_Builder.hxx>
@@ -322,11 +319,12 @@ TaskMassProperties::TaskMassProperties()
         this,
         &TaskMassProperties::onLcsButtonPressed
     );
+    panel->ui.materialButton->setRequirePhysical(true);
     connect(
         panel->ui.materialButton,
-        &QPushButton::clicked,
+        &MatGui::MaterialSelector::materialChanged,
         this,
-        &TaskMassProperties::onMaterialButtonPressed
+        &TaskMassProperties::tryUpdate
     );
 
     const int preferredSchemaIndex = getPreferredUnitsSchemaIndex();
@@ -510,8 +508,7 @@ void TaskMassProperties::removeTemporaryObjects()
 
 void TaskMassProperties::clearUiFields()
 {
-    panel->ui.materialButton->setEnabled(false);
-    panel->ui.materialButton->setText(tr("No material"));
+    panel->ui.materialButton->clearObjects();
     panel->ui.volumeEdit->clear();
     panel->ui.massEdit->clear();
     panel->ui.densityEdit->clear();
@@ -539,166 +536,16 @@ void TaskMassProperties::clearUiFields()
     panel->ui.axisInertiaText->clear();
 }
 
-void TaskMassProperties::updateMaterialButton()
+void TaskMassProperties::updateMaterialSelector()
 {
-    std::unordered_set<App::DocumentObject*> seenObjects;
-    QStringList materialNames;
-    bool hasAssignableMaterial = false;
-
+    std::vector<App::DocumentObject*> objects;
+    objects.reserve(objectsToMeasure.size());
     for (const auto& input : objectsToMeasure) {
-        if (!input.object || !seenObjects.insert(input.object).second) {
-            continue;
-        }
-
-        auto* materialProperty = freecad_cast<Materials::PropertyMaterial*>(
-            input.object->getPropertyByName("ShapeMaterial")
-        );
-        if (!materialProperty) {
-            continue;
-        }
-        hasAssignableMaterial = hasAssignableMaterial || !materialProperty->isReadOnly();
-
-        QString name = materialProperty->getValue().getName();
-        if (name.isEmpty()) {
-            name = tr("No material");
-        }
-        if (!materialNames.contains(name)) {
-            materialNames.append(name);
+        if (input.object) {
+            objects.push_back(input.object);
         }
     }
-
-    panel->ui.materialButton->setEnabled(hasAssignableMaterial);
-    if (materialNames.isEmpty()) {
-        panel->ui.materialButton->setText(tr("No material"));
-    }
-    else if (materialNames.size() <= 2) {
-        panel->ui.materialButton->setText(materialNames.join(QStringLiteral(", ")));
-    }
-    else {
-        panel->ui.materialButton->setText(
-            materialNames.first() + QStringLiteral(", ") + materialNames.at(1)
-            + QStringLiteral(", \u2026")
-        );
-    }
-}
-
-void TaskMassProperties::onMaterialButtonPressed()
-{
-    std::vector<App::DocumentObject*> targets;
-    std::unordered_set<App::DocumentObject*> seenObjects;
-    QString commonUuid;
-    bool hasCommonMaterial = true;
-
-    for (const auto& input : objectsToMeasure) {
-        if (!input.object || !seenObjects.insert(input.object).second) {
-            continue;
-        }
-
-        auto* materialProperty = freecad_cast<Materials::PropertyMaterial*>(
-            input.object->getPropertyByName("ShapeMaterial")
-        );
-        if (!materialProperty || materialProperty->isReadOnly()) {
-            continue;
-        }
-
-        targets.push_back(input.object);
-        const QString uuid = materialProperty->getValue().getUUID();
-        if (targets.size() == 1) {
-            commonUuid = uuid;
-        }
-        else if (uuid != commonUuid) {
-            hasCommonMaterial = false;
-        }
-    }
-
-    if (targets.empty()) {
-        return;
-    }
-
-    QDialog dialog(panel);
-    dialog.setWindowTitle(tr("Assign Material"));
-    auto* layout = new QVBoxLayout(&dialog);
-
-    Materials::MaterialFilter filter;
-    filter.requirePhysical(true);
-    auto* picker = new MatGui::MaterialTreeWidget(filter, &dialog);
-    picker->setObjectName(QStringLiteral("materialTreeWidget"));
-    picker->setExpanded(true);
-    if (hasCommonMaterial && !commonUuid.isEmpty()) {
-        picker->setMaterial(commonUuid);
-    }
-    layout->addWidget(picker);
-
-    auto* buttons = new QDialogButtonBox(
-        QDialogButtonBox::Ok | QDialogButtonBox::Cancel,
-        &dialog
-    );
-    auto* okButton = buttons->button(QDialogButtonBox::Ok);
-    okButton->setEnabled(!picker->getMaterialUUID().isEmpty());
-    connect(
-        picker,
-        &MatGui::MaterialTreeWidget::materialSelected,
-        okButton,
-        [okButton](const std::shared_ptr<Materials::Material>& material) {
-            okButton->setEnabled(static_cast<bool>(material));
-        }
-    );
-    connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
-    connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
-    layout->addWidget(buttons);
-
-    if (dialog.exec() != QDialog::Accepted) {
-        return;
-    }
-
-    try {
-        const auto material = Materials::MaterialManager::getManager().getMaterial(
-            picker->getMaterialUUID()
-        );
-        if (!material) {
-            return;
-        }
-
-        std::unordered_set<App::Document*> documents;
-        for (auto* target : targets) {
-            if (auto* doc = target->getDocument()) {
-                documents.insert(doc);
-            }
-        }
-        for (auto* doc : documents) {
-            doc->openTransaction("Assign Material");
-        }
-
-        try {
-            for (auto* target : targets) {
-                auto* materialProperty = freecad_cast<Materials::PropertyMaterial*>(
-                    target->getPropertyByName("ShapeMaterial")
-                );
-                if (materialProperty && !materialProperty->isReadOnly()) {
-                    materialProperty->setValue(*material);
-                }
-            }
-            for (auto* doc : documents) {
-                doc->commitTransaction();
-            }
-        }
-        catch (...) {
-            for (auto* doc : documents) {
-                if (doc->hasPendingTransaction()) {
-                    doc->abortTransaction();
-                }
-            }
-            throw;
-        }
-
-        tryUpdate();
-    }
-    catch (const Base::Exception& e) {
-        QMessageBox::warning(panel, tr("Assign Material"), QString::fromUtf8(e.what()));
-    }
-    catch (const std::exception& e) {
-        QMessageBox::warning(panel, tr("Assign Material"), QString::fromUtf8(e.what()));
-    }
+    panel->ui.materialButton->setObjects(objects);
 }
 
 void TaskMassProperties::onSelectionChanged(const Gui::SelectionChanges& msg)
@@ -1318,7 +1165,7 @@ void TaskMassProperties::tryUpdate()
         return;
     }
 
-    updateMaterialButton();
+    updateMaterialSelector();
 
     updateInertiaVisibility();
 

--- a/src/Mod/Measure/Gui/TaskMassProperties.h
+++ b/src/Mod/Measure/Gui/TaskMassProperties.h
@@ -68,6 +68,7 @@ public:
     void onCogDatumButtonPressed();
     void onCovDatumButtonPressed();
     void onLcsButtonPressed();
+    void onMaterialButtonPressed();
     void onCoordinateSystemChanged(MassPropertiesMode coordSystemMode);
     void onSelectCustomCoordinateSystem();
     void updateInertiaVisibility();
@@ -79,6 +80,7 @@ private:
     void escape();
     void removeTemporaryObjects();
     void clearUiFields();
+    void updateMaterialButton();
     void saveResult();
 
     TaskMassPropertiesWidget* panel = nullptr;

--- a/src/Mod/Measure/Gui/TaskMassProperties.h
+++ b/src/Mod/Measure/Gui/TaskMassProperties.h
@@ -68,7 +68,6 @@ public:
     void onCogDatumButtonPressed();
     void onCovDatumButtonPressed();
     void onLcsButtonPressed();
-    void onMaterialButtonPressed();
     void onCoordinateSystemChanged(MassPropertiesMode coordSystemMode);
     void onSelectCustomCoordinateSystem();
     void updateInertiaVisibility();
@@ -80,7 +79,7 @@ private:
     void escape();
     void removeTemporaryObjects();
     void clearUiFields();
-    void updateMaterialButton();
+    void updateMaterialSelector();
     void saveResult();
 
     TaskMassPropertiesWidget* panel = nullptr;

--- a/src/Mod/Measure/Gui/TaskMassProperties.ui
+++ b/src/Mod/Measure/Gui/TaskMassProperties.ui
@@ -174,7 +174,7 @@
 	   </widget>
 	  </item>
 	  <item row="0" column="1">
-	   <widget class="QPushButton" name="materialButton">
+	   <widget class="MatGui::MaterialSelector" name="materialButton">
 		<property name="enabled">
 		 <bool>false</bool>
 		</property>
@@ -826,6 +826,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MatGui::MaterialSelector</class>
+   <extends>QPushButton</extends>
+   <header>Mod/Material/Gui/MaterialSelector.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/Mod/Measure/Gui/TaskMassProperties.ui
+++ b/src/Mod/Measure/Gui/TaskMassProperties.ui
@@ -167,55 +167,72 @@
 	   <number>6</number>
 	  </property>
 	  <item row="0" column="0">
+	   <widget class="QLabel" name="materialLabel">
+		<property name="text">
+		 <string>Material</string>
+		</property>
+	   </widget>
+	  </item>
+	  <item row="0" column="1">
+	   <widget class="QPushButton" name="materialButton">
+		<property name="enabled">
+		 <bool>false</bool>
+		</property>
+		<property name="text">
+		 <string>No material</string>
+		</property>
+	   </widget>
+	  </item>
+	  <item row="1" column="0">
 	   <widget class="QLabel" name="volumeLabel">
 		<property name="text">
 		 <string>Volume</string>
 		</property>
 	   </widget>
 	  </item>
-	  <item row="0" column="1">
+	  <item row="1" column="1">
 	   <widget class="QLineEdit" name="volumeEdit">
 		<property name="readOnly">
 		 <bool>true</bool>
 		</property>
 	   </widget>
 	  </item>
-	  <item row="1" column="0">
+	  <item row="2" column="0">
 	   <widget class="QLabel" name="massLabel">
 		<property name="text">
 		 <string>Mass</string>
 		</property>
 	   </widget>
 	  </item>
-	  <item row="1" column="1">
+	  <item row="2" column="1">
 	   <widget class="QLineEdit" name="massEdit">
 		<property name="readOnly">
 		 <bool>true</bool>
 		</property>
 	   </widget>
 	  </item>
-	  <item row="2" column="0">
+	  <item row="3" column="0">
 	   <widget class="QLabel" name="densityLabel">
 		<property name="text">
 		 <string>Density</string>
 		</property>
 	   </widget>
 	  </item>
-	  <item row="2" column="1">
+	  <item row="3" column="1">
 	   <widget class="QLineEdit" name="densityEdit">
 		<property name="readOnly">
 		 <bool>true</bool>
 		</property>
 	   </widget>
 	  </item>
-	  <item row="3" column="0">
+	  <item row="4" column="0">
 	   <widget class="QLabel" name="surfaceAreaLabel">
 		<property name="text">
 		 <string>Surface area</string>
 		</property>
 	   </widget>
 	  </item>
-	  <item row="3" column="1">
+	  <item row="4" column="1">
 	   <widget class="QLineEdit" name="surfaceAreaEdit">
 		<property name="readOnly">
 		 <bool>true</bool>

--- a/src/Mod/Measure/InitGui.py
+++ b/src/Mod/Measure/InitGui.py
@@ -44,3 +44,5 @@ FreeCAD.MeasureManager.addMeasureType(
     QT_TRANSLATE_NOOP("TaskMeasure", "Center of mass"),
     MeasureCOM,
 )
+
+FreeCAD.__unit_test__ += ["TestMeasureGui"]

--- a/src/Mod/Measure/TestMeasureGui.py
+++ b/src/Mod/Measure/TestMeasureGui.py
@@ -44,6 +44,12 @@ class TestMassPropertiesMaterial(unittest.TestCase):
                 return button
         self.fail("Material button not found")
 
+    def test_material_selector_is_registered_widget(self):
+        selector = Gui.UiLoader().createWidget("MatGui::MaterialSelector")
+        self.assertIsNotNone(selector)
+        self.assertEqual(selector.metaObject().className(), "MatGui::MaterialSelector")
+        selector.deleteLater()
+
     def choose(self, uuid):
         errors = []
 

--- a/src/Mod/Measure/TestMeasureGui.py
+++ b/src/Mod/Measure/TestMeasureGui.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""GUI regressions for the core Measure tools."""
+
+import unittest
+
+import FreeCAD as App
+import FreeCADGui as Gui
+import MatGui
+import Materials
+import Part
+from PySide import QtCore, QtWidgets
+
+
+class TestMassPropertiesMaterial(unittest.TestCase):
+    def setUp(self):
+        self.doc = App.newDocument("MassPropertiesMaterialTest")
+        self.doc.UndoMode = 1
+
+    def tearDown(self):
+        if Gui.Control.activeDialog():
+            Gui.Control.closeDialog()
+        Gui.Selection.clearSelection()
+        App.closeDocument(self.doc.Name)
+
+    def material(self, name, density):
+        value = Materials.Material()
+        value.Name = name
+        value.addPhysicalModel(Materials.UUIDs().Density)
+        value.setPhysicalValue("Density", density)
+        return value
+
+    def feature(self, name, material_name, density):
+        obj = self.doc.addObject("Part::Feature", name)
+        obj.Shape = Part.makeBox(10, 10, 10)
+        obj.ShapeMaterial = self.material(material_name, density)
+        return obj
+
+    def material_button(self):
+        task = Gui.Control.activeTaskDialog()
+        self.assertIsNotNone(task)
+        for widget in task.getDialogContent():
+            button = widget.findChild(QtWidgets.QPushButton, "materialButton")
+            if button:
+                return button
+        self.fail("Material button not found")
+
+    def choose(self, uuid):
+        errors = []
+
+        def select_material():
+            dialog = QtWidgets.QApplication.activeModalWidget()
+            try:
+                widget = dialog.findChild(QtWidgets.QWidget, "materialTreeWidget")
+                self.assertIsNotNone(widget)
+                picker = MatGui.MaterialTreeWidget(widget)
+                picker.UUID = uuid
+                buttons = dialog.findChild(QtWidgets.QDialogButtonBox)
+                buttons.button(QtWidgets.QDialogButtonBox.Ok).click()
+            except Exception as error:
+                errors.append(error)
+                if dialog:
+                    dialog.reject()
+
+        QtCore.QTimer.singleShot(100, select_material)
+        self.material_button().click()
+        self.assertEqual(errors, [])
+
+    def test_mixed_materials_assignment_and_undo(self):
+        first = self.feature("First", "Brass", "8500 kg/m^3")
+        second = self.feature("Second", "Iron", "7874 kg/m^3")
+        third = self.feature("Third", "Aluminium", "2700 kg/m^3")
+        Gui.Selection.addSelection(first)
+        Gui.Selection.addSelection(second)
+        Gui.Selection.addSelection(third)
+        Gui.runCommand("Std_MassProperties")
+        Gui.updateGui()
+        self.assertEqual(self.material_button().text(), "Brass, Iron, …")
+
+        steel_uuid = "92589471-a6cb-4bbc-b748-d425a17dea7d"
+        self.choose(steel_uuid)
+        for obj in (first, second, third):
+            self.assertEqual(obj.ShapeMaterial.UUID, steel_uuid)
+        self.assertEqual(self.material_button().text(), "CalculiX-Steel")
+
+        self.doc.undo()
+        self.assertEqual(first.ShapeMaterial.Name, "Brass")
+        self.assertEqual(second.ShapeMaterial.Name, "Iron")
+        self.assertEqual(third.ShapeMaterial.Name, "Aluminium")
+
+    def test_link_selection_edits_source_material(self):
+        source = self.feature("Source", "Brass", "8500 kg/m^3")
+        link = self.doc.addObject("App::Link", "Occurrence")
+        link.setLink(source)
+        Gui.Selection.addSelection(link)
+        Gui.runCommand("Std_MassProperties")
+        Gui.updateGui()
+        self.assertEqual(self.material_button().text(), "Brass")
+
+        iron_uuid = "1826c364-d26a-43fb-8f61-288281236836"
+        self.choose(iron_uuid)
+        self.assertEqual(source.ShapeMaterial.UUID, iron_uuid)
+        self.assertEqual(self.material_button().text(), "Iron-Generic")


### PR DESCRIPTION
Add a material button in mass properties
<img width="417" height="292" alt="image" src="https://github.com/user-attachments/assets/2a5b3fc7-a9e7-48d7-b044-0bb9970d5fd1" />
Clicking the button opens the material picker.

This is for convenience to let user edit material easily.
Also it also shows the material name in the physical properties task box.

@FreeCAD/design-working-group 