### PR TITLE
Draft: flatten SVG faces

### DIFF
--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -575,6 +575,9 @@ class svgHandler(xml.sax.ContentHandler):
                 shape = Part.makeFace(aWires, "Part::FaceMakerBullseye")
             else:
                 shape = aWires[0]
+        elif shape.Faces:
+            # applyTrans results in a B-spline face, we want a planar face:
+            shape = Part.makeFace(shape.Wires, "Part::FaceMakerBullseye")
 
         obj = self.doc.addObject("Part::Feature", name)
         obj.Shape = shape


### PR DESCRIPTION
Fixes #31305.

SVG faces were transformed during the import process. As a result they came in as B-spline faces instead of planar faces. Recreating them from their wires avoids this.