### PR TITLE
CAM: Fix ToolBit units, precision and the task panel

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathToolBitListWidget.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolBitListWidget.py
@@ -56,8 +56,9 @@ class TestToolBitListWidget(PathTestWithAssets):
         self.assertEqual(cell_widget.tool_no, str(tool_no))
         self.assertEqual(cell_widget.upper_text, toolbit.label)
         # Assuming the 5mm_Endmill asset has a shape named 'Endmill'
-        normalized_lower_text = cell_widget.lower_text.replace(",00 ", ".00 ")
-        self.assertEqual(normalized_lower_text, "5.00 mm 4-flute endmill, 30.00 mm cutting edge")
+        # Metric bits list at tool precision, not the display preference.
+        normalized_lower_text = cell_widget.lower_text.replace(",000 ", ".000 ")
+        self.assertEqual(normalized_lower_text, "5.000 mm 4-flute endmill, 30.000 mm cutting edge")
 
         # Verify URI is stored in item data
         stored_uri = item.data(ToolBitUriRole)

--- a/src/Mod/CAM/CAMTests/TestPathToolBitPropertyEditorWidget.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolBitPropertyEditorWidget.py
@@ -26,6 +26,7 @@
 import unittest
 import FreeCAD
 from Path.Tool.docobject import DetachedDocumentObject
+from Path.Tool.toolbit.util import setToolBitSchema
 from Path.Tool.docobject.ui.property import (
     BasePropertyEditorWidget,
     QuantityPropertyEditorWidget,
@@ -116,6 +117,33 @@ class TestQuantityPropertyEditorWidget(unittest.TestCase):
         updated_value = self.obj.getPropertyByName("Length")
         self.assertIsInstance(updated_value, FreeCAD.Units.Quantity)
         self.assertEqual(updated_value, FreeCAD.Units.Quantity("15.5 in"))
+
+    def test_update_property_keeps_full_precision(self):
+        """A 3.175mm endmill stays 3.175mm: forum.freecad.org/viewtopic.php?t=79854"""
+        self.editor.lineEdit().setText("3.175")
+        self.widget.updateProperty()
+        self.assertEqual(self.obj.Length.Value, 3.175)
+
+    def test_fields_show_tool_precision(self):
+        """Loading a tool must not round it to the display default either."""
+        self.obj.Length = FreeCAD.Units.Quantity("3.175 mm")
+        self.widget.updateWidget()
+        self.assertEqual(self.editor.property("decimals"), 3)
+        self.assertEqual(self.editor.property("value").Value, 3.175)
+        self.assertIn("3.175", self.editor.lineEdit().text())
+
+    def test_fields_show_tool_precision_in_imperial(self):
+        """An inch needs the extra digit to say the same thing."""
+        original = FreeCAD.Units.getSchema()
+        try:
+            self.obj.Length = FreeCAD.Units.Quantity("0.375 in")
+            setToolBitSchema("Imperial")  # what the editor does on load
+            widget = QuantityPropertyEditorWidget(self.obj, "Length")
+            self.assertEqual(widget._editor_widget.property("decimals"), 4)
+            self.assertIn("0.3750", widget._editor_widget.lineEdit().text())
+            self.assertAlmostEqual(widget._editor_widget.property("value").Value, 9.525, places=6)
+        finally:
+            FreeCAD.Units.setSchema(original)
 
 
 class TestBoolPropertyEditorWidget(unittest.TestCase):

--- a/src/Mod/CAM/CAMTests/TestPathToolBitSerializer.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolBitSerializer.py
@@ -15,6 +15,7 @@ from Path.Tool.assets.asset import Asset
 from Path.Tool.assets.serializer import AssetSerializer
 from Path.Tool.assets.uri import AssetUri
 from Path.Tool.shape import ToolBitShapeEndmill
+from Path.Tool.toolbit.util import setToolBitSchema
 from typing import Mapping
 
 
@@ -111,6 +112,128 @@ class TestFCTBSerializer(_BaseToolBitSerializerTestCase):
             FreeCAD.Units.Quantity(data.get("parameter", {}).get("Length")),
             FreeCAD.Units.Quantity(15.0, FreeCAD.Units.Length),
         )
