### PR TITLE
CAM: fix error when finding longest edge for Profile

### DIFF
--- a/src/Mod/CAM/Path/Op/Area.py
+++ b/src/Mod/CAM/Path/Op/Area.py
@@ -204,12 +204,10 @@ class ObjectOp(PathOp.ObjectOp):
 
     def getMiddlePointLongestEdge(self, shape):
         """getMiddlePointLongestEdge(shape) ... return middle point of longest edge from shape."""
-        candidate = shape.Edges[0]
-        for edge in shape.Edges:
-            if edge.Length > candidate.Length:
-                candidate = edge
-
-        return candidate.discretize(3)[1]
+        longest = max(shape.Edges, key=lambda edge: edge.Length, default=None)
+        if longest is None:
+            return None
+        return longest.discretize(3)[1]
 
     def _buildPathArea(self, obj, baseobject, isHole, start, getsim):
         """_buildPathArea(obj, baseobject, isHole, start, getsim) ... internal function."""
@@ -275,7 +273,9 @@ class ObjectOp(PathOp.ObjectOp):
             and getattr(obj, "HandleMultipleFeatures", None) == "Individually"
             and getattr(obj, "UseLongestEdge", False)
         ):
-            pathParams["start"] = self.getMiddlePointLongestEdge(shapelist[0])
+            mid_longest = self.getMiddlePointLongestEdge(shapelist[0])
+            if mid_longest is not None:
+                pathParams["start"] = mid_longest
         elif self.endVector is not None:
             if self.endVector[:2] != (0, 0):
                 pathParams["start"] = self.endVector


### PR DESCRIPTION
When profiling the holes in a part where one of the holes is smaller than the cutter diameter and selecting "Use Longest Edge" as start point, I'm getting the following error:

[cam_use_longest_edge_fail.zip](https://github.com/user-attachments/files/31855384/cam_use_longest_edge_fail.zip)

```
02:23:42  list index out of rangeSomething unexpected happened. Check project and tool config.pyException: Traceback (most recent call last):
  File "/usr/lib/freecad/Mod/CAM/Path/Op/Profile.py", line 73, in execute
    return PathOp.ObjectOp.execute(self, obj)
  File "/usr/lib/freecad/Mod/CAM/PathScripts/PathUtils.py", line 66, in new_function
    res = function(*args, **kwargs)
  File "/usr/lib/freecad/Mod/CAM/Path/Op/Base.py", line 1187, in execute
    result = self.opExecute(obj)
  File "/usr/lib/freecad/Mod/CAM/Path/Op/Area.py", line 450, in opExecute
    raise e
  File "/usr/lib/freecad/Mod/CAM/Path/Op/Area.py", line 444, in opExecute
    pp, sim = self._buildPathArea(obj, shape, isHole, start, getsim)
  File "/usr/lib/freecad/Mod/CAM/Path/Op/Area.py", line 278, in _buildPathArea
    pathParams["start"] = self.getMiddlePointLongestEdge(shapelist[0])
  File "/usr/lib/freecad/Mod/CAM/Path/Op/Area.py", line 207, in getMiddlePointLongestEdge
    candidate = shape.Edges[0]
<class 'IndexError'>: list index out of range
02:23:42  Profile001: list index out of range
02:26:04  This plugin supports grabbing the mouse only for popup windows
02:26:05  This plugin supports grabbing the mouse only for popup windows
```

The problem is that `shape.Edges` is empty here:

https://github.com/FreeCAD/FreeCAD/blob/1ae6ec1fed29e40583de77d2db5178a8b53a9e17/src/Mod/CAM/Path/Op/Area.py#L205-L212

Fix by returning `None` and not settings `pathParams["start"]` in this case.