### PR TITLE
CAM: add a validator for machine (.fcm) definitions

### DIFF
--- a/src/Mod/CAM/CAMTests/TestMachineValidate.py
+++ b/src/Mod/CAM/CAMTests/TestMachineValidate.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+import json
+import pathlib
+import tempfile
+
+import CAMTests.PathTestUtils as PathTestUtils
+from Machine.models.machine import Machine, Toolhead, ToolheadType
+from Machine.models.validate import (
+    Severity,
+    validate_machine,
+    validate_file,
+    validate_paths,
+    format_findings,
+    main,
+    _normalize_path,
+)
+
+
+def _codes(findings, severity=None):
+    """Finding codes, optionally filtered by severity."""
+    return [f.code for f in findings if severity is None or f.severity is severity]
+
+
+class TestMachineValidate(PathTestUtils.PathTestBase):
+    """Validation of machine (.fcm) definitions."""
+
+    def _valid_machine(self):
+        """A machine that passes every check, as the starting point for each case.
+
+        create_3axis_config() defines no toolhead, so one is added here --
+        otherwise every test would also carry a no-toolheads warning.
+        """
+        machine = Machine.create_3axis_config()
+        machine.name = "Validator Test Machine"
+        machine.toolheads = [Toolhead(name="Spindle", toolhead_type=ToolheadType.ROTARY)]
+        return machine
+
+    # ------------------------------------------------------------------
+    # validate_machine
+    # ------------------------------------------------------------------
+
+    def test000_clean_machine_has_no_errors(self):
+        """A stock 3-axis machine produces no errors."""
+        findings = validate_machine(self._valid_machine(), check_postprocessor=False)
+        self.assertEqual(_codes(findings, Severity.ERROR), [])
+
+    def test010_empty_name_is_an_error(self):
+        """A machine with no name cannot be resolved by MachineFactory."""
+        machine = self._valid_machine()
+        machine.name = "   "
+        self.assertIn("no-name", _codes(validate_machine(machine, check_postprocessor=False)))
+
+    def test020_no_axes_is_an_error(self):
+        machine = self._valid_machine()
+        machine.linear_axes = {}
+        machine.rotary_axes = {}
+        self.assertIn("no-axes", _codes(validate_machine(machine, check_postprocessor=False)))
+
+    def test030_inverted_axis_limits_are_an_error(self):
+        """min_limit >= max_limit makes the envelope meaningless."""
+        machine = self._valid_machine()
+        machine.linear_axes["X"].min_limit = 500
+        machine.linear_axes["X"].max_limit = 100
+        findings = validate_machine(machine, check_postprocessor=False)
+        self.assertIn("axis-limits", _codes(findings, Severity.ERROR))
+
+    def test040_no_toolheads_is_a_warning(self):
+        machine = self._valid_machine()
+        machine.toolheads = []
+        findings = validate_machine(machine, check_postprocessor=False)
+        self.assertIn("no-toolheads", _codes(findings, Severity.WARNING))
+
+    def test050_broken_kinematic_chain_is_an_error(self):
+        """Errors from validate_kinematic_chain() are surfaced as findings."""
+        machine = self._valid_machine()
+        machine.linear_axes["X"].parent = "NoSuchAxis"
+        findings = validate_machine(machine, check_postprocessor=False)
+        self.assertIn("kinematics", _codes(findings, Severity.ERROR))
+
+    def test060_missing_postprocessor_is_an_error(self):
+        machine = self._valid_machine()
+        machine.postprocessor_file_name = ""
+        self.assertIn("no-postprocessor", _codes(validate_machine(machine)))
+
+        machine.postprocessor_file_name = "no_such_postprocessor_exists"
+        self.assertIn("postprocessor-missing", _codes(validate_machine(machine)))
+
+    def test070_unknown_postprocessor_property_is_a_warning(self):
+        """A misspelled property key is accepted by the model but never read."""
+        machine = self._valid_machine()
+        machine.postprocessor_file_name = "generic"
+        machine.postprocessor_properties = {"preamble": "G90", "not_a_real_property": 1}
+        findings = validate_machine(machine)
+        self.assertIn("unknown-properties", _codes(findings, Severity.WARNING))
+        self.assertIn("not_a_real_property", str(findings))
+
+    # ------------------------------------------------------------------
+    # dropped-data detection
+    # ------------------------------------------------------------------
+
+    def test100_keys_the_loader_ignores_are_reported(self):
+        """Data present in the file but never read must not pass silently."""
+        machine = self._valid_machine()
+        raw = machine.to_dict()
+        raw["machine"]["axes"]["X"]["min"] = 0
+        raw["machine"]["axes"]["X"]["max"] = 500
+        raw["invented_section"] = {"nested": True}
+
+        findings = validate_machine(machine, raw=raw, check_postprocessor=False)
+        self.assertIn("ignored-keys", _codes(findings, Severity.WARNING))
+        message = str(findings)
+        self.assertIn("machine.axes.X.max", message)
+        self.assertIn("invented_section", message)
+
+    def test110_round_trip_of_current_format_is_clean(self):
+        """A file written by the current model reports no dropped data."""
+        machine = self._valid_machine()
+        raw = machine.to_dict()
+        findings = validate_machine(machine, raw=raw, check_postprocessor=False)
+        self.assertEqual(_codes(findings, Severity.WARNING), [])
+
+    def test120_legacy_spellings_are_not_reported_as_dropped(self):
+        """Keys the loader still reads under an older name are not warnings.
+
+        Guards the rewrite table against becoming a source of false positives,
+        which is what would make the warning tier ignorable.
+        """
+        machine = self._valid_machine()
+        raw = machine.to_dict()
+
+        # machine.spindles is still read as machine.toolheads
+        raw["machine"]["spindles"] = raw["machine"].pop("toolheads")
+        # output_header is read from the output level as well as from header
+        raw["output"]["output_header"] = raw["output"]["header"].pop("output_header")
+        # joints are accepted as an object as well as a pair of arrays
+        for axis in raw["machine"]["axes"].values():
+            origin, vector = axis["joint"]
+            axis["joint"] = {"origin": origin, "axis": vector}
+
+        reloaded = Machine.from_dict(raw)
+        findings = validate_machine(reloaded, raw=raw, check_postprocessor=False)
+        self.assertEqual(
+            _codes(findings, Severity.WARNING),
+            [],
+            f"legacy spellings reported as dropped: {findings}",
+        )
+
+    def test130_normalize_path_chains_rewrites(self):
+        """One rewrite can expose another; all of them must be applied."""
+        self.assertEqual(
+            _normalize_path("machine.spindles.spindle_wait"),
+            "machine.toolheads.toolhead_wait",
+        )
+        self.assertEqual(_normalize_path("machine.spindles"), "machine.toolheads")
+        self.assertEqual(_normalize_path("machine.axes.X.joint.origin"), "machine.axes.X.joint")
+        self.assertEqual(_normalize_path("machine.name"), "machine.name")
+
+    # ------------------------------------------------------------------
+    # files and trees
+    # ------------------------------------------------------------------
+
+    def test200_invalid_json_is_a_single_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "broken.fcm"
+            path.write_text("{ not json")
+            findings = validate_file(path)
+            self.assertEqual(_codes(findings), ["invalid-json"])
+
+    def test210_unloadable_machine_is_a_single_error(self):
+        """An unknown enum value stops validation rather than cascading."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "bad_toolhead.fcm"
+            machine = self._valid_machine()
+            raw = machine.to_dict()
+            raw["machine"]["toolheads"][0]["toolhead_type"] = "not_a_toolhead_type"
+            path.write_text(json.dumps(raw))
+            findings = validate_file(path)
+            self.assertEqual(_codes(findings), ["load-failed"])
+
+    def test220_duplicate_names_across_files_are_an_error(self):
+        """MachineFactory resolves by display name, so collisions matter."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            machine = self._valid_machine()
+            for filename in ("one.fcm", "two.fcm"):
+                (root / filename).write_text(json.dumps(machine.to_dict()))
+
+            results = validate_paths([str(root)], check_postprocessor=False)
+            self.assertEqual(len(results), 2)
+            for findings in results.values():
+                self.assertIn("duplicate-name", _codes(findings, Severity.ERROR))
+
+    def test230_distinct_names_do_not_collide(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            for index, filename in enumerate(("one.fcm", "two.fcm")):
+                machine = self._valid_machine()
+                machine.name = f"Machine {index}"
+                (root / filename).write_text(json.dumps(machine.to_dict()))
+
+            results = validate_paths([str(root)], check_postprocessor=False)
+            for findings in results.values():
+                self.assertNotIn("duplicate-name", _codes(findings))
+
+    def test240_directories_are_searched_recursively(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            (root / "vendor").mkdir()
+            machine = self._valid_machine()
+            (root / "vendor" / "nested.fcm").write_text(json.dumps(machine.to_dict()))
+
+            results = validate_paths([str(root)], check_postprocessor=False)
+            self.assertEqual(len(results), 1)
+
+    # ------------------------------------------------------------------
+    # reporting and CLI
+    # ------------------------------------------------------------------
+
+    def test300_format_hides_info_unless_verbose(self):
+        machine = self._valid_machine()
+        raw = machine.to_dict()
+        del raw["processing"]  # makes the model look newer than the file
+        results = {"m.fcm": validate_machine(machine, raw=raw, check_postprocessor=False)}
+
+        self.assertNotIn("newer-model", format_findings(results))
+        self.assertIn("newer-model", format_findings(results, verbose=True))
+
+    def test310_cli_exit_codes(self):
+        """0 when clean, 1 on error, 1 on warning only with --strict, 2 when empty."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            self.assertEqual(main([str(root)]), 2)
+
+            machine = self._valid_machine()
+            (root / "good.fcm").write_text(json.dumps(machine.to_dict()))
+            self.assertEqual(main([str(root), "--no-postprocessor-check"]), 0)
+
+            warned = machine.to_dict()
+            warned["machine"]["name"] = "Warned Machine"
+            warned["a_key_nobody_reads"] = True
+            (root / "warn.fcm").write_text(json.dumps(warned))
+            self.assertEqual(main([str(root), "--no-postprocessor-check"]), 0)
+            self.assertEqual(main([str(root), "--no-postprocessor-check", "--strict"]), 1)
+
+            (root / "broken.fcm").write_text("{ not json")
+            self.assertEqual(main([str(root), "--no-postprocessor-check"]), 1)

--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -202,6 +202,7 @@ SET(PathPythonMachineModels_SRCS
     Machine/models/__init__.py
     Machine/models/machine.py
     Machine/models/mtconnect_import.py
+    Machine/models/validate.py
 )
 
 SET(PathPythonToolsToolBit_SRCS
@@ -578,6 +579,7 @@ SET(Tests_SRCS
     CAMTests/TestLinuxCNCLegacyPost.py
     CAMTests/TestLinkingGenerator.py
     CAMTests/TestMachine.py
+    CAMTests/TestMachineValidate.py
     CAMTests/TestMach3Mach4LegacyPost.py
     CAMTests/TestMach3Mach4Post.py
     CAMTests/TestMassoG3Post.py

--- a/src/Mod/CAM/Machine/models/validate.py
+++ b/src/Mod/CAM/Machine/models/validate.py
@@ -1,0 +1,539 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""Validation for machine (.fcm) configuration files.
+
+Machine definitions are data, and a large collection of them is distributed
+outside this repository (see https://github.com/FreeCAD/Machines).  Their
+correctness is defined by the loader in this package, so the validator lives
+next to the loader rather than in the repository that stores the files -- a
+separate implementation would drift from ``Machine.from_dict`` and reproduce
+the problem it is meant to detect.
+
+Findings come in three severities:
+
+``ERROR``
+    The definition will not load, or will load into something unusable:
+    invalid JSON, an unknown toolhead type, a broken kinematic chain, an
+    unresolvable postprocessor, a duplicate display name.
+
+``WARNING``
+    The definition loads, but data in the file is being dropped.  This is the
+    tier that catches silent behaviour change: a key that the loader no longer
+    reads looks exactly like a key that works.
+
+``INFO``
+    The model has fields the file does not.  Normal for a file written by an
+    older FreeCAD; worth knowing before deciding to re-save.
+
+Use as a library::
+
+    from Machine.models.validate import validate_file, Severity
+    findings = validate_file("My_Machine.fcm")
+
+Use from the command line::
+
+    FreeCADCmd path/to/validate.py --pass MACHINES_DIR [options]
+
+``--pass`` is required: FreeCAD otherwise treats trailing arguments as
+documents to open.
+"""
+
+import json
+import pathlib
+import re
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from Machine.models.machine import Machine
+
+__all__ = [
+    "Severity",
+    "Finding",
+    "validate_machine",
+    "validate_file",
+    "validate_paths",
+    "format_findings",
+    "main",
+]
+
+
+class Severity(Enum):
+    """How much a finding matters."""
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+@dataclass
+class Finding:
+    """A single validation result."""
+
+    severity: Severity
+    code: str
+    message: str
+    source: Optional[str] = None
+
+    def __str__(self):
+        prefix = f"{self.source}: " if self.source else ""
+        return f"{prefix}[{self.severity.value}] {self.code}: {self.message}"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "severity": self.severity.value,
+            "code": self.code,
+            "message": self.message,
+            "source": self.source,
+        }
+
+
+@dataclass
+class _Report:
+    findings: List[Finding] = field(default_factory=list)
+
+    def add(self, severity, code, message, source=None):
+        self.findings.append(Finding(severity, code, message, source))
+
+    def error(self, code, message, source=None):
+        self.add(Severity.ERROR, code, message, source)
+
+    def warning(self, code, message, source=None):
+        self.add(Severity.WARNING, code, message, source)
+
+    def info(self, code, message, source=None):
+        self.add(Severity.INFO, code, message, source)
+
+
+# Paths the loader still reads under an older spelling.  A round trip through
+# to_dict() renames them, which would otherwise look like dropped data, so the
+# on-disk path is rewritten to its modern equivalent before the comparison.
+#
+# This table is the fragile part of the drift check and is maintained by hand.
+# It becomes unnecessary once from_dict() can report which keys it consumed;
+# until then, keep it in step with the compatibility branches in machine.py.
+_PATH_REWRITES = [
+    # machine.py: machine_data.get("toolheads", machine_data.get("spindles", []))
+    (re.compile(r"^machine\.spindles(\.|$)"), r"machine.toolheads\1"),
+    # Toolhead.from_dict(): spindle_type / spindle_wait fallbacks
+    (re.compile(r"^(machine\.toolheads)\.spindle_type$"), r"\1.toolhead_type"),
+    (re.compile(r"^(machine\.toolheads)\.spindle_wait$"), r"\1.toolhead_wait"),
+    # Axis joints are accepted as either {"origin": [], "axis": []} or
+    # [[origin], [vector]]; both carry the same data.
+    (re.compile(r"^(machine\.axes\.[^.]+\.joint)\..+$"), r"\1"),
+    # output_header is read from the header subsection or the output level.
+    (re.compile(r"^output\.output_header$"), "output.header.output_header"),
+]
+
+
+def _normalize_path(path: str) -> str:
+    """Rewrite an on-disk key path to the spelling the current model uses.
+
+    Rewrites are applied in sequence, since one can expose another: a
+    ``machine.spindles.spindle_wait`` path first becomes
+    ``machine.toolheads.spindle_wait`` and then ``machine.toolheads.toolhead_wait``.
+    """
+    for pattern, replacement in _PATH_REWRITES:
+        path = pattern.sub(replacement, path)
+    return path
+
+
+def _walk_keys(node: Any, prefix: str = "") -> Iterable[Tuple[str, Any]]:
+    """Yield (dotted_path, value) for every mapping key beneath *node*.
+
+    List elements collapse onto the same dotted path, so a key present on any
+    toolhead is reported once rather than once per index.
+    """
+    if isinstance(node, dict):
+        for key, value in node.items():
+            path = f"{prefix}.{key}" if prefix else key
+            yield path, value
+            yield from _walk_keys(value, path)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _walk_keys(item, prefix)
+
+
+def _key_paths(node: Any) -> set:
+    return {path for path, _ in _walk_keys(node)}
+
+
+def _check_dropped_data(raw: Dict[str, Any], machine: Machine, report: _Report, source=None):
+    """Compare the file against a fresh serialisation of what was loaded.
+
+    Keys only on disk are data the loader ignored.  Keys only in the fresh
+    output are fields the model has gained since the file was written.
+    """
+    try:
+        fresh = machine.to_dict()
+    except Exception as exc:  # pragma: no cover - defensive
+        report.warning("serialise-failed", f"could not re-serialise for comparison: {exc}", source)
+        return
+
+    disk_keys = {_normalize_path(k) for k in _key_paths(raw)}
+    model_keys = _key_paths(fresh)
+
+    dropped = sorted(disk_keys - model_keys)
+    if dropped:
+        report.warning(
+            "ignored-keys",
+            "data in the file that the loader does not read: " + ", ".join(dropped),
+            source,
+        )
+
+    added = sorted(model_keys - disk_keys)
+    if added:
+        report.info(
+            "newer-model",
+            "fields the model adds that the file predates: " + ", ".join(added),
+            source,
+        )
+
+
+def _check_postprocessor(machine: Machine, report: _Report, source=None):
+    """Check the referenced postprocessor resolves and its property keys are known."""
+    name = machine.postprocessor_file_name
+    if not name:
+        report.error("no-postprocessor", "postprocessor_file_name is empty", source)
+        return
+
+    # Imported lazily: the postprocessor factory pulls in a large part of CAM,
+    # and the structural checks above should work without it.
+    try:
+        from Path.Post.Processor import PostProcessorFactory
+    except Exception as exc:  # pragma: no cover - defensive
+        report.info("no-post-factory", f"postprocessor checks skipped: {exc}", source)
+        return
+
+    try:
+        post = PostProcessorFactory.get_post_processor(None, name)
+    except Exception as exc:
+        report.error(
+            "postprocessor-missing",
+            f"postprocessor '{name}' could not be loaded: {type(exc).__name__}: {exc}",
+            source,
+        )
+        return
+
+    # A postprocessor that cannot be found is returned as a CAMError rather
+    # than raised, so a plain try/except is not enough to detect it.  Its
+    # message embeds the whole search path, which is too noisy to repeat here.
+    if isinstance(post, Exception):
+        report.error(
+            "postprocessor-missing",
+            f"postprocessor '{name}' was not found on the postprocessor search path "
+            f"(looked for '{name}_post.py')",
+            source,
+        )
+        return
+
+    try:
+        known = {prop["name"] for prop in post.get_full_property_schema()}
+    except Exception as exc:  # pragma: no cover - defensive
+        report.info("no-schema", f"property schema unavailable for '{name}': {exc}", source)
+        return
+
+    unknown = sorted(set(machine.postprocessor_properties) - known)
+    if unknown:
+        report.warning(
+            "unknown-properties",
+            f"postprocessor '{name}' has no such properties: " + ", ".join(unknown),
+            source,
+        )
+
+
+def validate_machine(
+    machine: Machine,
+    raw: Optional[Dict[str, Any]] = None,
+    source: Optional[str] = None,
+    check_postprocessor: bool = True,
+) -> List[Finding]:
+    """Validate a loaded :class:`Machine`.
+
+    Args:
+        machine: the machine to check.
+        raw: the dict it was loaded from, if available.  Enables the
+            dropped-data comparison, which cannot run without it.
+        source: label used in findings, normally a file name.
+        check_postprocessor: resolve the referenced postprocessor.  Turn off
+            for structural checks that should not import the post factory.
+
+    Returns:
+        Findings, most severe first.
+    """
+    report = _Report()
+
+    if not machine.name or not machine.name.strip():
+        report.error("no-name", "machine name is empty", source)
+
+    if not machine.linear_axes and not machine.rotary_axes:
+        report.error("no-axes", "machine defines no axes", source)
+
+    if not machine.toolheads:
+        report.warning("no-toolheads", "machine defines no toolheads", source)
+
+    for name, axis in machine.linear_axes.items():
+        if axis.min_limit >= axis.max_limit:
+            report.error(
+                "axis-limits",
+                f"linear axis {name}: min_limit ({axis.min_limit}) "
+                f">= max_limit ({axis.max_limit})",
+                source,
+            )
+    for name, axis in machine.rotary_axes.items():
+        if axis.min_limit >= axis.max_limit:
+            report.error(
+                "axis-limits",
+                f"rotary axis {name}: min_limit ({axis.min_limit}) "
+                f">= max_limit ({axis.max_limit})",
+                source,
+            )
+
+    for message in machine.validate_kinematic_chain():
+        report.error("kinematics", message, source)
+
+    if check_postprocessor:
+        _check_postprocessor(machine, report, source)
+
+    if raw is not None:
+        _check_dropped_data(raw, machine, report, source)
+
+    order = {Severity.ERROR: 0, Severity.WARNING: 1, Severity.INFO: 2}
+    return sorted(report.findings, key=lambda f: order[f.severity])
+
+
+def validate_file(path, check_postprocessor: bool = True) -> List[Finding]:
+    """Validate a single .fcm file.
+
+    A file that cannot be read, parsed, or loaded produces a single ERROR;
+    no further checks are attempted on it.
+    """
+    path = pathlib.Path(path)
+    source = path.name
+
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            raw = json.load(handle)
+    except json.JSONDecodeError as exc:
+        return [Finding(Severity.ERROR, "invalid-json", str(exc), source)]
+    except OSError as exc:
+        return [Finding(Severity.ERROR, "unreadable", str(exc), source)]
+
+    if not isinstance(raw, dict):
+        return [
+            Finding(
+                Severity.ERROR, "not-an-object", "top level of the file is not an object", source
+            )
+        ]
+
+    try:
+        machine = Machine.from_dict(raw)
+    except Exception as exc:
+        return [
+            Finding(
+                Severity.ERROR,
+                "load-failed",
+                f"{type(exc).__name__}: {exc}",
+                source,
+            )
+        ]
+
+    return validate_machine(
+        machine, raw=raw, source=source, check_postprocessor=check_postprocessor
+    )
+
+
+def _collect_files(paths: Sequence[str]) -> List[pathlib.Path]:
+    found: List[pathlib.Path] = []
+    for entry in paths:
+        p = pathlib.Path(entry)
+        if p.is_dir():
+            found.extend(sorted(p.rglob("*.fcm")))
+        else:
+            found.append(p)
+    return found
+
+
+def validate_paths(
+    paths: Sequence[str], check_postprocessor: bool = True
+) -> Dict[str, List[Finding]]:
+    """Validate files and/or directories, plus checks that span the whole set.
+
+    Display-name collisions can only be seen across files, because
+    ``MachineFactory.get_machine()`` resolves machines by name.
+
+    Returns:
+        Mapping of file path to its findings, in the order the files were found.
+    """
+    results: Dict[str, List[Finding]] = {}
+    names: Dict[str, List[str]] = {}
+
+    for path in _collect_files(paths):
+        key = str(path)
+        results[key] = validate_file(path, check_postprocessor=check_postprocessor)
+
+        # Only files that loaded contribute a name.
+        if not any(f.code in ("invalid-json", "unreadable", "load-failed") for f in results[key]):
+            try:
+                with open(path, "r", encoding="utf-8") as handle:
+                    name = json.load(handle).get("machine", {}).get("name", "")
+            except Exception:
+                name = ""
+            if name:
+                names.setdefault(name.lower(), []).append(key)
+
+    for name, holders in names.items():
+        if len(holders) > 1:
+            for holder in holders:
+                others = [h for h in holders if h != holder]
+                results[holder].insert(
+                    0,
+                    Finding(
+                        Severity.ERROR,
+                        "duplicate-name",
+                        f"machine name also used by: {', '.join(others)}",
+                        pathlib.Path(holder).name,
+                    ),
+                )
+
+    return results
+
+
+def format_findings(results: Dict[str, List[Finding]], verbose: bool = False) -> str:
+    """Render results as text.
+
+    Files with nothing to report are listed only when *verbose*.
+    """
+    lines: List[str] = []
+    for path, findings in results.items():
+        shown = findings if verbose else [f for f in findings if f.severity is not Severity.INFO]
+        if not shown:
+            if verbose:
+                lines.append(f"ok    {path}")
+            continue
+        worst = min(
+            (f.severity for f in shown),
+            key=lambda s: {Severity.ERROR: 0, Severity.WARNING: 1, Severity.INFO: 2}[s],
+        )
+        lines.append(f"{worst.value.upper():7} {path}")
+        for finding in shown:
+            lines.append(f"        {finding.severity.value:7} {finding.code}: {finding.message}")
+    return "\n".join(lines)
+
+
+def _script_args(argv: Optional[Sequence[str]]) -> List[str]:
+    """Return the arguments intended for this script.
+
+    FreeCAD passes its own command line through in ``sys.argv``; anything
+    after ``--pass`` belongs to the script.
+    """
+    if argv is not None:
+        return list(argv)
+    if "--pass" in sys.argv:
+        return sys.argv[sys.argv.index("--pass") + 1 :]
+    return sys.argv[1:]
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Command line entry point.
+
+    Returns:
+        0 when nothing worse than a warning was found (or nothing at all with
+        ``--strict``), 1 otherwise, 2 when no files were found.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="validate.py",
+        description="Validate FreeCAD CAM machine (.fcm) definitions.",
+    )
+    parser.add_argument("paths", nargs="+", help="files or directories to check")
+    parser.add_argument("--strict", action="store_true", help="treat warnings as failures")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    parser.add_argument(
+        "--verbose", action="store_true", help="also report info findings and passing files"
+    )
+    parser.add_argument(
+        "--no-postprocessor-check",
+        action="store_true",
+        help="skip resolving the referenced postprocessor",
+    )
+    args = parser.parse_args(_script_args(argv))
+
+    results = validate_paths(args.paths, check_postprocessor=not args.no_postprocessor_check)
+
+    if not results:
+        print(f"no .fcm files found in: {', '.join(args.paths)}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(
+            json.dumps(
+                {path: [f.to_dict() for f in findings] for path, findings in results.items()},
+                indent=2,
+            )
+        )
+    else:
+        text = format_findings(results, verbose=args.verbose)
+        if text:
+            print(text)
+
+    errors = sum(1 for fs in results.values() for f in fs if f.severity is Severity.ERROR)
+    warnings = sum(1 for fs in results.values() for f in fs if f.severity is Severity.WARNING)
+
+    if not args.json:
+        print(
+            f"\n{len(results)} definition(s) checked, {errors} error(s), {warnings} warning(s)",
+            file=sys.stderr,
+        )
+
+    if errors:
+        return 1
+    if warnings and args.strict:
+        return 1
+    return 0
+
+
+def _invoked_as_script() -> bool:
+    """Whether this module is being run rather than imported.
+
+    FreeCAD executes a script by importing it under a module name derived from
+    the file name, so ``__name__`` is never ``"__main__"`` under FreeCADCmd.
+    Fall back to comparing the script FreeCAD was asked to run with this file.
+    """
+    if __name__ == "__main__":
+        return True
+    try:
+        argv0 = sys.argv[1] if len(sys.argv) > 1 else ""
+        return bool(argv0) and pathlib.Path(argv0).resolve() == pathlib.Path(__file__).resolve()
+    except OSError:
+        return False
+
+
+if _invoked_as_script():
+    _exit_code = main()
+    # FreeCAD terminates on SystemExit without flushing Python's buffers, and
+    # stdout is block-buffered when redirected, so the report would be lost.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    sys.exit(_exit_code)