+
+    def test_serialize_uses_the_bits_own_units(self):
+        """A bit stores itself in the units it is specified in, not the ones on screen."""
+        self.test_tool_bit.obj.Units = "Imperial"
+        self.test_tool_bit.set_diameter(FreeCAD.Units.Quantity("0.375 in"))
+
+        for active in ("Metric", "Imperial"):
+            setToolBitSchema(active)
+            data = json.loads(self.serializer_class.serialize(self.test_tool_bit).decode("utf-8"))
+            diameter = data["parameter"]["Diameter"]
+            self.assertEqual(diameter, "0.3750 in", f"with the {active} schema active")
+        setToolBitSchema("Metric")
+
+    def test_serialize_keeps_tool_precision(self):
+        """Two decimals would save a 0.375" tap as 0.37" - 0.127mm out."""
+        cases = (("Metric", "9.525 mm"), ("Imperial", "0.3750 in"))
+        for units, expected in cases:
+            self.test_tool_bit.obj.Units = units
+            self.test_tool_bit.set_diameter(FreeCAD.Units.Quantity("0.375 in"))
+            data = json.loads(self.serializer_class.serialize(self.test_tool_bit).decode("utf-8"))
+            stored = data["parameter"]["Diameter"]
+            self.assertEqual(stored, expected)
+            self.assertAlmostEqual(
+                FreeCAD.Units.Quantity(stored).Value,
+                self.test_tool_bit.obj.Diameter.Value,
+                places=6,
+            )
+
+    def test_extract_dependencies(self):
+        """Test dependency extraction."""
+        # This test assumes that the serializers don't have dependencies
+        # and can be overridden in subclasses if needed.
+        serialized_data = self.serializer_class.serialize(self.test_tool_bit)
+        dependencies = self.serializer_class.extract_dependencies(serialized_data)
+        self.assertIsInstance(dependencies, list)
+        self.assertEqual(len(dependencies), 0)
+
+
+class TestCamoticsToolBitSerializer(_BaseToolBitSerializerTestCase):
+    serializer_class = CamoticsToolBitSerializer
+
+    def test_serialize(self):
+        super().test_serialize()
+        serialized_data = self.serializer_class.serialize(self.test_tool_bit)
+        # Camotics specific assertions
+        expected_substrings = [
+            b'"units": "metric"',
+            b'"shape": "Cylindrical"',
+            b'"length": 15',
+            b'"diameter": 4.12',
+            b'"description": "Test Tool"',
+        ]
+        for substring in expected_substrings:
+            self.assertIn(substring, serialized_data)
+
+    def test_deserialize(self):
+        # Create a known serialized data string based on the Camotics format
+        camotics_data = (
+            b'{"units": "metric", "shape": "Cylindrical", "length": 15, '
+            b'"diameter": 4.12, "description": "Test Tool"}'
+        )
+        deserialized_bit = cast(
+            ToolBitEndmill,
+            self.serializer_class.deserialize(camotics_data, id="test_id", dependencies=None),
+        )
+
+        self.assertIsInstance(deserialized_bit, ToolBit)
+        self.assertEqual(deserialized_bit.label, "Test Tool")
+        self.assertEqual(
+            deserialized_bit.get_diameter(), FreeCAD.Units.Quantity(4.12, FreeCAD.Units.Length)
+        )
+        self.assertEqual(
+            deserialized_bit.get_length(), FreeCAD.Units.Quantity(15.0, FreeCAD.Units.Length)
+        )
+        self.assertEqual(deserialized_bit.get_shape_name(), "Endmill")
+
+
+class TestFCTBSerializer(_BaseToolBitSerializerTestCase):
+    serializer_class = FCTBSerializer
+
+    def test_serialize(self):
+        super().test_serialize()
+        serialized_data = self.serializer_class.serialize(self.test_tool_bit)
+        # FCTB specific assertions (JSON format)
+        data = json.loads(serialized_data.decode("utf-8"))
+        self.assertEqual(data.get("name"), "Test Tool")
+        self.assertEqual(data.get("shape"), "endmill.fcstd")
+        self.assertEqual(
+            FreeCAD.Units.Quantity(data.get("parameter", {}).get("Diameter")),
+            FreeCAD.Units.Quantity(4.12, FreeCAD.Units.Length),
+        )
+        self.assertEqual(
+            FreeCAD.Units.Quantity(data.get("parameter", {}).get("Length")),
+            FreeCAD.Units.Quantity(15.0, FreeCAD.Units.Length),
+        )
+
+    def test_serialize_uses_the_bits_own_units(self):
+        """A bit stores itself in the units it is specified in, not the ones on screen."""
+        self.test_tool_bit.obj.Units = "Imperial"
+        self.test_tool_bit.set_diameter(FreeCAD.Units.Quantity("0.375 in"))
+
+        for active in ("Metric", "Imperial"):
+            setToolBitSchema(active)
+            data = json.loads(self.serializer_class.serialize(self.test_tool_bit).decode("utf-8"))
+            diameter = data["parameter"]["Diameter"]
+            self.assertEqual(diameter, "0.3750 in", f"with the {active} schema active")
+        setToolBitSchema("Metric")
+
+    def test_serialize_keeps_tool_precision(self):
+        """Two decimals would save a 0.375" tap as 0.37" - 0.127mm out."""
+        cases = (("Metric", "9.525 mm"), ("Imperial", "0.3750 in"))
+        for units, expected in cases:
+            self.test_tool_bit.obj.Units = units
+            self.test_tool_bit.set_diameter(FreeCAD.Units.Quantity("0.375 in"))
+            data = json.loads(self.serializer_class.serialize(self.test_tool_bit).decode("utf-8"))
+            stored = data["parameter"]["Diameter"]
+            self.assertEqual(stored, expected)
+            self.assertAlmostEqual(
+                FreeCAD.Units.Quantity(stored).Value,
+                self.test_tool_bit.obj.Diameter.Value,
+                places=6,
+            )
 
     def test_extract_dependencies(self):
         """Test dependency extraction for FCTB."""

