### PR TITLE
Sketcher: Fix solver failure for symmetric constraint with implied perpendicularity

### DIFF
--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -323,6 +323,7 @@ int Sketch::setUpSketch(
 #endif  // DEBUG_BLOCK_CONSTRAINT
 
     buildInternalAlignmentGeometryMap(ConstraintList);
+    buildSymmetryRedundancyMaps(ConstraintList);
 
     addGeometry(intGeoList, onlyBlockedGeometry, inGroupGeoIds);
     int extStart = Geoms.size();
@@ -441,6 +442,43 @@ void Sketch::buildInternalAlignmentGeometryMap(const std::vector<Constraint*>& c
             internalAlignmentGeometryMap[c->First] = c->Second;
         }
     }
+}
+
+void Sketch::buildSymmetryRedundancyMaps(const std::vector<Constraint*>& constraintList)
+{
+    lineDirectionConstraintMap.clear();
+    coincidenceRepresentativeMap.clear();
+
+    for (auto* c : constraintList) {
+        if (c->Type == Horizontal || c->Type == Vertical) {
+            if (c->Second == GeoEnum::GeoUndef) {  // direction of a single line
+                lineDirectionConstraintMap[c->First] = c->Type;
+            }
+        }
+        else if (c->Type == Coincident && c->FirstPos != PointPos::none
+                 && c->SecondPos != PointPos::none) {
+            // union-find: link the two coincident points
+            std::pair<int, Sketcher::PointPos> p1 = {c->First, c->FirstPos};
+            std::pair<int, Sketcher::PointPos> p2 = {c->Second, c->SecondPos};
+            auto rep1 = findCoincidenceRepresentative(p1);
+            auto rep2 = findCoincidenceRepresentative(p2);
+            if (rep1 != rep2) {
+                coincidenceRepresentativeMap[rep2] = rep1;
+            }
+        }
+    }
+}
+
+std::pair<int, Sketcher::PointPos> Sketch::findCoincidenceRepresentative(
+    std::pair<int, Sketcher::PointPos> point
+) const
+{
+    auto it = coincidenceRepresentativeMap.find(point);
+    while (it != coincidenceRepresentativeMap.end() && it->second != point) {
+        point = it->second;
+        it = coincidenceRepresentativeMap.find(point);
+    }
+    return point;
 }
 
 void Sketch::fixParametersAndDiagnose(std::vector<double*>& params_to_block)