--- a/src/Mod/CAM/Machine/ui/editor/machine_editor.py
+++ b/src/Mod/CAM/Machine/ui/editor/machine_editor.py
@@ -46,6 +46,7 @@ from Path.Post.Processor import (
 )
 from Machine.ui.editor.postprocessor_properties import PostProcessorPropertyManager
 from Machine.ui.editor.output_options_layout import build_output_options
+from Machine.models.validate import Severity, validate_machine
 import re
 
 translate = FreeCAD.Qt.translate
@@ -475,6 +476,17 @@ class MachineEditorDialog(QtGui.QDialog):
         self.toggle_button = QtGui.QPushButton(translate("CAM_MachineEditor", "Edit as Text"))
         self.toggle_button.clicked.connect(self.toggle_editor_mode)
         button_layout.addWidget(self.toggle_button)
+
+        self.validate_button = QtGui.QPushButton(translate("CAM_MachineEditor", "Validate"))
+        self.validate_button.setToolTip(
+            translate(
+                "CAM_MachineEditor",
+                "Check this machine for problems that would stop it loading or "
+                "would silently drop settings",
+            )
+        )
+        self.validate_button.clicked.connect(self.validate_current_machine)
+        button_layout.addWidget(self.validate_button)
 
         button_layout.addStretch()
 