--- a/src/Mod/CAM/CAMTests/TestPathToolShapeClasses.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolShapeClasses.py
@@ -2,6 +2,7 @@
 
 # Unit tests for the Path.Tool.Shape module and its utilities.
 
+import math
 from pathlib import Path
 from typing import Mapping, Tuple
 import FreeCAD
@@ -101,6 +102,40 @@ class TestPathToolShapeClasses(PathTestWithAssets):
         self.assertEqual(shape.get_parameter("Param1").Unit, FreeCAD.Units.Unit("mm"))
         with self.assertRaisesRegex(KeyError, "Shape 'dummy' has no parameter 'InvalidParam'"):
             shape.get_parameter("InvalidParam")
+
+    def test_base_set_parameter_from_bare_number(self):
+        """A bare number has to pick up the unit its schema declares."""
+        shape = DummyShape(id="dummy_shape_units", filepath=Path("/fake/dummy.fcstd"))
+        shape.set_parameter("Param1", 15.0)
+        shape.set_parameter("Param2", 30)
+        self.assertEqual(shape.get_parameter("Param1"), FreeCAD.Units.Quantity("15 mm"))
+        self.assertEqual(shape.get_parameter("Param1").Unit, FreeCAD.Units.Unit("mm"))
+        self.assertEqual(shape.get_parameter("Param2"), FreeCAD.Units.Quantity("30 deg"))
+        self.assertEqual(shape.get_parameter("Param2").Unit, FreeCAD.Units.Unit("deg"))
+
+    def test_chamfer_derived_diameter(self):
+        """The chamfer's Diameter is derived, and has to come back as a length."""
+        uri = ToolBitShape.resolve_name("chamfer")
+        shape = self.assets.get(uri)
+        shape.set_parameters(
+            TipDiameter=FreeCAD.Units.Quantity("1 mm"),
+            CuttingEdgeHeight=FreeCAD.Units.Quantity("5 mm"),
+            CuttingEdgeAngle=FreeCAD.Units.Quantity("60 deg"),
+            Diameter=FreeCAD.Units.Quantity("0 mm"),
+        )
+
+        changed = shape.apply_derived_parameters()
+        self.assertIn("Diameter", changed)
+
+        diameter = shape.get_parameter("Diameter")
+        expected = 1.0 + 2 * 5.0 * math.tan(math.radians(30.0))
+        self.assertAlmostEqual(diameter.Value, expected)
+        # A unitless Quantity reports .Value too, so the unit is the assertion.
+        self.assertEqual(diameter.Unit, FreeCAD.Units.Unit("mm"))
+        self.assertEqual(diameter.getValueAs("in").Value, expected / 25.4)
+
+        # Dimensioned, it compares equal to the stored value: no second write.
+        self.assertEqual(shape.apply_derived_parameters(), {})
 
     def test_base_get_parameters(self):
         """Test getting the full parameter dictionary."""

--- a/src/Mod/CAM/Path/Tool/docobject/ui/property.py
+++ b/src/Mod/CAM/Path/Tool/docobject/ui/property.py
@@ -30,6 +30,7 @@ import FreeCAD
 import FreeCADGui
 from PySide import QtGui, QtCore
 from typing import Optional
+from ...toolbit.util import at_tool_precision
 
 
 class BasePropertyEditorWidget(QtGui.QWidget):
@@ -122,16 +123,16 @@ class QuantityPropertyEditorWidget(BasePropertyEditorWidget):
         value: FreeCAD.Units.Quantity = self._obj.getPropertyByName(self._prop_name)
         # Block signals temporarily to prevent feedback loops
         self._editor_widget.blockSignals(True)
-        self._editor_widget.setProperty("value", value)
+        self._editor_widget.setProperty("value", at_tool_precision(value))
         self._editor_widget.blockSignals(False)
         self._editor_widget.setEnabled(not self._is_read_only)
 
     def updateProperty(self):
         current_value = self._obj.getPropertyByName(self._prop_name)
-        new_value_str: str = self._editor_widget.property("value").UserString
-        new_value = FreeCAD.Units.Quantity(new_value_str)
-        if new_value_str != current_value:
-            self._obj.setPropertyByName(self._prop_name, new_value)
+        # Via UserString this would round to the decimals on display.
+        new_value = self._editor_widget.property("value")
+        if new_value != current_value:
+            setattr(self._obj, self._prop_name, new_value)
             self.propertyChanged.emit()
 
 
