### PR TITLE
Fix ValueError crash on redundant or conflicting datum

### DIFF
--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -940,6 +940,11 @@ PyObject* SketchObjectPy::setDatum(PyObject* args)
                     << " for the constraint with index " << Index;
                 break;
         }
+        if (err == -2 || err == -3) {
+            PySys_WriteStdout("Warning: %s\n", str.str().c_str());
+            Py_Return; 
+        }
+
         PyErr_SetString(PyExc_ValueError, str.str().c_str());
         return nullptr;
     }

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -942,7 +942,7 @@ PyObject* SketchObjectPy::setDatum(PyObject* args)
         }
         if (err == -2 || err == -3) {
             PySys_WriteStdout("Warning: %s\n", str.str().c_str());
-            Py_Return; 
+            Py_Return;
         }
 
         PyErr_SetString(PyExc_ValueError, str.str().c_str());


### PR DESCRIPTION
This Pull Request resolves a fatal runtime exception and UI crash in the Sketcher module when a user applies a redundant or conflicting dimensional constraint (such as adding a conflicting angle constraint over an existing perpendicular constraint).

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

AI Assistance Disclosure:
Assisted-by: gemini-2.5-pro
All code changes have been independently verified, locally compiled, and manually tested by the contributor.

Issues
fixes #32264

Before and After Images

### Before

<img width="1628" height="822" alt="Screenshot 2026-09-02 015555" src="https://github.com/user-attachments/assets/ecf0e0b3-2895-469c-b9ea-f58d7385f786" />


### After

<img width="1615" height="821" alt="Screenshot 2026-09-02 015728" src="https://github.com/user-attachments/assets/34097836-d8fa-41ed-85cc-70a922dff094" />

