### PR TITLE
PD: Fix transform order for profile shape

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderSketchBased.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderSketchBased.cpp
@@ -107,7 +107,7 @@ void ViewProviderSketchBased::updateProfileShape()
 
     // set the correct coordinate space for the profile shape
     profileShape.setPlacement(
-        profileShape.getPlacement() * profileBased->Placement.getValue().inverse()
+        profileBased->Placement.getValue().inverse() * profileShape.getPlacement()
     );
 
     updatePreviewShape(profileShape, pcProfileShape);


### PR DESCRIPTION
Fixes the transform order which lead to wrong profile shape for rotated profiles when the sketch InternalFace is used.
No AI used.

Before:

https://github.com/user-attachments/assets/ff379b40-2c49-488a-bf23-4536de436fe6



After:

https://github.com/user-attachments/assets/6302faf4-5e6d-47ba-9385-03fe42802b8e

