### PR TITLE
BIM/CAM/Draft: change makeLine etc. to make_line etc.

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -1813,7 +1813,7 @@ def joinWalls(walls, delete=False, deletebase=False):
                 else:
                     newSk = None
             if newSk:
-                sk = Draft.makeSketch(base.Base, autoconstraints=True, addTo=newSk)
+                sk = Draft.make_sketch(base.Base, autoconstraints=True, addTo=newSk)
                 base.Base = sk
             else:
                 sk = base.Base

--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -745,7 +745,7 @@ def removeShape(objs, mark=True):
                     import Arch
 
                     place.move(place.Rotation.multVec(Vector(-length / 2, 0, 0)))
-                    line = Draft.makeLine(Vector(0, 0, 0), Vector(length, 0, 0))
+                    line = Draft.make_line(Vector(0, 0, 0), Vector(length, 0, 0))
                     line.Placement = place
                     wall = Arch.makeWall(
                         line, width=width, height=height, align="Center", name=name

--- a/src/Mod/BIM/ArchNesting.py
+++ b/src/Mod/BIM/ArchNesting.py
@@ -266,8 +266,8 @@ class Nester:
                     rotface.rotate(rotface.CenterOfMass, normal, rotation)
                 bof = rotface.BoundBox
                 rotverts = self.order(rotface)
-                # for i,v in enumerate(rotverts):
-                #    Draft.makeText([str(i)],point=v)
+                # for i, v in enumerate(rotverts):
+                #    Draft.make_text([str(i)], point=v)
                 basepoint = rotverts[0]  # leftmost point of the rotated face
                 basecorner = boc.getPoint(0)  # lower left corner of the container
 
@@ -362,7 +362,7 @@ class Nester:
 
                                 if outside:
                                     fpts.append([faceverts[0], i])
-                                    # Draft.makeText([str(i)],point=faceverts[0])
+                                    # Draft.make_text([str(i)], point=faceverts[0])
 
                             # reorder available solutions around a same point if needed
                             # ensure they are in the correct order
@@ -449,8 +449,8 @@ class Nester:
                             for p in sheet:
                                 Part.show(p[1])
                             Part.show(facecopy)
-                            # for i,p in enumerate(faceverts):
-                            #    Draft.makeText([str(i)],point=p)
+                            # for i, p in enumerate(faceverts):
+                            #    Draft.make_text([str(i)], point=p)
                             return
 
                         if pol.isValid():

--- a/src/Mod/BIM/bimcommands/BimCurtainwall.py
+++ b/src/Mod/BIM/bimcommands/BimCurtainwall.py
@@ -123,7 +123,7 @@ class Arch_CurtainWall:
             FreeCADGui.addModule("Draft")
             FreeCADGui.addModule("Arch")
             FreeCADGui.doCommand(
-                "base = Draft.makeLine(FreeCAD."
+                "base = Draft.make_line(FreeCAD."
                 + str(self.points[0])
                 + ",FreeCAD."
                 + str(self.points[1])

--- a/src/Mod/BIM/bimcommands/BimDrawingView.py
+++ b/src/Mod/BIM/bimcommands/BimDrawingView.py
@@ -77,11 +77,11 @@ class BIM_DrawingView:
             FreeCADGui.doCommand("obj = Arch.make2DDrawing()")
         FreeCADGui.doCommand("Draft.autogroup(obj)")
         if section:
-            FreeCADGui.doCommand("vobj = Draft.make_shape2dview(" + section_object + ")")
+            FreeCADGui.doCommand("vobj = Draft.make_shape_2d_view(" + section_object + ")")
             FreeCADGui.doCommand("vobj.Label = " + repr(translate("BIM", "Viewed lines")))
             FreeCADGui.doCommand("vobj.InPlace = False")
             FreeCADGui.doCommand("obj.addObject(vobj)")
-            FreeCADGui.doCommand("cobj = Draft.make_shape2dview(" + section_object + ")")
+            FreeCADGui.doCommand("cobj = Draft.make_shape_2d_view(" + section_object + ")")
             FreeCADGui.doCommand("cobj.Label = " + repr(translate("BIM", "Cut lines")))
             FreeCADGui.doCommand("cobj.InPlace = False")
             FreeCADGui.doCommand('cobj.ProjectionMode = "Cutfaces"')

--- a/src/Mod/BIM/bimcommands/BimProjectManager.py
+++ b/src/Mod/BIM/bimcommands/BimProjectManager.py
@@ -310,7 +310,7 @@ class BIM_ProjectManager:
             # Outline
             if buildingWidth and buildingLength:
                 if not outline:
-                    outline = Draft.makeRectangle(buildingLength, buildingWidth, face=False)
+                    outline = Draft.make_rectangle(buildingLength, buildingWidth, face=False)
                     outline.Label = translate("BIM", "Building Outline")
                     outline.ViewObject.DrawStyle = "Dashed"
                     grp.addObject(outline)

--- a/src/Mod/BIM/bimcommands/BimReextrude.py
+++ b/src/Mod/BIM/bimcommands/BimReextrude.py
@@ -87,7 +87,7 @@ class BIM_Reextrude:
             if wirable:
                 # recompose the base wire
                 verts = [v.Point for v in fac.Wires[0].OrderedVertexes]
-                wir = Draft.makeWire(verts, closed=True)
+                wir = Draft.make_wire(verts, closed=True)
             else:
                 # there are curves. Unable to make a wire. We just use the base face
                 wir = FreeCAD.ActiveDocument.addObject("Part::Feature", "Face")

--- a/src/Mod/BIM/bimcommands/BimRewire.py
+++ b/src/Mod/BIM/bimcommands/BimRewire.py
@@ -65,7 +65,7 @@ class BIM_Rewire:
                 nobj.shape = wire
                 selectlist.append(nobj)
             else:
-                selectlist.append(Draft.makeWire([v.Point for v in wire.OrderedVertexes]))
+                selectlist.append(Draft.make_wire([v.Point for v in wire.OrderedVertexes]))
         for name in names:
             FreeCAD.ActiveDocument.removeObject(name)
         FreeCAD.ActiveDocument.commitTransaction()

--- a/src/Mod/BIM/bimcommands/BimShape2DView.py
+++ b/src/Mod/BIM/bimcommands/BimShape2DView.py
@@ -73,7 +73,7 @@ class BIM_Shape2DView(gui_shape2dview.Shape2DView):
         commitlist = []
         FreeCADGui.addModule("Draft")
         if len(objs) == 1 and faces:
-            _cmd = "Draft.make_shape2dview"
+            _cmd = "Draft.make_shape_2d_view"
             _cmd += "("
             _cmd += "FreeCAD.ActiveDocument." + objs[0].Name + ", "
             _cmd += DraftVecUtils.toString(vec) + ", "
@@ -86,7 +86,7 @@ class BIM_Shape2DView(gui_shape2dview.Shape2DView):
         else:
             n = 0
             for o in objs:
-                _cmd = "Draft.make_shape2dview"
+                _cmd = "Draft.make_shape_2d_view"
                 _cmd += "("
                 _cmd += "FreeCAD.ActiveDocument." + o.Name + ", "
                 _cmd += DraftVecUtils.toString(vec)

--- a/src/Mod/BIM/bimcommands/BimTruss.py
+++ b/src/Mod/BIM/bimcommands/BimTruss.py
@@ -118,7 +118,7 @@ class Arch_Truss:
         FreeCADGui.addModule("Arch")
         if not basename:
             if self.points:
-                cmd = "base = Draft.makeLine(FreeCAD."
+                cmd = "base = Draft.make_line(FreeCAD."
                 cmd += str(self.points[0]) + ",FreeCAD." + str(self.points[1]) + ")"
                 FreeCADGui.doCommand(cmd)
                 basename = "base"

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -470,7 +470,7 @@ class BIM_Views:
         import WorkingPlane
 
         FreeCAD.ActiveDocument.openTransaction("Create WP Proxy")
-        obj = Draft.make_workingplaneproxy(WorkingPlane.get_working_plane().get_placement())
+        obj = Draft.make_working_plane_proxy(WorkingPlane.get_working_plane().get_placement())
         self.addToSelection(obj)
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -470,7 +470,7 @@ class BIM_Views:
         import WorkingPlane
 
         FreeCAD.ActiveDocument.openTransaction("Create WP Proxy")
-        obj = Draft.makeWorkingPlaneProxy(WorkingPlane.get_working_plane().get_placement())
+        obj = Draft.make_workingplaneproxy(WorkingPlane.get_working_plane().get_placement())
         self.addToSelection(obj)
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()

--- a/src/Mod/BIM/bimtests/TestArchBuildingPartGui.py
+++ b/src/Mod/BIM/bimtests/TestArchBuildingPartGui.py
@@ -16,7 +16,7 @@ class TestArchBuildingPartGui(TestArchBaseGui):
         # operation = "Arch BuildingPart"
         # _msg("  Test '{}'".format(operation))
         # Most of the code below taken from testWindow function.
-        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(3000, 0, 0))
+        line = Draft.make_line(App.Vector(0, 0, 0), App.Vector(3000, 0, 0))
         wall = Arch.makeWall(line)
         sk = App.ActiveDocument.addObject("Sketcher::SketchObject", "Sketch001")
         sk.Placement.Rotation = App.Rotation(App.Vector(1, 0, 0), 90)

--- a/src/Mod/BIM/bimtests/TestArchComponent.py
+++ b/src/Mod/BIM/bimtests/TestArchComponent.py
@@ -39,7 +39,7 @@ class TestArchComponent(TestArchBase.TestArchBase):
 
     def testAdd(self):
         App.Console.PrintLog("Checking Arch Add...\n")
-        l = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(2, 0, 0))
+        l = Draft.make_line(App.Vector(0, 0, 0), App.Vector(2, 0, 0))
         w = Arch.makeWall(l, width=0.2, height=2)
         sb = Part.makeBox(1, 1, 1)
         b = App.ActiveDocument.addObject("Part::Feature", "Box")
@@ -123,7 +123,7 @@ class TestArchComponent(TestArchBase.TestArchBase):
 
     def testRemove(self):
         App.Console.PrintLog("Checking Arch Remove...\n")
-        l = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(2, 0, 0))
+        l = Draft.make_line(App.Vector(0, 0, 0), App.Vector(2, 0, 0))
         w = Arch.makeWall(l, width=0.2, height=2, align="Right")
         sb = Part.makeBox(1, 1, 1)
         b = App.ActiveDocument.addObject("Part::Feature", "Box")
@@ -163,14 +163,14 @@ class TestArchComponent(TestArchBase.TestArchBase):
             points.append(App.Vector(x, y, 0))
 
         # Create Draft objects
-        bspline = Draft.makeBSpline(points, closed=False)
-        closingLine = Draft.makeLine(points[-1], points[0])
+        bspline = Draft.make_bspline(points, closed=False)
+        closingLine = Draft.make_line(points[-1], points[0])
         doc.recompute()
 
         # Create sketch
-        # We do this because Draft.make_wires does not support B-splines
+        # We do this because Draft.make_wire does not support B-splines
         # and we need a closed wire for the slab
-        sketch = Draft.makeSketch([bspline, closingLine], autoconstraints=True, delete=True)
+        sketch = Draft.make_sketch([bspline, closingLine], autoconstraints=True, delete=True)
         if sketch is None:
             self.fail("Sketch creation failed")
         sketch.recompute()
@@ -240,7 +240,7 @@ class TestArchComponent(TestArchBase.TestArchBase):
         ]
 
         # Create wire with automatic face creation
-        wire = Draft.makeWire(points, closed=True, face=True)
+        wire = Draft.make_wire(points, closed=True, face=True)
         if not wire:
             self.fail(f"Wire creation failed with points: {points}\n")
         doc.recompute()
@@ -302,7 +302,7 @@ class TestArchComponent(TestArchBase.TestArchBase):
         """
 
         # Create a basic wall
-        wall_base = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(3000, 0, 0))
+        wall_base = Draft.make_line(App.Vector(0, 0, 0), App.Vector(3000, 0, 0))
         wall = Arch.makeWall(wall_base, width=200, height=2500)
 
         # Create a window to be added to the wall
@@ -311,7 +311,7 @@ class TestArchComponent(TestArchBase.TestArchBase):
 
         # Create a Draft Rectangle for the window's Base. Arch.makeWindow can work with
         # either a Wire or a Face.
-        window_base = Draft.makeRectangle(length=window_width, height=window_height)
+        window_base = Draft.make_rectangle(length=window_width, height=window_height)
 
         window = Arch.makeWindow(baseobj=window_base)
         window.Width = window_width  # Manually set as makeWindow(base) doesn't
@@ -361,7 +361,7 @@ class TestArchComponent(TestArchBase.TestArchBase):
             return not (is_vertical(normal_z) or is_horizontal(normal_z))
 
         with self.subTest(case="Standard Wall"):
-            line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(10, 0, 0))
+            line = Draft.make_line(App.Vector(0, 0, 0), App.Vector(10, 0, 0))
             wall = Arch.makeWall(line, width=2, height=10)
             self.document.recompute()
 
@@ -384,7 +384,7 @@ class TestArchComponent(TestArchBase.TestArchBase):
 
         with self.subTest(case="Closed Extrusion"):
             points = [App.Vector(0, 0, 0), App.Vector(10, 0, 0), App.Vector(5, 5, 0)]
-            bspline = Draft.makeBSpline(points, closed=True)
+            bspline = Draft.make_bspline(points, closed=True)
             structure = Arch.makeStructure(bspline, height=10)
             self.document.recompute()
 
@@ -405,7 +405,7 @@ class TestArchComponent(TestArchBase.TestArchBase):
             )
 
         with self.subTest(case="Cylinder"):
-            circle = Draft.makeCircle(radius=5)
+            circle = Draft.make_circle(radius=5)
             struct = Arch.makeStructure(circle, height=20)
             self.document.recompute()
 
@@ -430,10 +430,10 @@ class TestArchComponent(TestArchBase.TestArchBase):
         with self.subTest(case="Generic Vertical Surface"):
             # Create two B-spline curves, vertically aligned
             points1 = [App.Vector(0, 0, 0), App.Vector(5, 5, 0), App.Vector(10, 0, 0)]
-            bspline1 = Draft.makeBSpline(points1, closed=False)
+            bspline1 = Draft.make_bspline(points1, closed=False)
 
             points2 = [App.Vector(0, 0, 20), App.Vector(5, 5, 20), App.Vector(10, 0, 20)]
-            bspline2 = Draft.makeBSpline(points2, closed=False)
+            bspline2 = Draft.make_bspline(points2, closed=False)
 
             # Create a ruled surface (Loft)
             loft = self.document.addObject("Part::Loft", "GenericVerticalLoft")
@@ -499,7 +499,7 @@ class TestArchComponent(TestArchBase.TestArchBase):
         Verify that VerticalArea property updates correctly even when the result is zero.
         """
 
