### PR TITLE
CI: increase ops per run for stale PRs

### DIFF
--- a/.github/workflows/auto-close_stale_issues_and_pull-requests.yml
+++ b/.github/workflows/auto-close_stale_issues_and_pull-requests.yml
@@ -121,7 +121,7 @@ jobs:
           days-before-issue-close: -1
           days-before-pr-stale: 120
           days-before-pr-close: 60
-          operations-per-run: 30  # max num of ops per run
+          operations-per-run: 150  # max num of ops per run
           stale-pr-label: 'Status: Stale'
           close-pr-label: 'Status: Auto-closing'
           exempt-pr-labels: 'Needs backport,Priority: High,Priority: Critical,no-auto-close'


### PR DESCRIPTION
The Stale PRs action [has trouble catching up](https://github.com/FreeCAD/FreeCAD/actions/runs/33822551595/job/100868148806) with the backlog of PRs, this increases the number of daily operations

@maxwxyz 