### PR TITLE
App: restore source string hasher when importing objects

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1786,6 +1786,17 @@ std::vector<DocumentObject*> Document::importObjects(Base::XMLReader& reader)
         reader.FileVersion = 0;
     }
 
+    // Imported objects may reference strings stored in the source document's
+    // StringHasher table, for example in topological element maps. Restore the
+    // source table before reading the objects so their persisted references can
+    // be resolved. Use a separate hasher instead of replacing the target
+    // document's table.
+    if (reader.hasAttribute("StringHasher")) {
+        StringHasherRef sourceHasher = new StringHasher;
+        sourceHasher->Restore(reader);
+        addStringHasher(sourceHasher);
+    }
+
     std::vector<DocumentObject*> objs = readObjects(reader);
     for (const auto o : objs) {
         if (o && o->isAttachedToDocument()) {
@@ -1814,6 +1825,7 @@ std::vector<DocumentObject*> Document::importObjects(Base::XMLReader& reader)
     reader.readEndElement("Document");
 
     signalImportObjects(objs, reader);
+    DocumentP::checkStringHasher(reader);
     afterRestore(objs, true);
 
     signalFinishImportObjects(objs);

--- a/tests/src/App/Document.cpp
+++ b/tests/src/App/Document.cpp
@@ -3,8 +3,12 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#include <cstdio>
+#include <fstream>
+
 #include "App/Application.h"
 #include "App/Document.h"
+#include "App/MergeDocuments.h"
 #include "App/StringHasher.h"
 #include "Base/Writer.h"
 #include <src/App/InitApplication.h>
@@ -92,6 +96,42 @@ TEST_F(DocumentTest, getStringHasherGivesExpectedHasher)
 
     // Assert
     EXPECT_EQ(hasher, foundHasher);
+}
+
+TEST_F(DocumentTest, importObjectsRestoresSourceStringHasher)
+{
+    // Arrange
+    auto& app = App::GetApplication();
+    const std::string sourceName = app.getUniqueDocumentName("MergeSource");
+    App::Document* source = app.newDocument(sourceName.c_str(), "testUser");
+    App::StringHasherRef sourceHasher = source->getStringHasher();
+    ASSERT_TRUE(sourceHasher);
+    sourceHasher->setSaveAll(true);
+    sourceHasher->getID("persisted element name");
+
+    const std::string path = App::Application::getTempFileName();
+    ASSERT_TRUE(source->saveAs(path.c_str()));
+    const std::string savedPath = source->getFileName();
+    app.closeDocument(sourceName.c_str());
+
+    std::size_t restoredStringCount = 0;
+    auto connection = doc()->signalFinishImportObjects.connect(
+        [this, &restoredStringCount](const std::vector<App::DocumentObject*>&) {
+            App::StringHasherRef importedHasher = doc()->getStringHasher(0);
+            restoredStringCount = importedHasher ? importedHasher->size() : 0;
+        }
+    );
+
+    // Act
+    std::ifstream stream(savedPath, std::ios::in | std::ios::binary);
+    ASSERT_TRUE(stream.is_open());
+    App::MergeDocuments merge(doc());
+    merge.importObjects(stream);
+
+    // Assert
+    EXPECT_GT(restoredStringCount, 0);
+    connection.disconnect();
+    std::remove(savedPath.c_str());
 }
 
 // NOLINTEND(readability-magic-numbers)


### PR DESCRIPTION
When importing objects from another document, restore the source document's `StringHasher` before reading those objects.

Imported objects can contain references to strings stored in the source hasher, such as topological element names. Keeping that hasher alongside the destination document's existing hasher allows those references to be resolved without replacing the destination table.

This also runs the existing string-hasher validation after the objects have been imported and adds a regression test covering the merge of a saved document with populated string-hasher data.

This is alternative to https://github.com/FreeCAD/FreeCAD/pull/31883.

Fixes https://github.com/FreeCAD/FreeCAD/issues/21180.
Fixes https://github.com/FreeCAD/FreeCAD/issues/31880.

Assisted-by: GPT5.6-Sol