### PR TITLE
App: make document property changes undoable

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2368,6 +2368,8 @@ void Application::initTypes()
     // register transaction type
     new App::TransactionProducer<TransactionDocumentObject>
             (DocumentObject::getClassTypeId());
+    new App::TransactionProducer<TransactionObject>
+            (Document::getClassTypeId());
 
     // register exception producer types
     // NOLINTBEGIN

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -281,11 +281,13 @@ Base::ScopeGuard Document::setDefiningTransaction()
     });
 }
 
-void Document::changePropertyOfObject(TransactionalObject* obj,
+void Document::changePropertyOfObject(PropertyContainer* obj,
                                       const Property* prop,
                                       const std::function<void()>& changeFunc)
 {
-    if (!prop || !obj || !obj->isAttachedToDocument()) {
+    auto* transactionObject = freecad_cast<TransactionalObject*>(obj);
+    if (!prop || !obj || (obj != this && (!transactionObject
+                                          || !transactionObject->isAttachedToDocument()))) {
         return;
     }
     if (!isPerformingTransaction() && !d->activeUndoTransaction) {
@@ -302,7 +304,7 @@ void Document::changePropertyOfObject(TransactionalObject* obj,
     }
 }
 
-void Document::renamePropertyOfObject(TransactionalObject* obj,
+void Document::renamePropertyOfObject(PropertyContainer* obj,
                                       const Property* prop, const char* oldName)
 {
     changePropertyOfObject(obj, prop, [this, obj, prop, oldName]() {
@@ -320,7 +322,7 @@ void Document::arrangeMovePropertyOfObject(TransactionalObject* obj,
     });
 }
 
-void Document::addOrRemovePropertyOfObject(TransactionalObject* obj,
+void Document::addOrRemovePropertyOfObject(PropertyContainer* obj,
                                            const Property* prop, const bool add)
 {
     changePropertyOfObject(obj, prop, [this, obj, prop, add]() {
@@ -852,10 +854,28 @@ unsigned int Document::getMaxUndoStackSize() const
 
 void Document::onBeforeChange(const Property* prop)
 {
+    changePropertyOfObject(this, prop, [this, prop]() {
+        d->activeUndoTransaction->addObjectChange(this, prop);
+    });
     if (prop == &Label) {
         oldLabel = Label.getValue();
     }
     signalBeforeChange(*this, *prop);
+}
+
+void Document::onDynamicPropertyAdded(const Property* prop)
+{
+    addOrRemovePropertyOfObject(this, prop, true);
+}
+
+void Document::onDynamicPropertyRemoving(const Property* prop)
+{
+    addOrRemovePropertyOfObject(this, prop, false);
+}
+
+void Document::onDynamicPropertyRenamed(const Property* prop, const char* oldName)
+{
+    renamePropertyOfObject(this, prop, oldName);
 }
 
 void Document::onChanged(const Property* prop)

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -1034,26 +1034,26 @@ public:
     bool isPerformingTransaction() const;
 
     /**
-     * @brief Register that a property of an object has changed in a transaction.
+     * @brief Register that a property of a container was added or removed.
      *
-     * @param[in] obj The object whose property has changed.
+     * @param[in] obj The container whose property has changed.
      * @param[in] prop The property that has changed.
      * @param[in] add If true, the property was added, if false it was removed.
      *
      * @warning This function is only for internal use.
      */
-    void addOrRemovePropertyOfObject(TransactionalObject* obj, const Property* prop, bool add);
+    void addOrRemovePropertyOfObject(PropertyContainer* obj, const Property* prop, bool add);
 
     /**
-     * @brief Register that a property of an object has been renamed in a transaction.
+     * @brief Register that a property of a container has been renamed in a transaction.
      *
-     * @param[in] obj The object whose property has changed.
+     * @param[in] obj The container whose property has changed.
      * @param[in] prop The property that has changed.
-     * @param[in] newName The new name of the property.
+     * @param[in] oldName The previous name of the property.
      *
      * @warning This function is only for internal use.
      */
-    void renamePropertyOfObject(TransactionalObject* obj, const Property* prop, const char* newName);
+    void renamePropertyOfObject(PropertyContainer* obj, const Property* prop, const char* oldName);
 
     /**
      * @brief Register in a transaction that a property move has been arranged.
@@ -1398,6 +1398,9 @@ protected:
 
     void onBeforeChange(const Property* prop) override;
     void onChanged(const Property* prop) override;
+    void onDynamicPropertyAdded(const Property* prop) override;
+    void onDynamicPropertyRemoving(const Property* prop) override;
+    void onDynamicPropertyRenamed(const Property* prop, const char* oldName) override;
 
     /**
      * @brief Notify the document that a property is about to be changed.
@@ -1468,7 +1471,7 @@ protected:
     void _abortTransaction();
 
 private:
-    void changePropertyOfObject(TransactionalObject* obj, const Property* prop,
+    void changePropertyOfObject(PropertyContainer* obj, const Property* prop,
                                 const std::function<void()>& changeFunc);
     [[nodiscard]] Base::ScopeGuard setDefiningTransaction();
 

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -837,8 +837,6 @@ bool DocumentObject::removeDynamicProperty(const char* name)
         clearOutListCache();
     }
 
-    _pDoc->addOrRemovePropertyOfObject(this, prop, false);
-
     auto expressions = ExpressionEngine.getExpressions();
     std::vector<App::ObjectIdentifier> removeExpr;
 
@@ -857,8 +855,6 @@ bool DocumentObject::removeDynamicProperty(const char* name)
 
 bool DocumentObject::renameDynamicProperty(Property* prop, const char* name)
 {
-    std::string oldName = prop->getName();
-
     auto expressions = ExpressionEngine.getExpressions();
     std::vector<std::shared_ptr<Expression>> expressionsToMove;
     std::vector<App::ObjectIdentifier> idsWithExprsToRemove;
@@ -875,11 +871,6 @@ bool DocumentObject::renameDynamicProperty(Property* prop, const char* name)
     }
 
     bool renamed = TransactionalObject::renameDynamicProperty(prop, name);
-    if (renamed && _pDoc) {
-        _pDoc->renamePropertyOfObject(this, prop, oldName.c_str());
-    }
-
-
     App::ObjectIdentifier idNewProp(prop->getContainer(), std::string(name));
     for (auto& exprToMove : expressionsToMove) {
         ExpressionEngine.setValue(idNewProp, exprToMove);
@@ -1029,11 +1020,28 @@ App::Property* DocumentObject::addDynamicProperty(
     bool hidden
 )
 {
-    auto prop = TransactionalObject::addDynamicProperty(type, name, group, doc, attr, ro, hidden);
-    if (prop && _pDoc) {
+    return TransactionalObject::addDynamicProperty(type, name, group, doc, attr, ro, hidden);
+}
+
+void DocumentObject::onDynamicPropertyAdded(const Property* prop)
+{
+    if (_pDoc) {
         _pDoc->addOrRemovePropertyOfObject(this, prop, true);
     }
-    return prop;
+}
+
+void DocumentObject::onDynamicPropertyRemoving(const Property* prop)
+{
+    if (_pDoc) {
+        _pDoc->addOrRemovePropertyOfObject(this, prop, false);
+    }
+}
+
+void DocumentObject::onDynamicPropertyRenamed(const Property* prop, const char* oldName)
+{
+    if (_pDoc) {
+        _pDoc->renamePropertyOfObject(this, prop, oldName);
+    }
 }
 
 void DocumentObject::onBeforeChange(const Property* prop)

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -1408,6 +1408,10 @@ public:
     static std::set<ObjectIdentifier> getPropertyUses(const App::Property* prop);
 
 protected:
+    void onDynamicPropertyAdded(const Property* prop) override;
+    void onDynamicPropertyRemoving(const Property* prop) override;
+    void onDynamicPropertyRenamed(const Property* prop, const char* oldName) override;
+
     /// Recompute only this object.
     virtual App::DocumentObjectExecReturn* recompute();
 

--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -78,7 +78,36 @@ App::Property* PropertyContainer::addDynamicProperty(
     bool hidden
 )
 {
-    return dynamicProps.addDynamicProperty(*this, type, name, group, doc, attr, ro, hidden);
+    auto* prop = dynamicProps.addDynamicProperty(*this, type, name, group, doc, attr, ro, hidden);
+    if (prop) {
+        onDynamicPropertyAdded(prop);
+    }
+    return prop;
+}
+
+bool PropertyContainer::renameDynamicProperty(Property* prop, const char* name)
+{
+    std::string oldName = prop ? prop->getName() : std::string();
+    bool renamed = dynamicProps.renameDynamicProperty(prop, name);
+    if (renamed) {
+        onDynamicPropertyRenamed(prop, oldName.c_str());
+    }
+    return renamed;
+}
+
+bool PropertyContainer::removeDynamicProperty(const char* name)
+{
+    auto* prop = getDynamicPropertyByName(name);
+    if (prop) {
+        if (prop->testStatus(Property::LockDynamic)) {
+            throw Base::RuntimeError("property is locked");
+        }
+        if (!prop->testStatus(Property::PropDynamic)) {
+            throw Base::RuntimeError("property is not dynamic");
+        }
+        onDynamicPropertyRemoving(prop);
+    }
+    return dynamicProps.removeDynamicProperty(name);
 }
 
 Property *PropertyContainer::getPropertyByName(const char* name) const
@@ -653,4 +682,3 @@ void PropertyData::visitProperties(OffsetBase offsetBase,
         visitor(reinterpret_cast<Property*>(spec.Offset + offset));
     };
 }
-

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -532,9 +532,7 @@ public:
    * @return `true` if the property was renamed; `false` otherwise.
    * @throw Base::NameError If the new name is invalid or already exists.
    */
-  virtual bool renameDynamicProperty(Property *prop, const char *name) {
-      return dynamicProps.renameDynamicProperty(prop, name);
-  }
+  virtual bool renameDynamicProperty(Property *prop, const char *name);
 
   /**
    * @brief Remove a dynamic property.
@@ -542,9 +540,7 @@ public:
    * @param[in] name The name of the property to remove.
    * @return `true` if the property was removed; `false` otherwise.
    */
-  virtual bool removeDynamicProperty(const char* name) {
-      return dynamicProps.removeDynamicProperty(name);
-  }
+  virtual bool removeDynamicProperty(const char* name);
 
   /**
    * @brief Get the names of all dynamic properties.
@@ -727,6 +723,10 @@ public:
   PropertyContainer& operator = (const PropertyContainer&) = delete;
 
 protected:
+  virtual void onDynamicPropertyAdded([[maybe_unused]] const Property* prop) {}
+  virtual void onDynamicPropertyRemoving([[maybe_unused]] const Property* prop) {}
+  virtual void onDynamicPropertyRenamed([[maybe_unused]] const Property* prop,
+                                        [[maybe_unused]] const char* oldName) {}
 
   /// The container for dynamic properties.
   DynamicProperty dynamicProps;

--- a/src/App/Transactions.cpp
+++ b/src/App/Transactions.cpp
@@ -70,7 +70,8 @@ Transaction::~Transaction()
             // to cause a memory leak. This usually is the case when the removal
             // of an object is not undone or when an addition is undone.
 
-            if (!It.first->isAttachedToDocument()) {
+            auto* transactionObject = freecad_cast<const TransactionalObject*>(It.first);
+            if (transactionObject && !transactionObject->isAttachedToDocument()) {
                 if (It.first->isDerivedFrom<DocumentObject>()) {
                     // #0003323: Crash when clearing transaction list
                     // It can happen that when clearing the transaction list several objects
@@ -132,7 +133,7 @@ bool Transaction::isEmpty() const
     return _Objects.empty();
 }
 
-bool Transaction::hasObject(const TransactionalObject* Obj) const
+bool Transaction::hasObject(const PropertyContainer* Obj) const
 {
 #if BOOST_VERSION < 107500
     return !!_Objects.get<1>().count(Obj);
@@ -141,7 +142,7 @@ bool Transaction::hasObject(const TransactionalObject* Obj) const
 #endif
 }
 
-void Transaction::changeProperty(TransactionalObject* Obj,
+void Transaction::changeProperty(PropertyContainer* Obj,
                                  std::function<void(TransactionObject* to)> changeFunc)
 {
     auto& index = _Objects.get<1>();
@@ -158,7 +159,7 @@ void Transaction::changeProperty(TransactionalObject* Obj,
     }
 }
 
-void Transaction::renameProperty(TransactionalObject* Obj, const Property* pcProp, const char* oldName)
+void Transaction::renameProperty(PropertyContainer* Obj, const Property* pcProp, const char* oldName)
 {
     changeProperty(Obj, [pcProp, oldName](TransactionObject* to) {
         to->renameProperty(pcProp, oldName);
@@ -173,7 +174,7 @@ void Transaction::arrangeMoveProperty(TransactionalObject* Obj, const Property* 
     });
 }
 
-void Transaction::addOrRemoveProperty(TransactionalObject* Obj, const Property* pcProp, bool add)
+void Transaction::addOrRemoveProperty(PropertyContainer* Obj, const Property* pcProp, bool add)
 {
     changeProperty(Obj, [pcProp, add](TransactionObject* to) {
         to->addOrRemoveProperty(pcProp, add);
@@ -190,13 +191,13 @@ void Transaction::apply(Document& Doc, bool forward)
     try {
         auto& index = _Objects.get<0>();
         for (auto& info : index) {
-            info.second->applyDel(Doc, const_cast<TransactionalObject*>(info.first));
+            info.second->applyDel(Doc, const_cast<PropertyContainer*>(info.first));
         }
         for (auto& info : index) {
-            info.second->applyNew(Doc, const_cast<TransactionalObject*>(info.first));
+            info.second->applyNew(Doc, const_cast<PropertyContainer*>(info.first));
         }
         for (auto& info : index) {
-            info.second->applyChn(Doc, const_cast<TransactionalObject*>(info.first), forward);
+            info.second->applyChn(Doc, const_cast<PropertyContainer*>(info.first), forward);
         }
     }
     catch (Base::Exception& e) {
@@ -262,7 +263,7 @@ void Transaction::addObjectDel(const TransactionalObject* Obj)
     }
 }
 
-void Transaction::addObjectChange(const TransactionalObject* Obj, const Property* Prop)
+void Transaction::addObjectChange(const PropertyContainer* Obj, const Property* Prop)
 {
     auto& index = _Objects.get<1>();
     auto pos = index.find(Obj);
@@ -304,13 +305,13 @@ TransactionObject::~TransactionObject()
     }
 }
 
-void TransactionObject::applyDel(Document& /*Doc*/, TransactionalObject* /*pcObj*/)
+void TransactionObject::applyDel(Document& /*Doc*/, PropertyContainer* /*pcObj*/)
 {}
 
-void TransactionObject::applyNew(Document& /*Doc*/, TransactionalObject* /*pcObj*/)
+void TransactionObject::applyNew(Document& /*Doc*/, PropertyContainer* /*pcObj*/)
 {}
 
-void TransactionObject::applyChn(Document& /*Doc*/, TransactionalObject* pcObj, bool /* Forward */)
+void TransactionObject::applyChn(Document& /*Doc*/, PropertyContainer* pcObj, bool /* Forward */)
 {
     if (status == New || status == Chn) {
         // Property change order is not preserved, as it is recursive in nature
@@ -541,7 +542,7 @@ TransactionDocumentObject::TransactionDocumentObject() = default;
  */
 TransactionDocumentObject::~TransactionDocumentObject() = default;
 
-void TransactionDocumentObject::applyDel(Document& Doc, TransactionalObject* pcObj)
+void TransactionDocumentObject::applyDel(Document& Doc, PropertyContainer* pcObj)
 {
     if (status == Del) {
         DocumentObject* obj = static_cast<DocumentObject*>(pcObj);
@@ -568,7 +569,7 @@ void TransactionDocumentObject::applyDel(Document& Doc, TransactionalObject* pcO
     }
 }
 
-void TransactionDocumentObject::applyNew(Document& Doc, TransactionalObject* pcObj)
+void TransactionDocumentObject::applyNew(Document& Doc, PropertyContainer* pcObj)
 {
     if (status == New) {
         DocumentObject* obj = static_cast<DocumentObject*>(pcObj);

--- a/src/App/Transactions.h
+++ b/src/App/Transactions.h
@@ -110,7 +110,7 @@ public:
      * @param[in] Obj The object to check.
      * @return true if the object is used in a transaction; otherwise false.
      */
-    bool hasObject(const TransactionalObject* Obj) const;
+    bool hasObject(const PropertyContainer* Obj) const;
 
     /**
      * @brief Record renaming a property.
@@ -119,7 +119,7 @@ public:
      * @param[in] pcProp The property with a new name.
      * @param[in] oldName The old name of the property.
      */
-    void renameProperty(TransactionalObject* Obj, const Property* pcProp, const char* oldName);
+    void renameProperty(PropertyContainer* Obj, const Property* pcProp, const char* oldName);
 
     /**
      * @brief Arrange moving a property.
@@ -143,7 +143,7 @@ public:
      * @param[in] pcProp The property to add or remove.
      * @param[in] add If true, add the property; otherwise, remove it.
      */
-    void addOrRemoveProperty(TransactionalObject* Obj, const Property* pcProp, bool add);
+    void addOrRemoveProperty(PropertyContainer* Obj, const Property* pcProp, bool add);
 
     /**
      * @brief Record adding a new object to the transaction.
@@ -165,20 +165,20 @@ public:
      * @param[in] Obj The object to change.
      * @param[in] Prop The property that is changed.
      */
-    void addObjectChange(const TransactionalObject* Obj, const Property* Prop);
+    void addObjectChange(const PropertyContainer* Obj, const Property* Prop);
 
 private:
-    void changeProperty(TransactionalObject* Obj,
+    void changeProperty(PropertyContainer* Obj,
                         std::function<void(TransactionObject* to)> changeFunc);
 
 private:
     int transID;
-    using Info = std::pair<const TransactionalObject*, TransactionObject*>;
+    using Info = std::pair<const PropertyContainer*, TransactionObject*>;
     bmi::multi_index_container<
         Info,
         bmi::indexed_by<
             bmi::sequenced<>,
-            bmi::hashed_unique<bmi::member<Info, const TransactionalObject*, &Info::first>>>>
+            bmi::hashed_unique<bmi::member<Info, const PropertyContainer*, &Info::first>>>>
         _Objects;
 };
 
@@ -205,7 +205,7 @@ public:
      * @param[in,out] doc The document to apply the transaction to.
      * @param[in,out] obj The object that is added in the transaction.
      */
-    virtual void applyNew(Document& doc, TransactionalObject* obj);
+    virtual void applyNew(Document& doc, PropertyContainer* obj);
 
     /**
      * @brief Apply the transaction that removes an object from the document.
@@ -213,7 +213,7 @@ public:
      * @param[in,out] doc The document to apply the transaction to.
      * @param[in,out] obj The object that is removed in the transaction.
      */
-    virtual void applyDel(Document& doc, TransactionalObject* obj);
+    virtual void applyDel(Document& doc, PropertyContainer* obj);
 
     /**
      * @brief Apply the transaction that changes an object in the document.
@@ -222,7 +222,7 @@ public:
      * @param[in,out] obj The object that is changed in the transaction.
      * @param[in] forward If true, apply the transaction; otherwise, undo it.
      */
-    virtual void applyChn(Document& doc, TransactionalObject* obj, bool forward);
+    virtual void applyChn(Document& doc, PropertyContainer* obj, bool forward);
 
     /**
      * @brief Set the property of the object that is affected by the transaction.
@@ -303,8 +303,8 @@ public:
 
     ~TransactionDocumentObject() override;
 
-    void applyNew(Document& Doc, TransactionalObject* pcObj) override;
-    void applyDel(Document& Doc, TransactionalObject* pcObj) override;
+    void applyNew(Document& Doc, PropertyContainer* pcObj) override;
+    void applyDel(Document& Doc, PropertyContainer* pcObj) override;
 };
 
 /**

--- a/src/Gui/TransactionObject.cpp
+++ b/src/Gui/TransactionObject.cpp
@@ -36,7 +36,7 @@ TransactionViewProvider::TransactionViewProvider() = default;
 
 TransactionViewProvider::~TransactionViewProvider() = default;
 
-void TransactionViewProvider::applyNew(App::Document& Doc, App::TransactionalObject* pcObj)
+void TransactionViewProvider::applyNew(App::Document& Doc, App::PropertyContainer* pcObj)
 {
     if (status == New) {
         Gui::Document* doc = Application::Instance->getDocument(&Doc);
@@ -46,7 +46,7 @@ void TransactionViewProvider::applyNew(App::Document& Doc, App::TransactionalObj
     }
 }
 
-void TransactionViewProvider::applyDel(App::Document& Doc, App::TransactionalObject* pcObj)
+void TransactionViewProvider::applyDel(App::Document& Doc, App::PropertyContainer* pcObj)
 {
     // nothing to do here
     Q_UNUSED(Doc);

--- a/src/Gui/TransactionObject.h
+++ b/src/Gui/TransactionObject.h
@@ -35,8 +35,8 @@ public:
     TransactionViewProvider();
     ~TransactionViewProvider() override;
 
-    void applyNew(App::Document& Doc, App::TransactionalObject* pcObj) override;
-    void applyDel(App::Document& Doc, App::TransactionalObject* pcObj) override;
+    void applyNew(App::Document& Doc, App::PropertyContainer* pcObj) override;
+    void applyDel(App::Document& Doc, App::PropertyContainer* pcObj) override;
 };
 
 }  // namespace Gui

--- a/tests/src/App/Document.cpp
+++ b/tests/src/App/Document.cpp
@@ -5,6 +5,7 @@
 
 #include "App/Application.h"
 #include "App/Document.h"
+#include "App/PropertyStandard.h"
 #include "App/StringHasher.h"
 #include "Base/Writer.h"
 #include <src/App/InitApplication.h>
@@ -92,6 +93,118 @@ TEST_F(DocumentTest, getStringHasherGivesExpectedHasher)
 
     // Assert
     EXPECT_EQ(hasher, foundHasher);
+}
+
+TEST_F(DocumentTest, dynamicPropertyAdditionCanBeUndoneAndRedone)
+{
+    doc()->openTransaction("Add document property");
+    doc()->addDynamicProperty("App::PropertyInteger", "DynamicInteger");
+    doc()->commitTransaction();
+
+    ASSERT_NE(doc()->getDynamicPropertyByName("DynamicInteger"), nullptr);
+    EXPECT_TRUE(doc()->undo());
+    EXPECT_EQ(doc()->getDynamicPropertyByName("DynamicInteger"), nullptr);
+    EXPECT_TRUE(doc()->redo());
+    EXPECT_NE(doc()->getDynamicPropertyByName("DynamicInteger"), nullptr);
+}
+
+TEST_F(DocumentTest, dynamicPropertyRemovalCanBeUndoneAndRedone)
+{
+    doc()->addDynamicProperty("App::PropertyInteger", "DynamicInteger");
+    doc()->clearUndos();
+
+    doc()->openTransaction("Remove document property");
+    doc()->removeDynamicProperty("DynamicInteger");
+    doc()->commitTransaction();
+
+    ASSERT_EQ(doc()->getDynamicPropertyByName("DynamicInteger"), nullptr);
+    EXPECT_TRUE(doc()->undo());
+    EXPECT_NE(doc()->getDynamicPropertyByName("DynamicInteger"), nullptr);
+    EXPECT_TRUE(doc()->redo());
+    EXPECT_EQ(doc()->getDynamicPropertyByName("DynamicInteger"), nullptr);
+}
+
+TEST_F(DocumentTest, dynamicPropertyValueCanBeUndoneAndRedone)
+{
+    auto* property = freecad_cast<App::PropertyInteger*>(
+        doc()->addDynamicProperty("App::PropertyInteger", "DynamicInteger")
+    );
+    ASSERT_NE(property, nullptr);
+    property->setValue(1);
+    doc()->clearUndos();
+
+    doc()->openTransaction("Change document property");
+    property->setValue(2);
+    doc()->commitTransaction();
+
+    EXPECT_TRUE(doc()->undo());
+    EXPECT_EQ(property->getValue(), 1);
+    EXPECT_TRUE(doc()->redo());
+    EXPECT_EQ(property->getValue(), 2);
+}
+
+TEST_F(DocumentTest, staticPropertyValueCanBeUndoneAndRedone)
+{
+    doc()->Label.setValue("Before");
+    doc()->clearUndos();
+
+    doc()->openTransaction("Change document label");
+    doc()->Label.setValue("After");
+    doc()->commitTransaction();
+
+    EXPECT_TRUE(doc()->undo());
+    EXPECT_STREQ(doc()->Label.getValue(), "Before");
+    EXPECT_TRUE(doc()->redo());
+    EXPECT_STREQ(doc()->Label.getValue(), "After");
+}
+
+TEST_F(DocumentTest, dynamicPropertyRenameCanBeUndoneAndRedone)
+{
+    auto* property = doc()->addDynamicProperty("App::PropertyInteger", "OriginalName");
+    doc()->clearUndos();
+
+    doc()->openTransaction("Rename document property");
+    ASSERT_TRUE(doc()->renameDynamicProperty(property, "NewName"));
+    doc()->commitTransaction();
+
+    EXPECT_TRUE(doc()->undo());
+    EXPECT_EQ(doc()->getDynamicPropertyByName("NewName"), nullptr);
+    EXPECT_EQ(doc()->getDynamicPropertyByName("OriginalName"), property);
+    EXPECT_TRUE(doc()->redo());
+    EXPECT_EQ(doc()->getDynamicPropertyByName("OriginalName"), nullptr);
+    EXPECT_EQ(doc()->getDynamicPropertyByName("NewName"), property);
+}
+
+TEST_F(DocumentTest, lockedPropertyRemovalDoesNotCreateUndoEntry)
+{
+    auto* property = doc()->addDynamicProperty("App::PropertyInteger", "DynamicInteger");
+    property->setStatus(App::Property::LockDynamic, true);
+    doc()->clearUndos();
+
+    doc()->openTransaction("Remove locked document property");
+    EXPECT_THROW(doc()->removeDynamicProperty("DynamicInteger"), Base::RuntimeError);
+    doc()->commitTransaction();
+
+    EXPECT_EQ(doc()->getDynamicPropertyByName("DynamicInteger"), property);
+    EXPECT_FALSE(doc()->undo());
+}
+
+TEST_F(DocumentTest, documentAndObjectPropertyAdditionsShareTransaction)
+{
+    auto* object = doc()->addObject("App::FeaturePython", "Feature");
+    doc()->clearUndos();
+
+    doc()->openTransaction("Add properties");
+    doc()->addDynamicProperty("App::PropertyInteger", "DocumentInteger");
+    object->addDynamicProperty("App::PropertyInteger", "ObjectInteger");
+    doc()->commitTransaction();
+
+    EXPECT_TRUE(doc()->undo());
+    EXPECT_EQ(doc()->getDynamicPropertyByName("DocumentInteger"), nullptr);
+    EXPECT_EQ(object->getDynamicPropertyByName("ObjectInteger"), nullptr);
+    EXPECT_TRUE(doc()->redo());
+    EXPECT_NE(doc()->getDynamicPropertyByName("DocumentInteger"), nullptr);
+    EXPECT_NE(object->getDynamicPropertyByName("ObjectInteger"), nullptr);
 }
 
 // NOLINTEND(readability-magic-numbers)


### PR DESCRIPTION
Make document property changes participate in transactions, so they can be undone and redone just like properties on document objects.

Transactions previously stored property changes against `TransactionalObject`. That works for `DocumentObject`, but not for `Document`, even though both are `PropertyContainer`s.

This change:

- moves the dynamic-property hooks into `PropertyContainer`;
- lets `Document` and `DocumentObject` record changes through those hooks;
- allows property transaction entries to target any `PropertyContainer`;
- keeps object creation and deletion limited to `TransactionalObject`.

## Why this approach?

The key point is that recording a property change only requires a property container—it does not require the full lifecycle of a transactional document object.

Making `PropertyContainer` itself a `TransactionalObject` would mix those two responsibilities and give every property container object-lifecycle semantics it may not need. Instead, this only generalizes the part that was too restrictive while leaving the existing hierarchy and object transaction behavior intact.

It also keeps the hooks close to where dynamic properties are actually changed, giving `Document` and `DocumentObject` one consistent path without duplicating the logic.

Regression tests cover adding, removing, changing, and renaming document properties, including locked properties and transactions that mix document and object changes.

Fixes https://github.com/FreeCAD/FreeCAD/issues/32354

Assisted-by: GPT5.6-Sol