### PR TITLE
Core: Transform context menu on Part datums

### DIFF
--- a/src/Gui/ViewProviderDatum.cpp
+++ b/src/Gui/ViewProviderDatum.cpp
@@ -152,6 +152,27 @@ void ViewProviderDatum::resetTemporarySize()
     soScale->scaleFactor = sz;
 }
 
+bool ViewProviderDatum::setEdit(int ModNum)
+{
+    if (ModNum != ViewProvider::Transform) {
+        return false;
+    }
+
+    auto* feat = static_cast<App::DatumElement*>(getObject());
+    if (feat && feat->isOriginFeature()) {
+        return false;
+    }
+
+    return ViewProviderGeometryObject::setEdit(ModNum);
+}
+
+void ViewProviderDatum::unsetEdit(int ModNum)
+{
+    if (ModNum == ViewProvider::Transform) {
+        ViewProviderGeometryObject::unsetEdit(ModNum);
+    }
+}
+
 void ViewProviderDatum::onChanged(const App::Property* prop)
 {
     ViewProviderGeometryObject::onChanged(prop);

--- a/src/Gui/ViewProviderDatum.h
+++ b/src/Gui/ViewProviderDatum.h
@@ -52,15 +52,10 @@ public:
     std::vector<std::string> getDisplayModes() const override;
     void setDisplayMode(const char* ModeName) override;
 
-    /// @name Suppress ViewProviderGeometryObject's behaviour
-    ///@{
-    bool setEdit(int) override
-    {
-        return false;
-    }
-    void unsetEdit(int) override
-    {}
-    ///@}
+    /// Origin-owned axes/planes stay non-editable. Standalone Part datums
+    /// still accept Transform so the tree-view Transform command can run.
+    bool setEdit(int ModNum) override;
+    void unsetEdit(int ModNum) override;
 
     void setTemporaryScale(double factor);
     void resetTemporarySize();

--- a/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
@@ -284,6 +284,9 @@ bool ViewProviderDatum::setEdit(int ModNum)
 
         return true;
     }
+    else if (ModNum == ViewProvider::Transform) {
+        return ViewProviderGeometryObject::setEdit(ModNum);
+    }
     else {
         return ViewProvider::setEdit(ModNum);
     }


### PR DESCRIPTION
Tree Transform on a Part datum called `setEdit(Transform)` on `Gui::ViewProviderDatum`, which always returned false, so the dragger never started. PartDesign datums then fell through to `ViewProvider::setEdit`, which also does not create a dragger.

Forward Transform to `ViewProviderGeometryObject::setEdit` for standalone Part/PartDesign datums. Origin axes still refuse edit.

Fixes #32385