@@ -160,7 +161,7 @@ class BoolPropertyEditorWidget(BasePropertyEditorWidget):
         current_value: bool = self._obj.getPropertyByName(self._prop_name)
         new_value: bool = bool(index)
         if new_value != current_value:
-            self._obj.setPropertyByName(self._prop_name, new_value)
+            setattr(self._obj, self._prop_name, new_value)
             self.propertyChanged.emit()
 
     def updateProperty(self):
@@ -191,7 +192,7 @@ class IntPropertyEditorWidget(BasePropertyEditorWidget):
         current_value: int = self._obj.getPropertyByName(self._prop_name)
         new_value: int = self._editor_widget.value()
         if new_value != current_value:
-            self._obj.setPropertyByName(self._prop_name, new_value)
+            setattr(self._obj, self._prop_name, new_value)
             self.propertyChanged.emit()
 
 
@@ -231,7 +232,7 @@ class EnumPropertyEditorWidget(BasePropertyEditorWidget):
         current_value: str = self._obj.getPropertyByName(self._prop_name)
         new_value: str = self._editor_widget.itemText(index)
         if new_value != current_value:
-            self._obj.setPropertyByName(self._prop_name, new_value)
+            setattr(self._obj, self._prop_name, new_value)
             self.propertyChanged.emit()
 
     def updateProperty(self):

--- a/src/Mod/CAM/Path/Tool/shape/models/base.py
+++ b/src/Mod/CAM/Path/Tool/shape/models/base.py
@@ -671,6 +671,10 @@ class ToolBitShape(Asset):
         """
         prop_type = self.get_parameter_property_type(name)
         if prop_type in ("App::PropertyDistance", "App::PropertyLength", "App::PropertyAngle"):
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                # Quantity() leaves a bare number dimensionless.
+                unit = "deg" if prop_type == "App::PropertyAngle" else "mm"
+                return FreeCAD.Units.Quantity(float(value), unit)
             return FreeCAD.Units.Quantity(value)
         elif prop_type == "App::PropertyInteger":
             return int(value)

--- a/src/Mod/CAM/Path/Tool/toolbit/models/base.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/models/base.py
@@ -1016,7 +1016,7 @@ class ToolBit(Asset, ABC):
                     f"(type {type(value).__name__ if value is not None else 'None'}, value {value})"
                 )
             try:
-                serialized_value = to_json(value)
+                serialized_value = to_json(value, units=getattr(self.obj, "Units", None))
                 attrs["parameter"][name] = serialized_value
             except (TypeError, ValueError) as e:
                 Path.Log.warning(
@@ -1069,7 +1069,7 @@ class ToolBit(Asset, ABC):
             "id": self._tool_bit_shape.get_id(),
             "name": self._tool_bit_shape.name,
             "parameters": {
-                name: to_json(getattr(self.obj, name, None))
+                name: to_json(getattr(self.obj, name, None), units=getattr(self.obj, "Units", None))
                 for name in self._tool_bit_shape.get_parameters()
                 if not isinstance(getattr(self.obj, name, None), FreeCAD.DocumentObject)
             },

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/editor.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/editor.py
@@ -146,11 +146,16 @@ class ToolBitPropertiesWidget(QtGui.QWidget):
 
     def _on_toolbit_type_changed(self, index):
         """Update the toolbit's type when the combo changes."""
-        if self._toolbit:
-            selected = self._toolbit_type_combo.itemData(index)
-            self._toolbit._shape_type = selected  # Save the user's selection
+        if not self._toolbit:
+            return
+        selected = self._toolbit_type_combo.itemData(index)
+        self._toolbit._shape_type = selected  # Save the user's selection
+        # The combo offers subtype aliases ("endmill", "downcut"); ShapeType is
+        # an enumeration of shape class names ("Endmill"), so most of them are
+        # not assignable to it and the alias alone records the choice.
+        if selected in self._toolbit.obj.getEnumerationsOfProperty("ShapeType"):
             self._toolbit.obj.ShapeType = selected
-            self.toolBitChanged.emit()
+        self.toolBitChanged.emit()
 
     def load_toolbit(self, toolbit: ToolBit):
         """Load a ToolBit object into the editor."""
@@ -225,6 +230,8 @@ class ToolBitPropertiesWidget(QtGui.QWidget):
             self._toolbit_type_combo.hide()
         else:
             # Editable - populate combo with aliases that don't have independent shape files
+            # Filling the combo is not the user choosing a type.
+            self._toolbit_type_combo.blockSignals(True)
             self._toolbit_type_combo.clear()
             for type_name in editable_types:
                 display = type_name.replace("_", " ").replace("-", " ").title()
@@ -245,6 +252,7 @@ class ToolBitPropertiesWidget(QtGui.QWidget):
                         # Unknown type - default to first item (class name)
                         self._toolbit_type_combo.setCurrentIndex(0)
                         self._toolbit._shape_type = editable_types[0] if editable_types else base
+            self._toolbit_type_combo.blockSignals(False)
             self._toolbit_type_edit.hide()
             self._toolbit_type_combo.show()
 
