### PR TITLE
Fix #32357: Enable Transform and Placement tools for Link to Group

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1959,7 +1959,7 @@ void StdCmdPlacement::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     std::vector<App::DocumentObject*> sel = Gui::Selection().getObjectsOfType(
-        App::GeoFeature::getClassTypeId()
+        App::DocumentObject::getClassTypeId()
     );
     auto plm = new Gui::Dialog::TaskPlacement();
     if (!sel.empty()) {
@@ -1988,9 +1988,7 @@ void StdCmdPlacement::activated(int iMsg)
 bool StdCmdPlacement::isActive()
 {
     std::vector<App::DocumentObject*> sel = Gui::Selection().getObjectsOfType(
-        App::GeoFeature::getClassTypeId(),
-        nullptr,
-        ResolveMode::FollowLink
+        App::DocumentObject::getClassTypeId()
     );
     return !(sel.empty() || std::ranges::any_of(sel, [](auto obj) {
                  auto* prop = obj->getPlacementProperty();
@@ -2021,9 +2019,7 @@ void StdCmdTransformManip::activated(int iMsg)
         getActiveGuiDocument()->resetEdit();
     }
     std::vector<App::DocumentObject*> sel = Gui::Selection().getObjectsOfType(
-        App::GeoFeature::getClassTypeId(),
-        nullptr,
-        ResolveMode::FollowLink
+        App::DocumentObject::getClassTypeId()
     );
     Gui::ViewProvider* vp = Application::Instance->getViewProvider(sel.front());
     // FIXME: Need a way to force 'Transform' edit mode
@@ -2036,9 +2032,7 @@ void StdCmdTransformManip::activated(int iMsg)
 bool StdCmdTransformManip::isActive()
 {
     std::vector<App::DocumentObject*> sel = Gui::Selection().getObjectsOfType(
-        App::GeoFeature::getClassTypeId(),
-        nullptr,
-        ResolveMode::FollowLink
+        App::DocumentObject::getClassTypeId()
     );
     return (
         sel.size() == 1 && !sel.front()->isFreezed() && sel.front()->getPlacementProperty()
@@ -2067,7 +2061,7 @@ void StdCmdAlignment::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     std::vector<App::DocumentObject*> sel = Gui::Selection().getObjectsOfType(
-        App::GeoFeature::getClassTypeId()
+        App::DocumentObject::getClassTypeId()
     );
     ManualAlignment* align = ManualAlignment::instance();
     QObject::connect(align, &ManualAlignment::emitCanceled, align, &QObject::deleteLater);


### PR DESCRIPTION
Fixes a UI regression where the "Transform" and "Placement" tools were incorrectly disabled when selecting an `App::Link` that targets a Group.

**Technical Details:**
Previously, `StdCmdPlacement` and `StdCmdTransformManip` queried the selection for `App::GeoFeature` using `ResolveMode::FollowLink`. This caused the logic to evaluate the linked Group (which lacks placement properties) instead of the Link itself. Updating the selection query to `App::DocumentObject` without `FollowLink` allows the command to properly identify the Link object. The existing `getPlacementProperty()` check securely handles the rest.


- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

*Disclosure: Code navigation and debugging of the C++ `isActive()` selection logic was assisted by Gemini.*

## Issues
Fixes #32357

## Before and After Images

**Before (Transform greyed out for Group Link):**
<!-- Drag and drop your "Before" screenshot here (image_967b8d.jpg) -->
<img width="1920" height="1080" alt="Screenshot 2026-09-03 031649" src="https://github.com/user-attachments/assets/6a706d70-899a-4e12-8e8e-82e3c03ca777" />


**After (Transform active for Group Link):**
<!-- Drag and drop your "After" screenshot here showing the clickable menu -->
<img width="1920" height="1080" alt="Screenshot 2026-09-03 034525" src="https://github.com/user-attachments/assets/7b7645a4-36e5-43f6-aa3d-537b1057d316" />


<!--  Notes on the PR Review Process
... (You can leave the rest of the default boilerplate intact below this line) ...
-->