-        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(10, 0, 0))
+        line = Draft.make_line(App.Vector(0, 0, 0), App.Vector(10, 0, 0))
         wall = Arch.makeWall(line, width=2, height=10)
         self.document.recompute()
 
@@ -550,9 +550,9 @@ class TestArchComponent(TestArchBase.TestArchBase):
         # Create generic geometry (Ruled Surface / Loft)
         # Reuse the B-Spline logic that triggers the fallback projection path
         points1 = [App.Vector(40, 0, 0), App.Vector(45, 5, 0), App.Vector(50, 0, 0)]
-        bspline1 = Draft.makeBSpline(points1, closed=False)
+        bspline1 = Draft.make_bspline(points1, closed=False)
         points2 = [App.Vector(40, 0, 10), App.Vector(45, 5, 10), App.Vector(50, 0, 10)]
-        bspline2 = Draft.makeBSpline(points2, closed=False)
+        bspline2 = Draft.make_bspline(points2, closed=False)
 
         loft = self.document.addObject("Part::Loft", "IntegrationLoft")
         loft.Sections = [bspline1, bspline2]
@@ -811,13 +811,13 @@ class TestArchComponent(TestArchBase.TestArchBase):
         self.printTestMessage(operation)
 
         # Create the host wall
-        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(4000, 0, 0))
+        line = Draft.make_line(App.Vector(0, 0, 0), App.Vector(4000, 0, 0))
         wall = Arch.makeWall(line, width=200, height=3000, align="Center")
         self.document.recompute()
         initial_volume = wall.Shape.Volume
 
         # Create a prototype window
-        rect = Draft.makeRectangle(length=1000, height=1500)
+        rect = Draft.make_rectangle(length=1000, height=1500)
         rect.Placement.Rotation = App.Rotation(App.Vector(1, 0, 0), 90)
         rect.Placement.Base = App.Vector(0, 0, 0)
         self.document.recompute()
@@ -852,13 +852,13 @@ class TestArchComponent(TestArchBase.TestArchBase):
         self.printTestMessage(operation)
 
         # Create the host wall
-        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(4000, 0, 0))
+        line = Draft.make_line(App.Vector(0, 0, 0), App.Vector(4000, 0, 0))
         wall = Arch.makeWall(line, width=200, height=3000, align="Center")
         self.document.recompute()
         initial_volume = wall.Shape.Volume
 
         # Create a prototype window
-        rect = Draft.makeRectangle(length=1000, height=1500)
+        rect = Draft.make_rectangle(length=1000, height=1500)
         rect.Placement.Rotation = App.Rotation(App.Vector(1, 0, 0), 90)
         rect.Placement.Base = App.Vector(0, 0, 0)
         self.document.recompute()
@@ -890,13 +890,13 @@ class TestArchComponent(TestArchBase.TestArchBase):
         self.printTestMessage(operation)
 
         # Create the host wall
-        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(4000, 0, 0))
+        line = Draft.make_line(App.Vector(0, 0, 0), App.Vector(4000, 0, 0))
         wall = Arch.makeWall(line, width=200, height=3000, align="Center")
         self.document.recompute()
         initial_volume = wall.Shape.Volume
 
         # Create a prototype window
-        rect = Draft.makeRectangle(length=1000, height=1500)
+        rect = Draft.make_rectangle(length=1000, height=1500)
         rect.Placement.Rotation = App.Rotation(App.Vector(1, 0, 0), 90)
         rect.Placement.Base = App.Vector(0, 0, 0)
         self.document.recompute()

--- a/src/Mod/BIM/bimtests/TestArchCovering.py
+++ b/src/Mod/BIM/bimtests/TestArchCovering.py
@@ -208,7 +208,7 @@ class TestArchCovering(TestArchBase.TestArchBase):
         """Verify that open wires are rejected as base objects."""
         self.printTestMessage("open wire guard...")
         # Create an open Draft Line
-        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(500, 0, 0))
+        line = Draft.make_line(App.Vector(0, 0, 0), App.Vector(500, 0, 0))
         self.document.recompute()
 
         covering = Arch.makeCovering(line)

--- a/src/Mod/BIM/bimtests/TestArchFence.py
+++ b/src/Mod/BIM/bimtests/TestArchFence.py
@@ -32,9 +32,9 @@ class TestArchFence(TestArchBase.TestArchBase):
 
     def test_makeFence(self):
         # Create section, post, and path objects
-        section = Draft.makeRectangle(100, 10)
-        post = Draft.makeRectangle(10, 10)
-        path = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(1000, 0, 0))
+        section = Draft.make_rectangle(100, 10)
+        post = Draft.make_rectangle(10, 10)
+        path = Draft.make_line(App.Vector(0, 0, 0), App.Vector(1000, 0, 0))
 
         # Create a fence
         fence = Arch.makeFence(section, post, path)

--- a/src/Mod/BIM/bimtests/TestArchFrame.py
+++ b/src/Mod/BIM/bimtests/TestArchFrame.py
@@ -38,7 +38,7 @@ class TestArchFrame(TestArchBase.TestArchBase):
         self.assertEqual(obj.Label, "Frame", "Incorrect default label for Frame")
 
     def testFrame(self):
-        l = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(-2, 0, 0))
-        p = Draft.makeRectangle(length=0.5, height=0.5)
+        l = Draft.make_line(App.Vector(0, 0, 0), App.Vector(-2, 0, 0))
+        p = Draft.make_rectangle(length=0.5, height=0.5)
         f = Arch.makeFrame(l, p)
         self.assertTrue(f, "Arch Frame failed")

--- a/src/Mod/BIM/bimtests/TestArchReport.py
+++ b/src/Mod/BIM/bimtests/TestArchReport.py
@@ -757,7 +757,7 @@ class TestArchReport(TestArchBase.TestArchBase):
         # 3. Child objects
         space1 = Arch.makeSpace(name="Living Room")
         space2 = Arch.makeSpace(name="Kitchen")
-        win_profile = Draft.makeRectangle(length=1000, height=1200)
+        win_profile = Draft.make_rectangle(length=1000, height=1200)
         window = Arch.makeWindow(baseobj=win_profile, name="Living Room Window")
 
         # 4. An intermediate generic group
@@ -1149,11 +1149,11 @@ class TestArchReport(TestArchBase.TestArchBase):
         building = Arch.makeBuilding(name="Test Building")
         floor = Arch.makeFloor(name="Test Floor")
         wall = Arch.makeWall(name="Test Wall")
-        win_profile = Draft.makeRectangle(1000, 1000)
+        win_profile = Draft.make_rectangle(1000, 1000)
         window = Arch.makeWindow(win_profile, name="Test Window")
 
         generic_group = self.doc.addObject("App::DocumentObjectGroup", "Test Generic Group")
-        space_profile = Draft.makeRectangle(2000, 2000)
+        space_profile = Draft.make_rectangle(2000, 2000)
         space = Arch.makeSpace(space_profile, name="Test Space")
 
         site.addObject(building)
@@ -1855,7 +1855,7 @@ class TestArchReport(TestArchBase.TestArchBase):
         # ARRANGE: Create a multi-level hierarchy (Floor -> Wall -> Window)
         floor = Arch.makeFloor(name="TraversalTestFloor")
         wall = Arch.makeWall(name="TraversalTestWall")
-        win_profile = Draft.makeRectangle(1000, 1000)
+        win_profile = Draft.make_rectangle(1000, 1000)
         window = Arch.makeWindow(win_profile, name="TraversalTestWindow")
 
         # Establish the relationships
@@ -1889,7 +1889,7 @@ class TestArchReport(TestArchBase.TestArchBase):
         # Floor -> Generic Group -> Space
         floor = Arch.makeFloor(name="GroupTestFloor")
         group = self.doc.addObject("App::DocumentObjectGroup", "GenericTestGroup")
-        space_profile = Draft.makeRectangle(500, 500)
+        space_profile = Draft.make_rectangle(500, 500)
         space = Arch.makeSpace(space_profile, name="GroupTestSpace")
 
         # Establish the relationships
@@ -1923,7 +1923,7 @@ class TestArchReport(TestArchBase.TestArchBase):
         # ARRANGE: Create a 3-level hierarchy (Floor -> Wall -> Window)
         floor = Arch.makeFloor(name="DepthTestFloor")
         wall = Arch.makeWall(name="DepthTestWall")
-        win_profile = Draft.makeRectangle(1000, 1000)
+        win_profile = Draft.make_rectangle(1000, 1000)
         window = Arch.makeWindow(win_profile, name="DepthTestWindow")
 
         floor.addObject(wall)
@@ -1973,7 +1973,7 @@ class TestArchReport(TestArchBase.TestArchBase):
         floor = Arch.makeFloor(name="SQLFuncTestFloor")
         group = self.doc.addObject("App::DocumentObjectGroup", "SQLFuncTestGroup")
         wall = Arch.makeWall(name="SQLFuncTestWall")
-        win_profile = Draft.makeRectangle(1000, 1000)
+        win_profile = Draft.make_rectangle(1000, 1000)
         window = Arch.makeWindow(win_profile, name="SQLFuncTestWindow")
 
         building.addObject(floor)

--- a/src/Mod/BIM/bimtests/TestArchRoof.py
+++ b/src/Mod/BIM/bimtests/TestArchRoof.py
@@ -39,7 +39,7 @@ class TestArchRoof(TestArchBase.TestArchBase):
         operation = "Checking Arch Roof..."
         self.printTestMessage(operation)
 
-        r = Draft.makeRectangle(length=2, height=-1)
+        r = Draft.make_rectangle(length=2, height=-1)
         r.recompute()  # required before calling Arch.makeRoof
         ro = Arch.makeRoof(r)
         self.assertTrue(ro, "Arch Roof failed")
@@ -69,7 +69,7 @@ class TestArchRoof(TestArchBase.TestArchBase):
                 runsLst = runsMod[iX % 3] + [0, 0, 0]
                 overhangsLst = overhangsMod[iX // 3] + [0, 0, 0]
                 pla.Base = App.Vector(iX * delta, iY * delta, 0)
-                wire = Draft.makeWire(pts, closed=True)
+                wire = Draft.make_wire(pts, closed=True)
                 wire.MakeFace = False
                 wire.Placement = pla
                 wire.recompute()  # required before calling Arch.makeRoof
@@ -92,7 +92,7 @@ class TestArchRoof(TestArchBase.TestArchBase):
             App.Vector(0, 2000, 0),
         ]
 
-        wire = Draft.makeWire(pts, closed=True)
+        wire = Draft.make_wire(pts, closed=True)
         wire.MakeFace = False
         wire.recompute()  # required before calling Arch.makeRoof
         roof = Arch.makeRoof(wire, angles=[90, 90, 90, 90])
@@ -107,7 +107,7 @@ class TestArchRoof(TestArchBase.TestArchBase):
         operation = "Arch Roof testRoofApex"
         self.printTestMessage(operation)
 
-        rec = Draft.makeRectangle(length=4000, height=3000, face=False)
+        rec = Draft.make_rectangle(length=4000, height=3000, face=False)
         rec.recompute()  # required before calling Arch.makeRoof
         roof = Arch.makeRoof(
             rec,
@@ -134,7 +134,7 @@ class TestArchRoof(TestArchBase.TestArchBase):
             App.Vector(4000, 2000, 0),
             App.Vector(-2000, 2000, 0),
         ]