@@ -271,7 +279,9 @@ class ToolBitPropertiesWidget(QtGui.QWidget):
             self._shape_widget = ShapeWidget(
                 shape=self._toolbit._tool_bit_shape, parent=self, interactive=True
             )
-            self._shape_widget.setMinimumSize(200, 150)
+            # No size is set here: the drawing is rendered at icon_size and is
+            # cropped rather than scaled by a smaller widget, so the widget's
+            # own minimumSizeHint is the only correct floor.
             # Insert into the middle slot of the HBox layout
             self._shape_display_layout.insertWidget(1, self._shape_widget)
             self.link_shape_widget(self._shape_widget)
@@ -320,7 +330,7 @@ class ToolBitEditorPanel(QtGui.QWidget):
         super().__init__(parent)
 
         # Create the main editor widget
-        self._editor_widget = ToolBitPropertiesWidget(toolbit, self)
+        self._editor_widget = ToolBitPropertiesWidget(toolbit, parent=self)
 
         # Create the button box
         buttons = QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel
@@ -373,10 +383,9 @@ class ToolBitEditor(QtGui.QWidget):
         self.tool_no = tool_no
         self.default_title = self.form.windowTitle()
 
-        # Store the original schema to restore on close
-        self._original_schema = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Units").GetInt(
-            "UserSchema", 6
-        )
+        # The schema in effect, not the raw preference, so a document on its
+        # own schema gets that back rather than the user default.
+        self._original_schema = FreeCAD.Units.getSchema()
         self._tab_closed = False
 
         # Get first tab from the form, add the shape widget to the right.
@@ -513,4 +522,9 @@ class ToolBitEditor(QtGui.QWidget):
         return self.tool_no
 
     def show(self):
-        return self.form.exec_()
+        # load_toolbit switches the global schema to the bit's units, so it
+        # has to come back however the dialog is left.
+        try:
+            return self.form.exec_()
+        finally:
+            self._restore_original_schema()

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/panel.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/panel.py
@@ -35,36 +35,32 @@ class TaskPanel:
         Path.Log.track(vobj.Object.Label)
         self.vobj = vobj
         self.obj = vobj.Object
-        self.editor = ToolBitEditorPanel(self.obj, self.editor.form)
+        self.editor = ToolBitEditorPanel(self.obj.Proxy)
+        # The task dialog supplies its own OK/Cancel.
+        self.editor._button_box.hide()
+        self.form = self.editor
         self.deleteOnReject = deleteOnReject
         FreeCAD.ActiveDocument.openTransaction("Edit ToolBit")
 
     def reject(self):
+        # The transaction holds every edit made in the panel, so aborting it
+        # is the undo; the editor has nothing of its own to roll back.
         FreeCAD.ActiveDocument.abortTransaction()
-        self.editor.reject()
         FreeCADGui.Control.closeDialog()
         if self.deleteOnReject:
             FreeCAD.ActiveDocument.openTransaction("Uncreate ToolBit")
-            self.editor.reject()
             FreeCAD.ActiveDocument.removeObject(self.obj.Name)
             FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()
+        return True
 
     def accept(self):
-        self.editor.accept()
-
+        self.editor.save_toolbit()
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCADGui.ActiveDocument.resetEdit()
         FreeCADGui.Control.closeDialog()
         FreeCAD.ActiveDocument.recompute()
-
-    def updateUI(self):
-        Path.Log.track()
-        self.editor.updateUI()
-
-    def updateModel(self):
-        self.editor.updateTool()
-        FreeCAD.ActiveDocument.recompute()
+        return True
 
     def setupUi(self):
-        self.editor.setupUI()
+        pass

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/view.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/view.py
@@ -99,7 +99,7 @@ class ViewProvider(object):
         return []
 
     def doubleClicked(self, vobj):
-        pass
+        return self.setEdit(vobj)
 
     def setupContextMenu(self, vobj, menu):
         # Override the base class method to prevent adding the "Edit" action

--- a/src/Mod/CAM/Path/Tool/toolbit/util.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/util.py
@@ -22,11 +22,69 @@
 # ***************************************************************************
 import FreeCAD
 
+UNITS_SCHEMA_MAP = {
+    "metric": 6,  # 6 = Metric schema in FreeCAD
+    "imperial": 3,  # 3 = Imperial schema in FreeCAD
+}
+AUTOSCALING_SCHEMA = 0  # the schema that drops to µm on its own
 
