### PR TITLE
PartDesign: name a loft profile reused as the first section

### DIFF
--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -194,6 +194,21 @@ App::DocumentObjectExecReturn* Loft::execute()
             );
         }
 
+        const auto wholeObject = [](const std::vector<std::string>& subs) {
+            return subs.empty() || (subs.size() == 1 && subs.front().empty());
+        };
+        const auto& firstSection = multisections.front();
+        if (Profile.getValue() && Profile.getValue() == firstSection.first) {
+            const auto& profileSubs = Profile.getSubValues();
+            if (profileSubs == firstSection.second
+                || (wholeObject(profileSubs) && wholeObject(firstSection.second))) {
+                return new App::DocumentObjectExecReturn(
+                    "Segment " + Profile.getValue()->Label.getStrValue()
+                    + " cannot be used both as profile and first segment"
+                );
+            }
+        }
+
         std::vector<std::vector<TopoShape>> wiresections;
         wiresections.reserve(wires.size());
         for (auto& wire : wires) {

--- a/src/Mod/PartDesign/PartDesignTests/TestLoft.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestLoft.py
@@ -58,6 +58,28 @@ class TestLoft(unittest.TestCase):
         self.Doc.recompute()
         self.assertAlmostEqual(self.AdditiveLoft.Shape.Volume, 1)
 
+    def testProfileReusedAsFirstSection(self):
+        body = self.Doc.addObject("PartDesign::Body", "Body")
+        sketch_a = self.Doc.addObject("Sketcher::SketchObject", "SketchA")
+        body.addObject(sketch_a)
+        sketch_a.Label = "A"
+        sketch_a.addGeometry(Part.Circle(Base.Vector(), Base.Vector(0, 0, 1), 10), False)
+        sketch_b = self.Doc.addObject("Sketcher::SketchObject", "SketchB")
+        body.addObject(sketch_b)
+        sketch_b.Label = "B"
+        sketch_b.Placement.Base.z = 20
+        sketch_b.addGeometry(Part.Circle(Base.Vector(), Base.Vector(0, 0, 1), 8), False)
+        loft = self.Doc.addObject("PartDesign::AdditiveLoft", "AdditiveLoft")
+        body.addObject(loft)
+        loft.Profile = sketch_a
+        loft.Sections = [sketch_a, sketch_b]
+        self.Doc.recompute()
+        self.assertFalse(loft.isValid())
+        self.assertIn(
+            "Segment A cannot be used both as profile and first segment",
+            loft.getStatusString(),
+        )
+
     def testSimpleSubtractiveLoftCase(self):
         self.Body = self.Doc.addObject("PartDesign::Body", "Body")
         self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "SketchPad")


### PR DESCRIPTION
If the same sketch is used as both the profile and the first section, say so instead of the generic separation error.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Written with help from Grok 4.6. I reviewed the older attempts on #32162.

Assisted-by: Grok 4.6

## Issues
Fixes #32162
