### PR TITLE
Test: hide Menu subcases from test list

### DIFF
--- a/src/Mod/Test/InitGui.py
+++ b/src/Mod/Test/InitGui.py
@@ -95,8 +95,6 @@ Gui.addWorkbench(TestWorkbench())
 FreeCAD.__unit_test__ += [
     "Workbench",
     "Menu",
-    "Menu.MenuDeleteCases",
-    "Menu.MenuCreateCases",
     "GuiDocument",
     "TestGraphicsViewWrapping",
     "TestMDIView",


### PR DESCRIPTION
`FreeCAD -t ` shows

```
Menu
Menu.MenuDeleteCases
Menu.MenuCreateCases
```

among others, where it usually only shows top-level test cases. This PR removes sub-cases from the list for coherence.

Just a simple PR to test AI coding, I think I used GPT Terra