-def to_json(value):
+# Less than this rounds a 3.175mm endmill to 3.18mm, on disk and in the
+# editor: forum.freecad.org/viewtopic.php?t=79854
+METRIC_DECIMALS = 3
+IMPERIAL_DECIMALS = 4
+
+
+def tool_decimals(units=None) -> int:
+    """Decimals for `units` ("Metric"/"Imperial"), or the active schema."""
+    schema = UNITS_SCHEMA_MAP.get(units.lower()) if isinstance(units, str) else None
+    if schema is None:
+        schema = FreeCAD.Units.getSchema()
+    return IMPERIAL_DECIMALS if schema == UNITS_SCHEMA_MAP["imperial"] else METRIC_DECIMALS
+
+
+def at_tool_precision(value: FreeCAD.Units.Quantity) -> FreeCAD.Units.Quantity:
+    """
+    Stamp tool precision onto the value's format.
+
+    Gui::QuantitySpinBox reads its precision from the Quantity it is given and
+    rounds to match, so this has to arrive with the value, not be set after.
+    """
+    value = FreeCAD.Units.Quantity(value)
+    fmt = value.Format
+    fmt["Precision"] = tool_decimals()
+    value.Format = fmt
+    return value
+
+
+def _in_microns(value) -> bool:
+    """True when the value is small enough that FreeCAD would render it in µm."""
+    return FreeCAD.Units.schemaTranslate(value, AUTOSCALING_SCHEMA)[2] == "\N{MICRO SIGN}m"
+
+
+def quantity_to_str(value, units=None):
+    """
+    Format a Quantity for storage, in the units the bit is specified in.
+
+    Not UserString: that follows the active schema rather than the bit's own,
+    and rounds to the display preference, saving a 0.375" tap as 0.37".
+    """
+    schema = UNITS_SCHEMA_MAP.get(units.lower()) if isinstance(units, str) else None
+    if schema is None:
+        schema = FreeCAD.Units.getSchema()
+    _, factor, unit = FreeCAD.Units.schemaTranslate(value, schema)
+    decimals = tool_decimals(units)
+    if decimals == METRIC_DECIMALS and _in_microns(value):
+        # Below 0.1mm FreeCAD would switch to µm itself; keep that resolution.
+        decimals += 1
+    text = f"{value.Value / factor:.{decimals}f}"
+    # FreeCAD writes degrees closed up against the symbol.
+    return f"{text}{unit}" if unit == "\N{DEGREE SIGN}" else f"{text} {unit}"
+
+
+def to_json(value, units=None):
     """Convert a value to JSON format."""
     if isinstance(value, FreeCAD.Units.Quantity):
-        return value.UserString
+        return quantity_to_str(value, units)
     return value
 
 
@@ -81,12 +139,14 @@ def format_value(
     """
     Format a numeric value as a string, optionally appending a unit and controlling precision.
 
-    This function uses the ToolBitSchema (via setToolBitSchema) to ensure that units are formatted according to the correct schema (Metric or Imperial) when a FreeCAD.Units.Quantity is provided. The schema is temporarily set for formatting and then restored.
+    Lengths are formatted in the bit's own units at tool precision, so a list
+    entry says the same thing as the editor field and the file.
 
     Args:
         value: The numeric value to format.
-        unit: (Optional) The unit string to append (e.g., 'mm', 'in').
-        precision: (Optional) Number of decimal places (default: 3).
+        units: (Optional) the bit's units, "Metric" or "Imperial".
+        precision: (Optional) present to ask for a formatted value at all;
+            the number of decimals follows the units.
 
     Returns:
         str: The formatted value as a string, with unit if provided.
@@ -105,10 +165,7 @@ def format_value(
                 formatted_value = f"{deg_val:.1f}".rstrip("0").rstrip(".")
                 return f"{formatted_value}°"
             # Format the value with the specified number of precision and strip trailing zeros
-            setToolBitSchema(units)
-            _value = value.getUserPreferred()[0]
-            setToolBitSchema()
-            return _value
+            return quantity_to_str(value, units)
         return value.UserString
     return str(value)
 
@@ -148,12 +205,8 @@ def setToolBitSchema(schema=None):
     Set the FreeCAD units schema. If passed 'Metric' or 'Imperial', set accordingly (case-insensitive).
     Otherwise, if a document is open, set to its schema. If no document, fallback to user preference or provided schema.
     """
-    units_schema_map = {
-        "metric": 6,  # 6 = Metric schema in FreeCAD
-        "imperial": 3,  # 3 = Imperial schema in FreeCAD
-    }
-    if isinstance(schema, str) and schema.lower() in units_schema_map:
-        FreeCAD.Units.setSchema(units_schema_map[schema.lower()])
+    if isinstance(schema, str) and schema.lower() in UNITS_SCHEMA_MAP:
+        FreeCAD.Units.setSchema(UNITS_SCHEMA_MAP[schema.lower()])
         return
     if FreeCAD.ActiveDocument is not None:
         try:

--- a/src/Mod/CAM/Tools/Bit/3.175mm_Endmill.fctb
+++ b/src/Mod/CAM/Tools/Bit/3.175mm_Endmill.fctb
@@ -7,7 +7,8 @@
     "CuttingEdgeHeight": "25.0000 mm",
     "Diameter": "3.1750 mm",
     "Length": "45.0000 mm",
-    "ShankDiameter": "3.1750 mm"
+    "ShankDiameter": "3.1750 mm",
+    "Units": "Metric"
   },
   "attribute": {}
 }

