### PR TITLE
CAM: restore default pre/postamble in KineticNCBeamicon2 legacy post

### DIFF
--- a/src/Mod/CAM/CAMTests/TestKineticNCBeamicon2LegacyPost.py
+++ b/src/Mod/CAM/CAMTests/TestKineticNCBeamicon2LegacyPost.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+from importlib import reload
+
+import FreeCAD
+
+import Path
+import CAMTests.PathTestUtils as PathTestUtils
+from Path.Post.scripts import KineticNCBeamicon2_legacy_post as postprocessor
+
+Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
+Path.Log.trackModule(Path.Log.thisModule())
+
+
+class TestKineticNCBeamicon2LegacyPost(PathTestUtils.PathTestBase):
+    @classmethod
+    def setUpClass(cls):
+        """setUpClass()...
+        This method is called upon instantiation of this test class.  Add code
+        and objects here that are needed for the duration of the test() methods
+        in this class.  In other words, set up the 'global' test environment
+        here; use the `setUp()` method to set up a 'local' test environment.
+        This method does not have access to the class `self` reference, but it
+        is able to call static methods within this same class.
+        """
+
+        FreeCAD.newDocument("Unnamed")
+
+    @classmethod
+    def tearDownClass(cls):
+        """tearDownClass()...
+        This method is called prior to destruction of this test class.  Add
+        code and objects here that cleanup the test environment after the
+        test() methods in this class have been executed.  This method does
+        not have access to the class `self` reference.  This method is able
+        to call static methods within this same class.
+        """
+        FreeCAD.closeDocument(FreeCAD.ActiveDocument.Name)
+
+    def setUp(self):
+        """setUp()...
+        This method is called prior to each `test()` method.  Add code and
+        objects here that are needed for multiple `test()` methods.
+        """
+        self.doc = FreeCAD.ActiveDocument
+        self.con = FreeCAD.Console
+        self.docobj = FreeCAD.ActiveDocument.addObject("Path::Feature", "testpath")
+        reload(
+            postprocessor
+        )  # technical debt.  This shouldn't be necessary but here to bypass a bug
+
+    def tearDown(self):
+        """tearDown()...
+        This method is called after each test() method. Add cleanup instructions here.
+        Such cleanup instructions will likely undo those in the setUp() method.
+        """
+        FreeCAD.ActiveDocument.removeObject("testpath")
+
+    def test000(self):
+        """Test Output Generation.
+        Empty path.  Produces only the preamble and postamble.
+        """
+
+        self.docobj.Path = Path.Path([])
+        postables = [self.docobj]
+
+        expected = """(begin preamble)
+%
+G17 G21 G40 G49 G80 G90
+G21
+(begin operation: testpath)
+(machine: not set, mm/min)
+(finish operation: testpath)
+(begin postamble)
+M05
+M09
+G17 G90 G80 G40
+M30
+"""
+
+        args = "--no-header --no-show-editor"
+        gcode = postprocessor.export(postables, "-", args)
+        self.assertEqual(gcode, expected)
+
+    def test010(self):
+        """Test that the default preamble and postamble survive an empty argstring.
+
+        Regression guard for issue #31387: argparse defaults of "" for
+        --preamble/--postamble silently overwrote the module defaults, which
+        dropped the spindle stop (M05) and program end (M30) from every file
+        this post produced.
+        """
+
+        self.docobj.Path = Path.Path([])
+        postables = [self.docobj]
+
+        args = "--no-header --no-comments --no-show-editor"
+        gcode = postprocessor.export(postables, "-", args)
+
+        self.assertEqual(
+            gcode,
+            """%
+G17 G21 G40 G49 G80 G90
+G21
+M05
+M09
+G17 G90 G80 G40
+M30
+""",
+        )
+
+    def test020(self):
+        """Test that an explicit preamble and postamble still override the defaults."""
+
+        self.docobj.Path = Path.Path([])
+        postables = [self.docobj]
+
+        args = "--no-header --no-comments --no-show-editor "
+        args += "--preamble='G18 G55' --postamble='G0 Z50\nM2'"
+        gcode = postprocessor.export(postables, "-", args)
+        lines = gcode.splitlines()
+
+        self.assertEqual(lines[0], "G18 G55")
+        self.assertEqual(lines[-2], "G0 Z50")
+        self.assertEqual(lines[-1], "M2")
+
+    def test030(self):
+        """Test that the argument help text is well formed.
+
+        The default preamble starts with "%", which argparse treats as a
+        format specifier when it expands a help string.  An unescaped "%"
+        makes parser.format_help() -- used to build TOOLTIP_ARGS -- raise
+        ValueError: badly formed help string.
+        """
+
+        tooltip_args = postprocessor.parser.format_help()
+        self.assertIn("--preamble", tooltip_args)
+        self.assertIn("--postamble", tooltip_args)

--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -574,6 +574,7 @@ SET(Tests_SRCS
     CAMTests/TestGenericPost.py
     CAMTests/TestGenericPlasma.py
     CAMTests/TestGrblPost.py
+    CAMTests/TestKineticNCBeamicon2LegacyPost.py
     CAMTests/TestLinuxCNCPost.py
     CAMTests/TestLinuxCNCLegacyPost.py
     CAMTests/TestLinkingGenerator.py

--- a/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_legacy_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_legacy_post.py
@@ -87,10 +87,20 @@ parser.add_argument(
     help="don't pop up editor before writing output",
 )
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
+# The "%" in the default preamble is escaped because argparse applies
+# %-formatting when it expands a help string.
 parser.add_argument(
-    "--preamble", help="set commands to be issued before the first command", default=""
+    "--preamble",
+    help='set commands to be issued before the first command, default="'
+    + PREAMBLE.replace("\n", "\\n").replace("%", "%%")
+    + '"',
 )
-parser.add_argument("--postamble", default="")
+parser.add_argument(
+    "--postamble",
+    help='set commands to be issued after the last command, default="'
+    + POSTAMBLE.replace("\n", "\\n").replace("%", "%%")
+    + '"',
+)
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"
 )


### PR DESCRIPTION


Commit 1eddca7 fixed a crash in this post's argument parser: the default PREAMBLE begins with "%", and argparse applies %-formatting when it expands a help string, so building the help text from PREAMBLE raised "ValueError: badly formed help string" from parser.format_help().

The fix removed the interpolated help text but also gave --preamble and --postamble a default of "".  processArguments() overrides the module defaults with "if args.preamble is not None", a guard that only holds when argparse yields None, so both defaults were silently replaced by the empty string on every run.  Output degraded to a single "G21" line: no program start, no G17/G40/G49/G90 initialisation, and -- the reason this is urgent -- no M05 spindle stop and no M30 at program end.

Restore the informative help text with "%" escaped as "%%", and drop the "" defaults so the module constants survive again.

Add TestKineticNCBeamicon2LegacyPost covering the default preamble and postamble, explicit overrides, and that format_help() stays well formed.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by Claude Code Fable


## Issues
Fixes #31387 

## Before and After Images
N/A