-        wire = Draft.makeWire(pts, closed=True)
+        wire = Draft.make_wire(pts, closed=True)
         wire.MakeFace = False
         wire.recompute()  # required before calling Arch.makeRoof
         roof = Arch.makeRoof(

--- a/src/Mod/BIM/bimtests/TestArchSectionPlane.py
+++ b/src/Mod/BIM/bimtests/TestArchSectionPlane.py
@@ -135,8 +135,8 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         # Create a drawing view
         section = Arch.makeSectionPlane(level)
         drawing = Arch.make2DDrawing()
-        view = Draft.make_shape2dview(section)
-        cut = Draft.make_shape2dview(section)
+        view = Draft.make_shape_2d_view(section)
+        cut = Draft.make_shape_2d_view(section)
         cut.InPlace = False
         cut.ProjectionMode = "Cutfaces"
         drawing.addObjects([view, cut])
@@ -178,7 +178,7 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         App.ActiveDocument.recompute()
 
         section = Arch.makeSectionPlane(wall)
-        shp_view = Draft.make_shape2dview(section)
+        shp_view = Draft.make_shape_2d_view(section)
         shp_view.InPlace = False
         shp_view.ProjectionMode = "Cutfaces"
         App.ActiveDocument.recompute()

--- a/src/Mod/BIM/bimtests/TestArchStairsGui.py
+++ b/src/Mod/BIM/bimtests/TestArchStairsGui.py
@@ -70,8 +70,8 @@ class TestArchStairsGui(TestArchBaseGui):
         self._assert_visibility(stairs, True)
 
     def test_stairs_multi_segment_railing_follow_parent_visibility(self):
-        wire1 = Draft.makeWire([FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(1000, 0, 0)])
-        wire2 = Draft.makeWire([FreeCAD.Vector(1000, 0, 0), FreeCAD.Vector(1000, 1000, 0)])
+        wire1 = Draft.make_wire([FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(1000, 0, 0)])
+        wire2 = Draft.make_wire([FreeCAD.Vector(1000, 0, 0), FreeCAD.Vector(1000, 1000, 0)])
         stairs = Arch.makeStairs(baseobj=[wire1, wire2], width=800, height=2500, steps=14)
         self.document.recompute()
 

--- a/src/Mod/BIM/bimtests/TestArchWall.py
+++ b/src/Mod/BIM/bimtests/TestArchWall.py
@@ -38,7 +38,7 @@ class TestArchWall(TestArchBase.TestArchBase):
         operation = "Checking Arch Wall..."
         self.printTestMessage(operation)
 
-        l = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(-2, 0, 0))
+        l = Draft.make_line(App.Vector(0, 0, 0), App.Vector(-2, 0, 0))
         w = Arch.makeWall(l)
         self.assertTrue(w, "Arch Wall failed")
 
@@ -58,7 +58,7 @@ class TestArchWall(TestArchBase.TestArchBase):
             App.Vector(2000, 1000, 0),
         ]
         # wall based on wire:
-        wire = Draft.makeWire(pts)
+        wire = Draft.make_wire(pts)
         wallWire = Arch.makeWall(wire)
         wallWire.Material = matMulti
         # wall based on sketch:
@@ -188,8 +188,8 @@ class TestArchWall(TestArchBase.TestArchBase):
         operation = "Testing joinWalls function"
         self.printTestMessage(operation)
 
-        base_line1 = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(5000, 0, 0))
-        base_line2 = Draft.makeLine(App.Vector(5000, 0, 0), App.Vector(5000, 3000, 0))
+        base_line1 = Draft.make_line(App.Vector(0, 0, 0), App.Vector(5000, 0, 0))
+        base_line2 = Draft.make_line(App.Vector(5000, 0, 0), App.Vector(5000, 3000, 0))
         wall1 = Arch.makeWall(base_line1, width=200, height=3000)
         wall2 = Arch.makeWall(base_line2, width=200, height=3000)
         joined_wall = Arch.joinWalls([wall1, wall2])
@@ -203,7 +203,7 @@ class TestArchWall(TestArchBase.TestArchBase):
         self.printTestMessage("Testing removal of a wall's base component...")
 
         # 1. Arrange: Create a wall with a base
-        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(2000, 0, 0))
+        line = Draft.make_line(App.Vector(0, 0, 0), App.Vector(2000, 0, 0))
         # Ensure the base object's shape is computed, making the wall debasable.
         line.recompute()
         wall = Arch.makeWall(line)
@@ -224,7 +224,7 @@ class TestArchWall(TestArchBase.TestArchBase):
     def test_is_debasable_with_valid_line_base(self):
         """Tests that a wall based on a single Draft.Line is debasable."""
         self.printTestMessage("Checking is_debasable with Draft.Line...")
-        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(1000, 0, 0))
+        line = Draft.make_line(App.Vector(0, 0, 0), App.Vector(1000, 0, 0))
         line.recompute()
         wall = Arch.makeWall(line)
         self.document.recompute()
@@ -242,7 +242,7 @@ class TestArchWall(TestArchBase.TestArchBase):
     def test_is_debasable_with_multi_edge_base(self):
         """Tests that a wall based on a multi-segment wire is not debasable."""
         self.printTestMessage("Checking is_debasable with multi-segment Wire...")
-        wire = Draft.makeWire(
+        wire = Draft.make_wire(
             [App.Vector(0, 0, 0), App.Vector(1000, 0, 0), App.Vector(1000, 1000, 0)]
         )
         wall = Arch.makeWall(wire)
@@ -274,7 +274,7 @@ class TestArchWall(TestArchBase.TestArchBase):
 
         # 1. Arrange: Create a rotated and translated line, and a wall from it.
         pl = App.Placement(App.Vector(1000, 500, 200), App.Rotation(App.Vector(0, 0, 1), 45))
-        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(2000, 0, 0))
+        line = Draft.make_line(App.Vector(0, 0, 0), App.Vector(2000, 0, 0))
         line.Placement = pl
         line.recompute()  # Use object-level recompute
 
@@ -520,7 +520,7 @@ class TestArchWall(TestArchBase.TestArchBase):
         expected_vol = L * W * H
 
         # Create both wall variants: one with a base line, one baseless
-        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(L, 0, 0))
+        line = Draft.make_line(App.Vector(0, 0, 0), App.Vector(L, 0, 0))
         self.document.recompute()
         based_wall = Arch.makeWall(line, width=W, height=H)
         baseless_wall = Arch.makeWall(None, length=L, width=W, height=H)
@@ -562,7 +562,7 @@ class TestArchWall(TestArchBase.TestArchBase):
         # Create a base line offset by 5 meters for a clear distinction between local (0,0,0) and
         # global coordinates.
         # Line start/end: (5000,0,0) / (7000,0,0). Midpoint/new placement: (6000,0,0).
-        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(2000, 0, 0))
+        line = Draft.make_line(App.Vector(0, 0, 0), App.Vector(2000, 0, 0))
         line.Placement.Base = App.Vector(5000, 0, 0)
         self.document.recompute()
 
@@ -593,7 +593,7 @@ class TestArchWall(TestArchBase.TestArchBase):
 
         # Child D: a hosted Arch.Window. This is not an Addition but is found via InList by
         # getMovableChildren.
-        win_base = Draft.makeRectangle(length=500, height=800)
+        win_base = Draft.make_rectangle(length=500, height=800)
         win_base.Placement.Rotation = App.Rotation(App.Vector(1, 0, 0), 90)  # Orient vertically
         win_base.Placement.Base = App.Vector(6500, 100, 1000)  # Position in wall center
         self.document.recompute()

--- a/src/Mod/BIM/bimtests/TestArchWallGui.py
+++ b/src/Mod/BIM/bimtests/TestArchWallGui.py
@@ -503,7 +503,7 @@ class TestArchWallGui(TestArchBaseGui.TestArchBaseGui):
         )
         self.printTestMessage("Testing line-based wall with JOIN_SKETCHES=True...")
 
-        line1 = Draft.makeLine(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(1000, 0, 0))
+        line1 = Draft.make_line(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(1000, 0, 0))
         wall1 = Arch.makeWall(line1)
         self.document.recompute()
         base1_initial_edges = len(wall1.Base.Shape.Edges)
@@ -536,7 +536,7 @@ class TestArchWallGui(TestArchBaseGui.TestArchBaseGui):
         )
         self.printTestMessage("Testing line-based wall with JOIN_SKETCHES=False, AUTOJOIN=True...")
 
-        line1 = Draft.makeLine(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(1000, 0, 0))
+        line1 = Draft.make_line(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(1000, 0, 0))
         wall1 = Arch.makeWall(line1)
         self.document.recompute()
         initial_object_count = len(self.document.Objects)
@@ -560,7 +560,7 @@ class TestArchWallGui(TestArchBaseGui.TestArchBaseGui):
         )
         self.printTestMessage("Testing line-based wall fallback to AUTOJOIN...")
 
-        line1 = Draft.makeLine(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(1000, 0, 0))
+        line1 = Draft.make_line(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(1000, 0, 0))
         wall1 = Arch.makeWall(line1, width=200)  # Incompatible width
         self.document.recompute()
 
@@ -650,7 +650,7 @@ class TestArchWallGui(TestArchBaseGui.TestArchBaseGui):
         self.printTestMessage("Testing no join action when preferences are off...")
 
         # Test with a based wall
-        line1 = Draft.makeLine(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(1000, 0, 0))
+        line1 = Draft.make_line(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(1000, 0, 0))
         wall1 = Arch.makeWall(line1)
         self.document.recompute()
         initial_object_count = len(self.document.Objects)

--- a/src/Mod/BIM/bimtests/TestArchWindow.py
+++ b/src/Mod/BIM/bimtests/TestArchWindow.py
@@ -234,7 +234,7 @@ class TestArchWindow(TestArchBase.TestArchBase):
         wall_thickness = 200.0
         wall_height = 2400.0
 