--- a/src/Mod/CAM/Tools/Bit/30degree_Vbit.fctb
+++ b/src/Mod/CAM/Tools/Bit/30degree_Vbit.fctb
@@ -5,11 +5,12 @@
   "shape-type": "VBit",
   "parameter": {
     "CuttingEdgeAngle": "30.0000 \u00b0",
-    "Diameter": "10.0000 mm",
     "CuttingEdgeHeight": "1.0000 mm",
-    "TipDiameter": "0.1000 mm",
+    "Diameter": "10.0000 mm",
     "Length": "30.0000 mm",
-    "ShankDiameter": "5.0000 mm"
+    "ShankDiameter": "5.0000 mm",
+    "TipDiameter": "0.1000 mm",
+    "Units": "Metric"
   },
   "attribute": {}
 }

--- a/src/Mod/CAM/Tools/Bit/375-16_Tap.fctb
+++ b/src/Mod/CAM/Tools/Bit/375-16_Tap.fctb
@@ -8,9 +8,10 @@
     "Diameter": "0.375 \"",
     "Flutes": "3",
     "Length": "2.500 \"",
-    "Pitch": "0.000 in",
+    "Pitch": "0.0625 in",
     "ShankDiameter": "0.250 \"",
-    "TipAngle": "90.000 \u00b0"
+    "TipAngle": "90.000 \u00b0",
+    "Units": "Imperial"
   },
   "attribute": {}
 }

--- a/src/Mod/CAM/Tools/Bit/45degree_Vbit.fctb
+++ b/src/Mod/CAM/Tools/Bit/45degree_Vbit.fctb
@@ -5,11 +5,12 @@
   "shape-type": "VBit",
   "parameter": {
     "CuttingEdgeAngle": "45.0000 \u00b0",
-    "Diameter": "10.0000 mm",
     "CuttingEdgeHeight": "1.0000 mm",
-    "TipDiameter": "0.1000 mm",
+    "Diameter": "10.0000 mm",
     "Length": "20.0000 mm",
-    "ShankDiameter": "5.0000 mm"
+    "ShankDiameter": "5.0000 mm",
+    "TipDiameter": "0.1000 mm",
+    "Units": "Metric"
   },
   "attribute": {}
 }

--- a/src/Mod/CAM/Tools/Bit/45degree_chamfer.fctb
+++ b/src/Mod/CAM/Tools/Bit/45degree_chamfer.fctb
@@ -9,7 +9,8 @@
     "Diameter": "12.3323 mm",
     "Length": "30.0000 mm",
     "ShankDiameter": "6.3500 mm",
-    "TipDiameter": "5.0000 mm"
+    "TipDiameter": "5.0000 mm",
+    "Units": "Metric"
   },
   "attribute": {}
 }

--- a/src/Mod/CAM/Tools/Bit/5mm-thread-cutter.fctb
+++ b/src/Mod/CAM/Tools/Bit/5mm-thread-cutter.fctb
@@ -9,7 +9,8 @@
     "Length": "50.00 mm",
     "NeckDiameter": "3.00 mm",
     "NeckLength": "20.00 mm",
-    "ShankDiameter": "5.00 mm"
+    "ShankDiameter": "5.00 mm",
+    "Units": "Metric"
   },
   "attribute": {}
 }

--- a/src/Mod/CAM/Tools/Bit/5mm_Drill.fctb
+++ b/src/Mod/CAM/Tools/Bit/5mm_Drill.fctb
@@ -6,7 +6,8 @@
   "parameter": {
     "Diameter": "5.0000 mm",
     "Length": "50.0000 mm",
-    "TipAngle": "119.0000 \u00b0"
+    "TipAngle": "119.0000 \u00b0",
+    "Units": "Metric"
   },
   "attribute": {}
 }

--- a/src/Mod/CAM/Tools/Bit/5mm_Endmill.fctb
+++ b/src/Mod/CAM/Tools/Bit/5mm_Endmill.fctb
@@ -7,7 +7,8 @@
     "CuttingEdgeHeight": "30.0000 mm",
     "Diameter": "5.0000 mm",
     "Length": "50.0000 mm",
-    "ShankDiameter": "3.0000 mm"
+    "ShankDiameter": "3.0000 mm",
+    "Units": "Metric"
   },
   "attribute": {}
 }

--- a/src/Mod/CAM/Tools/Bit/60degree_Vbit.fctb
+++ b/src/Mod/CAM/Tools/Bit/60degree_Vbit.fctb
@@ -5,11 +5,12 @@
   "shape-type": "VBit",
   "parameter": {
     "CuttingEdgeAngle": "60.0000 \u00b0",
-    "Diameter": "10.0000 mm",
     "CuttingEdgeHeight": "1.0000 mm",
-    "TipDiameter": "0.1000 mm",
+    "Diameter": "10.0000 mm",
     "Length": "20.0000 mm",
-    "ShankDiameter": "5.0000 mm"
+    "ShankDiameter": "5.0000 mm",
+    "TipDiameter": "0.1000 mm",
+    "Units": "Metric"
   },
   "attribute": {}
 }