@@ -4131,6 +4169,51 @@ int Sketch::addSymmetricConstraint(int geoId1, PointPos pos1, int geoId2, PointP
                 int tag = ++ConstraintsCounter;
                 // addConstraintMidpointOnLine is a GCS::System method, but we can call it from
                 // here.
+                GCSsys.addConstraintMidpointOnLine(p1, p2, l.p1, l.p2, tag);
+                return ConstraintsCounter;
+            }
+        }
+    }
+
+    // Special handling for line endpoint symmetry when the direction of the segment between the
+    // two points and the direction of the symmetry line are already constrained to transverse
+    // directions (e.g. a horizontal edge and a vertical symmetry line). In this configuration,
+    // the perpendicularity part of the symmetry constraint is inherently redundant, which makes
+    // the system rank-deficient and prevents the solver from converging. We detect this case and
+    // add only the midpoint-on-line part of the constraint, which is sufficient to enforce
+    // symmetry without causing redundancy.
+
+    // Step 1: The symmetry line must itself have a constrained direction.
+    auto itSym = lineDirectionConstraintMap.find(geoId3);
+    if (itSym != lineDirectionConstraintMap.end()) {
+        // Step 2: The two points must be (coincident with) the endpoints of a line whose
+        // constrained direction is transverse to the symmetry line's direction.
+        auto rep1 = findCoincidenceRepresentative({geoId1, pos1});
+        auto rep2 = findCoincidenceRepresentative({geoId2, pos2});
+
+        for (const auto& [lineGeoId, lineDir] : lineDirectionConstraintMap) {
+            if (lineDir == itSym->second || lineGeoId < 0
+                || lineGeoId >= int(Geoms.size())  // NOLINT
+                || Geoms[lineGeoId].type != Line) {
+                continue;  // same direction (would conflict) or not a line segment
+            }
+
+            // the endpoints of the line are resolved through the coincidence groups as well,
+            // since the representative of a coincident point group is order-dependent
+            auto lineStartRep = findCoincidenceRepresentative({lineGeoId, PointPos::start});
+            auto lineEndRep = findCoincidenceRepresentative({lineGeoId, PointPos::end});
+
+            if ((rep1 == lineStartRep && rep2 == lineEndRep)
+                || (rep1 == lineEndRep && rep2 == lineStartRep)) {
+                // The segment between the two points has a constrained direction transverse to
+                // the symmetry line's direction. Weaken the constraint by only adding the
+                // midpoint part.
+                int pointId1 = getPointId(geoId1, pos1);
+                int pointId2 = getPointId(geoId2, pos2);
+                GCS::Point& p1 = Points[pointId1];
+                GCS::Point& p2 = Points[pointId2];
+                GCS::Line& l = Lines[Geoms[geoId3].index];
+                int tag = ++ConstraintsCounter;
                 GCSsys.addConstraintMidpointOnLine(p1, p2, l.p1, l.p2, tag);
                 return ConstraintsCounter;
             }

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -24,6 +24,7 @@
 
 #include <cmath>
 #include <iostream>
+#include <optional>
 
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRep_Builder.hxx>
@@ -455,8 +456,9 @@ void Sketch::buildSymmetryRedundancyMaps(const std::vector<Constraint*>& constra
                 lineDirectionConstraintMap[c->First] = c->Type;
             }
         }
-        else if (c->Type == Coincident && c->FirstPos != PointPos::none
-                 && c->SecondPos != PointPos::none) {
+        else if (
+            c->Type == Coincident && c->FirstPos != PointPos::none && c->SecondPos != PointPos::none
+        ) {
             // union-find: link the two coincident points
             std::pair<int, Sketcher::PointPos> p1 = {c->First, c->FirstPos};
             std::pair<int, Sketcher::PointPos> p2 = {c->Second, c->SecondPos};
@@ -4110,9 +4112,36 @@ int Sketch::addPointOnObjectConstraint(int geoId1, PointPos pos1, int geoId2, do
     return -1;
 }
 
+namespace
+{
+// Returns the direction of a symmetry line: explicitly constrained lines carry a
+// Horizontal/Vertical constraint, while the horizontal and vertical sketch axes are
+// inherently direction-constrained.
+std::optional<Sketcher::ConstraintType> getSymmetryLineDirection(
+    int geoId,
+    const std::map<int, Sketcher::ConstraintType>& lineDirectionConstraintMap
+)
+{
+    if (geoId == GeoEnum::HAxis) {
+        return Sketcher::Horizontal;
+    }
+    if (geoId == GeoEnum::VAxis) {
+        return Sketcher::Vertical;
+    }
+    if (auto it = lineDirectionConstraintMap.find(geoId); it != lineDirectionConstraintMap.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+}  // namespace
+
 // symmetric points constraint
 int Sketch::addSymmetricConstraint(int geoId1, PointPos pos1, int geoId2, PointPos pos2, int geoId3)
 {
+    // the original GeoId of the symmetry line, kept to detect the sketch axes, as checkGeoId
+    // below converts negative external-geometry indices to indices into Geoms
+    int originalGeoId3 = geoId3;
+
     geoId1 = checkGeoId(geoId1);
     geoId2 = checkGeoId(geoId2);
     geoId3 = checkGeoId(geoId3);
@@ -4177,23 +4206,22 @@ int Sketch::addSymmetricConstraint(int geoId1, PointPos pos1, int geoId2, PointP
 
     // Special handling for line endpoint symmetry when the direction of the segment between the
     // two points and the direction of the symmetry line are already constrained to transverse
-    // directions (e.g. a horizontal edge and a vertical symmetry line). In this configuration,
-    // the perpendicularity part of the symmetry constraint is inherently redundant, which makes
-    // the system rank-deficient and prevents the solver from converging. We detect this case and
-    // add only the midpoint-on-line part of the constraint, which is sufficient to enforce
-    // symmetry without causing redundancy.
+    // directions (e.g. a horizontal edge and a vertical symmetry line, or a horizontal edge and
+    // the vertical sketch axis). In this configuration, the perpendicularity part of the
+    // symmetry constraint is inherently redundant, which makes the system rank-deficient and
+    // prevents the solver from converging. We detect this case and add only the midpoint-on-line
+    // part of the constraint, which is sufficient to enforce symmetry without causing redundancy.
 
-    // Step 1: The symmetry line must itself have a constrained direction.
-    auto itSym = lineDirectionConstraintMap.find(geoId3);
-    if (itSym != lineDirectionConstraintMap.end()) {
+    // Step 1: The symmetry line must itself have a constrained direction, either explicitly or,
+    // for the sketch axes, inherently.
+    if (auto symDir = getSymmetryLineDirection(originalGeoId3, lineDirectionConstraintMap)) {
         // Step 2: The two points must be (coincident with) the endpoints of a line whose
         // constrained direction is transverse to the symmetry line's direction.
         auto rep1 = findCoincidenceRepresentative({geoId1, pos1});
         auto rep2 = findCoincidenceRepresentative({geoId2, pos2});
 
         for (const auto& [lineGeoId, lineDir] : lineDirectionConstraintMap) {
-            if (lineDir == itSym->second || lineGeoId < 0
-                || lineGeoId >= int(Geoms.size())  // NOLINT
+            if (lineDir == *symDir || lineGeoId < 0 || lineGeoId >= int(Geoms.size())  // NOLINT
                 || Geoms[lineGeoId].type != Line) {
                 continue;  // same direction (would conflict) or not a line segment
             }

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -623,6 +623,15 @@ private:
     // defines (ellipse, hyperbola, B-Spline)
     std::map<int, int> internalAlignmentGeometryMap;
 
+    // maps a geoid of a line to the direction constraint type (Horizontal or Vertical) applied
+    // to it, if any. Only the single geometry form of those constraints is considered.
+    std::map<int, Sketcher::ConstraintType> lineDirectionConstraintMap;
+
+    // maps a point (geoid, pos) to the representative point of its coincidence group. Used to
+    // resolve points that are coincident with the endpoints of a constrained line.
+    std::map<std::pair<int, Sketcher::PointPos>, std::pair<int, Sketcher::PointPos>>
+        coincidenceRepresentativeMap;
+
     std::vector<std::set<std::pair<int, Sketcher::PointPos>>> pDependencyGroups;
 
     // this map is intended to convert a parameter (double *) into a GeoId/PointPos and parameter
@@ -809,6 +818,12 @@ private:
     void clearTemporaryConstraints();
 
     void buildInternalAlignmentGeometryMap(const std::vector<Constraint*>& constraintList);
+
+    void buildSymmetryRedundancyMaps(const std::vector<Constraint*>& constraintList);
+
+    std::pair<int, Sketcher::PointPos> findCoincidenceRepresentative(
+        std::pair<int, Sketcher::PointPos> point
+    ) const;
 
     int internalSolve(std::string& solvername, int level = 0);
 

--- a/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
@@ -44,6 +44,32 @@ def signedDistanceToLine(line, point):
     return (delta.x * (point.y - start.y) - delta.y * (point.x - start.x)) / delta.Length
 
 
+def createRectangleWithSpanningLine(sketch, line_x=20.0):
+    """Rectangle drawn with the diagonal rectangle tool and a vertical line spanning it.
+
+    The rectangle carries the autoconstraints the tool creates (coincidences, two horizontals,
+    two verticals) and the spanning line carries the autoconstraints created when drawing it
+    over the rectangle (vertical, endpoints on the top and bottom edges). The sketch has 5 DoF
+    when returned.
+    """
+    sketch.addGeometry(Part.LineSegment(vec(0, 40), vec(60, 40)), False)  # 0 top
+    sketch.addGeometry(Part.LineSegment(vec(60, 40), vec(60, 0)), False)  # 1 right
+    sketch.addGeometry(Part.LineSegment(vec(60, 0), vec(0, 0)), False)  # 2 bottom
+    sketch.addGeometry(Part.LineSegment(vec(0, 0), vec(0, 40)), False)  # 3 left
+    sketch.addConstraint(Sketcher.Constraint("Coincident", 0, 2, 1, 1))
+    sketch.addConstraint(Sketcher.Constraint("Coincident", 1, 2, 2, 1))
+    sketch.addConstraint(Sketcher.Constraint("Coincident", 2, 2, 3, 1))
+    sketch.addConstraint(Sketcher.Constraint("Coincident", 3, 2, 0, 1))
+    sketch.addConstraint(Sketcher.Constraint("Horizontal", 0))
+    sketch.addConstraint(Sketcher.Constraint("Horizontal", 2))
+    sketch.addConstraint(Sketcher.Constraint("Vertical", 1))
+    sketch.addConstraint(Sketcher.Constraint("Vertical", 3))
+    sketch.addGeometry(Part.LineSegment(vec(line_x, 40), vec(line_x, 0)), False)  # 4 spanning
+    sketch.addConstraint(Sketcher.Constraint("Vertical", 4))
+    sketch.addConstraint(Sketcher.Constraint("PointOnObject", 4, 1, 0))
+    sketch.addConstraint(Sketcher.Constraint("PointOnObject", 4, 2, 2))
+
+
 def makeDocumentLookLegacy(path):
     """Rewrite an FCStd in place so that its sketches look like they predate signed constraints.
 
@@ -889,6 +915,92 @@ class TestSketcherSolver(unittest.TestCase):
 
         after = signedDistanceToLine(sketch.Geometry[2], sketch.Geometry[3].Center)
         self.assertAlmostEqual(after, -before, delta=Precision.confusion())
+
+    def assertLineCentered(self, sketch):
+        # the constraint relation: the midpoint of the two corners lies on the symmetry line.
+        # Note the solver may move both the rectangle and the line towards each other, so the
+        # absolute position of the line is not asserted.
+        mid_x = (sketch.Geometry[0].StartPoint.x + sketch.Geometry[0].EndPoint.x) / 2
+        self.assertAlmostEqual(mid_x, sketch.Geometry[4].StartPoint.x)
+        self.assertAlmostEqual(mid_x, sketch.Geometry[4].EndPoint.x)
+
+    def testSymmetricLineCenteredInRectangle(self):
+        # Constraining two corners of a rectangle's top edge symmetric about a vertical line
+        # spanning the rectangle should center the line. The perpendicularity part of the
+        # symmetric constraint is inherently redundant with the horizontal and vertical
+        # direction constraints, which used to make the system rank-deficient, preventing the
+        # solver from converging and flagging the sketch as invalid (issue #22381).
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        createRectangleWithSpanningLine(sketch, line_x=20.0)
+        self.Doc.recompute()
+        self.assertEqual(sketch.DoF, 5)
+
+        sketch.addConstraint(Sketcher.Constraint("Symmetric", 0, 1, 0, 2, 4))
+        self.Doc.recompute()
+
+        self.assertSuccessfulSolve(sketch)
+        self.assertEqual(sketch.RedundantConstraints, [])
+        self.assertEqual(sketch.ConflictingConstraints, [])
+        self.assertLineCentered(sketch)
+
+    def testSymmetricLineCenteredInRectangleMixedCorners(self):
+        # Same as testSymmetricLineCenteredInRectangle, but the corners are selected through
+        # the coincident endpoints of the left and right edges, as happens when the user clicks
+        # the other representation of a corner.
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        createRectangleWithSpanningLine(sketch, line_x=20.0)
+        self.Doc.recompute()
+        self.assertEqual(sketch.DoF, 5)
+
+        sketch.addConstraint(Sketcher.Constraint("Symmetric", 3, 2, 1, 1, 4))
+        self.Doc.recompute()
+
+        self.assertSuccessfulSolve(sketch)
+        self.assertEqual(sketch.RedundantConstraints, [])
+        self.assertEqual(sketch.ConflictingConstraints, [])
+        self.assertLineCentered(sketch)
+
+    def testSymmetricStillEnforcesPerpendicularityWhenDirectionsUnconstrained(self):
+        # When the spanning line does not have a vertical constraint, the perpendicularity part
+        # of the symmetric constraint is not redundant and must still be enforced: the line
+        # between the two corners has to stay perpendicular to the symmetry line.
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        createRectangleWithSpanningLine(sketch, line_x=20.0)
+        sketch.delConstraint(8)  # drop the vertical constraint of the spanning line
+        self.Doc.recompute()
+
+        sketch.addConstraint(Sketcher.Constraint("Symmetric", 0, 1, 0, 2, 4))
+        self.Doc.recompute()
+        self.assertSuccessfulSolve(sketch)
+        self.assertEqual(sketch.RedundantConstraints, [])
+        self.assertLineCentered(sketch)
+
+        # drag the line's top endpoint: the solver must restore a configuration where the line
+        # is perpendicular to the (horizontal) top edge. If the symmetric constraint was
+        # wrongly weakened, the line would stay tilted.
+        sketch.moveGeometry(4, 1, vec(25.0, 42.0))
+        self.Doc.recompute()
+        self.assertSuccessfulSolve(sketch)
+        line_dir = sketch.Geometry[4].EndPoint - sketch.Geometry[4].StartPoint
+        edge_dir = sketch.Geometry[0].EndPoint - sketch.Geometry[0].StartPoint
+        self.assertAlmostEqual(line_dir.x * edge_dir.x + line_dir.y * edge_dir.y, 0.0, delta=1e-6)
+
+    def testSymmetricBetweenParallelDirectionConstraintsIsNotAccepted(self):
+        # Two corners of the left edge (vertical segment) symmetric about a vertical line is
+        # geometrically impossible without collapsing the rectangle: the constraint must not be
+        # silently weakened into a midpoint-on-line and the sketch must not solve cleanly.
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        createRectangleWithSpanningLine(sketch, line_x=30.0)
+        self.Doc.recompute()
+
+        sketch.addConstraint(Sketcher.Constraint("Symmetric", 0, 1, 3, 1, 4))
+        self.Doc.recompute()
+
+        status = sketch.solve()
+        self.assertTrue(
+            status != 0 or len(sketch.ConflictingConstraints) > 0,
+            "impossible symmetry request must not solve cleanly",
+        )
 
     def testReversedExternalGeometryLeavesSketchInPlace(self):
         # A signed constraint records the side of a line relative to the line direction. Reversing

--- a/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
@@ -985,6 +985,59 @@ class TestSketcherSolver(unittest.TestCase):
         edge_dir = sketch.Geometry[0].EndPoint - sketch.Geometry[0].StartPoint
         self.assertAlmostEqual(line_dir.x * edge_dir.x + line_dir.y * edge_dir.y, 0.0, delta=1e-6)
 
+    def testSymmetricLineCenteredOnVerticalAxis(self):
+        # A horizontal segment with its endpoints constrained symmetric about the built-in
+        # vertical axis should center the segment on the axis. The perpendicularity part of the
+        # symmetric constraint is inherently redundant with the horizontal constraint, which
+        # used to make the solver fail and flag the sketch as invalid (issue #22381).
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        sketch.addGeometry(Part.LineSegment(vec(-40, 10), vec(20, 10)), False)
+        sketch.addConstraint(Sketcher.Constraint("Horizontal", 0))
+        self.Doc.recompute()
+
+        sketch.addConstraint(Sketcher.Constraint("Symmetric", 0, 1, 0, 2, -2))
+        self.Doc.recompute()
+
+        self.assertSuccessfulSolve(sketch)
+        self.assertEqual(sketch.RedundantConstraints, [])
+        self.assertEqual(sketch.ConflictingConstraints, [])
+        mid_x = (sketch.Geometry[0].StartPoint.x + sketch.Geometry[0].EndPoint.x) / 2
+        self.assertAlmostEqual(mid_x, 0.0)
+
+    def testSymmetricLineCenteredOnHorizontalAxis(self):
+        # Same as testSymmetricLineCenteredOnVerticalAxis, with a vertical segment about the
+        # built-in horizontal axis.
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        sketch.addGeometry(Part.LineSegment(vec(10, 40), vec(10, -5)), False)
+        sketch.addConstraint(Sketcher.Constraint("Vertical", 0))
+        self.Doc.recompute()
+
+        sketch.addConstraint(Sketcher.Constraint("Symmetric", 0, 1, 0, 2, -1))
+        self.Doc.recompute()
+
+        self.assertSuccessfulSolve(sketch)
+        self.assertEqual(sketch.RedundantConstraints, [])
+        self.assertEqual(sketch.ConflictingConstraints, [])
+        mid_y = (sketch.Geometry[0].StartPoint.y + sketch.Geometry[0].EndPoint.y) / 2
+        self.assertAlmostEqual(mid_y, 0.0)
+
+    def testSymmetricAboutAxisStillEnforcedWhenSegmentUnconstrained(self):
+        # Without a direction constraint on the segment, the perpendicularity part of the
+        # symmetric constraint is not redundant: the full constraint must be added (2 DoF
+        # removed), not weakened to midpoint-on-line (1 DoF removed).
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        sketch.addGeometry(Part.LineSegment(vec(-40, 10), vec(20, 10)), False)
+        self.Doc.recompute()
+        self.assertEqual(sketch.DoF, 4)
+
+        sketch.addConstraint(Sketcher.Constraint("Symmetric", 0, 1, 0, 2, -2))
+        self.Doc.recompute()
+
+        self.assertSuccessfulSolve(sketch)
+        self.assertEqual(sketch.DoF, 2)
+        mid_x = (sketch.Geometry[0].StartPoint.x + sketch.Geometry[0].EndPoint.x) / 2
+        self.assertAlmostEqual(mid_x, 0.0)
+
     def testSymmetricBetweenParallelDirectionConstraintsIsNotAccepted(self):
         # Two corners of the left edge (vertical segment) symmetric about a vertical line is
         # geometrically impossible without collapsing the rectangle: the constraint must not be


### PR DESCRIPTION
# Sketcher: Fix solver failure for symmetric constraint with implied perpendicularity

> This PR and fix was created by GLM5.3 Flash under my supervision. I am an
> experienced software developer however am unfamiliar with this codebase. I
> have tested the fix on my Mac and it works and finally fixes the long
> standing bug #22381.

## Summary

Adding a Symmetric constraint between the endpoints of a line whose direction is
already constrained — e.g. the two corners of a rectangle's top edge, with a
vertical line spanning the rectangle selected as symmetry line — made the solver
fail to converge: the geometry never moved and the sketch was flagged invalid
(all geometry red, "Redundant constraints: (9)"). This is a functional failure of
a fundamental workflow, reported in #22381.

## Root cause

A symmetric constraint about a line decomposes into two GCS equations
(`System::addConstraintP2PSymmetric` in `planegcs/GCS.cpp`):

1. perpendicularity of the segment between the two points with the symmetry line
2. midpoint of the two points on the symmetry line

In the reported workflow, the rectangle edge carries a Horizontal constraint and
the spanning line a Vertical constraint (both added as autoconstraints while
drawing). The perpendicularity equation is therefore implied, the constraint
system becomes rank-deficient, and the solver fails to converge on the singular
system. The diagnosis then blames the pre-existing Vertical constraint, the user
sees a confusing "redundant constraints" report pointing at an innocent
constraint, and the sketch is drawn as invalid.

This is the same failure family as the arc-endpoint case already special-cased
in `Sketch::addSymmetricConstraint` (#24228) and the slot symmetry false
positive (#26604).

## Fix

When the two selected points are — resolved through coincidence groups — the
endpoints of a line whose constrained direction is transverse to the symmetry
line's constrained direction, only the midpoint-on-line part of the constraint
is added, mirroring the arc precedent. The detection is constraint-aware
(pre-scanned per setup into a direction map and a coincidence union-find,
following the existing `buildInternalAlignmentGeometryMap` pattern) and is
re-evaluated on every solve, so no constraint is ever deleted: if the implying
constraints are later removed, full symmetric enforcement resumes
automatically.

The sketch H/V axes are treated as inherently direction-constrained, which
fixes the same failure for symmetry about the axes (e.g. centering a horizontal
segment on the vertical axis).

## Testing

- 7 new regression tests in `TestSketcherSolver.py`: direct and
  coincidence-resolved corner selections for the constraint-line and axis
  cases, midpoint centering assertions, verification that perpendicularity is
  still enforced when it is not redundant (DoF accounting distinguishes full
  from weakened constraint), and that geometrically impossible requests
  (parallel directions) are still rejected rather than silently weakened.
- Full Sketcher test suite: 99 tests OK.
- Headless reproducer of the reported workflow: before `solve() = -2` with
  redundant constraint #9 and no geometry movement; after `solve() = 0` with
  the line centered.

## Note on #22381

The failure is platform-independent (reproduces headlessly with no GUI); the
macOS-only presentation of the original report was caused by a separate repaint
issue masking the solver failure. A Windows user in the issue thread reports
the same behavior on 1.1.0dev. The `AutoRemoveRedundants` preference (discussed
in the issue) works around the redundant case by deleting the blamed
constraint, but defaults to `false` on all platforms and is not related to the
root cause.
