### PR TITLE
Gui: fix eyeball/Space hide for link elements in assemblies

### DIFF
--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -1826,8 +1826,7 @@ void SelectionSingleton::setVisible(VisibleState vis)
         // multi-element Link VisibilityList entry. Walk shorter subname prefixes
         // until a parent that supports element visibility is found (same idea as
         // Tree DocumentObjectItem::getElementVisibilityParent).
-        if ((!parent || parent->isElementVisible(elementName.c_str()) < 0)
-            && !sel.SubName.empty()) {
+        if ((!parent || parent->isElementVisible(elementName.c_str()) < 0) && !sel.SubName.empty()) {
             std::string sub = sel.SubName;
             while (!sub.empty()) {
                 auto pos = sub.find_last_of('.');
@@ -1844,8 +1843,8 @@ void SelectionSingleton::setVisible(VisibleState vis)
                 }
                 App::DocumentObject* walkParent = nullptr;
                 std::string walkElement;
-                App::DocumentObject* walkObj =
-                    selObj->resolve(trySub.c_str(), &walkParent, &walkElement);
+                App::DocumentObject* walkObj
+                    = selObj->resolve(trySub.c_str(), &walkParent, &walkElement);
                 if (!walkObj || !walkObj->isAttachedToDocument() || !walkParent
                     || !walkParent->isAttachedToDocument()) {
                     continue;

--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -1809,18 +1809,56 @@ void SelectionSingleton::setVisible(VisibleState vis)
         if (!doc) {
             continue;
         }
-        App::DocumentObject* obj = doc->getObject(sel.FeatName.c_str());
-        if (!obj) {
+        App::DocumentObject* selObj = doc->getObject(sel.FeatName.c_str());
+        if (!selObj) {
             continue;
         }
 
         // get parent object
         App::DocumentObject* parent = nullptr;
         std::string elementName;
-        obj = obj->resolve(sel.SubName.c_str(), &parent, &elementName);
+        App::DocumentObject* obj = selObj->resolve(sel.SubName.c_str(), &parent, &elementName);
         if (!obj || !obj->isAttachedToDocument() || (parent && !parent->isAttachedToDocument())) {
             continue;
         }
+
+        // Deep 3D picks (e.g. Link.Link_i0.Pad.Face4) often resolve past the
+        // multi-element Link VisibilityList entry. Walk shorter subname prefixes
+        // until a parent that supports element visibility is found (same idea as
+        // Tree DocumentObjectItem::getElementVisibilityParent).
+        if ((!parent || parent->isElementVisible(elementName.c_str()) < 0)
+            && !sel.SubName.empty()) {
+            std::string sub = sel.SubName;
+            while (!sub.empty()) {
+                auto pos = sub.find_last_of('.');
+                if (pos == std::string::npos) {
+                    break;
+                }
+                sub.resize(pos);
+                if (sub.empty()) {
+                    break;
+                }
+                std::string trySub = sub;
+                if (trySub.back() != '.') {
+                    trySub.push_back('.');
+                }
+                App::DocumentObject* walkParent = nullptr;
+                std::string walkElement;
+                App::DocumentObject* walkObj =
+                    selObj->resolve(trySub.c_str(), &walkParent, &walkElement);
+                if (!walkObj || !walkObj->isAttachedToDocument() || !walkParent
+                    || !walkParent->isAttachedToDocument()) {
+                    continue;
+                }
+                if (walkParent->isElementVisible(walkElement.c_str()) >= 0) {
+                    obj = walkObj;
+                    parent = walkParent;
+                    elementName = std::move(walkElement);
+                    break;
+                }
+            }
+        }
+
         // try call parent object's setElementVisible
         if (parent) {
             // prevent setting the same object visibility more than once

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1987,19 +1987,21 @@ void TreeWidget::keyPressEvent(QKeyEvent* event)
     }
 
     else if (event->key() == Qt::Key_Space && event->modifiers() == Qt::NoModifier) {
-        // Toggle each selected feature's own visibility directly
+        // Toggle each selected feature's visibility (element VisibilityList when
+        // applicable, otherwise object Visibility — same as the tree eyeball).
         for (auto* raw : selectedItems()) {
             if (raw->type() != ObjectType) {
                 continue;
             }
-            auto* vp = static_cast<DocumentObjectItem*>(raw)->object();
+            auto* item = static_cast<DocumentObjectItem*>(raw);
+            auto* vp = item->object();
             if (!vp || !vp->canToggleVisibility()) {
                 continue;
             }
             auto* appObj = vp->getObject();
-            vp->Gui::ViewProvider::toggleVisibility();
+            item->toggleVisibilityInTree();
             Selection().updateSelection(
-                vp->isShow(),
+                item->isVisibleInTree(),
                 appObj->getDocument()->getName(),
                 appObj->getNameInDocument()
             );
@@ -2045,24 +2047,9 @@ void TreeWidget::mousePressEvent(QMouseEvent* event)
 
             // If the visibility icon was clicked, toggle the DocumentObject visibility
             if (iconRect.contains(mousePos)) {
-                auto obj = objitem->object()->getObject();
-                char const* objname = obj->getNameInDocument();
-
-                App::DocumentObject* parent = nullptr;
-                std::ostringstream subName;
-                objitem->getSubName(subName, parent);
-
-                // Try the ElementVisible API, if that is not supported toggle the Visibility property
-                int visible = -1;
-                if (parent) {
-                    visible = parent->isElementVisible(objname);
-                }
-                if (parent && visible >= 0) {
-                    parent->setElementVisible(objname, !visible);
-                }
-                else {
-                    visible = obj->Visibility.getValue();
-                    obj->Visibility.setValue(!visible);
+                auto* vp = objitem->object();
+                if (vp && vp->canToggleVisibility()) {
+                    objitem->toggleVisibilityInTree();
                 }
                 visibilityIconDoubleClickTimer.start();
                 visibilityIconPressed = true;
@@ -6457,38 +6444,69 @@ QIcon DocumentObjectItem::getVisibilityIcon(int currentStatus, QIcon& original_i
     return new_icon;
 }
 
+bool DocumentObjectItem::getElementVisibilityParent(
+    App::DocumentObject*& visParent,
+    std::string& elementName
+) const
+{
+    visParent = nullptr;
+    elementName.clear();
+
+    auto* obj = object()->getObject();
+    if (!obj || !obj->isAttachedToDocument()) {
+        return false;
+    }
+
+    App::DocumentObject* topParent = nullptr;
+    std::ostringstream ss;
+    getSubName(ss, topParent);
+    if (!topParent || !topParent->isAttachedToDocument()) {
+        return false;
+    }
+
+    // Full subname relative to topParent, matching Selection::setVisible.
+    ss << obj->getNameInDocument() << '.';
+    App::DocumentObject* parent = nullptr;
+    auto* resolved = topParent->resolve(ss.str().c_str(), &parent, &elementName);
+    if (!resolved || !resolved->isAttachedToDocument() || !parent
+        || !parent->isAttachedToDocument()) {
+        return false;
+    }
+    if (parent->isElementVisible(elementName.c_str()) < 0) {
+        return false;
+    }
+
+    visParent = parent;
+    return true;
+}
+
+void DocumentObjectItem::toggleVisibilityInTree()
+{
+    auto* obj = object()->getObject();
+    if (!obj || !obj->isAttachedToDocument()) {
+        return;
+    }
+
+    App::DocumentObject* visParent = nullptr;
+    std::string elementName;
+    if (getElementVisibilityParent(visParent, elementName)) {
+        int visible = visParent->isElementVisible(elementName.c_str());
+        visParent->setElementVisible(elementName.c_str(), !visible);
+        return;
+    }
+
+    obj->Visibility.setValue(!obj->Visibility.getValue());
+}
+
 bool DocumentObjectItem::isVisibleInTree() const
 {
-    App::DocumentObject* pObject = object()->getObject();
-
-    int visible = -1;
-    auto parentItem = getParentItem();
-    if (parentItem) {
-        auto parent = parentItem->object()->getObject();
-        auto ext = parent->getExtensionByType<App::GroupExtension>(true, false);
-        if (!ext) {
-            visible = parent->isElementVisible(pObject->getNameInDocument());
-        }
-        else {
-            // We are dealing with a plain group. It has special handling when
-            // linked, which allows it to have indpenedent visibility control.
-            // We need to go up the hierarchy and see if there is any link to
-            // it.
-            for (auto pp = parentItem->getParentItem(); pp; pp = pp->getParentItem()) {
-                auto obj = pp->object()->getObject();
-                if (!obj->hasExtension(App::GroupExtension::getExtensionClassTypeId(), false)) {
-                    visible = pp->object()->getObject()->isElementVisible(pObject->getNameInDocument());
-                    break;
-                }
-            }
-        }
+    App::DocumentObject* visParent = nullptr;
+    std::string elementName;
+    if (getElementVisibilityParent(visParent, elementName)) {
+        return visParent->isElementVisible(elementName.c_str()) != 0;
     }
 
-    if (visible < 0) {
-        visible = object()->isShow() ? 1 : 0;
-    }
-
-    return visible != 0;
+    return object()->isShow();
 }
 
 void DocumentObjectItem::testStatus(bool resetStatus, QIcon& icon1, QIcon& icon2)

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -6468,8 +6468,7 @@ bool DocumentObjectItem::getElementVisibilityParent(
     ss << obj->getNameInDocument() << '.';
     App::DocumentObject* parent = nullptr;
     auto* resolved = topParent->resolve(ss.str().c_str(), &parent, &elementName);
-    if (!resolved || !resolved->isAttachedToDocument() || !parent
-        || !parent->isAttachedToDocument()) {
+    if (!resolved || !resolved->isAttachedToDocument() || !parent || !parent->isAttachedToDocument()) {
         return false;
     }
     if (parent->isElementVisible(elementName.c_str()) < 0) {

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -569,10 +569,7 @@ private:
 
     /** If this item is a link/array element, set visParent and elementName to
      *  the object that owns isElementVisible/setElementVisible. */
-    bool getElementVisibilityParent(
-        App::DocumentObject*& visParent,
-        std::string& elementName
-    ) const;
+    bool getElementVisibilityParent(App::DocumentObject*& visParent, std::string& elementName) const;
 
     void setIconOverlays(int currentStatus, QPixmap& overlays) const;
     void generateIcon(int currentStatus, QIcon::Mode mode, QIcon& icon);

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -497,6 +497,9 @@ public:
     void testStatus(bool resetStatus, QIcon& icon1, QIcon& icon2);
     void testStatus(bool resetStatus);
     bool isVisibleInTree() const;
+    /** Toggle visibility the same way as Selection::setVisible: prefer the
+     *  element's VisibilityList owner (via resolve), else object Visibility. */
+    void toggleVisibilityInTree();
     void displayStatusInfo();
 
     QVariant data(int column, int role) const override;
@@ -563,6 +566,13 @@ private:
         const std::vector<bool>& snapshot,
         std::vector<bool>::const_iterator& from
     );
+
+    /** If this item is a link/array element, set visParent and elementName to
+     *  the object that owns isElementVisible/setElementVisible. */
+    bool getElementVisibilityParent(
+        App::DocumentObject*& visParent,
+        std::string& elementName
+    ) const;
 
     void setIconOverlays(int currentStatus, QPixmap& overlays) const;
     void generateIcon(int currentStatus, QIcon::Mode mode, QIcon& icon);


### PR DESCRIPTION
Fixes #32386
Problem was that for multi-element links inside an assembly clicking the tree eyeball or pressing Space on Link_i0 etc did nothing right click toggle visibility still worked 
cause was eyeball/Space asked the assembly for element visibility, assembly doesn't support that, so we ended up flipping the LinkElement's visibility instead of the Link's VisibilityList
fix: resolve the real visibility parent the same way Selection::setVisible does DocumentObject::resolve, then toggle that eyeball space and the tree eye icon all use this path now
tested with the file from the issue: Link_i0 eyeball/Space hide and show correctly; parent link and normal features still fine

Took AI assistance:Cursor
Manually verified

https://github.com/user-attachments/assets/c3a3d63f-54e0-49a5-8f1c-b59c497ff66a


