### PR TITLE
Sketcher: Constrain toolbar is now aware of selection

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -22,11 +22,13 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <array>
 #include <limits>
 #include <cmath>
 #include <initializer_list>
 #include <numbers>
 #include <optional>
+#include <string_view>
 #include <utility>
 
 #include <Precision.hxx>
@@ -333,6 +335,12 @@ namespace SketcherGui
 class ViewProviderSketchCommandConstraintsAttorney
 {
 public:
+    static std::vector<std::string> getSelectionContextMenuCommands(
+        const ViewProviderSketch& viewProvider)
+    {
+        return viewProvider.getSelectionContextMenuCommands();
+    }
+
     static void moveConstraint(ViewProviderSketch& viewProvider,
                                int constraintIndex,
                                const Base::Vector2d& position)
@@ -1267,9 +1275,69 @@ protected:
     virtual void applyConstraint(std::vector<SelIdPair>&, int)
     {}
     void activated(int /*iMsg*/) override;
+    bool isActive() override;
+};
+
+bool CmdSketcherConstraint::isActive()
+{
+    auto* document = getActiveGuiDocument();
+    if (!isCommandActive(document)) {
+        return false;
+    }
+
+    static constexpr std::array<std::string_view, 10> contextFilteredCommands {
+        "Sketcher_ConstrainCoincidentUnified",
+        "Sketcher_ConstrainHorVer",
+        "Sketcher_ConstrainHorizontal",
+        "Sketcher_ConstrainVertical",
+        "Sketcher_ConstrainParallel",
+        "Sketcher_ConstrainPerpendicular",
+        "Sketcher_ConstrainTangent",
+        "Sketcher_ConstrainEqual",
+        "Sketcher_ConstrainSymmetric",
+        "Sketcher_ConstrainBlock",
+    };
+    const std::string_view commandName {getName()};
+
+    if (std::find(contextFilteredCommands.cbegin(), contextFilteredCommands.cend(), commandName)
+        == contextFilteredCommands.cend()) {
+        return true;
+    }
+
+    auto* sketchView = document
+        ? freecad_cast<SketcherGui::ViewProviderSketch*>(document->getInEdit())
+        : nullptr;
+    if (!sketchView) {
+        return true;
+    }
+
+    // Keep toolbar availability aligned with the existing context-menu suggestions.
+    const auto contextCommands =
+        SketcherGui::ViewProviderSketchCommandConstraintsAttorney::
+            getSelectionContextMenuCommands(*sketchView);
+    const auto isContextCommand = [&contextCommands](std::string_view candidate) {
+        return std::any_of(contextCommands.cbegin(), contextCommands.cend(),
+                           [candidate](const std::string& command) {
+                               return command == candidate;
+                           });
+    };
+
+    return std::none_of(contextFilteredCommands.cbegin(),
+                        contextFilteredCommands.cend(),
+                        isContextCommand)
+        || isContextCommand(commandName);
+}
+
+class CmdSketcherSelectionAwareConstraintGroup: public Gui::GroupCommand
+{
+public:
+    using Gui::GroupCommand::GroupCommand;
+
     bool isActive() override
     {
-        return isCommandActive(getActiveGuiDocument());
+        return std::any_of(cmds.cbegin(), cmds.cend(), [](const auto& entry) {
+            return entry.first && entry.first->isActive();
+        });
     }
 };
 
@@ -1921,11 +1989,11 @@ public:
 
 // Comp for constrain tools =============================================
 
