### PR TITLE
Part: Limit global tesselation to avoid computational explosion for complex parts

### DIFF
--- a/src/Mod/Part/Gui/DlgSettings3DViewPart.ui
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPart.ui
@@ -116,6 +116,41 @@
           </property>
          </widget>
         </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="toolTip">
+           <string>Total number of triangles used to display all visible Part objects. The limit is shared between the visible objects of all open documents. Set to 0 to disable the limit.</string>
+          </property>
+          <property name="text">
+           <string>Maximum facets for display (0 = unlimited)</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="Gui::PrefSpinBox" name="maxFacets">
+          <property name="specialValueText">
+           <string>Unlimited</string>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>1000000000</number>
+          </property>
+          <property name="singleStep">
+           <number>100000</number>
+          </property>
+          <property name="value">
+           <number>2000000</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>MaxFacetsForDisplay</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Part</cstring>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>
@@ -141,6 +176,11 @@
   <customwidget>
    <class>Gui::PrefDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefSpinBox</class>
+   <extends>QSpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>

--- a/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
@@ -27,12 +27,14 @@
 
 #include <App/Application.h>
 #include <App/Document.h>
+#include <Base/Parameter.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
 
 #include "DlgSettings3DViewPartImp.h"
 #include "ui_DlgSettings3DViewPart.h"
 #include "ViewProvider.h"
+#include "ViewProviderExt.h"
 
 
 using namespace PartGui;
@@ -119,8 +121,16 @@ void DlgSettings3DViewPart::onMaxAngularDeflectionEditingFinished()
 
 void DlgSettings3DViewPart::saveSettings()
 {
+    const ParameterGrp::handle hPart = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Part"
+    );
+    const int oldBudget = hPart->GetInt("MaxFacetsForDisplay", 2000000);
+
     ui->maxDeviation->onSave();
     ui->maxAngularDeflection->onSave();
+    ui->maxFacets->onSave();
+
+    const int newBudget = hPart->GetInt("MaxFacetsForDisplay", 2000000);
 
     // search for Part view providers and apply the new settings
     std::vector<App::Document*> docs = App::GetApplication().getDocuments();
@@ -133,11 +143,18 @@ void DlgSettings3DViewPart::saveSettings()
             static_cast<ViewProviderPart*>(view)->reload();
         }
     }