-        line = Draft.makeLine(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(wall_length, 0, 0))
+        line = Draft.make_line(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(wall_length, 0, 0))
         self.document.recompute()
 
         wall = Arch.makeWall(
@@ -491,7 +491,7 @@ class TestArchWindow(TestArchBase.TestArchBase):
     def test_custom_subvolume_creates_opening(self):
         """Test that a custom Subvolume shape correctly creates an opening in a host wall."""
         # Create a wall and store its initial state
-        wall_base = Draft.makeLine(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(4000, 0, 0))
+        wall_base = Draft.make_line(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(4000, 0, 0))
         wall = Arch.makeWall(wall_base, width=200, height=3000, align="Left")
         self.document.recompute()
         initial_wall_volume = wall.Shape.Volume
@@ -554,7 +554,7 @@ class TestArchWindow(TestArchBase.TestArchBase):
         wall_length = 3000.0
         wall_thickness = 200.0
         wall_height = 2500.0
-        wall_base = Draft.makeLine(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(wall_length, 0, 0))
+        wall_base = Draft.make_line(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(wall_length, 0, 0))
         wall = Arch.makeWall(
             wall_base, width=wall_thickness, height=wall_height, name="WallForClonedWindow"
         )
@@ -634,7 +634,7 @@ class TestArchWindow(TestArchBase.TestArchBase):
         self.printTestMessage("Testing Arch.addComponents for window-wall hosting...")
 
         # Create the wall and window
-        wall_base = Draft.makeLine(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(3000, 0, 0))
+        wall_base = Draft.make_line(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(3000, 0, 0))
         wall = Arch.makeWall(wall_base, width=200, height=2500, name="HostWall")
         self.document.recompute()
         initial_wall_volume = wall.Shape.Volume

--- a/src/Mod/BIM/bimtests/fixtures/BimFixtures.py
+++ b/src/Mod/BIM/bimtests/fixtures/BimFixtures.py
@@ -88,7 +88,7 @@ def create_test_model(document, **overrides):
     p2 = FreeCAD.Vector(building_length, 0, 0)
     p3 = FreeCAD.Vector(building_length, building_width, 0)
     p4 = FreeCAD.Vector(0, building_width, 0)
-    exterior_wire = Draft.makeWire([p1, p2, p3, p4], closed=True)
+    exterior_wire = Draft.make_wire([p1, p2, p3, p4], closed=True)
     exterior_wall = Arch.makeWall(
         exterior_wire, name=LABELS["exterior_wall"], height=ground_floor_height
     )
@@ -96,7 +96,7 @@ def create_test_model(document, **overrides):
 
     p5 = FreeCAD.Vector(building_length / 2, 0, 0)
     p6 = FreeCAD.Vector(building_length / 2, building_width, 0)
-    interior_wire = Draft.makeWire([p5, p6])
+    interior_wire = Draft.make_wire([p5, p6])
     interior_wall = Arch.makeWall(
         interior_wire, name=LABELS["interior_wall"], height=interior_wall_height
     )
@@ -163,7 +163,7 @@ def create_test_model(document, **overrides):
     level_0.addObject(beam)
 
     # --- 6. Upper Floor Slab and Roof ---
-    slab_profile = Draft.makeRectangle(
+    slab_profile = Draft.make_rectangle(
         length=building_length,
         height=building_width,
         placement=FreeCAD.Placement(FreeCAD.Vector(0, 0, interior_wall_height), FreeCAD.Rotation()),
@@ -172,7 +172,7 @@ def create_test_model(document, **overrides):
     slab.IfcType = "Slab"
     level_1.addObject(slab)
 
-    roof_profile = Draft.makeRectangle(
+    roof_profile = Draft.make_rectangle(
         length=building_length + (2 * roof_overhang),
         height=building_width + (2 * roof_overhang),
         placement=FreeCAD.Placement(

--- a/src/Mod/BIM/importers/importIFC.py
+++ b/src/Mod/BIM/importers/importIFC.py
@@ -602,7 +602,7 @@ def insert(srcfile, docname, skip=[], only=[], root=None, preferences=None):
                                         if (len(ex[0].Edges) == 1) and isinstance(
                                             ex[0].Edges[0].Curve, Part.Circle
                                         ):
-                                            baseface = Draft.makeCircle(ex[0].Edges[0])
+                                            baseface = Draft.make_circle(ex[0].Edges[0])
                                         else:
                                             # curves or holes? We just make a Part face
                                             baseface = doc.addObject(
@@ -627,10 +627,10 @@ def insert(srcfile, docname, skip=[], only=[], root=None, preferences=None):
                                         # TODO verts are different if shape is made of RectangleProfileDef or not
                                         # is this a rectangle?
                                         if importIFCHelper.isRectangle(verts):
-                                            baseface = Draft.makeRectangle(verts, face=True)
+                                            baseface = Draft.make_rectangle(verts, face=True)
                                         else:
                                             # no hole and no curves, we make a Draft Wire instead
-                                            baseface = Draft.makeWire(verts, closed=True)
+                                            baseface = Draft.make_wire(verts, closed=True)
                                     if profileid:
                                         # store for possible shared use
                                         profiles[profileid] = baseface

--- a/src/Mod/BIM/importers/importSH3DHelper.py
+++ b/src/Mod/BIM/importers/importSH3DHelper.py
@@ -699,10 +699,10 @@ class SH3DImporter:
             NO = App.Vector(bb.XMin - dx, bb.YMax + dy, 0)
             NE = App.Vector(bb.XMax + dx, bb.YMax + dy, 0)
             SE = App.Vector(bb.XMax + dx, bb.YMin - dy, 0)
-            edge0 = Part.makeLine(SO, NO)
-            edge1 = Part.makeLine(NO, NE)
-            edge2 = Part.makeLine(NE, SE)
-            edge3 = Part.makeLine(SE, SO)
+            edge0 = Part.make_line(SO, NO)
+            edge1 = Part.make_line(NO, NE)
+            edge2 = Part.make_line(NE, SE)
+            edge3 = Part.make_line(SE, SO)
             ground_face = Part.makeFace([Part.Wire([edge0, edge1, edge2, edge3])])
 
             ground = App.ActiveDocument.addObject("Mesh::Feature", "Ground")
@@ -2009,7 +2009,7 @@ class WallHandler(BaseHandler):
         section_start = self._get_section(wall_details, True, prev_wall_details, a1, a2)
         section_end = self._get_section(wall_details, False, next_wall_details, a1, a2)
 
-        spine = Draft.makeLine(start, end)
+        spine = Draft.make_line(start, end)
 
         return section_start, section_end, spine
 
@@ -2036,15 +2036,15 @@ class WallHandler(BaseHandler):
             self._debug_vector(end - center, "end-center", BLUE, center)
 
         placement = App.Placement(center, App.Rotation())
-        # BEWARE: makeCircle always draws counter-clockwise (i.e. in positive
+        # BEWARE: make_circle always draws counter-clockwise (i.e. in positive
         # direction in xYz coordinate system). We therefore need to invert
         # the start and end angle (as in SweetHome the wall is drawn in
         # clockwise fashion).
         length = abs(radius * math.radians(a2 - a1))
         if invert_angle:
-            spine = Draft.makeCircle(radius, placement, False, a1, a2)
+            spine = Draft.make_circle(radius, placement, False, a1, a2)
         else:
-            spine = Draft.makeCircle(radius, placement, False, a2, a1)
+            spine = Draft.make_circle(radius, placement, False, a2, a1)
 
         # The Length property is used in the Wall to calculate volume, etc...
         # Since make Circle does not calculate this Length I calculate it here...
@@ -2108,7 +2108,7 @@ class WallHandler(BaseHandler):
                 _log(f"    wall: {self._pe(lside)},{self._pe(rside)}")
                 _log(f" sibling: {self._pe(s_lside)},{self._pe(s_rside)}")
                 _log(f"intersec: {self._pv(i_start)},{self._pv(i_end)}")
-            section = Draft.makeRectangle([i_start, i_end, i_end_z, i_start_z], face=True)
+            section = Draft.make_rectangle([i_start, i_end, i_end_z, i_start_z], face=True)
             if debug_geometry:
                 _log(f"section: {section}")
         else:
@@ -2116,7 +2116,7 @@ class WallHandler(BaseHandler):
             height = height_start if at_start else height_end
             center = start if at_start else end
             z_rotation = a1 if at_start else a2
-            section = Draft.makeRectangle(thickness, height, face=True)
+            section = Draft.make_rectangle(thickness, height, face=True)
             Draft.move([section], App.Vector(-thickness / 2, 0, 0))
             Draft.rotate([section], 90, ORIGIN, X_NORM)
             Draft.rotate([section], z_rotation, ORIGIN, Z_NORM)
@@ -2394,9 +2394,9 @@ class WallHandler(BaseHandler):
             )
 
         edge0 = bottom_edge.copy()
-        edge1 = Part.makeLine(bottom_edge.Vertexes[1].Point, offset_bottom_edge.Vertexes[1].Point)
+        edge1 = Part.make_line(bottom_edge.Vertexes[1].Point, offset_bottom_edge.Vertexes[1].Point)
         edge2 = offset_bottom_edge
-        edge3 = Part.makeLine(offset_bottom_edge.Vertexes[0].Point, bottom_edge.Vertexes[0].Point)
+        edge3 = Part.make_line(offset_bottom_edge.Vertexes[0].Point, bottom_edge.Vertexes[0].Point)
 
         # make sure all edges are coplanar...
         ref_z = bottom_edge.CenterOfGravity.z

--- a/src/Mod/BIM/importers/importSH3DHelper.py
+++ b/src/Mod/BIM/importers/importSH3DHelper.py
@@ -699,10 +699,10 @@ class SH3DImporter:
             NO = App.Vector(bb.XMin - dx, bb.YMax + dy, 0)
             NE = App.Vector(bb.XMax + dx, bb.YMax + dy, 0)
             SE = App.Vector(bb.XMax + dx, bb.YMin - dy, 0)
-            edge0 = Part.make_line(SO, NO)
-            edge1 = Part.make_line(NO, NE)
-            edge2 = Part.make_line(NE, SE)
-            edge3 = Part.make_line(SE, SO)
+            edge0 = Part.makeLine(SO, NO)
+            edge1 = Part.makeLine(NO, NE)
+            edge2 = Part.makeLine(NE, SE)
+            edge3 = Part.makeLine(SE, SO)
             ground_face = Part.makeFace([Part.Wire([edge0, edge1, edge2, edge3])])
 
             ground = App.ActiveDocument.addObject("Mesh::Feature", "Ground")
@@ -2394,9 +2394,9 @@ class WallHandler(BaseHandler):
             )
 
         edge0 = bottom_edge.copy()
-        edge1 = Part.make_line(bottom_edge.Vertexes[1].Point, offset_bottom_edge.Vertexes[1].Point)
+        edge1 = Part.makeLine(bottom_edge.Vertexes[1].Point, offset_bottom_edge.Vertexes[1].Point)
         edge2 = offset_bottom_edge
-        edge3 = Part.make_line(offset_bottom_edge.Vertexes[0].Point, bottom_edge.Vertexes[0].Point)
+        edge3 = Part.makeLine(offset_bottom_edge.Vertexes[0].Point, bottom_edge.Vertexes[0].Point)
 
         # make sure all edges are coplanar...
         ref_z = bottom_edge.CenterOfGravity.z

--- a/src/Mod/BIM/nativeifc/ifc_selftest.py
+++ b/src/Mod/BIM/nativeifc/ifc_selftest.py
@@ -314,7 +314,7 @@ class NativeIFCTest(unittest.TestCase):
         beam = Arch.makeStructure(None, 20, 200, 20)
         beam.IfcType = "Beam"
         beam = ifc_tools.aggregate(beam, storey)
-        rect = Draft.makeRectangle(200, 200)
+        rect = Draft.make_rectangle(200, 200)
         slab = Arch.makeStructure(rect, height=20)
         slab.IfcType = "Slab"
         slab = ifc_tools.aggregate(slab, storey)

--- a/src/Mod/CAM/Path/Op/SurfaceSupport.py
+++ b/src/Mod/CAM/Path/Op/SurfaceSupport.py
@@ -1071,7 +1071,7 @@ def getProjectedFace(tempGroup, wire):
     F.purgeTouched()
     tempGroup.addObject(F)
     try:
-        prj = Draft.makeShape2DView(F, FreeCAD.Vector(0, 0, 1))
+        prj = Draft.make_shape2dview(F, FreeCAD.Vector(0, 0, 1))
         prj.recompute()
         prj.purgeTouched()
         tempGroup.addObject(prj)

--- a/src/Mod/CAM/Path/Op/SurfaceSupport.py
+++ b/src/Mod/CAM/Path/Op/SurfaceSupport.py
@@ -1071,7 +1071,7 @@ def getProjectedFace(tempGroup, wire):
     F.purgeTouched()
     tempGroup.addObject(F)
     try:
-        prj = Draft.make_shape2dview(F, FreeCAD.Vector(0, 0, 1))
+        prj = Draft.make_shape_2d_view(F, FreeCAD.Vector(0, 0, 1))
         prj.recompute()
         prj.purgeTouched()
         tempGroup.addObject(prj)

--- a/src/Mod/Draft/App/DraftUtils.module.pyi
+++ b/src/Mod/Draft/App/DraftUtils.module.pyi
@@ -12,7 +12,7 @@ from Base.Metadata import deprecated
 
 @deprecated(
     deprecated_in="26.3",
-    removed_in="27.2",
+    removed_in="28.3",
     replacement="Import.readDXF",
     details="This compatibility entry point no longer imports files.",
 )

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -190,7 +190,7 @@ from draftobjects.circle import Circle, _Circle
 from draftmake.make_circle import make_circle, makeCircle
 
 # arcs
-from draftmake.make_arc_3points import make_arc_3points
+from draftmake.make_arc_3points import make_arc_3_points, make_arc_3points
 
 # ellipse
 from draftobjects.ellipse import Ellipse, _Ellipse
@@ -225,14 +225,13 @@ if App.GuiUp:
 
 # bezcurve
 from draftobjects.bezcurve import BezCurve, _BezCurve
-from draftmake.make_bezcurve import make_bezcurve, makeBezCurve
+from draftmake.make_bezcurve import make_bez_curve, make_bezcurve, makeBezCurve
 
 if App.GuiUp:
     from draftviewproviders.view_bezcurve import ViewProviderBezCurve, _ViewProviderBezCurve
 
 # copy
-from draftmake.make_copy import make_copy
-from draftmake.make_copy import make_copy as makeCopy
+from draftmake.make_copy import make_copy, makeCopy
 
 # clone
 from draftobjects.clone import Clone, _Clone
@@ -253,8 +252,10 @@ from draftobjects.array import Array, _Array
 from draftmake.make_array import make_array, makeArray
 from draftmake.make_orthoarray import (
     make_ortho_array,
+    make_ortho_array_2d,
     make_ortho_array2d,
     make_rect_array,
+    make_rect_array_2d,
     make_rect_array2d,
 )
 from draftmake.make_polararray import make_polar_array
@@ -282,21 +283,21 @@ from draftmake.make_block import make_block, makeBlock
 
 # shapestring
 from draftobjects.shapestring import ShapeString, _ShapeString
-from draftmake.make_shapestring import make_shapestring, makeShapeString
+from draftmake.make_shapestring import make_shape_string, make_shapestring, makeShapeString
 
 if App.GuiUp:
     from draftviewproviders.view_shapestring import ViewProviderShapeString
 
 # shape 2d view
 from draftobjects.shape2dview import Shape2DView, _Shape2DView
-from draftmake.make_shape2dview import make_shape2dview, makeShape2DView
+from draftmake.make_shape2dview import make_shape_2d_view, make_shape2dview, makeShape2DView
 
 # sketch
 from draftmake.make_sketch import make_sketch, makeSketch
 
 # working plane proxy
 from draftobjects.wpproxy import WorkingPlaneProxy
-from draftmake.make_wpproxy import make_workingplaneproxy, makeWorkingPlaneProxy
+from draftmake.make_wpproxy import make_working_plane_proxy, make_workingplaneproxy, makeWorkingPlaneProxy
 
 if App.GuiUp:
     from draftviewproviders.view_wpproxy import ViewProviderWorkingPlaneProxy

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -297,7 +297,11 @@ from draftmake.make_sketch import make_sketch, makeSketch
 
 # working plane proxy
 from draftobjects.wpproxy import WorkingPlaneProxy
-from draftmake.make_wpproxy import make_working_plane_proxy, make_workingplaneproxy, makeWorkingPlaneProxy
+from draftmake.make_wpproxy import (
+    make_working_plane_proxy,
+    make_workingplaneproxy,
+    makeWorkingPlaneProxy,
+)
 
 if App.GuiUp:
     from draftviewproviders.view_wpproxy import ViewProviderWorkingPlaneProxy

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -56,7 +56,7 @@ __url__ = "https://www.freecad.org"
 
 @deprecated(
     deprecated_in="26.3",
-    removed_in="27.2",
+    removed_in="28.3",
     replacement="Draft.precision()",
 )
 def precision() -> int:

--- a/src/Mod/Draft/draftfunctions/draftify.py
+++ b/src/Mod/Draft/draftfunctions/draftify.py
@@ -112,15 +112,15 @@ def draftify_shape(shape):
                         edge.Curve.value((first_parameter + last_parameter) / 2),
                         edge.Curve.value(last_parameter),
                     ]
-                    nobj = make_arc_3points.make_arc_3points(points)
+                    nobj = make_arc_3points.make_arc_3_points(points)
         # TODO: take into consideration trimmed curves and capture the specific
         # type of BSpline and Bezier that can be converted to a draft object.
         # elif edge_type == "BSplineCurve":
         #     knots = [edge.Curve.value(p) for p in edge.Curve.getKnots()]
         #     nobj = make_bspline.make_bspline(knots, closed=edge.isClosed())
         # elif edge_type == "BezierCurve":
-        #     nobj = make_bezcurve.make_bezcurve(edge.Curve.getPoles(),
-        #                                        closed=edge.isClosed())
+        #     nobj = make_bezcurve.make_bez_curve(edge.Curve.getPoles(),
+        #                                         closed=edge.isClosed())
     else:
         nobj = make_wire.make_wire(shape)
 

--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -601,7 +601,7 @@ class Arc_3Points(gui_base.GuiCommandBase):
             # Draw a simple `Part::Feature` if the parameter is `True`.
             Gui.addModule("Draft")
             Gui.addModule("WorkingPlane")
-            _cmd = "Draft.make_arc_3points(["
+            _cmd = "Draft.make_arc_3_points(["
             _cmd += "FreeCAD." + str(self.points[0])
             _cmd += ", FreeCAD." + str(self.points[1])
             _cmd += ", FreeCAD." + str(self.points[2])

--- a/src/Mod/Draft/draftguitools/gui_beziers.py
+++ b/src/Mod/Draft/draftguitools/gui_beziers.py
@@ -210,7 +210,7 @@ class BezCurve(gui_lines.Line):
             try:
                 rot, sup, pts, fil = self.getStrings()
                 Gui.addModule("Draft")
-                _cmd = "Draft.make_bezcurve"
+                _cmd = "Draft.make_bez_curve"
                 _cmd += "("
                 _cmd += "points, "
                 _cmd += "closed=" + str(closed) + ", "
@@ -469,7 +469,7 @@ class CubicBezCurve(gui_lines.Line):
                 # to be committed through the `draftutils.todo.ToDo` class.
                 rot, sup, pts, fil = self.getStrings()
                 Gui.addModule("Draft")
-                _cmd = "Draft.make_bezcurve"
+                _cmd = "Draft.make_bez_curve"
                 _cmd += "("
                 _cmd += "points, "
                 _cmd += "closed=" + str(closed) + ", "

--- a/src/Mod/Draft/draftguitools/gui_planeproxy.py
+++ b/src/Mod/Draft/draftguitools/gui_planeproxy.py
@@ -63,7 +63,7 @@ class Draft_WorkingPlaneProxy:
         Gui.addModule("Draft")
         Gui.addModule("WorkingPlane")
         Gui.doCommand("pl = WorkingPlane.get_working_plane().get_placement()")
-        Gui.doCommand("Draft.make_workingplaneproxy(pl)")
+        Gui.doCommand("Draft.make_working_plane_proxy(pl)")
         App.ActiveDocument.commitTransaction()
         App.ActiveDocument.recompute()
 

--- a/src/Mod/Draft/draftguitools/gui_shape2dview.py
+++ b/src/Mod/Draft/draftguitools/gui_shape2dview.py
@@ -101,7 +101,7 @@ class Shape2DView(gui_base_original.Modifier):
         commitlist = []
         Gui.addModule("Draft")
         if len(objs) == 1 and faces:
-            _cmd = "Draft.make_shape2dview"
+            _cmd = "Draft.make_shape_2d_view"
             _cmd += "("
             _cmd += "FreeCAD.ActiveDocument." + objs[0].Name + ", "
             _cmd += DraftVecUtils.toString(vec) + ", "
@@ -111,7 +111,7 @@ class Shape2DView(gui_base_original.Modifier):
         else:
             n = 0
             for o in objs:
-                _cmd = "Draft.make_shape2dview"
+                _cmd = "Draft.make_shape_2d_view"
                 _cmd += "("
                 _cmd += "FreeCAD.ActiveDocument." + o.Name + ", "
                 _cmd += DraftVecUtils.toString(vec)

--- a/src/Mod/Draft/draftmake/make_arc_3points.py
+++ b/src/Mod/Draft/draftmake/make_arc_3points.py
@@ -40,7 +40,7 @@ from draftutils.messages import _err
 from draftutils.translate import translate
 
 
-def make_arc_3points(points, placement=None, face=False, support=None, primitive=False):
+def make_arc_3_points(points, placement=None, face=False, support=None, primitive=False):
     """Draw a circular arc defined by three points on the circumference.
 
     Parameters
@@ -82,7 +82,7 @@ def make_arc_3points(points, placement=None, face=False, support=None, primitive
     None
         Returns `None` if there is a problem and the object cannot be created.
     """
-    _name = "make_arc_3points"
+    _name = "make_arc_3_points"
 
     try:
         utils.type_check([(points, (list, tuple))], name=_name)
@@ -124,6 +124,16 @@ def make_arc_3points(points, placement=None, face=False, support=None, primitive
         return obj
 
     return make_circle.make_circle(edge, placement=placement, face=face, support=support)
+
+
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_arc_3_points()",
+)
+def make_arc_3points(*args, **kwarg):
+    """DEPRECATED. Use 'make_arc_3_points'."""
+    return make_arc_3_points(*args, **kwarg)
 
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_arc_3points.py
+++ b/src/Mod/Draft/draftmake/make_arc_3points.py
@@ -38,6 +38,7 @@ from draftmake import make_circle
 from draftutils import utils
 from draftutils.messages import _err
 from draftutils.translate import translate
+from freecad.deprecation import deprecated
 
 
 def make_arc_3_points(points, placement=None, face=False, support=None, primitive=False):

--- a/src/Mod/Draft/draftmake/make_array.py
+++ b/src/Mod/Draft/draftmake/make_array.py
@@ -34,12 +34,12 @@ This includes orthogonal arrays, polar arrays, and circular arrays.
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.utils as utils
-import draftutils.gui_utils as gui_utils
-
-from draftutils.messages import _wrn, _err
-from draftutils.translate import translate
 from draftobjects.array import Array
+from draftutils import gui_utils
+from draftutils import utils
+from draftutils.messages import _err
+from draftutils.translate import translate
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_array import ViewProviderDraftArray
@@ -140,16 +140,15 @@ def make_array(base_object, arg1, arg2, arg3, arg4=None, arg5=None, arg6=None, u
     return new_obj
 
 
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_array()",
+)
 def makeArray(
     baseobject, arg1, arg2, arg3, arg4=None, arg5=None, arg6=None, name="Array", use_link=False
 ):
-    """Create an Array. DEPRECATED. Use 'make_array'."""
-    _wrn(
-        "Do not use this function directly; instead, use "
-        "'make_ortho_array', 'make_polar_array', "
-        "or 'make_circular_array'."
-    )
-
+    """DEPRECATED. Use 'make_array'."""
     return make_array(baseobject, arg1, arg2, arg3, arg4, arg5, arg6, use_link)
 
 

--- a/src/Mod/Draft/draftmake/make_bezcurve.py
+++ b/src/Mod/Draft/draftmake/make_bezcurve.py
@@ -40,8 +40,8 @@ if App.GuiUp:
     from draftviewproviders.view_bezcurve import ViewProviderBezCurve
 
 
-def make_bezcurve(pointslist, closed=False, placement=None, face=None, support=None, degree=None):
-    """make_bezcurve(pointslist, [closed], [placement])
+def make_bez_curve(pointslist, closed=False, placement=None, face=None, support=None, degree=None):
+    """make_bez_curve(pointslist, [closed], [placement])
 
     Creates a Bezier Curve object from the given list of vectors.
 
@@ -78,7 +78,7 @@ def make_bezcurve(pointslist, closed=False, placement=None, face=None, support=N
             nlist.append(v.Point)
         pointslist = nlist
     if placement:
-        utils.type_check([(placement, App.Placement)], "make_bezcurve")
+        utils.type_check([(placement, App.Placement)], "make_bez_curve")
     if len(pointslist) == 2:
         fname = "Line"
     else:
@@ -113,11 +113,21 @@ def make_bezcurve(pointslist, closed=False, placement=None, face=None, support=N
 @deprecated(
     deprecated_in="26.3",
     removed_in="28.3",
-    replacement="Draft.make_bezcurve()",
+    replacement="Draft.make_bez_curve()",
+)
+def make_bezcurve(*args, **kwarg):
+    """DEPRECATED. Use 'make_bez_curve'."""
+    return make_bez_curve(*args, **kwarg)
+
+
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_bez_curve()",
 )
 def makeBezCurve(*args, **kwarg):
-    """DEPRECATED. Use 'make_bezcurve'."""
-    return make_bezcurve(*args, **kwarg)
+    """DEPRECATED. Use 'make_bez_curve'."""
+    return make_bez_curve(*args, **kwarg)
 
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_bezcurve.py
+++ b/src/Mod/Draft/draftmake/make_bezcurve.py
@@ -31,11 +31,10 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.utils as utils
-import draftutils.gui_utils as gui_utils
-
-from draftutils.translate import translate
 from draftobjects.bezcurve import BezCurve
+from draftutils import gui_utils
+from draftutils import utils
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_bezcurve import ViewProviderBezCurve
@@ -111,6 +110,14 @@ def make_bezcurve(pointslist, closed=False, placement=None, face=None, support=N
     return obj
 
 
-makeBezCurve = make_bezcurve
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_bezcurve()",
+)
+def makeBezCurve(*args, **kwarg):
+    """DEPRECATED. Use 'make_bezcurve'."""
+    return make_bezcurve(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_block.py
+++ b/src/Mod/Draft/draftmake/make_block.py
@@ -31,9 +31,9 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.gui_utils as gui_utils
-
 from draftobjects.block import Block
+from draftutils import gui_utils
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_base import ViewProviderDraftPart
@@ -65,6 +65,14 @@ def make_block(objectslist):
     return obj
 
 
-makeBlock = make_block
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_block()",
+)
+def makeBlock(*args, **kwarg):
+    """DEPRECATED. Use 'make_block'."""
+    return make_block(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_bspline.py
+++ b/src/Mod/Draft/draftmake/make_bspline.py
@@ -31,11 +31,11 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.utils as utils
-import draftutils.gui_utils as gui_utils
-
-from draftutils.translate import translate
 from draftobjects.bspline import BSpline
+from draftutils import gui_utils
+from draftutils import utils
+from draftutils.translate import translate
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_bspline import ViewProviderBSpline
@@ -115,6 +115,14 @@ def make_bspline(pointslist, closed=False, placement=None, face=None, support=No
     return obj
 
 
-makeBSpline = make_bspline
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_bspline()",
+)
+def makeBSpline(*args, **kwarg):
+    """DEPRECATED. Use 'make_bspline'."""
+    return make_bspline(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_circle.py
+++ b/src/Mod/Draft/draftmake/make_circle.py
@@ -39,6 +39,7 @@ from draftgeoutils import general as geo_general
 from draftobjects.circle import Circle
 from draftutils import utils
 from draftutils import gui_utils
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_base import ViewProviderDraft
@@ -157,6 +158,14 @@ def make_circle(radius, placement=None, face=None, startangle=None, endangle=Non
     return obj
 
 
-makeCircle = make_circle
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_circle()",
+)
+def makeCircle(*args, **kwarg):
+    """DEPRECATED. Use 'make_circle'."""
+    return make_circle(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_clone.py
+++ b/src/Mod/Draft/draftmake/make_clone.py
@@ -35,6 +35,7 @@ from draftobjects.clone import Clone
 from draftutils import params
 from draftutils import utils
 from draftutils import gui_utils
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from PySide import QtCore
@@ -158,6 +159,14 @@ def make_clone(obj, delta=None, forcedraft=False):
     return cl
 
 
-clone = make_clone
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_clone()",
+)
+def clone(*args, **kwarg):
+    """DEPRECATED. Use 'make_clone'."""
+    return make_clone(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_copy.py
+++ b/src/Mod/Draft/draftmake/make_copy.py
@@ -95,4 +95,14 @@ def make_copy(obj, force=None, reparent=False, simple_copy=False):
     return newobj
 
 
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_copy()",
+)
+def makeCopy(*args, **kwarg):
+    """DEPRECATED. Use 'make_copy'."""
+    return make_copy(*args, **kwarg)
+
+
 ## @}

--- a/src/Mod/Draft/draftmake/make_copy.py
+++ b/src/Mod/Draft/draftmake/make_copy.py
@@ -31,8 +31,9 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.utils as utils
-import draftutils.gui_utils as gui_utils
+from draftutils import gui_utils
+from draftutils import utils
+from freecad.deprecation import deprecated
 
 
 def make_copy(obj, force=None, reparent=False, simple_copy=False):

--- a/src/Mod/Draft/draftmake/make_dimension.py
+++ b/src/Mod/Draft/draftmake/make_dimension.py
@@ -40,15 +40,14 @@ import math
 import FreeCAD as App
 import DraftVecUtils
 import WorkingPlane
-
-from draftgeoutils import edges
+from draftgeoutils import edges as geo_edges
+from draftobjects.dimension import AngularDimension, LinearDimension
 from draftutils import gui_utils
 from draftutils import params
 from draftutils import utils
-from draftutils.messages import _wrn, _err
+from draftutils.messages import _err, _wrn
 from draftutils.translate import translate
-
-from draftobjects.dimension import LinearDimension, AngularDimension
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_dimension import (
@@ -90,7 +89,7 @@ def _get_flip_text_ang(cen, sta, end, normal):
     import Part
 
     circle = Part.makeCircle(1, cen, normal, sta, end)
-    mid = edges.findMidpoint(circle)
+    mid = geo_edges.findMidpoint(circle)
     wp = WorkingPlane.get_working_plane(update=False)
     ang = DraftVecUtils.angle(wp.u, mid.sub(cen), normal)
     tol = 1e-4  # high tolerance
@@ -220,11 +219,13 @@ def make_dimension(p1, p2, p3=None, p4=None):
     return new_obj
 
 
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_dimension()",
+)
 def makeDimension(p1, p2, p3=None, p4=None):
     """Create a dimension. DEPRECATED. Use 'make_dimension'."""
-    _wrn(translate("draft", "This function is deprecated. Do not use this function directly."))
-    _wrn(translate("draft", "Use one of 'make_linear_dimension', or 'make_linear_dimension_obj'."))
-
     return make_dimension(p1, p2, p3, p4)
 
 
@@ -672,13 +673,15 @@ def make_angular_dimension(
     return new_obj
 
 
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_angular_dimension()",
+)
 def makeAngularDimension(center, angles, p3, normal=None):
-    """Create an angle dimension. DEPRECATED. Use 'make_angular_dimension'."""
-    utils.use_instead("make_angular_dimension")
-
+    """DEPRECATED. Use 'make_angular_dimension'."""
     ang1, ang2 = angles
     angles = [math.degrees(ang2), math.degrees(ang1)]
-
     return make_angular_dimension(center=center, angles=angles, dim_line=p3, normal=normal)
 
 

--- a/src/Mod/Draft/draftmake/make_ellipse.py
+++ b/src/Mod/Draft/draftmake/make_ellipse.py
@@ -31,9 +31,9 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.gui_utils as gui_utils
-
 from draftobjects.ellipse import Ellipse
+from draftutils import gui_utils
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_base import ViewProviderDraft
@@ -91,6 +91,14 @@ def make_ellipse(majradius, minradius, placement=None, face=None, support=None):
     return obj
 
 
-makeEllipse = make_ellipse
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_ellipse()",
+)
+def makeEllipse(*args, **kwarg):
+    """DEPRECATED. Use 'make_ellipse'."""
+    return make_ellipse(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_facebinder.py
+++ b/src/Mod/Draft/draftmake/make_facebinder.py
@@ -70,7 +70,7 @@ def make_facebinder(selectionset, name="Facebinder"):
 @deprecated(
     deprecated_in="26.3",
     removed_in="28.3",
-    replacement="Draft.make_bezcurve()",
+    replacement="Draft.make_facebinder()",
 )
 def makeFacebinder(*args, **kwarg):
     """DEPRECATED. Use 'make_facebinder'."""

--- a/src/Mod/Draft/draftmake/make_facebinder.py
+++ b/src/Mod/Draft/draftmake/make_facebinder.py
@@ -31,9 +31,9 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.gui_utils as gui_utils
-
 from draftobjects.facebinder import Facebinder
+from draftutils import gui_utils
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_facebinder import ViewProviderFacebinder
@@ -67,6 +67,14 @@ def make_facebinder(selectionset, name="Facebinder"):
     return fb
 
 
-makeFacebinder = make_facebinder
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_bezcurve()",
+)
+def makeFacebinder(*args, **kwarg):
+    """DEPRECATED. Use 'make_facebinder'."""
+    return make_facebinder(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_label.py
+++ b/src/Mod/Draft/draftmake/make_label.py
@@ -37,8 +37,9 @@ from draftobjects import label
 from draftutils import gui_utils
 from draftutils import params
 from draftutils import utils
-from draftutils.messages import _wrn, _err
+from draftutils.messages import _err, _wrn
 from draftutils.translate import translate
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_label import ViewProviderLabel
@@ -370,12 +371,15 @@ def make_label(
     return new_obj
 
 
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_label()",
+)
 def makeLabel(
     targetpoint=None, target=None, direction=None, distance=None, labeltype=None, placement=None
 ):
-    """Create a Label. DEPRECATED. Use 'make_label'."""
-    utils.use_instead("make_label")
-
+    """DEPRECATED. Use 'make_label'."""
     _name = "makeLabel"
     subelements = None
 

--- a/src/Mod/Draft/draftmake/make_layer.py
+++ b/src/Mod/Draft/draftmake/make_layer.py
@@ -36,6 +36,7 @@ from draftobjects.layer import Layer, LayerContainer
 from draftutils import utils
 from draftutils.messages import _err
 from draftutils.translate import translate
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_layer import ViewProviderLayer, ViewProviderLayerContainer
@@ -71,10 +72,13 @@ def get_layer_container():
     return obj
 
 
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.get_layer_container()",
+)
 def getLayerContainer():
-    """Get the Layer container. DEPRECATED. Use 'get_layer_container'."""
-    utils.use_instead("get_layer_container")
-
+    """DEPRECATED. Use 'get_layer_container'."""
     return get_layer_container()
 
 

--- a/src/Mod/Draft/draftmake/make_line.py
+++ b/src/Mod/Draft/draftmake/make_line.py
@@ -32,10 +32,11 @@
 # @{
 import FreeCAD as App
 import draftmake.make_wire as make_wire
+from freecad.deprecation import deprecated
 
 
 def make_line(first_param, last_param=None):
-    """makeLine(first_param, p2)
+    """make_line(first_param, p2)
 
     Creates a line from 2 points or from a given object.
 
@@ -70,6 +71,14 @@ def make_line(first_param, last_param=None):
     return obj
 
 
-makeLine = make_line
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_line()",
+)
+def makeLine(*args, **kwarg):
+    """DEPRECATED. Use 'make_line'."""
+    return make_line(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_orthoarray.py
+++ b/src/Mod/Draft/draftmake/make_orthoarray.py
@@ -54,9 +54,9 @@ def _make_ortho_array(
     function to be used by the different orthogonal arrays.
 
     - `make_ortho_array`
-    - `make_ortho_array2d`, no Z direction
+    - `make_ortho_array_2d`, no Z direction
     - `make_rect_array`, strictly rectangular
-    - `make_rect_array2d`, strictly rectangular, no Z direction
+    - `make_rect_array_2d`, strictly rectangular, no Z direction
 
     This function has no error checking, nor does it display messages.
     This should be handled by the subfunctions that use this one.
@@ -249,7 +249,7 @@ def make_ortho_array(
 
     See Also
     --------
-    make_ortho_array2d, make_rect_array, make_rect_array2d, make_polar_array,
+    make_ortho_array_2d, make_rect_array, make_rect_array_2d, make_polar_array,
     make_circular_array, make_path_array, make_point_array
     """
     _name = "make_ortho_array"
@@ -274,7 +274,7 @@ def make_ortho_array(
     return new_obj
 
 
-def make_ortho_array2d(
+def make_ortho_array_2d(
     base_object, v_x=App.Vector(10, 0, 0), v_y=App.Vector(0, 10, 0), n_x=2, n_y=2, use_link=True
 ):
     """Create a 2D orthogonal array from the given object.
@@ -317,10 +317,10 @@ def make_ortho_array2d(
 
     See Also
     --------
-    make_ortho_array, make_rect_array, make_rect_array2d, make_polar_array,
+    make_ortho_array, make_rect_array, make_rect_array_2d, make_polar_array,
     make_circular_array, make_path_array, make_point_array
     """
-    _name = "make_ortho_array2d"
+    _name = "make_ortho_array_2d"
 
     found, base_object = _find_object_in_doc(base_object, doc=App.activeDocument())
     if not found:
@@ -338,6 +338,16 @@ def make_ortho_array2d(
 
     new_obj = _make_ortho_array(base_object, v_x=v_x, v_y=v_y, n_x=n_x, n_y=n_y, use_link=use_link)
     return new_obj
+
+
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_ortho_array_2d()",
+)
+def make_ortho_array2d(*args, **kwarg):
+    """DEPRECATED. Use 'make_ortho_array_2d'."""
+    return make_ortho_array_2d(*args, **kwarg)
 
 
 def make_rect_array(base_object, d_x=10, d_y=10, d_z=10, n_x=2, n_y=2, n_z=1, use_link=True):
@@ -378,7 +388,7 @@ def make_rect_array(base_object, d_x=10, d_y=10, d_z=10, n_x=2, n_y=2, n_z=1, us
 
     See Also
     --------
-    make_ortho_array, make_ortho_array2d, make_rect_array2d, make_polar_array,
+    make_ortho_array, make_ortho_array_2d, make_rect_array_2d, make_polar_array,
     make_circular_array, make_path_array, make_point_array
     """
     _name = "make_rect_array"
@@ -410,7 +420,7 @@ def make_rect_array(base_object, d_x=10, d_y=10, d_z=10, n_x=2, n_y=2, n_z=1, us
     return new_obj
 
 
-def make_rect_array2d(base_object, d_x=10, d_y=10, n_x=2, n_y=2, use_link=True):
+def make_rect_array_2d(base_object, d_x=10, d_y=10, n_x=2, n_y=2, use_link=True):
     """Create a 2D rectangular array from the given object.
 
     This function wraps around `make_ortho_array`,
@@ -449,10 +459,10 @@ def make_rect_array2d(base_object, d_x=10, d_y=10, n_x=2, n_y=2, use_link=True):
 
     See Also
     --------
-    make_ortho_array, make_ortho_array2d, make_rect_array, make_polar_array,
+    make_ortho_array, make_ortho_array_2d, make_rect_array, make_polar_array,
     make_circular_array, make_path_array, make_point_array
     """
-    _name = "make_rect_array2d"
+    _name = "make_rect_array_2d"
 
     found, base_object = _find_object_in_doc(base_object, doc=App.activeDocument())
     if not found:
@@ -477,6 +487,16 @@ def make_rect_array2d(base_object, d_x=10, d_y=10, n_x=2, n_y=2, use_link=True):
         use_link=use_link,
     )
     return new_obj
+
+
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_rect_array_2d()",
+)
+def make_rect_array2d(*args, **kwarg):
+    """DEPRECATED. Use 'make_rect_array_2d'."""
+    return make_rect_array_2d(*args, **kwarg)
 
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_orthoarray.py
+++ b/src/Mod/Draft/draftmake/make_orthoarray.py
@@ -31,11 +31,11 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.utils as utils
-import draftmake.make_array as make_array
-
-from draftutils.messages import _wrn, _err
+from draftmake import make_array
+from draftutils import utils
+from draftutils.messages import _err, _wrn
 from draftutils.translate import translate
+from freecad.deprecation import deprecated
 
 
 def _make_ortho_array(

--- a/src/Mod/Draft/draftmake/make_patharray.py
+++ b/src/Mod/Draft/draftmake/make_patharray.py
@@ -315,9 +315,19 @@ def make_path_array(
     removed_in="28.3",
     replacement="Draft.make_path_array()",
 )
-def makePathArray(*args, **kwarg):
+def makePathArray(
+    baseobject, pathobject, count, xlate=None, align=False, pathobjsubs=[], use_link=False
+):
     """DEPRECATED. Use 'make_path_array'."""
-    return make_path_array(*args, **kwarg)
+    return make_path_array(
+        baseobject,
+        pathobject,
+        count=count,
+        extra=xlate,
+        subelements=pathobjsubs,
+        align=align,
+        use_link=use_link,
+    )
 
 
 def make_path_twisted_array(base_object, path_object, count=15, rot_factor=0.25, use_link=True):

--- a/src/Mod/Draft/draftmake/make_patharray.py
+++ b/src/Mod/Draft/draftmake/make_patharray.py
@@ -40,13 +40,13 @@ curve.
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.utils as utils
-import draftutils.gui_utils as gui_utils
-
-from draftutils.messages import _err
-from draftutils.translate import translate
 from draftobjects.patharray import PathArray
 from draftobjects.pathtwistedarray import PathTwistedArray
+from draftutils import gui_utils
+from draftutils import utils
+from draftutils.messages import _err
+from draftutils.translate import translate
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_array import ViewProviderDraftArray
@@ -310,13 +310,14 @@ def make_path_array(
     return new_obj
 
 
-def makePathArray(
-    baseobject, pathobject, count, xlate=None, align=False, pathobjsubs=[], use_link=False
-):
-    """Create PathArray. DEPRECATED. Use 'make_path_array'."""
-    utils.use_instead("make_path_array")
-
-    return make_path_array(baseobject, pathobject, count, xlate, pathobjsubs, align, use_link)
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_path_array()",
+)
+def makePathArray(*args, **kwarg):
+    """DEPRECATED. Use 'make_path_array'."""
+    return make_path_array(*args, **kwarg)
 
 
 def make_path_twisted_array(base_object, path_object, count=15, rot_factor=0.25, use_link=True):

--- a/src/Mod/Draft/draftmake/make_point.py
+++ b/src/Mod/Draft/draftmake/make_point.py
@@ -31,9 +31,9 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.gui_utils as gui_utils
-
 from draftobjects.point import Point
+from draftutils import gui_utils
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     import FreeCADGui as Gui
@@ -91,6 +91,14 @@ def make_point(X=0, Y=0, Z=0, color=None, name="Point", point_size=5):
     return obj
 
 
-makePoint = make_point
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_point()",
+)
+def makePoint(*args, **kwarg):
+    """DEPRECATED. Use 'make_point'."""
+    return make_point(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_pointarray.py
+++ b/src/Mod/Draft/draftmake/make_pointarray.py
@@ -38,12 +38,12 @@ The copies will be created at the points of a point object.
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.utils as utils
-import draftutils.gui_utils as gui_utils
-
+from draftobjects.pointarray import PointArray
+from draftutils import utils
+from draftutils import gui_utils
 from draftutils.messages import _err
 from draftutils.translate import translate
-from draftobjects.pointarray import PointArray
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_array import ViewProviderDraftArray
@@ -153,11 +153,14 @@ def make_point_array(base_object, point_object, extra=None, use_link=True):
     return new_obj
 
 
-def makePointArray(base, ptlst):
-    """Create PointArray. DEPRECATED. Use 'make_point_array'."""
-    utils.use_instead("make_point_array")
-
-    return make_point_array(base, ptlst)
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_point_array()",
+)
+def makePointArray(*args, **kwarg):
+    """DEPRECATED. Use 'make_point_array'."""
+    return make_point_array(*args, **kwarg)
 
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_pointarray.py
+++ b/src/Mod/Draft/draftmake/make_pointarray.py
@@ -158,9 +158,9 @@ def make_point_array(base_object, point_object, extra=None, use_link=True):
     removed_in="28.3",
     replacement="Draft.make_point_array()",
 )
-def makePointArray(*args, **kwarg):
+def makePointArray(base, ptlst):
     """DEPRECATED. Use 'make_point_array'."""
-    return make_point_array(*args, **kwarg)
+    return make_point_array(base, ptlst)
 
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_polygon.py
+++ b/src/Mod/Draft/draftmake/make_polygon.py
@@ -31,10 +31,12 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.gui_utils as gui_utils
-
 from draftobjects.polygon import Polygon
-from draftviewproviders.view_base import ViewProviderDraft
+from draftutils import gui_utils
+from freecad.deprecation import deprecated
+
+if App.GuiUp:
+    from draftviewproviders.view_base import ViewProviderDraft
 
 
 def make_polygon(nfaces, radius=1, inscribed=True, placement=None, face=None, support=None):
@@ -89,6 +91,14 @@ def make_polygon(nfaces, radius=1, inscribed=True, placement=None, face=None, su
     return obj
 
 
-makePolygon = make_polygon
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_polygon()",
+)
+def makePolygon(*args, **kwarg):
+    """DEPRECATED. Use 'make_polygon'."""
+    return make_polygon(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_rectangle.py
+++ b/src/Mod/Draft/draftmake/make_rectangle.py
@@ -31,10 +31,10 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.utils as utils
-import draftutils.gui_utils as gui_utils
-
 from draftobjects.rectangle import Rectangle
+from draftutils import utils
+from draftutils import gui_utils
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_rectangle import ViewProviderRectangle
@@ -101,6 +101,14 @@ def make_rectangle(length, height=0, placement=None, face=None, support=None):
     return obj
 
 
-makeRectangle = make_rectangle
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_rectangle()",
+)
+def makeRectangle(*args, **kwarg):
+    """DEPRECATED. Use 'make_rectangle'."""
+    return make_rectangle(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_shape2dview.py
+++ b/src/Mod/Draft/draftmake/make_shape2dview.py
@@ -39,17 +39,17 @@ if App.GuiUp:
     from draftviewproviders.view_base import ViewProviderDraftAlt
 
 
-def make_shape2dview(baseobj, projectionVector=None, facenumbers=[]):
-    """make_shape2dview(object, [projectionVector], [facenumbers])
+def make_shape_2d_view(baseobj, projection=None, facenumbers=[]):
+    """make_shape_2d_view(baseobj, [projection], [facenumbers])
 
     Add a 2D shape to the document, which is a 2D projection of the given object.
 
     Parameters
     ----------
-    object :
+    baseobj :
         TODO: Describe
 
-    projectionVector : Base.Vector
+    projection : Base.Vector
         Custom vector for the projection
 
     facenumbers : [] TODO: Describe
@@ -63,8 +63,8 @@ def make_shape2dview(baseobj, projectionVector=None, facenumbers=[]):
     if App.GuiUp:
         ViewProviderDraftAlt(obj.ViewObject)
     obj.Base = baseobj
-    if projectionVector:
-        obj.Projection = projectionVector
+    if projection:
+        obj.Projection = projection
     if facenumbers:
         obj.FaceNumbers = facenumbers
     gui_utils.select(obj)
@@ -75,11 +75,21 @@ def make_shape2dview(baseobj, projectionVector=None, facenumbers=[]):
 @deprecated(
     deprecated_in="26.3",
     removed_in="28.3",
-    replacement="Draft.make_shape2dview()",
+    replacement="Draft.make_shape_2d_view()",
 )
-def makeShape2DView(*args, **kwarg):
-    """DEPRECATED. Use 'make_shape2dview'."""
-    return make_shape2dview(*args, **kwarg)
+def make_shape2dview(baseobj, projectionVector=None, facenumbers=[]):
+    """DEPRECATED. Use 'make_shape_2d_view'."""
+    return make_shape_2d_view(baseobj, projection=projectionVector, facenumbers=facenumbers)
+
+
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_shape_2d_view()",
+)
+def makeShape2DView(baseobj, projectionVector=None, facenumbers=[]):
+    """DEPRECATED. Use 'make_shape_2d_view'."""
+    return make_shape_2d_view(baseobj, projection=projectionVector, facenumbers=facenumbers)
 
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_shape2dview.py
+++ b/src/Mod/Draft/draftmake/make_shape2dview.py
@@ -31,9 +31,9 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.gui_utils as gui_utils
-
 from draftobjects.shape2dview import Shape2DView
+from draftutils import gui_utils
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_base import ViewProviderDraftAlt
@@ -72,6 +72,14 @@ def make_shape2dview(baseobj, projectionVector=None, facenumbers=[]):
     return obj
 
 
-makeShape2DView = make_shape2dview
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_shape2dview()",
+)
+def makeShape2DView(*args, **kwarg):
+    """DEPRECATED. Use 'make_shape2dview'."""
+    return make_shape2dview(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_shapestring.py
+++ b/src/Mod/Draft/draftmake/make_shapestring.py
@@ -31,9 +31,9 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.gui_utils as gui_utils
-
 from draftobjects.shapestring import ShapeString
+from draftutils import gui_utils
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_shapestring import ViewProviderShapeString
@@ -72,6 +72,14 @@ def make_shapestring(String, FontFile, Size=100, Tracking=0):
     return obj
 
 
-makeShapeString = make_shapestring
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_shapestring()",
+)
+def makeShapeString(*args, **kwarg):
+    """DEPRECATED. Use 'make_shapestring'."""
+    return make_shapestring(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_shapestring.py
+++ b/src/Mod/Draft/draftmake/make_shapestring.py
@@ -39,8 +39,8 @@ if App.GuiUp:
     from draftviewproviders.view_shapestring import ViewProviderShapeString
 
 
-def make_shapestring(String, FontFile, Size=100, Tracking=0):
-    """ShapeString(Text,FontFile,[Height],[Track])
+def make_shape_string(string, fontfile, size=100, tracking=0):
+    """make_shape_string(string, fontfile, [size], [tracking])
 
     Turns a text string into a Compound Shape
 
@@ -56,10 +56,10 @@ def make_shapestring(String, FontFile, Size=100, Tracking=0):
 
     obj = App.ActiveDocument.addObject("Part::Part2DObjectPython", "ShapeString")
     ShapeString(obj)
-    obj.String = String
-    obj.FontFile = FontFile
-    obj.Size = Size
-    obj.Tracking = Tracking
+    obj.String = string
+    obj.FontFile = fontfile
+    obj.Size = size
+    obj.Tracking = tracking
 
     if App.GuiUp:
         ViewProviderShapeString(obj.ViewObject)
@@ -75,11 +75,21 @@ def make_shapestring(String, FontFile, Size=100, Tracking=0):
 @deprecated(
     deprecated_in="26.3",
     removed_in="28.3",
-    replacement="Draft.make_shapestring()",
+    replacement="Draft.make_shape_string()",
 )
-def makeShapeString(*args, **kwarg):
-    """DEPRECATED. Use 'make_shapestring'."""
-    return make_shapestring(*args, **kwarg)
+def make_shapestring(String, FontFile, Size=100, Tracking=0):
+    """DEPRECATED. Use 'make_shape_string'."""
+    return make_shape_string(String, FontFile, size=Size, tracking=Tracking)
+
+
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_shape_string()",
+)
+def makeShapeString(String, FontFile, Size=100, Tracking=0):
+    """DEPRECATED. Use 'make_shape_string'."""
+    return make_shape_string(String, FontFile, size=Size, tracking=Tracking)
 
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_sketch.py
+++ b/src/Mod/Draft/draftmake/make_sketch.py
@@ -41,6 +41,7 @@ from draftgeoutils import geometry as geo_geometry
 from draftutils import gui_utils
 from draftutils import utils
 from draftutils.translate import translate
+from freecad.deprecation import deprecated
 
 
 def make_sketch(
@@ -265,6 +266,14 @@ def make_sketch(
     return nobj
 
 
-makeSketch = make_sketch
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_sketch()",
+)
+def makeSketch(*args, **kwarg):
+    """DEPRECATED. Use 'make_sketch'."""
+    return make_sketch(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_text.py
+++ b/src/Mod/Draft/draftmake/make_text.py
@@ -152,9 +152,9 @@ def make_text(string, placement=None, screen=False, height=None, line_spacing=1)
     removed_in="28.3",
     replacement="Draft.make_text()",
 )
-def makeText(*args, **kwarg):
+def makeText(stringlist, point=App.Vector(0, 0, 0), screen=False):
     """DEPRECATED. Use 'make_text'."""
-    return make_text(*args, **kwarg)
+    return make_text(stringlist, point, screen)
 
 
 def convert_draft_texts(textslist=None):

--- a/src/Mod/Draft/draftmake/make_text.py
+++ b/src/Mod/Draft/draftmake/make_text.py
@@ -33,12 +33,12 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import draftutils.utils as utils
-import draftutils.gui_utils as gui_utils
-
+from draftobjects.text import Text
+from draftutils import gui_utils
+from draftutils import utils
 from draftutils.messages import _err
 from draftutils.translate import translate
-from draftobjects.text import Text
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_text import ViewProviderText
@@ -147,11 +147,14 @@ def make_text(string, placement=None, screen=False, height=None, line_spacing=1)
     return new_obj
 
 
-def makeText(stringlist, point=App.Vector(0, 0, 0), screen=False):
-    """Create Text. DEPRECATED. Use 'make_text'."""
-    utils.use_instead("make_text")
-
-    return make_text(stringlist, point, screen)
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_text()",
+)
+def makeText(*args, **kwarg):
+    """DEPRECATED. Use 'make_text'."""
+    return make_text(*args, **kwarg)
 
 
 def convert_draft_texts(textslist=None):
@@ -210,10 +213,10 @@ def convert_draft_texts(textslist=None):
         doc.removeObject(obj.Name)
 
 
-def convertDraftTexts(textslist=[]):
-    """Convert Text. DEPRECATED. Use 'convert_draft_texts'."""
+def convertDraftTexts(*args, **kwarg):
+    """DEPRECATED. Use 'convert_draft_texts'."""
     utils.use_instead("convert_draft_texts")
-    return convert_draft_texts(textslist)
+    return convert_draft_texts(*args, **kwarg)
 
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_wire.py
+++ b/src/Mod/Draft/draftmake/make_wire.py
@@ -32,8 +32,9 @@
 import FreeCAD as App
 from draftgeoutils import geometry as geo_geometry
 from draftobjects.wire import Wire
-from draftutils import utils
 from draftutils import gui_utils
+from draftutils import utils
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_wire import ViewProviderWire
@@ -129,6 +130,14 @@ def make_wire(pointslist, closed=False, placement=None, face=None, support=None,
     return obj
 
 
-makeWire = make_wire
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_wire()",
+)
+def makeWire(*args, **kwarg):
+    """DEPRECATED. Use 'make_wire'."""
+    return make_wire(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_wpproxy.py
+++ b/src/Mod/Draft/draftmake/make_wpproxy.py
@@ -38,7 +38,7 @@ if App.GuiUp:
     from draftviewproviders.view_wpproxy import ViewProviderWorkingPlaneProxy
 
 
-def make_workingplaneproxy(placement):
+def make_working_plane_proxy(placement):
     """make_working_plane_proxy(placement)
 
     Creates a Working Plane proxy object in the current document.
@@ -62,11 +62,21 @@ def make_workingplaneproxy(placement):
 @deprecated(
     deprecated_in="26.3",
     removed_in="28.3",
-    replacement="Draft.make_workingplaneproxy()",
+    replacement="Draft.make_working_plane_proxy()",
+)
+def make_workingplaneproxy(*args, **kwarg):
+    """DEPRECATED. Use 'make_working_plane_proxy'."""
+    return make_working_plane_proxy(*args, **kwarg)
+
+
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_working_plane_proxy()",
 )
 def makeWorkingPlaneProxy(*args, **kwarg):
-    """DEPRECATED. Use 'make_workingplaneproxy'."""
-    return make_workingplaneproxy(*args, **kwarg)
+    """DEPRECATED. Use 'make_working_plane_proxy'."""
+    return make_working_plane_proxy(*args, **kwarg)
 
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_wpproxy.py
+++ b/src/Mod/Draft/draftmake/make_wpproxy.py
@@ -31,8 +31,8 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-
 from draftobjects.wpproxy import WorkingPlaneProxy
+from freecad.deprecation import deprecated
 
 if App.GuiUp:
     from draftviewproviders.view_wpproxy import ViewProviderWorkingPlaneProxy
@@ -59,6 +59,14 @@ def make_workingplaneproxy(placement):
         return obj
 
 
-makeWorkingPlaneProxy = make_workingplaneproxy
+@deprecated(
+    deprecated_in="26.3",
+    removed_in="28.3",
+    replacement="Draft.make_workingplaneproxy()",
+)
+def makeWorkingPlaneProxy(*args, **kwarg):
+    """DEPRECATED. Use 'make_workingplaneproxy'."""
+    return make_workingplaneproxy(*args, **kwarg)
+
 
 ## @}

--- a/src/Mod/Draft/drafttaskpanels/task_shapestring.py
+++ b/src/Mod/Draft/drafttaskpanels/task_shapestring.py
@@ -235,7 +235,7 @@ class ShapeStringTaskPanelCmd(ShapeStringTaskPanel):
         """Create object in the current document."""
         Gui.addModule("Draft")
         Gui.addModule("WorkingPlane")
-        cmd = "Draft.make_shapestring("
+        cmd = "Draft.make_shape_string("
         cmd += "String=" + self.quote_string(self.text) + ", "
         cmd += "FontFile=" + self.quote_string(self.font_file) + ", "
         cmd += "Size=" + str(self.height) + ", "

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -150,7 +150,7 @@ def _create_objects(doc=None, font_file=None, hatch_file=None, hatch_name=None):
     # Circular arc 3 points
     _msg(16 * "-")
     _msg("Circular arc 3 points")
-    Draft.make_arc_3points([Vector(4250, 0, 0), Vector(4000, 250, 0), Vector(4250, 500, 0)])
+    Draft.make_arc_3_points([Vector(4250, 0, 0), Vector(4000, 250, 0), Vector(4250, 500, 0)])
     _set_text(["Circular arc 3 points"], Vector(4000, -200, 0))
 
     # Circle
@@ -192,7 +192,7 @@ def _create_objects(doc=None, font_file=None, hatch_file=None, hatch_name=None):
     # Cubic bezier
     _msg(16 * "-")
     _msg("Cubic bezier")
-    Draft.make_bezcurve(
+    Draft.make_bez_curve(
         [Vector(10000, 0, 0), Vector(10000, 500, 0), Vector(10500, 0, 0), Vector(10500, 500, 0)],
         degree=3,
     )
@@ -201,7 +201,7 @@ def _create_objects(doc=None, font_file=None, hatch_file=None, hatch_name=None):
     # N-degree bezier
     _msg(16 * "-")
     _msg("N-degree bezier")
-    Draft.make_bezcurve(
+    Draft.make_bez_curve(
         [
             Vector(11000, 0, 0),
             Vector(11100, 400, 0),
@@ -238,7 +238,7 @@ def _create_objects(doc=None, font_file=None, hatch_file=None, hatch_name=None):
     _msg(16 * "-")
     _msg("Shapestring")
     try:
-        shape_string = Draft.make_shapestring("Testing", font_file, 100)
+        shape_string = Draft.make_shape_string("Testing", font_file, 100)
         shape_string.Placement.Base = Vector(14000, 0)
     except Exception:
         _wrn("Shapestring could not be created")
@@ -526,14 +526,14 @@ def _create_objects(doc=None, font_file=None, hatch_file=None, hatch_name=None):
     box.Placement = place
     if App.GuiUp:
         box.ViewObject.Visibility = False
-    Draft.make_shape2dview(box)
+    Draft.make_shape_2d_view(box)
     _set_text(["Shape2DView"], Vector(2000, 5800, 0))
 
     # WorkingPlaneProxy
     _msg(16 * "-")
     _msg("WorkingPlaneProxy")
     place = App.Placement(Vector(3250, 6250, 0), App.Rotation())
-    proxy = Draft.make_workingplaneproxy(place)
+    proxy = Draft.make_working_plane_proxy(place)
     if App.GuiUp:
         proxy.ViewObject.DisplaySize = 500
         proxy.ViewObject.ArrowSize = 50

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -121,7 +121,7 @@ class DraftCreation(test_base.DraftTestCaseDoc):
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={}".format(c))
 
-        obj = Draft.make_arc_3points([a, b, c])
+        obj = Draft.make_arc_3_points([a, b, c])
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_ellipse(self):
@@ -254,7 +254,7 @@ class DraftCreation(test_base.DraftTestCaseDoc):
         fontfile = App.getResourceDir() + "Mod/TechDraw/Resources/fonts/osifont-lgpl3fe.ttf"
         _msg("  text='{0}'".format(text))
         _msg("  fontfile='{0}'".format(fontfile))
-        obj = Draft.make_shapestring(text, fontfile)
+        obj = Draft.make_shape_string(text, fontfile)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_facebinder(self):
@@ -293,7 +293,7 @@ class DraftCreation(test_base.DraftTestCaseDoc):
         d = Vector(9, 0, 0)
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={0}, d={1}".format(c, d))
-        obj = Draft.make_bezcurve([a, b, c, d], degree=3)
+        obj = Draft.make_bez_curve([a, b, c, d], degree=3)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_bezcurve(self):
@@ -309,7 +309,7 @@ class DraftCreation(test_base.DraftTestCaseDoc):
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={0}, d={1}".format(c, d))
         _msg("  e={0}, f={1}".format(e, f))
-        obj = Draft.make_bezcurve([a, b, c, d, e, f])
+        obj = Draft.make_bez_curve([a, b, c, d, e, f])
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_label(self):
@@ -356,7 +356,7 @@ class DraftCreation(test_base.DraftTestCaseDoc):
         _msg("  Test '{}'".format(operation))
         placement = App.Placement(Vector(10, 20, 0), App.Rotation())
         _msg("  placement={}".format(placement))
-        obj = Draft.make_workingplaneproxy(placement)
+        obj = Draft.make_working_plane_proxy(placement)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_hatch(self):

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -444,7 +444,7 @@ class DraftModification(test_base.DraftTestCaseDoc):
         direction = Vector(0, 0, 1)
         _msg("  Projection 2D view")
         _msg("  direction={}".format(direction))
-        obj = Draft.make_shape2dview(prism, direction)
+        obj = Draft.make_shape_2d_view(prism, direction)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_draft_to_sketch(self):

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -1458,7 +1458,7 @@ def drawSpline(spline, forceShape=False):
     -------
     Part::Feature or Part::TopoShape ('Edge', 'Face')
         The returned object is normally a `Draft BezCurve`
-        created with `make_bezcurve.make_bezcurve(controlpoints, degree=degree)`,
+        created with `make_bezcurve.make_bez_curve(controlpoints, degree=degree)`,
         if `forceShape` is `False` and there are no weights.
 
         Otherwise it tries to return a `Part.Shape` of type `'Wire'`,
@@ -1488,7 +1488,7 @@ def drawSpline(spline, forceShape=False):
 
     See also
     --------
-    drawBlock, make_bezcurve.make_bezcurve, Part.BezierCurve, drawSplineIterpolation,
+    drawBlock, make_bezcurve.make_bez_curve, Part.BezierCurve, drawSplineIterpolation,
     Part.BSplineCurve.buildFromPolesMultsKnots
 
     To do
@@ -1580,7 +1580,7 @@ def drawSpline(spline, forceShape=False):
             if not forceShape and weights is None:
                 points = controlpoints[:]
                 del points[degree + 1 :: degree + 1]
-                return make_bezcurve.make_bezcurve(points, degree=degree)
+                return make_bezcurve.make_bez_curve(points, degree=degree)
             else:
                 poles = controlpoints[:]
                 edges = []

--- a/src/Mod/OpenSCAD/importCSG.py
+++ b/src/Mod/OpenSCAD/importCSG.py
@@ -1108,13 +1108,13 @@ def p_cylinder_action(p):
                     mycyl.Dir = (0,0,h)
                     try :
                         import Draft
-                        mycyl.Base = Draft.makePolygon(n,r1,face=True)
+                        mycyl.Base = Draft.make_polygon(n, r1, face=True)
                     except Exception:
                         # If Draft can't import (probably due to lack of Pivy on Mac and
                         # Linux builds of FreeCAD), this is a fallback.
                         # or old level of FreeCAD
                         if printverbose:
-                            print("Draft makePolygon Failed, falling back on manual polygon")
+                            print("Draft make_polygon failed, falling back on manual polygon")
                         mycyl.Base = myPolygon(n,r1)
 
                     else :
@@ -1210,7 +1210,7 @@ def p_circle_action(p) :
         Draft._Circle(mycircle)
         mycircle.Radius = r
         mycircle.MakeFace = True
-        mycircle = Draft.makeCircle(r,face=True) # would call doc.recompute
+        mycircle = Draft.make_circle(r, face=True)
         FreeCAD.ActiveDocument.recompute()
     else :
         mycircle = FreeCAD.ActiveDocument.addObject("Part::Part2DObjectPython",'polygon')

--- a/src/Mod/OpenSCAD/prototype.py
+++ b/src/Mod/OpenSCAD/prototype.py
@@ -156,8 +156,8 @@ class Node:
                 else: #Use Part::Loft and GetWire Feature
                     obj = doc.addObject('Part::Loft', 'frustum')
                     import Draft
-                    p1 = Draft.makePolygon(int(self.arguments['$fn']), r1)
-                    p2 = Draft.makePolygon(int(self.arguments['$fn']), r2)
+                    p1 = Draft.make_polygon(int(self.arguments['$fn']), r1)
+                    p2 = Draft.make_polygon(int(self.arguments['$fn']), r2)
                     if self.arguments['center']:
                         p1.Placement = FreeCAD.Placement(\
                         FreeCAD.Vector(0.0,0.0,-h/2.0),FreeCAD.Rotation())
@@ -226,9 +226,9 @@ class Node:
             import Draft
             if '$fn' in self.arguments and self.arguments['$fn'] != 0 \
             and self.arguments['$fn']<=Node.fnmin:
-                obj = Draft.makePolygon(int(self.arguments['$fn']),r)
+                obj = Draft.make_polygon(int(self.arguments['$fn']), r)
             else:
-                obj = Draft.makeCircle(r) # create a Face
+                obj = Draft.make_circle(r) # create a Face
                 #obj = doc.addObject("Part::Circle",namel);obj.Radius = r
         elif namel == 'color':
             if len(self.children) == 1:

--- a/src/Mod/Test/testPathArray.py
+++ b/src/Mod/Test/testPathArray.py
@@ -21,7 +21,7 @@
 # *                                                                         *
 # ***************************************************************************/
 
-# Tester for Draft makePathArray - shapes on a path - without subelements (see testPathArraySel.py)
+# Tester for Draft make_path_array - shapes on a path - without subelements (see testPathArraySel.py)
 # Usage: in FC gui, select a "shape" document object (sphere, box, etc) (!!select in
 # tree, not document view!!), then a "wire" document object (Wire, Circle, Rectangle,
 # DWire, etc) then run this macro.
@@ -34,9 +34,9 @@ import Draft
 print("testPathArray started")
 items = 4  # count
 centretrans = FreeCAD.Vector(0, 0, 0)  # no translation
-# centretrans = FreeCAD.Vector(-5,-5,0)                     # translation
+# centretrans = FreeCAD.Vector(-5,-5,0)  # translation
 orient = True  # align to curve
-# orient = False                                            # don't align to curve
+# orient = False  # don't align to curve
 
 s = FreeCADGui.Selection.getSelection()
 print("testPathArray: Objects in selection: ", len(s))
@@ -46,7 +46,9 @@ base = s[0]
 path = s[1]
 pathsubs = []
 
-# o = Draft.makePathArray(base,path,items)                            # test with defaults
-o = Draft.makePathArray(base, path, items, centretrans, orient, pathsubs)  # test with non-defaults
+# o = Draft.make_path_array(base, path, items)  # test with defaults
+o = Draft.make_path_array(
+    base, path, items, extra=centretrans, subelements=pathsubs, align=orient
+)  # test with non-defaults
 
 print("testPathArray ended")

--- a/src/Mod/Test/testPathArraySel.py
+++ b/src/Mod/Test/testPathArraySel.py
@@ -21,7 +21,7 @@
 # *                                                                         *
 # ***************************************************************************/
 
-# Tester for Draft makePathArray - shapes on a path - with selected subobjects
+# Tester for Draft make_path_array - shapes on a path - with selected subobjects
 # Usage: in FC gui, select a "shape" document object (sphere, box, etc) (!select in
 # tree, not document view!!), then select edges from the "wire" object.
 
@@ -33,9 +33,9 @@ import Draft
 print("testPathArray started")
 items = 4  # count
 centretrans = FreeCAD.Vector(0, 0, 0)  # translation
-# centretrans = FreeCAD.Vector(10,10,10)                     # translation
+# centretrans = FreeCAD.Vector(10,10,10)  # translation
 orient = True  # align to curve
-# orient = False                                             # don't align to curve
+# orient = False  # don't align to curve
 
 # use this to test w/ path subelements
 s = FreeCADGui.Selection.getSelectionEx()
@@ -52,9 +52,9 @@ path = s[1].Object
 pathsubs = list(s[1].SubElementNames)
 print("testPathArray: pathsubs: ", pathsubs)
 
-# o = Draft.makePathArray(base,path,items)                                        # test with defaults
-o = Draft.makePathArray(
-    base, path, items, centretrans, orient, pathsubs
+# o = Draft.make_path_array(base, path, items)  # test with defaults
+o = Draft.make_path_array(
+    base, path, items, extra=centretrans, subelements=pathsubs, align=orient
 )  # test w/o orienting shapes
 
 print("testPathArray ended")


### PR DESCRIPTION
PR to update Draft `make*` camelCase function calls to `make_*` calls. Old functions are deprecated with `freecad.deprecation`.

Supersedes #30809.