-class CmdSketcherCompConstrainTools : public Gui::GroupCommand
+class CmdSketcherCompConstrainTools: public CmdSketcherSelectionAwareConstraintGroup
 {
 public:
     CmdSketcherCompConstrainTools()
-        : GroupCommand("Sketcher_CompConstrainTools")
+        : CmdSketcherSelectionAwareConstraintGroup("Sketcher_CompConstrainTools")
     {
         sAppModule = "Sketcher";
         sGroup = "Sketcher";
@@ -3725,11 +3793,11 @@ bool CmdSketcherDimension::isActive(void)
 
 // Comp for horizontal/vertical =============================================
 
-class CmdSketcherCompHorizontalVertical : public Gui::GroupCommand
+class CmdSketcherCompHorizontalVertical: public CmdSketcherSelectionAwareConstraintGroup
 {
 public:
     CmdSketcherCompHorizontalVertical()
-        : GroupCommand("Sketcher_CompHorVer")
+        : CmdSketcherSelectionAwareConstraintGroup("Sketcher_CompHorVer")
     {
         sAppModule = "Sketcher";
         sGroup = "Sketcher";
@@ -3750,11 +3818,6 @@ public:
     const char* className() const override
     {
         return "CmdSketcherCompHorizontalVertical";
-    }
-
-    bool isActive() override
-    {
-        return isCommandActive(getActiveGuiDocument());
     }
 };
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -5344,11 +5344,10 @@ bool ViewProviderSketch::isInEditMode() const
 {
     return editCoinManager != nullptr;
 }
-void ViewProviderSketch::generateContextMenu()
+void ViewProviderSketch::buildSelectionContextMenu(Gui::MenuItem& menu) const
 {
-    if (blockContextMenu) return;
-
     int selectedEdges = 0;
+    int selectedInternalEdges = 0;
     int selectedLines = 0;
     int selectedConics = 0;
     int selectedPoints = 0;
@@ -5359,26 +5358,39 @@ void ViewProviderSketch::generateContextMenu()
     int selectedEndPoints = 0;
     bool onlyOrigin = false;
 
-    Gui::MenuItem menu;
     menu.setCommand("Sketcher Context");
 
     std::vector<Gui::SelectionObject> selection =
         Gui::Selection().getSelectionEx(0, Sketcher::SketchObject::getClassTypeId());
 
+    const auto selectedSketch =
+        std::find_if(selection.cbegin(), selection.cend(), [this](const auto& item) {
+            return item.getObject() == getSketchObject();
+        });
+
     // if something is selected, count different elements in the current selection
-    if (selection.size() > 0) {
-        const std::vector<std::string> SubNames = selection[0].getSubNames();
+    if (selectedSketch != selection.cend()) {
+        const std::vector<std::string> SubNames = selectedSketch->getSubNames();
         const Sketcher::SketchObject* obj;
         bool shouldAddChangeConstraintValue = false;
-        if (selection[0].getObject()->isDerivedFrom<Sketcher::SketchObject>()) {
-            obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
-            for (auto& name : SubNames) {
-                int geoId = std::atoi(name.substr(4, 4000).c_str()) - 1;
-                const Part::Geometry* geo = getSketchObject()->getGeometry(geoId);
+        if (selectedSketch->getObject()->isDerivedFrom<Sketcher::SketchObject>()) {
+            obj = getSketchObject();
+            for (const auto& name : SubNames) {
                 if (name.substr(0, 4) == "Edge" || name.substr(0, 12) == "ExternalEdge") {
-                    ++selectedEdges;
+                    int geoId;
+                    Sketcher::PointPos posId;
+                    getIdsFromName(name, obj, geoId, posId);
+                    if (!isEdge(geoId, posId)) {
+                        continue;
+                    }
+                    const Part::Geometry* geo = obj->getGeometry(geoId);
 
+                    ++selectedEdges;
                     if (geoId >= 0) {
+                        ++selectedInternalEdges;
+                    }
+
+                    if (geo) {
                         if (isLineSegment(*geo)) {
                             ++selectedLines;
                         }
@@ -5392,6 +5404,7 @@ void ViewProviderSketch::generateContextMenu()
                 }
                 else if (name.substr(0, 4) == "Vert") {
                     ++selectedPoints;
+                    int geoId;
                     Sketcher::PointPos posId;
                     getIdsFromName(name, obj, geoId, posId);
                     if (isBsplineKnotOrEndPoint(obj, geoId, posId)) {
@@ -5456,7 +5469,6 @@ void ViewProviderSketch::generateContextMenu()
 
                     menu << "Sketcher_ConstrainEqual";
                 }
-                menu << "Sketcher_ConstrainBlock";
             }
             else if (selectedConics > 1 && selectedLines == 0) {
                 menu << "Sketcher_ConstrainCoincidentUnified"
@@ -5535,8 +5547,14 @@ void ViewProviderSketch::generateContextMenu()
             }
         }
 
+        // Block accepts any set of internal edges, including conics and B-splines.
+        if (selectedPoints == 0 && selectedEdges > 0
+            && selectedInternalEdges == selectedEdges && !onlyOrigin) {
+            menu << "Sketcher_ConstrainBlock";
+        }
+
         // context menu if only constraints are selected
-        else if (selectedConstraints >= 1) {
+        if (selectedConstraints >= 1 && selectedPoints == 0 && selectedEdges == 0) {
             if (shouldAddChangeConstraintValue) {
                 menu << "Sketcher_ChangeDimensionConstraint";
             }
@@ -5603,7 +5621,30 @@ void ViewProviderSketch::generateContextMenu()
              << "Separator"
              << "Sketcher_LeaveSketch";
     }
-    // create context menu
+}
+
+std::vector<std::string> ViewProviderSketch::getSelectionContextMenuCommands() const
+{
+    Gui::MenuItem menu;
+    buildSelectionContextMenu(menu);
+
+    std::vector<std::string> commands;
+    commands.reserve(menu.count());
+    for (const Gui::MenuItem* item : menu.getItems()) {
+        commands.push_back(item->command());
+    }
+    return commands;
+}
+
+void ViewProviderSketch::generateContextMenu()
+{
+    if (blockContextMenu) {
+        return;
+    }
+
+    Gui::MenuItem menu;
+    buildSelectionContextMenu(menu);
+
     Gui::Application::Instance->setupContextMenu("Sketch", &menu);
     QMenu contextMenu(
         qobject_cast<Gui::View3DInventor*>(this->getActiveView())->getViewer()->getGLWidget());

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -89,8 +89,9 @@ class Geometry;
 
 namespace Gui
 {
+class MenuItem;
 class View3DInventorViewer;
-}
+}  // namespace Gui
 
 namespace Sketcher
 {
@@ -895,6 +896,9 @@ private:
 
     /** @name Selection functions */
     //@{
+    void buildSelectionContextMenu(Gui::MenuItem& menu) const;
+    std::vector<std::string> getSelectionContextMenuCommands() const;
+
     /// box selection method
     void doBoxSelection(
         const SbVec2s& startPos,


### PR DESCRIPTION
The relevant constrain is activated or deactivated according to the selection.

Constraints that are not possible according to the selections made are deactivated; if you press it, you will get an error message. Here, the lock sometimes behaved differently, so I had to add some exceptions for that situation. For the HorVer group, I also ensured that if all are deactivated, the group is also deactivated. I wrote the first code myself and asked ChatGpt 5 to review it.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/e763b328-0761-4bde-9fab-b40b443ba67b



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
