### PR TITLE
Core: Fix locked property added in transaction cannot be undone

### DIFF
--- a/src/App/Transactions.cpp
+++ b/src/App/Transactions.cpp
@@ -352,6 +352,12 @@ void TransactionObject::applyChn(Document& /*Doc*/, TransactionalObject* pcObj, 
 
             if (!data.property) {
                 // here means we are undoing/redoing and property add operation
+                Property* propToRemove = pcObj->getDynamicPropertyByName(v.second.name.c_str());
+                if (propToRemove) {
+                    // Temporarily remove the lock so the transaction can undo the creation
+                    propToRemove->setStatus(App::Property::LockDynamic, false);
+                }
+                
                 pcObj->removeDynamicProperty(v.second.name.c_str());
                 continue;
             }


### PR DESCRIPTION
Temporarily removes the App::Property::LockDynamic flag during transaction rollback so the property can be successfully deleted. Fixes #32285.

**Summary of changes:**
When adding a locked dynamic property within a transaction, the undo process (`TransactionObject::applyChn`) attempts to remove it via `removeDynamicProperty`. However, `removeDynamicProperty` strictly blocks the removal of properties with the `LockDynamic` status set, causing the newly added property to be orphaned (left behind) while standard properties successfully revert. This PR temporarily unsets the `LockDynamic` flag right before the transaction deletes the property during a rollback, restoring expected undo behavior.

*(Note: The debugging and formulation of this fix was assisted by Gemini).*

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

## Issues
Fixes #32285

## Before and After Images


 ### Before


https://github.com/user-attachments/assets/50dc77c0-93fb-4a6f-b620-3b44405b6d7d



 ### After

https://github.com/user-attachments/assets/3ab79396-788e-43c6-aaf8-aa4a023c0044



