### PR TITLE
Gui: Fix the mouse wheel filter missing spin boxes on macOS

### DIFF
--- a/src/Gui/GuiApplication.cpp
+++ b/src/Gui/GuiApplication.cpp
@@ -35,6 +35,7 @@
 #include <QAbstractSpinBox>
 #include <QByteArray>
 #include <QComboBox>
+#include <QLineEdit>
 #include <QTextStream>
 #include <QFileInfo>
 #include <QFileOpenEvent>
@@ -377,26 +378,90 @@ bool WheelEventFilter::isEnabled() const
     return hGrp->GetBool("ComboBoxWheelEventFilter", true);
 }
 
+namespace
+{
+// Marks the widgets whose focus policy this filter changed, so that turning the preference off
+// restores only those.
+const char* wheelFocusDowngraded = "_fc_wheelFocusDowngraded";
+
+// A wheel event goes to the widget under the cursor, which for a spin box or an editable combo box
+// is its internal line edit. Qt propagates it to the parent only for spontaneous events, so pick
+// the widget of interest here.
+QWidget* wheelTarget(QObject* obj)
+{
+    auto* widget = qobject_cast<QWidget*>(obj);
+    if (!widget) {
+        return nullptr;
+    }
+    if (qobject_cast<QAbstractSpinBox*>(widget) || qobject_cast<QComboBox*>(widget)) {
+        return widget;
+    }
+    if (qobject_cast<QLineEdit*>(widget)) {
+        QWidget* parent = widget->parentWidget();
+        if (qobject_cast<QAbstractSpinBox*>(parent) || qobject_cast<QComboBox*>(parent)) {
+            return parent;
+        }
+    }
+    return nullptr;
+}
+}  // namespace
+
+void WheelEventFilter::updateFocusPolicy(QWidget* widget) const
+{
+    if (isEnabled()) {
+        if (widget->focusPolicy() == Qt::WheelFocus) {
+            widget->setFocusPolicy(Qt::StrongFocus);
+            widget->setProperty(wheelFocusDowngraded, true);
+        }
+    }
+    else if (widget->property(wheelFocusDowngraded).toBool()) {
+        widget->setFocusPolicy(Qt::WheelFocus);
+        widget->setProperty(wheelFocusDowngraded, QVariant());
+    }
+}
+
 bool WheelEventFilter::eventFilter(QObject* obj, QEvent* ev)
 {
-    if (qobject_cast<QComboBox*>(obj) && ev->type() == QEvent::Wheel) {
-        return isEnabled();
+    const QEvent::Type type = ev->type();
+    if (type != QEvent::Wheel && type != QEvent::Show && type != QEvent::Polish) {
+        return false;
     }
-    auto sb = qobject_cast<QAbstractSpinBox*>(obj);
+
+    QWidget* target = wheelTarget(obj);
+    if (!target) {
+        return false;
+    }
+
+    auto* sb = qobject_cast<QAbstractSpinBox*>(target);
+
+    if (type != QEvent::Wheel) {
+        // Polish as well as Show: a spin box shown before the filter is installed would keep
+        // Qt::WheelFocus and defeat the filter.
+        if (sb) {
+            updateFocusPolicy(sb);
+        }
+        return false;
+    }
+
+    if (!isEnabled()) {
+        return false;
+    }
+
     if (sb) {
-        if (ev->type() == QEvent::Show) {
-            if (isEnabled()) {
-                sb->setFocusPolicy(Qt::StrongFocus);
-            }
-            else if (sb->focusPolicy() == Qt::StrongFocus) {
-                sb->setFocusPolicy(Qt::WheelFocus);
-            }
+        // Qt focuses a Qt::WheelFocus widget before delivering the wheel event, so such a spin box
+        // would focus itself on the first notch and then pass the hasFocus() check. Fix the policy
+        // and swallow this event.
+        if (sb->focusPolicy() == Qt::WheelFocus) {
+            updateFocusPolicy(sb);
         }
-        else if (ev->type() == QEvent::Wheel) {
-            return isEnabled() && !sb->hasFocus();
+        else if (sb->hasFocus()) {
+            return false;
         }
     }
-    return false;
+
+    // Ignore instead of accept so the scroll reaches the containing scroll area.
+    ev->ignore();
+    return true;
 }
 
 #include "moc_GuiApplication.cpp"

--- a/src/Gui/GuiApplication.h
+++ b/src/Gui/GuiApplication.h
@@ -30,6 +30,7 @@
 #include <memory>
 
 class QSessionManager;
+class QWidget;
 
 namespace Gui
 {
@@ -94,6 +95,7 @@ public:
 
 private:
     bool isEnabled() const;
+    void updateFocusPolicy(QWidget* widget) const;
 
     ParameterGrp::handle hGrp;
 };


### PR DESCRIPTION
A spin box still set to Qt::WheelFocus takes keyboard focus from the wheel event itself, so hovering and scrolling focused it and the filter let the event through. The QEvent::Show handler that cleared the policy did not always run.

Clear Qt::WheelFocus on QEvent::Polish and on the wheel event as well as on show, resolve the spin box from its line edit, and restore the policy only where the filter changed it. Blocked events are ignored, so the panel still scrolls.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Follow-up to #32141 