+
+    // If the global facet budget changed, rebuild the tessellation of all visible Part
+    // objects so that the new limit takes effect immediately.
+    if (oldBudget != newBudget) {
+        ViewProviderPartExt::updateVisualOfAllParts();
+    }
 }
 void DlgSettings3DViewPart::loadSettings()
 {
     ui->maxDeviation->onRestore();
     ui->maxAngularDeflection->onRestore();
+    ui->maxFacets->onRestore();
 }
 
 /**

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -22,14 +22,18 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <algorithm>
+
 #include <Bnd_Box.hxx>
 #include <BRep_Tool.hxx>
 #include <BRepTools.hxx>
 #include <BRepBndLib.hxx>
 #include <BRepBuilderAPI_MakeVertex.hxx>
 #include <BRepExtrema_DistShapeShape.hxx>
+#include <BRepGProp.hxx>
 #include <BRepMesh_IncrementalMesh.hxx>
 #include <gp_Trsf.hxx>
+#include <GProp_GProps.hxx>
 #include <Precision.hxx>
 #include <Poly_Array1OfTriangle.hxx>
 #include <Poly_Polygon3D.hxx>
@@ -77,7 +81,9 @@
 #include <Base/Tools.h>
 
 #include <Gui/BitmapFactory.h>
+#include <Gui/Application.h>
 #include <Gui/Control.h>
+#include <Gui/Document.h>
 #include <Gui/Selection/SoFCSelectionAction.h>
 #include <Gui/Selection/SoFCUnifiedSelection.h>
 #include <Gui/ViewParams.h>
@@ -87,6 +93,7 @@
 #include <Mod/Part/App/Tools.h>
 
 #include "ViewProviderExt.h"
+#include "ViewProvider.h"
 #include "ViewProviderPartExtPy.h"
 #include "SoBrepEdgeSet.h"
 #include "SoBrepFaceSet.h"
@@ -1048,6 +1055,58 @@ void ViewProviderPartExt::unsetEdit(int ModNum)
     }
 }
 
+int ViewProviderPartExt::getFacetBudget()
+{
+    const ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Part"
+    );
+
+    // MaxFacetsForDisplay is the total triangle budget for all visible Part objects of
+    // all open documents. A value of 0 disables the tessellation limit.
+    const int globalBudget = hGrp->GetInt("MaxFacetsForDisplay", 2000000);
+    if (globalBudget <= 0) {
+        return 0;
+    }
+
+    // Count the visible Part view providers that share the budget. Hidden objects do
+    // not consume rendering capacity and therefore do not reduce the budget of the
+    // visible ones.
+    int count = 0;
+    for (const auto doc : App::GetApplication().getDocuments()) {
+        Gui::Document* guiDoc = Gui::Application::Instance->getDocument(doc);
+        if (!guiDoc) {
+            continue;
+        }
+        for (const auto vp : guiDoc->getViewProvidersOfType(ViewProviderPart::getClassTypeId())) {
+            if (vp->isVisible()) {
+                count++;
+            }
+        }
+    }
+
+    // Split the global budget evenly among the visible objects. Keep a reasonable
+    // minimum so that objects of huge assemblies are not reduced below a recognizable
+    // level, and a maximum so that a single visible pathological shape (e.g. a long
+    // ball screw with hundreds of thousands of facets) does not consume the meshing
+    // time of the whole global budget by itself.
+    return std::clamp(globalBudget / std::max(count, 1), 5000, 100000);
+}
+
+void ViewProviderPartExt::updateVisualOfAllParts()
+{
+    for (const auto doc : App::GetApplication().getDocuments()) {
+        Gui::Document* guiDoc = Gui::Application::Instance->getDocument(doc);
+        if (!guiDoc) {
+            continue;
+        }
+        for (const auto vp : guiDoc->getViewProvidersOfType(ViewProviderPart::getClassTypeId())) {
+            if (vp->isVisible()) {
+                static_cast<ViewProviderPartExt*>(vp)->updateVisual();
+            }
+        }
+    }
+}
+
 void ViewProviderPartExt::setupCoinGeometry(
     TopoDS_Shape shape,
     SoCoordinate3* coords,
@@ -1104,14 +1163,115 @@ void ViewProviderPartExt::setupCoinGeometry(
     meshParams.InParallel = Standard_True;
     meshParams.AllowQualityDecrease = Standard_True;
 
-    // Clear triangulation and PCurves from geometry which can slow down the process
+    // Tessellation facet budget. Some shapes (e.g. long helical surfaces such as ball
+    // screws, or B-spline surfaces with thousands of control points) can produce an
+    // enormous number of triangles when tessellated with a small deviation. The meshing
+    // itself can then take many minutes and the resulting multi-million triangle meshes
+    // make the 3D view unusably slow when rendering, orbiting or pre-selecting objects.
+    //
+    // To keep the GUI responsive the tessellation is limited by a facet budget that is
+    // shared among all visible Part objects (see getFacetBudget()). The expected number
+    // of triangles is estimated beforehand from the surface area (triangle count
+    // ~ area / deflection^2), so that the very expensive fine mesh is never even
+    // attempted when it would exceed the budget. If after meshing the budget is still
+    // exceeded, both the linear and the angular deflection are scaled by the same factor
+    // and the shape is re-meshed (a few iterations at most). Set MaxFacetsForDisplay to
+    // 0 to disable the limit.
+    const int maxFacets = getFacetBudget();
+
+    // Limit the number of warning messages so that opening an assembly with hundreds of
+    // objects does not flood the report view.
+    static int budgetWarningCount = 0;
+    const bool doWarn = maxFacets > 0 && budgetWarningCount < 10;
+
+    if (maxFacets > 0) {
+        // Estimate the number of triangles the requested deflection would produce from
+        // the overall surface area and scale the deflection accordingly beforehand.
+        // This avoids starting an extremely expensive meshing of pathological geometry.
+        GProp_GProps props;
+        BRepGProp::SurfaceProperties(shape, props);
+        const double area = props.Mass();
+        if (area > Precision::Confusion() && deflection > Precision::Confusion()) {
+            const double estTriangles = area / (deflection * deflection);
+            if (estTriangles > maxFacets) {
+                const double scale = std::sqrt(estTriangles / maxFacets);
+                meshParams.Deflection *= scale;
+                meshParams.Angle *= scale;
+                if (doWarn) {
+                    budgetWarningCount++;
+                    FC_WARN(
+                        "Part tessellation estimated at "
+                        << static_cast<long>(estTriangles)
+                        << " triangles, which exceeds the facet budget of " << maxFacets
+                        << ". Increasing linear deflection to " << meshParams.Deflection
+                        << " and angular deflection to " << meshParams.Angle << " rad."
+                        << (budgetWarningCount == 10 ? " Further messages suppressed." : "")
+                    );
+                }
+            }
+        }
+    }
+
+    for (int attempt = 0; attempt < 4; attempt++) {
+        // Clear triangulation and PCurves from geometry which can slow down the process.
+        // This must be done before each meshing attempt, otherwise OCCT keeps the finer
+        // mesh of a previous attempt when asked for a coarser one.
 #if OCC_VERSION_HEX < 0x070600
-    BRepTools::Clean(shape);
+        BRepTools::Clean(shape);
 #else
-    BRepTools::Clean(shape, Standard_True);
+        BRepTools::Clean(shape, Standard_True);
 #endif
 
-    BRepMesh_IncrementalMesh(shape, meshParams);
+        BRepMesh_IncrementalMesh(shape, meshParams);
+
+        if (maxFacets <= 0) {
+            break;
+        }
+
+        // count the triangles of the produced mesh
+        TopTools_IndexedMapOfShape budgetFaceMap;
+        TopExp::MapShapes(shape, TopAbs_FACE, budgetFaceMap);
+        int count = 0;
+        for (int i = 1; i <= budgetFaceMap.Extent(); i++) {
+            TopLoc_Location budgetLoc;
+            Handle(Poly_Triangulation)
+                mesh = BRep_Tool::Triangulation(TopoDS::Face(budgetFaceMap(i)), budgetLoc);
+            if (mesh.IsNull()) {
+                mesh = Part::Tools::triangulationOfFace(TopoDS::Face(budgetFaceMap(i)));
+            }
+            if (!mesh.IsNull()) {
+                count += mesh->NbTriangles();
+            }
+        }
+
+        if (count <= maxFacets || attempt == 3) {
+            if (count > maxFacets) {
+                if (doWarn) {
+                    budgetWarningCount++;
+                    FC_WARN(
+                        "Part tessellation still exceeds the facet budget after adaptive "
+                        "deflection scaling: "
+                        << count << " triangles (budget " << maxFacets
+                        << "). Consider raising the object's Deviation property."
+                    );
+                }
+            }
+            break;
+        }
+
+        const double scale = std::sqrt(static_cast<double>(count) / maxFacets);
+        meshParams.Deflection *= scale;
+        meshParams.Angle *= scale;
+        if (doWarn) {
+            budgetWarningCount++;
+            FC_WARN(
+                "Part tessellation exceeds the facet budget ("
+                << count << " > " << maxFacets << " triangles). Increasing linear deflection to "
+                << meshParams.Deflection << " and angular deflection to " << meshParams.Angle
+                << " rad and re-tessellating."
+            );
+        }
+    }
 
     // We must reset the location here because the transformation data
     // are set in the placement property

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -30,10 +30,8 @@
 #include <BRepBndLib.hxx>
 #include <BRepBuilderAPI_MakeVertex.hxx>
 #include <BRepExtrema_DistShapeShape.hxx>
-#include <BRepGProp.hxx>
 #include <BRepMesh_IncrementalMesh.hxx>
 #include <gp_Trsf.hxx>
-#include <GProp_GProps.hxx>
 #include <Precision.hxx>
 #include <Poly_Array1OfTriangle.hxx>
 #include <Poly_Polygon3D.hxx>
@@ -1170,13 +1168,16 @@ void ViewProviderPartExt::setupCoinGeometry(
     // make the 3D view unusably slow when rendering, orbiting or pre-selecting objects.
     //
     // To keep the GUI responsive the tessellation is limited by a facet budget that is
-    // shared among all visible Part objects (see getFacetBudget()). The expected number
-    // of triangles is estimated beforehand from the surface area (triangle count
-    // ~ area / deflection^2), so that the very expensive fine mesh is never even
-    // attempted when it would exceed the budget. If after meshing the budget is still
-    // exceeded, both the linear and the angular deflection are scaled by the same factor
-    // and the shape is re-meshed (a few iterations at most). Set MaxFacetsForDisplay to
-    // 0 to disable the limit.
+    // shared among all visible Part objects (see getFacetBudget()). To avoid ever
+    // starting an extremely expensive fine mesh, the shape is first meshed once at a
+    // coarse "probe" deflection, which is cheap for any shape (at most a few thousand
+    // triangles). The facet count of the probe mesh is then used to compute the
+    // deflection that will hit the budget: for meshes of the same shape the triangle
+    // count grows roughly quadratically with the inverse deflection, so the deflection
+    // of the final mesh follows directly from the measured count. If after meshing the
+    // budget is still exceeded, both the linear and the angular deflection are scaled
+    // by the same factor and the shape is re-meshed (at most a few iterations). Set
+    // MaxFacetsForDisplay to 0 to disable the limit.
     const int maxFacets = getFacetBudget();
 
     // Limit the number of warning messages so that opening an assembly with hundreds of
@@ -1184,31 +1185,26 @@ void ViewProviderPartExt::setupCoinGeometry(
     static int budgetWarningCount = 0;
     const bool doWarn = maxFacets > 0 && budgetWarningCount < 10;
 
+    // Coarse deflection used for the probe mesh. A deflection of the bounding box
+    // diagonal / 100 keeps the probe at a few thousand triangles even for very large
+    // shapes. The angular deflection is scaled by the same factor, otherwise the probe
+    // of shapes with fine features (threads, ball screw grooves) would still discretize
+    // their high-pole-count curves at the requested angular tolerance and remain
+    // expensive.
+    double probeDeflection = deflection;
     if (maxFacets > 0) {
-        // Estimate the number of triangles the requested deflection would produce from
-        // the overall surface area and scale the deflection accordingly beforehand.
-        // This avoids starting an extremely expensive meshing of pathological geometry.
-        GProp_GProps props;
-        BRepGProp::SurfaceProperties(shape, props);
-        const double area = props.Mass();
-        if (area > Precision::Confusion() && deflection > Precision::Confusion()) {
-            const double estTriangles = area / (deflection * deflection);
-            if (estTriangles > maxFacets) {
-                const double scale = std::sqrt(estTriangles / maxFacets);
-                meshParams.Deflection *= scale;
-                meshParams.Angle *= scale;
-                if (doWarn) {
-                    budgetWarningCount++;
-                    FC_WARN(
-                        "Part tessellation estimated at "
-                        << static_cast<long>(estTriangles)
-                        << " triangles, which exceeds the facet budget of " << maxFacets
-                        << ". Increasing linear deflection to " << meshParams.Deflection
-                        << " and angular deflection to " << meshParams.Angle << " rad."
-                        << (budgetWarningCount == 10 ? " Further messages suppressed." : "")
-                    );
-                }
-            }
+        const Bnd_Box bounds = Part::Tools::getBounds(shape);
+        double xMin, yMin, zMin, xMax, yMax, zMax;
+        bounds.Get(xMin, yMin, zMin, xMax, yMax, zMax);
+        const double diag = std::sqrt(
+            (xMax - xMin) * (xMax - xMin) + (yMax - yMin) * (yMax - yMin)
+            + (zMax - zMin) * (zMax - zMin)
+        );
+        probeDeflection = std::max(deflection, diag / 100.0);
+        if (probeDeflection > deflection) {
+            const double probeScale = probeDeflection / deflection;
+            meshParams.Deflection = probeDeflection;
+            meshParams.Angle *= probeScale;
         }
     }
 
@@ -1242,6 +1238,48 @@ void ViewProviderPartExt::setupCoinGeometry(
             if (!mesh.IsNull()) {
                 count += mesh->NbTriangles();
             }
+        }
+
+        if (attempt == 0) {
+            // The first mesh is the probe. Predict the triangle count at the requested
+            // deflection from the measured count.
+            const double growth = (probeDeflection / deflection) * (probeDeflection / deflection);
+            const double predicted = static_cast<double>(count) * growth;
+            if (predicted > maxFacets) {
+                // The requested deflection would exceed the budget. Mesh directly at a
+                // deflection derived from the measured count, so that the expensive fine
+                // mesh is never attempted. This target is never finer than the requested
+                // deflection: target <= deflection would imply predicted <= maxFacets.
+                const double target = std::max(
+                    deflection,
+                    probeDeflection * std::sqrt(static_cast<double>(count) / maxFacets)
+                );
+                const double scale = target / meshParams.Deflection;
+                meshParams.Deflection = target;
+                meshParams.Angle *= scale;
+                if (doWarn) {
+                    budgetWarningCount++;
+                    FC_WARN(
+                        "Part tessellation probe of "
+                        << count << " triangles predicts " << static_cast<long>(predicted)
+                        << " at the requested deflection, which exceeds the facet budget of "
+                        << maxFacets << ". Increasing linear deflection to " << target
+                        << " and angular deflection to " << meshParams.Angle << " rad."
+                        << (budgetWarningCount == 10 ? " Further messages suppressed." : "")
+                    );
+                }
+                continue;
+            }
+            if (probeDeflection > deflection) {
+                // The probe predicts the requested deflection fits the budget; mesh
+                // again at the requested deflection.
+                meshParams.Deflection = deflection;
+                meshParams.Angle = AngDeflectionRads;
+                continue;
+            }
+            // The probe was already meshed at the requested deflection and fits the
+            // budget.
+            break;
         }
 
         if (count <= maxFacets || attempt == 3) {

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -200,6 +200,20 @@ public:
         bool normalsFromUV = false
     );
 
+    /// Compute the tessellation facet budget for a single Part view provider.
+    ///
+    /// The budget is derived from the global limit MaxFacetsForDisplay (parameter
+    /// BaseApp/Preferences/Mod/Part) and is shared among all currently visible Part
+    /// view providers of all open documents, so that the total number of displayed
+    /// triangles stays bounded even in huge assemblies. Returns 0 if the limit is
+    /// disabled (MaxFacetsForDisplay <= 0).
+    static int getFacetBudget();
+
+    /// Re-tessellate all visible Part view providers of all open documents. Used when
+    /// the global facet budget parameter has changed and the existing meshes should be
+    /// rebuilt with the new limit.
+    static void updateVisualOfAllParts();
+
 protected:
     bool setEdit(int ModNum) override;
     void unsetEdit(int ModNum) override;


### PR DESCRIPTION
# Problem
When opening the STEP export of my milling machine which has been designed by the company who built it
in SolidWorks, FreeCAD practically froze, taking multiple minutes between frames when trying to rotate
the machine in the viewport.

<img width="2345" height="1765" alt="image" src="https://github.com/user-attachments/assets/a6e1c581-d092-4816-b7eb-ba43a3af1355" />

This was caused by a computational explosion, because FreeCAD was trying to mesh complex parts (in this design the ball screws and their nuts) into something in the order of billions of triangles:

<img width="2116" height="1321" alt="image" src="https://github.com/user-attachments/assets/0c1c3bee-9368-46bc-931f-bfc21e919003" />

# Solution
A practical solution to this problem is to limit the complexity of the generated meshes for visible
objects with lots of detail.
For this purpose a new parameter `Maximum facets for display` is introduced in `Preferences -> Part/Part Design -> Shape View` with a default of 2000000 facets. A value of zero disables the limit here.
<img width="825" height="625" alt="image" src="https://github.com/user-attachments/assets/f2aa09df-669e-4cf7-b28d-7fa6e7fc7a31" />

# Implementation
 `setupCoinGeometry()` estimates the expected triangle count from the
  surface area  and scales both the  linear and angular deflection 
 before meshing, to prevent the mesh containing too many triangles.
  If the resulting mesh still exceeds the budget,
  the deflections are scaled again and the shape is re-meshed with a maximum number of 4
  attempts. 
  When doing so a warning is issued to notify the user, with a limit of 10 warnings per session,
  so that large assemblies do not flood the error pane.

# Test
I opened the attached design in FreeCAD and after limiting the maximum facets to 2000,
navigating the machine in FreeCAD became useable for the first time, what you can see in the
screenshots.

[MesinMilling.zip](https://github.com/user-attachments/files/31819981/MesinMilling.zip)

I also verified that a normal document (torus) is unaffected and that setting
 `MaxFacetsForDisplay` to 0 restores the previous behaviour.

The budget warning also appears once per object class of problem and  is throttled (10 messages max per session).
## AI assistance disclosure

This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

I used an AI coding agent (DeepSeek, deepseek-v4-pro) while working on this
PR: it helped me profile the example file, locate the hotspots in the Part
workbench code and sketch the tessellation-budget implementation. I went
through every changed line myself, adjusted the design (global budget shared
between visible objects, per-object clamp, area-based pre-estimate), built
and tested the result on my machine, and I stand behind the change.

Assisted-by: DeepSeek (deepseek-v4-pro)