@@ -2283,6 +2295,78 @@ class MachineEditorDialog(QtGui.QDialog):
                     translate("CAM_MachineEditor", "Error"),
                     translate("CAM_MachineEditor", "Failed to generate JSON: {}").format(str(e)),
                 )
+
+    def _current_machine_and_raw(self):
+        """Return (machine, raw_dict) for whatever is currently in the editor.
+
+        In text mode the JSON buffer is the truth and has not been parsed yet.
+        Otherwise ``self.machine`` is kept current by the field signal handlers,
+        and the dict is produced from it -- which means the dropped-data check
+        cannot fire, since there is no on-disk document to compare against.
+
+        Raises:
+            json.JSONDecodeError: the text buffer is not valid JSON.
+            Exception: the document does not load into a Machine.
+        """
+        if self.text_mode:
+            raw = json.loads(self.text_editor.toPlainText())
+            return Machine.from_dict(raw), raw
+        return self.machine, None
+
+    def validate_current_machine(self):
+        """Run the shared validator against the machine being edited.
+
+        Uses the same checks as the command line validator, so a definition
+        that passes here will pass CI in the machine repository.
+        """
+        try:
+            machine, raw = self._current_machine_and_raw()
+        except json.JSONDecodeError as exc:
+            QtGui.QMessageBox.critical(
+                self,
+                translate("CAM_MachineEditor", "Validation"),
+                translate("CAM_MachineEditor", "Invalid JSON: {}").format(str(exc)),
+            )
+            return
+        except Exception as exc:
+            QtGui.QMessageBox.critical(
+                self,
+                translate("CAM_MachineEditor", "Validation"),
+                translate("CAM_MachineEditor", "This machine does not load: {}").format(str(exc)),
+            )
+            return
+
+        if machine is None:
+            return
+
+        findings = validate_machine(machine, raw=raw, source=self.filename)
+
+        errors = [f for f in findings if f.severity is Severity.ERROR]
+        warnings = [f for f in findings if f.severity is Severity.WARNING]
+
+        if not errors and not warnings:
+            QtGui.QMessageBox.information(
+                self,
+                translate("CAM_MachineEditor", "Validation"),
+                translate("CAM_MachineEditor", "No problems found."),
+            )
+            return
+
+        if errors:
+            icon = QtGui.QMessageBox.Critical
+            summary = translate("CAM_MachineEditor", "{} error(s) and {} warning(s) found.").format(
+                len(errors), len(warnings)
+            )
+        else:
+            icon = QtGui.QMessageBox.Warning
+            summary = translate("CAM_MachineEditor", "{} warning(s) found.").format(len(warnings))
+
+        box = QtGui.QMessageBox(self)
+        box.setIcon(icon)
+        box.setWindowTitle(translate("CAM_MachineEditor", "Validation"))
+        box.setText(summary)
+        box.setDetailedText("\n\n".join(f"[{f.severity.value}] {f.message}" for f in findings))
+        box.exec_()
 
     def accept(self):
         """Handle save and close action."""