--- a/src/Mod/CAM/Tools/Bit/6mm_Ball_End.fctb
+++ b/src/Mod/CAM/Tools/Bit/6mm_Ball_End.fctb
@@ -7,7 +7,8 @@
     "CuttingEdgeHeight": "40.0000 mm",
     "Diameter": "6.0000 mm",
     "Length": "50.0000 mm",
-    "ShankDiameter": "3.0000 mm"
+    "ShankDiameter": "3.0000 mm",
+    "Units": "Metric"
   },
   "attribute": {}
 }

--- a/src/Mod/CAM/Tools/Bit/6mm_Bullnose.fctb
+++ b/src/Mod/CAM/Tools/Bit/6mm_Bullnose.fctb
@@ -4,11 +4,12 @@
   "shape": "bullnose.fcstd",
   "shape-type": "Bullnose",
   "parameter": {
+    "CornerRadius": "1.5000 mm",
     "CuttingEdgeHeight": "40.0000 mm",
     "Diameter": "6.0000 mm",
-    "CornerRadius": "1.5000 mm",
     "Length": "50.0000 mm",
-    "ShankDiameter": "3.0000 mm"
+    "ShankDiameter": "3.0000 mm",
+    "Units": "Metric"
   },
   "attribute": {}
 }

--- a/src/Mod/CAM/Tools/Bit/90degree_Vbit.fctb
+++ b/src/Mod/CAM/Tools/Bit/90degree_Vbit.fctb
@@ -5,11 +5,12 @@
   "shape-type": "VBit",
   "parameter": {
     "CuttingEdgeAngle": "90.0000 \u00b0",
-    "Diameter": "10.0000 mm",
     "CuttingEdgeHeight": "1.0000 mm",
-    "TipDiameter": "0.1000 mm",
+    "Diameter": "10.0000 mm",
     "Length": "20.0000 mm",
-    "ShankDiameter": "5.0000 mm"
+    "ShankDiameter": "5.0000 mm",
+    "TipDiameter": "0.1000 mm",
+    "Units": "Metric"
   },
   "attribute": {}
 }

--- a/src/Mod/CAM/Tools/Bit/M8x1.25_Tap.fctb
+++ b/src/Mod/CAM/Tools/Bit/M8x1.25_Tap.fctb
@@ -10,7 +10,8 @@
     "Length": "79 mm",
     "Pitch": "1.25 mm",
     "ShankDiameter": "8 mm",
-    "TipAngle": "90.000 \u00b0"
+    "TipAngle": "90.000 \u00b0",
+    "Units": "Metric"
   },
   "attribute": {}
 }

--- a/src/Mod/CAM/Tools/Bit/probe.fctb
+++ b/src/Mod/CAM/Tools/Bit/probe.fctb
@@ -6,7 +6,8 @@
   "parameter": {
     "Diameter": "6.0000 mm",
     "Length": "50.0000 mm",
-    "ShaftDiameter": "4.0000 mm"
+    "ShaftDiameter": "4.0000 mm",
+    "Units": "Metric"
   },
   "attribute": {}
 }

--- a/src/Mod/CAM/Tools/Bit/slittingsaw.fctb
+++ b/src/Mod/CAM/Tools/Bit/slittingsaw.fctb
@@ -5,11 +5,12 @@
   "shape-type": "SlittingSaw",
   "parameter": {
     "BladeThickness": "3.0000 mm",
-    "CapHeight": "3.0000 mm",
     "CapDiameter": "8.0000 mm",
+    "CapHeight": "3.0000 mm",
     "Diameter": "76.2000 mm",
     "Length": "50.0000 mm",
-    "ShankDiameter": "19.0500 mm"
+    "ShankDiameter": "19.0500 mm",
+    "Units": "Metric"
   },
   "attribute": {}
 }


### PR DESCRIPTION
Derived shape values kept no unit, and saving and display followed the active units schema and the user's decimals preference, storing a 0.375" tap as 0.37 in and rounding a 3.175mm endmill to 3.18mm. Values now use the bit's own Units at 3 decimals metric, 4 imperial, and the editor restores the global schema on every exit path. Shipped bits declare their Units, and the 375-16 tap gets its 16 TPI pitch.

The ToolBit task panel never constructed, so editing a tool in a document was unreachable. Fixing it exposed three more: a write through a setter only the detached stand-in provides, subtype aliases assigned to an enumeration that rejects them, and a shape drawing cropped by a minimum size set below the size it renders at.

Fixes: #32349

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<img width="439" height="1072" alt="image" src="https://github.com/user-attachments/assets/e862f9bf-89a4-4a07-8077-94638c7df65e" />