### PR DESCRIPTION
Machine definitions are data, and a growing collection of them is distributed outside this repository through the FreeCAD/Machines addon. Their correctness is defined by Machine.from_dict, but nothing checks a definition against it.  

This is step one to put infrastructure in place that will verify machine definition correctness and prevent regressions.

This PR adds Machine/models/validate.py.  

Findings come in three severity levels.  
- ERROR covers definitions that will not load or will load into something unusable: invalid JSON, an unknown toolhead type, a broken kinematic chain, an unresolvable post-processor, inverted axis limits, a display name shared with another file (machines resolve by name, so collisions are a correctness problem).  
- WARNING covers data the loader silently drops, found by comparing the file against a fresh serialization of what was loaded.  
- INFO covers fields the model has gained since the file was written.



The module is usable as a library and as a command line tool:

```
FreeCADCmd Machine/models/validate.py --pass MACHINES_DIR [options]
```

--pass is required because FreeCAD otherwise treats trailing arguments as documents to open.  

This also wires the same checks into the machine editor as a Validate button, so a definition can be checked before it is saved or submitted rather than after.  Not terribly useful but should help detect problems with the validator.


[x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: claude fable

## Issues

This addresses proposal #1 in 
https://github.com/FreeCAD/Machines/issues/10


## Before and After Images

Adds this button...
<img width="918" height="940" alt="image" src="https://github.com/user-attachments/assets/733b73ea-face-4575-a994-f05c7ce0ecc3" />

Shows warnings and errors
<img width="912" height="885" alt="image" src="https://github.com/user-attachments/assets/571a28aa-5f2e-4501-ac99-c2d868ba57d3" />

